### PR TITLE
ci: speed up backend and post-merge polling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,14 +90,14 @@ jobs:
         run: |
           uv run --with pyyaml python scripts/check_manifest.py
   backend:
-    name: Backend Tests (Shard ${{ matrix.shard }}/4)
+    name: Backend Tests (Shard ${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
     needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     
     services:
       postgres:
@@ -146,7 +146,7 @@ jobs:
 
 
 
-      - name: Run Tests (Shard ${{ matrix.shard }}/4)
+      - name: Run Tests (Shard ${{ matrix.shard }}/6)
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/finance_report_test
           S3_ACCESS_KEY: minio
@@ -158,7 +158,7 @@ jobs:
           cd apps/backend
           uv run pytest -n auto -v \
             -m "not slow and not e2e and not integration" \
-            --splits 4 \
+            --splits 6 \
             --group ${{ matrix.shard }} \
             --cov=src \
             --cov-report=lcov:coverage-backend-${{ matrix.shard }}.lcov \

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -66,7 +66,7 @@ jobs:
             --branch main \
             --event push \
             --timeout-seconds 2700 \
-            --poll-seconds 30
+            --poll-seconds 10
 
       - name: Install moon
         uses: moonrepo/setup-toolchain@v0

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -23,7 +23,7 @@ classify-changes → backend shards + frontend → unified-coverage → finish
 |-----|---------|--------------|
 | **classify-changes** | Detect whether changed paths require heavy backend/frontend/coverage jobs | None |
 | **lint** | Static analysis (ruff check + format check) + manifest/doc checks | None (first job) |
-| **backend** (Shards 1-4) | Backend unit + integration tests when heavy CI is required | `needs: [classify-changes]` |
+| **backend** (Shards 1-6) | Backend unit + integration tests when heavy CI is required | `needs: [classify-changes]` |
 | **frontend** | Frontend build + tests when heavy CI is required | `needs: [classify-changes]` |
 | **unified-coverage** | Calculate unified coverage, audit source-tree/LCOV policy, compare to baseline, update Coveralls when heavy CI is required | `needs: [classify-changes, backend, frontend]` |
 | **ac-traceability** | Verify AC-to-test traceability for all PR/main changes, including docs-only changes | None |
@@ -134,8 +134,8 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Change classification is implemented in `scripts/ci_change_classifier.py` and skips backend/frontend/unified coverage for lightweight docs and docs workflow changes.
 - Markdown outside the documented lightweight trees is treated as heavy; this prevents runtime-adjacent README or script documentation changes from being hidden by a global `*.md` skip.
 - Backend shards and AC traceability run in parallel with lint once change classification has finished, so lint remains visible without delaying independent test work.
-- 4-way parallel test sharding via `pytest-split`
-- Each shard: `pytest --splits 4 --group N`
+- 6-way parallel test sharding via `pytest-split`
+- Each shard: `pytest --splits 6 --group N`
 - Coverage reports merged post-run
 - Coverage policy audited after backend, frontend, and scripts LCOV reports exist
 - Coveralls unified upload uses repository-root-relative backend + frontend + scripts LCOV, matching the local unified calculation.
@@ -176,7 +176,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 >
 > | Environment | Parallelism | Test Scope | Resource Usage |
 > |-------------|-------------|------------|----------------|
-> | **GitHub CI** | `-n auto` + `--splits 4` | ~25% tests per shard | Low (ephemeral runners) |
+> | **GitHub CI** | `-n auto` + `--splits 6` | ~17% tests per shard | Medium (ephemeral runners) |
 > | **Local CI** | `-n 4` (fixed) | 100% tests | Controlled (shared machine) |
 >
 > This is intentional design, not inconsistency.
@@ -200,8 +200,8 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Caching: UV ✅ (2.9s), Next.js ✅, venv ✅
 
 **CI Pipeline (2026-05-19 observed baseline):**
-- Full heavy CI on `main`: **~7m 02s**.
-- Longest backend shard: **~6m 03s**.
+- Full heavy CI on `main`: **~7m 39s** before 6-way backend sharding.
+- Longest backend shard: **~6m 23s** before 6-way backend sharding.
 - Frontend build and coverage test: **~2m 32s** before npm cache standardization.
 - Unified coverage: **~28s**.
 - Lightweight docs/docs-workflow changes skip backend, frontend, and unified coverage; lint, AC traceability, and finish still run.

--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -53,7 +53,7 @@ The authoritative component/file policy lives in `scripts/coverage_policy.py`. C
 
 - **Tool**: pytest + pytest-cov
 - **Config**: `apps/backend/pyproject.toml`
-- **Output**: `coverage-backend-{shard}.lcov` (4 shards, merged into `coverage/backend.lcov`)
+- **Output**: `coverage-backend-{shard}.lcov` (6 shards, merged into `coverage/backend.lcov`)
 - **Excluded**:
   - `tests/**`
   - `migrations/**`
@@ -92,7 +92,7 @@ The authoritative component/file policy lives in `scripts/coverage_policy.py`. C
 ```yaml
 jobs:
   backend:
-    # 4 shards → coverage-backend-{0..3}.lcov
+    # 6 shards → coverage-backend-{1..6}.lcov
 
   frontend:
     # vitest --coverage → lcov.info

--- a/docs/ssot/tdd.md
+++ b/docs/ssot/tdd.md
@@ -246,7 +246,7 @@ During PR review:
 - Local coverage threshold: **90%** backend (`--cov-fail-under=90` in pyproject.toml); **96%** unified
 - CI coverage threshold: No-regression baseline + unified 96% gate
 - Branch coverage tracking: enabled via `--cov-branch`
-- **CI now enforces no-regression**: Each shard runs ~25% of tests, merged unified coverage validated post-merge
+- **CI now enforces no-regression**: Each backend shard runs ~17% of tests, merged unified coverage validated post-merge
 
 #### 2.1 Local Configuration
 

--- a/scripts/check_ci_metrics_contract.py
+++ b/scripts/check_ci_metrics_contract.py
@@ -136,6 +136,8 @@ def _validate_repo_contract_files(repo_root: Path) -> list[str]:
             'scripts/build_ac_traceability.py --output "$RUNNER_TEMP/AC-TEST-TRACEABILITY-AUDIT.md"',
             "scripts/wait_for_github_status.py",
             '--context "Coveralls - unified"',
+            "Backend Tests (Shard ${{ matrix.shard }}/6)",
+            "--splits 6",
             "--failure-confirmation-seconds",
         )
         for token in required_workflow_tokens:

--- a/scripts/tests/test_ci_metrics_contract.py
+++ b/scripts/tests/test_ci_metrics_contract.py
@@ -79,6 +79,9 @@ def test_AC8_13_26_ci_workflow_runs_metrics_contract_and_defines_metric_semantic
     assert workflow.index("scripts/check_ci_metrics_contract.py") < workflow.index(
         "scripts/check_coverage_policy.py"
     )
+    assert "Backend Tests (Shard ${{ matrix.shard }}/6)" in workflow
+    assert "shard: [1, 2, 3, 4, 5, 6]" in workflow
+    assert "--splits 6" in workflow
     assert "--failure-confirmation-seconds" in workflow
     assert "single CI metrics contract" in ci_cd
     assert "AC traceability is a reference metric, not behavioral coverage" in ci_cd

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -253,6 +253,7 @@ def test_AC8_13_21_post_merge_ai_ocr_waits_for_matching_ci_success() -> None:
     assert "scripts/wait_for_github_ci.py" in workflow
     assert "--workflow CI" in workflow
     assert '--sha "${{ github.sha }}"' in workflow
+    assert "--poll-seconds 10" in workflow
     assert workflow.index("Wait for matching CI success") < workflow.index("Build and push Backend")
     assert "gh run list" in wait_script
     assert "matching CI run failed" in wait_script


### PR DESCRIPTION
## Summary

Reduce heavy CI critical-path time by increasing backend sharding from 4 to 6, and reduce post-merge staging wait latency by polling matching CI every 10 seconds instead of 30 seconds.

Closes #<!-- issue number -->

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.21, AC8.13.25, AC8.13.26 |
| **AC Registry updated** | N/A — reuses existing CI/post-merge guardrail ACs |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/ci-cd.md` — documents 6-way backend sharding and updated observed CI baseline
- [x] `docs/ssot/coverage.md` — documents 6 backend coverage shard artifacts
- [x] `docs/ssot/tdd.md` — documents the new per-shard backend test fraction
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | `N/A` | Performance hardening from observed main CI: backend shard critical path reached ~6m23s and staging spent up to 30s per matching-CI poll |
| Green (passing test) | `96d1ec3` | CI contract and post-merge gate tests cover 6-way sharding and 10s staging CI polling |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable)
- [x] `repo/` submodule updated for production config changes (if applicable)
- [x] `scripts/check_env_keys.py` passes (if env vars changed)
- [x] `scripts/check_manifest.py` passes (if SSOT files changed)
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
uv run --with pytest --with pytest-cov --with pytest-asyncio --with anyio --with pyyaml --with pydantic --with pydantic-settings --with sqlalchemy --with asyncpg --with pdfplumber --with reportlab pytest scripts/tests/test_ci_metrics_contract.py scripts/tests/test_post_merge_e2e_gates.py -q
uv run python scripts/check_ci_metrics_contract.py
uv run --with pyyaml python scripts/lint_doc_consistency.py
uv run --with pyyaml python scripts/check_manifest.py
git diff --check
```

---

## Screenshots / Evidence

- PR CI passed: https://github.com/wangzitian0/finance_report/actions/runs/26152860334
- Before this change, latest successful main CI was ~7m39s with the slowest backend shard at ~6m23s.
- With this change, PR CI completed in ~5m51s; slowest backend shard was 4m43s, and unified coverage/Coveralls completed successfully.
- Post-merge staging still waits for the same commit's CI before deployment, but polling now checks every 10s instead of 30s.
