### PR TITLE
ci: centralize GLM E2E provider gate

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -198,7 +198,7 @@ jobs:
             # provider-backed GLM gate is centralized in post-merge staging.
             echo "AI_PROVIDER=zai"
             echo "ZAI_API_KEY="
-            echo "AI_BASE_URL=https://api.z.ai/api/paas/v4"
+            echo "AI_BASE_URL=https://api.z.ai/api/coding/paas/v4"
             echo "AI_CHAT_COMPLETIONS_PATH=/chat/completions"
             echo "AI_LAYOUT_PARSING_PATH=/layout_parsing"
             echo "AI_MODEL_CATALOG_SOURCE=configured"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -194,8 +194,10 @@ jobs:
             echo "MINIO_API_PORTS=127.0.0.1:$MINIO_API_PORT:9000"
             echo "MINIO_CONSOLE_PORTS=127.0.0.1:$MINIO_CONSOLE_PORT:9001"
             
+            # PR preview CI must not call the real AI/OCR provider. The
+            # provider-backed GLM gate is centralized in post-merge staging.
             echo "AI_PROVIDER=zai"
-            echo "ZAI_API_KEY=${{ secrets.ZAI_API_KEY }}"
+            echo "ZAI_API_KEY="
             echo "AI_BASE_URL=https://api.z.ai/api/paas/v4"
             echo "AI_CHAT_COMPLETIONS_PATH=/chat/completions"
             echo "AI_LAYOUT_PARSING_PATH=/layout_parsing"
@@ -380,8 +382,8 @@ jobs:
           echo "--- Phase 1: Smoke Check (Shell) ---"
           bash scripts/smoke_test.sh "$APP_URL" staging
           
-          echo "--- Phase 2: Core Flow Validation (Python) ---"
-          pytest tests/e2e -v -m "smoke or e2e" --junit-xml=test-results.xml
+          echo "--- Phase 2: Core Flow Validation (Python, no real AI/OCR) ---"
+          pytest tests/e2e -v -m "(smoke or e2e) and not llm" --junit-xml=test-results.xml
           
           echo "✅ E2E Pipeline passed!"
 

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -118,7 +118,7 @@ class Settings(BaseSettings):
     # AI model provider settings. Defaults target Z.AI/GLM, but these remain
     # provider-neutral so the base model can be swapped through env vars.
     ai_base_url: str = Field(
-        default="https://api.z.ai/api/paas/v4",
+        default="https://api.z.ai/api/coding/paas/v4",
         validation_alias=AliasChoices("AI_BASE_URL", "ZAI_BASE_URL", "OPENROUTER_BASE_URL"),
     )
     ai_chat_completions_path: str = Field(

--- a/apps/backend/tests/ai/test_openrouter_streaming.py
+++ b/apps/backend/tests/ai/test_openrouter_streaming.py
@@ -193,7 +193,7 @@ class TestStreamOpenRouterChat:
                 messages=[{"role": "user", "content": "Hi"}],
                 model="glm-5.1",
                 api_key="test-key",
-                base_url="https://api.z.ai/api/paas/v4",
+                base_url="https://api.z.ai/api/coding/paas/v4",
             ):
                 chunks.append(chunk)
 

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -9,6 +9,7 @@ import pytest
 from src.boot import Bootloader, Bootloader as BootloaderClass, BootMode, ServiceStatus
 
 _ORIGINAL_CHECK_DATABASE = BootloaderClass._check_database
+ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
 
 
 @pytest.fixture
@@ -26,7 +27,7 @@ def mock_settings():
         mock.environment = "test"
         mock.base_currency = "USD"
         mock.ai_provider = "zai"
-        mock.ai_base_url = "https://api.z.ai/api/paas/v4"
+        mock.ai_base_url = ZAI_CODING_BASE_URL
         mock.ai_model_catalog_source = "remote"
         mock.primary_model = "test-model"
         mock.ocr_model = "glm-ocr"
@@ -34,7 +35,7 @@ def mock_settings():
         mock.cors_origin_regex = ".*"
         mock.otel_exporter_otlp_endpoint = None
         mock.otel_service_name = "test"
-        mock.openrouter_base_url = "https://api.z.ai/api/paas/v4"
+        mock.openrouter_base_url = ZAI_CODING_BASE_URL
         yield mock
 
 
@@ -168,7 +169,7 @@ class TestBootloaderPrintConfig:
         mock_settings.base_currency = "USD"
         mock_settings.primary_model = "gemini"
         mock_settings.ai_provider = "zai"
-        mock_settings.ai_base_url = "https://api.z.ai/api/paas/v4"
+        mock_settings.ai_base_url = ZAI_CODING_BASE_URL
         mock_settings.ocr_model = "glm-ocr"
         mock_settings.vision_model = "glm-5v-turbo"
         mock_settings.s3_endpoint = "http://localhost:9000"
@@ -193,7 +194,7 @@ class TestBootloaderPrintConfig:
         mock_settings.base_currency = "USD"
         mock_settings.primary_model = "gemini"
         mock_settings.ai_provider = "zai"
-        mock_settings.ai_base_url = "https://api.z.ai/api/paas/v4"
+        mock_settings.ai_base_url = ZAI_CODING_BASE_URL
         mock_settings.ocr_model = "glm-ocr"
         mock_settings.vision_model = "glm-5v-turbo"
         mock_settings.s3_endpoint = "http://localhost:9000"
@@ -221,7 +222,7 @@ class TestBootloaderPrintConfig:
         mock_settings.base_currency = "USD"
         mock_settings.primary_model = "gemini"
         mock_settings.ai_provider = "zai"
-        mock_settings.ai_base_url = "https://api.z.ai/api/paas/v4"
+        mock_settings.ai_base_url = ZAI_CODING_BASE_URL
         mock_settings.ocr_model = "glm-ocr"
         mock_settings.vision_model = "glm-5v-turbo"
         mock_settings.s3_endpoint = "http://localhost:9000"
@@ -242,7 +243,7 @@ class TestBootloaderPrintConfig:
                 "BASE_CURRENCY": "USD",
                 "PRIMARY_MODEL": "gemini",
                 "AI_PROVIDER": "zai",
-                "AI_BASE_URL": "https://api.z.ai/api/paas/v4",
+                "AI_BASE_URL": ZAI_CODING_BASE_URL,
                 "OCR_MODEL": "glm-ocr",
                 "VISION_MODEL": "glm-5v-turbo",
                 "S3_ENDPOINT": "http://localhost:9000",
@@ -373,7 +374,7 @@ class TestBootloaderOpenrouter:
     async def test_check_openrouter_success(self, mock_settings):
         mock_settings.openrouter_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
-        mock_settings.ai_base_url = "https://api.z.ai/api/paas/v4"
+        mock_settings.ai_base_url = ZAI_CODING_BASE_URL
 
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
@@ -391,7 +392,7 @@ class TestBootloaderOpenrouter:
     async def test_check_openrouter_auth_failure(self, mock_settings):
         mock_settings.openrouter_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
-        mock_settings.ai_base_url = "https://api.z.ai/api/paas/v4"
+        mock_settings.ai_base_url = ZAI_CODING_BASE_URL
 
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
@@ -409,7 +410,7 @@ class TestBootloaderOpenrouter:
     async def test_check_openrouter_exception(self, mock_settings):
         mock_settings.openrouter_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
-        mock_settings.ai_base_url = "https://api.z.ai/api/paas/v4"
+        mock_settings.ai_base_url = ZAI_CODING_BASE_URL
 
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_class.return_value.__aenter__.side_effect = Exception("Network error")

--- a/apps/backend/tests/infra/test_config.py
+++ b/apps/backend/tests/infra/test_config.py
@@ -29,3 +29,11 @@ def test_environment_alias_reads_deployment_environment(monkeypatch) -> None:
     monkeypatch.setenv("ENV", "staging")
     settings = Settings(_env_file=None)
     assert settings.environment == "staging"
+
+
+def test_ai_base_url_defaults_to_zai_coding_endpoint(monkeypatch) -> None:
+    monkeypatch.delenv("AI_BASE_URL", raising=False)
+    monkeypatch.delenv("ZAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    settings = Settings(_env_file=None)
+    assert settings.ai_base_url == "https://api.z.ai/api/coding/paas/v4"

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -438,8 +438,8 @@ These scenarios represent the "Vertical Slices" of user value.
 2. **Full Statement Journey (Tier 3)** (`test_statement_full_journey.py`):
    - **Status**: Implemented hard gate — requires `APP_URL` pointing to a running frontend+backend
    - **Coverage**: AC8.13.1–5 (PDF upload, parse polling, transactions, approve, balance sheet)
-   - **Hard-gate rule**: When `STRICT_E2E_GATES=true`, critical E2E skips are converted to failures; `status=rejected` fails instead of skips. PR preview environments may run the same tests without strict gates so they surface provider instability as skips while post-merge staging remains deploy-blocking.
-   - **Provider budget rule**: Tests marked `llm` run serially in the post-merge staging job, not under the `-n 4` parallel phase. Staging pins `PRIMARY_MODEL=glm-5.1` for the AI/OCR gate while preserving the dedicated OCR model.
+   - **Hard-gate rule**: When `STRICT_E2E_GATES=true`, critical E2E skips are converted to failures; `status=rejected` fails instead of skips. Post-merge staging is the deploy-blocking AI/OCR gate.
+   - **Provider budget rule**: Tests marked `llm` run serially in the post-merge staging job, not under the `-n 4` parallel phase. PR preview E2E excludes `llm` tests and does not inject `ZAI_API_KEY`, so automated GLM/OCR provider calls are centralized in the staging gate. Staging pins `PRIMARY_MODEL=glm-5.1` for the AI/OCR gate while preserving the dedicated OCR model.
 
 3. **Production Read-only E2E Smoke** (`test_production_readonly_smoke.py`):
    - **Status**: Implemented for production release

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -101,6 +101,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 **PR preview E2E** (`.github/workflows/pr-test.yml`):
 - PR preview environments do not inject `ZAI_API_KEY`; they validate app wiring without real GLM/OCR provider calls.
 - PR preview E2E explicitly excludes tests marked `llm`. The post-merge staging job is the single automated CI entry point that may spend provider quota.
+- GLM/OCR CI traffic uses `AI_BASE_URL=https://api.z.ai/api/coding/paas/v4`; the URL remains an env override so the base provider can be replaced without code changes.
 
 > **Local vs GitHub CI Parallelism**
 >

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -95,7 +95,12 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 **Post-merge staging E2E** (`.github/workflows/staging-deploy.yml`):
 - Non-LLM smoke/E2E tests run in parallel with `-n 4`.
 - Tests marked `llm` are the only tests allowed to call the configured AI/OCR provider and run once, serially, in the same staging deploy job.
+- Staging deploys use a workflow-level `staging-deploy` concurrency group with `cancel-in-progress: false`, so post-merge deployments and the provider-backed GLM gate queue instead of overlapping.
 - Staging deploys may set `DEPLOY_PRIMARY_MODEL_OVERRIDE`; the current post-merge gate pins `PRIMARY_MODEL=glm-5.1` while keeping `OCR_MODEL` as the dedicated OCR model.
+
+**PR preview E2E** (`.github/workflows/pr-test.yml`):
+- PR preview environments do not inject `ZAI_API_KEY`; they validate app wiring without real GLM/OCR provider calls.
+- PR preview E2E explicitly excludes tests marked `llm`. The post-merge staging job is the single automated CI entry point that may spend provider quota.
 
 > **Local vs GitHub CI Parallelism**
 >
@@ -165,7 +170,8 @@ deploy-blocking usability gates:
 | Environment | Gate | Command | Skip Policy |
 |-------------|------|---------|-------------|
 | Staging | Shell smoke | `bash scripts/smoke_test.sh "$APP_URL" staging` | No skips; any failed check fails deploy |
-| Staging | Full E2E | `STRICT_E2E_GATES=true pytest tests/e2e -v -m "smoke or e2e" -n 4` | Tests marked `critical` must fail instead of skip |
+| Staging | Non-LLM E2E | `STRICT_E2E_GATES=true pytest tests/e2e -v -m "(smoke or e2e) and not llm" -n 4` | Tests marked `critical` must fail instead of skip |
+| Staging | AI/OCR E2E | `STRICT_E2E_GATES=true pytest tests/e2e/test_statement_full_journey.py tests/e2e/test_statement_upload_e2e.py -v -m "llm"` | Serial provider-backed GLM gate; `rejected` fails deploy |
 | Production | Shell smoke | `bash scripts/smoke_test.sh https://report.zitian.party production` | Read-only checks only |
 | Production | Prod-safe E2E | `pytest tests/e2e/test_production_readonly_smoke.py -v -m "prod_safe"` | Authenticated dashboard check may skip only when read-only smoke credentials are absent |
 
@@ -176,10 +182,11 @@ approve, and load the balance sheet. A `rejected` parsing status is a deploy
 failure because it usually indicates AI provider, OCR, secret, or model config
 breakage.
 
-PR preview E2E may run the same AI/OCR tests without `STRICT_E2E_GATES=true`.
-In that mode, provider/service rejection is reported as a skip so pull requests
-can still verify non-AI regressions while post-merge staging remains the hard
-AI/OCR usability gate.
+PR preview E2E intentionally excludes the `llm` marker and does not inject the
+provider API key. This keeps provider spend and concurrency concentrated in the
+post-merge staging job, where `STRICT_E2E_GATES=true` makes provider/config
+failures block deploy. PR preview remains useful for app wiring and non-provider
+flows without turning provider instability into PR noise.
 
 ---
 

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -146,7 +146,7 @@ Required environment variables:
 ```bash
 AI_PROVIDER=zai
 ZAI_API_KEY=<YOUR_ZAI_API_KEY>
-AI_BASE_URL=https://api.z.ai/api/paas/v4
+AI_BASE_URL=https://api.z.ai/api/coding/paas/v4
 AI_CHAT_COMPLETIONS_PATH=/chat/completions
 AI_LAYOUT_PARSING_PATH=/layout_parsing
 AI_MODEL_CATALOG_SOURCE=configured

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -64,10 +64,13 @@ def test_AC8_13_9_production_release_runs_prod_safe_e2e_smoke() -> None:
 def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     """AC8.13.7: Post-merge AI/OCR E2E is a single-provider-access gate."""
     workflow = read(".github/workflows/staging-deploy.yml")
+    pr_workflow = read(".github/workflows/pr-test.yml")
     journey = read("tests/e2e/test_statement_full_journey.py")
     upload = read("tests/e2e/test_statement_upload_e2e.py")
     deploy_script = read("scripts/dokploy_deploy.sh")
 
+    assert "group: staging-deploy" in workflow
+    assert "cancel-in-progress: false" in workflow
     assert "STAGING_E2E_PRIMARY_MODEL: glm-5.1" in workflow
     assert (
         "DEPLOY_PRIMARY_MODEL_OVERRIDE: ${{ env.STAGING_E2E_PRIMARY_MODEL }}"
@@ -81,3 +84,6 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     assert '-v -m "llm"' in workflow
     assert "@pytest.mark.llm" in journey
     assert upload.count("@pytest.mark.llm") >= 2
+    assert 'echo "ZAI_API_KEY="' in pr_workflow
+    assert '-m "(smoke or e2e) and not llm"' in pr_workflow
+    assert '-m "smoke or e2e"' not in pr_workflow

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -85,5 +85,7 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     assert "@pytest.mark.llm" in journey
     assert upload.count("@pytest.mark.llm") >= 2
     assert 'echo "ZAI_API_KEY="' in pr_workflow
+    assert 'echo "AI_BASE_URL=https://api.z.ai/api/coding/paas/v4"' in pr_workflow
+    assert "https://api.z.ai/api/coding/paas/v4" in read("docs/ssot/ci-cd.md")
     assert '-m "(smoke or e2e) and not llm"' in pr_workflow
     assert '-m "smoke or e2e"' not in pr_workflow


### PR DESCRIPTION
## Summary

Centralize real GLM/OCR CI access in the post-merge staging gate and keep PR preview E2E provider-free.

Closes #<!-- issue number -->

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.7 |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/ci-cd.md` — documents PR preview as non-provider E2E and post-merge staging as the single serialized GLM/OCR gate
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | N/A | Existing workflow allowed PR preview E2E to include `llm` tests |
| Green (passing test) | `0d4856b` | Enforce PR preview excludes `llm` and does not inject `ZAI_API_KEY` |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable)
- [x] `repo/` submodule updated for production config changes (if applicable)
- [x] `scripts/check_env_keys.py` passes (if env vars changed)
- [x] `scripts/check_manifest.py` passes (if SSOT files changed)
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
uv run pytest scripts/tests/test_post_merge_e2e_gates.py -q
```

---

## Screenshots / Evidence

N/A
