### PR TITLE
[codex] Preserve latest holdings router default

### DIFF
--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -87,7 +87,7 @@ async def get_holdings(
         holdings = await _portfolio_service.get_holdings(
             db=db,
             user_id=user_id,
-            as_of_date=as_of_date or date.today(),
+            as_of_date=as_of_date,
             include_disposed=include_disposed,
         )
     except (PortfolioNotFoundError, AssetNotFoundError):

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -107,6 +107,89 @@ async def test_get_holdings_with_date_filter(client: AsyncClient, portfolio_with
 
 
 @pytest.mark.asyncio
+async def test_get_holdings_defaults_to_future_imported_snapshot(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+    investment_account,
+):
+    """AC8.13.10: Default holdings endpoint returns latest imported snapshot."""
+    future_date = date.today() + timedelta(days=12)
+    position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=investment_account.id,
+        asset_identifier="FULLERTON-SGD-MMF",
+        quantity=Decimal("100"),
+        cost_basis=Decimal("1000.00"),
+        currency="SGD",
+        acquisition_date=date.today(),
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    atomic = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=future_date,
+        asset_identifier="FULLERTON-SGD-MMF",
+        broker="Moomoo E2E Portfolio",
+        quantity=Decimal("100"),
+        market_value=Decimal("1234.00"),
+        currency="SGD",
+        dedup_hash="router_future_snapshot",
+        source_documents={},
+    )
+    db.add_all([position, atomic])
+    await db.commit()
+
+    response = await client.get("/portfolio/holdings")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["asset_identifier"] == "FULLERTON-SGD-MMF"
+    assert data[0]["market_value"] == "1234.00"
+
+
+@pytest.mark.asyncio
+async def test_get_holdings_explicit_date_does_not_use_future_snapshot(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+    investment_account,
+):
+    """AC8.13.10: Explicit holdings date remains date-bounded."""
+    future_date = date.today() + timedelta(days=12)
+    position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=investment_account.id,
+        asset_identifier="FULLERTON-SGD-MMF",
+        quantity=Decimal("100"),
+        cost_basis=Decimal("1000.00"),
+        currency="SGD",
+        acquisition_date=date.today(),
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    atomic = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=future_date,
+        asset_identifier="FULLERTON-SGD-MMF",
+        broker="Moomoo E2E Portfolio",
+        quantity=Decimal("100"),
+        market_value=Decimal("1234.00"),
+        currency="SGD",
+        dedup_hash="router_explicit_future_snapshot",
+        source_documents={},
+    )
+    db.add_all([position, atomic])
+    await db.commit()
+
+    response = await client.get(f"/portfolio/holdings?as_of_date={date.today().isoformat()}")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
 async def test_get_holdings_include_disposed(client: AsyncClient, portfolio_with_data):
     """AC17.6.4: GET /portfolio/holdings with include_disposed=true returns 200.
 

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -146,7 +146,7 @@ async def test_get_holdings_defaults_to_future_imported_snapshot(
     data = response.json()
     assert len(data) == 1
     assert data[0]["asset_identifier"] == "FULLERTON-SGD-MMF"
-    assert data[0]["market_value"] == "1234.00"
+    assert Decimal(data[0]["market_value"]) == Decimal("1234.00")
 
 
 @pytest.mark.asyncio

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -516,7 +516,7 @@
 | AC8.13.7 | yes | Strict full statement journey fails on rejected AI/OCR parsing | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.8 | yes | Strict upload readiness E2E does not accept rejected statements | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.9 | yes | Production release runs prod-safe read-only E2E smoke | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
-| AC8.13.10 | yes | Multi-brokerage PDF upload -> position import -> latest portfolio value | `apps/backend/tests/accounting/test_validation.py`<br>`apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py`<br>`apps/backend/tests/portfolio/test_portfolio_service.py`<br>`scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
+| AC8.13.10 | yes | Multi-brokerage PDF upload -> position import -> latest portfolio value | `apps/backend/tests/accounting/test_validation.py`<br>`apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py`<br>`apps/backend/tests/portfolio/test_brokerage_position_parsing.py`<br>`apps/backend/tests/portfolio/test_portfolio_router.py`<br>`apps/backend/tests/portfolio/test_portfolio_service.py`<br>`scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.11 | yes | Staging health check diagnoses API route 404 with route probes | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.12 | yes | AI/OCR gate failures include statement validation context | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |
 | AC8.13.13 | yes | Staging deploy cancels stale runs and bounds E2E gate duration with phase timing logs | `scripts/tests/test_post_merge_e2e_gates.py` | ✅ |


### PR DESCRIPTION
## Summary\n- Preserve a missing holdings `as_of_date` through the router so PortfolioService can use the latest imported snapshot default.\n- Add router-level regression coverage for future-dated brokerage snapshots and explicit date strictness.\n- Refresh AC traceability for AC8.13.10.\n\n## Verification\n- `cd apps/backend && uv run ruff format src/routers/portfolio.py tests/portfolio/test_portfolio_router.py --check`\n- `cd apps/backend && uv run ruff check src/routers/portfolio.py tests/portfolio/test_portfolio_router.py`\n- `uv run --with pyyaml python scripts/build_ac_traceability.py && uv run --with pyyaml python scripts/build_ac_traceability.py --check`\n- `uv run --with pytest --with pyyaml pytest scripts/tests/test_post_merge_e2e_gates.py -q`\n- `uv run --with pyyaml python scripts/check_manifest.py`\n- `uv run --with pyyaml python scripts/lint_doc_consistency.py`\n- `python scripts/check_ssot_ownership.py --verbose`\n- `git diff --check`\n\nFocused DB-backed router tests were attempted locally, but local PostgreSQL was unavailable at 127.0.0.1:5432. CI backend shards should verify them.