### PR TITLE
[codex] Fix latest holdings snapshot valuation

### DIFF
--- a/apps/backend/src/services/portfolio.py
+++ b/apps/backend/src/services/portfolio.py
@@ -5,7 +5,7 @@ from datetime import date
 from decimal import Decimal
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -79,8 +79,7 @@ class PortfolioService:
         Raises:
             PortfolioNotFoundError: If user has no positions
         """
-        # Default to today if not specified
-        eval_date = as_of_date or date.today()
+        eval_date = as_of_date or await self._default_holdings_eval_date(db, user_id)
 
         # Get all managed positions for user
         positions_query = (
@@ -597,6 +596,16 @@ class PortfolioService:
 
         # No price data available
         raise AssetNotFoundError(f"No price data available for {position.asset_identifier} on {eval_date}")
+
+    async def _default_holdings_eval_date(self, db: AsyncSession, user_id: UUID) -> date:
+        """Use today unless the latest imported portfolio snapshot is newer."""
+        latest_snapshot_date = await db.scalar(
+            select(func.max(AtomicPosition.snapshot_date)).where(AtomicPosition.user_id == user_id)
+        )
+        today = date.today()
+        if latest_snapshot_date and latest_snapshot_date > today:
+            return latest_snapshot_date
+        return today
 
     async def _get_latest_atomic(
         self,

--- a/apps/backend/tests/portfolio/test_portfolio_service.py
+++ b/apps/backend/tests/portfolio/test_portfolio_service.py
@@ -103,6 +103,74 @@ async def test_get_holdings_happy_path(db, test_user, svc, active_position, atom
 
 
 @pytest.mark.asyncio
+async def test_get_holdings_defaults_to_latest_future_brokerage_snapshot(db, test_user, svc, account):
+    """AC8.13.10/Issue #424: Latest holdings include current-month brokerage snapshots."""
+    future_snapshot_date = date.today() + timedelta(days=12)
+    position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=account.id,
+        asset_identifier="FULLERTON_SGD_MMF",
+        quantity=Decimal("100"),
+        cost_basis=Decimal("1000.00"),
+        currency="SGD",
+        acquisition_date=future_snapshot_date,
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    atom = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=future_snapshot_date,
+        asset_identifier="FULLERTON_SGD_MMF",
+        broker="Moomoo",
+        quantity=Decimal("100"),
+        market_value=Decimal("1234.00"),
+        currency="SGD",
+        dedup_hash="future_brokerage_snapshot",
+        source_documents={},
+    )
+    db.add_all([position, atom])
+    await db.flush()
+
+    holdings = await svc.get_holdings(db, test_user.id)
+
+    assert len(holdings) == 1
+    assert holdings[0].asset_identifier == "FULLERTON_SGD_MMF"
+    assert holdings[0].market_value == Decimal("1234.00")
+
+
+@pytest.mark.asyncio
+async def test_get_holdings_explicit_as_of_date_does_not_use_future_snapshot(db, test_user, svc, account):
+    """AC8.13.10/Issue #424: Explicit historical holdings remain date bounded."""
+    position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=account.id,
+        asset_identifier="FUTU_STOCK_AND_OPTIONS",
+        quantity=Decimal("1"),
+        cost_basis=Decimal("250.00"),
+        currency="SGD",
+        acquisition_date=date.today() + timedelta(days=12),
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    atom = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=date.today() + timedelta(days=12),
+        asset_identifier="FUTU_STOCK_AND_OPTIONS",
+        broker="Futu",
+        quantity=Decimal("1"),
+        market_value=Decimal("250.00"),
+        currency="SGD",
+        dedup_hash="explicit_date_future_brokerage_snapshot",
+        source_documents={},
+    )
+    db.add_all([position, atom])
+    await db.flush()
+
+    with pytest.raises(AssetNotFoundError):
+        await svc.get_holdings(db, test_user.id, as_of_date=date.today())
+
+
+@pytest.mark.asyncio
 async def test_get_holdings_no_positions_raises(db, test_user, svc):
     """AC17.1.2: Holdings on empty portfolio raises PortfolioNotFoundError.
 

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -516,7 +516,7 @@
 | AC8.13.7 | yes | Strict full statement journey fails on rejected AI/OCR parsing | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.8 | yes | Strict upload readiness E2E does not accept rejected statements | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.9 | yes | Production release runs prod-safe read-only E2E smoke | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
-| AC8.13.10 | yes | Multi-brokerage PDF upload -> position import -> latest portfolio value | `apps/backend/tests/accounting/test_validation.py`<br>`apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py`<br>`scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
+| AC8.13.10 | yes | Multi-brokerage PDF upload -> position import -> latest portfolio value | `apps/backend/tests/accounting/test_validation.py`<br>`apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py`<br>`apps/backend/tests/portfolio/test_portfolio_service.py`<br>`scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.11 | yes | Staging health check diagnoses API route 404 with route probes | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.12 | yes | AI/OCR gate failures include statement validation context | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.13 | yes | Staging deploy cancels stale runs and bounds E2E gate duration with phase timing logs | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |

--- a/docs/ssot/assets.md
+++ b/docs/ssot/assets.md
@@ -54,6 +54,10 @@ For each latest atomic position:
 
 `_get_or_create_broker_account` automatically creates an `ASSET`-type account for each broker encountered during reconciliation. Broker name falls back to `"Unknown Broker"` when not provided.
 
+### Latest Holdings Valuation Date
+
+`GET /portfolio/holdings` without `as_of_date` returns the latest portfolio value. The valuation date is `today` unless the user's latest imported `AtomicPosition.snapshot_date` is newer, which can happen for current-month brokerage statement fixtures or provider outputs that normalize month-only periods to month end. Explicit `as_of_date` requests remain date-bounded and must not use future snapshots.
+
 ---
 
 ## 3. API Endpoints


### PR DESCRIPTION
## Summary

- Fix default `/portfolio/holdings` valuation to use the latest imported `AtomicPosition.snapshot_date` when it is newer than today.
- Preserve strict historical behavior when callers pass an explicit `as_of_date`.
- Add regression coverage for current-month brokerage snapshots and update the Assets SSOT.

## Root Cause

The #424 post-merge `Deploy Staging` failure reached the brokerage import step successfully: both brokerage statements parsed, `/statements/{id}/brokerage/import` returned 200, and `parsed_positions` totaled 2. The subsequent `/portfolio/holdings` call returned `[]` because default holdings valuation used `date.today()`, while current-month brokerage fixture/provider output can normalize a month-only snapshot to month end. `_get_latest_price()` then filtered with `AtomicPosition.snapshot_date <= today`, found no price row, raised `AssetNotFoundError`, and the router returned an empty holdings list.

## Validation

- `uv run --with pytest --with pyyaml pytest scripts/tests/test_post_merge_e2e_gates.py -q`
- `uv run --with pyyaml python scripts/check_manifest.py && uv run --with pyyaml python scripts/lint_doc_consistency.py && python scripts/check_ssot_ownership.py --verbose`
- `cd apps/backend && uv run ruff check src/services/portfolio.py tests/portfolio/test_portfolio_service.py && uv run ruff format src/services/portfolio.py tests/portfolio/test_portfolio_service.py --check`

Local DB-backed backend tests could not run because local PostgreSQL was not listening on `127.0.0.1:5432`; GitHub CI will run the new regression tests in its database-backed environment.
