### PR TITLE
test(e2e): cover brokerage upload to portfolio value

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -147,6 +147,7 @@ jobs:
           echo "--- Phase 3: AI/OCR Gate (single process, primary=${STAGING_E2E_PRIMARY_MODEL}, ocr=${STAGING_E2E_OCR_MODEL}, vision=${STAGING_E2E_VISION_MODEL}) ---"
           pytest \
             tests/e2e/test_statement_full_journey.py \
+            tests/e2e/test_brokerage_upload_to_portfolio_value.py \
             tests/e2e/test_statement_upload_e2e.py \
             -v -m "llm"
           

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -37,6 +37,7 @@ from src.schemas import (
     RetryParsingRequest,
     StatementDecisionRequest,
 )
+from src.schemas.portfolio import BrokerageImportResponse
 from src.schemas.review import (
     BalanceValidationResult,
     EditAndApproveRequest,
@@ -45,6 +46,7 @@ from src.schemas.review import (
     StatementReviewResponse,
 )
 from src.services import StorageError, StorageService
+from src.services.brokerage_positions import BrokeragePositionImportService
 from src.services.openrouter_models import ModelCatalogError, get_model_info, model_matches_modality
 from src.services.review_queue import create_entry_from_txn, get_or_create_account
 from src.services.statement_parsing import parse_statement_background
@@ -70,6 +72,7 @@ logger = get_logger(__name__)
 
 # Track background parsing tasks to avoid garbage collection
 _PENDING_PARSE_TASKS: set[asyncio.Task[None]] = set()
+_BROKERAGE_IMPORT_SERVICE = BrokeragePositionImportService()
 
 
 def _track_task(task: asyncio.Task[None]) -> None:
@@ -464,6 +467,66 @@ async def list_statement_transactions(
 
     items = [BankStatementTransactionResponse.model_validate(t) for t in statement.transactions]
     return BankStatementTransactionListResponse(items=items, total=len(items))
+
+
+def _brokerage_payload_from_statement(statement: BankStatement) -> dict:
+    """Build an import payload from a parsed brokerage statement."""
+    events = []
+    for txn in statement.transactions:
+        signed_amount = txn.amount if txn.direction == "IN" else -txn.amount
+        events.append(
+            {
+                "date": txn.txn_date.isoformat(),
+                "description": txn.description,
+                "amount": str(signed_amount),
+                "currency": txn.currency or statement.currency,
+                "raw_text": txn.raw_text or txn.description,
+                "balance_after": str(txn.balance_after) if txn.balance_after is not None else None,
+            }
+        )
+
+    return {
+        "institution": statement.institution,
+        "statement": {
+            "institution": statement.institution,
+            "period_end": statement.period_end.isoformat() if statement.period_end else None,
+            "currency": statement.currency,
+        },
+        "transactions": events,
+        "events": events,
+    }
+
+
+@router.post("/{statement_id}/brokerage/import", response_model=BrokerageImportResponse)
+async def import_brokerage_statement_positions(
+    statement_id: UUID,
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> BrokerageImportResponse:
+    """Import portfolio positions from an already parsed brokerage statement."""
+    result = await db.execute(
+        select(BankStatement)
+        .where(BankStatement.id == statement_id)
+        .where(BankStatement.user_id == user_id)
+        .options(selectinload(BankStatement.transactions))
+    )
+    statement = result.scalar_one_or_none()
+
+    if not statement:
+        raise_not_found("Statement")
+    if statement.status not in (BankStatementStatus.PARSED, BankStatementStatus.APPROVED):
+        raise_bad_request("Statement must be parsed before importing brokerage positions")
+
+    payload = _brokerage_payload_from_statement(statement)
+    import_result = await _BROKERAGE_IMPORT_SERVICE.import_positions(
+        db,
+        user_id=user_id,
+        payload=payload,
+        filename=statement.original_filename,
+        source_document_id=str(statement.id),
+    )
+    await db.commit()
+    return BrokerageImportResponse(**import_result.__dict__)
 
 
 @router.post("/{statement_id}/approve", response_model=BankStatementResponse, deprecated=True)

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from src.models import BankStatement, BankStatementStatus, BankStatementTransaction, ConfidenceLevel
 from src.models.layer2 import AssetType, AtomicPosition
 from src.models.layer3 import ManagedPosition
+from src.routers.statements import _brokerage_payload_from_statement
 from src.schemas.portfolio import BrokerageImportRequest, BrokerageImportResponse
 from src.services.brokerage_positions import (
     BrokeragePositionImportService,
@@ -432,3 +433,55 @@ async def test_statement_scoped_brokerage_import_requires_parsed_status(client, 
 
     assert response.status_code == 400
     assert "must be parsed" in response.text
+
+
+@pytest.mark.asyncio
+async def test_statement_scoped_brokerage_import_returns_404_for_missing_statement(client):
+    """AC8.13.10/Issue #404: Statement-scoped brokerage import is user-scoped."""
+    response = await client.post(f"/statements/{uuid4()}/brokerage/import")
+
+    assert response.status_code == 404
+
+
+def test_brokerage_payload_from_statement_preserves_outflows_and_empty_metadata():
+    """AC8.13.10/Issue #404: Statement payload keeps signed cash events deterministic."""
+    statement = BankStatement(
+        id=uuid4(),
+        user_id=uuid4(),
+        file_path="statements/futu/test.pdf",
+        file_hash="issue-404-futu-outflow",
+        original_filename="futu-2506.pdf",
+        institution="Futu",
+        currency="SGD",
+        status=BankStatementStatus.APPROVED,
+        transactions=[
+            BankStatementTransaction(
+                txn_date=date(2026, 5, 18),
+                description="Platform fee",
+                amount=Decimal("4.23"),
+                direction="OUT",
+                reference=None,
+                currency=None,
+                balance_after=None,
+                confidence=ConfidenceLevel.HIGH,
+                raw_text=None,
+            )
+        ],
+    )
+
+    payload = _brokerage_payload_from_statement(statement)
+
+    assert payload["institution"] == "Futu"
+    assert payload["statement"]["period_end"] is None
+    assert payload["statement"]["currency"] == "SGD"
+    assert payload["transactions"] == payload["events"]
+    assert payload["transactions"] == [
+        {
+            "date": "2026-05-18",
+            "description": "Platform fee",
+            "amount": "-4.23",
+            "currency": "SGD",
+            "raw_text": "Platform fee",
+            "balance_after": None,
+        }
+    ]

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -1,12 +1,15 @@
 """Tests for brokerage position parsing into AtomicPosition."""
 
 import json
+from datetime import date
 from decimal import Decimal
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import select
 
+from src.models import BankStatement, BankStatementStatus, BankStatementTransaction, ConfidenceLevel
 from src.models.layer2 import AssetType, AtomicPosition
 from src.models.layer3 import ManagedPosition
 from src.schemas.portfolio import BrokerageImportRequest, BrokerageImportResponse
@@ -354,3 +357,78 @@ async def test_brokerage_import_endpoint(client, db):
     assert data["parsed_positions"] == 1
     assert data["created_atomic_positions"] == 1
     assert data["reconcile_created"] == 1
+
+
+@pytest.mark.asyncio
+async def test_statement_scoped_brokerage_import_uses_parsed_transactions(client, db, test_user):
+    """AC8.13.10/Issue #404: Parsed brokerage statements can import portfolio positions."""
+    statement = BankStatement(
+        id=uuid4(),
+        user_id=test_user.id,
+        file_path="statements/moomoo/test.pdf",
+        file_hash="issue-404-moomoo",
+        original_filename="moomoo-2504.pdf",
+        institution="Moomoo",
+        account_last4="1582",
+        currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 31),
+        opening_balance=Decimal("1000.00"),
+        closing_balance=Decimal("2250.50"),
+        status=BankStatementStatus.PARSED,
+        confidence_score=95,
+        balance_validated=True,
+        transactions=[
+            BankStatementTransaction(
+                txn_date=date(2026, 5, 18),
+                description="Fullerton SGD Money Market Fund",
+                amount=Decimal("1250.50"),
+                direction="IN",
+                reference=None,
+                currency="SGD",
+                balance_after=Decimal("2250.50"),
+                confidence=ConfidenceLevel.HIGH,
+                raw_text="Subscription 0001 Fullerton SGD Money Market Fund SGD 2026/05/18 settled 1.0000 1250.50 1250.50",
+            )
+        ],
+    )
+    statement_id = statement.id
+    db.add(statement)
+    await db.commit()
+
+    response = await client.post(f"/statements/{statement_id}/brokerage/import")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["broker"] == "Moomoo"
+    assert data["parsed_positions"] == 1
+    assert data["created_atomic_positions"] == 1
+    assert data["reconcile_created"] == 1
+
+    positions = (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == test_user.id))).scalars().all()
+    assert len(positions) == 1
+    assert positions[0].asset_identifier == "Fullerton SGD Money Market Fund"
+    assert positions[0].market_value == Decimal("1250.50")
+
+
+@pytest.mark.asyncio
+async def test_statement_scoped_brokerage_import_requires_parsed_status(client, db, test_user):
+    """AC8.13.10/Issue #404: Position import cannot run before OCR parsing completes."""
+    statement = BankStatement(
+        id=uuid4(),
+        user_id=test_user.id,
+        file_path="statements/moomoo/pending.pdf",
+        file_hash="issue-404-pending",
+        original_filename="moomoo-pending.pdf",
+        institution="Moomoo",
+        currency="SGD",
+        status=BankStatementStatus.PARSING,
+    )
+    statement_id = statement.id
+    db.add(statement)
+    await db.commit()
+
+    response = await client.post(f"/statements/{statement_id}/brokerage/import")
+
+    assert response.status_code == 400
+    assert "must be parsed" in response.text

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1245,6 +1245,11 @@ acs:
     epic_name: testing-strategy
     description: 'Production release runs prod-safe read-only E2E smoke'
     mandatory: true
+  - id: AC8.13.10
+    epic: 8
+    epic_name: testing-strategy
+    description: 'Multi-brokerage PDF upload -> position import -> latest portfolio value'
+    mandatory: true
   # EPIC-011: asset-lifecycle
   - id: AC11.1.1
     epic: 11

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -321,11 +321,12 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.7 | Strict full statement journey fails on rejected AI/OCR parsing | `test_dbs_statement_full_journey` | `tests/e2e/test_statement_full_journey.py` | P0 |
 | AC8.13.8 | Strict upload readiness E2E does not accept rejected statements | `test_statement_upload_full_flow` | `tests/e2e/test_statement_upload_e2e.py` | P0 |
 | AC8.13.9 | Production release runs prod-safe read-only E2E smoke | `test_production_*` | `tests/e2e/test_production_readonly_smoke.py` | P0 |
+| AC8.13.10 | Multi-brokerage PDF upload → position import → latest portfolio value | `test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value` | `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | P0 |
 
 **Traceability Result**:
 - Total AC IDs: 59
 - Requirements converted to AC IDs: 100% (EPIC-008 scenario checklist + CI/CD integration)
-- **ACs with passing Tier 1 tests: 50/59 (84.7%); 5 additional covered by Tier 3 E2E (AC8.13)**
+- **ACs with passing Tier 1 tests: 50/59 (84.7%); 6 additional covered by Tier 3 E2E (AC8.13)**
 - ACs covered by AC group:
   - AC8.1: 4/4 (100% — health check, backend reachable, frontend proxy, DB connectivity)
   - AC8.2: 5/5 (100% — register, create cash, create bank, update, delete)
@@ -338,10 +339,10 @@ These scenarios represent the "Vertical Slices" of user value.
   - AC8.9: 4/4 (100% — CI/CD integration verified via file-system assertion tests)
   - AC8.10: 9/9 (100% — all must-have scenarios with dedicated traceability tests)
   - AC8.11: 5/5 (100% — income, credit card spend/repayment, internal transfer, split transaction)
-  - AC8.13: 9/9 (Tier 3 E2E — DBS PDF upload, parse polling, transaction detail, approve, balance sheet report, hard-gate skip enforcement, production-safe smoke)
-- Test files: 1 fully implemented (`tests/e2e/test_core_journeys.py` — 46 tests), 1 existing (`tests/e2e/test_statement_upload_e2e.py`), 1 new Tier 3 (`tests/e2e/test_statement_full_journey.py`), 3 Playwright (skip without `APP_URL` or `FRONTEND_URL`)
+  - AC8.13: 10/10 (Tier 3 E2E — DBS PDF upload, parse polling, transaction detail, approve, balance sheet report, multi-brokerage portfolio value, hard-gate skip enforcement, production-safe smoke)
+- Test files: 1 fully implemented (`tests/e2e/test_core_journeys.py` — 46 tests), 1 existing (`tests/e2e/test_statement_upload_e2e.py`), 2 Tier 3 hard gates (`tests/e2e/test_statement_full_journey.py`, `tests/e2e/test_brokerage_upload_to_portfolio_value.py`), 3 Playwright (skip without `APP_URL` or `FRONTEND_URL`)
 - **Previous state**: 44.9% with 22 Tier 1 tests
-- **Current state**: 50/54 Tier 1 ACs (92.6%) + AC8.13 9/9 Tier 3/deploy-gate ACs (total 63 ACs: 54 Tier 1 + 9 Tier 3/deploy-gate)
+- **Current state**: 50/54 Tier 1 ACs (92.6%) + AC8.13 10/10 Tier 3/deploy-gate ACs (total 64 ACs: 54 Tier 1 + 10 Tier 3/deploy-gate)
 
 ---
 
@@ -354,6 +355,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | `tests/e2e/test_core_journeys.py` | API E2E | Tier 1 | 41 | Health, accounts CRUD, journal entries, reports, reconciliation, auth, statement upload/flow, CI/CD integration, traceability |
 | `tests/e2e/test_statement_upload_e2e.py` | Playwright | Tier 3 | 2 | Statement upload + model selection (skips without `FRONTEND_URL`) |
 | `tests/e2e/test_statement_full_journey.py` | Playwright | Tier 3 | 1 | Full journey: DBS PDF upload → parse polling → detail/transactions → approve → balance sheet (AC8.13.1–5) |
+| `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | API E2E | Tier 3 | 1 | Issue #404 hard gate: Moomoo + Futu PDF upload → real OCR parsing → brokerage import → holdings + balance sheet value (AC8.13.10) |
 | `tests/e2e/test_production_readonly_smoke.py` | Playwright/API | Tier 3 | 3 | Production-safe read-only smoke: health, auth boundary, browser shell, optional credential-gated dashboard |
 | `tests/e2e/test_e2e_flows.py` | Playwright | Tier 3 | 3 | Navigation, registration, reports view (skips without `FRONTEND_URL`) |
 | `tests/e2e/test_auth_flows.py` | Playwright | Tier 3 | 2 | Authentication flows (skips without `FRONTEND_URL`) |
@@ -441,7 +443,13 @@ These scenarios represent the "Vertical Slices" of user value.
    - **Hard-gate rule**: When `STRICT_E2E_GATES=true`, critical E2E skips are converted to failures; `status=rejected` fails instead of skips. Post-merge staging is the deploy-blocking AI/OCR gate.
    - **Provider budget rule**: Tests marked `llm` run serially in the post-merge staging job, not under the `-n 4` parallel phase. PR preview E2E excludes `llm` tests and does not inject `ZAI_API_KEY`, so automated GLM/OCR provider calls are centralized in the staging gate. Staging pins `PRIMARY_MODEL=glm-5.1`, `OCR_MODEL=glm-4.6v`, and `VISION_MODEL=glm-4.6v` for the AI/OCR gate.
 
-3. **Production Read-only E2E Smoke** (`test_production_readonly_smoke.py`):
+3. **Multi-Brokerage Upload to Portfolio Value (Tier 3)** (`test_brokerage_upload_to_portfolio_value.py`):
+   - **Status**: Implemented hard gate for Issue #404
+   - **Coverage**: AC8.13.10 (Moomoo + Futu PDF upload, real OCR parse polling, parsed-statement position import, holdings visibility, balance-sheet asset value)
+   - **Failure diagnostics**: Assertions include statement IDs and response bodies for OCR rejection, import zero-counts, missing holdings, and reporting failures.
+   - **Provider budget rule**: Runs in the same serialized `llm` staging phase as the DBS full journey.
+
+4. **Production Read-only E2E Smoke** (`test_production_readonly_smoke.py`):
    - **Status**: Implemented for production release
    - **Coverage**: Health payload, anonymous auth boundary, browser shell/login route, optional credential-gated dashboard
    - **Allowed skip**: Authenticated dashboard check may skip only when `PROD_SMOKE_EMAIL` / `PROD_SMOKE_PASSWORD` are not configured; it must not mutate production data

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -13,10 +13,10 @@
 | Metric | Count | Percentage |
 |--------|-------|------------|
 | **Total EPICs** | 18 | 100% |
-| **Total ACs (registries)** | 930 | 100% |
-| **Mandatory ACs** | 770 | 82.8% |
+| **Total ACs (registries)** | 931 | 100% |
+| **Mandatory ACs** | 771 | 82.8% |
 | **Deprecated ACs** | 3 | 0.3% |
-| **Mandatory ACs with test reference** | 770 | 100.0% |
+| **Mandatory ACs with test reference** | 771 | 100.0% |
 | **Mandatory ACs without test reference** | 0 | 0.0% |
 | **Test files referenced** | 181 | - |
 | **ACs flagged as manual verification (heuristic)** | 0 | 0.0% |
@@ -32,7 +32,7 @@
 | [EPIC-005](#epic-005-reporting-visualization) | reporting-visualization | 36 | 0 | 25 | 25 | 100.0% |
 | [EPIC-006](#epic-006-ai-advisor) | ai-advisor | 63 | 0 | 55 | 55 | 100.0% |
 | [EPIC-007](#epic-007-deployment) | deployment | 39 | 0 | 39 | 39 | 100.0% |
-| [EPIC-008](#epic-008-testing-strategy) | testing-strategy | 65 | 0 | 59 | 59 | 100.0% |
+| [EPIC-008](#epic-008-testing-strategy) | testing-strategy | 66 | 0 | 60 | 60 | 100.0% |
 | [EPIC-009](#epic-009-pdf-fixture-generation) | pdf-fixture-generation | 37 | 0 | 36 | 36 | 100.0% |
 | [EPIC-010](#epic-010-signoz-logging) | signoz-logging | 21 | 0 | 21 | 21 | 100.0% |
 | [EPIC-011](#epic-011-asset-lifecycle) | asset-lifecycle | 38 | 0 | 38 | 38 | 100.0% |
@@ -445,9 +445,9 @@
 
 <a id="epic-008-testing-strategy"></a>
 
-- **Total ACs**: 65
-- **Mandatory ACs**: 59
-- **Mandatory ACs with test reference**: 59 (100.0%)
+- **Total ACs**: 66
+- **Mandatory ACs**: 60
+- **Mandatory ACs with test reference**: 60 (100.0%)
 
 | AC ID | Mandatory | Description | Test References | Status |
 |-------|-----------|-------------|-----------------|--------|
@@ -516,6 +516,7 @@
 | AC8.13.7 | yes | Strict full statement journey fails on rejected AI/OCR parsing | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.8 | yes | Strict upload readiness E2E does not accept rejected statements | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.9 | yes | Production release runs prod-safe read-only E2E smoke | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
+| AC8.13.10 | yes | Multi-brokerage PDF upload -> position import -> latest portfolio value | `apps/backend/tests/portfolio/test_brokerage_position_parsing.py`<br>`scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 
 ---
 

--- a/docs/ssot/ai.md
+++ b/docs/ssot/ai.md
@@ -113,6 +113,7 @@ The advisor only reads summarized, posted/reconciled data:
 2. Client sends the selected `model` in `POST /api/chat`.
 3. If omitted, the service uses `PRIMARY_MODEL` and may try `FALLBACK_MODELS` for chat responses.
 4. Statement OCR uses `OCR_MODEL`; if it is separate from `VISION_MODEL`, the provider layout parsing API runs first, otherwise the shared vision OCR path is used directly.
+5. The post-merge staging brokerage gate uses the same configured OCR path for PDF uploads. It does not mock OCR: Moomoo and Futu PDF fixtures are sent through `/api/statements/upload`, then parsed statements are imported into portfolio positions through `/api/statements/{id}/brokerage/import`.
 
 ### SOP-003: Cached Common Q&A
 
@@ -130,6 +131,7 @@ The advisor only reads summarized, posted/reconciled data:
 | Disclaimer appended | `test_chat_refusal_and_history` | ✅ Done |
 | Session history | `test_chat_refusal_and_history` | ✅ Done |
 | Suggestions endpoint | `test_chat_suggestions` | ✅ Done |
+| Real OCR brokerage upload → portfolio value | `test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value` | ✅ Staging gate |
 
 ---
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -98,6 +98,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Staging deploys use a workflow-level `staging-deploy` concurrency group with `cancel-in-progress: false`, so post-merge deployments and the provider-backed GLM gate queue instead of overlapping.
 - Staging deploys may set `DEPLOY_PRIMARY_MODEL_OVERRIDE`, `DEPLOY_OCR_MODEL_OVERRIDE`, and `DEPLOY_VISION_MODEL_OVERRIDE`; the current post-merge gate pins `PRIMARY_MODEL=glm-5.1`, `OCR_MODEL=glm-4.6v`, and `VISION_MODEL=glm-4.6v`.
 - The GLM-backed PDF gate allows a longer parsing window than normal UI tests: JSON extraction requests use `AI_JSON_TIMEOUT_SECONDS=360`, and the browser gate waits up to `PARSING_TIMEOUT_MS=480000` so slow but successful `glm-4.6v` PDF parsing is not misclassified as a failed deployment.
+- The serialized GLM gate includes `tests/e2e/test_brokerage_upload_to_portfolio_value.py`, which uploads Moomoo and Futu PDF fixtures through `/api/statements/upload`, waits for parsed statements, imports positions through `/api/statements/{id}/brokerage/import`, and verifies `/api/portfolio/holdings` plus `/api/reports/balance-sheet`. Failures identify whether OCR parsing, brokerage import, portfolio valuation, or reporting failed.
 
 **PR preview E2E** (`.github/workflows/pr-test.yml`):
 - PR preview environments do not inject `ZAI_API_KEY`; they validate app wiring without real GLM/OCR provider calls.
@@ -173,7 +174,7 @@ deploy-blocking usability gates:
 |-------------|------|---------|-------------|
 | Staging | Shell smoke | `bash scripts/smoke_test.sh "$APP_URL" staging` | No skips; any failed check fails deploy |
 | Staging | Non-LLM E2E | `STRICT_E2E_GATES=true pytest tests/e2e -v -m "(smoke or e2e) and not llm" -n 4` | Tests marked `critical` must fail instead of skip |
-| Staging | AI/OCR E2E | `STRICT_E2E_GATES=true pytest tests/e2e/test_statement_full_journey.py tests/e2e/test_statement_upload_e2e.py -v -m "llm"` | Serial provider-backed GLM gate; `rejected` fails deploy |
+| Staging | AI/OCR E2E | `STRICT_E2E_GATES=true pytest tests/e2e/test_statement_full_journey.py tests/e2e/test_brokerage_upload_to_portfolio_value.py tests/e2e/test_statement_upload_e2e.py -v -m "llm"` | Serial provider-backed GLM gate; `rejected` fails deploy |
 | Production | Shell smoke | `bash scripts/smoke_test.sh https://report.zitian.party production` | Read-only checks only |
 | Production | Prod-safe E2E | `pytest tests/e2e/test_production_readonly_smoke.py -v -m "prod_safe"` | Authenticated dashboard check may skip only when read-only smoke credentials are absent |
 
@@ -183,6 +184,11 @@ is the AI/OCR hard gate: DBS PDF upload must reach `parsed`, show transactions,
 approve, and load the balance sheet. A `rejected` parsing status is a deploy
 failure because it usually indicates AI provider, OCR, secret, or model config
 breakage.
+
+`tests/e2e/test_brokerage_upload_to_portfolio_value.py::test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value`
+is the upload-to-report portfolio hard gate for Issue #404. It proves that at
+least two brokerage PDFs can be parsed by the real configured OCR path, imported
+as portfolio positions, and reflected in the latest balance-sheet asset value.
 
 PR preview E2E intentionally excludes the `llm` marker and does not inject the
 provider API key. This keeps provider spend and concurrency concentrated in the

--- a/scripts/pdf_fixtures/README.md
+++ b/scripts/pdf_fixtures/README.md
@@ -1,6 +1,6 @@
 # PDF Fixture Generation Tool
 
-This directory contains a complete tool for generating synthetic PDF bank statements for testing.
+This directory contains a complete tool for generating synthetic PDF bank and brokerage statements for testing.
 
 ## Directory Structure
 
@@ -14,10 +14,16 @@ pdf_fixtures/
 │   ├── base_generator.py
 │   ├── dbs_generator.py
 │   ├── cmb_generator.py
+│   ├── moomoo_generator.py
+│   ├── futu_generator.py
+│   ├── pingan_generator.py
 │   └── mari_generator.py
 ├── templates/                 # Format templates (committed)
 │   ├── dbs_template.yaml
 │   ├── cmb_template.yaml
+│   ├── moomoo_template.yaml
+│   ├── futu_template.yaml
+│   ├── pingan_template.yaml
 │   └── mari_template.yaml
 ├── data/                      # Fictional data generators
 │   └── fake_data.py
@@ -37,7 +43,7 @@ pdf_fixtures/
 # From repository root
 cd scripts/pdf_fixtures
 
-# Generate all sources (DBS, CMB, Mari Bank, Moomoo, Pingan)
+# Generate all sources (DBS, CMB, Mari Bank, Moomoo, Futu, Pingan)
 python generate_pdf_fixtures.py --source all
 
 # Generate specific source
@@ -45,6 +51,7 @@ python generate_pdf_fixtures.py --source dbs
 python generate_pdf_fixtures.py --source cmb
 python generate_pdf_fixtures.py --source mari
 python generate_pdf_fixtures.py --source moomoo
+python generate_pdf_fixtures.py --source futu
 python generate_pdf_fixtures.py --source pingan
 
 # Output will be in: output/{source}/test_{source}_{period}.pdf

--- a/scripts/pdf_fixtures/data/fake_data.py
+++ b/scripts/pdf_fixtures/data/fake_data.py
@@ -1,18 +1,19 @@
 """Generate fictional transaction data for test PDFs."""
+
 import random
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import List, Dict, Any
+from typing import Any
 
 
 def generate_dbs_transactions(
     start_date: datetime,
     count: int = 15,
     opening_balance: Decimal = Decimal("5000.00"),
-) -> tuple[List[Dict[str, Any]], Decimal]:
+) -> tuple[list[dict[str, Any]], Decimal]:
     """
     Generate fictional DBS transactions.
-    
+
     Returns:
         (transactions, closing_balance)
     """
@@ -30,17 +31,17 @@ def generate_dbs_transactions(
         ("GIRO PAYMENT", -100, -300),
         ("INTEREST EARNED", 0.50, 2.00),
     ]
-    
+
     txns = []
     balance = opening_balance
     current_date = start_date
-    
+
     for _ in range(count):
         # Advance date by 0-3 days
         current_date += timedelta(days=random.randint(0, 3))
-        
+
         desc, min_amt, max_amt = random.choice(descriptions)
-        
+
         # Generate random amount
         if min_amt == max_amt:
             amount = Decimal(str(min_amt))
@@ -52,9 +53,9 @@ def generate_dbs_transactions(
             max_cents = int(max_val * 100)
             cents = random.randint(min_cents, max_cents)
             amount = Decimal(cents) / Decimal(100)
-        
+
         balance += amount
-        
+
         txn = {
             "date": current_date.strftime("%d/%m/%Y"),
             "description": desc,
@@ -64,7 +65,7 @@ def generate_dbs_transactions(
             "amount": amount,  # For internal calculation
         }
         txns.append(txn)
-    
+
     return txns, balance
 
 
@@ -72,10 +73,10 @@ def generate_cmb_transactions(
     start_date: datetime,
     count: int = 20,
     opening_balance: Decimal = Decimal("10000.00"),
-) -> tuple[List[Dict[str, Any]], Decimal]:
+) -> tuple[list[dict[str, Any]], Decimal]:
     """
     Generate fictional CMB transactions.
-    
+
     Returns:
         (transactions, closing_balance)
     """
@@ -90,16 +91,16 @@ def generate_cmb_transactions(
         ("基金赎回", 2000, 10000),
         ("网联收款", 100, -100),  # Can be positive or negative
     ]
-    
+
     txns = []
     balance = opening_balance
     current_date = start_date
-    
+
     for _ in range(count):
         current_date += timedelta(days=random.randint(0, 2))
-        
+
         desc, min_amt, max_amt = random.choice(descriptions)
-        
+
         # Generate amount (can be positive or negative for some types)
         if "网联收款" in desc:
             # Can be either direction
@@ -116,9 +117,9 @@ def generate_cmb_transactions(
                 max_amount_int = int(max_val)
                 amount_int = random.randint(min_amount_int, max_amount_int)
                 amount = Decimal(amount_int)
-        
+
         balance += amount
-        
+
         txn = {
             "date": current_date.strftime("%Y-%m-%d"),
             "currency": "CNY",
@@ -129,7 +130,7 @@ def generate_cmb_transactions(
             "amount_decimal": amount,  # For internal calculation
         }
         txns.append(txn)
-    
+
     return txns, balance
 
 
@@ -137,10 +138,10 @@ def generate_mari_transactions(
     start_date: datetime,
     count: int = 12,
     opening_balance: Decimal = Decimal("3000.00"),
-) -> tuple[List[Dict[str, Any]], Decimal]:
+) -> tuple[list[dict[str, Any]], Decimal]:
     """
     Generate fictional Mari Bank transactions.
-    
+
     Returns:
         (transactions, closing_balance)
     """
@@ -150,16 +151,16 @@ def generate_mari_transactions(
         ("PayNow Payment", -20, -100),
         ("Interest Credit", 0.50, 2.00),
     ]
-    
+
     txns = []
     balance = opening_balance
     current_date = start_date
-    
+
     for _ in range(count):
         current_date += timedelta(days=random.randint(1, 3))
-        
+
         desc, min_amt, max_amt = random.choice(descriptions)
-        
+
         if min_amt == max_amt:
             amount = Decimal(str(min_amt))
         else:
@@ -170,7 +171,7 @@ def generate_mari_transactions(
             max_cents = int(max_val * 100)
             cents = random.randint(min_cents, max_cents)
             amount = Decimal(cents) / Decimal(100)
-        
+
         # Determine if outgoing or incoming
         if amount < 0:
             is_outgoing = True
@@ -181,9 +182,9 @@ def generate_mari_transactions(
         else:
             is_outgoing = False
             is_incoming = False
-        
+
         balance += amount
-        
+
         txn = {
             "date": current_date.strftime("%d %b").upper(),  # "15 JAN"
             "description": desc,
@@ -192,7 +193,7 @@ def generate_mari_transactions(
             "amount": amount,  # For internal calculation
         }
         txns.append(txn)
-    
+
     return txns, balance
 
 
@@ -200,10 +201,10 @@ def generate_moomoo_transactions(
     start_date: datetime,
     count: int = 10,
     opening_balance: Decimal = Decimal("10000.00"),
-) -> tuple[List[Dict[str, Any]], Decimal]:
+) -> tuple[list[dict[str, Any]], Decimal]:
     """
     Generate fictional Moomoo brokerage transactions.
-    
+
     Returns:
         (transactions, closing_balance)
     """
@@ -214,16 +215,30 @@ def generate_moomoo_transactions(
         ("INTEREST", 1.00, 5.00),
         ("FEE", -1.00, -10.00),
     ]
-    
+
     txns = []
     balance = opening_balance
     current_date = start_date
-    
-    for _ in range(count):
+
+    position_amount = Decimal("1250.50")
+    current_date += timedelta(days=1)
+    balance += position_amount
+    txns.append(
+        {
+            "date": current_date.strftime("%Y-%m-%d"),
+            "type": "SUBSCRIPTION",
+            "description": "Fullerton SGD Money Market Fund",
+            "amount": f"{position_amount:,.2f}",
+            "currency": "SGD",
+            "amount_decimal": position_amount,
+        }
+    )
+
+    for _ in range(max(count - 1, 0)):
         current_date += timedelta(days=random.randint(1, 5))
-        
+
         txn_type, min_amt, max_amt = random.choice(transaction_types)
-        
+
         if min_amt == max_amt:
             amount = Decimal(str(min_amt))
         else:
@@ -234,19 +249,75 @@ def generate_moomoo_transactions(
             max_cents = int(max_val * 100)
             cents = random.randint(min_cents, max_cents)
             amount = Decimal(cents) / Decimal(100)
-        
+
         balance += amount
-        
+
         txn = {
             "date": current_date.strftime("%Y-%m-%d"),
             "type": txn_type,
             "description": f"{txn_type} Transaction",
             "amount": f"{amount:,.2f}",
-            "currency": "USD",
+            "currency": "SGD",
             "amount_decimal": amount,  # For internal calculation
         }
         txns.append(txn)
-    
+
+    return txns, balance
+
+
+def generate_futu_transactions(
+    start_date: datetime,
+    count: int = 8,
+    opening_balance: Decimal = Decimal("20000.00"),
+) -> tuple[list[dict[str, Any]], Decimal]:
+    """
+    Generate fictional Futu brokerage statement events.
+
+    Returns:
+        (transactions, closing_balance)
+    """
+    txns = []
+    balance = opening_balance
+    current_date = start_date
+
+    valuation_amount = Decimal("323730.00")
+    current_date += timedelta(days=1)
+    balance += valuation_amount
+    txns.append(
+        {
+            "date": current_date.strftime("%Y-%m-%d"),
+            "type": "VALUATION",
+            "description": "Stock and options valuation",
+            "amount": f"{valuation_amount:,.2f}",
+            "currency": "SGD",
+            "amount_decimal": valuation_amount,
+        }
+    )
+
+    event_types = [
+        ("DIVIDEND", "Dividend income", 20, 150),
+        ("INTEREST", "Brokerage cash interest", 1, 8),
+        ("FEE", "Platform fee", -1, -12),
+        ("CASH", "Cash balance movement", -50, 50),
+    ]
+    for _ in range(max(count - 1, 0)):
+        current_date += timedelta(days=random.randint(1, 4))
+        txn_type, description, min_amt, max_amt = random.choice(event_types)
+        min_cents = int(min(min_amt, max_amt) * 100)
+        max_cents = int(max(min_amt, max_amt) * 100)
+        amount = Decimal(random.randint(min_cents, max_cents)) / Decimal(100)
+        balance += amount
+        txns.append(
+            {
+                "date": current_date.strftime("%Y-%m-%d"),
+                "type": txn_type,
+                "description": description,
+                "amount": f"{amount:,.2f}",
+                "currency": "SGD",
+                "amount_decimal": amount,
+            }
+        )
+
     return txns, balance
 
 
@@ -254,10 +325,10 @@ def generate_pingan_transactions(
     start_date: datetime,
     count: int = 15,
     opening_balance: Decimal = Decimal("8000.00"),
-) -> tuple[List[Dict[str, Any]], Decimal]:
+) -> tuple[list[dict[str, Any]], Decimal]:
     """
     Generate fictional Pingan (平安银行) transactions.
-    
+
     Returns:
         (transactions, closing_balance)
     """
@@ -270,16 +341,16 @@ def generate_pingan_transactions(
         ("基金申购", -1000, -5000),
         ("基金赎回", 1000, 5000),
     ]
-    
+
     txns = []
     balance = opening_balance
     current_date = start_date
-    
+
     for _ in range(count):
         current_date += timedelta(days=random.randint(0, 2))
-        
+
         desc, min_amt, max_amt = random.choice(descriptions)
-        
+
         if min_amt == max_amt:
             amount = Decimal(str(min_amt))
         else:
@@ -290,9 +361,9 @@ def generate_pingan_transactions(
             max_amount_int = int(max_val)
             amount_int = random.randint(min_amount_int, max_amount_int)
             amount = Decimal(amount_int)
-        
+
         balance += amount
-        
+
         # Determine transaction type
         if "工资" in desc or "结息" in desc or "赎回" in desc:
             txn_type = "收入"
@@ -300,7 +371,7 @@ def generate_pingan_transactions(
             txn_type = "支出"
         else:
             txn_type = "转账"
-        
+
         txn = {
             "date": current_date.strftime("%Y-%m-%d"),
             "type": txn_type,
@@ -310,5 +381,5 @@ def generate_pingan_transactions(
             "amount_decimal": amount,  # For internal calculation
         }
         txns.append(txn)
-    
+
     return txns, balance

--- a/scripts/pdf_fixtures/generate_pdf_fixtures.py
+++ b/scripts/pdf_fixtures/generate_pdf_fixtures.py
@@ -19,33 +19,31 @@ Usage:
 Requires: reportlab, pyyaml
 """
 
-import sys
 import argparse
-from pathlib import Path
+import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 
 try:
     from reportlab.lib import colors
     from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
     from reportlab.platypus import (
+        Paragraph,
         SimpleDocTemplate,
+        Spacer,
         Table,
         TableStyle,
-        Paragraph,
-        Spacer,
     )
-    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 except ImportError:
-    print(
-        "❌ reportlab not installed. Please run 'uv sync' from the repository root or 'pip install reportlab'."
-    )
+    print("❌ reportlab not installed. Please run 'uv sync' from the repository root or 'pip install reportlab'.")
     sys.exit(1)
 
 
 def generate_legacy_dbs_pdf(output_path: Path):
     """Generate legacy DBS PDF for backward compatibility with existing E2E tests."""
-    from decimal import Decimal
     import random
+    from decimal import Decimal
 
     def generate_transactions(start_date: datetime, count: int = 15):
         """Generate a list of synthetic transactions."""
@@ -102,9 +100,7 @@ def generate_legacy_dbs_pdf(output_path: Path):
     styles = getSampleStyleSheet()
 
     # Header
-    header_style = ParagraphStyle(
-        "Header", parent=styles["Heading1"], fontSize=18, spaceAfter=12
-    )
+    header_style = ParagraphStyle("Header", parent=styles["Heading1"], fontSize=18, spaceAfter=12)
     elements.append(Paragraph("DBS Bank - E-Statement", header_style))
     elements.append(Paragraph(f"Statement Period: {period_str}", styles["Normal"]))
     elements.append(Spacer(1, 20))
@@ -118,9 +114,7 @@ def generate_legacy_dbs_pdf(output_path: Path):
     txns = generate_transactions(start_date, count=15)
     data = [["Date", "Transaction Description", "Withdrawal", "Deposit", "Balance"]]
     for t in txns:
-        data.append(
-            [t["date"], t["description"], t["withdrawal"], t["deposit"], t["balance"]]
-        )
+        data.append([t["date"], t["description"], t["withdrawal"], t["deposit"], t["balance"]])
 
     # Table Styling
     t = Table(data, colWidths=[70, 200, 60, 60, 70])
@@ -149,9 +143,9 @@ def main():
     parser = argparse.ArgumentParser(description="Generate E2E PDF Fixtures")
     parser.add_argument(
         "--source",
-        choices=["dbs", "cmb", "mari", "moomoo", "pingan", "all"],
+        choices=["dbs", "cmb", "mari", "moomoo", "futu", "pingan", "all"],
         default=None,
-        help="Source to generate (dbs, cmb, mari, moomoo, pingan, all). If not specified, uses legacy mode.",
+        help="Source to generate (dbs, cmb, mari, moomoo, futu, pingan, all). If not specified, uses legacy mode.",
     )
     parser.add_argument(
         "--output",
@@ -186,8 +180,9 @@ def main():
 
     # Import generators
     try:
-        from generators.dbs_generator import DBSGenerator
         from generators.cmb_generator import CMBGenerator
+        from generators.dbs_generator import DBSGenerator
+        from generators.futu_generator import FutuGenerator
         from generators.mari_generator import MariGenerator
         from generators.moomoo_generator import MoomooGenerator
         from generators.pingan_generator import PinganGenerator
@@ -209,7 +204,7 @@ def main():
 
     sources_to_generate = []
     if args.source == "all":
-        sources_to_generate = ["dbs", "cmb", "mari", "moomoo", "pingan"]
+        sources_to_generate = ["dbs", "cmb", "mari", "moomoo", "futu", "pingan"]
     else:
         sources_to_generate = [args.source]
 
@@ -233,6 +228,9 @@ def main():
                 generator.generate(output_path, period_start, period_end)
             elif source == "moomoo":
                 generator = MoomooGenerator(template_path)
+                generator.generate(output_path, period_start, period_end)
+            elif source == "futu":
+                generator = FutuGenerator(template_path)
                 generator.generate(output_path, period_start, period_end)
             elif source == "pingan":
                 generator = PinganGenerator(template_path)

--- a/scripts/pdf_fixtures/generators/futu_generator.py
+++ b/scripts/pdf_fixtures/generators/futu_generator.py
@@ -1,32 +1,31 @@
-"""Moomoo SG Brokerage PDF generator."""
+"""Futu brokerage PDF generator."""
 
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
 
-from data.fake_data import generate_moomoo_transactions
+from data.fake_data import generate_futu_transactions
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.platypus import Paragraph, Spacer, Table
 
 from generators.base_generator import BasePDFGenerator
 
 
-class MoomooGenerator(BasePDFGenerator):
-    """Generate Moomoo brokerage statement PDF."""
+class FutuGenerator(BasePDFGenerator):
+    """Generate a Futu brokerage statement PDF."""
 
     def generate(
         self,
         output_path: Path,
         period_start: datetime,
         period_end: datetime,
-        account_last4: str = "1582",
+        account_last4: str = "6688",
     ):
-        """Generate Moomoo statement PDF."""
+        """Generate Futu statement PDF."""
         doc = self.create_document(output_path)
         elements = []
         styles = getSampleStyleSheet()
 
-        # Header
         font_family, font_size = self._get_font("header")
         header_style = ParagraphStyle(
             "Header",
@@ -35,27 +34,23 @@ class MoomooGenerator(BasePDFGenerator):
             fontSize=font_size,
             spaceAfter=12,
         )
-        elements.append(Paragraph("Moomoo SG - Monthly Statement", header_style))
+        elements.append(Paragraph("Futu Securities - Monthly Statement", header_style))
 
-        # Statement Period
         period_str = period_end.strftime("%B %Y")
         elements.append(Paragraph(f"Statement Period: {period_str}", styles["Normal"]))
         elements.append(Spacer(1, 20))
 
-        # Account Info
         account_no = f"Account: ****{account_last4}"
         elements.append(Paragraph(account_no, styles["Normal"]))
         elements.append(Spacer(1, 20))
 
-        # Generate transactions
-        opening_balance = Decimal("10000.00")
-        txns, closing_balance = generate_moomoo_transactions(
+        opening_balance = Decimal("20000.00")
+        txns, closing_balance = generate_futu_transactions(
             period_start,
-            count=10,
+            count=8,
             opening_balance=opening_balance,
         )
 
-        # Account Summary
         if "account_summary" in self.template["tables"]:
             summary_config = self.template["tables"]["account_summary"]
             summary_data = [
@@ -71,34 +66,27 @@ class MoomooGenerator(BasePDFGenerator):
             elements.append(summary_table)
             elements.append(Spacer(1, 20))
 
-        # Transaction Details
-        elements.append(Paragraph("Transaction Details", styles["Heading2"]))
+        elements.append(Paragraph("Activity and Valuation", styles["Heading2"]))
         elements.append(Spacer(1, 10))
 
         table_config = self.template["tables"]["transaction_details"]
         columns = table_config["columns"]
+        data = [[col["name"] for col in columns]]
 
-        # Table header
-        header_row = [col["name"] for col in columns]
-        data = [header_row]
-
-        # Transaction rows
         for txn in txns:
-            row = [
-                txn["date"],
-                txn["type"],
-                txn["description"],
-                txn["amount"],
-                txn["currency"],
-            ]
-            data.append(row)
+            data.append(
+                [
+                    txn["date"],
+                    txn["type"],
+                    txn["description"],
+                    txn["amount"],
+                    txn["currency"],
+                ]
+            )
 
-        # Create table
-        col_widths = self._get_column_widths(table_config)
-        table = Table(data, colWidths=col_widths)
+        table = Table(data, colWidths=self._get_column_widths(table_config))
         table.setStyle(self._create_table_style(table_config))
         elements.append(table)
 
-        # Build PDF
         doc.build(elements)
-        print(f"✅ Generated Moomoo PDF: {output_path}")
+        print(f"✅ Generated Futu PDF: {output_path}")

--- a/scripts/pdf_fixtures/templates/futu_template.yaml
+++ b/scripts/pdf_fixtures/templates/futu_template.yaml
@@ -1,0 +1,75 @@
+# Futu Brokerage PDF Format Template
+# Synthetic format for E2E testing only; contains no sensitive data.
+
+source: futu
+
+page:
+  size: A4
+  width: 595.27
+  height: 841.89
+  margins:
+    top: 72
+    bottom: 72
+    left: 72
+    right: 72
+
+fonts:
+  header:
+    family: Helvetica-Bold
+    size: 14
+  body:
+    family: Helvetica
+    size: 10
+  table_header:
+    family: Helvetica-Bold
+    size: 9
+  table_body:
+    family: Helvetica
+    size: 9
+
+tables:
+  account_summary:
+    columns:
+      - name: Account
+        width: 100
+        align: left
+      - name: Opening Balance
+        width: 100
+        align: right
+      - name: Closing Balance
+        width: 100
+        align: right
+    header_style:
+      background: "#CCCCCC"
+      text_color: "#000000"
+
+  transaction_details:
+    columns:
+      - name: Date
+        width: 80
+        align: left
+      - name: Type
+        width: 100
+        align: left
+      - name: Description
+        width: 200
+        align: left
+      - name: Amount
+        width: 100
+        align: right
+      - name: Currency
+        width: 60
+        align: left
+    header_style:
+      background: "#CCCCCC"
+      text_color: "#000000"
+    row_style:
+      background: "#FFFFFF"
+      border: "1px solid #000000"
+
+text_elements:
+  account_number:
+    format: "Account: ****{last4}"
+  statement_period:
+    format: "Statement Period: MMM YYYY"
+  currency: "SGD"

--- a/scripts/tests/test_pdf_fixture_parseable.py
+++ b/scripts/tests/test_pdf_fixture_parseable.py
@@ -10,6 +10,7 @@ from pathlib import Path
 DBS_DATE_PATTERN = re.compile(r"^\d{2}/\d{2}/\d{4}$")
 CMB_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 MARI_DATE_PATTERN = re.compile(r"^\d{2}\s[A-Z]{3}$")
+FUTU_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _parse_decimal(raw: str) -> Decimal:
@@ -87,6 +88,17 @@ def _extract_mari_rows(tables: list[list[list[str | None]]]) -> list[list[str]]:
     return rows
 
 
+def _extract_futu_rows(tables: list[list[list[str | None]]]) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for table in tables:
+        for row in table:
+            if not row or len(row) < 5:
+                continue
+            if row[0] and FUTU_DATE_PATTERN.match(row[0].strip()):
+                rows.append([cell.strip() if cell else "" for cell in row[:5]])
+    return rows
+
+
 def _extract_mari_summary_balances(
     text: str,
     tables: list[list[list[str | None]]],
@@ -112,6 +124,58 @@ def _extract_mari_summary_balances(
     raise AssertionError(
         "Mari account summary table with opening/ending balance not found"
     )
+
+
+def test_ac8_13_10_futu_generated_pdf_parseable(tmp_path: Path) -> None:
+    futu_generator = import_module("generators.futu_generator").FutuGenerator
+    output_path = tmp_path / "futu" / "test_futu.pdf"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    generator = futu_generator(
+        Path(__file__).parent.parent
+        / "pdf_fixtures"
+        / "templates"
+        / "futu_template.yaml"
+    )
+    generator.generate(output_path, datetime(2025, 1, 1), datetime(2025, 1, 31))
+
+    _assert_valid_pdf(output_path)
+    text, tables = _read_pdf_text_and_tables(output_path)
+    rows = _extract_futu_rows(tables)
+
+    assert "Futu Securities - Monthly Statement" in text
+    assert "Activity and Valuation" in text
+    assert "SGD 20,000.00" in text
+    assert len(rows) == 8
+    assert rows[0][1] == "VALUATION"
+    assert rows[0][2] == "Stock and options valuation"
+    assert _parse_decimal(rows[0][3]) == Decimal("323730.00")
+    assert all(FUTU_DATE_PATTERN.match(row[0]) for row in rows)
+
+
+def test_ac8_13_10_futu_fake_data_count_boundaries() -> None:
+    generate_futu_transactions = import_module(
+        "data.fake_data"
+    ).generate_futu_transactions
+    start_date = datetime(2025, 1, 1)
+
+    zero_txns, zero_closing = generate_futu_transactions(
+        start_date,
+        count=0,
+        opening_balance=Decimal("100.00"),
+    )
+    one_txn, one_closing = generate_futu_transactions(
+        start_date,
+        count=1,
+        opening_balance=Decimal("100.00"),
+    )
+
+    assert len(zero_txns) == 1
+    assert len(one_txn) == 1
+    assert zero_txns[0]["type"] == "VALUATION"
+    assert one_txn[0]["type"] == "VALUATION"
+    assert zero_closing == Decimal("323830.00")
+    assert one_closing == Decimal("323830.00")
 
 
 def test_ac9_3_2_dbs_generated_pdf_parseable(tmp_path: Path) -> None:

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -66,6 +66,7 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     workflow = read(".github/workflows/staging-deploy.yml")
     pr_workflow = read(".github/workflows/pr-test.yml")
     journey = read("tests/e2e/test_statement_full_journey.py")
+    brokerage = read("tests/e2e/test_brokerage_upload_to_portfolio_value.py")
     upload = read("tests/e2e/test_statement_upload_e2e.py")
     deploy_script = read("scripts/dokploy_deploy.sh")
 
@@ -105,8 +106,10 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     )
     assert '-m "(smoke or e2e) and not llm" -n 4' in workflow
     assert "PARSING_TIMEOUT_MS: 480000" in workflow
+    assert "test_brokerage_upload_to_portfolio_value.py" in workflow
     assert '-v -m "llm"' in workflow
     assert "@pytest.mark.llm" in journey
+    assert "@pytest.mark.llm" in brokerage
     assert upload.count("@pytest.mark.llm") >= 2
     assert 'echo "ZAI_API_KEY="' in pr_workflow
     assert 'echo "AI_BASE_URL=https://api.z.ai/api/coding/paas/v4"' in pr_workflow
@@ -117,3 +120,29 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     assert "https://api.z.ai/api/coding/paas/v4" in read("docs/ssot/ci-cd.md")
     assert '-m "(smoke or e2e) and not llm"' in pr_workflow
     assert '-m "smoke or e2e"' not in pr_workflow
+
+
+def test_AC8_13_10_multi_brokerage_upload_to_portfolio_value_gate() -> None:
+    """AC8.13.10: Staging proves multi-brokerage upload through latest value."""
+    workflow = read(".github/workflows/staging-deploy.yml")
+    brokerage = read("tests/e2e/test_brokerage_upload_to_portfolio_value.py")
+    statements_router = read("apps/backend/src/routers/statements.py")
+    generator = read("scripts/pdf_fixtures/generate_pdf_fixtures.py")
+
+    assert "test_brokerage_upload_to_portfolio_value.py" in workflow
+    assert '-m "llm"' in workflow
+    assert "pytest tests/e2e -v -m \"(smoke or e2e) and not llm\" -n 4" in workflow
+    assert "pytest.mark.critical" in brokerage
+    assert "pytest.mark.llm" in brokerage
+    assert '("moomoo", "Moomoo E2E Portfolio")' in brokerage
+    assert '("futu", "Futu E2E Portfolio")' in brokerage
+    assert "/statements/upload" in brokerage
+    assert "/brokerage/import" in brokerage
+    assert "/portfolio/holdings" in brokerage
+    assert "/reports/balance-sheet" in brokerage
+    assert "fail_or_skip_ai_ocr_gate(" in brokerage
+    assert "parsed_positions" in brokerage
+    assert "total_assets" in brokerage
+    assert "BrokeragePositionImportService" in statements_router
+    assert "Statement must be parsed before importing brokerage positions" in statements_router
+    assert '"futu"' in generator

--- a/tests/e2e/test_brokerage_upload_to_portfolio_value.py
+++ b/tests/e2e/test_brokerage_upload_to_portfolio_value.py
@@ -1,0 +1,204 @@
+"""
+Tier 3 Browser/API E2E: Multi-brokerage upload to latest portfolio value.
+
+Issue #404 / AC8.13.10:
+Upload multiple brokerage PDFs through the configured real OCR path, import
+positions from the parsed statements, and verify the latest portfolio value is
+visible through product APIs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import httpx
+import pytest
+from conftest import AuthState, fail_or_skip_ai_ocr_gate
+
+APP_URL: str = os.getenv("APP_URL", "http://localhost:3000")
+PARSING_TIMEOUT_MS: int = int(os.getenv("PARSING_TIMEOUT_MS", "480000"))
+
+
+def _api_url(path: str) -> str:
+    return f"{APP_URL.rstrip('/')}/api{path}"
+
+
+def _get_pdf_path(source: str) -> Path:
+    from datetime import datetime
+
+    root = Path(__file__).resolve().parents[2]
+    source_dir = root / "scripts" / "pdf_fixtures" / "output" / source
+    yymm = datetime.now().strftime("%y%m")
+    prebuilt = source_dir / f"test_{source}_{yymm}.pdf"
+    if prebuilt.exists():
+        return prebuilt
+    if source_dir.exists():
+        pdfs = sorted(source_dir.glob(f"test_{source}_*.pdf"))
+        if pdfs:
+            return pdfs[-1]
+
+    script = root / "scripts" / "pdf_fixtures" / "generate_pdf_fixtures.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--source", source],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            f"PDF fixture generation failed for {source}.\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    pdfs = sorted(source_dir.glob(f"test_{source}_*.pdf")) if source_dir.exists() else []
+    if not pdfs:
+        pytest.skip(f"PDF generation for {source} produced no files in {source_dir}")
+    return pdfs[-1]
+
+
+def _unique_pdf_copy(src: Path) -> Path:
+    suffix = int(time.time() * 1000) % 1_000_000
+    tmp = Path(tempfile.mkdtemp())
+    dest = tmp / f"{src.stem}_{suffix}{src.suffix}"
+    shutil.copy2(src, dest)
+    with open(dest, "ab") as f:
+        f.write(f"\n%% E2E test run {uuid.uuid4()}\n".encode())
+    return dest
+
+
+async def _default_image_model(client: httpx.AsyncClient) -> str:
+    response = await client.get(_api_url("/ai/models?modality=image"))
+    assert response.status_code == 200, (
+        f"model catalog request failed: {response.status_code} {response.text}"
+    )
+    payload = response.json()
+    return payload.get("default_model") or payload["models"][0]["id"]
+
+
+async def _upload_brokerage_pdf(
+    client: httpx.AsyncClient,
+    *,
+    source: str,
+    institution: str,
+    model: str,
+) -> str:
+    pdf_path = _unique_pdf_copy(_get_pdf_path(source))
+    with pdf_path.open("rb") as fh:
+        response = await client.post(
+            _api_url("/statements/upload"),
+            data={"institution": institution, "model": model},
+            files={"file": (pdf_path.name, fh, "application/pdf")},
+        )
+    assert response.status_code in (200, 201, 202), (
+        f"{source} upload failed: {response.status_code} {response.text}"
+    )
+    statement_id = response.json().get("id")
+    assert statement_id, f"{source} upload response missing id: {response.text}"
+    return str(statement_id)
+
+
+async def _wait_for_parsed_statement(client: httpx.AsyncClient, statement_id: str) -> dict:
+    deadline = asyncio.get_event_loop().time() + PARSING_TIMEOUT_MS / 1000
+    last_payload: dict | None = None
+    while asyncio.get_event_loop().time() < deadline:
+        response = await client.get(_api_url(f"/statements/{statement_id}"))
+        assert response.status_code == 200, (
+            f"statement poll failed for {statement_id}: {response.status_code} {response.text}"
+        )
+        last_payload = response.json()
+        status = last_payload.get("status")
+        if status == "rejected":
+            fail_or_skip_ai_ocr_gate(
+                f"brokerage OCR/import gate rejected statement {statement_id}: "
+                f"{last_payload.get('validation_error')}"
+            )
+        if status == "parsed":
+            assert last_payload.get("transactions"), (
+                f"parsed statement {statement_id} has no transactions: {last_payload}"
+            )
+            return last_payload
+        await asyncio.sleep(5)
+
+    pytest.fail(
+        f"statement {statement_id} did not reach parsed within {PARSING_TIMEOUT_MS}ms. "
+        f"last payload: {last_payload}"
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.tier3
+@pytest.mark.critical
+@pytest.mark.llm
+async def test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value(
+    shared_auth_state: AuthState,
+) -> None:
+    """AC8.13.10: two brokerage PDFs → real OCR → positions → balance sheet value."""
+    headers = {"Authorization": f"Bearer {shared_auth_state.access_token}"}
+    async with httpx.AsyncClient(headers=headers, verify=False, timeout=120.0) as client:
+        model = await _default_image_model(client)
+        uploads = [
+            ("moomoo", "Moomoo E2E Portfolio"),
+            ("futu", "Futu E2E Portfolio"),
+        ]
+
+        statement_ids = []
+        for source, institution in uploads:
+            statement_ids.append(
+                await _upload_brokerage_pdf(
+                    client,
+                    source=source,
+                    institution=institution,
+                    model=model,
+                )
+            )
+
+        parsed_statements = [
+            await _wait_for_parsed_statement(client, statement_id)
+            for statement_id in statement_ids
+        ]
+        assert len(parsed_statements) == 2
+
+        imported_positions = Decimal("0")
+        for parsed_statement in parsed_statements:
+            response = await client.post(
+                _api_url(f"/statements/{parsed_statement['id']}/brokerage/import")
+            )
+            assert response.status_code == 200, (
+                f"brokerage import failed for {parsed_statement['id']}: "
+                f"{response.status_code} {response.text}"
+            )
+            payload = response.json()
+            assert payload["parsed_positions"] > 0, (
+                f"no positions imported for {parsed_statement['id']}: {payload}"
+            )
+            imported_positions += Decimal(str(payload["parsed_positions"]))
+
+        holdings_response = await client.get(_api_url("/portfolio/holdings"))
+        assert holdings_response.status_code == 200, (
+            f"holdings check failed: {holdings_response.status_code} {holdings_response.text}"
+        )
+        holdings = holdings_response.json()
+        assert len(holdings) >= int(imported_positions), f"missing imported holdings: {holdings}"
+        total_market_value = sum(Decimal(str(item["market_value"])) for item in holdings)
+        assert total_market_value > Decimal("0.00"), f"holdings have no market value: {holdings}"
+
+        balance_response = await client.get(
+            _api_url(f"/reports/balance-sheet?as_of_date={date.today().isoformat()}")
+        )
+        assert balance_response.status_code == 200, (
+            f"balance sheet check failed: {balance_response.status_code} {balance_response.text}"
+        )
+        balance_sheet = balance_response.json()
+        assert Decimal(str(balance_sheet["total_assets"])) >= total_market_value, balance_sheet
+        assert Decimal(str(balance_sheet["net_worth_adjustment_gain_loss"])) > Decimal("0.00"), (
+            balance_sheet
+        )


### PR DESCRIPTION
## Summary

Add the Issue #404 post-merge staging gate for multi-brokerage PDF upload through latest portfolio value.

Closes #404

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Comprehensive Testing Strategy |
| **AC IDs** | AC8.13.10 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/ci-cd.md` — documents the serialized brokerage upload-to-report GLM gate
- [x] `docs/ssot/ai.md` — documents that the brokerage gate uses the configured real OCR path

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | N/A | AC8.13.10 test and static gate assertions were added before implementation in the working tree |
| Green | `3b5318f` | Added parsed-statement brokerage import API, fixtures, staging workflow wiring, and docs |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no new enums)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable; no infra/env changes)
- [x] `scripts/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `scripts/check_manifest.py` passes
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
moon run :lint
cd apps/backend && uv run pytest tests/portfolio/test_brokerage_position_parsing.py -q --no-cov -n0
uv run --with pytest --with pyyaml pytest scripts/tests/test_post_merge_e2e_gates.py -q
uv run --with pytest --with pdfplumber --with reportlab --with pyyaml pytest scripts/tests/test_pdf_fixture_parseable.py -q
cd scripts/pdf_fixtures && uv run python generate_pdf_fixtures.py --source moomoo && uv run python generate_pdf_fixtures.py --source futu
uv run python scripts/lint_doc_consistency.py
uv run --with pyyaml python scripts/check_manifest.py
python scripts/check_ssot_ownership.py --verbose
git diff --check
```

`moon run :test` is still blocked locally by Podman `proxy already running` while starting test infra, before tests execute. The targeted backend and script checks above pass.

---

## Screenshots / Evidence

N/A
