### PR TITLE
[codex] Add macro proof contract guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,33 @@ Known proof-quality caveats:
 Do not hand-maintain open/closed blocker lists here. GitHub issue state and
 labels are the source of truth for current tracker status.
 
-- North-star tracker: [#444](https://github.com/wangzitian0/finance_report/issues/444)
+- Macro proof tracker: [#521](https://github.com/wangzitian0/finance_report/issues/521)
 - Related live work is tracked with labels such as `flow: upload-to-report`,
   `flow: net-worth`, and `scope: valuation`.
 - If a stable proof path is needed in docs, write a parseable matrix and attach
   a checker rather than copying issue state by hand.
+
+## Core Proof Paths
+
+Macro correctness is owned by
+[`docs/ssot/critical-proof-matrix.yaml`](docs/ssot/critical-proof-matrix.yaml)
+and checked by `python scripts/check_critical_proof_matrix.py`. This is the
+README -> EPIC -> E2E contract. The EPIC -> AC -> test contract remains owned by
+the generated AC registries and AC traceability reports.
+
+The macro outcome set is closed and parseable:
+
+| Outcome ID | Purpose |
+|---|---|
+| `asset-distribution-net-worth` | Asset distribution, liabilities, and as-of net worth |
+| `monthly-income-spending` | Current-period income, expenses, and net income |
+| `investment-performance` | Portfolio import, valuation, and performance proof path |
+| `annualized-income-long-term` | Salary, dividends, ESOP/restricted holdings, and long-term income proof path |
+| `source-ledger-report-traceability` | Source document -> ledger -> report traceability |
+
+Covered outcomes must point to explicit E2E proof anchors in the matrix. Partial
+or gap outcomes must point to a GitHub issue instead of being implied by broad
+AC coverage.
 
 ## Documentation Debt Tracked As Issues
 

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1984,6 +1984,12 @@ groups:
         epic_name: testing-strategy
         description: Staging AI/OCR gates publish audit input inventory and replay summary fields.
         mandatory: true
+      - id: AC8.13.50
+        epic: 8
+        epic_name: testing-strategy
+        description: Critical proof matrix validates the closed macro outcome set from README through owner EPICs and E2E
+          proof anchors.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/analysis/ac-epic-mismatch-report.md
+++ b/docs/analysis/ac-epic-mismatch-report.md
@@ -1,6 +1,6 @@
 # AC↔EPIC Mismatch Triage
 
-- Total ACx.y.z refs scanned: **2159**
+- Total ACx.y.z refs scanned: **2168**
 - Actionable mismatched refs: **0**
 - Fixture-only mismatched refs: **67**
 - Actionable files affected: **0**
@@ -15,7 +15,7 @@
 
 ## `scripts/tests/test_generate_ac_registry.py` — 12 bad / 6 unique
 - **Suggest**: FIXTURE-EXCLUDE
-- Alt-epic matches: EPIC-11:10, EPIC-17:8, EPIC-2:6, EPIC-6:6, EPIC-8:6, EPIC-13:6, EPIC-16:6, EPIC-7:6, EPIC-12:6, EPIC-1:4, EPIC-3:2, EPIC-4:2, EPIC-5:2, EPIC-15:2, EPIC-18:2, EPIC-9:2
+- Alt-epic matches: EPIC-11:10, EPIC-17:8, EPIC-2:6, EPIC-6:6, EPIC-8:6, EPIC-13:6, EPIC-16:6, EPIC-7:6, EPIC-12:6, EPIC-1:4, EPIC-10:4, EPIC-3:2, EPIC-4:2, EPIC-5:2, EPIC-15:2, EPIC-18:2, EPIC-9:2
 - Bad IDs: AC1.1.9, AC1.1.10, AC1.99.1, AC9.8.1, AC9.8.2, AC10.2.1
 
 ## `scripts/tests/test_lint_doc_consistency.py` — 11 bad / 4 unique

--- a/docs/analysis/ac-epic-mismatch-report.md
+++ b/docs/analysis/ac-epic-mismatch-report.md
@@ -1,17 +1,17 @@
 # AC↔EPIC Mismatch Triage
 
-- Total ACx.y.z refs scanned: **1955**
+- Total ACx.y.z refs scanned: **2159**
 - Actionable mismatched refs: **0**
-- Fixture-only mismatched refs: **52**
+- Fixture-only mismatched refs: **67**
 - Actionable files affected: **0**
-- Fixture-only files affected: **5**
+- Fixture-only files affected: **7**
 
 ## Fixture-Only Mismatches
 
-## `scripts/tests/test_analyze_test_ac_coverage.py` — 17 bad / 5 unique
+## `scripts/tests/test_analyze_test_ac_coverage.py` — 28 bad / 9 unique
 - **Suggest**: FIXTURE-EXCLUDE
-- Alt-epic matches: EPIC-16:13, EPIC-1:10, EPIC-2:10, EPIC-13:10, EPIC-17:10, EPIC-18:10, EPIC-7:10, EPIC-9:10, EPIC-3:8, EPIC-4:8, EPIC-5:8, EPIC-8:8, EPIC-11:8, EPIC-12:8, EPIC-6:6, EPIC-15:4, EPIC-10:4, EPIC-14:4
-- Bad IDs: AC4.4.4, AC8.12.7, AC9.9.9, AC19.1.1, AC99.3.3
+- Alt-epic matches: EPIC-2:18, EPIC-13:18, EPIC-16:16, EPIC-17:16, EPIC-15:15, EPIC-4:14, EPIC-5:14, EPIC-6:14, EPIC-1:13, EPIC-18:13, EPIC-7:13, EPIC-9:13, EPIC-10:12, EPIC-3:11, EPIC-8:11, EPIC-11:11, EPIC-12:11, EPIC-14:7
+- Bad IDs: AC4.4.4, AC6.6.6, AC7.7.7, AC8.12.7, AC9.9.9, AC19.1.1, AC77.7.7, AC99.1.1, AC99.3.3
 
 ## `scripts/tests/test_generate_ac_registry.py` — 12 bad / 6 unique
 - **Suggest**: FIXTURE-EXCLUDE
@@ -32,4 +32,12 @@
 - **Suggest**: FIXTURE-EXCLUDE
 - Alt-epic matches: EPIC-1:1, EPIC-2:1, EPIC-3:1, EPIC-4:1, EPIC-5:1, EPIC-6:1, EPIC-8:1, EPIC-11:1, EPIC-13:1, EPIC-15:1, EPIC-16:1, EPIC-17:1, EPIC-18:1, EPIC-7:1, EPIC-9:1, EPIC-10:1, EPIC-12:1, EPIC-14:1
 - Bad IDs: AC8.9.9, AC9.9.9, AC99.1.1
+
+## `scripts/tests/test_issue_493_foundation_ttd_behavior.py` — 2 bad / 1 unique
+- **Suggest**: FIXTURE-EXCLUDE
+- Bad IDs: AC1.99.1
+
+## `scripts/tests/test_check_critical_proof_matrix.py` — 2 bad / 1 unique
+- **Suggest**: FIXTURE-EXCLUDE
+- Bad IDs: AC8.13.99
 

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-05-28 04:42:57 UTC by `scripts/analyze_test_ac_coverage.py`
+> Generated: 2026-05-28 07:38:18 UTC by `scripts/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 995 |
-| Active ACs | 992 |
+| Registered ACs | 1001 |
+| Active ACs | 998 |
 | Deprecated ACs excluded from coverage gate | 3 |
-| Covered by real test candidates | 992 (100.0%) |
+| Covered by real test candidates | 998 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -32,9 +32,9 @@
 
 | Source | Files scanned | Unique AC refs (real) | Unique AC refs (placeholder) | Unique AC refs (stub) |
 |---|---:|---:|---:|---:|
-| backend | 167 | 648 | 0 | 0 |
+| backend | 168 | 652 | 0 | 0 |
 | frontend | 80 | 190 | 7 | 0 |
-| scripts_tests | 47 | 205 | 23 | 0 |
+| scripts_tests | 47 | 207 | 23 | 0 |
 | e2e | 11 | 22 | 0 | 0 |
 | repo_e2e | 18 | 0 | 0 | 0 |
 
@@ -49,9 +49,9 @@
 | EPIC-005 | reporting-visualization | 36 | 0 | 36 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 0 | 63 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-008 | testing-strategy | 105 | 0 | 105 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 107 | 0 | 107 | 0 | 0 | 0 | 100.0% |
 | EPIC-009 | pdf-fixture-generation | 37 | 0 | 37 | 0 | 0 | 0 | 100.0% |
-| EPIC-010 | signoz-logging | 21 | 0 | 21 | 0 | 0 | 0 | 100.0% |
+| EPIC-010 | signoz-logging | 25 | 0 | 25 | 0 | 0 | 0 | 100.0% |
 | EPIC-011 | asset-lifecycle | 38 | 0 | 38 | 0 | 0 | 0 | 100.0% |
 | EPIC-012 | foundation-libs | 62 | 3 | 59 | 0 | 0 | 0 | 100.0% |
 | EPIC-013 | statement-parsing-v2 | 60 | 0 | 60 | 0 | 0 | 0 | 100.0% |

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -82,6 +82,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.47**: Remaining delivery-engine optimizations are captured in a tracked project recommendation note.
 - **AC8.13.48**: Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99%.
 - **AC8.13.49**: Staging AI/OCR gates publish audit input inventory and replay summary fields.
+- **AC8.13.50**: Critical proof matrix validates the closed macro outcome set from README through owner EPICs and E2E proof anchors.
 
 **Current state (2026-02-23):**
 - **Tier 1**: 41 tests in `test_core_journeys.py` covering 45 ACs → **91.8% AC pass rate** (45/49)
@@ -402,6 +403,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.47 | Remaining delivery-engine optimizations are captured in a tracked project recommendation note | `test_AC8_13_47_delivery_engine_recommendations_are_tracked` | `scripts/tests/test_post_merge_e2e_gates.py` | P1 |
 | AC8.13.48 | Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99% | `test_AC8_13_48_*` | `apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx`, `apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx`, `apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx`, `apps/frontend/src/__tests__/StatementUploader.test.tsx`, `apps/frontend/src/__tests__/journalPage.test.tsx`, `apps/frontend/src/__tests__/reconciliationWorkbenchComponent.test.tsx`, `apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx`, `apps/frontend/src/__tests__/apiFunctions.test.ts`, `apps/frontend/src/__tests__/accountsPage.test.tsx`, `apps/frontend/src/__tests__/assetsPage.test.tsx`, `apps/frontend/src/__tests__/statementsPage.test.tsx`, `apps/frontend/src/__tests__/useWorkspaceHook.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.netWorthTimeSeries.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx` | P0 |
 | AC8.13.49 | Staging AI/OCR gates publish audit input inventory and replay summary fields | `test_AC8_13_49_staging_ai_ocr_gate_publishes_audit_inventory_and_summary` | `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
+| AC8.13.50 | Critical proof matrix validates the closed macro outcome set from README through owner EPICs and E2E proof anchors | `test_AC8_13_50_*` | `scripts/tests/test_check_critical_proof_matrix.py` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -252,8 +252,9 @@ concepts:
 
   critical_proof_matrix:
     owner: docs/ssot/critical-proof-matrix.yaml
-    description: Parseable guard for core product proof paths that must not be satisfied by broad AC references.
+    description: Parseable README -> EPIC -> E2E macro outcome guard and core proof-path matrix.
     cross_refs:
+      - README.md
       - docs/ssot/tdd.md
       - docs/ssot/ci-cd.md
       - .github/workflows/ci.yml

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -10,6 +10,16 @@ Project hierarchy:
 README.md -> EPIC -> AC -> test
 ```
 
+The macro product-proof layer is separate from AC traceability:
+
+```text
+README.md -> EPIC -> E2E
+```
+
+That macro contract is owned by
+[critical-proof-matrix.yaml](./critical-proof-matrix.yaml) and checked by
+`scripts/check_critical_proof_matrix.py`.
+
 SSOT documents support that hierarchy by explaining why a contract exists and
 linking to its code owner and proof tests.
 
@@ -64,6 +74,7 @@ contracts is tracked in
 
 | Report | Purpose |
 |---|---|
+| [critical-proof-matrix.yaml](./critical-proof-matrix.yaml) | Parseable README -> EPIC -> E2E macro outcome contract |
 | [../analysis/test-ac-coverage-report.md](../analysis/test-ac-coverage-report.md) | Generated AC-to-test coverage report |
 | [../../unified-coverage.json](../../unified-coverage.json) | Current committed coverage baseline |
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -72,7 +72,7 @@ The test system separates proof by where the failure can be acted on:
 | Behavioral tests | PR CI before merge | Prove deterministic product behavior, accounting invariants, API contracts, frontend flows, and script/tool contracts before code enters `main`. |
 | Environment gates | Post-merge deploy workflows | Prove the exact merged SHA can run in staging/production-like environments with real routing, Vault/Dokploy/GHCR/SigNoz wiring, deployed images, and provider-backed OCR/LLM credentials. |
 | Reference traceability | PR and `main` CI | Prove every mandatory AC has a real non-placeholder test reference; this is not behavioral coverage by itself. |
-| Critical proof matrix | PR and `main` CI | Prove selected core proof paths point to explicit behavioral, static/doc, or manual-gate anchors instead of broad AC string references. |
+| Critical proof matrix | PR and `main` CI | Prove the closed README -> EPIC -> E2E macro outcome set and selected core proof paths point to explicit behavioral, static/doc, or manual-gate anchors instead of broad AC string references. |
 
 Behavioral tests should move left into PR CI whenever they can be deterministic
 without external singleton state or provider spend. Environment-dependent checks

--- a/docs/ssot/critical-proof-matrix.yaml
+++ b/docs/ssot/critical-proof-matrix.yaml
@@ -4,6 +4,62 @@ description: >
   references. This matrix protects only the small set of core user journeys;
   full AC traceability remains a separate hygiene gate.
 
+outcomes:
+  - id: asset-distribution-net-worth
+    question: "How much money do I have, and where is it distributed?"
+    status: covered
+    owner_epics:
+      - EPIC-005
+      - EPIC-008
+      - EPIC-011
+      - EPIC-017
+    proof_ids:
+      - deterministic-upload-to-dashboard
+      - four-asset-as-of-net-worth
+    issue: "#444"
+
+  - id: monthly-income-spending
+    question: "How much did I earn and spend this month?"
+    status: covered
+    owner_epics:
+      - EPIC-005
+      - EPIC-008
+    proof_ids:
+      - deterministic-upload-to-dashboard
+
+  - id: investment-performance
+    question: "How are my investments performing?"
+    status: partial
+    owner_epics:
+      - EPIC-005
+      - EPIC-008
+      - EPIC-017
+    proof_ids:
+      - brokerage-pdf-to-portfolio-value
+    issue: "#521"
+
+  - id: annualized-income-long-term
+    question: "What is my annualized income across salary, ESOP, dividends, and other long-term components?"
+    status: partial
+    owner_epics:
+      - EPIC-005
+      - EPIC-011
+      - EPIC-017
+    issue: "#521"
+
+  - id: source-ledger-report-traceability
+    question: "Can every trusted dashboard number be traced from source document to ledger to report?"
+    status: covered
+    owner_epics:
+      - EPIC-003
+      - EPIC-004
+      - EPIC-008
+      - EPIC-016
+      - EPIC-018
+    proof_ids:
+      - dbs-pdf-full-journey
+      - deterministic-upload-to-dashboard
+
 proofs:
   - id: dbs-pdf-full-journey
     scope: behavioral

--- a/docs/ssot/tdd.md
+++ b/docs/ssot/tdd.md
@@ -74,10 +74,12 @@ generated.
 
 Core product journeys have one extra guard:
 `docs/ssot/critical-proof-matrix.yaml`. That matrix is deliberately small. It
-only lists P0 proof paths where a broad AC string reference would create false
-confidence, and `scripts/check_critical_proof_matrix.py` verifies that each row
-points to an existing test anchor with the listed AC IDs in the test name or
-docstring. It is not a general-purpose semantic parser for all tests.
+owns the macro README -> EPIC -> E2E contract for the closed set of core
+vision outcomes and lists P0 proof paths where a broad AC string reference
+would create false confidence. `scripts/check_critical_proof_matrix.py`
+verifies that each covered macro outcome points to owner EPICs and explicit E2E
+proof anchors with the listed AC IDs in the test name or docstring. It is not a
+general-purpose semantic parser for all tests.
 
 ## Proof Semantics
 
@@ -96,6 +98,14 @@ For critical proof matrix rows, behavioral proof must be a product test anchor,
 not a broad contract bucket. Static/doc checks and manual gates may be listed in
 the matrix only when they are explicitly labeled as such; they do not satisfy a
 behavioral row.
+
+Macro and micro proof are intentionally separate:
+
+- **Macro**: README -> EPIC -> E2E, owned by
+  `docs/ssot/critical-proof-matrix.yaml`. Covered outcomes require explicit E2E
+  proof IDs; partial or gap outcomes require a GitHub issue.
+- **Micro**: EPIC -> AC -> test, owned by EPIC AC tables, generated registries,
+  and AC traceability gates.
 
 Manual verification cleanup is tracked in
 [issue #454](https://github.com/wangzitian0/finance_report/issues/454).

--- a/scripts/check_critical_proof_matrix.py
+++ b/scripts/check_critical_proof_matrix.py
@@ -31,6 +31,16 @@ REGISTRY_PATHS = (
 
 VALID_SCOPES = {"behavioral", "static_contract", "manual_gate"}
 VALID_CI_TIERS = {"pr_ci", "post_merge_environment", "manual"}
+VALID_OUTCOME_STATUSES = {"covered", "partial", "gap"}
+REQUIRED_OUTCOME_IDS = {
+    "asset-distribution-net-worth",
+    "monthly-income-spending",
+    "investment-performance",
+    "annualized-income-long-term",
+    "source-ledger-report-traceability",
+}
+ISSUE_RE = re.compile(r"^#\d+$")
+EPIC_RE = re.compile(r"^EPIC-\d{3}$")
 BEHAVIORAL_ROOTS = (
     "apps/backend/tests/",
     "apps/frontend/src/",
@@ -63,6 +73,30 @@ class ProofResult:
     errors: list[str] = field(default_factory=list)
 
 
+@dataclass
+class OutcomeResult:
+    outcome_id: str
+    status: str
+    owner_epics: list[str]
+    proof_ids: list[str]
+    issue: str
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class MatrixValidation:
+    proofs: list[ProofResult]
+    outcomes: list[OutcomeResult]
+
+    @property
+    def errors(self) -> list[str]:
+        return [
+            error
+            for result in [*self.proofs, *self.outcomes]
+            for error in result.errors
+        ]
+
+
 def _rel(path: Path, repo_root: Path) -> str:
     try:
         return path.relative_to(repo_root).as_posix()
@@ -86,6 +120,10 @@ def _load_matrix(path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"{path} must contain a YAML mapping")
     return data
+
+
+def _epic_exists(repo_root: Path, epic_id: str) -> bool:
+    return any((repo_root / "docs" / "project").glob(f"{epic_id}.*.md"))
 
 
 def _decorator_markers(node: ast.AST) -> set[str]:
@@ -246,7 +284,193 @@ def validate_matrix(repo_root: Path, matrix_path: Path) -> list[ProofResult]:
     ]
 
 
-def render_report(results: list[ProofResult]) -> str:
+def _validate_outcome(
+    outcome: dict[str, Any],
+    *,
+    repo_root: Path,
+    proof_by_id: dict[str, ProofResult],
+    index: int,
+) -> OutcomeResult:
+    outcome_id = str(outcome.get("id", f"outcome[{index}]"))
+    status = str(outcome.get("status", ""))
+    raw_owner_epics = outcome.get("owner_epics", [])
+    raw_proof_ids = outcome.get("proof_ids", [])
+    owner_epics = (
+        [str(epic) for epic in raw_owner_epics]
+        if isinstance(raw_owner_epics, list)
+        else []
+    )
+    proof_ids = (
+        [str(proof_id) for proof_id in raw_proof_ids]
+        if isinstance(raw_proof_ids, list)
+        else []
+    )
+    issue = str(outcome.get("issue", ""))
+    errors: list[str] = []
+
+    required = {"id", "status", "owner_epics"}
+    missing = sorted(required - set(outcome))
+    if missing:
+        errors.append(f"{outcome_id}: missing required outcome keys: {', '.join(missing)}")
+
+    if status not in VALID_OUTCOME_STATUSES:
+        errors.append(f"{outcome_id}: invalid status {status!r}")
+
+    if not isinstance(raw_owner_epics, list) or not owner_epics:
+        errors.append(f"{outcome_id}: owner_epics must be a non-empty list")
+    if "proof_ids" in outcome and not isinstance(raw_proof_ids, list):
+        errors.append(f"{outcome_id}: proof_ids must be a list")
+    for epic_id in owner_epics:
+        if not EPIC_RE.fullmatch(epic_id):
+            errors.append(f"{outcome_id}: invalid owner EPIC id {epic_id!r}")
+        elif not _epic_exists(repo_root, epic_id):
+            errors.append(f"{outcome_id}: owner EPIC does not exist: {epic_id}")
+
+    if status == "covered" and not proof_ids:
+        errors.append(f"{outcome_id}: covered outcome requires at least one proof_id")
+    if status in {"partial", "gap"} and not ISSUE_RE.fullmatch(issue):
+        errors.append(f"{outcome_id}: {status} outcome requires issue like #521")
+    if issue and not ISSUE_RE.fullmatch(issue):
+        errors.append(f"{outcome_id}: invalid issue reference {issue!r}")
+
+    for proof_id in proof_ids:
+        proof = proof_by_id.get(proof_id)
+        if proof is None:
+            errors.append(f"{outcome_id}: unknown proof_id {proof_id}")
+            continue
+        if proof.errors:
+            errors.append(f"{outcome_id}: proof {proof_id} has validation errors")
+        if proof.scope != "behavioral" or not proof.file.startswith("tests/e2e/"):
+            errors.append(f"{outcome_id}: proof {proof_id} must be behavioral E2E")
+
+    return OutcomeResult(
+        outcome_id=outcome_id,
+        status=status,
+        owner_epics=owner_epics,
+        proof_ids=proof_ids,
+        issue=issue,
+        errors=errors,
+    )
+
+
+def _validate_readme_contract(repo_root: Path, outcomes: list[OutcomeResult]) -> OutcomeResult:
+    readme_path = repo_root / "README.md"
+    errors: list[str] = []
+    text = readme_path.read_text(encoding="utf-8") if readme_path.exists() else ""
+    if not text:
+        errors.append("README.md missing")
+    if "## Core Proof Paths" not in text:
+        errors.append("README.md missing `## Core Proof Paths` section")
+    if "docs/ssot/critical-proof-matrix.yaml" not in text:
+        errors.append("README.md missing critical proof matrix source link")
+    if "scripts/check_critical_proof_matrix.py" not in text:
+        errors.append("README.md missing critical proof matrix checker command")
+
+    for outcome in outcomes:
+        if outcome.outcome_id.startswith("__"):
+            continue
+        if outcome.outcome_id not in text:
+            errors.append(f"README.md missing macro outcome id `{outcome.outcome_id}`")
+
+    return OutcomeResult(
+        outcome_id="__readme_contract__",
+        status="contract",
+        owner_epics=[],
+        proof_ids=[],
+        issue="",
+        errors=errors,
+    )
+
+
+def validate_outcomes(
+    repo_root: Path,
+    matrix_payload: dict[str, Any],
+    proof_results: list[ProofResult],
+) -> list[OutcomeResult]:
+    raw_outcomes = matrix_payload.get("outcomes")
+    if not isinstance(raw_outcomes, list) or not raw_outcomes:
+        return [
+            OutcomeResult(
+                outcome_id="__macro_outcomes__",
+                status="fail",
+                owner_epics=[],
+                proof_ids=[],
+                issue="",
+                errors=["critical proof matrix must define a non-empty outcomes list"],
+            )
+        ]
+
+    proof_by_id = {proof.proof_id: proof for proof in proof_results}
+    outcomes: list[OutcomeResult] = []
+    for index, outcome in enumerate(raw_outcomes):
+        if not isinstance(outcome, dict):
+            outcomes.append(
+                OutcomeResult(
+                    outcome_id=f"__outcome_{index}__",
+                    status="fail",
+                    owner_epics=[],
+                    proof_ids=[],
+                    issue="",
+                    errors=[f"outcome[{index}] must be a mapping"],
+                )
+            )
+            continue
+        outcomes.append(
+            _validate_outcome(
+                outcome,
+                repo_root=repo_root,
+                proof_by_id=proof_by_id,
+                index=index,
+            )
+        )
+
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for outcome in outcomes:
+        if outcome.outcome_id.startswith("__"):
+            continue
+        if outcome.outcome_id in seen:
+            duplicates.add(outcome.outcome_id)
+        seen.add(outcome.outcome_id)
+
+    missing = sorted(REQUIRED_OUTCOME_IDS - seen)
+    unknown = sorted(seen - REQUIRED_OUTCOME_IDS)
+    global_errors: list[str] = []
+    if duplicates:
+        global_errors.append(f"macro outcomes duplicate ids: {', '.join(sorted(duplicates))}")
+    if missing:
+        global_errors.append(f"macro outcomes missing required ids: {', '.join(missing)}")
+    if unknown:
+        global_errors.append(f"macro outcomes include unknown ids: {', '.join(unknown)}")
+    if global_errors:
+        outcomes.append(
+            OutcomeResult(
+                outcome_id="__macro_outcomes__",
+                status="fail",
+                owner_epics=[],
+                proof_ids=[],
+                issue="",
+                errors=global_errors,
+            )
+        )
+
+    readme_contract = _validate_readme_contract(repo_root, outcomes)
+    if readme_contract.errors:
+        outcomes.append(readme_contract)
+    return outcomes
+
+
+def validate_matrix_contract(repo_root: Path, matrix_path: Path) -> MatrixValidation:
+    matrix_payload = _load_matrix(matrix_path)
+    proofs = validate_matrix(repo_root, matrix_path)
+    outcomes = validate_outcomes(repo_root, matrix_payload, proofs)
+    return MatrixValidation(proofs=proofs, outcomes=outcomes)
+
+
+def render_report(
+    results: list[ProofResult],
+    outcomes: list[OutcomeResult] | None = None,
+) -> str:
     counts = {scope: 0 for scope in sorted(VALID_SCOPES)}
     failed = 0
     for result in results:
@@ -284,7 +508,33 @@ def render_report(results: list[ProofResult]) -> str:
             f"{ac_cell} | {anchor} | {status} |"
         )
 
-    errors = [error for result in results for error in result.errors]
+    if outcomes is not None:
+        lines.extend(
+            [
+                "",
+                "## Macro Outcomes",
+                "",
+                "| Outcome | Status | Owner EPICs | Proof IDs | Issue | Validation |",
+                "|---|---|---|---|---|---|",
+            ]
+        )
+        for outcome in outcomes:
+            if outcome.outcome_id.startswith("__") and not outcome.errors:
+                continue
+            owners = ", ".join(f"`{epic}`" for epic in outcome.owner_epics) or "-"
+            proofs = ", ".join(f"`{proof_id}`" for proof_id in outcome.proof_ids) or "-"
+            issue = outcome.issue or "-"
+            validation = "fail" if outcome.errors else "ok"
+            lines.append(
+                f"| `{outcome.outcome_id}` | {outcome.status} | {owners} | "
+                f"{proofs} | {issue} | {validation} |"
+            )
+
+    errors = [
+        error
+        for result in [*results, *(outcomes or [])]
+        for error in result.errors
+    ]
     lines.extend(["", "## Errors", ""])
     if errors:
         lines.extend(f"- {error}" for error in errors)
@@ -305,8 +555,8 @@ def main() -> int:
     args = parse_args()
     repo_root = args.repo_root.resolve()
     matrix_path = args.matrix if args.matrix.is_absolute() else repo_root / args.matrix
-    results = validate_matrix(repo_root, matrix_path)
-    report = render_report(results)
+    validation = validate_matrix_contract(repo_root, matrix_path)
+    report = render_report(validation.proofs, validation.outcomes)
 
     output_path = args.output
     if output_path is not None:
@@ -317,12 +567,17 @@ def main() -> int:
     else:
         print(report)
 
-    errors = [error for result in results for error in result.errors]
+    errors = validation.errors
     if errors:
         for error in errors:
             print(f"::error title=Critical proof matrix::{error}", file=sys.stderr)
         return 1
-    print(f"Critical proof matrix passed: {len(results)} proof path(s) validated.")
+    print(
+        "Critical proof matrix passed: "
+        f"{len(validation.proofs)} proof path(s), "
+        f"{len([outcome for outcome in validation.outcomes if not outcome.outcome_id.startswith('__')])} "
+        "macro outcome(s) validated."
+    )
     return 0
 
 

--- a/scripts/tests/test_check_critical_proof_matrix.py
+++ b/scripts/tests/test_check_critical_proof_matrix.py
@@ -15,6 +15,30 @@ import check_critical_proof_matrix as matrix  # noqa: E402
 def _write_registry(repo_root: Path) -> None:
     docs = repo_root / "docs"
     docs.mkdir(parents=True, exist_ok=True)
+    project = docs / "project"
+    project.mkdir(parents=True, exist_ok=True)
+    (project / "EPIC-008.testing-strategy.md").write_text(
+        "# EPIC-008: Testing Strategy\n",
+        encoding="utf-8",
+    )
+    (repo_root / "README.md").write_text(
+        """
+# Test README
+
+## Core Proof Paths
+
+Source: docs/ssot/critical-proof-matrix.yaml
+Checker: scripts/check_critical_proof_matrix.py
+
+- asset-distribution-net-worth
+- monthly-income-spending
+- investment-performance
+- annualized-income-long-term
+- source-ledger-report-traceability
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
     (docs / "ac_registry.yaml").write_text(
         """
 version: '1.0'
@@ -36,6 +60,11 @@ groups:
         epic_name: testing-strategy
         description: critical proof matrix validates core paths
         mandatory: true
+      - id: AC8.13.50
+        epic: 8
+        epic_name: testing-strategy
+        description: critical proof matrix validates macro outcomes
+        mandatory: true
 """.strip()
         + "\n",
         encoding="utf-8",
@@ -49,7 +78,33 @@ groups:
 def _write_matrix(repo_root: Path, content: str) -> Path:
     matrix_path = repo_root / "docs" / "ssot" / "critical-proof-matrix.yaml"
     matrix_path.parent.mkdir(parents=True, exist_ok=True)
-    matrix_path.write_text(content.strip() + "\n", encoding="utf-8")
+    rendered = content.strip()
+    if "\noutcomes:" not in f"\n{rendered}":
+        rendered += """
+
+outcomes:
+  - id: asset-distribution-net-worth
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+  - id: monthly-income-spending
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+  - id: investment-performance
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+  - id: annualized-income-long-term
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+  - id: source-ledger-report-traceability
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+"""
+    matrix_path.write_text(rendered + "\n", encoding="utf-8")
     return matrix_path
 
 
@@ -334,6 +389,155 @@ proofs: []
         matrix.validate_matrix(tmp_path, empty_matrix)
 
 
+def test_AC8_13_50_macro_outcome_contract_requires_closed_set_and_e2e_proofs(
+    tmp_path: Path,
+) -> None:
+    """AC8.13.50: Macro outcomes are closed and covered outcomes must point to E2E proofs."""
+    _write_registry(tmp_path)
+    test_dir = tmp_path / "tests" / "e2e"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_core.py").write_text(
+        """
+import pytest
+
+@pytest.mark.e2e
+@pytest.mark.critical
+async def test_core_flow():
+    \"\"\"AC8.13.1: macro path proof.\"\"\"
+    assert True
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    matrix_path = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+proofs:
+  - id: core-flow
+    scope: behavioral
+    ci_tier: post_merge_environment
+    file: tests/e2e/test_core.py
+    test: test_core_flow
+    required_markers: [e2e, critical]
+    ac_ids: [AC8.13.1]
+
+outcomes:
+  - id: asset-distribution-net-worth
+    status: covered
+    owner_epics: [EPIC-008]
+    proof_ids: [core-flow]
+  - id: monthly-income-spending
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+  - id: investment-performance
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+  - id: annualized-income-long-term
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+  - id: source-ledger-report-traceability
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+""",
+    )
+
+    validation = matrix.validate_matrix_contract(tmp_path, matrix_path)
+    assert [outcome.outcome_id for outcome in validation.outcomes] == [
+        "asset-distribution-net-worth",
+        "monthly-income-spending",
+        "investment-performance",
+        "annualized-income-long-term",
+        "source-ledger-report-traceability",
+    ]
+    assert not validation.errors
+
+
+def test_AC8_13_50_macro_outcome_contract_rejects_drift(
+    tmp_path: Path,
+) -> None:
+    """AC8.13.50: Covered macro outcomes cannot drift from README, EPICs, or E2E anchors."""
+    _write_registry(tmp_path)
+    (tmp_path / "README.md").write_text(
+        """
+# Test README
+
+## Core Proof Paths
+
+Source: docs/ssot/critical-proof-matrix.yaml
+Checker: scripts/check_critical_proof_matrix.py
+
+- asset-distribution-net-worth
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    script_dir = tmp_path / "scripts" / "tests"
+    script_dir.mkdir(parents=True)
+    (script_dir / "test_contract.py").write_text(
+        """
+def test_contract():
+    \"\"\"AC8.13.1: not an E2E macro proof.\"\"\"
+    assert True
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    matrix_path = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+proofs:
+  - id: contract-proof
+    scope: static_contract
+    ci_tier: pr_ci
+    file: scripts/tests/test_contract.py
+    test: test_contract
+    ac_ids: [AC8.13.1]
+
+outcomes:
+  - id: asset-distribution-net-worth
+    status: covered
+    owner_epics: [EPIC-999]
+    proof_ids: [contract-proof]
+  - id: monthly-income-spending
+    status: covered
+    owner_epics: [EPIC-008]
+  - id: investment-performance
+    status: gap
+    owner_epics: [EPIC-008]
+  - id: annualized-income-long-term
+    status: unknown
+    owner_epics: [EPIC-008]
+    issue: "521"
+  - id: source-ledger-report-traceability
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+  - id: surprise-outcome
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#521"
+  - not-a-mapping
+""",
+    )
+
+    validation = matrix.validate_matrix_contract(tmp_path, matrix_path)
+    errors = validation.errors
+    assert "macro outcomes include unknown ids: surprise-outcome" in errors
+    assert any("owner EPIC does not exist: EPIC-999" in error for error in errors)
+    assert any("covered outcome requires at least one proof_id" in error for error in errors)
+    assert any("proof contract-proof must be behavioral E2E" in error for error in errors)
+    assert any("gap outcome requires issue like #521" in error for error in errors)
+    assert any("invalid status 'unknown'" in error for error in errors)
+    assert any("outcome[6] must be a mapping" in error for error in errors)
+    assert any("README.md missing macro outcome id `monthly-income-spending`" in error for error in errors)
+
+
 def test_stub_path_unknown_suffix_and_external_relative_helpers(tmp_path: Path) -> None:
     """AC8.13.41: Critical proof cannot be delegated to stubs or unknown anchors."""
     _write_registry(tmp_path)
@@ -410,7 +614,7 @@ proofs:
     assert matrix.main() == 0
     stdout = capsys.readouterr().out
     assert "Wrote critical proof matrix report" in stdout
-    assert "Critical proof matrix passed: 1 proof path(s) validated." in stdout
+    assert "Critical proof matrix passed: 1 proof path(s), 5 macro outcome(s) validated." in stdout
     assert "| `core-flow` | behavioral | pr_ci |" in output_path.read_text(encoding="utf-8")
 
     failure_matrix = _write_matrix(


### PR DESCRIPTION
## Summary

Adds a parseable README -> EPIC -> E2E macro proof contract for core product outcomes, while keeping EPIC -> AC -> test as the separate micro traceability layer.

Refs #521. Related: #444.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.48 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/MANIFEST.yaml` — updates `critical_proof_matrix` as the README -> EPIC -> E2E macro outcome guard
- [x] `docs/ssot/critical-proof-matrix.yaml` — adds the closed macro outcome set with owner EPICs, proof IDs, statuses, and issue references
- [x] `docs/ssot/README.md` — documents the macro proof layer separately from AC traceability
- [x] `docs/ssot/ci-cd.md` — clarifies the CI role of the critical proof matrix
- [x] `docs/ssot/tdd.md` — documents macro vs micro proof semantics

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | `748b6de` | Adds AC8.13.48 tests; `pytest scripts/tests/test_check_critical_proof_matrix.py -q` fails with 3 failures before implementation |
| Green | `328aaf8` | Implements macro outcome validation and documentation; targeted checks pass |

---

## Engineering Audit

- [x] MECE framing: macro README -> EPIC -> E2E and micro EPIC -> AC -> test are separate contracts
- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter: N/A, no SQLAlchemy model changes
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV`: N/A, no frontend env changes
- [x] `repo/` submodule updated for production config changes: N/A, no config changes; verified `repo/` HEAD matches `origin/main`
- [x] `scripts/check_manifest.py` passes via targeted manifest/SSOT tests
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
pytest scripts/tests/test_check_critical_proof_matrix.py scripts/tests/test_check_manifest.py scripts/tests/test_check_ssot_ownership.py -q
python scripts/check_critical_proof_matrix.py
python scripts/check_ac_traceability.py
python scripts/generate_ac_registry.py --check
python scripts/lint_doc_consistency.py
python scripts/check_ssot_ownership.py
python scripts/audit_ac_epic_mismatches.py > /tmp/ac-epic-mismatch-current.md && diff -u docs/analysis/ac-epic-mismatch-report.md /tmp/ac-epic-mismatch-current.md
git diff --check
moon run :lint
```

`moon run :test` could not run locally because this machine has no Podman machine/socket configured; backend test lifecycle cannot start the database.

---

## Screenshots / Evidence

N/A — documentation/checker/test-only change.