### PR TITLE
[codex] Raise frontend line coverage to 99%

### DIFF
--- a/apps/frontend/src/__tests__/StatementUploader.test.tsx
+++ b/apps/frontend/src/__tests__/StatementUploader.test.tsx
@@ -203,7 +203,24 @@ describe("AC3.5.3 StatementUploader model selection", () => {
       fallback_models: [],
       models: baseModels,
     });
-    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('Quota exceeded') });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: () => {
+        throw new Error("Quota exceeded");
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+      key: (index: number) => Array.from(store.keys())[index] ?? null,
+      get length() {
+        return store.size;
+      },
+    });
     render(<StatementUploader />);
     const select = await screen.findByLabelText(/ai model/i);
     // Wait for models to load (select starts disabled until fetchAiModels resolves)
@@ -211,8 +228,72 @@ describe("AC3.5.3 StatementUploader model selection", () => {
       expect(select).not.toBeDisabled();
     });
     await userEvent.selectOptions(select, "qwen/qwen-2.5-vl-7b-instruct:free");
-    spy.mockRestore();
-    // This should trigger the warning toast (but we didn't mock showToast properly here to check it easily, 80%+ should still be fine)
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Storage] Failed to write statement_model_v1:",
+      expect.any(Error),
+    );
+    vi.unstubAllGlobals();
+    warnSpy.mockRestore();
+  });
+
+  it("test_AC8_13_48 falls back to the default model when storage reads fail", async () => {
+    vi.mocked(fetchAiModels).mockResolvedValue({
+      default_model: "google/gemini-3-flash-preview",
+      fallback_models: [],
+      models: baseModels,
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("storage blocked");
+      },
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      key: vi.fn(),
+      length: 0,
+    });
+
+    render(<StatementUploader />);
+
+    const select = await screen.findByLabelText(/ai model/i);
+    await waitFor(() => {
+      expect(select).toHaveValue("google/gemini-3-flash-preview");
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Storage] Failed to read statement_model_v1:",
+      expect.any(Error),
+    );
+
+    vi.unstubAllGlobals();
+    warnSpy.mockRestore();
+  });
+
+  it("test_AC8_13_48 removes invalid stored model ids and tolerates removal failures", async () => {
+    vi.mocked(fetchAiModels).mockResolvedValue({
+      default_model: "google/gemini-3-flash-preview",
+      fallback_models: [],
+      models: baseModels,
+    });
+    localStorage.setItem("statement_model_v1", "obsolete-model");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const removeSpy = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("remove blocked");
+    });
+
+    render(<StatementUploader />);
+
+    const select = await screen.findByLabelText(/ai model/i);
+    await waitFor(() => {
+      expect(select).toHaveValue("google/gemini-3-flash-preview");
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Storage] Failed to remove statement_model_v1:",
+      expect.any(Error),
+    );
+
+    removeSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it("handles drag events", async () => {

--- a/apps/frontend/src/__tests__/accountsPage.test.tsx
+++ b/apps/frontend/src/__tests__/accountsPage.test.tsx
@@ -231,4 +231,41 @@ describe("AccountsPage", () => {
     await waitFor(() => expect(screen.queryByText("Edit:Cash")).toBeNull())
     expect(screen.queryByText("Create Account Modal")).toBeNull()
   })
+
+  it("test_AC8_13_48 opens and closes the account details sidebar", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path.startsWith("/api/accounts")) {
+        return Promise.resolve({
+          items: [
+            {
+              id: "a1",
+              name: "Cash",
+              type: "ASSET",
+              currency: "SGD",
+              is_active: true,
+              balance: 1000,
+              code: "1000",
+              description: "Operating cash",
+            },
+          ],
+          total: 1,
+        } satisfies AccountListResponse)
+      }
+      if (path === "/api/journal-entries?limit=50") {
+        return Promise.resolve({ items: [], total: 0 })
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    render(<AccountsPage />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByText("Cash")).toBeInTheDocument())
+    fireEvent.click(screen.getByText("Cash"))
+
+    expect(await screen.findByRole("dialog", { name: "Account Details" })).toBeInTheDocument()
+    expect(screen.getAllByText("Operating cash").length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByRole("button", { name: "Close panel" }))
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Account Details" })).not.toBeInTheDocument())
+  })
 })

--- a/apps/frontend/src/__tests__/apiFunctions.test.ts
+++ b/apps/frontend/src/__tests__/apiFunctions.test.ts
@@ -113,6 +113,37 @@ describe('apiFetch', () => {
     const calledHeaders = fetchMock.mock.calls[0][1].headers as Record<string, string>;
     expect(calledHeaders['Authorization']).toBe('Bearer test-jwt-token');
   });
+
+  it('test_AC8_13_48 uses raw text when apiFetch error JSON is not an object', async () => {
+    const fetchMock = makeFetchMock(422, 'false');
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { apiFetch } = await import('../lib/api');
+    await expect(apiFetch('/api/test')).rejects.toThrow('false');
+  });
+
+  it('test_AC8_13_48 reports redirect assignment failures', async () => {
+    const fetchMock = makeFetchMock(401, {});
+    vi.stubGlobal('fetch', fetchMock);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal('window', {
+      location: {
+        get href() {
+          return '';
+        },
+        set href(_: string) {
+          throw new Error('navigation blocked');
+        },
+      },
+    });
+
+    const { apiFetch, resetRedirectGuard } = await import('../lib/api');
+    resetRedirectGuard();
+
+    await expect(apiFetch('/api/statements')).rejects.toThrow('Authentication required - redirect failed');
+    expect(consoleSpy).toHaveBeenCalledWith('[api] Failed to redirect to login:', expect.any(Error));
+    consoleSpy.mockRestore();
+  });
 });
 
 describe('resetRedirectGuard', () => {
@@ -175,6 +206,19 @@ describe('apiDelete', () => {
     await expect(apiDelete('/api/delete-unauth')).rejects.toThrow('Authentication required');
     expect(window.location.href).toBe('/login');
   });
+
+  it('test_AC8_13_48 includes Authorization header when deleting with a token', async () => {
+    localStorageMock.setItem('finance_access_token', 'delete-token');
+    const fetchMock = makeFetchMock(200, '');
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { apiDelete } = await import('../lib/api');
+    await apiDelete('api/resource/1');
+
+    const calledHeaders = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(fetchMock.mock.calls[0][0]).toMatch(/\/api\/resource\/1/);
+    expect(calledHeaders['Authorization']).toBe('Bearer delete-token');
+  });
 });
 
 
@@ -213,6 +257,34 @@ describe('apiStream', () => {
 
     const { apiStream } = await import('../lib/api');
     await expect(apiStream('/api/stream')).rejects.toThrow('Service Unavailable');
+  });
+
+  it('test_AC8_13_48 includes Authorization header on streams', async () => {
+    localStorageMock.setItem('finance_access_token', 'stream-token');
+    const fetchMock = makeFetchMock(200, {}, { 'X-Session-Id': 'sess-auth' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { apiStream } = await import('../lib/api');
+    const result = await apiStream('api/stream-auth');
+
+    const calledHeaders = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(result.sessionId).toBe('sess-auth');
+    expect(fetchMock.mock.calls[0][0]).toMatch(/\/api\/stream-auth/);
+    expect(calledHeaders['Authorization']).toBe('Bearer stream-token');
+  });
+
+  it('test_AC8_13_48 handles non-object and invalid JSON stream errors', async () => {
+    const { apiStream } = await import('../lib/api');
+
+    vi.stubGlobal('fetch', makeFetchMock(429, 'false'));
+    await expect(apiStream('/api/stream')).rejects.toThrow('false');
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('{bad json'),
+    }));
+    await expect(apiStream('/api/stream')).rejects.toThrow('{bad json');
   });
 });
 
@@ -299,5 +371,14 @@ describe('apiUpload', () => {
     const { apiUpload } = await import('../lib/api');
     const fd = new FormData();
     await expect(apiUpload('/api/upload', fd)).rejects.toThrow('Server Crash');
+  });
+
+  it('test_AC8_13_48 uses raw text when apiUpload error JSON is not an object', async () => {
+    const fetchMock = makeFetchMock(413, 'false');
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { apiUpload } = await import('../lib/api');
+    const fd = new FormData();
+    await expect(apiUpload('/api/upload', fd)).rejects.toThrow('false');
   });
 });

--- a/apps/frontend/src/__tests__/assetsPage.test.tsx
+++ b/apps/frontend/src/__tests__/assetsPage.test.tsx
@@ -417,7 +417,8 @@ describe("AssetsPage", () => {
     fireEvent.change(screen.getByLabelText("As of date"), { target: { value: "2026-05-18" } })
     fireEvent.change(screen.getByLabelText("Value"), { target: { value: "1250000.00" } })
     fireEvent.change(screen.getByLabelText("Currency"), { target: { value: "SGD" } })
-    fireEvent.change(screen.getByLabelText("Source"), { target: { value: "manual" } })
+    fireEvent.change(screen.getByLabelText("Source"), { target: { value: "broker portal" } })
+    fireEvent.change(screen.getByLabelText("Notes"), { target: { value: "Audited manually" } })
     fireEvent.click(screen.getByRole("button", { name: "Add valuation" }))
 
     await waitFor(() => {
@@ -427,5 +428,30 @@ describe("AssetsPage", () => {
       )
     })
     expect(showToastMock).toHaveBeenCalledWith("Manual valuation saved", "success")
+  })
+
+  it("test_AC8_13_48 shows an error toast when manual valuation creation fails", async () => {
+    mockedApiFetch.mockImplementation((path: string, options?: RequestInit) => {
+      if (path === "/api/assets/valuation-snapshots" && options?.method === "POST") {
+        return Promise.reject(new Error("valuation failed"))
+      }
+      if (path.startsWith("/api/assets/valuation-snapshots")) {
+        return Promise.resolve(emptyValuations)
+      }
+      return Promise.resolve({ items: [], total: 0 } satisfies ManagedPositionListResponse)
+    })
+
+    render(<AssetsPage />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByText("Manual Valuations")).toBeInTheDocument())
+    fireEvent.change(screen.getByLabelText("Value"), { target: { value: "1250000.00" } })
+    fireEvent.change(screen.getByLabelText("Currency"), { target: { value: "usd" } })
+    fireEvent.change(screen.getByLabelText("Source"), { target: { value: "broker portal" } })
+    fireEvent.change(screen.getByLabelText("Notes"), { target: { value: "Needs follow-up" } })
+    fireEvent.click(screen.getByRole("button", { name: "Add valuation" }))
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith("Failed to save valuation: valuation failed", "error")
+    })
   })
 })

--- a/apps/frontend/src/__tests__/balanceSheetPage.test.tsx
+++ b/apps/frontend/src/__tests__/balanceSheetPage.test.tsx
@@ -35,27 +35,34 @@ describe("BalanceSheetPage", () => {
     expect(mockedApiFetch).toHaveBeenCalled()
   })
 
-  it("AC16.14.2 renders totals and sections on success", async () => {
+  it("AC16.14.2 / test_AC8_13_48 renders string totals and refetches by date", async () => {
     mockedApiFetch.mockResolvedValue({
       as_of_date: "2026-02-01",
       currency: "SGD",
-      assets: [{ account_id: "a-root", name: "Cash", type: "ASSET", parent_id: null, amount: 1000 }],
-      liabilities: [{ account_id: "l-root", name: "Loan", type: "LIABILITY", parent_id: null, amount: 200 }],
-      equity: [{ account_id: "e-root", name: "Capital", type: "EQUITY", parent_id: null, amount: 800 }],
-      total_assets: 1000,
-      total_liabilities: 200,
-      total_equity: 800,
-      equation_delta: 0,
+      assets: [{ account_id: "a-root", name: "Cash", type: "ASSET", parent_id: null, amount: "1000" }],
+      liabilities: [{ account_id: "l-root", name: "Loan", type: "LIABILITY", parent_id: null, amount: "200" }],
+      equity: [{ account_id: "e-root", name: "Capital", type: "EQUITY", parent_id: null, amount: "800" }],
+      total_assets: "1000",
+      total_liabilities: "200",
+      total_equity: "800",
+      equation_delta: "0",
       is_balanced: true,
     })
 
-    render(<BalanceSheetPage />)
+    const { container } = render(<BalanceSheetPage />)
 
     await waitFor(() => expect(screen.getByText("Balance Sheet")).toBeInTheDocument())
     expect(screen.getByRole("heading", { name: "Assets", level: 2 })).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Liabilities", level: 2 })).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Equity", level: 2 })).toBeInTheDocument()
     expect(screen.getAllByText(/Total:/)).toHaveLength(3)
+
+    const dateInput = container.querySelector('input[type="date"]')
+    expect(dateInput).not.toBeNull()
+    fireEvent.change(dateInput!, { target: { value: "2026-03-01" } })
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenLastCalledWith(expect.stringContaining("as_of_date=2026-03-01")),
+    )
   })
 
   it("AC16.14.3 toggles tree expansion controls", async () => {

--- a/apps/frontend/src/__tests__/cashFlowPage.test.tsx
+++ b/apps/frontend/src/__tests__/cashFlowPage.test.tsx
@@ -38,21 +38,21 @@ describe("CashFlowPage", () => {
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument()
   })
 
-  it("AC16.14.8 renders summary and activity sections", async () => {
+  it("AC16.14.8 / test_AC8_13_48 renders string summary and activity sections", async () => {
     mockedApiFetch.mockResolvedValue({
       start_date: "2026-01-01",
       end_date: "2026-02-01",
       currency: "SGD",
-      operating: [{ category: "operating", subcategory: "Sales", amount: 1000, description: "Main ops" }],
-      investing: [{ category: "investing", subcategory: "ETF", amount: -300, description: null }],
-      financing: [{ category: "financing", subcategory: "Loan", amount: 200, description: null }],
+      operating: [{ category: "operating", subcategory: "Sales", amount: "1000", description: "Main ops" }],
+      investing: [{ category: "investing", subcategory: "ETF", amount: "-300", description: null }],
+      financing: [{ category: "financing", subcategory: "Loan", amount: "200", description: null }],
       summary: {
-        operating_activities: 1000,
-        investing_activities: -300,
-        financing_activities: 200,
-        net_cash_flow: 900,
-        beginning_cash: 5000,
-        ending_cash: 5900,
+        operating_activities: "1000",
+        investing_activities: "-300",
+        financing_activities: "200",
+        net_cash_flow: "900",
+        beginning_cash: "5000",
+        ending_cash: "5900",
       },
     })
 
@@ -107,7 +107,7 @@ describe("CashFlowPage", () => {
     await waitFor(() => expect(screen.getByText("SankeyChartMock")).toBeInTheDocument())
   })
 
-  it("AC16.14.10 refetches when filters change and shows empty category states", async () => {
+  it("AC16.14.10 / test_AC8_13_48 refetches when filters and dates change", async () => {
     mockedApiFetch.mockResolvedValue({
       start_date: "2026-01-01",
       end_date: "2026-02-01",
@@ -129,8 +129,6 @@ describe("CashFlowPage", () => {
 
     await waitFor(() => expect(screen.getByText("Cash Flow Statement")).toBeInTheDocument())
 
-    const dateInputs = container.querySelectorAll('input[type="date"]')
-    expect(dateInputs).toHaveLength(2)
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "USD" } })
 
     await waitFor(() =>
@@ -138,6 +136,22 @@ describe("CashFlowPage", () => {
         expect.stringContaining("currency=USD")
       )
     )
+    await waitFor(() => expect(screen.getByText("Cash Flow Statement")).toBeInTheDocument())
+
+    const dateInputs = container.querySelectorAll('input[type="date"]')
+    expect(dateInputs).toHaveLength(2)
+    fireEvent.change(dateInputs[0], { target: { value: "2026-01-15" } })
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenLastCalledWith(expect.stringContaining("start_date=2026-01-15")),
+    )
+    await waitFor(() => expect(screen.getByText("Cash Flow Statement")).toBeInTheDocument())
+    fireEvent.change(container.querySelectorAll('input[type="date"]')[1], { target: { value: "2026-02-15" } })
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenLastCalledWith(expect.stringContaining("end_date=2026-02-15")),
+    )
+    const lastCall = String(mockedApiFetch.mock.calls.at(-1)?.[0])
+    expect(lastCall).toContain("start_date=2026-01-15")
+    expect(lastCall).toContain("end_date=2026-02-15")
     expect(screen.getAllByText("No items in this category.")).toHaveLength(3)
   })
 })

--- a/apps/frontend/src/__tests__/incomeStatementPage.test.tsx
+++ b/apps/frontend/src/__tests__/incomeStatementPage.test.tsx
@@ -39,17 +39,17 @@ describe("IncomeStatementPage", () => {
     expect(mockedApiFetch).toHaveBeenCalled()
   })
 
-  it("AC16.14.5 renders KPI cards and category lists", async () => {
+  it("AC16.14.5 / test_AC8_13_48 renders string KPI cards and category lists", async () => {
     mockedApiFetch.mockResolvedValue({
       start_date: "2026-01-01",
       end_date: "2026-02-01",
       currency: "SGD",
-      income: [{ account_id: "i1", name: "Salary", type: "INCOME", amount: 5000 }],
-      expenses: [{ account_id: "e1", name: "Rent", type: "EXPENSE", amount: 1200 }],
-      total_income: 5000,
-      total_expenses: 1200,
-      net_income: 3800,
-      trends: [{ period_start: "2026-01-01", period_end: "2026-01-31", total_income: 5000, total_expenses: 1200, net_income: 3800 }],
+      income: [{ account_id: "i1", name: "Salary", type: "INCOME", amount: "5000" }],
+      expenses: [{ account_id: "e1", name: "Rent", type: "EXPENSE", amount: "1200" }],
+      total_income: "5000",
+      total_expenses: "1200",
+      net_income: "3800",
+      trends: [{ period_start: "2026-01-01", period_end: "2026-01-31", total_income: "5000", total_expenses: "1200", net_income: "3800" }],
       filters_applied: { tags: null, account_type: null },
     })
 
@@ -132,7 +132,7 @@ describe("IncomeStatementPage", () => {
     expect(screen.getByText("No expense categories.")).toBeInTheDocument()
   })
 
-  it("AC16.14.11 refetches when account type and tags change", async () => {
+  it("AC16.14.11 / test_AC8_13_48 refetches when account type, tags, and dates change", async () => {
     mockedApiFetch.mockResolvedValue({
       start_date: "2026-01-01",
       end_date: "2026-02-01",
@@ -146,7 +146,7 @@ describe("IncomeStatementPage", () => {
       filters_applied: { tags: null, account_type: null },
     })
 
-    render(<IncomeStatementPage />)
+    const { container } = render(<IncomeStatementPage />)
 
     await waitFor(() => expect(screen.getByText("Income Statement")).toBeInTheDocument())
     const selects = screen.getAllByRole("combobox")
@@ -156,6 +156,24 @@ describe("IncomeStatementPage", () => {
       const lastCall = mockedApiFetch.mock.calls.at(-1)?.[0]
       expect(lastCall).toContain("/api/reports/income-statement?")
       expect(lastCall).toContain("account_type=INCOME")
+    })
+    await waitFor(() => expect(screen.getByText("Income Statement")).toBeInTheDocument())
+
+    const dateInputs = container.querySelectorAll('input[type="date"]')
+    fireEvent.change(dateInputs[0], { target: { value: "2026-01-15" } })
+    await waitFor(() => {
+      const lastCall = mockedApiFetch.mock.calls.at(-1)?.[0]
+      expect(lastCall).toContain("start_date=2026-01-15")
+    })
+    await waitFor(() => expect(screen.getByText("Income Statement")).toBeInTheDocument())
+    fireEvent.change(container.querySelectorAll('input[type="date"]')[1], { target: { value: "2026-02-15" } })
+
+    await waitFor(() => {
+      const lastCall = mockedApiFetch.mock.calls.at(-1)?.[0]
+      expect(lastCall).toContain("/api/reports/income-statement?")
+      expect(lastCall).toContain("account_type=INCOME")
+      expect(lastCall).toContain("start_date=2026-01-15")
+      expect(lastCall).toContain("end_date=2026-02-15")
     })
   })
 })

--- a/apps/frontend/src/__tests__/journalPage.test.tsx
+++ b/apps/frontend/src/__tests__/journalPage.test.tsx
@@ -137,4 +137,121 @@ describe("JournalPage", () => {
       }),
     )
   })
+
+  it("test_AC8_13_48 opens the entry form from header and empty state actions", async () => {
+    mockedApiFetch.mockResolvedValue({ items: [] })
+
+    render(<JournalPage />)
+
+    await waitFor(() => expect(screen.getByText("No journal entries yet")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "New Entry" }))
+    fireEvent.click(screen.getByRole("button", { name: "Mock Submit Entry" }))
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledTimes(2))
+
+    fireEvent.click(screen.getByRole("button", { name: "Create First Entry" }))
+    expect(screen.getByRole("button", { name: "Mock Submit Entry" })).toBeInTheDocument()
+  })
+
+  it("test_AC8_13_48 surfaces post failures without closing the page", async () => {
+    const entriesResponse = {
+      items: [
+        {
+          id: "d-error",
+          memo: "Draft Error",
+          entry_date: "2026-01-01",
+          status: "draft",
+          source_type: "manual",
+          lines: [
+            { id: "l1", account_id: "a1", direction: "DEBIT", amount: 200, description: "d" },
+            { id: "l2", account_id: "a2", direction: "CREDIT", amount: 200, description: "c" },
+          ],
+        },
+      ],
+    }
+
+    mockedApiFetch.mockResolvedValueOnce(entriesResponse).mockRejectedValueOnce(new Error("post denied"))
+
+    render(<JournalPage />)
+
+    await waitFor(() => expect(screen.getByText("Draft Error")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Post" }))
+    await waitFor(() => expect(screen.getAllByText("post denied").length).toBeGreaterThan(0))
+  })
+
+  it("test_AC8_13_48 surfaces delete failures from the confirmation dialog", async () => {
+    const entriesResponse = {
+      items: [
+        {
+          id: "d-error",
+          memo: "Draft Error",
+          entry_date: "2026-01-01",
+          status: "draft",
+          source_type: "manual",
+          lines: [
+            { id: "l1", account_id: "a1", direction: "DEBIT", amount: 200, description: "d" },
+            { id: "l2", account_id: "a2", direction: "CREDIT", amount: 200, description: "c" },
+          ],
+        },
+      ],
+    }
+
+    mockedApiFetch.mockResolvedValueOnce(entriesResponse).mockRejectedValueOnce(new Error("delete denied"))
+
+    render(<JournalPage />)
+
+    await waitFor(() => expect(screen.getByText("Draft Error")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }))
+    fireEvent.click(screen.getByRole("button", { name: "Delete Entry" }))
+    await waitFor(() => expect(screen.getAllByText("delete denied").length).toBeGreaterThan(0))
+  })
+
+  it("test_AC8_13_48 covers delete and void dialog cancel plus void failure", async () => {
+    const entriesResponse = {
+      items: [
+        {
+          id: "d-cancel",
+          memo: "Draft Cancel",
+          entry_date: "2026-01-01",
+          status: "draft",
+          source_type: "manual",
+          lines: [
+            { id: "l1", account_id: "a1", direction: "DEBIT", amount: 100, description: "d" },
+            { id: "l2", account_id: "a2", direction: "CREDIT", amount: 100, description: "c" },
+          ],
+        },
+        {
+          id: "p-error",
+          memo: "Posted Error",
+          entry_date: "2026-01-02",
+          status: "posted",
+          source_type: "manual",
+          lines: [
+            { id: "l3", account_id: "a1", direction: "DEBIT", amount: 300, description: "d" },
+            { id: "l4", account_id: "a2", direction: "CREDIT", amount: 300, description: "c" },
+          ],
+        },
+      ],
+    }
+
+    mockedApiFetch.mockResolvedValueOnce(entriesResponse).mockRejectedValueOnce(new Error("void denied"))
+
+    render(<JournalPage />)
+
+    await waitFor(() => expect(screen.getByText("Draft Cancel")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }))
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Delete Entry" })).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Void" }))
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Void Entry" })).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Void" }))
+    fireEvent.click(screen.getByRole("button", { name: "Void Entry" }))
+    await waitFor(() => expect(screen.getAllByText("void denied").length).toBeGreaterThan(0))
+  })
 })

--- a/apps/frontend/src/__tests__/reconciliationWorkbenchComponent.test.tsx
+++ b/apps/frontend/src/__tests__/reconciliationWorkbenchComponent.test.tsx
@@ -29,6 +29,25 @@ describe("ReconciliationWorkbench", () => {
     mockedApiFetch.mockReset()
   })
 
+  const statsResponse = {
+    total_transactions: 5,
+    matched_transactions: 2,
+    unmatched_transactions: 3,
+    pending_review: 2,
+    auto_accepted: 1,
+    match_rate: 40,
+    score_distribution: { high: 1, medium: 2, low: 2 },
+  }
+
+  const matchResponse = {
+    id: "m1",
+    match_score: 85,
+    status: "pending_review",
+    transaction: { id: "t1", description: "Rent", txn_date: "2026-01-02", direction: "OUT", amount: 800 },
+    entries: [{ id: "e1", memo: "Rent", entry_date: "2026-01-02", total_amount: 800 }],
+    score_breakdown: { amount: 50, date: 20, description: 15 },
+  }
+
   it("AC16.20.1 loads stats and pending queue with default selection", async () => {
     mockedApiFetch.mockImplementation((path: string) => {
       const url = String(path)
@@ -162,6 +181,105 @@ describe("ReconciliationWorkbench", () => {
       return h.endsWith("%") && h !== "0%"
     })
     expect(nonZeroBars.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("test_AC8_13_48 surfaces query failures for stats and pending matches", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      const url = String(path)
+      if (url.includes("/api/reconciliation/stats")) {
+        return Promise.reject(new Error("stats down"))
+      }
+      if (url.includes("/api/reconciliation/pending")) {
+        return Promise.resolve({ items: [] })
+      }
+      return Promise.resolve({})
+    })
+
+    render(<ReconciliationWorkbench />, { wrapper: createWrapper() })
+
+    expect(await screen.findByText("Failed to load reconciliation stats: stats down")).toBeInTheDocument()
+
+    mockedApiFetch.mockReset()
+    mockedApiFetch.mockImplementation((path: string) => {
+      const url = String(path)
+      if (url.includes("/api/reconciliation/stats")) {
+        return Promise.resolve(statsResponse)
+      }
+      if (url.includes("/api/reconciliation/pending")) {
+        return Promise.reject(new Error("pending down"))
+      }
+      return Promise.resolve({})
+    })
+
+    render(<ReconciliationWorkbench />, { wrapper: createWrapper() })
+
+    expect(await screen.findByText("Failed to load pending matches: pending down")).toBeInTheDocument()
+  })
+
+  it("test_AC8_13_48 reports mutation failures without dropping the review queue", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      const url = String(path)
+      if (url.includes("/api/reconciliation/stats")) return Promise.resolve(statsResponse)
+      if (url.includes("/api/reconciliation/pending")) return Promise.resolve({ items: [matchResponse] })
+      if (url.includes("/api/reconciliation/transactions/t1/anomalies")) return Promise.resolve([])
+      if (url.includes("/api/reconciliation/run")) return Promise.reject(new Error("run failed"))
+      if (url.includes("/api/reconciliation/batch-accept")) return Promise.reject(new Error("batch failed"))
+      if (url.includes("/api/reconciliation/matches/m1/accept")) return Promise.reject(new Error("accept failed"))
+      if (url.includes("/api/reconciliation/matches/m1/reject")) return Promise.reject(new Error("reject failed"))
+      return Promise.resolve({})
+    })
+
+    render(<ReconciliationWorkbench />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByText("Rent")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Run Matching" }))
+    expect(await screen.findByText("run failed")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Batch Accept ≥ 80" }))
+    expect(await screen.findByText("Batch accept failed: batch failed")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept" }))
+    expect(await screen.findByText("Failed to accept match: accept failed")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }))
+    expect(await screen.findByText("Failed to reject match: reject failed")).toBeInTheDocument()
+  })
+
+  it("test_AC8_13_48 refreshes an existing selection and clears it when the queue becomes empty", async () => {
+    const pendingResponses = [
+      { items: [matchResponse] },
+      {
+        items: [
+          {
+            ...matchResponse,
+            transaction: { ...matchResponse.transaction, amount: 825 },
+            score_breakdown: { amount: 55, date: 20, description: 10 },
+          },
+        ],
+      },
+      { items: [] },
+    ]
+
+    mockedApiFetch.mockImplementation((path: string) => {
+      const url = String(path)
+      if (url.includes("/api/reconciliation/stats")) return Promise.resolve(statsResponse)
+      if (url.includes("/api/reconciliation/pending")) return Promise.resolve(pendingResponses.shift() ?? { items: [] })
+      if (url.includes("/api/reconciliation/transactions/t1/anomalies")) return Promise.resolve([])
+      if (url.includes("/api/reconciliation/run")) return Promise.resolve({})
+      return Promise.resolve({})
+    })
+
+    render(<ReconciliationWorkbench />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getAllByText("800.00").length).toBeGreaterThan(0))
+
+    fireEvent.click(screen.getByRole("button", { name: "Run Matching" }))
+    await waitFor(() => expect(screen.getByText("825.00")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Run Matching" }))
+    await waitFor(() => expect(screen.getByText("No pending matches")).toBeInTheDocument())
+    expect(screen.getByText("Select a match to review")).toBeInTheDocument()
   })
 
 })

--- a/apps/frontend/src/__tests__/sankeyChartComponent.test.tsx
+++ b/apps/frontend/src/__tests__/sankeyChartComponent.test.tsx
@@ -69,7 +69,7 @@ describe("SankeyChart", () => {
     })
   })
 
-  it("AC16.21.7 builds sankey nodes and links for inflows and outflows", () => {
+  it("AC16.21.7 / test_AC8_13_48 builds sankey nodes, links, and tooltips", () => {
     render(
       <SankeyChart
         title="Detailed Cash Flow"
@@ -107,6 +107,14 @@ describe("SankeyChart", () => {
         { source: "Financing-Inflows", target: "Financing-Loan", value: 220 },
       ]),
     )
+
+    const formatter = (capturedProps?.option as {
+      tooltip: { formatter: (params: { data: { name?: string; value?: number; source?: string; target?: string } }) => string }
+    }).tooltip.formatter
+    expect(formatter({ data: { source: "Operating-Inflows", target: "Operating-Sales", value: 3000 } })).toBe(
+      "Operating-Inflows → Operating-Sales: 3,000",
+    )
+    expect(formatter({ data: { name: "Operating", value: 12 } })).toBe("Operating: 12")
   })
 
   it("AC16.21.8 recomputes theme-driven colors on root attribute change", async () => {

--- a/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
+++ b/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
@@ -1,0 +1,363 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { Stage2ReviewQueue } from "@/components/review/Stage2ReviewQueue"
+import { apiFetch } from "@/lib/api"
+
+import { renderReviewComponent } from "./helpers/renderReviewComponent"
+
+const navState = vi.hoisted(() => ({
+  pathname: "/reconciliation/review-queue",
+  replace: vi.fn(),
+  push: vi.fn(),
+  searchParams: new URLSearchParams(),
+}))
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }))
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: navState.replace, push: navState.push }),
+  useSearchParams: () => navState.searchParams,
+  usePathname: () => navState.pathname,
+}))
+
+const mockedApiFetch = vi.mocked(apiFetch)
+
+const pendingMatch = {
+  id: "m1",
+  match_score: 88,
+  status: "pending_review",
+  created_at: "2026-01-01T00:00:00Z",
+  description: "Salary transfer",
+  amount: 1200,
+  txn_date: "2026-01-01",
+}
+
+const lowMatch = {
+  id: "m2",
+  match_score: 55,
+  status: "pending_review",
+  created_at: "2026-01-02T00:00:00Z",
+  description: "Low confidence transfer",
+  amount: null,
+  txn_date: null,
+}
+
+const duplicateCheck = {
+  id: "c1",
+  check_type: "duplicate",
+  status: "pending",
+  related_txn_ids: [],
+  details: { message: "Potential duplicate" },
+  severity: "high",
+  resolved_at: null,
+  resolution_note: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+}
+
+const customCheck = {
+  id: "c2",
+  check_type: "manual_review",
+  status: "pending",
+  related_txn_ids: [],
+  details: { reason: "Needs human review" },
+  severity: "low",
+  resolved_at: null,
+  resolution_note: null,
+  created_at: "2026-01-02T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+}
+
+function queue(overrides: Partial<{
+  pending_matches: unknown[]
+  consistency_checks: unknown[]
+  has_unresolved_checks: boolean
+}> = {}) {
+  return {
+    pending_matches: [pendingMatch],
+    consistency_checks: [],
+    has_unresolved_checks: false,
+    ...overrides,
+  }
+}
+
+describe("AC8.13.48 Stage2ReviewQueue frontend coverage lift", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset()
+    navState.pathname = "/reconciliation/review-queue"
+    navState.searchParams = new URLSearchParams()
+    navState.replace.mockReset()
+    navState.push.mockReset()
+  })
+
+  it("test_AC8_13_48_run_review_approves_matches_after_filter_changes", async () => {
+    navState.pathname = "/review/run/run%201"
+    navState.searchParams = new URLSearchParams("check_type=duplicate&status=pending&severity=high,medium&min_score=60")
+
+    mockedApiFetch.mockImplementation((path: string, options?: RequestInit) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ pending_matches: [pendingMatch, lowMatch], consistency_checks: [] }) as never)
+      }
+      if (path === "/api/accounts/processing/summary") {
+        return Promise.resolve({ pending_count: 0, pending_total: "0", currency: "SGD", oldest_pending_date: null } as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [] } as never)
+      }
+      if (path === "/api/statements/batch-approve-matches") {
+        expect(options).toMatchObject({
+          method: "POST",
+          body: JSON.stringify({ match_ids: ["m1", "m2"] }),
+        })
+        return Promise.resolve({ success: true, approved_count: 2 } as never)
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderReviewComponent(<Stage2ReviewQueue />)
+
+    expect(await screen.findByText("Stage 2 Run Review")).toBeInTheDocument()
+    expect(screen.getByText("run 1")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "HIGH" }))
+    const [checkTypeSelect, statusSelect] = screen.getAllByRole("combobox")
+    fireEvent.change(checkTypeSelect, { target: { value: "anomaly" } })
+    fireEvent.change(statusSelect, { target: { value: "resolved" } })
+
+    fireEvent.click(screen.getByRole("button", { name: "Select all" }))
+    await waitFor(() => expect(screen.getByText("1 selected")).toBeInTheDocument())
+    fireEvent.click(screen.getByRole("button", { name: "Deselect all" }))
+    await waitFor(() => expect(screen.getByText("0 selected")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve Run" }))
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/api/statements/batch-approve-matches",
+        expect.objectContaining({ method: "POST" }),
+      )
+    })
+    expect(navState.replace).toHaveBeenCalled()
+  })
+
+  it("test_AC8_13_48_dialog_dismissal_and_resolution_error_paths", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ consistency_checks: [customCheck], has_unresolved_checks: true }) as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.reject(new Error("filter failed"))
+      }
+      if (path === "/api/statements/consistency-checks/c2/resolve") {
+        return Promise.reject(new Error("resolve failed"))
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderReviewComponent(<Stage2ReviewQueue />)
+
+    expect(await screen.findByText("manual_review")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Resolve" }))
+    expect(await screen.findByRole("dialog", { name: "Resolve Consistency Check" })).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: "Escape" })
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Resolve Consistency Check" })).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Resolve" }))
+    const overlay = document.querySelector("[aria-hidden='true']") as HTMLElement
+    fireEvent.click(overlay)
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Resolve Consistency Check" })).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Resolve" }))
+    const dialog = await screen.findByRole("dialog", { name: "Resolve Consistency Check" })
+    fireEvent.change(within(dialog).getByRole("textbox"), { target: { value: "Keep reviewing" } })
+    fireEvent.click(within(dialog).getByRole("button", { name: "Reject" }))
+
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/api/statements/consistency-checks/c2/resolve",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ action: "reject", note: "Keep reviewing" }),
+        }),
+      )
+    })
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }))
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Resolve Consistency Check" })).not.toBeInTheDocument())
+  })
+
+  it("test_AC8_13_48_batch_and_run_error_branches_surface_actionable_feedback", async () => {
+    navState.pathname = "/review/run/run-2"
+
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ pending_matches: [pendingMatch], consistency_checks: [] }) as never)
+      }
+      if (path === "/api/accounts/processing/summary") {
+        return Promise.resolve({ pending_count: 0, pending_total: "0", currency: "SGD", oldest_pending_date: null } as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [] } as never)
+      }
+      if (path === "/api/statements/batch-approve-matches") {
+        return Promise.resolve({ success: false, error: "approval rejected by server" } as never)
+      }
+      if (path === "/api/statements/batch-reject-matches") {
+        return Promise.reject(new Error("batch reject failed"))
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderReviewComponent(<Stage2ReviewQueue />)
+
+    expect(await screen.findByText("Stage 2 Run Review")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Select all" }))
+    fireEvent.click(screen.getByRole("button", { name: "Approve Selected" }))
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/api/statements/batch-approve-matches",
+        expect.objectContaining({ method: "POST" }),
+      )
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }))
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/api/statements/batch-reject-matches",
+        expect.objectContaining({ method: "POST" }),
+      )
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve Run" }))
+    await waitFor(() => {
+      const approveCalls = mockedApiFetch.mock.calls.filter((call) => call[0] === "/api/statements/batch-approve-matches")
+      expect(approveCalls.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  it("test_AC8_13_48_filters_checks_and_toggles_individual_match_selection", async () => {
+    navState.pathname = "/review/run/run-3"
+
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ pending_matches: [pendingMatch], consistency_checks: [duplicateCheck, customCheck] }) as never)
+      }
+      if (path === "/api/accounts/processing/summary") {
+        return Promise.reject(new Error("processing summary failed"))
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [duplicateCheck, customCheck] } as never)
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderReviewComponent(<Stage2ReviewQueue />)
+
+    expect(await screen.findByText("Stage 2 Run Review")).toBeInTheDocument()
+    expect(await screen.findByText("manual_review")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "HIGH" }))
+    await waitFor(() => expect(screen.queryByText("manual_review")).not.toBeInTheDocument())
+    expect(screen.getAllByText("Duplicate").length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByText("Salary transfer"))
+    await waitFor(() => expect(screen.getByText("1 selected")).toBeInTheDocument())
+    fireEvent.click(screen.getByText("Salary transfer"))
+    await waitFor(() => expect(screen.getByText("0 selected")).toBeInTheDocument())
+  })
+
+  it("test_AC8_13_48_run_approval_guard_states_explain_disabled_actions", async () => {
+    navState.pathname = "/review/run/run-4"
+
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ pending_matches: [pendingMatch], consistency_checks: [duplicateCheck], has_unresolved_checks: true }) as never)
+      }
+      if (path === "/api/accounts/processing/summary") {
+        return Promise.resolve({ pending_count: 0, pending_total: "0", currency: "SGD", oldest_pending_date: null } as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [duplicateCheck] } as never)
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    const first = renderReviewComponent(<Stage2ReviewQueue />)
+    const unresolvedButton = await screen.findByRole("button", { name: "Approve Run" })
+    expect(unresolvedButton).toBeDisabled()
+    expect(unresolvedButton).toHaveAttribute("title", "Resolve consistency checks first")
+    first.unmount()
+
+    mockedApiFetch.mockReset()
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ pending_matches: [pendingMatch], consistency_checks: [] }) as never)
+      }
+      if (path === "/api/accounts/processing/summary") {
+        return Promise.resolve({ pending_count: 1, pending_total: "10", currency: "SGD", oldest_pending_date: "2026-01-01" } as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [] } as never)
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    const second = renderReviewComponent(<Stage2ReviewQueue />)
+    const processingButton = await screen.findByRole("button", { name: "Approve Run" })
+    expect(processingButton).toBeDisabled()
+    expect(processingButton).toHaveAttribute("title", "Clear Processing Account pending transfers first")
+    second.unmount()
+
+    mockedApiFetch.mockReset()
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ pending_matches: [], consistency_checks: [] }) as never)
+      }
+      if (path === "/api/accounts/processing/summary") {
+        return Promise.resolve({ pending_count: 0, pending_total: "0", currency: "SGD", oldest_pending_date: null } as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [] } as never)
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderReviewComponent(<Stage2ReviewQueue />)
+    const emptyButton = await screen.findByRole("button", { name: "Approve Run" })
+    expect(emptyButton).toBeDisabled()
+    expect(emptyButton).toHaveAttribute("title", "No pending matches remain")
+  })
+
+  it("test_AC8_13_48_run_approval_network_errors_are_reported", async () => {
+    navState.pathname = "/review/run/run-5"
+
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ pending_matches: [pendingMatch], consistency_checks: [] }) as never)
+      }
+      if (path === "/api/accounts/processing/summary") {
+        return Promise.resolve({ pending_count: 0, pending_total: "0", currency: "SGD", oldest_pending_date: null } as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [] } as never)
+      }
+      if (path === "/api/statements/batch-approve-matches") {
+        return Promise.reject(new Error("approve run failed"))
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderReviewComponent(<Stage2ReviewQueue />)
+
+    fireEvent.click(await screen.findByRole("button", { name: "Approve Run" }))
+    await waitFor(() => {
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/api/statements/batch-approve-matches",
+        expect.objectContaining({ method: "POST" }),
+      )
+    })
+    expect(await screen.findByText("approve run failed")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, screen, fireEvent, waitFor } from "@testing-library/react";
 import StatementDetailPage from "@/app/(main)/statements/[id]/page";
 import { apiFetch } from "@/lib/api";
 import { renderReviewComponent } from "./helpers/renderReviewComponent";
@@ -34,6 +34,9 @@ const parsedBrokerageStatement = {
 
 describe("StatementDetailPage - coverage additions", () => {
     beforeEach(() => vi.clearAllMocks());
+    afterEach(() => {
+        vi.useRealTimers();
+    });
 
     it("renders parsing stopped alert and resume polling button", async () => {
         const stmt = {
@@ -176,5 +179,53 @@ describe("StatementDetailPage - coverage additions", () => {
         expect(
             screen.queryByRole("button", { name: /import brokerage positions to portfolio/i }),
         ).not.toBeInTheDocument();
+    });
+
+    it("test_AC8_13_48 stops stuck parsing auto-refresh and resumes polling on demand", async () => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+        const parsingStatement = {
+            ...parsedBrokerageStatement,
+            status: "parsing",
+            parsing_progress: 30,
+            transactions: [],
+        };
+        mockedApi.mockResolvedValue(parsingStatement as any);
+
+        renderReviewComponent(<StatementDetailPage /> as any);
+
+        expect(await screen.findByText(/Parsing in progress/)).toBeInTheDocument();
+
+        await act(async () => {
+            vi.setSystemTime(new Date("2026-01-01T00:05:01Z"));
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        expect(await screen.findByText("Auto-refresh Stopped")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Resume Auto-Refresh" }));
+        await waitFor(() => expect(mockedApi).toHaveBeenCalledWith("/api/statements/s1"));
+    });
+
+    it("test_AC8_13_48 shows retry parsing errors for rejected statements", async () => {
+        const rejectedStatement = {
+            ...parsedBrokerageStatement,
+            status: "rejected",
+            validation_error: "Bad parse",
+            transactions: [],
+        };
+
+        mockedApi
+            .mockResolvedValueOnce(rejectedStatement as any)
+            .mockRejectedValueOnce(new Error("retry failed"));
+
+        renderReviewComponent(<StatementDetailPage /> as any);
+
+        await screen.findByText("Parsing Failed");
+        fireEvent.click(screen.getAllByRole("button", { name: "Retry Parse" })[0]);
+
+        await waitFor(() => expect(screen.getAllByText("retry failed").length).toBeGreaterThan(0));
+        expect(mockedApi).toHaveBeenCalledWith("/api/statements/s1/retry", { method: "POST" });
     });
 });

--- a/apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import StatementReviewPage from "@/app/(main)/statements/[id]/review/page";
 import { apiFetch } from "@/lib/api";
 import { renderReviewComponent } from "./helpers/renderReviewComponent";
@@ -203,5 +203,79 @@ describe("StatementReviewPage - coverage additions", () => {
             }
             expect(mockedApi.mock.calls.some(c => String(c[0]).includes("/review/reject"))).toBe(true);
         })();
+    });
+
+    it("test_AC8_13_48 surfaces failed inline edit saves", async () => {
+        const stmt = {
+            id: "s1",
+            original_filename: "file.pdf",
+            institution: "BankX",
+            currency: "SGD",
+            period_start: "2024-01-01",
+            period_end: "2024-01-31",
+            opening_balance: 100,
+            closing_balance: 200,
+            status: "pending",
+            stage1_status: null,
+            balance_validation_result: { opening_match: true, closing_match: true, calculated_closing: "200" },
+            pdf_url: null,
+            transactions: [
+                { id: "t1", txn_date: "2024-01-02", description: "Lunch", amount: 12.5, direction: "OUT", currency: "SGD", confidence: "medium" },
+            ],
+        };
+
+        mockedApi
+            .mockResolvedValueOnce(stmt as any)
+            .mockResolvedValueOnce({ items: [{ id: "s1" }] })
+            .mockRejectedValueOnce(new Error("edit failed"));
+
+        renderReviewComponent(<StatementReviewPage /> as any);
+
+        fireEvent.click(await screen.findByText("Lunch"));
+        fireEvent.change(await screen.findByDisplayValue("Lunch"), { target: { value: "Lunch at cafe" } });
+        fireEvent.blur(screen.getByDisplayValue("Lunch at cafe"));
+        fireEvent.click(await screen.findByRole("button", { name: /Save Edits/i }));
+
+        expect(await screen.findByText("edit failed")).toBeInTheDocument();
+        expect(mockedApi.mock.calls.some((call) => String(call[0]).includes("/review/edit"))).toBe(true);
+    });
+
+    it("test_AC8_13_48 surfaces approve and reject mutation failures", async () => {
+        const stmt = {
+            id: "s1",
+            original_filename: "file.pdf",
+            institution: "BankX",
+            currency: "SGD",
+            period_start: "2024-01-01",
+            period_end: "2024-01-31",
+            opening_balance: 0,
+            closing_balance: 0,
+            status: "pending",
+            stage1_status: null,
+            balance_validation_result: { opening_match: true, closing_match: true, calculated_closing: "0" },
+            pdf_url: null,
+            transactions: [],
+        };
+
+        mockedApi.mockImplementation((path: string) => {
+            if (path === "/api/statements/s1/review") return Promise.resolve(stmt as any);
+            if (path === "/api/statements/pending-review") return Promise.resolve({ items: [{ id: "s1" }] });
+            if (path === "/api/statements/s1/review/approve") return Promise.reject(new Error("approve failed"));
+            if (path === "/api/statements/s1/review/reject") return Promise.reject(new Error("reject failed"));
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
+
+        renderReviewComponent(<StatementReviewPage /> as any);
+
+        fireEvent.click(await screen.findByRole("button", { name: "Approve" }));
+        const approveDialog = await screen.findByRole("dialog", { name: "Approve Statement" });
+        fireEvent.click(within(approveDialog).getByRole("button", { name: "Approve" }));
+        expect(await screen.findByText("approve failed")).toBeInTheDocument();
+        fireEvent.click(within(approveDialog).getByRole("button", { name: "Cancel" }));
+
+        fireEvent.click(await screen.findByRole("button", { name: "Reject" }));
+        const rejectDialog = await screen.findByRole("dialog", { name: "Reject Statement" });
+        fireEvent.click(within(rejectDialog).getByRole("button", { name: "Reject" }));
+        expect(await screen.findByText("reject failed")).toBeInTheDocument();
     });
 });

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -148,4 +148,45 @@ describe("StatementsPage", () => {
     expect(showToastMock).toHaveBeenCalledWith("Statement deleted successfully", "success")
 })
 
+  it("test_AC8_13_48 renders missing statement values and surfaces delete failures", async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "s4",
+            original_filename: "needs-review.pdf",
+            institution: "Unknown",
+            status: "parsed",
+            period_start: null,
+            period_end: null,
+            currency: null,
+            confidence_score: null,
+            transactions: [],
+            opening_balance: null,
+            closing_balance: undefined,
+            balance_validated: false,
+            validation_error: "Balance mismatch",
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new Error("delete failed"))
+
+    render(<StatementsPage />)
+
+    await waitFor(() => expect(screen.getByText("needs-review.pdf")).toBeInTheDocument())
+    expect(screen.getByText("Parsing...")).toBeInTheDocument()
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText("Needs Review")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle("Delete Statement"))
+    await waitFor(() => expect(screen.getByTestId("confirm-dialog")).toBeInTheDocument())
+    fireEvent.click(screen.getByText("Cancel Delete"))
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle("Delete Statement"))
+    fireEvent.click(screen.getByText("Confirm Delete"))
+
+    await waitFor(() => expect(screen.getAllByText("delete failed").length).toBeGreaterThan(0))
+  })
+
 })

--- a/apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx
+++ b/apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx
@@ -126,6 +126,14 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
     );
   });
 
+  it("test_AC8_13_48 — AI suggestions page renders load errors", async () => {
+    mockedApiFetch.mockRejectedValueOnce(new Error("suggestions unavailable"));
+
+    render(<AiSuggestionsPage />);
+
+    expect(await screen.findByText("suggestions unavailable")).toBeInTheDocument();
+  });
+
   it("AC18.5.5 — Settings AI toggles persist placeholder", async () => {
     mockedApiFetch
       .mockResolvedValueOnce({ enable_ai_reconciliation: true, enable_ai_classification: false })
@@ -176,5 +184,32 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
 
     expect(await screen.findByLabelText("Enable AI reconciliation")).not.toBeChecked();
     expect(screen.getByLabelText("Enable AI classification")).toBeChecked();
+  });
+
+  it("test_AC8_13_48 — AI settings handles load and reconciliation update failures", async () => {
+    mockedApiFetch.mockRejectedValueOnce(new Error("settings unavailable"));
+
+    render(<AiSettingsPage />);
+
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledWith("/api/users/me/settings"));
+    expect(screen.getByText("Loading AI settings...")).toBeInTheDocument();
+
+    mockedApiFetch.mockReset();
+    mockedApiFetch
+      .mockResolvedValueOnce({ enable_ai_reconciliation: false, enable_ai_classification: true })
+      .mockRejectedValueOnce(new Error("update failed"));
+
+    render(<AiSettingsPage />);
+
+    const reconciliationToggle = await screen.findByLabelText("Enable AI reconciliation");
+    fireEvent.click(reconciliationToggle);
+
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenCalledWith("/api/users/me/settings", {
+        method: "PATCH",
+        body: JSON.stringify({ enable_ai_reconciliation: true }),
+      }),
+    );
+    expect(await screen.findByText("update failed")).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/__tests__/uiGapAudit.netWorthTimeSeries.test.tsx
+++ b/apps/frontend/src/__tests__/uiGapAudit.netWorthTimeSeries.test.tsx
@@ -6,8 +6,13 @@ import { NetWorthTimeSeriesChart } from "@/components/charts/NetWorthTimeSeriesC
 import { apiFetch } from "@/lib/api";
 import type { NetWorthTimeSeriesResponse } from "@/lib/types";
 
+let capturedChartOption: { tooltip?: { valueFormatter?: (value: number) => string } } | null = null;
+
 vi.mock("echarts-for-react", () => ({
-  default: () => <div role="img" aria-label="ECharts net worth line chart" />,
+  default: (props: { option: { tooltip?: { valueFormatter?: (value: number) => string } } }) => {
+    capturedChartOption = props.option;
+    return <div role="img" aria-label="ECharts net worth line chart" />;
+  },
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -19,6 +24,7 @@ describe("EPIC-005 / UI Gap Audit / Net Worth Time Series", () => {
 
   beforeEach(() => {
     mockedApiFetch.mockReset();
+    capturedChartOption = null;
   });
 
   it("AC5.7.2/AC5.7.6 mounts an ECharts-backed net worth line chart", async () => {
@@ -35,6 +41,7 @@ describe("EPIC-005 / UI Gap Audit / Net Worth Time Series", () => {
 
     await waitFor(() => expect(screen.getByTestId("net-worth-echarts")).toBeInTheDocument());
     expect(screen.getByRole("img", { name: "ECharts net worth line chart" })).toBeInTheDocument();
+    expect(capturedChartOption?.tooltip?.valueFormatter?.(1234)).toContain("1,234.00");
     expect(mockedApiFetch).toHaveBeenCalledWith(expect.stringContaining("/api/reports/net-worth/timeseries"));
   });
 
@@ -55,6 +62,11 @@ describe("EPIC-005 / UI Gap Audit / Net Worth Time Series", () => {
     await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledTimes(2));
     expect(String(mockedApiFetch.mock.calls[1][0])).toContain("granularity=daily");
     expect(String(mockedApiFetch.mock.calls[1][0])).toContain("from=");
+
+    fireEvent.click(screen.getByRole("tab", { name: "All" }));
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledTimes(3));
+    expect(String(mockedApiFetch.mock.calls[2][0])).toContain("from=1970-01-01");
+    expect(String(mockedApiFetch.mock.calls[2][0])).toContain("granularity=monthly");
   });
 
   it("AC5.7.5 renders an empty state when fewer than two points exist", async () => {
@@ -71,5 +83,13 @@ describe("EPIC-005 / UI Gap Audit / Net Worth Time Series", () => {
     await waitFor(() =>
       expect(screen.getByText("At least two net worth points are needed to draw a line.")).toBeInTheDocument(),
     );
+  });
+
+  it("test_AC8_13_48 shows net worth history load failures", async () => {
+    mockedApiFetch.mockRejectedValueOnce(new Error("history failed"));
+
+    render(<NetWorthTimeSeriesChart />);
+
+    expect(await screen.findByText("history failed")).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx
+++ b/apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx
@@ -139,6 +139,14 @@ describe('EPIC-015 / UI Gap Audit / Processing Account Visibility', () => {
     });
   });
 
+  it('test_AC8_13_48 — /processing listing renders load errors', async () => {
+    mockedApiFetch.mockRejectedValueOnce(new Error("processing unavailable"));
+
+    render(<ProcessingPage />);
+
+    expect(await screen.findByText("processing unavailable")).toBeInTheDocument();
+  });
+
   it('AC15.7.5 — ProcessingSummaryCard mount test', async () => {
     mockedApiFetch.mockImplementation((path) => {
       if (path === '/api/accounts/processing/summary') {

--- a/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
+++ b/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
@@ -25,6 +25,16 @@ describe("UnmatchedBoard", () => {
     })
   })
 
+  const unmatchedItem = {
+    id: "u1",
+    statement_id: "s1",
+    txn_date: "2026-01-11",
+    description: "Card payment",
+    amount: 88,
+    direction: "OUT",
+    status: "unmatched",
+  }
+
   it("AC16.20.3 loads unmatched items and creates entry", async () => {
     mockedApiFetch
       .mockResolvedValueOnce({
@@ -88,6 +98,7 @@ describe("UnmatchedBoard", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Ignore" }))
     await waitFor(() => expect(screen.queryAllByText("Card payment")).toHaveLength(0))
+    expect(screen.getByText("Select a transaction to review")).toBeInTheDocument()
   })
 
   it("creates all entries with batch action", async () => {
@@ -166,5 +177,55 @@ describe("UnmatchedBoard", () => {
     fireEvent.click(screen.getByRole("button", { name: "Create All Entries" }))
     expect(await screen.findByText("bulk failed")).toBeInTheDocument()
     expect(screen.queryByText("Created 1 journal entry from unmatched transactions.")).not.toBeInTheDocument()
+  })
+
+  it("test_AC8_13_48 tolerates invalid flagged storage and refresh failures", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    localStorage.setItem("finance-unmatched-flagged", "{not-json")
+    mockedApiFetch.mockRejectedValueOnce(new Error("load failed"))
+
+    render(<UnmatchedBoard />)
+
+    expect(await screen.findByText("load failed")).toBeInTheDocument()
+    expect(screen.getByText("No unmatched transactions")).toBeInTheDocument()
+    warnSpy.mockRestore()
+  })
+
+  it("test_AC8_13_48 tolerates flagged storage write failures while unflagging", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    vi.stubGlobal("localStorage", {
+      getItem: () => JSON.stringify(["u1"]),
+      setItem: () => {
+        throw new Error("storage full")
+      },
+      removeItem: vi.fn(),
+    })
+    mockedApiFetch.mockResolvedValueOnce({ items: [unmatchedItem], total: 1 })
+
+    render(<UnmatchedBoard />)
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Unflag" })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole("button", { name: "Unflag" }))
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Flag" })).toBeInTheDocument())
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[UnmatchedBoard] Failed to save flagged state:",
+      expect.any(Error),
+    )
+    warnSpy.mockRestore()
+  })
+
+  it("test_AC8_13_48 surfaces single-entry creation failures", async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce({ items: [unmatchedItem], total: 1 })
+      .mockRejectedValueOnce(new Error("create failed"))
+
+    render(<UnmatchedBoard />)
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Create Entry" })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole("button", { name: "Create Entry" }))
+
+    expect(await screen.findByText("create failed")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Create Entry" })).toBeEnabled()
   })
 })

--- a/apps/frontend/src/__tests__/useWorkspaceHook.test.tsx
+++ b/apps/frontend/src/__tests__/useWorkspaceHook.test.tsx
@@ -139,6 +139,21 @@ describe("useWorkspace and WorkspaceProvider", () => {
     await waitFor(() => expect(screen.getByTestId("tabs-json").textContent).toBe("[]"))
   })
 
+  it("test_AC8_13_48 can explicitly activate an existing tab", async () => {
+    render(
+      <WorkspaceProvider>
+        <WorkspaceHarness />
+      </WorkspaceProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Dashboard" }))
+    fireEvent.click(screen.getByRole("button", { name: "Add Reports" }))
+    await waitFor(() => expect(screen.getByTestId("active-id").textContent).toBe("tab-uuid-2"))
+
+    fireEvent.click(screen.getByRole("button", { name: "Activate First" }))
+    await waitFor(() => expect(screen.getByTestId("active-id").textContent).toBe("tab-uuid-1"))
+  })
+
   it("AC16.21.10 syncs tabs from storage events", async () => {
     render(
       <WorkspaceProvider>
@@ -203,5 +218,43 @@ describe("useWorkspace and WorkspaceProvider", () => {
     )
 
     await waitFor(() => expect(screen.getByTestId("tabs-json").textContent).toBe("[]"))
+  })
+
+  it("test_AC8_13_48 logs storage load and save failures in development", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    storage.set("finance-workspace-tabs", "not-json")
+    render(
+      <WorkspaceProvider>
+        <WorkspaceHarness />
+      </WorkspaceProvider>,
+    )
+
+    await waitFor(() =>
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to load workspace tabs:", expect.any(Error)),
+    )
+
+    consoleSpy.mockClear()
+    vi.stubGlobal("localStorage", {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("save blocked")
+      },
+      removeItem: vi.fn(),
+    })
+
+    render(
+      <WorkspaceProvider>
+        <WorkspaceHarness />
+      </WorkspaceProvider>,
+    )
+
+    await waitFor(() =>
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to save workspace tabs:", expect.any(Error)),
+    )
+
+    consoleSpy.mockRestore()
+    vi.unstubAllEnvs()
   })
 })

--- a/apps/frontend/src/app/(main)/statements/[id]/page.tsx
+++ b/apps/frontend/src/app/(main)/statements/[id]/page.tsx
@@ -143,17 +143,6 @@ export default function StatementDetailPage() {
         }
     };
 
-    const formatAmount = (amount: number, direction: string, currency?: string | null) => {
-        const sign = direction === "IN" ? "+" : "-";
-        const prefix = currency ? `${currency} ` : "";
-        return `${prefix}${sign}${Math.abs(amount).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-    };
-
-    const formatCurrency = (amount?: number | null) => {
-        if (amount === null || amount === undefined) return "—";
-        return amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-    };
-
     const formatCode = (currency?: string | null) => currency || "—";
 
     const formatPeriod = (start?: string | null, end?: string | null) => {

--- a/apps/frontend/src/app/(main)/statements/page.tsx
+++ b/apps/frontend/src/app/(main)/statements/page.tsx
@@ -69,11 +69,6 @@ export default function StatementsPage() {
 
     const formatCurrency = (currency?: string | null) => currency || "—";
 
-    const formatAmount = (amount?: number | null) => {
-        if (amount === null || amount === undefined) return "—";
-        return amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-    };
-
     const formatPeriod = (start?: string | null, end?: string | null) => {
         if (!start || !end) return "Parsing...";
         return `${start} → ${end}`;

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
         '**/types/**',
       ],
       thresholds: {
-        lines: 87,
+        lines: 99,
         functions: 80,
         branches: 70,
         statements: 87,

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1974,6 +1974,11 @@ groups:
         epic_name: testing-strategy
         description: Remaining delivery-engine optimizations are captured in a tracked project recommendation note.
         mandatory: true
+      - id: AC8.13.48
+        epic: 8
+        epic_name: testing-strategy
+        description: Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99%.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-05-27 08:42:47 UTC by `scripts/analyze_test_ac_coverage.py`
+> Generated: 2026-05-28 04:42:57 UTC by `scripts/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 991 |
-| Active ACs | 988 |
+| Registered ACs | 995 |
+| Active ACs | 992 |
 | Deprecated ACs excluded from coverage gate | 3 |
-| Covered by real test candidates | 988 (100.0%) |
+| Covered by real test candidates | 992 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -33,8 +33,8 @@
 | Source | Files scanned | Unique AC refs (real) | Unique AC refs (placeholder) | Unique AC refs (stub) |
 |---|---:|---:|---:|---:|
 | backend | 167 | 648 | 0 | 0 |
-| frontend | 79 | 189 | 7 | 0 |
-| scripts_tests | 47 | 202 | 23 | 0 |
+| frontend | 80 | 190 | 7 | 0 |
+| scripts_tests | 47 | 205 | 23 | 0 |
 | e2e | 11 | 22 | 0 | 0 |
 | repo_e2e | 18 | 0 | 0 | 0 |
 
@@ -49,7 +49,7 @@
 | EPIC-005 | reporting-visualization | 36 | 0 | 36 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 0 | 63 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-008 | testing-strategy | 101 | 0 | 101 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 105 | 0 | 105 | 0 | 0 | 0 | 100.0% |
 | EPIC-009 | pdf-fixture-generation | 37 | 0 | 37 | 0 | 0 | 0 | 100.0% |
 | EPIC-010 | signoz-logging | 21 | 0 | 21 | 0 | 0 | 0 | 100.0% |
 | EPIC-011 | asset-lifecycle | 38 | 0 | 38 | 0 | 0 | 0 | 100.0% |

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -80,6 +80,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.45**: Local verification entry points fail on the same backend format errors and route `make test` through the root Moon test command without hashing the infra submodule gitlink as a file input.
 - **AC8.13.46**: PR preview non-LLM E2E uses the same strict, parallel gate shape as staging non-LLM E2E.
 - **AC8.13.47**: Remaining delivery-engine optimizations are captured in a tracked project recommendation note.
+- **AC8.13.48**: Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99%.
 
 **Current state (2026-02-23):**
 - **Tier 1**: 41 tests in `test_core_journeys.py` covering 45 ACs → **91.8% AC pass rate** (45/49)
@@ -398,6 +399,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.45 | Local verification entry points fail on the same backend format errors and route `make test` through the root Moon test command without hashing the infra submodule gitlink as a file input | `test_AC8_13_45_*` | `scripts/tests/test_cli_and_dev_servers.py`, `scripts/tests/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.46 | PR preview non-LLM E2E uses the same strict, parallel gate shape as staging non-LLM E2E | `test_AC8_13_46_pr_preview_non_llm_gate_matches_staging_strict_parallelism` | `scripts/tests/test_post_merge_e2e_gates.py` | P1 |
 | AC8.13.47 | Remaining delivery-engine optimizations are captured in a tracked project recommendation note | `test_AC8_13_47_delivery_engine_recommendations_are_tracked` | `scripts/tests/test_post_merge_e2e_gates.py` | P1 |
+| AC8.13.48 | Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99% | `test_AC8_13_48_*` | `apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx`, `apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx`, `apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx`, `apps/frontend/src/__tests__/StatementUploader.test.tsx`, `apps/frontend/src/__tests__/journalPage.test.tsx`, `apps/frontend/src/__tests__/reconciliationWorkbenchComponent.test.tsx`, `apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx`, `apps/frontend/src/__tests__/apiFunctions.test.ts`, `apps/frontend/src/__tests__/accountsPage.test.tsx`, `apps/frontend/src/__tests__/assetsPage.test.tsx`, `apps/frontend/src/__tests__/statementsPage.test.tsx`, `apps/frontend/src/__tests__/useWorkspaceHook.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.netWorthTimeSeries.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -225,6 +225,7 @@ SSOT edits: [DELIVERY_ENGINE_RECOMMENDATIONS.md](../project/DELIVERY_ENGINE_RECO
 ## Coverage Requirements
 
 - Backend line coverage: **≥ 90%** (enforced by `pytest-cov`)
+- Frontend line coverage: **≥ 99%** (enforced by `vitest`)
 - Unified coverage: **no-regression from `unified-coverage.json`** (currently 94.38% floor after AC8.13.15 policy unification)
 - Branch coverage: Required (via `--cov-branch`)
 - See [coverage.md](./coverage.md) and [tdd.md](./tdd.md) for details

--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -23,7 +23,7 @@ unified_coverage = total_covered_lines / total_executable_lines
                    (backend_executable + frontend_executable + scripts_executable)
 ```
 
-**CI Gate**: No-regression baseline comparison (zero tolerance for drops), plus a source tree vs LCOV policy audit. No fixed minimum threshold enforced.
+**Unified CI Gate**: No-regression baseline comparison (zero tolerance for drops), plus a source tree vs LCOV policy audit. No fixed minimum unified threshold is enforced.
 
 **Baseline ownership**: Component line counts, coverage percentages, and
 committed no-regression floors are generated facts. Read
@@ -180,8 +180,8 @@ python scripts/calculate_unified_coverage.py
 
 | Mode    | Backend | Frontend (vitest) | Unified (CI) |
 |---------|---------|-------------------|--------------|
-| CI      | 90%     | 87% lines         | No regression from baseline |
-| Local   | 90%     | 87% lines         | No regression from baseline |
+| CI      | 90%     | 99% lines         | No regression from baseline |
+| Local   | 90%     | 99% lines         | No regression from baseline |
 
 > **Note**: The unified baseline is the primary cross-component gate. Frontend vitest keeps its own local line/function/branch floors, while CI also verifies that frontend LCOV files match the shared policy.
 
@@ -221,7 +221,7 @@ coverage: {
     '**/vitest.setup.ts', '**/*.config.*', '**/types/**',
   ],
   thresholds: {
-    lines: 87,
+    lines: 99,
     functions: 80,
     branches: 70,
     statements: 87,


### PR DESCRIPTION
## Summary

Raise frontend LCOV line coverage to the requested 99% floor and enforce it through vitest.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.48 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/coverage.md` — updated frontend vitest line threshold from 87% to 99% and clarified the unified gate wording.
- [x] `docs/ssot/ci-cd.md` — documented the frontend 99% line coverage requirement.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | `N/A` | Local TDD sequence was not preserved as a separate commit. |
| Green (passing test) | `47c4238` | Add AC8.13.48 frontend coverage tests and set vitest line threshold to 99%. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no backend model changes.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` — N/A, no env changes.
- [x] `repo/` submodule updated for production config changes — N/A, no infra changes.
- [x] `scripts/check_env_keys.py` passes — N/A, no env vars changed.
- [x] `scripts/check_manifest.py` passes.
- [x] `scripts/lint_doc_consistency.py` passes.

---

## Testing

```bash
cd apps/frontend && npm run test:coverage
# 80 test files passed, 522 tests passed
# LCOV lines: 2397/2421 = 99.008674%

moon run :lint
python scripts/generate_ac_registry.py --check
python scripts/analyze_test_ac_coverage.py --stdout
python scripts/check_ac_traceability.py
python scripts/check_manifest.py
python scripts/check_ssot_ownership.py
python scripts/check_critical_proof_matrix.py
python scripts/check_ci_metrics_contract.py
python scripts/check_toolchain_contract.py
python scripts/lint_doc_consistency.py
git diff --check
```

Local limitations:

```bash
moon run :test
# Blocked before tests: local Podman is installed but not running and Docker is not installed.

python scripts/check_coverage_policy.py
# Frontend policy passed: expected=78 reported=78 using apps/frontend/coverage/lcov.info.
# Full local policy check is blocked by stale/missing backend and scripts LCOV artifacts.
```

Local pre-push note: the hook additionally checks `apps/backend/tests` formatting and found existing unrelated files that would be reformatted. This PR intentionally avoids changing those unrelated backend test files.

---

## Screenshots / Evidence

N/A — test coverage and configuration change only.
