### PR TITLE
[codex] test: enforce traceability exception coverage

### DIFF
--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -1,6 +1,7 @@
 # Traceability Exceptions
 
 > Generated from the issue #475 audit on 2026-05-21.
+> Updated for issue #511 on 2026-05-26.
 
 The project proof chain is `README.md -> docs/project/EPIC-*.md ->
 docs/*_registry.yaml -> tests`. Tests that assert product behavior should carry
@@ -15,17 +16,24 @@ These files are test infrastructure, not behavior proof.
 
 | Path | Classification |
 |---|---|
+| `apps/backend/tests/__init__.py` | Package marker |
 | `apps/backend/tests/accounting/__init__.py` | Package marker |
 | `apps/backend/tests/ai/__init__.py` | Package marker |
 | `apps/backend/tests/assets/__init__.py` | Package marker |
 | `apps/backend/tests/auth/__init__.py` | Package marker |
+| `apps/backend/tests/conftest.py` | Shared backend pytest fixtures |
 | `apps/backend/tests/e2e/conftest.py` | Shared E2E fixtures |
 | `apps/backend/tests/extraction/__init__.py` | Package marker |
+| `apps/backend/tests/factories.py` | Shared backend test factories |
 | `apps/backend/tests/infra/__init__.py` | Package marker |
+| `apps/backend/tests/locustfile.py` | Load-test harness, not AC proof |
 | `apps/backend/tests/market_data/__init__.py` | Package marker |
 | `apps/backend/tests/portfolio/__init__.py` | Package marker |
 | `apps/backend/tests/reconciliation/__init__.py` | Package marker |
 | `apps/backend/tests/reporting/__init__.py` | Package marker |
+| `scripts/tests/__init__.py` | Package marker |
+| `scripts/tests/conftest.py` | Shared scripts-test fixtures |
+| `tests/e2e/conftest.py` | Shared top-level E2E fixtures |
 | `apps/backend/tests/unit/conftest.py` | Shared unit fixtures |
 | `apps/frontend/src/__tests__/helpers/renderReviewComponent.tsx` | Shared frontend render helper |
 
@@ -75,6 +83,7 @@ explicit AC IDs for the behavior.
 | `apps/backend/tests/unit/schemas/test_schemas.py` | `docs/ssot/schema.md` |
 | `apps/backend/tests/unit/services/test_source_type_priority.py` | `docs/ssot/source-type-priority.md` |
 | `apps/backend/tests/unit/utils/test_exceptions.py` | `docs/ssot/development.md` |
+| `apps/backend/tests/test_factories.py` | `apps/backend/tests/factories.py` |
 | `apps/frontend/src/__tests__/ConflictResolutionDialog.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/__tests__/ThemeToggle.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/__tests__/TransactionTable.test.tsx` | `docs/ssot/frontend-patterns.md` |
@@ -96,6 +105,29 @@ explicit AC IDs for the behavior.
 | `apps/frontend/src/components/review/__tests__/ConflictResolutionDialog.keydown.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/components/review/__tests__/TransactionTable.keyEvents.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/hooks/__tests__/useFocusTrap.test.tsx` | `docs/ssot/frontend-patterns.md` |
+| `apps/frontend/src/lib/currency.test.ts` | `docs/ssot/frontend-patterns.md` |
+| `scripts/tests/test_check_env_keys.py` | `docs/ssot/development.md` |
+| `scripts/tests/test_check_manifest.py` | `docs/ssot/MANIFEST.yaml` |
+| `scripts/tests/test_check_ssot_ownership.py` | `docs/ssot/MANIFEST.yaml` |
+| `scripts/tests/test_coverage_analyzer.py` | `docs/ssot/coverage.md` |
+| `scripts/tests/test_generate_fixtures.py` | `docs/ssot/extraction.md` |
+| `scripts/tests/test_github_workflow_timing_summary.py` | `docs/ssot/ci-cd.md` |
+| `scripts/tests/test_merge_lcov.py` | `docs/ssot/coverage.md` |
+| `scripts/tests/test_sanitize_fixtures.py` | `docs/agents/red-lines.md` |
+| `scripts/tests/test_seed_fx_rates.py` | `docs/ssot/market_data.md` |
+| `scripts/tests/test_validate_schemas.py` | `docs/ssot/schema.md` |
+
+### Needs AC Triage
+
+These files assert broad E2E behavior. They remain outside AC proof until EPICs
+assign current AC IDs or replace them with narrower AC-owned tests.
+
+| Path | Owner |
+|---|---|
+| `tests/e2e/test_auth_flows.py` | EPIC-008 |
+| `tests/e2e/test_core_journeys.py` | EPIC-008 |
+| `tests/e2e/test_e2e_flows.py` | EPIC-008 |
+| `tests/e2e/test_version_check.py` | EPIC-008 |
 
 ## Source Direct-Test Heuristic Exceptions
 
@@ -116,5 +148,6 @@ router, or generated-fixture flows.
 ## Rule
 
 New tests for user-visible behavior must include an AC reference. New helper,
-fixture, or pure contract tests without AC references must be added to this file
-in the same PR, with an SSOT owner.
+fixture, broad legacy E2E, or pure contract tests without AC references must be
+added to this file in the same PR, with an SSOT or EPIC owner. This allow-list
+is enforced by `scripts/lint_doc_consistency.py`.

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -65,6 +65,22 @@ issue templates, or `.github/workflows/docs.yml`. Other workflow changes are not
 skipped because they may affect CI, deploy, or release behavior and must exercise
 the full gate.
 
+### Proof Placement Policy
+
+The test system separates proof by where the failure can be acted on:
+
+| Proof type | Runs where | Purpose |
+|---|---|---|
+| Behavioral tests | PR CI before merge | Prove deterministic product behavior, accounting invariants, API contracts, frontend flows, and script/tool contracts before code enters `main`. |
+| Environment gates | Post-merge deploy workflows | Prove the exact merged SHA can run in staging/production-like environments with real routing, Vault/Dokploy/GHCR/SigNoz wiring, deployed images, and provider-backed OCR/LLM credentials. |
+| Reference traceability | PR and `main` CI | Prove every mandatory AC has a real non-placeholder test reference; this is not behavioral coverage by itself. |
+
+Behavioral tests should move left into PR CI whenever they can be deterministic
+without external singleton state or provider spend. Environment-dependent checks
+belong in post-merge staging/production workflows because they validate the
+deployed merge commit and shared infrastructure. A post-merge environment gate
+must not be the first proof for deterministic business behavior.
+
 ---
 
 ## No-Regression Coverage Gate

--- a/scripts/lint_doc_consistency.py
+++ b/scripts/lint_doc_consistency.py
@@ -24,6 +24,11 @@ Hard-fail checks enforced in CI:
      are excluded from check #6 because they intentionally reference
      synthetic AC IDs (e.g. ``AC9.9.9``) that are not present in the
      registries.
+  7. docs/ssot/ci-cd.md MUST keep the proof placement policy that
+     distinguishes pre-merge behavioral tests from post-merge
+     environment gates.
+  8. Every test file without an ``ACx.y.z`` reference MUST be listed in
+     docs/analysis/traceability-exceptions.md.
 
 The script exits 0 on success and 1 on any violation.
 
@@ -65,12 +70,24 @@ VISION_PATH = REPO_ROOT / "vision.md"
 EPIC_DIR = REPO_ROOT / "docs" / "project"
 AC_REGISTRY = REPO_ROOT / "docs" / "ac_registry.yaml"
 INFRA_REGISTRY = REPO_ROOT / "docs" / "infra_registry.yaml"
+CI_CD_SSOT = REPO_ROOT / "docs" / "ssot" / "ci-cd.md"
+TRACEABILITY_EXCEPTIONS = REPO_ROOT / "docs" / "analysis" / "traceability-exceptions.md"
 
 TEST_ROOTS = [
     REPO_ROOT / "apps" / "backend" / "tests",
     REPO_ROOT / "apps" / "frontend" / "src" / "__tests__",
     REPO_ROOT / "scripts" / "tests",
 ]
+
+NO_AC_SCAN_TARGETS: tuple[tuple[Path, tuple[str, ...]], ...] = (
+    (REPO_ROOT / "apps" / "backend" / "tests", ("**/*.py",)),
+    (
+        REPO_ROOT / "apps" / "frontend" / "src",
+        ("**/*.test.ts", "**/*.test.tsx"),
+    ),
+    (REPO_ROOT / "scripts" / "tests", ("**/*.py",)),
+    (REPO_ROOT / "tests" / "e2e", ("**/*.py",)),
+)
 
 CHECK6_TEST_ROOTS = [r for r in TEST_ROOTS if r != REPO_ROOT / "scripts" / "tests"]
 
@@ -160,6 +177,19 @@ HTML_ANCHOR_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+PROOF_PLACEMENT_REQUIRED_TOKENS = (
+    "### Proof Placement Policy",
+    "| Behavioral tests | PR CI before merge |",
+    "| Environment gates | Post-merge deploy workflows |",
+    "| Reference traceability | PR and `main` CI |",
+    "Behavioral tests should move left into PR CI",
+    "Environment-dependent checks",
+    "post-merge staging/production workflows",
+    "must not be the first proof for deterministic business behavior",
+)
+
+MARKDOWN_CODE_SPAN_PATTERN = re.compile(r"`([^`]+)`")
+
 
 class Violation(NamedTuple):
     check: str
@@ -247,6 +277,84 @@ def collect_ac_refs_in_tests(test_roots: list[Path]) -> dict[str, set[str]]:
                         str(fpath.relative_to(REPO_ROOT))
                     )
     return refs
+
+
+def _is_excluded_path(path: Path) -> bool:
+    return any(part in EXCLUDED_DIRS for part in path.parts)
+
+
+def discover_no_ac_test_files(
+    scan_targets: tuple[tuple[Path, tuple[str, ...]], ...] | None = None,
+) -> list[Path]:
+    """Return test/support files under test roots that contain no AC reference."""
+    if scan_targets is None:
+        scan_targets = (
+            (REPO_ROOT / "apps" / "backend" / "tests", ("**/*.py",)),
+            (
+                REPO_ROOT / "apps" / "frontend" / "src",
+                ("**/*.test.ts", "**/*.test.tsx"),
+            ),
+            (REPO_ROOT / "scripts" / "tests", ("**/*.py",)),
+            (REPO_ROOT / "tests" / "e2e", ("**/*.py",)),
+        )
+
+    candidates: set[Path] = set()
+    for base, patterns in scan_targets:
+        if not base.exists():
+            continue
+        for pattern in patterns:
+            candidates.update(path for path in base.glob(pattern) if path.is_file())
+
+    no_ac_files: list[Path] = []
+    for path in sorted(candidates):
+        if _is_excluded_path(path):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if not AC_PATTERN.search(text):
+            no_ac_files.append(path)
+    return no_ac_files
+
+
+def load_traceability_exception_paths(exception_path: Path) -> set[str]:
+    """Extract path-like Markdown code spans from traceability exceptions."""
+    if not exception_path.exists():
+        return set()
+    text = exception_path.read_text(encoding="utf-8")
+    return {
+        value
+        for value in MARKDOWN_CODE_SPAN_PATTERN.findall(text)
+        if "/" in value and not value.startswith("docs/*")
+    }
+
+
+def check_no_ac_test_exceptions(
+    no_ac_files: list[Path] | None = None,
+    exception_path: Path | None = None,
+) -> list[Violation]:
+    """Check #8: no-AC test files must be explicitly classified."""
+    if exception_path is None:
+        exception_path = REPO_ROOT / "docs" / "analysis" / "traceability-exceptions.md"
+    if no_ac_files is None:
+        no_ac_files = discover_no_ac_test_files()
+
+    exception_paths = load_traceability_exception_paths(exception_path)
+    violations: list[Violation] = []
+    for path in no_ac_files:
+        rel = _display_path(path)
+        if rel not in exception_paths:
+            violations.append(
+                Violation(
+                    check="check8_no_ac_test_exceptions",
+                    message=(
+                        f"{rel}: test/support file has no AC reference and is "
+                        "not classified in docs/analysis/traceability-exceptions.md"
+                    ),
+                )
+            )
+    return violations
 
 
 def check_epic_anchors(
@@ -449,6 +557,42 @@ def check_test_id_epic_alignment(
     return violations
 
 
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def check_proof_placement_policy(ci_cd_path: Path | None = None) -> list[Violation]:
+    """Check #7: CI/CD SSOT defines pre-merge vs post-merge proof placement."""
+    if ci_cd_path is None:
+        ci_cd_path = REPO_ROOT / "docs" / "ssot" / "ci-cd.md"
+    try:
+        text = ci_cd_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [
+            Violation(
+                check="check7_proof_placement_policy",
+                message=f"{ci_cd_path}: cannot read file ({exc})",
+            )
+        ]
+
+    violations: list[Violation] = []
+    for token in PROOF_PLACEMENT_REQUIRED_TOKENS:
+        if token not in text:
+            violations.append(
+                Violation(
+                    check="check7_proof_placement_policy",
+                    message=(
+                        f"{_display_path(ci_cd_path)}: missing proof "
+                        f"placement token {token!r}"
+                    ),
+                )
+            )
+    return violations
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=("Lint vision <-> EPIC <-> AC registry <-> test consistency.")
@@ -496,6 +640,8 @@ def main() -> int:
     violations.extend(check_epic_to_registry(epic_refs, registry_ids))
     violations.extend(check_registry_to_tests(all_acs, test_refs))
     violations.extend(check_test_id_epic_alignment(all_acs, test_refs))
+    violations.extend(check_proof_placement_policy())
+    violations.extend(check_no_ac_test_exceptions())
 
     if args.verbose or violations:
         print("=" * 72)

--- a/scripts/tests/test_lint_doc_consistency.py
+++ b/scripts/tests/test_lint_doc_consistency.py
@@ -237,6 +237,94 @@ class TestLineIsAcAnnotation:
 
 
 # ---------------------------------------------------------------------------
+# check_proof_placement_policy
+# ---------------------------------------------------------------------------
+
+
+class TestProofPlacementPolicy:
+    def test_policy_passes_with_required_tokens(self, tmp_path):
+        doc = tmp_path / "ci-cd.md"
+        doc.write_text(
+            "\n".join(ldc.PROOF_PLACEMENT_REQUIRED_TOKENS),
+            encoding="utf-8",
+        )
+
+        assert ldc.check_proof_placement_policy(doc) == []
+
+    def test_policy_fails_when_behavioral_and_environment_split_is_missing(
+        self, tmp_path
+    ):
+        doc = tmp_path / "ci-cd.md"
+        doc.write_text("### CI\nNo proof placement policy here.\n", encoding="utf-8")
+
+        violations = ldc.check_proof_placement_policy(doc)
+
+        assert violations
+        assert {v.check for v in violations} == {"check7_proof_placement_policy"}
+        assert any("Proof Placement Policy" in v.message for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# no-AC test exception allow-list
+# ---------------------------------------------------------------------------
+
+
+class TestNoAcTestExceptions:
+    def test_discover_no_ac_test_files_includes_support_files(self, tmp_path):
+        tests = tmp_path / "apps" / "backend" / "tests"
+        tests.mkdir(parents=True)
+        no_ac = tests / "conftest.py"
+        no_ac.write_text("import pytest\n")
+        with_ac = tests / "test_accounting.py"
+        with_ac.write_text('def test_x():\n    """AC1.1.1"""\n    assert True\n')
+
+        result = ldc.discover_no_ac_test_files(((tests, ("**/*.py",)),))
+
+        assert result == [no_ac]
+
+    def test_load_traceability_exception_paths_reads_markdown_code_spans(
+        self, tmp_path
+    ):
+        exceptions = tmp_path / "traceability-exceptions.md"
+        exceptions.write_text(
+            "| Path | Classification |\n"
+            "|---|---|\n"
+            "| `tests/conftest.py` | Shared fixtures |\n",
+            encoding="utf-8",
+        )
+
+        assert "tests/conftest.py" in ldc.load_traceability_exception_paths(exceptions)
+
+    def test_check_no_ac_test_exceptions_passes_when_listed(self, tmp_path):
+        test_file = tmp_path / "tests" / "conftest.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text("import pytest\n")
+        exceptions = tmp_path / "docs" / "analysis" / "traceability-exceptions.md"
+        exceptions.parent.mkdir(parents=True)
+        exceptions.write_text("| `tests/conftest.py` | Shared fixtures |\n")
+
+        with mock.patch.object(ldc, "REPO_ROOT", tmp_path):
+            violations = ldc.check_no_ac_test_exceptions([test_file], exceptions)
+
+        assert violations == []
+
+    def test_check_no_ac_test_exceptions_fails_when_missing(self, tmp_path):
+        test_file = tmp_path / "tests" / "test_legacy.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text("def test_legacy():\n    assert True\n")
+        exceptions = tmp_path / "docs" / "analysis" / "traceability-exceptions.md"
+        exceptions.parent.mkdir(parents=True)
+        exceptions.write_text("| `tests/other.py` | Other |\n")
+
+        with mock.patch.object(ldc, "REPO_ROOT", tmp_path):
+            violations = ldc.check_no_ac_test_exceptions([test_file], exceptions)
+
+        assert len(violations) == 1
+        assert violations[0].check == "check8_no_ac_test_exceptions"
+        assert "tests/test_legacy.py" in violations[0].message
+
+
+# ---------------------------------------------------------------------------
 # collect_ac_refs_in_epics
 # ---------------------------------------------------------------------------
 
@@ -583,6 +671,13 @@ class TestMain:
         )
         infra = tmp_path / "docs" / "infra_registry.yaml"
         infra.write_text("version: '1.0'\ngroups: {}\n")
+
+        ci_cd = tmp_path / "docs" / "ssot" / "ci-cd.md"
+        ci_cd.parent.mkdir(parents=True, exist_ok=True)
+        ci_cd.write_text(
+            "\n".join(ldc.PROOF_PLACEMENT_REQUIRED_TOKENS),
+            encoding="utf-8",
+        )
 
         # test file
         tests = tmp_path / "apps" / "backend" / "tests"


### PR DESCRIPTION
## Summary

- classify the remaining no-AC test/support files in `docs/analysis/traceability-exceptions.md`
- add `check8_no_ac_test_exceptions` so new no-AC test files must be AC-tagged or explicitly exception-listed
- add lint coverage for the pre-merge behavioral vs post-merge environment proof placement policy

## Why

Issue #511 found no-AC test files that were not part of the traceability exception allow-list. Without a mechanical guard, new helper, contract, or broad legacy E2E tests can silently sit outside the AC proof system.

This keeps those files visible without pretending they are AC proof. Broad legacy E2E files are marked as needing AC triage rather than counted as covered behavior.

## Validation

- `pytest scripts/tests/test_lint_doc_consistency.py -q`
- `uv run --with pyyaml python scripts/lint_doc_consistency.py --verbose`
- `python scripts/generate_ac_registry.py --check`
- `python scripts/check_ac_traceability.py`
- `python scripts/check_manifest.py`
- `python scripts/check_ssot_ownership.py`
- `uv run ruff check scripts/lint_doc_consistency.py scripts/tests/test_lint_doc_consistency.py`
- `git diff --check HEAD~1..HEAD`

Refs #511
