### PR TITLE
fix: align AC coverage analyzer with script tests

### DIFF
--- a/apps/backend/tests/ai/test_ai_models_integration.py
+++ b/apps/backend/tests/ai/test_ai_models_integration.py
@@ -4,6 +4,8 @@ These tests validate the configured provider model catalog. The default catalog
 is local/configured so CI does not depend on remote model-list availability.
 """
 
+import re
+
 import pytest
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
@@ -57,8 +59,7 @@ class TestModelCatalogIntegration:
         assert len(settings.fallback_models) > 0, "FALLBACK_MODELS list is empty"
 
         for model_id in settings.fallback_models:
-            assert model_id.startswith("glm-"), f"Invalid fallback model format: {model_id}"
-            assert len(model_id) > 5, f"Fallback model ID too short: {model_id}"
+            assert re.fullmatch(r"glm-[\d.a-z-]+", model_id), f"Invalid fallback model format: {model_id}"
 
     async def test_glm_models_available(self):
         """AC6.11.1: At least one GLM model available in catalog."""

--- a/apps/backend/tests/reconciliation/test_reconciliation_matching_unit.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_matching_unit.py
@@ -18,6 +18,7 @@ from src.models import (
     BankStatementTransactionStatus,
     Direction,
     JournalEntry,
+    JournalEntrySourceType,
     JournalEntryStatus,
     JournalLine,
     ReconciliationMatch,
@@ -26,7 +27,10 @@ from src.models import (
 )
 from src.services.reconciliation import (
     DEFAULT_CONFIG,
+    MatchCandidate,
     ReconciliationConfig,
+    _candidate_is_better,
+    _find_normal_candidates,
     calculate_match_score,
     entry_total_amount,
     execute_matching,
@@ -239,6 +243,84 @@ def test_score_business_logic_combinations():
     # Unknown direction
     txn_unknown = BankStatementTransaction(direction="???")
     assert score_business_logic(txn_unknown, entry_income) == 50.0
+
+
+def test_AC4_6_3_candidate_tie_breaker_prefers_higher_source_trust():
+    """AC4.6.3: Manual-sourced entries win deterministic same-score conflicts."""
+    manual_id = uuid4()
+    parsed_id = uuid4()
+    manual_entry = JournalEntry(
+        id=manual_id,
+        source_type=JournalEntrySourceType.MANUAL,
+    )
+    parsed_entry = JournalEntry(
+        id=parsed_id,
+        source_type=JournalEntrySourceType.AUTO_PARSED,
+    )
+    entries_by_id = {str(manual_id): manual_entry, str(parsed_id): parsed_entry}
+
+    manual_candidate = MatchCandidate(
+        journal_entry_ids=[str(manual_id)],
+        score=88,
+        breakdown={},
+    )
+    parsed_candidate = MatchCandidate(
+        journal_entry_ids=[str(parsed_id)],
+        score=88,
+        breakdown={},
+    )
+
+    assert _candidate_is_better(manual_candidate, parsed_candidate, entries_by_id)
+    assert manual_candidate.breakdown["source_type_winner_rank"] > manual_candidate.breakdown["source_type_loser_rank"]
+    assert not _candidate_is_better(parsed_candidate, manual_candidate, entries_by_id)
+    assert manual_candidate.breakdown["source_type_winner_rank"] > manual_candidate.breakdown["source_type_loser_rank"]
+
+
+def test_AC4_2_3_normal_candidates_cover_multi_entry_boundaries():
+    """AC4.2.3: Normal matching accepts balanced split entries and skips invalid candidates."""
+    base_date = date(2026, 1, 15)
+    txn = BankStatementTransaction(
+        id=uuid4(),
+        txn_date=base_date,
+        description="Vendor ABC",
+        amount=Decimal("100.00"),
+        direction="OUT",
+    )
+
+    def entry(amount: str, memo: str, *, balanced: bool = True) -> JournalEntry:
+        entry_id = uuid4()
+        debit = Decimal(amount)
+        credit = debit if balanced else debit - Decimal("1.00")
+        return JournalEntry(
+            id=entry_id,
+            entry_date=base_date,
+            memo=memo,
+            source_type=JournalEntrySourceType.MANUAL,
+            lines=[
+                JournalLine(direction=Direction.DEBIT, amount=debit, account=Account(type=AccountType.EXPENSE)),
+                JournalLine(direction=Direction.CREDIT, amount=credit, account=Account(type=AccountType.ASSET)),
+            ],
+        )
+
+    candidates = [
+        entry("40.00", "Vendor ABC part 1"),
+        entry("60.00", "Vendor ABC part 2"),
+        entry("10.00", "Unbalanced ignored", balanced=False),
+        entry("300.00", "Too large ignored"),
+    ]
+
+    results = _find_normal_candidates(
+        [txn],
+        candidates,
+        pattern_scores={"vendor": 90.0},
+        config=DEFAULT_CONFIG,
+    )
+
+    assert len(results) == 1
+    matched_txn, candidate = results[0]
+    assert matched_txn is txn
+    assert len(candidate.journal_entry_ids) == 2
+    assert candidate.breakdown["multi_entry"] == 1
 
 
 def test_extract_merchant_tokens():

--- a/apps/backend/tests/unit/infra/test_test_lifecycle.py
+++ b/apps/backend/tests/unit/infra/test_test_lifecycle.py
@@ -28,6 +28,18 @@ def test_sanitize_namespace():
         test_lifecycle._sanitize_namespace("")
 
 
+def test_long_namespace_resource_names_are_bounded():
+    """AC8.1.1: Long branch namespaces remain valid for Postgres and S3."""
+    namespace = "codex_issue_490_testing_strategy_ac_coverage_0bb5607e"
+
+    db_name = test_lifecycle.get_test_db_name(namespace)
+    bucket = test_lifecycle.get_s3_bucket(namespace)
+
+    assert len(db_name) <= 63
+    assert len(bucket) <= 63
+    assert "_" not in bucket
+
+
 @patch("test_lifecycle.subprocess.run")
 def test_is_db_ready(mock_run):
     """AC8.2.1: Verify is_db_ready correctly checks container status."""

--- a/apps/frontend/src/__tests__/StatementUploader.test.tsx
+++ b/apps/frontend/src/__tests__/StatementUploader.test.tsx
@@ -262,4 +262,66 @@ describe("AC3.5.3 StatementUploader model selection", () => {
     await userEvent.click(uploadButton);
     await screen.findByText("Server Error");
   });
+
+  it("AC8.4.1 rejects unsupported and oversized statement files before upload", async () => {
+    vi.mocked(fetchAiModels).mockResolvedValue({
+      default_model: "google/gemini-3-flash-preview",
+      fallback_models: [],
+      models: baseModels,
+    });
+
+    render(<StatementUploader />);
+
+    const fileInput = screen.getByLabelText(/drop files here or click to upload/i);
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["data"], "statement.exe", { type: "application/octet-stream" })] },
+    });
+    expect(await screen.findByText("Invalid file type: .exe. Allowed: PDF, CSV, PNG, JPG")).toBeInTheDocument();
+
+    const hugeFile = new File([new Uint8Array(10 * 1024 * 1024 + 1)], "statement.pdf", { type: "application/pdf" });
+    fireEvent.change(fileInput, { target: { files: [hugeFile] } });
+    expect(await screen.findByText("File exceeds 10MB limit")).toBeInTheDocument();
+    expect(apiUpload).not.toHaveBeenCalled();
+  });
+
+  it("AC8.4.1 requires a file and calls completion callback after successful upload", async () => {
+    vi.mocked(fetchAiModels).mockResolvedValue({
+      default_model: "google/gemini-3-flash-preview",
+      fallback_models: [],
+      models: baseModels,
+    });
+    vi.mocked(apiUpload).mockResolvedValue({});
+    const onUploadComplete = vi.fn();
+
+    render(<StatementUploader onUploadComplete={onUploadComplete} />);
+
+    const uploadButton = screen.getByRole("button", { name: /upload & parse statement/i });
+    await userEvent.click(uploadButton);
+    expect(await screen.findByText("Please select a file")).toBeInTheDocument();
+
+    const fileInput = screen.getByLabelText(/drop files here or click to upload/i);
+    const file = new File(["data"], "statement.pdf", { type: "application/pdf" });
+    await userEvent.upload(fileInput, file);
+    await userEvent.click(uploadButton);
+
+    await waitFor(() => expect(apiUpload).toHaveBeenCalledWith("/api/statements/upload", expect.any(FormData)));
+    expect(onUploadComplete).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/drop files here or click to upload/i)).toBeInTheDocument();
+  });
+
+  it("AC8.4.1 accepts dropped statement files", async () => {
+    vi.mocked(fetchAiModels).mockResolvedValue({
+      default_model: "google/gemini-3-flash-preview",
+      fallback_models: [],
+      models: baseModels,
+    });
+
+    render(<StatementUploader />);
+
+    const dropZone = screen.getByText(/drop files here or click to upload/i).closest(".card")!;
+    const file = new File(["data"], "statement.png", { type: "image/png" });
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+    expect(await screen.findByText("statement.png")).toBeInTheDocument();
+  });
 });

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -8,7 +8,9 @@
 - Covered AC = has at least one real test reference outside `_ac_stubs`, trivial placeholder assertions, pure `pass`, and pure skipped tests.
 - `expect(true).toBe(true)`, pure `pass`, and pure skipped references are tracked as placeholder-only and **do not** count as covered.
 - `_ac_stubs` references are tracked as placeholders (`stub-only`) and **do not** count as covered.
-- Invalid AC references are AC IDs found in tests but missing from registries.
+- Strikethrough deprecated ACs are excluded from active coverage and untested counts.
+- Synthetic AC IDs inside `scripts/tests` fixtures are excluded from invalid-ref counts; fixture-only mismatches are audited separately.
+- Invalid AC references are other AC IDs found in tests but missing from registries.
 - Untested AC = registered AC without any real passing-test candidate reference.
 
 ## Executive summary
@@ -16,10 +18,12 @@
 | Metric | Count |
 |---|---:|
 | Registered ACs | 984 |
-| Covered by real test candidates | 816 (82.9%) |
+| Active ACs | 981 |
+| Deprecated ACs excluded from coverage gate | 3 |
+| Covered by real test candidates | 981 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
-| Registered but untested | 168 |
+| Active registered but untested | 0 |
 | Invalid AC refs in real tests | 0 |
 | Invalid AC refs in placeholders | 0 |
 | Invalid AC refs in stubs | 0 |
@@ -30,31 +34,32 @@
 |---|---:|---:|---:|---:|
 | backend | 166 | 628 | 0 | 0 |
 | frontend | 79 | 189 | 7 | 0 |
+| scripts_tests | 38 | 209 | 23 | 0 |
 | e2e | 10 | 16 | 0 | 0 |
 | repo_e2e | 18 | 0 | 0 | 0 |
 
 ## Coverage by EPIC
 
-| EPIC | Name | Registered | Covered | Placeholder-only | Stub-only | Untested | Coverage |
-|---|---|---:|---:|---:|---:|---:|---:|
-| EPIC-001 | phase0-setup | 29 | 28 | 0 | 0 | 1 | 96.6% |
-| EPIC-002 | double-entry-core | 59 | 59 | 0 | 0 | 0 | 100.0% |
-| EPIC-003 | statement-parsing | 47 | 47 | 0 | 0 | 0 | 100.0% |
-| EPIC-004 | reconciliation-engine | 39 | 37 | 0 | 0 | 2 | 94.9% |
-| EPIC-005 | reporting-visualization | 36 | 36 | 0 | 0 | 0 | 100.0% |
-| EPIC-006 | ai-advisor | 63 | 63 | 0 | 0 | 0 | 100.0% |
-| EPIC-007 | deployment | 39 | 6 | 0 | 0 | 33 | 15.4% |
-| EPIC-008 | testing-strategy | 94 | 71 | 0 | 0 | 23 | 75.5% |
-| EPIC-009 | pdf-fixture-generation | 37 | 0 | 0 | 0 | 37 | 0.0% |
-| EPIC-010 | signoz-logging | 21 | 5 | 0 | 0 | 16 | 23.8% |
-| EPIC-011 | asset-lifecycle | 38 | 38 | 0 | 0 | 0 | 100.0% |
-| EPIC-012 | foundation-libs | 62 | 56 | 0 | 0 | 6 | 90.3% |
-| EPIC-013 | statement-parsing-v2 | 60 | 60 | 0 | 0 | 0 | 100.0% |
-| EPIC-014 | ttd-transformation | 6 | 0 | 0 | 0 | 6 | 0.0% |
-| EPIC-015 | processing-account | 31 | 31 | 0 | 0 | 0 | 100.0% |
-| EPIC-016 | two-stage-review-ui | 217 | 173 | 0 | 0 | 44 | 79.7% |
-| EPIC-017 | portfolio-management | 82 | 82 | 0 | 0 | 0 | 100.0% |
-| EPIC-018 | ai-driven-pipeline | 24 | 24 | 0 | 0 | 0 | 100.0% |
+| EPIC | Name | Registered | Deprecated | Covered | Placeholder-only | Stub-only | Untested | Coverage |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| EPIC-001 | phase0-setup | 29 | 0 | 29 | 0 | 0 | 0 | 100.0% |
+| EPIC-002 | double-entry-core | 59 | 0 | 59 | 0 | 0 | 0 | 100.0% |
+| EPIC-003 | statement-parsing | 47 | 0 | 47 | 0 | 0 | 0 | 100.0% |
+| EPIC-004 | reconciliation-engine | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
+| EPIC-005 | reporting-visualization | 36 | 0 | 36 | 0 | 0 | 0 | 100.0% |
+| EPIC-006 | ai-advisor | 63 | 0 | 63 | 0 | 0 | 0 | 100.0% |
+| EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 94 | 0 | 94 | 0 | 0 | 0 | 100.0% |
+| EPIC-009 | pdf-fixture-generation | 37 | 0 | 37 | 0 | 0 | 0 | 100.0% |
+| EPIC-010 | signoz-logging | 21 | 0 | 21 | 0 | 0 | 0 | 100.0% |
+| EPIC-011 | asset-lifecycle | 38 | 0 | 38 | 0 | 0 | 0 | 100.0% |
+| EPIC-012 | foundation-libs | 62 | 3 | 59 | 0 | 0 | 0 | 100.0% |
+| EPIC-013 | statement-parsing-v2 | 60 | 0 | 60 | 0 | 0 | 0 | 100.0% |
+| EPIC-014 | ttd-transformation | 6 | 0 | 6 | 0 | 0 | 0 | 100.0% |
+| EPIC-015 | processing-account | 31 | 0 | 31 | 0 | 0 | 0 | 100.0% |
+| EPIC-016 | two-stage-review-ui | 217 | 0 | 217 | 0 | 0 | 0 | 100.0% |
+| EPIC-017 | portfolio-management | 82 | 0 | 82 | 0 | 0 | 0 | 100.0% |
+| EPIC-018 | ai-driven-pipeline | 24 | 0 | 24 | 0 | 0 | 0 | 100.0% |
 
 ## Invalid AC references (unregistered)
 
@@ -68,40 +73,6 @@ No stub-only AC placeholders found.
 
 No placeholder-only AC assertions found.
 
-## Registered ACs with no real test reference
+## Active registered ACs with no real test reference
 
-### EPIC-001 (phase0-setup) — 1 untested
-
-`AC1.2.3`
-
-### EPIC-004 (reconciliation-engine) — 2 untested
-
-`AC4.6.1`, `AC4.6.2`
-
-### EPIC-007 (deployment) — 33 untested
-
-`AC7.1.1`, `AC7.1.2`, `AC7.1.3`, `AC7.2.1`, `AC7.2.2`, `AC7.2.3`, `AC7.2.4`, `AC7.2.5`, `AC7.3.1`, `AC7.3.2`, `AC7.3.3`, `AC7.3.4`, `AC7.3.5`, `AC7.4.1`, `AC7.4.2`, `AC7.4.3`, `AC7.4.4`, `AC7.4.5`, `AC7.4.6`, `AC7.5.1`, `AC7.5.2`, `AC7.5.3`, `AC7.5.4`, `AC7.5.5`, `AC7.6.2`, `AC7.9.1`, `AC7.9.2`, `AC7.9.3`, `AC7.9.4`, `AC7.9.5`, `AC7.9.6`, `AC7.9.7`, `AC7.9.8`
-
-### EPIC-008 (testing-strategy) — 23 untested
-
-`AC8.13.6`, `AC8.13.7`, `AC8.13.8`, `AC8.13.11`, `AC8.13.12`, `AC8.13.13`, `AC8.13.14`, `AC8.13.15`, `AC8.13.16`, `AC8.13.17`, `AC8.13.20`, `AC8.13.21`, `AC8.13.22`, `AC8.13.23`, `AC8.13.24`, `AC8.13.25`, `AC8.13.26`, `AC8.13.27`, `AC8.13.33`, `AC8.13.34`, `AC8.13.35`, `AC8.13.36`, `AC8.13.37`
-
-### EPIC-009 (pdf-fixture-generation) — 37 untested
-
-`AC9.1.1`, `AC9.1.2`, `AC9.1.3`, `AC9.1.4`, `AC9.1.5`, `AC9.1.6`, `AC9.2.1`, `AC9.2.2`, `AC9.2.3`, `AC9.2.4`, `AC9.2.5`, `AC9.2.6`, `AC9.2.7`, `AC9.3.1`, `AC9.3.2`, `AC9.3.3`, `AC9.3.4`, `AC9.3.5`, `AC9.3.6`, `AC9.3.7`, `AC9.4.1`, `AC9.4.2`, `AC9.4.3`, `AC9.4.4`, `AC9.5.1`, `AC9.5.2`, `AC9.5.3`, `AC9.5.4`, `AC9.5.5`, `AC9.6.1`, `AC9.6.2`, `AC9.6.3`, `AC9.6.4`, `AC9.6.5`, `AC9.7.1`, `AC9.7.2`, `AC9.7.3`
-
-### EPIC-010 (signoz-logging) — 16 untested
-
-`AC10.1.1`, `AC10.5.1`, `AC10.5.2`, `AC10.5.3`, `AC10.5.4`, `AC10.6.1`, `AC10.6.2`, `AC10.6.3`, `AC10.6.4`, `AC10.7.1`, `AC10.7.2`, `AC10.7.3`, `AC10.7.4`, `AC10.7.5`, `AC10.7.6`, `AC10.7.7`
-
-### EPIC-012 (foundation-libs) — 6 untested
-
-`AC12.19.1`, `AC12.22.1`, `AC12.22.2`, `AC12.24.1`, `AC12.24.2`, `AC12.24.3`
-
-### EPIC-014 (ttd-transformation) — 6 untested
-
-`AC14.1.1`, `AC14.1.2`, `AC14.1.3`, `AC14.1.4`, `AC14.1.5`, `AC14.1.6`
-
-### EPIC-016 (two-stage-review-ui) — 44 untested
-
-`AC16.1.1`, `AC16.11.1`, `AC16.11.2`, `AC16.11.3`, `AC16.11.4`, `AC16.11.5`, `AC16.11.6`, `AC16.11.7`, `AC16.11.8`, `AC16.11.9`, `AC16.11.10`, `AC16.11.11`, `AC16.11.12`, `AC16.11.13`, `AC16.11.14`, `AC16.11.15`, `AC16.11.16`, `AC16.11.17`, `AC16.11.18`, `AC16.11.19`, `AC16.11.20`, `AC16.11.21`, `AC16.11.22`, `AC16.11.23`, `AC16.11.24`, `AC16.11.25`, `AC16.11.26`, `AC16.11.27`, `AC16.11.28`, `AC16.11.29`, `AC16.11.30`, `AC16.11.31`, `AC16.13.1`, `AC16.13.2`, `AC16.13.3`, `AC16.13.4`, `AC16.13.5`, `AC16.13.6`, `AC16.13.7`, `AC16.13.8`, `AC16.13.9`, `AC16.13.10`, `AC16.13.11`, `AC16.13.12`
+All active registered ACs have at least one real test reference.

--- a/docs/infra_registry.yaml
+++ b/docs/infra_registry.yaml
@@ -1064,7 +1064,7 @@ groups:
       - id: AC16.13.4
         epic: 16
         epic_name: two-stage-review-ui
-        description: "test_lifecycle \u2014 get_test_db_name and get_s3_bucket format names deterministically"
+        description: "test_lifecycle \u2014 get_test_db_name and get_s3_bucket format bounded names deterministically"
         mandatory: true
       - id: AC16.13.5
         epic: 16

--- a/docs/project/AUDITS.md
+++ b/docs/project/AUDITS.md
@@ -14,8 +14,10 @@ reports for current metrics.
 Current generated AC snapshot:
 
 - 984 registered ACs
-- 816 ACs with real test-candidate references
-- 168 registered ACs without real test reference
+- 981 active ACs
+- 3 deprecated ACs excluded from the coverage gate
+- 981 active ACs with real test-candidate references
+- 0 active registered ACs without real test reference
 - 0 stub-only placeholders
 - 0 invalid AC refs in real tests
 - 0 actionable AC-to-EPIC mismatches

--- a/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
+++ b/docs/project/archive/AC-TEST-TRACEABILITY-AUDIT.md
@@ -13,14 +13,14 @@
 | Metric | Count | Percentage |
 |--------|-------|------------|
 | **Total EPICs** | 18 | 100% |
-| **Total ACs (registries)** | 984 | 100% |
-| **Mandatory ACs** | 824 | 83.7% |
+| **Total ACs (registries)** | 985 | 100% |
+| **Mandatory ACs** | 825 | 83.8% |
 | **Deprecated ACs** | 3 | 0.3% |
-| **Mandatory ACs with real test reference** | 824 | 100.0% |
+| **Mandatory ACs with real test reference** | 825 | 100.0% |
 | **Mandatory ACs with only placeholder reference** | 0 | - |
 | **Mandatory ACs with only stub reference** | 0 | - |
 | **Mandatory ACs without any test reference** | 0 | - |
-| **Test files referenced** | 202 | - |
+| **Test files referenced** | 205 | - |
 | **ACs flagged as manual verification (heuristic)** | 0 | 0.0% |
 
 ### Coverage by EPIC
@@ -34,7 +34,7 @@
 | [EPIC-005](#epic-005-reporting-visualization) | reporting-visualization | 36 | 0 | 25 | 25 | 0 | 0 | 0 | 100.0% |
 | [EPIC-006](#epic-006-ai-advisor) | ai-advisor | 63 | 0 | 55 | 55 | 0 | 0 | 0 | 100.0% |
 | [EPIC-007](#epic-007-deployment) | deployment | 39 | 0 | 39 | 39 | 0 | 0 | 0 | 100.0% |
-| [EPIC-008](#epic-008-testing-strategy) | testing-strategy | 94 | 0 | 88 | 88 | 0 | 0 | 0 | 100.0% |
+| [EPIC-008](#epic-008-testing-strategy) | testing-strategy | 95 | 0 | 89 | 89 | 0 | 0 | 0 | 100.0% |
 | [EPIC-009](#epic-009-pdf-fixture-generation) | pdf-fixture-generation | 37 | 0 | 36 | 36 | 0 | 0 | 0 | 100.0% |
 | [EPIC-010](#epic-010-signoz-logging) | signoz-logging | 21 | 0 | 21 | 21 | 0 | 0 | 0 | 100.0% |
 | [EPIC-011](#epic-011-asset-lifecycle) | asset-lifecycle | 38 | 0 | 38 | 38 | 0 | 0 | 0 | 100.0% |
@@ -250,7 +250,7 @@
 | AC4.1.4 | yes | Description Similarity | real: `apps/backend/tests/reconciliation/test_reconciliation_matching_unit.py`<br>real: `apps/backend/tests/reconciliation/test_reconciliation_scoring.py` | ✅ real |
 | AC4.2.1 | yes | Many-to-One (Batch Payment) | real: `apps/backend/tests/api/test_reconciliation_router.py`<br>real: `apps/backend/tests/reconciliation/test_reconciliation_engine.py` | ✅ real |
 | AC4.2.2 | yes | Many-to-One Bonus | real: `apps/backend/tests/api/test_reconciliation_router.py` | ✅ real |
-| AC4.2.3 | yes | One-to-Many (Split) | real: `apps/backend/tests/reconciliation/test_reconciliation_engine.py` | ✅ real |
+| AC4.2.3 | yes | One-to-Many (Split) | real: `apps/backend/tests/reconciliation/test_reconciliation_engine.py`<br>real: `apps/backend/tests/reconciliation/test_reconciliation_matching_unit.py` | ✅ real |
 | AC4.3.1 | yes | Auto-Accept Logic | real: `apps/backend/tests/api/test_reconciliation_router.py`<br>real: `apps/backend/tests/reconciliation/test_reconciliation_dual_read.py`<br>real: `apps/backend/tests/reconciliation/test_reconciliation_engine.py`<br>real: `apps/backend/tests/reconciliation/test_review_queue.py`<br>real: `scripts/tests/test_reconciliation_thresholds_unit.py` | ✅ real |
 | AC4.3.2 | yes | Review Queue Logic | real: `apps/backend/tests/api/test_reconciliation_router.py`<br>real: `apps/backend/tests/reconciliation/test_reconciliation_engine.py`<br>real: `scripts/tests/test_reconciliation_thresholds_unit.py` | ✅ real |
 | AC4.3.3 | yes | Batch Accept | real: `apps/backend/tests/api/test_reconciliation_router.py`<br>real: `apps/backend/tests/reconciliation/test_reconciliation_router_additional.py` | ✅ real |
@@ -272,7 +272,7 @@
 | AC4.5.2 | no |  | real: `apps/backend/tests/api/test_reconciliation_router.py` | ✅ real (optional) |
 | AC4.6.1 | yes | 0.1 USD boundary: amount delta = 0.10 USD passes, 0.11 USD fails | real: `scripts/tests/test_reconciliation_thresholds_unit.py` | ✅ real |
 | AC4.6.2 | yes | Transfer detection: matching OUT/IN within ±3 days not mis-reconciled | real: `scripts/tests/test_reconciliation_thresholds_unit.py` | ✅ real |
-| AC4.6.3 | yes | source_type=manual wins over auto_matched in conflict | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
+| AC4.6.3 | yes | source_type=manual wins over auto_matched in conflict | real: `apps/backend/tests/reconciliation/test_reconciliation_matching_unit.py`<br>real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
 | AC4.6.4 | yes | Stage 2 batch approve blocked when duplicate flags unresolved | real: `apps/backend/tests/reconciliation/test_review_queue.py`<br>real: `apps/frontend/src/__tests__/reviewQueuePage.test.tsx` | ✅ real |
 | AC4.6.5 | yes | Reconciliation score considers source_type weight (manual > auto) | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
 | AC4.6.6 | no |  | real: `apps/backend/tests/reconciliation/test_reconciliation_engine.py` | ✅ real (optional) |
@@ -476,9 +476,9 @@
 
 <a id="epic-008-testing-strategy"></a>
 
-- **Total ACs**: 94
-- **Mandatory ACs**: 88
-- **Mandatory ACs with real test reference**: 88 (100.0%)
+- **Total ACs**: 95
+- **Mandatory ACs**: 89
+- **Mandatory ACs with real test reference**: 89 (100.0%)
 - **Mandatory ACs with only placeholder reference**: 0
 - **Mandatory ACs with only stub reference**: 0
 - **Mandatory ACs without any test reference**: 0
@@ -579,6 +579,7 @@
 | AC8.13.35 | yes | AC traceability reporting distinguishes real test references from _ac_stubs and trivial placeholder assertions. | real: `scripts/tests/test_audit_ac_epic_mismatches.py`<br>real: `scripts/tests/test_ci_metrics_contract.py`<br>placeholder: `scripts/tests/test_analyze_test_ac_coverage.py`<br>placeholder: `scripts/tests/test_build_ac_traceability.py`<br>placeholder: `scripts/tests/test_check_ac_traceability.py` | ✅ real |
 | AC8.13.36 | yes | Main CI builds SHA-tagged staging images and post-merge staging reuses them after same-SHA CI success. | real: `scripts/tests/test_check_ghcr_image_tag.py`<br>real: `scripts/tests/test_post_merge_e2e_gates.py` | ✅ real |
 | AC8.13.37 | yes | AC traceability fails mandatory ACs that are covered only by _ac_stubs. | real: `scripts/tests/test_issue_459_traceability_gate.py`<br>placeholder: `scripts/tests/test_build_ac_traceability.py`<br>placeholder: `scripts/tests/test_check_ac_traceability.py` | ✅ real |
+| AC8.13.38 | yes | Scheduled PR preview cleanup removes stale closed-PR VPS resources while preserving open PR previews. | real: `scripts/tests/test_cleanup_pr_preview_resources.py` | ✅ real |
 
 ---
 
@@ -595,9 +596,9 @@
 
 | AC ID | Mandatory | Description | Test References | Status |
 |-------|-----------|-------------|-----------------|--------|
-| AC9.1.1 | yes | PDF analyzer exists | real: `scripts/tests/test_generate_ac_registry.py` | ✅ real |
+| AC9.1.1 | yes | PDF analyzer exists | real: `scripts/tests/test_generate_ac_registry.py`<br>real: `scripts/tests/test_pdf_fixture_tooling_coverage.py` | ✅ real |
 | AC9.1.2 | yes | Template extractor exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
-| AC9.1.3 | yes | CLI tool exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
+| AC9.1.3 | yes | CLI tool exists | real: `scripts/tests/test_issue_459_infra_contracts.py`<br>real: `scripts/tests/test_pdf_fixture_tooling_coverage.py` | ✅ real |
 | AC9.1.4 | yes | DBS template exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
 | AC9.1.5 | yes | CMB template exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
 | AC9.1.6 | yes | Mari Bank template exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
@@ -605,10 +606,10 @@
 | AC9.2.2 | yes | DBS generator exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
 | AC9.2.3 | yes | CMB generator exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
 | AC9.2.4 | yes | Mari Bank generator exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
-| AC9.2.5 | yes | Font utilities exist | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
-| AC9.2.6 | yes | Fake data generator exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
+| AC9.2.5 | yes | Font utilities exist | real: `scripts/tests/test_issue_459_infra_contracts.py`<br>real: `scripts/tests/test_pdf_fixture_tooling_coverage.py` | ✅ real |
+| AC9.2.6 | yes | Fake data generator exists | real: `scripts/tests/test_issue_459_infra_contracts.py`<br>real: `scripts/tests/test_pdf_fixture_tooling_coverage.py` | ✅ real |
 | AC9.2.7 | yes | Main script exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
-| AC9.3.1 | yes | Format validator exists | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
+| AC9.3.1 | yes | Format validator exists | real: `scripts/tests/test_issue_459_infra_contracts.py`<br>real: `scripts/tests/test_pdf_fixture_tooling_coverage.py` | ✅ real |
 | AC9.3.2 | yes | Generated DBS PDF parseable | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
 | AC9.3.3 | yes | Generated CMB PDF parseable | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
 | AC9.3.4 | yes | Generated Mari PDF parseable | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
@@ -629,8 +630,8 @@
 | AC9.6.3 | yes | CMB generator supports Chinese fonts | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
 | AC9.6.4 | yes | Mari generator generates interest section | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
 | AC9.6.5 | yes | Generators use fictional data | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
-| AC9.7.1 | yes | Main script supports --source parameter | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
-| AC9.7.2 | yes | Main script supports --output parameter | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
+| AC9.7.1 | yes | Main script supports --source parameter | real: `scripts/tests/test_issue_459_infra_contracts.py`<br>real: `scripts/tests/test_pdf_fixture_tooling_coverage.py` | ✅ real |
+| AC9.7.2 | yes | Main script supports --output parameter | real: `scripts/tests/test_issue_459_infra_contracts.py`<br>real: `scripts/tests/test_pdf_fixture_tooling_coverage.py` | ✅ real |
 | AC9.7.3 | yes | Analyzer CLI supports input/output | real: `scripts/tests/test_issue_459_infra_contracts.py` | ✅ real |
 
 ---
@@ -873,7 +874,7 @@
 | AC13.10.1 | yes | Source type stamped on manual entry creation | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
 | AC13.10.2 | yes | Auto-match sets source_type=auto_matched | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
 | AC13.10.3 | yes | Stage-1 approve promotes to user_confirmed | real: `apps/backend/tests/extraction/test_source_type_promotion.py` | ✅ real |
-| AC13.10.4 | yes | Manual entry wins over auto_parsed in conflict | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
+| AC13.10.4 | yes | Manual entry wins over auto_parsed in conflict | real: `apps/backend/tests/infra/test_migrations.py`<br>real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
 | AC13.10.5 | yes | source_type cannot be downgraded | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
 | AC13.10.6 | yes | All four source_type values accepted by API | real: `apps/backend/tests/reconciliation/test_source_type.py` | ✅ real |
 | AC13.11.1 | no |  | real: `apps/backend/tests/extraction/test_extraction_error_paths.py` | ✅ real (optional) |
@@ -1076,7 +1077,7 @@
 | AC16.13.1 | yes | test_lifecycle — sanitize_namespace normalizes branch/workspace names | real: `scripts/tests/test_generate_ac_registry.py` | ✅ real |
 | AC16.13.2 | yes | test_lifecycle — get_namespace honors BRANCH_NAME and optional WORKSPACE_ID | real: `scripts/tests/test_lifecycle_and_pdf_scripts.py` | ✅ real |
 | AC16.13.3 | yes | test_lifecycle — get_namespace falls back to git branch plus path hash when env vars absent | real: `scripts/tests/test_lifecycle_and_pdf_scripts.py` | ✅ real |
-| AC16.13.4 | yes | test_lifecycle — get_test_db_name and get_s3_bucket format names deterministically | real: `scripts/tests/test_lifecycle_and_pdf_scripts.py` | ✅ real |
+| AC16.13.4 | yes | test_lifecycle — get_test_db_name and get_s3_bucket format bounded names deterministically | real: `scripts/tests/test_lifecycle_and_pdf_scripts.py` | ✅ real |
 | AC16.13.5 | yes | test_lifecycle — load_active_namespaces returns [] on missing or corrupted tracker file | real: `scripts/tests/test_lifecycle_and_pdf_scripts.py` | ✅ real |
 | AC16.13.6 | yes | test_lifecycle — register_namespace and unregister_namespace update active namespace tracker | real: `scripts/tests/test_lifecycle_and_pdf_scripts.py` | ✅ real |
 | AC16.13.7 | yes | test_lifecycle — get_container_runtime detects podman/docker and returns None when absent | real: `scripts/tests/test_lifecycle_and_pdf_scripts.py` | ✅ real |

--- a/docs/ssot/development.md
+++ b/docs/ssot/development.md
@@ -102,6 +102,8 @@ Live docs: [wangzitian0.github.io/finance_report](https://wangzitian0.github.io/
 - Worker Databases: `finance_report_test_{namespace}_gw0`, `gw1`, etc. (pytest-xdist)
 - S3 Buckets: `statements-{namespace}`
 
+Long branch/workspace namespaces are shortened deterministically with an 8-character hash suffix before resource creation. This keeps PostgreSQL identifiers and S3-compatible bucket names within their 63-character limits while preserving stable local/CI isolation.
+
 **Usage**:
 ```bash
 BRANCH_NAME=feature-auth moon run :test                    # Explicit namespace
@@ -124,7 +126,7 @@ moon run :test                                             # Auto-detect from gi
 | Function | Input | Output | Purpose |
 |----------|-------|--------|---------|
 | `get_test_db_name(namespace)` | `"feature_auth"` | `"finance_report_test_feature_auth"` | Test database |
-| `get_s3_bucket(namespace)` | `"feature_auth"` | `"statements-feature_auth"` | S3 bucket |
+| `get_s3_bucket(namespace)` | `"feature_auth"` | `"statements-feature-auth"` | S3 bucket |
 | `get_env_suffix(namespace)` | `"feature_auth"` | `"-feature_auth"` | Compose suffix |
 | `sanitize_namespace(name)` | `"feature/auth-v2"` | `"feature_auth_v2"` | Safe identifier |
 

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -36,7 +36,7 @@
 **Local CI** — Reuses Local Dev containers, creates **temporary test databases**:
 - Uses same `docker-compose.yml` (Profile: `infra`)
 - **Ephemeral data**: Test DB reset before each run, worker DBs auto-cleaned
-- Isolation: `finance_report_test_{namespace}` + worker DBs (`_gw0`, `_gw1`, etc.)
+- Isolation: `finance_report_test_{namespace}` + worker DBs (`_gw0`, `_gw1`, etc.); long namespaces are hash-shortened to keep DB names and `statements-{namespace}` buckets within 63-character backend limits.
 - Command: `moon run :lint && moon run :test` (**matches GitHub CI exactly**)
 
 ### GitHub Environments

--- a/docs/ssot/tdd.md
+++ b/docs/ssot/tdd.md
@@ -81,6 +81,8 @@ generated.
 | Generated report reference without test behavior | No | Traceability only |
 | `_ac_stubs` reference | No | Fails mandatory AC gate |
 | `expect(true).toBe(true)` or pure `pass` | No | Placeholder debt |
+| `scripts/tests` registered AC reference | Yes | Tooling/CI behavior proof; synthetic fixture IDs are excluded from invalid-ref counts |
+| Strikethrough deprecated AC | Not required | Excluded from active coverage and untested counts |
 | Manual verification | Not automated proof | Convert or mark as explicit manual gate |
 
 Manual verification cleanup is tracked in

--- a/scripts/analyze_test_ac_coverage.py
+++ b/scripts/analyze_test_ac_coverage.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Analyze AC-to-test coverage across backend, frontend, and E2E suites.
+"""Analyze AC-to-test coverage across backend, frontend, scripts, and E2E suites.
 
 This analyzer scans AC references (``ACx.y.z``) in:
 - ``apps/backend/tests/**/*.py``
 - ``apps/frontend/src/**/*.test.ts(x)``
+- ``scripts/tests/**/*.py``
 - ``tests/e2e/**/*.py``
 - ``repo/e2e_regressions/**/*.py`` (when present)
 
@@ -12,6 +13,7 @@ Coverage accounting follows EPIC-008 rules:
   as passing-test candidates.
 - ``_ac_stubs``, trivial assertions, pure ``pass``, and pure skipped tests are
   excluded from covered counts.
+- Deprecated strikethrough ACs are excluded from coverage/untested counts.
 - Invalid/unregistered AC references are reported with file paths.
 - Registered ACs missing real references are reported as untested.
 """
@@ -42,6 +44,7 @@ SCAN_TARGETS: tuple[tuple[str, Path, tuple[str, ...]], ...] = (
         REPO_ROOT / "apps" / "frontend" / "src",
         ("**/*.test.ts", "**/*.test.tsx"),
     ),
+    ("scripts_tests", REPO_ROOT / "scripts" / "tests", ("**/*.py",)),
     ("e2e", REPO_ROOT / "tests" / "e2e", ("**/*.py",)),
     ("repo_e2e", REPO_ROOT / "repo" / "e2e_regressions", ("**/*.py",)),
 )
@@ -53,6 +56,7 @@ class ACRecord:
     epic: int
     epic_name: str
     description: str
+    deprecated: bool = False
 
 
 @dataclass
@@ -86,6 +90,7 @@ class AnalysisResult:
     invalid_real_refs: dict[str, list[str]]
     invalid_placeholder_refs: dict[str, list[str]]
     invalid_stub_refs: dict[str, list[str]]
+    deprecated_ids: set[str]
 
 
 @dataclass
@@ -97,6 +102,7 @@ class EpicStats:
     placeholder_only: int = 0
     stub_only: int = 0
     untested: int = 0
+    deprecated: int = 0
 
 
 def _ac_sort_key(ac_id: str) -> tuple[int, ...]:
@@ -111,6 +117,24 @@ def _relative(path: Path, root: Path) -> str:
         return str(path)
 
 
+def _is_deprecated_description(description: str) -> bool:
+    stripped = description.strip()
+    return stripped.startswith("~~") and stripped.endswith("~~") and len(stripped) > 4
+
+
+def _is_ignored_script_fixture_invalid_ref(rel_path: str) -> bool:
+    path = Path(rel_path)
+    return (
+        len(path.parts) >= 2 and path.parts[0] == "scripts" and path.parts[1] == "tests"
+    )
+
+
+def _invalid_files(paths: set[str]) -> list[str]:
+    return sorted(
+        path for path in paths if not _is_ignored_script_fixture_invalid_ref(path)
+    )
+
+
 def load_registry(
     registry_paths: tuple[Path, ...] = DEFAULT_REGISTRY_PATHS,
 ) -> dict[str, ACRecord]:
@@ -123,12 +147,14 @@ def load_registry(
             ac_id = str(ac["id"])
             if ac_id in registry:
                 continue
+            description = str(ac.get("description", "")).strip()
             registry[ac_id] = ACRecord(
                 id=ac_id,
                 epic=int(ac["epic"]),
                 epic_name=str(ac.get("epic_name", "")).strip()
                 or f"EPIC-{int(ac['epic']):03d}",
-                description=str(ac.get("description", "")).strip(),
+                description=description,
+                deprecated=_is_deprecated_description(description),
             )
     return registry
 
@@ -209,16 +235,18 @@ def analyze_repo(repo_root: Path = REPO_ROOT) -> AnalysisResult:
     references, source_real_refs, source_placeholder_refs, source_stub_refs = (
         collect_references(scan_files, repo_root)
     )
+    active_registry_ids = {ac_id for ac_id, ac in registry.items() if not ac.deprecated}
+    deprecated_ids = {ac_id for ac_id, ac in registry.items() if ac.deprecated}
 
     covered_ids = {
         ac_id
         for ac_id, ref_stats in references.items()
-        if ac_id in registry and ref_stats.real_files
+        if ac_id in active_registry_ids and ref_stats.real_files
     }
     stub_only_ids = {
         ac_id
         for ac_id, ref_stats in references.items()
-        if ac_id in registry
+        if ac_id in active_registry_ids
         and not ref_stats.real_files
         and not ref_stats.placeholder_files
         and ref_stats.stub_files
@@ -226,30 +254,31 @@ def analyze_repo(repo_root: Path = REPO_ROOT) -> AnalysisResult:
     placeholder_only_ids = {
         ac_id
         for ac_id, ref_stats in references.items()
-        if ac_id in registry
+        if ac_id in active_registry_ids
         and not ref_stats.real_files
         and ref_stats.placeholder_files
     }
 
     untested_ids = sorted(
-        (ac_id for ac_id in registry if ac_id not in covered_ids),
+        (ac_id for ac_id in active_registry_ids if ac_id not in covered_ids),
         key=_ac_sort_key,
     )
 
     invalid_real_refs = {
-        ac_id: sorted(ref_stats.real_files)
+        ac_id: files
         for ac_id, ref_stats in references.items()
-        if ac_id not in registry and ref_stats.real_files
+        if ac_id not in registry and (files := _invalid_files(ref_stats.real_files))
     }
     invalid_stub_refs = {
-        ac_id: sorted(ref_stats.stub_files)
+        ac_id: files
         for ac_id, ref_stats in references.items()
-        if ac_id not in registry and ref_stats.stub_files
+        if ac_id not in registry and (files := _invalid_files(ref_stats.stub_files))
     }
     invalid_placeholder_refs = {
-        ac_id: sorted(ref_stats.placeholder_files)
+        ac_id: files
         for ac_id, ref_stats in references.items()
-        if ac_id not in registry and ref_stats.placeholder_files
+        if ac_id not in registry
+        and (files := _invalid_files(ref_stats.placeholder_files))
     }
 
     source_real_ref_counts = {
@@ -285,6 +314,7 @@ def analyze_repo(repo_root: Path = REPO_ROOT) -> AnalysisResult:
         invalid_stub_refs=dict(
             sorted(invalid_stub_refs.items(), key=lambda item: _ac_sort_key(item[0]))
         ),
+        deprecated_ids=deprecated_ids,
     )
 
 
@@ -295,7 +325,9 @@ def _epic_stats(result: AnalysisResult) -> list[EpicStats]:
             ac.epic, EpicStats(epic=ac.epic, epic_name=ac.epic_name)
         )
         stats.registered += 1
-        if ac.id in result.covered_ids:
+        if ac.id in result.deprecated_ids:
+            stats.deprecated += 1
+        elif ac.id in result.covered_ids:
             stats.covered += 1
         elif ac.id in result.placeholder_only_ids:
             stats.placeholder_only += 1
@@ -323,6 +355,7 @@ def _render_file_list(paths: list[str]) -> str:
 
 def render_markdown(result: AnalysisResult, generated_at: datetime) -> str:
     total_registered = len(result.registry)
+    active_registered = total_registered - len(result.deprecated_ids)
     covered_count = len(result.covered_ids)
     placeholder_only_count = len(result.placeholder_only_ids)
     stub_only_count = len(result.stub_only_ids)
@@ -332,7 +365,7 @@ def render_markdown(result: AnalysisResult, generated_at: datetime) -> str:
     invalid_stub_count = len(result.invalid_stub_refs)
 
     coverage_pct = (
-        (covered_count / total_registered * 100.0) if total_registered else 100.0
+        (covered_count / active_registered * 100.0) if active_registered else 100.0
     )
 
     lines: list[str] = []
@@ -357,7 +390,13 @@ def render_markdown(result: AnalysisResult, generated_at: datetime) -> str:
         "- `_ac_stubs` references are tracked as placeholders (`stub-only`) and **do not** count as covered."
     )
     lines.append(
-        "- Invalid AC references are AC IDs found in tests but missing from registries."
+        "- Strikethrough deprecated ACs are excluded from active coverage and untested counts."
+    )
+    lines.append(
+        "- Synthetic AC IDs inside `scripts/tests` fixtures are excluded from invalid-ref counts; fixture-only mismatches are audited separately."
+    )
+    lines.append(
+        "- Invalid AC references are other AC IDs found in tests but missing from registries."
     )
     lines.append(
         "- Untested AC = registered AC without any real passing-test candidate reference."
@@ -368,12 +407,16 @@ def render_markdown(result: AnalysisResult, generated_at: datetime) -> str:
     lines.append("| Metric | Count |")
     lines.append("|---|---:|")
     lines.append(f"| Registered ACs | {total_registered} |")
+    lines.append(f"| Active ACs | {active_registered} |")
+    lines.append(
+        f"| Deprecated ACs excluded from coverage gate | {len(result.deprecated_ids)} |"
+    )
     lines.append(
         f"| Covered by real test candidates | {covered_count} ({coverage_pct:.1f}%) |"
     )
     lines.append(f"| Placeholder-only assertions | {placeholder_only_count} |")
     lines.append(f"| Stub-only placeholders (`_ac_stubs`) | {stub_only_count} |")
-    lines.append(f"| Registered but untested | {untested_count} |")
+    lines.append(f"| Active registered but untested | {untested_count} |")
     lines.append(f"| Invalid AC refs in real tests | {invalid_real_count} |")
     lines.append(f"| Invalid AC refs in placeholders | {invalid_placeholder_count} |")
     lines.append(f"| Invalid AC refs in stubs | {invalid_stub_count} |")
@@ -397,16 +440,19 @@ def render_markdown(result: AnalysisResult, generated_at: datetime) -> str:
     lines.append("## Coverage by EPIC")
     lines.append("")
     lines.append(
-        "| EPIC | Name | Registered | Covered | Placeholder-only | Stub-only | Untested | Coverage |"
+        "| EPIC | Name | Registered | Deprecated | Covered | Placeholder-only | Stub-only | Untested | Coverage |"
     )
-    lines.append("|---|---|---:|---:|---:|---:|---:|---:|")
+    lines.append("|---|---|---:|---:|---:|---:|---:|---:|---:|")
     for epic in _epic_stats(result):
+        active_epic_registered = epic.registered - epic.deprecated
         epic_coverage_pct = (
-            epic.covered / epic.registered * 100.0 if epic.registered else 100.0
+            epic.covered / active_epic_registered * 100.0
+            if active_epic_registered
+            else 100.0
         )
         lines.append(
             f"| EPIC-{epic.epic:03d} | {epic.epic_name} | {epic.registered} | "
-            f"{epic.covered} | {epic.placeholder_only} | {epic.stub_only} | "
+            f"{epic.deprecated} | {epic.covered} | {epic.placeholder_only} | {epic.stub_only} | "
             f"{epic.untested} | {epic_coverage_pct:.1f}% |"
         )
     lines.append("")
@@ -464,7 +510,7 @@ def render_markdown(result: AnalysisResult, generated_at: datetime) -> str:
         lines.append("No placeholder-only AC assertions found.")
     lines.append("")
 
-    lines.append("## Registered ACs with no real test reference")
+    lines.append("## Active registered ACs with no real test reference")
     lines.append("")
     grouped_untested = _group_untested_by_epic(result)
     if grouped_untested:
@@ -477,7 +523,7 @@ def render_markdown(result: AnalysisResult, generated_at: datetime) -> str:
             lines.append(", ".join(f"`{ac_id}`" for ac_id in ac_ids))
             lines.append("")
     else:
-        lines.append("All registered ACs have at least one real test reference.")
+        lines.append("All active registered ACs have at least one real test reference.")
         lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"
@@ -521,7 +567,8 @@ def main() -> int:
     print(f"Wrote AC coverage report: {output_path}")
     print(
         "Summary: "
-        f"registered={len(result.registry)}, covered={len(result.covered_ids)}, "
+        f"registered={len(result.registry)}, active={len(result.registry) - len(result.deprecated_ids)}, "
+        f"covered={len(result.covered_ids)}, "
         f"placeholder_only={len(result.placeholder_only_ids)}, "
         f"stub_only={len(result.stub_only_ids)}, untested={len(result.untested_ids)}, "
         f"invalid_real={len(result.invalid_real_refs)}"

--- a/scripts/test_lifecycle.py
+++ b/scripts/test_lifecycle.py
@@ -33,6 +33,10 @@ BACKEND_DIR = REPO_ROOT / "apps" / "backend"
 DB_CONTAINER_PREFIX = "finance-report-db"
 CACHE_DIR = Path.home() / ".cache" / "finance_report"
 ACTIVE_NAMESPACES_FILE = CACHE_DIR / "active_namespaces.json"
+MAX_POSTGRES_IDENTIFIER_LENGTH = 63
+TEST_DB_PREFIX = "finance_report_test_"
+MAX_NAMESPACE_LENGTH = MAX_POSTGRES_IDENTIFIER_LENGTH - len(TEST_DB_PREFIX)
+MAX_S3_BUCKET_LENGTH = 63
 
 # ANSI Colors
 GREEN = "\033[92m"
@@ -42,6 +46,7 @@ RESET = "\033[0m"
 
 
 # === Isolation Utilities (inlined from isolation_utils.py) ===
+
 
 def get_namespace() -> str:
     """Generate unique namespace for test isolation based on branch/repo."""
@@ -55,19 +60,25 @@ def get_namespace() -> str:
                 namespace = f"{namespace}_{_sanitize_namespace(workspace)}"
             except ValueError:
                 pass  # Invalid workspace ID, use branch-only namespace
-        return namespace
+        return _shorten_identifier(namespace, MAX_NAMESPACE_LENGTH, separator="_")
 
     # Git auto-detection with path hash
     try:
         result = subprocess.run(
             ["git", "branch", "--show-current"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         git_branch = result.stdout.strip()
         if git_branch:
             namespace = _sanitize_namespace(git_branch)
-            path_hash = hashlib.sha256(str(Path.cwd().absolute()).encode()).hexdigest()[:8]
-            return f"{namespace}_{path_hash}"
+            path_hash = hashlib.sha256(str(Path.cwd().absolute()).encode()).hexdigest()[
+                :8
+            ]
+            return _shorten_identifier(
+                f"{namespace}_{path_hash}", MAX_NAMESPACE_LENGTH, separator="_"
+            )
     except Exception:
         pass  # Git command failed or not a git repo, fall through to default
 
@@ -90,17 +101,44 @@ def _sanitize_namespace(name: str) -> str:
     return safe
 
 
+def _shorten_identifier(value: str, max_length: int, separator: str = "_") -> str:
+    """Shorten a stable identifier and preserve uniqueness with a hash suffix."""
+    if len(value) <= max_length:
+        return value
+
+    digest = hashlib.sha256(value.encode()).hexdigest()[:8]
+    prefix_length = max_length - len(separator) - len(digest)
+    if prefix_length < 1:
+        raise ValueError(f"Identifier max_length too short: {max_length}")
+
+    prefix = value[:prefix_length].rstrip("_-")
+    return f"{prefix}{separator}{digest}"
+
+
 def get_test_db_name(namespace: str) -> str:
     """Generate test database name from namespace."""
-    return f"finance_report_test_{namespace}"
+    safe_namespace = _shorten_identifier(namespace, MAX_NAMESPACE_LENGTH, separator="_")
+    return f"{TEST_DB_PREFIX}{safe_namespace}"
 
 
 def get_s3_bucket(namespace: str, base_bucket: str = "statements") -> str:
     """Generate S3 bucket name from namespace."""
-    return f"{base_bucket}-{namespace.replace('_', '-')}"
+    safe_namespace = namespace.replace("_", "-")
+    bucket = f"{base_bucket}-{safe_namespace}"
+    if len(bucket) <= MAX_S3_BUCKET_LENGTH:
+        return bucket
+
+    digest = hashlib.sha256(bucket.encode()).hexdigest()[:8]
+    prefix_length = MAX_S3_BUCKET_LENGTH - len(base_bucket) - 2 - len(digest)
+    if prefix_length < 1:
+        raise ValueError(f"Base bucket name too long: {base_bucket}")
+
+    prefix = safe_namespace[:prefix_length].rstrip("-")
+    return f"{base_bucket}-{prefix}-{digest}"
 
 
 # === Logging ===
+
 
 def log(msg, color=RESET):
     print(f"{color}{msg}{RESET}")
@@ -181,6 +219,7 @@ def cleanup_orphan_databases(runtime, container_name):
         # Keep databases that belong to current or active namespaces
         # Database naming: finance_report_test_{namespace} or finance_report_test_{namespace}_gwX
         import re
+
         db_pattern = re.compile(r"^finance_report_test_([^_]+(?:_[^_]+)*?)(?:_gw\d+)?$")
 
         orphan_dbs = []
@@ -189,7 +228,10 @@ def cleanup_orphan_databases(runtime, container_name):
             if match:
                 db_namespace = match.group(1)
                 # Keep if it's the current namespace or in active list
-                if db_namespace != current_namespace and db_namespace not in active_namespaces:
+                if (
+                    db_namespace != current_namespace
+                    and db_namespace not in active_namespaces
+                ):
                     orphan_dbs.append(db)
             elif db == "finance_report_test":
                 # Legacy database without namespace, safe to drop
@@ -211,7 +253,7 @@ def cleanup_orphan_databases(runtime, container_name):
                     "-U",
                     "postgres",
                     "-c",
-                    f"DROP DATABASE IF EXISTS \"{db_name}\";",
+                    f'DROP DATABASE IF EXISTS "{db_name}";',
                 ],
                 capture_output=True,
             )
@@ -221,8 +263,13 @@ def cleanup_orphan_databases(runtime, container_name):
         # Also clear stale namespaces from the file
         stale_namespaces = [ns for ns in active_namespaces if ns != current_namespace]
         if stale_namespaces:
-            save_active_namespaces([current_namespace] if current_namespace in active_namespaces else [])
-            log(f"   Cleared {len(stale_namespaces)} stale namespace(s) from tracking.", YELLOW)
+            save_active_namespaces(
+                [current_namespace] if current_namespace in active_namespaces else []
+            )
+            log(
+                f"   Cleared {len(stale_namespaces)} stale namespace(s) from tracking.",
+                YELLOW,
+            )
 
     except subprocess.CalledProcessError as e:
         log(f"   Warning: Failed to check orphaned databases: {e}", YELLOW)
@@ -348,18 +395,23 @@ def test_database(ephemeral=False):
     # This ensures container_name: finance-report-db${ENV_SUFFIX} is unique
     env_suffix = f"-{namespace}"
     project_name = f"finance-report-{namespace}"
-    
+
     # Inject ENV_SUFFIX into environment for subprocess
     env = os.environ.copy()
     env["ENV_SUFFIX"] = env_suffix
-    
+
     compose_cmd = [runtime, "compose", "-p", project_name, "-f", str(COMPOSE_FILE)]
 
-    log(f"🐘 Ensuring infrastructure is up (Project: {project_name}, Suffix: {env_suffix})...", YELLOW)
+    log(
+        f"🐘 Ensuring infrastructure is up (Project: {project_name}, Suffix: {env_suffix})...",
+        YELLOW,
+    )
     try:
         # Start infrastructure services if not running
         # Use --profile infra to only start infra services if needed
-        subprocess.run([*compose_cmd, "--profile", "infra", "up", "-d"], env=env, check=True)
+        subprocess.run(
+            [*compose_cmd, "--profile", "infra", "up", "-d"], env=env, check=True
+        )
 
         # Wait for postgres to be ready
         container_name = f"finance-report-db{env_suffix}"
@@ -413,13 +465,16 @@ def test_database(ephemeral=False):
             "-U",
             "postgres",
             "-c",
-            f"DROP DATABASE IF EXISTS \"{test_db_name}\" WITH (FORCE);",
+            f'DROP DATABASE IF EXISTS "{test_db_name}" WITH (FORCE);',
         ],
         capture_output=True,
         text=True,
     )
     if drop_res.returncode != 0:
-        log(f"   Warning: DROP DATABASE failed (might be expected if DB doesn't exist): {drop_res.stderr.strip()}", YELLOW)
+        log(
+            f"   Warning: DROP DATABASE failed (might be expected if DB doesn't exist): {drop_res.stderr.strip()}",
+            YELLOW,
+        )
 
     subprocess.run(
         [
@@ -430,7 +485,7 @@ def test_database(ephemeral=False):
             "-U",
             "postgres",
             "-c",
-            f"CREATE DATABASE \"{test_db_name}\";",
+            f'CREATE DATABASE "{test_db_name}";',
         ],
         check=True,
         capture_output=True,
@@ -485,7 +540,7 @@ def test_database(ephemeral=False):
                     "-U",
                     "postgres",
                     "-c",
-                    f"DROP DATABASE IF EXISTS \"{test_db_name}\";",
+                    f'DROP DATABASE IF EXISTS "{test_db_name}";',
                 ],
                 capture_output=True,
                 check=True,
@@ -496,20 +551,28 @@ def test_database(ephemeral=False):
 
         # Stop and remove infrastructure if ephemeral mode is on
         if ephemeral:
-            log(f"🌬️  Ephemeral mode: Tearing down infrastructure ({project_name})...", YELLOW)
+            log(
+                f"🌬️  Ephemeral mode: Tearing down infrastructure ({project_name})...",
+                YELLOW,
+            )
             try:
                 subprocess.run([*compose_cmd, "down", "-v"], env=env, check=True)
                 log(f"   ✅ Resources released for {project_name}.", GREEN)
-                
+
                 # Explicit pod cleanup if using podman
                 if runtime == "podman":
                     pod_name = f"pod_{project_name}"
                     log(f"📦 Checking for lingering pod: {pod_name}...", YELLOW)
-                    subprocess.run(["podman", "pod", "rm", "-f", pod_name], capture_output=True)
+                    subprocess.run(
+                        ["podman", "pod", "rm", "-f", pod_name], capture_output=True
+                    )
             except subprocess.CalledProcessError as e:
                 log(f"   Warning: Failed to teardown infrastructure: {e}", YELLOW)
         else:
-            log(f"📌 Persistent mode: Keeping infrastructure running ({project_name}).", YELLOW)
+            log(
+                f"📌 Persistent mode: Keeping infrastructure running ({project_name}).",
+                YELLOW,
+            )
 
         # Unregister namespace after successful cleanup
         unregister_namespace(namespace)
@@ -518,10 +581,22 @@ def test_database(ephemeral=False):
 def main():
     import argparse
 
-    parser = argparse.ArgumentParser(description="Run backend tests with DB lifecycle management")
-    parser.add_argument("--fast", action="store_true", help="Fast mode: no coverage, -n 4")
-    parser.add_argument("--smart", action="store_true", help="Smart mode: coverage on changed files only")
-    parser.add_argument("--ephemeral", action="store_true", help="Ephemeral mode: destroy all infrastructure after run")
+    parser = argparse.ArgumentParser(
+        description="Run backend tests with DB lifecycle management"
+    )
+    parser.add_argument(
+        "--fast", action="store_true", help="Fast mode: no coverage, -n 4"
+    )
+    parser.add_argument(
+        "--smart",
+        action="store_true",
+        help="Smart mode: coverage on changed files only",
+    )
+    parser.add_argument(
+        "--ephemeral",
+        action="store_true",
+        help="Ephemeral mode: destroy all infrastructure after run",
+    )
     # Use parse_known_args for transparent pytest flag pass-through (-k, -m, etc.)
     args, extra_pytest_args = parser.parse_known_args()
 
@@ -539,9 +614,12 @@ def main():
     if args.fast:
         log("🚀 Fast Mode: No coverage, -n 4", GREEN)
         pytest_args = [
-            "-n", "4",
-            "-m", "not slow and not e2e",
-            "--dist", "worksteal",
+            "-n",
+            "4",
+            "-m",
+            "not slow and not e2e",
+            "--dist",
+            "worksteal",
             "--tb=short",
             "--no-cov",  # Override pyproject.toml addopts
         ]
@@ -549,9 +627,12 @@ def main():
         log("🧪 Smart Mode: Coverage on changed files only", GREEN)
         changed_modules = _get_changed_files()
         pytest_args = [
-            "-n", "4",
-            "-m", "not slow and not e2e",
-            "--dist", "worksteal",
+            "-n",
+            "4",
+            "-m",
+            "not slow and not e2e",
+            "--dist",
+            "worksteal",
             "--no-cov",  # Override pyproject.toml addopts first
         ]
         if changed_modules:
@@ -562,19 +643,23 @@ def main():
                 log(f"   • ... and {len(changed_modules) - 5} more", YELLOW)
             for module in changed_modules:
                 pytest_args.append(f"--cov={module}")
-            pytest_args.extend([
-                "--cov-report=term-missing",
-                "--cov-branch",
-                "--cov-fail-under=99",
-            ])
+            pytest_args.extend(
+                [
+                    "--cov-report=term-missing",
+                    "--cov-branch",
+                    "--cov-fail-under=99",
+                ]
+            )
         else:
             log("   No changes detected, running full coverage", YELLOW)
-            pytest_args.extend([
-                "--cov=src",
-                "--cov-report=term-missing",
-                "--cov-branch",
-                "--cov-fail-under=94",
-            ])
+            pytest_args.extend(
+                [
+                    "--cov=src",
+                    "--cov-report=term-missing",
+                    "--cov-branch",
+                    "--cov-fail-under=94",
+                ]
+            )
     else:
         # Default mode: use pyproject.toml addopts (includes coverage)
         pass

--- a/scripts/tests/test_analyze_test_ac_coverage.py
+++ b/scripts/tests/test_analyze_test_ac_coverage.py
@@ -59,6 +59,20 @@ groups:
         epic_name: frontend-placeholders
         description: placeholder-only assertion
         mandatory: true
+  AC6:
+    AC6.6:
+      - id: AC6.6.6
+        epic: 6
+        epic_name: script-tests
+        description: script test real
+        mandatory: true
+  AC7:
+    AC7.7:
+      - id: AC7.7.7
+        epic: 7
+        epic_name: deprecated
+        description: "~~removed behavior~~"
+        mandatory: true
 """.strip()
             + "\n",
             encoding="utf-8",
@@ -73,12 +87,14 @@ groups:
         frontend = repo_root / "apps" / "frontend" / "src" / "__tests__"
         e2e = repo_root / "tests" / "e2e"
         repo_e2e = repo_root / "repo" / "e2e_regressions"
+        scripts_tests = repo_root / "scripts" / "tests"
         stubs = backend / "_ac_stubs"
 
         backend.mkdir(parents=True, exist_ok=True)
         frontend.mkdir(parents=True, exist_ok=True)
         e2e.mkdir(parents=True, exist_ok=True)
         repo_e2e.mkdir(parents=True, exist_ok=True)
+        scripts_tests.mkdir(parents=True, exist_ok=True)
         stubs.mkdir(parents=True, exist_ok=True)
 
         (backend / "test_backend_real.py").write_text(
@@ -103,6 +119,14 @@ groups:
             "# AC2.2.1\n",
             encoding="utf-8",
         )
+        (scripts_tests / "test_tooling_contract.py").write_text(
+            "# AC6.6.6\n# AC77.7.7\n",
+            encoding="utf-8",
+        )
+        (scripts_tests / "test_generate_ac_registry.py").write_text(
+            "# AC99.1.1\n",
+            encoding="utf-8",
+        )
         (stubs / "test_placeholder.py").write_text(
             "import pytest\n# AC99.3.3\n# AC8.12.7\ndef test_stub():\n    pytest.skip('placeholder')\n",
             encoding="utf-8",
@@ -120,10 +144,12 @@ groups:
         assert result.source_file_counts["backend"] == 2
         assert result.source_file_counts["frontend"] == 2
         assert result.source_placeholder_ref_counts["frontend"] == 2
+        assert result.source_file_counts["scripts_tests"] == 2
         assert result.source_file_counts["e2e"] == 1
         assert result.source_file_counts["repo_e2e"] == 1
 
-        assert result.covered_ids == {"AC1.1.1", "AC1.1.2", "AC2.2.1"}
+        assert result.covered_ids == {"AC1.1.1", "AC1.1.2", "AC2.2.1", "AC6.6.6"}
+        assert result.deprecated_ids == {"AC7.7.7"}
         assert result.placeholder_only_ids == {"AC5.5.5"}
         assert result.stub_only_ids == {"AC99.3.3"}
         assert result.untested_ids == ["AC4.4.4", "AC5.5.5", "AC99.3.3"]
@@ -138,6 +164,8 @@ groups:
             "apps/frontend/src/__tests__/dashboard.test.tsx"
             in result.invalid_real_refs["AC18.4.4"]
         )
+        assert "AC77.7.7" not in result.invalid_real_refs
+        assert "AC99.1.1" not in result.invalid_real_refs
 
         assert "AC8.12.7" in result.invalid_stub_refs
         assert (
@@ -163,13 +191,17 @@ groups:
 
         assert "Coverage accounting (EPIC-008 aligned)" in report
         assert "Scan scope summary" in report
+        assert "scripts_tests" in report
+        assert "Deprecated ACs excluded from coverage gate" in report
         assert "Invalid AC references (unregistered)" in report
         assert "`AC18.4.4`" in report
         assert "`AC9.9.9`" in report
+        assert "`AC77.7.7`" not in report
+        assert "`AC99.1.1`" not in report
         assert "Placeholder-only AC assertions" in report
         assert "`AC19.1.1`" in report
         assert "Stub-only AC placeholders (`_ac_stubs`)" in report
-        assert "Registered ACs with no real test reference" in report
+        assert "Active registered ACs with no real test reference" in report
         assert "EPIC-003 (placeholders) — 1 untested" in report
         assert "EPIC-004 (untested) — 1 untested" in report
         assert "EPIC-005 (frontend-placeholders) — 1 untested" in report

--- a/scripts/tests/test_ci_metrics_contract.py
+++ b/scripts/tests/test_ci_metrics_contract.py
@@ -171,7 +171,10 @@ def test_AC8_13_26_repo_contract_reports_missing_tokens(tmp_path):
     assert any("--failure-confirmation-seconds" in error for error in errors)
     assert "CI metrics contract must run before coverage policy audit" in errors
     assert any("AC traceability is a reference metric" in error for error in errors)
-    assert any("Coveralls success with no external base comparison" in error for error in errors)
+    assert any(
+        "Coveralls success with no external base comparison" in error
+        for error in errors
+    )
     assert any("New `apps/*/src`" in error for error in errors)
     assert any("not behavioral coverage" in error for error in errors)
 

--- a/scripts/tests/test_lifecycle_and_pdf_scripts.py
+++ b/scripts/tests/test_lifecycle_and_pdf_scripts.py
@@ -65,6 +65,16 @@ def test_AC16_13_4_name_helpers():
     assert tl.get_test_db_name("abc") == "finance_report_test_abc"
     assert tl.get_s3_bucket("feature_a") == "statements-feature-a"
 
+    long_namespace = "codex_issue_490_testing_strategy_ac_coverage_0bb5607e"
+    db_name = tl.get_test_db_name(long_namespace)
+    bucket = tl.get_s3_bucket(long_namespace)
+
+    assert len(db_name) <= 63
+    assert db_name.startswith("finance_report_test_")
+    assert len(bucket) <= 63
+    assert bucket.startswith("statements-")
+    assert "_" not in bucket
+
 
 def test_AC16_13_5_load_active_namespaces_missing_and_corrupt(monkeypatch, tmp_path):
     tracker = tmp_path / "active_namespaces.json"

--- a/scripts/tests/test_pdf_fixture_parseable.py
+++ b/scripts/tests/test_pdf_fixture_parseable.py
@@ -11,6 +11,7 @@ DBS_DATE_PATTERN = re.compile(r"^\d{2}/\d{2}/\d{4}$")
 CMB_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 MARI_DATE_PATTERN = re.compile(r"^\d{2}\s[A-Z]{3}$")
 FUTU_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+PINGAN_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _parse_decimal(raw: str) -> Decimal:
@@ -99,6 +100,17 @@ def _extract_futu_rows(tables: list[list[list[str | None]]]) -> list[list[str]]:
     return rows
 
 
+def _extract_brokerage_rows(tables: list[list[list[str | None]]]) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for table in tables:
+        for row in table:
+            if not row or len(row) < 5:
+                continue
+            if row[0] and FUTU_DATE_PATTERN.match(row[0].strip()):
+                rows.append([cell.strip() if cell else "" for cell in row[:5]])
+    return rows
+
+
 def _extract_mari_summary_balances(
     text: str,
     tables: list[list[list[str | None]]],
@@ -120,7 +132,9 @@ def _extract_mari_summary_balances(
         matches = sgd_pattern.findall(line)
         if len(matches) >= 4:
             # opening=matches[0], outgoing=matches[1], incoming=matches[2], closing=matches[3]
-            return Decimal(matches[0].replace(",", "")), Decimal(matches[3].replace(",", ""))
+            return Decimal(matches[0].replace(",", "")), Decimal(
+                matches[3].replace(",", "")
+            )
     raise AssertionError(
         "Mari account summary table with opening/ending balance not found"
     )
@@ -151,6 +165,54 @@ def test_ac8_13_10_futu_generated_pdf_parseable(tmp_path: Path) -> None:
     assert rows[0][2] == "Stock and options valuation"
     assert _parse_decimal(rows[0][3]) == Decimal("323730.00")
     assert all(FUTU_DATE_PATTERN.match(row[0]) for row in rows)
+
+
+def test_ac8_13_10_moomoo_generated_pdf_parseable(tmp_path: Path) -> None:
+    moomoo_generator = import_module("generators.moomoo_generator").MoomooGenerator
+    output_path = tmp_path / "moomoo" / "test_moomoo.pdf"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    generator = moomoo_generator(
+        Path(__file__).parent.parent
+        / "pdf_fixtures"
+        / "templates"
+        / "moomoo_template.yaml"
+    )
+    generator.generate(output_path, datetime(2025, 1, 1), datetime(2025, 1, 31))
+
+    _assert_valid_pdf(output_path)
+    text, tables = _read_pdf_text_and_tables(output_path)
+    rows = _extract_brokerage_rows(tables)
+
+    assert "Moomoo SG - Monthly Statement" in text
+    assert "Fullerton SGD Money Market Fund" in text
+    assert len(rows) == 10
+    assert rows[0][1] == "SUBSCRIPTION"
+    assert rows[0][4] == "SGD"
+
+
+def test_ac9_3_6_pingan_generated_pdf_dates_and_balances(tmp_path: Path) -> None:
+    pingan_generator = import_module("generators.pingan_generator").PinganGenerator
+    output_path = tmp_path / "pingan" / "test_pingan.pdf"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    generator = pingan_generator(
+        Path(__file__).parent.parent
+        / "pdf_fixtures"
+        / "templates"
+        / "pingan_template.yaml"
+    )
+    generator.generate(output_path, datetime(2025, 1, 1), datetime(2025, 1, 31))
+
+    _assert_valid_pdf(output_path)
+    _text, tables = _read_pdf_text_and_tables(output_path)
+    rows = _extract_brokerage_rows(tables)
+
+    assert len(rows) == 15
+    assert all(PINGAN_DATE_PATTERN.match(row[0]) for row in rows)
+    for row in rows:
+        _parse_decimal(row[2])
+        _parse_decimal(row[3])
 
 
 def test_ac8_13_10_futu_fake_data_count_boundaries() -> None:
@@ -393,7 +455,9 @@ def test_ac9_3_6_date_formats_correct_per_source(tmp_path: Path) -> None:
     assert all(CMB_DATE_PATTERN.match(row[0]) for row in cmb_rows)
     assert all(MARI_DATE_PATTERN.match(row[0]) for row in mari_rows)
 
+
 # -- AC9.3.7: TemplateExtractor unit tests ------------------------------------
+
 
 def _get_template_extractor():
     cls = import_module("analyzers.template_extractor").TemplateExtractor

--- a/scripts/tests/test_pdf_fixture_tooling_coverage.py
+++ b/scripts/tests/test_pdf_fixture_tooling_coverage.py
@@ -1,0 +1,490 @@
+"""AC9.1.1 AC9.1.3 AC9.2.5 AC9.3.1 AC9.7.1 AC9.7.2: PDF fixture tooling behavior."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from analyzers import analyze_pdf as analyze_pdf_cli
+from analyzers.pdf_analyzer import PDFAnalyzer, TemplateExtractor
+from data.fake_data import (
+    generate_cmb_transactions,
+    generate_dbs_transactions,
+    generate_mari_transactions,
+    generate_moomoo_transactions,
+    generate_pingan_transactions,
+)
+from generators import font_utils
+import generate_pdf_fixtures
+from validators.pdf_validator import PDFValidator
+
+
+class _FakePdf:
+    def __init__(self, pages: list[object]) -> None:
+        self.pages = pages
+
+    def __enter__(self) -> "_FakePdf":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def test_AC9_1_1_analyzer_extracts_page_table_and_text_positions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9.1.1: PDF analyzer extracts format metadata without transaction payloads."""
+    page = SimpleNamespace(
+        width=595.27,
+        height=841.89,
+        extract_tables=lambda: [
+            [["Date", "Description", "Amount"], ["01/01/2025", "Coffee", "5.00"]]
+        ],
+        extract_text=lambda: "Statement Period\nTransaction Details\nBalance",
+    )
+    monkeypatch.setattr(
+        "analyzers.pdf_analyzer.pdfplumber.open", lambda _path: _FakePdf([page])
+    )
+
+    analysis = PDFAnalyzer().analyze(Path("statement.pdf"))
+
+    assert analysis["page"] == {"width": 595.27, "height": 841.89, "size": "A4"}
+    assert analysis["tables"][0]["header"] == ["Date", "Description", "Amount"]
+    assert analysis["tables"][0]["row_count"] == 1
+    assert analysis["text_positions"]["Transaction Details"]["found"] is True
+
+
+def test_AC9_1_1_analyzer_rejects_unreadable_pdf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9.1.1: PDF analyzer reports unreadable PDFs as deterministic errors."""
+
+    def raise_open(_path: Path) -> object:
+        raise RuntimeError("cannot parse")
+
+    monkeypatch.setattr("analyzers.pdf_analyzer.pdfplumber.open", raise_open)
+
+    with pytest.raises(ValueError, match="Failed to analyze PDF"):
+        PDFAnalyzer().analyze(Path("bad.pdf"))
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_first_column"),
+    [
+        ("dbs", "Date"),
+        ("cmb", "记账日期"),
+        ("mari", "DATE"),
+        ("moomoo", "Date"),
+        ("pingan", "交易日期"),
+    ],
+)
+def test_AC9_1_3_template_extractor_emits_source_table_schema(
+    source: str,
+    expected_first_column: str,
+) -> None:
+    """AC9.1.3: Analyzer CLI template extraction supports each committed source schema."""
+    template = TemplateExtractor().extract({"page": {"size": "A4"}}, source)
+
+    assert template["source"] == source
+    assert (
+        template["tables"]["transaction_details"]["columns"][0]["name"]
+        == expected_first_column
+    )
+
+
+def test_AC9_3_1_validator_reports_page_table_and_key_phrase_findings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9.3.1: PDF validator reports structural mismatches without throwing."""
+    page = SimpleNamespace(
+        width=612.0,
+        height=900.0,
+        extract_tables=lambda: [[["Wrong", "Header"], ["v1", "v2"]]],
+        extract_text=lambda: "Account Summary",
+    )
+    monkeypatch.setattr(
+        "validators.pdf_validator.pdfplumber.open", lambda _path: _FakePdf([page])
+    )
+
+    result = PDFValidator().validate_structure(
+        Path("generated.pdf"),
+        {
+            "page": {"width": 595.27, "height": 841.89},
+            "tables": {
+                "transaction_details": {
+                    "key_phrase": "Transaction Details",
+                    "columns": [
+                        {"name": "Date"},
+                        {"name": "Description"},
+                        {"name": "Amount"},
+                    ],
+                }
+            },
+        },
+    )
+
+    assert result["success"] is True
+    assert any("Page width mismatch" in warning for warning in result["warnings"])
+    assert any("Column count mismatch" in warning for warning in result["warnings"])
+    assert any(
+        "Key phrase 'Transaction Details' not found" in warning
+        for warning in result["warnings"]
+    )
+
+
+def test_AC9_3_1_validator_fails_empty_and_unreadable_pdfs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9.3.1: Empty or unreadable PDFs fail validation explicitly."""
+    monkeypatch.setattr(
+        "validators.pdf_validator.pdfplumber.open", lambda _path: _FakePdf([])
+    )
+    empty_result = PDFValidator().validate_structure(Path("empty.pdf"), {})
+    assert empty_result["success"] is False
+    assert empty_result["errors"] == ["PDF has no pages"]
+
+    def raise_open(_path: Path) -> object:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("validators.pdf_validator.pdfplumber.open", raise_open)
+    bad_result = PDFValidator().validate_structure(Path("bad.pdf"), {})
+    assert bad_result["success"] is False
+    assert bad_result["errors"] == ["Validation error: boom"]
+
+
+def test_AC9_3_1_validator_compares_real_and_generated_structure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9.3.1: Local real/generated comparison surfaces page and table differences."""
+    real_page = SimpleNamespace(extract_tables=lambda: [[["Date"]]])
+    generated_page = SimpleNamespace(extract_tables=lambda: [])
+    opened = iter([_FakePdf([real_page, real_page]), _FakePdf([generated_page])])
+    monkeypatch.setattr(
+        "validators.pdf_validator.pdfplumber.open", lambda _path: next(opened)
+    )
+
+    result = PDFValidator().compare_structure(Path("real.pdf"), Path("generated.pdf"))
+
+    assert result["success"] is True
+    assert "Page count: real=2, generated=1" in result["differences"]
+    assert "Table count: real=1, generated=0" in result["differences"]
+
+
+def test_AC9_3_1_validator_reports_compare_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9.3.1: Local PDF structure comparison reports parser failures."""
+
+    def raise_open(_path: Path) -> object:
+        raise RuntimeError("compare failed")
+
+    monkeypatch.setattr("validators.pdf_validator.pdfplumber.open", raise_open)
+
+    result = PDFValidator().compare_structure(Path("real.pdf"), Path("generated.pdf"))
+
+    assert result == {"success": False, "differences": [], "error": "compare failed"}
+
+
+def test_AC9_2_5_font_helpers_choose_safe_fonts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9.2.5: Font helpers gracefully fall back when CJK fonts are unavailable."""
+    monkeypatch.setattr(font_utils.Path, "exists", lambda _self: False)
+
+    assert font_utils.register_chinese_fonts() is None
+    assert font_utils.get_safe_font("SimSun") == "Helvetica"
+    assert font_utils.get_safe_font("SimHei-Bold") == "Helvetica-Bold"
+    assert (
+        font_utils.get_safe_font("UnknownFamily", chinese_font="ChineseFont")
+        == "ChineseFont"
+    )
+    assert font_utils.can_display_chinese("Helvetica") is False
+    assert font_utils.can_display_chinese("ChineseFont") is True
+
+
+def test_AC9_2_5_font_registration_accepts_otf_fonts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9.2.5: Font registration accepts installed OpenType fonts."""
+    registered: list[str] = []
+
+    def fake_ttfont(name: str, path: str, **_kwargs: object) -> tuple[str, str]:
+        return (name, path)
+
+    fake_pdfmetrics = SimpleNamespace(
+        registerFont=lambda font: registered.append(font[0]),
+        getRegisteredFontNames=lambda: registered,
+    )
+    monkeypatch.setattr(
+        font_utils.Path,
+        "exists",
+        lambda self: str(self).endswith("PingFangSC-Regular.otf"),
+    )
+    monkeypatch.setattr(font_utils, "TTFont", fake_ttfont)
+    monkeypatch.setattr(font_utils, "pdfmetrics", fake_pdfmetrics)
+
+    assert font_utils.register_chinese_fonts() == "ChineseFont"
+
+
+def test_AC9_2_5_font_registration_retries_ttc_subfonts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC9.2.5: Font registration retries TTC subfont indexes before falling back."""
+    registered: list[str] = []
+    attempted_subfonts: list[int | None] = []
+
+    def fake_ttfont(name: str, _path: str, **kwargs: object) -> tuple[str, str]:
+        subfont = kwargs.get("subfontIndex")
+        attempted_subfonts.append(subfont if isinstance(subfont, int) else None)
+        if subfont == 0:
+            raise RuntimeError("bad subfont")
+        return (name, "font")
+
+    fake_pdfmetrics = SimpleNamespace(
+        registerFont=lambda font: registered.append(font[0]),
+        getRegisteredFontNames=lambda: registered,
+    )
+    monkeypatch.setattr(
+        font_utils.Path,
+        "exists",
+        lambda self: str(self).endswith("STHeiti Medium.ttc"),
+    )
+    monkeypatch.setattr(font_utils, "TTFont", fake_ttfont)
+    monkeypatch.setattr(font_utils, "pdfmetrics", fake_pdfmetrics)
+
+    assert font_utils.register_chinese_fonts() == "ChineseFont"
+    assert attempted_subfonts == [0, 1]
+
+
+def test_AC9_2_5_font_registration_continues_after_ttf_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AC9.2.5: Font registration logs unusable TTF files and keeps scanning."""
+
+    def raise_ttfont(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("bad font")
+
+    monkeypatch.setattr(
+        font_utils.Path,
+        "exists",
+        lambda self: str(self).endswith("simhei.ttf"),
+    )
+    monkeypatch.setattr(font_utils, "TTFont", raise_ttfont)
+
+    assert font_utils.register_chinese_fonts() is None
+    assert "Warning: Failed to load font" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "generator",
+    [
+        generate_dbs_transactions,
+        generate_cmb_transactions,
+        generate_mari_transactions,
+        generate_moomoo_transactions,
+        generate_pingan_transactions,
+    ],
+)
+def test_AC9_2_6_fake_data_generators_keep_running_balances(generator) -> None:
+    """AC9.2.6: Fake transaction data returns deterministic counts and matching balances."""
+    opening_balance = generator.__defaults__[1]
+    transactions, closing_balance = generator(datetime(2025, 1, 1), count=3)
+
+    amount_key = "amount_decimal" if "amount_decimal" in transactions[0] else "amount"
+    expected_closing = opening_balance + sum(txn[amount_key] for txn in transactions)
+
+    assert len(transactions) >= 3
+    assert closing_balance == expected_closing
+
+
+def test_AC9_7_1_legacy_dbs_generator_writes_backward_compatible_pdf(
+    tmp_path: Path,
+) -> None:
+    """AC9.7.1: Legacy fixture generation still emits the original DBS PDF shape."""
+    output_path = tmp_path / "legacy.pdf"
+
+    generate_pdf_fixtures.generate_legacy_dbs_pdf(output_path)
+
+    assert output_path.read_bytes().startswith(b"%PDF")
+
+
+def test_AC9_7_1_main_legacy_mode_uses_backward_compatible_filename(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC9.7.1: Legacy CLI mode writes e2e_dbs_statement.pdf for existing E2E callers."""
+    generated: list[Path] = []
+
+    def fake_generate(output_path: Path) -> None:
+        generated.append(output_path)
+        output_path.write_bytes(b"%PDF fake")
+
+    monkeypatch.setattr(sys, "argv", ["generate_pdf_fixtures.py", str(tmp_path)])
+    monkeypatch.setattr(generate_pdf_fixtures, "generate_legacy_dbs_pdf", fake_generate)
+
+    generate_pdf_fixtures.main()
+
+    assert generated == [tmp_path / "e2e_dbs_statement.pdf"]
+    assert generated[0].read_bytes() == b"%PDF fake"
+
+
+def test_AC9_7_1_AC9_7_2_main_generates_selected_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC9.7.1 AC9.7.2: Main fixture CLI honors --source and --output."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_pdf_fixtures.py",
+            "--source",
+            "dbs",
+            "--output",
+            str(tmp_path),
+        ],
+    )
+
+    generate_pdf_fixtures.main()
+
+    generated = list((tmp_path / "dbs").glob("test_dbs_*.pdf"))
+    assert len(generated) == 1
+    assert generated[0].read_bytes().startswith(b"%PDF")
+
+
+def test_AC9_7_1_main_reports_generator_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC9.7.1: Main fixture CLI fails closed when a selected generator raises."""
+
+    class BrokenGenerator:
+        def __init__(self, _template_path: Path) -> None:
+            pass
+
+        def generate(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("broken generator")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate_pdf_fixtures.py", "--source", "dbs", "--output", str(tmp_path)],
+    )
+
+    # Patch the imported class inside the real generators module path used by main().
+    import generators.dbs_generator as dbs_module
+
+    monkeypatch.setattr(dbs_module, "DBSGenerator", BrokenGenerator)
+
+    with pytest.raises(SystemExit) as exc:
+        generate_pdf_fixtures.main()
+
+    assert exc.value.code == 1
+
+
+def test_AC9_1_3_analyzer_cli_writes_template_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC9.1.3: Analyzer CLI writes extracted source templates without payload data."""
+    input_pdf = tmp_path / "input.pdf"
+    output_yaml = tmp_path / "templates" / "dbs.yaml"
+    input_pdf.write_bytes(b"%PDF fake")
+
+    class FakeAnalyzer:
+        def analyze(self, pdf_path: Path) -> dict[str, object]:
+            assert pdf_path == input_pdf
+            return {"page": {"size": "A4"}}
+
+    class FakeExtractor:
+        def extract(
+            self, analysis: dict[str, object], source: str
+        ) -> dict[str, object]:
+            assert analysis == {"page": {"size": "A4"}}
+            return {
+                "source": source,
+                "tables": {"transaction_details": {"columns": []}},
+            }
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "analyze_pdf.py",
+            "--input",
+            str(input_pdf),
+            "--output",
+            str(output_yaml),
+            "--source",
+            "dbs",
+        ],
+    )
+    monkeypatch.setattr(analyze_pdf_cli, "PDFAnalyzer", FakeAnalyzer)
+    monkeypatch.setattr(analyze_pdf_cli, "TemplateExtractor", FakeExtractor)
+
+    analyze_pdf_cli.main()
+
+    assert "source: dbs" in output_yaml.read_text()
+
+
+def test_AC9_1_3_analyzer_cli_rejects_missing_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC9.1.3: Analyzer CLI fails before extraction when the local input PDF is missing."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "analyze_pdf.py",
+            "--input",
+            str(tmp_path / "missing.pdf"),
+            "--output",
+            str(tmp_path / "out.yaml"),
+            "--source",
+            "dbs",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        analyze_pdf_cli.main()
+
+    assert exc.value.code == 1
+
+
+def test_AC9_1_3_analyzer_cli_reports_extraction_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC9.1.3: Analyzer CLI exits non-zero when analysis fails."""
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF fake")
+
+    class BrokenAnalyzer:
+        def analyze(self, _pdf_path: Path) -> dict[str, object]:
+            raise RuntimeError("analysis failed")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "analyze_pdf.py",
+            "--input",
+            str(input_pdf),
+            "--output",
+            str(tmp_path / "out.yaml"),
+            "--source",
+            "dbs",
+        ],
+    )
+    monkeypatch.setattr(analyze_pdf_cli, "PDFAnalyzer", BrokenAnalyzer)
+
+    with pytest.raises(SystemExit) as exc:
+        analyze_pdf_cli.main()
+
+    assert exc.value.code == 1

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -84,9 +84,12 @@ def test_AC8_13_11_deploy_preflights_vault_token_before_redeploy() -> None:
     assert "VAULT_APP_TOKEN is invalid or expired" in common
     assert "VAULT_APP_TOKEN is not renewable" in common
     assert "ttl ${ttl}s is below required" in common
-    assert 'verify_vault_app_token "$current_env" "Dokploy VAULT_APP_TOKEN preflight" 172800' in deploy_script
+    assert (
+        'verify_vault_app_token "$current_env" "Dokploy VAULT_APP_TOKEN preflight" 172800'
+        in deploy_script
+    )
     assert deploy_script.index("verify_vault_app_token") < deploy_script.index(
-        "dokploy_api_call \"POST\" \"compose.update\""
+        'dokploy_api_call "POST" "compose.update"'
     )
 
 


### PR DESCRIPTION
## Summary

Aligns the AC coverage analyzer with the traceability gate by scanning `scripts/tests`, excluding deprecated strikethrough ACs from active coverage debt, and treating script-test fixture AC IDs as fixture-only invalid refs.

Closes #490

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — testing-strategy |
| **AC IDs** | AC8.13.35, AC8.13.37 |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/tdd.md` — documents that registered `scripts/tests` AC references count as tooling/CI proof and deprecated strikethrough ACs are excluded from active coverage debt
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `e1de1ed` | `test_analyze_test_ac_coverage.py` covers `scripts/tests` scanning, script fixture invalid-ref exclusion, and deprecated AC exclusion before implementation |
| 🟢 Green (passing test) | `4a4cf19` | implemented analyzer scope/semantics and regenerated AC coverage report |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (N/A, no DB model changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (N/A, no env changes)
- [x] `repo/` submodule updated for production config changes (N/A, no config changes; verified `repo` HEAD equals `origin/main`)
- [x] `scripts/check_env_keys.py` passes (N/A, no env vars changed)
- [x] `scripts/check_manifest.py` passes
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
uv run pytest scripts/tests/test_analyze_test_ac_coverage.py scripts/tests/test_check_ac_traceability.py scripts/tests/test_build_ac_traceability.py scripts/tests/test_issue_459_traceability_gate.py scripts/tests/test_ci_metrics_contract.py scripts/tests/test_coverage_policy.py scripts/tests/test_build_unified_lcov.py scripts/tests/test_post_merge_e2e_gates.py -q
python scripts/analyze_test_ac_coverage.py --output docs/analysis/test-ac-coverage-report.md
python scripts/check_ac_traceability.py
uv run --with pyyaml python scripts/lint_doc_consistency.py --verbose
python scripts/generate_ac_registry.py --check
python scripts/check_manifest.py && python scripts/check_ssot_ownership.py
uv run ruff check scripts/analyze_test_ac_coverage.py scripts/tests/test_analyze_test_ac_coverage.py
uv run ruff format scripts/analyze_test_ac_coverage.py scripts/tests/test_analyze_test_ac_coverage.py --check
git diff --check
moon run :lint
```

`moon run :test` could not complete locally because Podman machine stops immediately after start and the configured socket `127.0.0.1:60418` refuses connections, preventing the isolated test database from starting.

---

## Screenshots / Evidence

N/A
