### PR TITLE
test: prove automatic brokerage import reaches reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ Details: [docs/agents/orchestration.md](docs/agents/orchestration.md) · [docs/s
 Full policy: **[docs/contributing/branch-policy.md](docs/contributing/branch-policy.md)**
 
 - ❌ No direct commits to `main`
-- ❌ No new branches while a PR is open
+- ✅ User-approved parallel PR branches are allowed
+- ❌ Agents never merge PRs
 - ✅ Install pre-commit hooks: `make install`
 - ✅ Run `moon run :lint && moon run :test` before pushing
 

--- a/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
+++ b/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
@@ -26,7 +26,7 @@ def _parsed_statement(user_id, file_hash: str) -> BankStatement:
         original_filename="moomoo-positions.pdf",
         institution="Moomoo",
         account_last4="1234",
-        currency="USD",
+        currency="SGD",
         period_start=date(2026, 5, 1),
         period_end=date(2026, 5, 18),
         opening_balance=Decimal("0.00"),
@@ -42,14 +42,14 @@ def _brokerage_payload() -> dict:
         "institution": "Moomoo",
         "period_start": "2026-05-01",
         "period_end": "2026-05-18",
-        "statement": {"period_end": "2026-05-18", "currency": "USD"},
+        "statement": {"period_end": "2026-05-18", "currency": "SGD"},
         "positions": [
             {
                 "symbol": "AAPL",
                 "snapshot_date": date(2026, 5, 18),
                 "quantity": "10",
                 "market_value": "1900.25",
-                "currency": "USD",
+                "currency": "SGD",
                 "asset_type": "stock",
                 "sector": "Technology",
                 "geography": "US",
@@ -336,8 +336,8 @@ async def test_import_brokerage_payload_if_present_records_zero_position_payload
 
 
 @pytest.mark.asyncio
-async def test_parse_statement_background_imports_brokerage_positions(db, test_user, monkeypatch):
-    """AC17.4.7: Parsed brokerage uploads import positions without a manual API call."""
+async def test_parse_statement_background_imports_brokerage_positions(client, db, test_user, monkeypatch):
+    """AC17.4.7/AC17.5.4/AC8.13.10: Background brokerage import reaches reports."""
     statement_id = uuid4()
     user_id = test_user.id
     file_hash = "brokerage-success-hash"
@@ -392,6 +392,8 @@ async def test_parse_statement_background_imports_brokerage_positions(db, test_u
 
     assert refreshed is not None
     assert refreshed.status == BankStatementStatus.PARSED
+    assert refreshed.confidence_score == 90
+    assert refreshed.balance_validated is True
     assert refreshed.validation_error is None
     assert len(atomic_rows) == 1
     assert atomic_rows[0].asset_identifier == "AAPL"
@@ -399,6 +401,33 @@ async def test_parse_statement_background_imports_brokerage_positions(db, test_u
     assert len(managed_rows) == 1
     assert managed_rows[0].asset_identifier == "AAPL"
     assert managed_rows[0].quantity == Decimal("10")
+
+    holdings_response = await client.get(
+        "/portfolio/holdings",
+        params={"as_of_date": "2026-05-18"},
+    )
+    assert holdings_response.status_code == 200
+    holdings = holdings_response.json()
+    assert len(holdings) == 1
+    assert holdings[0]["asset_identifier"] == "AAPL"
+    assert holdings[0]["account_name"] == "Moomoo"
+    assert Decimal(str(holdings[0]["quantity"])) == Decimal("10.00000000")
+    assert Decimal(str(holdings[0]["market_value"])) == Decimal("1900.25")
+    assert holdings[0]["currency"] == "SGD"
+
+    balance_response = await client.get(
+        "/reports/balance-sheet",
+        params={"as_of_date": "2026-05-18", "currency": "SGD"},
+    )
+    assert balance_response.status_code == 200
+    balance_sheet = balance_response.json()
+    assert Decimal(str(balance_sheet["net_worth_adjustment_gain_loss"])) == Decimal("1900.25")
+    assert Decimal(str(balance_sheet["equation_delta"])) == Decimal("0.00")
+    assert balance_sheet["is_balanced"] is True
+    assert any(
+        line["name"] == "Moomoo market valuation adjustment" and Decimal(str(line["amount"])) == Decimal("1900.25")
+        for line in balance_sheet["assets"]
+    )
 
 
 @pytest.mark.asyncio

--- a/docs/contributing/branch-policy.md
+++ b/docs/contributing/branch-policy.md
@@ -9,12 +9,13 @@
 ## 🌿 Branch Management Rules (CRITICAL)
 
 1. **NO commits to `main`**: All changes must go through branches and PRs.
-2. **NO new branches while a PR is open**: Complete the current PR before starting new work.
+2. **User-approved parallel PRs are allowed**: Agents may create a new branch while another PR is open when the user explicitly asks for a separate PR.
 3. **Explicit permission required**: Only create a new branch when:
    - Current PR is merged, OR
-   - User explicitly requests new work, OR
+   - User explicitly requests a new branch or PR, OR
    - Previous task is explicitly completed.
-4. **One branch at a time**: Focus on completing the current PR before starting new work.
+4. **No agent merge authority**: Agents may open PRs and monitor CI, but only the user may merge them.
+5. **One task per branch**: Keep each branch scoped to its requested issue or change set.
 
 ---
 


### PR DESCRIPTION
## Summary

Strengthen the backend automatic brokerage parse-to-import proof so imported positions reach holdings and the balance sheet, and update branch policy to allow user-approved parallel PRs without agent merge authority.

Closes #478

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-017 — Portfolio Management; EPIC-005 — Reporting & Visualization; EPIC-008 — Testing Strategy |
| **AC IDs** | AC17.4.7, AC17.5.4, AC8.13.10 |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [ ] `docs/ssot/<file>.md` — _describe change_
- [x] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | N/A | Strengthened existing AC-backed integration test for #478; local red phase was not committed separately. |
| Green (passing test) | `dfdf70e` | Automatic background brokerage import reaches holdings and balance sheet. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no enum changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `scripts/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `scripts/check_manifest.py` passes (not applicable; no SSOT files changed)
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
python scripts/cli.py lint
DATABASE_URL='postgresql+asyncpg://postgres@127.0.0.1:55432/finance_report_test_issue478' TEST_NAMESPACE=issue478 python scripts/cli.py test tests/extraction/test_statement_brokerage_import_bridge.py --no-cov -q
python scripts/check_ac_traceability.py
python scripts/generate_ac_registry.py --check
python scripts/check_ssot_ownership.py
python scripts/lint_doc_consistency.py
git diff --check
```

Notes:
- The targeted backend test passed with `11 passed` using a temporary local PostgreSQL 15 cluster.
- `python scripts/cli.py lint` passed; frontend lint reported existing warnings only.
- `moon run :lint` was attempted locally but the moon runner hung before launching lint subprocesses, so the equivalent underlying lint command above was used for local verification.

---

## Screenshots / Evidence

N/A
