### PR TITLE
ci: install frontend deps for production release

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -24,6 +24,7 @@ env:
   DOKPLOY_API_URL: https://cloud.zitian.party/api
   PRODUCTION_COMPOSE_ID: lNn9gVS1Zyw79Jzw5dlbu
   PYTHON_VERSION: "3.12.12"
+  NODE_VERSION: "20.19.0"
   UV_VERSION: "0.9.18"
 
 jobs:
@@ -31,6 +32,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
     
 
@@ -54,6 +56,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: apps/frontend
 
       - name: Verify Codebase
         env:
@@ -106,6 +119,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: read
     environment:
       name: production

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -74,7 +74,7 @@ Triggers:
   - Tag push (v*.*.*): Build release images
   - Manual dispatch:   Deploy to production
 
-Build job:  Tag → Build backend + frontend → Push to GHCR
+Build job:  Tag → Install backend/frontend toolchains → Verify → Build backend + frontend → Push to GHCR
 Deploy job: Verify images → Deploy → Health (4min) → Smoke test
 
 URL: https://report.zitian.party

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -272,6 +272,14 @@ def test_AC8_13_9_production_release_runs_prod_safe_e2e_smoke() -> None:
     workflow = read(".github/workflows/production-release.yml")
     prod_smoke = read("tests/e2e/test_production_readonly_smoke.py")
 
+    assert 'NODE_VERSION: "20.19.0"' in workflow
+    assert "Set up Node" in workflow
+    assert "Install frontend dependencies" in workflow
+    assert "cache-dependency-path: apps/frontend/package-lock.json" in workflow
+    assert "working-directory: apps/frontend" in workflow
+    assert workflow.index("Install frontend dependencies") < workflow.index(
+        "moon run :lint"
+    )
     assert "Setup E2E Tests" in workflow
     assert "test_production_readonly_smoke.py" in workflow
     assert "TEST_ENV: production" in workflow


### PR DESCRIPTION
## Summary

Fix the production release build path so frontend lint has installed Next.js before `moon run :lint` runs.

Related #532

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy / CI gates |
| **AC IDs** | AC8.13.9 |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/deployment.md` — production release build now documents backend/frontend toolchain install before verification.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `52ec3b3` | Added production-release frontend setup assertions; failed because `NODE_VERSION` and frontend install were missing. |
| 🟢 Green (passing test) | `85298e6` | Added Node setup, `npm ci`, explicit checkout permissions, and SSOT update. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable; no SQLAlchemy changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable; existing Dockerfile already has these)
- [x] `repo/` submodule updated for production config changes (not applicable; workflow-only deploy path change)
- [x] `scripts/check_env_keys.py` passes (not applicable; no env key contract changes)
- [x] `scripts/check_manifest.py` passes
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
uv run pytest scripts/tests/test_post_merge_e2e_gates.py::test_AC8_13_9_production_release_runs_prod_safe_e2e_smoke -q
uv run pytest scripts/tests/test_post_merge_e2e_gates.py scripts/tests/test_toolchain_contract.py -q
uv run --with pyyaml python scripts/check_manifest.py
uv run --with pyyaml python scripts/lint_doc_consistency.py
```

Results:

- Targeted red check failed before implementation as expected.
- `41 passed in 0.12s` after implementation.

---

## Screenshots / Evidence

Production release attempt for `v0.1.1` failed before this PR in `Verify Codebase` because `next` was missing during frontend lint.
