### PR TITLE
ci: reuse staging images after post-merge CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ permissions:
   contents: read
   statuses: read
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
+
 jobs:
   changes:
     name: Classify Changes
@@ -239,6 +243,58 @@ jobs:
           path: apps/frontend/coverage/lcov.info
           retention-days: 1
 
+  container-images:
+    name: Build Staging Images
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.heavy_required == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get Commit SHA
+        id: get_sha
+        run: |
+          short_sha=$(git rev-parse --short HEAD)
+          echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
+          echo "Building staging images for commit: $short_sha"
+
+      - name: Log in to Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Backend SHA image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./apps/backend
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.get_sha.outputs.short_sha }}
+          build-args: |
+            GIT_COMMIT_SHA=${{ steps.get_sha.outputs.short_sha }}
+
+      - name: Build and push Frontend SHA image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./apps/frontend
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.get_sha.outputs.short_sha }}
+          build-args: |
+            GIT_COMMIT_SHA=${{ steps.get_sha.outputs.short_sha }}
+            NEXT_PUBLIC_API_URL=https://report-staging.zitian.party
+            NEXT_PUBLIC_APP_URL=https://report-staging.zitian.party
+
   unified-coverage:
     name: Calculate Unified Coverage
     needs: [changes, backend, frontend]
@@ -374,7 +430,7 @@ jobs:
           retention-days: 14
 
   finish:
-    needs: [changes, backend, frontend, lint, unified-coverage, ac-traceability]
+    needs: [changes, backend, frontend, container-images, lint, unified-coverage, ac-traceability]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -399,6 +455,7 @@ jobs:
         echo "Classification Reason: ${{ needs.changes.outputs.reason }}"
         echo "Backend: ${{ needs.backend.result }}"
         echo "Frontend: ${{ needs.frontend.result }}"
+        echo "Staging Images: ${{ needs.container-images.result }}"
         echo "Unified Coverage: ${{ needs.unified-coverage.result }}"
         echo "Lint: ${{ needs.lint.result }}"
         echo "AC Traceability: ${{ needs.ac-traceability.result }}"
@@ -425,6 +482,10 @@ jobs:
           fi
           if [[ "${{ needs.unified-coverage.result }}" != "success" ]]; then
             echo "::error::Unified coverage check failed"
+            exit 1
+          fi
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" && "${{ needs.container-images.result }}" != "success" ]]; then
+            echo "::error::Staging image build failed"
             exit 1
           fi
         else

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -87,33 +87,55 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Resolve Backend Image
+        id: backend_image
+        run: |
+          bash scripts/check_ghcr_image_tag.sh \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.get_sha.outputs.short_sha }}"
+
       - name: Build and push Backend
+        if: steps.backend_image.outputs.build_required == 'true'
         uses: docker/build-push-action@v5
         with:
           context: ./apps/backend
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.get_sha.outputs.short_sha }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:staging
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.get_sha.outputs.short_sha }}
           build-args: |
             GIT_COMMIT_SHA=${{ steps.get_sha.outputs.short_sha }}
 
+      - name: Resolve Frontend Image
+        id: frontend_image
+        run: |
+          bash scripts/check_ghcr_image_tag.sh \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.get_sha.outputs.short_sha }}"
+
       - name: Build and push Frontend
+        if: steps.frontend_image.outputs.build_required == 'true'
         uses: docker/build-push-action@v5
         with:
           context: ./apps/frontend
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.get_sha.outputs.short_sha }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:staging
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.get_sha.outputs.short_sha }}
           build-args: |
             GIT_COMMIT_SHA=${{ steps.get_sha.outputs.short_sha }}
             NEXT_PUBLIC_API_URL=https://report-staging.zitian.party
             NEXT_PUBLIC_APP_URL=https://report-staging.zitian.party
+
+      - name: Promote Backend Image to Staging Tag
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:staging" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.get_sha.outputs.short_sha }}"
+
+      - name: Promote Frontend Image to Staging Tag
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:staging" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.get_sha.outputs.short_sha }}"
 
       - name: Check Deployment Dependencies
         env:

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1903,6 +1903,11 @@ groups:
         epic_name: testing-strategy
         description: AC traceability reporting distinguishes real test references from _ac_stubs and trivial placeholder assertions.
         mandatory: true
+      - id: AC8.13.36
+        epic: 8
+        epic_name: testing-strategy
+        description: Main CI builds SHA-tagged staging images and post-merge staging reuses them after same-SHA CI success.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -68,6 +68,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.33**: Shared E2E setup caches Python virtualenv and Playwright browser artifacts for staging and preview gates.
 - **AC8.13.34**: CI and post-merge workflows append queue, execution, and per-job timing summaries to GitHub Step Summary.
 - **AC8.13.35**: AC traceability reporting distinguishes real test references from `_ac_stubs` and trivial placeholder assertions.
+- **AC8.13.36**: Main CI builds SHA-tagged staging images and post-merge staging reuses them after same-SHA CI success.
 
 **Current state (2026-02-23):**
 - **Tier 1**: 41 tests in `test_core_journeys.py` covering 45 ACs → **91.8% AC pass rate** (45/49)

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -153,7 +153,9 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 **Post-merge staging deploy health gate** (`.github/workflows/staging-deploy.yml`):
 - Non-LLM smoke/E2E tests run in parallel with `-n 4`.
 - The shared E2E setup action caches `.venv` and Playwright browsers so staging, manual AI/OCR, PR preview, and production smoke runs do not repeatedly download identical E2E dependencies.
-- Staging deploy waits for the same commit's `CI` push workflow to complete successfully before building images, pushing `staging` tags, or changing the Dokploy staging environment. If matching CI fails, is cancelled, or times out, staging is not overwritten.
+- Main push CI builds SHA-tagged staging images in parallel with tests when heavy CI is required. These images are immutable commit artifacts and do not move the live `staging` tag.
+- Staging deploy waits for the same commit's `CI` push workflow to complete successfully before promoting images, pushing `staging` tags, or changing the Dokploy staging environment. If matching CI fails, is cancelled, or times out, staging is not overwritten.
+- After same-SHA CI passes, post-merge staging first looks up the backend and frontend SHA-tagged staging images from GHCR. If a SHA image is missing, the workflow falls back to building only the missing image. Once both SHA images are present, staging retags those immutable images as `staging` before deploy. This keeps deploy detection strict while moving normal image build time out of the serialized post-merge lane.
 - Deploy health covers image build/push, Dokploy rollout, `/api/health`, shell smoke checks, and core non-LLM E2E.
 - Automatic provider-backed AI/OCR validation runs as a downstream job in the same serialized post-merge workflow unit. This keeps staging stable for the SHA under validation: a newer deploy cannot overwrite staging while an older automatic AI/OCR gate is running.
 - Staging deploys use a workflow-level `staging-post-merge-${{ github.ref }}` concurrency group with `cancel-in-progress: false`, so GitHub Actions does not cancel a running post-merge lane when a newer `main` commit is pushed. Because GitHub concurrency allows at most one running and one pending run per group, the latest pending post-merge run is retained and older pending runs may be replaced. This is latest-pending serial validation, not strict FIFO for every SHA.
@@ -221,6 +223,11 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Build and deploy job execution: **~5m 19s**.
 - Automatic AI/OCR gate execution: **~4m 38s**.
 - AI/OCR `Setup E2E Tests`: **~2m 54s** before E2E virtualenv and Playwright browser caching.
+
+**Post-merge staging image promotion (2026-05-21 target):**
+- Main push CI owns SHA-tagged staging image creation for heavy runtime changes.
+- The serialized staging lane promotes existing SHA images to the moving `staging` tag after same-SHA CI success, avoiding redundant Docker builds in the normal path.
+- Missing SHA images trigger a per-service fallback build, preserving deployability for manual reruns and unusual cache/package states.
 
 **Backend Test Parallelization:**
 

--- a/scripts/check_ghcr_image_tag.sh
+++ b/scripts/check_ghcr_image_tag.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Check whether an immutable GHCR image tag already exists.
+#
+# Usage:
+#   scripts/check_ghcr_image_tag.sh <image>
+#
+# Outputs:
+#   build_required=true|false is written to $GITHUB_OUTPUT when available.
+
+set -euo pipefail
+
+IMAGE="${1:-}"
+
+if [[ -z "$IMAGE" ]]; then
+  echo "Usage: $0 <image>" >&2
+  exit 2
+fi
+
+write_output() {
+  local key="$1"
+  local value="$2"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+if docker buildx imagetools inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "Found reusable image: $IMAGE"
+  write_output "build_required" "false"
+  exit 0
+fi
+
+echo "Reusable image not found: $IMAGE"
+echo "A fresh build is required."
+write_output "build_required" "true"

--- a/scripts/tests/test_check_ghcr_image_tag.py
+++ b/scripts/tests/test_check_ghcr_image_tag.py
@@ -1,0 +1,71 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "check_ghcr_image_tag.sh"
+
+
+def _write_fake_docker(bin_dir: Path, inspect_status: int) -> None:
+    docker = bin_dir / "docker"
+    docker.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$DOCKER_CALLS"
+if [[ "$1 $2 $3" == "buildx imagetools inspect" ]]; then
+  exit {inspect_status}
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+
+
+def _run_script(tmp_path: Path, inspect_status: int) -> tuple[subprocess.CompletedProcess[str], str, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "docker-calls.txt"
+    output = tmp_path / "github-output.txt"
+    _write_fake_docker(bin_dir, inspect_status)
+
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "DOCKER_CALLS": str(calls),
+        "GITHUB_OUTPUT": str(output),
+    }
+    result = subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "ghcr.io/acme/app-backend:abc123",
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, calls.read_text(encoding="utf-8"), output.read_text(encoding="utf-8")
+
+
+def test_AC8_13_36_existing_image_skips_fresh_build(tmp_path: Path) -> None:
+    """AC8.13.36: Existing SHA-tagged staging image is reused without a rebuild."""
+    result, calls, output = _run_script(tmp_path, inspect_status=0)
+
+    assert result.returncode == 0
+    assert "buildx imagetools inspect ghcr.io/acme/app-backend:abc123" in calls
+    assert "buildx imagetools create" not in calls
+    assert "build_required=false" in output
+
+
+def test_AC8_13_36_missing_image_requests_fresh_build(tmp_path: Path) -> None:
+    """AC8.13.36: Missing SHA-tagged image falls back to the workflow build step."""
+    result, calls, output = _run_script(tmp_path, inspect_status=1)
+
+    assert result.returncode == 0
+    assert "buildx imagetools inspect ghcr.io/acme/app-backend:abc123" in calls
+    assert "buildx imagetools create" not in calls
+    assert "build_required=true" in output

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -163,7 +163,7 @@ def test_AC8_13_16_ci_change_classification_and_frontend_cache() -> None:
     assert "if: needs.changes.outputs.heavy_required == 'true'" in workflow
     assert "name: AC Traceability Check" in workflow
     assert (
-        "needs: [changes, backend, frontend, lint, unified-coverage, ac-traceability]"
+        "needs: [changes, backend, frontend, container-images, lint, unified-coverage, ac-traceability]"
         in workflow
     )
     assert (
@@ -319,6 +319,47 @@ def test_AC8_13_22_staging_deploy_waits_for_matching_ci_before_building() -> Non
     assert workflow.index("Wait for matching CI success") < workflow.index(
         "Deploy to Staging"
     )
+
+
+def test_AC8_13_36_post_merge_reuses_sha_tagged_staging_images() -> None:
+    """AC8.13.36: Main CI builds SHA images and staging reuses them after CI passes."""
+    ci_workflow = read(".github/workflows/ci.yml")
+    deploy_workflow = read(".github/workflows/staging-deploy.yml")
+    check_script = read("scripts/check_ghcr_image_tag.sh")
+    ci_cd = read("docs/ssot/ci-cd.md")
+
+    assert "container-images:" in ci_workflow
+    assert "name: Build Staging Images" in ci_workflow
+    assert "github.event_name == 'push'" in ci_workflow
+    assert "github.ref == 'refs/heads/main'" in ci_workflow
+    assert "packages: write" in ci_workflow
+    assert "Build and push Backend SHA image" in ci_workflow
+    assert "Build and push Frontend SHA image" in ci_workflow
+    assert "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.get_sha.outputs.short_sha }}" in ci_workflow
+    assert "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.get_sha.outputs.short_sha }}" in ci_workflow
+    assert "backend:staging" not in ci_workflow
+    assert "frontend:staging" not in ci_workflow
+
+    assert "Resolve Backend Image" in deploy_workflow
+    assert "Resolve Frontend Image" in deploy_workflow
+    assert "scripts/check_ghcr_image_tag.sh" in deploy_workflow
+    assert "steps.backend_image.outputs.build_required == 'true'" in deploy_workflow
+    assert "steps.frontend_image.outputs.build_required == 'true'" in deploy_workflow
+    assert "Promote Backend Image to Staging Tag" in deploy_workflow
+    assert "Promote Frontend Image to Staging Tag" in deploy_workflow
+    assert deploy_workflow.index("Wait for matching CI success") < deploy_workflow.index("Resolve Backend Image")
+    assert deploy_workflow.index("Resolve Backend Image") < deploy_workflow.index("Build and push Backend")
+    assert deploy_workflow.index("Resolve Frontend Image") < deploy_workflow.index("Build and push Frontend")
+    assert deploy_workflow.index("Build and push Frontend") < deploy_workflow.index("Promote Backend Image to Staging Tag")
+    assert deploy_workflow.index("Promote Backend Image to Staging Tag") < deploy_workflow.index("Deploy to Staging")
+
+    assert "docker buildx imagetools inspect" in check_script
+    assert "docker buildx imagetools create" not in check_script
+    assert 'write_output "build_required" "false"' in check_script
+    assert 'write_output "build_required" "true"' in check_script
+    assert "SHA-tagged staging images" in ci_cd
+    assert "retags those immutable images as `staging`" in ci_cd
+    assert "falls back to building only the missing image" in ci_cd
 
 
 def test_AC8_13_23_post_merge_deploy_and_ai_ocr_are_one_serial_unit() -> None:


### PR DESCRIPTION
## Summary

Build immutable staging images during main CI and have post-merge staging promote those SHA-tagged images instead of rebuilding them in the serialized deploy lane.

Closes #470

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.36 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/ci-cd.md` — documents main CI SHA image creation, staging tag promotion, fallback builds, and queue behavior
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | local before implementation | Added AC8.13.36 workflow/script tests before updating CI/staging behavior |
| Green (passing test) | `6f76871` | Implement SHA image build, GHCR image check, staging promotion, and docs |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable; no DB enum changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (already present; workflow preserves existing args)
- [x] `repo/` submodule updated for production config changes (not applicable; workflow-only image promotion)
- [x] `scripts/check_env_keys.py` passes (not applicable; no env keys changed)
- [x] `scripts/check_manifest.py` passes (ran)
- [x] `scripts/lint_doc_consistency.py` passes (ran)

---

## Testing

```bash
uv run --with pytest --with pyyaml pytest scripts/tests/test_check_ghcr_image_tag.py scripts/tests/test_post_merge_e2e_gates.py -q
uv run --with pyyaml python scripts/generate_ac_registry.py --check
uv run --with pyyaml python scripts/build_ac_traceability.py --output /tmp/AC-TEST-TRACEABILITY-AUDIT.md
actionlint .github/workflows/ci.yml .github/workflows/staging-deploy.yml
uv run --with pyyaml python scripts/check_ci_metrics_contract.py
uv run --with pyyaml python scripts/lint_doc_consistency.py
python scripts/check_ssot_ownership.py --verbose
uv run --with pyyaml python scripts/check_manifest.py
cd apps/backend && uv run ruff check src/ && uv run ruff format src/ --check
```

Note: `moon run :lint` hung without output locally, so I ran the CI lint job's underlying commands directly.

---

## Screenshots / Evidence

N/A
