### PR TITLE
[codex] Add investment transaction accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,11 @@ Known proof-quality caveats:
 
 Minimum blocker set for a fresh user to reach the accurate-dashboard journey:
 
-1. Upload flow polish: `wangzitian0/finance_report#366`
-2. Stage 1 review entry in sidebar: `wangzitian0/finance_report#365`
-3. Unified approval path: `wangzitian0/finance_report#362`
-4. Stage 2 run-level review UI: `wangzitian0/finance_report#368`
-5. Approve -> auto-post journal entries: `wangzitian0/finance_report#363`
-6. Processing account sidebar/status: `wangzitian0/finance_report#367`
-7. Reconciliation idempotency: `wangzitian0/finance_report#354`
-8. Unrealized FX gain/loss reporting: `wangzitian0/finance_report#197`
-9. PDF export for reports: `wangzitian0/finance_report#205`
-10. Dashboard empty-state onboarding: `wangzitian0/finance_report#369`
+1. North-star PDF upload to accurate net worth: `wangzitian0/finance_report#444`
+2. Brokerage buy/sell/dividend investment accounting: `wangzitian0/finance_report#393`
+3. Source-type trust hierarchy and no-downgrade promotion: `wangzitian0/finance_report#395`
+4. Account-level statement coverage and balance continuity: `wangzitian0/finance_report#396`
+5. Processing account sidebar/status: `wangzitian0/finance_report#367`
 
 ## Documentation Debt Tracked As Issues
 

--- a/apps/backend/migrations/versions/0017_investment_accounting.py
+++ b/apps/backend/migrations/versions/0017_investment_accounting.py
@@ -1,0 +1,103 @@
+"""Add investment transaction accounting tables.
+
+Revision ID: 0017_investment_accounting
+Revises: 0016_manual_valuation_snapshots
+Create Date: 2026-05-20
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0017_investment_accounting"
+down_revision = "0016_manual_valuation_snapshots"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "DO $$ BEGIN "
+        "CREATE TYPE investment_transaction_type_enum AS ENUM ('buy', 'sell', 'dividend'); "
+        "EXCEPTION WHEN duplicate_object THEN null; END $$;"
+    )
+
+    op.create_table(
+        "investment_transactions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("position_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("journal_entry_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("source_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("transaction_date", sa.Date(), nullable=False),
+        sa.Column(
+            "transaction_type",
+            postgresql.ENUM("buy", "sell", "dividend", name="investment_transaction_type_enum", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("asset_identifier", sa.String(100), nullable=False),
+        sa.Column("quantity", sa.Numeric(18, 6), nullable=True),
+        sa.Column("unit_price", sa.Numeric(18, 6), nullable=True),
+        sa.Column("gross_amount", sa.Numeric(18, 2), nullable=False),
+        sa.Column("fees", sa.Numeric(18, 2), nullable=False),
+        sa.Column("currency", sa.String(3), nullable=False),
+        sa.Column("cost_basis", sa.Numeric(18, 2), nullable=True),
+        sa.Column("realized_pnl", sa.Numeric(18, 2), nullable=True),
+        sa.Column(
+            "cost_basis_method",
+            postgresql.ENUM("FIFO", "LIFO", "AvgCost", name="cost_basis_method_enum", create_type=False),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journal_entries.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["position_id"], ["managed_positions.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_investment_transactions_user_id", "investment_transactions", ["user_id"])
+    op.create_index("ix_investment_transactions_position_id", "investment_transactions", ["position_id"])
+    op.create_index("ix_investment_transactions_journal_entry_id", "investment_transactions", ["journal_entry_id"])
+    op.create_index("ix_investment_transactions_transaction_date", "investment_transactions", ["transaction_date"])
+    op.create_index("ix_investment_transactions_asset_identifier", "investment_transactions", ["asset_identifier"])
+
+    op.create_table(
+        "investment_lots",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("position_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("opening_transaction_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("asset_identifier", sa.String(100), nullable=False),
+        sa.Column("acquisition_date", sa.Date(), nullable=False),
+        sa.Column("original_quantity", sa.Numeric(18, 6), nullable=False),
+        sa.Column("remaining_quantity", sa.Numeric(18, 6), nullable=False),
+        sa.Column("unit_cost", sa.Numeric(18, 6), nullable=False),
+        sa.Column("currency", sa.String(3), nullable=False),
+        sa.Column("disposed_date", sa.Date(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["opening_transaction_id"], ["investment_transactions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["position_id"], ["managed_positions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_investment_lots_user_id", "investment_lots", ["user_id"])
+    op.create_index("ix_investment_lots_position_id", "investment_lots", ["position_id"])
+    op.create_index("ix_investment_lots_opening_transaction_id", "investment_lots", ["opening_transaction_id"])
+    op.create_index("ix_investment_lots_asset_identifier", "investment_lots", ["asset_identifier"])
+    op.create_index("ix_investment_lots_acquisition_date", "investment_lots", ["acquisition_date"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_investment_lots_acquisition_date", table_name="investment_lots")
+    op.drop_index("ix_investment_lots_asset_identifier", table_name="investment_lots")
+    op.drop_index("ix_investment_lots_opening_transaction_id", table_name="investment_lots")
+    op.drop_index("ix_investment_lots_position_id", table_name="investment_lots")
+    op.drop_index("ix_investment_lots_user_id", table_name="investment_lots")
+    op.drop_table("investment_lots")
+
+    op.drop_index("ix_investment_transactions_asset_identifier", table_name="investment_transactions")
+    op.drop_index("ix_investment_transactions_transaction_date", table_name="investment_transactions")
+    op.drop_index("ix_investment_transactions_journal_entry_id", table_name="investment_transactions")
+    op.drop_index("ix_investment_transactions_position_id", table_name="investment_transactions")
+    op.drop_index("ix_investment_transactions_user_id", table_name="investment_transactions")
+    op.drop_table("investment_transactions")
+    op.execute("DROP TYPE IF EXISTS investment_transaction_type_enum")

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -28,7 +28,15 @@ from src.models.layer3 import (
 from src.models.layer4 import ReportSnapshot, ReportType
 from src.models.market_data import FxRate
 from src.models.ping_state import PingState
-from src.models.portfolio import DividendIncome, DividendType, MarketDataOverride, PriceSource
+from src.models.portfolio import (
+    DividendIncome,
+    DividendType,
+    InvestmentLot,
+    InvestmentTransaction,
+    InvestmentTransactionType,
+    MarketDataOverride,
+    PriceSource,
+)
 from src.models.reconciliation import ReconciliationMatch, ReconciliationStatus
 from src.models.statement import (
     BankStatement,
@@ -81,6 +89,9 @@ __all__ = [
     "JournalLine",
     "DividendIncome",
     "DividendType",
+    "InvestmentLot",
+    "InvestmentTransaction",
+    "InvestmentTransactionType",
     "PingState",
     "PositionStatus",
     "ManagedPosition",

--- a/apps/backend/src/models/portfolio.py
+++ b/apps/backend/src/models/portfolio.py
@@ -1,4 +1,4 @@
-"""Portfolio management models - dividend income and market data overrides."""
+"""Portfolio management models - investment accounting and market data."""
 
 from datetime import date
 from decimal import Decimal
@@ -8,13 +8,101 @@ from uuid import UUID
 
 from sqlalchemy import Date, Enum as SQLEnum, ForeignKey, Numeric, String
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
 from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
+from src.models.layer3 import CostBasisMethod
 
 if TYPE_CHECKING:
-    pass
+    from src.models.journal import JournalEntry
+    from src.models.layer3 import ManagedPosition
+
+
+class InvestmentTransactionType(str, Enum):
+    """Brokerage investment transaction type."""
+
+    BUY = "buy"
+    SELL = "sell"
+    DIVIDEND = "dividend"
+
+
+class InvestmentTransaction(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
+    """Auditable brokerage transaction that drives portfolio accounting."""
+
+    __tablename__ = "investment_transactions"
+
+    position_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("managed_positions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    journal_entry_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("journal_entries.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    source_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
+
+    transaction_date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+    transaction_type: Mapped[InvestmentTransactionType] = mapped_column(
+        SQLEnum(
+            InvestmentTransactionType,
+            name="investment_transaction_type_enum",
+            values_callable=lambda obj: [e.value for e in obj],
+        ),
+        nullable=False,
+    )
+    asset_identifier: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    quantity: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    unit_price: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    gross_amount: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False)
+    fees: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False, default=Decimal("0.00"))
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    cost_basis: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+    realized_pnl: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+    cost_basis_method: Mapped[CostBasisMethod | None] = mapped_column(
+        SQLEnum(
+            CostBasisMethod,
+            name="cost_basis_method_enum",
+            values_callable=lambda obj: [e.value for e in obj],
+        ),
+        nullable=True,
+    )
+
+    position: Mapped["ManagedPosition | None"] = relationship("ManagedPosition")
+    journal_entry: Mapped["JournalEntry | None"] = relationship("JournalEntry")
+
+
+class InvestmentLot(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
+    """Open tax/accounting lot for cost-basis calculations."""
+
+    __tablename__ = "investment_lots"
+
+    position_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("managed_positions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    opening_transaction_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("investment_transactions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    asset_identifier: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    acquisition_date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+    original_quantity: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    remaining_quantity: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    unit_cost: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    disposed_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+
+    position: Mapped["ManagedPosition"] = relationship("ManagedPosition")
+    opening_transaction: Mapped[InvestmentTransaction] = relationship("InvestmentTransaction")
 
 
 class DividendType(str, Enum):

--- a/apps/backend/src/services/investment_accounting.py
+++ b/apps/backend/src/services/investment_accounting.py
@@ -1,0 +1,561 @@
+"""Brokerage investment transaction accounting service."""
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import ROUND_HALF_UP, Decimal
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.account import Account, AccountType
+from src.models.journal import Direction, JournalEntry, JournalEntrySourceType
+from src.models.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
+from src.models.portfolio import (
+    DividendIncome,
+    DividendType,
+    InvestmentLot,
+    InvestmentTransaction,
+    InvestmentTransactionType,
+)
+from src.services.accounting import create_journal_entry, post_journal_entry
+
+MONEY = Decimal("0.01")
+QUANTITY = Decimal("0.000001")
+
+
+class InvestmentAccountingError(Exception):
+    """Base exception for investment accounting errors."""
+
+
+class InvestmentAccountingValidationError(InvestmentAccountingError):
+    """Raised when an investment transaction cannot be posted."""
+
+
+@dataclass(frozen=True)
+class InvestmentAccountingResult:
+    """Result of posting an investment accounting transaction."""
+
+    transaction: InvestmentTransaction
+    journal_entry: JournalEntry
+    position: ManagedPosition
+
+
+def _money(value: Decimal) -> Decimal:
+    return value.quantize(MONEY, rounding=ROUND_HALF_UP)
+
+
+def _quantity(value: Decimal) -> Decimal:
+    return value.quantize(QUANTITY, rounding=ROUND_HALF_UP)
+
+
+class InvestmentAccountingService:
+    """Post buy, sell, and dividend transactions into ledger and portfolio state."""
+
+    async def post_buy(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        transaction_date: date,
+        asset_identifier: str,
+        quantity: Decimal,
+        unit_price: Decimal,
+        currency: str,
+        cash_account_id: UUID,
+        investment_account_id: UUID,
+        fees: Decimal = Decimal("0.00"),
+        fx_rate: Decimal | None = None,
+        source_id: UUID | None = None,
+        cost_basis_method: CostBasisMethod = CostBasisMethod.FIFO,
+    ) -> InvestmentAccountingResult:
+        """Post a buy transaction as Dr investment / Cr brokerage cash."""
+        self._validate_positive(quantity, "quantity")
+        self._validate_non_negative(unit_price, "unit_price")
+        self._validate_non_negative(fees, "fees")
+
+        cash_account = await self._get_account(db, user_id, cash_account_id, AccountType.ASSET)
+        investment_account = await self._get_account(db, user_id, investment_account_id, AccountType.ASSET)
+        amount = _money(quantity * unit_price + fees)
+        if amount <= Decimal("0"):
+            raise InvestmentAccountingValidationError("buy amount must be positive")
+
+        position = await self._get_or_create_position(
+            db,
+            user_id=user_id,
+            account_id=investment_account.id,
+            asset_identifier=asset_identifier,
+            transaction_date=transaction_date,
+            currency=currency,
+            cost_basis_method=cost_basis_method,
+        )
+
+        entry = await create_journal_entry(
+            db,
+            user_id=user_id,
+            entry_date=transaction_date,
+            memo=f"Buy {asset_identifier}",
+            source_type=JournalEntrySourceType.SYSTEM,
+            source_id=source_id,
+            lines_data=[
+                {
+                    "account_id": investment_account.id,
+                    "direction": Direction.DEBIT,
+                    "amount": amount,
+                    "currency": currency,
+                    "fx_rate": fx_rate,
+                    "event_type": "investment_buy",
+                    "tags": {"asset_identifier": asset_identifier},
+                },
+                {
+                    "account_id": cash_account.id,
+                    "direction": Direction.CREDIT,
+                    "amount": amount,
+                    "currency": currency,
+                    "fx_rate": fx_rate,
+                    "event_type": "investment_buy",
+                    "tags": {"asset_identifier": asset_identifier},
+                },
+            ],
+        )
+        posted = await self._post_and_load(db, entry.id, user_id)
+
+        transaction = InvestmentTransaction(
+            user_id=user_id,
+            position_id=position.id,
+            journal_entry_id=posted.id,
+            source_id=source_id,
+            transaction_date=transaction_date,
+            transaction_type=InvestmentTransactionType.BUY,
+            asset_identifier=asset_identifier,
+            quantity=_quantity(quantity),
+            unit_price=_quantity(unit_price),
+            gross_amount=amount,
+            fees=_money(fees),
+            currency=currency,
+            cost_basis=amount,
+            realized_pnl=Decimal("0.00"),
+            cost_basis_method=cost_basis_method,
+        )
+        db.add(transaction)
+        await db.flush()
+
+        lot = InvestmentLot(
+            user_id=user_id,
+            position_id=position.id,
+            opening_transaction_id=transaction.id,
+            asset_identifier=asset_identifier,
+            acquisition_date=transaction_date,
+            original_quantity=_quantity(quantity),
+            remaining_quantity=_quantity(quantity),
+            unit_cost=_quantity(amount / quantity),
+            currency=currency,
+        )
+        db.add(lot)
+
+        position.quantity = _quantity(position.quantity + quantity)
+        position.cost_basis = _money(position.cost_basis + amount)
+        position.cost_basis_method = cost_basis_method
+        position.status = PositionStatus.ACTIVE
+        position.disposal_date = None
+        await db.flush()
+        await db.refresh(transaction)
+        await db.refresh(position)
+        return InvestmentAccountingResult(transaction=transaction, journal_entry=posted, position=position)
+
+    async def post_sell(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        transaction_date: date,
+        asset_identifier: str,
+        quantity: Decimal,
+        unit_price: Decimal,
+        currency: str,
+        cash_account_id: UUID,
+        investment_account_id: UUID,
+        realized_pnl_account_id: UUID,
+        fees: Decimal = Decimal("0.00"),
+        fx_rate: Decimal | None = None,
+        source_id: UUID | None = None,
+        cost_basis_method: CostBasisMethod = CostBasisMethod.FIFO,
+    ) -> InvestmentAccountingResult:
+        """Post a sell transaction and realize gain or loss from investment lots."""
+        self._validate_positive(quantity, "quantity")
+        self._validate_non_negative(unit_price, "unit_price")
+        self._validate_non_negative(fees, "fees")
+
+        cash_account = await self._get_account(db, user_id, cash_account_id, AccountType.ASSET)
+        investment_account = await self._get_account(db, user_id, investment_account_id, AccountType.ASSET)
+        pnl_account = await self._get_account(db, user_id, realized_pnl_account_id, AccountType.INCOME)
+        position = await self._get_position(
+            db,
+            user_id=user_id,
+            account_id=investment_account.id,
+            asset_identifier=asset_identifier,
+        )
+
+        proceeds = _money(quantity * unit_price - fees)
+        if proceeds <= Decimal("0"):
+            raise InvestmentAccountingValidationError("sell proceeds must be positive")
+        cost_basis = await self._consume_lots(
+            db,
+            user_id=user_id,
+            position=position,
+            quantity=quantity,
+            method=cost_basis_method,
+            disposal_date=transaction_date,
+        )
+        realized_pnl = _money(proceeds - cost_basis)
+
+        lines = [
+            {
+                "account_id": cash_account.id,
+                "direction": Direction.DEBIT,
+                "amount": proceeds,
+                "currency": currency,
+                "fx_rate": fx_rate,
+                "event_type": "investment_sell",
+                "tags": {"asset_identifier": asset_identifier},
+            },
+            {
+                "account_id": investment_account.id,
+                "direction": Direction.CREDIT,
+                "amount": cost_basis,
+                "currency": currency,
+                "fx_rate": fx_rate,
+                "event_type": "investment_sell",
+                "tags": {"asset_identifier": asset_identifier},
+            },
+        ]
+        if realized_pnl > Decimal("0"):
+            lines.append(
+                {
+                    "account_id": pnl_account.id,
+                    "direction": Direction.CREDIT,
+                    "amount": realized_pnl,
+                    "currency": currency,
+                    "fx_rate": fx_rate,
+                    "event_type": "investment_realized_pnl",
+                    "tags": {"asset_identifier": asset_identifier},
+                }
+            )
+        elif realized_pnl < Decimal("0"):
+            lines.append(
+                {
+                    "account_id": pnl_account.id,
+                    "direction": Direction.DEBIT,
+                    "amount": abs(realized_pnl),
+                    "currency": currency,
+                    "fx_rate": fx_rate,
+                    "event_type": "investment_realized_pnl",
+                    "tags": {"asset_identifier": asset_identifier},
+                }
+            )
+
+        entry = await create_journal_entry(
+            db,
+            user_id=user_id,
+            entry_date=transaction_date,
+            memo=f"Sell {asset_identifier}",
+            source_type=JournalEntrySourceType.SYSTEM,
+            source_id=source_id,
+            lines_data=lines,
+        )
+        posted = await self._post_and_load(db, entry.id, user_id)
+
+        position.quantity = _quantity(position.quantity - quantity)
+        position.cost_basis = _money(position.cost_basis - cost_basis)
+        position.realized_pnl = _money((position.realized_pnl or Decimal("0.00")) + realized_pnl)
+        position.cost_basis_method = cost_basis_method
+        if position.quantity == Decimal("0.000000"):
+            position.status = PositionStatus.DISPOSED
+            position.disposal_date = transaction_date
+
+        transaction = InvestmentTransaction(
+            user_id=user_id,
+            position_id=position.id,
+            journal_entry_id=posted.id,
+            source_id=source_id,
+            transaction_date=transaction_date,
+            transaction_type=InvestmentTransactionType.SELL,
+            asset_identifier=asset_identifier,
+            quantity=_quantity(quantity),
+            unit_price=_quantity(unit_price),
+            gross_amount=proceeds,
+            fees=_money(fees),
+            currency=currency,
+            cost_basis=cost_basis,
+            realized_pnl=realized_pnl,
+            cost_basis_method=cost_basis_method,
+        )
+        db.add(transaction)
+        await db.flush()
+        await db.refresh(transaction)
+        await db.refresh(position)
+        return InvestmentAccountingResult(transaction=transaction, journal_entry=posted, position=position)
+
+    async def post_dividend(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        payment_date: date,
+        asset_identifier: str,
+        gross_amount: Decimal,
+        currency: str,
+        cash_account_id: UUID,
+        investment_account_id: UUID,
+        dividend_income_account_id: UUID,
+        withholding_tax: Decimal = Decimal("0.00"),
+        withholding_tax_account_id: UUID | None = None,
+        fx_rate: Decimal | None = None,
+        source_id: UUID | None = None,
+        dividend_type: DividendType = DividendType.ORDINARY,
+    ) -> InvestmentAccountingResult:
+        """Post a dividend transaction as cash plus dividend income."""
+        self._validate_positive(gross_amount, "gross_amount")
+        self._validate_non_negative(withholding_tax, "withholding_tax")
+        if withholding_tax > gross_amount:
+            raise InvestmentAccountingValidationError("withholding_tax cannot exceed gross_amount")
+
+        cash_account = await self._get_account(db, user_id, cash_account_id, AccountType.ASSET)
+        investment_account = await self._get_account(db, user_id, investment_account_id, AccountType.ASSET)
+        income_account = await self._get_account(db, user_id, dividend_income_account_id, AccountType.INCOME)
+        tax_account = None
+        if withholding_tax > Decimal("0"):
+            if withholding_tax_account_id is None:
+                raise InvestmentAccountingValidationError("withholding_tax_account_id is required for tax withheld")
+            tax_account = await self._get_account(db, user_id, withholding_tax_account_id, AccountType.EXPENSE)
+
+        position = await self._get_position(
+            db,
+            user_id=user_id,
+            account_id=investment_account.id,
+            asset_identifier=asset_identifier,
+        )
+        gross = _money(gross_amount)
+        tax = _money(withholding_tax)
+        net_cash = _money(gross - tax)
+
+        lines = []
+        if net_cash > Decimal("0"):
+            lines.append(
+                {
+                    "account_id": cash_account.id,
+                    "direction": Direction.DEBIT,
+                    "amount": net_cash,
+                    "currency": currency,
+                    "fx_rate": fx_rate,
+                    "event_type": "investment_dividend",
+                    "tags": {"asset_identifier": asset_identifier},
+                }
+            )
+        if tax > Decimal("0") and tax_account is not None:
+            lines.append(
+                {
+                    "account_id": tax_account.id,
+                    "direction": Direction.DEBIT,
+                    "amount": tax,
+                    "currency": currency,
+                    "fx_rate": fx_rate,
+                    "event_type": "investment_dividend_tax",
+                    "tags": {"asset_identifier": asset_identifier},
+                }
+            )
+        lines.append(
+            {
+                "account_id": income_account.id,
+                "direction": Direction.CREDIT,
+                "amount": gross,
+                "currency": currency,
+                "fx_rate": fx_rate,
+                "event_type": "investment_dividend",
+                "tags": {"asset_identifier": asset_identifier},
+            }
+        )
+
+        entry = await create_journal_entry(
+            db,
+            user_id=user_id,
+            entry_date=payment_date,
+            memo=f"Dividend {asset_identifier}",
+            source_type=JournalEntrySourceType.SYSTEM,
+            source_id=source_id,
+            lines_data=lines,
+        )
+        posted = await self._post_and_load(db, entry.id, user_id)
+
+        transaction = InvestmentTransaction(
+            user_id=user_id,
+            position_id=position.id,
+            journal_entry_id=posted.id,
+            source_id=source_id,
+            transaction_date=payment_date,
+            transaction_type=InvestmentTransactionType.DIVIDEND,
+            asset_identifier=asset_identifier,
+            quantity=None,
+            unit_price=None,
+            gross_amount=gross,
+            fees=Decimal("0.00"),
+            currency=currency,
+            cost_basis=None,
+            realized_pnl=None,
+            cost_basis_method=position.cost_basis_method,
+        )
+        dividend = DividendIncome(
+            user_id=user_id,
+            position_id=position.id,
+            payment_date=payment_date,
+            amount=gross,
+            currency=currency,
+            dividend_type=dividend_type,
+        )
+        db.add_all([transaction, dividend])
+        await db.flush()
+        await db.refresh(transaction)
+        await db.refresh(position)
+        return InvestmentAccountingResult(transaction=transaction, journal_entry=posted, position=position)
+
+    async def _get_account(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        account_id: UUID,
+        expected_type: AccountType,
+    ) -> Account:
+        account = await db.scalar(select(Account).where(Account.id == account_id).where(Account.user_id == user_id))
+        if account is None:
+            raise InvestmentAccountingValidationError(f"account {account_id} not found")
+        if account.type != expected_type:
+            raise InvestmentAccountingValidationError(f"account {account.name} must be {expected_type.value}")
+        if not account.is_active:
+            raise InvestmentAccountingValidationError(f"account {account.name} is inactive")
+        return account
+
+    async def _get_or_create_position(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        account_id: UUID,
+        asset_identifier: str,
+        transaction_date: date,
+        currency: str,
+        cost_basis_method: CostBasisMethod,
+    ) -> ManagedPosition:
+        position = await db.scalar(
+            select(ManagedPosition)
+            .where(ManagedPosition.user_id == user_id)
+            .where(ManagedPosition.account_id == account_id)
+            .where(ManagedPosition.asset_identifier == asset_identifier)
+        )
+        if position is not None:
+            return position
+
+        position = ManagedPosition(
+            user_id=user_id,
+            account_id=account_id,
+            asset_identifier=asset_identifier,
+            quantity=Decimal("0.000000"),
+            cost_basis=Decimal("0.00"),
+            currency=currency,
+            acquisition_date=transaction_date,
+            status=PositionStatus.ACTIVE,
+            cost_basis_method=cost_basis_method,
+            realized_pnl=Decimal("0.00"),
+        )
+        db.add(position)
+        await db.flush()
+        return position
+
+    async def _get_position(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        account_id: UUID,
+        asset_identifier: str,
+    ) -> ManagedPosition:
+        position = await db.scalar(
+            select(ManagedPosition)
+            .where(ManagedPosition.user_id == user_id)
+            .where(ManagedPosition.account_id == account_id)
+            .where(ManagedPosition.asset_identifier == asset_identifier)
+        )
+        if position is None:
+            raise InvestmentAccountingValidationError(f"position {asset_identifier} not found")
+        return position
+
+    async def _consume_lots(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        position: ManagedPosition,
+        quantity: Decimal,
+        method: CostBasisMethod,
+        disposal_date: date,
+    ) -> Decimal:
+        lots = await self._open_lots(db, user_id=user_id, position_id=position.id, method=method)
+        total_available = sum((lot.remaining_quantity for lot in lots), Decimal("0.000000"))
+        if total_available < quantity:
+            raise InvestmentAccountingValidationError(
+                f"cannot sell {quantity} {position.asset_identifier}; only {total_available} available"
+            )
+
+        if method == CostBasisMethod.AVGCOST:
+            avg_unit_cost = _quantity(
+                sum((lot.remaining_quantity * lot.unit_cost for lot in lots), Decimal("0.00")) / total_available
+            )
+            for lot in lots:
+                lot.unit_cost = avg_unit_cost
+
+        remaining_to_sell = _quantity(quantity)
+        cost_basis = Decimal("0.00")
+        for lot in lots:
+            if remaining_to_sell <= Decimal("0"):
+                break
+            consumed = min(lot.remaining_quantity, remaining_to_sell)
+            cost_basis += consumed * lot.unit_cost
+            lot.remaining_quantity = _quantity(lot.remaining_quantity - consumed)
+            if lot.remaining_quantity == Decimal("0.000000"):
+                lot.disposed_date = disposal_date
+            remaining_to_sell = _quantity(remaining_to_sell - consumed)
+
+        await db.flush()
+        return _money(cost_basis)
+
+    async def _open_lots(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        position_id: UUID,
+        method: CostBasisMethod,
+    ) -> list[InvestmentLot]:
+        query = (
+            select(InvestmentLot)
+            .where(InvestmentLot.user_id == user_id)
+            .where(InvestmentLot.position_id == position_id)
+            .where(InvestmentLot.remaining_quantity > Decimal("0"))
+        )
+        if method == CostBasisMethod.LIFO:
+            query = query.order_by(InvestmentLot.acquisition_date.desc(), InvestmentLot.created_at.desc())
+        else:
+            query = query.order_by(InvestmentLot.acquisition_date.asc(), InvestmentLot.created_at.asc())
+        return list((await db.execute(query)).scalars().all())
+
+    async def _post_and_load(self, db: AsyncSession, entry_id: UUID, user_id: UUID) -> JournalEntry:
+        posted = await post_journal_entry(db, entry_id, user_id)
+        await db.refresh(posted, ["lines"])
+        return posted
+
+    def _validate_positive(self, value: Decimal, field: str) -> None:
+        if value <= Decimal("0"):
+            raise InvestmentAccountingValidationError(f"{field} must be positive")
+
+    def _validate_non_negative(self, value: Decimal, field: str) -> None:
+        if value < Decimal("0"):
+            raise InvestmentAccountingValidationError(f"{field} cannot be negative")

--- a/apps/backend/tests/portfolio/test_investment_accounting.py
+++ b/apps/backend/tests/portfolio/test_investment_accounting.py
@@ -1,0 +1,265 @@
+"""AC17.5/AC17.6: Investment transaction accounting tests."""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.account import Account, AccountType
+from src.models.journal import Direction, JournalEntryStatus
+from src.models.layer3 import CostBasisMethod
+from src.models.portfolio import DividendIncome, InvestmentLot, InvestmentTransaction
+from src.services.investment_accounting import InvestmentAccountingService
+
+
+@pytest.fixture
+async def chart(db: AsyncSession, test_user):
+    accounts = {
+        "cash": Account(
+            user_id=test_user.id,
+            name="Brokerage Cash",
+            type=AccountType.ASSET,
+            currency="SGD",
+        ),
+        "investment": Account(
+            user_id=test_user.id,
+            name="Investment Securities",
+            type=AccountType.ASSET,
+            currency="SGD",
+        ),
+        "realized_pnl": Account(
+            user_id=test_user.id,
+            name="Realized Investment P&L",
+            type=AccountType.INCOME,
+            currency="SGD",
+        ),
+        "dividend_income": Account(
+            user_id=test_user.id,
+            name="Dividend Income",
+            type=AccountType.INCOME,
+            currency="SGD",
+        ),
+    }
+    db.add_all(accounts.values())
+    await db.flush()
+    return accounts
+
+
+@pytest.fixture
+def svc() -> InvestmentAccountingService:
+    return InvestmentAccountingService()
+
+
+def _line_amount(entry, account_id, direction):
+    return next(line.amount for line in entry.lines if line.account_id == account_id and line.direction == direction)
+
+
+@pytest.mark.asyncio
+async def test_buy_transaction_creates_balanced_journal_entry_and_lot(
+    db: AsyncSession,
+    test_user,
+    chart,
+    svc: InvestmentAccountingService,
+):
+    """AC17.5.1: Buy transactions increase investments and reduce brokerage cash."""
+    result = await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 1, 5),
+        asset_identifier="VWRA",
+        quantity=Decimal("10"),
+        unit_price=Decimal("100.00"),
+        fees=Decimal("5.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+
+    assert result.journal_entry.status == JournalEntryStatus.POSTED
+    assert _line_amount(result.journal_entry, chart["investment"].id, Direction.DEBIT) == Decimal("1005.00")
+    assert _line_amount(result.journal_entry, chart["cash"].id, Direction.CREDIT) == Decimal("1005.00")
+    assert result.position.quantity == Decimal("10")
+    assert result.position.cost_basis == Decimal("1005.00")
+
+    lots = (
+        (await db.execute(select(InvestmentLot).where(InvestmentLot.position_id == result.position.id))).scalars().all()
+    )
+    assert len(lots) == 1
+    assert lots[0].remaining_quantity == Decimal("10")
+    assert lots[0].unit_cost == Decimal("100.500000")
+
+
+@pytest.mark.asyncio
+async def test_sell_transaction_uses_fifo_and_records_realized_gain(
+    db: AsyncSession,
+    test_user,
+    chart,
+    svc: InvestmentAccountingService,
+):
+    """AC17.5.2/AC17.6.1: Sell transactions consume FIFO lots and record realized P&L."""
+    await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 1, 5),
+        asset_identifier="VWRA",
+        quantity=Decimal("10"),
+        unit_price=Decimal("100.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+    await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 2, 5),
+        asset_identifier="VWRA",
+        quantity=Decimal("5"),
+        unit_price=Decimal("120.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+
+    result = await svc.post_sell(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 3, 5),
+        asset_identifier="VWRA",
+        quantity=Decimal("12"),
+        unit_price=Decimal("130.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+        realized_pnl_account_id=chart["realized_pnl"].id,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+
+    assert _line_amount(result.journal_entry, chart["cash"].id, Direction.DEBIT) == Decimal("1560.00")
+    assert _line_amount(result.journal_entry, chart["investment"].id, Direction.CREDIT) == Decimal("1240.00")
+    assert _line_amount(result.journal_entry, chart["realized_pnl"].id, Direction.CREDIT) == Decimal("320.00")
+    assert result.transaction.cost_basis == Decimal("1240.00")
+    assert result.transaction.realized_pnl == Decimal("320.00")
+    assert result.position.quantity == Decimal("3")
+    assert result.position.cost_basis == Decimal("360.00")
+    assert result.position.realized_pnl == Decimal("320.00")
+
+    remaining = (
+        (
+            await db.execute(
+                select(InvestmentLot)
+                .where(InvestmentLot.position_id == result.position.id)
+                .order_by(InvestmentLot.acquisition_date)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [lot.remaining_quantity for lot in remaining] == [Decimal("0"), Decimal("3")]
+
+
+@pytest.mark.asyncio
+async def test_sell_transaction_uses_average_cost_for_realized_pnl(
+    db: AsyncSession,
+    test_user,
+    chart,
+    svc: InvestmentAccountingService,
+):
+    """AC17.5.2: Average cost basis is explicit and persisted on sell transactions."""
+    await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 1, 5),
+        asset_identifier="AAPL",
+        quantity=Decimal("10"),
+        unit_price=Decimal("100.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+    await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 2, 5),
+        asset_identifier="AAPL",
+        quantity=Decimal("10"),
+        unit_price=Decimal("140.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+
+    result = await svc.post_sell(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 3, 5),
+        asset_identifier="AAPL",
+        quantity=Decimal("5"),
+        unit_price=Decimal("150.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+        realized_pnl_account_id=chart["realized_pnl"].id,
+        cost_basis_method=CostBasisMethod.AVGCOST,
+    )
+
+    assert result.transaction.cost_basis_method == CostBasisMethod.AVGCOST
+    assert result.transaction.cost_basis == Decimal("600.00")
+    assert result.transaction.realized_pnl == Decimal("150.00")
+    assert result.position.cost_basis == Decimal("1800.00")
+
+
+@pytest.mark.asyncio
+async def test_dividend_transaction_posts_income_and_dividend_record(
+    db: AsyncSession,
+    test_user,
+    chart,
+    svc: InvestmentAccountingService,
+):
+    """AC17.5.3/AC17.6.2: Dividends create cash, income, and DividendIncome records."""
+    buy = await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 1, 5),
+        asset_identifier="VWRA",
+        quantity=Decimal("10"),
+        unit_price=Decimal("100.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+
+    result = await svc.post_dividend(
+        db,
+        user_id=test_user.id,
+        payment_date=date(2026, 4, 5),
+        asset_identifier="VWRA",
+        gross_amount=Decimal("25.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+        dividend_income_account_id=chart["dividend_income"].id,
+    )
+
+    assert result.position.id == buy.position.id
+    assert _line_amount(result.journal_entry, chart["cash"].id, Direction.DEBIT) == Decimal("25.00")
+    assert _line_amount(result.journal_entry, chart["dividend_income"].id, Direction.CREDIT) == Decimal("25.00")
+
+    dividend = (
+        await db.execute(select(DividendIncome).where(DividendIncome.position_id == buy.position.id))
+    ).scalar_one()
+    assert dividend.amount == Decimal("25.00")
+
+    transactions = (
+        (
+            await db.execute(
+                select(InvestmentTransaction)
+                .where(InvestmentTransaction.position_id == buy.position.id)
+                .order_by(InvestmentTransaction.transaction_date)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [txn.transaction_type.value for txn in transactions] == ["buy", "dividend"]

--- a/apps/backend/tests/portfolio/test_investment_accounting.py
+++ b/apps/backend/tests/portfolio/test_investment_accounting.py
@@ -2,6 +2,8 @@
 
 from datetime import date
 from decimal import Decimal
+from types import SimpleNamespace
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import select
@@ -60,6 +62,14 @@ def svc() -> InvestmentAccountingService:
 
 def _line_amount(entry, account_id, direction):
     return next(line.amount for line in entry.lines if line.account_id == account_id and line.direction == direction)
+
+
+class _ScalarStub:
+    def __init__(self, value):
+        self.value = value
+
+    async def scalar(self, _query):
+        return self.value
 
 
 @pytest.mark.asyncio
@@ -478,4 +488,32 @@ async def test_investment_accounting_rejects_invalid_transactions(
             cash_account_id=chart["cash"].id,
             investment_account_id=chart["investment"].id,
             dividend_income_account_id=chart["dividend_income"].id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_investment_accounting_rejects_invalid_account_and_position_helpers(
+    svc: InvestmentAccountingService,
+):
+    """AC17.5.1/AC17.5.2: Ledger helpers reject invalid accounts and missing positions."""
+    user_id = uuid4()
+    account_id = uuid4()
+
+    with pytest.raises(InvestmentAccountingValidationError, match=f"account {account_id} not found"):
+        await svc._get_account(_ScalarStub(None), user_id, account_id, AccountType.ASSET)
+
+    liability_account = SimpleNamespace(name="Loan", type=AccountType.LIABILITY, is_active=True)
+    with pytest.raises(InvestmentAccountingValidationError, match="account Loan must be ASSET"):
+        await svc._get_account(_ScalarStub(liability_account), user_id, account_id, AccountType.ASSET)
+
+    inactive_account = SimpleNamespace(name="Closed Cash", type=AccountType.ASSET, is_active=False)
+    with pytest.raises(InvestmentAccountingValidationError, match="account Closed Cash is inactive"):
+        await svc._get_account(_ScalarStub(inactive_account), user_id, account_id, AccountType.ASSET)
+
+    with pytest.raises(InvestmentAccountingValidationError, match="position MISSING not found"):
+        await svc._get_position(
+            _ScalarStub(None),
+            user_id=user_id,
+            account_id=account_id,
+            asset_identifier="MISSING",
         )

--- a/apps/backend/tests/portfolio/test_investment_accounting.py
+++ b/apps/backend/tests/portfolio/test_investment_accounting.py
@@ -9,9 +9,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.account import Account, AccountType
 from src.models.journal import Direction, JournalEntryStatus
-from src.models.layer3 import CostBasisMethod
+from src.models.layer3 import CostBasisMethod, PositionStatus
 from src.models.portfolio import DividendIncome, InvestmentLot, InvestmentTransaction
-from src.services.investment_accounting import InvestmentAccountingService
+from src.services.investment_accounting import InvestmentAccountingService, InvestmentAccountingValidationError
 
 
 @pytest.fixture
@@ -39,6 +39,12 @@ async def chart(db: AsyncSession, test_user):
             user_id=test_user.id,
             name="Dividend Income",
             type=AccountType.INCOME,
+            currency="SGD",
+        ),
+        "withholding_tax": Account(
+            user_id=test_user.id,
+            name="Dividend Withholding Tax",
+            type=AccountType.EXPENSE,
             currency="SGD",
         ),
     }
@@ -211,6 +217,74 @@ async def test_sell_transaction_uses_average_cost_for_realized_pnl(
 
 
 @pytest.mark.asyncio
+async def test_sell_transaction_uses_lifo_loss_and_disposes_position(
+    db: AsyncSession,
+    test_user,
+    chart,
+    svc: InvestmentAccountingService,
+):
+    """AC17.5.2/AC17.6.1: LIFO sells can realize losses and close positions."""
+    await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 1, 5),
+        asset_identifier="SWRD",
+        quantity=Decimal("10"),
+        unit_price=Decimal("100.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+    await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 2, 5),
+        asset_identifier="SWRD",
+        quantity=Decimal("5"),
+        unit_price=Decimal("120.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+
+    loss = await svc.post_sell(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 3, 5),
+        asset_identifier="SWRD",
+        quantity=Decimal("5"),
+        unit_price=Decimal("110.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+        realized_pnl_account_id=chart["realized_pnl"].id,
+        cost_basis_method=CostBasisMethod.LIFO,
+    )
+
+    assert _line_amount(loss.journal_entry, chart["realized_pnl"].id, Direction.DEBIT) == Decimal("50.00")
+    assert loss.transaction.cost_basis == Decimal("600.00")
+    assert loss.transaction.realized_pnl == Decimal("-50.00")
+
+    closed = await svc.post_sell(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 4, 5),
+        asset_identifier="SWRD",
+        quantity=Decimal("10"),
+        unit_price=Decimal("100.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+        realized_pnl_account_id=chart["realized_pnl"].id,
+        cost_basis_method=CostBasisMethod.LIFO,
+    )
+
+    assert closed.position.quantity == Decimal("0")
+    assert closed.position.status == PositionStatus.DISPOSED
+    assert closed.position.disposal_date == date(2026, 4, 5)
+
+
+@pytest.mark.asyncio
 async def test_dividend_transaction_posts_income_and_dividend_record(
     db: AsyncSession,
     test_user,
@@ -263,3 +337,145 @@ async def test_dividend_transaction_posts_income_and_dividend_record(
         .all()
     )
     assert [txn.transaction_type.value for txn in transactions] == ["buy", "dividend"]
+
+
+@pytest.mark.asyncio
+async def test_dividend_transaction_posts_withholding_tax(
+    db: AsyncSession,
+    test_user,
+    chart,
+    svc: InvestmentAccountingService,
+):
+    """AC17.5.3/AC17.6.2: Withholding tax splits dividend cash and tax expense."""
+    await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 1, 5),
+        asset_identifier="VWRA",
+        quantity=Decimal("10"),
+        unit_price=Decimal("100.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+
+    result = await svc.post_dividend(
+        db,
+        user_id=test_user.id,
+        payment_date=date(2026, 4, 5),
+        asset_identifier="VWRA",
+        gross_amount=Decimal("25.00"),
+        withholding_tax=Decimal("7.50"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+        dividend_income_account_id=chart["dividend_income"].id,
+        withholding_tax_account_id=chart["withholding_tax"].id,
+    )
+
+    assert _line_amount(result.journal_entry, chart["cash"].id, Direction.DEBIT) == Decimal("17.50")
+    assert _line_amount(result.journal_entry, chart["withholding_tax"].id, Direction.DEBIT) == Decimal("7.50")
+    assert _line_amount(result.journal_entry, chart["dividend_income"].id, Direction.CREDIT) == Decimal("25.00")
+
+
+@pytest.mark.asyncio
+async def test_investment_accounting_rejects_invalid_transactions(
+    db: AsyncSession,
+    test_user,
+    chart,
+    svc: InvestmentAccountingService,
+):
+    """AC17.5.1/AC17.5.2/AC17.5.3: Invalid transaction inputs are rejected."""
+    with pytest.raises(InvestmentAccountingValidationError, match="buy amount must be positive"):
+        await svc.post_buy(
+            db,
+            user_id=test_user.id,
+            transaction_date=date(2026, 1, 5),
+            asset_identifier="VWRA",
+            quantity=Decimal("10"),
+            unit_price=Decimal("0.00"),
+            currency="SGD",
+            cash_account_id=chart["cash"].id,
+            investment_account_id=chart["investment"].id,
+        )
+
+    buy = await svc.post_buy(
+        db,
+        user_id=test_user.id,
+        transaction_date=date(2026, 1, 5),
+        asset_identifier="VWRA",
+        quantity=Decimal("10"),
+        unit_price=Decimal("100.00"),
+        currency="SGD",
+        cash_account_id=chart["cash"].id,
+        investment_account_id=chart["investment"].id,
+    )
+
+    with pytest.raises(InvestmentAccountingValidationError, match="sell proceeds must be positive"):
+        await svc.post_sell(
+            db,
+            user_id=test_user.id,
+            transaction_date=date(2026, 2, 5),
+            asset_identifier="VWRA",
+            quantity=Decimal("1"),
+            unit_price=Decimal("0.00"),
+            currency="SGD",
+            cash_account_id=chart["cash"].id,
+            investment_account_id=chart["investment"].id,
+            realized_pnl_account_id=chart["realized_pnl"].id,
+        )
+
+    with pytest.raises(InvestmentAccountingValidationError, match="only 10.000000 available"):
+        await svc.post_sell(
+            db,
+            user_id=test_user.id,
+            transaction_date=date(2026, 2, 5),
+            asset_identifier="VWRA",
+            quantity=Decimal("11"),
+            unit_price=Decimal("100.00"),
+            currency="SGD",
+            cash_account_id=chart["cash"].id,
+            investment_account_id=chart["investment"].id,
+            realized_pnl_account_id=chart["realized_pnl"].id,
+        )
+
+    with pytest.raises(InvestmentAccountingValidationError, match="withholding_tax cannot exceed gross_amount"):
+        await svc.post_dividend(
+            db,
+            user_id=test_user.id,
+            payment_date=date(2026, 4, 5),
+            asset_identifier="VWRA",
+            gross_amount=Decimal("25.00"),
+            withholding_tax=Decimal("25.01"),
+            currency="SGD",
+            cash_account_id=chart["cash"].id,
+            investment_account_id=chart["investment"].id,
+            dividend_income_account_id=chart["dividend_income"].id,
+        )
+
+    with pytest.raises(InvestmentAccountingValidationError, match="withholding_tax_account_id is required"):
+        await svc.post_dividend(
+            db,
+            user_id=test_user.id,
+            payment_date=date(2026, 4, 5),
+            asset_identifier=buy.position.asset_identifier,
+            gross_amount=Decimal("25.00"),
+            withholding_tax=Decimal("7.50"),
+            currency="SGD",
+            cash_account_id=chart["cash"].id,
+            investment_account_id=chart["investment"].id,
+            dividend_income_account_id=chart["dividend_income"].id,
+        )
+
+    with pytest.raises(InvestmentAccountingValidationError, match="position UNKNOWN not found"):
+        await svc.post_dividend(
+            db,
+            user_id=test_user.id,
+            payment_date=date(2026, 4, 5),
+            asset_identifier="UNKNOWN",
+            gross_amount=Decimal("25.00"),
+            currency="SGD",
+            cash_account_id=chart["cash"].id,
+            investment_account_id=chart["investment"].id,
+            dividend_income_account_id=chart["dividend_income"].id,
+        )

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -277,17 +277,17 @@ Build a **100% self-developed** investment portfolio management system with comp
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC17.5.1 | Buy Transaction → Journal Entry | `TBD` | `TBD (test to be implemented)` | P0 |
-| AC17.5.2 | Sell Transaction → Journal Entry + Realized P&L | `TBD` | `TBD (test to be implemented)` | P0 |
-| AC17.5.3 | Dividend → Journal Entry → Income Statement | `TBD` | `TBD (test to be implemented)` | P0 |
+| AC17.5.1 | Buy Transaction → Journal Entry | `test_buy_transaction_creates_balanced_journal_entry_and_lot` | `portfolio/test_investment_accounting.py` | P0 |
+| AC17.5.2 | Sell Transaction → Journal Entry + Realized P&L | `test_sell_transaction_uses_fifo_and_records_realized_gain`, `test_sell_transaction_uses_average_cost_for_realized_pnl` | `portfolio/test_investment_accounting.py` | P0 |
+| AC17.5.3 | Dividend → Journal Entry → Income Statement | `test_dividend_transaction_posts_income_and_dividend_record` | `portfolio/test_investment_accounting.py` | P0 |
 | AC17.5.4 | Unrealized P&L → Balance Sheet | `test_unrealized_pnl_happy_path` | `portfolio/test_portfolio_service.py` | P0 |
 
 ### AC17.6: Integration & End-to-End
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC17.6.1 | Full Buy/Sell Cycle | `TBD` | `TBD (test to be implemented)` | P0 |
-| AC17.6.2 | Dividend Accrual to Income | `TBD` | `TBD (test to be implemented)` | P0 |
+| AC17.6.1 | Full Buy/Sell Cycle | `test_sell_transaction_uses_fifo_and_records_realized_gain` | `portfolio/test_investment_accounting.py` | P0 |
+| AC17.6.2 | Dividend Accrual to Income | `test_dividend_transaction_posts_income_and_dividend_record` | `portfolio/test_investment_accounting.py` | P0 |
 
 ### AC17.8: Brokerage Import Completion UI
 
@@ -311,7 +311,7 @@ Build a **100% self-developed** investment portfolio management system with comp
 - Total AC IDs: 27
 - Requirements converted to AC IDs: 100% (EPIC-017 Must Have checklist)
 - Requirements with test references: 100% (some TBD — tests to be implemented)
-- Test files: 3 implemented (`test_portfolio_service.py`, `test_performance_service.py`, `test_allocation_service.py`); 3 TBD (`test_cost_basis_methods.py`, `test_brokerage_parsing.py`, integration tests)
+- Test files: 4 implemented (`test_portfolio_service.py`, `test_performance_service.py`, `test_allocation_service.py`, `test_investment_accounting.py`); remaining brokerage/parser coverage lives in dedicated parsing and bridge tests.
 
 ---
 

--- a/docs/ssot/assets.md
+++ b/docs/ssot/assets.md
@@ -58,7 +58,17 @@ For each latest atomic position:
 
 `GET /portfolio/holdings` without `as_of_date` returns the latest portfolio value from `ManagedPosition` plus the latest eligible price snapshot. The valuation date is `today` unless the user's latest imported `AtomicPosition.snapshot_date` is newer, which can happen for current-month brokerage statement fixtures or provider outputs that normalize month-only periods to month end.
 
-Explicit `as_of_date` requests are point-in-time views: holdings are derived from the latest immutable `AtomicPosition` snapshot per `(asset_identifier, broker)` at or before the requested date. Quantity and market value must come from that selected snapshot, and future snapshots must not be used. Cost basis remains a snapshot-value proxy until lot-level buy/sell accounting is implemented under EPIC-017 follow-up work.
+Explicit `as_of_date` requests are point-in-time views: holdings are derived from the latest immutable `AtomicPosition` snapshot per `(asset_identifier, broker)` at or before the requested date. Quantity and market value must come from that selected snapshot, and future snapshots must not be used. When structured brokerage transactions are available, `InvestmentTransaction` and `InvestmentLot` provide the auditable cost-basis trail for buy/sell/dividend accounting; snapshot-only imports still use market value as the fallback cost-basis proxy.
+
+### Investment Accounting Pipeline
+
+Structured brokerage transactions are posted through `InvestmentAccountingService`:
+
+1. **Buy**: debit the investment asset account, credit brokerage cash, create an `InvestmentTransaction`, create an `InvestmentLot`, and increase `ManagedPosition.quantity` plus `cost_basis`.
+2. **Sell**: consume open lots by the explicit `CostBasisMethod` (`FIFO`, `LIFO`, or `AvgCost`), debit brokerage cash, credit the investment asset account at consumed cost basis, record realized gain/loss to the realized P&L income account, and update `ManagedPosition.realized_pnl`.
+3. **Dividend**: debit brokerage cash, credit dividend income, persist `DividendIncome`, and link the event to the position through `InvestmentTransaction`.
+
+Until #395 expands source-type trust semantics, investment-accounting journal entries use `source_type=system` and preserve any upstream parser/source identifier in `source_id`.
 
 ---
 
@@ -164,6 +174,51 @@ CREATE TABLE managed_positions (
 );
 ```
 
+### InvestmentTransaction
+
+```sql
+CREATE TABLE investment_transactions (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    position_id UUID REFERENCES managed_positions(id) ON DELETE SET NULL,
+    journal_entry_id UUID REFERENCES journal_entries(id) ON DELETE SET NULL,
+    source_id UUID,
+    transaction_date DATE NOT NULL,
+    transaction_type investment_transaction_type_enum NOT NULL,
+    asset_identifier VARCHAR(100) NOT NULL,
+    quantity NUMERIC(18,6),
+    unit_price NUMERIC(18,6),
+    gross_amount NUMERIC(18,2) NOT NULL,
+    fees NUMERIC(18,2) NOT NULL,
+    currency VARCHAR(3) NOT NULL,
+    cost_basis NUMERIC(18,2),
+    realized_pnl NUMERIC(18,2),
+    cost_basis_method cost_basis_method_enum,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+```
+
+### InvestmentLot
+
+```sql
+CREATE TABLE investment_lots (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    position_id UUID NOT NULL REFERENCES managed_positions(id) ON DELETE CASCADE,
+    opening_transaction_id UUID NOT NULL REFERENCES investment_transactions(id) ON DELETE CASCADE,
+    asset_identifier VARCHAR(100) NOT NULL,
+    acquisition_date DATE NOT NULL,
+    original_quantity NUMERIC(18,6) NOT NULL,
+    remaining_quantity NUMERIC(18,6) NOT NULL,
+    unit_cost NUMERIC(18,6) NOT NULL,
+    currency VARCHAR(3) NOT NULL,
+    disposed_date DATE,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+```
+
 ### PositionStatus Enum
 
 | Value | Meaning |
@@ -200,7 +255,7 @@ Manual snapshots cover property value, mortgage or loan balance, CPF or long-ter
 
 ### ✅ Recommended Patterns
 - **Pattern A**: Use `Decimal` for all monetary/quantity fields (never `float`)
-- **Pattern B**: `cost_basis` uses `market_value` as proxy — true FIFO/LIFO lot tracking is future scope
+- **Pattern B**: Use `InvestmentLot` for realized P&L whenever buy/sell transactions are available; use snapshot market value as a fallback proxy only for position-snapshot imports without transaction detail.
 - **Pattern C**: Reconciliation is idempotent — running twice with same data produces same result
 - **Pattern D**: Always record `position_metadata` (JSONB) for audit trail of source data
 - **Pattern E**: Manual valuation values are positive `Decimal` amounts; use `liquidity_class` to separate liquid, restricted, illiquid, and liability presentation.

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -270,6 +270,49 @@ Journal entry line table.
 | event_type | VARCHAR(100) | | Event type |
 | tags | JSONB | | Tags |
 
+### InvestmentTransactions
+Auditable brokerage transaction table for buy, sell, and dividend accounting.
+
+| Column | Type | Constraint | Description |
+|--------|------|------------|-------------|
+| id | UUID | PK | Primary key |
+| user_id | UUID | FK -> Users, NOT NULL | Owner user |
+| position_id | UUID | FK -> ManagedPositions | Linked position |
+| journal_entry_id | UUID | FK -> JournalEntries | Posted ledger entry |
+| source_id | UUID | | Upstream statement/parser source |
+| transaction_date | DATE | NOT NULL | Trade or payment date |
+| transaction_type | ENUM | NOT NULL | buy/sell/dividend |
+| asset_identifier | VARCHAR(100) | NOT NULL | Symbol or broker identifier |
+| quantity | DECIMAL(18,6) | | Units for buy/sell |
+| unit_price | DECIMAL(18,6) | | Per-unit trade price |
+| gross_amount | DECIMAL(18,2) | NOT NULL | Posted cash or trade amount |
+| fees | DECIMAL(18,2) | NOT NULL | Brokerage fees included in accounting |
+| currency | VARCHAR(3) | NOT NULL | Transaction currency |
+| cost_basis | DECIMAL(18,2) | | Consumed or created cost basis |
+| realized_pnl | DECIMAL(18,2) | | Realized gain/loss for sells |
+| cost_basis_method | ENUM | | FIFO/LIFO/AvgCost used for the transaction |
+| created_at | TIMESTAMP | NOT NULL | Creation time |
+| updated_at | TIMESTAMP | NOT NULL | Update time |
+
+### InvestmentLots
+Open lot table used for FIFO, LIFO, and average-cost realized P&L.
+
+| Column | Type | Constraint | Description |
+|--------|------|------------|-------------|
+| id | UUID | PK | Primary key |
+| user_id | UUID | FK -> Users, NOT NULL | Owner user |
+| position_id | UUID | FK -> ManagedPositions, NOT NULL | Linked position |
+| opening_transaction_id | UUID | FK -> InvestmentTransactions, NOT NULL | Buy transaction that opened the lot |
+| asset_identifier | VARCHAR(100) | NOT NULL | Symbol or broker identifier |
+| acquisition_date | DATE | NOT NULL | Lot acquisition date |
+| original_quantity | DECIMAL(18,6) | NOT NULL | Original units |
+| remaining_quantity | DECIMAL(18,6) | NOT NULL | Unsold units |
+| unit_cost | DECIMAL(18,6) | NOT NULL | Cost per unit |
+| currency | VARCHAR(3) | NOT NULL | Lot currency |
+| disposed_date | DATE | | Date the lot was fully consumed |
+| created_at | TIMESTAMP | NOT NULL | Creation time |
+| updated_at | TIMESTAMP | NOT NULL | Update time |
+
 ### ChatSessions
 Chat session header table.
 


### PR DESCRIPTION
## Summary

Fixes #393. Tracked by #444.

Adds the backend accounting foundation for brokerage buy/sell/dividend transactions:

- adds `InvestmentTransaction` and `InvestmentLot` persistence for auditable transaction and lot-level cost-basis history
- adds `InvestmentAccountingService` for buy, sell, and dividend posting into balanced journal entries
- supports FIFO, LIFO, and AvgCost lot consumption for realized P&L
- persists dividend events through `DividendIncome`
- updates EPIC-017, assets/schema SSOT, and the README blocker map

## Acceptance Criteria

- AC17.5.1: buy transaction creates a posted balanced journal entry and investment lot
- AC17.5.2: sell transaction consumes lots, posts realized P&L, and persists the cost-basis method
- AC17.5.3: dividend transaction posts cash plus dividend income and stores `DividendIncome`
- AC17.6.1 / AC17.6.2: service-level buy/sell and dividend integration tests now exist

## Validation

- GitHub Actions CI passed for head `4dd47c6`.
- Coveralls contexts passed: unified, backend, and frontend.
- PR Test Environment passed, including E2E tests.
- Preview health passed: `https://report-pr-462.zitian.party/api/health` returned healthy database and S3 checks.
- `moon run :lint` passed. Existing frontend lint warnings remain unchanged.
- `uv run ruff check ...` passed for changed backend files, migration, and tests.
- `uv run ruff format ... --check` passed for changed backend files, migration, and tests.
- `uv run python -m compileall -q ...` passed for changed backend files, migration, and tests.
- `cd apps/backend && alembic heads` shows `0017_investment_accounting` as the single head.
- `uv run python scripts/generate_ac_registry.py --check` passed.
- `uv run python scripts/check_ac_traceability.py --report-only` passed.

Local DB-backed pytest could not run because this machine's Podman/Postgres connection is unavailable; CI backend shards ran the DB-backed tests successfully.
