### PR TITLE
[codex] fix post-merge staging gate diagnostics

### DIFF
--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1250,6 +1250,16 @@ acs:
     epic_name: testing-strategy
     description: 'Multi-brokerage PDF upload -> position import -> latest portfolio value'
     mandatory: true
+  - id: AC8.13.11
+    epic: 8
+    epic_name: testing-strategy
+    description: 'Staging health check diagnoses API route 404 with route probes'
+    mandatory: true
+  - id: AC8.13.12
+    epic: 8
+    epic_name: testing-strategy
+    description: 'AI/OCR gate failures include statement validation context'
+    mandatory: true
   # EPIC-011: asset-lifecycle
   - id: AC11.1.1
     epic: 11

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -322,11 +322,13 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.8 | Strict upload readiness E2E does not accept rejected statements | `test_statement_upload_full_flow` | `tests/e2e/test_statement_upload_e2e.py` | P0 |
 | AC8.13.9 | Production release runs prod-safe read-only E2E smoke | `test_production_*` | `tests/e2e/test_production_readonly_smoke.py` | P0 |
 | AC8.13.10 | Multi-brokerage PDF upload → position import → latest portfolio value | `test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value` | `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | P0 |
+| AC8.13.11 | Staging health check diagnoses API route 404 with route probes | `test_AC8_13_11_health_check_diagnoses_staging_api_route_404` | `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
+| AC8.13.12 | AI/OCR gate failures include statement validation context | `test_AC8_13_12_ai_ocr_gate_failure_includes_statement_context` | `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 
 **Traceability Result**:
-- Total AC IDs: 59
+- Total AC IDs: 61
 - Requirements converted to AC IDs: 100% (EPIC-008 scenario checklist + CI/CD integration)
-- **ACs with passing Tier 1 tests: 50/59 (84.7%); 6 additional covered by Tier 3 E2E (AC8.13)**
+- **ACs with passing Tier 1 tests: 50/61 (82.0%); 8 additional covered by Tier 3 E2E (AC8.13)**
 - ACs covered by AC group:
   - AC8.1: 4/4 (100% — health check, backend reachable, frontend proxy, DB connectivity)
   - AC8.2: 5/5 (100% — register, create cash, create bank, update, delete)
@@ -339,10 +341,10 @@ These scenarios represent the "Vertical Slices" of user value.
   - AC8.9: 4/4 (100% — CI/CD integration verified via file-system assertion tests)
   - AC8.10: 9/9 (100% — all must-have scenarios with dedicated traceability tests)
   - AC8.11: 5/5 (100% — income, credit card spend/repayment, internal transfer, split transaction)
-  - AC8.13: 10/10 (Tier 3 E2E — DBS PDF upload, parse polling, transaction detail, approve, balance sheet report, multi-brokerage portfolio value, hard-gate skip enforcement, production-safe smoke)
+  - AC8.13: 12/12 (Tier 3 E2E — DBS PDF upload, parse polling, transaction detail, approve, balance sheet report, multi-brokerage portfolio value, hard-gate skip enforcement, production-safe smoke, staging route diagnostics, AI/OCR failure context)
 - Test files: 1 fully implemented (`tests/e2e/test_core_journeys.py` — 46 tests), 1 existing (`tests/e2e/test_statement_upload_e2e.py`), 2 Tier 3 hard gates (`tests/e2e/test_statement_full_journey.py`, `tests/e2e/test_brokerage_upload_to_portfolio_value.py`), 3 Playwright (skip without `APP_URL` or `FRONTEND_URL`)
 - **Previous state**: 44.9% with 22 Tier 1 tests
-- **Current state**: 50/54 Tier 1 ACs (92.6%) + AC8.13 10/10 Tier 3/deploy-gate ACs (total 64 ACs: 54 Tier 1 + 10 Tier 3/deploy-gate)
+- **Current state**: 50/54 Tier 1 ACs (92.6%) + AC8.13 12/12 Tier 3/deploy-gate ACs (total 66 ACs: 54 Tier 1 + 12 Tier 3/deploy-gate)
 
 ---
 
@@ -440,8 +442,9 @@ These scenarios represent the "Vertical Slices" of user value.
 2. **Full Statement Journey (Tier 3)** (`test_statement_full_journey.py`):
    - **Status**: Implemented hard gate — requires `APP_URL` pointing to a running frontend+backend
    - **Coverage**: AC8.13.1–5 (PDF upload, parse polling, transactions, approve, balance sheet)
-   - **Hard-gate rule**: When `STRICT_E2E_GATES=true`, critical E2E skips are converted to failures; `status=rejected` fails instead of skips. Post-merge staging is the deploy-blocking AI/OCR gate.
+   - **Hard-gate rule**: When `STRICT_E2E_GATES=true`, critical E2E skips are converted to failures; `status=rejected` fails instead of skips and reports the statement id, validation error, parsing progress, confidence, and selected model. Post-merge staging is the deploy-blocking AI/OCR gate.
    - **Provider budget rule**: Tests marked `llm` run serially in the post-merge staging job, not under the `-n 4` parallel phase. PR preview E2E excludes `llm` tests and does not inject `ZAI_API_KEY`, so automated GLM/OCR provider calls are centralized in the staging gate. Staging pins `PRIMARY_MODEL=glm-5.1`, `OCR_MODEL=glm-4.6v`, and `VISION_MODEL=glm-4.6v` for the AI/OCR gate.
+   - **Route diagnostics**: If staging `/api/health` remains 404, `scripts/health_check.sh` probes `/api/ping` and `/` and identifies a likely Traefik API route miss or web-route shadow before failing the deploy.
 
 3. **Multi-Brokerage Upload to Portfolio Value (Tier 3)** (`test_brokerage_upload_to_portfolio_value.py`):
    - **Status**: Implemented hard gate for Issue #404

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -1,6 +1,6 @@
 # AC-to-Test Traceability Audit
 
-> **Generated**: 2026-05-18 (mechanically by `scripts/build_ac_traceability.py`)
+> **Generated**: 2026-05-19 (mechanically by `scripts/build_ac_traceability.py`)
 > **Purpose**: Complete mapping of every Acceptance Criterion (`ACx.y.z`) declared in `docs/ac_registry.yaml` + `docs/infra_registry.yaml` to the test file(s) that reference it.
 > **Scope**: All EPICs in `docs/project/`. Test scan: `apps/backend/tests`, `apps/frontend/src`, `scripts/tests`.
 
@@ -13,10 +13,10 @@
 | Metric | Count | Percentage |
 |--------|-------|------------|
 | **Total EPICs** | 18 | 100% |
-| **Total ACs (registries)** | 931 | 100% |
-| **Mandatory ACs** | 771 | 82.8% |
+| **Total ACs (registries)** | 934 | 100% |
+| **Mandatory ACs** | 774 | 82.9% |
 | **Deprecated ACs** | 3 | 0.3% |
-| **Mandatory ACs with test reference** | 771 | 100.0% |
+| **Mandatory ACs with test reference** | 774 | 100.0% |
 | **Mandatory ACs without test reference** | 0 | 0.0% |
 | **Test files referenced** | 182 | - |
 | **ACs flagged as manual verification (heuristic)** | 0 | 0.0% |
@@ -32,7 +32,7 @@
 | [EPIC-005](#epic-005-reporting-visualization) | reporting-visualization | 36 | 0 | 25 | 25 | 100.0% |
 | [EPIC-006](#epic-006-ai-advisor) | ai-advisor | 63 | 0 | 55 | 55 | 100.0% |
 | [EPIC-007](#epic-007-deployment) | deployment | 39 | 0 | 39 | 39 | 100.0% |
-| [EPIC-008](#epic-008-testing-strategy) | testing-strategy | 66 | 0 | 60 | 60 | 100.0% |
+| [EPIC-008](#epic-008-testing-strategy) | testing-strategy | 68 | 0 | 62 | 62 | 100.0% |
 | [EPIC-009](#epic-009-pdf-fixture-generation) | pdf-fixture-generation | 37 | 0 | 36 | 36 | 100.0% |
 | [EPIC-010](#epic-010-signoz-logging) | signoz-logging | 21 | 0 | 21 | 21 | 100.0% |
 | [EPIC-011](#epic-011-asset-lifecycle) | asset-lifecycle | 38 | 0 | 38 | 38 | 100.0% |
@@ -445,9 +445,9 @@
 
 <a id="epic-008-testing-strategy"></a>
 
-- **Total ACs**: 66
-- **Mandatory ACs**: 60
-- **Mandatory ACs with test reference**: 60 (100.0%)
+- **Total ACs**: 68
+- **Mandatory ACs**: 62
+- **Mandatory ACs with test reference**: 62 (100.0%)
 
 | AC ID | Mandatory | Description | Test References | Status |
 |-------|-----------|-------------|-----------------|--------|
@@ -517,6 +517,8 @@
 | AC8.13.8 | yes | Strict upload readiness E2E does not accept rejected statements | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.9 | yes | Production release runs prod-safe read-only E2E smoke | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.10 | yes | Multi-brokerage PDF upload -> position import -> latest portfolio value | `apps/backend/tests/portfolio/test_brokerage_position_parsing.py`<br>`scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
+| AC8.13.11 | yes | Staging health check diagnoses API route 404 with route probes | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
+| AC8.13.12 | yes | AI/OCR gate failures include statement validation context | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 
 ---
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -98,6 +98,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Staging deploys use a workflow-level `staging-deploy` concurrency group with `cancel-in-progress: false`, so post-merge deployments and the provider-backed GLM gate queue instead of overlapping.
 - Staging deploys may set `DEPLOY_PRIMARY_MODEL_OVERRIDE`, `DEPLOY_OCR_MODEL_OVERRIDE`, and `DEPLOY_VISION_MODEL_OVERRIDE`; the current post-merge gate pins `PRIMARY_MODEL=glm-5.1`, `OCR_MODEL=glm-4.6v`, and `VISION_MODEL=glm-4.6v`.
 - The GLM-backed PDF gate allows a longer parsing window than normal UI tests: JSON extraction requests use `AI_JSON_TIMEOUT_SECONDS=360`, and the browser gate waits up to `PARSING_TIMEOUT_MS=480000` so slow but successful `glm-4.6v` PDF parsing is not misclassified as a failed deployment.
+- Repeated `/api/health` 404 responses are treated as route failures, not generic backend failures: the health script probes `/api/ping` and `/` so logs distinguish a missing or shadowed Traefik API route from an unhealthy backend container.
 - The serialized GLM gate includes `tests/e2e/test_brokerage_upload_to_portfolio_value.py`, which uploads Moomoo and Futu PDF fixtures through `/api/statements/upload`, waits for parsed statements, imports positions through `/api/statements/{id}/brokerage/import`, and verifies `/api/portfolio/holdings` plus `/api/reports/balance-sheet`. Failures identify whether OCR parsing, brokerage import, portfolio valuation, or reporting failed.
 
 **PR preview E2E** (`.github/workflows/pr-test.yml`):
@@ -183,7 +184,9 @@ reachable. `tests/e2e/test_statement_full_journey.py::test_dbs_statement_full_jo
 is the AI/OCR hard gate: DBS PDF upload must reach `parsed`, show transactions,
 approve, and load the balance sheet. A `rejected` parsing status is a deploy
 failure because it usually indicates AI provider, OCR, secret, or model config
-breakage.
+breakage. Rejection failures include the selected model and statement validation
+context (`validation_error`, `parsing_progress`, `confidence_score`, and
+`balance_validated`) so the post-merge gate is actionable from the CI log.
 
 `tests/e2e/test_brokerage_upload_to_portfolio_value.py::test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value`
 is the upload-to-report portfolio hard gate for Issue #404. It proves that at

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -47,6 +47,40 @@ response_file=$(mktemp)
 error_file=$(mktemp)
 register_cleanup "$response_file" "$error_file"
 
+APP_BASE_URL="${HEALTH_URL%/api/health}"
+
+probe_route() {
+  local label="$1"
+  local url="$2"
+  local probe_file
+  local probe_error_file
+  local code
+
+  probe_file=$(mktemp)
+  probe_error_file=$(mktemp)
+
+  code=$(curl -sS --max-time 5 -o "$probe_file" -w "%{http_code}" "$url" 2>"$probe_error_file" || echo "000")
+  echo "  - $label: HTTP $code ($url)"
+  if [[ "$code" == "000" ]]; then
+    sed -n '1,3p' "$probe_error_file" 2>/dev/null || true
+  else
+    sed -n '1,3p' "$probe_file" 2>/dev/null || true
+  fi
+
+  rm -f "$probe_file" "$probe_error_file"
+}
+
+print_404_route_diagnostics() {
+  echo ""
+  echo "Route diagnostics:"
+  echo "The backend health endpoint returned 404 after deployment."
+  echo "This usually means the Traefik API route is missing or shadowed by the frontend route."
+  echo "Expected route: Host(report*) && PathPrefix(/api) -> backend, with higher priority than the web route."
+  probe_route "API ping" "$APP_BASE_URL/api/ping"
+  probe_route "Frontend shell" "$APP_BASE_URL/"
+  echo ""
+}
+
 echo "Starting health check for $ENVIRONMENT environment"
 echo "URL: $HEALTH_URL"
 echo "Max attempts: $MAX_ATTEMPTS (timeout: $((MAX_ATTEMPTS * 10))s)"
@@ -101,6 +135,9 @@ while (( attempt <= MAX_ATTEMPTS )); do
       echo "Response:"
       cat "$response_file" 2>/dev/null || echo "(no response body)"
       echo ""
+      if [[ "$http_code" == "404" ]]; then
+        print_404_route_diagnostics
+      fi
       echo "Troubleshooting: Check SigNoz for application logs"
       echo "========================================="
       exit 1

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -27,19 +26,53 @@ def test_AC8_13_7_full_statement_journey_is_a_hard_ai_ocr_gate() -> None:
     assert "@pytest.mark.critical" in journey
     assert "fail_or_skip_ai_ocr_gate(" in test_body
     assert "status=rejected" in test_body
+    assert "/api/statements/{statement_id}" in test_body
+    assert "validation_error" in read("tests/e2e/conftest.py")
+    assert "Last statement payload" in test_body
     assert "pytest.skip(" not in test_body
 
 
 def test_AC8_13_8_upload_readiness_gate_rejects_rejected_status() -> None:
     """AC8.13.8: Upload readiness E2E does not accept rejected statements."""
     upload = read("tests/e2e/test_statement_upload_e2e.py")
-    test_body = upload.split("async def test_statement_upload_full_flow", 1)[1].split(
-        "@pytest.mark.e2e", 1
-    )[0]
+    test_body = upload.split("async def test_statement_upload_full_flow", 1)[1].split("@pytest.mark.e2e", 1)[0]
 
     assert "AI/OCR readiness gate" in test_body
     assert "fail_or_skip_ai_ocr_gate(" in test_body
+    assert "statement=statement" in test_body
     assert '"rejected"' not in test_body.split("assert status in", 1)[1]
+
+
+def test_AC8_13_11_health_check_diagnoses_staging_api_route_404() -> None:
+    """AC8.13.11: Staging health 404 reports API route diagnostics."""
+    health_check = read("scripts/health_check.sh")
+
+    assert "print_404_route_diagnostics" in health_check
+    assert "Traefik API route is missing or shadowed" in health_check
+    assert 'probe_route "API ping" "$APP_BASE_URL/api/ping"' in health_check
+    assert 'probe_route "Frontend shell" "$APP_BASE_URL/"' in health_check
+    assert '[[ "$http_code" == "404" ]]' in health_check
+
+
+def test_AC8_13_12_ai_ocr_gate_failure_includes_statement_context() -> None:
+    """AC8.13.12: AI/OCR gate failures include statement validation context."""
+    conftest = read("tests/e2e/conftest.py")
+    journey = read("tests/e2e/test_statement_full_journey.py")
+    upload = read("tests/e2e/test_statement_upload_e2e.py")
+    brokerage = read("tests/e2e/test_brokerage_upload_to_portfolio_value.py")
+
+    assert "format_ai_ocr_gate_failure" in conftest
+    for token in (
+        "validation_error",
+        "confidence_score",
+        "parsing_progress",
+        "balance_validated",
+    ):
+        assert token in conftest
+    assert "model=default_model" in journey
+    assert "statement=last_statement" in journey
+    assert "statement=statement" in upload
+    assert "statement=last_payload" in brokerage
 
 
 def test_AC8_13_9_production_release_runs_prod_safe_e2e_smoke() -> None:
@@ -76,34 +109,13 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     assert "STAGING_E2E_PRIMARY_MODEL: glm-5.1" in workflow
     assert "STAGING_E2E_OCR_MODEL: glm-4.6v" in workflow
     assert "STAGING_E2E_VISION_MODEL: glm-4.6v" in workflow
-    assert (
-        "DEPLOY_PRIMARY_MODEL_OVERRIDE: ${{ env.STAGING_E2E_PRIMARY_MODEL }}"
-        in workflow
-    )
-    assert (
-        "DEPLOY_OCR_MODEL_OVERRIDE: ${{ env.STAGING_E2E_OCR_MODEL }}"
-        in workflow
-    )
-    assert (
-        "DEPLOY_VISION_MODEL_OVERRIDE: ${{ env.STAGING_E2E_VISION_MODEL }}"
-        in workflow
-    )
-    assert (
-        'update_env_var "$new_env" "PRIMARY_MODEL" "$DEPLOY_PRIMARY_MODEL_OVERRIDE"'
-        in deploy_script
-    )
-    assert (
-        'update_env_var "$new_env" "OCR_MODEL" "$DEPLOY_OCR_MODEL_OVERRIDE"'
-        in deploy_script
-    )
-    assert (
-        'update_env_var "$new_env" "VISION_MODEL" "$DEPLOY_VISION_MODEL_OVERRIDE"'
-        in deploy_script
-    )
-    assert (
-        'update_env_var "$new_env" "IAC_CONFIG_HASH" "models-${IMAGE_TAG}-$(date +%s)"'
-        in deploy_script
-    )
+    assert "DEPLOY_PRIMARY_MODEL_OVERRIDE: ${{ env.STAGING_E2E_PRIMARY_MODEL }}" in workflow
+    assert "DEPLOY_OCR_MODEL_OVERRIDE: ${{ env.STAGING_E2E_OCR_MODEL }}" in workflow
+    assert "DEPLOY_VISION_MODEL_OVERRIDE: ${{ env.STAGING_E2E_VISION_MODEL }}" in workflow
+    assert 'update_env_var "$new_env" "PRIMARY_MODEL" "$DEPLOY_PRIMARY_MODEL_OVERRIDE"' in deploy_script
+    assert 'update_env_var "$new_env" "OCR_MODEL" "$DEPLOY_OCR_MODEL_OVERRIDE"' in deploy_script
+    assert 'update_env_var "$new_env" "VISION_MODEL" "$DEPLOY_VISION_MODEL_OVERRIDE"' in deploy_script
+    assert 'update_env_var "$new_env" "IAC_CONFIG_HASH" "models-${IMAGE_TAG}-$(date +%s)"' in deploy_script
     assert '-m "(smoke or e2e) and not llm" -n 4' in workflow
     assert "PARSING_TIMEOUT_MS: 480000" in workflow
     assert "test_brokerage_upload_to_portfolio_value.py" in workflow
@@ -131,7 +143,7 @@ def test_AC8_13_10_multi_brokerage_upload_to_portfolio_value_gate() -> None:
 
     assert "test_brokerage_upload_to_portfolio_value.py" in workflow
     assert '-m "llm"' in workflow
-    assert "pytest tests/e2e -v -m \"(smoke or e2e) and not llm\" -n 4" in workflow
+    assert 'pytest tests/e2e -v -m "(smoke or e2e) and not llm" -n 4' in workflow
     assert "pytest.mark.critical" in brokerage
     assert "pytest.mark.llm" in brokerage
     assert '("moomoo", "Moomoo E2E Portfolio")' in brokerage

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,17 +2,18 @@
 Global pytest fixtures and configuration for Finance Report E2E tests.
 """
 
+import asyncio
 import json
 import logging
 import os
 import sys
-import asyncio
 import uuid
+from collections.abc import AsyncGenerator
 from datetime import datetime
 from pathlib import Path
-from typing import AsyncGenerator, Optional
+
 import pytest
-from playwright.async_api import async_playwright, Browser, BrowserContext, Page
+from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +25,7 @@ if str(ROOT) not in sys.path:
 class TestConfig:
     """Test configuration from environment variables."""
 
-    APP_URL = (
-        os.getenv("APP_URL") or os.getenv("FRONTEND_URL") or "http://localhost:3000"
-    )
+    APP_URL = os.getenv("APP_URL") or os.getenv("FRONTEND_URL") or "http://localhost:3000"
     TEST_ENV = os.getenv("TEST_ENV", "staging").lower()
     EXPECTED_SHA = os.getenv("EXPECTED_SHA")
 
@@ -41,10 +40,47 @@ def _strict_e2e_gates_enabled() -> bool:
     return os.getenv("STRICT_E2E_GATES", "").lower() in {"1", "true", "yes"}
 
 
-def fail_or_skip_ai_ocr_gate(message: str) -> None:
+def format_ai_ocr_gate_failure(
+    message: str,
+    *,
+    statement: dict | None = None,
+    model: str | None = None,
+) -> str:
+    details: list[str] = []
+    if model:
+        details.append(f"model={model}")
+    if statement:
+        for key in (
+            "id",
+            "status",
+            "validation_error",
+            "confidence_score",
+            "parsing_progress",
+            "balance_validated",
+        ):
+            value = statement.get(key)
+            if value not in (None, ""):
+                details.append(f"{key}={value}")
+
+    if not details:
+        return message
+    return f"{message}. Details: " + "; ".join(details)
+
+
+def fail_or_skip_ai_ocr_gate(
+    message: str,
+    *,
+    statement: dict | None = None,
+    model: str | None = None,
+) -> None:
+    failure_message = format_ai_ocr_gate_failure(
+        message,
+        statement=statement,
+        model=model,
+    )
     if _strict_e2e_gates_enabled():
-        pytest.fail(message)
-    pytest.skip(f"{message} STRICT_E2E_GATES is not enabled for this environment.")
+        pytest.fail(failure_message)
+    pytest.skip(f"{failure_message} STRICT_E2E_GATES is not enabled for this environment.")
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -68,10 +104,10 @@ def pytest_runtest_makereport(item, call):
 class AuthState:
     """Shared authentication state across test session."""
 
-    user_id: Optional[str] = None
-    email: Optional[str] = None
-    access_token: Optional[str] = None
-    password: Optional[str] = None
+    user_id: str | None = None
+    email: str | None = None
+    access_token: str | None = None
+    password: str | None = None
 
 
 @pytest.fixture(scope="session")
@@ -123,29 +159,22 @@ async def shared_auth_state() -> AsyncGenerator[AuthState, None]:
             )
 
             if response.status_code not in (200, 201):
-                pytest.fail(
-                    f"[SESSION SETUP] Failed to register shared user: {response.status_code} - {response.text}"
-                )
+                pytest.fail(f"[SESSION SETUP] Failed to register shared user: {response.status_code} - {response.text}")
 
             try:
                 data = response.json()
             except ValueError as e:
-                pytest.fail(
-                    f"[SESSION SETUP] API returned invalid JSON: {response.text[:200]}... Error: {e}"
-                )
+                pytest.fail(f"[SESSION SETUP] API returned invalid JSON: {response.text[:200]}... Error: {e}")
 
             if not isinstance(data, dict):
-                pytest.fail(
-                    f"[SESSION SETUP] API returned non-dict: {type(data).__name__}"
-                )
+                pytest.fail(f"[SESSION SETUP] API returned non-dict: {type(data).__name__}")
 
             state.user_id = data.get("id")
             state.access_token = data.get("access_token")
 
             if not state.user_id or not state.access_token:
                 pytest.fail(
-                    f"[SESSION SETUP] Registration response missing id or access_token. "
-                    f"Got keys: {list(data.keys())}"
+                    f"[SESSION SETUP] Registration response missing id or access_token. Got keys: {list(data.keys())}"
                 )
 
             logger.info(f"[SESSION SETUP] Shared user created: {state.user_id}")
@@ -165,9 +194,7 @@ async def shared_auth_state() -> AsyncGenerator[AuthState, None]:
                     headers={"Authorization": f"Bearer {state.access_token}"},
                 )
                 if delete_response.status_code in (200, 204):
-                    logger.info(
-                        "[SESSION TEARDOWN] Shared user cleaned up successfully"
-                    )
+                    logger.info("[SESSION TEARDOWN] Shared user cleaned up successfully")
                 elif delete_response.status_code == 404:
                     logger.debug(
                         f"[SESSION TEARDOWN] DELETE /api/users endpoint not found (status 404). "
@@ -215,9 +242,7 @@ async def page(context: BrowserContext) -> AsyncGenerator[Page, None]:
 
 
 @pytest.fixture
-async def authenticated_page(
-    context: BrowserContext, shared_auth_state: AuthState
-) -> AsyncGenerator[Page, None]:
+async def authenticated_page(context: BrowserContext, shared_auth_state: AuthState) -> AsyncGenerator[Page, None]:
     """Create browser page with authenticated user (using shared session auth).
 
     This fixture:
@@ -238,16 +263,12 @@ async def authenticated_page(
     try:
         import jwt
 
-        decoded = jwt.decode(
-            shared_auth_state.access_token, options={"verify_signature": False}
-        )
+        decoded = jwt.decode(shared_auth_state.access_token, options={"verify_signature": False})
         exp_timestamp = decoded.get("exp")
         if exp_timestamp:
             time_until_expiry = exp_timestamp - datetime.now().timestamp()
             if time_until_expiry < 300:
-                logger.warning(
-                    f"Token expires in {time_until_expiry:.0f}s, test may fail for long runs"
-                )
+                logger.warning(f"Token expires in {time_until_expiry:.0f}s, test may fail for long runs")
     except ImportError:
         pass
     except Exception as e:
@@ -312,17 +333,13 @@ async def authenticated_page_unique(
             )
 
             if response.status_code not in (200, 201):
-                pytest.fail(
-                    f"Failed to register test user: {response.status_code} - {response.text}"
-                )
+                pytest.fail(f"Failed to register test user: {response.status_code} - {response.text}")
 
             # Validate JSON response
             try:
                 data = response.json()
             except ValueError as e:
-                pytest.fail(
-                    f"API returned invalid JSON: {response.text[:200]}... Error: {e}"
-                )
+                pytest.fail(f"API returned invalid JSON: {response.text[:200]}... Error: {e}")
 
             # data is guaranteed to be set here if we didn't pytest.fail()
             if not isinstance(data, dict):
@@ -332,10 +349,7 @@ async def authenticated_page_unique(
             access_token = data.get("access_token")
 
             if not user_id or not access_token:
-                pytest.fail(
-                    f"Registration response missing id or access_token. "
-                    f"Got keys: {list(data.keys())}"
-                )
+                pytest.fail(f"Registration response missing id or access_token. Got keys: {list(data.keys())}")
 
             logger.info(f"User registered successfully: {user_id}")
 
@@ -351,9 +365,7 @@ async def authenticated_page_unique(
         if exp_timestamp:
             time_until_expiry = exp_timestamp - datetime.now().timestamp()
             if time_until_expiry < 300:  # Less than 5 minutes
-                logger.warning(
-                    f"Token expires in {time_until_expiry:.0f}s, test may fail for long runs"
-                )
+                logger.warning(f"Token expires in {time_until_expiry:.0f}s, test may fail for long runs")
     except ImportError:
         # PyJWT not installed, skip expiration check
         pass
@@ -411,9 +423,6 @@ async def authenticated_page_unique(
                             f"Consider implementing user cleanup endpoint."
                         )
                     else:
-                        logger.warning(
-                            f"Failed to cleanup test user {user_id}: "
-                            f"status {delete_response.status_code}"
-                        )
+                        logger.warning(f"Failed to cleanup test user {user_id}: status {delete_response.status_code}")
             except Exception as e:
                 logger.debug(f"User cleanup error (non-critical): {e}")

--- a/tests/e2e/test_brokerage_upload_to_portfolio_value.py
+++ b/tests/e2e/test_brokerage_upload_to_portfolio_value.py
@@ -54,11 +54,7 @@ def _get_pdf_path(source: str) -> Path:
         text=True,
     )
     if result.returncode != 0:
-        pytest.skip(
-            f"PDF fixture generation failed for {source}.\n"
-            f"stdout:\n{result.stdout}\n"
-            f"stderr:\n{result.stderr}"
-        )
+        pytest.skip(f"PDF fixture generation failed for {source}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
     pdfs = sorted(source_dir.glob(f"test_{source}_*.pdf")) if source_dir.exists() else []
     if not pdfs:
         pytest.skip(f"PDF generation for {source} produced no files in {source_dir}")
@@ -77,9 +73,7 @@ def _unique_pdf_copy(src: Path) -> Path:
 
 async def _default_image_model(client: httpx.AsyncClient) -> str:
     response = await client.get(_api_url("/ai/models?modality=image"))
-    assert response.status_code == 200, (
-        f"model catalog request failed: {response.status_code} {response.text}"
-    )
+    assert response.status_code == 200, f"model catalog request failed: {response.status_code} {response.text}"
     payload = response.json()
     return payload.get("default_model") or payload["models"][0]["id"]
 
@@ -98,9 +92,7 @@ async def _upload_brokerage_pdf(
             data={"institution": institution, "model": model},
             files={"file": (pdf_path.name, fh, "application/pdf")},
         )
-    assert response.status_code in (200, 201, 202), (
-        f"{source} upload failed: {response.status_code} {response.text}"
-    )
+    assert response.status_code in (200, 201, 202), f"{source} upload failed: {response.status_code} {response.text}"
     statement_id = response.json().get("id")
     assert statement_id, f"{source} upload response missing id: {response.text}"
     return str(statement_id)
@@ -118,8 +110,8 @@ async def _wait_for_parsed_statement(client: httpx.AsyncClient, statement_id: st
         status = last_payload.get("status")
         if status == "rejected":
             fail_or_skip_ai_ocr_gate(
-                f"brokerage OCR/import gate rejected statement {statement_id}: "
-                f"{last_payload.get('validation_error')}"
+                f"brokerage OCR/import gate rejected statement {statement_id}: {last_payload.get('validation_error')}",
+                statement=last_payload,
             )
         if status == "parsed":
             assert last_payload.get("transactions"), (
@@ -129,8 +121,7 @@ async def _wait_for_parsed_statement(client: httpx.AsyncClient, statement_id: st
         await asyncio.sleep(5)
 
     pytest.fail(
-        f"statement {statement_id} did not reach parsed within {PARSING_TIMEOUT_MS}ms. "
-        f"last payload: {last_payload}"
+        f"statement {statement_id} did not reach parsed within {PARSING_TIMEOUT_MS}ms. last payload: {last_payload}"
     )
 
 
@@ -161,25 +152,17 @@ async def test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_p
                 )
             )
 
-        parsed_statements = [
-            await _wait_for_parsed_statement(client, statement_id)
-            for statement_id in statement_ids
-        ]
+        parsed_statements = [await _wait_for_parsed_statement(client, statement_id) for statement_id in statement_ids]
         assert len(parsed_statements) == 2
 
         imported_positions = Decimal("0")
         for parsed_statement in parsed_statements:
-            response = await client.post(
-                _api_url(f"/statements/{parsed_statement['id']}/brokerage/import")
-            )
+            response = await client.post(_api_url(f"/statements/{parsed_statement['id']}/brokerage/import"))
             assert response.status_code == 200, (
-                f"brokerage import failed for {parsed_statement['id']}: "
-                f"{response.status_code} {response.text}"
+                f"brokerage import failed for {parsed_statement['id']}: {response.status_code} {response.text}"
             )
             payload = response.json()
-            assert payload["parsed_positions"] > 0, (
-                f"no positions imported for {parsed_statement['id']}: {payload}"
-            )
+            assert payload["parsed_positions"] > 0, f"no positions imported for {parsed_statement['id']}: {payload}"
             imported_positions += Decimal(str(payload["parsed_positions"]))
 
         holdings_response = await client.get(_api_url("/portfolio/holdings"))
@@ -191,14 +174,10 @@ async def test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_p
         total_market_value = sum(Decimal(str(item["market_value"])) for item in holdings)
         assert total_market_value > Decimal("0.00"), f"holdings have no market value: {holdings}"
 
-        balance_response = await client.get(
-            _api_url(f"/reports/balance-sheet?as_of_date={date.today().isoformat()}")
-        )
+        balance_response = await client.get(_api_url(f"/reports/balance-sheet?as_of_date={date.today().isoformat()}"))
         assert balance_response.status_code == 200, (
             f"balance sheet check failed: {balance_response.status_code} {balance_response.text}"
         )
         balance_sheet = balance_response.json()
         assert Decimal(str(balance_sheet["total_assets"])) >= total_market_value, balance_sheet
-        assert Decimal(str(balance_sheet["net_worth_adjustment_gain_loss"])) > Decimal("0.00"), (
-            balance_sheet
-        )
+        assert Decimal(str(balance_sheet["net_worth_adjustment_gain_loss"])) > Decimal("0.00"), balance_sheet

--- a/tests/e2e/test_statement_full_journey.py
+++ b/tests/e2e/test_statement_full_journey.py
@@ -75,9 +75,7 @@ def _get_dbs_pdf_path() -> Path:
         )
     pdfs = sorted(dbs_dir.glob("test_dbs_*.pdf")) if dbs_dir.exists() else []
     if not pdfs:
-        pytest.skip(
-            f"PDF generation script exited 0 but produced no output in {dbs_dir} — skipping."
-        )
+        pytest.skip(f"PDF generation script exited 0 but produced no output in {dbs_dir} — skipping.")
     return pdfs[-1]
 
 
@@ -115,9 +113,7 @@ async def test_dbs_statement_full_journey(authenticated_page: Page) -> None:
     await page.wait_for_load_state("networkidle")
 
     if "/login" in page.url:
-        pytest.fail(
-            f"Redirected to /login despite authenticated_page fixture. URL: {page.url}"
-        )
+        pytest.fail(f"Redirected to /login despite authenticated_page fixture. URL: {page.url}")
 
     await page.locator("#institution").fill(INSTITUTION_LABEL)
     # Fetch the default model from the backend API and select it explicitly.
@@ -125,63 +121,68 @@ async def test_dbs_statement_full_journey(authenticated_page: Page) -> None:
     models_resp = await page.evaluate(
         "async () => { const r = await fetch('/api/ai/models?modality=image'); return r.json(); }"
     )
-    default_model: str = (
-        models_resp.get("default_model") or models_resp["models"][0]["id"]
-    )
+    default_model: str = models_resp.get("default_model") or models_resp["models"][0]["id"]
     model_select = page.locator("select#ai-model")
     await expect(model_select).to_be_visible(timeout=15_000)
     await expect(model_select).not_to_have_value("", timeout=15_000)
     await model_select.select_option(value=default_model)
     await page.set_input_files("#file-upload", str(pdf_path))
-    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(
-        timeout=5_000
-    )
+    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(timeout=5_000)
 
-    async with (
-        page.expect_response(
-            lambda r: "/api/statements/upload" in r.url,
-            timeout=120_000,  # Upload + AI model validation may take up to 120s on cold-start
-        ) as resp_info
-    ):
+    async with page.expect_response(
+        lambda r: "/api/statements/upload" in r.url,
+        timeout=120_000,  # Upload + AI model validation may take up to 120s on cold-start
+    ) as resp_info:
         await page.get_by_role("button", name="Upload & Parse Statement").click()
     upload_resp = await resp_info.value
     assert upload_resp.status in (200, 201, 202), (
         f"Upload endpoint returned unexpected status {upload_resp.status} — "
         f"expected 2xx. Response body: {await upload_resp.text()}"
     )
+    upload_body = await upload_resp.json()
+    statement_id = upload_body.get("id")
+    assert statement_id, f"Upload response missing 'id' field: {upload_body}"
+    token = await page.evaluate("() => window.localStorage.getItem('finance_access_token')")
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
 
     # === AC8.13.2: Poll until "parsed" status badge appears in the list ===
     # The list page polls via TanStack Query every 3 s — we wait up to PARSING_TIMEOUT_MS.
     statement_row = page.locator("a").filter(has_text=INSTITUTION_LABEL).first
     await expect(statement_row).to_be_visible(timeout=15_000)
 
-    parsed_badge = (
-        page.locator("a")
-        .filter(has_text=INSTITUTION_LABEL)
-        .locator("span.badge", has_text="parsed")
-    )
-    rejected_badge = (
-        page.locator("a")
-        .filter(has_text=INSTITUTION_LABEL)
-        .locator("span.badge", has_text="rejected")
-    )
-    # Poll until parsed, but fail fast if rejected appears (AI parsing error).
+    parsed_badge = page.locator("a").filter(has_text=INSTITUTION_LABEL).locator("span.badge", has_text="parsed")
+    rejected_badge = page.locator("a").filter(has_text=INSTITUTION_LABEL).locator("span.badge", has_text="rejected")
+    # Poll the statement API by ID until parsed, but fail fast with the stored
+    # validation error if the AI/OCR provider rejects parsing.
     # This avoids waiting the full PARSING_TIMEOUT_MS when the AI service fails.
     import asyncio
 
     deadline = asyncio.get_event_loop().time() + PARSING_TIMEOUT_MS / 1000
+    last_statement: dict | None = None
     while asyncio.get_event_loop().time() < deadline:
-        if await rejected_badge.is_visible():
+        api_resp = await page.request.get(
+            _get_url(f"/api/statements/{statement_id}"),
+            headers=headers,
+        )
+        assert api_resp.status == 200, (
+            f"GET /api/statements/{statement_id} returned {api_resp.status} — response body: {await api_resp.text()}"
+        )
+        last_statement = await api_resp.json()
+        if last_statement.get("status") == "rejected" or await rejected_badge.is_visible():
             fail_or_skip_ai_ocr_gate(
                 "Statement parsing failed (status=rejected) — AI service may be "
-                "unavailable or misconfigured on the test environment."
+                "unavailable or misconfigured on the test environment.",
+                statement=last_statement,
+                model=default_model,
             )
-        if await parsed_badge.is_visible():
+        if last_statement.get("status") == "parsed":
+            await expect(parsed_badge).to_be_visible(timeout=15_000)
             break
         await page.wait_for_timeout(3_000)
     else:
         pytest.fail(
-            f"Statement never reached 'parsed' status within {PARSING_TIMEOUT_MS}ms"
+            f"Statement never reached 'parsed' status within {PARSING_TIMEOUT_MS}ms. "
+            f"Last statement payload: {last_statement}"
         )
 
     # === AC8.13.3: Detail page shows transactions ===
@@ -190,44 +191,30 @@ async def test_dbs_statement_full_journey(authenticated_page: Page) -> None:
     # can resolve before the Next.js router commits the URL change.
     await expect(page).to_have_url(re.compile(r"/statements/[^/]+$"), timeout=15_000)
 
-    await expect(page.get_by_text("Transactions", exact=False)).to_be_visible(
-        timeout=10_000
-    )
+    await expect(page.get_by_text("Transactions", exact=False)).to_be_visible(timeout=10_000)
     await expect(page.locator("table tbody tr").first).to_be_visible(timeout=10_000)
 
     # === AC8.13.4: Start Review → approve via ConfirmDialog ===
     await page.get_by_role("link", name=re.compile("Start Review")).click()
-    await expect(page).to_have_url(
-        re.compile(r"/statements/[^/]+/review$"), timeout=15_000
-    )
+    await expect(page).to_have_url(re.compile(r"/statements/[^/]+/review$"), timeout=15_000)
     await page.get_by_role("button", name="Approve").click()
     dialog = page.locator('[role="dialog"]')
     await expect(dialog).to_be_visible(timeout=5_000)
     confirm_button = dialog.get_by_role("button", name="Approve")
     await expect(confirm_button).to_be_visible(timeout=3_000)
     await confirm_button.click()
-    await expect(page).to_have_url(
-        re.compile(r"/statements/[^/?]+(?:\?.*)?$"), timeout=15_000
-    )
-    await expect(page.locator("span.badge", has_text="approved")).to_be_visible(
-        timeout=15_000
-    )
+    await expect(page).to_have_url(re.compile(r"/statements/[^/?]+(?:\?.*)?$"), timeout=15_000)
+    await expect(page.locator("span.badge", has_text="approved")).to_be_visible(timeout=15_000)
 
     await page.goto(_get_url("/statements"))
     await expect(page).to_have_url(re.compile(r"/statements$"), timeout=15_000)
     approved_row = page.locator("a").filter(has_text=INSTITUTION_LABEL).first
     await expect(approved_row).to_be_visible(timeout=15_000)
-    await expect(approved_row.locator("span.badge", has_text="approved")).to_be_visible(
-        timeout=15_000
-    )
+    await expect(approved_row.locator("span.badge", has_text="approved")).to_be_visible(timeout=15_000)
 
     # === AC8.13.5: Balance sheet report loads ===
     await page.goto(_get_url("/reports/balance-sheet"))
     await page.wait_for_load_state("networkidle")
 
-    await expect(page.get_by_text("Balance Sheet", exact=False).first).to_be_visible(
-        timeout=10_000
-    )
-    await expect(page.get_by_text("Assets", exact=False).first).to_be_visible(
-        timeout=10_000
-    )
+    await expect(page.get_by_text("Balance Sheet", exact=False).first).to_be_visible(timeout=10_000)
+    await expect(page.get_by_text("Assets", exact=False).first).to_be_visible(timeout=10_000)

--- a/tests/e2e/test_statement_upload_e2e.py
+++ b/tests/e2e/test_statement_upload_e2e.py
@@ -114,9 +114,7 @@ async def test_statement_upload_full_flow(authenticated_page: Page) -> None:
     await expect(model_select).not_to_have_value("", timeout=15_000)
     await model_select.select_option(index=0)
     await page.set_input_files("#file-upload", str(pdf_path))
-    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(
-        timeout=5_000
-    )
+    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(timeout=5_000)
 
     async with page.expect_response(
         lambda r: "/api/statements/upload" in r.url,
@@ -136,17 +134,14 @@ async def test_statement_upload_full_flow(authenticated_page: Page) -> None:
     await expect(statement_row).to_be_visible(timeout=15_000)
     # Verify the statement is immediately accessible via the API.
     # Read the JWT from localStorage, then use Playwright's request API (no JS-in-browser needed).
-    token = await page.evaluate(
-        "() => window.localStorage.getItem('finance_access_token')"
-    )
+    token = await page.evaluate("() => window.localStorage.getItem('finance_access_token')")
     headers = {"Authorization": f"Bearer {token}"} if token else {}
     api_resp = await page.request.get(
         _get_url(f"/api/statements/{statement_id}"),
         headers=headers,
     )
     assert api_resp.status == 200, (
-        f"GET /api/statements/{statement_id} returned {api_resp.status} \u2014 "
-        f"response body: {await api_resp.text()}"
+        f"GET /api/statements/{statement_id} returned {api_resp.status} \u2014 response body: {await api_resp.text()}"
     )
     statement = await api_resp.json()
     assert statement and statement.get("id") == statement_id
@@ -154,7 +149,10 @@ async def test_statement_upload_full_flow(authenticated_page: Page) -> None:
     # validation failed before the full journey can even poll to parsed.
     status = statement.get("status")
     if status == "rejected":
-        fail_or_skip_ai_ocr_gate("Statement upload returned status=rejected")
+        fail_or_skip_ai_ocr_gate(
+            "Statement upload returned status=rejected",
+            statement=statement,
+        )
     assert status in {"uploaded", "parsing", "parsed", "approved"}, (
         f"Unexpected statement status: {statement.get('status')}"
     )
@@ -178,9 +176,7 @@ async def test_model_selection_and_upload(authenticated_page: Page) -> None:
 
     await page.locator("#institution").fill("E2E Model Test Bank")
     await page.set_input_files("#file-upload", str(pdf_path))
-    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(
-        timeout=5_000
-    )
+    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(timeout=5_000)
 
     async with page.expect_response(
         lambda r: "/api/statements/upload" in r.url,
@@ -193,9 +189,7 @@ async def test_model_selection_and_upload(authenticated_page: Page) -> None:
         f"expected 2xx. Response body: {await upload_resp.text()}"
     )
 
-    await expect(
-        page.locator("a").filter(has_text="E2E Model Test Bank").first
-    ).to_be_visible(timeout=15_000)
+    await expect(page.locator("a").filter(has_text="E2E Model Test Bank").first).to_be_visible(timeout=15_000)
 
 
 @pytest.mark.e2e
@@ -217,9 +211,5 @@ async def test_stale_model_id_auto_cleanup(authenticated_page: Page) -> None:
     await page.evaluate(f'localStorage.setItem("statement_model_v1", "{stale_id}")')
     await page.reload()
     await page.wait_for_load_state("networkidle")
-    stored_model: str | None = await page.evaluate(
-        'localStorage.getItem("statement_model_v1")'
-    )
-    assert stored_model != stale_id, (
-        f"Stale model ID '{stale_id}' was not cleared from localStorage after reload"
-    )
+    stored_model: str | None = await page.evaluate('localStorage.getItem("statement_model_v1")')
+    assert stored_model != stale_id, f"Stale model ID '{stale_id}' was not cleared from localStorage after reload"


### PR DESCRIPTION
## Summary

Hardens post-merge staging diagnostics for the two dominant failure classes: `/api/health` routing 404s and AI/OCR `status=rejected` gates.

Closes #<!-- none: follow-up issues #409-#412 track categories 3-6 -->

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.11, AC8.13.12 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/ci-cd.md` — documented staging route diagnostics and AI/OCR failure context

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | Working tree before implementation | Added AC8.13.11/12 assertions in `scripts/tests/test_post_merge_e2e_gates.py` before code/docs updates |
| Green | `ab4f782` | Implement health 404 route probes and AI/OCR statement-context failure messages |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable; no DB changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable; existing local `repo` pointer change was not committed)
- [x] `scripts/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `scripts/check_manifest.py` passes
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
uv run --with pytest --with pyyaml pytest scripts/tests/test_post_merge_e2e_gates.py -q
uv run --with pytest --with pyyaml pytest scripts/tests/test_post_merge_e2e_gates.py scripts/tests/test_build_ac_traceability.py -q
cd apps/backend && uv run ruff check src/ && uv run ruff format src/ --check
cd apps/backend && uv run ruff check ../../tests/e2e/conftest.py ../../tests/e2e/test_statement_full_journey.py ../../tests/e2e/test_statement_upload_e2e.py ../../tests/e2e/test_brokerage_upload_to_portfolio_value.py ../../scripts/tests/test_post_merge_e2e_gates.py
cd apps/backend && uv run ruff format ../../tests/e2e/conftest.py ../../tests/e2e/test_statement_full_journey.py ../../tests/e2e/test_statement_upload_e2e.py ../../tests/e2e/test_brokerage_upload_to_portfolio_value.py ../../scripts/tests/test_post_merge_e2e_gates.py --check
bash -n scripts/health_check.sh
uv run --with pyyaml python scripts/build_ac_traceability.py --check
uv run --with pyyaml python scripts/check_manifest.py
uv run --with pyyaml python scripts/lint_doc_consistency.py
python scripts/check_ssot_ownership.py --verbose
```

`moon run :lint` was attempted but hung for about five minutes with no child processes or output, so I terminated the stuck wrapper and ran the CI-equivalent lint/doc checks above directly.

---

## Screenshots / Evidence

_N/A_
