### PR TITLE
[codex] Add README status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Finance Report
 
+[![CI](https://github.com/wangzitian0/finance_report/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/wangzitian0/finance_report/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/wangzitian0/finance_report/badge.svg?branch=main)](https://coveralls.io/github/wangzitian0/finance_report?branch=main)
+[![Deploy Staging](https://github.com/wangzitian0/finance_report/actions/workflows/staging-deploy.yml/badge.svg?branch=main)](https://github.com/wangzitian0/finance_report/actions/workflows/staging-deploy.yml)
+[![Docs](https://github.com/wangzitian0/finance_report/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/wangzitian0/finance_report/actions/workflows/docs.yml)
+
 Personal finance system for accurate, auditable asset reporting: double-entry
 bookkeeping, statement import, reconciliation, reports, AI-assisted review, and
 portfolio tracking.


### PR DESCRIPTION
## Summary

Add dynamic README badges for CI, Coveralls coverage, staging deploy, and documentation deploy.

Issue: N/A

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | N/A — README presentation polish |
| **AC IDs** | N/A |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [x] None — this is a README navigation/status presentation change using existing CI/CD and coverage sources.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | N/A | Documentation-only badge addition; no behavioral test added. |
| Green | `acf0888` | Added README badges and validated existing gates. |

---

## Engineering Audit

- [x] MECE task frame: one README-only slice; no backend, frontend, DB, env, or infra change.
- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no SQLAlchemy changes.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` — N/A, no frontend env changes.
- [x] `repo/` submodule updated for production config changes — N/A; verified `repo` HEAD matches `origin/main`.
- [x] `scripts/check_env_keys.py` passes — N/A, no env vars changed.
- [x] `scripts/check_manifest.py` passes — N/A, no SSOT files changed.
- [x] `scripts/lint_doc_consistency.py` passes — covered by `moon run :lint`.

---

## Testing

```bash
moon run :lint && moon run :test
python scripts/check_ac_traceability.py
python scripts/generate_ac_registry.py --check
git diff --check
```

Results:

- `moon run :lint` passed with existing frontend lint warnings.
- `moon run :test` passed: 1894 backend tests, 98.15% coverage.
- AC traceability passed: 828/828 mandatory ACs have real coverage.
- AC registry check passed.
- `git diff --check` passed.

---

## Screenshots / Evidence

N/A — README Markdown-only change.
