### PR TITLE
[codex] Fix AC-to-EPIC mismatch triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Current generated numbers:
 
 | Metric | Current |
 |---|---:|
-| Registered ACs | 982 |
-| ACs with real test-candidate references | 744 / 982 (75.8%) |
-| Registered ACs without real test reference | 238 |
+| Registered ACs | 983 |
+| ACs with real test-candidate references | 744 / 983 (75.7%) |
+| Registered ACs without real test reference | 239 |
 | Stub-only AC placeholders | 215 |
 | Invalid AC refs in real tests | 0 |
 | Unified coverage floor | 94.38% |
@@ -84,7 +84,7 @@ refreshing the report.
 | [EPIC-005](docs/project/EPIC-005.reporting-visualization.md) | Reports & visualization | Complete, with investment metric gaps | 32 / 36 (88.9%) |
 | [EPIC-006](docs/project/EPIC-006.ai-advisor.md) | AI advisor | Complete | 52 / 63 (82.5%) |
 | [EPIC-007](docs/project/EPIC-007.deployment.md) | Deployment | Complete, manual-gate heavy | 6 / 39 (15.4%) |
-| [EPIC-008](docs/project/EPIC-008.testing-strategy.md) | Testing strategy & E2E gates | Core complete | 71 / 92 (77.2%) |
+| [EPIC-008](docs/project/EPIC-008.testing-strategy.md) | Testing strategy & E2E gates | Core complete | 71 / 93 (76.3%) |
 | [EPIC-009](docs/project/EPIC-009.pdf-fixture-generation.md) | PDF fixture generation | Complete, manual-gate heavy | 0 / 37 (0.0%) |
 | [EPIC-010](docs/project/EPIC-010.signoz-logging.md) | SigNoz logging | Complete, manual-gate heavy | 0 / 21 (0.0%) |
 | [EPIC-011](docs/project/EPIC-011.asset-lifecycle.md) | Asset lifecycle | In progress (P0 complete) | 38 / 38 (100.0%) |
@@ -104,8 +104,9 @@ Known proof-quality caveats:
   [issue #452](https://github.com/wangzitian0/finance_report/issues/452).
 - Manual-verification ACs need automation or an explicit manual-gate category.
   See [issue #454](https://github.com/wangzitian0/finance_report/issues/454).
-- Invalid AC references are currently zero; AC-to-EPIC mismatch cleanup remains
-  tracked in [issue #456](https://github.com/wangzitian0/finance_report/issues/456).
+- Invalid AC references are currently zero; the AC-to-EPIC mismatch audit
+  reports zero actionable mismatches and tracks fixture-only fake IDs separately
+  in [docs/analysis/ac-epic-mismatch-report.md](docs/analysis/ac-epic-mismatch-report.md).
 - README EPIC metrics should eventually be generated or validated by CI. See
   [issue #455](https://github.com/wangzitian0/finance_report/issues/455).
 
@@ -133,8 +134,8 @@ Recently resolved blockers:
 - [#455](https://github.com/wangzitian0/finance_report/issues/455):
   Generate README EPIC status and completion metrics from registries and test
   reports.
-- [#456](https://github.com/wangzitian0/finance_report/issues/456):
-  Fix AC-to-EPIC mismatch and invalid test references.
+- AC-to-EPIC mismatch and invalid test references:
+  [docs/analysis/ac-epic-mismatch-report.md](docs/analysis/ac-epic-mismatch-report.md).
 
 ## Quick Start
 

--- a/docs/analysis/ac-epic-mismatch-report.md
+++ b/docs/analysis/ac-epic-mismatch-report.md
@@ -1,0 +1,35 @@
+# AC↔EPIC Mismatch Triage
+
+- Total ACx.y.z refs scanned: **1703**
+- Actionable mismatched refs: **0**
+- Fixture-only mismatched refs: **52**
+- Actionable files affected: **0**
+- Fixture-only files affected: **5**
+
+## Fixture-Only Mismatches
+
+## `scripts/tests/test_analyze_test_ac_coverage.py` — 17 bad / 5 unique
+- **Suggest**: FIXTURE-EXCLUDE
+- Alt-epic matches: EPIC-16:13, EPIC-1:10, EPIC-2:10, EPIC-13:10, EPIC-17:10, EPIC-18:10, EPIC-7:10, EPIC-9:10, EPIC-3:8, EPIC-4:8, EPIC-5:8, EPIC-8:8, EPIC-11:8, EPIC-12:8, EPIC-6:6, EPIC-15:4, EPIC-10:4, EPIC-14:4
+- Bad IDs: AC4.4.4, AC8.12.7, AC9.9.9, AC19.1.1, AC99.3.3
+
+## `scripts/tests/test_generate_ac_registry.py` — 12 bad / 6 unique
+- **Suggest**: FIXTURE-EXCLUDE
+- Alt-epic matches: EPIC-11:10, EPIC-17:8, EPIC-2:6, EPIC-6:6, EPIC-8:6, EPIC-13:6, EPIC-16:6, EPIC-7:6, EPIC-12:6, EPIC-1:4, EPIC-3:2, EPIC-4:2, EPIC-5:2, EPIC-15:2, EPIC-18:2, EPIC-9:2
+- Bad IDs: AC1.1.9, AC1.1.10, AC1.99.1, AC9.8.1, AC9.8.2, AC10.2.1
+
+## `scripts/tests/test_lint_doc_consistency.py` — 11 bad / 4 unique
+- **Suggest**: FIXTURE-EXCLUDE
+- Alt-epic matches: EPIC-6:8, EPIC-8:8, EPIC-13:8, EPIC-16:8, EPIC-12:8, EPIC-11:8, EPIC-17:8, EPIC-1:5, EPIC-2:5, EPIC-3:5, EPIC-4:5, EPIC-5:5, EPIC-15:5, EPIC-18:5, EPIC-7:5, EPIC-9:5, EPIC-10:4, EPIC-14:4
+- Bad IDs: AC1.1.9, AC2.11.1, AC10.2.1, AC99.1.1
+
+## `scripts/tests/test_build_ac_traceability.py` — 7 bad / 3 unique
+- **Suggest**: FIXTURE-EXCLUDE
+- Alt-epic matches: EPIC-16:5, EPIC-12:5, EPIC-17:1
+- Bad IDs: AC1.2.9, AC1.2.10, AC99.24.1
+
+## `scripts/tests/test_audit_ac_epic_mismatches.py` — 5 bad / 3 unique
+- **Suggest**: FIXTURE-EXCLUDE
+- Alt-epic matches: EPIC-1:1, EPIC-2:1, EPIC-3:1, EPIC-4:1, EPIC-5:1, EPIC-6:1, EPIC-8:1, EPIC-11:1, EPIC-13:1, EPIC-15:1, EPIC-16:1, EPIC-17:1, EPIC-18:1, EPIC-7:1, EPIC-9:1, EPIC-10:1, EPIC-12:1, EPIC-14:1
+- Bad IDs: AC8.9.9, AC9.9.9, AC99.1.1
+

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-05-21 09:33:56 UTC by `scripts/analyze_test_ac_coverage.py`
+> Generated: 2026-05-25 05:15:01 UTC by `scripts/analyze_test_ac_coverage.py`
 
 ## Coverage accounting (EPIC-008 aligned)
 
@@ -14,11 +14,11 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 982 |
-| Covered by real test candidates | 744 (75.8%) |
+| Registered ACs | 983 |
+| Covered by real test candidates | 744 (75.7%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 215 |
-| Registered but untested | 238 |
+| Registered but untested | 239 |
 | Invalid AC refs in real tests | 0 |
 | Invalid AC refs in placeholders | 0 |
 | Invalid AC refs in stubs | 0 |
@@ -43,7 +43,7 @@
 | EPIC-005 | reporting-visualization | 36 | 32 | 0 | 4 | 4 | 88.9% |
 | EPIC-006 | ai-advisor | 63 | 52 | 0 | 11 | 11 | 82.5% |
 | EPIC-007 | deployment | 39 | 6 | 0 | 33 | 33 | 15.4% |
-| EPIC-008 | testing-strategy | 92 | 71 | 0 | 0 | 21 | 77.2% |
+| EPIC-008 | testing-strategy | 93 | 71 | 0 | 0 | 22 | 76.3% |
 | EPIC-009 | pdf-fixture-generation | 37 | 0 | 0 | 36 | 37 | 0.0% |
 | EPIC-010 | signoz-logging | 21 | 0 | 0 | 21 | 21 | 0.0% |
 | EPIC-011 | asset-lifecycle | 38 | 38 | 0 | 0 | 0 | 100.0% |
@@ -313,9 +313,9 @@ No placeholder-only AC assertions found.
 
 `AC7.1.1`, `AC7.1.2`, `AC7.1.3`, `AC7.2.1`, `AC7.2.2`, `AC7.2.3`, `AC7.2.4`, `AC7.2.5`, `AC7.3.1`, `AC7.3.2`, `AC7.3.3`, `AC7.3.4`, `AC7.3.5`, `AC7.4.1`, `AC7.4.2`, `AC7.4.3`, `AC7.4.4`, `AC7.4.5`, `AC7.4.6`, `AC7.5.1`, `AC7.5.2`, `AC7.5.3`, `AC7.5.4`, `AC7.5.5`, `AC7.6.2`, `AC7.9.1`, `AC7.9.2`, `AC7.9.3`, `AC7.9.4`, `AC7.9.5`, `AC7.9.6`, `AC7.9.7`, `AC7.9.8`
 
-### EPIC-008 (testing-strategy) — 21 untested
+### EPIC-008 (testing-strategy) — 22 untested
 
-`AC8.13.6`, `AC8.13.7`, `AC8.13.8`, `AC8.13.11`, `AC8.13.12`, `AC8.13.13`, `AC8.13.14`, `AC8.13.15`, `AC8.13.16`, `AC8.13.17`, `AC8.13.20`, `AC8.13.21`, `AC8.13.22`, `AC8.13.23`, `AC8.13.24`, `AC8.13.25`, `AC8.13.26`, `AC8.13.27`, `AC8.13.33`, `AC8.13.34`, `AC8.13.35`
+`AC8.13.6`, `AC8.13.7`, `AC8.13.8`, `AC8.13.11`, `AC8.13.12`, `AC8.13.13`, `AC8.13.14`, `AC8.13.15`, `AC8.13.16`, `AC8.13.17`, `AC8.13.20`, `AC8.13.21`, `AC8.13.22`, `AC8.13.23`, `AC8.13.24`, `AC8.13.25`, `AC8.13.26`, `AC8.13.27`, `AC8.13.33`, `AC8.13.34`, `AC8.13.35`, `AC8.13.36`
 
 ### EPIC-009 (pdf-fixture-generation) — 37 untested
 

--- a/docs/project/AUDITS.md
+++ b/docs/project/AUDITS.md
@@ -8,22 +8,24 @@ reports for current metrics.
 | Report | Purpose |
 |---|---|
 | [../analysis/test-ac-coverage-report.md](../analysis/test-ac-coverage-report.md) | Current AC-to-test coverage, stub-only ACs, untested ACs, invalid AC references |
+| [../analysis/ac-epic-mismatch-report.md](../analysis/ac-epic-mismatch-report.md) | Current AC-to-EPIC mismatch triage, separated into actionable and fixture-only refs |
 | [../analysis/traceability-exceptions.md](../analysis/traceability-exceptions.md) | Classified helper/SSOT tests and source surfaces that are not AC proof |
 
 Current generated AC snapshot:
 
-- 982 registered ACs
+- 983 registered ACs
 - 744 ACs with real test-candidate references
-- 238 registered ACs without real test reference
+- 239 registered ACs without real test reference
 - 215 stub-only placeholders
 - 0 invalid AC refs in real tests
+- 0 actionable AC-to-EPIC mismatches
 
 Placeholder assertion detection is enforced by the generated report; remaining
 proof-quality hardening is tracked in
 [#452](https://github.com/wangzitian0/finance_report/issues/452).
 
-AC-to-EPIC mismatch cleanup is tracked in
-[#456](https://github.com/wangzitian0/finance_report/issues/456).
+Fixture-only fake AC IDs in script tests are classified separately in the
+generated AC-to-EPIC mismatch report.
 
 ## Historical Audits
 

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -1,6 +1,6 @@
 # AC-to-Test Traceability Audit
 
-> **Generated**: 2026-05-21 (mechanically by `scripts/build_ac_traceability.py`)
+> **Generated**: 2026-05-25 (mechanically by `scripts/build_ac_traceability.py`)
 > **Purpose**: Complete mapping of every Acceptance Criterion (`ACx.y.z`) declared in `docs/ac_registry.yaml` + `docs/infra_registry.yaml` to the test file(s) that reference it. This is not behavioral coverage; it separates real test candidates from `_ac_stubs` and trivial placeholder assertions so product-level E2E evidence remains the source of behavioral proof.
 > **Scope**: All EPICs in `docs/project/`. Test scan: `apps/backend/tests`, `apps/frontend/src`, `scripts/tests`, `tests/e2e`.
 
@@ -13,14 +13,14 @@
 | Metric | Count | Percentage |
 |--------|-------|------------|
 | **Total EPICs** | 18 | 100% |
-| **Total ACs (registries)** | 976 | 100% |
-| **Mandatory ACs** | 816 | 83.6% |
+| **Total ACs (registries)** | 983 | 100% |
+| **Mandatory ACs** | 823 | 83.7% |
 | **Deprecated ACs** | 3 | 0.3% |
-| **Mandatory ACs with real test reference** | 610 | 74.8% |
+| **Mandatory ACs with real test reference** | 618 | 75.1% |
 | **Mandatory ACs with only placeholder reference** | 0 | - |
-| **Mandatory ACs with only stub reference** | 206 | - |
+| **Mandatory ACs with only stub reference** | 205 | - |
 | **Mandatory ACs without any test reference** | 0 | - |
-| **Test files referenced** | 206 | - |
+| **Test files referenced** | 208 | - |
 | **ACs flagged as manual verification (heuristic)** | 0 | 0.0% |
 
 ### Coverage by EPIC
@@ -29,12 +29,12 @@
 |------|------|-----------|------------|-----------|----------|------------------|-----------|---------|---------------|
 | [EPIC-001](#epic-001-phase0-setup) | phase0-setup | 29 | 0 | 27 | 18 | 0 | 9 | 0 | 66.7% |
 | [EPIC-002](#epic-002-double-entry-core) | double-entry-core | 59 | 0 | 44 | 37 | 0 | 7 | 0 | 84.1% |
-| [EPIC-003](#epic-003-statement-parsing) | statement-parsing | 43 | 0 | 23 | 18 | 0 | 5 | 0 | 78.3% |
+| [EPIC-003](#epic-003-statement-parsing) | statement-parsing | 47 | 0 | 27 | 22 | 0 | 5 | 0 | 81.5% |
 | [EPIC-004](#epic-004-reconciliation-engine) | reconciliation-engine | 39 | 0 | 18 | 14 | 0 | 4 | 0 | 77.8% |
-| [EPIC-005](#epic-005-reporting-visualization) | reporting-visualization | 36 | 0 | 25 | 20 | 0 | 5 | 0 | 80.0% |
+| [EPIC-005](#epic-005-reporting-visualization) | reporting-visualization | 36 | 0 | 25 | 21 | 0 | 4 | 0 | 84.0% |
 | [EPIC-006](#epic-006-ai-advisor) | ai-advisor | 63 | 0 | 55 | 44 | 0 | 11 | 0 | 80.0% |
 | [EPIC-007](#epic-007-deployment) | deployment | 39 | 0 | 39 | 7 | 0 | 32 | 0 | 17.9% |
-| [EPIC-008](#epic-008-testing-strategy) | testing-strategy | 91 | 0 | 85 | 85 | 0 | 0 | 0 | 100.0% |
+| [EPIC-008](#epic-008-testing-strategy) | testing-strategy | 93 | 0 | 87 | 87 | 0 | 0 | 0 | 100.0% |
 | [EPIC-009](#epic-009-pdf-fixture-generation) | pdf-fixture-generation | 37 | 0 | 36 | 1 | 0 | 35 | 0 | 2.8% |
 | [EPIC-010](#epic-010-signoz-logging) | signoz-logging | 21 | 0 | 21 | 1 | 0 | 20 | 0 | 4.8% |
 | [EPIC-011](#epic-011-asset-lifecycle) | asset-lifecycle | 38 | 0 | 38 | 38 | 0 | 0 | 0 | 100.0% |
@@ -44,7 +44,7 @@
 | [EPIC-015](#epic-015-processing-account) | processing-account | 31 | 0 | 31 | 31 | 0 | 0 | 0 | 100.0% |
 | [EPIC-016](#epic-016-two-stage-review-ui) | two-stage-review-ui | 217 | 0 | 193 | 138 | 0 | 55 | 0 | 71.5% |
 | [EPIC-017](#epic-017-portfolio-management) | portfolio-management | 82 | 0 | 39 | 39 | 0 | 0 | 0 | 100.0% |
-| [EPIC-018](#epic-018-ai-driven-pipeline) | ai-driven-pipeline | 23 | 0 | 23 | 13 | 0 | 10 | 0 | 56.5% |
+| [EPIC-018](#epic-018-ai-driven-pipeline) | ai-driven-pipeline | 24 | 0 | 24 | 14 | 0 | 10 | 0 | 58.3% |
 
 ---
 
@@ -172,9 +172,9 @@
 
 <a id="epic-003-statement-parsing"></a>
 
-- **Total ACs**: 43
-- **Mandatory ACs**: 23
-- **Mandatory ACs with real test reference**: 18 (78.3%)
+- **Total ACs**: 47
+- **Mandatory ACs**: 27
+- **Mandatory ACs with real test reference**: 22 (81.5%)
 - **Mandatory ACs with only placeholder reference**: 0
 - **Mandatory ACs with only stub reference**: 5
 - **Mandatory ACs without any test reference**: 0
@@ -224,6 +224,10 @@
 | AC3.6.2 | yes | No Silent Fallback Posting | real: `apps/backend/tests/api/test_statements_router.py`<br>real: `apps/backend/tests/reconciliation/test_review_queue.py` | ✅ real |
 | AC3.6.3 | yes | Ambiguous Mapping Blocked | real: `apps/backend/tests/api/test_statements_router.py` | ✅ real |
 | AC3.6.4 | yes | Explicit First-Upload Account Creation | real: `apps/backend/tests/api/test_statements_router.py` | ✅ real |
+| AC3.7.1 | yes | Latest Confirmed Source | real: `apps/backend/tests/accounting/test_account_statement_coverage.py` | ✅ real |
+| AC3.7.2 | yes | Adjacent Opening Continuity | real: `apps/backend/tests/accounting/test_account_statement_coverage.py` | ✅ real |
+| AC3.7.3 | yes | Missing/Overlapping/Duplicate Periods | real: `apps/backend/tests/accounting/test_account_statement_coverage.py` | ✅ real |
+| AC3.7.4 | yes | Broker Daily Snapshot Override | real: `apps/backend/tests/accounting/test_account_statement_coverage.py` | ✅ real |
 
 ---
 
@@ -288,9 +292,9 @@
 
 - **Total ACs**: 36
 - **Mandatory ACs**: 25
-- **Mandatory ACs with real test reference**: 20 (80.0%)
+- **Mandatory ACs with real test reference**: 21 (84.0%)
 - **Mandatory ACs with only placeholder reference**: 0
-- **Mandatory ACs with only stub reference**: 5
+- **Mandatory ACs with only stub reference**: 4
 - **Mandatory ACs without any test reference**: 0
 
 | AC ID | Mandatory | Description | Test References | Status |
@@ -317,7 +321,7 @@
 | AC5.6.1 | yes | XIRR calculation accuracy ≤ 0.01% error vs Excel XIRR | stub: `apps/backend/tests/_ac_stubs/test_epic_05_stubs.py` | 🧱 stub-only |
 | AC5.6.2 | yes | Annualized return (TWR) computed correctly | stub: `apps/backend/tests/_ac_stubs/test_epic_05_stubs.py` | 🧱 stub-only |
 | AC5.6.3 | yes | Dividend yield = annual dividends / current value | stub: `apps/backend/tests/_ac_stubs/test_epic_05_stubs.py` | 🧱 stub-only |
-| AC5.6.4 | yes | Annualized income in income statement KPI block | stub: `apps/backend/tests/_ac_stubs/test_epic_05_stubs.py` | 🧱 stub-only |
+| AC5.6.4 | yes | Annualized income KPI is surfaced through the dashboard/reporting path and delegates calculation ownership to AC11.8.1 | real: `apps/backend/tests/reporting/test_income_annualized_router.py`<br>real: `apps/frontend/src/__tests__/dashboardPage.test.tsx`<br>stub: `apps/backend/tests/_ac_stubs/test_epic_05_stubs.py` | ✅ real |
 | AC5.6.5 | yes | Unrealized P&L reflected in balance sheet equity | real: `apps/backend/tests/reporting/test_reporting.py`<br>stub: `apps/backend/tests/_ac_stubs/test_epic_05_stubs.py` | ✅ real |
 | AC5.6.6 | yes | MWR (money-weighted return) matches XIRR for single cashflow | stub: `apps/backend/tests/_ac_stubs/test_epic_05_stubs.py` | 🧱 stub-only |
 | AC5.6.7 | no |  | real: `apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py`<br>real: `apps/backend/tests/reporting/test_reporting_fx_revaluation_integration.py` | ✅ real (optional) |
@@ -472,9 +476,9 @@
 
 <a id="epic-008-testing-strategy"></a>
 
-- **Total ACs**: 91
-- **Mandatory ACs**: 85
-- **Mandatory ACs with real test reference**: 85 (100.0%)
+- **Total ACs**: 93
+- **Mandatory ACs**: 87
+- **Mandatory ACs with real test reference**: 87 (100.0%)
 - **Mandatory ACs with only placeholder reference**: 0
 - **Mandatory ACs with only stub reference**: 0
 - **Mandatory ACs without any test reference**: 0
@@ -537,6 +541,7 @@
 | AC8.12.3 | no |  | real: `apps/backend/tests/reporting/test_fx_revaluation.py` | ✅ real (optional) |
 | AC8.12.4 | no |  | real: `apps/backend/tests/extraction/test_extraction_error_paths.py` | ✅ real (optional) |
 | AC8.12.5 | no |  | real: `apps/backend/tests/extraction/test_extraction_error_paths.py` | ✅ real (optional) |
+| AC8.12.6 | yes | OCR/vision provider fallback, timeout, and empty-response errors are deterministic | real: `apps/backend/tests/extraction/test_extraction_error_paths.py` | ✅ real |
 | AC8.13.1 | yes | DBS PDF upload → appears in list | real: `tests/e2e/test_statement_full_journey.py`<br>stub: `apps/backend/tests/_ac_stubs/test_epic_08_stubs.py` | ✅ real |
 | AC8.13.2 | yes | Polling → parsed status visible | real: `tests/e2e/test_statement_full_journey.py`<br>stub: `apps/backend/tests/_ac_stubs/test_epic_08_stubs.py` | ✅ real |
 | AC8.13.3 | yes | Detail page shows transactions | real: `tests/e2e/test_statement_full_journey.py`<br>stub: `apps/backend/tests/_ac_stubs/test_epic_08_stubs.py` | ✅ real |
@@ -571,7 +576,8 @@
 | AC8.13.32 | yes | Dashboard, balance sheet, income statement, and cash-flow totals exactly match the deterministic upload fixture. | real: `scripts/tests/test_post_merge_e2e_gates.py`<br>real: `tests/e2e/test_vision_upload_to_dashboard_hard_gate.py` | ✅ real |
 | AC8.13.33 | yes | Shared E2E setup caches Python virtualenv and Playwright browser artifacts for staging and preview gates. | real: `scripts/tests/test_post_merge_e2e_gates.py` | ✅ real |
 | AC8.13.34 | yes | CI and post-merge workflows append queue, execution, and per-job timing summaries to GitHub Step Summary. | real: `scripts/tests/test_post_merge_e2e_gates.py` | ✅ real |
-| AC8.13.35 | yes | AC traceability reporting distinguishes real test references from _ac_stubs and trivial placeholder assertions. | real: `scripts/tests/test_ci_metrics_contract.py`<br>placeholder: `scripts/tests/test_analyze_test_ac_coverage.py`<br>placeholder: `scripts/tests/test_build_ac_traceability.py`<br>placeholder: `scripts/tests/test_check_ac_traceability.py` | ✅ real |
+| AC8.13.35 | yes | AC traceability reporting distinguishes real test references from _ac_stubs and trivial placeholder assertions. | real: `scripts/tests/test_audit_ac_epic_mismatches.py`<br>real: `scripts/tests/test_ci_metrics_contract.py`<br>placeholder: `scripts/tests/test_analyze_test_ac_coverage.py`<br>placeholder: `scripts/tests/test_build_ac_traceability.py`<br>placeholder: `scripts/tests/test_check_ac_traceability.py` | ✅ real |
+| AC8.13.36 | yes | Main CI builds SHA-tagged staging images and post-merge staging reuses them after same-SHA CI success. | real: `scripts/tests/test_check_ghcr_image_tag.py`<br>real: `scripts/tests/test_post_merge_e2e_gates.py` | ✅ real |
 
 ---
 
@@ -1278,9 +1284,9 @@
 
 <a id="epic-018-ai-driven-pipeline"></a>
 
-- **Total ACs**: 23
-- **Mandatory ACs**: 23
-- **Mandatory ACs with real test reference**: 13 (56.5%)
+- **Total ACs**: 24
+- **Mandatory ACs**: 24
+- **Mandatory ACs with real test reference**: 14 (58.3%)
 - **Mandatory ACs with only placeholder reference**: 0
 - **Mandatory ACs with only stub reference**: 10
 - **Mandatory ACs without any test reference**: 0
@@ -1303,6 +1309,7 @@
 | AC18.4.1 | yes | Reports read Layer 3 TransactionClassification for category breakdowns | stub: `apps/backend/tests/_ac_stubs/test_epic_18_stubs.py` | 🧱 stub-only |
 | AC18.4.2 | yes | ReportSnapshot (Layer 4) generated and queryable via API | stub: `apps/backend/tests/_ac_stubs/test_epic_18_stubs.py` | 🧱 stub-only |
 | AC18.4.3 | yes | AI CSV parsing handles unknown institutions as fallback | real: `apps/backend/tests/extraction/test_ai_csv_parsing.py` | ✅ real |
+| AC18.4.4 | yes | 4 | real: `apps/backend/tests/reporting/test_reporting_net_worth_components.py`<br>placeholder: `scripts/tests/test_analyze_test_ac_coverage.py` | ✅ real |
 | AC18.5.1 | yes | <ConfidenceBadge /> component renders TRUSTED / HIGH / MEDIUM / LOW pill with consistent color tokens (green / blue / am | real: `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx`<br>placeholder: `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.ts`<br>stub: `apps/backend/tests/_ac_stubs/test_epic_18_stubs.py` | ✅ real |
 | AC18.5.2 | yes | ConfidenceBadge mounted on every transaction row in Stage 1 review, Stage 2 listing, and processing-account listing; rea | real: `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx`<br>placeholder: `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.ts`<br>stub: `apps/backend/tests/_ac_stubs/test_epic_18_stubs.py` | ✅ real |
 | AC18.5.3 | yes | AI Suggestion Review Queue page /review/ai-suggestions lists pending AI classifications and AI reconciliation matches in | real: `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx`<br>placeholder: `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.ts`<br>stub: `apps/backend/tests/_ac_stubs/test_epic_18_stubs.py` | ✅ real |

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -74,8 +74,10 @@ contracts is tracked in
   [#454](https://github.com/wangzitian0/finance_report/issues/454).
 - README/project metrics should be generated or validated. See
   [#455](https://github.com/wangzitian0/finance_report/issues/455).
-- AC-to-EPIC mismatches and invalid real-test AC refs should be cleaned up. See
-  [#456](https://github.com/wangzitian0/finance_report/issues/456).
+- AC-to-EPIC mismatch triage is generated in
+  [../analysis/ac-epic-mismatch-report.md](../analysis/ac-epic-mismatch-report.md);
+  current actionable mismatches are zero, with fixture-only fake IDs classified
+  separately.
 
 ## Related
 

--- a/docs/ssot/tdd.md
+++ b/docs/ssot/tdd.md
@@ -83,8 +83,11 @@ The current hardened coverage work is tracked in
 
 Manual verification cleanup is tracked in
 [issue #454](https://github.com/wangzitian0/finance_report/issues/454).
-Invalid AC references and AC-to-EPIC mismatch cleanup are tracked in
-[issue #456](https://github.com/wangzitian0/finance_report/issues/456).
+Invalid AC references are reported by
+[../analysis/test-ac-coverage-report.md](../analysis/test-ac-coverage-report.md).
+AC-to-EPIC mismatch triage is reported by
+[../analysis/ac-epic-mismatch-report.md](../analysis/ac-epic-mismatch-report.md),
+which separates actionable refs from fixture-only fake IDs.
 
 Current coverage enforcement:
 

--- a/scripts/audit_ac_epic_mismatches.py
+++ b/scripts/audit_ac_epic_mismatches.py
@@ -62,13 +62,59 @@ def walk_tests() -> list[Path]:
     return out
 
 
+def is_fixture_test_file(path: Path) -> bool:
+    """Return True for script tests that intentionally embed fake AC IDs."""
+    try:
+        rel = path.relative_to(ROOT)
+    except ValueError:
+        return False
+    return len(rel.parts) >= 2 and rel.parts[0] == "scripts" and rel.parts[1] == "tests"
+
+
+def print_rows(
+    rows: list[tuple[Path, Counter]],
+    file_alt_epic: dict[Path, Counter],
+) -> None:
+    for f, ctr in rows:
+        rel = f.relative_to(ROOT)
+        bad_total = sum(ctr.values())
+        unique_bad = len(ctr)
+        ref_epics = {int(k.split(".")[0][2:]) for k in ctr}
+        primary_epic = next(iter(ref_epics)) if len(ref_epics) == 1 else None
+        alt = file_alt_epic[f]
+        suggest = ""
+        if is_fixture_test_file(f):
+            suggest = "FIXTURE-EXCLUDE"
+        elif (
+            primary_epic is not None
+            and alt
+            and alt.most_common(1)[0][1] >= bad_total * 0.6
+        ):
+            tgt = alt.most_common(1)[0][0]
+            suggest = f"RELOCATE-FILE -> EPIC-{tgt} (or RENUMBER refs to EPIC-{tgt})"
+        elif primary_epic is not None:
+            suggest = f"EXTEND-REGISTRY EPIC-{primary_epic} or RENUMBER-REF"
+        else:
+            suggest = "MIXED - per-ref decision"
+        print(f"## `{rel}` — {bad_total} bad / {unique_bad} unique")
+        print(f"- **Suggest**: {suggest}")
+        if alt:
+            alt_str = ", ".join(f"EPIC-{e}:{c}" for e, c in alt.most_common())
+            print(f"- Alt-epic matches: {alt_str}")
+        ids = sorted(ctr.keys(), key=lambda s: tuple(int(x) for x in s[2:].split(".")))
+        print(f"- Bad IDs: {', '.join(ids)}")
+        print()
+
+
 def main() -> None:
     valid = load_registry()
     files = walk_tests()
     per_file: dict[Path, Counter] = defaultdict(Counter)
+    fixture_per_file: dict[Path, Counter] = defaultdict(Counter)
     file_alt_epic: dict[Path, Counter] = defaultdict(Counter)
     total_refs = 0
     total_bad = 0
+    fixture_bad = 0
     for f in files:
         try:
             text = f.read_text(errors="ignore")
@@ -80,8 +126,12 @@ def main() -> None:
             ac_id = f"AC{epic}.{sec}.{item}"
             if ac_id in valid.get(epic, set()):
                 continue
-            total_bad += 1
-            per_file[f][ac_id] += 1
+            if is_fixture_test_file(f):
+                fixture_bad += 1
+                fixture_per_file[f][ac_id] += 1
+            else:
+                total_bad += 1
+                per_file[f][ac_id] += 1
             # which other epics contain this exact y.z?
             for other_epic, ids in valid.items():
                 if other_epic == epic:
@@ -91,42 +141,23 @@ def main() -> None:
                     file_alt_epic[f][other_epic] += 1
     # Sort files by bad-ref count desc
     rows = sorted(per_file.items(), key=lambda kv: -sum(kv[1].values()))
+    fixture_rows = sorted(fixture_per_file.items(), key=lambda kv: -sum(kv[1].values()))
     print("# AC↔EPIC Mismatch Triage")
     print()
     print(f"- Total ACx.y.z refs scanned: **{total_refs}**")
-    print(f"- Mismatched refs: **{total_bad}**")
-    print(f"- Files affected: **{len(per_file)}**")
+    print(f"- Actionable mismatched refs: **{total_bad}**")
+    print(f"- Fixture-only mismatched refs: **{fixture_bad}**")
+    print(f"- Actionable files affected: **{len(per_file)}**")
+    print(f"- Fixture-only files affected: **{len(fixture_per_file)}**")
     print()
-    for f, ctr in rows:
-        rel = f.relative_to(ROOT)
-        bad_total = sum(ctr.values())
-        unique_bad = len(ctr)
-        # Suggest action
-        ref_epics = {int(k.split(".")[0][2:]) for k in ctr}
-        primary_epic = next(iter(ref_epics)) if len(ref_epics) == 1 else None
-        alt = file_alt_epic[f]
-        suggest = ""
-        if "scripts/tests/" in str(rel):
-            suggest = "FIXTURE-EXCLUDE"
-        elif (
-            primary_epic is not None
-            and alt
-            and alt.most_common(1)[0][1] >= bad_total * 0.6
-        ):
-            tgt = alt.most_common(1)[0][0]
-            suggest = f"RELOCATE-FILE → EPIC-{tgt} (or RENUMBER refs to EPIC-{tgt})"
-        elif primary_epic is not None:
-            suggest = f"EXTEND-REGISTRY EPIC-{primary_epic} or RENUMBER-REF"
-        else:
-            suggest = "MIXED — per-ref decision"
-        print(f"## `{rel}` — {bad_total} bad / {unique_bad} unique")
-        print(f"- **Suggest**: {suggest}")
-        if alt:
-            alt_str = ", ".join(f"EPIC-{e}:{c}" for e, c in alt.most_common())
-            print(f"- Alt-epic matches: {alt_str}")
-        ids = sorted(ctr.keys(), key=lambda s: tuple(int(x) for x in s[2:].split(".")))
-        print(f"- Bad IDs: {', '.join(ids)}")
+    if rows:
+        print("## Actionable Mismatches")
         print()
+        print_rows(rows, file_alt_epic)
+    if fixture_rows:
+        print("## Fixture-Only Mismatches")
+        print()
+        print_rows(fixture_rows, file_alt_epic)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_audit_ac_epic_mismatches.py
+++ b/scripts/tests/test_audit_ac_epic_mismatches.py
@@ -179,6 +179,29 @@ class TestWalkTests:
         assert not any(f.name == "models.py" for f in files)
 
 
+class TestFixtureClassification:
+    def test_scripts_tests_file_is_fixture_file(self, tmp_path):
+        scripts_tests = tmp_path / "scripts" / "tests"
+        scripts_tests.mkdir(parents=True)
+        fixture = scripts_tests / "test_fake_ac_fixture.py"
+        fixture.write_text("# AC99.1.1\n")
+        with mock.patch.object(aam, "ROOT", tmp_path):
+            assert aam.is_fixture_test_file(fixture)
+
+    def test_product_test_file_is_not_fixture_file(self, tmp_path):
+        product_tests = tmp_path / "apps" / "backend" / "tests"
+        product_tests.mkdir(parents=True)
+        test_file = product_tests / "test_real_behavior.py"
+        test_file.write_text("# AC1.1.1\n")
+        with mock.patch.object(aam, "ROOT", tmp_path):
+            assert not aam.is_fixture_test_file(test_file)
+
+    def test_path_outside_root_is_not_fixture_file(self, tmp_path):
+        outside = tmp_path.parent / "test_outside.py"
+        with mock.patch.object(aam, "ROOT", tmp_path):
+            assert not aam.is_fixture_test_file(outside)
+
+
 class TestMain:
     def _setup(self, tmp_path):
         docs = tmp_path / "docs"
@@ -195,7 +218,8 @@ class TestMain:
         with mock.patch.object(aam, "ROOT", tmp_path):
             aam.main()
         out = capsys.readouterr().out
-        assert "Mismatched refs: **0**" in out
+        assert "Actionable mismatched refs: **0**" in out
+        assert "Fixture-only mismatched refs: **0**" in out
 
     def test_bad_ref_detected(self, tmp_path, capsys):
         tests = self._setup(tmp_path)
@@ -203,9 +227,12 @@ class TestMain:
         with mock.patch.object(aam, "ROOT", tmp_path):
             aam.main()
         out = capsys.readouterr().out
-        assert "Mismatched refs: **1**" in out
+        assert "Actionable mismatched refs: **1**" in out
+        assert "Fixture-only mismatched refs: **0**" in out
+        assert "## Actionable Mismatches" in out
 
     def test_fixture_exclude_label_for_scripts_tests(self, tmp_path, capsys):
+        """AC8.13.35: Synthetic script-test fixture IDs are not actionable mismatches."""
         self._setup(tmp_path)
         scripts_tests = tmp_path / "scripts" / "tests"
         scripts_tests.mkdir(parents=True)
@@ -213,6 +240,8 @@ class TestMain:
         with mock.patch.object(aam, "ROOT", tmp_path):
             aam.main()
         out = capsys.readouterr().out
+        assert "Actionable mismatched refs: **0**" in out
+        assert "Fixture-only mismatched refs: **1**" in out
         assert "FIXTURE-EXCLUDE" in out
 
     def test_relocate_suggestion_when_alt_epic_matches(self, tmp_path, capsys):
@@ -237,6 +266,15 @@ class TestMain:
             aam.main()
         out = capsys.readouterr().out
         assert "RELOCATE-FILE" in out or "EXTEND-REGISTRY" in out or "MIXED" in out
+
+    def test_mixed_actionable_suggestion_for_multiple_ref_epics(self, tmp_path, capsys):
+        tests = self._setup(tmp_path)
+        (tests / "test_x.py").write_text("# AC8.9.9 AC9.9.9\n")
+        with mock.patch.object(aam, "ROOT", tmp_path):
+            aam.main()
+        out = capsys.readouterr().out
+        assert "Actionable mismatched refs: **2**" in out
+        assert "MIXED - per-ref decision" in out
 
     def test_total_refs_counted(self, tmp_path, capsys):
         tests = self._setup(tmp_path)


### PR DESCRIPTION
## Summary
- Split AC-to-EPIC mismatch reporting into actionable mismatches and fixture-only fake IDs from script tests.
- Add a generated AC/EPIC mismatch report under `docs/analysis/` and update project/SSOT indexes to link to it.
- Refresh generated AC coverage and traceability reports so current metrics match the 983 registered AC inventory.

Closes #456

## Validation
- `pytest -q scripts/tests/test_audit_ac_epic_mismatches.py scripts/tests/test_analyze_test_ac_coverage.py scripts/tests/test_build_ac_traceability.py scripts/tests/test_check_ac_traceability.py`
- `uv run ruff check scripts/audit_ac_epic_mismatches.py scripts/tests/test_audit_ac_epic_mismatches.py`
- `uv run ruff format --check scripts/audit_ac_epic_mismatches.py scripts/tests/test_audit_ac_epic_mismatches.py`
- `python scripts/audit_ac_epic_mismatches.py`
- `python scripts/analyze_test_ac_coverage.py --output /tmp/test-ac-coverage-report.md`
- `python scripts/build_ac_traceability.py --check`
- `python scripts/generate_ac_registry.py --check`
- `python scripts/check_ac_traceability.py`
- `python scripts/lint_doc_consistency.py`
- `git diff --check`

## Current Audit Result
- Actionable mismatched refs: 0
- Fixture-only mismatched refs: 52
- Invalid AC refs in real tests: 0
