### PR TITLE
[codex] Add account statement coverage checks

### DIFF
--- a/apps/backend/src/routers/accounts.py
+++ b/apps/backend/src/routers/accounts.py
@@ -1,5 +1,6 @@
 """Account management API router."""
 
+from datetime import date
 from decimal import Decimal
 from uuid import UUID
 
@@ -11,6 +12,7 @@ from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
 from src.models import AccountType, JournalLine
 from src.schemas import (
+    AccountCoverageListResponse,
     AccountCreate,
     AccountListResponse,
     AccountResponse,
@@ -25,6 +27,7 @@ from src.services import (
     calculate_account_balance,
     calculate_account_balances,
 )
+from src.services.account_coverage import DEFAULT_STALE_AFTER_DAYS, get_account_statement_coverage
 from src.services.processing_account import (
     find_transfer_pairs,
     get_processing_balance,
@@ -118,6 +121,27 @@ async def list_processing_pending(
     legs = [leg for leg in await list_processing_transfer_legs(db, user_id) if leg["entry_id"] not in paired_ids]
     items = [ProcessingPendingItem(**leg) for leg in legs]
     return ProcessingPendingListResponse(items=items, total=len(items))
+
+
+@router.get("/coverage", response_model=AccountCoverageListResponse)
+async def list_account_statement_coverage(
+    db: DbSession,
+    user_id: CurrentUserId,
+    as_of: date | None = Query(None, description="Date used for stale-account evaluation"),
+    stale_after_days: int = Query(
+        DEFAULT_STALE_AFTER_DAYS,
+        ge=1,
+        le=366,
+        description="Number of days after latest confirmed source date before an account is stale",
+    ),
+) -> AccountCoverageListResponse:
+    """List statement coverage status for active accounts."""
+    return await get_account_statement_coverage(
+        db,
+        user_id,
+        as_of=as_of,
+        stale_after_days=stale_after_days,
+    )
 
 
 @router.get("/{account_id}", response_model=AccountResponse)

--- a/apps/backend/src/schemas/__init__.py
+++ b/apps/backend/src/schemas/__init__.py
@@ -1,6 +1,11 @@
 """Pydantic schemas package."""
 
 from src.schemas.account import (
+    AccountCoverageCadence,
+    AccountCoverageIssue,
+    AccountCoverageIssueType,
+    AccountCoverageListResponse,
+    AccountCoverageResponse,
     AccountCreate,
     AccountListResponse,
     AccountResponse,
@@ -97,6 +102,11 @@ from .extraction import (
 
 __all__ = [
     "AccountCreate",
+    "AccountCoverageCadence",
+    "AccountCoverageIssue",
+    "AccountCoverageIssueType",
+    "AccountCoverageListResponse",
+    "AccountCoverageResponse",
     "AccountListResponse",
     "AccountResponse",
     "AccountTrendResponse",

--- a/apps/backend/src/schemas/account.py
+++ b/apps/backend/src/schemas/account.py
@@ -2,6 +2,7 @@
 
 from datetime import date, datetime
 from decimal import Decimal
+from enum import Enum
 from typing import Annotated
 from uuid import UUID
 
@@ -51,6 +52,51 @@ class AccountResponse(AccountBase, BaseResponse):
 
 
 AccountListResponse = ListResponse[AccountResponse]
+
+
+class AccountCoverageCadence(str, Enum):
+    MONTHLY = "monthly"
+    DAILY_SNAPSHOT = "daily_snapshot"
+
+
+class AccountCoverageIssueType(str, Enum):
+    GAP = "gap"
+    OVERLAP = "overlap"
+    DUPLICATE_PERIOD = "duplicate_period"
+    OPENING_BALANCE_MISMATCH = "opening_balance_mismatch"
+
+
+class AccountCoverageIssue(BaseResponse):
+    type: AccountCoverageIssueType
+    severity: str
+    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    period_start: date
+    period_end: date
+    statement_id: UUID | None = None
+    previous_statement_id: UUID | None = None
+    expected_opening_balance: Annotated[Decimal, Field(decimal_places=2)] | None = None
+    actual_opening_balance: Annotated[Decimal, Field(decimal_places=2)] | None = None
+    delta: Annotated[Decimal, Field(decimal_places=2)] | None = None
+
+
+class AccountCoverageResponse(BaseResponse):
+    account_id: UUID
+    account_name: str
+    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    cadence: AccountCoverageCadence
+    latest_source_date: date | None = None
+    latest_confirmed_balance: Annotated[Decimal, Field(decimal_places=2)] | None = None
+    stale_after_days: int
+    is_stale: bool
+    has_daily_snapshot_override: bool
+    coverage_complete: bool
+    issues: list[AccountCoverageIssue]
+
+
+class AccountCoverageListResponse(BaseResponse):
+    items: list[AccountCoverageResponse]
+    total: int
+    as_of: date
 
 
 class ProcessingSummaryResponse(BaseResponse):

--- a/apps/backend/src/services/account_coverage.py
+++ b/apps/backend/src/services/account_coverage.py
@@ -1,0 +1,214 @@
+"""Account-level statement coverage and balance continuity checks."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import Account, BankStatement, BankStatementStatus
+from src.schemas.account import (
+    AccountCoverageCadence,
+    AccountCoverageIssue,
+    AccountCoverageIssueType,
+    AccountCoverageListResponse,
+    AccountCoverageResponse,
+)
+from src.services.statement_validation import BALANCE_TOLERANCE
+
+DEFAULT_STALE_AFTER_DAYS = 45
+CRITICAL_SEVERITY = "critical"
+WARNING_SEVERITY = "warning"
+
+
+def _statement_currency(statement: BankStatement, fallback: str) -> str:
+    return statement.currency or fallback
+
+
+def _is_complete_period(statement: BankStatement) -> bool:
+    return statement.period_start is not None and statement.period_end is not None
+
+
+def _is_daily_snapshot(statement: BankStatement) -> bool:
+    return _is_complete_period(statement) and statement.period_start == statement.period_end
+
+
+def _abs_decimal_delta(left: Decimal, right: Decimal) -> Decimal:
+    return abs(left - right)
+
+
+def _latest_statement(statements: list[BankStatement]) -> BankStatement | None:
+    candidates = [
+        statement
+        for statement in statements
+        if statement.period_end is not None and statement.closing_balance is not None
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda statement: (statement.period_end, statement.updated_at, str(statement.id)))
+
+
+def _coverage_issues(statements: list[BankStatement], currency: str) -> list[AccountCoverageIssue]:
+    complete_statements = [statement for statement in statements if _is_complete_period(statement)]
+    monthly_statements = [statement for statement in complete_statements if not _is_daily_snapshot(statement)]
+    monthly_statements.sort(key=lambda statement: (statement.period_start, statement.period_end, str(statement.id)))
+
+    issues: list[AccountCoverageIssue] = []
+    seen_periods: dict[tuple[date, date], BankStatement] = {}
+
+    for statement in monthly_statements:
+        assert statement.period_start is not None
+        assert statement.period_end is not None
+        period = (statement.period_start, statement.period_end)
+        previous = seen_periods.get(period)
+        if previous is not None:
+            issues.append(
+                AccountCoverageIssue(
+                    type=AccountCoverageIssueType.DUPLICATE_PERIOD,
+                    severity=CRITICAL_SEVERITY,
+                    currency=currency,
+                    period_start=statement.period_start,
+                    period_end=statement.period_end,
+                    statement_id=statement.id,
+                    previous_statement_id=previous.id,
+                )
+            )
+        else:
+            seen_periods[period] = statement
+
+    for previous, current in zip(monthly_statements, monthly_statements[1:], strict=False):
+        assert previous.period_start is not None
+        assert previous.period_end is not None
+        assert current.period_start is not None
+        assert current.period_end is not None
+
+        expected_start = previous.period_end + timedelta(days=1)
+        if current.period_start <= previous.period_end:
+            issues.append(
+                AccountCoverageIssue(
+                    type=AccountCoverageIssueType.OVERLAP,
+                    severity=CRITICAL_SEVERITY,
+                    currency=currency,
+                    period_start=current.period_start,
+                    period_end=previous.period_end,
+                    statement_id=current.id,
+                    previous_statement_id=previous.id,
+                )
+            )
+            continue
+
+        if current.period_start > expected_start:
+            issues.append(
+                AccountCoverageIssue(
+                    type=AccountCoverageIssueType.GAP,
+                    severity=WARNING_SEVERITY,
+                    currency=currency,
+                    period_start=expected_start,
+                    period_end=current.period_start - timedelta(days=1),
+                    statement_id=current.id,
+                    previous_statement_id=previous.id,
+                )
+            )
+            continue
+
+        if previous.closing_balance is None or current.opening_balance is None:
+            continue
+
+        delta = _abs_decimal_delta(current.opening_balance, previous.closing_balance)
+        if delta > BALANCE_TOLERANCE:
+            issues.append(
+                AccountCoverageIssue(
+                    type=AccountCoverageIssueType.OPENING_BALANCE_MISMATCH,
+                    severity=CRITICAL_SEVERITY,
+                    currency=currency,
+                    period_start=current.period_start,
+                    period_end=current.period_end,
+                    statement_id=current.id,
+                    previous_statement_id=previous.id,
+                    expected_opening_balance=previous.closing_balance,
+                    actual_opening_balance=current.opening_balance,
+                    delta=delta,
+                )
+            )
+
+    return issues
+
+
+async def get_account_statement_coverage(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    as_of: date | None = None,
+    stale_after_days: int = DEFAULT_STALE_AFTER_DAYS,
+) -> AccountCoverageListResponse:
+    """Return statement continuity status for every active account/currency pair."""
+    coverage_as_of = as_of or date.today()
+
+    account_result = await db.execute(
+        select(Account)
+        .where(Account.user_id == user_id)
+        .where(Account.is_active.is_(True))
+        .order_by(Account.name, Account.id)
+    )
+    accounts = list(account_result.scalars().all())
+    account_by_id = {account.id: account for account in accounts}
+    account_ids = set(account_by_id)
+
+    if account_ids:
+        statement_result = await db.execute(
+            select(BankStatement)
+            .where(BankStatement.user_id == user_id)
+            .where(BankStatement.status == BankStatementStatus.APPROVED)
+            .where(BankStatement.account_id.in_(account_ids))
+            .order_by(BankStatement.account_id, BankStatement.currency, BankStatement.period_start, BankStatement.id)
+        )
+        statements = list(statement_result.scalars().all())
+    else:
+        statements = []
+
+    grouped: dict[tuple[UUID, str], list[BankStatement]] = defaultdict(list)
+    for statement in statements:
+        assert statement.account_id is not None
+        account = account_by_id[statement.account_id]
+        grouped[(statement.account_id, _statement_currency(statement, account.currency))].append(statement)
+
+    account_currencies: dict[UUID, set[str]] = {account.id: {account.currency} for account in accounts}
+    for account_id, currency in grouped:
+        account_currencies.setdefault(account_id, set()).add(currency)
+
+    items: list[AccountCoverageResponse] = []
+    for account in accounts:
+        for currency in sorted(account_currencies.get(account.id, {account.currency})):
+            account_statements = grouped.get((account.id, currency), [])
+            latest = _latest_statement(account_statements)
+            latest_source_date = latest.period_end if latest is not None else None
+            latest_confirmed_balance = latest.closing_balance if latest is not None else None
+            has_daily_snapshot_override = latest is not None and _is_daily_snapshot(latest)
+            cadence = (
+                AccountCoverageCadence.DAILY_SNAPSHOT if has_daily_snapshot_override else AccountCoverageCadence.MONTHLY
+            )
+            stale_days = None if latest_source_date is None else (coverage_as_of - latest_source_date).days
+            is_stale = stale_days is None or stale_days > stale_after_days
+            issues = _coverage_issues(account_statements, currency)
+
+            items.append(
+                AccountCoverageResponse(
+                    account_id=account.id,
+                    account_name=account.name,
+                    currency=currency,
+                    cadence=cadence,
+                    latest_source_date=latest_source_date,
+                    latest_confirmed_balance=latest_confirmed_balance,
+                    stale_after_days=stale_after_days,
+                    is_stale=is_stale,
+                    has_daily_snapshot_override=has_daily_snapshot_override,
+                    coverage_complete=not is_stale and not issues,
+                    issues=issues,
+                )
+            )
+
+    return AccountCoverageListResponse(items=items, total=len(items), as_of=coverage_as_of)

--- a/apps/backend/tests/accounting/test_account_statement_coverage.py
+++ b/apps/backend/tests/accounting/test_account_statement_coverage.py
@@ -1,0 +1,319 @@
+"""AC3.7: Account-level statement coverage and balance continuity API."""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import Account, AccountType, BankStatement, BankStatementStatus
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_account(
+    db: AsyncSession,
+    user_id,
+    *,
+    name: str,
+    currency: str = "SGD",
+) -> Account:
+    account = Account(user_id=user_id, name=name, type=AccountType.ASSET, currency=currency)
+    db.add(account)
+    await db.flush()
+    return account
+
+
+async def _create_statement(
+    db: AsyncSession,
+    user_id,
+    account: Account,
+    *,
+    file_hash: str,
+    period_start: date,
+    period_end: date,
+    opening_balance: Decimal | None,
+    closing_balance: Decimal | None,
+    institution: str = "DBS",
+    currency: str = "SGD",
+) -> BankStatement:
+    statement = BankStatement(
+        user_id=user_id,
+        account_id=account.id,
+        file_path=f"test/{file_hash}.pdf",
+        file_hash=file_hash,
+        original_filename=f"{file_hash}.pdf",
+        institution=institution,
+        currency=currency,
+        period_start=period_start,
+        period_end=period_end,
+        opening_balance=opening_balance,
+        closing_balance=closing_balance,
+        status=BankStatementStatus.APPROVED,
+        balance_validated=True,
+    )
+    db.add(statement)
+    await db.flush()
+    return statement
+
+
+def _coverage_item(payload: dict, account: Account) -> dict:
+    for item in payload["items"]:
+        if item["account_id"] == str(account.id):
+            return item
+    raise AssertionError(f"missing coverage item for {account.id}")
+
+
+def _decimal(value) -> Decimal:
+    return Decimal(str(value))
+
+
+async def test_account_coverage_reports_latest_confirmed_balance_and_stale_status(
+    client: AsyncClient, db: AsyncSession, test_user
+) -> None:
+    """AC3.7.1: Each account reports latest source date, balance, and stale status."""
+    account = await _create_account(db, test_user.id, name="DBS Multiplier")
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac371-jan",
+        period_start=date(2025, 1, 1),
+        period_end=date(2025, 1, 31),
+        opening_balance=Decimal("1000.00"),
+        closing_balance=Decimal("1200.00"),
+    )
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac371-feb",
+        period_start=date(2025, 2, 1),
+        period_end=date(2025, 2, 28),
+        opening_balance=Decimal("1200.00"),
+        closing_balance=Decimal("1250.00"),
+    )
+    await db.commit()
+
+    response = await client.get("/accounts/coverage?as_of=2025-03-10&stale_after_days=45")
+
+    assert response.status_code == 200
+    payload = response.json()
+    item = _coverage_item(payload, account)
+    assert item["latest_source_date"] == "2025-02-28"
+    assert _decimal(item["latest_confirmed_balance"]) == Decimal("1250.00")
+    assert item["is_stale"] is False
+    assert item["coverage_complete"] is True
+    assert item["issues"] == []
+
+
+async def test_account_coverage_reports_empty_active_account_as_stale(
+    client: AsyncClient, db: AsyncSession, test_user
+) -> None:
+    """AC3.7.1: Active accounts without approved statements are stale and incomplete."""
+    account = await _create_account(db, test_user.id, name="Unconfirmed Cash")
+    await db.commit()
+
+    response = await client.get("/accounts/coverage?as_of=2025-03-10&stale_after_days=45")
+
+    assert response.status_code == 200
+    item = _coverage_item(response.json(), account)
+    assert item["latest_source_date"] is None
+    assert item["latest_confirmed_balance"] is None
+    assert item["is_stale"] is True
+    assert item["coverage_complete"] is False
+    assert item["issues"] == []
+
+
+async def test_account_coverage_detects_adjacent_opening_balance_mismatch(
+    client: AsyncClient, db: AsyncSession, test_user
+) -> None:
+    """AC3.7.2: Adjacent monthly statements verify previous close equals next open."""
+    account = await _create_account(db, test_user.id, name="DBS Continuity")
+    previous = await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac372-jan",
+        period_start=date(2025, 1, 1),
+        period_end=date(2025, 1, 31),
+        opening_balance=Decimal("1000.00"),
+        closing_balance=Decimal("1100.00"),
+    )
+    current = await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac372-feb",
+        period_start=date(2025, 2, 1),
+        period_end=date(2025, 2, 28),
+        opening_balance=Decimal("1099.99"),
+        closing_balance=Decimal("1200.00"),
+    )
+    await db.commit()
+
+    response = await client.get("/accounts/coverage?as_of=2025-03-01&stale_after_days=45")
+
+    assert response.status_code == 200
+    item = _coverage_item(response.json(), account)
+    assert item["coverage_complete"] is False
+    issue = item["issues"][0]
+    assert issue["type"] == "opening_balance_mismatch"
+    assert issue["statement_id"] == str(current.id)
+    assert issue["previous_statement_id"] == str(previous.id)
+    assert _decimal(issue["expected_opening_balance"]) == Decimal("1100.00")
+    assert _decimal(issue["actual_opening_balance"]) == Decimal("1099.99")
+    assert _decimal(issue["delta"]) == Decimal("0.01")
+
+
+async def test_account_coverage_skips_opening_mismatch_when_boundary_balances_are_missing(
+    client: AsyncClient, db: AsyncSession, test_user
+) -> None:
+    """AC3.7.2: Balance continuity is skipped when either boundary balance is absent."""
+    account = await _create_account(db, test_user.id, name="Pending Balance Boundary")
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac372-missing-jan",
+        period_start=date(2025, 1, 1),
+        period_end=date(2025, 1, 31),
+        opening_balance=Decimal("1000.00"),
+        closing_balance=None,
+    )
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac372-missing-feb",
+        period_start=date(2025, 2, 1),
+        period_end=date(2025, 2, 28),
+        opening_balance=Decimal("1100.00"),
+        closing_balance=Decimal("1200.00"),
+    )
+    await db.commit()
+
+    response = await client.get("/accounts/coverage?as_of=2025-03-01&stale_after_days=45")
+
+    assert response.status_code == 200
+    item = _coverage_item(response.json(), account)
+    assert [issue["type"] for issue in item["issues"]] == []
+
+
+async def test_account_coverage_reports_missing_overlapping_and_duplicate_ranges(
+    client: AsyncClient, db: AsyncSession, test_user
+) -> None:
+    """AC3.7.3: Missing, overlapping, and duplicate statement periods are visible."""
+    account = await _create_account(db, test_user.id, name="DBS Coverage Defects")
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac373-jan-a",
+        period_start=date(2025, 1, 1),
+        period_end=date(2025, 1, 31),
+        opening_balance=Decimal("1000.00"),
+        closing_balance=Decimal("1100.00"),
+    )
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac373-jan-b",
+        period_start=date(2025, 1, 1),
+        period_end=date(2025, 1, 31),
+        opening_balance=Decimal("1000.00"),
+        closing_balance=Decimal("1100.00"),
+    )
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac373-overlap",
+        period_start=date(2025, 1, 15),
+        period_end=date(2025, 2, 15),
+        opening_balance=Decimal("1050.00"),
+        closing_balance=Decimal("1125.00"),
+    )
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac373-apr",
+        period_start=date(2025, 4, 1),
+        period_end=date(2025, 4, 30),
+        opening_balance=Decimal("1125.00"),
+        closing_balance=Decimal("1300.00"),
+    )
+    await db.commit()
+
+    response = await client.get("/accounts/coverage?as_of=2025-05-01&stale_after_days=45")
+
+    assert response.status_code == 200
+    item = _coverage_item(response.json(), account)
+    issue_types = {issue["type"] for issue in item["issues"]}
+    assert {"duplicate_period", "overlap", "gap"}.issubset(issue_types)
+    gap = next(issue for issue in item["issues"] if issue["type"] == "gap")
+    assert gap["period_start"] == "2025-02-16"
+    assert gap["period_end"] == "2025-03-31"
+
+
+async def test_account_coverage_accepts_broker_monthly_cadence_with_daily_snapshot_override(
+    client: AsyncClient, db: AsyncSession, test_user
+) -> None:
+    """AC3.7.4: Broker monthly cadence can use a daily snapshot as latest source."""
+    account = await _create_account(db, test_user.id, name="Brokerage Cash")
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac374-jan",
+        institution="Futu",
+        period_start=date(2025, 1, 1),
+        period_end=date(2025, 1, 31),
+        opening_balance=Decimal("1000.00"),
+        closing_balance=Decimal("1100.00"),
+    )
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac374-feb",
+        institution="Futu",
+        period_start=date(2025, 2, 1),
+        period_end=date(2025, 2, 28),
+        opening_balance=Decimal("1100.00"),
+        closing_balance=Decimal("1200.00"),
+    )
+    await _create_statement(
+        db,
+        test_user.id,
+        account,
+        file_hash="ac374-mar15",
+        institution="Futu",
+        period_start=date(2025, 3, 15),
+        period_end=date(2025, 3, 15),
+        opening_balance=Decimal("1200.00"),
+        closing_balance=Decimal("1300.00"),
+    )
+    await db.commit()
+
+    response = await client.get("/accounts/coverage?as_of=2025-03-16&stale_after_days=45")
+
+    assert response.status_code == 200
+    item = _coverage_item(response.json(), account)
+    assert item["cadence"] == "daily_snapshot"
+    assert item["has_daily_snapshot_override"] is True
+    assert item["latest_source_date"] == "2025-03-15"
+    assert _decimal(item["latest_confirmed_balance"]) == Decimal("1300.00")
+    assert item["coverage_complete"] is True
+    assert item["issues"] == []
+
+
+async def test_account_coverage_returns_empty_list_when_user_has_no_active_accounts(client: AsyncClient) -> None:
+    """AC3.7.1: Users without active accounts receive an empty coverage list."""
+    response = await client.get("/accounts/coverage?as_of=2025-03-10&stale_after_days=45")
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "total": 0, "as_of": "2025-03-10"}

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -686,6 +686,27 @@ groups:
         epic_name: statement-parsing
         description: Explicit First-Upload Account Creation
         mandatory: true
+    AC3.7:
+      - id: AC3.7.1
+        epic: 3
+        epic_name: statement-parsing
+        description: Latest Confirmed Source
+        mandatory: true
+      - id: AC3.7.2
+        epic: 3
+        epic_name: statement-parsing
+        description: Adjacent Opening Continuity
+        mandatory: true
+      - id: AC3.7.3
+        epic: 3
+        epic_name: statement-parsing
+        description: Missing/Overlapping/Duplicate Periods
+        mandatory: true
+      - id: AC3.7.4
+        epic: 3
+        epic_name: statement-parsing
+        description: Broker Daily Snapshot Override
+        mandatory: true
   AC4:
     AC4.1:
       - id: AC4.1.1

--- a/docs/project/EPIC-003.statement-parsing.md
+++ b/docs/project/EPIC-003.statement-parsing.md
@@ -160,11 +160,19 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 | AC3.6.3 | Ambiguous Mapping Blocked | `test_approve_statement_stage1_blocks_ambiguous_account_mapping` | `api/test_statements_router.py` | P0 |
 | AC3.6.4 | Explicit First-Upload Account Creation | `test_approve_statement_stage1_creates_account_with_explicit_confirmation` | `api/test_statements_router.py` | P0 |
 
+### AC3.7: Account Statement Coverage
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC3.7.1 | Latest Confirmed Source | `test_account_coverage_reports_latest_confirmed_balance_and_stale_status` | `accounting/test_account_statement_coverage.py` | P1 |
+| AC3.7.2 | Adjacent Opening Continuity | `test_account_coverage_detects_adjacent_opening_balance_mismatch` | `accounting/test_account_statement_coverage.py` | P1 |
+| AC3.7.3 | Missing/Overlapping/Duplicate Periods | `test_account_coverage_reports_missing_overlapping_and_duplicate_ranges` | `accounting/test_account_statement_coverage.py` | P1 |
+| AC3.7.4 | Broker Daily Snapshot Override | `test_account_coverage_accepts_broker_monthly_cadence_with_daily_snapshot_override` | `accounting/test_account_statement_coverage.py` | P1 |
+
 **Traceability Result**:
-- Total AC IDs: 18
+- Total AC IDs: 22
 - Requirements converted to AC IDs: 100% (EPIC-003 checklist + must-have standards)
 - Requirements with test references: 100%
-- Test files: 7
+- Test files: 8
 
 ---
 
@@ -179,6 +187,7 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 | **Confidence score routing enforced** | `test_high_confidence`, `test_medium_confidence` | 🔴 Critical |
 | **Parsing errors not persisted** | `test_extraction_error_not_persisted` | 🔴 Critical |
 | **Statement account confirmed before posting** | `test_approve_statement_stage1_blocks_unmapped_account_without_fallback`, `test_approve_statement_stage1_creates_account_with_explicit_confirmation` | 🔴 Critical |
+| **Account coverage visible before dashboard completion** | `test_account_coverage_reports_missing_overlapping_and_duplicate_ranges`, `test_account_coverage_detects_adjacent_opening_balance_mismatch` | Required |
 | Support PDF format (DBS/POSB, CMB, Maybank) | `test_dbs_fixture_has_valid_structure` | Required |
 | Support CSV format (Wise/fintech, generic) | `test_csv_parsing.py` suite | Required |
 | File size limit 10MB | `test_upload_file_exceeds_10mb_limit` | Required |

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -532,9 +532,10 @@ HEADLESS=false pytest tests/e2e -v
 ## 6. Archive Integration Notes
 
 Useful content from `docs/project/archive/testing-implementation.md`,
-`docs/project/archive/testing-gap-analysis.md`, and
-`docs/project/archive/TEST-COVERAGE-PLAN.md` is consolidated into this EPIC and
-the current generated coverage report:
+`docs/project/archive/testing-gap-analysis.md`,
+`docs/project/archive/TEST-COVERAGE-PLAN.md`, and
+`docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md` is consolidated into the
+active README -> EPIC -> AC registry -> tests -> CI artifact chain:
 
 - The durable testing assets are factories, performance/load-test entry points,
   Playwright E2E scaffolding, Moon task integration, and critical-path smoke
@@ -542,6 +543,8 @@ the current generated coverage report:
 - Historical coverage numbers in the archive are superseded by
   `docs/analysis/test-ac-coverage-report.md`, `unified-coverage.json`, and
   `scripts/coverage_policy.py`.
+- Historical AC traceability snapshots in the archive are superseded by the
+  generated `ac-test-traceability-audit` CI artifact.
 - The business-critical service focus remains valid: reporting,
   reconciliation, FX revaluation, assets, review queue, processing account,
   accounting, and validation.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -19,6 +19,10 @@ EPIC directory index.
 - AC definitions are discovered from EPIC documents and generated into
   `docs/ac_registry.yaml` and `docs/infra_registry.yaml`.
 - Test proof is reported by `docs/analysis/test-ac-coverage-report.md`.
+- Current AC traceability follows this live chain:
+  `README.md` -> `docs/project/EPIC-*.md` -> `docs/*_registry.yaml` ->
+  tests -> CI artifact. Do not refresh archive audit snapshots in routine
+  feature PRs.
 - Coverage policy is owned by `scripts/coverage_policy.py`.
 - Project status metrics should be generated or validated, not hand-maintained.
   See [issue #455](https://github.com/wangzitian0/finance_report/issues/455).

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -119,6 +119,7 @@ The system is currently migrating to a 4-layer architecture. During Phase 2, dat
 | GET | `/api/statements/{id}` | Get statement with transactions |
 | GET | `/api/statements/{id}/transactions` | Transaction list |
 | GET | `/api/statements/pending-review` | List items needing review |
+| GET | `/api/accounts/coverage` | Account-level latest confirmed source date, stale status, and statement period continuity issues |
 | POST | `/api/statements/{id}/review/approve` | Stage 1 approve with balance-chain validation (canonical) |
 | POST | `/api/statements/{id}/review/reject` | Stage 1 reject (canonical) |
 | POST | `/api/statements/{id}/approve` | Deprecated compatibility endpoint (proxies to Stage 1 approve) |
@@ -245,6 +246,22 @@ If no confident match exists, or multiple accounts match the same metadata, the
 approval flow must block posting with a clear account-mapping action item. Draft
 candidate entries may still use legacy defaults in manual workflows, but posted
 entries cannot silently use `Bank - Main`.
+
+## Account Coverage Contract
+
+Approved statements are the only source for account-level statement coverage.
+`GET /api/accounts/coverage` returns one row per active account/currency pair
+with the latest confirmed source date, latest confirmed closing balance, stale
+status, and period-level continuity issues.
+
+Coverage checks compare monthly statement periods within each account/currency:
+
+- adjacent monthly statements must have `previous.closing_balance ==
+  current.opening_balance` within `BALANCE_TOLERANCE`;
+- gaps, overlaps, and duplicate monthly periods are emitted as issues before a
+  dashboard can treat the account as complete;
+- one-day broker snapshots may override the latest confirmed source date and
+  balance without requiring daily statement continuity.
 
 ## Files
 

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -368,6 +368,16 @@ Statement header table for imported statements.
 **Constraints**:
 - `(user_id, file_hash)` unique to prevent duplicate imports
 
+**Derived API Surface**:
+- `GET /api/accounts/coverage` derives account-level statement coverage from
+  approved `BankStatements` only. It reports the latest confirmed `period_end`
+  and `closing_balance` per active account/currency pair, stale status based on
+  the caller's `as_of` date and `stale_after_days`, and continuity issues for
+  gaps, overlaps, duplicate periods, and adjacent opening/closing mismatches.
+- One-day brokerage snapshots (`period_start == period_end`) can update the
+  latest confirmed source date and balance without forcing daily continuity;
+  monthly statements remain the baseline for gap and overlap detection.
+
 ### BankStatementTransactions
 Statement transaction table (reconciliation input).
 

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -35,7 +35,9 @@ def test_AC8_13_7_full_statement_journey_is_a_hard_ai_ocr_gate() -> None:
 def test_AC8_13_8_upload_readiness_gate_rejects_rejected_status() -> None:
     """AC8.13.8: Upload readiness E2E does not accept rejected statements."""
     upload = read("tests/e2e/test_statement_upload_e2e.py")
-    test_body = upload.split("async def test_statement_upload_full_flow", 1)[1].split("@pytest.mark.e2e", 1)[0]
+    test_body = upload.split("async def test_statement_upload_full_flow", 1)[1].split(
+        "@pytest.mark.e2e", 1
+    )[0]
 
     assert "AI/OCR readiness gate" in test_body
     assert "fail_or_skip_ai_ocr_gate(" in test_body
@@ -106,14 +108,20 @@ def test_AC8_13_14_staging_ai_ocr_gate_is_separate_deploy_job() -> None:
     assert "needs: [build-and-deploy]" in deploy_workflow
     assert "name: Staging AI/OCR Gate" in deploy_workflow
     assert "PARSING_TIMEOUT_MS: 480000" in deploy_workflow
-    assert "EXPECTED_SHA: ${{ needs.build-and-deploy.outputs.commit_sha }}" in deploy_workflow
+    assert (
+        "EXPECTED_SHA: ${{ needs.build-and-deploy.outputs.commit_sha }}"
+        in deploy_workflow
+    )
     assert 'run_timed_phase "Staging AI/OCR Gate' in deploy_workflow
     assert "test_statement_full_journey.py" in deploy_workflow
     assert "test_brokerage_upload_to_portfolio_value.py" in deploy_workflow
     assert "test_statement_upload_e2e.py" in deploy_workflow
     assert '-v -m "llm"' in deploy_workflow
     assert (
-        '-v -m "llm"' not in deploy_workflow.split("name: End-to-End Tests", 1)[1].split("Performance Benchmark", 1)[0]
+        '-v -m "llm"'
+        not in deploy_workflow.split("name: End-to-End Tests", 1)[1].split(
+            "Performance Benchmark", 1
+        )[0]
     )
     assert "name: Staging AI/OCR Gate" in ai_workflow
     assert 'workflows: ["Deploy Staging"]' not in ai_workflow
@@ -154,8 +162,14 @@ def test_AC8_13_16_ci_change_classification_and_frontend_cache() -> None:
     assert "needs: [changes]" in workflow
     assert "if: needs.changes.outputs.heavy_required == 'true'" in workflow
     assert "name: AC Traceability Check" in workflow
-    assert "needs: [changes, backend, frontend, lint, unified-coverage, ac-traceability]" in workflow
-    assert "Heavy backend/frontend/coverage jobs skipped for lightweight changes." in workflow
+    assert (
+        "needs: [changes, backend, frontend, lint, unified-coverage, ac-traceability]"
+        in workflow
+    )
+    assert (
+        "Heavy backend/frontend/coverage jobs skipped for lightweight changes."
+        in workflow
+    )
     assert "uses: actions/setup-node@v4" in workflow
     assert "cache: npm" in workflow
     assert "cache-dependency-path: apps/frontend/package-lock.json" in workflow
@@ -164,7 +178,9 @@ def test_AC8_13_16_ci_change_classification_and_frontend_cache() -> None:
     assert "PR vs Main CI Responsibilities" in ci_cd
     assert "Lightweight changes do not repeat the heavy path" in ci_cd
     assert "Frontend dependency installation uses `actions/setup-node@v4`" in ci_cd
-    assert "Markdown outside the documented lightweight trees is treated as heavy" in ci_cd
+    assert (
+        "Markdown outside the documented lightweight trees is treated as heavy" in ci_cd
+    )
     assert "lightweight documentation" in environments.lower()
 
 
@@ -173,8 +189,14 @@ def test_AC8_13_17_ac_traceability_runs_registry_generation_check() -> None:
     workflow = read(".github/workflows/ci.yml")
     ci_cd = read("docs/ssot/ci-cd.md")
 
-    assert "uv run --with pyyaml python scripts/generate_ac_registry.py --check" in workflow
-    assert "uv run --with pyyaml python scripts/build_ac_traceability.py --output" in workflow
+    assert (
+        "uv run --with pyyaml python scripts/generate_ac_registry.py --check"
+        in workflow
+    )
+    assert (
+        "uv run --with pyyaml python scripts/build_ac_traceability.py --output"
+        in workflow
+    )
     assert workflow.index("scripts/generate_ac_registry.py --check") < workflow.index(
         "scripts/build_ac_traceability.py --output"
     )
@@ -216,13 +238,30 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     assert "STAGING_E2E_PRIMARY_MODEL: glm-5.1" in workflow
     assert "STAGING_E2E_OCR_MODEL: glm-4.6v" in workflow
     assert "STAGING_E2E_VISION_MODEL: glm-4.6v" in workflow
-    assert "DEPLOY_PRIMARY_MODEL_OVERRIDE: ${{ env.STAGING_E2E_PRIMARY_MODEL }}" in workflow
+    assert (
+        "DEPLOY_PRIMARY_MODEL_OVERRIDE: ${{ env.STAGING_E2E_PRIMARY_MODEL }}"
+        in workflow
+    )
     assert "DEPLOY_OCR_MODEL_OVERRIDE: ${{ env.STAGING_E2E_OCR_MODEL }}" in workflow
-    assert "DEPLOY_VISION_MODEL_OVERRIDE: ${{ env.STAGING_E2E_VISION_MODEL }}" in workflow
-    assert 'update_env_var "$new_env" "PRIMARY_MODEL" "$DEPLOY_PRIMARY_MODEL_OVERRIDE"' in deploy_script
-    assert 'update_env_var "$new_env" "OCR_MODEL" "$DEPLOY_OCR_MODEL_OVERRIDE"' in deploy_script
-    assert 'update_env_var "$new_env" "VISION_MODEL" "$DEPLOY_VISION_MODEL_OVERRIDE"' in deploy_script
-    assert 'update_env_var "$new_env" "IAC_CONFIG_HASH" "models-${IMAGE_TAG}-$(date +%s)"' in deploy_script
+    assert (
+        "DEPLOY_VISION_MODEL_OVERRIDE: ${{ env.STAGING_E2E_VISION_MODEL }}" in workflow
+    )
+    assert (
+        'update_env_var "$new_env" "PRIMARY_MODEL" "$DEPLOY_PRIMARY_MODEL_OVERRIDE"'
+        in deploy_script
+    )
+    assert (
+        'update_env_var "$new_env" "OCR_MODEL" "$DEPLOY_OCR_MODEL_OVERRIDE"'
+        in deploy_script
+    )
+    assert (
+        'update_env_var "$new_env" "VISION_MODEL" "$DEPLOY_VISION_MODEL_OVERRIDE"'
+        in deploy_script
+    )
+    assert (
+        'update_env_var "$new_env" "IAC_CONFIG_HASH" "models-${IMAGE_TAG}-$(date +%s)"'
+        in deploy_script
+    )
     assert '-m "(smoke or e2e) and not llm" -n 4' in workflow
     assert "PARSING_TIMEOUT_MS: 480000" in workflow
     assert "Wait for matching CI success" in workflow
@@ -254,10 +293,15 @@ def test_AC8_13_21_post_merge_ai_ocr_waits_for_matching_ci_success() -> None:
     assert "--workflow CI" in workflow
     assert '--sha "${{ github.sha }}"' in workflow
     assert "--poll-seconds 10" in workflow
-    assert workflow.index("Wait for matching CI success") < workflow.index("Build and push Backend")
+    assert workflow.index("Wait for matching CI success") < workflow.index(
+        "Build and push Backend"
+    )
     assert "gh run list" in wait_script
     assert "matching CI run failed" in wait_script
-    assert "waits for the same commit's `CI` push workflow to complete successfully" in ci_cd
+    assert (
+        "waits for the same commit's `CI` push workflow to complete successfully"
+        in ci_cd
+    )
 
 
 def test_AC8_13_22_staging_deploy_waits_for_matching_ci_before_building() -> None:
@@ -269,8 +313,12 @@ def test_AC8_13_22_staging_deploy_waits_for_matching_ci_before_building() -> Non
     assert "packages: write" in workflow
     assert "Wait for matching CI success" in workflow
     assert "timeout-minutes: 45" in workflow
-    assert workflow.index("Wait for matching CI success") < workflow.index("Build and push Backend")
-    assert workflow.index("Wait for matching CI success") < workflow.index("Deploy to Staging")
+    assert workflow.index("Wait for matching CI success") < workflow.index(
+        "Build and push Backend"
+    )
+    assert workflow.index("Wait for matching CI success") < workflow.index(
+        "Deploy to Staging"
+    )
 
 
 def test_AC8_13_23_post_merge_deploy_and_ai_ocr_are_one_serial_unit() -> None:
@@ -283,25 +331,41 @@ def test_AC8_13_23_post_merge_deploy_and_ai_ocr_are_one_serial_unit() -> None:
     assert "cancel-in-progress: false" in deploy_workflow
     assert "ai-ocr-gate:" in deploy_workflow
     assert "needs: [build-and-deploy]" in deploy_workflow
-    assert "EXPECTED_SHA: ${{ needs.build-and-deploy.outputs.commit_sha }}" in deploy_workflow
+    assert (
+        "EXPECTED_SHA: ${{ needs.build-and-deploy.outputs.commit_sha }}"
+        in deploy_workflow
+    )
     assert 'workflows: ["Deploy Staging"]' not in ai_workflow
     assert "same serialized post-merge workflow unit" in ci_cd
-    assert "newer deploy cannot overwrite staging while an older automatic AI/OCR gate is running" in ci_cd
+    assert (
+        "newer deploy cannot overwrite staging while an older automatic AI/OCR gate is running"
+        in ci_cd
+    )
 
 
-def test_AC8_13_24_ac_traceability_uploads_audit_artifact_without_stale_doc_gate() -> None:
+def test_AC8_13_24_ac_traceability_uploads_audit_artifact_without_stale_doc_gate() -> (
+    None
+):
     """AC8.13.24: CI uploads traceability audit instead of failing on stale archive output."""
     workflow = read(".github/workflows/ci.yml")
     audit_builder = read("scripts/build_ac_traceability.py")
     ci_cd = read("docs/ssot/ci-cd.md")
+    project_readme = read("docs/project/README.md")
 
-    assert "uv run --with pyyaml python scripts/generate_ac_registry.py --check" in workflow
-    assert 'scripts/build_ac_traceability.py --output "$RUNNER_TEMP/AC-TEST-TRACEABILITY-AUDIT.md"' in workflow
+    assert (
+        "uv run --with pyyaml python scripts/generate_ac_registry.py --check"
+        in workflow
+    )
+    assert (
+        'scripts/build_ac_traceability.py --output "$RUNNER_TEMP/AC-TEST-TRACEABILITY-AUDIT.md"'
+        in workflow
+    )
     assert "uses: actions/upload-artifact@v4" in workflow
     assert "name: ac-test-traceability-audit" in workflow
     assert "scripts/build_ac_traceability.py --check" not in workflow
     assert "CI uploads the generated audit as an artifact" in audit_builder
     assert "uploaded as a CI artifact" in ci_cd
+    assert "Do not refresh archive audit snapshots in routine" in project_readme
 
 
 def test_AC8_13_25_backend_and_traceability_do_not_wait_for_lint() -> None:
@@ -310,7 +374,9 @@ def test_AC8_13_25_backend_and_traceability_do_not_wait_for_lint() -> None:
     ci_cd = read("docs/ssot/ci-cd.md")
 
     backend_block = workflow.split("  backend:", 1)[1].split("  frontend:", 1)[0]
-    traceability_block = workflow.split("  ac-traceability:", 1)[1].split("  finish:", 1)[0]
+    traceability_block = workflow.split("  ac-traceability:", 1)[1].split(
+        "  finish:", 1
+    )[0]
 
     assert "needs: [changes]" in backend_block
     assert "needs: [changes, lint]" not in backend_block
@@ -324,18 +390,24 @@ def test_AC8_13_27_coveralls_unified_status_blocks_ci_before_merge() -> None:
     wait_script = read("scripts/wait_for_github_status.py")
     ci_cd = read("docs/ssot/ci-cd.md")
 
-    unified_block = workflow.split("- name: Upload unified coverage to Coveralls", 1)[1].split(
-        "- name: Wait for Coveralls unified status", 1
+    unified_block = workflow.split("- name: Upload unified coverage to Coveralls", 1)[
+        1
+    ].split("- name: Wait for Coveralls unified status", 1)[0]
+    frontend_block = workflow.split("- name: Upload frontend to Coveralls", 1)[1].split(
+        "  ac-traceability:", 1
     )[0]
-    frontend_block = workflow.split("- name: Upload frontend to Coveralls", 1)[1].split("  ac-traceability:", 1)[0]
 
     assert "github.event_name == 'push'" not in unified_block
     assert "github.event_name == 'push'" not in frontend_block
     assert "statuses: read" in workflow
     assert "scripts/wait_for_github_status.py" in workflow
     assert '--context "Coveralls - unified"' in workflow
-    assert workflow.index("Upload unified coverage to Coveralls") < workflow.index("Wait for Coveralls unified status")
-    assert workflow.index("Wait for Coveralls unified status") < workflow.index("Upload backend to Coveralls")
+    assert workflow.index("Upload unified coverage to Coveralls") < workflow.index(
+        "Wait for Coveralls unified status"
+    )
+    assert workflow.index("Wait for Coveralls unified status") < workflow.index(
+        "Upload backend to Coveralls"
+    )
     assert "wait_for_status_success" in wait_script
     assert "Coveralls - unified" in ci_cd
     assert "Pull requests wait for the external `Coveralls - unified` status" in ci_cd
@@ -365,7 +437,10 @@ def test_AC8_13_10_multi_brokerage_upload_to_portfolio_value_gate() -> None:
     assert "market_valuation_adjustment_total" in brokerage
     assert "non_portfolio_asset_total" in brokerage
     assert "BrokeragePositionImportService" in statements_router
-    assert "Statement must be parsed before importing brokerage positions" in statements_router
+    assert (
+        "Statement must be parsed before importing brokerage positions"
+        in statements_router
+    )
     assert '"futu"' in generator
 
 
@@ -384,7 +459,9 @@ def test_AC8_13_19_brokerage_gate_reports_portfolio_diagnostics() -> None:
         assert token in brokerage
 
 
-def test_AC8_13_28_vision_hard_gate_uses_deterministic_fixture_with_fresh_user() -> None:
+def test_AC8_13_28_vision_hard_gate_uses_deterministic_fixture_with_fresh_user() -> (
+    None
+):
     """AC8.13.28/29/30/31: deterministic upload-to-dashboard gate covers the full fresh-user flow."""
     gate = read("tests/e2e/test_vision_upload_to_dashboard_hard_gate.py")
     epic = read("docs/project/EPIC-008.testing-strategy.md")
@@ -434,10 +511,16 @@ def test_AC8_13_33_e2e_setup_caches_virtualenv_and_playwright_browsers() -> None
 
     assert "Cache E2E virtualenv" in action
     assert "path: .venv" in action
-    assert "e2e-venv-${{ runner.os }}-${{ hashFiles('tests/e2e/requirements.txt') }}" in action
+    assert (
+        "e2e-venv-${{ runner.os }}-${{ hashFiles('tests/e2e/requirements.txt') }}"
+        in action
+    )
     assert "Cache Playwright browsers" in action
     assert "path: ~/.cache/ms-playwright" in action
-    assert "playwright-${{ runner.os }}-${{ hashFiles('tests/e2e/requirements.txt') }}" in action
+    assert (
+        "playwright-${{ runner.os }}-${{ hashFiles('tests/e2e/requirements.txt') }}"
+        in action
+    )
     assert "if [ ! -x .venv/bin/python ]; then" in action
     assert "uv pip install -r tests/e2e/requirements.txt" in action
     assert "shared E2E setup action caches `.venv` and Playwright browsers" in ci_cd
@@ -453,7 +536,7 @@ def test_AC8_13_34_ci_and_post_merge_write_timing_summaries() -> None:
     assert "Write CI timing summary" in ci_workflow
     assert "scripts/github_workflow_timing_summary.py" in ci_workflow
     assert '--title "CI Timing Summary"' in ci_workflow
-    assert "--run-id \"${{ github.run_id }}\"" in ci_workflow
+    assert '--run-id "${{ github.run_id }}"' in ci_workflow
     assert '--summary-path "$GITHUB_STEP_SUMMARY"' in ci_workflow
     assert "post-merge-summary:" in deploy_workflow
     assert "needs: [build-and-deploy, ai-ocr-gate]" in deploy_workflow


### PR DESCRIPTION
## Summary
- Adds account-level statement coverage for #396 under the #444 net-worth correctness umbrella.
- Exposes `GET /accounts/coverage` with latest confirmed source date, latest confirmed balance, stale status, cadence, and period continuity issues.
- Detects monthly gaps, overlaps, duplicate periods, and adjacent previous-close/current-open mismatches using `Decimal` balance comparisons.
- Treats one-day broker snapshots as latest-source overrides without requiring daily continuity.
- Registers AC3.7 and updates SSOT/API documentation plus the AC traceability audit.

## Validation
- `uv run ruff format apps/backend/src/routers/accounts.py apps/backend/src/schemas/__init__.py apps/backend/src/schemas/account.py apps/backend/src/services/account_coverage.py apps/backend/tests/accounting/test_account_statement_coverage.py`
- `uv run ruff check apps/backend/src/routers/accounts.py apps/backend/src/schemas/__init__.py apps/backend/src/schemas/account.py apps/backend/src/services/account_coverage.py apps/backend/tests/accounting/test_account_statement_coverage.py`
- `uv run python -m compileall -q apps/backend/src/routers/accounts.py apps/backend/src/schemas/account.py apps/backend/src/schemas/__init__.py apps/backend/src/services/account_coverage.py apps/backend/tests/accounting/test_account_statement_coverage.py`
- `uv run python scripts/generate_ac_registry.py --check`
- `uv run python scripts/check_ac_traceability.py`
- `uv run python scripts/build_ac_traceability.py --check --today 2026-05-20`
- `uv run --project apps/backend python -c "from src.main import app; print(any(getattr(route, 'path', '') == '/accounts/coverage' for route in app.routes))"`

## Local test note
- `uv run pytest apps/backend/tests/accounting/test_account_statement_coverage.py -q` is blocked locally because this machine has no Postgres on `127.0.0.1:5432` and no `docker` command to start the compose service. GitHub CI has the Postgres service configured and should run these API tests there.

Closes #396.
Refs #444.
