### PR TITLE
ci: harden Coveralls status gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,8 @@ jobs:
             --sha "${{ github.sha }}" \
             --context "Coveralls - unified" \
             --timeout-seconds 300 \
-            --poll-seconds 10
+            --poll-seconds 10 \
+            --failure-confirmation-seconds 30
 
       - name: Upload backend to Coveralls (per-flag)
         uses: coverallsapp/github-action@v2

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -35,7 +35,7 @@ classify-changes → backend shards + frontend → unified-coverage → finish
 2. **Change Classification**: Lightweight documentation, issue-template, markdown, and `.github/workflows/docs.yml` changes skip backend, frontend, and unified coverage. Runtime, test, script, CI, dependency, and coverage-policy changes run the full heavy path.
 3. **Stable Required Checks**: Heavy jobs are skipped through job-level conditions rather than removing the workflow, so required check names remain visible and mergeable.
 4. **AC Traceability Always Runs**: AC traceability is separate from unified coverage so docs-only AC/EPIC changes still get traceability validation. The job first runs `scripts/generate_ac_registry.py --check` to ensure EPIC-defined ACs are registered without rewriting historical registry descriptions, then generates `AC-TEST-TRACEABILITY-AUDIT.md` into `$RUNNER_TEMP`; the audit is uploaded as a CI artifact. CI does not fail solely because the checked-in archive copy is stale.
-5. **Coveralls Upload and Status Gate**: Unified, backend, and frontend Coveralls uploads run on both pull requests and `main` pushes when heavy CI is required. Pull requests wait for the external `Coveralls - unified` status before the `unified-coverage` job can pass, so asynchronous Coveralls regressions are blocked before merge.
+5. **Coveralls Upload and Status Gate**: Unified, backend, and frontend Coveralls uploads run on both pull requests and `main` pushes when heavy CI is required. Pull requests wait for the external `Coveralls - unified` status before the `unified-coverage` job can pass, and `main` pushes use the same gate before post-merge staging, so asynchronous Coveralls regressions are blocked before merge and before staging. A terminal external failure is re-polled once before CI fails; confirmed coverage decreases, errors, and missing statuses still fail closed.
 6. **Single CI Metrics Contract**: `scripts/check_ci_metrics_contract.py` is the single CI metrics contract. It validates that source-root discovery, `scripts/coverage_policy.py`, workflow gates, and AC traceability semantics stay aligned before coverage is calculated.
 7. **Coverage Policy Audit**: `scripts/check_coverage_policy.py` fails CI if backend, frontend, or script source files drift from their LCOV report.
 8. **No-regression gate**: Zero-tolerance; if ANY component is below baseline, CI fails immediately.
@@ -51,8 +51,11 @@ already ran required checks. The retained post-merge run provides three signals
 that PR checks cannot fully replace: validation of the exact merge commit,
 Coveralls status from `main`, and a final gate before post-merge staging/AI
 workflows consume the new commit. The same `Coveralls - unified` status gate runs
-on PR and `main`, so the post-merge lane should not be the first place an
-external unified coverage decrease is observed.
+on PR and `main`, so the post-merge lane should not be the first place a
+confirmed external unified coverage decrease is observed. The gate re-checks a
+terminal external failure before failing to reduce unexpected failures from
+transient external status flips without weakening confirmed coverage-decrease
+detection.
 
 Lightweight changes do not repeat the heavy path on either PRs or `main`.
 Lightweight means all changed files are limited to documentation, markdown,
@@ -136,8 +139,13 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Coverage reports merged post-run
 - Coverage policy audited after backend, frontend, and scripts LCOV reports exist
 - Coveralls unified upload uses repository-root-relative backend + frontend + scripts LCOV, matching the local unified calculation.
-- CI calls `scripts/wait_for_github_status.py` after unified upload and fails the `unified-coverage` job if the external `Coveralls - unified` commit status reports `failure`, `error`, or never appears before timeout.
+- CI calls `scripts/wait_for_github_status.py` after unified upload and fails the `unified-coverage` job if the external `Coveralls - unified` commit status reports a confirmed `failure`/`error`, or never appears before timeout.
 - Frontend dependency installation uses `actions/setup-node@v4` with npm cache and deterministic `npm ci`.
+
+**Checked-in AC traceability archive** (`docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md`):
+- This file is a historical/manual snapshot, not the current CI source of truth.
+- Routine PRs should not refresh it solely because ACs or test references changed; the current audit is generated in CI and uploaded as the `ac-test-traceability-audit` artifact.
+- Refresh the checked-in archive only for an intentional documentation snapshot/release, otherwise it creates unnecessary merge conflicts across parallel PRs.
 
 **Post-merge staging deploy health gate** (`.github/workflows/staging-deploy.yml`):
 - Non-LLM smoke/E2E tests run in parallel with `-n 4`.

--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -66,7 +66,7 @@ The authoritative component/file policy lives in `scripts/coverage_policy.py`. C
 - **Config**: `apps/frontend/vitest.config.ts`
 - **Output**: `apps/frontend/coverage/lcov.info` (copied to `coverage/frontend.lcov` in CI)
 - **LCOV paths**: `SF:` entries are relative to `apps/frontend` (for example, `src/app/page.tsx`); Coveralls uploads must use `base-path: apps/frontend`.
-- **Coveralls upload**: frontend/unified Coveralls uploads run on `push` only; PRs rely on the local unified no-regression gate and backend Coveralls flag to avoid comparing a new frontend flag against the old backend-only Coveralls baseline.
+- **Coveralls upload**: frontend/unified Coveralls uploads run on PRs and `main` pushes; CI waits for the external `Coveralls - unified` status and confirms terminal failures before failing.
 - **Key config**: `include: ['src/**/*.{ts,tsx}']` plus the shared policy audit ensures source files appear in LCOV consistently.
 - **Excluded**:
   - `**/tests/**`, `**/__tests__/**`

--- a/scripts/check_ci_metrics_contract.py
+++ b/scripts/check_ci_metrics_contract.py
@@ -136,6 +136,7 @@ def _validate_repo_contract_files(repo_root: Path) -> list[str]:
             'scripts/build_ac_traceability.py --output "$RUNNER_TEMP/AC-TEST-TRACEABILITY-AUDIT.md"',
             "scripts/wait_for_github_status.py",
             '--context "Coveralls - unified"',
+            "--failure-confirmation-seconds",
         )
         for token in required_workflow_tokens:
             if token not in workflow_text:

--- a/scripts/tests/test_analyze_test_ac_coverage.py
+++ b/scripts/tests/test_analyze_test_ac_coverage.py
@@ -40,6 +40,11 @@ acs:
     epic_name: placeholders
     description: stub only
     mandatory: true
+  - id: AC4.4.4
+    epic: 4
+    epic_name: untested
+    description: no real or stub reference
+    mandatory: true
 """.strip()
             + "\n",
             encoding="utf-8",
@@ -96,7 +101,7 @@ acs:
 
         assert result.covered_ids == {"AC1.1.1", "AC1.1.2", "AC2.2.1"}
         assert result.stub_only_ids == {"AC3.3.3"}
-        assert result.untested_ids == ["AC3.3.3"]
+        assert result.untested_ids == ["AC3.3.3", "AC4.4.4"]
 
         assert "AC9.9.9" in result.invalid_real_refs
         assert "apps/backend/tests/test_backend_real.py" in result.invalid_real_refs["AC9.9.9"]
@@ -127,6 +132,61 @@ acs:
         assert "Stub-only AC placeholders (`_ac_stubs`)" in report
         assert "Registered ACs with no real test reference" in report
         assert "EPIC-003 (placeholders) — 1 untested" in report
+        assert "EPIC-004 (untested) — 1 untested" in report
+
+    def test_analyze_repo_handles_missing_duplicate_unreadable_and_external_paths(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        self._write_registry(tmp_path)
+        self._write_tests(tmp_path)
+
+        missing_registry = tmp_path / "docs" / "missing_registry.yaml"
+        duplicate_registry = tmp_path / "docs" / "duplicate_registry.yaml"
+        extra_ac_id = "AC" + "5.5.5"
+        duplicate_registry.write_text(
+            f"""
+version: '1.0'
+total: 2
+acs:
+  - id: AC1.1.1
+    epic: 99
+    epic_name: duplicate
+    description: should be ignored
+  - id: {extra_ac_id}
+    epic: 5
+    epic_name: extra
+    description: extra registry entry
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        registry = coverage.load_registry(
+            (
+                tmp_path / "docs" / "ac_registry.yaml",
+                missing_registry,
+                duplicate_registry,
+            )
+        )
+
+        assert registry["AC1.1.1"].epic == 1
+        assert registry[extra_ac_id].epic == 5
+
+        external_file = tmp_path.parent / "external_ac_test.py"
+        assert coverage._relative(external_file, tmp_path) == str(external_file)
+
+        references, source_real_refs, source_stub_refs = coverage.collect_references(
+            [
+                coverage.ScanFile(source="backend", path=tmp_path / "missing.py"),
+                coverage.ScanFile(source="backend", path=external_file),
+            ],
+            repo_root=tmp_path,
+        )
+
+        assert references == {}
+        assert source_real_refs == {}
+        assert source_stub_refs == {}
 
 
 class TestMain:
@@ -163,3 +223,43 @@ class TestMain:
         text = output.read_text(encoding="utf-8")
         assert "AC Coverage Analysis Report" in text
         assert "Registered ACs" in text
+
+    def test_main_can_print_report_to_stdout(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        capsys,
+    ) -> None:
+        docs = tmp_path / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        (docs / "ac_registry.yaml").write_text(
+            "version: '1.0'\ntotal: 1\nacs:\n  - id: AC1.1.1\n    epic: 1\n    epic_name: phase0\n    description: demo\n    mandatory: true\n",
+            encoding="utf-8",
+        )
+        (docs / "infra_registry.yaml").write_text(
+            "version: '1.0'\ntotal: 0\nacs: []\n",
+            encoding="utf-8",
+        )
+        backend = tmp_path / "apps" / "backend" / "tests"
+        backend.mkdir(parents=True, exist_ok=True)
+        (backend / "test_demo.py").write_text("# AC1.1.1\n", encoding="utf-8")
+
+        output = tmp_path / "docs" / "analysis" / "out.md"
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "analyze_test_ac_coverage.py",
+                "--repo-root",
+                str(tmp_path),
+                "--output",
+                str(output),
+                "--stdout",
+            ],
+        )
+
+        assert coverage.main() == 0
+        captured = capsys.readouterr()
+        assert "AC Coverage Analysis Report" in captured.out
+        assert "Summary: registered=1" in captured.out

--- a/scripts/tests/test_ci_metrics_contract.py
+++ b/scripts/tests/test_ci_metrics_contract.py
@@ -79,6 +79,7 @@ def test_AC8_13_26_ci_workflow_runs_metrics_contract_and_defines_metric_semantic
     assert workflow.index("scripts/check_ci_metrics_contract.py") < workflow.index(
         "scripts/check_coverage_policy.py"
     )
+    assert "--failure-confirmation-seconds" in workflow
     assert "single CI metrics contract" in ci_cd
     assert "AC traceability is a reference metric, not behavioral coverage" in ci_cd
     assert "not behavioral coverage" in traceability

--- a/scripts/tests/test_wait_for_github_status.py
+++ b/scripts/tests/test_wait_for_github_status.py
@@ -28,7 +28,7 @@ class FakeClock:
 
 
 def completed_process(
-    statuses: list[dict[str, object]],
+    statuses: list[dict[str, object] | object],
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(
         args=["gh"],
@@ -108,6 +108,170 @@ def test_AC8_13_27_wait_fails_closed_on_coveralls_failure(
         )
 
 
+def test_AC8_13_27_wait_confirms_coveralls_failure_before_failing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.27: Confirmed Coveralls failures still fail after a re-poll."""
+    responses = [
+        completed_process(
+            [
+                {
+                    "context": "Coveralls - unified",
+                    "state": "failure",
+                    "description": "Coverage decreased (-0.02%) to 92.335%",
+                    "target_url": "https://coveralls.io/jobs/4",
+                }
+            ]
+        ),
+        completed_process(
+            [
+                {
+                    "context": "Coveralls - unified",
+                    "state": "failure",
+                    "description": "Coverage decreased (-0.02%) to 92.335%",
+                    "target_url": "https://coveralls.io/jobs/4",
+                }
+            ]
+        ),
+    ]
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return responses.pop(0)
+
+    monkeypatch.setattr(wait_status.subprocess, "run", fake_run)
+    clock = FakeClock()
+
+    with pytest.raises(RuntimeError, match="Coverage decreased"):
+        wait_status.wait_for_status_success(
+            repo="owner/repo",
+            sha="def456",
+            context="Coveralls - unified",
+            timeout_seconds=60,
+            poll_seconds=5,
+            failure_confirmation_seconds=15,
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )
+
+    assert clock.sleeps == [15]
+
+
+def test_AC8_13_27_wait_allows_transient_coveralls_failure_to_recover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.27: A transient external failure does not fail if it recovers."""
+    responses = [
+        completed_process(
+            [
+                {
+                    "context": "Coveralls - unified",
+                    "state": "failure",
+                    "description": "temporary processing error",
+                    "target_url": "https://coveralls.io/jobs/5",
+                }
+            ]
+        ),
+        completed_process(
+            [
+                {
+                    "context": "Coveralls - unified",
+                    "state": "success",
+                    "description": "Coverage remained the same",
+                    "target_url": "https://coveralls.io/jobs/5",
+                }
+            ]
+        ),
+    ]
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return responses.pop(0)
+
+    monkeypatch.setattr(wait_status.subprocess, "run", fake_run)
+    clock = FakeClock()
+
+    status = wait_status.wait_for_status_success(
+        repo="owner/repo",
+        sha="abc123",
+        context="Coveralls - unified",
+        timeout_seconds=60,
+        poll_seconds=5,
+        failure_confirmation_seconds=15,
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+    assert status.state == "success"
+    assert clock.sleeps == [15]
+
+
+def test_AC8_13_27_wait_reconfirms_failure_after_nonterminal_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.27: A later failure is confirmed again after pending status."""
+    responses = [
+        completed_process(
+            [
+                {
+                    "context": "Coveralls - unified",
+                    "state": "failure",
+                    "description": "temporary processing error",
+                    "target_url": "https://coveralls.io/jobs/7",
+                }
+            ]
+        ),
+        completed_process(
+            [
+                {
+                    "context": "Coveralls - unified",
+                    "state": "pending",
+                    "description": "Coverage is being processed",
+                    "target_url": "https://coveralls.io/jobs/7",
+                }
+            ]
+        ),
+        completed_process(
+            [
+                {
+                    "context": "Coveralls - unified",
+                    "state": "failure",
+                    "description": "Coverage decreased (-0.02%) to 92.335%",
+                    "target_url": "https://coveralls.io/jobs/7",
+                }
+            ]
+        ),
+        completed_process(
+            [
+                {
+                    "context": "Coveralls - unified",
+                    "state": "failure",
+                    "description": "Coverage decreased (-0.02%) to 92.335%",
+                    "target_url": "https://coveralls.io/jobs/7",
+                }
+            ]
+        ),
+    ]
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return responses.pop(0)
+
+    monkeypatch.setattr(wait_status.subprocess, "run", fake_run)
+    clock = FakeClock()
+
+    with pytest.raises(RuntimeError, match="Coverage decreased"):
+        wait_status.wait_for_status_success(
+            repo="owner/repo",
+            sha="abc123",
+            context="Coveralls - unified",
+            timeout_seconds=60,
+            poll_seconds=5,
+            failure_confirmation_seconds=15,
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )
+
+    assert clock.sleeps == [15, 5, 15]
+
+
 def test_AC8_13_27_wait_polls_until_status_appears(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -156,6 +320,31 @@ def test_AC8_13_27_wait_polls_until_status_appears(
     assert clock.sleeps == [5, 5]
 
 
+def test_AC8_13_27_wait_times_out_when_status_never_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.27: Missing external statuses do not pass silently."""
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return completed_process([])
+
+    monkeypatch.setattr(wait_status.subprocess, "run", fake_run)
+    clock = FakeClock()
+
+    with pytest.raises(TimeoutError, match="Timed out waiting"):
+        wait_status.wait_for_status_success(
+            repo="owner/repo",
+            sha="abc123",
+            context="Coveralls - unified",
+            timeout_seconds=10,
+            poll_seconds=5,
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )
+
+    assert clock.sleeps == [5, 5]
+
+
 def test_AC8_13_27_wait_fails_when_github_status_query_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -179,3 +368,59 @@ def test_AC8_13_27_wait_fails_when_github_status_query_fails(
             timeout_seconds=1,
             poll_seconds=1,
         )
+
+
+def test_AC8_13_27_wait_rejects_malformed_status_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.27: Unexpected GitHub status shapes fail closed."""
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps({"statuses": {"context": "Coveralls - unified"}}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(wait_status.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="did not contain a status list"):
+        wait_status.wait_for_status_success(
+            repo="owner/repo",
+            sha="abc123",
+            context="Coveralls - unified",
+            timeout_seconds=1,
+            poll_seconds=1,
+        )
+
+
+def test_AC8_13_27_wait_ignores_non_object_status_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.27: Non-object status entries cannot spoof success or failure."""
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return completed_process(
+            [
+                "bad-status",
+                {
+                    "context": "Coveralls - unified",
+                    "state": "success",
+                    "description": "Coverage passed",
+                    "target_url": "https://coveralls.io/jobs/6",
+                },
+            ]
+        )
+
+    monkeypatch.setattr(wait_status.subprocess, "run", fake_run)
+
+    status = wait_status.wait_for_status_success(
+        repo="owner/repo",
+        sha="abc123",
+        context="Coveralls - unified",
+        timeout_seconds=1,
+        poll_seconds=1,
+    )
+
+    assert status.state == "success"

--- a/scripts/wait_for_github_status.py
+++ b/scripts/wait_for_github_status.py
@@ -68,15 +68,18 @@ def wait_for_status_success(
     context: str,
     timeout_seconds: int = 300,
     poll_seconds: int = 10,
+    failure_confirmation_seconds: int = 0,
     monotonic=time.monotonic,
     sleep=time.sleep,
 ) -> GitHubCommitStatus:
     """Poll GitHub until the requested commit status succeeds or fails."""
     deadline = monotonic() + timeout_seconds
+    terminal_failure_seen = False
 
     while True:
         status = _latest_status_for_context(_run_gh_status(repo, sha), context)
         if status is None:
+            terminal_failure_seen = False
             print(f"Waiting for GitHub status {context!r} on {sha}: not found")
         else:
             print(
@@ -87,10 +90,19 @@ def wait_for_status_success(
             if status.state == "success":
                 return status
             if status.state in {"failure", "error"}:
+                if failure_confirmation_seconds > 0 and not terminal_failure_seen:
+                    print(
+                        f"Confirming terminal GitHub status {context!r} on {sha} "
+                        f"after {failure_confirmation_seconds}s"
+                    )
+                    terminal_failure_seen = True
+                    sleep(failure_confirmation_seconds)
+                    continue
                 raise RuntimeError(
                     f"{context} failed for {sha}: "
                     f"{status.description or status.state} {status.target_url or ''}"
                 )
+            terminal_failure_seen = False
 
         if monotonic() >= deadline:
             raise TimeoutError(
@@ -108,6 +120,12 @@ def main() -> None:
     parser.add_argument("--context", required=True)
     parser.add_argument("--timeout-seconds", type=int, default=300)
     parser.add_argument("--poll-seconds", type=int, default=10)
+    parser.add_argument(
+        "--failure-confirmation-seconds",
+        type=int,
+        default=0,
+        help="Re-poll after a failure/error status before failing.",
+    )
     args = parser.parse_args()
 
     try:
@@ -117,6 +135,7 @@ def main() -> None:
             context=args.context,
             timeout_seconds=args.timeout_seconds,
             poll_seconds=args.poll_seconds,
+            failure_confirmation_seconds=args.failure_confirmation_seconds,
         )
     except (RuntimeError, TimeoutError) as exc:
         print(f"::error title=GitHub status wait failed::{exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Harden the unified Coveralls gate and restore scripts coverage headroom after the latest post-merge coverage failure, without adding generated registry/archive churn.

Refs #414

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.27 |
| **AC Registry updated** | N/A — reused existing AC8.13.27 to avoid generated registry conflicts |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/ci-cd.md` — documented confirmed external Coveralls failures, PR/main status gate behavior, and why generated traceability archive should not be refreshed in routine PRs
- [x] `docs/ssot/coverage.md` — documented PR/main Coveralls upload and confirmed failure handling
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | `N/A` | Post-merge CI failed on `f9f3c0e`: `Coveralls - unified failed: Coverage decreased (-0.02%) to 92.335%` |
| Green (passing test) | `ef8ccc0` | Added AC8.13.27 tests, analyzer coverage tests, and confirmed failure handling |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable)
- [x] `repo/` submodule updated for production config changes (if applicable)
- [x] `scripts/check_env_keys.py` passes (if env vars changed)
- [x] `scripts/check_manifest.py` passes (if SSOT files changed)
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
uv run --with pytest --with pytest-cov --with pytest-asyncio --with anyio --with pyyaml --with pydantic --with pydantic-settings --with sqlalchemy --with asyncpg --with pdfplumber --with reportlab pytest scripts/tests/ --cov=scripts --cov-config=/tmp/scripts-coveragerc --cov-report=term-missing --cov-report=lcov:coverage/scripts.lcov -q
uv run --with pytest --with pytest-cov --with pytest-asyncio --with anyio --with pyyaml --with pydantic --with pydantic-settings --with sqlalchemy --with asyncpg --with pdfplumber --with reportlab pytest scripts/tests/test_wait_for_github_status.py scripts/tests/test_analyze_test_ac_coverage.py scripts/tests/test_ci_metrics_contract.py scripts/tests/test_post_merge_e2e_gates.py -q
uv run python scripts/check_ci_metrics_contract.py
uv run --with pyyaml python scripts/generate_ac_registry.py --check
uv run --with pyyaml python scripts/lint_doc_consistency.py
uv run --with pyyaml python scripts/check_manifest.py
git diff --check
```

---

## Screenshots / Evidence

- Scripts coverage: `746 passed, 2 skipped`; scripts coverage `87%`, above current scripts baseline `86.43%`.
- Latest observed `main` CI and staging AI/OCR gate for `0412f66` passed.
- This PR intentionally does not modify `docs/ac_registry.yaml` or `docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md` to reduce generated-file conflict rate.
