### PR TITLE
test: cover residual setup and reconciliation AC gaps

### DIFF
--- a/apps/backend/tests/infra/test_migrations.py
+++ b/apps/backend/tests/infra/test_migrations.py
@@ -4,6 +4,9 @@ import pytest
 from alembic.config import Config
 from alembic.script import ScriptDirectory
 
+import src.models  # noqa: F401
+from src.database import Base
+
 # Paths relative to this test file: apps/backend/tests/infra/test_migrations.py
 BACKEND_DIR = Path(__file__).parent.parent.parent
 ALEMBIC_INI_PATH = BACKEND_DIR / "alembic.ini"
@@ -43,6 +46,25 @@ def test_single_head(alembic_script):
     """
     heads = alembic_script.get_heads()
     assert len(heads) == 1, f"Migration graph has multiple heads: {heads}. History must be linear."
+
+
+def test_sqlalchemy_metadata_and_alembic_graph_are_valid(alembic_script):
+    """AC1.2.3: SQLAlchemy models are registered and Alembic has a valid linear graph."""
+    expected_tables = {
+        "accounts",
+        "bank_statements",
+        "journal_entries",
+        "journal_lines",
+        "reconciliation_matches",
+        "users",
+    }
+
+    assert expected_tables <= set(Base.metadata.tables)
+
+    revisions = list(alembic_script.walk_revisions("base", "head"))
+    assert revisions
+    assert len(alembic_script.get_heads()) == 1
+    assert any(revision.down_revision is None for revision in revisions)
 
 
 def test_AC13_10_4_source_type_migration_handles_missing_legacy_enum_label():

--- a/apps/backend/tests/reconciliation/test_reconciliation_engine.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_engine.py
@@ -186,6 +186,79 @@ async def test_execute_matching_no_candidates(db: AsyncSession):
     assert txn.status == BankTransactionStatus.UNMATCHED
 
 
+async def test_transfer_pair_not_double_counted(db: AsyncSession) -> None:
+    """AC4.6.2: Matching transfer OUT/IN within 3 days uses Processing entries only."""
+    user_id = uuid4()
+    user = User(id=user_id, email=f"transfer-{uuid4()}@example.com", hashed_password="hashed")
+    checking = Account(
+        user_id=user_id,
+        name="Bank - Checking",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    savings = Account(
+        user_id=user_id,
+        name="Bank - Savings",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add_all([user, checking, savings])
+    await db.flush()
+
+    out_statement = _make_statement(owner_id=user_id, base_date=date(2024, 3, 10))
+    out_statement.account_id = checking.id
+    in_statement = _make_statement(owner_id=user_id, base_date=date(2024, 3, 12))
+    in_statement.account_id = savings.id
+    db.add_all([out_statement, in_statement])
+    await db.flush()
+
+    out_txn = AccountEvent(
+        statement_id=out_statement.id,
+        txn_date=date(2024, 3, 10),
+        description="FAST transfer to savings",
+        amount=Decimal("500.00"),
+        direction="OUT",
+        status=BankTransactionStatus.PENDING,
+        confidence=ConfidenceLevel.HIGH,
+    )
+    in_txn = AccountEvent(
+        statement_id=in_statement.id,
+        txn_date=date(2024, 3, 12),
+        description="FAST transfer from checking",
+        amount=Decimal("500.00"),
+        direction="IN",
+        status=BankTransactionStatus.PENDING,
+        confidence=ConfidenceLevel.HIGH,
+    )
+    db.add_all([out_txn, in_txn])
+    await db.commit()
+
+    matches = await execute_matching(db, user_id=user_id)
+
+    assert len(matches) == 2
+    assert {match.status for match in matches} == {ReconciliationStatus.AUTO_ACCEPTED}
+    breakdowns = sorted((match.score_breakdown for match in matches), key=lambda item: sorted(item))
+    assert breakdowns == [
+        {"transfer_in": 100.0},
+        {"transfer_out": 100.0},
+    ]
+
+    await db.refresh(out_txn)
+    await db.refresh(in_txn)
+    assert out_txn.status == BankTransactionStatus.MATCHED
+    assert in_txn.status == BankTransactionStatus.MATCHED
+
+    transfer_entries_result = await db.execute(
+        select(JournalEntry)
+        .where(JournalEntry.user_id == user_id)
+        .where(JournalEntry.source_type == JournalEntrySourceType.SYSTEM)
+        .options(selectinload(JournalEntry.lines))
+    )
+    transfer_entries = transfer_entries_result.scalars().unique().all()
+    assert len(transfer_entries) == 2
+    assert {entry.status for entry in transfer_entries} == {JournalEntryStatus.RECONCILED}
+
+
 async def test_execute_matching_pending_review_and_unmatched(db: AsyncSession) -> None:
     """Pending review and unmatched cases are handled correctly."""
     user_id = uuid4()

--- a/apps/backend/tests/reconciliation/test_reconciliation_scoring.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_scoring.py
@@ -235,6 +235,14 @@ def test_score_amount_branches() -> None:
     assert score_amount(Decimal("100.00"), Decimal("160.00"), config) == 40.0
 
 
+def test_amount_tolerance_0_10_boundary() -> None:
+    """AC4.6.1: Absolute amount delta of 0.10 passes, but 0.11 fails."""
+    config = DEFAULT_CONFIG
+
+    assert score_amount(Decimal("10.00"), Decimal("10.10"), config) == 90.0
+    assert score_amount(Decimal("10.00"), Decimal("10.11"), config) < 90.0
+
+
 def test_score_date_branches() -> None:
     """[AC4.1.2] Test score_date logic."""
     config = DEFAULT_CONFIG

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-05-25 08:30:29 UTC by `scripts/analyze_test_ac_coverage.py`
+> Generated: 2026-05-25 11:54:17 UTC by `scripts/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 984 |
-| Active ACs | 981 |
+| Registered ACs | 985 |
+| Active ACs | 982 |
 | Deprecated ACs excluded from coverage gate | 3 |
-| Covered by real test candidates | 981 (100.0%) |
+| Covered by real test candidates | 982 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -32,9 +32,9 @@
 
 | Source | Files scanned | Unique AC refs (real) | Unique AC refs (placeholder) | Unique AC refs (stub) |
 |---|---:|---:|---:|---:|
-| backend | 166 | 628 | 0 | 0 |
+| backend | 166 | 631 | 0 | 0 |
 | frontend | 79 | 189 | 7 | 0 |
-| scripts_tests | 38 | 209 | 23 | 0 |
+| scripts_tests | 40 | 210 | 23 | 0 |
 | e2e | 10 | 16 | 0 | 0 |
 | repo_e2e | 18 | 0 | 0 | 0 |
 
@@ -49,7 +49,7 @@
 | EPIC-005 | reporting-visualization | 36 | 0 | 36 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 0 | 63 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-008 | testing-strategy | 94 | 0 | 94 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 95 | 0 | 95 | 0 | 0 | 0 | 100.0% |
 | EPIC-009 | pdf-fixture-generation | 37 | 0 | 37 | 0 | 0 | 0 | 100.0% |
 | EPIC-010 | signoz-logging | 21 | 0 | 21 | 0 | 0 | 0 | 100.0% |
 | EPIC-011 | asset-lifecycle | 38 | 0 | 38 | 0 | 0 | 0 | 100.0% |


### PR DESCRIPTION
## Summary

Adds real backend proof for the residual setup and reconciliation AC gaps tracked in #488.

Closes #488

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-001 — phase0-setup; EPIC-004 — reconciliation-engine |
| **AC IDs** | AC1.2.3, AC4.6.1, AC4.6.2 |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [x] None — existing SSOT already covers this change
- [x] Generated `docs/analysis/test-ac-coverage-report.md` refreshed

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | N/A | Test-only coverage issue; local first run failed on an over-strict test oracle, then passed after correcting the oracle. Existing production code satisfied the new behavior tests. |
| 🟢 Green (passing test) | `fdb94c6` | Added behavioral coverage for Alembic/SQLAlchemy metadata, 0.10/0.11 amount tolerance, and transfer OUT/IN Processing-entry matching. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (N/A, tests only)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (N/A, no frontend/env changes)
- [x] `repo/` submodule updated for production config changes (N/A, no production config changes)
- [x] `scripts/check_env_keys.py` passes (N/A, no env vars changed)
- [x] `scripts/check_manifest.py` passes
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
uv run --project apps/backend pytest apps/backend/tests/infra/test_migrations.py apps/backend/tests/reconciliation/test_reconciliation_scoring.py::test_amount_tolerance_0_10_boundary apps/backend/tests/reconciliation/test_reconciliation_engine.py::test_transfer_pair_not_double_counted -q --no-cov
uv run --project apps/backend pytest apps/backend/tests/reconciliation/test_reconciliation_scoring.py apps/backend/tests/reconciliation/test_reconciliation_engine.py -q --no-cov
python scripts/analyze_test_ac_coverage.py --output docs/analysis/test-ac-coverage-report.md
python scripts/check_ac_traceability.py
python scripts/generate_ac_registry.py --check
uv run --project apps/backend ruff check apps/backend/tests/infra/test_migrations.py apps/backend/tests/reconciliation/test_reconciliation_scoring.py apps/backend/tests/reconciliation/test_reconciliation_engine.py
python scripts/check_manifest.py
python scripts/check_ssot_ownership.py
uv run --with pyyaml python scripts/lint_doc_consistency.py --verbose
git diff --check
moon run :lint
```

`moon run :test` was attempted locally but blocked before tests by Podman compose infra startup: `proxy already running` / internal libpod error while starting the test database containers.

---

## Screenshots / Evidence

N/A
