### PR TITLE
fix: correct API docs link to point to backend FastAPI docs

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+import { API_URL } from '@/lib/api'
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Problem
The 'API Docs' links on the homepage were pointing to `/api/docs`, which requests Next.js frontend's route (404).

## Solution
Changed links to use `${API_URL}/docs` to correctly point to FastAPI's Swagger documentation at `http://localhost:8000/docs`.

## Changes
- Added `API_URL` constant using `NEXT_PUBLIC_API_URL` environment variable
- Updated both API docs links in the header and footer