### PR TITLE
[codex] Add one-command local bootstrap

### DIFF
--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -3,12 +3,12 @@ $schema: 'https://moonrepo.dev/schemas/toolchain.json'
 # Node.js toolchain configuration
 # Moved from workspace.yml per moon v0.20+ requirements
 node:
-  version: '20.10.0'  # Explicit version for reproducibility
+  version: '20.19.0'  # Mirrors toolchain.toml runtime.node
   packageManager: npm
   inferTasksFromScripts: false
 
   # npm settings
   npm:
-    version: '10.2.3'
+    version: '10.8.2'
 
 # Python is managed externally via uv, not through moon toolchain

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,12 @@ help:
 	@echo "  make env-check    Validate env var consistency"
 	@echo "  make clean        Clean generated files"
 
-install: pre-commit
-	cd apps/backend && uv sync
-	cd apps/frontend && npm install
+install:
+	bash scripts/bootstrap.sh
 
 pre-commit:
-	pip install pre-commit
-	pre-commit install
-	@echo "✅ Pre-commit hooks installed"
+	uvx pre-commit install
+	@echo "Pre-commit hooks installed"
 
 dev:
 	@echo "Starting dev servers (use Ctrl+C to stop)..."

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ labels are the source of truth for current tracker status.
 
 Host prerequisites:
 
-- Bash, Git, and curl
+- A POSIX shell: macOS Terminal, Linux, or WSL Ubuntu
+- Bash, Git, and curl in that same shell
 - Docker Desktop with WSL integration or Podman for backend/full tests, local
   infrastructure, and smoke tests
 
@@ -148,6 +149,15 @@ cd finance_report
 
 bash scripts/bootstrap.sh
 moon run :dev
+```
+
+Windows developers should run project commands inside WSL Ubuntu. Windows
+PowerShell, Git Bash, Scoop-installed Python/uv, and the Codex Windows runner do
+not share PATH entries or Python/Node packages with WSL. From PowerShell, enter
+the project through WSL explicitly:
+
+```powershell
+wsl.exe -d Ubuntu --cd /home/<user>/workspace/finance_report --exec /bin/bash -lc "bash scripts/bootstrap.sh"
 ```
 
 Open <http://localhost:3000>.

--- a/README.md
+++ b/README.md
@@ -132,11 +132,21 @@ labels are the source of truth for current tracker status.
 
 ## Quick Start
 
+Host prerequisites:
+
+- Bash, Git, and curl
+- Docker Desktop with WSL integration or Podman for backend/full tests, local
+  infrastructure, and smoke tests
+
+The project bootstrap command installs or verifies the repo-pinned user-space
+toolchain: uv, Python, nvm/Node.js, Moon CLI, backend dependencies, frontend
+dependencies, and pre-commit hooks.
+
 ```bash
 git clone https://github.com/wangzitian0/finance_report.git
 cd finance_report
 
-moon run :setup
+bash scripts/bootstrap.sh
 moon run :dev
 ```
 

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1952,6 +1952,12 @@ groups:
         epic_name: testing-strategy
         description: Staging deploy reports healthy-but-stale state and failed CI jobs when same-SHA CI blocks deployment.
         mandatory: true
+      - id: AC8.13.44
+        epic: 8
+        epic_name: testing-strategy
+        description: Local bootstrap provides one command for runtimes, dependency setup, pre-commit hooks, and container-runtime
+          diagnostics
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-05-26 09:35:12 UTC by `scripts/analyze_test_ac_coverage.py`
+> Generated: 2026-05-27 08:42:47 UTC by `scripts/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 989 |
-| Active ACs | 986 |
+| Registered ACs | 991 |
+| Active ACs | 988 |
 | Deprecated ACs excluded from coverage gate | 3 |
-| Covered by real test candidates | 986 (100.0%) |
+| Covered by real test candidates | 988 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -34,7 +34,7 @@
 |---|---:|---:|---:|---:|
 | backend | 167 | 648 | 0 | 0 |
 | frontend | 79 | 189 | 7 | 0 |
-| scripts_tests | 46 | 200 | 23 | 0 |
+| scripts_tests | 47 | 202 | 23 | 0 |
 | e2e | 11 | 22 | 0 | 0 |
 | repo_e2e | 18 | 0 | 0 | 0 |
 
@@ -49,7 +49,7 @@
 | EPIC-005 | reporting-visualization | 36 | 0 | 36 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 0 | 63 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-008 | testing-strategy | 99 | 0 | 99 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 101 | 0 | 101 | 0 | 0 | 0 | 100.0% |
 | EPIC-009 | pdf-fixture-generation | 37 | 0 | 37 | 0 | 0 | 0 | 100.0% |
 | EPIC-010 | signoz-logging | 21 | 0 | 21 | 0 | 0 | 0 | 100.0% |
 | EPIC-011 | asset-lifecycle | 38 | 0 | 38 | 0 | 0 | 0 | 100.0% |

--- a/docs/contributing/branch-policy.md
+++ b/docs/contributing/branch-policy.md
@@ -24,9 +24,9 @@
 Before your first commit, install pre-commit hooks to prevent CI failures:
 
 ```bash
-make install          # Install deps + pre-commit hooks
+make install          # Runs scripts/bootstrap.sh
 # OR manually:
-pip install pre-commit && pre-commit install
+uvx pre-commit install
 ```
 
 **What hooks do**:

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -76,6 +76,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.41**: Critical proof matrix fails when a core product proof path is backed only by broad or reference-only AC strings.
 - **AC8.13.42**: Four-asset as-of net worth golden path runs as a critical fresh-user post-merge E2E.
 - **AC8.13.43**: Staging deploy reports healthy-but-stale state and failed CI jobs when same-SHA CI blocks deployment.
+- **AC8.13.44**: Local bootstrap provides one command for runtimes, dependency setup, pre-commit hooks, and container-runtime diagnostics.
 
 **Current state (2026-02-23):**
 - **Tier 1**: 41 tests in `test_core_journeys.py` covering 45 ACs → **91.8% AC pass rate** (45/49)
@@ -390,6 +391,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.41 | Critical proof matrix fails when a core product proof path is backed only by broad or reference-only AC strings | `test_*critical_proof_matrix*` | `scripts/tests/test_check_critical_proof_matrix.py` | P0 |
 | AC8.13.42 | Four-asset as-of net worth golden path runs as a critical fresh-user post-merge E2E | `test_four_asset_as_of_net_worth_golden_path`, `test_AC8_13_42_four_asset_net_worth_golden_path_is_post_merge_critical` | `tests/e2e/test_four_asset_net_worth_golden_path.py`, `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.43 | Staging deploy reports healthy-but-stale state and failed CI jobs when same-SHA CI blocks deployment | `test_AC8_13_43_*` | `scripts/tests/` | P0 |
+| AC8.13.44 | Local bootstrap provides one command for runtimes, dependency setup, pre-commit hooks, and container-runtime diagnostics | `test_AC8_13_44_*` | `scripts/tests/test_bootstrap_local.py`, `scripts/tests/test_cli_and_dev_servers.py`, `scripts/tests/test_toolchain_contract.py` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -168,7 +168,9 @@ concepts:
     description: Python, Node.js, uv, and container image versions shared by local, CI, and Docker environments.
     cross_refs:
       - toolchain.toml
+      - scripts/bootstrap.sh
       - scripts/check_toolchain_contract.py
+      - .moon/toolchain.yml
       - .github/workflows/ci.yml
       - docker-compose.yml
 

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -174,6 +174,14 @@ concepts:
       - .github/workflows/ci.yml
       - docker-compose.yml
 
+  local_host_shells:
+    owner: docs/ssot/development.md#local-host-shell-matrix
+    description: Supported local command shells and PATH/tool-install boundaries across WSL Ubuntu, macOS/Linux, Windows PowerShell, and Codex runner contexts.
+    cross_refs:
+      - README.md
+      - docs/ssot/environments.md#host-shell-boundaries
+      - scripts/bootstrap.sh
+
   namespace_isolation:
     owner: docs/ssot/development.md#local-test-isolation
     description: Namespace-based test DB and S3 bucket isolation for parallel runs.

--- a/docs/ssot/development.md
+++ b/docs/ssot/development.md
@@ -7,14 +7,19 @@
 
 ### Prerequisites
 - **Node.js**: `20.19.0`
-- **npm**: Used for frontend dependencies via `npm ci`
+- **npm**: `10.8.2` (bundled with Node.js `20.19.0`)
 - **Python**: `3.12.12` (managed by uv)
 - **uv**: `0.9.18`
+- **Host container runtime**: Docker Desktop with WSL integration or Podman
+  for backend/full tests, local infrastructure, and smoke tests
+- **Base shell tools**: Bash, Git, and curl
 
 | File | Purpose |
 |------|---------|
+| `scripts/bootstrap.sh` | One-command local bootstrap for runtimes, dependencies, hooks, and container-runtime diagnostics |
 | `toolchain.toml` | Runtime and container image version SSOT |
 | `.python-version` / `.node-version` / `.nvmrc` / `.tool-versions` | Local tool manager mirrors checked by CI |
+| `.moon/toolchain.yml` | Moon's local Node/npm toolchain mirror |
 | `moon.yml` | Root workspace tasks |
 | `apps/*/moon.yml` | Per-project tasks |
 | `scripts/test_lifecycle.py` | Database lifecycle (Python Context Manager) |
@@ -33,6 +38,7 @@ development, GitHub Actions, and Docker/Compose:
 |-----------------|---------|
 | Python | `3.12.12` |
 | Node.js | `20.19.0` |
+| npm | `10.8.2` |
 | uv | `0.9.18` |
 | Backend base image | `python:3.12.12-slim` |
 | Frontend base image | `node:20.19.0-alpine` |
@@ -51,11 +57,19 @@ fails when workflow runtime declarations, local tool files, Docker base images,
 Compose service images, or frontend engine constraints drift from
 `toolchain.toml`.
 
+Local bootstrapping is owned by `scripts/bootstrap.sh`. It installs or verifies
+uv, Python, nvm/Node.js, Moon CLI, project dependencies, and pre-commit hooks,
+then reports whether Docker or Podman is available for workflows that need a
+host container runtime.
+
 ---
 
 ## Moon Commands (Primary Interface)
 
 ```bash
+# First-time local setup
+bash scripts/bootstrap.sh
+
 # Development
 moon run :dev -- --backend        # Full Stack (App + DB + Redis + MinIO)
 moon run :dev -- --frontend       # Next.js on :3000

--- a/docs/ssot/development.md
+++ b/docs/ssot/development.md
@@ -62,6 +62,32 @@ uv, Python, nvm/Node.js, Moon CLI, project dependencies, and pre-commit hooks,
 then reports whether Docker or Podman is available for workflows that need a
 host container runtime.
 
+### Local Host Shell Matrix
+
+The local toolchain belongs to the shell that runs it. PATH entries, Python
+packages, Node packages, and CLI installs are not shared across WSL, macOS/Linux
+shells, Windows PowerShell, Git Bash, Scoop, or the Codex Windows runner.
+
+| Host shell | Support | Command entry point | Tool install scope |
+|---|---|---|---|
+| WSL Ubuntu | Primary Windows path | `bash scripts/bootstrap.sh` inside WSL | `/usr/bin`, `/usr/local/bin`, `$HOME/.local/bin`, `$HOME/.nvm` in WSL |
+| macOS Terminal | Supported POSIX path | `bash scripts/bootstrap.sh` | Homebrew/system tools plus `$HOME/.local/bin` and `$HOME/.nvm` |
+| Linux shell | Supported POSIX path | `bash scripts/bootstrap.sh` | Distro tools plus `$HOME/.local/bin` and `$HOME/.nvm` |
+| Windows PowerShell | Not a direct project shell | Use `wsl.exe -d Ubuntu --cd ... --exec /bin/bash -lc "bash scripts/bootstrap.sh"` | Windows PATH and Scoop installs only; not visible to WSL |
+| Git Bash/MSYS/Cygwin | Not supported for repo bootstrap | Use WSL Ubuntu instead | Windows-mounted POSIX compatibility layer; not the repo target shell |
+| Codex Windows runner | Not the repo command runner | Delegate repo commands to WSL | Runner PATH may omit interactive profile entries and WSL-only tools |
+
+Non-interactive shells often skip interactive profile files such as `.zshrc` or
+`.bashrc`. Scripts that need tools must set PATH explicitly or run through
+`scripts/bootstrap.sh`; do not rely on an interactive terminal having loaded the
+right Python, Node, `gh`, `uv`, `op`, `jq`, `yq`, `direnv`, Docker, or Podman.
+
+From Windows PowerShell, run the bootstrap through WSL:
+
+```powershell
+wsl.exe -d Ubuntu --cd /home/<user>/workspace/finance_report --exec /bin/bash -lc "bash scripts/bootstrap.sh"
+```
+
 ---
 
 ## Moon Commands (Primary Interface)

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -39,6 +39,28 @@
 - Isolation: `finance_report_test_{namespace}` + worker DBs (`_gw0`, `_gw1`, etc.); long namespaces are hash-shortened to keep DB names and `statements-{namespace}` buckets within 63-character backend limits.
 - Command: `moon run :lint && moon run :test` (**matches GitHub CI exactly**)
 
+### Host Shell Boundaries
+
+Local Dev and Local CI are POSIX-shell environments. On Windows, the supported
+host is WSL Ubuntu, not native Windows PowerShell. WSL tools such as
+`/usr/bin/podman`, `/usr/bin/op`, `/usr/local/bin/yq`, `/usr/bin/jq`,
+`/usr/bin/direnv`, and WSL `gh` do not appear in Windows PATH automatically.
+Windows tools installed with Scoop, including Python or `uv`, likewise do not
+appear inside WSL.
+
+The Codex Windows runner follows the Windows side of this split: it may see
+Scoop Python and a non-interactive PowerShell PATH while missing WSL-only `gh`,
+`podman`, `op`, or Python packages. Repo commands should enter WSL explicitly:
+
+```powershell
+wsl.exe -d Ubuntu --cd /home/<user>/workspace/finance_report --exec /bin/bash -lc "moon run :lint"
+```
+
+Non-interactive shells usually do not load the same profile files as an
+interactive terminal. Treat PATH, `NVM_DIR`, and tool locations as part of the
+environment contract; bootstrap and automation scripts must set them explicitly
+before invoking `moon`, `uv`, `npm`, `gh`, Docker, or Podman.
+
 ### GitHub Environments
 
 **GitHub CI** — Temporary services, runs same commands as Local CI:

--- a/moon.yml
+++ b/moon.yml
@@ -5,22 +5,22 @@ layer: tool
 
 tasks:
   setup:
-    command: 'python scripts/cli.py setup'
+    command: 'python3 scripts/cli.py setup'
     deps: []
 
   dev:
-    command: 'python scripts/cli.py dev'
+    command: 'python3 scripts/cli.py dev'
     preset: 'server'
 
   test:
-    command: 'python scripts/cli.py test'
+    command: 'python3 scripts/cli.py test'
 
   lint:
-    command: 'python scripts/cli.py lint'
+    command: 'python3 scripts/cli.py lint'
 
   build:
-    command: 'python scripts/cli.py build'
+    command: 'python3 scripts/cli.py build'
 
   clean:
-    command: 'python scripts/cli.py clean'
+    command: 'python3 scripts/cli.py clean'
     preset: 'server'

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,6 +5,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 LOCAL_BIN="${HOME}/.local/bin"
+export NVM_DIR="${NVM_DIR:-${HOME}/.nvm}"
 NVM_VERSION="0.40.3"
 mkdir -p "$LOCAL_BIN"
 export PATH="${LOCAL_BIN}:${PATH}"
@@ -47,6 +48,72 @@ require_command() {
   fi
 }
 
+detect_host_environment() {
+  local kernel
+  kernel="$(uname -s 2>/dev/null || printf 'unknown')"
+
+  case "$kernel" in
+    MINGW* | MSYS* | CYGWIN*)
+      printf 'windows-bash'
+      return
+      ;;
+    Darwin)
+      printf 'macos'
+      return
+      ;;
+  esac
+
+  if [ -n "${WSL_DISTRO_NAME:-}" ]; then
+    printf 'wsl'
+    return
+  fi
+
+  if [ -r /proc/sys/kernel/osrelease ] && grep -qi microsoft /proc/sys/kernel/osrelease; then
+    printf 'wsl'
+    return
+  fi
+
+  case "$kernel" in
+    Linux)
+      printf 'linux'
+      ;;
+    *)
+      printf 'unknown'
+      ;;
+  esac
+}
+
+configure_host_environment() {
+  local host_environment
+  host_environment="${FINANCE_REPORT_HOST_ENV:-$(detect_host_environment)}"
+
+  case "$host_environment" in
+    wsl)
+      log "Execution environment: WSL Ubuntu (${WSL_DISTRO_NAME:-unknown distro})"
+      export PATH="${LOCAL_BIN}:/usr/local/bin:/usr/bin:/bin:${PATH}"
+      ;;
+    macos)
+      log "Execution environment: macOS POSIX shell"
+      export PATH="${LOCAL_BIN}:${PATH}"
+      ;;
+    linux)
+      log "Execution environment: Linux POSIX shell"
+      export PATH="${LOCAL_BIN}:/usr/local/bin:/usr/bin:/bin:${PATH}"
+      ;;
+    windows-bash)
+      die "This bootstrap must run in WSL Ubuntu, macOS Terminal, or a Linux shell. Windows PowerShell, Git Bash, MSYS, Cygwin, and Scoop paths do not share WSL tools or Python packages. From Windows PowerShell, run: wsl.exe -d Ubuntu --cd /home/<user>/workspace/finance_report --exec /bin/bash -lc \"bash scripts/bootstrap.sh\""
+      ;;
+    *)
+      warn "Unknown execution environment. Continuing with explicit PATH setup; prefer WSL Ubuntu, macOS Terminal, or a Linux shell."
+      export PATH="${LOCAL_BIN}:${PATH}"
+      ;;
+  esac
+
+  if [ -d "${NVM_DIR}/versions/node/v${NODE_VERSION}/bin" ]; then
+    export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PATH}"
+  fi
+}
+
 ensure_uv() {
   if command -v uv >/dev/null 2>&1 && [ "$(uv --version)" = "uv ${UV_VERSION}" ]; then
     log "uv ${UV_VERSION} already available"
@@ -85,7 +152,6 @@ ensure_python() {
 }
 
 load_nvm() {
-  export NVM_DIR="${NVM_DIR:-${HOME}/.nvm}"
   if [ -s "${NVM_DIR}/nvm.sh" ]; then
     # shellcheck disable=SC1091
     . "${NVM_DIR}/nvm.sh"
@@ -138,15 +204,42 @@ install_pre_commit() {
   uvx pre-commit install
 }
 
-check_container_runtime() {
-  if command -v podman >/dev/null 2>&1; then
-    log "Container runtime detected: $(podman --version)"
+check_optional_tool() {
+  local name="$1"
+  local purpose="$2"
+
+  if command -v "$name" >/dev/null 2>&1; then
+    log "${name} detected for ${purpose}: $(command -v "$name")"
     return
   fi
 
+  warn "${name} not found for ${purpose}. Install it in this execution environment; PATH and package installations are not shared between WSL Ubuntu, macOS/Linux shells, and Windows PowerShell/Scoop."
+}
+
+check_optional_agent_tools() {
+  log "Checking optional developer and agent tools"
+  check_optional_tool gh "GitHub PR and CI operations"
+  check_optional_tool jq "JSON shell processing"
+  check_optional_tool yq "YAML shell processing"
+  check_optional_tool direnv "per-directory environment variables"
+  check_optional_tool op "1Password CLI secrets access"
+}
+
+check_container_runtime() {
+  if command -v podman >/dev/null 2>&1; then
+    if podman compose version >/dev/null 2>&1; then
+      log "Container runtime detected: $(podman --version)"
+      return
+    fi
+    warn "podman is installed, but 'podman compose' is not available in this execution environment."
+  fi
+
   if command -v docker >/dev/null 2>&1; then
-    log "Container runtime detected: $(docker --version)"
-    return
+    if docker compose version >/dev/null 2>&1; then
+      log "Container runtime detected: $(docker --version)"
+      return
+    fi
+    warn "docker is installed, but 'docker compose' is not available in this execution environment."
   fi
 
   warn "No container runtime found. Install Docker Desktop with WSL integration or Podman before running backend/full tests, dev infra, or smoke tests."
@@ -154,6 +247,8 @@ check_container_runtime() {
 
 main() {
   log "Bootstrapping Finance Report"
+  configure_host_environment
+  check_optional_agent_tools
   ensure_uv
   ensure_python
   ensure_node

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+LOCAL_BIN="${HOME}/.local/bin"
+NVM_VERSION="0.40.3"
+mkdir -p "$LOCAL_BIN"
+export PATH="${LOCAL_BIN}:${PATH}"
+
+log() {
+  printf '\n[%s] %s\n' "bootstrap" "$*"
+}
+
+warn() {
+  printf '\n[bootstrap] WARNING: %s\n' "$*" >&2
+}
+
+die() {
+  printf '\n[bootstrap] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+runtime_version() {
+  local key="$1"
+  awk -v key="$key" '
+    /^\[runtime\]/ { in_runtime = 1; next }
+    /^\[/ { in_runtime = 0 }
+    in_runtime && $1 == key {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+  ' toolchain.toml
+}
+
+PYTHON_VERSION="$(runtime_version python)"
+NODE_VERSION="$(runtime_version node)"
+UV_VERSION="$(runtime_version uv)"
+
+require_command() {
+  local name="$1"
+  local install_hint="$2"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    die "$name is not available. ${install_hint}"
+  fi
+}
+
+ensure_uv() {
+  if command -v uv >/dev/null 2>&1 && [ "$(uv --version)" = "uv ${UV_VERSION}" ]; then
+    log "uv ${UV_VERSION} already available"
+    return
+  fi
+
+  require_command curl "Install curl, then rerun: bash scripts/bootstrap.sh"
+  log "Installing uv ${UV_VERSION}"
+  local installer
+  installer="$(mktemp)"
+  curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" -o "$installer"
+  sh "$installer"
+  rm -f "$installer"
+  export PATH="${LOCAL_BIN}:${PATH}"
+}
+
+ensure_python() {
+  log "Installing Python ${PYTHON_VERSION} with uv"
+  uv python install "$PYTHON_VERSION"
+
+  local python_target
+  python_target="$(uv python find "$PYTHON_VERSION")"
+
+  if command -v python >/dev/null 2>&1 && [ "$(python --version 2>&1)" = "Python ${PYTHON_VERSION}" ]; then
+    log "python resolves to ${PYTHON_VERSION}"
+    return
+  fi
+
+  if [ ! -e "${LOCAL_BIN}/python" ] || [ -L "${LOCAL_BIN}/python" ]; then
+    ln -sfn "$python_target" "${LOCAL_BIN}/python"
+    log "Linked ${LOCAL_BIN}/python to Python ${PYTHON_VERSION}"
+    return
+  fi
+
+  warn "Not replacing existing ${LOCAL_BIN}/python. Moon tasks use python3; backend venv is pinned with uv."
+}
+
+load_nvm() {
+  export NVM_DIR="${NVM_DIR:-${HOME}/.nvm}"
+  if [ -s "${NVM_DIR}/nvm.sh" ]; then
+    # shellcheck disable=SC1091
+    . "${NVM_DIR}/nvm.sh"
+  fi
+}
+
+ensure_nvm() {
+  load_nvm
+  if type nvm >/dev/null 2>&1; then
+    return
+  fi
+
+  require_command curl "Install curl, then rerun: bash scripts/bootstrap.sh"
+  log "Installing nvm ${NVM_VERSION}"
+  local installer
+  installer="$(mktemp)"
+  curl -LsSf "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" -o "$installer"
+  bash "$installer"
+  rm -f "$installer"
+  load_nvm
+  type nvm >/dev/null 2>&1 || die "nvm installation did not load. Restart the shell and rerun bootstrap."
+}
+
+ensure_node() {
+  ensure_nvm
+  log "Installing Node.js ${NODE_VERSION} with nvm"
+  nvm install "$NODE_VERSION"
+  nvm use "$NODE_VERSION"
+  export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PATH}"
+}
+
+ensure_moon() {
+  local moon_bin="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/moon"
+  if [ -x "$moon_bin" ]; then
+    log "Moon CLI already available for Node ${NODE_VERSION}"
+    return
+  fi
+
+  log "Installing Moon CLI for Node ${NODE_VERSION}"
+  npm install -g @moonrepo/cli
+}
+
+install_project_dependencies() {
+  log "Installing project dependencies through Moon"
+  moon run :setup
+}
+
+install_pre_commit() {
+  log "Installing pre-commit hooks"
+  uvx pre-commit install
+}
+
+check_container_runtime() {
+  if command -v podman >/dev/null 2>&1; then
+    log "Container runtime detected: $(podman --version)"
+    return
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    log "Container runtime detected: $(docker --version)"
+    return
+  fi
+
+  warn "No container runtime found. Install Docker Desktop with WSL integration or Podman before running backend/full tests, dev infra, or smoke tests."
+}
+
+main() {
+  log "Bootstrapping Finance Report"
+  ensure_uv
+  ensure_python
+  ensure_node
+  ensure_moon
+  install_project_dependencies
+  install_pre_commit
+  check_container_runtime
+
+  log "Done. Next command: moon run :dev"
+}
+
+main "$@"

--- a/scripts/check_repo_submodule.sh
+++ b/scripts/check_repo_submodule.sh
@@ -15,7 +15,7 @@ cd "$REPO_ROOT" || {
     exit 0
 }
 
-if [ ! -d "repo/.git" ]; then
+if [ ! -e "repo/.git" ]; then
     echo "❌ repo/ submodule is not initialized."
     echo ""
     echo "To initialize the submodule, run:"
@@ -36,6 +36,7 @@ git fetch origin main --quiet 2>/dev/null || {
 # Get commit SHAs
 CURRENT_SHA=$(git rev-parse HEAD)
 LATEST_SHA=$(git rev-parse origin/main)
+if [ "$CURRENT_SHA" != "$LATEST_SHA" ]; then
     echo "❌ repo/ submodule is behind infra2 main!"
     echo ""
     echo "Current: $CURRENT_SHA"

--- a/scripts/check_toolchain_contract.py
+++ b/scripts/check_toolchain_contract.py
@@ -66,6 +66,19 @@ def check_frontend_package(repo_root: Path, toolchain: dict, errors: list[str]) 
         )
 
 
+def check_moon_toolchain(repo_root: Path, toolchain: dict, errors: list[str]) -> None:
+    node_version = toolchain["runtime"]["node"]
+    npm_version = toolchain["runtime"]["npm"]
+    moon_toolchain = read_text(repo_root, ".moon/toolchain.yml")
+
+    for needle in (
+        "packageManager: npm",
+        f"version: '{node_version}'",
+        f"version: '{npm_version}'",
+    ):
+        expect_contains(errors, ".moon/toolchain.yml", moon_toolchain, needle)
+
+
 def check_workflows(repo_root: Path, toolchain: dict, errors: list[str]) -> None:
     python_version = toolchain["runtime"]["python"]
     node_version = toolchain["runtime"]["node"]
@@ -153,6 +166,7 @@ def run_contract(repo_root: Path) -> int:
     toolchain = load_toolchain(repo_root)
     check_tool_files(repo_root, toolchain, errors)
     check_frontend_package(repo_root, toolchain, errors)
+    check_moon_toolchain(repo_root, toolchain, errors)
     check_workflows(repo_root, toolchain, errors)
     check_container_files(repo_root, toolchain, errors)
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -19,11 +19,19 @@ import os
 import shutil
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent.absolute()
 BACKEND_DIR = REPO_ROOT / "apps" / "backend"
 FRONTEND_DIR = REPO_ROOT / "apps" / "frontend"
+
+
+def get_runtime_version(name: str) -> str:
+    """Read a runtime version from the repository toolchain contract."""
+    with (REPO_ROOT / "toolchain.toml").open("rb") as fh:
+        toolchain = tomllib.load(fh)
+    return str(toolchain["runtime"][name])
 
 
 def get_compose_cmd() -> list[str]:
@@ -52,30 +60,30 @@ def run(cmd: list[str], cwd: Path = REPO_ROOT, env: dict = None, check: bool = T
 def cmd_setup(args):
     """Install dependencies."""
     if args.backend or not args.frontend:
-        run(["uv", "sync"], cwd=BACKEND_DIR)
+        run(["uv", "sync", "--python", get_runtime_version("python")], cwd=BACKEND_DIR)
     if args.frontend or not args.backend:
-        run(["npm", "install"], cwd=FRONTEND_DIR)
+        run(["npm", "ci"], cwd=FRONTEND_DIR)
 
 
 def cmd_dev(args):
     """Start development environment."""
     compose_cmd = get_compose_cmd()
-    
+
     if args.infra or (not args.backend and not args.frontend):
         run([*compose_cmd, "--profile", "infra", "up", "-d"])
-    
+
     if args.migrate:
         run(["uv", "run", "alembic", "upgrade", "head"], cwd=BACKEND_DIR)
         return
-    
+
     if args.check:
         run(["uv", "run", "python", "-m", "src.boot", "--mode=full"], cwd=BACKEND_DIR)
         return
 
     if args.backend:
-        run(["python", "../../scripts/dev_backend.py"], cwd=BACKEND_DIR)
+        run([sys.executable, "../../scripts/dev_backend.py"], cwd=BACKEND_DIR)
     elif args.frontend:
-        run(["python", "../../scripts/dev_frontend.py"], cwd=FRONTEND_DIR)
+        run([sys.executable, "../../scripts/dev_frontend.py"], cwd=FRONTEND_DIR)
     elif not args.infra:
         print("\n🚀 Infrastructure started. Now run in separate terminals:")
         print("   moon run :dev -- --backend")
@@ -88,16 +96,32 @@ def cmd_test(args, extra_args: list[str]):
         run(["npm", "run", "test"] + extra_args, cwd=FRONTEND_DIR)
         return
     if args.e2e:
-        run(["uv", "run", "pytest", "-m", "e2e", "tests/e2e/"] + extra_args, cwd=BACKEND_DIR)
+        run(
+            ["uv", "run", "pytest", "-m", "e2e", "tests/e2e/"] + extra_args,
+            cwd=BACKEND_DIR,
+        )
         return
     if args.perf:
-        run([
-            "uv", "run", "locust", "-f", "tests/locustfile.py",
-            "--host=http://localhost:8000", "--users", "10",
-            "--spawn-rate", "2", "--run-time", "30s", "--headless"
-        ], cwd=BACKEND_DIR)
+        run(
+            [
+                "uv",
+                "run",
+                "locust",
+                "-f",
+                "tests/locustfile.py",
+                "--host=http://localhost:8000",
+                "--users",
+                "10",
+                "--spawn-rate",
+                "2",
+                "--run-time",
+                "30s",
+                "--headless",
+            ],
+            cwd=BACKEND_DIR,
+        )
         return
-    
+
     if extra_args and extra_args[0].startswith("tests/"):
         run(["uv", "run", "pytest"] + extra_args, cwd=BACKEND_DIR)
         return
@@ -109,7 +133,10 @@ def cmd_test(args, extra_args: list[str]):
     if args.ephemeral:
         lifecycle_args.append("--ephemeral")
     lifecycle_args.extend(extra_args)
-    run(["python", "../../scripts/test_lifecycle.py"] + lifecycle_args, cwd=BACKEND_DIR)
+    run(
+        [sys.executable, "../../scripts/test_lifecycle.py"] + lifecycle_args,
+        cwd=BACKEND_DIR,
+    )
 
 
 def cmd_lint(args):
@@ -120,8 +147,12 @@ def cmd_lint(args):
             run(["uv", "run", "ruff", "check", "src/", "--fix"], cwd=BACKEND_DIR)
         else:
             run(["uv", "run", "ruff", "check", "src/"], cwd=BACKEND_DIR)
-            run(["uv", "run", "ruff", "format", "src/", "--check"], cwd=BACKEND_DIR, check=False)
-    
+            run(
+                ["uv", "run", "ruff", "format", "src/", "--check"],
+                cwd=BACKEND_DIR,
+                check=False,
+            )
+
     if args.frontend or not args.backend:
         if args.fix:
             run(["npm", "run", "lint", "--", "--fix"], cwd=FRONTEND_DIR, check=False)
@@ -138,9 +169,9 @@ def cmd_build(args):
 def cmd_clean(args):
     """Clean up resources."""
     compose_cmd = get_compose_cmd()
-    
+
     if args.db:
-        run(["python", "scripts/cleanup_orphaned_dbs.py"])
+        run([sys.executable, "scripts/cleanup_orphaned_dbs.py"])
     elif args.containers:
         run([*compose_cmd, "--profile", "infra", "down"])
     else:
@@ -172,8 +203,14 @@ def main():
     # test - use parse_known_args for transparent pass-through
     p_test = subparsers.add_parser("test", help="Run tests")
     p_test.add_argument("--fast", action="store_true", help="No coverage, fast")
-    p_test.add_argument("--smart", action="store_true", help="Coverage on changed files")
-    p_test.add_argument("--ephemeral", action="store_true", help="Ephemeral mode: destroy all infra after run")
+    p_test.add_argument(
+        "--smart", action="store_true", help="Coverage on changed files"
+    )
+    p_test.add_argument(
+        "--ephemeral",
+        action="store_true",
+        help="Ephemeral mode: destroy all infra after run",
+    )
     p_test.add_argument("--e2e", action="store_true", help="E2E tests (Playwright)")
     p_test.add_argument("--perf", action="store_true", help="Performance tests")
     p_test.add_argument("--frontend", action="store_true", help="Frontend tests")
@@ -192,8 +229,12 @@ def main():
     p_clean = subparsers.add_parser("clean", help="Clean up resources")
     p_clean.add_argument("--db", action="store_true", help="Clean test databases")
     p_clean.add_argument("--containers", action="store_true", help="Stop containers")
-    p_clean.add_argument("--force", action="store_true", help="Force clean processes/leaked containers")
-    p_clean.add_argument("--all", action="store_true", help="Deep clean (including volumes)")
+    p_clean.add_argument(
+        "--force", action="store_true", help="Force clean processes/leaked containers"
+    )
+    p_clean.add_argument(
+        "--all", action="store_true", help="Deep clean (including volumes)"
+    )
 
     # Use parse_known_args for test command to allow pass-through of pytest args
     args, extra = parser.parse_known_args()

--- a/scripts/tests/test_bootstrap_local.py
+++ b/scripts/tests/test_bootstrap_local.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_AC8_13_44_bootstrap_script_installs_local_toolchain_and_project_deps() -> None:
+    """AC8.13.44: The local bootstrap command owns runtime and dependency setup."""
+    script = ROOT / "scripts" / "bootstrap.sh"
+
+    assert script.exists()
+    assert script.stat().st_mode & stat.S_IXUSR
+
+    content = script.read_text(encoding="utf-8")
+    for expected in (
+        "uv python install",
+        "nvm install",
+        "@moonrepo/cli",
+        "moon run :setup",
+        "uvx pre-commit install",
+    ):
+        assert expected in content
+
+
+def test_AC8_13_44_bootstrap_reports_container_runtime_prerequisite() -> None:
+    """AC8.13.44: Bootstrap diagnoses the host container runtime instead of hiding it."""
+    content = (ROOT / "scripts" / "bootstrap.sh").read_text(encoding="utf-8")
+
+    assert "docker" in content
+    assert "podman" in content
+    assert "container runtime" in content.lower()
+
+
+def test_AC8_13_44_readme_documents_one_command_and_host_prerequisite() -> None:
+    """AC8.13.44: README exposes one setup command and the host-level prerequisite."""
+    content = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "bash scripts/bootstrap.sh" in content
+    assert "Docker Desktop" in content
+    assert "Podman" in content
+
+
+def test_AC8_13_44_submodule_hook_accepts_standard_gitfile_checkout() -> None:
+    """AC8.13.44: The pre-commit submodule hook supports normal gitfile submodules."""
+    content = (ROOT / "scripts" / "check_repo_submodule.sh").read_text(encoding="utf-8")
+
+    assert '[ ! -e "repo/.git" ]' in content
+    assert 'if [ "$CURRENT_SHA" != "$LATEST_SHA" ]; then' in content
+
+
+def test_AC8_13_44_root_moon_tasks_use_python3_entrypoint() -> None:
+    """AC8.13.44: Moon tasks avoid relying on a nonstandard `python` command."""
+    content = (ROOT / "moon.yml").read_text(encoding="utf-8")
+
+    assert "python3 scripts/cli.py setup" in content
+    assert "python scripts/cli.py" not in content

--- a/scripts/tests/test_cli_and_dev_servers.py
+++ b/scripts/tests/test_cli_and_dev_servers.py
@@ -143,7 +143,7 @@ def test_AC16_11_17_cmd_test_lifecycle_route(monkeypatch):
         ["-k", "foo"],
     )
     cmd = calls[0][0]
-    assert cmd[0:2] == ["python", "../../scripts/test_lifecycle.py"]
+    assert cmd[0:2] == [sys.executable, "../../scripts/test_lifecycle.py"]
     assert "--fast" in cmd
     assert "--ephemeral" in cmd
     assert "-k" in cmd
@@ -162,7 +162,7 @@ def test_AC16_11_18_cmd_clean_routes(monkeypatch):
     cli.cmd_clean(SimpleNamespace(db=False, containers=True, force=False, all=False))
     cli.cmd_clean(SimpleNamespace(db=False, containers=False, force=True, all=False))
 
-    assert calls[0] == ["python", "scripts/cleanup_orphaned_dbs.py"]
+    assert calls[0] == [sys.executable, "scripts/cleanup_orphaned_dbs.py"]
     assert calls[1] == ["docker", "compose", "--profile", "infra", "down"]
     assert calls[2] == ["bash", "scripts/cleanup_dev_resources.sh", "--force"]
 
@@ -265,26 +265,26 @@ class TestCmdSetup:
     """Tests for cmd_setup dependency installation."""
 
     def test_setup_backend_only(self, monkeypatch):
-        """Given --backend flag, should only run uv sync."""
+        """AC8.13.44: Given --backend flag, setup should pin uv sync to the SSOT Python."""
         calls = _mock_run(monkeypatch)
         cli.cmd_setup(SimpleNamespace(backend=True, frontend=False))
         assert len(calls) == 1
-        assert calls[0]["cmd"] == ["uv", "sync"]
+        assert calls[0]["cmd"] == ["uv", "sync", "--python", "3.12.12"]
 
     def test_setup_frontend_only(self, monkeypatch):
-        """Given --frontend flag, should only run npm install."""
+        """AC8.13.44: Given --frontend flag, setup should only run deterministic npm ci."""
         calls = _mock_run(monkeypatch)
         cli.cmd_setup(SimpleNamespace(backend=False, frontend=True))
         assert len(calls) == 1
-        assert calls[0]["cmd"] == ["npm", "install"]
+        assert calls[0]["cmd"] == ["npm", "ci"]
 
     def test_setup_both(self, monkeypatch):
-        """Given no flags, should run both uv sync and npm install."""
+        """AC8.13.44: Given no flags, setup should run uv sync and deterministic npm ci."""
         calls = _mock_run(monkeypatch)
         cli.cmd_setup(SimpleNamespace(backend=False, frontend=False))
         assert len(calls) == 2
-        assert calls[0]["cmd"] == ["uv", "sync"]
-        assert calls[1]["cmd"] == ["npm", "install"]
+        assert calls[0]["cmd"] == ["uv", "sync", "--python", "3.12.12"]
+        assert calls[1]["cmd"] == ["npm", "ci"]
 
 
 class TestCmdDev:
@@ -491,7 +491,7 @@ class TestMainDispatch:
         calls = _mock_run(monkeypatch)
         monkeypatch.setattr(cli, "get_compose_cmd", lambda: ["docker", "compose"])
         cli.main()
-        assert calls[0]["cmd"] == ["python", "scripts/cleanup_orphaned_dbs.py"]
+        assert calls[0]["cmd"] == [sys.executable, "scripts/cleanup_orphaned_dbs.py"]
 
     def test_main_test_with_extra_args(self, monkeypatch):
         """Given 'test' with extra pytest args, should pass them through."""

--- a/scripts/tests/test_issue_493_foundation_ttd_behavior.py
+++ b/scripts/tests/test_issue_493_foundation_ttd_behavior.py
@@ -58,7 +58,7 @@ def test_AC12_19_1_moon_workspace_loads_root_and_app_projects() -> None:
     assert set(root_project["tasks"]) == expected_tasks
     for task in expected_tasks:
         command = root_project["tasks"][task]["command"]
-        assert command.startswith("python scripts/cli.py ")
+        assert command.startswith("python3 scripts/cli.py ")
 
 
 def test_AC12_22_1_stage2_review_schemas_live_outside_statements_router() -> None:

--- a/scripts/tests/test_toolchain_contract.py
+++ b/scripts/tests/test_toolchain_contract.py
@@ -23,6 +23,7 @@ def _copy_contract_inputs(target_root: Path) -> None:
         ".nvmrc",
         ".tool-versions",
         ".npmrc",
+        ".moon/toolchain.yml",
         "apps/frontend/package.json",
         ".github/workflows/ci.yml",
         ".github/workflows/staging-deploy.yml",
@@ -85,13 +86,31 @@ def test_AC8_13_39_contract_fails_when_frontend_engine_drifts(tmp_path: Path) ->
     assert contract.run_contract(tmp_path) == 1
 
 
+def test_AC8_13_39_contract_fails_when_moon_toolchain_drifts(tmp_path: Path) -> None:
+    """AC8.13.39: Moon's local toolchain declaration cannot drift from toolchain.toml."""
+    _copy_contract_inputs(tmp_path)
+
+    moon_toolchain = tmp_path / ".moon/toolchain.yml"
+    moon_toolchain.write_text(
+        moon_toolchain.read_text(encoding="utf-8").replace(
+            "version: '20.19.0'",
+            "version: '25.9.0'",
+        ),
+        encoding="utf-8",
+    )
+
+    assert contract.run_contract(tmp_path) == 1
+
+
 def test_AC8_13_39_contract_reports_missing_toolchain(tmp_path: Path) -> None:
     """AC8.13.39: Missing runtime SSOT fails instead of silently passing."""
     with pytest.raises(FileNotFoundError):
         contract.load_toolchain(tmp_path)
 
 
-def test_AC8_13_39_cli_accepts_explicit_repo_root(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_AC8_13_39_cli_accepts_explicit_repo_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """AC8.13.39: The CLI validates an explicit checkout root."""
     monkeypatch.setattr(
         sys,

--- a/toolchain.toml
+++ b/toolchain.toml
@@ -1,6 +1,7 @@
 [runtime]
 python = "3.12.12"
 node = "20.19.0"
+npm = "10.8.2"
 uv = "0.9.18"
 
 [images]


### PR DESCRIPTION
## Summary

Adds a one-command local bootstrap path for new checkouts:

```bash
bash scripts/bootstrap.sh
```

The bootstrap installs or verifies the repo-pinned user-space toolchain (`uv`, Python 3.12.12, nvm/Node 20.19.0, Moon CLI), runs dependency setup through Moon, installs pre-commit hooks, detects the active host shell, sets PATH/NVM environment basics explicitly, and reports whether Docker/Podman plus common agent/dev CLIs are available in the same execution environment.

## Root Cause

Local initialization depended on several implicit assumptions that were not true in a fresh WSL checkout or a Windows/Codex runner context:

- `moon.yml` invoked `python`, but Ubuntu exposes `python3` by default.
- `moon run :setup` could sync backend dependencies with the wrong Python patch version.
- Frontend setup used `npm install`, which could reorder/change lockfile metadata during initialization.
- `.moon/toolchain.yml` still carried stale Node/npm versions and was not covered by the toolchain contract check.
- The repo submodule pre-commit hook rejected normal gitfile-style submodule checkouts and had a missing SHA comparison guard.
- Developer docs did not explain that WSL Ubuntu, macOS/Linux shells, Windows PowerShell/Scoop, Git Bash, and the Codex Windows runner have separate PATH and package-install scopes.

## Changes

- Added `scripts/bootstrap.sh` as the documented first-run setup command.
- Switched root Moon tasks to `python3` and pinned backend setup to `uv sync --python 3.12.12`.
- Switched frontend setup to `npm ci`.
- Added npm to `toolchain.toml` and aligned `.moon/toolchain.yml` with the runtime contract.
- Extended `scripts/check_toolchain_contract.py` to validate Moon's Node/npm mirror.
- Fixed `scripts/check_repo_submodule.sh` for standard submodule gitfiles and restored the missing behind-main comparison.
- Documented the local host-shell matrix in README and SSOT docs: macOS/Linux, WSL Ubuntu, Windows PowerShell/Scoop, Git Bash/MSYS/Cygwin, and Codex runner boundaries.
- Added bash-only bootstrap diagnostics for host detection, explicit PATH/NVM setup, optional `gh`/`jq`/`yq`/`direnv`/`op` discovery, and Docker/Podman Compose availability.
- Updated README, development SSOT, environments SSOT, manifest, contributor docs, AC registry, and AC coverage snapshot.
- Added AC8.13.44 plus focused tests for bootstrap behavior.

## Validation

Local WSL validation:

- `bash scripts/bootstrap.sh`
- `bash -n scripts/bootstrap.sh`
- `moon run :lint`
- `apps/backend/.venv/bin/python -m pytest scripts/tests/test_bootstrap_local.py scripts/tests/test_toolchain_contract.py scripts/tests/test_cli_and_dev_servers.py -q` (`64 passed`)
- `moon run :test -- --frontend` (`79` files / `485` tests passed)
- `python scripts/check_toolchain_contract.py`
- `python scripts/generate_ac_registry.py --check`
- `python scripts/check_ac_traceability.py`
- `python scripts/check_critical_proof_matrix.py`
- `python scripts/check_manifest.py`
- `python scripts/check_ssot_ownership.py`
- `python scripts/analyze_test_ac_coverage.py --stdout`
- `bash scripts/check_repo_submodule.sh`
- `git diff --check`

GitHub validation for head `af56cea`:

- `PR Test Environment` run 1736: success
- `CI` run 1909: success
  - AC Traceability Check
  - Lint, Doc Consistency, SSOT Ownership, SSOT Manifest
  - Build Staging Images
  - Backend Tests shards 1/6 through 6/6
  - Frontend Build & Test
  - Calculate Unified Coverage
  - finish aggregate job

## Notes

The host-shell boundary update intentionally stays in bash and docs. It does not add Python/JS test layers for the pure environment split; existing CI gates cover the repo-level docs, lint, scripts, frontend, backend, and coverage contracts.
