### PR TITLE
[codex] Unify coverage low-file reporting

### DIFF
--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -113,6 +113,20 @@ jobs:
 2. Uses LCOV `LF:` as denominator (NOT filesystem line counts)
 3. Aggregates backend + frontend + scripts covered/executable counts
 4. Reports unified percentage and exits 1 if coverage dropped below baseline
+5. Lists file-level low coverage from the same component LCOV files when run
+   with `--list-low-files`
+
+File-level coverage audits must use the same LCOV inputs as the unified gate,
+not `coverage.py report` text output or stale component-local artifacts:
+
+```bash
+python scripts/build_unified_lcov.py coverage/unified.lcov
+python scripts/calculate_unified_coverage.py --list-low-files --threshold 90
+```
+
+The `--threshold` flag applies only to the printed file-level low-coverage
+report. The CI pass/fail gate remains the no-regression comparison against
+`unified-coverage.json`.
 
 ---
 

--- a/scripts/calculate_unified_coverage.py
+++ b/scripts/calculate_unified_coverage.py
@@ -14,12 +14,13 @@ Output: unified-coverage.json with:
 - unified: {total_lines, covered_lines, coverage_percent}
 """
 
+import argparse
 import json
 import os
 import sys
 from pathlib import Path
 
-from coverage_policy import CoverageComponent, get_component
+from coverage_policy import COMPONENTS, CoverageComponent, get_component
 
 # Configuration
 ROOT_DIR = Path(__file__).parent.parent
@@ -82,27 +83,24 @@ def count_code_lines(directory: Path, extensions: list[str]) -> dict:
     total_lines = 0
     file_count = 0
     files_detail = []
-    
+
     for ext in extensions:
         for file_path in directory.rglob(f"*{ext}"):
             relative_path = str(file_path.relative_to(ROOT_DIR))
-            
+
             if is_test_file(relative_path):
                 continue
-            
+
             lines = count_lines(file_path)
             if lines > 0:
                 total_lines += lines
                 file_count += 1
-                files_detail.append({
-                    "path": relative_path,
-                    "lines": lines
-                })
-    
+                files_detail.append({"path": relative_path, "lines": lines})
+
     return {
         "total_lines": total_lines,
         "file_count": file_count,
-        "files": files_detail[:10]  # Only keep first 10 for summary
+        "files": files_detail[:10],  # Only keep first 10 for summary
     }
 
 
@@ -114,54 +112,93 @@ def count_policy_files(component: CoverageComponent) -> dict:
     }
 
 
-def parse_lcov_file(lcov_path: Path) -> dict:
-    """Parse lcov coverage file and extract covered line counts.
-    
-    LCOV format has per-file records with LH/LF summaries.
-    We must accumulate LH/LF from each file, not override.
-    """
+def _coverage_percent(covered_lines: int, total_lines: int) -> float:
+    return round(covered_lines / max(total_lines, 1) * 100, 2) if total_lines > 0 else 0
+
+
+def parse_lcov_records(
+    lcov_path: Path,
+    component: CoverageComponent | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> list[dict]:
+    """Parse LCOV and return per-source line coverage records."""
     if not lcov_path.exists():
-        return {"covered_lines": 0, "total_measured_lines": 0}
-    total_covered = 0
-    total_measured = 0
-    
-    # Parse file by file, accumulating LH/LF from each record
+        return []
+
+    records: dict[str, dict] = {}
+    current_source = ""
     current_file_covered = 0
     current_file_total = 0
     in_record = False
+
+    def flush_record() -> None:
+        nonlocal current_source, current_file_covered, current_file_total, in_record
+        if not in_record or not current_source:
+            return
+        source = (
+            component.normalize_lcov_source(current_source, repo_root)
+            if component is not None
+            else current_source.replace("\\", "/")
+        )
+        record = records.setdefault(
+            source,
+            {
+                "path": source,
+                "covered_lines": 0,
+                "total_lines": 0,
+            },
+        )
+        record["covered_lines"] += current_file_covered
+        record["total_lines"] += current_file_total
+        current_source = ""
+        current_file_covered = 0
+        current_file_total = 0
+        in_record = False
+
     with open(lcov_path, "r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line.startswith("SF:"):
-                # Start of new file record
+                flush_record()
                 in_record = True
+                current_source = line[3:]
                 current_file_covered = 0
                 current_file_total = 0
             elif line.startswith("LH:"):
-                # Lines hit in current file
                 try:
                     current_file_covered = int(line[3:])
                 except ValueError:
                     pass
             elif line.startswith("LF:"):
-                # Lines found in current file
                 try:
                     current_file_total = int(line[3:])
                 except ValueError:
                     pass
             elif line == "end_of_record":
-                # End of file record, accumulate to totals
-                if in_record:
-                    total_covered += current_file_covered
-                    total_measured += current_file_total
-                    in_record = False
-                    current_file_covered = 0
-                    current_file_total = 0
-    
-    # Handle last record if no end_of_record marker
-    if in_record and current_file_total > 0:
-        total_covered += current_file_covered
-        total_measured += current_file_total
+                flush_record()
+
+    flush_record()
+
+    return [
+        {
+            **record,
+            "coverage_percent": _coverage_percent(
+                record["covered_lines"], record["total_lines"]
+            ),
+        }
+        for record in records.values()
+    ]
+
+
+def parse_lcov_file(lcov_path: Path) -> dict:
+    """Parse lcov coverage file and extract covered line counts.
+
+    LCOV format has per-file records with LH/LF summaries.
+    We must accumulate LH/LF from each file, not override.
+    """
+    records = parse_lcov_records(lcov_path)
+    total_covered = sum(record["covered_lines"] for record in records)
+    total_measured = sum(record["total_lines"] for record in records)
     return {
         "covered_lines": total_covered,
         "total_measured_lines": total_measured,
@@ -176,7 +213,9 @@ def get_component_coverage(component: CoverageComponent) -> dict:
     return {
         "total_lines": total_lines,
         "covered_lines": coverage_data["covered_lines"],
-        "coverage_percent": round(coverage_data["covered_lines"] / max(total_lines, 1) * 100, 2) if total_lines > 0 else 0,
+        "coverage_percent": _coverage_percent(
+            coverage_data["covered_lines"], total_lines
+        ),
         "file_count": policy_stats["file_count"],
     }
 
@@ -195,19 +234,78 @@ def get_scripts_coverage() -> dict:
 
 def calculate_unified_coverage(backend: dict, frontend: dict, scripts: dict) -> dict:
     """Calculate unified coverage across all components."""
-    total_lines = backend["total_lines"] + frontend["total_lines"] + scripts["total_lines"]
-    covered_lines = backend["covered_lines"] + frontend["covered_lines"] + scripts["covered_lines"]
-    
+    total_lines = (
+        backend["total_lines"] + frontend["total_lines"] + scripts["total_lines"]
+    )
+    covered_lines = (
+        backend["covered_lines"] + frontend["covered_lines"] + scripts["covered_lines"]
+    )
+
     return {
         "total_lines": total_lines,
         "covered_lines": covered_lines,
-        "coverage_percent": round(covered_lines / max(total_lines, 1) * 100, 2) if total_lines > 0 else 0,
+        "coverage_percent": _coverage_percent(covered_lines, total_lines),
         "breakdown": {
             "backend": backend,
             "frontend": frontend,
             "scripts": scripts,
         },
     }
+
+
+def _repo_relative_path(
+    component: CoverageComponent, component_relative_path: str
+) -> str:
+    if component.component_root:
+        return f"{component.component_root}/{component_relative_path}"
+    return component_relative_path
+
+
+def collect_low_coverage_files(
+    threshold: float,
+    repo_root: Path = ROOT_DIR,
+    components: tuple[CoverageComponent, ...] = COMPONENTS,
+) -> list[dict]:
+    """Return file-level LCOV records below threshold using the shared policy."""
+    rows = []
+    for component in components:
+        for record in parse_lcov_records(
+            component.lcov_path(repo_root), component, repo_root
+        ):
+            total_lines = record["total_lines"]
+            coverage_percent = record["coverage_percent"]
+            if total_lines > 0 and coverage_percent < threshold:
+                rows.append(
+                    {
+                        "component": component.name,
+                        "path": _repo_relative_path(component, record["path"]),
+                        "covered_lines": record["covered_lines"],
+                        "total_lines": total_lines,
+                        "coverage_percent": coverage_percent,
+                    }
+                )
+    return sorted(
+        rows, key=lambda row: (row["coverage_percent"], row["component"], row["path"])
+    )
+
+
+def print_low_coverage_files(rows: list[dict], threshold: float) -> None:
+    print("\n" + "=" * 60)
+    print(f"LOW COVERAGE FILES (< {threshold:g}%)")
+    print("=" * 60)
+    if not rows:
+        print(f"✅ No files below {threshold:g}%")
+        return
+    print(f"{'Component':<10} {'Coverage':>9} {'Lines':>11}  File")
+    print("-" * 60)
+    for row in rows:
+        lines = f"{row['covered_lines']}/{row['total_lines']}"
+        print(
+            f"{row['component']:<10} "
+            f"{row['coverage_percent']:>8.2f}% "
+            f"{lines:>11}  "
+            f"{row['path']}"
+        )
 
 
 def _format_regression_error(
@@ -233,49 +331,76 @@ def _format_regression_error(
     return "\n".join(lines)
 
 
-def main() -> None:
+def parse_args(argv: list[str] | tuple[str, ...]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Calculate unified LCOV coverage.")
+    parser.add_argument(
+        "--list-low-files",
+        action="store_true",
+        help="Print files below the file-level LCOV threshold.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=90.0,
+        help=(
+            "File-level threshold for --list-low-files only; "
+            "does not affect the coverage gate."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | tuple[str, ...] = ()) -> None:
     """Main entry point."""
+    args = parse_args(argv)
+
     print("=" * 60)
     print("Unified Coverage Calculator")
     print("=" * 60)
-    
+
     # Get coverage for each component
     print("\n📊 Backend Coverage...")
     backend = get_backend_coverage()
     print(f"   Total lines: {backend['total_lines']:,}")
     print(f"   Covered lines: {backend['covered_lines']:,}")
     print(f"   Coverage: {backend['coverage_percent']}%")
-    
+
     print("\n📊 Frontend Coverage...")
     frontend = get_frontend_coverage()
     print(f"   Total lines: {frontend['total_lines']:,}")
     print(f"   Covered lines: {frontend['covered_lines']:,}")
     print(f"   Coverage: {frontend['coverage_percent']}%")
-    
+
     print("\n📊 Scripts Coverage...")
     scripts = get_scripts_coverage()
     print(f"   Total lines: {scripts['total_lines']:,}")
     print(f"   Covered lines: {scripts['covered_lines']:,}")
     print(f"   Coverage: {scripts['coverage_percent']}%")
-    
+
     # Calculate unified coverage
     unified = calculate_unified_coverage(backend, frontend, scripts)
-    
+
+    if args.list_low_files:
+        print_low_coverage_files(
+            collect_low_coverage_files(args.threshold, ROOT_DIR),
+            args.threshold,
+        )
+
     # Baseline comparison
     baseline_file = os.environ.get("BASELINE_FILE", "").strip()
     if not baseline_file:
         baseline_file = "unified-coverage.json"
     baseline_path = ROOT_DIR / baseline_file
-    
+
     try:
         if baseline_path.exists():
             with open(baseline_path, "r") as f:
                 baseline = json.load(f)
-            
+
             # Compare each component against baseline
             baseline_breakdown = baseline.get("breakdown", {})
             baseline_unified = baseline.get("coverage_percent", 0)
-            
+
             regressions: list[tuple[str, float, float]] = []
             unified_current = round(unified["coverage_percent"], 2)
             unified_floor = round(float(baseline_unified), 2)
@@ -285,17 +410,25 @@ def main() -> None:
             # Component breakdown comparison (if available)
             components_to_check = []
             if "backend" in baseline_breakdown:
-                components_to_check.append(("backend", backend, baseline_breakdown["backend"]))
+                components_to_check.append(
+                    ("backend", backend, baseline_breakdown["backend"])
+                )
             if "frontend" in baseline_breakdown:
-                components_to_check.append(("frontend", frontend, baseline_breakdown["frontend"]))
+                components_to_check.append(
+                    ("frontend", frontend, baseline_breakdown["frontend"])
+                )
             if "scripts" in baseline_breakdown:
-                components_to_check.append(("scripts", scripts, baseline_breakdown["scripts"]))
-            
+                components_to_check.append(
+                    ("scripts", scripts, baseline_breakdown["scripts"])
+                )
+
             for component_name, current_data, baseline_data in components_to_check:
                 current_percent = round(float(current_data["coverage_percent"]), 2)
                 baseline_percent = round(float(baseline_data["coverage_percent"]), 2)
                 if current_percent < baseline_percent:
-                    regressions.append((component_name, current_percent, baseline_percent))
+                    regressions.append(
+                        (component_name, current_percent, baseline_percent)
+                    )
 
             if regressions:
                 print(
@@ -306,12 +439,12 @@ def main() -> None:
                     file=sys.stderr,
                 )
                 sys.exit(1)
-            
+
             print("✅ No regression: all coverage at or above baseline")
         else:
             print(f"⚠️  Baseline file not found: {baseline_path}", file=sys.stderr)
             print("⚠️  Continuing with coverage threshold check...", file=sys.stderr)
-            
+
     except FileNotFoundError:
         print(f"⚠️  Baseline file not found: {baseline_path}", file=sys.stderr)
         print("⚠️  Continuing with coverage threshold check...", file=sys.stderr)
@@ -321,7 +454,7 @@ def main() -> None:
     except Exception as e:
         print(f"⚠️  Error reading baseline file: {e}", file=sys.stderr)
         print("⚠️  Continuing with coverage threshold check...", file=sys.stderr)
-    
+
     print("\n" + "=" * 60)
     print("🎯 UNIFIED COVERAGE")
     print("=" * 60)
@@ -329,22 +462,26 @@ def main() -> None:
     print(f"   Covered lines: {unified['covered_lines']:,}")
     print(f"   Coverage: {unified['coverage_percent']}%")
     print("\n" + "-" * 60)
-    
+
     # Write output JSON
     output_path = ROOT_DIR / "unified-coverage.json"
     with open(output_path, "w") as f:
         json.dump(unified, f, indent=2)
     print(f"\n📄 Report saved to: {output_path}")
-    
+
     # Exit with appropriate code (safety net after baseline check)
     threshold = int(os.environ.get("COVERAGE_THRESHOLD", "0"))
     if unified["coverage_percent"] >= threshold:
-        print(f"✅ Coverage ({unified['coverage_percent']}%) meets threshold ({threshold}%)")
+        print(
+            f"✅ Coverage ({unified['coverage_percent']}%) meets threshold ({threshold}%)"
+        )
         sys.exit(0)
     else:
-        print(f"❌ Coverage ({unified['coverage_percent']}%) below threshold ({threshold}%)")
+        print(
+            f"❌ Coverage ({unified['coverage_percent']}%) below threshold ({threshold}%)"
+        )
         sys.exit(1)
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/scripts/tests/test_calculate_unified_coverage.py
+++ b/scripts/tests/test_calculate_unified_coverage.py
@@ -234,6 +234,88 @@ end_of_record
         assert result["total_measured_lines"] == 30
 
 
+class TestLcovFileRecords:
+    """AC8.13.15: file-level reports reuse unified LCOV semantics."""
+
+    def _component(self, lcov_path: str) -> cuc.CoverageComponent:
+        return cuc.CoverageComponent(
+            name="frontend",
+            component_root="apps/frontend",
+            source_subdir="src",
+            extensions=(".ts", ".tsx"),
+            ci_lcov_path=lcov_path,
+            local_lcov_paths=(),
+            exclude_patterns=(),
+        )
+
+    def test_records_accumulate_duplicate_sources_and_normalize_paths(self, tmp_path):
+        coverage_dir = tmp_path / "coverage"
+        coverage_dir.mkdir()
+        lcov = coverage_dir / "frontend.lcov"
+        lcov.write_text(
+            "\n".join(
+                [
+                    "SF:apps/frontend/src/app/page.tsx",
+                    "LH:1",
+                    "LF:4",
+                    "end_of_record",
+                    "SF:src/app/page.tsx",
+                    "LH:2",
+                    "LF:4",
+                    "end_of_record",
+                ]
+            )
+        )
+        component = self._component("coverage/frontend.lcov")
+
+        records = cuc.parse_lcov_records(lcov, component, tmp_path)
+
+        assert records == [
+            {
+                "path": "src/app/page.tsx",
+                "covered_lines": 3,
+                "total_lines": 8,
+                "coverage_percent": 37.5,
+            }
+        ]
+
+    def test_collect_low_coverage_files_uses_repo_relative_paths(self, tmp_path):
+        coverage_dir = tmp_path / "coverage"
+        coverage_dir.mkdir()
+        (coverage_dir / "frontend.lcov").write_text(
+            "\n".join(
+                [
+                    "SF:src/low.tsx",
+                    "LH:1",
+                    "LF:4",
+                    "end_of_record",
+                    "SF:src/high.tsx",
+                    "LH:9",
+                    "LF:10",
+                    "end_of_record",
+                ]
+            )
+        )
+        component = self._component("coverage/frontend.lcov")
+
+        rows = cuc.collect_low_coverage_files(90, tmp_path, (component,))
+
+        assert rows == [
+            {
+                "component": "frontend",
+                "path": "apps/frontend/src/low.tsx",
+                "covered_lines": 1,
+                "total_lines": 4,
+                "coverage_percent": 25.0,
+            }
+        ]
+
+    def test_print_low_coverage_files_reports_empty_state(self, capfd):
+        cuc.print_low_coverage_files([], 90)
+
+        assert "No files below 90%" in capfd.readouterr().out
+
+
 # ---------------------------------------------------------------------------
 # calculate_unified_coverage
 # ---------------------------------------------------------------------------
@@ -403,6 +485,41 @@ class TestMain:
         assert "coverage_percent" in data
         assert "breakdown" in data
 
+    def test_main_lists_low_coverage_files(self, tmp_path, monkeypatch, capfd):
+        monkeypatch.setattr(cuc, "ROOT_DIR", tmp_path)
+        monkeypatch.setenv("COVERAGE_THRESHOLD", "0")
+        monkeypatch.setattr(
+            cuc, "get_backend_coverage", lambda: self._fake_coverage(100, 90)
+        )
+        monkeypatch.setattr(
+            cuc, "get_frontend_coverage", lambda: self._fake_coverage(100, 90)
+        )
+        monkeypatch.setattr(
+            cuc, "get_scripts_coverage", lambda: self._fake_coverage(100, 90)
+        )
+        monkeypatch.setattr(
+            cuc,
+            "collect_low_coverage_files",
+            lambda threshold, repo_root: [
+                {
+                    "component": "frontend",
+                    "path": "apps/frontend/src/app/page.tsx",
+                    "covered_lines": 1,
+                    "total_lines": 4,
+                    "coverage_percent": 25.0,
+                }
+            ],
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            cuc.main(["--list-low-files", "--threshold", "90"])
+
+        assert exc.value.code == 0
+        out = capfd.readouterr().out
+        assert "LOW COVERAGE FILES (< 90%)" in out
+        assert "apps/frontend/src/app/page.tsx" in out
+
+
 # ---------------------------------------------------------------------------
 # Baseline comparison — compares current run against historical baseline
 # ---------------------------------------------------------------------------
@@ -420,10 +537,22 @@ class TestBaselineComparison:
             "total_lines": 10000,
             "covered_lines": 8315,
             "breakdown": {
-                "backend": {"total_lines": 5000, "covered_lines": 4700, "coverage_percent": 94.0},
-                "frontend": {"total_lines": 3000, "covered_lines": 2494, "coverage_percent": 83.13},
-                "scripts": {"total_lines": 2000, "covered_lines": 1662, "coverage_percent": 83.10}
-            }
+                "backend": {
+                    "total_lines": 5000,
+                    "covered_lines": 4700,
+                    "coverage_percent": 94.0,
+                },
+                "frontend": {
+                    "total_lines": 3000,
+                    "covered_lines": 2494,
+                    "coverage_percent": 83.13,
+                },
+                "scripts": {
+                    "total_lines": 2000,
+                    "covered_lines": 1662,
+                    "coverage_percent": 83.10,
+                },
+            },
         }
         baseline_file.write_text(json.dumps(baseline_data))
 
@@ -436,16 +565,24 @@ class TestBaselineComparison:
         def mock_coverage(name):
             return baseline_data["breakdown"][name]
 
-        monkeypatch.setattr(cuc, "get_backend_coverage", lambda: mock_coverage("backend"))
-        monkeypatch.setattr(cuc, "get_frontend_coverage", lambda: mock_coverage("frontend"))
-        monkeypatch.setattr(cuc, "get_scripts_coverage", lambda: mock_coverage("scripts"))
+        monkeypatch.setattr(
+            cuc, "get_backend_coverage", lambda: mock_coverage("backend")
+        )
+        monkeypatch.setattr(
+            cuc, "get_frontend_coverage", lambda: mock_coverage("frontend")
+        )
+        monkeypatch.setattr(
+            cuc, "get_scripts_coverage", lambda: mock_coverage("scripts")
+        )
 
         # Should exit 0 (no regression)
         with pytest.raises(SystemExit) as exc:
             cuc.main()
         assert exc.value.code == 0
 
-    def test_fails_when_unified_drops_below_baseline(self, tmp_path, monkeypatch, capfd):
+    def test_fails_when_unified_drops_below_baseline(
+        self, tmp_path, monkeypatch, capfd
+    ):
         """When unified coverage drops below baseline, expect exit 1 with message."""
         # Setup baseline file
         baseline_file = tmp_path / "baseline.json"
@@ -454,10 +591,22 @@ class TestBaselineComparison:
             "total_lines": 10000,
             "covered_lines": 8315,
             "breakdown": {
-                "backend": {"total_lines": 5000, "covered_lines": 4700, "coverage_percent": 94.0},
-                "frontend": {"total_lines": 3000, "covered_lines": 2494, "coverage_percent": 83.13},
-                "scripts": {"total_lines": 2000, "covered_lines": 1662, "coverage_percent": 83.10}
-            }
+                "backend": {
+                    "total_lines": 5000,
+                    "covered_lines": 4700,
+                    "coverage_percent": 94.0,
+                },
+                "frontend": {
+                    "total_lines": 3000,
+                    "covered_lines": 2494,
+                    "coverage_percent": 83.13,
+                },
+                "scripts": {
+                    "total_lines": 2000,
+                    "covered_lines": 1662,
+                    "coverage_percent": 83.10,
+                },
+            },
         }
         baseline_file.write_text(json.dumps(baseline_data))
 
@@ -472,18 +621,36 @@ class TestBaselineComparison:
             "total_lines": 10000,
             "covered_lines": 8200,
             "breakdown": {
-                "backend": {"total_lines": 5000, "covered_lines": 4500, "coverage_percent": 90.0},
-                "frontend": {"total_lines": 3000, "covered_lines": 2400, "coverage_percent": 80.0},
-                "scripts": {"total_lines": 2000, "covered_lines": 1300, "coverage_percent": 65.0}
-            }
+                "backend": {
+                    "total_lines": 5000,
+                    "covered_lines": 4500,
+                    "coverage_percent": 90.0,
+                },
+                "frontend": {
+                    "total_lines": 3000,
+                    "covered_lines": 2400,
+                    "coverage_percent": 80.0,
+                },
+                "scripts": {
+                    "total_lines": 2000,
+                    "covered_lines": 1300,
+                    "coverage_percent": 65.0,
+                },
+            },
         }
 
         def mock_coverage(name):
             return current_data["breakdown"][name]
 
-        monkeypatch.setattr(cuc, "get_backend_coverage", lambda: mock_coverage("backend"))
-        monkeypatch.setattr(cuc, "get_frontend_coverage", lambda: mock_coverage("frontend"))
-        monkeypatch.setattr(cuc, "get_scripts_coverage", lambda: mock_coverage("scripts"))
+        monkeypatch.setattr(
+            cuc, "get_backend_coverage", lambda: mock_coverage("backend")
+        )
+        monkeypatch.setattr(
+            cuc, "get_frontend_coverage", lambda: mock_coverage("frontend")
+        )
+        monkeypatch.setattr(
+            cuc, "get_scripts_coverage", lambda: mock_coverage("scripts")
+        )
 
         # Should exit 1 with message containing both values
         with pytest.raises(SystemExit) as exc:
@@ -552,10 +719,22 @@ class TestBaselineComparison:
             "total_lines": 10000,
             "covered_lines": 8315,
             "breakdown": {
-                "backend": {"total_lines": 5000, "covered_lines": 4700, "coverage_percent": 94.0},
-                "frontend": {"total_lines": 3000, "covered_lines": 2494, "coverage_percent": 83.13},
-                "scripts": {"total_lines": 2000, "covered_lines": 1662, "coverage_percent": 83.10}
-            }
+                "backend": {
+                    "total_lines": 5000,
+                    "covered_lines": 4700,
+                    "coverage_percent": 94.0,
+                },
+                "frontend": {
+                    "total_lines": 3000,
+                    "covered_lines": 2494,
+                    "coverage_percent": 83.13,
+                },
+                "scripts": {
+                    "total_lines": 2000,
+                    "covered_lines": 1662,
+                    "coverage_percent": 83.10,
+                },
+            },
         }
         baseline_file.write_text(json.dumps(baseline_data))
 
@@ -565,13 +744,25 @@ class TestBaselineComparison:
 
         # Mock: backend drops 94.0% → 90.0%, unified stays 83.15%
         def mock_backend():
-            return {"total_lines": 5000, "covered_lines": 4500, "coverage_percent": 90.0}
+            return {
+                "total_lines": 5000,
+                "covered_lines": 4500,
+                "coverage_percent": 90.0,
+            }
 
         def mock_frontend():
-            return {"total_lines": 3000, "covered_lines": 2494, "coverage_percent": 83.13}
+            return {
+                "total_lines": 3000,
+                "covered_lines": 2494,
+                "coverage_percent": 83.13,
+            }
 
         def mock_scripts():
-            return {"total_lines": 2000, "covered_lines": 1662, "coverage_percent": 83.10}
+            return {
+                "total_lines": 2000,
+                "covered_lines": 1662,
+                "coverage_percent": 83.10,
+            }
 
         monkeypatch.setattr(cuc, "get_backend_coverage", mock_backend)
         monkeypatch.setattr(cuc, "get_frontend_coverage", mock_frontend)
@@ -590,10 +781,22 @@ class TestBaselineComparison:
             "total_lines": 10000,
             "covered_lines": 8315,
             "breakdown": {
-                "backend": {"total_lines": 5000, "covered_lines": 4159, "coverage_percent": 83.18},
-                "frontend": {"total_lines": 3000, "covered_lines": 2494, "coverage_percent": 83.13},
-                "scripts": {"total_lines": 2000, "covered_lines": 1662, "coverage_percent": 83.10}
-            }
+                "backend": {
+                    "total_lines": 5000,
+                    "covered_lines": 4159,
+                    "coverage_percent": 83.18,
+                },
+                "frontend": {
+                    "total_lines": 3000,
+                    "covered_lines": 2494,
+                    "coverage_percent": 83.13,
+                },
+                "scripts": {
+                    "total_lines": 2000,
+                    "covered_lines": 1662,
+                    "coverage_percent": 83.10,
+                },
+            },
         }
         baseline_file.write_text(json.dumps(baseline_data))
 
@@ -603,13 +806,25 @@ class TestBaselineComparison:
 
         # Frontend drops 61.77% → 60.0%
         def mock_backend():
-            return {"total_lines": 5000, "covered_lines": 4159, "coverage_percent": 83.18}
+            return {
+                "total_lines": 5000,
+                "covered_lines": 4159,
+                "coverage_percent": 83.18,
+            }
 
         def mock_frontend():
-            return {"total_lines": 3000, "covered_lines": 1800, "coverage_percent": 60.0}
+            return {
+                "total_lines": 3000,
+                "covered_lines": 1800,
+                "coverage_percent": 60.0,
+            }
 
         def mock_scripts():
-            return {"total_lines": 2000, "covered_lines": 1662, "coverage_percent": 83.10}
+            return {
+                "total_lines": 2000,
+                "covered_lines": 1662,
+                "coverage_percent": 83.10,
+            }
 
         monkeypatch.setattr(cuc, "get_backend_coverage", mock_backend)
         monkeypatch.setattr(cuc, "get_frontend_coverage", mock_frontend)
@@ -627,10 +842,22 @@ class TestBaselineComparison:
             "total_lines": 10000,
             "covered_lines": 8315,
             "breakdown": {
-                "backend": {"total_lines": 5000, "covered_lines": 4159, "coverage_percent": 83.18},
-                "frontend": {"total_lines": 3000, "covered_lines": 2494, "coverage_percent": 83.13},
-                "scripts": {"total_lines": 2000, "covered_lines": 1662, "coverage_percent": 83.10}
-            }
+                "backend": {
+                    "total_lines": 5000,
+                    "covered_lines": 4159,
+                    "coverage_percent": 83.18,
+                },
+                "frontend": {
+                    "total_lines": 3000,
+                    "covered_lines": 2494,
+                    "coverage_percent": 83.13,
+                },
+                "scripts": {
+                    "total_lines": 2000,
+                    "covered_lines": 1662,
+                    "coverage_percent": 83.10,
+                },
+            },
         }
         baseline_file.write_text(json.dumps(baseline_data))
 
@@ -640,13 +867,25 @@ class TestBaselineComparison:
 
         # Scripts drops 68.02% → 65.0%
         def mock_backend():
-            return {"total_lines": 5000, "covered_lines": 4159, "coverage_percent": 83.18}
+            return {
+                "total_lines": 5000,
+                "covered_lines": 4159,
+                "coverage_percent": 83.18,
+            }
 
         def mock_frontend():
-            return {"total_lines": 3000, "covered_lines": 2494, "coverage_percent": 83.13}
+            return {
+                "total_lines": 3000,
+                "covered_lines": 2494,
+                "coverage_percent": 83.13,
+            }
 
         def mock_scripts():
-            return {"total_lines": 2000, "covered_lines": 1300, "coverage_percent": 65.0}
+            return {
+                "total_lines": 2000,
+                "covered_lines": 1300,
+                "coverage_percent": 65.0,
+            }
 
         monkeypatch.setattr(cuc, "get_backend_coverage", mock_backend)
         monkeypatch.setattr(cuc, "get_frontend_coverage", mock_frontend)
@@ -664,10 +903,22 @@ class TestBaselineComparison:
             "total_lines": 10000,
             "covered_lines": 8000,
             "breakdown": {
-                "backend": {"total_lines": 5000, "covered_lines": 4000, "coverage_percent": 80.0},
-                "frontend": {"total_lines": 3000, "covered_lines": 2400, "coverage_percent": 80.0},
-                "scripts": {"total_lines": 2000, "covered_lines": 1600, "coverage_percent": 80.0}
-            }
+                "backend": {
+                    "total_lines": 5000,
+                    "covered_lines": 4000,
+                    "coverage_percent": 80.0,
+                },
+                "frontend": {
+                    "total_lines": 3000,
+                    "covered_lines": 2400,
+                    "coverage_percent": 80.0,
+                },
+                "scripts": {
+                    "total_lines": 2000,
+                    "covered_lines": 1600,
+                    "coverage_percent": 80.0,
+                },
+            },
         }
         baseline_file.write_text(json.dumps(baseline_data))
 
@@ -677,13 +928,25 @@ class TestBaselineComparison:
 
         # All components improve
         def mock_backend():
-            return {"total_lines": 5000, "covered_lines": 4500, "coverage_percent": 90.0}
+            return {
+                "total_lines": 5000,
+                "covered_lines": 4500,
+                "coverage_percent": 90.0,
+            }
 
         def mock_frontend():
-            return {"total_lines": 3000, "covered_lines": 2700, "coverage_percent": 90.0}
+            return {
+                "total_lines": 3000,
+                "covered_lines": 2700,
+                "coverage_percent": 90.0,
+            }
 
         def mock_scripts():
-            return {"total_lines": 2000, "covered_lines": 1800, "coverage_percent": 90.0}
+            return {
+                "total_lines": 2000,
+                "covered_lines": 1800,
+                "coverage_percent": 90.0,
+            }
 
         monkeypatch.setattr(cuc, "get_backend_coverage", mock_backend)
         monkeypatch.setattr(cuc, "get_frontend_coverage", mock_frontend)
@@ -705,9 +968,15 @@ class TestBaselineComparison:
         def mock_coverage(name):
             return {"total_lines": 1000, "covered_lines": 800, "coverage_percent": 80.0}
 
-        monkeypatch.setattr(cuc, "get_backend_coverage", lambda: mock_coverage("backend"))
-        monkeypatch.setattr(cuc, "get_frontend_coverage", lambda: mock_coverage("frontend"))
-        monkeypatch.setattr(cuc, "get_scripts_coverage", lambda: mock_coverage("scripts"))
+        monkeypatch.setattr(
+            cuc, "get_backend_coverage", lambda: mock_coverage("backend")
+        )
+        monkeypatch.setattr(
+            cuc, "get_frontend_coverage", lambda: mock_coverage("frontend")
+        )
+        monkeypatch.setattr(
+            cuc, "get_scripts_coverage", lambda: mock_coverage("scripts")
+        )
 
         # Should exit 0 (threshold check passes, baseline check is skipped)
         with pytest.raises(SystemExit) as exc:
@@ -720,29 +989,61 @@ class TestBaselineComparison:
         baseline_file1 = tmp_path / "baseline.json"
         baseline_file2 = tmp_path / "old-baseline.json"
 
-        baseline_file1.write_text(json.dumps({
-            "coverage_percent": 83.15,
-            "total_lines": 10000,
-            "covered_lines": 8315,
-            "breakdown": {
-                "backend": {"total_lines": 5000, "covered_lines": 4159, "coverage_percent": 83.18},
-                "frontend": {"total_lines": 3000, "covered_lines": 2494, "coverage_percent": 83.13},
-                "scripts": {"total_lines": 2000, "covered_lines": 1662, "coverage_percent": 83.10}
-            }
-        }))
+        baseline_file1.write_text(
+            json.dumps(
+                {
+                    "coverage_percent": 83.15,
+                    "total_lines": 10000,
+                    "covered_lines": 8315,
+                    "breakdown": {
+                        "backend": {
+                            "total_lines": 5000,
+                            "covered_lines": 4159,
+                            "coverage_percent": 83.18,
+                        },
+                        "frontend": {
+                            "total_lines": 3000,
+                            "covered_lines": 2494,
+                            "coverage_percent": 83.13,
+                        },
+                        "scripts": {
+                            "total_lines": 2000,
+                            "covered_lines": 1662,
+                            "coverage_percent": 83.10,
+                        },
+                    },
+                }
+            )
+        )
 
         baseline_data1 = json.loads(baseline_file1.read_text())
 
-        baseline_file2.write_text(json.dumps({
-            "coverage_percent": 85.0,
-            "total_lines": 10000,
-            "covered_lines": 8500,
-            "breakdown": {
-                "backend": {"total_lines": 5000, "covered_lines": 4250, "coverage_percent": 85.0},
-                "frontend": {"total_lines": 3000, "covered_lines": 2550, "coverage_percent": 85.0},
-                "scripts": {"total_lines": 2000, "covered_lines": 1700, "coverage_percent": 85.0}
-            }
-        }))
+        baseline_file2.write_text(
+            json.dumps(
+                {
+                    "coverage_percent": 85.0,
+                    "total_lines": 10000,
+                    "covered_lines": 8500,
+                    "breakdown": {
+                        "backend": {
+                            "total_lines": 5000,
+                            "covered_lines": 4250,
+                            "coverage_percent": 85.0,
+                        },
+                        "frontend": {
+                            "total_lines": 3000,
+                            "covered_lines": 2550,
+                            "coverage_percent": 85.0,
+                        },
+                        "scripts": {
+                            "total_lines": 2000,
+                            "covered_lines": 1700,
+                            "coverage_percent": 85.0,
+                        },
+                    },
+                }
+            )
+        )
 
         baseline_data2 = json.loads(baseline_file2.read_text())
 
@@ -754,9 +1055,15 @@ class TestBaselineComparison:
         def mock_coverage(name):
             return baseline_data1["breakdown"][name]
 
-        monkeypatch.setattr(cuc, "get_backend_coverage", lambda: mock_coverage("backend"))
-        monkeypatch.setattr(cuc, "get_frontend_coverage", lambda: mock_coverage("frontend"))
-        monkeypatch.setattr(cuc, "get_scripts_coverage", lambda: mock_coverage("scripts"))
+        monkeypatch.setattr(
+            cuc, "get_backend_coverage", lambda: mock_coverage("backend")
+        )
+        monkeypatch.setattr(
+            cuc, "get_frontend_coverage", lambda: mock_coverage("frontend")
+        )
+        monkeypatch.setattr(
+            cuc, "get_scripts_coverage", lambda: mock_coverage("scripts")
+        )
 
         with pytest.raises(SystemExit) as exc:
             cuc.main()
@@ -920,6 +1227,7 @@ class TestMainBaselineExceptionPaths:
 
         # Patch json.load to raise a generic Exception
         import json as _json
+
         def raiser(f):
             raise RuntimeError("disk read error")
 


### PR DESCRIPTION
## Summary

Add file-level low-coverage reporting to the existing unified coverage calculator, reusing the same LCOV/component policy that feeds Coveralls and the unified gate.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — CI / quality gate coverage policy |
| **AC IDs** | AC8.13.15 |
| **AC Registry updated** | N/A — existing registered AC coverage |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/coverage.md` — documents that file-level audits use the same LCOV inputs as the unified gate and that `--threshold` only controls printed low-file reporting
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | N/A | Tests were added in the implementation commit for the existing coverage tooling path |
| Green (passing test) | `5da69d2` | Add LCOV file-record parsing, low-file reporting, and docs |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no SQLAlchemy changes
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A
- [x] `scripts/check_env_keys.py` passes (if env vars changed) — N/A, no env changes
- [x] `scripts/check_manifest.py` passes (if SSOT files changed)
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
uv run ruff check scripts/calculate_unified_coverage.py scripts/tests/test_calculate_unified_coverage.py
uv run ruff format scripts/calculate_unified_coverage.py scripts/tests/test_calculate_unified_coverage.py --check
uv run pytest scripts/tests/test_calculate_unified_coverage.py -q
uv run pytest scripts/tests/test_calculate_unified_coverage.py scripts/tests/test_build_unified_lcov.py scripts/tests/test_coverage_policy.py scripts/tests/test_ci_metrics_contract.py -q
python scripts/generate_ac_registry.py --check
python scripts/check_ac_traceability.py
python scripts/check_manifest.py
python scripts/lint_doc_consistency.py
python scripts/build_unified_lcov.py /tmp/finance-report-unified-check.lcov
python scripts/calculate_unified_coverage.py --help
moon run :lint
moon run :test
```

Local full-suite result before rebase: `moon run :lint && moon run :test` passed. The first local `moon run :test` attempt was blocked by an existing Podman proxy/resource conflict from prior persistent test infrastructure; `./scripts/cleanup_dev_resources.sh --force` cleared the local resource leak and the rerun passed (`1894 passed`, backend coverage `98.15%`).

After rebasing on latest `main`, the focused coverage/script checks, ruff checks, SSOT/doc consistency checks, and AC traceability check passed again. Remote CI was green before this latest rebase; after rebasing to `5da69d2`, local focused checks passed again and the latest pull_request CI and PR Test Environment checks are green.

---

## Screenshots / Evidence

N/A — tooling/docs change only.



