### PR TITLE
[codex] sync CI delivery gates

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -65,7 +65,7 @@ jobs:
               echo "PR info: ${{ github.event.pull_request.number }} (${{ github.event.action }})" >&2
               echo "pr_number=${{ github.event.pull_request.number }}"
               echo "compose_name=pr-${{ github.event.pull_request.number }}"
-              
+
               if [ "${{ github.event.action }}" == "closed" ]; then
                 echo "action=cleanup"
               else
@@ -138,15 +138,15 @@ jobs:
             "${{ env.DOKPLOY_API_URL }}/environment.one?environmentId=${{ env.TEST_ENV_ID }}" 2>&1)
           curl_exit=$?
           set -e
-          
+
           if [ $curl_exit -ne 0 ]; then
             echo "::warning::Failed to fetch environment (curl exit $curl_exit). Assuming compose doesn't exist."
             echo "Response: $response"
             response='{"compose":[]}'
           fi
-          
+
           compose_id=$(echo "$response" | jq -r --arg name "${{ needs.setup.outputs.compose_name }}" '.compose[] | select(.name == $name) | .composeId' | head -1)
-          
+
           if [ -n "$compose_id" ] && [ "$compose_id" != "null" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "compose_id=$compose_id" >> "$GITHUB_OUTPUT"
@@ -169,9 +169,9 @@ jobs:
             -d "{
               \"name\": \"${{ needs.setup.outputs.compose_name }}\",
               \"description\": \"PR #${{ needs.setup.outputs.pr_number }}: $PR_TITLE\",
-              \"environmentId\": \"${{ env.TEST_ENV_ID }}\" 
+              \"environmentId\": \"${{ env.TEST_ENV_ID }}\"
             }")
-          
+
           compose_id=$(echo "$response" | jq -r '.composeId')
           echo "compose_id=$compose_id" >> "$GITHUB_OUTPUT"
           echo "Created compose: $compose_id"
@@ -213,14 +213,14 @@ jobs:
           COMPOSE_ID="${{ steps.compose.outputs.id }}"
           PR_NUMBER="${{ needs.setup.outputs.pr_number }}"
           DOMAIN="${{ needs.setup.outputs.internal_domain }}"
-          
+
           # Calculate unique ports based on PR number to avoid conflicts
           # Range: 30000-34000 (Modulo 1000 to keep within range)
           PR_MOD=$((PR_NUMBER % 1000))
           DB_PORT=$((30000 + PR_MOD))
           MINIO_API_PORT=$((32000 + PR_MOD))
           MINIO_CONSOLE_PORT=$((33000 + PR_MOD))
-          
+
           # Construct environment variables in a temporary file to avoid indentation issues
           {
             echo "GIT_COMMIT_SHA=${{ github.sha }}"
@@ -234,12 +234,12 @@ jobs:
             echo "NEXT_PUBLIC_API_URL=https://report-pr-$PR_NUMBER.$DOMAIN"
             echo "NEXT_PUBLIC_APP_URL=https://report-pr-$PR_NUMBER.$DOMAIN"
             echo "DEBUG=true"
-            
+
             # Host binding: 127.0.0.1 to avoid exposing to public internet
             echo "DB_PORTS=127.0.0.1:$DB_PORT:5432"
             echo "MINIO_API_PORTS=127.0.0.1:$MINIO_API_PORT:9000"
             echo "MINIO_CONSOLE_PORTS=127.0.0.1:$MINIO_CONSOLE_PORT:9001"
-            
+
             # PR preview CI must not call the real AI/OCR provider. The
             # provider-backed GLM gate is centralized in post-merge staging.
             echo "AI_PROVIDER=zai"
@@ -256,7 +256,7 @@ jobs:
             echo "AI_JSON_MAX_TOKENS=8192"
             echo "AI_JSON_DISABLE_THINKING=true"
             echo "COMPOSE_PROFILES=infra,app"
-            
+
             # CRITICAL: Use unique hostnames in Dokploy shared network
             # Container names with ENV_SUFFIX are used as hostnames
             echo "DB_HOST=finance-report-db-pr-$PR_NUMBER"
@@ -266,7 +266,7 @@ jobs:
             echo "MINIO_ROOT_PASSWORD=minio_local_secret"
             echo "S3_ACCESS_KEY=minio"
             echo "S3_SECRET_KEY=minio_local_secret"
-            
+
             # SigNoz Logging (EPIC-010)
             echo "OTEL_EXPORTER_OTLP_ENDPOINT=http://platform-signoz-otel-collector:4318"
             echo "OTEL_SERVICE_NAME=finance-report-backend"
@@ -277,18 +277,18 @@ jobs:
             echo "API_RATE_LIMIT_REQUESTS=10000"
             echo "REGISTER_RATE_LIMIT_REQUESTS=10000"
           } > .env.dokploy
-          
+
           ENV_CONTENT=$(cat .env.dokploy)
-          
+
           # Send to Dokploy
           # Use --arg properly without extra escaping that breaks shell/jq boundary
           PAYLOAD=$(jq -n --arg id "$COMPOSE_ID" --arg env "$ENV_CONTENT" '{composeId: $id, env: $env}')
-          
+
           curl -sf -X POST "${{ env.DOKPLOY_API_URL }}/compose.update" \
             -H "Content-Type: application/json" \
             -H "x-api-key: ${{ secrets.DOKPLOY_API_KEY }}" \
             -d "$PAYLOAD"
-          
+
           echo "Environment variables configured"
 
       - name: Deploy compose
@@ -299,31 +299,31 @@ jobs:
           COMPOSE_ID="${{ steps.compose.outputs.id }}"
           echo "compose_id=$COMPOSE_ID" >> "$GITHUB_OUTPUT"
           echo "Deploying compose: $COMPOSE_ID"
-          
+
           # Stop existing compose (best-effort, log but don't fail)
           echo "Stopping existing compose..."
           STOP_RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST "${{ env.DOKPLOY_API_URL }}/compose.stop" \
             -H "Content-Type: application/json" \
             -H "x-api-key: $DOKPLOY_API_KEY" \
             -d "{\"composeId\": \"$COMPOSE_ID\"}" 2>&1) || true
-          
+
           STOP_HTTP=$(echo "$STOP_RESPONSE" | tail -1)
           if [[ "$STOP_HTTP" != "200" && "$STOP_HTTP" != "000" ]]; then
             echo "::warning::compose.stop returned HTTP $STOP_HTTP (may be expected if already stopped)"
           fi
-          
+
           sleep 5
           # Record exact time before triggering deploy (used by polling step)
           TRIGGER_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "trigger_time=$TRIGGER_TIME" >> "$GITHUB_OUTPUT"
           echo "Deploy trigger time: $TRIGGER_TIME"
-          
-          
+
+
           curl -sf -X POST "${{ env.DOKPLOY_API_URL }}/compose.deploy" \
             -H "Content-Type: application/json" \
             -H "x-api-key: $DOKPLOY_API_KEY" \
             -d "{\"composeId\": \"$COMPOSE_ID\"}"
-          
+
           echo "Deployment triggered, waiting 10s for status to update..."
           sleep 10
 
@@ -389,11 +389,11 @@ jobs:
 
           url = os.environ["APP_URL"] + "/api/health"
           print(f"Waiting for API readiness at {url}")
-          
+
           ctx = ssl.create_default_context()
           ctx.check_hostname = False
           ctx.verify_mode = ssl.CERT_NONE
-          
+
           max_attempts = 30
           for attempt in range(1, max_attempts + 1):
               delay = min(5 + (attempt // 5) * 5, 30)
@@ -405,10 +405,10 @@ jobs:
                       print(f"⚠️ Attempt {attempt}/{max_attempts}: status {response.getcode()}")
               except Exception as e:
                   print(f"❌ Attempt {attempt}/{max_attempts}: {type(e).__name__}: {e}")
-              
+
               print(f"   Retrying in {delay}s...")
               time.sleep(delay)
-          
+
           print("::error::API not ready after all attempts")
           sys.exit(1)
           EOF
@@ -431,15 +431,16 @@ jobs:
           EXPECTED_SHA: ${{ github.sha }}
           TIMEOUT_MS: 60000
           E2E_API_TIMEOUT: 30
+          STRICT_E2E_GATES: true
         run: |
           echo "🚀 Starting E2E Pipeline for $APP_URL"
-          
+
           echo "--- Phase 1: Smoke Check (Shell) ---"
           bash scripts/smoke_test.sh "$APP_URL" staging
-          
+
           echo "--- Phase 2: Core Flow Validation (Python, no real AI/OCR) ---"
-          pytest tests/e2e -v -m "(smoke or e2e) and not llm" --junit-xml=test-results.xml
-          
+          pytest tests/e2e -v -m "(smoke or e2e) and not llm" -n 4 --junit-xml=test-results.xml
+
           echo "✅ E2E Pipeline passed!"
 
       - name: Rollback on E2E Failure
@@ -449,13 +450,13 @@ jobs:
         run: |
           COMPOSE_ID="${{ steps.deploy.outputs.compose_id }}"
           echo "::warning::E2E tests failed. Stopping compose to prevent broken deployment..."
-          
+
           # Best-effort stop, log result but don't fail the job
           STOP_RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST "${{ env.DOKPLOY_API_URL }}/compose.stop" \
             -H "Content-Type: application/json" \
             -H "x-api-key: $DOKPLOY_API_KEY" \
             -d "{\"composeId\": \"$COMPOSE_ID\"}" 2>&1) || true
-          
+
           STOP_HTTP=$(echo "$STOP_RESPONSE" | tail -1)
           if [[ "$STOP_HTTP" == "200" ]]; then
             echo "✅ Compose stopped successfully"
@@ -463,7 +464,7 @@ jobs:
             echo "::warning::compose.stop returned HTTP $STOP_HTTP"
             echo "Response: $(echo "$STOP_RESPONSE" | head -n -1)"
           fi
-          
+
           echo "Check logs for E2E failure details."
 
       - name: Comment on PR
@@ -477,31 +478,31 @@ jobs:
           script: |
             const url = `https://report-pr-${process.env.PR_NUMBER}.${process.env.INTERNAL_DOMAIN}`;
             const body = `## 🧪 Test Environment Deployed
-            
+
             | Service | URL |
             |---------|-----|
             | Frontend | [${url}](${url}) |
             | API Health | [${url}/api/health](${url}/api/health) |
-            
+
             **Details:**
             - Compose: \`${process.env.COMPOSE_NAME}\`
             - Branch: \`${process.env.BRANCH_NAME}\`
             - Commit: \`${{ github.sha }}\`
-            
+
             > ⏳ First deployment may take 3-5 minutes for build + SSL certificate.
-            
+
             _This environment will be automatically cleaned up when the PR is closed._`;
-            
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: Number(process.env.PR_NUMBER),
             });
-            
-            const botComment = comments.find(c => 
+
+            const botComment = comments.find(c =>
               c.user.type === 'Bot' && c.body.includes('🧪 Test Environment Deployed')
             );
-            
+
             if (botComment) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
@@ -531,44 +532,44 @@ jobs:
       - name: Find and remove compose
         run: |
           echo "Looking for compose: ${{ needs.setup.outputs.compose_name }}"
-          
+
           # Get environment to find compose
           set +e
           response=$(curl -sf -H "x-api-key: ${{ secrets.DOKPLOY_API_KEY }}" \
             "${{ env.DOKPLOY_API_URL }}/environment.one?environmentId=${{ env.TEST_ENV_ID }}" 2>&1)
           curl_exit=$?
           set -e
-          
+
           if [ $curl_exit -ne 0 ]; then
             echo "::warning::Failed to fetch environment (curl exit $curl_exit). Response: $response"
             response='{"compose":[]}'
           fi
-          
+
           compose_id=$(echo "$response" | jq -r --arg name "${{ needs.setup.outputs.compose_name }}" '.compose[] | select(.name == $name) | .composeId' | head -1)
-          
+
           if [ -n "$compose_id" ] && [ "$compose_id" != "null" ]; then
             echo "Found compose: $compose_id"
-            
+
             # Stop compose (best-effort with logging)
             echo "Stopping compose..."
             STOP_RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST "${{ env.DOKPLOY_API_URL }}/compose.stop" \
               -H "Content-Type: application/json" \
               -H "x-api-key: ${{ secrets.DOKPLOY_API_KEY }}" \
               -d "{\"composeId\": \"$compose_id\"}" 2>&1) || true
-            
+
             STOP_HTTP=$(echo "$STOP_RESPONSE" | tail -1)
             if [[ "$STOP_HTTP" != "200" ]]; then
               echo "::warning::compose.stop returned HTTP $STOP_HTTP (continuing with deletion)"
             fi
-            
+
             sleep 15
-            
+
             # Delete compose (removes containers but may leave volumes)
             curl -sf -X POST "${{ env.DOKPLOY_API_URL }}/compose.delete" \
               -H "Content-Type: application/json" \
               -H "x-api-key: ${{ secrets.DOKPLOY_API_KEY }}" \
               -d "{\"composeId\": \"$compose_id\"}"
-            
+
             echo "Compose deleted"
           else
             echo "Compose not found, nothing to cleanup"
@@ -580,42 +581,42 @@ jobs:
           VPS_HOST: cloud.zitian.party
         run: |
           echo "🧹 Cleaning Docker volumes for PR #$PR_NUMBER..."
-          
+
           # Use GitHub's built-in SSH key if available, or skip volume cleanup
           if [ -z "${{ secrets.VPS_SSH_KEY }}" ]; then
             echo "::warning::VPS_SSH_KEY not configured. Skipping volume cleanup."
             echo "Volumes will be cleaned by scheduled system prune."
             exit 0
           fi
-          
+
           # Setup SSH key
           mkdir -p ~/.ssh
           echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/vps_key
           chmod 600 ~/.ssh/vps_key
           ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-          
+
           # List and remove PR volumes
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=accept-new root@"$VPS_HOST" << 'EOF'
             PR_SUFFIX="-pr-${{ needs.setup.outputs.pr_number }}"
-            
+
             echo "Searching for volumes matching pattern: *${PR_SUFFIX}"
             VOLUMES=$(docker volume ls --format "{{.Name}}" | grep "${PR_SUFFIX}" || true)
-            
+
             if [ -z "$VOLUMES" ]; then
               echo "No volumes found for this PR"
             else
               echo "Found volumes:"
               echo "$VOLUMES"
-              
+
               echo "Removing volumes..."
               echo "$VOLUMES" | xargs -r docker volume rm 2>&1 || {
                 echo "::warning::Some volumes may still be in use or already deleted"
               }
-              
+
               echo "✅ Volume cleanup complete"
             fi
           EOF
-          
+
           # Cleanup SSH key
           rm -f ~/.ssh/vps_key
 
@@ -626,28 +627,28 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "🗑️  Deleting PR images from GitHub Container Registry..."
-          
+
           for service in backend frontend; do
             IMAGE_NAME="finance_report-${service}"
             TAG="pr-${PR_NUMBER}"
-            
+
             echo "Searching for ${IMAGE_NAME}:${TAG}..."
-            
+
             # Get package version ID for this tag
             VERSION_ID=$(gh api \
               -H "Accept: application/vnd.github+json" \
               "/orgs/${{ github.repository_owner }}/packages/container/${IMAGE_NAME}/versions" \
               --jq ".[] | select(.metadata.container.tags[] | contains(\"${TAG}\")) | .id" \
               2>/dev/null || echo "")
-            
+
             if [ -z "$VERSION_ID" ]; then
               echo "  Image ${IMAGE_NAME}:${TAG} not found (may be already deleted)"
               continue
             fi
-            
+
             echo "  Found version ID: $VERSION_ID"
             echo "  Deleting..."
-            
+
             gh api \
               --method DELETE \
               -H "Accept: application/vnd.github+json" \
@@ -655,10 +656,10 @@ jobs:
               2>&1 || {
                 echo "::warning::Failed to delete ${IMAGE_NAME}:${TAG} (may require org admin permissions)"
               }
-            
+
             echo "  ✅ Deleted ${IMAGE_NAME}:${TAG}"
           done
-          
+
           echo "GHCR cleanup complete"
 
       - name: Comment cleanup notice
@@ -668,15 +669,15 @@ jobs:
         with:
           script: |
             const body = `## 🧹 PR Resources Released
-            
+
             All temporary resources for this PR have been released:
-            
+
             - **Dokploy Stack**: \`${{ needs.setup.outputs.compose_name }}\` ✓ deleted
             - **Docker Volumes**: Cleaned (postgres_data, minio_data)
             - **GHCR Images**: Deleted (backend:pr-${{ needs.setup.outputs.pr_number }}, frontend:pr-${{ needs.setup.outputs.pr_number }})
-            
+
             _Cleanup completed successfully._`;
-            
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ check: lint env-check
 	@echo "✅ All checks passed"
 
 test:
-	moon run backend:test
+	moon run :test
 
 env-check:
 	python scripts/check_env_keys.py

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1958,6 +1958,22 @@ groups:
         description: Local bootstrap provides one command for runtimes, dependency setup, pre-commit hooks, and container-runtime
           diagnostics
         mandatory: true
+      - id: AC8.13.45
+        epic: 8
+        epic_name: testing-strategy
+        description: Local verification entry points fail on the same backend format errors and route `make test` through
+          the root Moon test command.
+        mandatory: true
+      - id: AC8.13.46
+        epic: 8
+        epic_name: testing-strategy
+        description: PR preview non-LLM E2E uses the same strict, parallel gate shape as staging non-LLM E2E.
+        mandatory: true
+      - id: AC8.13.47
+        epic: 8
+        epic_name: testing-strategy
+        description: Remaining delivery-engine optimizations are captured in a tracked project recommendation note.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1962,7 +1962,7 @@ groups:
         epic: 8
         epic_name: testing-strategy
         description: Local verification entry points fail on the same backend format errors and route `make test` through
-          the root Moon test command.
+          the root Moon test command without hashing the infra submodule gitlink as a file input.
         mandatory: true
       - id: AC8.13.46
         epic: 8

--- a/docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md
+++ b/docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md
@@ -1,0 +1,59 @@
+# Delivery Engine Recommendations
+
+> Owner: EPIC-008 testing strategy
+> See: docs/ssot/ci-cd.md
+
+This note captures the CI and post-merge optimization items intentionally left
+out of the narrow delivery-sync PR. The PR fixes local/CI drift and PR-preview
+gate parity; the items below change workflow topology or branch-protection
+behavior and should be handled as separate reviewed PRs.
+
+## Current baseline
+
+Observed on May 27, 2026:
+
+| Lane | Recent duration | Main contributor |
+|---|---:|---|
+| Main CI heavy path | 8m 56s | Backend shard wall time plus unified coverage |
+| Unified coverage job | 3m 36s | Coveralls reporting-only status normalization |
+| Staging post-merge lane | 18m 04s | Waiting for same-SHA CI, then deploy and E2E |
+| Staging AI/OCR gate | 3m 53s | Provider-backed E2E execution |
+
+## Recommended follow-ups
+
+### Coveralls reporting split
+
+Keep local deterministic coverage gates required, but move Coveralls upload and
+status normalization into a non-required reporting job after unified coverage
+passes. This should reduce the required CI critical path by roughly the time now
+spent in `Mark Coveralls statuses reporting-only`, while preserving dashboards.
+
+Risk: branch protection and existing Coveralls status contexts must be audited
+before changing required checks.
+
+### workflow_run staging trigger
+
+Replace the staging workflow's in-job wait for same-SHA CI with a `workflow_run`
+trigger that starts staging only after the matching CI run succeeds. Keep manual
+dispatch as a recovery path and keep the healthy-but-stale diagnostic for failed
+or delayed CI.
+
+Risk: GitHub Actions event semantics need careful testing so staging still
+targets the exact merged SHA and does not deploy a stale or superseded commit.
+
+### parallel image build jobs
+
+Split backend and frontend SHA image builds into separate jobs or a matrix. The
+latest observed frontend image build dominated the image-build job, while the
+backend image was much shorter. Parallel jobs would make the bottleneck visible
+and may shorten the normal main-push path.
+
+Risk: GHCR tagging and cache behavior must remain identical for PR dry-runs and
+main pushes.
+
+## Out of scope for this PR
+
+- Changing branch-protection required contexts.
+- Moving Coveralls status publication out of the current required job.
+- Replacing the staging push trigger with `workflow_run`.
+- Reworking Docker image build topology.

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -77,6 +77,9 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.42**: Four-asset as-of net worth golden path runs as a critical fresh-user post-merge E2E.
 - **AC8.13.43**: Staging deploy reports healthy-but-stale state and failed CI jobs when same-SHA CI blocks deployment.
 - **AC8.13.44**: Local bootstrap provides one command for runtimes, dependency setup, pre-commit hooks, and container-runtime diagnostics.
+- **AC8.13.45**: Local verification entry points fail on the same backend format errors and route `make test` through the root Moon test command.
+- **AC8.13.46**: PR preview non-LLM E2E uses the same strict, parallel gate shape as staging non-LLM E2E.
+- **AC8.13.47**: Remaining delivery-engine optimizations are captured in a tracked project recommendation note.
 
 **Current state (2026-02-23):**
 - **Tier 1**: 41 tests in `test_core_journeys.py` covering 45 ACs → **91.8% AC pass rate** (45/49)
@@ -392,6 +395,9 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.42 | Four-asset as-of net worth golden path runs as a critical fresh-user post-merge E2E | `test_four_asset_as_of_net_worth_golden_path`, `test_AC8_13_42_four_asset_net_worth_golden_path_is_post_merge_critical` | `tests/e2e/test_four_asset_net_worth_golden_path.py`, `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.43 | Staging deploy reports healthy-but-stale state and failed CI jobs when same-SHA CI blocks deployment | `test_AC8_13_43_*` | `scripts/tests/` | P0 |
 | AC8.13.44 | Local bootstrap provides one command for runtimes, dependency setup, pre-commit hooks, and container-runtime diagnostics | `test_AC8_13_44_*` | `scripts/tests/test_bootstrap_local.py`, `scripts/tests/test_cli_and_dev_servers.py`, `scripts/tests/test_toolchain_contract.py` | P0 |
+| AC8.13.45 | Local verification entry points fail on the same backend format errors and route `make test` through the root Moon test command | `test_AC8_13_45_*` | `scripts/tests/test_cli_and_dev_servers.py`, `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
+| AC8.13.46 | PR preview non-LLM E2E uses the same strict, parallel gate shape as staging non-LLM E2E | `test_AC8_13_46_pr_preview_non_llm_gate_matches_staging_strict_parallelism` | `scripts/tests/test_post_merge_e2e_gates.py` | P1 |
+| AC8.13.47 | Remaining delivery-engine optimizations are captured in a tracked project recommendation note | `test_AC8_13_47_delivery_engine_recommendations_are_tracked` | `scripts/tests/test_post_merge_e2e_gates.py` | P1 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -77,7 +77,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.42**: Four-asset as-of net worth golden path runs as a critical fresh-user post-merge E2E.
 - **AC8.13.43**: Staging deploy reports healthy-but-stale state and failed CI jobs when same-SHA CI blocks deployment.
 - **AC8.13.44**: Local bootstrap provides one command for runtimes, dependency setup, pre-commit hooks, and container-runtime diagnostics.
-- **AC8.13.45**: Local verification entry points fail on the same backend format errors and route `make test` through the root Moon test command.
+- **AC8.13.45**: Local verification entry points fail on the same backend format errors and route `make test` through the root Moon test command without hashing the infra submodule gitlink as a file input.
 - **AC8.13.46**: PR preview non-LLM E2E uses the same strict, parallel gate shape as staging non-LLM E2E.
 - **AC8.13.47**: Remaining delivery-engine optimizations are captured in a tracked project recommendation note.
 
@@ -395,7 +395,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.42 | Four-asset as-of net worth golden path runs as a critical fresh-user post-merge E2E | `test_four_asset_as_of_net_worth_golden_path`, `test_AC8_13_42_four_asset_net_worth_golden_path_is_post_merge_critical` | `tests/e2e/test_four_asset_net_worth_golden_path.py`, `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.43 | Staging deploy reports healthy-but-stale state and failed CI jobs when same-SHA CI blocks deployment | `test_AC8_13_43_*` | `scripts/tests/` | P0 |
 | AC8.13.44 | Local bootstrap provides one command for runtimes, dependency setup, pre-commit hooks, and container-runtime diagnostics | `test_AC8_13_44_*` | `scripts/tests/test_bootstrap_local.py`, `scripts/tests/test_cli_and_dev_servers.py`, `scripts/tests/test_toolchain_contract.py` | P0 |
-| AC8.13.45 | Local verification entry points fail on the same backend format errors and route `make test` through the root Moon test command | `test_AC8_13_45_*` | `scripts/tests/test_cli_and_dev_servers.py`, `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
+| AC8.13.45 | Local verification entry points fail on the same backend format errors and route `make test` through the root Moon test command without hashing the infra submodule gitlink as a file input | `test_AC8_13_45_*` | `scripts/tests/test_cli_and_dev_servers.py`, `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.46 | PR preview non-LLM E2E uses the same strict, parallel gate shape as staging non-LLM E2E | `test_AC8_13_46_pr_preview_non_llm_gate_matches_staging_strict_parallelism` | `scripts/tests/test_post_merge_e2e_gates.py` | P1 |
 | AC8.13.47 | Remaining delivery-engine optimizations are captured in a tracked project recommendation note | `test_AC8_13_47_delivery_engine_recommendations_are_tracked` | `scripts/tests/test_post_merge_e2e_gates.py` | P1 |
 

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -69,6 +69,7 @@ owning source instead of copying:
 |---|---|
 | [AUDITS.md](./AUDITS.md) | Audit index |
 | [AC-AUDIT-2026-05-04.md](./AC-AUDIT-2026-05-04.md) | Historical vision -> EPIC -> AC consistency audit |
+| [DELIVERY_ENGINE_RECOMMENDATIONS.md](./DELIVERY_ENGINE_RECOMMENDATIONS.md) | Remaining CI/post-merge delivery-engine optimization recommendations |
 | [../analysis/test-ac-coverage-report.md](../analysis/test-ac-coverage-report.md) | Current generated AC-to-test coverage report |
 | [../analysis/traceability-exceptions.md](../analysis/traceability-exceptions.md) | Classified helper/SSOT tests and source surfaces that are not AC proof |
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -203,8 +203,13 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 **PR preview E2E** (`.github/workflows/pr-test.yml`):
 - PR preview environments do not inject `ZAI_API_KEY`; they validate app wiring without real GLM/OCR provider calls.
 - PR preview E2E explicitly excludes tests marked `llm`. The post-merge `Staging AI/OCR Gate` workflow is the single automated CI entry point that may spend provider quota.
+- PR preview non-LLM E2E mirrors the staging non-LLM command shape: `STRICT_E2E_GATES=true`, marker `(smoke or e2e) and not llm`, and `-n 4` parallelism. The provider-backed `llm` marker remains post-merge only.
 - PR preview cleanup has two paths: the PR `closed` event removes the Dokploy stack, volumes, and GHCR PR images; the scheduled `PR Preview Cleanup` fallback removes stale VPS preview containers/compose volumes for closed or missing PRs and prunes aged Docker build cache/images without touching open PR previews.
 - GLM/OCR CI traffic uses `AI_BASE_URL=https://api.z.ai/api/coding/paas/v4`; the URL remains an env override so the base provider can be replaced without code changes.
+
+The remaining higher-risk CI and post-merge optimization candidates are tracked
+in the delivery-engine recommendation note instead of being mixed into routine
+SSOT edits: [DELIVERY_ENGINE_RECOMMENDATIONS.md](../project/DELIVERY_ENGINE_RECOMMENDATIONS.md).
 
 > **Local vs GitHub CI Parallelism**
 >

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -57,10 +57,15 @@ Smoke:   ❌ Not run (unit tests only)
 ### staging-deploy.yml
 
 ```yaml
-Trigger: Push to main (apps/** changed)
-Flow:    Build (commit SHA) → Deploy → Health (6min) → E2E tests
+Trigger: Push to main or manual dispatch
+Flow:    Wait for same-SHA CI -> promote SHA images -> deploy -> smoke/non-LLM E2E -> AI/OCR gate
 URL:     https://report-staging.zitian.party
 ```
+
+Normal staging deploys reuse SHA-tagged backend and frontend images built by the
+matching `CI` push workflow. If a SHA image is missing, staging falls back to
+building only the missing image before promotion. Provider-backed AI/OCR tests
+run after deploy health in the same serialized post-merge workflow unit.
 
 ### production-release.yml
 

--- a/docs/ssot/development.md
+++ b/docs/ssot/development.md
@@ -101,7 +101,7 @@ moon run :dev -- --backend        # Full Stack (App + DB + Redis + MinIO)
 moon run :dev -- --frontend       # Next.js on :3000
 
 # Local CI / Verification (Recommended)
-moon run :lint && moon run :test  # One-button check (matches GitHub CI exactly)
+moon run :lint && moon run :test  # One-button local gate (same gate family as GitHub CI)
 
 # Testing
 moon run :test                    # All tests (default, 90% backend coverage)
@@ -212,7 +212,8 @@ Integration points:
 
 > **See dedicated file** → **[docs/ssot/ci-cd.md](./ci-cd.md)**
 >
-> Covers: smart/fast/full test modes, 4-way CI sharding, no-regression coverage gate,
+> Covers: smart/fast/full test modes, 4-way local test parallelism,
+> GitHub CI sharding, no-regression coverage gate,
 > CI job structure, and performance metrics.
 
 ---

--- a/docs/ssot/development.md
+++ b/docs/ssot/development.md
@@ -123,6 +123,11 @@ python scripts/check_toolchain_contract.py  # Runtime/toolchain drift check
 moon run :build             # Build all
 ```
 
+Root Moon tasks are uncached wrappers with explicit workspace inputs, so local
+verification runs fresh and never treats the `repo` infra submodule gitlink as a
+file input. The `repo/` submodule is verified separately by the agent
+orchestration infra sync check.
+
 ---
 
 ## Documentation

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -37,7 +37,7 @@
 - Uses same `docker-compose.yml` (Profile: `infra`)
 - **Ephemeral data**: Test DB reset before each run, worker DBs auto-cleaned
 - Isolation: `finance_report_test_{namespace}` + worker DBs (`_gw0`, `_gw1`, etc.); long namespaces are hash-shortened to keep DB names and `statements-{namespace}` buckets within 63-character backend limits.
-- Command: `moon run :lint && moon run :test` (**matches GitHub CI exactly**)
+- Command: `moon run :lint && moon run :test` (**same gate family as GitHub CI**; GitHub adds sharding, frontend coverage, scripts coverage, traceability, and image validation)
 
 ### Host Shell Boundaries
 
@@ -112,7 +112,7 @@ before invoking `moon`, `uv`, `npm`, `gh`, Docker, or Podman.
 
 | Workflow File | Environment | Trigger | Actions |
 |---------------|-------------|---------|---------|
-| `.github/workflows/ci.yml` | GitHub CI | Push/PR to main | Run `moon run :lint && moon run :test`, upload coverage |
+| `.github/workflows/ci.yml` | GitHub CI | Push/PR to main | Run lint, traceability, backend shards, frontend build/tests, scripts coverage, unified coverage, and image validation |
 | `.github/workflows/pr-test.yml` | PR Preview | PR opened/sync | Build images, deploy to Dokploy, cleanup on close |
 | `.github/workflows/staging-deploy.yml` | Staging | Push to main | Build images (`:staging` tag), deploy |
 | `.github/workflows/production-release.yml` | Production | Tag `v*.*.*` or manual | Build release images, deploy on manual trigger |

--- a/moon.yml
+++ b/moon.yml
@@ -3,24 +3,65 @@ $schema: 'https://moonrepo.dev/schemas/project.json'
 # Root project - 6 unified commands
 layer: tool
 
+fileGroups:
+  workspace:
+    - '.github/**/*'
+    - '.moon/**/*'
+    - 'apps/**/*'
+    - 'docs/**/*'
+    - 'infra/**/*'
+    - 'scripts/**/*'
+    - 'tests/**/*'
+    - '*.md'
+    - '*.toml'
+    - '*.yml'
+    - '*.yaml'
+    - '*.ini'
+    - 'Makefile'
+    - 'package*.json'
+
 tasks:
   setup:
     command: 'python3 scripts/cli.py setup'
     deps: []
+    inputs:
+      - '@group(workspace)'
+    options:
+      cache: false
 
   dev:
     command: 'python3 scripts/cli.py dev'
     preset: 'server'
+    inputs:
+      - '@group(workspace)'
+    options:
+      cache: false
 
   test:
     command: 'python3 scripts/cli.py test'
+    inputs:
+      - '@group(workspace)'
+    options:
+      cache: false
 
   lint:
     command: 'python3 scripts/cli.py lint'
+    inputs:
+      - '@group(workspace)'
+    options:
+      cache: false
 
   build:
     command: 'python3 scripts/cli.py build'
+    inputs:
+      - '@group(workspace)'
+    options:
+      cache: false
 
   clean:
     command: 'python3 scripts/cli.py clean'
     preset: 'server'
+    inputs:
+      - '@group(workspace)'
+    options:
+      cache: false

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -150,7 +150,6 @@ def cmd_lint(args):
             run(
                 ["uv", "run", "ruff", "format", "src/", "--check"],
                 cwd=BACKEND_DIR,
-                check=False,
             )
 
     if args.frontend or not args.backend:

--- a/scripts/tests/test_cli_and_dev_servers.py
+++ b/scripts/tests/test_cli_and_dev_servers.py
@@ -371,6 +371,17 @@ class TestCmdLint:
         cli.cmd_lint(SimpleNamespace(backend=True, frontend=False, fix=False))
         assert any("ruff" in str(c["cmd"]) and "check" in str(c["cmd"]) for c in calls)
 
+    def test_AC8_13_45_lint_backend_format_check_is_required(self, monkeypatch):
+        """AC8.13.45: Local lint must fail on backend formatting drift like CI."""
+        calls = _mock_run(monkeypatch)
+        cli.cmd_lint(SimpleNamespace(backend=True, frontend=False, fix=False))
+
+        format_calls = [
+            call for call in calls if call["cmd"][:4] == ["uv", "run", "ruff", "format"]
+        ]
+        assert format_calls
+        assert format_calls[0]["check"] is True
+
     def test_lint_backend_fix(self, monkeypatch):
         """Given --backend --fix, should run ruff format then ruff check --fix."""
         calls = _mock_run(monkeypatch)

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -628,6 +628,57 @@ def test_AC8_13_43_stale_staging_diagnostic_runs_before_deploy() -> None:
     assert "same-SHA CI gate" in ci_cd
 
 
+def test_AC8_13_45_make_test_routes_through_root_moon_test() -> None:
+    """AC8.13.45: make test uses the root Moon verification entry point."""
+    makefile = read("Makefile")
+    development = read("docs/ssot/development.md")
+    environments = read("docs/ssot/environments.md")
+
+    assert "\n\tmoon run :test\n" in makefile
+    assert "moon run backend:test" not in makefile
+    assert "same gate family as GitHub CI" in development
+    assert "same gate family as GitHub CI" in environments
+
+
+def test_AC8_13_46_pr_preview_non_llm_gate_matches_staging_strict_parallelism() -> None:
+    """AC8.13.46: PR preview non-LLM E2E mirrors staging strictness and workers."""
+    preview = read(".github/workflows/pr-test.yml")
+    staging = read(".github/workflows/staging-deploy.yml")
+    ci_cd = read("docs/ssot/ci-cd.md")
+
+    preview_block = preview.split("- name: End-to-End Tests", 1)[1].split(
+        "- name: Rollback on E2E Failure", 1
+    )[0]
+    staging_block = staging.split("- name: End-to-End Tests", 1)[1].split(
+        "- name: Performance Benchmark", 1
+    )[0]
+
+    for block in (preview_block, staging_block):
+        assert "STRICT_E2E_GATES: true" in block
+        assert 'pytest tests/e2e -v -m "(smoke or e2e) and not llm" -n 4' in block
+
+    assert "PR preview non-LLM E2E mirrors the staging non-LLM command shape" in ci_cd
+
+
+def test_AC8_13_47_delivery_engine_recommendations_are_tracked() -> None:
+    """AC8.13.47: remaining delivery-engine work is captured outside mutable SSOT."""
+    recommendation = read("docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md")
+    project_readme = read("docs/project/README.md")
+    ci_cd = read("docs/ssot/ci-cd.md")
+
+    for token in (
+        "Coveralls reporting split",
+        "workflow_run staging trigger",
+        "parallel image build jobs",
+        "Current baseline",
+        "Out of scope for this PR",
+    ):
+        assert token in recommendation
+
+    assert "DELIVERY_ENGINE_RECOMMENDATIONS.md" in project_readme
+    assert "delivery-engine recommendation note" in ci_cd
+
+
 def test_AC8_13_10_multi_brokerage_upload_to_portfolio_value_gate() -> None:
     """AC8.13.10: Staging proves multi-brokerage upload through latest value."""
     workflow = read(".github/workflows/staging-deploy.yml")

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -638,6 +640,24 @@ def test_AC8_13_45_make_test_routes_through_root_moon_test() -> None:
     assert "moon run backend:test" not in makefile
     assert "same gate family as GitHub CI" in development
     assert "same gate family as GitHub CI" in environments
+
+
+def test_AC8_13_45_root_moon_tasks_do_not_hash_repo_submodule() -> None:
+    """AC8.13.45: Root Moon gates avoid hashing the infra submodule gitlink."""
+    moon = yaml.safe_load(read("moon.yml"))
+
+    workspace_inputs = moon["fileGroups"]["workspace"]
+    assert "repo" not in workspace_inputs
+    assert "**/*" not in workspace_inputs
+    assert "uncached wrappers with explicit workspace inputs" in read(
+        "docs/ssot/development.md"
+    )
+
+    for task_name in ("setup", "dev", "test", "lint", "build", "clean"):
+        task = moon["tasks"][task_name]
+        task_inputs = task["inputs"]
+        assert task_inputs == ["@group(workspace)"]
+        assert task["options"]["cache"] is False
 
 
 def test_AC8_13_46_pr_preview_non_llm_gate_matches_staging_strict_parallelism() -> None:


### PR DESCRIPTION
## What changed

- Tightened local verification drift: `moon run :lint` now fails on backend Ruff format drift, and `make test` routes through the root `moon run :test` command.
- Kept root Moon wrapper tasks uncached with explicit workspace inputs so local Moon gates run fresh and do not hash the `repo` infra submodule gitlink before executing.
- Aligned PR preview non-LLM E2E with the staging non-LLM gate by enabling `STRICT_E2E_GATES=true` and `-n 4` parallelism while still excluding `llm` tests.
- Updated EPIC-008, AC registry, CI/CD/deployment/environment SSOT docs, and added `docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md` for the larger follow-up recommendations.

## Why

The delivery engine had the right overall shape, but local, preview, and documentation entry points had drifted from the actual CI/post-merge design. This keeps the low-risk fixes in one PR and parks topology-level changes for separate review.

## Validation

- `moon run :lint`
- `uv run --with pytest --with pyyaml pytest scripts/tests/test_cli_and_dev_servers.py scripts/tests/test_post_merge_e2e_gates.py -q`
- `uv run --with ruff ruff format --check scripts/cli.py scripts/tests/test_cli_and_dev_servers.py scripts/tests/test_post_merge_e2e_gates.py`
- `uv run --with ruff ruff check scripts/cli.py scripts/tests/test_cli_and_dev_servers.py scripts/tests/test_post_merge_e2e_gates.py`
- `uv run --with pyyaml python scripts/generate_ac_registry.py --check`
- `uv run --with pyyaml python scripts/lint_doc_consistency.py`
- `uv run --with pyyaml python scripts/check_ac_traceability.py`
- `python scripts/check_ci_metrics_contract.py`
- `python scripts/check_toolchain_contract.py`
- `uv run --with pyyaml python scripts/check_critical_proof_matrix.py --output /tmp/critical-proof.md`
- `gh run watch 26553305795 --exit-status` (CI success on `61288ad748f16a115a0281213d4dd5db456da7e0`)
- `gh run watch 26553305765 --exit-status` (PR Test Environment workflow success; deploy skipped by the workflow classifier for the tooling/docs-only follow-up commit)
- `curl -fsS https://report-pr-530.zitian.party/api/health` (healthy existing preview at prior app SHA `48dffac07dd017458f91ea157be700cddb897055`)
- `cd repo && git fetch origin main && git log --oneline -1 origin/main && git log --oneline -1 HEAD` (both `299a6d1`)

Note: `moon run :test` now reaches the backend test lifecycle, but this local host has no Docker binary and no Podman machine/connection, so the full root test gate cannot run locally here. The equivalent full backend/frontend/coverage gate is green in GitHub CI for the PR head.
