### PR TITLE
[codex] serialize post-merge LLM E2E gate

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -21,6 +21,7 @@ env:
   IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
   DOKPLOY_API_URL: https://cloud.zitian.party/api
   STAGING_COMPOSE_ID: A6V-hbJlgHMwgPDoTDnhH
+  STAGING_E2E_PRIMARY_MODEL: glm-5.1
 
 jobs:
   build-and-deploy:
@@ -102,6 +103,7 @@ jobs:
           IMAGE_TAG: ${{ steps.get_sha.outputs.short_sha }}
           DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
           DOKPLOY_API_URL: ${{ env.DOKPLOY_API_URL }}
+          DEPLOY_PRIMARY_MODEL_OVERRIDE: ${{ env.STAGING_E2E_PRIMARY_MODEL }}
         run: |
           bash scripts/dokploy_deploy.sh \
             "${{ env.STAGING_COMPOSE_ID }}" \
@@ -132,9 +134,15 @@ jobs:
           bash scripts/smoke_test.sh "$APP_URL" staging
           
           echo "--- Phase 2: Core Flow Validation (Python) ---"
-          # Run full suite including UI tests since SKIP_UI_TESTS=false
-          # Using 4 workers for parallel execution
-          pytest tests/e2e -v -m "smoke or e2e" -n 4
+          # Parallelize non-LLM tests only. Real AI/OCR calls are run once below
+          # to avoid four workers hitting the provider at the same time.
+          pytest tests/e2e -v -m "(smoke or e2e) and not llm" -n 4
+
+          echo "--- Phase 3: AI/OCR Gate (single process, ${STAGING_E2E_PRIMARY_MODEL}) ---"
+          pytest \
+            tests/e2e/test_statement_full_journey.py \
+            tests/e2e/test_statement_upload_e2e.py \
+            -v -m "llm"
           
           echo "✅ Staging E2E Pipeline passed!"
 

--- a/apps/backend/src/services/openrouter_models.py
+++ b/apps/backend/src/services/openrouter_models.py
@@ -105,7 +105,7 @@ def _to_decimal(value: Any) -> Decimal | None:
 def _configured_model_catalog() -> list[dict[str, Any]]:
     """Build a local catalog from configured model env vars.
 
-    Z.AI does not need the OpenRouter `/models` catalog for validation. Keeping
+    Z.AI does not need a remote `/models` catalog for validation. Keeping
     the catalog local makes CI/prod deterministic and lets model swaps happen by
     changing env vars only.
     """

--- a/apps/backend/tests/ai/test_openrouter_models.py
+++ b/apps/backend/tests/ai/test_openrouter_models.py
@@ -1,4 +1,4 @@
-"""Tests for OpenRouter model catalog service."""
+"""Tests for AI provider model catalog service."""
 
 from __future__ import annotations
 

--- a/apps/backend/tests/ai/test_openrouter_streaming.py
+++ b/apps/backend/tests/ai/test_openrouter_streaming.py
@@ -165,6 +165,44 @@ class TestStreamOpenRouterChat:
             assert headers["X-Title"] == "Finance Report Backend"
 
     @pytest.mark.asyncio
+    async def test_stream_omits_openrouter_headers_for_zai_provider(self):
+        """Provider-neutral GLM access does not send OpenRouter-only headers."""
+        events = [
+            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
+            ServerSentEvent(data="[DONE]"),
+        ]
+
+        mock_event_source = MagicMock()
+        mock_event_source.response.status_code = 200
+        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.__aenter__.return_value = mock_client
+
+        with (
+            patch("src.services.openrouter_streaming.httpx.AsyncClient", return_value=mock_client),
+            patch("src.services.openrouter_streaming.aconnect_sse") as mock_aconnect,
+            patch("src.services.openrouter_streaming.settings") as mock_settings,
+        ):
+            mock_settings.ai_provider = "zai"
+            mock_settings.ai_chat_completions_path = "/chat/completions"
+            mock_aconnect.return_value.__aenter__.return_value = mock_event_source
+
+            chunks = []
+            async for chunk in stream_openrouter_chat(
+                messages=[{"role": "user", "content": "Hi"}],
+                model="glm-5.1",
+                api_key="test-key",
+                base_url="https://api.z.ai/api/paas/v4",
+            ):
+                chunks.append(chunk)
+
+            headers = mock_aconnect.call_args.kwargs["headers"]
+            assert chunks == ["Hello"]
+            assert "HTTP-Referer" not in headers
+            assert "X-Title" not in headers
+
+    @pytest.mark.asyncio
     async def test_stream_openrouter_chat_handles_http_error(self):
         """AC6.7.2: Stream handles HTTP errors."""
         mock_response = MagicMock(spec=httpx.Response)

--- a/apps/frontend/src/components/statements/StatementUploader.tsx
+++ b/apps/frontend/src/components/statements/StatementUploader.tsx
@@ -81,7 +81,7 @@ export default function StatementUploader({
                 const stored = getSafeStorage(STORAGE_KEY);
 
                 // IMPORTANT: Validate stored model ID against current catalog
-                // OpenRouter periodically removes models (e.g., Gemini 2.0 → 3.0 upgrade)
+                // Provider catalogs can change, so persisted model IDs must be revalidated.
                 const isStoredValid = stored && data.models.some((m) => m.id === stored);
                 const isDefaultValid = data.models.some((m) => m.id === data.default_model);
 
@@ -316,7 +316,7 @@ export default function StatementUploader({
                     )}
                 </select>
                 <p className="text-xs text-muted mt-1">
-                    Defaults to the configured free model. Paid models are available if enabled in OpenRouter.
+                    Defaults to the configured OCR model. Paid models are available if enabled.
                 </p>
             </div>
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -439,6 +439,7 @@ These scenarios represent the "Vertical Slices" of user value.
    - **Status**: Implemented hard gate — requires `APP_URL` pointing to a running frontend+backend
    - **Coverage**: AC8.13.1–5 (PDF upload, parse polling, transactions, approve, balance sheet)
    - **Hard-gate rule**: When `STRICT_E2E_GATES=true`, critical E2E skips are converted to failures; `status=rejected` fails instead of skips. PR preview environments may run the same tests without strict gates so they surface provider instability as skips while post-merge staging remains deploy-blocking.
+   - **Provider budget rule**: Tests marked `llm` run serially in the post-merge staging job, not under the `-n 4` parallel phase. Staging pins `PRIMARY_MODEL=glm-5.1` for the AI/OCR gate while preserving the dedicated OCR model.
 
 3. **Production Read-only E2E Smoke** (`test_production_readonly_smoke.py`):
    - **Status**: Implemented for production release

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -92,6 +92,11 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Each shard: `pytest --splits 4 --group N`
 - Coverage reports merged post-run
 
+**Post-merge staging E2E** (`.github/workflows/staging-deploy.yml`):
+- Non-LLM smoke/E2E tests run in parallel with `-n 4`.
+- Tests marked `llm` are the only tests allowed to call the configured AI/OCR provider and run once, serially, in the same staging deploy job.
+- Staging deploys may set `DEPLOY_PRIMARY_MODEL_OVERRIDE`; the current post-merge gate pins `PRIMARY_MODEL=glm-5.1` while keeping `OCR_MODEL` as the dedicated OCR model.
+
 > **Local vs GitHub CI Parallelism**
 >
 > | Environment | Parallelism | Test Scope | Resource Usage |

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,4 +9,5 @@ markers =
     api: API health tests
     e2e: full end-to-end tests
     critical: deploy-blocking E2E tests that must not skip under STRICT_E2E_GATES
+    llm: tests that may call the configured AI/OCR provider
     prod_safe: read-only production-safe smoke tests

--- a/scripts/dokploy_deploy.sh
+++ b/scripts/dokploy_deploy.sh
@@ -88,6 +88,10 @@ new_env=$(update_env_var "$new_env" "NEXT_PUBLIC_APP_URL" "$APP_URL")
 new_env=$(update_env_var "$new_env" "COMPOSE_PROFILES" "app")
 new_env=$(update_env_var "$new_env" "TRAEFIK_ENABLE" "true")
 
+if [[ -n "${DEPLOY_PRIMARY_MODEL_OVERRIDE:-}" ]]; then
+  new_env=$(update_env_var "$new_env" "PRIMARY_MODEL" "$DEPLOY_PRIMARY_MODEL_OVERRIDE")
+fi
+
 # Traefik routing configuration
 # Detect environment from APP_URL (staging/production)
 if [[ "$APP_URL" == *"-staging"* ]]; then

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -59,3 +59,25 @@ def test_AC8_13_9_production_release_runs_prod_safe_e2e_smoke() -> None:
         ".delete(",
     ):
         assert mutating_token not in prod_smoke
+
+
+def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
+    """AC8.13.7: Post-merge AI/OCR E2E is a single-provider-access gate."""
+    workflow = read(".github/workflows/staging-deploy.yml")
+    journey = read("tests/e2e/test_statement_full_journey.py")
+    upload = read("tests/e2e/test_statement_upload_e2e.py")
+    deploy_script = read("scripts/dokploy_deploy.sh")
+
+    assert "STAGING_E2E_PRIMARY_MODEL: glm-5.1" in workflow
+    assert (
+        "DEPLOY_PRIMARY_MODEL_OVERRIDE: ${{ env.STAGING_E2E_PRIMARY_MODEL }}"
+        in workflow
+    )
+    assert (
+        'update_env_var "$new_env" "PRIMARY_MODEL" "$DEPLOY_PRIMARY_MODEL_OVERRIDE"'
+        in deploy_script
+    )
+    assert '-m "(smoke or e2e) and not llm" -n 4' in workflow
+    assert '-v -m "llm"' in workflow
+    assert "@pytest.mark.llm" in journey
+    assert upload.count("@pytest.mark.llm") >= 2

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -5,5 +5,6 @@ markers =
     e2e: End-to-end tests
     api: API integration tests
     critical: Critical tests that must not be skipped
+    llm: tests that may call the configured AI/OCR provider
     prod_safe: Read-only production-safe smoke tests
     tier3: Tier 3 full-journey browser E2E tests (upload → parse → approve → report)

--- a/tests/e2e/test_statement_full_journey.py
+++ b/tests/e2e/test_statement_full_journey.py
@@ -104,6 +104,7 @@ def _unique_pdf_copy(src: Path) -> Path:
 @pytest.mark.e2e
 @pytest.mark.tier3
 @pytest.mark.critical
+@pytest.mark.llm
 async def test_dbs_statement_full_journey(authenticated_page: Page) -> None:
     """AC8.13.1–AC8.13.5: DBS PDF → parse → approve → balance sheet."""
     page = authenticated_page
@@ -120,8 +121,7 @@ async def test_dbs_statement_full_journey(authenticated_page: Page) -> None:
 
     await page.locator("#institution").fill(INSTITUTION_LABEL)
     # Fetch the default model from the backend API and select it explicitly.
-    # Using index=0 would pick openrouter/free — a random router that fails structured
-    # extraction. Selecting by value ensures we always use the backend-configured model.
+    # Selecting by value ensures we always use the backend-configured OCR model.
     models_resp = await page.evaluate(
         "async () => { const r = await fetch('/api/ai/models?modality=image'); return r.json(); }"
     )

--- a/tests/e2e/test_statement_upload_e2e.py
+++ b/tests/e2e/test_statement_upload_e2e.py
@@ -97,6 +97,7 @@ async def _find_statement_by_institution(page: Page, institution: str) -> dict |
 
 
 @pytest.mark.e2e
+@pytest.mark.llm
 async def test_statement_upload_full_flow(authenticated_page: Page) -> None:
     """AC8.4.3: Upload PDF → wait for processing → verify statement appears."""
     _skip_if_no_url()
@@ -162,6 +163,7 @@ async def test_statement_upload_full_flow(authenticated_page: Page) -> None:
 
 
 @pytest.mark.e2e
+@pytest.mark.llm
 async def test_model_selection_and_upload(authenticated_page: Page) -> None:
     """AC8.4.2: Select AI model from dropdown → upload → verify model persisted."""
     _skip_if_no_url()
@@ -203,7 +205,7 @@ async def test_stale_model_id_auto_cleanup(authenticated_page: Page) -> None:
     """AC8.4.2: Stale localStorage model ID is cleaned up on page reload.
 
     Uses a deliberately invalid/fictional model ID that can never appear in the
-    OpenRouter catalog, guaranteeing the stale-cleanup branch always fires.
+    AI provider catalog, guaranteeing the stale-cleanup branch always fires.
     """
     _skip_if_no_url()
     page = authenticated_page
@@ -211,7 +213,7 @@ async def test_stale_model_id_auto_cleanup(authenticated_page: Page) -> None:
     await page.wait_for_load_state("networkidle")
 
     # Use a guaranteed-nonexistent model ID so the test is catalog-independent.
-    # Real model IDs are fetched from OpenRouter and may change over time; using
+    # Real model IDs are provider-configured and may change over time; using
     # a clearly fake ID ensures the stale-cleanup logic is always exercised.
     stale_id = "test/nonexistent-model-for-stale-cleanup-test"
     await page.evaluate(f'localStorage.setItem("statement_model_v1", "{stale_id}")')


### PR DESCRIPTION
## Summary

Serialize the post-merge staging AI/OCR E2E gate, pin that gate to `glm-5.1`, and add small provider-access coverage for the GLM migration.

Closes #378 follow-up.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.7, AC8.13.9 |
| **AC Registry updated** | N/A — existing ACs cover the post-merge hard gate behavior |

---

## SSOT Changes

- [x] `docs/ssot/ci-cd.md` — documents serial LLM/OCR staging gate and `glm-5.1` primary-model override

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | N/A | Small CI/test-contract hardening over existing AC8.13 gates |
| Green | `389c5ed` | Added marker/contract/unit coverage and CI workflow change |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — not applicable
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` — not applicable
- [x] `repo/` submodule updated for production config changes — not applicable; existing local submodule state intentionally not included
- [x] `scripts/check_env_keys.py` passes — not applicable; no new app config key, only optional deploy-script override
- [x] `scripts/check_manifest.py` passes
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
uv run --with pytest pytest scripts/tests/test_post_merge_e2e_gates.py -q
cd apps/backend && uv run pytest tests/ai/test_openrouter_streaming.py::TestStreamOpenRouterChat::test_stream_omits_openrouter_headers_for_zai_provider --no-cov -q
uv run --with pytest --with pytest-asyncio --with pytest-playwright pytest tests/e2e/test_statement_full_journey.py tests/e2e/test_statement_upload_e2e.py --collect-only -q
uv run --with pyyaml python scripts/lint_doc_consistency.py
uv run --with pyyaml python scripts/check_manifest.py
python scripts/check_ssot_ownership.py --verbose
uv run --with ruff ruff check scripts/tests/test_post_merge_e2e_gates.py apps/backend/tests/ai/test_openrouter_streaming.py apps/backend/src/services/openrouter_models.py
uv run --with ruff ruff format --check scripts/tests/test_post_merge_e2e_gates.py apps/backend/tests/ai/test_openrouter_streaming.py apps/backend/src/services/openrouter_models.py
git diff --check
```

`moon run :lint` was attempted locally but hung for more than two minutes with no output and was terminated; targeted lint/doc/test checks above passed.

---

## Notes

There are existing unrelated open PRs (#374 and #375). This PR is intentionally scoped to the post-merge LLM/OCR CI gate and does not touch those branches.
