### PR TITLE
fix: use short SHA tags to match Docker metadata action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -100,8 +100,12 @@ jobs:
           echo "Updating compose file with SHA-tagged images..."
           cd repo/finance_report/finance_report/10.app
           
-          # Replace environment variable references with SHA tags
-          sed -i "s|\${IMAGE_TAG:-latest}|sha-${{ github.sha }}|g" compose.yaml
+          # Use short SHA (first 7 chars) to match Docker metadata action default
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "Using short SHA: sha-$SHORT_SHA"
+          
+          # Replace environment variable references with short SHA tags
+          sed -i "s|\${IMAGE_TAG:-latest}|sha-$SHORT_SHA|g" compose.yaml
           
           echo "Updated compose.yaml image lines:"
           cat compose.yaml | grep "image:"


### PR DESCRIPTION
## Root Cause
Found via Dokploy API: deployments were failing with `status: error` because images couldn't be pulled.

The issue: Docker metadata action with `type=sha,format=short` produces **7-character SHA tags** like:
- `sha-01af189` ✅

But our workflow was using **40-character full SHA** in compose file:
- `sha-01af189acefe562128f4b27c5894535321be2b10` ❌

This caused Dokploy to try pulling non-existent images, failing instantly.

## Solution  
Use `cut -c1-7` to extract short SHA matching Docker's default format.

## Verification
- Dokploy status API shows `composeStatus: error` currently
- Recent deployments at 04:01 and 04:09 failed in <1 second
- This fix will use tags that actually exist in GHCR

Related: #19 #20