### PR TITLE
feat(portfolio): parse brokerage position snapshots

### DIFF
--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -8,8 +8,14 @@ from pydantic import BaseModel, Field
 
 from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
-from src.schemas.portfolio import HoldingResponse, PriceUpdateRequest as SchemaPriceUpdateRequest
+from src.schemas.portfolio import (
+    BrokerageImportRequest,
+    BrokerageImportResponse,
+    HoldingResponse,
+    PriceUpdateRequest as SchemaPriceUpdateRequest,
+)
 from src.services import allocation, performance
+from src.services.brokerage_positions import BrokeragePositionImportService
 from src.services.performance import InsufficientDataError, PerformanceError
 from src.services.portfolio import AssetNotFoundError, PortfolioNotFoundError, PortfolioService
 
@@ -17,6 +23,7 @@ router = APIRouter(prefix="/portfolio", tags=["portfolio"])
 logger = get_logger(__name__)
 
 _portfolio_service = PortfolioService()
+_brokerage_import_service = BrokeragePositionImportService()
 
 
 class AllocationBreakdownResponse(BaseModel):
@@ -41,6 +48,24 @@ class PriceUpdateRequest(BaseModel):
 
 class PriceUpdateBatchRequest(BaseModel):
     updates: list[PriceUpdateRequest]
+
+
+@router.post("/brokerage/import", response_model=BrokerageImportResponse, status_code=status.HTTP_200_OK)
+async def import_brokerage_positions(
+    request: BrokerageImportRequest,
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> BrokerageImportResponse:
+    """Import parsed brokerage holdings into AtomicPosition and reconcile ManagedPosition."""
+    result = await _brokerage_import_service.import_positions(
+        db,
+        user_id=user_id,
+        payload=request.payload,
+        filename=request.filename,
+        source_document_id=request.source_document_id,
+    )
+    await db.commit()
+    return BrokerageImportResponse(**result.__dict__)
 
 
 @router.get("/holdings", response_model=list[HoldingResponse])

--- a/apps/backend/src/schemas/portfolio.py
+++ b/apps/backend/src/schemas/portfolio.py
@@ -98,6 +98,27 @@ class PortfolioSummaryResponse(BaseModel):
     currency: Annotated[str, Field(min_length=3, max_length=3)]
 
 
+class BrokerageImportRequest(BaseModel):
+    """Request to import parsed brokerage positions."""
+
+    payload: dict
+    filename: str | None = None
+    source_document_id: str | None = None
+
+
+class BrokerageImportResponse(BaseModel):
+    """Response for brokerage position import."""
+
+    broker: str
+    parsed_positions: int = Field(ge=0)
+    created_atomic_positions: int = Field(ge=0)
+    existing_atomic_positions: int = Field(ge=0)
+    reconcile_created: int = Field(ge=0)
+    reconcile_updated: int = Field(ge=0)
+    reconcile_disposed: int = Field(ge=0)
+    skipped: int = Field(ge=0)
+
+
 HoldingListResponse = ListResponse[HoldingResponse]
 RealizedPnLListResponse = ListResponse[RealizedPnLResponse]
 UnrealizedPnLListResponse = ListResponse[UnrealizedPnLResponse]

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -423,15 +423,22 @@ class AssetService:
 
             if position:
                 quantity_changed = position.quantity != quantity
-                if quantity_changed:
+                valuation_changed = position.cost_basis != snap.market_value or position.currency != snap.currency
+                if quantity_changed or valuation_changed:
                     logger.info(
-                        "Updating position quantity",
+                        "Updating managed position from latest atomic snapshot",
                         asset=snap.asset_identifier,
                         old_qty=str(position.quantity),
                         new_qty=str(quantity),
                     )
                     position.quantity = quantity
                     position.cost_basis = snap.market_value
+                    position.currency = snap.currency
+                    position.position_metadata = {
+                        **(position.position_metadata or {}),
+                        "broker": snap.broker,
+                        "latest_snapshot_date": snap.snapshot_date.isoformat(),
+                    }
 
                 if quantity == Decimal("0"):
                     position.status = PositionStatus.DISPOSED
@@ -440,7 +447,7 @@ class AssetService:
                 else:
                     position.status = PositionStatus.ACTIVE
                     position.disposal_date = None
-                    if quantity_changed:
+                    if quantity_changed or valuation_changed:
                         result.updated += 1
 
             else:
@@ -456,7 +463,7 @@ class AssetService:
                         acquisition_date=snap.snapshot_date,
                         status=PositionStatus.ACTIVE,
                         currency=snap.currency,
-                        position_metadata={"broker": snap.broker},
+                        position_metadata={"broker": snap.broker, "latest_snapshot_date": snap.snapshot_date.isoformat()},
                     )
                     db.add(position)
                     result.created += 1

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -463,7 +463,10 @@ class AssetService:
                         acquisition_date=snap.snapshot_date,
                         status=PositionStatus.ACTIVE,
                         currency=snap.currency,
-                        position_metadata={"broker": snap.broker, "latest_snapshot_date": snap.snapshot_date.isoformat()},
+                        position_metadata={
+                            "broker": snap.broker,
+                            "latest_snapshot_date": snap.snapshot_date.isoformat(),
+                        },
                     )
                     db.add(position)
                     result.created += 1

--- a/apps/backend/src/services/brokerage_positions.py
+++ b/apps/backend/src/services/brokerage_positions.py
@@ -157,7 +157,9 @@ def _iter_structured_positions(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return []
 
 
-def _parse_structured_positions(payload: dict[str, Any], broker: str, snapshot_date: date) -> list[BrokeragePositionSnapshot]:
+def _parse_structured_positions(
+    payload: dict[str, Any], broker: str, snapshot_date: date
+) -> list[BrokeragePositionSnapshot]:
     snapshots: list[BrokeragePositionSnapshot] = []
     default_currency = _payload_currency(payload)
     for item in _iter_structured_positions(payload):
@@ -310,7 +312,9 @@ class BrokeragePositionImportService:
         snapshots = parse_brokerage_positions(payload, filename=filename)
         created = 0
         existing = 0
-        broker = snapshots[0].broker if snapshots else detect_broker(filename=filename, institution=None, text=str(payload))
+        broker = (
+            snapshots[0].broker if snapshots else detect_broker(filename=filename, institution=None, text=str(payload))
+        )
 
         for snapshot in snapshots:
             dedup_hash = _dedup_hash(user_id, snapshot)

--- a/apps/backend/src/services/brokerage_positions.py
+++ b/apps/backend/src/services/brokerage_positions.py
@@ -1,0 +1,368 @@
+"""Brokerage statement position parsing and import."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from calendar import monthrange
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, InvalidOperation
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.layer2 import AssetType, AtomicPosition
+from src.services.assets import AssetService
+
+
+@dataclass(frozen=True)
+class BrokeragePositionSnapshot:
+    """Brokerage position snapshot before persistence."""
+
+    snapshot_date: date
+    asset_identifier: str
+    broker: str
+    quantity: Decimal
+    market_value: Decimal
+    currency: str
+    asset_type: AssetType | None = None
+    sector: str | None = None
+    geography: str | None = None
+
+
+@dataclass(frozen=True)
+class BrokerageImportResult:
+    """Result of importing brokerage positions."""
+
+    broker: str
+    parsed_positions: int
+    created_atomic_positions: int
+    existing_atomic_positions: int
+    reconcile_created: int
+    reconcile_updated: int
+    reconcile_disposed: int
+    skipped: int
+
+
+_BROKER_ALIASES = (
+    ("Interactive Brokers", ("interactive brokers", "ibkr", "ib llc")),
+    ("Moomoo", ("moomoo", "futu sg")),
+    ("Futu", ("futu", "富途")),
+)
+
+_MOOMOO_SUBSCRIPTION_RE = re.compile(
+    r"Subscription\s+\S+\s+(?P<name>.+?)\s+(?P<currency>[A-Z]{3})\s+"
+    r"\d{4}/\d{2}/\d{2}\s+\S+\s+(?P<price>[\d,.]+)\s+"
+    r"(?P<quantity>[\d,.]+)\s+(?P<value>[\d,.]+)",
+    re.IGNORECASE,
+)
+
+
+def _clean_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    text = str(value).strip().replace(",", "")
+    if not text or text.upper() in {"N/A", "UNKNOWN", "NULL", "NONE"}:
+        return None
+    try:
+        return Decimal(text)
+    except InvalidOperation:
+        return None
+
+
+def _parse_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value
+    text = str(value).strip()
+    if not text or text.upper() == "UNKNOWN":
+        return None
+    if re.fullmatch(r"\d{4}-\d{2}", text):
+        year, month = (int(part) for part in text.split("-"))
+        return date(year, month, monthrange(year, month)[1])
+    if re.fullmatch(r"\d{4}/\d{2}/\d{2}", text):
+        text = text.replace("/", "-")
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        return None
+
+
+def _statement_date(payload: dict[str, Any]) -> date:
+    statement = payload.get("statement") if isinstance(payload.get("statement"), dict) else {}
+    for candidate in (
+        payload.get("snapshot_date"),
+        payload.get("as_of_date"),
+        payload.get("period_end"),
+        statement.get("snapshot_date"),
+        statement.get("as_of_date"),
+        statement.get("period_end"),
+    ):
+        parsed = _parse_date(candidate)
+        if parsed:
+            return parsed
+    return date.today()
+
+
+def _payload_currency(payload: dict[str, Any], default: str = "USD") -> str:
+    statement = payload.get("statement") if isinstance(payload.get("statement"), dict) else {}
+    currency = payload.get("currency") or statement.get("currency") or default
+    return str(currency).upper()
+
+
+def _asset_type(value: Any) -> AssetType | None:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    aliases = {
+        "fund": AssetType.MUTUAL_FUND,
+        "money_market": AssetType.MUTUAL_FUND,
+        "stock_and_options": AssetType.OTHER,
+        "equity": AssetType.STOCK,
+    }
+    if text in aliases:
+        return aliases[text]
+    try:
+        return AssetType(text)
+    except ValueError:
+        return None
+
+
+def detect_broker(*, filename: str | None, institution: str | None, text: str | None) -> str:
+    """Detect broker from filename, institution, or extracted text."""
+    haystack = " ".join(part for part in (filename, institution, text) if part).lower()
+    for broker, aliases in _BROKER_ALIASES:
+        if any(alias in haystack for alias in aliases):
+            return broker
+    return "Unknown Broker"
+
+
+def _iter_structured_positions(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    for key in ("positions", "holdings", "securities"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, dict)]
+    statement = payload.get("statement")
+    if isinstance(statement, dict):
+        for key in ("positions", "holdings", "securities"):
+            value = statement.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _parse_structured_positions(payload: dict[str, Any], broker: str, snapshot_date: date) -> list[BrokeragePositionSnapshot]:
+    snapshots: list[BrokeragePositionSnapshot] = []
+    default_currency = _payload_currency(payload)
+    for item in _iter_structured_positions(payload):
+        identifier = item.get("asset_identifier") or item.get("symbol") or item.get("ticker") or item.get("isin")
+        quantity = _clean_decimal(item.get("quantity") or item.get("qty") or item.get("position"))
+        market_value = _clean_decimal(item.get("market_value") or item.get("value") or item.get("marketValue"))
+        if not identifier or quantity is None or market_value is None:
+            continue
+        snapshots.append(
+            BrokeragePositionSnapshot(
+                snapshot_date=_parse_date(item.get("snapshot_date") or item.get("as_of_date")) or snapshot_date,
+                asset_identifier=str(identifier).strip(),
+                broker=str(item.get("broker") or broker),
+                quantity=quantity,
+                market_value=market_value.quantize(Decimal("0.01")),
+                currency=str(item.get("currency") or default_currency).upper(),
+                asset_type=_asset_type(item.get("asset_type") or item.get("asset_class")),
+                sector=str(item["sector"]).strip() if item.get("sector") else None,
+                geography=str(item["geography"]).strip() if item.get("geography") else None,
+            )
+        )
+    return snapshots
+
+
+def _parse_moomoo_subscription_positions(
+    payload: dict[str, Any], broker: str, snapshot_date: date
+) -> list[BrokeragePositionSnapshot]:
+    snapshots: list[BrokeragePositionSnapshot] = []
+    for event in payload.get("events") or payload.get("transactions") or []:
+        if not isinstance(event, dict):
+            continue
+        raw_text = str(event.get("raw_text") or "")
+        match = _MOOMOO_SUBSCRIPTION_RE.search(raw_text)
+        if not match:
+            description = str(event.get("description") or "")
+            amount = _clean_decimal(event.get("amount"))
+            if "Money Market Fund" not in description or amount is None or amount <= 0:
+                continue
+            snapshots.append(
+                BrokeragePositionSnapshot(
+                    snapshot_date=snapshot_date,
+                    asset_identifier=description.strip(),
+                    broker=broker,
+                    quantity=Decimal("1"),
+                    market_value=amount.quantize(Decimal("0.01")),
+                    currency=_payload_currency(payload),
+                    asset_type=AssetType.MUTUAL_FUND,
+                )
+            )
+            continue
+
+        quantity = _clean_decimal(match.group("quantity"))
+        market_value = _clean_decimal(match.group("value"))
+        if quantity is None or market_value is None:
+            continue
+        snapshots.append(
+            BrokeragePositionSnapshot(
+                snapshot_date=snapshot_date,
+                asset_identifier=match.group("name").strip(),
+                broker=broker,
+                quantity=quantity,
+                market_value=market_value.quantize(Decimal("0.01")),
+                currency=match.group("currency").upper(),
+                asset_type=AssetType.MUTUAL_FUND,
+            )
+        )
+    return snapshots
+
+
+def _parse_futu_aggregate_position(
+    payload: dict[str, Any], broker: str, snapshot_date: date
+) -> list[BrokeragePositionSnapshot]:
+    best_value: Decimal | None = None
+    for event in payload.get("events") or payload.get("transactions") or []:
+        if not isinstance(event, dict):
+            continue
+        description = str(event.get("description") or "").lower()
+        if "cash" in description or "現金" in description:
+            continue
+        value = _clean_decimal(event.get("amount"))
+        if value is None:
+            continue
+        if "valuation" in description or best_value is None or value > best_value:
+            best_value = value
+    if best_value is None:
+        return []
+    return [
+        BrokeragePositionSnapshot(
+            snapshot_date=snapshot_date,
+            asset_identifier="FUTU_STOCK_AND_OPTIONS",
+            broker=broker,
+            quantity=Decimal("1"),
+            market_value=best_value.quantize(Decimal("0.01")),
+            currency=_payload_currency(payload, "HKD"),
+            asset_type=AssetType.OTHER,
+        )
+    ]
+
+
+def parse_brokerage_positions(
+    payload: dict[str, Any],
+    *,
+    filename: str | None = None,
+    institution: str | None = None,
+) -> list[BrokeragePositionSnapshot]:
+    """Parse brokerage position snapshots from structured or fallback payloads."""
+    statement = payload.get("statement") if isinstance(payload.get("statement"), dict) else {}
+    broker = detect_broker(
+        filename=filename or str(payload.get("file") or ""),
+        institution=institution or payload.get("institution") or statement.get("institution"),
+        text=str(payload),
+    )
+    snapshot_date = _statement_date(payload)
+
+    structured = _parse_structured_positions(payload, broker, snapshot_date)
+    if structured:
+        return structured
+    if broker == "Moomoo":
+        return _parse_moomoo_subscription_positions(payload, broker, snapshot_date)
+    if broker == "Futu":
+        return _parse_futu_aggregate_position(payload, broker, snapshot_date)
+    return []
+
+
+def _dedup_hash(user_id: UUID, snapshot: BrokeragePositionSnapshot) -> str:
+    material = "|".join(
+        [
+            str(user_id),
+            snapshot.snapshot_date.isoformat(),
+            snapshot.asset_identifier,
+            snapshot.broker,
+        ]
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+class BrokeragePositionImportService:
+    """Import parsed brokerage positions into AtomicPosition then reconcile."""
+
+    async def import_positions(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        payload: dict[str, Any],
+        filename: str | None = None,
+        source_document_id: str | None = None,
+        reconcile: bool = True,
+    ) -> BrokerageImportResult:
+        snapshots = parse_brokerage_positions(payload, filename=filename)
+        created = 0
+        existing = 0
+        broker = snapshots[0].broker if snapshots else detect_broker(filename=filename, institution=None, text=str(payload))
+
+        for snapshot in snapshots:
+            dedup_hash = _dedup_hash(user_id, snapshot)
+            existing_row = (
+                await db.execute(
+                    select(AtomicPosition)
+                    .where(AtomicPosition.user_id == user_id)
+                    .where(AtomicPosition.dedup_hash == dedup_hash)
+                )
+            ).scalar_one_or_none()
+            if existing_row:
+                existing += 1
+                continue
+
+            db.add(
+                AtomicPosition(
+                    user_id=user_id,
+                    snapshot_date=snapshot.snapshot_date,
+                    asset_identifier=snapshot.asset_identifier,
+                    broker=snapshot.broker,
+                    quantity=snapshot.quantity,
+                    market_value=snapshot.market_value,
+                    currency=snapshot.currency,
+                    asset_type=snapshot.asset_type,
+                    sector=snapshot.sector,
+                    geography=snapshot.geography,
+                    dedup_hash=dedup_hash,
+                    source_documents={
+                        "documents": [
+                            {
+                                "doc_id": source_document_id,
+                                "doc_type": "brokerage_statement",
+                                "broker": snapshot.broker,
+                            }
+                        ]
+                    },
+                )
+            )
+            created += 1
+
+        await db.flush()
+        reconcile_result = None
+        if reconcile and snapshots:
+            reconcile_result = await AssetService().reconcile_positions(db, user_id)
+
+        return BrokerageImportResult(
+            broker=broker,
+            parsed_positions=len(snapshots),
+            created_atomic_positions=created,
+            existing_atomic_positions=existing,
+            reconcile_created=reconcile_result.created if reconcile_result else 0,
+            reconcile_updated=reconcile_result.updated if reconcile_result else 0,
+            reconcile_disposed=reconcile_result.disposed if reconcile_result else 0,
+            skipped=reconcile_result.skipped if reconcile_result else 0,
+        )

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -16,6 +16,7 @@ from src.services.brokerage_positions import (
     _clean_decimal,
     _parse_date,
     _payload_currency,
+    _statement_date,
     detect_broker,
     parse_brokerage_positions,
 )
@@ -53,9 +54,11 @@ def test_brokerage_parser_helpers_handle_common_empty_and_alias_values():
     assert _parse_date("bad-date") is None
 
     assert _payload_currency({}, default="sgd") == "SGD"
+    assert _statement_date({"snapshot_date": "2026-06-01"}).isoformat() == "2026-06-01"
     assert _asset_type("fund") == AssetType.MUTUAL_FUND
     assert _asset_type("money_market") == AssetType.MUTUAL_FUND
     assert _asset_type("equity") == AssetType.STOCK
+    assert _asset_type("etf") == AssetType.ETF
     assert _asset_type("unsupported") is None
 
 
@@ -144,6 +147,36 @@ def test_parse_statement_holdings_skips_invalid_rows_and_normalizes_metadata():
     assert snapshots[0].asset_type == AssetType.MUTUAL_FUND
     assert snapshots[0].sector == "Cash"
     assert snapshots[0].geography == "SG"
+
+
+def test_parse_top_level_securities_accepts_item_broker_and_snapshot_date():
+    """AC17.4.3: Top-level securities payloads can override broker and snapshot date per row."""
+    payload = {
+        "institution": "Interactive Brokers",
+        "snapshot_date": "2026-06-01",
+        "currency": "USD",
+        "securities": [
+            {
+                "ticker": "VWRA",
+                "broker": "IBKR UK",
+                "snapshot_date": "2026-06-02",
+                "position": "3",
+                "value": "360.123",
+                "asset_type": "etf",
+                "currency": "usd",
+            }
+        ],
+    }
+
+    snapshots = parse_brokerage_positions(payload, filename="ibkr.csv")
+
+    assert len(snapshots) == 1
+    assert snapshots[0].broker == "IBKR UK"
+    assert snapshots[0].snapshot_date.isoformat() == "2026-06-02"
+    assert snapshots[0].asset_identifier == "VWRA"
+    assert snapshots[0].quantity == Decimal("3")
+    assert snapshots[0].market_value == Decimal("360.12")
+    assert snapshots[0].asset_type == AssetType.ETF
 
 
 def test_parse_moomoo_raw_subscription_text_position():
@@ -242,6 +275,25 @@ async def test_import_empty_payload_without_reconcile_returns_zero_counts(db, te
     assert result.reconcile_created == 0
     assert result.reconcile_updated == 0
     assert result.reconcile_disposed == 0
+
+
+@pytest.mark.asyncio
+async def test_brokerage_import_endpoint_empty_payload_returns_zero_counts(client):
+    """AC17.4.6: Brokerage import endpoint accepts empty parsed payloads without reconciliation."""
+    response = await client.post(
+        "/portfolio/brokerage/import",
+        json={
+            "filename": "unknown.pdf",
+            "payload": {"transactions": []},
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["broker"] == "Unknown Broker"
+    assert data["parsed_positions"] == 0
+    assert data["created_atomic_positions"] == 0
+    assert data["reconcile_created"] == 0
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -197,6 +197,22 @@ def test_parse_moomoo_raw_subscription_text_position():
     assert snapshots[0].currency == "SGD"
 
 
+def test_parse_moomoo_skips_non_position_subscription_events():
+    """AC17.4.1: Moomoo fallback parsing ignores non-position and invalid subscription events."""
+    payload = {
+        "statement": {"period_end": "2026-05-18", "currency": "SGD"},
+        "events": [
+            "not a dict",
+            {"description": "Money Market Fund rebate", "amount": "UNKNOWN"},
+            {"description": "Money Market Fund redemption", "amount": "-10.00"},
+            {"raw_text": ("Subscription 0001 Bad Quantity Fund SGD 2026/05/18 settled 1.0000 UNKNOWN 1250.50")},
+            {"description": "Cash transfer", "amount": "100.00"},
+        ],
+    }
+
+    assert parse_brokerage_positions(payload, filename="moomoo.pdf") == []
+
+
 def test_parse_futu_cash_only_and_unknown_broker_payloads_return_no_positions():
     """AC17.4.2/AC17.4.5: Non-position events and unsupported brokers do not create snapshots."""
     futu_cash_only = {
@@ -209,6 +225,26 @@ def test_parse_futu_cash_only_and_unknown_broker_payloads_return_no_positions():
 
     assert parse_brokerage_positions(futu_cash_only, filename="futu.pdf") == []
     assert parse_brokerage_positions(unknown_payload, filename="unknown.pdf") == []
+
+
+def test_parse_futu_aggregate_ignores_invalid_events_and_uses_best_value():
+    """AC17.4.2: Futu aggregate fallback ignores invalid rows and keeps best securities value."""
+    payload = {
+        "statement": {"period_end": "2026-05-18", "currency": "HKD"},
+        "events": [
+            "not a dict",
+            {"description": "Cash balance", "amount": "9999.00"},
+            {"description": "Stock valuation", "amount": "UNKNOWN"},
+            {"description": "Stock valuation", "amount": "100.00"},
+            {"description": "Stock and options value", "amount": "250.00"},
+        ],
+    }
+
+    snapshots = parse_brokerage_positions(payload, filename="futu.pdf")
+
+    assert len(snapshots) == 1
+    assert snapshots[0].asset_identifier == "FUTU_STOCK_AND_OPTIONS"
+    assert snapshots[0].market_value == Decimal("250.00")
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -1,0 +1,120 @@
+"""Tests for brokerage position parsing into AtomicPosition."""
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from src.models.layer2 import AssetType, AtomicPosition
+from src.models.layer3 import ManagedPosition
+from src.services.brokerage_positions import BrokeragePositionImportService, detect_broker, parse_brokerage_positions
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def _load_fixture(name: str) -> dict:
+    with (FIXTURES / name).open() as fh:
+        return json.load(fh)
+
+
+def test_detect_broker_moomoo_futu_and_interactive_brokers():
+    """AC17.4.4/AC17.4.5: Broker auto-detection supports known broker names."""
+    assert detect_broker(filename="moomoo-2504.pdf", institution=None, text="") == "Moomoo"
+    assert detect_broker(filename="statement.pdf", institution="Futu Securities", text="") == "Futu"
+    assert detect_broker(filename="activity.csv", institution=None, text="Interactive Brokers LLC") == "Interactive Brokers"
+
+
+def test_parse_moomoo_fixture_subscription_positions():
+    """AC17.4.1: Moomoo parsed fixtures produce AtomicPosition-ready snapshots."""
+    payload = _load_fixture("moomoo-2504_parsed.json")
+
+    snapshots = parse_brokerage_positions(payload, filename="moomoo-2504.pdf")
+
+    csop = next(item for item in snapshots if item.asset_identifier == "CSOP USD Money Market Fund")
+    assert csop.broker == "Moomoo"
+    assert csop.snapshot_date.isoformat() == "2025-04-30"
+    assert csop.quantity == Decimal("1")
+    assert csop.market_value == Decimal("80.27")
+    assert csop.currency == "SGD"
+    assert csop.asset_type == AssetType.MUTUAL_FUND
+
+
+def test_parse_futu_fixture_aggregate_position():
+    """AC17.4.2: Futu parsed fixtures preserve aggregate securities valuation."""
+    payload = _load_fixture("futu-2506_parsed.json")
+
+    snapshots = parse_brokerage_positions(payload, filename="futu-2506.pdf")
+
+    assert len(snapshots) == 1
+    assert snapshots[0].broker == "Futu"
+    assert snapshots[0].asset_identifier == "FUTU_STOCK_AND_OPTIONS"
+    assert snapshots[0].snapshot_date.isoformat() == "2025-06-30"
+    assert snapshots[0].quantity == Decimal("1")
+    assert snapshots[0].market_value == Decimal("323730.00")
+    assert snapshots[0].currency == "HKD"
+
+
+@pytest.mark.asyncio
+async def test_import_interactive_brokers_positions_idempotently_reconciles(db, test_user):
+    """AC17.4.3: Interactive Brokers payloads import to AtomicPosition and reconcile once."""
+    service = BrokeragePositionImportService()
+    payload = {
+        "institution": "Interactive Brokers",
+        "statement": {"period_end": "2026-05-18", "currency": "USD"},
+        "positions": [
+            {
+                "symbol": "AAPL",
+                "quantity": "10",
+                "market_value": "1900.25",
+                "currency": "USD",
+                "asset_type": "stock",
+                "sector": "Technology",
+                "geography": "US",
+            }
+        ],
+    }
+
+    first = await service.import_positions(db, user_id=test_user.id, payload=payload, source_document_id="doc-ibkr")
+    second = await service.import_positions(db, user_id=test_user.id, payload=payload, source_document_id="doc-ibkr")
+    await db.commit()
+
+    assert first.created_atomic_positions == 1
+    assert first.reconcile_created == 1
+    assert second.created_atomic_positions == 0
+    assert second.reconcile_created == 0
+
+    atomic_rows = (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == test_user.id))).scalars().all()
+    assert len(atomic_rows) == 1
+    assert atomic_rows[0].asset_identifier == "AAPL"
+    assert atomic_rows[0].sector == "Technology"
+
+    managed_rows = (await db.execute(select(ManagedPosition).where(ManagedPosition.user_id == test_user.id))).scalars().all()
+    assert len(managed_rows) == 1
+    assert managed_rows[0].asset_identifier == "AAPL"
+    assert managed_rows[0].quantity == Decimal("10")
+
+
+@pytest.mark.asyncio
+async def test_brokerage_import_endpoint(client, db):
+    """AC17.4.6: Brokerage import endpoint returns atomic and reconciliation counts."""
+    response = await client.post(
+        "/portfolio/brokerage/import",
+        json={
+            "filename": "ibkr.csv",
+            "payload": {
+                "institution": "Interactive Brokers",
+                "statement": {"period_end": "2026-05-18", "currency": "USD"},
+                "positions": [{"symbol": "MSFT", "quantity": "2", "market_value": "860.00", "currency": "USD"}],
+            },
+            "source_document_id": "doc-msft",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["broker"] == "Interactive Brokers"
+    assert data["parsed_positions"] == 1
+    assert data["created_atomic_positions"] == 1
+    assert data["reconcile_created"] == 1

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -9,7 +9,16 @@ from sqlalchemy import select
 
 from src.models.layer2 import AssetType, AtomicPosition
 from src.models.layer3 import ManagedPosition
-from src.services.brokerage_positions import BrokeragePositionImportService, detect_broker, parse_brokerage_positions
+from src.schemas.portfolio import BrokerageImportRequest, BrokerageImportResponse
+from src.services.brokerage_positions import (
+    BrokeragePositionImportService,
+    _asset_type,
+    _clean_decimal,
+    _parse_date,
+    _payload_currency,
+    detect_broker,
+    parse_brokerage_positions,
+)
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -27,6 +36,50 @@ def test_detect_broker_moomoo_futu_and_interactive_brokers():
         detect_broker(filename="activity.csv", institution=None, text="Interactive Brokers LLC")
         == "Interactive Brokers"
     )
+
+
+def test_brokerage_parser_helpers_handle_common_empty_and_alias_values():
+    """AC17.4.5: Parser helpers normalize common brokerage statement values."""
+    assert _clean_decimal(None) is None
+    assert _clean_decimal("N/A") is None
+    assert _clean_decimal("1,234.56") == Decimal("1234.56")
+    assert _clean_decimal(Decimal("7.89")) == Decimal("7.89")
+    assert _clean_decimal("not-a-number") is None
+
+    assert _parse_date(None) is None
+    assert _parse_date("UNKNOWN") is None
+    assert _parse_date("2026-05").isoformat() == "2026-05-31"
+    assert _parse_date("2026/05/18").isoformat() == "2026-05-18"
+    assert _parse_date("bad-date") is None
+
+    assert _payload_currency({}, default="sgd") == "SGD"
+    assert _asset_type("fund") == AssetType.MUTUAL_FUND
+    assert _asset_type("money_market") == AssetType.MUTUAL_FUND
+    assert _asset_type("equity") == AssetType.STOCK
+    assert _asset_type("unsupported") is None
+
+
+def test_brokerage_import_schemas_accept_zero_count_responses():
+    """AC17.4.6: Brokerage import schemas expose payload and non-negative count contract."""
+    request = BrokerageImportRequest(
+        payload={"positions": []},
+        filename="ibkr.csv",
+        source_document_id="doc-1",
+    )
+    response = BrokerageImportResponse(
+        broker="Interactive Brokers",
+        parsed_positions=0,
+        created_atomic_positions=0,
+        existing_atomic_positions=0,
+        reconcile_created=0,
+        reconcile_updated=0,
+        reconcile_disposed=0,
+        skipped=0,
+    )
+
+    assert request.filename == "ibkr.csv"
+    assert request.source_document_id == "doc-1"
+    assert response.created_atomic_positions == 0
 
 
 def test_parse_moomoo_fixture_subscription_positions():

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -23,7 +23,10 @@ def test_detect_broker_moomoo_futu_and_interactive_brokers():
     """AC17.4.4/AC17.4.5: Broker auto-detection supports known broker names."""
     assert detect_broker(filename="moomoo-2504.pdf", institution=None, text="") == "Moomoo"
     assert detect_broker(filename="statement.pdf", institution="Futu Securities", text="") == "Futu"
-    assert detect_broker(filename="activity.csv", institution=None, text="Interactive Brokers LLC") == "Interactive Brokers"
+    assert (
+        detect_broker(filename="activity.csv", institution=None, text="Interactive Brokers LLC")
+        == "Interactive Brokers"
+    )
 
 
 def test_parse_moomoo_fixture_subscription_positions():
@@ -56,6 +59,72 @@ def test_parse_futu_fixture_aggregate_position():
     assert snapshots[0].currency == "HKD"
 
 
+def test_parse_statement_holdings_skips_invalid_rows_and_normalizes_metadata():
+    """AC17.4.3: Structured statement holdings skip incomplete rows and normalize metadata."""
+    payload = {
+        "statement": {
+            "institution": "Interactive Brokers",
+            "period_end": "2026-05",
+            "currency": "usd",
+            "holdings": [
+                {"symbol": "BROKEN", "quantity": "N/A", "market_value": "100.00"},
+                {
+                    "isin": "SG9999000001",
+                    "quantity": "1,234.5",
+                    "marketValue": "9,876.54",
+                    "asset_class": "money_market",
+                    "sector": "Cash",
+                    "geography": "SG",
+                },
+            ],
+        }
+    }
+
+    snapshots = parse_brokerage_positions(payload, filename="activity.csv")
+
+    assert len(snapshots) == 1
+    assert snapshots[0].snapshot_date.isoformat() == "2026-05-31"
+    assert snapshots[0].asset_identifier == "SG9999000001"
+    assert snapshots[0].quantity == Decimal("1234.5")
+    assert snapshots[0].market_value == Decimal("9876.54")
+    assert snapshots[0].currency == "USD"
+    assert snapshots[0].asset_type == AssetType.MUTUAL_FUND
+    assert snapshots[0].sector == "Cash"
+    assert snapshots[0].geography == "SG"
+
+
+def test_parse_moomoo_raw_subscription_text_position():
+    """AC17.4.1: Moomoo raw subscription event text is parsed when structured holdings are absent."""
+    payload = {
+        "statement": {"period_end": "2026/05/18", "currency": "SGD"},
+        "events": [
+            {"raw_text": ("Subscription 0001 Fullerton SGD Cash Fund SGD 2026/05/18 settled 1.0000 1250.50 1250.50")}
+        ],
+    }
+
+    snapshots = parse_brokerage_positions(payload, filename="moomoo-statement.pdf")
+
+    assert len(snapshots) == 1
+    assert snapshots[0].asset_identifier == "Fullerton SGD Cash Fund"
+    assert snapshots[0].quantity == Decimal("1250.50")
+    assert snapshots[0].market_value == Decimal("1250.50")
+    assert snapshots[0].currency == "SGD"
+
+
+def test_parse_futu_cash_only_and_unknown_broker_payloads_return_no_positions():
+    """AC17.4.2/AC17.4.5: Non-position events and unsupported brokers do not create snapshots."""
+    futu_cash_only = {
+        "statement": {"period_end": "2026-05-18", "currency": "HKD"},
+        "events": [{"description": "Cash balance", "amount": "999.00"}],
+    }
+    unknown_payload = {
+        "positions": [{"symbol": "BAD", "quantity": "UNKNOWN", "market_value": None}],
+    }
+
+    assert parse_brokerage_positions(futu_cash_only, filename="futu.pdf") == []
+    assert parse_brokerage_positions(unknown_payload, filename="unknown.pdf") == []
+
+
 @pytest.mark.asyncio
 async def test_import_interactive_brokers_positions_idempotently_reconciles(db, test_user):
     """AC17.4.3: Interactive Brokers payloads import to AtomicPosition and reconcile once."""
@@ -85,15 +154,41 @@ async def test_import_interactive_brokers_positions_idempotently_reconciles(db, 
     assert second.created_atomic_positions == 0
     assert second.reconcile_created == 0
 
-    atomic_rows = (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == test_user.id))).scalars().all()
+    atomic_rows = (
+        (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == test_user.id))).scalars().all()
+    )
     assert len(atomic_rows) == 1
     assert atomic_rows[0].asset_identifier == "AAPL"
     assert atomic_rows[0].sector == "Technology"
 
-    managed_rows = (await db.execute(select(ManagedPosition).where(ManagedPosition.user_id == test_user.id))).scalars().all()
+    managed_rows = (
+        (await db.execute(select(ManagedPosition).where(ManagedPosition.user_id == test_user.id))).scalars().all()
+    )
     assert len(managed_rows) == 1
     assert managed_rows[0].asset_identifier == "AAPL"
     assert managed_rows[0].quantity == Decimal("10")
+
+
+@pytest.mark.asyncio
+async def test_import_empty_payload_without_reconcile_returns_zero_counts(db, test_user):
+    """AC17.4.6: Empty imports return zero counts without invoking reconciliation."""
+    service = BrokeragePositionImportService()
+
+    result = await service.import_positions(
+        db,
+        user_id=test_user.id,
+        payload={"institution": "Unknown Broker", "transactions": []},
+        filename="unknown.pdf",
+        reconcile=False,
+    )
+
+    assert result.broker == "Unknown Broker"
+    assert result.parsed_positions == 0
+    assert result.created_atomic_positions == 0
+    assert result.existing_atomic_positions == 0
+    assert result.reconcile_created == 0
+    assert result.reconcile_updated == 0
+    assert result.reconcile_disposed == 0
 
 
 @pytest.mark.asyncio

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -3083,9 +3083,9 @@ acs:
     mandatory: false
   - id: AC17.4.6
     epic: 17
-    title: stub
-    status: stub
-    mandatory: false
+    epic_name: portfolio-management
+    description: 'Brokerage import endpoint creates AtomicPosition rows and reconciles ManagedPosition idempotently'
+    mandatory: true
   - id: AC17.5.5
     epic: 17
     title: stub

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -265,11 +265,12 @@ Build a **100% self-developed** investment portfolio management system with comp
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC17.4.1 | Moomoo Statement Parsing | `TBD` | `TBD (test to be implemented)` | P0 |
-| AC17.4.2 | Futu Statement Parsing | `TBD` | `TBD (test to be implemented)` | P1 |
-| AC17.4.3 | Interactive Brokers Parsing | `TBD` | `TBD (test to be implemented)` | P1 |
-| AC17.4.4 | Broker Auto-Detection (Moomoo) | `TBD` | `TBD (test to be implemented)` | P1 |
-| AC17.4.5 | Broker Auto-Detection (Futu) | `TBD` | `TBD (test to be implemented)` | P1 |
+| AC17.4.1 | Moomoo Statement Parsing | `test_parse_moomoo_fixture_subscription_positions` | `portfolio/test_brokerage_position_parsing.py` | P0 |
+| AC17.4.2 | Futu Statement Parsing | `test_parse_futu_fixture_aggregate_position` | `portfolio/test_brokerage_position_parsing.py` | P1 |
+| AC17.4.3 | Interactive Brokers Parsing | `test_import_interactive_brokers_positions_idempotently_reconciles` | `portfolio/test_brokerage_position_parsing.py` | P1 |
+| AC17.4.4 | Broker Auto-Detection (Moomoo) | `test_detect_broker_moomoo_futu_and_interactive_brokers` | `portfolio/test_brokerage_position_parsing.py` | P1 |
+| AC17.4.5 | Broker Auto-Detection (Futu) | `test_detect_broker_moomoo_futu_and_interactive_brokers` | `portfolio/test_brokerage_position_parsing.py` | P1 |
+| AC17.4.6 | Brokerage Import Endpoint | `test_brokerage_import_endpoint` | `portfolio/test_brokerage_position_parsing.py` | P1 |
 
 ### AC17.5: Investment Accounting (Journal Entries)
 

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -14,11 +14,11 @@
 |--------|-------|------------|
 | **Total EPICs** | 18 | 100% |
 | **Total ACs (registries)** | 930 | 100% |
-| **Mandatory ACs** | 769 | 82.7% |
+| **Mandatory ACs** | 770 | 82.8% |
 | **Deprecated ACs** | 3 | 0.3% |
-| **Mandatory ACs with test reference** | 769 | 100.0% |
+| **Mandatory ACs with test reference** | 770 | 100.0% |
 | **Mandatory ACs without test reference** | 0 | 0.0% |
-| **Test files referenced** | 177 | - |
+| **Test files referenced** | 179 | - |
 | **ACs flagged as manual verification (heuristic)** | 0 | 0.0% |
 
 ### Coverage by EPIC
@@ -41,7 +41,7 @@
 | [EPIC-014](#epic-014-ttd-transformation) | ttd-transformation | 6 | 0 | 6 | 6 | 100.0% |
 | [EPIC-015](#epic-015-processing-account) | processing-account | 28 | 0 | 28 | 28 | 100.0% |
 | [EPIC-016](#epic-016-two-stage-review-ui) | two-stage-review-ui | 213 | 0 | 189 | 189 | 100.0% |
-| [EPIC-017](#epic-017-portfolio-management) | portfolio-management | 73 | 0 | 29 | 29 | 100.0% |
+| [EPIC-017](#epic-017-portfolio-management) | portfolio-management | 73 | 0 | 30 | 30 | 100.0% |
 | [EPIC-018](#epic-018-ai-driven-pipeline) | ai-driven-pipeline | 23 | 0 | 23 | 23 | 100.0% |
 
 ---
@@ -1094,8 +1094,8 @@
 <a id="epic-017-portfolio-management"></a>
 
 - **Total ACs**: 73
-- **Mandatory ACs**: 29
-- **Mandatory ACs with test reference**: 29 (100.0%)
+- **Mandatory ACs**: 30
+- **Mandatory ACs with test reference**: 30 (100.0%)
 
 | AC ID | Mandatory | Description | Test References | Status |
 |-------|-----------|-------------|-----------------|--------|
@@ -1131,12 +1131,12 @@
 | AC17.3.12 | no |  | `apps/backend/tests/portfolio/test_performance_service.py` | ✅ (optional) |
 | AC17.3.13 | no |  | `apps/backend/tests/portfolio/test_performance_service.py` | ✅ (optional) |
 | AC17.3.14 | no |  | `apps/backend/tests/portfolio/test_performance_service.py` | ✅ (optional) |
-| AC17.4.1 | yes | Moomoo Statement Parsing | `apps/backend/tests/portfolio/test_allocation_service.py` | ✅ |
-| AC17.4.2 | yes | Futu Statement Parsing | `apps/backend/tests/portfolio/test_allocation_service.py` | ✅ |
-| AC17.4.3 | yes | Interactive Brokers Parsing | `apps/backend/tests/portfolio/test_allocation_service.py` | ✅ |
-| AC17.4.4 | yes | Broker Auto-Detection (Moomoo) | `apps/backend/tests/portfolio/test_allocation_service.py` | ✅ |
-| AC17.4.5 | yes | Broker Auto-Detection (Futu) | `apps/backend/tests/portfolio/test_allocation_service.py` | ✅ |
-| AC17.4.6 | no |  | `apps/backend/tests/portfolio/test_allocation_service.py` | ✅ (optional) |
+| AC17.4.1 | yes | Moomoo Statement Parsing | `apps/backend/tests/portfolio/test_allocation_service.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | ✅ |
+| AC17.4.2 | yes | Futu Statement Parsing | `apps/backend/tests/portfolio/test_allocation_service.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | ✅ |
+| AC17.4.3 | yes | Interactive Brokers Parsing | `apps/backend/tests/portfolio/test_allocation_service.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | ✅ |
+| AC17.4.4 | yes | Broker Auto-Detection (Moomoo) | `apps/backend/tests/portfolio/test_allocation_service.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | ✅ |
+| AC17.4.5 | yes | Broker Auto-Detection (Futu) | `apps/backend/tests/portfolio/test_allocation_service.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | ✅ |
+| AC17.4.6 | yes | Brokerage import endpoint creates AtomicPosition rows and reconciles ManagedPosition idempotently | `apps/backend/tests/portfolio/test_allocation_service.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | ✅ |
 | AC17.5.1 | yes | Buy Transaction → Journal Entry | `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ |
 | AC17.5.2 | yes | Sell Transaction → Journal Entry + Realized P&L | `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ |
 | AC17.5.3 | yes | Dividend → Journal Entry → Income Statement | `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -140,6 +140,23 @@ The system is currently migrating to a 4-layer architecture. During Phase 2, dat
 | GXS | PDF | Extended | Digital bank |
 | Futu (Futu Holdings) | PDF | Extended | HK brokerage |
 
+## Brokerage Position Import
+
+Brokerage extraction feeds Layer 2 `AtomicPosition` through `apps/backend/src/services/brokerage_positions.py`.
+
+Parsing priority:
+1. Prefer structured `positions`, `holdings`, or `securities` arrays from OCR/LLM output.
+2. For Moomoo, recover money-market fund snapshots from subscription rows when no holdings table is available.
+3. For Futu, preserve aggregate securities valuation as `FUTU_STOCK_AND_OPTIONS` when the statement only exposes a portfolio total.
+4. For Interactive Brokers, consume structured position rows from CSV/PDF extraction payloads.
+
+Import endpoint: `POST /portfolio/brokerage/import`
+
+Import behavior:
+- Creates immutable `AtomicPosition` rows with dedup hash `SHA256(user_id|snapshot_date|asset_identifier|broker)`.
+- Re-running the same payload is idempotent and does not create duplicate atomic rows.
+- Reconciliation runs after import to refresh `ManagedPosition` with latest quantity, market value, currency, and snapshot metadata.
+
 ## Configuration
 
 Required environment variables:


### PR DESCRIPTION
## Summary
- add brokerage position parser/import service for structured holdings, Moomoo fallback rows, Futu aggregate valuations, and IBKR structured payloads
- persist parsed holdings as immutable AtomicPosition rows with dedup hashes and reconcile ManagedPosition idempotently
- expose POST /portfolio/brokerage/import and update EPIC/SSOT traceability for AC17.4

## Verification
- PYTEST_ADDOPTS='--no-cov -n0' uv run pytest tests/portfolio/test_brokerage_position_parsing.py tests/assets/test_asset_service.py -q
- uv run ruff check src/services/brokerage_positions.py src/routers/portfolio.py src/schemas/portfolio.py src/services/assets.py tests/portfolio/test_brokerage_position_parsing.py
- git diff --check

Closes #391