### PR TITLE
[codex] test: cover foundation and TTD traceability gaps

### DIFF
--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-05-26 06:47:12 UTC by `scripts/analyze_test_ac_coverage.py`
+> Generated: 2026-05-26 07:25:51 UTC by `scripts/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 986 |
-| Active ACs | 983 |
+| Registered ACs | 987 |
+| Active ACs | 984 |
 | Deprecated ACs excluded from coverage gate | 3 |
-| Covered by real test candidates | 983 (100.0%) |
+| Covered by real test candidates | 984 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -34,7 +34,7 @@
 |---|---:|---:|---:|---:|
 | backend | 166 | 632 | 0 | 0 |
 | frontend | 79 | 189 | 7 | 0 |
-| scripts_tests | 43 | 211 | 23 | 0 |
+| scripts_tests | 45 | 212 | 23 | 0 |
 | e2e | 10 | 16 | 0 | 0 |
 | repo_e2e | 18 | 0 | 0 | 0 |
 
@@ -49,7 +49,7 @@
 | EPIC-005 | reporting-visualization | 36 | 0 | 36 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 0 | 63 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-008 | testing-strategy | 96 | 0 | 96 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 97 | 0 | 97 | 0 | 0 | 0 | 100.0% |
 | EPIC-009 | pdf-fixture-generation | 37 | 0 | 37 | 0 | 0 | 0 | 100.0% |
 | EPIC-010 | signoz-logging | 21 | 0 | 21 | 0 | 0 | 0 | 100.0% |
 | EPIC-011 | asset-lifecycle | 38 | 0 | 38 | 0 | 0 | 0 | 100.0% |

--- a/scripts/tests/test_issue_459_infra_contracts.py
+++ b/scripts/tests/test_issue_459_infra_contracts.py
@@ -106,14 +106,30 @@ def test_epic_007_secret_and_health_contracts_are_documented() -> None:
 
 def test_epic_009_pdf_fixture_tooling_contracts() -> None:
     """PDF fixture tooling modules, templates, and docs exist."""
-    _assert_python_defines_class(PDF_FIXTURES / "generators" / "base_generator.py", "BasePDFGenerator")
-    _assert_python_defines_class(PDF_FIXTURES / "generators" / "dbs_generator.py", "DBSGenerator")
-    _assert_python_defines_class(PDF_FIXTURES / "generators" / "cmb_generator.py", "CMBGenerator")
-    _assert_python_defines_class(PDF_FIXTURES / "generators" / "mari_generator.py", "MariGenerator")
-    _assert_python_defines_function(PDF_FIXTURES / "generators" / "font_utils.py", "register_chinese_fonts")
-    _assert_python_defines_function(PDF_FIXTURES / "data" / "fake_data.py", "generate_dbs_transactions")
-    _assert_python_defines_class(PDF_FIXTURES / "analyzers" / "template_extractor.py", "TemplateExtractor")
-    _assert_python_defines_class(PDF_FIXTURES / "validators" / "pdf_validator.py", "PDFValidator")
+    _assert_python_defines_class(
+        PDF_FIXTURES / "generators" / "base_generator.py", "BasePDFGenerator"
+    )
+    _assert_python_defines_class(
+        PDF_FIXTURES / "generators" / "dbs_generator.py", "DBSGenerator"
+    )
+    _assert_python_defines_class(
+        PDF_FIXTURES / "generators" / "cmb_generator.py", "CMBGenerator"
+    )
+    _assert_python_defines_class(
+        PDF_FIXTURES / "generators" / "mari_generator.py", "MariGenerator"
+    )
+    _assert_python_defines_function(
+        PDF_FIXTURES / "generators" / "font_utils.py", "register_chinese_fonts"
+    )
+    _assert_python_defines_function(
+        PDF_FIXTURES / "data" / "fake_data.py", "generate_dbs_transactions"
+    )
+    _assert_python_defines_class(
+        PDF_FIXTURES / "analyzers" / "template_extractor.py", "TemplateExtractor"
+    )
+    _assert_python_defines_class(
+        PDF_FIXTURES / "validators" / "pdf_validator.py", "PDFValidator"
+    )
 
     for template in ("dbs_template.yaml", "cmb_template.yaml", "mari_template.yaml"):
         data = _load_yaml(PDF_FIXTURES / "templates" / template)
@@ -138,9 +154,9 @@ def test_epic_009_generator_templates_and_cli_options() -> None:
     assert "Decimal" in generator_text
     assert "%y%m" in generator_text or "strftime" in generator_text
     assert "generate_" in fake_data_text and "transactions" in fake_data_text
-    assert '{source}_template.yaml' in generator_text
+    assert "{source}_template.yaml" in generator_text
     assert "register_chinese_fonts" in cmb_text
-    assert '{source}_template.yaml' in generator_text
+    assert "{source}_template.yaml" in generator_text
     assert "interest_details" in mari_template_text
     assert "--source" in generator_text
     assert "--output" in generator_text
@@ -179,17 +195,19 @@ def test_epic_010_observability_docs_and_templates() -> None:
 
 
 def test_epic_012_and_014_tooling_contracts() -> None:
-    """Moon, schema, and quality tooling contracts exist.
-
-    AC12.19.1 AC12.22.1 AC12.22.2
-    AC14.1.1 AC14.1.2 AC14.1.3 AC14.1.4 AC14.1.5 AC14.1.6
-    """
+    """Moon, schema, and quality tooling contracts exist."""
     assert (REPO_ROOT / "moon.yml").exists()
     assert (REPO_ROOT / ".moon" / "workspace.yml").exists()
 
-    statements_router = _read(REPO_ROOT / "apps" / "backend" / "src" / "routers" / "statements.py")
-    review_schemas = _read(REPO_ROOT / "apps" / "backend" / "src" / "schemas" / "review.py")
-    statement_parsing = _read(REPO_ROOT / "apps" / "backend" / "src" / "services" / "statement_parsing.py")
+    statements_router = _read(
+        REPO_ROOT / "apps" / "backend" / "src" / "routers" / "statements.py"
+    )
+    review_schemas = _read(
+        REPO_ROOT / "apps" / "backend" / "src" / "schemas" / "review.py"
+    )
+    statement_parsing = _read(
+        REPO_ROOT / "apps" / "backend" / "src" / "services" / "statement_parsing.py"
+    )
     pyproject = _read(REPO_ROOT / "apps" / "backend" / "pyproject.toml")
     precommit = _read(REPO_ROOT / ".pre-commit-config.yaml")
 

--- a/scripts/tests/test_issue_493_foundation_ttd_behavior.py
+++ b/scripts/tests/test_issue_493_foundation_ttd_behavior.py
@@ -1,0 +1,321 @@
+"""Behavior-backed coverage for issue #493 foundation and TTD ACs."""
+
+from __future__ import annotations
+
+import ast
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = SCRIPTS_ROOT.parent
+sys.path.insert(0, str(SCRIPTS_ROOT))
+
+import check_env_keys  # noqa: E402
+import generate_ac_registry as gar  # noqa: E402
+import validate_schemas  # noqa: E402
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _parse_python(path: Path) -> ast.Module:
+    return ast.parse(_read(path), filename=str(path))
+
+
+def _class_names(path: Path) -> set[str]:
+    return {
+        node.name for node in _parse_python(path).body if isinstance(node, ast.ClassDef)
+    }
+
+
+def _imported_names_from_module(path: Path, module_name: str) -> set[str]:
+    imported: set[str] = set()
+    for node in _parse_python(path).body:
+        if isinstance(node, ast.ImportFrom) and node.module == module_name:
+            imported.update(alias.name for alias in node.names)
+    return imported
+
+
+def test_AC12_19_1_moon_workspace_loads_root_and_app_projects() -> None:
+    """AC12.19.1: Moon workspace config discovers apps, infra, and root tasks."""
+    workspace = yaml.safe_load(_read(REPO_ROOT / ".moon" / "workspace.yml"))
+    root_project = yaml.safe_load(_read(REPO_ROOT / "moon.yml"))
+
+    assert workspace["vcs"]["client"] == "git"
+    assert workspace["vcs"]["defaultBranch"] == "main"
+    assert workspace["projects"] == ["apps/*", "infra", "."]
+    assert root_project["layer"] == "tool"
+    expected_tasks = {"setup", "dev", "test", "lint", "build", "clean"}
+    assert set(root_project["tasks"]) == expected_tasks
+    for task in expected_tasks:
+        command = root_project["tasks"][task]["command"]
+        assert command.startswith("python scripts/cli.py ")
+
+
+def test_AC12_22_1_stage2_review_schemas_live_outside_statements_router() -> None:
+    """AC12.22.1: Stage 2 review request/response schemas are in schemas.review."""
+    review_schema_path = (
+        REPO_ROOT / "apps" / "backend" / "src" / "schemas" / "review.py"
+    )
+    statements_router_path = (
+        REPO_ROOT / "apps" / "backend" / "src" / "routers" / "statements.py"
+    )
+    review_router_path = (
+        REPO_ROOT / "apps" / "backend" / "src" / "routers" / "review.py"
+    )
+
+    moved_schema_names = {
+        "ConsistencyCheckResponse",
+        "ConsistencyCheckListResponse",
+        "ResolveCheckRequest",
+        "BatchApproveRequest",
+        "BatchRejectRequest",
+        "Stage2ReviewQueueResponse",
+    }
+
+    assert moved_schema_names <= _class_names(review_schema_path)
+    assert moved_schema_names.isdisjoint(_class_names(statements_router_path))
+    assert moved_schema_names <= _imported_names_from_module(
+        review_router_path,
+        "src.schemas.review",
+    )
+
+
+def test_AC12_22_2_background_task_payload_schemas_are_module_owned() -> None:
+    """AC12.22.2: Statement background/retry payload schemas stay in schemas.extraction."""
+    extraction_schema_path = (
+        REPO_ROOT / "apps" / "backend" / "src" / "schemas" / "extraction.py"
+    )
+    statements_router_path = (
+        REPO_ROOT / "apps" / "backend" / "src" / "routers" / "statements.py"
+    )
+    statement_parsing_path = (
+        REPO_ROOT / "apps" / "backend" / "src" / "services" / "statement_parsing.py"
+    )
+
+    payload_schema_names = {
+        "StatementDecisionRequest",
+        "RetryParsingRequest",
+        "TransactionUpdateRequest",
+        "ParsedStatementPreview",
+    }
+
+    assert payload_schema_names <= _class_names(extraction_schema_path)
+    assert payload_schema_names.isdisjoint(_class_names(statements_router_path))
+    assert payload_schema_names.isdisjoint(_class_names(statement_parsing_path))
+    public_schema_imports = _imported_names_from_module(
+        statements_router_path, "src.schemas"
+    )
+    assert {"StatementDecisionRequest", "RetryParsingRequest"} <= public_schema_imports
+
+
+def test_AC14_1_1_backend_pyproject_enforces_local_coverage_threshold() -> None:
+    """AC14.1.1: Backend pytest config enforces coverage above the 90 percent target."""
+    pyproject = tomllib.loads(_read(REPO_ROOT / "apps" / "backend" / "pyproject.toml"))
+    addopts = pyproject["tool"]["pytest"]["ini_options"]["addopts"]
+
+    assert "--cov=src" in addopts
+    assert "--cov-branch" in addopts
+    threshold_index = addopts.index("--cov-fail-under=96")
+    threshold = int(addopts[threshold_index].split("=", maxsplit=1)[1])
+    assert threshold >= 90
+
+
+def test_AC14_1_2_pre_commit_mypy_hook_blocks_backend_type_errors() -> None:
+    """AC14.1.2: Pre-commit runs mypy against backend source files."""
+    config = yaml.safe_load(_read(REPO_ROOT / ".pre-commit-config.yaml"))
+    hooks = {
+        hook["id"]: hook
+        for repo in config["repos"]
+        if repo["repo"] == "https://github.com/pre-commit/mirrors-mypy"
+        for hook in repo["hooks"]
+    }
+
+    mypy = hooks["mypy"]
+    assert mypy["files"] == "^apps/backend/src/"
+    assert "--warn-unused-ignores" in mypy["args"]
+    assert "--ignore-missing-imports" in mypy["args"]
+    assert "sqlalchemy>=2.0.30" in mypy["additional_dependencies"]
+
+
+def test_AC14_1_3_validate_schemas_exits_nonzero_for_missing_field_descriptions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC14.1.3: validate_schemas.py exits non-zero for Field() without descriptions."""
+    root = tmp_path
+    config_path = root / "apps" / "backend" / "src" / "config.py"
+    schemas_dir = root / "apps" / "backend" / "src" / "schemas"
+    config_path.parent.mkdir(parents=True)
+    schemas_dir.mkdir(parents=True)
+    config_path.write_text(
+        "class Settings:\n    debug: bool = False\n", encoding="utf-8"
+    )
+    (schemas_dir / "bad.py").write_text(
+        "from pydantic import BaseModel, Field\n\n"
+        "class BadSchema(BaseModel):\n"
+        "    name: str = Field()\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(validate_schemas, "get_project_root", lambda: root)
+    monkeypatch.setattr(sys, "argv", ["validate_schemas.py"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        validate_schemas.main()
+
+    assert exc_info.value.code == 1
+
+
+def test_AC14_1_4_check_env_keys_exits_nonzero_for_secret_config_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC14.1.4: check_env_keys.py detects mismatched secrets/config/env keys."""
+    root = tmp_path
+    ctmpl_path = (
+        root / "repo" / "finance_report" / "finance_report" / "10.app" / "secrets.ctmpl"
+    )
+    config_path = root / "apps" / "backend" / "src" / "config.py"
+    env_path = root / ".env.example"
+    ctmpl_path.parent.mkdir(parents=True)
+    config_path.parent.mkdir(parents=True)
+    ctmpl_path.write_text(
+        "DATABASE_URL={{ .Data.data.DATABASE_URL }}\n", encoding="utf-8"
+    )
+    config_path.write_text(
+        'class Settings:\n    redis_url: str = Field(validation_alias="REDIS_URL")\n',
+        encoding="utf-8",
+    )
+    env_path.write_text("REDIS_URL=redis://localhost:6379/0\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_env_keys, "get_project_root", lambda: root)
+    monkeypatch.setattr(sys, "argv", ["check_env_keys.py"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        check_env_keys.main()
+
+    assert exc_info.value.code == 1
+
+
+def test_AC14_1_5_smoke_test_succeeds_against_mocked_local_environment(
+    tmp_path: Path,
+) -> None:
+    """AC14.1.5: smoke_test.sh succeeds when health, pages, auth, and CORS pass."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import sys
+
+            args = sys.argv[1:]
+            url = next((arg for arg in reversed(args) if arg.startswith("http")), "")
+
+            if "-I" in args:
+                print("HTTP/1.1 204 No Content")
+                print("Access-Control-Allow-Origin: http://example.test")
+                raise SystemExit(0)
+
+            status = "401" if url.endswith("/api/statements") else "200"
+            body = '{"status":"healthy","state":"pong"}' if url.endswith("/api/health") or url.endswith("/api/ping") else "OK"
+
+            if "-o" in args and "/dev/null" in args:
+                print(status, end="")
+            elif "-w" in args:
+                print(body)
+                print(status)
+            else:
+                print(body)
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_curl.chmod(fake_curl.stat().st_mode | stat.S_IXUSR)
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "SMOKE_READY_ATTEMPTS": "1",
+        "SMOKE_READY_SLEEP_SECONDS": "0",
+    }
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "smoke_test.sh"),
+            "http://example.test",
+            "prod",
+        ],
+        check=False,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "All smoke tests passed!" in result.stdout
+    assert "Protected endpoint is secured" in result.stdout
+
+
+def test_AC14_1_6_generate_ac_registry_check_rejects_ghosts_and_keeps_no_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC14.1.6: Registry generation ignores ghost AC references and splits infra/feature IDs."""
+    project_dir = tmp_path / "docs" / "project"
+    project_dir.mkdir(parents=True)
+    (project_dir / "EPIC-001.phase0-setup.md").write_text(
+        "| AC1.1.1 | Feature setup AC |\n"
+        "Reference-only prose mentions AC1.99.1 but must not create it.\n",
+        encoding="utf-8",
+    )
+    (project_dir / "EPIC-014.ttd-transformation.md").write_text(
+        "| AC14.1.6 | Registry generation keeps zero ghost ACs and zero overlap |\n",
+        encoding="utf-8",
+    )
+
+    feature_registry = tmp_path / "docs" / "ac_registry.yaml"
+    infra_registry = tmp_path / "docs" / "infra_registry.yaml"
+    feature_registry.parent.mkdir(parents=True, exist_ok=True)
+    gar.write_registry(
+        {
+            "AC1.1.1": {
+                "epic": 1,
+                "epic_name": "phase0-setup",
+                "description": "Feature setup AC",
+            }
+        },
+        output_path=str(feature_registry),
+    )
+    gar.write_registry(
+        {
+            "AC14.1.6": {
+                "epic": 14,
+                "epic_name": "ttd-transformation",
+                "description": "Registry generation keeps zero ghost ACs and zero overlap",
+            }
+        },
+        output_path=str(infra_registry),
+    )
+
+    monkeypatch.setattr(gar, "EPIC_DIR", str(project_dir))
+    monkeypatch.setattr(gar, "OUTPUT_FEATURE", str(feature_registry))
+    monkeypatch.setattr(gar, "OUTPUT_INFRA", str(infra_registry))
+
+    extracted = gar.extract_acs()
+    assert "AC1.99.1" not in extracted
+    assert gar.main(["--check"]) == 0
+    feature_ids = set(gar.load_existing_registry(feature_registry))
+    infra_ids = set(gar.load_existing_registry(infra_registry))
+    assert feature_ids.isdisjoint(infra_ids)


### PR DESCRIPTION
## Summary
- Add behavior-backed tests for issue #493 active ACs: AC12.19.1, AC12.22.1, AC12.22.2, and AC14.1.1 through AC14.1.6.
- Move #493 AC references out of broad issue #459 contract coverage so traceability points to explicit behavior tests.
- Regenerate the AC coverage report and update the infra submodule pointer to latest infra2 main per PR checklist.

## Verification
- uv run ruff check scripts/tests/test_issue_493_foundation_ttd_behavior.py scripts/tests/test_issue_459_infra_contracts.py
- uv run --with pytest --with pyyaml pytest scripts/tests/test_issue_493_foundation_ttd_behavior.py scripts/tests/test_issue_459_infra_contracts.py -q
- python scripts/lint_doc_consistency.py --verbose
- python scripts/check_ac_traceability.py
- python scripts/analyze_test_ac_coverage.py --output docs/analysis/test-ac-coverage-report.md
- python scripts/build_ac_traceability.py --output /tmp/AC-TEST-TRACEABILITY-AUDIT-493.md
- git diff --check
- moon run :lint
- moon run :test

Fixes #493