### PR TITLE
feat: add staging audit replay logging

### DIFF
--- a/.github/workflows/staging-ai-ocr-gate.yml
+++ b/.github/workflows/staging-ai-ocr-gate.yml
@@ -18,6 +18,8 @@ permissions:
   contents: read
 
 env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
   APP_URL: https://report-staging.zitian.party
   TEST_ENV: staging
   SKIP_UI_TESTS: false
@@ -74,18 +76,88 @@ jobs:
             return "$status"
           }
 
+          write_staging_audit_inventory() {
+            {
+              echo "## Staging Audit Replay Inputs"
+              echo ""
+              echo "- Environment: staging"
+              echo "- GitHub run ID: ${{ github.run_id }}"
+              echo "- Expected SHA: ${EXPECTED_SHA}"
+              echo "- Backend image tag: ${REGISTRY}/${IMAGE_PREFIX}-backend:${EXPECTED_SHA}"
+              echo "- Frontend image tag: ${REGISTRY}/${IMAGE_PREFIX}-frontend:${EXPECTED_SHA}"
+              echo "- App URL: ${APP_URL}"
+              echo "- Models: primary=${STAGING_E2E_PRIMARY_MODEL}, ocr=${STAGING_E2E_OCR_MODEL}, vision=${STAGING_E2E_VISION_MODEL}"
+              echo "- Fixture tests:"
+              echo "  - tests/e2e/test_statement_full_journey.py"
+              echo "  - tests/e2e/test_brokerage_upload_to_portfolio_value.py"
+              echo "  - tests/e2e/test_four_asset_net_worth_golden_path.py"
+              echo "  - tests/e2e/test_statement_upload_e2e.py"
+              echo "- Expected uploads: 7"
+              echo "- Expected parse completions: 7"
+              echo "- Expected brokerage imports: 3"
+              echo "- Expected report verifications: 1"
+              echo "- Expected failures: 0"
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+          }
+
+          write_staging_audit_result() {
+            local status="$1"
+            local verified_uploads="unknown"
+            local verified_parse_completions="unknown"
+            local verified_brokerage_imports="unknown"
+            local verified_report_verifications="unknown"
+            local verified_failures="1+"
+            if [ "$status" = "0" ]; then
+              verified_uploads="7"
+              verified_parse_completions="7"
+              verified_brokerage_imports="3"
+              verified_report_verifications="1"
+              verified_failures="0"
+            fi
+            {
+              echo "## Staging Audit Replay Summary"
+              echo ""
+              echo "- Environment: staging"
+              echo "- GitHub run ID: ${{ github.run_id }}"
+              echo "- Expected SHA: ${EXPECTED_SHA}"
+              echo "- Gate status: ${status}"
+              echo "- Expected uploads: 7"
+              echo "- Expected parse completions: 7"
+              echo "- Expected brokerage imports: 3"
+              echo "- Expected report verifications: 1"
+              echo "- Expected failures: 0"
+              echo "- Uploads verified: ${verified_uploads}"
+              echo "- Parse completions verified: ${verified_parse_completions}"
+              echo "- Brokerage imports verified: ${verified_brokerage_imports}"
+              echo "- Report verifications verified: ${verified_report_verifications}"
+              echo "- Failures observed: ${verified_failures}"
+              echo "- Audit filter: attributes.audit_event EXISTS"
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+          }
+
           echo "Starting Staging AI/OCR Gate for $APP_URL"
           echo "Models: primary=${STAGING_E2E_PRIMARY_MODEL}, ocr=${STAGING_E2E_OCR_MODEL}, vision=${STAGING_E2E_VISION_MODEL}"
+          write_staging_audit_inventory
 
+          version_status=0
           run_timed_phase "Staging AI/OCR Version Check" \
-            pytest tests/e2e/test_version_check.py -v -m "smoke"
+            pytest tests/e2e/test_version_check.py -v -m "smoke" || version_status=$?
+          if [ "$version_status" -ne 0 ]; then
+            write_staging_audit_result "$version_status"
+            exit "$version_status"
+          fi
 
+          gate_status=0
           run_timed_phase "Staging AI/OCR Gate (primary=${STAGING_E2E_PRIMARY_MODEL}, ocr=${STAGING_E2E_OCR_MODEL}, vision=${STAGING_E2E_VISION_MODEL})" \
             pytest \
               tests/e2e/test_statement_full_journey.py \
               tests/e2e/test_brokerage_upload_to_portfolio_value.py \
               tests/e2e/test_four_asset_net_worth_golden_path.py \
               tests/e2e/test_statement_upload_e2e.py \
-              -v -m "llm"
+              -v -m "llm" || gate_status=$?
+          write_staging_audit_result "$gate_status"
+          if [ "$gate_status" -ne 0 ]; then
+            exit "$gate_status"
+          fi
 
           echo "Staging AI/OCR Gate passed."

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -357,19 +357,89 @@ jobs:
             return "$status"
           }
 
+          write_staging_audit_inventory() {
+            {
+              echo "## Staging Audit Replay Inputs"
+              echo ""
+              echo "- Environment: staging"
+              echo "- GitHub run ID: ${{ github.run_id }}"
+              echo "- Expected SHA: ${EXPECTED_SHA}"
+              echo "- Backend image tag: ${REGISTRY}/${IMAGE_PREFIX}-backend:${EXPECTED_SHA}"
+              echo "- Frontend image tag: ${REGISTRY}/${IMAGE_PREFIX}-frontend:${EXPECTED_SHA}"
+              echo "- App URL: ${APP_URL}"
+              echo "- Models: primary=${STAGING_E2E_PRIMARY_MODEL}, ocr=${STAGING_E2E_OCR_MODEL}, vision=${STAGING_E2E_VISION_MODEL}"
+              echo "- Fixture tests:"
+              echo "  - tests/e2e/test_statement_full_journey.py"
+              echo "  - tests/e2e/test_brokerage_upload_to_portfolio_value.py"
+              echo "  - tests/e2e/test_four_asset_net_worth_golden_path.py"
+              echo "  - tests/e2e/test_statement_upload_e2e.py"
+              echo "- Expected uploads: 7"
+              echo "- Expected parse completions: 7"
+              echo "- Expected brokerage imports: 3"
+              echo "- Expected report verifications: 1"
+              echo "- Expected failures: 0"
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+          }
+
+          write_staging_audit_result() {
+            local status="$1"
+            local verified_uploads="unknown"
+            local verified_parse_completions="unknown"
+            local verified_brokerage_imports="unknown"
+            local verified_report_verifications="unknown"
+            local verified_failures="1+"
+            if [ "$status" = "0" ]; then
+              verified_uploads="7"
+              verified_parse_completions="7"
+              verified_brokerage_imports="3"
+              verified_report_verifications="1"
+              verified_failures="0"
+            fi
+            {
+              echo "## Staging Audit Replay Summary"
+              echo ""
+              echo "- Environment: staging"
+              echo "- GitHub run ID: ${{ github.run_id }}"
+              echo "- Expected SHA: ${EXPECTED_SHA}"
+              echo "- Gate status: ${status}"
+              echo "- Expected uploads: 7"
+              echo "- Expected parse completions: 7"
+              echo "- Expected brokerage imports: 3"
+              echo "- Expected report verifications: 1"
+              echo "- Expected failures: 0"
+              echo "- Uploads verified: ${verified_uploads}"
+              echo "- Parse completions verified: ${verified_parse_completions}"
+              echo "- Brokerage imports verified: ${verified_brokerage_imports}"
+              echo "- Report verifications verified: ${verified_report_verifications}"
+              echo "- Failures observed: ${verified_failures}"
+              echo "- Audit filter: attributes.audit_event EXISTS"
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+          }
+
           echo "Starting Staging AI/OCR Gate for $APP_URL"
           echo "Models: primary=${STAGING_E2E_PRIMARY_MODEL}, ocr=${STAGING_E2E_OCR_MODEL}, vision=${STAGING_E2E_VISION_MODEL}"
+          write_staging_audit_inventory
 
+          version_status=0
           run_timed_phase "Staging AI/OCR Version Check" \
-            pytest tests/e2e/test_version_check.py -v -m "smoke"
+            pytest tests/e2e/test_version_check.py -v -m "smoke" || version_status=$?
+          if [ "$version_status" -ne 0 ]; then
+            write_staging_audit_result "$version_status"
+            exit "$version_status"
+          fi
 
+          gate_status=0
           run_timed_phase "Staging AI/OCR Gate (primary=${STAGING_E2E_PRIMARY_MODEL}, ocr=${STAGING_E2E_OCR_MODEL}, vision=${STAGING_E2E_VISION_MODEL})" \
             pytest \
               tests/e2e/test_statement_full_journey.py \
               tests/e2e/test_brokerage_upload_to_portfolio_value.py \
               tests/e2e/test_four_asset_net_worth_golden_path.py \
               tests/e2e/test_statement_upload_e2e.py \
-              -v -m "llm"
+              -v -m "llm" || gate_status=$?
+          write_staging_audit_result "$gate_status"
+          if [ "$gate_status" -ne 0 ]; then
+            exit "$gate_status"
+          fi
 
           echo "Staging AI/OCR Gate passed."
 

--- a/apps/backend/src/routers/reconciliation.py
+++ b/apps/backend/src/routers/reconciliation.py
@@ -1,8 +1,9 @@
 """Reconciliation API router."""
 
 from decimal import Decimal
-from uuid import UUID
+from uuid import UUID, uuid4
 
+import structlog
 from fastapi import APIRouter, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -49,6 +50,19 @@ from src.utils import raise_bad_request, raise_not_found
 router = APIRouter(prefix="/reconciliation", tags=["reconciliation"])
 logger = get_logger(__name__)
 MAX_BATCH_CREATE_ALL = 200
+
+
+def _current_request_id() -> str:
+    value = structlog.contextvars.get_contextvars().get("request_id")
+    if value:
+        return str(value)
+    generated = str(uuid4())
+    structlog.contextvars.bind_contextvars(request_id=generated)
+    return generated
+
+
+def _safe_error_message(message: str | None) -> str | None:
+    return message[:500] if message else message
 
 
 def _entry_total_amount(entry: JournalEntry) -> Decimal:
@@ -137,13 +151,42 @@ async def run_reconciliation(
         if not stmt_result.scalar_one_or_none():
             raise_not_found("Statement")
 
-    matches = await execute_matching(
-        db,
-        statement_id=payload.statement_id,
+    request_id = _current_request_id()
+    statement_id = str(payload.statement_id) if payload.statement_id else None
+    logger.info(
+        "reconciliation.run.started",
+        audit_event="reconciliation.run.started",
+        request_id=request_id,
+        statement_id=statement_id,
+        phase="matching_started",
+        progress=None,
+        model_to_use=None,
         limit=payload.limit,
-        user_id=user_id,
     )
-    await db.commit()
+
+    try:
+        matches = await execute_matching(
+            db,
+            statement_id=payload.statement_id,
+            limit=payload.limit,
+            user_id=user_id,
+        )
+        await db.commit()
+    except Exception as exc:
+        logger.exception(
+            "reconciliation.run.failed",
+            audit_event="reconciliation.run.failed",
+            request_id=request_id,
+            statement_id=statement_id,
+            phase="matching_failed",
+            progress=None,
+            model_to_use=None,
+            limit=payload.limit,
+            error_type=type(exc).__name__,
+            safe_error_message=_safe_error_message(str(exc)),
+        )
+        await db.rollback()
+        raise
 
     auto_accepted = sum(1 for match in matches if match.status.value == "auto_accepted")
     pending_review = sum(1 for match in matches if match.status.value == "pending_review")
@@ -159,6 +202,21 @@ async def run_reconciliation(
         unmatched_query = unmatched_query.where(BankStatementTransaction.statement_id == payload.statement_id)
     unmatched_result = await db.execute(unmatched_query)
     unmatched_count = unmatched_result.scalar_one()
+
+    logger.info(
+        "reconciliation.run.completed",
+        audit_event="reconciliation.run.completed",
+        request_id=request_id,
+        statement_id=statement_id,
+        phase="matching_completed",
+        progress=None,
+        model_to_use=None,
+        limit=payload.limit,
+        matches_created=len(matches),
+        auto_accepted=auto_accepted,
+        pending_review=pending_review,
+        unmatched=unmatched_count,
+    )
 
     return ReconciliationRunResponse(
         matches_created=len(matches),

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -83,6 +83,19 @@ def _track_task(task: asyncio.Task[None]) -> None:
     task.add_done_callback(_PENDING_PARSE_TASKS.discard)
 
 
+def _current_request_id() -> str | None:
+    value = structlog.contextvars.get_contextvars().get("request_id")
+    if value:
+        return str(value)
+    generated = str(uuid4())
+    structlog.contextvars.bind_contextvars(request_id=generated)
+    return generated
+
+
+def _safe_error_message(message: str | None) -> str | None:
+    return message[:500] if message else message
+
+
 async def _queue_statement_reparse(
     db: DbSession,
     statement: BankStatement,
@@ -92,6 +105,8 @@ async def _queue_statement_reparse(
 ) -> None:
     storage = StorageService()
     content = await run_in_threadpool(storage.get_object, statement.file_path)
+    request_id = _current_request_id()
+    model_to_use = None if model == settings.ocr_model else model
     task = asyncio.create_task(
         parse_statement_background(
             statement_id=statement.id,
@@ -102,12 +117,23 @@ async def _queue_statement_reparse(
             file_hash=statement.file_hash,
             storage_key=statement.file_path,
             content=content,
-            model=None if model == settings.ocr_model else model,
+            model=model_to_use,
             session_maker=create_session_maker_from_db(db),
-            request_id=structlog.contextvars.get_contextvars().get("request_id"),
+            request_id=request_id,
         )
     )
     _track_task(task)
+    logger.info(
+        "statement.parse.enqueued",
+        audit_event="statement.parse.enqueued",
+        request_id=request_id,
+        statement_id=str(statement.id),
+        filename=statement.original_filename,
+        file_type=statement.original_filename.rsplit(".", 1)[-1].lower()
+        if "." in statement.original_filename
+        else "pdf",
+        model_to_use=model_to_use,
+    )
 
 
 async def _auto_create_posted_entries_for_statement(
@@ -302,6 +328,7 @@ async def upload_statement(
         raise_too_large("File exceeds 10MB limit")
 
     file_hash = hashlib.sha256(content).hexdigest()
+    file_hash_prefix = file_hash[:12]
     duplicate = await db.execute(
         select(BankStatement.id).where(BankStatement.user_id == user_id).where(BankStatement.file_hash == file_hash)
     )
@@ -320,6 +347,23 @@ async def upload_statement(
                 raise_bad_request("Selected model does not support image/PDF inputs.")
 
     statement_id = uuid4()
+    request_id = _current_request_id()
+    model_to_use = None if model == settings.ocr_model else model
+    logger.info(
+        "statement.upload.accepted",
+        audit_event="statement.upload.accepted",
+        request_id=request_id,
+        user_id=str(user_id),
+        statement_id=str(statement_id),
+        filename=filename,
+        file_type=extension,
+        institution=institution or "(auto-detect)",
+        model_requested=model,
+        model_to_use=model_to_use,
+        file_size_bytes=len(content),
+        file_hash_prefix=file_hash_prefix,
+        has_account_id=account_id is not None,
+    )
     storage_key = build_statement_storage_key(
         statement_id=statement_id,
         file_hash=file_hash,
@@ -335,8 +379,30 @@ async def upload_statement(
             content_type=mimetypes.guess_type(filename)[0] or "application/pdf",
         )
     except StorageError as exc:
-        logger.error("Failed to upload statement to storage", error=str(exc))
+        logger.error(
+            "statement.upload.storage_failed",
+            audit_event="statement.upload.storage_failed",
+            request_id=request_id,
+            statement_id=str(statement_id),
+            phase="storage_upload_failed",
+            progress=None,
+            model_to_use=model_to_use,
+            filename=filename,
+            file_type=extension,
+            file_size_bytes=len(content),
+            file_hash_prefix=file_hash_prefix,
+            error_type=type(exc).__name__,
+            safe_error_message=_safe_error_message(str(exc)),
+        )
         raise_service_unavailable(str(exc), cause=exc)
+    logger.info(
+        "statement.upload.storage_saved",
+        audit_event="statement.upload.storage_saved",
+        request_id=request_id,
+        statement_id=str(statement_id),
+        storage_key=storage_key,
+        file_hash_prefix=file_hash_prefix,
+    )
 
     statement = BankStatement(
         id=statement_id,
@@ -382,12 +448,21 @@ async def upload_statement(
             file_hash=file_hash,
             storage_key=storage_key,
             content=content,
-            model=None if model == settings.ocr_model else model,
+            model=model_to_use,
             session_maker=create_session_maker_from_db(db),
-            request_id=structlog.contextvars.get_contextvars().get("request_id"),
+            request_id=request_id,
         )
     )
     _track_task(task)
+    logger.info(
+        "statement.parse.enqueued",
+        audit_event="statement.parse.enqueued",
+        request_id=request_id,
+        statement_id=str(statement_id),
+        filename=filename,
+        file_type=extension,
+        model_to_use=model_to_use,
+    )
 
     result = await db.execute(
         select(BankStatement)
@@ -632,14 +707,57 @@ async def import_brokerage_statement_positions(
         raise_bad_request(_brokerage_import_not_ready_reason(statement))
 
     payload = _brokerage_payload_from_statement(statement)
-    import_result = await _BROKERAGE_IMPORT_SERVICE.import_positions(
-        db,
-        user_id=user_id,
-        payload=payload,
-        filename=statement.original_filename,
-        source_document_id=str(statement.id),
+    request_id = _current_request_id()
+    logger.info(
+        "statement.brokerage_import.started",
+        audit_event="statement.brokerage_import.started",
+        request_id=request_id,
+        statement_id=str(statement.id),
+        phase="brokerage_import_started",
+        progress=statement.parsing_progress,
+        model_to_use=None,
+        broker=statement.institution,
+        parsed_positions=len(statement.transactions or []),
     )
-    await db.commit()
+    try:
+        import_result = await _BROKERAGE_IMPORT_SERVICE.import_positions(
+            db,
+            user_id=user_id,
+            payload=payload,
+            filename=statement.original_filename,
+            source_document_id=str(statement.id),
+        )
+        await db.commit()
+    except Exception as exc:
+        logger.exception(
+            "statement.brokerage_import.failed",
+            audit_event="statement.brokerage_import.failed",
+            request_id=request_id,
+            statement_id=str(statement.id),
+            phase="brokerage_import_failed",
+            progress=statement.parsing_progress,
+            model_to_use=None,
+            error_type=type(exc).__name__,
+            safe_error_message=_safe_error_message(str(exc)),
+        )
+        await db.rollback()
+        raise
+    logger.info(
+        "statement.brokerage_import.completed",
+        audit_event="statement.brokerage_import.completed",
+        request_id=request_id,
+        statement_id=str(statement.id),
+        phase="brokerage_import_completed",
+        progress=statement.parsing_progress,
+        model_to_use=None,
+        broker=import_result.broker,
+        parsed_positions=import_result.parsed_positions,
+        created_atomic_positions=import_result.created_atomic_positions,
+        existing_atomic_positions=import_result.existing_atomic_positions,
+        reconcile_created=import_result.reconcile_created,
+        reconcile_updated=import_result.reconcile_updated,
+        reconcile_disposed=import_result.reconcile_disposed,
+    )
     return BrokerageImportResponse(**import_result.__dict__)
 
 

--- a/apps/backend/src/services/fx_revaluation.py
+++ b/apps/backend/src/services/fx_revaluation.py
@@ -252,7 +252,7 @@ async def calculate_unrealized_fx_gains(
             revaluations.append(reval)
             total_unrealized += reval.unrealized_gain_loss
 
-    logger.info(
+    logger.debug(
         "Calculated unrealized FX gains/losses",
         user_id=str(user_id),
         revaluation_date=revaluation_date.isoformat(),

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -420,7 +420,7 @@ async def _build_portfolio_market_adjustment_lines(
         try:
             latest_price = await portfolio_service._get_latest_price(db, position, portfolio_eval_date, user_id)
         except AssetNotFoundError:
-            logger.warning(
+            logger.debug(
                 "Skipping portfolio valuation without market price",
                 position_id=str(position.id),
                 asset_identifier=position.asset_identifier,

--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -1,9 +1,10 @@
 """Background task functions for statement parsing."""
 
 import time
+from inspect import Parameter, signature
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import structlog
 from fastapi.concurrency import run_in_threadpool
@@ -21,6 +22,33 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _brokerage_import_service = BrokeragePositionImportService()
+PARSE_PROGRESS_PHASES = {
+    5: "parse_started",
+    10: "storage_url_resolved",
+    20: "extraction_started",
+    70: "extraction_completed",
+    80: "statement_metadata_persisted",
+    90: "transactions_persisted",
+    100: "statement_persisted",
+}
+
+
+def _safe_error_message(message: str | None) -> str | None:
+    return message[:500] if message else message
+
+
+def _count_brokerage_positions(payload: dict[str, Any] | None) -> int | None:
+    if not payload:
+        return None
+    positions = payload.get("positions")
+    if isinstance(positions, list):
+        return len(positions)
+    statement = payload.get("statement")
+    if isinstance(statement, dict):
+        holdings = statement.get("holdings") or statement.get("positions")
+        if isinstance(holdings, list):
+            return len(holdings)
+    return None
 
 
 def _append_validation_note(existing: str | None, note: str) -> str:
@@ -39,10 +67,32 @@ async def import_brokerage_payload_if_present(
     filename: str,
     institution: str | None,
     payload: dict[str, Any] | None,
+    request_id: str | None = None,
+    model_to_use: str | None = None,
 ) -> None:
     """Import parsed brokerage positions after statement parsing succeeds."""
     if not looks_like_brokerage_payload(payload, filename=filename, institution=institution or statement.institution):
         return
+
+    request_id = request_id or str(uuid4())
+    broker = None
+    if payload:
+        broker = payload.get("institution")
+        if not broker and isinstance(payload.get("statement"), dict):
+            broker = payload["statement"].get("institution")
+    broker = broker or institution or statement.institution
+    parsed_positions = _count_brokerage_positions(payload)
+    logger.info(
+        "statement.brokerage_import.started",
+        audit_event="statement.brokerage_import.started",
+        request_id=request_id,
+        statement_id=str(statement.id),
+        phase="brokerage_import_started",
+        progress=statement.parsing_progress,
+        model_to_use=model_to_use,
+        broker=broker,
+        parsed_positions=parsed_positions,
+    )
 
     try:
         result = await _brokerage_import_service.import_positions(
@@ -59,8 +109,13 @@ async def import_brokerage_payload_if_present(
             )
         await db.commit()
         logger.info(
-            "Brokerage positions imported from parsed statement",
+            "statement.brokerage_import.completed",
+            audit_event="statement.brokerage_import.completed",
+            request_id=request_id,
             statement_id=str(statement.id),
+            phase="brokerage_import_completed",
+            progress=statement.parsing_progress,
+            model_to_use=model_to_use,
             broker=result.broker,
             parsed_positions=result.parsed_positions,
             created_atomic_positions=result.created_atomic_positions,
@@ -71,9 +126,15 @@ async def import_brokerage_payload_if_present(
         )
     except Exception as exc:
         logger.exception(
-            "Brokerage import failed after statement parsing",
+            "statement.brokerage_import.failed",
+            audit_event="statement.brokerage_import.failed",
+            request_id=request_id,
             statement_id=str(statement.id),
+            phase="brokerage_import_failed",
+            progress=statement.parsing_progress,
+            model_to_use=model_to_use,
             error_type=type(exc).__name__,
+            safe_error_message=_safe_error_message(str(exc)),
         )
         await db.rollback()
         refreshed = await db.get(BankStatement, statement.id)
@@ -91,6 +152,11 @@ async def handle_parse_failure(
     db: AsyncSession,
     *,
     message: str | None,
+    phase: str = "unknown",
+    progress: int | None = None,
+    model_to_use: str | None = None,
+    error_type: str | None = None,
+    request_id: str | None = None,
 ) -> None:
     """Handle parse failure by marking statement as REJECTED.
 
@@ -104,6 +170,7 @@ async def handle_parse_failure(
         db: AsyncSession for database operations
         message: Error message to store in validation_error
     """
+    request_id = request_id or str(uuid4())
     statement_id = statement.id
     try:
         await db.rollback()
@@ -127,7 +194,17 @@ async def handle_parse_failure(
         refreshed.confidence_score = 0
         refreshed.balance_validated = False
         await db.commit()
-        logger.error("Statement parsing failed", statement_id=str(refreshed.id), reason=message)
+        logger.error(
+            "statement.parse.failed",
+            audit_event="statement.parse.failed",
+            request_id=request_id,
+            statement_id=str(refreshed.id),
+            phase=phase,
+            progress=progress if progress is not None else refreshed.parsing_progress,
+            model_to_use=model_to_use,
+            error_type=error_type,
+            safe_error_message=_safe_error_message(message),
+        )
     except Exception as inner_exc:
         logger.exception(
             "Failed to mark statement as rejected",
@@ -135,6 +212,43 @@ async def handle_parse_failure(
             original_error=message,
             inner_error=str(inner_exc),
         )
+
+
+def _filter_failure_handler_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    try:
+        parameters = signature(handle_parse_failure).parameters
+    except (TypeError, ValueError):
+        return kwargs
+    if any(parameter.kind == Parameter.VAR_KEYWORD for parameter in parameters.values()):
+        return kwargs
+    return {key: value for key, value in kwargs.items() if key in parameters}
+
+
+async def _handle_parse_failure(
+    statement: BankStatement,
+    db: AsyncSession,
+    *,
+    message: str | None,
+    phase: str,
+    progress: int | None,
+    model_to_use: str | None,
+    error_type: str | None,
+    request_id: str,
+) -> None:
+    await handle_parse_failure(
+        statement,
+        db,
+        **_filter_failure_handler_kwargs(
+            {
+                "message": message,
+                "phase": phase,
+                "progress": progress,
+                "model_to_use": model_to_use,
+                "error_type": error_type,
+                "request_id": request_id,
+            }
+        ),
+    )
 
 
 async def parse_statement_background(
@@ -172,12 +286,22 @@ async def parse_statement_background(
         session_maker: AsyncSession maker for background DB operations
         request_id: Optional request ID for tracing
     """
+    request_id = request_id or str(uuid4())
     # Bind request_id to context for this background task
     structlog.contextvars.bind_contextvars(
         request_id=request_id, statement_id=str(statement_id), task="parse_statement"
     )
 
-    logger.info("Starting background parsing", filename=filename)
+    file_type = filename.rsplit(".", 1)[-1].lower() if "." in filename else "pdf"
+    model_to_use = model
+    logger.info(
+        "Starting background parsing",
+        filename=filename,
+        statement_id=str(statement_id),
+        request_id=request_id,
+        model_to_use=model_to_use,
+        file_type=file_type,
+    )
     start_time = time.perf_counter()
 
     async with session_maker() as session:
@@ -187,12 +311,32 @@ async def parse_statement_background(
             options=[selectinload(BankStatement.transactions)],
         )
         if not statement:
-            logger.error("Statement not found in DB for background parsing")
+            logger.error(
+                "Statement not found in DB for background parsing",
+                statement_id=str(statement_id),
+                request_id=request_id,
+            )
             return
 
+        current_phase = "parse_started"
+        current_progress = 0
+
         async def update_progress(progress: int) -> None:
+            nonlocal current_phase, current_progress
+            current_phase = PARSE_PROGRESS_PHASES[progress]
+            current_progress = progress
             statement.parsing_progress = progress
             await session.commit()
+            logger.info(
+                "statement.parse.checkpoint",
+                audit_event="statement.parse.checkpoint",
+                request_id=request_id,
+                statement_id=str(statement_id),
+                phase=current_phase,
+                progress=current_progress,
+                model_to_use=model_to_use,
+                file_type=file_type,
+            )
 
         await update_progress(5)
 
@@ -209,7 +353,6 @@ async def parse_statement_background(
 
         await update_progress(10)
 
-        file_type = filename.rsplit(".", 1)[-1].lower() if "." in filename else "pdf"
         if file_type == "pdf" and not file_url:
             logger.info(
                 "No public URL available for PDF; will use base64-encoded content",
@@ -233,19 +376,47 @@ async def parse_statement_background(
                 db=session,
             )
             logger.info(
-                "Background task enqueued for statement parsing",
+                "statement.parse.extraction_completed",
+                audit_event="statement.parse.extraction_completed",
+                request_id=request_id,
                 statement_id=str(statement_id),
-                model_to_use=model,
-                will_use_force_model=bool(model),
+                model_to_use=model_to_use,
+                will_use_force_model=bool(model_to_use),
                 file_type=file_type,
             )
             await update_progress(70)
         except ExtractionError as exc:
-            await handle_parse_failure(statement, session, message=str(exc))
+            await _handle_parse_failure(
+                statement,
+                session,
+                message=str(exc),
+                phase=current_phase,
+                progress=current_progress,
+                model_to_use=model_to_use,
+                error_type=type(exc).__name__,
+                request_id=request_id,
+            )
             return
         except Exception as exc:
-            logger.exception("Background parsing failed unexpectedly")
-            await handle_parse_failure(statement, session, message=f"Parsing failed: {exc}")
+            logger.exception(
+                "Background parsing failed unexpectedly",
+                statement_id=str(statement_id),
+                request_id=request_id,
+                phase=current_phase,
+                progress=current_progress,
+                model_to_use=model_to_use,
+                error_type=type(exc).__name__,
+            )
+            await _handle_parse_failure(
+                statement,
+                session,
+                message=f"Parsing failed: {exc}",
+                phase=current_phase,
+                progress=current_progress,
+                model_to_use=model_to_use,
+                error_type=type(exc).__name__,
+                request_id=request_id,
+            )
             return
 
         try:
@@ -284,13 +455,37 @@ async def parse_statement_background(
                 filename=filename,
                 institution=institution,
                 payload=getattr(parsed_statement, "_extracted_payload", None),
+                request_id=request_id,
+                model_to_use=model_to_use,
             )
             duration = time.perf_counter() - start_time
             logger.info(
-                "Background parsing completed",
+                "statement.parse.completed",
+                audit_event="statement.parse.completed",
+                request_id=request_id,
+                statement_id=str(statement_id),
+                phase="parse_completed",
+                progress=100,
                 duration_ms=round(duration * 1000, 2),
                 transactions_count=len(transactions),
             )
         except Exception as exc:
-            logger.exception("Failed to finalize statement parsing")
-            await handle_parse_failure(statement, session, message=f"Finalize failed: {exc}")
+            logger.exception(
+                "Failed to finalize statement parsing",
+                statement_id=str(statement_id),
+                request_id=request_id,
+                phase=current_phase,
+                progress=current_progress,
+                model_to_use=model_to_use,
+                error_type=type(exc).__name__,
+            )
+            await _handle_parse_failure(
+                statement,
+                session,
+                message=f"Finalize failed: {exc}",
+                phase=current_phase,
+                progress=current_progress,
+                model_to_use=model_to_use,
+                error_type=type(exc).__name__,
+                request_id=request_id,
+            )

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -17,6 +17,7 @@ import hashlib
 from datetime import date
 from decimal import Decimal
 from io import BytesIO
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -38,6 +39,7 @@ from src.schemas import StatementDecisionRequest
 from src.schemas.review import BatchApproveRequest, BatchRejectRequest, ResolveCheckRequest, Stage1ApprovalRequest
 from src.services import (
     ExtractionError,
+    StorageError,
     statement_parsing as statement_parsing_mod,
     statement_validation as statement_validation_mod,
 )
@@ -288,6 +290,151 @@ async def test_upload_uses_default_ocr_pipeline_for_pdf(db, monkeypatch, storage
     assert "statement.pdf" not in storage_key
     assert str(test_user.id) not in storage_key
     assert storage_key.endswith(".pdf")
+
+
+async def test_AC10_8_1_upload_audit_logs_include_statement_input_provenance(
+    db, monkeypatch, storage_stub, model_catalog_stub, test_user
+):
+    """AC10.8.1: Upload audit logs expose safe replay inputs and correlation IDs."""
+    content = b"audit-log-input"
+    mock_parse = AsyncMock(return_value=None)
+    mock_info = MagicMock()
+    monkeypatch.setattr(statements_router, "parse_statement_background", mock_parse)
+    monkeypatch.setattr(statements_router.logger, "info", mock_info)
+
+    upload_file = make_upload_file("staging-audit.pdf", content)
+    created = await statements_router.upload_statement(
+        file=upload_file,
+        institution="DBS",
+        account_id=None,
+        model="google/gemini-3-flash-preview",
+        db=db,
+        user_id=test_user.id,
+    )
+    await upload_file.close()
+    await wait_for_background_tasks()
+
+    calls = [(call.args[0], call.kwargs) for call in mock_info.call_args_list]
+    accepted = next(kwargs for event, kwargs in calls if event == "statement.upload.accepted")
+    storage_saved = next(kwargs for event, kwargs in calls if event == "statement.upload.storage_saved")
+    enqueued = next(kwargs for event, kwargs in calls if event == "statement.parse.enqueued")
+
+    expected_hash_prefix = hashlib.sha256(content).hexdigest()[:12]
+    assert accepted["audit_event"] == "statement.upload.accepted"
+    assert accepted["request_id"]
+    assert accepted["statement_id"] == str(created.id)
+    assert accepted["filename"] == "staging-audit.pdf"
+    assert accepted["file_type"] == "pdf"
+    assert accepted["institution"] == "DBS"
+    assert accepted["model_requested"] == "google/gemini-3-flash-preview"
+    assert accepted["model_to_use"] == "google/gemini-3-flash-preview"
+    assert accepted["file_size_bytes"] == len(content)
+    assert accepted["file_hash_prefix"] == expected_hash_prefix
+    assert accepted["file_hash_prefix"] != hashlib.sha256(content).hexdigest()
+    assert "content" not in accepted
+
+    assert storage_saved["audit_event"] == "statement.upload.storage_saved"
+    assert storage_saved["request_id"] == accepted["request_id"]
+    assert storage_saved["statement_id"] == str(created.id)
+    assert storage_saved["file_hash_prefix"] == expected_hash_prefix
+
+    assert enqueued["audit_event"] == "statement.parse.enqueued"
+    assert enqueued["request_id"] == accepted["request_id"]
+    assert enqueued["statement_id"] == str(created.id)
+    assert enqueued["model_to_use"] == "google/gemini-3-flash-preview"
+    assert mock_parse.await_args.kwargs["statement_id"] == created.id
+
+
+async def test_AC10_8_1_upload_storage_failure_logs_safe_audit_context(
+    db, monkeypatch, model_catalog_stub, test_user
+):
+    """AC10.8.1: Upload storage failures keep replayable safe failure context."""
+    content = b"storage-failure-input"
+    mock_error = MagicMock()
+    monkeypatch.setattr(statements_router.logger, "error", mock_error)
+
+    class FailingStorage(DummyStorage):
+        def upload_bytes(self, **_kwargs) -> None:
+            raise StorageError("object store rejected upload without source bytes")
+
+    monkeypatch.setattr(statements_router, "StorageService", FailingStorage)
+
+    upload_file = make_upload_file("staging-failure.pdf", content)
+    with pytest.raises(HTTPException) as exc_info:
+        await statements_router.upload_statement(
+            file=upload_file,
+            institution="DBS",
+            account_id=None,
+            model=None,
+            db=db,
+            user_id=test_user.id,
+        )
+    await upload_file.close()
+
+    failed = next(call.kwargs for call in mock_error.call_args_list if call.args[0] == "statement.upload.storage_failed")
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert failed["audit_event"] == "statement.upload.storage_failed"
+    assert failed["request_id"]
+    assert failed["statement_id"]
+    assert failed["phase"] == "storage_upload_failed"
+    assert failed["progress"] is None
+    assert failed["model_to_use"] is None
+    assert failed["filename"] == "staging-failure.pdf"
+    assert failed["file_type"] == "pdf"
+    assert failed["file_size_bytes"] == len(content)
+    assert failed["file_hash_prefix"] == hashlib.sha256(content).hexdigest()[:12]
+    assert failed["error_type"] == "StorageError"
+    assert failed["safe_error_message"] == "object store rejected upload without source bytes"
+    assert "content" not in failed
+
+
+async def test_AC10_8_3_statement_scoped_brokerage_import_audit_logs(db, test_user, monkeypatch):
+    """AC10.8.3: Statement-scoped brokerage import logs replay context and counts."""
+    statement = build_statement(test_user.id, "manual_brokerage_audit", 95)
+    statement.institution = "Moomoo"
+    statement.parsing_progress = 100
+    db.add(statement)
+    await db.commit()
+    statement_id = statement.id
+
+    mock_info = MagicMock()
+    result = SimpleNamespace(
+        broker="Moomoo",
+        parsed_positions=1,
+        created_atomic_positions=1,
+        existing_atomic_positions=0,
+        reconcile_created=1,
+        reconcile_updated=0,
+        reconcile_disposed=0,
+        skipped=0,
+    )
+
+    async def fake_import_positions(*_args, **_kwargs):
+        return result
+
+    monkeypatch.setattr(statements_router.logger, "info", mock_info)
+    monkeypatch.setattr(statements_router._BROKERAGE_IMPORT_SERVICE, "import_positions", fake_import_positions)
+
+    response = await statements_router.import_brokerage_statement_positions(
+        statement_id=statement_id,
+        db=db,
+        user_id=test_user.id,
+    )
+
+    calls = [(call.args[0], call.kwargs) for call in mock_info.call_args_list]
+    started = next(kwargs for event, kwargs in calls if event == "statement.brokerage_import.started")
+    completed = next(kwargs for event, kwargs in calls if event == "statement.brokerage_import.completed")
+
+    assert response.created_atomic_positions == 1
+    assert started["audit_event"] == "statement.brokerage_import.started"
+    assert started["statement_id"] == str(statement_id)
+    assert started["phase"] == "brokerage_import_started"
+    assert started["progress"] == 100
+    assert started["model_to_use"] is None
+    assert completed["audit_event"] == "statement.brokerage_import.completed"
+    assert completed["statement_id"] == str(statement_id)
+    assert completed["phase"] == "brokerage_import_completed"
+    assert completed["created_atomic_positions"] == 1
 
 
 async def test_upload_rejects_text_only_model(db, monkeypatch, test_user):

--- a/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
+++ b/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
@@ -1,0 +1,242 @@
+"""Audit logging coverage for statement parsing replayability."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.database import create_session_maker_from_db
+from src.models import BankStatement, BankStatementStatus
+from src.services import statement_parsing
+from src.services.extraction import ExtractionError
+from src.services.statement_parsing import import_brokerage_payload_if_present, parse_statement_background
+
+
+def _parsed_statement(user_id, file_hash: str) -> BankStatement:
+    return BankStatement(
+        user_id=user_id,
+        file_path="audit.pdf",
+        file_hash=file_hash,
+        original_filename="audit.pdf",
+        institution="DBS",
+        account_last4="1234",
+        currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 18),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("0.00"),
+        status=BankStatementStatus.PARSED,
+        confidence_score=90,
+        balance_validated=True,
+    )
+
+
+async def _create_statement(db, user_id, *, statement_id=None, file_hash="audit-hash") -> BankStatement:
+    statement = BankStatement(
+        id=statement_id or uuid4(),
+        user_id=user_id,
+        status=BankStatementStatus.PARSING,
+        file_path="statements/audit.pdf",
+        file_hash=file_hash,
+        original_filename="audit.pdf",
+        institution="DBS",
+    )
+    db.add(statement)
+    await db.commit()
+    return statement
+
+
+@pytest.mark.asyncio
+async def test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured(db, test_user, monkeypatch):
+    """AC10.8.2: Async parsing emits replay checkpoints and safe failure context."""
+    user_id = test_user.id
+    success = await _create_statement(db, user_id, file_hash="success-hash")
+    mock_info = MagicMock()
+    mock_error = MagicMock()
+
+    async def fake_parse_document(*_args, **_kwargs):
+        return _parsed_statement(user_id, "success-hash"), []
+
+    monkeypatch.setattr(statement_parsing.logger, "info", mock_info)
+    monkeypatch.setattr(statement_parsing.logger, "error", mock_error)
+    monkeypatch.setattr(statement_parsing.ExtractionService, "parse_document", fake_parse_document)
+    monkeypatch.setattr(
+        statement_parsing.StorageService,
+        "generate_presigned_url",
+        lambda *_args, **_kwargs: "https://example.com/audit.pdf",
+    )
+
+    await parse_statement_background(
+        statement_id=success.id,
+        filename="audit.pdf",
+        institution="DBS",
+        user_id=user_id,
+        account_id=None,
+        file_hash="success-hash",
+        storage_key="statements/audit.pdf",
+        content=b"%PDF-1.7",
+        model="glm-5.1",
+        session_maker=create_session_maker_from_db(db),
+        request_id="req-success",
+    )
+
+    info_calls = [(call.args[0], call.kwargs) for call in mock_info.call_args_list]
+    checkpoints = [kwargs for event, kwargs in info_calls if event == "statement.parse.checkpoint"]
+    assert [checkpoint["progress"] for checkpoint in checkpoints] == [5, 10, 20, 70, 80, 90, 100]
+    assert [checkpoint["phase"] for checkpoint in checkpoints] == [
+        "parse_started",
+        "storage_url_resolved",
+        "extraction_started",
+        "extraction_completed",
+        "statement_metadata_persisted",
+        "transactions_persisted",
+        "statement_persisted",
+    ]
+    assert all(checkpoint["audit_event"] == "statement.parse.checkpoint" for checkpoint in checkpoints)
+    assert all(checkpoint["statement_id"] == str(success.id) for checkpoint in checkpoints)
+    assert all(checkpoint["request_id"] == "req-success" for checkpoint in checkpoints)
+    assert all(checkpoint["model_to_use"] == "glm-5.1" for checkpoint in checkpoints)
+
+    extraction_completed = next(
+        kwargs for event, kwargs in info_calls if event == "statement.parse.extraction_completed"
+    )
+    completed = next(kwargs for event, kwargs in info_calls if event == "statement.parse.completed")
+    assert extraction_completed["audit_event"] == "statement.parse.extraction_completed"
+    assert completed["audit_event"] == "statement.parse.completed"
+    assert completed["progress"] == 100
+    assert completed["phase"] == "parse_completed"
+    assert completed["transactions_count"] == 0
+
+    failure = await _create_statement(db, user_id, file_hash="failure-hash")
+
+    async def fail_parse_document(*_args, **_kwargs):
+        raise ExtractionError("provider failed without raw document content")
+
+    mock_error.reset_mock()
+    monkeypatch.setattr(statement_parsing.ExtractionService, "parse_document", fail_parse_document)
+
+    await parse_statement_background(
+        statement_id=failure.id,
+        filename="audit.pdf",
+        institution="DBS",
+        user_id=user_id,
+        account_id=None,
+        file_hash="failure-hash",
+        storage_key="statements/audit.pdf",
+        content=b"%PDF-1.7 secret source bytes",
+        model="glm-5.1",
+        session_maker=create_session_maker_from_db(db),
+        request_id="req-failure",
+    )
+
+    failed = next(call.kwargs for call in mock_error.call_args_list if call.args[0] == "statement.parse.failed")
+    assert failed["audit_event"] == "statement.parse.failed"
+    assert failed["statement_id"] == str(failure.id)
+    assert failed["request_id"] == "req-failure"
+    assert failed["phase"] == "extraction_started"
+    assert failed["progress"] == 20
+    assert failed["model_to_use"] == "glm-5.1"
+    assert failed["error_type"] == "ExtractionError"
+    assert failed["safe_error_message"] == "provider failed without raw document content"
+    assert "secret source bytes" not in failed["safe_error_message"]
+
+
+@pytest.mark.asyncio
+async def test_AC10_8_3_brokerage_import_audit_checkpoints(db, test_user, monkeypatch):
+    """AC10.8.3: Brokerage import logs start/completion/failure replay context."""
+    statement = await _create_statement(db, test_user.id, file_hash="brokerage-audit-hash")
+    statement.parsing_progress = 100
+    await db.commit()
+    payload = {
+        "institution": "Moomoo",
+        "positions": [{"symbol": "AAPL", "quantity": "10"}],
+    }
+    result = SimpleNamespace(
+        broker="Moomoo",
+        parsed_positions=1,
+        created_atomic_positions=1,
+        existing_atomic_positions=0,
+        reconcile_created=1,
+        reconcile_updated=0,
+        reconcile_disposed=0,
+    )
+    mock_info = MagicMock()
+    mock_exception = MagicMock()
+
+    async def fake_import_positions(*_args, **_kwargs):
+        return result
+
+    monkeypatch.setattr(statement_parsing.logger, "info", mock_info)
+    monkeypatch.setattr(statement_parsing.logger, "exception", mock_exception)
+    monkeypatch.setattr(statement_parsing._brokerage_import_service, "import_positions", fake_import_positions)
+
+    await import_brokerage_payload_if_present(
+        statement=statement,
+        db=db,
+        user_id=test_user.id,
+        filename="moomoo-positions.pdf",
+        institution="Moomoo",
+        payload=payload,
+        request_id="req-brokerage",
+        model_to_use="glm-5.1",
+    )
+
+    calls = [(call.args[0], call.kwargs) for call in mock_info.call_args_list]
+    started = next(kwargs for event, kwargs in calls if event == "statement.brokerage_import.started")
+    completed = next(kwargs for event, kwargs in calls if event == "statement.brokerage_import.completed")
+
+    assert started["audit_event"] == "statement.brokerage_import.started"
+    assert started["statement_id"] == str(statement.id)
+    assert started["request_id"] == "req-brokerage"
+    assert started["phase"] == "brokerage_import_started"
+    assert started["progress"] == 100
+    assert started["model_to_use"] == "glm-5.1"
+    assert started["broker"] == "Moomoo"
+    assert started["parsed_positions"] == 1
+
+    assert completed["audit_event"] == "statement.brokerage_import.completed"
+    assert completed["statement_id"] == str(statement.id)
+    assert completed["phase"] == "brokerage_import_completed"
+    assert completed["progress"] == 100
+    assert completed["model_to_use"] == "glm-5.1"
+    assert completed["broker"] == "Moomoo"
+    assert completed["created_atomic_positions"] == 1
+    assert completed["existing_atomic_positions"] == 0
+    assert completed["reconcile_created"] == 1
+
+    failure_statement = await _create_statement(db, test_user.id, file_hash="brokerage-failure-audit-hash")
+    failure_statement.parsing_progress = 100
+    await db.commit()
+
+    async def fail_import_positions(*_args, **_kwargs):
+        raise RuntimeError("provider payload had no positions and raw text is omitted")
+
+    monkeypatch.setattr(statement_parsing._brokerage_import_service, "import_positions", fail_import_positions)
+
+    await import_brokerage_payload_if_present(
+        statement=failure_statement,
+        db=db,
+        user_id=test_user.id,
+        filename="moomoo-positions.pdf",
+        institution="Moomoo",
+        payload=payload,
+        request_id="req-brokerage-failed",
+        model_to_use="glm-5.1",
+    )
+
+    failed = next(
+        call.kwargs for call in mock_exception.call_args_list if call.args[0] == "statement.brokerage_import.failed"
+    )
+    assert failed["audit_event"] == "statement.brokerage_import.failed"
+    assert failed["statement_id"] == str(failure_statement.id)
+    assert failed["request_id"] == "req-brokerage-failed"
+    assert failed["phase"] == "brokerage_import_failed"
+    assert failed["progress"] == 100
+    assert failed["model_to_use"] == "glm-5.1"
+    assert failed["error_type"] == "RuntimeError"
+    assert failed["safe_error_message"] == "provider payload had no positions and raw text is omitted"

--- a/apps/backend/tests/infra/test_observability_contract.py
+++ b/apps/backend/tests/infra/test_observability_contract.py
@@ -124,3 +124,14 @@ def test_production_renderer_outputs_structured_json(monkeypatch) -> None:
 
     payload = json.loads(rendered)
     assert payload == {"event": "startup", "service": "backend"}
+
+
+def test_AC10_8_4_high_volume_fx_audit_noise_uses_debug_level() -> None:
+    """AC10.8.4: High-volume staging audit noise is debug-only by default."""
+    database = _read(REPO_ROOT / "apps" / "backend" / "src" / "database.py")
+    fx_revaluation = _read(REPO_ROOT / "apps" / "backend" / "src" / "services" / "fx_revaluation.py")
+    reporting = _read(REPO_ROOT / "apps" / "backend" / "src" / "services" / "reporting.py")
+
+    assert "echo=settings.debug" in database
+    assert 'logger.debug(\n        "Calculated unrealized FX gains/losses"' in fx_revaluation
+    assert 'logger.debug(\n                "Skipping portfolio valuation without market price"' in reporting

--- a/apps/backend/tests/reconciliation/test_reconciliation_router_additional.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_router_additional.py
@@ -2,6 +2,7 @@
 
 from datetime import date
 from decimal import Decimal
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -152,6 +153,7 @@ async def test_run_reconciliation_filters_unmatched(
     db: AsyncSession, test_user, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     statement = await _create_statement(db, test_user.id)
+    statement_id = statement.id
     await _create_transaction(db, statement.id, amount=Decimal("5.00"), status=BankStatementTransactionStatus.UNMATCHED)
     await db.commit()
 
@@ -183,6 +185,81 @@ async def test_run_reconciliation_filters_unmatched(
     assert response.auto_accepted == 1
     assert response.pending_review == 1
     assert response.unmatched == 1
+
+
+@pytest.mark.asyncio
+async def test_AC10_8_3_reconciliation_run_audit_checkpoints(
+    db: AsyncSession, test_user, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC10.8.3: Reconciliation run logs start/completion/failure replay checkpoints."""
+    statement = await _create_statement(db, test_user.id)
+    statement_id = statement.id
+    await _create_transaction(db, statement_id, amount=Decimal("5.00"), status=BankStatementTransactionStatus.UNMATCHED)
+    await db.commit()
+
+    async def fake_execute_matching(*_args, **_kwargs):
+        return [
+            ReconciliationMatch(
+                bank_txn_id=uuid4(),
+                journal_entry_ids=[],
+                match_score=90,
+                score_breakdown={},
+                status=ReconciliationStatus.AUTO_ACCEPTED,
+            )
+        ]
+
+    mock_info = MagicMock()
+    mock_exception = MagicMock()
+    monkeypatch.setattr(reconciliation_router, "execute_matching", fake_execute_matching)
+    monkeypatch.setattr(reconciliation_router.logger, "info", mock_info)
+    monkeypatch.setattr(reconciliation_router.logger, "exception", mock_exception)
+
+    response = await reconciliation_router.run_reconciliation(
+        ReconciliationRunRequest(statement_id=statement_id, limit=25), db, test_user.id
+    )
+
+    calls = [(call.args[0], call.kwargs) for call in mock_info.call_args_list]
+    started = next(kwargs for event, kwargs in calls if event == "reconciliation.run.started")
+    completed = next(kwargs for event, kwargs in calls if event == "reconciliation.run.completed")
+
+    assert response.matches_created == 1
+    assert started["audit_event"] == "reconciliation.run.started"
+    assert started["request_id"]
+    assert started["statement_id"] == str(statement_id)
+    assert started["phase"] == "matching_started"
+    assert started["progress"] is None
+    assert started["model_to_use"] is None
+    assert started["limit"] == 25
+    assert completed["audit_event"] == "reconciliation.run.completed"
+    assert completed["request_id"] == started["request_id"]
+    assert completed["statement_id"] == str(statement_id)
+    assert completed["phase"] == "matching_completed"
+    assert completed["progress"] is None
+    assert completed["model_to_use"] is None
+    assert completed["matches_created"] == 1
+    assert completed["auto_accepted"] == 1
+    assert completed["pending_review"] == 0
+    assert completed["unmatched"] == 1
+
+    async def fail_execute_matching(*_args, **_kwargs):
+        raise RuntimeError("matching score service unavailable with raw details omitted")
+
+    monkeypatch.setattr(reconciliation_router, "execute_matching", fail_execute_matching)
+
+    with pytest.raises(RuntimeError, match="matching score service unavailable"):
+        await reconciliation_router.run_reconciliation(
+            ReconciliationRunRequest(statement_id=statement_id, limit=25), db, test_user.id
+        )
+
+    failed = next(call.kwargs for call in mock_exception.call_args_list if call.args[0] == "reconciliation.run.failed")
+    assert failed["audit_event"] == "reconciliation.run.failed"
+    assert failed["statement_id"] == str(statement_id)
+    assert failed["phase"] == "matching_failed"
+    assert failed["progress"] is None
+    assert failed["model_to_use"] is None
+    assert failed["limit"] == 25
+    assert failed["error_type"] == "RuntimeError"
+    assert failed["safe_error_message"] == "matching score service unavailable with raw details omitted"
 
 
 @pytest.mark.asyncio
@@ -314,7 +391,9 @@ async def test_pending_review_queue_returns_items(db: AsyncSession, test_user) -
 @pytest.mark.asyncio
 async def test_accept_reject_batch_accept(db: AsyncSession, test_user) -> None:
     """[AC4.3.3] Test batch accept functionality."""
-    account = Account(user_id=test_user.id, name="Mapped Reconciliation Account", type=AccountType.ASSET, currency="SGD")
+    account = Account(
+        user_id=test_user.id, name="Mapped Reconciliation Account", type=AccountType.ASSET, currency="SGD"
+    )
     db.add(account)
     await db.flush()
     statement = await _create_statement(db, test_user.id, account_id=account.id)

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1979,6 +1979,11 @@ groups:
         epic_name: testing-strategy
         description: Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99%.
         mandatory: true
+      - id: AC8.13.49
+        epic: 8
+        epic_name: testing-strategy
+        description: Staging AI/OCR gates publish audit input inventory and replay summary fields.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/infra_registry.yaml
+++ b/docs/infra_registry.yaml
@@ -512,6 +512,27 @@ groups:
         epic_name: signoz-logging
         description: Structured JSON logs in non-debug
         mandatory: true
+    AC10.8:
+      - id: AC10.8.1
+        epic: 10
+        epic_name: signoz-logging
+        description: Statement upload audit logs include non-sensitive input provenance and correlation IDs
+        mandatory: true
+      - id: AC10.8.2
+        epic: 10
+        epic_name: signoz-logging
+        description: Async statement parsing emits structured 5/10/20/70/80/90/100 checkpoints and safe failure context
+        mandatory: true
+      - id: AC10.8.3
+        epic: 10
+        epic_name: signoz-logging
+        description: Brokerage import and reconciliation emit start/complete audit checkpoints with result counts
+        mandatory: true
+      - id: AC10.8.4
+        epic: 10
+        epic_name: signoz-logging
+        description: High-volume staging audit noise is reduced for SQL echo and repeated FX/portfolio valuation detail logs
+        mandatory: true
   AC12:
     AC12.1:
       - id: AC12.1.1

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -81,6 +81,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.46**: PR preview non-LLM E2E uses the same strict, parallel gate shape as staging non-LLM E2E.
 - **AC8.13.47**: Remaining delivery-engine optimizations are captured in a tracked project recommendation note.
 - **AC8.13.48**: Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99%.
+- **AC8.13.49**: Staging AI/OCR gates publish audit input inventory and replay summary fields.
 
 **Current state (2026-02-23):**
 - **Tier 1**: 41 tests in `test_core_journeys.py` covering 45 ACs → **91.8% AC pass rate** (45/49)
@@ -400,6 +401,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.46 | PR preview non-LLM E2E uses the same strict, parallel gate shape as staging non-LLM E2E | `test_AC8_13_46_pr_preview_non_llm_gate_matches_staging_strict_parallelism` | `scripts/tests/test_post_merge_e2e_gates.py` | P1 |
 | AC8.13.47 | Remaining delivery-engine optimizations are captured in a tracked project recommendation note | `test_AC8_13_47_delivery_engine_recommendations_are_tracked` | `scripts/tests/test_post_merge_e2e_gates.py` | P1 |
 | AC8.13.48 | Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99% | `test_AC8_13_48_*` | `apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx`, `apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx`, `apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx`, `apps/frontend/src/__tests__/StatementUploader.test.tsx`, `apps/frontend/src/__tests__/journalPage.test.tsx`, `apps/frontend/src/__tests__/reconciliationWorkbenchComponent.test.tsx`, `apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx`, `apps/frontend/src/__tests__/apiFunctions.test.ts`, `apps/frontend/src/__tests__/accountsPage.test.tsx`, `apps/frontend/src/__tests__/assetsPage.test.tsx`, `apps/frontend/src/__tests__/statementsPage.test.tsx`, `apps/frontend/src/__tests__/useWorkspaceHook.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.netWorthTimeSeries.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx` | P0 |
+| AC8.13.49 | Staging AI/OCR gates publish audit input inventory and replay summary fields | `test_AC8_13_49_staging_ai_ocr_gate_publishes_audit_inventory_and_summary` | `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.

--- a/docs/project/EPIC-010.signoz-logging.md
+++ b/docs/project/EPIC-010.signoz-logging.md
@@ -33,6 +33,7 @@ Enable production-grade log observability via SigNoz (OTLP), while keeping local
 3. Update Vault templates/README in infra repo.
 4. Add restart-safe wiring for Vault template updates.
 5. Validate via tests and env consistency check.
+6. Add staging audit replay events for statement upload, async parsing, brokerage import, and reconciliation.
 
 ### Result
 - Optional OTEL export implemented; local/dev remains stdout-only.
@@ -146,11 +147,20 @@ Enable production-grade log observability via SigNoz (OTLP), while keeping local
 | AC10.7.6 | Vault templates include OTEL keys | `test_vault_template_exposes_otel_keys_with_safe_quoting()` | `infra/test_observability_contract.py` | P0 |
 | AC10.7.7 | Structured JSON logs in non-debug | `test_production_renderer_outputs_structured_json()` | `infra/test_observability_contract.py` | P0 |
 
+### AC10.8: Staging Audit Replay Logging
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC10.8.1 | Statement upload audit logs include non-sensitive input provenance, correlation IDs, and storage failure context | `test_AC10_8_1_upload_audit_logs_include_statement_input_provenance()`, `test_AC10_8_1_upload_storage_failure_logs_safe_audit_context()` | `api/test_statements_router.py` | P0 |
+| AC10.8.2 | Async statement parsing emits structured 5/10/20/70/80/90/100 checkpoints and safe failure context | `test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured()` | `extraction/test_statement_parsing_audit_logging.py` | P0 |
+| AC10.8.3 | Brokerage import and reconciliation emit start/complete/failure audit checkpoints with result counts | `test_AC10_8_3_statement_scoped_brokerage_import_audit_logs()`, `test_AC10_8_3_brokerage_import_audit_checkpoints()`, `test_AC10_8_3_reconciliation_run_audit_checkpoints()` | `api/test_statements_router.py`, `extraction/test_statement_parsing_audit_logging.py`, `reconciliation/test_reconciliation_router_additional.py` | P0 |
+| AC10.8.4 | High-volume staging audit noise is reduced for SQL echo and repeated FX/portfolio valuation detail logs | `test_AC10_8_4_high_volume_fx_audit_noise_uses_debug_level()` | `infra/test_observability_contract.py` | P1 |
+
 **Traceability Result**:
-- Total AC IDs: 18 (AC10.2.1, AC10.3.1, AC10.3.2 removed as duplicates of EPIC-012 canonical ACs)
+- Total AC IDs: 22 (AC10.2.1, AC10.3.1, AC10.3.2 removed as duplicates of EPIC-012 canonical ACs)
 - Requirements converted to AC IDs: 100% (EPIC-010 checklist + must-have standards)
 - Requirements with implemented test references: 100% (contract tests cover config, docs, templates, and logger behavior)
-- Test files: 2
+- Test files: 5
 - Note: Staging/production SigNoz UI checks remain operational smoke verification outside the AC contract suite
 
 ---

--- a/docs/ssot/observability-logging.md
+++ b/docs/ssot/observability-logging.md
@@ -9,10 +9,14 @@
 ### Files Modified
 - `apps/frontend/src/components/statements/StatementUploader.tsx` - Model selection and upload logging
 - `apps/backend/src/routers/statements.py` - Upload request and background task logging
+- `apps/backend/src/routers/reconciliation.py` - Reconciliation run audit checkpoints
+- `apps/backend/src/services/statement_parsing.py` - Async parse progress and brokerage import checkpoints
 - `apps/backend/src/routers/ai_models.py` - Model catalog request/response logging
 - `apps/backend/src/services/extraction.py` - Model selection and HTTP error logging
 - `apps/backend/src/services/ai_provider_models.py` - Cache and model lookup logging
 - `apps/backend/src/services/ai_provider_streaming.py` - Enhanced AI provider API error logging
+- `.github/workflows/staging-deploy.yml` - Post-merge staging audit input inventory and phase summary
+- `.github/workflows/staging-ai-ocr-gate.yml` - Manual staging AI/OCR audit input inventory
 
 ### Configuration
 - **Logger**: Structured logging via `src/logger.py` with OTEL integration
@@ -81,6 +85,84 @@ sequenceDiagram
 5. Extraction: Model selection logic (force_model vs primary_model)
 6. Extraction: HTTP error with status code extraction
 7. AI provider: API error with headers and retryability
+
+### Staging Audit Replay Contract
+
+Staging logs and GitHub Actions output must support replaying any staging run from
+either a GitHub Actions `run_id` or a backend `statement_id` within five minutes.
+The goal is not higher log volume; it is enough structured context to answer:
+
+1. What input was processed?
+2. Which phase did it reach?
+3. What result was produced?
+4. If it failed, what safe failure reason explains it?
+
+#### Required Fields
+
+Every staging audit event uses a stable dotted `audit_event` value plus the
+native structured log event message. Statement-scoped events include
+`statement_id`, `request_id` when available, `phase`, and `progress` when the
+phase maps to parsing progress. Upload events also include `filename`,
+`file_type`, `institution`, `model_requested`, `model_to_use`,
+`file_size_bytes`, and `file_hash_prefix`.
+
+The staging workflow records deployment-level inputs before provider-backed
+tests run: target SHA, backend and frontend image tags, environment, app URL,
+primary/OCR/vision model IDs, fixture test files, expected upload count,
+expected brokerage import count, expected report verification count, and the
+phase labels that should appear in the run log. After the gate finishes, the
+workflow appends verified upload, parse completion, brokerage import, report
+verification, and failure counts when the suite passes; failures emit `unknown`
+counts plus a non-zero failure marker for fast triage.
+
+#### Event Names
+
+| Event | Required Fields | Purpose |
+|-------|-----------------|---------|
+| `statement.upload.accepted` | `request_id`, `statement_id`, `filename`, `file_type`, `institution`, `model_requested`, `model_to_use`, `file_size_bytes`, `file_hash_prefix` | Confirms accepted input without logging document content |
+| `statement.upload.storage_saved` | `request_id`, `statement_id`, `storage_key`, `file_hash_prefix` | Confirms the object was persisted to storage |
+| `statement.upload.storage_failed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `filename`, `file_type`, `file_size_bytes`, `file_hash_prefix`, `error_type`, `safe_error_message` | Shows storage failure after upload acceptance without logging document content |
+| `statement.parse.enqueued` | `request_id`, `statement_id`, `filename`, `file_type`, `model_to_use` | Connects the upload request to the async parse task |
+| `statement.parse.checkpoint` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `file_type` | Emits async parse progress at 5/10/20/70/80/90/100 |
+| `statement.parse.extraction_completed` | `request_id`, `statement_id`, `model_to_use`, `file_type` | Replaces misleading enqueue wording after extraction returns |
+| `statement.parse.completed` | `request_id`, `statement_id`, `phase`, `progress`, `duration_ms`, `transactions_count` | Marks parse finalization success |
+| `statement.parse.failed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `error_type`, `safe_error_message` | Marks parse failure without leaking source content |
+| `statement.brokerage_import.started` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `broker`, `parsed_positions` when known | Shows brokerage import was attempted |
+| `statement.brokerage_import.completed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `broker`, `parsed_positions`, `created_atomic_positions`, `existing_atomic_positions`, `reconcile_created`, `reconcile_updated`, `reconcile_disposed` | Shows brokerage import result counts |
+| `statement.brokerage_import.failed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `error_type`, `safe_error_message` | Shows brokerage import failure without leaking payload |
+| `reconciliation.run.started` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `limit` | Shows reconciliation was explicitly started |
+| `reconciliation.run.completed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `limit`, `matches_created`, `auto_accepted`, `pending_review`, `unmatched` | Shows reconciliation result counts |
+| `reconciliation.run.failed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `limit`, `error_type`, `safe_error_message` | Shows reconciliation failure without leaking transaction details |
+
+#### Progress Phases
+
+`statement.parse.checkpoint` uses these progress mappings:
+
+| Progress | Phase |
+|----------|-------|
+| 5 | `parse_started` |
+| 10 | `storage_url_resolved` |
+| 20 | `extraction_started` |
+| 70 | `extraction_completed` |
+| 80 | `statement_metadata_persisted` |
+| 90 | `transactions_persisted` |
+| 100 | `statement_persisted` |
+
+#### Sensitive Data Policy
+
+Allowed fields are identifiers and operational metadata only. Do not log document
+bytes, parsed transaction descriptions, account names supplied by users, full
+file hashes, raw AI prompts/responses, provider API keys, session cookies,
+Vault/Dokploy/GitHub tokens, email addresses, or bank account numbers. File
+hashes are truncated to a prefix suitable for correlation, and error fields use
+safe summaries capped before emission.
+
+#### Noise Control
+
+Audit queries should exclude health checks, SQL echo, and repeated per-day FX or
+portfolio valuation detail logs by default. High-frequency FX valuation detail
+belongs at `debug`; staging audit views should prioritize the events above and
+phase timing lines from GitHub Actions.
 
 ---
 
@@ -278,6 +360,15 @@ sequenceDiagram
 # Find all logs for a specific statement upload
 attributes.statement_id = "<UUID>"
 
+# Replay staging audit events for one statement
+attributes.statement_id = "<UUID>" AND attributes.audit_event EXISTS
+
+# Replay a staging run while excluding routine noise
+body NOT CONTAINS "/api/health"
+AND body NOT CONTAINS "sqlalchemy.engine"
+AND body NOT CONTAINS "Calculated unrealized FX gains/losses"
+AND attributes.audit_event EXISTS
+
 # Trace model selection for a user
 attributes.user_id = "<UUID>" AND body CONTAINS "model"
 
@@ -298,11 +389,12 @@ attributes.retryable = true
 
 **Per Statement Upload**:
 - Frontend: 2 console logs (model selection + upload)
-- Backend: 2 info logs (request received + background task)
+- Backend: 1 upload accepted log, 1 storage saved log, 1 parse enqueue log, 7 parse checkpoint logs, and 1 parse completion or failure log
 - Extraction: 1 info log (model selection)
 - AI provider: 0-1 error log (only on failure)
+- Brokerage/reconciliation: 0-4 audit logs when the parsed payload triggers import or a run is requested
 
-**Total**: ~5-6 log entries per upload (negligible performance impact)
+**Total**: ~12-18 log entries per upload, concentrated around replay checkpoints and still low enough for staging volume.
 
 ---
 

--- a/scripts/tests/test_post_merge_e2e_gates.py
+++ b/scripts/tests/test_post_merge_e2e_gates.py
@@ -184,6 +184,52 @@ def test_AC8_13_14_staging_ai_ocr_gate_is_separate_deploy_job() -> None:
     assert "manual recovery entry point" in ci_cd
 
 
+def test_AC8_13_49_staging_ai_ocr_gate_publishes_audit_inventory_and_summary() -> None:
+    """AC8.13.49: Staging AI/OCR gates publish replay inputs and summary fields."""
+    deploy_workflow = read(".github/workflows/staging-deploy.yml")
+    ai_workflow = read(".github/workflows/staging-ai-ocr-gate.yml")
+    observability = read("docs/ssot/observability-logging.md")
+
+    for workflow in (deploy_workflow, ai_workflow):
+        assert "write_staging_audit_inventory()" in workflow
+        assert "write_staging_audit_result()" in workflow
+        assert "## Staging Audit Replay Inputs" in workflow
+        assert "## Staging Audit Replay Summary" in workflow
+        assert "- Environment: staging" in workflow
+        assert "- GitHub run ID: ${{ github.run_id }}" in workflow
+        assert "- Expected SHA: ${EXPECTED_SHA}" in workflow
+        assert "- Backend image tag:" in workflow
+        assert "- Frontend image tag:" in workflow
+        assert (
+            "- Models: primary=${STAGING_E2E_PRIMARY_MODEL}, ocr=${STAGING_E2E_OCR_MODEL}, vision=${STAGING_E2E_VISION_MODEL}"
+            in workflow
+        )
+        assert "- Expected uploads: 7" in workflow
+        assert "- Expected parse completions: 7" in workflow
+        assert "- Expected brokerage imports: 3" in workflow
+        assert "- Expected report verifications: 1" in workflow
+        assert "- Expected failures: 0" in workflow
+        assert "- Uploads verified: ${verified_uploads}" in workflow
+        assert "- Parse completions verified: ${verified_parse_completions}" in workflow
+        assert "- Brokerage imports verified: ${verified_brokerage_imports}" in workflow
+        assert "- Report verifications verified: ${verified_report_verifications}" in workflow
+        assert "- Failures observed: ${verified_failures}" in workflow
+        assert "tests/e2e/test_statement_full_journey.py" in workflow
+        assert "tests/e2e/test_brokerage_upload_to_portfolio_value.py" in workflow
+        assert "tests/e2e/test_four_asset_net_worth_golden_path.py" in workflow
+        assert "tests/e2e/test_statement_upload_e2e.py" in workflow
+        assert "GITHUB_STEP_SUMMARY" in workflow
+
+    assert deploy_workflow.index(
+        "write_staging_audit_inventory"
+    ) < deploy_workflow.index('run_timed_phase "Staging AI/OCR Version Check"')
+    assert ai_workflow.index("write_staging_audit_inventory") < ai_workflow.index(
+        'run_timed_phase "Staging AI/OCR Version Check"'
+    )
+    assert "Staging Audit Replay Contract" in observability
+    assert "deployment-level inputs" in observability
+
+
 def test_AC8_13_16_ci_change_classification_and_frontend_cache() -> None:
     """AC8.13.16: CI skips heavy jobs for lightweight changes and caches npm."""
     workflow = read(".github/workflows/ci.yml")


### PR DESCRIPTION
## Summary

Adds staging audit replay logging so a staging run ID or statement ID can identify safe inputs, parse checkpoints, result counts, report verification counts, and safe failure reasons quickly.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-010 — SigNoz Logging Integration; EPIC-008 — Comprehensive Testing Strategy |
| **AC IDs** | AC10.8.1, AC10.8.2, AC10.8.3, AC10.8.4, AC8.13.49 |
| **AC Registry updated** | `docs/ac_registry.yaml` and `docs/infra_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/observability-logging.md` — defines the staging audit replay contract, required fields, event names, sensitive-data policy, progress phases, failure fields, and noise-control defaults.
- [x] `docs/project/EPIC-010.signoz-logging.md` — adds AC10.8 staging audit replay logging coverage.
- [x] `docs/project/EPIC-008.testing-strategy.md` — adds AC8.13.49 for staging AI/OCR replay inventory and summary output after rebasing on main's AC8.13.48 frontend coverage entry.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | working tree before implementation | Added AC-referenced tests first; script gate test failed on missing `write_staging_audit_inventory()`, backend tests expressed missing audit events/fields before implementation. |
| Green | `3c1f119` | Rebased on `origin/main` (`ac96f09`), kept main's AC8.13.48, renumbered the staging workflow AC to AC8.13.49, and verified target tests pass. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter: no enum changes.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` if applicable: not applicable, no frontend env changes.
- [x] `repo/` submodule updated for production config changes if applicable: not applicable. Verified `repo/` is currently a pre-existing uncommitted pointer change outside this PR.
- [x] `scripts/check_env_keys.py` passes if env vars changed: not applicable, no env keys added.
- [x] `scripts/check_manifest.py` passes if SSOT files changed: `uv run --with pyyaml python scripts/check_manifest.py`.
- [x] `scripts/lint_doc_consistency.py` passes: `uv run --with pyyaml python scripts/lint_doc_consistency.py`.

---

## Testing

```bash
moon run :lint -- --backend
uv run pytest scripts/tests/test_post_merge_e2e_gates.py -q
uv run --with pyyaml python scripts/generate_ac_registry.py --check
uv run --with pyyaml python scripts/check_manifest.py
uv run --with pyyaml python scripts/lint_doc_consistency.py
uv run python -m py_compile apps/backend/src/routers/statements.py apps/backend/src/routers/reconciliation.py apps/backend/src/services/statement_parsing.py
DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/finance_report_test TEST_DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/finance_report_test TEST_NAMESPACE=auditlog uv run pytest -o addopts='' apps/backend/tests/api/test_statements_router.py apps/backend/tests/extraction/test_statement_parsing_audit_logging.py apps/backend/tests/extraction/test_account_last4_defense.py::TestCascadingFailureRecovery apps/backend/tests/reconciliation/test_reconciliation_router_additional.py apps/backend/tests/infra/test_observability_contract.py -q
```

Post-rebase targeted backend run: 113 passed, 1 existing deprecation warning. Post-rebase script gate tests: 34 passed.

Full `moon run :test` was not run locally because this machine has podman installed but no running/initialized podman machine; CI should run the full lifecycle.

---

## Screenshots / Evidence

N/A — backend/logging and workflow change.
