### PR TITLE
[codex] harden coveralls coverage parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,8 @@ jobs:
             --context "Coveralls - unified" \
             --timeout-seconds 300 \
             --poll-seconds 10 \
-            --failure-confirmation-seconds 30
+            --failure-confirmation-seconds 30 \
+            --reject-success-description-regex "(?i)no base build|no base build to compare|no base to compare|base build.*not found|could not compare"
 
       - name: Upload backend to Coveralls (per-flag)
         uses: coverallsapp/github-action@v2

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -35,7 +35,7 @@ classify-changes → backend shards + frontend → unified-coverage → finish
 2. **Change Classification**: Lightweight documentation, issue-template, markdown, and `.github/workflows/docs.yml` changes skip backend, frontend, and unified coverage. Runtime, test, script, CI, dependency, and coverage-policy changes run the full heavy path.
 3. **Stable Required Checks**: Heavy jobs are skipped through job-level conditions rather than removing the workflow, so required check names remain visible and mergeable.
 4. **AC Traceability Always Runs**: AC traceability is separate from unified coverage so docs-only AC/EPIC changes still get traceability validation. The job first runs `scripts/generate_ac_registry.py --check` to ensure EPIC-defined ACs are registered without rewriting historical registry descriptions, then runs `scripts/check_ac_traceability.py` as the fail-closed gate, then generates `AC-TEST-TRACEABILITY-AUDIT.md` into `$RUNNER_TEMP`; the audit is uploaded as a CI artifact. The audit distinguishes real test references from `_ac_stubs`, trivial placeholder assertions, pure `pass`, and pure skipped tests. CI fails on mandatory AC coverage that is missing, placeholder-only, or stub-only; full-strikethrough deprecated ACs are excluded from the mandatory gate. CI does not fail solely because the checked-in archive copy is stale.
-5. **Coveralls Upload and Status Gate**: Unified, backend, and frontend Coveralls uploads run on both pull requests and `main` pushes when heavy CI is required. Pull requests wait for the external `Coveralls - unified` status before the `unified-coverage` job can pass, and `main` pushes use the same gate before post-merge staging, so asynchronous Coveralls regressions are blocked before merge and before staging. A terminal external failure is re-polled once before CI fails; confirmed coverage decreases, errors, and missing statuses still fail closed.
+5. **Coveralls Upload and Status Gate**: Unified, backend, and frontend Coveralls uploads run on both pull requests and `main` pushes when heavy CI is required. Pull requests wait for the external `Coveralls - unified` status before the `unified-coverage` job can pass, and `main` pushes use the same gate before post-merge staging, so asynchronous Coveralls regressions are blocked before merge and before staging. A terminal external failure is re-polled once before CI fails; confirmed coverage decreases, errors, missing statuses, and success without a valid base comparison still fail closed.
 6. **Single CI Metrics Contract**: `scripts/check_ci_metrics_contract.py` is the single CI metrics contract. It validates that source-root discovery, `scripts/coverage_policy.py`, workflow gates, and AC traceability semantics stay aligned before coverage is calculated.
 7. **Coverage Policy Audit**: `scripts/check_coverage_policy.py` fails CI if backend, frontend, or script source files drift from their LCOV report.
 8. **No-regression gate**: Zero-tolerance; if ANY component is below baseline, CI fails immediately.
@@ -55,7 +55,9 @@ on PR and `main`, so the post-merge lane should not be the first place a
 confirmed external unified coverage decrease is observed. The gate re-checks a
 terminal external failure before failing to reduce unexpected failures from
 transient external status flips without weakening confirmed coverage-decrease
-detection.
+detection. A PR-side external Coveralls success that reports no base build or no
+valid comparison is rejected rather than treated as equivalent to a successful
+coverage delta check.
 
 Lightweight changes do not repeat the heavy path on either PRs or `main`.
 Lightweight means all changed files are limited to documentation, markdown,

--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -66,7 +66,7 @@ The authoritative component/file policy lives in `scripts/coverage_policy.py`. C
 - **Config**: `apps/frontend/vitest.config.ts`
 - **Output**: `apps/frontend/coverage/lcov.info` (copied to `coverage/frontend.lcov` in CI)
 - **LCOV paths**: `SF:` entries are relative to `apps/frontend` (for example, `src/app/page.tsx`); Coveralls uploads must use `base-path: apps/frontend`.
-- **Coveralls upload**: frontend/unified Coveralls uploads run on PRs and `main` pushes; CI waits for the external `Coveralls - unified` status and confirms terminal failures before failing.
+- **Coveralls upload**: frontend/unified Coveralls uploads run on PRs and `main` pushes; CI waits for the external `Coveralls - unified` status, confirms terminal failures before failing, and rejects success statuses that report no base build or no valid comparison.
 - **Key config**: `include: ['src/**/*.{ts,tsx}']` plus the shared policy audit ensures source files appear in LCOV consistently.
 - **Excluded**:
   - `**/tests/**`, `**/__tests__/**`
@@ -124,6 +124,7 @@ jobs:
 The CI workflow uses baseline comparison to prevent coverage regressions. There is no fixed minimum threshold.
 
 - **Rationale**: No-regression is the primary gate; coverage must not drop from the committed baseline.
+- **External parity**: PR and `main` both wait for `Coveralls - unified`; a success without a valid base comparison fails closed so post-merge CI is not the first lane to see an external coverage delta.
 
 #### How It Works
 1. **Primary gate**: Baseline comparison (zero tolerance for drops)

--- a/scripts/check_ci_metrics_contract.py
+++ b/scripts/check_ci_metrics_contract.py
@@ -147,6 +147,7 @@ def _validate_repo_contract_files(repo_root: Path) -> list[str]:
             "Backend Tests (Shard ${{ matrix.shard }}/6)",
             "--splits 6",
             "--failure-confirmation-seconds",
+            "--reject-success-description-regex",
         )
         for token in required_workflow_tokens:
             if token not in workflow_text:
@@ -174,6 +175,7 @@ def _validate_repo_contract_files(repo_root: Path) -> list[str]:
             "single CI metrics contract",
             "AC traceability is a reference metric, not behavioral coverage",
             "trivial placeholder assertions",
+            "success without a valid base comparison",
             "New `apps/*/src` or `packages/*/src` source roots fail CI",
         ):
             if token not in ci_cd_text:

--- a/scripts/tests/test_ci_change_classifier.py
+++ b/scripts/tests/test_ci_change_classifier.py
@@ -136,6 +136,24 @@ def test_AC8_13_20_github_outputs_and_summary_include_heavy_files(
     assert "- `scripts/ci_change_classifier.py`" in summary_text
 
 
+def test_AC8_13_20_summary_includes_pr_preview_files(tmp_path: Path) -> None:
+    """AC8.13.20: PR preview-triggering files are visible in the summary."""
+    result = classify_changed_paths(
+        [
+            "apps/frontend/src/app/page.tsx",
+            "tests/e2e/test_core_journeys.py",
+        ]
+    )
+    summary = tmp_path / "github-summary.md"
+
+    classifier.write_github_summary(result, summary)
+
+    summary_text = summary.read_text(encoding="utf-8")
+    assert "PR preview-triggering files:" in summary_text
+    assert "- `apps/frontend/src/app/page.tsx`" in summary_text
+    assert "- `tests/e2e/test_core_journeys.py`" in summary_text
+
+
 def test_AC8_13_20_cli_writes_outputs_summary_and_stdout(
     tmp_path: Path,
     monkeypatch,

--- a/scripts/tests/test_ci_metrics_contract.py
+++ b/scripts/tests/test_ci_metrics_contract.py
@@ -81,6 +81,7 @@ def test_AC8_13_26_ci_workflow_runs_metrics_contract_and_defines_metric_semantic
     assert "shard: [1, 2, 3, 4, 5, 6]" in workflow
     assert "--splits 6" in workflow
     assert "--failure-confirmation-seconds" in workflow
+    assert "--reject-success-description-regex" in workflow
     assert "scripts/check_ac_traceability.py" in workflow
     assert workflow.index("scripts/check_ac_traceability.py") < workflow.index(
         "scripts/build_ac_traceability.py --output"
@@ -88,6 +89,7 @@ def test_AC8_13_26_ci_workflow_runs_metrics_contract_and_defines_metric_semantic
     assert "single CI metrics contract" in ci_cd
     assert "AC traceability is a reference metric, not behavioral coverage" in ci_cd
     assert "trivial placeholder assertions" in ci_cd
+    assert "success without a valid base comparison" in ci_cd
     assert "not behavioral coverage" in traceability
     assert "placeholder assertions" in traceability
 
@@ -166,8 +168,10 @@ def test_AC8_13_26_repo_contract_reports_missing_tokens(tmp_path):
     assert any("scripts/calculate_unified_coverage.py" in error for error in errors)
     assert any("scripts/check_ac_traceability.py" in error for error in errors)
     assert any("scripts/build_ac_traceability.py --output" in error for error in errors)
+    assert any("--reject-success-description-regex" in error for error in errors)
     assert "CI metrics contract must run before coverage policy audit" in errors
     assert any("AC traceability is a reference metric" in error for error in errors)
+    assert any("success without a valid base comparison" in error for error in errors)
     assert any("New `apps/*/src`" in error for error in errors)
     assert any("not behavioral coverage" in error for error in errors)
 

--- a/scripts/tests/test_wait_for_github_status.py
+++ b/scripts/tests/test_wait_for_github_status.py
@@ -76,6 +76,36 @@ def test_AC8_13_27_wait_returns_when_coveralls_unified_succeeds(
     assert clock.sleeps == []
 
 
+def test_AC8_13_27_wait_rejects_success_without_base_comparison(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.27: Coveralls success without a base comparison fails closed."""
+
+    def fake_run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return completed_process(
+            [
+                {
+                    "context": "Coveralls - unified",
+                    "state": "success",
+                    "description": "Coverage at 92.915% (no base build to compare)",
+                    "target_url": "https://coveralls.io/jobs/8",
+                }
+            ]
+        )
+
+    monkeypatch.setattr(wait_status.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="was rejected"):
+        wait_status.wait_for_status_success(
+            repo="owner/repo",
+            sha="abc123",
+            context="Coveralls - unified",
+            timeout_seconds=60,
+            poll_seconds=5,
+            reject_success_description_patterns=(r"(?i)no base build",),
+        )
+
+
 def test_AC8_13_27_wait_fails_closed_on_coveralls_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -202,6 +232,90 @@ def test_AC8_13_27_wait_allows_transient_coveralls_failure_to_recover(
 
     assert status.state == "success"
     assert clock.sleeps == [15]
+
+
+def test_AC8_13_27_cli_passes_success_rejection_patterns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.27: CLI exposes success-description rejection patterns to CI."""
+    calls: list[dict[str, object]] = []
+
+    def fake_wait(**kwargs: object) -> wait_status.GitHubCommitStatus:
+        calls.append(kwargs)
+        return wait_status.GitHubCommitStatus(
+            context="Coveralls - unified",
+            state="success",
+            description="Coverage remained the same",
+            target_url="https://coveralls.io/jobs/9",
+        )
+
+    monkeypatch.setattr(wait_status, "wait_for_status_success", fake_wait)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "wait_for_github_status.py",
+            "--repo",
+            "owner/repo",
+            "--sha",
+            "abc123",
+            "--context",
+            "Coveralls - unified",
+            "--timeout-seconds",
+            "11",
+            "--poll-seconds",
+            "3",
+            "--failure-confirmation-seconds",
+            "7",
+            "--reject-success-description-regex",
+            "(?i)no base build",
+        ],
+    )
+
+    wait_status.main()
+
+    assert calls == [
+        {
+            "repo": "owner/repo",
+            "sha": "abc123",
+            "context": "Coveralls - unified",
+            "timeout_seconds": 11,
+            "poll_seconds": 3,
+            "failure_confirmation_seconds": 7,
+            "reject_success_description_patterns": ("(?i)no base build",),
+        }
+    ]
+
+
+def test_AC8_13_27_cli_exits_one_when_status_wait_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AC8.13.27: CLI failures are emitted as GitHub annotations."""
+
+    def fake_wait(**_: object) -> wait_status.GitHubCommitStatus:
+        raise RuntimeError("coverage comparison missing")
+
+    monkeypatch.setattr(wait_status, "wait_for_status_success", fake_wait)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "wait_for_github_status.py",
+            "--repo",
+            "owner/repo",
+            "--sha",
+            "abc123",
+            "--context",
+            "Coveralls - unified",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        wait_status.main()
+
+    assert exc.value.code == 1
+    assert "coverage comparison missing" in capsys.readouterr().err
 
 
 def test_AC8_13_27_wait_reconfirms_failure_after_nonterminal_status(

--- a/scripts/wait_for_github_status.py
+++ b/scripts/wait_for_github_status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import time
@@ -34,7 +35,9 @@ def _run_gh_status(repo: str, sha: str) -> list[GitHubCommitStatus]:
     payload = json.loads(result.stdout or "{}")
     statuses = payload.get("statuses", [])
     if not isinstance(statuses, list):
-        raise RuntimeError("GitHub commit status response did not contain a status list")
+        raise RuntimeError(
+            "GitHub commit status response did not contain a status list"
+        )
 
     parsed: list[GitHubCommitStatus] = []
     for status in statuses:
@@ -61,6 +64,17 @@ def _latest_status_for_context(
     return None
 
 
+def _matches_rejected_success_description(
+    status: GitHubCommitStatus,
+    patterns: tuple[str, ...],
+) -> str | None:
+    description = status.description or ""
+    for pattern in patterns:
+        if re.search(pattern, description):
+            return pattern
+    return None
+
+
 def wait_for_status_success(
     *,
     repo: str,
@@ -69,6 +83,7 @@ def wait_for_status_success(
     timeout_seconds: int = 300,
     poll_seconds: int = 10,
     failure_confirmation_seconds: int = 0,
+    reject_success_description_patterns: tuple[str, ...] = (),
     monotonic=time.monotonic,
     sleep=time.sleep,
 ) -> GitHubCommitStatus:
@@ -88,6 +103,16 @@ def wait_for_status_success(
                 f"url={status.target_url}"
             )
             if status.state == "success":
+                rejected_pattern = _matches_rejected_success_description(
+                    status,
+                    reject_success_description_patterns,
+                )
+                if rejected_pattern:
+                    raise RuntimeError(
+                        f"{context} success for {sha} was rejected by "
+                        f"description pattern {rejected_pattern!r}: "
+                        f"{status.description or ''} {status.target_url or ''}"
+                    )
                 return status
             if status.state in {"failure", "error"}:
                 if failure_confirmation_seconds > 0 and not terminal_failure_seen:
@@ -126,6 +151,15 @@ def main() -> None:
         default=0,
         help="Re-poll after a failure/error status before failing.",
     )
+    parser.add_argument(
+        "--reject-success-description-regex",
+        action="append",
+        default=[],
+        help=(
+            "Reject a success status whose description matches this regex. "
+            "May be specified multiple times."
+        ),
+    )
     args = parser.parse_args()
 
     try:
@@ -136,6 +170,9 @@ def main() -> None:
             timeout_seconds=args.timeout_seconds,
             poll_seconds=args.poll_seconds,
             failure_confirmation_seconds=args.failure_confirmation_seconds,
+            reject_success_description_patterns=tuple(
+                args.reject_success_description_regex
+            ),
         )
     except (RuntimeError, TimeoutError) as exc:
         print(f"::error title=GitHub status wait failed::{exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Reject Coveralls unified `success` statuses that do not include a valid base comparison, such as `no base build to compare`, so PR CI and post-merge CI fail the same way.
- Add focused AC8.13.27 tests for the Coveralls status wait CLI and no-base success rejection.
- Add focused coverage for PR preview summary output and extend the CI metrics contract/SSOT docs for the new parity requirement.

## Root Cause
PR #495 passed because Coveralls reported `Coveralls - unified` as successful even though it had no base build to compare against. After merge, the `main` push had a base build and Coveralls failed the same coverage with `Coverage decreased (-0.008%) to 92.915%`. The local baseline gate and the external Coveralls comparison were both present, but the external PR status did not prove a real delta comparison.

## Validation
- `uv run --with pytest --with pytest-cov --with pyyaml pytest -q scripts/tests/test_wait_for_github_status.py scripts/tests/test_ci_change_classifier.py scripts/tests/test_ci_metrics_contract.py`
- `printf '[run]\nomit = scripts/tests/*\n' > /tmp/scripts-coveragerc && uv run --with pytest --with pytest-cov --with pytest-asyncio --with anyio --with pyyaml --with pydantic --with pydantic-settings --with sqlalchemy --with asyncpg --with pdfplumber --with reportlab pytest scripts/tests/ --cov=scripts --cov-config=/tmp/scripts-coveragerc --cov-report=term-missing --cov-report=lcov:coverage/scripts.lcov -q`
- `uv run ruff check scripts/wait_for_github_status.py scripts/check_ci_metrics_contract.py scripts/tests/test_wait_for_github_status.py scripts/tests/test_ci_change_classifier.py scripts/tests/test_ci_metrics_contract.py`
- `uv run ruff format --check scripts/wait_for_github_status.py scripts/check_ci_metrics_contract.py scripts/tests/test_wait_for_github_status.py scripts/tests/test_ci_change_classifier.py scripts/tests/test_ci_metrics_contract.py`
- `uv run --with pyyaml python scripts/generate_ac_registry.py --check && uv run python scripts/check_ci_metrics_contract.py && uv run --with pyyaml python scripts/lint_doc_consistency.py && actionlint .github/workflows/ci.yml .github/workflows/pr-test.yml`
- `uv run --with pyyaml python scripts/check_ac_traceability.py && uv run --with pyyaml python scripts/build_ac_traceability.py --check`

## Notes
Local `scripts/check_coverage_policy.py` was not used as a final local signal because the available backend/frontend LCOV files in the workspace are stale; GitHub CI regenerates those artifacts before running the policy audit.
