### PR TITLE
feat: bridge brokerage statement parsing to positions

### DIFF
--- a/apps/backend/src/services/brokerage_positions.py
+++ b/apps/backend/src/services/brokerage_positions.py
@@ -143,6 +143,28 @@ def detect_broker(*, filename: str | None, institution: str | None, text: str | 
     return "Unknown Broker"
 
 
+def looks_like_brokerage_payload(
+    payload: dict[str, Any] | None,
+    *,
+    filename: str | None = None,
+    institution: str | None = None,
+) -> bool:
+    """Return whether parsed extraction output should enter the brokerage import path."""
+    if not isinstance(payload, dict):
+        return False
+
+    if any(key in payload for key in ("positions", "holdings", "securities")):
+        return True
+
+    statement = payload.get("statement") if isinstance(payload.get("statement"), dict) else {}
+    broker = detect_broker(
+        filename=filename or str(payload.get("file") or ""),
+        institution=institution or payload.get("institution") or statement.get("institution"),
+        text=str(payload),
+    )
+    return broker != "Unknown Broker"
+
+
 def _iter_structured_positions(payload: dict[str, Any]) -> list[dict[str, Any]]:
     for key in ("positions", "holdings", "securities"):
         value = payload.get(key)

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -15,8 +15,9 @@ import httpx
 
 from src.config import settings
 from src.logger import get_logger
-from src.models import BankStatement, BankStatementTransaction, ConfidenceLevel
+from src.models import BankStatement, BankStatementStatus, BankStatementTransaction, ConfidenceLevel
 from src.prompts import get_parsing_prompt
+from src.services.brokerage_positions import looks_like_brokerage_payload
 from src.services.deduplication import DeduplicationService, dual_write_layer2
 from src.services.openrouter_streaming import (
     OpenRouterStreamError,
@@ -70,6 +71,12 @@ class ExtractionService:
                 error_type=type(exc).__name__,
             )
             raise ValueError(f"Invalid date format: {value}") from exc
+
+    def _safe_optional_date(self, value: str | None) -> date | None:
+        """Safely parse an optional date from extraction output."""
+        if not value:
+            return None
+        return self._safe_date(value)
 
     def _safe_decimal(self, value: str | None, default: str | None = None, *, required: bool = False) -> Decimal | None:
         """Safely convert string to Decimal."""
@@ -333,6 +340,11 @@ class ExtractionService:
 
             detected_institution = extracted.get("institution")
             final_institution = institution or detected_institution or "Unknown"
+            is_brokerage_payload = looks_like_brokerage_payload(
+                extracted,
+                filename=original_filename or (file_path.name if file_path else None),
+                institution=final_institution,
+            )
 
             statement = BankStatement(
                 user_id=user_id,
@@ -343,16 +355,37 @@ class ExtractionService:
                 institution=final_institution,
                 account_last4=self._sanitize_account_last4(extracted.get("account_last4")),
                 currency=extracted.get("currency", "SGD"),
-                period_start=self._safe_date(extracted.get("period_start")),
-                period_end=self._safe_date(extracted.get("period_end")),
-                opening_balance=self._safe_decimal(extracted.get("opening_balance"), required=True),
-                closing_balance=self._safe_decimal(extracted.get("closing_balance"), required=True),
+                period_start=(
+                    self._safe_optional_date(extracted.get("period_start"))
+                    if is_brokerage_payload
+                    else self._safe_date(extracted.get("period_start"))
+                ),
+                period_end=(
+                    self._safe_optional_date(extracted.get("period_end"))
+                    if is_brokerage_payload
+                    else self._safe_date(extracted.get("period_end"))
+                ),
+                opening_balance=self._safe_decimal(
+                    extracted.get("opening_balance"),
+                    required=not is_brokerage_payload,
+                ),
+                closing_balance=self._safe_decimal(
+                    extracted.get("closing_balance"),
+                    required=not is_brokerage_payload,
+                ),
             )
+            statement._extracted_payload = extracted
 
             transactions = []
             net_transactions = Decimal("0.00")
             for txn in extracted.get("transactions", []):
                 if not txn.get("date") or txn.get("amount") is None:
+                    if is_brokerage_payload:
+                        logger.info(
+                            "Skipping non-bank transaction row in brokerage payload",
+                            filename=original_filename or (file_path.name if file_path else "unknown"),
+                        )
+                        continue
                     raise ExtractionError("Transaction missing required fields: date or amount")
 
                 # Handle case where the model returns date as non-string
@@ -374,11 +407,23 @@ class ExtractionService:
                 try:
                     parsed_date = date.fromisoformat(txn_date_val)
                 except ValueError as exc:
+                    if is_brokerage_payload:
+                        logger.info(
+                            "Skipping brokerage transaction row with non-bank date",
+                            filename=original_filename or (file_path.name if file_path else "unknown"),
+                        )
+                        continue
                     raise ExtractionError(f"Invalid transaction date format: {txn_date_val}") from exc
 
                 try:
                     amount = Decimal(str(txn["amount"]))
                 except (ValueError, TypeError, InvalidOperation) as exc:
+                    if is_brokerage_payload:
+                        logger.info(
+                            "Skipping brokerage transaction row with non-bank amount",
+                            filename=original_filename or (file_path.name if file_path else "unknown"),
+                        )
+                        continue
                     raise ExtractionError(f"Invalid transaction amount: {txn.get('amount')}") from exc
                 direction = txn.get("direction", "IN")
                 if direction == "IN":
@@ -417,7 +462,11 @@ class ExtractionService:
 
             # For confidence score, we use the original extracted dict to maintain logic
             confidence = compute_confidence_score(extracted, balance_result)
-            status = route_by_threshold(confidence, is_valid)
+            status = (
+                BankStatementStatus.PARSED
+                if is_brokerage_payload and is_valid
+                else route_by_threshold(confidence, is_valid)
+            )
 
             statement.balance_validated = is_valid
             statement.confidence_score = confidence

--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -2,7 +2,7 @@
 
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 import structlog
@@ -14,11 +14,76 @@ from src.config import settings
 from src.logger import get_logger
 from src.models import BankStatement, BankStatementStatus
 from src.services import ExtractionError, ExtractionService, StorageError, StorageService
+from src.services.brokerage_positions import BrokeragePositionImportService, looks_like_brokerage_payload
 
 if TYPE_CHECKING:
     pass
 
 logger = get_logger(__name__)
+_brokerage_import_service = BrokeragePositionImportService()
+
+
+def _append_validation_note(existing: str | None, note: str) -> str:
+    if existing:
+        combined = f"{existing}; {note}"
+    else:
+        combined = note
+    return combined[:500]
+
+
+async def import_brokerage_payload_if_present(
+    *,
+    statement: BankStatement,
+    db: AsyncSession,
+    user_id: UUID,
+    filename: str,
+    institution: str | None,
+    payload: dict[str, Any] | None,
+) -> None:
+    """Import parsed brokerage positions after statement parsing succeeds."""
+    if not looks_like_brokerage_payload(payload, filename=filename, institution=institution or statement.institution):
+        return
+
+    try:
+        result = await _brokerage_import_service.import_positions(
+            db,
+            user_id=user_id,
+            payload=payload or {},
+            filename=filename,
+            source_document_id=str(statement.id),
+        )
+        if result.parsed_positions == 0:
+            statement.validation_error = _append_validation_note(
+                statement.validation_error,
+                "Brokerage import skipped: no positions detected in parsed brokerage payload",
+            )
+        await db.commit()
+        logger.info(
+            "Brokerage positions imported from parsed statement",
+            statement_id=str(statement.id),
+            broker=result.broker,
+            parsed_positions=result.parsed_positions,
+            created_atomic_positions=result.created_atomic_positions,
+            existing_atomic_positions=result.existing_atomic_positions,
+            reconcile_created=result.reconcile_created,
+            reconcile_updated=result.reconcile_updated,
+            reconcile_disposed=result.reconcile_disposed,
+        )
+    except Exception as exc:
+        logger.exception(
+            "Brokerage import failed after statement parsing",
+            statement_id=str(statement.id),
+            error_type=type(exc).__name__,
+        )
+        await db.rollback()
+        refreshed = await db.get(BankStatement, statement.id)
+        if refreshed is None:
+            return
+        refreshed.validation_error = _append_validation_note(
+            refreshed.validation_error,
+            "Brokerage import failed: parsed statement was saved but positions were not imported",
+        )
+        await db.commit()
 
 
 async def handle_parse_failure(
@@ -212,6 +277,14 @@ async def parse_statement_background(
             statement.status = parsed_statement.status
 
             await update_progress(100)
+            await import_brokerage_payload_if_present(
+                statement=statement,
+                db=session,
+                user_id=user_id,
+                filename=filename,
+                institution=institution,
+                payload=getattr(parsed_statement, "_extracted_payload", None),
+            )
             duration = time.perf_counter() - start_time
             logger.info(
                 "Background parsing completed",

--- a/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
+++ b/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
@@ -1,0 +1,322 @@
+"""Tests for the statement upload to brokerage position import bridge."""
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from src.database import create_session_maker_from_db
+from src.models import BankStatement, BankStatementStatus, BankStatementTransaction
+from src.models.layer2 import AtomicPosition
+from src.models.layer3 import ManagedPosition
+from src.services.brokerage_positions import looks_like_brokerage_payload, parse_brokerage_positions
+from src.services.extraction import ExtractionService
+from src.services.statement_parsing import import_brokerage_payload_if_present, parse_statement_background
+
+
+def _parsed_statement(user_id, file_hash: str) -> BankStatement:
+    return BankStatement(
+        user_id=user_id,
+        file_path="moomoo-positions.pdf",
+        file_hash=file_hash,
+        original_filename="moomoo-positions.pdf",
+        institution="Moomoo",
+        account_last4="1234",
+        currency="USD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 18),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("0.00"),
+        status=BankStatementStatus.PARSED,
+        confidence_score=90,
+        balance_validated=True,
+    )
+
+
+def _brokerage_payload() -> dict:
+    return {
+        "institution": "Moomoo",
+        "period_start": "2026-05-01",
+        "period_end": "2026-05-18",
+        "statement": {"period_end": "2026-05-18", "currency": "USD"},
+        "positions": [
+            {
+                "symbol": "AAPL",
+                "snapshot_date": date(2026, 5, 18),
+                "quantity": "10",
+                "market_value": "1900.25",
+                "currency": "USD",
+                "asset_type": "stock",
+                "sector": "Technology",
+                "geography": "US",
+            }
+        ],
+    }
+
+
+def test_looks_like_brokerage_payload_detection_paths():
+    """AC17.4.7: Brokerage detection handles structured, nested, and non-broker payloads."""
+    assert looks_like_brokerage_payload({"positions": []}, filename="unknown.pdf")
+    assert looks_like_brokerage_payload(
+        {"statement": {"holdings": []}},
+        filename="statement.pdf",
+        institution="Interactive Brokers",
+    )
+    assert not looks_like_brokerage_payload(
+        {"institution": "DBS", "transactions": []},
+        filename="dbs-statement.pdf",
+        institution="DBS",
+    )
+
+
+def test_parse_brokerage_positions_skips_malformed_moomoo_subscription_row():
+    """AC17.4.7: Malformed brokerage rows are ignored instead of imported as positions."""
+    snapshots = parse_brokerage_positions(
+        {
+            "institution": "Moomoo",
+            "transactions": [
+                {
+                    "raw_text": "Subscription X FULLERTON SGD CASH FUND SGD 2026/05/18 X . . .",
+                },
+            ],
+        },
+        filename="moomoo-statement.pdf",
+    )
+
+    assert snapshots == []
+
+
+@pytest.mark.asyncio
+async def test_parse_document_preserves_brokerage_payload_for_background_import(test_user):
+    """AC17.4.7: Extraction keeps structured brokerage payloads available for import."""
+    service = ExtractionService()
+    payload = _brokerage_payload()
+    service.extract_financial_data = AsyncMock(return_value=payload)
+
+    statement, transactions = await service.parse_document(
+        file_path=Path("moomoo-positions.pdf"),
+        institution="Moomoo",
+        user_id=test_user.id,
+        file_content=b"%PDF-1.7",
+        file_hash="brokerage-payload-hash",
+        original_filename="moomoo-positions.pdf",
+    )
+
+    assert transactions == []
+    assert statement.status == BankStatementStatus.PARSED
+    assert statement.period_start == date(2026, 5, 1)
+    assert statement.period_end == date(2026, 5, 18)
+    assert statement.opening_balance is None
+    assert statement.closing_balance is None
+    assert statement._extracted_payload == payload
+
+
+@pytest.mark.asyncio
+async def test_parse_document_skips_non_bank_rows_in_brokerage_payload(test_user):
+    """AC17.4.7: Brokerage transaction-like rows do not block position import handoff."""
+    service = ExtractionService()
+    payload = {
+        "institution": "Moomoo",
+        "transactions": [
+            {"raw_text": "FULLERTON SGD CASH FUND 100 units market value 100.00"},
+            {"date": "not-a-date", "amount": "10.00", "description": "not bank txn"},
+            {"date": "2026-05-18", "amount": "not-a-number", "description": "not bank amount"},
+        ],
+    }
+    service.extract_financial_data = AsyncMock(return_value=payload)
+
+    statement, transactions = await service.parse_document(
+        file_path=Path("moomoo-statement.pdf"),
+        institution="Moomoo",
+        user_id=test_user.id,
+        file_content=b"%PDF-1.7",
+        file_hash="brokerage-raw-rows-hash",
+        original_filename="moomoo-statement.pdf",
+    )
+
+    assert transactions == []
+    assert statement.status == BankStatementStatus.PARSED
+    assert statement._extracted_payload == payload
+
+
+@pytest.mark.asyncio
+async def test_import_brokerage_payload_if_present_ignores_bank_payload(db, test_user, monkeypatch):
+    """AC17.4.7: Bank statement payloads do not call brokerage import."""
+    statement = _parsed_statement(test_user.id, "bank-hash")
+
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("brokerage import should not be called for bank payloads")
+
+    monkeypatch.setattr("src.services.statement_parsing._brokerage_import_service.import_positions", fail_if_called)
+
+    await import_brokerage_payload_if_present(
+        statement=statement,
+        db=db,
+        user_id=test_user.id,
+        filename="dbs.pdf",
+        institution="DBS",
+        payload={"institution": "DBS", "transactions": []},
+    )
+
+    assert statement.validation_error is None
+
+
+@pytest.mark.asyncio
+async def test_import_brokerage_payload_if_present_records_zero_position_payload(db, test_user):
+    """AC17.4.7: Recognized brokerage payloads with no positions remain visible."""
+    statement_id = uuid4()
+    statement = BankStatement(
+        id=statement_id,
+        user_id=test_user.id,
+        status=BankStatementStatus.PARSED,
+        file_path="statements/futu-empty.pdf",
+        file_hash="futu-empty-hash",
+        original_filename="futu-empty.pdf",
+        institution="Futu",
+    )
+    db.add(statement)
+    await db.commit()
+
+    await import_brokerage_payload_if_present(
+        statement=statement,
+        db=db,
+        user_id=test_user.id,
+        filename="futu-empty.pdf",
+        institution="Futu",
+        payload={"institution": "Futu", "positions": []},
+    )
+
+    db.expire_all()
+    refreshed = await db.get(BankStatement, statement_id)
+
+    assert refreshed is not None
+    assert refreshed.validation_error is not None
+    assert "no positions detected" in refreshed.validation_error
+
+
+@pytest.mark.asyncio
+async def test_parse_statement_background_imports_brokerage_positions(db, test_user, monkeypatch):
+    """AC17.4.7: Parsed brokerage uploads import positions without a manual API call."""
+    statement_id = uuid4()
+    user_id = test_user.id
+    file_hash = "brokerage-success-hash"
+    statement = BankStatement(
+        id=statement_id,
+        user_id=user_id,
+        status=BankStatementStatus.PARSING,
+        file_path="statements/moomoo.pdf",
+        file_hash=file_hash,
+        original_filename="moomoo-positions.pdf",
+        institution="Moomoo",
+    )
+    statement.transactions = [
+        BankStatementTransaction(
+            txn_date=date(2026, 5, 17),
+            description="stale transaction",
+            amount=Decimal("1.00"),
+            direction="IN",
+        )
+    ]
+    db.add(statement)
+    await db.commit()
+
+    async def fake_parse_document(*args, **kwargs):
+        parsed = _parsed_statement(user_id, file_hash)
+        parsed._extracted_payload = _brokerage_payload()
+        return parsed, []
+
+    monkeypatch.setattr("src.services.statement_parsing.ExtractionService.parse_document", fake_parse_document)
+    monkeypatch.setattr(
+        "src.services.statement_parsing.StorageService.generate_presigned_url",
+        lambda *args, **kwargs: "https://example.com/moomoo-positions.pdf",
+    )
+
+    await parse_statement_background(
+        statement_id=statement_id,
+        filename="moomoo-positions.pdf",
+        institution="Moomoo",
+        user_id=user_id,
+        account_id=None,
+        file_hash=file_hash,
+        storage_key="statements/moomoo.pdf",
+        content=b"%PDF-1.7",
+        model=None,
+        session_maker=create_session_maker_from_db(db),
+    )
+
+    db.expire_all()
+    atomic_rows = (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == user_id))).scalars().all()
+    managed_rows = (await db.execute(select(ManagedPosition).where(ManagedPosition.user_id == user_id))).scalars().all()
+    refreshed = await db.get(BankStatement, statement_id)
+
+    assert refreshed is not None
+    assert refreshed.status == BankStatementStatus.PARSED
+    assert refreshed.validation_error is None
+    assert len(atomic_rows) == 1
+    assert atomic_rows[0].asset_identifier == "AAPL"
+    assert atomic_rows[0].source_documents["documents"][0]["doc_id"] == str(statement_id)
+    assert len(managed_rows) == 1
+    assert managed_rows[0].asset_identifier == "AAPL"
+    assert managed_rows[0].quantity == Decimal("10")
+
+
+@pytest.mark.asyncio
+async def test_parse_statement_background_persists_brokerage_import_failure(db, test_user, monkeypatch):
+    """AC17.4.7: Brokerage import failures are visible on the parsed statement."""
+    statement_id = uuid4()
+    user_id = test_user.id
+    file_hash = "brokerage-failure-hash"
+    statement = BankStatement(
+        id=statement_id,
+        user_id=user_id,
+        status=BankStatementStatus.PARSING,
+        file_path="statements/moomoo-fail.pdf",
+        file_hash=file_hash,
+        original_filename="moomoo-fail.pdf",
+        institution="Moomoo",
+    )
+    db.add(statement)
+    await db.commit()
+
+    async def fake_parse_document(*args, **kwargs):
+        parsed = _parsed_statement(user_id, file_hash)
+        parsed._extracted_payload = _brokerage_payload()
+        parsed.validation_error = "existing parser note"
+        return parsed, []
+
+    async def fail_import(*args, **kwargs):
+        raise RuntimeError("forced import failure")
+
+    monkeypatch.setattr("src.services.statement_parsing.ExtractionService.parse_document", fake_parse_document)
+    monkeypatch.setattr(
+        "src.services.statement_parsing.StorageService.generate_presigned_url",
+        lambda *args, **kwargs: "https://example.com/moomoo-fail.pdf",
+    )
+    monkeypatch.setattr("src.services.statement_parsing._brokerage_import_service.import_positions", fail_import)
+
+    await parse_statement_background(
+        statement_id=statement_id,
+        filename="moomoo-fail.pdf",
+        institution="Moomoo",
+        user_id=user_id,
+        account_id=None,
+        file_hash=file_hash,
+        storage_key="statements/moomoo-fail.pdf",
+        content=b"%PDF-1.7",
+        model=None,
+        session_maker=create_session_maker_from_db(db),
+    )
+
+    db.expire_all()
+    refreshed = await db.get(BankStatement, statement_id)
+
+    assert refreshed is not None
+    assert refreshed.status == BankStatementStatus.PARSED
+    assert refreshed.validation_error is not None
+    assert refreshed.validation_error.startswith("existing parser note; ")
+    assert "Brokerage import failed" in refreshed.validation_error
+    assert "forced import failure" not in refreshed.validation_error

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2665,6 +2665,11 @@ acs:
     epic_name: portfolio-management
     description: 'Broker Auto-Detection (Futu)'
     mandatory: true
+  - id: AC17.4.7
+    epic: 17
+    epic_name: portfolio-management
+    description: 'Statement upload background parsing imports detected brokerage positions into AtomicPosition and reconciles ManagedPosition without a manual API call'
+    mandatory: true
   - id: AC17.5.1
     epic: 17
     epic_name: portfolio-management

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -271,6 +271,7 @@ Build a **100% self-developed** investment portfolio management system with comp
 | AC17.4.4 | Broker Auto-Detection (Moomoo) | `test_detect_broker_moomoo_futu_and_interactive_brokers` | `portfolio/test_brokerage_position_parsing.py` | P1 |
 | AC17.4.5 | Broker Auto-Detection (Futu) | `test_detect_broker_moomoo_futu_and_interactive_brokers` | `portfolio/test_brokerage_position_parsing.py` | P1 |
 | AC17.4.6 | Brokerage Import Endpoint | `test_brokerage_import_endpoint` | `portfolio/test_brokerage_position_parsing.py` | P1 |
+| AC17.4.7 | Upload Parse-to-Import Bridge | `test_parse_statement_background_imports_brokerage_positions` | `extraction/test_statement_brokerage_import_bridge.py` | P0 |
 
 ### AC17.5: Investment Accounting (Journal Entries)
 

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -13,12 +13,12 @@
 | Metric | Count | Percentage |
 |--------|-------|------------|
 | **Total EPICs** | 18 | 100% |
-| **Total ACs (registries)** | 930 | 100% |
-| **Mandatory ACs** | 770 | 82.8% |
+| **Total ACs (registries)** | 931 | 100% |
+| **Mandatory ACs** | 771 | 82.8% |
 | **Deprecated ACs** | 3 | 0.3% |
-| **Mandatory ACs with test reference** | 770 | 100.0% |
+| **Mandatory ACs with test reference** | 771 | 100.0% |
 | **Mandatory ACs without test reference** | 0 | 0.0% |
-| **Test files referenced** | 181 | - |
+| **Test files referenced** | 182 | - |
 | **ACs flagged as manual verification (heuristic)** | 0 | 0.0% |
 
 ### Coverage by EPIC
@@ -41,7 +41,7 @@
 | [EPIC-014](#epic-014-ttd-transformation) | ttd-transformation | 6 | 0 | 6 | 6 | 100.0% |
 | [EPIC-015](#epic-015-processing-account) | processing-account | 28 | 0 | 28 | 28 | 100.0% |
 | [EPIC-016](#epic-016-two-stage-review-ui) | two-stage-review-ui | 213 | 0 | 189 | 189 | 100.0% |
-| [EPIC-017](#epic-017-portfolio-management) | portfolio-management | 73 | 0 | 30 | 30 | 100.0% |
+| [EPIC-017](#epic-017-portfolio-management) | portfolio-management | 74 | 0 | 31 | 31 | 100.0% |
 | [EPIC-018](#epic-018-ai-driven-pipeline) | ai-driven-pipeline | 23 | 0 | 23 | 23 | 100.0% |
 
 ---
@@ -1093,9 +1093,9 @@
 
 <a id="epic-017-portfolio-management"></a>
 
-- **Total ACs**: 73
-- **Mandatory ACs**: 30
-- **Mandatory ACs with test reference**: 30 (100.0%)
+- **Total ACs**: 74
+- **Mandatory ACs**: 31
+- **Mandatory ACs with test reference**: 31 (100.0%)
 
 | AC ID | Mandatory | Description | Test References | Status |
 |-------|-----------|-------------|-----------------|--------|
@@ -1137,6 +1137,7 @@
 | AC17.4.4 | yes | Broker Auto-Detection (Moomoo) | `apps/backend/tests/portfolio/test_allocation_service.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | ✅ |
 | AC17.4.5 | yes | Broker Auto-Detection (Futu) | `apps/backend/tests/portfolio/test_allocation_service.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | ✅ |
 | AC17.4.6 | yes | Brokerage import endpoint creates AtomicPosition rows and reconciles ManagedPosition idempotently | `apps/backend/tests/portfolio/test_allocation_service.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | ✅ |
+| AC17.4.7 | yes | Statement upload background parsing imports detected brokerage positions into AtomicPosition and reconciles ManagedPosition without a manual API call | `apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py` | ✅ |
 | AC17.5.1 | yes | Buy Transaction → Journal Entry | `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ |
 | AC17.5.2 | yes | Sell Transaction → Journal Entry + Realized P&L | `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ |
 | AC17.5.3 | yes | Dividend → Journal Entry → Income Statement | `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -150,12 +150,15 @@ Parsing priority:
 3. For Futu, preserve aggregate securities valuation as `FUTU_STOCK_AND_OPTIONS` when the statement only exposes a portfolio total.
 4. For Interactive Brokers, consume structured position rows from CSV/PDF extraction payloads.
 
-Import endpoint: `POST /portfolio/brokerage/import`
+Import entry points:
+- Automatic: successful statement background parsing inspects the structured extraction payload. If it contains brokerage `positions`, `holdings`, or `securities`, or if broker detection recognizes the filename/institution/content, the parser calls `BrokeragePositionImportService` with the current statement ID as `source_document_id`.
+- Manual/API: `POST /portfolio/brokerage/import` remains available for parsed payload backfills and tests.
 
 Import behavior:
 - Creates immutable `AtomicPosition` rows with dedup hash `SHA256(user_id|snapshot_date|asset_identifier|broker)`.
 - Re-running the same payload is idempotent and does not create duplicate atomic rows.
 - Reconciliation runs after import to refresh `ManagedPosition` with latest quantity, market value, currency, and snapshot metadata.
+- Import failures do not discard the parsed statement; the statement remains visible and receives a sanitized `validation_error` noting that brokerage positions were not imported.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Bridge parsed brokerage statement payloads from the upload background parser into AtomicPosition import and ManagedPosition reconciliation.

Fixes #403

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-017 — Investment Portfolio Management |
| **AC IDs** | AC17.4.7 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/extraction.md` — documents automatic brokerage parse-to-import behavior and sanitized import failure visibility.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `765db43` | Added AC17.4.7 tests for statement-background brokerage import, stale transaction replacement, malformed brokerage rows, and failure persistence before implementation in the local worktree. |
| 🟢 Green (passing test) | `765db43` | Implemented brokerage payload detection, extraction payload handoff, automatic import, sanitized validation errors, and regenerated AC traceability. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter; no new enums/migrations added.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable; no frontend/env changes).
- [x] `repo/` submodule updated for production config changes (not applicable; no production config changes).
- [x] `scripts/check_env_keys.py` passes (not applicable; no env vars changed).
- [x] `scripts/check_manifest.py` passes (not run; no manifest changes).
- [x] `scripts/lint_doc_consistency.py` passes (not run; scoped SSOT/project docs only).

---

## Testing

```bash
cd apps/backend && uv run pytest tests/extraction/test_statement_brokerage_import_bridge.py -q --no-cov
cd apps/backend && uv run pytest tests/extraction/test_statement_brokerage_import_bridge.py tests/portfolio/test_brokerage_position_parsing.py tests/extraction/test_extraction_flow.py -q --no-cov
python scripts/cli.py lint --backend
uv run --with pyyaml python scripts/build_ac_traceability.py --check
```

Result:
- New bridge tests: 8 passed.
- Targeted regression suite: 41 passed.
- Backend lint: passed.
- AC traceability check: passed.

Full fast backend suite was attempted with `python scripts/cli.py test --fast`, but local Podman infra failed before tests started with `proxy already running`. The created test containers for this namespace were removed afterward.

---

## Screenshots / Evidence

N/A — backend pipeline change.
