### PR TITLE
[codex] test: align four-asset report total assertion

### DIFF
--- a/tests/e2e/test_four_asset_net_worth_golden_path.py
+++ b/tests/e2e/test_four_asset_net_worth_golden_path.py
@@ -53,6 +53,11 @@ def _dashboard_amount(amount: Decimal) -> str:
     return f"{int(rounded):,}"
 
 
+def _report_amount(amount: Decimal) -> str:
+    rounded = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return f"{rounded:,.2f}"
+
+
 def _write_bank_fixture(tmp_path: Path, report_date: date) -> Path:
     path = tmp_path / "four_asset_bank_statement.csv"
     path.write_text(
@@ -509,12 +514,12 @@ async def test_four_asset_as_of_net_worth_golden_path(
     await expect(
         page.locator(".card").filter(has_text="Assets").filter(has_text="Total:")
     ).to_contain_text(
-        _dashboard_amount(expected_assets),
+        _report_amount(expected_assets),
         timeout=15_000,
     )
     await expect(
         page.locator(".card").filter(has_text="Liabilities").filter(has_text="Total:")
     ).to_contain_text(
-        _dashboard_amount(expected_liabilities),
+        _report_amount(expected_liabilities),
         timeout=15_000,
     )


### PR DESCRIPTION
## Summary
- Align the #444 four-asset E2E report-page total assertion with the Balance Sheet UI, which renders cents via `formatCurrencyLocale`.
- Keep dashboard KPI assertions rounded to whole dollars, because those cards use the existing compact display expectation.

## Root cause
The post-merge staging AI/OCR gate proved the underlying net-worth math was correct, but the test reused the dashboard integer formatter for the Balance Sheet report page. The report page showed `SGD 1,245,750.50`; the test incorrectly expected the rounded text `1,245,751`.

## Validation
- `uv run --project apps/backend ruff check tests/e2e/test_four_asset_net_worth_golden_path.py`
- `uv run --project apps/backend pytest tests/e2e/test_four_asset_net_worth_golden_path.py --collect-only --no-cov -q`

## Follow-up
After this PR merges, rerun `Deploy Staging` on `main` to complete the #444 post-merge AI/OCR proof.
