### PR TITLE
[codex] test: add four-asset net worth golden path

### DIFF
--- a/.github/workflows/staging-ai-ocr-gate.yml
+++ b/.github/workflows/staging-ai-ocr-gate.yml
@@ -84,6 +84,7 @@ jobs:
             pytest \
               tests/e2e/test_statement_full_journey.py \
               tests/e2e/test_brokerage_upload_to_portfolio_value.py \
+              tests/e2e/test_four_asset_net_worth_golden_path.py \
               tests/e2e/test_statement_upload_e2e.py \
               -v -m "llm"
 

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -294,6 +294,7 @@ jobs:
             pytest \
               tests/e2e/test_statement_full_journey.py \
               tests/e2e/test_brokerage_upload_to_portfolio_value.py \
+              tests/e2e/test_four_asset_net_worth_golden_path.py \
               tests/e2e/test_statement_upload_e2e.py \
               -v -m "llm"
 

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -77,6 +77,7 @@ class ReportType(str, Enum):
 async def balance_sheet(
     as_of_date: date | None = Query(default=None),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
+    include_restricted: bool = Query(default=True),
     db: DbSession = None,
     user_id: CurrentUserId = None,
 ) -> BalanceSheetResponse:
@@ -87,6 +88,7 @@ async def balance_sheet(
             user_id,
             as_of_date=as_of_date or date.today(),
             currency=currency,
+            include_restricted=include_restricted,
         )
     except ReportError as exc:
         logger.warning(

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -488,13 +488,14 @@ async def _build_manual_valuation_lines(
     *,
     as_of_date: date,
     target_currency: str,
+    include_restricted: bool = True,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Build balance sheet lines from latest manual valuation components."""
     components = await AssetService().get_latest_valuation_components(
         db,
         user_id,
         as_of_date=as_of_date,
-        include_restricted=True,
+        include_restricted=include_restricted,
     )
     asset_lines: list[dict[str, Any]] = []
     liability_lines: list[dict[str, Any]] = []
@@ -538,6 +539,7 @@ async def generate_balance_sheet(
     *,
     as_of_date: date,
     currency: str | None = None,
+    include_restricted: bool = True,
 ) -> dict[str, object]:
     """Generate balance sheet report as of a given date."""
     target_currency = _normalize_currency(currency)
@@ -576,6 +578,7 @@ async def generate_balance_sheet(
         user_id,
         as_of_date=as_of_date,
         target_currency=target_currency,
+        include_restricted=include_restricted,
     )
     assets.extend(portfolio_adjustments)
     assets.extend(valuation_assets)

--- a/apps/backend/tests/reporting/test_reporting_net_worth_components.py
+++ b/apps/backend/tests/reporting/test_reporting_net_worth_components.py
@@ -477,6 +477,76 @@ async def test_manual_property_and_mortgage_valuations_change_net_worth(db: Asyn
 
 
 @pytest.mark.asyncio
+async def test_balance_sheet_can_exclude_restricted_and_illiquid_valuation_assets(
+    db: AsyncSession,
+    test_user,
+):
+    """AC11.9.3: Balance sheet restricted toggle excludes restricted and illiquid asset snapshots."""
+    report_date = date(2025, 3, 31)
+    await _create_valuation(
+        db,
+        test_user.id,
+        component_type=ManualValuationComponentType.PROPERTY_VALUE,
+        component_name="Singapore Condo",
+        liquidity_class=ManualValuationLiquidityClass.ILLIQUID,
+        value=Decimal("1200000.00"),
+        currency="SGD",
+        as_of_date=report_date,
+    )
+    await _create_valuation(
+        db,
+        test_user.id,
+        component_type=ManualValuationComponentType.ESOP,
+        component_name="Employer ESOP",
+        liquidity_class=ManualValuationLiquidityClass.RESTRICTED,
+        value=Decimal("42000.00"),
+        currency="SGD",
+        as_of_date=report_date,
+    )
+    await _create_valuation(
+        db,
+        test_user.id,
+        component_type=ManualValuationComponentType.TAX_REFUND,
+        component_name="IRAS refund",
+        liquidity_class=ManualValuationLiquidityClass.LIQUID,
+        value=Decimal("1200.00"),
+        currency="SGD",
+        as_of_date=report_date,
+    )
+    await _create_valuation(
+        db,
+        test_user.id,
+        component_type=ManualValuationComponentType.MORTGAGE_BALANCE,
+        component_name="Singapore Condo Mortgage",
+        liquidity_class=ManualValuationLiquidityClass.LIABILITY,
+        value=Decimal("600000.00"),
+        currency="SGD",
+        as_of_date=report_date,
+    )
+    await db.commit()
+
+    liquid_report = await generate_balance_sheet(
+        db,
+        test_user.id,
+        as_of_date=report_date,
+        currency="SGD",
+        include_restricted=False,
+    )
+    full_report = await generate_balance_sheet(
+        db,
+        test_user.id,
+        as_of_date=report_date,
+        currency="SGD",
+        include_restricted=True,
+    )
+
+    assert liquid_report["total_assets"] == Decimal("1200.00")
+    assert liquid_report["total_liabilities"] == Decimal("600000.00")
+    assert full_report["total_assets"] == Decimal("1243200.00")
+    assert full_report["total_liabilities"] == Decimal("600000.00")
+
+
+@pytest.mark.asyncio
 async def test_manual_valuation_uses_as_of_historical_fx_rate(db: AsyncSession, test_user):
     """AC5.7.3: Non-base valuation snapshots use historical FX for the requested as-of date."""
     report_date = date(2025, 3, 31)

--- a/apps/frontend/src/__tests__/dashboardPage.test.tsx
+++ b/apps/frontend/src/__tests__/dashboardPage.test.tsx
@@ -52,7 +52,13 @@ function mockDashboardApi(overrides: Record<string, unknown> = {}) {
   const hasOverride = (key: string) => Object.prototype.hasOwnProperty.call(overrides, key)
   let trendCalls = 0
   mockedApiFetch.mockImplementation((path: string) => {
-    if (path.startsWith("/api/reports/balance-sheet")) return Promise.resolve(hasOverride("balance") ? overrides.balance : baseBalance)
+    if (path.startsWith("/api/reports/balance-sheet")) {
+      const includeRestricted = path.includes("include_restricted=true")
+      const defaultBalance = includeRestricted
+        ? { ...baseBalance, total_assets: 17500, total_equity: 16500 }
+        : baseBalance
+      return Promise.resolve(hasOverride("balance") ? overrides.balance : defaultBalance)
+    }
     if (path.startsWith("/api/reports/income-statement")) return Promise.resolve(hasOverride("income") ? overrides.income : baseIncome)
     if (path.startsWith("/api/income/annualized")) {
       return Promise.resolve(
@@ -80,19 +86,6 @@ function mockDashboardApi(overrides: Record<string, unknown> = {}) {
                 currency: "USD",
               },
             ],
-      )
-    }
-    if (path.startsWith("/api/assets/valuation-components")) {
-      const includeRestricted = path.includes("include_restricted=true")
-      return Promise.resolve(
-        hasOverride("valuation")
-          ? overrides.valuation
-          : {
-              items: [],
-              total_assets: includeRestricted ? 12500 : 0,
-              total_liabilities: 0,
-              net_worth_delta: includeRestricted ? 12500 : 0,
-            },
       )
     }
     if (path.startsWith("/api/reconciliation/stats")) {
@@ -207,17 +200,19 @@ describe("DashboardPage", () => {
     render(<DashboardPage />)
 
     await waitFor(() => expect(screen.getByText("Include restricted holdings")).toBeInTheDocument())
-    expect(mockedApiFetch).toHaveBeenCalledWith("/api/assets/valuation-components?include_restricted=false")
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/reports/balance-sheet?include_restricted=false")
+    expect(screen.getAllByText("$4,000").length).toBeGreaterThanOrEqual(1)
 
     fireEvent.click(screen.getByLabelText("Include restricted holdings"))
 
     await waitFor(() =>
-      expect(mockedApiFetch).toHaveBeenCalledWith("/api/assets/valuation-components?include_restricted=true"),
+      expect(mockedApiFetch).toHaveBeenCalledWith("/api/reports/balance-sheet?include_restricted=true"),
     )
+    await waitFor(() => expect(screen.getAllByText("$16,500").length).toBeGreaterThanOrEqual(1))
   })
 
-  it("uses empty fallbacks when optional valuation APIs return null", async () => {
-    mockDashboardApi({ restricted: null, valuation: null })
+  it("uses empty fallbacks when optional asset APIs return null", async () => {
+    mockDashboardApi({ restricted: null })
 
     render(<DashboardPage />)
 

--- a/apps/frontend/src/app/(main)/dashboard/page.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/page.tsx
@@ -22,7 +22,6 @@ import {
   ReconciliationStatsResponse,
   RestrictedHolding,
   TrendResponse,
-  ValuationComponentsResponse,
   UnmatchedTransactionsResponse
 } from "@/lib/types";
 
@@ -47,7 +46,6 @@ export default function DashboardPage() {
   const [onboardingStatus, setOnboardingStatus] = useState<OnboardingStatus | null>(null);
   const [annualizedIncome, setAnnualizedIncome] = useState<AnnualizedIncomeResponse | null>(null);
   const [restrictedHoldings, setRestrictedHoldings] = useState<RestrictedHolding[]>([]);
-  const [valuationComponents, setValuationComponents] = useState<ValuationComponentsResponse | null>(null);
   const [includeRestricted, setIncludeRestricted] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -65,7 +63,6 @@ export default function DashboardPage() {
         incomeData,
         annualizedData,
         restrictedData,
-        valuationData,
         statsData,
         unmatchedData,
         journalData,
@@ -73,11 +70,10 @@ export default function DashboardPage() {
         statementData,
         postedJournalData,
       ] = await Promise.all([
-        apiFetch<BalanceSheetResponse>("/api/reports/balance-sheet"),
+        apiFetch<BalanceSheetResponse>(`/api/reports/balance-sheet?include_restricted=${includeRestricted ? "true" : "false"}`),
         apiFetch<IncomeStatementResponse>(`/api/reports/income-statement?start_date=${incomeStart}&end_date=${incomeEnd}`),
         apiFetch<AnnualizedIncomeResponse>("/api/income/annualized"),
         apiFetch<RestrictedHolding[]>("/api/assets/restricted"),
-        apiFetch<ValuationComponentsResponse>(`/api/assets/valuation-components?include_restricted=${includeRestricted ? "true" : "false"}`),
         apiFetch<ReconciliationStatsResponse>("/api/reconciliation/stats"),
         apiFetch<UnmatchedTransactionsResponse>("/api/reconciliation/unmatched?limit=5"),
         apiFetch<JournalEntryListResponse>("/api/journal-entries?page=1&page_size=5"),
@@ -89,7 +85,6 @@ export default function DashboardPage() {
       setIncomeStatement(incomeData || { start_date: "", end_date: "", currency: "SGD", income: [], expenses: [], total_income: 0, total_expenses: 0, net_income: 0, trends: [] });
       setAnnualizedIncome(annualizedData || { annualized_salary: 0, annualized_bonus: 0, annualized_dividend: 0, annualized_total: 0, currency: "SGD", as_of: "" });
       setRestrictedHoldings(restrictedData || []);
-      setValuationComponents(valuationData || { items: [], total_assets: 0, total_liabilities: 0, net_worth_delta: 0 });
       setStats(statsData || { total_transactions: 0, matched_transactions: 0, unmatched_transactions: 0, pending_review: 0, auto_accepted: 0, match_rate: 0, score_distribution: {} });
       setUnmatched(unmatchedData || { items: [], total: 0 });
       setRecentEntries(journalData || { items: [], total: 0 });
@@ -132,9 +127,8 @@ export default function DashboardPage() {
   }, [fetchTrend, balanceSheet]);
 
   const netAssets = useMemo(() => {
-    const ledgerNetAssets = balanceSheet ? toNumber(balanceSheet.total_assets) - toNumber(balanceSheet.total_liabilities) : 0;
-    return ledgerNetAssets + (valuationComponents ? toNumber(valuationComponents.net_worth_delta) : 0);
-  }, [balanceSheet, valuationComponents]);
+    return balanceSheet ? toNumber(balanceSheet.total_assets) - toNumber(balanceSheet.total_liabilities) : 0;
+  }, [balanceSheet]);
   const trendPoints = useMemo(() => trend ? trend.points.map((p) => ({ label: formatMonthLabel(p.period_start), value: toNumber(p.amount) })) : [], [trend]);
   const incomeBars = useMemo(() => incomeStatement && incomeStatement.trends ? incomeStatement.trends.slice(-6).map((t) => ({ label: formatMonthLabel(t.period_start), income: toNumber(t.total_income), expense: toNumber(t.total_expenses) })) : [], [incomeStatement]);
   const assetSegments = useMemo(() => {

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1866,7 +1866,8 @@ groups:
       - id: AC8.13.27
         epic: 8
         epic_name: testing-strategy
-        description: Coveralls uploads and asynchronous Coveralls commit statuses remain reporting-only while local deterministic coverage gates decide CI pass/fail.
+        description: Coveralls uploads and asynchronous Coveralls commit statuses remain reporting-only while local deterministic
+          coverage gates decide CI pass/fail.
         mandatory: true
       - id: AC8.13.28
         epic: 8
@@ -1940,6 +1941,11 @@ groups:
         epic_name: testing-strategy
         description: Critical proof matrix fails when a core product proof path is backed only by broad or reference-only
           AC strings.
+        mandatory: true
+      - id: AC8.13.42
+        epic: 8
+        epic_name: testing-strategy
+        description: Four-asset as-of net worth golden path runs as a critical fresh-user post-merge E2E.
         mandatory: true
   AC11:
     AC11.1:

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-05-26 07:53:36 UTC by `scripts/analyze_test_ac_coverage.py`
+> Generated: 2026-05-26 09:35:12 UTC by `scripts/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 988 |
-| Active ACs | 985 |
+| Registered ACs | 989 |
+| Active ACs | 986 |
 | Deprecated ACs excluded from coverage gate | 3 |
-| Covered by real test candidates | 985 (100.0%) |
+| Covered by real test candidates | 986 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -34,8 +34,8 @@
 |---|---:|---:|---:|---:|
 | backend | 167 | 648 | 0 | 0 |
 | frontend | 79 | 189 | 7 | 0 |
-| scripts_tests | 46 | 199 | 23 | 0 |
-| e2e | 10 | 16 | 0 | 0 |
+| scripts_tests | 46 | 200 | 23 | 0 |
+| e2e | 11 | 22 | 0 | 0 |
 | repo_e2e | 18 | 0 | 0 | 0 |
 
 ## Coverage by EPIC
@@ -49,7 +49,7 @@
 | EPIC-005 | reporting-visualization | 36 | 0 | 36 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 0 | 63 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-008 | testing-strategy | 98 | 0 | 98 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 99 | 0 | 99 | 0 | 0 | 0 | 100.0% |
 | EPIC-009 | pdf-fixture-generation | 37 | 0 | 37 | 0 | 0 | 0 | 100.0% |
 | EPIC-010 | signoz-logging | 21 | 0 | 21 | 0 | 0 | 0 | 100.0% |
 | EPIC-011 | asset-lifecycle | 38 | 0 | 38 | 0 | 0 | 0 | 100.0% |

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -74,6 +74,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.39**: Runtime and container versions stay aligned across local, CI, and Docker environments.
 - **AC8.13.40**: PR CI dry-runs staging image builds before merge; main push CI is the only path that pushes SHA-tagged images.
 - **AC8.13.41**: Critical proof matrix fails when a core product proof path is backed only by broad or reference-only AC strings.
+- **AC8.13.42**: Four-asset as-of net worth golden path runs as a critical fresh-user post-merge E2E.
 
 **Current state (2026-02-23):**
 - **Tier 1**: 41 tests in `test_core_journeys.py` covering 45 ACs → **91.8% AC pass rate** (45/49)
@@ -386,6 +387,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.39 | Runtime and container versions stay aligned across local, CI, and Docker environments | `test_AC8_13_39_*` | `scripts/tests/test_toolchain_contract.py` | P0 |
 | AC8.13.40 | PR CI dry-runs staging image builds before merge; main push CI is the only path that pushes SHA-tagged images | `test_AC8_13_40_pr_ci_dry_runs_staging_image_builds_before_merge` | `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.41 | Critical proof matrix fails when a core product proof path is backed only by broad or reference-only AC strings | `test_*critical_proof_matrix*` | `scripts/tests/test_check_critical_proof_matrix.py` | P0 |
+| AC8.13.42 | Four-asset as-of net worth golden path runs as a critical fresh-user post-merge E2E | `test_four_asset_as_of_net_worth_golden_path`, `test_AC8_13_42_four_asset_net_worth_golden_path_is_post_merge_critical` | `tests/e2e/test_four_asset_net_worth_golden_path.py`, `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.
@@ -415,6 +417,7 @@ coverage status; use the generated coverage report and CI artifacts for that.
 | `tests/e2e/test_statement_full_journey.py` | Playwright | Tier 3 | 1 | Full journey: DBS PDF upload → parse polling → detail/transactions → approve → balance sheet (AC8.13.1–5) |
 | `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | API E2E | Tier 3 | 1 | Issue #404 hard gate: Moomoo + Futu PDF upload → real OCR parsing → brokerage import → holdings + balance sheet value (AC8.13.10) |
 | `tests/e2e/test_vision_upload_to_dashboard_hard_gate.py` | Playwright/API | Tier 3 | 3 | Deterministic vision gate: fresh-user CSV upload → Stage 1 auto-post → reconciliation idempotency → Stage 2 cleared state → processing visibility → exact dashboard/report totals (AC8.13.28–32) |
+| `tests/e2e/test_four_asset_net_worth_golden_path.py` | Browser/API E2E | Tier 3 | 1 | Issue #444 hard gate: fresh-user bank CSV upload → Stage 1/Stage 2 posting → brokerage PDF import → property/mortgage/ESOP manual snapshots → exact as-of net worth and dashboard/report totals (AC8.13.42) |
 | `tests/e2e/test_production_readonly_smoke.py` | Playwright/API | Tier 3 | 3 | Production-safe read-only smoke: health, auth boundary, browser shell, optional credential-gated dashboard |
 | `tests/e2e/test_e2e_flows.py` | Playwright | Tier 3 | 3 | Navigation, registration, reports view (skips without `FRONTEND_URL`) |
 | `tests/e2e/test_auth_flows.py` | Playwright | Tier 3 | 2 | Authentication flows (skips without `FRONTEND_URL`) |
@@ -511,7 +514,12 @@ coverage status; use the generated coverage report and CI artifacts for that.
    - **Failure diagnostics**: Assertions include statement IDs and response bodies for OCR rejection, import zero-counts, missing holdings, and reporting failures. Portfolio value coverage is checked against balance-sheet market valuation adjustment lines, not whole `total_assets`, so unrelated cash or bank lines cannot mask or falsely fail the imported portfolio valuation check. Failures include imported position count, holdings total market value, valuation adjustment total, non-portfolio asset total, total assets, net worth adjustment, and relevant asset lines.
    - **Provider budget rule**: Runs in the same serialized `Staging AI/OCR Gate` as the DBS full journey.
 
-4. **Production Read-only E2E Smoke** (`test_production_readonly_smoke.py`):
+4. **Four-Asset As-of Net Worth Golden Path (Tier 3)** (`test_four_asset_net_worth_golden_path.py`):
+   - **Status**: Implemented hard gate for Issue #444
+   - **Coverage**: AC8.13.42 proves one fresh-user path across bank cash, brokerage PDF positions, property value, mortgage liability, and ESOP restricted equity. The test completes explicit upload, Stage 1 approval/posting, Stage 2 reconciliation, brokerage import, manual valuation creation, exact Decimal-safe as-of balance-sheet totals, and dashboard/report total assertions.
+   - **Provider budget rule**: Runs in the same serialized `Staging AI/OCR Gate` as the DBS and brokerage PDF hard gates because it imports a real brokerage PDF through the configured OCR path.
+
+5. **Production Read-only E2E Smoke** (`test_production_readonly_smoke.py`):
    - **Status**: Implemented for production release
    - **Coverage**: Health payload, anonymous auth boundary, browser shell/login route, optional credential-gated dashboard
    - **Allowed skip**: Authenticated dashboard check may skip only when `PROD_SMOKE_EMAIL` / `PROD_SMOKE_PASSWORD` are not configured; it must not mutate production data

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -196,7 +196,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Tests marked `llm` are the only tests allowed to call the configured AI/OCR provider and run once, serially, in this provider-backed gate.
 - The automatic gate passes the deployed short SHA as `EXPECTED_SHA`, so version checks still validate the deployed commit before provider-backed parsing starts.
 - The GLM-backed PDF gate allows a longer parsing window than normal UI tests: JSON extraction requests use `AI_JSON_TIMEOUT_SECONDS=360`, and the browser gate waits up to `PARSING_TIMEOUT_MS=480000` so slow but successful `glm-4.6v` PDF parsing is not misclassified as a failed provider gate.
-- The serialized GLM gate includes `tests/e2e/test_statement_full_journey.py`, `tests/e2e/test_statement_upload_e2e.py`, and `tests/e2e/test_brokerage_upload_to_portfolio_value.py`. The brokerage test uploads Moomoo and Futu PDF fixtures through `/api/statements/upload`, waits for parsed statements, imports positions through `/api/statements/{id}/brokerage/import`, and verifies `/api/portfolio/holdings` plus `/api/reports/balance-sheet`. Failures identify whether OCR parsing, parsed-data state transition, brokerage import, portfolio valuation, or reporting failed. The path-level proof matrix is maintained in [EPIC-017](../project/EPIC-017.portfolio-management.md#brokerage-pdf-to-asset-report-proof-matrix) with the compact entry-point version in the README.
+- The serialized GLM gate includes `tests/e2e/test_statement_full_journey.py`, `tests/e2e/test_statement_upload_e2e.py`, `tests/e2e/test_brokerage_upload_to_portfolio_value.py`, and `tests/e2e/test_four_asset_net_worth_golden_path.py`. The brokerage test uploads Moomoo and Futu PDF fixtures through `/api/statements/upload`, waits for parsed statements, imports positions through `/api/statements/{id}/brokerage/import`, and verifies `/api/portfolio/holdings` plus `/api/reports/balance-sheet`. The four-asset gate uses an isolated user to combine deterministic bank statement posting, brokerage PDF import, property/mortgage/ESOP manual valuation snapshots, exact as-of net worth, and dashboard/report totals. Failures identify whether OCR parsing, parsed-data state transition, brokerage import, manual valuation, reporting, or dashboard aggregation failed. The path-level proof matrix is maintained in [EPIC-017](../project/EPIC-017.portfolio-management.md#brokerage-pdf-to-asset-report-proof-matrix) with the compact entry-point version in the README; critical product proof anchors live in [critical-proof-matrix.yaml](critical-proof-matrix.yaml).
 
 **PR preview E2E** (`.github/workflows/pr-test.yml`):
 - PR preview environments do not inject `ZAI_API_KEY`; they validate app wiring without real GLM/OCR provider calls.
@@ -296,7 +296,7 @@ deploy-blocking usability gates:
 |-------------|------|---------|-------------|
 | Staging | Shell smoke | `bash scripts/smoke_test.sh "$APP_URL" staging` | No skips; any failed check fails deploy |
 | Staging | Non-LLM E2E | `STRICT_E2E_GATES=true pytest tests/e2e -v -m "(smoke or e2e) and not llm" -n 4` | Tests marked `critical` must fail instead of skip |
-| Staging | AI/OCR E2E | `STRICT_E2E_GATES=true pytest tests/e2e/test_statement_full_journey.py tests/e2e/test_brokerage_upload_to_portfolio_value.py tests/e2e/test_statement_upload_e2e.py -v -m "llm"` | Serial provider-backed GLM gate; `rejected` fails deploy |
+| Staging | AI/OCR E2E | `STRICT_E2E_GATES=true pytest tests/e2e/test_statement_full_journey.py tests/e2e/test_brokerage_upload_to_portfolio_value.py tests/e2e/test_four_asset_net_worth_golden_path.py tests/e2e/test_statement_upload_e2e.py -v -m "llm"` | Serial provider-backed GLM gate; `rejected` fails deploy |
 | Production | Shell smoke | `bash scripts/smoke_test.sh https://report.zitian.party production` | Read-only checks only |
 | Production | Prod-safe E2E | `pytest tests/e2e/test_production_readonly_smoke.py -v -m "prod_safe"` | Authenticated dashboard check may skip only when read-only smoke credentials are absent |
 
@@ -326,6 +326,13 @@ negative cash or bank balances from other E2E journeys, can lower total assets
 without invalidating portfolio valuation coverage. Failure output includes the
 holdings total market value, valuation adjustment total, non-portfolio asset
 total, total assets, net worth adjustment, and relevant asset lines.
+
+`tests/e2e/test_four_asset_net_worth_golden_path.py::test_four_asset_as_of_net_worth_golden_path`
+is the north-star net-worth hard gate for Issue #444. It uses an isolated user
+to upload bank statement data, explicitly post and reconcile the statement,
+import a brokerage PDF, create property, mortgage, and ESOP valuation snapshots,
+then prove exact as-of assets, liabilities, net worth, and dashboard/report
+totals.
 
 PR preview E2E intentionally excludes the `llm` marker and does not inject the
 provider API key. This keeps provider spend and concurrency concentrated in the

--- a/docs/ssot/critical-proof-matrix.yaml
+++ b/docs/ssot/critical-proof-matrix.yaml
@@ -53,3 +53,23 @@ proofs:
       - llm
     ac_ids:
       - AC8.13.10
+
+  - id: four-asset-as-of-net-worth
+    scope: behavioral
+    ci_tier: post_merge_environment
+    issue: "#444"
+    file: tests/e2e/test_four_asset_net_worth_golden_path.py
+    test: test_four_asset_as_of_net_worth_golden_path
+    required_markers:
+      - e2e
+      - tier3
+      - critical
+      - llm
+    ac_ids:
+      - AC8.13.42
+      - AC8.13.10
+      - AC5.7.3
+      - AC11.9.1
+      - AC11.9.2
+      - AC11.9.3
+      - AC17.5.4

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -99,6 +99,7 @@ def test_AC8_13_12_ai_ocr_gate_failure_includes_statement_context() -> None:
     journey = read("tests/e2e/test_statement_full_journey.py")
     upload = read("tests/e2e/test_statement_upload_e2e.py")
     brokerage = read("tests/e2e/test_brokerage_upload_to_portfolio_value.py")
+    four_asset = read("tests/e2e/test_four_asset_net_worth_golden_path.py")
 
     assert "format_ai_ocr_gate_failure" in conftest
     for token in (
@@ -112,6 +113,7 @@ def test_AC8_13_12_ai_ocr_gate_failure_includes_statement_context() -> None:
     assert "statement=last_statement" in journey
     assert "statement=statement" in upload
     assert "statement=last_payload" in brokerage
+    assert "fail_or_skip_ai_ocr_gate(" in four_asset
 
 
 def test_AC8_13_13_staging_deploy_fast_fail_guardrails() -> None:
@@ -152,6 +154,7 @@ def test_AC8_13_14_staging_ai_ocr_gate_is_separate_deploy_job() -> None:
     assert 'run_timed_phase "Staging AI/OCR Gate' in deploy_workflow
     assert "test_statement_full_journey.py" in deploy_workflow
     assert "test_brokerage_upload_to_portfolio_value.py" in deploy_workflow
+    assert "test_four_asset_net_worth_golden_path.py" in deploy_workflow
     assert "test_statement_upload_e2e.py" in deploy_workflow
     assert '-v -m "llm"' in deploy_workflow
     assert (
@@ -172,6 +175,7 @@ def test_AC8_13_14_staging_ai_ocr_gate_is_separate_deploy_job() -> None:
     assert "test_version_check.py" in ai_workflow
     assert "test_statement_full_journey.py" in ai_workflow
     assert "test_brokerage_upload_to_portfolio_value.py" in ai_workflow
+    assert "test_four_asset_net_worth_golden_path.py" in ai_workflow
     assert "test_statement_upload_e2e.py" in ai_workflow
     assert '-v -m "llm"' in ai_workflow
     assert "same serialized post-merge workflow unit" in ci_cd
@@ -287,6 +291,7 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     pr_workflow = read(".github/workflows/pr-test.yml")
     journey = read("tests/e2e/test_statement_full_journey.py")
     brokerage = read("tests/e2e/test_brokerage_upload_to_portfolio_value.py")
+    four_asset = read("tests/e2e/test_four_asset_net_worth_golden_path.py")
     upload = read("tests/e2e/test_statement_upload_e2e.py")
     deploy_script = read("scripts/dokploy_deploy.sh")
 
@@ -324,10 +329,12 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     assert "PARSING_TIMEOUT_MS: 480000" in workflow
     assert "Wait for matching CI success" in workflow
     assert "test_brokerage_upload_to_portfolio_value.py" in workflow
+    assert "test_four_asset_net_worth_golden_path.py" in workflow
     assert '-v -m "llm"' in workflow
     assert "PARSING_TIMEOUT_MS: 480000" in ai_workflow
     assert "@pytest.mark.llm" in journey
     assert "@pytest.mark.llm" in brokerage
+    assert "@pytest.mark.llm" in four_asset
     assert upload.count("@pytest.mark.llm") >= 2
     assert 'echo "ZAI_API_KEY="' in pr_workflow
     assert 'echo "AI_BASE_URL=https://api.z.ai/api/coding/paas/v4"' in pr_workflow
@@ -668,6 +675,51 @@ def test_AC8_13_32_vision_hard_gate_proves_trusted_reporting_totals() -> None:
     ):
         assert token in gate
     assert "upload-to-dashboard vision hard gate" in ci_cd
+
+
+def test_AC8_13_42_four_asset_net_worth_golden_path_is_post_merge_critical() -> None:
+    """AC8.13.42: four-asset as-of net worth proof is wired into the post-merge hard gate."""
+    gate = read("tests/e2e/test_four_asset_net_worth_golden_path.py")
+    deploy_workflow = read(".github/workflows/staging-deploy.yml")
+    ai_workflow = read(".github/workflows/staging-ai-ocr-gate.yml")
+    matrix = read("docs/ssot/critical-proof-matrix.yaml")
+    epic = read("docs/project/EPIC-008.testing-strategy.md")
+    ci_cd = read("docs/ssot/ci-cd.md")
+
+    for token in (
+        "@pytest.mark.e2e",
+        "@pytest.mark.tier3",
+        "@pytest.mark.critical",
+        "@pytest.mark.llm",
+        "authenticated_page_unique",
+        "/statements/upload",
+        "/review/approve",
+        "/reconciliation/run",
+        "/brokerage/import",
+        "/assets/valuation-snapshots",
+        "/assets/valuation-components",
+        "/reports/balance-sheet",
+        "/dashboard",
+        'BANK_CASH = Decimal("2500.00")',
+        'PROPERTY_VALUE = Decimal("1200000.00")',
+        'MORTGAGE_BALANCE = Decimal("650000.00")',
+        'ESOP_VALUE = Decimal("42000.00")',
+        "expected_net_worth",
+        "net_worth_adjustment_gain_loss",
+        "market valuation adjustment",
+    ):
+        assert token in gate
+
+    for workflow in (deploy_workflow, ai_workflow):
+        assert "test_four_asset_net_worth_golden_path.py" in workflow
+        assert '-v -m "llm"' in workflow
+
+    assert "four-asset-as-of-net-worth" in matrix
+    assert "test_four_asset_as_of_net_worth_golden_path" in matrix
+    assert "AC8.13.42" in matrix
+    assert "AC8.13.42" in epic
+    assert "test_four_asset_as_of_net_worth_golden_path" in epic
+    assert "four-asset gate" in ci_cd
 
 
 def test_AC8_13_33_e2e_setup_caches_virtualenv_and_playwright_browsers() -> None:

--- a/tests/e2e/test_four_asset_net_worth_golden_path.py
+++ b/tests/e2e/test_four_asset_net_worth_golden_path.py
@@ -1,0 +1,520 @@
+"""
+Tier 3 Browser/API E2E: four-asset as-of net worth golden path.
+
+Issue #444:
+Fresh user uploads deterministic bank statement data, imports a brokerage PDF,
+creates manual property, mortgage, and ESOP valuation snapshots, then verifies
+exact as-of net worth through reports and dashboard totals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from datetime import date
+from decimal import ROUND_HALF_UP, Decimal
+from pathlib import Path
+
+import httpx
+import pytest
+from conftest import fail_or_skip_ai_ocr_gate
+from playwright.async_api import Page, expect
+
+APP_URL: str = os.getenv("APP_URL", "http://localhost:3000")
+PARSING_TIMEOUT_MS: int = int(os.getenv("PARSING_TIMEOUT_MS", "480000"))
+
+BANK_INSTITUTION = "Four Asset E2E Bank"
+BANK_CASH = Decimal("2500.00")
+PROPERTY_VALUE = Decimal("1200000.00")
+MORTGAGE_BALANCE = Decimal("650000.00")
+ESOP_VALUE = Decimal("42000.00")
+
+
+def _api_url(path: str) -> str:
+    return f"{APP_URL.rstrip('/')}/api{path}"
+
+
+def _get_url(path: str) -> str:
+    return f"{APP_URL.rstrip('/')}{path}"
+
+
+def _money(value: object) -> Decimal:
+    return Decimal(str(value)).quantize(Decimal("0.01"))
+
+
+def _dashboard_amount(amount: Decimal) -> str:
+    rounded = amount.quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    return f"{int(rounded):,}"
+
+
+def _write_bank_fixture(tmp_path: Path, report_date: date) -> Path:
+    path = tmp_path / "four_asset_bank_statement.csv"
+    path.write_text(
+        "\n".join(
+            [
+                "Date,Description,Amount",
+                f"{report_date.isoformat()},Four Asset Salary,3000.00",
+                f"{report_date.isoformat()},Four Asset Rent,-500.00",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _get_pdf_path(source: str) -> Path:
+    from datetime import datetime
+
+    root = Path(__file__).resolve().parents[2]
+    source_dir = root / "scripts" / "pdf_fixtures" / "output" / source
+    yymm = datetime.now().strftime("%y%m")
+    prebuilt = source_dir / f"test_{source}_{yymm}.pdf"
+    if prebuilt.exists():
+        return prebuilt
+    if source_dir.exists():
+        pdfs = sorted(source_dir.glob(f"test_{source}_*.pdf"))
+        if pdfs:
+            return pdfs[-1]
+
+    script = root / "scripts" / "pdf_fixtures" / "generate_pdf_fixtures.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--source", source],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            f"PDF fixture generation failed for {source}.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    pdfs = (
+        sorted(source_dir.glob(f"test_{source}_*.pdf")) if source_dir.exists() else []
+    )
+    if not pdfs:
+        pytest.skip(f"PDF generation for {source} produced no files in {source_dir}")
+    return pdfs[-1]
+
+
+def _unique_pdf_copy(src: Path) -> Path:
+    suffix = int(time.time() * 1000) % 1_000_000
+    tmp = Path(tempfile.mkdtemp())
+    dest = tmp / f"{src.stem}_{suffix}{src.suffix}"
+    shutil.copy2(src, dest)
+    with dest.open("ab") as fh:
+        fh.write(f"\n%% E2E test run {uuid.uuid4()}\n".encode())
+    return dest
+
+
+async def _auth_headers(page: Page) -> dict[str, str]:
+    token = await page.evaluate(
+        "() => window.localStorage.getItem('finance_access_token')"
+    )
+    assert token, "Missing finance_access_token in localStorage"
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _default_image_model(client: httpx.AsyncClient) -> str:
+    response = await client.get(_api_url("/ai/models?modality=image"))
+    assert response.status_code == 200, (
+        f"model catalog request failed: {response.status_code} {response.text}"
+    )
+    payload = response.json()
+    return payload.get("default_model") or payload["models"][0]["id"]
+
+
+async def _upload_bank_csv(client: httpx.AsyncClient, fixture_path: Path) -> str:
+    with fixture_path.open("rb") as fh:
+        response = await client.post(
+            _api_url("/statements/upload"),
+            data={"institution": BANK_INSTITUTION},
+            files={"file": (fixture_path.name, fh, "text/csv")},
+        )
+    assert response.status_code in (200, 201, 202), (
+        f"bank upload failed: {response.status_code} {response.text}"
+    )
+    statement_id = response.json().get("id")
+    assert statement_id, f"bank upload response missing id: {response.text}"
+    return str(statement_id)
+
+
+async def _upload_brokerage_pdf(
+    client: httpx.AsyncClient,
+    *,
+    source: str,
+    institution: str,
+    model: str,
+) -> str:
+    pdf_path = _unique_pdf_copy(_get_pdf_path(source))
+    with pdf_path.open("rb") as fh:
+        response = await client.post(
+            _api_url("/statements/upload"),
+            data={"institution": institution, "model": model},
+            files={"file": (pdf_path.name, fh, "application/pdf")},
+        )
+    assert response.status_code in (200, 201, 202), (
+        f"{source} upload failed: {response.status_code} {response.text}"
+    )
+    statement_id = response.json().get("id")
+    assert statement_id, f"{source} upload response missing id: {response.text}"
+    return str(statement_id)
+
+
+def _transaction_count(payload: dict | None) -> int | None:
+    transactions = payload.get("transactions") if payload else None
+    return len(transactions) if isinstance(transactions, list) else None
+
+
+def _statement_timeout_message(statement_id: str, last_payload: dict | None) -> str:
+    if not last_payload:
+        return f"statement {statement_id} did not reach parsed within {PARSING_TIMEOUT_MS}ms"
+    return (
+        f"statement {statement_id} did not reach parsed within {PARSING_TIMEOUT_MS}ms; "
+        f"status={last_payload.get('status')!r}; "
+        f"parsing_progress={last_payload.get('parsing_progress')!r}; "
+        f"transactions={_transaction_count(last_payload)!r}; "
+        f"balance_validated={last_payload.get('balance_validated')!r}; "
+        f"validation_error={last_payload.get('validation_error')!r}"
+    )
+
+
+async def _wait_for_parsed_statement(
+    client: httpx.AsyncClient,
+    statement_id: str,
+    *,
+    gate_name: str,
+) -> dict:
+    deadline = asyncio.get_running_loop().time() + PARSING_TIMEOUT_MS / 1000
+    last_payload: dict | None = None
+    while asyncio.get_running_loop().time() < deadline:
+        response = await client.get(_api_url(f"/statements/{statement_id}"))
+        assert response.status_code == 200, (
+            f"{gate_name} statement poll failed for {statement_id}: {response.status_code} {response.text}"
+        )
+        last_payload = response.json()
+        status = last_payload.get("status")
+        if status == "rejected":
+            fail_or_skip_ai_ocr_gate(
+                f"{gate_name} gate rejected statement {statement_id}: {last_payload.get('validation_error')}",
+                statement=last_payload,
+            )
+        if status == "parsed":
+            assert last_payload.get("transactions"), (
+                f"{gate_name} parsed statement {statement_id} has no transactions: {last_payload}"
+            )
+            return last_payload
+        await asyncio.sleep(5)
+
+    pytest.fail(_statement_timeout_message(statement_id, last_payload))
+
+
+async def _create_manual_snapshot(
+    client: httpx.AsyncClient,
+    *,
+    component_type: str,
+    as_of_date: date,
+    value: Decimal,
+    source: str,
+) -> dict:
+    payload = {
+        "component_type": component_type,
+        "as_of_date": as_of_date.isoformat(),
+        "value": str(value),
+        "currency": "SGD",
+        "source": source,
+    }
+    response = await client.post(_api_url("/assets/valuation-snapshots"), json=payload)
+    assert response.status_code == 201, (
+        f"manual valuation snapshot create failed for {component_type}: {response.status_code} {response.text}"
+    )
+    return response.json()
+
+
+def _line_total(lines: list[dict]) -> Decimal:
+    return sum(
+        (_money(line.get("amount", "0")) for line in lines), Decimal("0.00")
+    ).quantize(Decimal("0.01"))
+
+
+def _lines_by_name(lines: list[dict], token: str) -> list[dict]:
+    token_lower = token.lower()
+    return [line for line in lines if token_lower in str(line.get("name", "")).lower()]
+
+
+def _line_total_by_name(lines: list[dict], token: str) -> Decimal:
+    matches = _lines_by_name(lines, token)
+    assert matches, f"missing balance-sheet line containing {token!r}; lines={lines}"
+    return _line_total(matches)
+
+
+@pytest.mark.e2e
+@pytest.mark.tier3
+@pytest.mark.critical
+@pytest.mark.llm
+async def test_four_asset_as_of_net_worth_golden_path(
+    authenticated_page_unique: Page,
+    tmp_path: Path,
+) -> None:
+    """AC8.13.42 AC8.13.10 AC5.7.3 AC11.9.1 AC11.9.2 AC11.9.3 AC17.5.4: four assets produce exact as-of net worth."""
+    page = authenticated_page_unique
+    report_date = date.today()
+    headers = await _auth_headers(page)
+
+    async with httpx.AsyncClient(
+        headers=headers, verify=False, timeout=120.0
+    ) as client:
+        bank_fixture = _write_bank_fixture(tmp_path, report_date)
+        bank_statement_id = await _upload_bank_csv(client, bank_fixture)
+        parsed_bank = await _wait_for_parsed_statement(
+            client, bank_statement_id, gate_name="bank CSV"
+        )
+        assert len(parsed_bank.get("transactions") or []) == 2
+
+        approve_response = await client.post(
+            _api_url(f"/statements/{bank_statement_id}/review/approve"),
+            json={"create_account_if_missing": True},
+        )
+        assert approve_response.status_code == 200, (
+            f"bank stage 1 approve failed: {approve_response.status_code} {approve_response.text}"
+        )
+        approve_payload = approve_response.json()
+        assert approve_payload["journal_entries_created"] == 2
+
+        journal_response = await client.get(_api_url("/journal-entries?limit=6"))
+        assert journal_response.status_code == 200, (
+            f"journal entry check failed: {journal_response.status_code} {journal_response.text}"
+        )
+        journal_payload = journal_response.json()
+        assert journal_payload["total"] == 2
+        assert {item["status"].lower() for item in journal_payload["items"]} == {
+            "posted"
+        }
+        assert {item["memo"] for item in journal_payload["items"]} == {
+            "Four Asset Salary",
+            "Four Asset Rent",
+        }
+
+        first_reconciliation = await client.post(
+            _api_url("/reconciliation/run"),
+            json={"statement_id": bank_statement_id},
+        )
+        assert first_reconciliation.status_code == 200, (
+            f"first reconciliation failed: {first_reconciliation.status_code} {first_reconciliation.text}"
+        )
+        assert first_reconciliation.json() == {
+            "matches_created": 2,
+            "auto_accepted": 2,
+            "pending_review": 0,
+            "unmatched": 0,
+        }
+
+        second_reconciliation = await client.post(
+            _api_url("/reconciliation/run"),
+            json={"statement_id": bank_statement_id},
+        )
+        assert second_reconciliation.status_code == 200, (
+            f"second reconciliation failed: {second_reconciliation.status_code} {second_reconciliation.text}"
+        )
+        assert second_reconciliation.json() == {
+            "matches_created": 0,
+            "auto_accepted": 0,
+            "pending_review": 0,
+            "unmatched": 0,
+        }
+
+        stage2_queue = await client.get(_api_url("/statements/stage2/queue"))
+        assert stage2_queue.status_code == 200, (
+            f"stage 2 queue check failed: {stage2_queue.status_code} {stage2_queue.text}"
+        )
+        stage2_payload = stage2_queue.json()
+        assert stage2_payload["pending_matches"] == []
+        assert stage2_payload["has_unresolved_checks"] is False
+
+        model = await _default_image_model(client)
+        brokerage_statement_id = await _upload_brokerage_pdf(
+            client,
+            source="moomoo",
+            institution="Moomoo Four Asset E2E",
+            model=model,
+        )
+        parsed_brokerage = await _wait_for_parsed_statement(
+            client,
+            brokerage_statement_id,
+            gate_name="brokerage PDF",
+        )
+        import_response = await client.post(
+            _api_url(f"/statements/{parsed_brokerage['id']}/brokerage/import")
+        )
+        assert import_response.status_code == 200, (
+            f"brokerage import failed: {import_response.status_code} {import_response.text}"
+        )
+        import_payload = import_response.json()
+        assert import_payload["parsed_positions"] > 0, (
+            f"no brokerage positions imported: {import_payload}"
+        )
+
+        holdings_response = await client.get(_api_url("/portfolio/holdings"))
+        assert holdings_response.status_code == 200, (
+            f"holdings check failed: {holdings_response.status_code} {holdings_response.text}"
+        )
+        holdings = holdings_response.json()
+        assert len(holdings) >= import_payload["parsed_positions"], (
+            f"missing imported holdings: {holdings}"
+        )
+        brokerage_value = sum(
+            (_money(item["market_value"]) for item in holdings), Decimal("0.00")
+        ).quantize(Decimal("0.01"))
+        assert brokerage_value > Decimal("0.00"), (
+            f"brokerage holdings have no market value: {holdings}"
+        )
+
+        property_snapshot = await _create_manual_snapshot(
+            client,
+            component_type="property_value",
+            as_of_date=report_date,
+            value=PROPERTY_VALUE,
+            source="Four Asset Condo",
+        )
+        mortgage_snapshot = await _create_manual_snapshot(
+            client,
+            component_type="mortgage_balance",
+            as_of_date=report_date,
+            value=MORTGAGE_BALANCE,
+            source="Four Asset Mortgage",
+        )
+        esop_snapshot = await _create_manual_snapshot(
+            client,
+            component_type="esop",
+            as_of_date=report_date,
+            value=ESOP_VALUE,
+            source="Four Asset ESOP",
+        )
+        assert property_snapshot["liquidity_class"] == "illiquid"
+        assert mortgage_snapshot["liquidity_class"] == "liability"
+        assert esop_snapshot["liquidity_class"] == "restricted"
+
+        components_response = await client.get(
+            _api_url(
+                f"/assets/valuation-components?as_of_date={report_date.isoformat()}&include_restricted=true"
+            )
+        )
+        assert components_response.status_code == 200, (
+            f"valuation components check failed: {components_response.status_code} {components_response.text}"
+        )
+        components = components_response.json()
+        assert _money(components["total_assets"]) == PROPERTY_VALUE + ESOP_VALUE
+        assert _money(components["total_liabilities"]) == MORTGAGE_BALANCE
+        assert (
+            _money(components["net_worth_delta"])
+            == PROPERTY_VALUE + ESOP_VALUE - MORTGAGE_BALANCE
+        )
+
+        balance_response = await client.get(
+            _api_url(
+                f"/reports/balance-sheet?as_of_date={report_date.isoformat()}&currency=SGD&include_restricted=true"
+            )
+        )
+        assert balance_response.status_code == 200, (
+            f"balance sheet check failed: {balance_response.status_code} {balance_response.text}"
+        )
+        balance_sheet = balance_response.json()
+        asset_lines = [
+            line for line in balance_sheet.get("assets", []) if isinstance(line, dict)
+        ]
+        liability_lines = [
+            line
+            for line in balance_sheet.get("liabilities", [])
+            if isinstance(line, dict)
+        ]
+        market_lines = _lines_by_name(asset_lines, "market valuation adjustment")
+        market_total = _line_total(market_lines)
+
+        expected_assets = (
+            BANK_CASH + brokerage_value + PROPERTY_VALUE + ESOP_VALUE
+        ).quantize(Decimal("0.01"))
+        expected_liabilities = MORTGAGE_BALANCE
+        expected_net_worth = (expected_assets - expected_liabilities).quantize(
+            Decimal("0.01")
+        )
+        expected_net_worth_adjustment = (
+            brokerage_value + PROPERTY_VALUE + ESOP_VALUE - MORTGAGE_BALANCE
+        ).quantize(Decimal("0.01"))
+
+        assert _line_total_by_name(asset_lines, BANK_INSTITUTION) == BANK_CASH
+        assert market_total == brokerage_value, (
+            f"brokerage market value did not reach reporting exactly; holdings={holdings}; "
+            f"market_lines={market_lines}; balance_sheet={balance_sheet}"
+        )
+        assert _line_total_by_name(asset_lines, "Four Asset Condo") == PROPERTY_VALUE
+        assert _line_total_by_name(asset_lines, "Four Asset ESOP") == ESOP_VALUE
+        assert (
+            _line_total_by_name(liability_lines, "Four Asset Mortgage")
+            == MORTGAGE_BALANCE
+        )
+        assert _money(balance_sheet["total_assets"]) == expected_assets
+        assert _money(balance_sheet["total_liabilities"]) == expected_liabilities
+        assert (
+            _money(balance_sheet["total_assets"])
+            - _money(balance_sheet["total_liabilities"])
+            == expected_net_worth
+        )
+        assert (
+            _money(balance_sheet["net_worth_adjustment_gain_loss"])
+            == expected_net_worth_adjustment
+        )
+        assert _money(balance_sheet["equation_delta"]) == Decimal("0.00")
+        assert balance_sheet["is_balanced"] is True
+
+    await page.goto(_get_url("/dashboard"))
+    await page.wait_for_load_state("networkidle")
+    await expect(page.get_by_role("heading", name="Dashboard")).to_be_visible(
+        timeout=10_000
+    )
+    include_checkbox = page.get_by_label("Include restricted holdings")
+    await expect(include_checkbox).to_be_visible(timeout=10_000)
+    if not await include_checkbox.is_checked():
+        await include_checkbox.check()
+
+    await expect(
+        page.locator(".card")
+        .filter(has_text="Total Assets")
+        .filter(has_text=_dashboard_amount(expected_assets))
+    ).to_be_visible(timeout=15_000)
+    await expect(
+        page.locator(".card")
+        .filter(has_text="Total Liabilities")
+        .filter(has_text=_dashboard_amount(expected_liabilities))
+    ).to_be_visible(timeout=15_000)
+    await expect(
+        page.locator(".card")
+        .filter(has_text="Net Assets")
+        .filter(has_text=_dashboard_amount(expected_net_worth))
+    ).to_be_visible(timeout=15_000)
+
+    await page.goto(
+        _get_url(
+            f"/reports/balance-sheet?as_of_date={report_date.isoformat()}&currency=SGD"
+        )
+    )
+    await page.wait_for_load_state("networkidle")
+    await expect(page.get_by_role("heading", name="Balance Sheet")).to_be_visible(
+        timeout=10_000
+    )
+    await expect(
+        page.locator(".card").filter(has_text="Assets").filter(has_text="Total:")
+    ).to_contain_text(
+        _dashboard_amount(expected_assets),
+        timeout=15_000,
+    )
+    await expect(
+        page.locator(".card").filter(has_text="Liabilities").filter(has_text="Total:")
+    ).to_contain_text(
+        _dashboard_amount(expected_liabilities),
+        timeout=15_000,
+    )


### PR DESCRIPTION
Closes #444

## Summary
- Add AC8.13.42 and a critical proof-matrix row for the four-asset as-of net-worth golden path.
- Add a post-merge AI/OCR E2E that starts from an isolated user, posts bank statement data, imports a brokerage PDF, creates property/mortgage/ESOP valuation snapshots, and asserts exact Decimal-safe balance-sheet, dashboard, and report totals.
- Add balance-sheet `include_restricted` support and fix dashboard net assets to use the balance-sheet total directly instead of double-counting valuation components.
- Wire the new proof into both staging AI/OCR gates and static CI contract tests.

## Issue 480 Blocking Status
#480 is explicitly non-blocking for #444: #480 is P2 traceability tooling under the hygiene track, while #444 now has executable ownership through AC8.13.42, `docs/ssot/critical-proof-matrix.yaml`, `scripts/check_critical_proof_matrix.py`, and the post-merge AI/OCR gate. #477, #478, and #479 are already closed.

## Validation
- `uv run --with pyyaml python scripts/generate_ac_registry.py --check`
- `uv run --with pyyaml python scripts/check_critical_proof_matrix.py`
- `uv run --with pyyaml python scripts/check_ac_traceability.py`
- `uv run --with pyyaml python scripts/check_manifest.py`
- `uv run --with pyyaml python scripts/check_ssot_ownership.py`
- `uv run --project apps/backend ruff check apps/backend/src/routers/reports.py apps/backend/src/services/reporting.py apps/backend/tests/reporting/test_reporting_net_worth_components.py tests/e2e/test_four_asset_net_worth_golden_path.py scripts/tests/test_post_merge_e2e_gates.py`
- `uv run --project apps/backend pytest scripts/tests/test_post_merge_e2e_gates.py --no-cov -q`
- `uv run --project apps/backend pytest apps/backend/tests/reporting/test_reporting_net_worth_components.py --no-cov -q`
- `uv run --project apps/backend pytest tests/e2e/test_four_asset_net_worth_golden_path.py --collect-only --no-cov -q`
- `npm run lint`
- `npm test -- --run`
- `PRIMARY_MODEL=glm-5.1 FALLBACK_MODELS=glm-5-turbo,glm-5 AI_BASE_URL=https://api.z.ai/api/coding/paas/v4 OPENROUTER_BASE_URL=https://api.z.ai/api/coding/paas/v4 OTEL_EXPORTER_OTLP_ENDPOINT= python scripts/cli.py test --fast --ephemeral`
- `git diff --check`

Note: `moon run :lint && moon run :test` was attempted first, but `moon run :lint` hung in the local moon scheduler before launching child lint/test commands. I ran the direct command equivalents above. The backend fast rerun pins GLM env vars because local `apps/backend/.env` contains developer OpenRouter/Gemini overrides that are not part of repo/CI defaults.