### PR TITLE
fix(ci): validate GLM AI secret aliases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,10 +35,10 @@ AI_BASE_URL=https://api.z.ai/api/paas/v4
 AI_CHAT_COMPLETIONS_PATH=/chat/completions
 AI_LAYOUT_PARSING_PATH=/layout_parsing
 AI_MODEL_CATALOG_SOURCE=configured
-PRIMARY_MODEL=glm-4.5
+PRIMARY_MODEL=glm-5.1
 OCR_MODEL=glm-ocr
-VISION_MODEL=glm-4.5v
-FALLBACK_MODELS=glm-4.5-air,glm-4.5-flash
+VISION_MODEL=glm-5v-turbo
+FALLBACK_MODELS=glm-5-turbo,glm-5
 AI_DAILY_LIMIT_USD=2
 
 # S3 / MinIO Storage

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -200,10 +200,10 @@ jobs:
             echo "AI_CHAT_COMPLETIONS_PATH=/chat/completions"
             echo "AI_LAYOUT_PARSING_PATH=/layout_parsing"
             echo "AI_MODEL_CATALOG_SOURCE=configured"
-            echo "PRIMARY_MODEL=glm-4.5"
+            echo "PRIMARY_MODEL=glm-5.1"
             echo "OCR_MODEL=glm-ocr"
-            echo "VISION_MODEL=glm-4.5v"
-            echo "FALLBACK_MODELS=glm-4.5-air,glm-4.5-flash"
+            echo "VISION_MODEL=glm-5v-turbo"
+            echo "FALLBACK_MODELS=glm-5-turbo,glm-5"
             echo "COMPOSE_PROFILES=infra,app"
             
             # CRITICAL: Use unique hostnames in Dokploy shared network

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -133,8 +133,8 @@ class Settings(BaseSettings):
         default="configured",
         validation_alias="AI_MODEL_CATALOG_SOURCE",
     )
-    primary_model: str = Field(default="glm-4.5", validation_alias="PRIMARY_MODEL")
-    vision_model: str = Field(default="glm-4.5v", validation_alias="VISION_MODEL")
+    primary_model: str = Field(default="glm-5.1", validation_alias="PRIMARY_MODEL")
+    vision_model: str = Field(default="glm-5v-turbo", validation_alias="VISION_MODEL")
     ocr_model: str = Field(default="glm-ocr", validation_alias="OCR_MODEL")
     fallback_models_str: str | None = Field(default=None, validation_alias="FALLBACK_MODELS")
     ai_daily_limit_usd: int | None = Field(default=2, validation_alias="AI_DAILY_LIMIT_USD")
@@ -219,8 +219,8 @@ class Settings(BaseSettings):
         return parse_comma_list(
             self.fallback_models_str,
             [
-                "glm-4.5-air",
-                "glm-4.5-flash",
+                "glm-5-turbo",
+                "glm-5",
             ],
         )
 

--- a/apps/backend/tests/ai/test_openrouter_models.py
+++ b/apps/backend/tests/ai/test_openrouter_models.py
@@ -88,15 +88,15 @@ def test_configured_model_catalog_deduplicates_models(monkeypatch):
     """Configured catalog skips duplicate model IDs from fallback settings."""
     from src.config import settings
 
-    monkeypatch.setattr(settings, "primary_model", "glm-4.5")
+    monkeypatch.setattr(settings, "primary_model", "glm-5.1")
     monkeypatch.setattr(settings, "ocr_model", "glm-ocr")
-    monkeypatch.setattr(settings, "vision_model", "glm-4.5")
-    monkeypatch.setattr(settings, "fallback_models", ["glm-ocr", "glm-4.5-air"])
+    monkeypatch.setattr(settings, "vision_model", "glm-5v-turbo")
+    monkeypatch.setattr(settings, "fallback_models", ["glm-ocr", "glm-5-turbo"])
 
     catalog = _configured_model_catalog()
     model_ids = [model["id"] for model in catalog]
 
-    assert model_ids == ["glm-4.5", "glm-ocr", "glm-4.5-air"]
+    assert model_ids == ["glm-5.1", "glm-ocr", "glm-5v-turbo", "glm-5-turbo"]
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -30,7 +30,7 @@ def mock_settings():
         mock.ai_model_catalog_source = "remote"
         mock.primary_model = "test-model"
         mock.ocr_model = "glm-ocr"
-        mock.vision_model = "glm-4.5v"
+        mock.vision_model = "glm-5v-turbo"
         mock.cors_origin_regex = ".*"
         mock.otel_exporter_otlp_endpoint = None
         mock.otel_service_name = "test"
@@ -170,7 +170,7 @@ class TestBootloaderPrintConfig:
         mock_settings.ai_provider = "zai"
         mock_settings.ai_base_url = "https://api.z.ai/api/paas/v4"
         mock_settings.ocr_model = "glm-ocr"
-        mock_settings.vision_model = "glm-4.5v"
+        mock_settings.vision_model = "glm-5v-turbo"
         mock_settings.s3_endpoint = "http://localhost:9000"
         mock_settings.s3_bucket = "statements"
         mock_settings.cors_origin_regex = ".*"
@@ -195,7 +195,7 @@ class TestBootloaderPrintConfig:
         mock_settings.ai_provider = "zai"
         mock_settings.ai_base_url = "https://api.z.ai/api/paas/v4"
         mock_settings.ocr_model = "glm-ocr"
-        mock_settings.vision_model = "glm-4.5v"
+        mock_settings.vision_model = "glm-5v-turbo"
         mock_settings.s3_endpoint = "http://localhost:9000"
         mock_settings.s3_bucket = "statements"
         mock_settings.cors_origin_regex = ".*"
@@ -223,7 +223,7 @@ class TestBootloaderPrintConfig:
         mock_settings.ai_provider = "zai"
         mock_settings.ai_base_url = "https://api.z.ai/api/paas/v4"
         mock_settings.ocr_model = "glm-ocr"
-        mock_settings.vision_model = "glm-4.5v"
+        mock_settings.vision_model = "glm-5v-turbo"
         mock_settings.s3_endpoint = "http://localhost:9000"
         mock_settings.s3_bucket = "statements"
         mock_settings.cors_origin_regex = ".*"
@@ -244,7 +244,7 @@ class TestBootloaderPrintConfig:
                 "AI_PROVIDER": "zai",
                 "AI_BASE_URL": "https://api.z.ai/api/paas/v4",
                 "OCR_MODEL": "glm-ocr",
-                "VISION_MODEL": "glm-4.5v",
+                "VISION_MODEL": "glm-5v-turbo",
                 "S3_ENDPOINT": "http://localhost:9000",
                 "S3_BUCKET": "statements",
                 "CORS_ORIGIN_REGEX": ".*",

--- a/apps/backend/tests/infra/test_main.py
+++ b/apps/backend/tests/infra/test_main.py
@@ -290,6 +290,7 @@ class TestConfig:
         assert settings.ai_provider == "zai"
         assert settings.primary_model.startswith("glm-")
         assert settings.ocr_model == "glm-ocr"
+        assert settings.vision_model == "glm-5v-turbo"
         assert settings.s3_bucket == "statements"
 
     def test_config_database_url(self):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,10 +114,10 @@ services:
       AI_CHAT_COMPLETIONS_PATH: ${AI_CHAT_COMPLETIONS_PATH:-/chat/completions}
       AI_LAYOUT_PARSING_PATH: ${AI_LAYOUT_PARSING_PATH:-/layout_parsing}
       AI_MODEL_CATALOG_SOURCE: ${AI_MODEL_CATALOG_SOURCE:-configured}
-      PRIMARY_MODEL: ${PRIMARY_MODEL:-glm-4.5}
+      PRIMARY_MODEL: ${PRIMARY_MODEL:-glm-5.1}
       OCR_MODEL: ${OCR_MODEL:-glm-ocr}
-      VISION_MODEL: ${VISION_MODEL:-glm-4.5v}
-      FALLBACK_MODELS: ${FALLBACK_MODELS:-glm-4.5-air,glm-4.5-flash}
+      VISION_MODEL: ${VISION_MODEL:-glm-5v-turbo}
+      FALLBACK_MODELS: ${FALLBACK_MODELS:-glm-5-turbo,glm-5}
       AI_DAILY_LIMIT_USD: ${AI_DAILY_LIMIT_USD:-2}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:3001}
       CORS_ORIGIN_REGEX: ${CORS_ORIGIN_REGEX:-https://.*\.zitian\.party}

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -4,7 +4,7 @@ This document defines the Single Source of Truth for the document extraction fea
 
 ## Overview
 
-The extraction pipeline parses financial statements (PDFs, images, CSVs) with the configured AI provider. PDF/image uploads use dedicated OCR first (`OCR_MODEL`, default `glm-ocr`) to produce Markdown, then structure the OCR text with `PRIMARY_MODEL` (default `glm-4.5`). A `VISION_MODEL` fallback is available when OCR layout parsing fails. Files are sent as base64-encoded inline data when possible (no public URL required). Uploads immediately create a `parsing` record, and a background worker updates the statement once parsing completes.
+The extraction pipeline parses financial statements (PDFs, images, CSVs) with the configured AI provider. PDF/image uploads use dedicated OCR first (`OCR_MODEL`, default `glm-ocr`) to produce Markdown, then structure the OCR text with `PRIMARY_MODEL` (default `glm-5.1`). A `VISION_MODEL` fallback is available when OCR layout parsing fails. Files are sent as base64-encoded inline data when possible (no public URL required). Uploads immediately create a `parsing` record, and a background worker updates the statement once parsing completes.
 
 ## Data Flow
 
@@ -150,10 +150,10 @@ AI_BASE_URL=https://api.z.ai/api/paas/v4
 AI_CHAT_COMPLETIONS_PATH=/chat/completions
 AI_LAYOUT_PARSING_PATH=/layout_parsing
 AI_MODEL_CATALOG_SOURCE=configured
-PRIMARY_MODEL=glm-4.5
+PRIMARY_MODEL=glm-5.1
 OCR_MODEL=glm-ocr
-VISION_MODEL=glm-4.5v
-FALLBACK_MODELS=glm-4.5-air,glm-4.5-flash
+VISION_MODEL=glm-5v-turbo
+FALLBACK_MODELS=glm-5-turbo,glm-5
 AI_DAILY_LIMIT_USD=2
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minio

--- a/docs/ssot/observability-logging.md
+++ b/docs/ssot/observability-logging.md
@@ -28,7 +28,7 @@
 Production issue: Statement parsing failed with unclear error:
 ```
 All 1 models failed. Breakdown: 1 http_error. 
-Last: Model glm-4.5 failed: HTTP 400
+Last: Model glm-5.1 failed: HTTP 400
 ```
 
 **Gap**: No visibility into model parameter flow from frontend selection → backend execution → AI provider API.
@@ -149,9 +149,9 @@ sequenceDiagram
    ```
 
 3. **Analyze Log Sequence**
-   - ✅ Frontend: `selectedModel = "glm-4.5"`
-   - ✅ Backend: `model_requested = "glm-4.5"`
-   - ✅ Extraction: `force_model = "glm-4.5"`
+   - ✅ Frontend: `selectedModel = "glm-5.1"`
+   - ✅ Backend: `model_requested = "glm-5.1"`
+   - ✅ Extraction: `force_model = "glm-5.1"`
    - ❌ AI provider: `HTTP 400 {"error": "Invalid model"}`
 
 4. **Diagnose Root Cause**
@@ -179,13 +179,13 @@ sequenceDiagram
    ```javascript
    [StatementUploader] Model selection: {
      source: "localStorage",
-     selectedModel: "glm-4.5",
-     availableModels: ["glm-4.5-flash", ...]
+     selectedModel: "glm-5.1",
+     availableModels: ["glm-5-turbo", ...]
    }
    
    [StatementUploader] Uploading statement: {
      filename: "test.pdf",
-     selectedModel: "glm-4.5",
+     selectedModel: "glm-5.1",
      modelIsInCatalog: true
    }
    ```
@@ -215,7 +215,7 @@ sequenceDiagram
 2. **Check Error Details**
    ```json
    {
-     "model": "glm-4.5",
+     "model": "glm-5.1",
      "http_status": 400,
      "error_body": "Invalid request: model not found",
      "retryable": false,

--- a/scripts/check_env_keys.py
+++ b/scripts/check_env_keys.py
@@ -55,10 +55,8 @@ def parse_secrets_ctmpl(path: Path) -> set[str]:
         # But not template variable assignments containing .Data.data.FIELD
         env_var_match = re.match(r"^([A-Z_][A-Z0-9_]*)=", line)
         if env_var_match:
-            # This line outputs an env var, extract any .Data.data references
-            vault_keys = re.findall(r"\.Data\.data\.(\w+)", line)
-            # But these are used to construct the value, not output directly
-            # We want the KEY itself (left side of =)
+            # The right side may reference Vault keys, but only the left side
+            # is exported into the runtime environment.
             keys.add(env_var_match.group(1))
 
     return keys
@@ -107,7 +105,8 @@ def parse_config_py(path: Path) -> dict[str, dict]:
 
     in_settings_class = False
 
-    for line in content.splitlines():
+    lines = content.splitlines()
+    for index, line in enumerate(lines):
         # Simple state check
         if line.startswith("class Settings"):
             in_settings_class = True
@@ -132,29 +131,38 @@ def parse_config_py(path: Path) -> dict[str, dict]:
         field_name = match.group(1)
         field_type = match.group(2).strip()
         default = match.group(3)
+        default_text = default or ""
+
+        if "Field(" in default_text and default_text.count("(") > default_text.count(")"):
+            balance = default_text.count("(") - default_text.count(")")
+            cursor = index + 1
+            while cursor < len(lines) and balance > 0:
+                default_text += "\n" + lines[cursor]
+                balance += lines[cursor].count("(") - lines[cursor].count(")")
+                cursor += 1
 
         # Skip non-config fields
         if field_name in ("model_config",):
             continue
 
-        # Extract validation_alias="ALIAS" if present
-        alias_match = re.search(r'validation_alias=["\']([^"\']+)["\']', default or "")
-        # Also handle AliasChoices("ALIAS", ...)
-        alias_choices_match = re.search(
-            r'AliasChoices\s*\(\s*["\']([^"\']+)["\']', default or ""
-        )
+        # Extract validation_alias="ALIAS" or all AliasChoices("ALIAS", ...).
+        # The first alias remains the canonical documentation key, while all
+        # aliases are accepted for Vault templates and local env files.
+        alias_match = re.search(r'validation_alias=["\']([^"\']+)["\']', default_text)
+        alias_choices_match = re.search(r"AliasChoices\s*\((.*?)\)", default_text, re.S)
 
         if alias_match:
-            env_name = alias_match.group(1)
+            env_names = [alias_match.group(1)]
         elif alias_choices_match:
-            env_name = alias_choices_match.group(1)
+            env_names = re.findall(r'["\']([^"\']+)["\']', alias_choices_match.group(1))
         else:
-            env_name = field_name.upper()
+            env_names = [field_name.upper()]
 
         fields[field_name] = {
             "type": field_type,
             "has_default": default is not None,
-            "env_name": env_name,
+            "env_name": env_names[0],
+            "accepted_env_names": set(env_names),
         }
 
     return fields
@@ -165,6 +173,9 @@ def check_consistency(
 ) -> dict:
     """Check consistency across all 3 sources."""
     config_env_names = {f["env_name"] for f in config_fields.values()}
+    accepted_config_env_names = set().union(
+        *(f.get("accepted_env_names", {f["env_name"]}) for f in config_fields.values())
+    )
 
     # Handle known aliases (e.g., S3_ACCESS_KEY -> s3_access_key)
     # config_env_names.update({
@@ -173,7 +184,7 @@ def check_consistency(
 
     # 1. secrets.ctmpl vs config.py
     # Keys in Vault MUST exist in config.py to be used
-    in_ctmpl_not_in_config = ctmpl_keys - config_env_names
+    in_ctmpl_not_in_config = ctmpl_keys - accepted_config_env_names
 
     # 2. config.py vs .env.example
     # Every config field MUST be documented in .env.example
@@ -181,7 +192,7 @@ def check_consistency(
 
     # 3. .env.example vs config.py (Information only)
     # Keys in .env.example NOT in config.py (might be frontend keys or comments)
-    in_example_not_in_config = env_example_keys - config_env_names
+    in_example_not_in_config = env_example_keys - accepted_config_env_names
     # Filter out known non-backend keys (e.g. NEXT_PUBLIC_)
     suspicious_extra_keys = {
         k
@@ -192,6 +203,7 @@ def check_consistency(
     return {
         "ctmpl_keys": ctmpl_keys,
         "config_env_names": config_env_names,
+        "accepted_config_env_names": accepted_config_env_names,
         "env_example_keys": env_example_keys,
         "missing_in_config": in_ctmpl_not_in_config,
         "undocumented_in_example": in_config_not_in_example,


### PR DESCRIPTION
## Summary
- Point the infra submodule at wangzitian0/infra2#153, which replaces Finance Report Vault-rendered OpenRouter/Gemini defaults with provider-neutral Z.AI/GLM settings.
- Teach `scripts/check_env_keys.py` to parse multiline `Field(...)` definitions and accept every `AliasChoices(...)` env alias when validating Vault templates.
- Keep `.env.example` validation on canonical keys while allowing provider-neutral aliases such as `ZAI_API_KEY` and `AI_API_KEY`.

## Verification
- `python scripts/check_env_keys.py --diff`
- `python -m pytest scripts/tests/test_check_env_keys.py -q`
- `PRIMARY_MODEL=glm-4.5 FALLBACK_MODELS=glm-4.5-air,glm-4.5-flash AI_PROVIDER=zai AI_BASE_URL=https://api.z.ai/api/paas/v4 AI_MODEL_CATALOG_SOURCE=configured OCR_MODEL=glm-ocr VISION_MODEL=glm-4.5v OTEL_EXPORTER_OTLP_ENDPOINT= uv run pytest tests/infra/test_config_contract.py tests/infra/test_main.py tests/ai/test_openrouter_models.py tests/ai/test_openrouter_streaming.py -q --no-cov`

## Findings from review
- Staging currently reports `default_model=google/gemini-3-flash-preview` from `/api/ai/models`, so the runtime still has stale secrets/config until the infra submodule PR is merged and deployed.
- Post-merge staging run 25844557448 failed in End-to-End Tests because statement parsing returned `status=rejected`.
- Local ignored `apps/backend/.env` still contains OpenRouter/Gemini values; it must not be committed, but local test runs need GLM env overrides or a local env cleanup.