### PR TITLE
refactor: update infra2 via PR instead of direct Dokploy API

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Build, Deploy and Smoke Test
+name: Build and Update Infrastructure
 
 on:
   push:
@@ -85,142 +85,58 @@ jobs:
           build-args: |
             NEXT_PUBLIC_API_URL=https://report.zitian.party/api
 
-  deploy:
-    name: Deploy to Production
+  update-infra:
+    name: Update Infrastructure Config
     needs: [build-backend, build-frontend]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout finance_report repo
         uses: actions/checkout@v4
         with:
-          submodules: true
+          path: finance_report
+      
+      - name: Checkout infra2 repo
+        uses: actions/checkout@v4
+        with:
+          repository: wangzitian0/infra2
+          path: infra2
+          token: ${{ secrets.INFRA2_PAT }}
       
       - name: Update compose file with SHA tags
         run: |
-          echo "Updating compose file with SHA-tagged images..."
-          cd repo/finance_report/finance_report/10.app
+          cd infra2/finance_report/finance_report/10.app
           
           # Use short SHA (first 7 chars) to match Docker metadata action default
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          echo "Using short SHA: sha-$SHORT_SHA"
+          echo "Updating to sha-$SHORT_SHA"
           
-          # Replace environment variable references with short SHA tags
+          # Replace IMAGE_TAG environment variable with specific SHA
           sed -i "s|\${IMAGE_TAG:-latest}|sha-$SHORT_SHA|g" compose.yaml
           
           echo "Updated compose.yaml image lines:"
-          cat compose.yaml | grep "image:"
-
-      - name: Upload updated compose to Dokploy
-        run: |
-          cd repo/finance_report/finance_report/10.app
-          COMPOSE_CONTENT=$(cat compose.yaml | jq -Rs .)
-          
-          echo "Uploading compose file to Dokploy..."
-          curl -s -X POST "https://cloud.zitian.party/api/compose.update" \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.DOKPLOY_API_KEY }}" \
-            -d "{\"composeId\": \"${{ secrets.DOKPLOY_COMPOSE_ID }}\", \"composeFile\": $COMPOSE_CONTENT, \"sourceType\": \"raw\"}"
-
-      - name: Stop existing containers
-        run: |
-          echo "Stopping containers..."
-          curl -s -X POST "https://cloud.zitian.party/api/compose.stop" \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.DOKPLOY_API_KEY }}" \
-            -d '{"composeId": "${{ secrets.DOKPLOY_COMPOSE_ID }}"}'
-          
-          echo "Waiting 15 seconds for containers to stop..."
-          sleep 15
-
-      - name: Deploy with new images
-        run: |
-          echo "Deploying with SHA-tagged images (sha-${{ github.sha }})..."
-          response=$(curl -s -X POST "https://cloud.zitian.party/api/compose.deploy" \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.DOKPLOY_API_KEY }}" \
-            -d '{"composeId": "${{ secrets.DOKPLOY_COMPOSE_ID }}"}' \
-            -w "\n%{http_code}")
-          
-          http_code=$(echo "$response" | tail -n1)
-          body=$(echo "$response" | head -n-1)
-          
-          echo "Deploy response: $body"
-          echo "HTTP Code: $http_code"
-          
-          if [ "$http_code" != "200" ] && [ "$http_code" != "201" ] && [ "$http_code" != "204" ]; then
-            echo "Deployment failed with HTTP $http_code"
-            exit 1
-          fi
-          
-          echo "Deployment triggered successfully"
-
-      - name: Wait for deployment to complete
-        run: |
-          echo "Waiting 90 seconds for containers to pull and restart..."
-          sleep 90
-
-  smoke-test:
-    name: Smoke Tests
-    needs: deploy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test homepage
-        run: |
-          status=$(curl -sf -o /dev/null -w "%{http_code}" "${{ env.DEPLOY_URL }}/")
-          if [ "$status" != "200" ]; then
-            echo "Homepage failed: HTTP $status"
-            exit 1
-          fi
-          echo "✓ Homepage OK"
-
-      - name: Test API health
-        run: |
-          response=$(curl -sf "${{ env.DEPLOY_URL }}/api/health")
-          echo "Health response: $response"
-          echo "✓ API Health OK"
-
-      - name: Test API docs
-        run: |
-          status=$(curl -sf -o /dev/null -w "%{http_code}" "${{ env.DEPLOY_URL }}/api/docs")
-          if [ "$status" != "200" ]; then
-            echo "API docs failed: HTTP $status"
-            exit 1
-          fi
-          echo "✓ API Docs OK"
-
-      - name: Test ping-pong page
-        run: |
-          status=$(curl -sf -o /dev/null -w "%{http_code}" "${{ env.DEPLOY_URL }}/ping-pong")
-          if [ "$status" != "200" ]; then
-            echo "Ping-pong page failed: HTTP $status"
-            exit 1
-          fi
-          echo "✓ Ping-Pong Page OK"
-
-      - name: Test reconciliation page
-        run: |
-          status=$(curl -sf -o /dev/null -w "%{http_code}" "${{ env.DEPLOY_URL }}/reconciliation")
-          if [ "$status" != "200" ]; then
-            echo "Reconciliation page failed: HTTP $status"
-            exit 1
-          fi
-          echo "✓ Reconciliation Page OK"
-
-      - name: Test API accounts endpoint
-        run: |
-          response=$(curl -sf "${{ env.DEPLOY_URL }}/api/api/accounts")
-          echo "Accounts response: $response"
-          echo "✓ Accounts API OK"
-
-      - name: Test API ping endpoint
-        run: |
-          response=$(curl -sf "${{ env.DEPLOY_URL }}/api/ping")
-          echo "Ping response: $response"
-          echo "✓ Ping API OK"
-
-      - name: Summary
-        run: |
-          echo "=========================================="
-          echo "All smoke tests passed!"
-          echo "Deployment URL: ${{ env.DEPLOY_URL }}"
-          echo "=========================================="
+          grep "image:" compose.yaml
+      
+      - name: Create Pull Request to infra2
+        uses: peter-evans/create-pull-request@v5
+        with:
+          path: infra2
+          token: ${{ secrets.INFRA2_PAT }}
+          commit-message: "chore: update finance_report images to sha-${{ github.sha }}"
+          branch: auto/finance-report-sha-${{ github.sha }}
+          title: "Deploy finance_report sha-${{ github.sha }}"
+          body: |
+            ## Auto-generated deployment PR
+            
+            Updates finance_report backend and frontend images to:
+            - `ghcr.io/wangzitian0/finance_report-backend:sha-${{ github.sha }}`
+            - `ghcr.io/wangzitian0/finance_report-frontend:sha-${{ github.sha }}`
+            
+            Triggered by: ${{ github.event.head_commit.message }}
+            Finance Report commit: ${{ github.sha }}
+            
+            ## Changes
+            - Updated `finance_report/finance_report/10.app/compose.yaml`
+            
+            **Merge this PR to trigger IaC sync and deploy to production.**
+          labels: auto-deploy,finance-report
+          team-reviewers: wangzitian0


### PR DESCRIPTION
## Root Cause

The deployment pipeline was broken because of architectural mismatch:

**IaC Architecture (GitOps)**:
- infra2 repo uses webhook-based sync
- Changes to `finance_report/10.app/compose.yaml` trigger deployment
- IaC runner computes config hash and syncs idempotently

**Previous Workflow (Incorrect)**:
- Updated compose.yaml in local checkout submodule
- Directly called Dokploy API to upload raw compose
- **No commit to infra2 repo → no webhook → no sync → no deployment**

## Solution

Follow the GitOps pattern:

1. ✅ Build images with SHA tags
2. ✅ Create PR to infra2 updating compose.yaml
3. ⏭️  Merge PR triggers webhook
4. ⏭️  IaC runner syncs finance_report
5. ⏭️  Production deploys with new images

## Changes

- **Removed**: Direct Dokploy API manipulation
- **Removed**: Smoke tests (will run post-deployment)
- **Added**: PR creation to infra2 using `peter-evans/create-pull-request`
- **Required**: `INFRA2_PAT` secret (Personal Access Token with repo write)

## Testing

After merge:
1. Workflow will create auto-PR to infra2
2. Merge infra2 PR to trigger deployment
3. Verify finance_report pages work

Related: #19 #20 #21