### PR TITLE
feat: move ping-pong demo to /ping-pong, add proper homepage

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -82,7 +82,12 @@ export default function Home() {
               <Link href="/ping-pong" className="hover:text-slate-300 transition-colors">
                 Demo
               </Link>
-              <a href="/api/docs" className="hover:text-slate-300 transition-colors">
+              <a
+                href="/api/docs"
+                className="hover:text-slate-300 transition-colors"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 API
               </a>
             </div>
@@ -96,7 +101,7 @@ export default function Home() {
 function FeatureCard({ icon, title, description }: { icon: string; title: string; description: string }) {
   return (
     <div className="bg-slate-800/30 border border-slate-700/50 rounded-xl p-6 hover:bg-slate-800/50 transition-colors">
-      <div className="text-4xl mb-4">{icon}</div>
+      <div className="text-4xl mb-4" role="img" aria-label={title}>{icon}</div>
       <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
       <p className="text-slate-400 text-sm">{description}</p>
     </div>

--- a/apps/frontend/src/app/ping-pong/page.tsx
+++ b/apps/frontend/src/app/ping-pong/page.tsx
@@ -10,7 +10,7 @@ interface PingState {
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 
-export default function Home() {
+export default function PingPongPage() {
   const [pingState, setPingState] = useState<PingState | null>(null)
   const [loading, setLoading] = useState(true)
   const [toggling, setToggling] = useState(false)


### PR DESCRIPTION
## Summary

Reorganizes the frontend routes to have a proper landing page.

## Changes

- Move ping-pong demo from `/` to `/ping-pong` route
- Create proper landing page at `/` with:
  - Feature cards for core functionality
  - Navigation to demo and API docs
  - "Under Development" notice
  - Clean, professional design

## Routes After Merge

| URL | Content |
|-----|---------|
| `/` | Landing page with feature overview |
| `/ping-pong` | Ping-pong demo (backend connectivity test) |
| `/api/docs` | Swagger API documentation |