### PR TITLE
[codex] Harden brokerage import to asset report path

### DIFF
--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -413,6 +413,83 @@ async def test_statement_scoped_brokerage_import_uses_parsed_transactions(client
 
 
 @pytest.mark.asyncio
+async def test_statement_import_flows_to_holdings_and_balance_sheet(client, db, test_user):
+    """AC8.13.10/AC17.4.6/AC17.5.4: Parsed brokerage import reaches holdings and balance sheet."""
+    statement = BankStatement(
+        id=uuid4(),
+        user_id=test_user.id,
+        file_path="statements/moomoo/full-path.pdf",
+        file_hash="core-path-moomoo",
+        original_filename="moomoo-core-path.pdf",
+        institution="Moomoo",
+        account_last4="1582",
+        currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 31),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("1250.50"),
+        status=BankStatementStatus.PARSED,
+        confidence_score=98,
+        balance_validated=True,
+        transactions=[
+            BankStatementTransaction(
+                txn_date=date(2026, 5, 18),
+                description="Fullerton SGD Money Market Fund",
+                amount=Decimal("1250.50"),
+                direction="IN",
+                reference=None,
+                currency="SGD",
+                balance_after=Decimal("1250.50"),
+                confidence=ConfidenceLevel.HIGH,
+                raw_text="Subscription 0001 Fullerton SGD Money Market Fund SGD 2026/05/18 settled 1.0000 1250.50 1250.50",
+            )
+        ],
+    )
+    statement_id = statement.id
+    db.add(statement)
+    await db.commit()
+
+    import_response = await client.post(f"/statements/{statement_id}/brokerage/import")
+
+    assert import_response.status_code == 200
+    import_data = import_response.json()
+    assert import_data["broker"] == "Moomoo"
+    assert import_data["parsed_positions"] == 1
+    assert import_data["created_atomic_positions"] == 1
+    assert import_data["reconcile_created"] == 1
+
+    holdings_response = await client.get(
+        "/portfolio/holdings",
+        params={"as_of_date": "2026-05-31"},
+    )
+
+    assert holdings_response.status_code == 200
+    holdings = holdings_response.json()
+    assert len(holdings) == 1
+    assert holdings[0]["asset_identifier"] == "Fullerton SGD Money Market Fund"
+    assert holdings[0]["account_name"] == "Moomoo"
+    assert Decimal(str(holdings[0]["quantity"])) == Decimal("1250.50")
+    assert Decimal(str(holdings[0]["market_value"])) == Decimal("1250.50")
+    assert holdings[0]["currency"] == "SGD"
+
+    balance_response = await client.get(
+        "/reports/balance-sheet",
+        params={"as_of_date": "2026-05-31", "currency": "SGD"},
+    )
+
+    assert balance_response.status_code == 200
+    balance_sheet = balance_response.json()
+    assert Decimal(str(balance_sheet["total_assets"])) == Decimal("1250.50")
+    assert Decimal(str(balance_sheet["net_worth_adjustment_gain_loss"])) == Decimal("1250.50")
+    assert Decimal(str(balance_sheet["equation_delta"])) == Decimal("0.00")
+    assert balance_sheet["is_balanced"] is True
+    assert any(
+        line["name"] == "Moomoo market valuation adjustment" and Decimal(str(line["amount"])) == Decimal("1250.50")
+        for line in balance_sheet["assets"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_statement_scoped_brokerage_import_requires_parsed_status(client, db, test_user):
     """AC8.13.10/Issue #404: Position import cannot run before OCR parsing completes."""
     statement = BankStatement(

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -343,7 +343,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.7 | Strict full statement journey fails on rejected AI/OCR parsing | `test_dbs_statement_full_journey` | `tests/e2e/test_statement_full_journey.py` | P0 |
 | AC8.13.8 | Strict upload readiness E2E does not accept rejected statements | `test_statement_upload_full_flow` | `tests/e2e/test_statement_upload_e2e.py` | P0 |
 | AC8.13.9 | Production release runs prod-safe read-only E2E smoke | `test_production_*` | `tests/e2e/test_production_readonly_smoke.py` | P0 |
-| AC8.13.10 | Multi-brokerage PDF upload → position import → latest portfolio value | `test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value` | `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | P0 |
+| AC8.13.10 | Multi-brokerage PDF upload → position import → latest portfolio value | `test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value`, `test_statement_import_flows_to_holdings_and_balance_sheet` | `tests/e2e/test_brokerage_upload_to_portfolio_value.py`, `apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | P0 |
 | AC8.13.11 | Staging health check diagnoses API route 404 with route probes | `test_AC8_13_11_health_check_diagnoses_staging_api_route_404` | `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.12 | AI/OCR gate failures include statement validation context | `test_AC8_13_12_ai_ocr_gate_failure_includes_statement_context` | `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.13 | Staging deploy cancels stale runs and bounds E2E gate duration with phase timing logs | `test_AC8_13_13_staging_deploy_fast_fail_guardrails` | `scripts/tests/test_post_merge_e2e_gates.py` | P0 |

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -270,7 +270,7 @@ Build a **100% self-developed** investment portfolio management system with comp
 | AC17.4.3 | Interactive Brokers Parsing | `test_import_interactive_brokers_positions_idempotently_reconciles` | `portfolio/test_brokerage_position_parsing.py` | P1 |
 | AC17.4.4 | Broker Auto-Detection (Moomoo) | `test_detect_broker_moomoo_futu_and_interactive_brokers` | `portfolio/test_brokerage_position_parsing.py` | P1 |
 | AC17.4.5 | Broker Auto-Detection (Futu) | `test_detect_broker_moomoo_futu_and_interactive_brokers` | `portfolio/test_brokerage_position_parsing.py` | P1 |
-| AC17.4.6 | Brokerage Import Endpoint | `test_brokerage_import_endpoint` | `portfolio/test_brokerage_position_parsing.py` | P1 |
+| AC17.4.6 | Brokerage Import Endpoint | `test_brokerage_import_endpoint`, `test_statement_import_flows_to_holdings_and_balance_sheet` | `portfolio/test_brokerage_position_parsing.py` | P1 |
 | AC17.4.7 | Upload Parse-to-Import Bridge | `test_parse_statement_background_imports_brokerage_positions` | `extraction/test_statement_brokerage_import_bridge.py` | P0 |
 
 ### AC17.5: Investment Accounting (Journal Entries)
@@ -280,7 +280,7 @@ Build a **100% self-developed** investment portfolio management system with comp
 | AC17.5.1 | Buy Transaction → Journal Entry | `test_buy_transaction_creates_balanced_journal_entry_and_lot` | `portfolio/test_investment_accounting.py` | P0 |
 | AC17.5.2 | Sell Transaction → Journal Entry + Realized P&L | `test_sell_transaction_uses_fifo_and_records_realized_gain`, `test_sell_transaction_uses_average_cost_for_realized_pnl` | `portfolio/test_investment_accounting.py` | P0 |
 | AC17.5.3 | Dividend → Journal Entry → Income Statement | `test_dividend_transaction_posts_income_and_dividend_record` | `portfolio/test_investment_accounting.py` | P0 |
-| AC17.5.4 | Unrealized P&L → Balance Sheet | `test_unrealized_pnl_happy_path` | `portfolio/test_portfolio_service.py` | P0 |
+| AC17.5.4 | Unrealized P&L → Balance Sheet | `test_unrealized_pnl_happy_path`, `test_statement_import_flows_to_holdings_and_balance_sheet` | `portfolio/test_portfolio_service.py`, `portfolio/test_brokerage_position_parsing.py` | P0 |
 
 ### AC17.6: Integration & End-to-End
 

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -16,11 +16,11 @@
 | **Total ACs (registries)** | 976 | 100% |
 | **Mandatory ACs** | 816 | 83.6% |
 | **Deprecated ACs** | 3 | 0.3% |
-| **Mandatory ACs with real test reference** | 604 | 74.0% |
+| **Mandatory ACs with real test reference** | 610 | 74.8% |
 | **Mandatory ACs with only placeholder reference** | 0 | - |
-| **Mandatory ACs with only stub reference** | 212 | - |
+| **Mandatory ACs with only stub reference** | 206 | - |
 | **Mandatory ACs without any test reference** | 0 | - |
-| **Test files referenced** | 205 | - |
+| **Test files referenced** | 206 | - |
 | **ACs flagged as manual verification (heuristic)** | 0 | 0.0% |
 
 ### Coverage by EPIC
@@ -39,7 +39,7 @@
 | [EPIC-010](#epic-010-signoz-logging) | signoz-logging | 21 | 0 | 21 | 1 | 0 | 20 | 0 | 4.8% |
 | [EPIC-011](#epic-011-asset-lifecycle) | asset-lifecycle | 38 | 0 | 38 | 38 | 0 | 0 | 0 | 100.0% |
 | [EPIC-012](#epic-012-foundation-libs) | foundation-libs | 62 | 3 | 55 | 48 | 0 | 7 | 0 | 87.3% |
-| [EPIC-013](#epic-013-statement-parsing-v2) | statement-parsing-v2 | 60 | 0 | 58 | 52 | 0 | 6 | 0 | 89.7% |
+| [EPIC-013](#epic-013-statement-parsing-v2) | statement-parsing-v2 | 60 | 0 | 58 | 58 | 0 | 0 | 0 | 100.0% |
 | [EPIC-014](#epic-014-ttd-transformation) | ttd-transformation | 6 | 0 | 6 | 0 | 0 | 6 | 0 | 0.0% |
 | [EPIC-015](#epic-015-processing-account) | processing-account | 31 | 0 | 31 | 31 | 0 | 0 | 0 | 100.0% |
 | [EPIC-016](#epic-016-two-stage-review-ui) | two-stage-review-ui | 217 | 0 | 193 | 138 | 0 | 55 | 0 | 71.5% |
@@ -804,9 +804,9 @@
 
 - **Total ACs**: 60
 - **Mandatory ACs**: 58
-- **Mandatory ACs with real test reference**: 52 (89.7%)
+- **Mandatory ACs with real test reference**: 58 (100.0%)
 - **Mandatory ACs with only placeholder reference**: 0
-- **Mandatory ACs with only stub reference**: 6
+- **Mandatory ACs with only stub reference**: 0
 - **Mandatory ACs without any test reference**: 0
 
 | AC ID | Mandatory | Description | Test References | Status |
@@ -863,12 +863,12 @@
 | AC13.8.13 | yes | Test missing currencies penalized | real: `apps/backend/tests/extraction/test_extraction.py` | ✅ real |
 | AC13.9.1 | yes | Test full score with all factors | real: `apps/backend/tests/extraction/test_extraction.py` | ✅ real |
 | AC13.9.2 | yes | Test no new factors caps at 85 | real: `apps/backend/tests/extraction/test_extraction.py` | ✅ real |
-| AC13.10.1 | yes | Source type stamped on manual entry creation | stub: `apps/backend/tests/_ac_stubs/test_epic_13_stubs.py` | 🧱 stub-only |
-| AC13.10.2 | yes | Auto-match sets source_type=auto_matched | stub: `apps/backend/tests/_ac_stubs/test_epic_13_stubs.py` | 🧱 stub-only |
-| AC13.10.3 | yes | Stage-1 approve promotes to user_confirmed | stub: `apps/backend/tests/_ac_stubs/test_epic_13_stubs.py` | 🧱 stub-only |
-| AC13.10.4 | yes | Manual entry wins over auto_parsed in conflict | stub: `apps/backend/tests/_ac_stubs/test_epic_13_stubs.py` | 🧱 stub-only |
-| AC13.10.5 | yes | source_type cannot be downgraded | stub: `apps/backend/tests/_ac_stubs/test_epic_13_stubs.py` | 🧱 stub-only |
-| AC13.10.6 | yes | All four source_type values accepted by API | stub: `apps/backend/tests/_ac_stubs/test_epic_13_stubs.py` | 🧱 stub-only |
+| AC13.10.1 | yes | Source type stamped on manual entry creation | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
+| AC13.10.2 | yes | Auto-match sets source_type=auto_matched | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
+| AC13.10.3 | yes | Stage-1 approve promotes to user_confirmed | real: `apps/backend/tests/extraction/test_source_type_promotion.py` | ✅ real |
+| AC13.10.4 | yes | Manual entry wins over auto_parsed in conflict | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
+| AC13.10.5 | yes | source_type cannot be downgraded | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
+| AC13.10.6 | yes | All four source_type values accepted by API | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
 | AC13.11.1 | no |  | real: `apps/backend/tests/extraction/test_extraction_error_paths.py` | ✅ real (optional) |
 | AC13.11.2 | no |  | real: `apps/backend/tests/extraction/test_deduplication.py` | ✅ real (optional) |
 
@@ -1231,7 +1231,7 @@
 | AC17.5.1 | yes | Buy Transaction → Journal Entry | real: `apps/backend/tests/portfolio/test_investment_accounting.py`<br>real: `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ real |
 | AC17.5.2 | yes | Sell Transaction → Journal Entry + Realized P&L | real: `apps/backend/tests/portfolio/test_investment_accounting.py`<br>real: `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ real |
 | AC17.5.3 | yes | Dividend → Journal Entry → Income Statement | real: `apps/backend/tests/portfolio/test_investment_accounting.py`<br>real: `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ real |
-| AC17.5.4 | yes | Unrealized P&L → Balance Sheet | real: `apps/backend/tests/portfolio/test_portfolio_service.py`<br>real: `apps/backend/tests/reporting/test_reporting_net_worth_components.py` | ✅ real |
+| AC17.5.4 | yes | Unrealized P&L → Balance Sheet | real: `apps/backend/tests/portfolio/test_brokerage_position_parsing.py`<br>real: `apps/backend/tests/portfolio/test_portfolio_service.py`<br>real: `apps/backend/tests/reporting/test_reporting_net_worth_components.py` | ✅ real |
 | AC17.5.5 | no |  | real: `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ real (optional) |
 | AC17.5.6 | no |  | real: `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ real (optional) |
 | AC17.5.7 | no |  | real: `apps/backend/tests/portfolio/test_portfolio_service.py` | ✅ real (optional) |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -158,6 +158,7 @@ Import behavior:
 - Creates immutable `AtomicPosition` rows with dedup hash `SHA256(user_id|snapshot_date|asset_identifier|broker)`.
 - Re-running the same payload is idempotent and does not create duplicate atomic rows.
 - Reconciliation runs after import to refresh `ManagedPosition` with latest quantity, market value, currency, and snapshot metadata.
+- A successful statement-scoped brokerage import must make the imported position visible through `GET /portfolio/holdings` and through the balance sheet's broker market valuation adjustment for the same as-of date.
 - Import failures do not discard the parsed statement; the statement remains visible and receives a sanitized `validation_error` noting that brokerage positions were not imported.
 
 ## Configuration


### PR DESCRIPTION
## Summary

Adds default-CI backend coverage for the core parsed brokerage statement path: statement-scoped import -> portfolio holdings -> balance sheet asset report.

Refs #459
Refs #452

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy; EPIC-017 — Portfolio Management |
| **AC IDs** | AC8.13.10, AC17.4.6, AC17.5.4 |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [x] `docs/ssot/extraction.md` — documents that successful statement-scoped brokerage import must surface through `/portfolio/holdings` and balance sheet valuation for the same as-of date.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | N/A | Test hardening over an existing path; local DB dependency was unavailable before execution. |
| Green | `6953d18` | Adds `test_statement_import_flows_to_holdings_and_balance_sheet` and docs/traceability updates. |

---

## Engineering Audit

- [x] No `sa.Enum` changes.
- [x] No `NEXT_PUBLIC_` variable changes.
- [x] No production config or `repo/` submodule changes.
- [x] No env var changes.
- [ ] `scripts/check_manifest.py` not run; no manifest ownership changes.
- [ ] `scripts/lint_doc_consistency.py` not run.

---

## Testing

Passed locally:

```bash
moon run :lint
moon run :build
python scripts/check_ac_traceability.py
python scripts/build_ac_traceability.py --check --today 2026-05-21
git diff --check
```

Blocked locally:

```bash
moon run :test
python scripts/cli.py test --fast
```

Both test commands failed before pytest because local Podman reports `unable to connect to Podman socket` and cannot start the Postgres test database. The focused pytest also cannot reach `127.0.0.1:5432` in this local environment.

---

## Screenshots / Evidence

N/A