### PR TITLE
feat(review): add Stage 2 run review page

### DIFF
--- a/apps/frontend/src/__tests__/reviewRunPage.test.tsx
+++ b/apps/frontend/src/__tests__/reviewRunPage.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import RunReviewPage from "@/app/(main)/review/run/[runId]/page";
+import { apiFetch } from "@/lib/api";
+import { renderReviewComponent } from "./helpers/renderReviewComponent";
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+vi.mock("next/navigation", () => ({
+    useRouter: vi.fn(() => ({ replace: vi.fn(), push: vi.fn() })),
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+    usePathname: vi.fn(() => "/review/run/run-123"),
+}));
+
+const mockedApi = vi.mocked(apiFetch);
+
+describe("RunReviewPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("AC16.24.1 and AC16.24.2 summarizes unresolved run checks and blocks approval", async () => {
+        const checks = [
+            {
+                id: "c-transfer",
+                check_type: "transfer_pair",
+                status: "pending",
+                related_txn_ids: [],
+                details: { message: "Unpaired transfer out" },
+                severity: "high",
+                resolved_at: null,
+                resolution_note: null,
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+            },
+            {
+                id: "c-duplicate",
+                check_type: "duplicate",
+                status: "pending",
+                related_txn_ids: [],
+                details: { message: "Duplicate card charge" },
+                severity: "medium",
+                resolved_at: null,
+                resolution_note: null,
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+            },
+        ];
+
+        mockedApi.mockImplementation((path: string) => {
+            if (path.includes("/stage2/queue")) {
+                return Promise.resolve({
+                    pending_matches: [{ id: "m1", match_score: 90, status: "pending", amount: 10, txn_date: "2024-01-02", description: "Transfer" }],
+                    consistency_checks: checks,
+                    has_unresolved_checks: true,
+                } as any);
+            }
+            if (path.includes("consistency-checks/list")) {
+                return Promise.resolve({ items: checks } as any);
+            }
+            if (path.includes("/accounts/processing/summary")) {
+                return Promise.resolve({ pending_count: 1, pending_total: "10.00", currency: "SGD", oldest_pending_date: "2024-01-01" } as any);
+            }
+            return Promise.resolve(null as any);
+        });
+
+        renderReviewComponent(<RunReviewPage /> as any);
+
+        expect(await screen.findByText("Stage 2 Run Review")).toBeInTheDocument();
+        expect(screen.getByText("run-123")).toBeInTheDocument();
+        expect(screen.getByText("1 unresolved transfer")).toBeInTheDocument();
+        expect(screen.getByText("1 duplicate")).toBeInTheDocument();
+        expect(screen.getByText("1 pending")).toBeInTheDocument();
+
+        const approveRun = screen.getByRole("button", { name: /Approve Run/i });
+        expect(approveRun).toBeDisabled();
+    });
+
+    it("AC16.24.3 approves all pending matches through the batch approval API", async () => {
+        const data = {
+            pending_matches: [
+                { id: "m1", match_score: 95, status: "pending", amount: 10, txn_date: "2024-01-02", description: "Bank A out" },
+                { id: "m2", match_score: 92, status: "pending", amount: 10, txn_date: "2024-01-02", description: "Bank B in" },
+            ],
+            consistency_checks: [],
+            has_unresolved_checks: false,
+        };
+
+        mockedApi.mockImplementation((path: string, options?: RequestInit) => {
+            if (path.includes("/stage2/queue")) return Promise.resolve(data as any);
+            if (path.includes("consistency-checks/list")) return Promise.resolve({ items: [] } as any);
+            if (path.includes("/accounts/processing/summary")) {
+                return Promise.resolve({ pending_count: 0, pending_total: "0.00", currency: "SGD", oldest_pending_date: null } as any);
+            }
+            if (path.includes("batch-approve-matches")) {
+                expect(JSON.parse(String(options?.body))).toEqual({ match_ids: ["m1", "m2"] });
+                return Promise.resolve({ success: true, approved_count: 2 } as any);
+            }
+            return Promise.resolve(null as any);
+        });
+
+        renderReviewComponent(<RunReviewPage /> as any);
+
+        const approveRun = await screen.findByRole("button", { name: /Approve Run/i });
+        expect(approveRun).toBeEnabled();
+        fireEvent.click(approveRun);
+
+        await waitFor(() => {
+            expect(mockedApi.mock.calls.some((call) => String(call[0]).includes("batch-approve-matches"))).toBe(true);
+        });
+    });
+});

--- a/apps/frontend/src/app/(main)/review/run/[runId]/page.tsx
+++ b/apps/frontend/src/app/(main)/review/run/[runId]/page.tsx
@@ -2,6 +2,6 @@
 
 import { Stage2ReviewQueue } from "@/components/review/Stage2ReviewQueue";
 
-export default function Stage2ReviewQueuePage() {
+export default function RunReviewPage() {
     return <Stage2ReviewQueue />;
 }

--- a/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
+++ b/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
@@ -1,0 +1,769 @@
+"use client";
+
+import { useCallback, useEffect, useId, useState, useRef } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { useToast } from "@/components/ui/Toast";
+
+import { apiFetch } from "@/lib/api";
+
+import { formatDateDisplay, formatDateTimeDisplay } from "@/lib/date";
+
+interface ConsistencyCheck {
+    id: string;
+    check_type: string;
+    status: string;
+    related_txn_ids: string[];
+    details: Record<string, unknown>;
+    severity: string;
+    resolved_at: string | null;
+    resolution_note: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+interface PendingMatch {
+    id: string;
+    match_score: number;
+    status: string;
+    created_at: string | null;
+    description?: string;
+    amount?: number;
+    txn_date?: string;
+}
+
+interface Stage2Data {
+    pending_matches: PendingMatch[];
+    consistency_checks: ConsistencyCheck[];
+    has_unresolved_checks: boolean;
+}
+
+interface ProcessingSummary {
+    pending_count: number;
+    pending_total: string | number;
+    currency: string;
+    oldest_pending_date: string | null;
+}
+
+export function Stage2ReviewQueue() {
+    const { showToast } = useToast();
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const pathname = usePathname();
+
+    const [data, setData] = useState<Stage2Data | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [selectedMatches, setSelectedMatches] = useState<Set<string>>(new Set());
+    const [actionLoading, setActionLoading] = useState(false);
+    const [resolveDialogOpen, setResolveDialogOpen] = useState(false);
+    const [selectedCheck, setSelectedCheck] = useState<ConsistencyCheck | null>(null);
+    const [resolveNote, setResolveNote] = useState("");
+    const [processingSummary, setProcessingSummary] = useState<ProcessingSummary | null>(null);
+    const resolveDialogRef = useRef<HTMLDivElement>(null);
+    
+    // Filters state
+    const [checkTypeFilter, setCheckTypeFilter] = useState<string>(searchParams.get("check_type") || "");
+    const [statusFilter, setStatusFilter] = useState<string>(searchParams.get("status") || "");
+    const [severityFilter, setSeverityFilter] = useState<string[]>(searchParams.get("severity")?.split(",").filter(Boolean) || []);
+    const [minScore, setMinScore] = useState<number>(Number(searchParams.get("min_score")) || 0);
+
+    const [filteredChecks, setFilteredChecks] = useState<ConsistencyCheck[] | null>(null);
+    const [filtering, setFiltering] = useState(false);
+    const resolveTitleId = useId();
+    const runIdMatch = pathname.match(/^\/review\/run\/([^/?#]+)/);
+    const runId = runIdMatch ? decodeURIComponent(runIdMatch[1]) : null;
+    const isRunReview = Boolean(runId);
+
+    const fetchData = useCallback(async () => {
+        try {
+            const result = await apiFetch<Stage2Data>("/api/statements/stage2/queue");
+            setData(result);
+            setError(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to load review queue");
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchData();
+    }, [fetchData]);
+
+    const fetchProcessingSummary = useCallback(async () => {
+        if (!isRunReview) return;
+
+        try {
+            const result = await apiFetch<ProcessingSummary>("/api/accounts/processing/summary");
+            setProcessingSummary(result);
+        } catch (err) {
+            showToast(err instanceof Error ? err.message : "Failed to load processing summary", "error");
+        }
+    }, [isRunReview, showToast]);
+
+    useEffect(() => {
+        fetchProcessingSummary();
+    }, [fetchProcessingSummary]);
+
+    const updateUrlParams = useCallback(() => {
+        const params = new URLSearchParams();
+        if (checkTypeFilter) params.set("check_type", checkTypeFilter);
+        if (statusFilter) params.set("status", statusFilter);
+        if (severityFilter.length > 0) params.set("severity", severityFilter.join(","));
+        if (minScore > 0) params.set("min_score", minScore.toString());
+        
+        const queryString = params.toString();
+        router.replace(queryString ? `${pathname}?${queryString}` : pathname, { scroll: false });
+    }, [checkTypeFilter, statusFilter, severityFilter, minScore, router, pathname]);
+
+    const fetchFilteredChecks = useCallback(async () => {
+        setFiltering(true);
+        try {
+            const params = new URLSearchParams();
+            if (checkTypeFilter) params.append("check_type", checkTypeFilter);
+            if (statusFilter) params.append("status", statusFilter);
+
+            const result = await apiFetch<{ items: ConsistencyCheck[] }>(`/api/statements/consistency-checks/list?${params.toString()}`);
+            const severityFilteredItems =
+                severityFilter.length > 0
+                    ? result.items.filter((check) => severityFilter.includes(check.severity))
+                    : result.items;
+            setFilteredChecks(severityFilteredItems);
+        } catch (err) {
+            showToast(err instanceof Error ? err.message : "Failed to filter checks", "error");
+        } finally {
+            setFiltering(false);
+        }
+    }, [checkTypeFilter, statusFilter, severityFilter, showToast]);
+
+    useEffect(() => {
+        fetchFilteredChecks();
+        updateUrlParams();
+    }, [fetchFilteredChecks, updateUrlParams]);
+
+    useEffect(() => {
+        if (!resolveDialogOpen) return;
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape" && !actionLoading) {
+                setResolveDialogOpen(false);
+                setSelectedCheck(null);
+                setResolveNote("");
+            }
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [resolveDialogOpen, actionLoading]);
+
+    useFocusTrap(resolveDialogRef, resolveDialogOpen);
+
+    const toggleMatch = (id: string) => {
+        setSelectedMatches((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+            return next;
+        });
+    };
+
+    const toggleAll = () => {
+        if (!data) return;
+        const visibleIds = data.pending_matches
+            .filter((m) => m.match_score >= minScore)
+            .map((m) => m.id);
+        if (visibleIds.every((id) => selectedMatches.has(id)) && visibleIds.length > 0) {
+            setSelectedMatches((prev) => {
+                const next = new Set(prev);
+                visibleIds.forEach((id) => next.delete(id));
+                return next;
+            });
+        } else {
+            setSelectedMatches((prev) => {
+                const next = new Set(prev);
+                visibleIds.forEach((id) => next.add(id));
+                return next;
+            });
+        }
+    };
+
+    const handleBatchApprove = async () => {
+        if (data?.has_unresolved_checks) {
+            showToast("Resolve consistency checks first", "error");
+            return;
+        }
+        if (selectedMatches.size === 0) return;
+
+        setActionLoading(true);
+        try {
+            const result = await apiFetch<{ success: boolean; approved_count: number; error?: string }>(
+                "/api/statements/batch-approve-matches",
+                {
+                    method: "POST",
+                    body: JSON.stringify({ match_ids: Array.from(selectedMatches) }),
+                }
+            );
+            if (result.success) {
+                showToast(`Approved ${result.approved_count} matches`, "success");
+                setSelectedMatches(new Set());
+                fetchData();
+                fetchFilteredChecks();
+            } else {
+                showToast(result.error || "Failed to approve", "error");
+            }
+        } catch (err) {
+            showToast(err instanceof Error ? err.message : "Failed to approve", "error");
+        } finally {
+            setActionLoading(false);
+        }
+    };
+
+    const handleBatchReject = async () => {
+        if (selectedMatches.size === 0) return;
+
+        setActionLoading(true);
+        try {
+            const result = await apiFetch<{ success: boolean; rejected_count: number }>(
+                "/api/statements/batch-reject-matches",
+                {
+                    method: "POST",
+                    body: JSON.stringify({ match_ids: Array.from(selectedMatches) }),
+                }
+            );
+            if (result.success) {
+                showToast(`Rejected ${result.rejected_count} matches`, "success");
+                setSelectedMatches(new Set());
+                fetchData();
+                fetchFilteredChecks();
+            }
+        } catch (err) {
+            showToast(err instanceof Error ? err.message : "Failed to reject", "error");
+        } finally {
+            setActionLoading(false);
+        }
+    };
+
+    const handleApproveRun = async () => {
+        if (!data) return;
+
+        if (data.has_unresolved_checks) {
+            showToast("Resolve consistency checks before approving the run", "error");
+            return;
+        }
+
+        if ((processingSummary?.pending_count ?? 0) > 0) {
+            showToast("Clear Processing Account pending transfers before approving the run", "error");
+            return;
+        }
+
+        const matchIds = data.pending_matches.map((match) => match.id);
+        if (matchIds.length === 0) {
+            showToast("No pending matches remain for this run", "success");
+            return;
+        }
+
+        setActionLoading(true);
+        try {
+            const result = await apiFetch<{ success: boolean; approved_count: number; error?: string }>(
+                "/api/statements/batch-approve-matches",
+                {
+                    method: "POST",
+                    body: JSON.stringify({ match_ids: matchIds }),
+                }
+            );
+            if (result.success) {
+                showToast(`Approved ${result.approved_count} run matches`, "success");
+                setSelectedMatches(new Set());
+                fetchData();
+                fetchFilteredChecks();
+                fetchProcessingSummary();
+            } else {
+                showToast(result.error || "Failed to approve run", "error");
+            }
+        } catch (err) {
+            showToast(err instanceof Error ? err.message : "Failed to approve run", "error");
+        } finally {
+            setActionLoading(false);
+        }
+    };
+
+    const handleResolveCheck = async (action: string, note?: string) => {
+        if (!selectedCheck) return;
+
+        setActionLoading(true);
+        try {
+            await apiFetch(`/api/statements/consistency-checks/${selectedCheck.id}/resolve`, {
+                method: "POST",
+                body: JSON.stringify({ action, note }),
+            });
+            
+            const actionLabels: Record<string, string> = {
+                approve: "approved",
+                reject: "rejected",
+                flag: "flagged",
+            };
+            const label = actionLabels[action] ?? `${action}ed`;
+            showToast(`Check ${label}`, "success");
+            
+            setResolveDialogOpen(false);
+            setSelectedCheck(null);
+            setResolveNote("");
+            fetchData();
+            fetchFilteredChecks();
+        } catch (err) {
+            showToast(err instanceof Error ? err.message : "Failed to resolve", "error");
+        } finally {
+            setActionLoading(false);
+        }
+    };
+
+    const toggleSeverity = (severity: string) => {
+        setSeverityFilter(prev => 
+            prev.includes(severity) 
+                ? prev.filter(s => s !== severity) 
+                : [...prev, severity]
+        );
+    };
+
+    const getSeverityColor = (severity: string) => {
+        switch (severity) {
+            case "high":
+                return "text-[var(--error)]";
+            case "medium":
+                return "text-[var(--warning)]";
+            default:
+                return "text-muted";
+        }
+    };
+
+    const getCheckTypeLabel = (type: string) => {
+        switch (type) {
+            case "duplicate":
+                return "Duplicate";
+            case "transfer_pair":
+                return "Transfer Pair";
+            case "anomaly":
+                return "Anomaly";
+            default:
+                return type;
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="p-6">
+                <div className="card p-8 text-center text-muted">
+                    <div className="inline-block w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin mb-2" />
+                    <p className="text-sm">Loading review queue...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (!data) {
+        return (
+            <div className="p-6">
+                <div className="card p-8 text-center">
+                    <p className="text-muted mb-4">Failed to load review queue</p>
+                    <button type="button" onClick={fetchData} className="btn-primary">
+                        Retry
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    const allChecks = filteredChecks ?? data.consistency_checks;
+    const unresolvedChecks = data.consistency_checks.filter((check) => check.status === "pending");
+    const unresolvedTransferCount = unresolvedChecks.filter((check) => check.check_type === "transfer_pair").length;
+    const unresolvedDuplicateCount = unresolvedChecks.filter((check) => check.check_type === "duplicate").length;
+    const unresolvedAnomalyCount = unresolvedChecks.filter((check) => check.check_type === "anomaly").length;
+    const matchesFilteredByScore = data.pending_matches.filter(m => m.match_score >= minScore);
+    const processingPendingCount = processingSummary?.pending_count ?? 0;
+    const approveRunDisabled = actionLoading || data.has_unresolved_checks || processingPendingCount > 0 || data.pending_matches.length === 0;
+    const runApprovalTitle = data.has_unresolved_checks
+        ? "Resolve consistency checks first"
+        : processingPendingCount > 0
+          ? "Clear Processing Account pending transfers first"
+        : data.pending_matches.length === 0
+          ? "No pending matches remain"
+          : "Approve all pending matches in this run";
+
+    return (
+        <div className="p-6">
+            <div className="mb-6">
+                <h1 className="page-title">{isRunReview ? "Stage 2 Run Review" : "Reconciliation Review Queue"}</h1>
+                <p className="page-description">
+                    {isRunReview
+                        ? "Review batch-level consistency checks and approve all resolved matches as one run"
+                        : "Review consistency checks and approve reconciliation matches"}
+                </p>
+            </div>
+
+            {isRunReview && (
+                <div className="mb-6 space-y-4">
+                    <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-4">
+                        <div className="card p-4">
+                            <p className="text-xs uppercase text-muted font-medium">Run ID</p>
+                            <p className="mt-1 text-sm font-semibold break-all">{runId}</p>
+                        </div>
+                        <div className="card p-4">
+                            <p className="text-xs uppercase text-muted font-medium">Unresolved transfers</p>
+                            <p className="mt-1 text-lg font-semibold text-[var(--warning)]">
+                                {unresolvedTransferCount} unresolved transfer{unresolvedTransferCount === 1 ? "" : "s"}
+                            </p>
+                        </div>
+                        <div className="card p-4">
+                            <p className="text-xs uppercase text-muted font-medium">Duplicates</p>
+                            <p className="mt-1 text-lg font-semibold">
+                                {unresolvedDuplicateCount} duplicate{unresolvedDuplicateCount === 1 ? "" : "s"}
+                            </p>
+                        </div>
+                        <div className="card p-4">
+                            <p className="text-xs uppercase text-muted font-medium">Anomalies</p>
+                            <p className="mt-1 text-lg font-semibold">
+                                {unresolvedAnomalyCount} anomal{unresolvedAnomalyCount === 1 ? "y" : "ies"}
+                            </p>
+                        </div>
+                        <div className="card p-4">
+                            <p className="text-xs uppercase text-muted font-medium">Processing</p>
+                            <p className={`mt-1 text-lg font-semibold ${processingPendingCount > 0 ? "text-[var(--warning)]" : ""}`}>
+                                {processingPendingCount} pending
+                            </p>
+                        </div>
+                        <div className="card p-4">
+                            <p className="text-xs uppercase text-muted font-medium">Pending matches</p>
+                            <p className="mt-1 text-lg font-semibold">{data.pending_matches.length}</p>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 p-4 rounded-lg border border-[var(--border)] bg-[var(--background-card)]">
+                        <div>
+                            <p className="text-sm font-medium">Run approval gate</p>
+                            <p className="text-sm text-muted">
+                                Resolve transfer, duplicate, and anomaly checks and clear Processing Account pending transfers before approving the run.
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={handleApproveRun}
+                            disabled={approveRunDisabled}
+                            className="btn-primary disabled:opacity-50 md:min-w-36"
+                            title={runApprovalTitle}
+                        >
+                            {actionLoading ? "Processing..." : "Approve Run"}
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            <div className="mb-6 grid grid-cols-1 md:grid-cols-4 gap-4 bg-[var(--background-card)] p-4 rounded-lg border border-[var(--border)]">
+                <div className="space-y-2">
+                    <label className="text-xs font-medium text-muted uppercase">Severity</label>
+                    <div className="flex flex-wrap gap-2">
+                        {["high", "medium", "low"].map(s => (
+                            <button
+                                key={s}
+                                onClick={() => toggleSeverity(s)}
+                                className={`px-2 py-1 text-xs rounded-full border transition-colors ${
+                                    severityFilter.includes(s)
+                                        ? "bg-[var(--accent)] text-white border-[var(--accent)]"
+                                        : "bg-[var(--background)] text-muted border-[var(--border)] hover:border-[var(--accent)]"
+                                }`}
+                            >
+                                {s.toUpperCase()}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+                
+                <div className="space-y-2">
+                    <label className="text-xs font-medium text-muted uppercase">Check Type</label>
+                    <select
+                        className="input text-sm py-1"
+                        value={checkTypeFilter}
+                        onChange={(e) => setCheckTypeFilter(e.target.value)}
+                    >
+                        <option value="">All Types</option>
+                        <option value="duplicate">Duplicate</option>
+                        <option value="transfer_pair">Transfer Pair</option>
+                        <option value="anomaly">Anomaly</option>
+                    </select>
+                </div>
+
+                <div className="space-y-2">
+                    <label className="text-xs font-medium text-muted uppercase">Status</label>
+                    <select
+                        className="input text-sm py-1"
+                        value={statusFilter}
+                        onChange={(e) => setStatusFilter(e.target.value)}
+                    >
+                        <option value="">All Statuses</option>
+                        <option value="pending">Pending</option>
+                        <option value="resolved">Resolved</option>
+                    </select>
+                </div>
+
+                <div className="space-y-2">
+                    <label className="text-xs font-medium text-muted uppercase">Min Match Score: {minScore}</label>
+                    <input 
+                        type="range" 
+                        min="0" 
+                        max="100" 
+                        step="5"
+                        value={minScore}
+                        onChange={(e) => setMinScore(parseInt(e.target.value))}
+                        className="w-full h-2 bg-[var(--border)] rounded-lg appearance-none cursor-pointer accent-[var(--accent)]"
+                    />
+                </div>
+            </div>
+
+            {error && <div className="mb-4 alert-error">{error}</div>}
+
+            {data.has_unresolved_checks && (
+                <div className="mb-4 p-4 border border-[var(--warning)]/30 bg-[var(--warning-muted)] rounded-lg">
+                    <div className="flex items-center gap-2">
+                        <span className="text-[var(--warning)]">⚠</span>
+                        <span className="font-medium text-[var(--warning)]">
+                            Unresolved consistency checks block batch approval
+                        </span>
+                    </div>
+                    <p className="text-sm text-muted mt-1">
+                        Resolve all checks below before approving matches.
+                    </p>
+                </div>
+            )}
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <div className="card">
+                    <div className="card-header flex items-center justify-between">
+                        <h3 className="text-sm font-medium">Consistency Checks</h3>
+                        <span className="text-xs text-muted">{allChecks.length} total</span>
+                    </div>
+
+                    {allChecks.length === 0 ? (
+                        <div className="p-8 text-center text-muted">No pending checks</div>
+                    ) : (
+                        <div className="divide-y divide-[var(--border)]">
+                            {allChecks.map((check) => (
+                                <div key={check.id} className="p-4 flex items-start justify-between gap-4">
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 mb-1">
+                                            <span className={`font-medium text-xs ${getSeverityColor(check.severity)}`}>
+                                                {check.severity.toUpperCase()}
+                                            </span>
+                                            <span className="badge badge-muted text-[10px]">{getCheckTypeLabel(check.check_type)}</span>
+                                        </div>
+                                        <p className="text-sm text-muted truncate">
+                                            {(check.details.message as string | undefined) || JSON.stringify(check.details)}
+                                        </p>
+                                        <p className="text-xs text-muted mt-1">
+                                            {formatDateTimeDisplay(check.created_at)}
+                                        </p>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setSelectedCheck(check);
+                                            setResolveDialogOpen(true);
+                                        }}
+                                        className="btn-secondary text-sm"
+                                    >
+                                        Resolve
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                <div className="card">
+                    <div className="card-header flex items-center justify-between">
+                        <h3 className="text-sm font-medium">Pending Matches</h3>
+                        <div className="flex items-center gap-2">
+                            <button
+                                type="button"
+                                onClick={toggleAll}
+                                className="text-xs text-muted hover:text-[var(--foreground)]"
+                            >
+                                {matchesFilteredByScore.length > 0 && matchesFilteredByScore.every((m) => selectedMatches.has(m.id)) ? "Deselect all" : "Select all"}
+                            </button>
+                            <span className="text-xs text-muted">{matchesFilteredByScore.length} total</span>
+                        </div>
+                    </div>
+
+                    {matchesFilteredByScore.length === 0 ? (
+                        <div className="p-8 text-center text-muted">No pending matches</div>
+                    ) : (
+                        <>
+                            <div className="overflow-auto max-h-[400px]">
+                                <table className="w-full text-sm">
+                                    <thead className="sticky top-0 bg-[var(--background)]">
+                                        <tr className="border-b border-[var(--border)]">
+                                            <th className="text-left px-4 py-2 w-8">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={selectedMatches.size === matchesFilteredByScore.length && matchesFilteredByScore.length > 0}
+                                                    onChange={toggleAll}
+                                                    className="rounded"
+                                                />
+                                            </th>
+                                            <th className="text-left px-4 py-2 font-medium">Score</th>
+                                            <th className="text-left px-4 py-2 font-medium">Description</th>
+                                            <th className="text-right px-4 py-2 font-medium">Amount</th>
+                                            <th className="text-left px-4 py-2 font-medium">Date</th>
+                                            <th className="text-left px-4 py-2 font-medium">Status</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody className="divide-y divide-[var(--border)]">
+                                        {matchesFilteredByScore.map((match) => (
+                                            <tr
+                                                key={match.id}
+                                                className="hover:bg-[var(--background-muted)]/50 cursor-pointer"
+                                                onClick={() => toggleMatch(match.id)}
+                                            >
+                                                <td className="px-4 py-2">
+                                                    <input
+                                                        onClick={(e) => e.stopPropagation()}
+                                                        type="checkbox"
+                                                        checked={selectedMatches.has(match.id)}
+                                                        onChange={(e) => {
+                                                            e.stopPropagation();
+                                                            toggleMatch(match.id);
+                                                        }}
+                                                        className="rounded"
+                                                    />
+                                                </td>
+                                                <td className="px-4 py-2">
+                                                    <span
+                                                        className={`font-medium ${
+                                                            match.match_score >= 85
+                                                                ? "text-[var(--success)]"
+                                                                : match.match_score >= 60
+                                                                  ? "text-[var(--warning)]"
+                                                                  : "text-[var(--error)]"
+                                                        }`}
+                                                    >
+                                                        {match.match_score}
+                                                    </span>
+                                                </td>
+                                                <td className="px-4 py-2 text-muted truncate max-w-[200px]">
+                                                    {match.description || "—"}
+                                                </td>
+                                                <td className="px-4 py-2 text-right font-medium">
+                                                    {match.amount != null ? match.amount.toFixed(2) : "—"}
+                                                </td>
+                                                <td className="px-4 py-2 text-muted">
+                                                    {match.txn_date ? formatDateDisplay(match.txn_date) : "—"}
+                                                </td>
+                                                <td className="px-4 py-2">
+                                                    <span className="badge badge-warning">{match.status}</span>
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <div className="p-4 border-t border-[var(--border)] flex items-center justify-between">
+                                <span className="text-sm text-muted">{selectedMatches.size} selected</span>
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        type="button"
+                                        onClick={handleBatchReject}
+                                        disabled={actionLoading || selectedMatches.size === 0}
+                                        className="btn-secondary text-[var(--error)]"
+                                    >
+                                        Reject
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={handleBatchApprove}
+                                        disabled={
+                                            actionLoading ||
+                                            selectedMatches.size === 0 ||
+                                            data.has_unresolved_checks
+                                        }
+                                        className="btn-primary disabled:opacity-50"
+                                        title={
+                                            data.has_unresolved_checks
+                                                ? "Resolve consistency checks first"
+                                                : ""
+                                        }
+                                    >
+                                        {actionLoading ? "Processing..." : "Approve Selected"}
+                                    </button>
+                                </div>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+
+            {resolveDialogOpen && selectedCheck && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center">
+                    <div className="fixed inset-0 bg-black/60" onClick={() => { if (!actionLoading) { setResolveDialogOpen(false); setSelectedCheck(null); setResolveNote(""); } }} aria-hidden="true" />
+                    <div ref={resolveDialogRef} role="dialog" aria-modal="true" aria-labelledby={resolveTitleId} className="relative z-10 w-full max-w-md card animate-slide-up">
+                        <div className="card-header">
+                            <h2 id={resolveTitleId} className="text-lg font-semibold">Resolve Consistency Check</h2>
+                        </div>
+                        <div className="p-6 space-y-4">
+                            <p className="text-sm text-muted">
+                                <span className="font-medium text-[var(--foreground)]">{selectedCheck.severity.toUpperCase()}</span>{" "}
+                                {getCheckTypeLabel(selectedCheck.check_type)} —{" "}
+                                {(selectedCheck.details.message as string | undefined) || JSON.stringify(selectedCheck.details)}
+                            </p>
+                            <div>
+                                <label className="block text-sm font-medium mb-1.5">Note (optional)</label>
+                                <input
+                                    type="text"
+                                    value={resolveNote}
+                                    onChange={(e) => setResolveNote(e.target.value)}
+                                    placeholder="Add resolution note..."
+                                    className="input"
+                                />
+                            </div>
+                            <div className="flex gap-2 pt-2">
+                                <button
+                                    type="button"
+                                    onClick={() => { setResolveDialogOpen(false); setSelectedCheck(null); setResolveNote(""); }}
+                                    className="btn-secondary flex-1"
+                                    disabled={actionLoading}
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => handleResolveCheck("reject", resolveNote)}
+                                    className="btn-secondary flex-1 text-[var(--error)] border-[var(--error)]/30 hover:bg-[var(--error-muted)]"
+                                    disabled={actionLoading}
+                                >
+                                    Reject
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => handleResolveCheck("flag", resolveNote)}
+                                    className="btn-secondary flex-1 text-[var(--warning)] border-[var(--warning)]/30 hover:bg-[var(--warning-muted)]"
+                                    disabled={actionLoading}
+                                >
+                                    Flag
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => handleResolveCheck("approve", resolveNote)}
+                                    className="btn-primary flex-1"
+                                    disabled={actionLoading}
+                                >
+                                    {actionLoading ? "Processing..." : "Approve"}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2544,6 +2544,21 @@ acs:
     epic_name: two-stage-review-ui
     description: 'Frontend tests mount each new component (PdfPreviewPane, TransactionTable, ConflictResolutionDialog, MobileNav) and assert primary affordance renders'
     mandatory: true
+  - id: AC16.24.1
+    epic: 16
+    epic_name: two-stage-review-ui
+    description: 'Stage 2 run-level page at `/review/run/[runId]` summarizes duplicate, transfer-pair, and anomaly checks for a batch'
+    mandatory: true
+  - id: AC16.24.2
+    epic: 16
+    epic_name: two-stage-review-ui
+    description: 'Stage 2 run-level page shows unresolved transfer and Processing pending counts, then disables run approval while either remains unresolved'
+    mandatory: true
+  - id: AC16.24.3
+    epic: 16
+    epic_name: two-stage-review-ui
+    description: 'Stage 2 run-level approval submits all pending matches through the batch approval API after checks are resolved'
+    mandatory: true
   # EPIC-017: portfolio-management
   - id: AC17.1.1
     epic: 17

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -727,6 +727,12 @@ Stage 2: Run-Level Review (Consistency Checks)
 - [x] **AC16.23.5** Mobile navigation drawer (`<MobileNav />`) renders below 768 px with links to Dashboard / Review / Processing / Portfolio; existing desktop sidebar hidden on mobile
 - [x] **AC16.23.6** Frontend tests mount each new component (PdfPreviewPane, TransactionTable, ConflictResolutionDialog, MobileNav) and assert primary affordance renders
 
+### Acceptance Criteria — Feature (group 24, run-level Stage 2)
+
+- [x] **AC16.24.1** Stage 2 run-level page at `/review/run/[runId]` summarizes duplicate, transfer-pair, and anomaly checks for a batch
+- [x] **AC16.24.2** Stage 2 run-level page shows unresolved transfer and Processing pending counts, then disables run approval while either remains unresolved
+- [x] **AC16.24.3** Stage 2 run-level approval submits all pending matches through the batch approval API after checks are resolved
+
 ### Acceptance Criteria — Infra (group 11, test infra extension)
 
 - [x] **AC16.11.32** Vitest harness for Stage 1 split components — shared `renderReviewComponent()` helper in `apps/frontend/src/__tests__/helpers/`

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -13,12 +13,12 @@
 | Metric | Count | Percentage |
 |--------|-------|------------|
 | **Total EPICs** | 18 | 100% |
-| **Total ACs (registries)** | 923 | 100% |
-| **Mandatory ACs** | 762 | 82.6% |
+| **Total ACs (registries)** | 926 | 100% |
+| **Mandatory ACs** | 765 | 82.6% |
 | **Deprecated ACs** | 3 | 0.3% |
-| **Mandatory ACs with test reference** | 762 | 100.0% |
+| **Mandatory ACs with test reference** | 765 | 100.0% |
 | **Mandatory ACs without test reference** | 0 | 0.0% |
-| **Test files referenced** | 175 | - |
+| **Test files referenced** | 176 | - |
 | **ACs flagged as manual verification (heuristic)** | 0 | 0.0% |
 
 ### Coverage by EPIC
@@ -40,7 +40,7 @@
 | [EPIC-013](#epic-013-statement-parsing-v2) | statement-parsing-v2 | 60 | 0 | 58 | 58 | 100.0% |
 | [EPIC-014](#epic-014-ttd-transformation) | ttd-transformation | 6 | 0 | 6 | 6 | 100.0% |
 | [EPIC-015](#epic-015-processing-account) | processing-account | 28 | 0 | 28 | 28 | 100.0% |
-| [EPIC-016](#epic-016-two-stage-review-ui) | two-stage-review-ui | 210 | 0 | 186 | 186 | 100.0% |
+| [EPIC-016](#epic-016-two-stage-review-ui) | two-stage-review-ui | 213 | 0 | 189 | 189 | 100.0% |
 | [EPIC-017](#epic-017-portfolio-management) | portfolio-management | 73 | 0 | 29 | 29 | 100.0% |
 | [EPIC-018](#epic-018-ai-driven-pipeline) | ai-driven-pipeline | 23 | 0 | 23 | 23 | 100.0% |
 
@@ -863,9 +863,9 @@
 
 <a id="epic-016-two-stage-review-ui"></a>
 
-- **Total ACs**: 210
-- **Mandatory ACs**: 186
-- **Mandatory ACs with test reference**: 186 (100.0%)
+- **Total ACs**: 213
+- **Mandatory ACs**: 189
+- **Mandatory ACs with test reference**: 189 (100.0%)
 
 | AC ID | Mandatory | Description | Test References | Status |
 |-------|-----------|-------------|-----------------|--------|
@@ -1079,6 +1079,9 @@
 | AC16.23.4 | yes | Stage 2 listing exposes severity filter, check-type filter, and score-range slider; filters persist in URL query string for shareable links | `apps/backend/tests/_ac_stubs/test_epic_16_stubs.py`<br>`apps/frontend/src/__tests__/assetsPage.test.tsx`<br>`apps/frontend/src/__tests__/uiGapAudit.stage1Refactor.test.ts` | ✅ |
 | AC16.23.5 | yes | Mobile navigation drawer (`<MobileNav />`) renders below 768 px with links to Dashboard / Review / Processing / Portfolio; existing desktop sidebar hidden on mobile | `apps/backend/tests/_ac_stubs/test_epic_16_stubs.py`<br>`apps/frontend/src/__tests__/reportsPage.test.tsx`<br>`apps/frontend/src/__tests__/uiGapAudit.stage1Refactor.test.ts` | ✅ |
 | AC16.23.6 | yes | Frontend tests mount each new component (PdfPreviewPane, TransactionTable, ConflictResolutionDialog, MobileNav) and assert primary affordance renders | `apps/backend/tests/_ac_stubs/test_epic_16_stubs.py`<br>`apps/frontend/src/__tests__/dashboardPage.test.tsx`<br>`apps/frontend/src/__tests__/epic016Components.test.tsx`<br>`apps/frontend/src/__tests__/mobileNav.coverage.test.tsx`<br>`apps/frontend/src/__tests__/uiGapAudit.stage1Refactor.test.ts` | ✅ |
+| AC16.24.1 | yes | Stage 2 run-level page at `/review/run/[runId]` summarizes duplicate, transfer-pair, and anomaly checks for a batch | `apps/frontend/src/__tests__/reviewRunPage.test.tsx` | ✅ |
+| AC16.24.2 | yes | Stage 2 run-level page shows unresolved transfer and Processing pending counts, then disables run approval while either remains unresolved | `apps/frontend/src/__tests__/reviewRunPage.test.tsx` | ✅ |
+| AC16.24.3 | yes | Stage 2 run-level approval submits all pending matches through the batch approval API after checks are resolved | `apps/frontend/src/__tests__/reviewRunPage.test.tsx` | ✅ |
 
 ---
 

--- a/docs/ssot/reconciliation.md
+++ b/docs/ssot/reconciliation.md
@@ -312,4 +312,6 @@ pending --> flagged: Needs manual review
 | Service | `apps/backend/src/services/consistency_checks.py` |
 | Router | `apps/backend/src/routers/statements.py` |
 | Frontend | `apps/frontend/src/app/(main)/statements/[id]/review/page.tsx` |
+| Frontend | `apps/frontend/src/components/review/Stage2ReviewQueue.tsx` |
 | Frontend | `apps/frontend/src/app/(main)/reconciliation/review-queue/page.tsx` |
+| Frontend | `apps/frontend/src/app/(main)/review/run/[runId]/page.tsx` |


### PR DESCRIPTION
## Summary

Add a Stage 2 run-level review entry at `/review/run/[runId]` with run gates for unresolved consistency checks and Processing Account pending transfers.

Closes #368

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-016 — Two-Stage Review UI |
| **AC IDs** | AC16.24.1, AC16.24.2, AC16.24.3 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/reconciliation.md` — added the shared Stage 2 review component and run-level route to the reconciliation frontend file map

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | local pre-commit | `reviewRunPage.test.tsx` failed before `/review/run/[runId]` existed |
| 🟢 Green (passing test) | `51f2989` | implemented run-level Stage 2 route and gates; tests pass |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — no DB changes
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — not applicable
- [x] `repo/` submodule updated for production config changes (if applicable) — not applicable
- [x] `scripts/check_env_keys.py` passes (if env vars changed) — not applicable
- [x] `scripts/check_manifest.py` passes
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
cd apps/frontend && npm test -- reviewRunPage.test.tsx reviewQueuePage.actions.test.tsx reviewQueuePage.coverage.test.tsx reviewPages.test.tsx
cd apps/frontend && npm test
cd apps/frontend && npm run lint
cd apps/frontend && npm run build
cd apps/backend && uv run ruff check src/
cd apps/backend && uv run ruff format src/ --check
python scripts/check_manifest.py
python scripts/lint_doc_consistency.py
```

Note: `moon run :lint && moon run :test` hung locally in `moon run :lint` without output after more than one minute, so I terminated it and ran the underlying frontend/backend/doc checks directly.

---

## Screenshots / Evidence

- `/review/run/[runId]` appears in the Next build route table.
- Existing `/reconciliation/review-queue` now uses the shared `Stage2ReviewQueue` component.
