### PR TITLE
Fix report FX lazy loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ ENV=development
 ENVIRONMENT=development
 DEBUG=true
 BASE_CURRENCY=SGD
+# Report-side FX lazy resolution. Set to false to prevent outbound Yahoo Finance calls.
+MARKET_DATA_LAZY_FETCH_ENABLED=true
+MARKET_DATA_FX_BRIDGE_CURRENCY=USD
+MARKET_DATA_YAHOO_TIMEOUT_SECONDS=5
 # Optional Redis URL for staging/production background coordination
 REDIS_URL=
 

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -100,6 +100,14 @@ class Settings(BaseSettings):
     environment: str = Field(default="development", validation_alias=AliasChoices("ENVIRONMENT", "ENV"))
     debug: bool = False
     base_currency: str = "SGD"
+    market_data_lazy_fetch_enabled: bool = Field(default=True, validation_alias="MARKET_DATA_LAZY_FETCH_ENABLED")
+    market_data_fx_bridge_currency: str = Field(default="USD", validation_alias="MARKET_DATA_FX_BRIDGE_CURRENCY")
+    market_data_yahoo_timeout_seconds: int = Field(
+        default=5,
+        ge=1,
+        le=30,
+        validation_alias="MARKET_DATA_YAHOO_TIMEOUT_SECONDS",
+    )
     redis_url: str | None = Field(default=None, validation_alias="REDIS_URL")
     # Backend reference to the frontend URL; should match the frontend NEXT_PUBLIC_APP_URL
     # and is used by backend components when they need to link to the frontend app.

--- a/apps/backend/src/services/fx.py
+++ b/apps/backend/src/services/fx.py
@@ -91,6 +91,8 @@ async def get_exchange_rate(
     base_currency: str,
     quote_currency: str,
     rate_date: date,
+    *,
+    lazy_load: bool = False,
 ) -> Decimal:
     """Get FX rate for a given date, falling back to the most recent prior rate."""
     base = _normalize_currency(base_currency)
@@ -115,6 +117,11 @@ async def get_exchange_rate(
     result = await db.execute(stmt)
     rate = result.scalar_one_or_none()
 
+    if rate is None and lazy_load:
+        from src.services.market_data import resolve_missing_fx_rate
+
+        rate = await resolve_missing_fx_rate(db, base, quote, rate_date)
+
     if rate is None:
         raise FxRateError(f"No FX rate available for {base}/{quote} on {rate_date}")
 
@@ -133,6 +140,7 @@ async def get_average_rate(
     end_date: date,
     *,
     fx_warnings: list[FxWarning] | None = None,
+    lazy_load: bool = False,
 ) -> Decimal:
     """Get average FX rate over a period, falling back to period-end rate."""
     base = _normalize_currency(base_currency)
@@ -178,7 +186,7 @@ async def get_average_rate(
             "end_date": end_date.isoformat(),
         }
         _append_fx_warning(fx_warnings, fallback_warning)
-        avg_rate = await get_exchange_rate(db, base, quote, end_date)
+        avg_rate = await get_exchange_rate(db, base, quote, end_date, lazy_load=lazy_load)
     elif not isinstance(avg_rate, Decimal):
         avg_rate = Decimal(str(avg_rate))
         fallback_warning = None
@@ -199,6 +207,7 @@ async def convert_amount(
     average_start: date | None = None,
     average_end: date | None = None,
     fx_warnings: list[FxWarning] | None = None,
+    lazy_load: bool = False,
 ) -> Decimal:
     """Convert an amount into the target currency using FX rates."""
     source = _normalize_currency(currency)
@@ -208,9 +217,17 @@ async def convert_amount(
         return amount
 
     if average_start and average_end:
-        rate = await get_average_rate(db, source, target, average_start, average_end, fx_warnings=fx_warnings)
+        rate = await get_average_rate(
+            db,
+            source,
+            target,
+            average_start,
+            average_end,
+            fx_warnings=fx_warnings,
+            lazy_load=lazy_load,
+        )
     else:
-        rate = await get_exchange_rate(db, source, target, rate_date)
+        rate = await get_exchange_rate(db, source, target, rate_date, lazy_load=lazy_load)
 
     return amount * rate
 
@@ -234,9 +251,10 @@ async def convert_to_base(
 class PrefetchedFxRates:
     """Helper to pre-fetch and store FX rates for batch processing."""
 
-    def __init__(self, fx_warnings: list[FxWarning] | None = None) -> None:
+    def __init__(self, fx_warnings: list[FxWarning] | None = None, *, lazy_load: bool = False) -> None:
         self._rates: dict[str, Decimal] = {}
         self._fx_warnings = fx_warnings
+        self._lazy_load = lazy_load
 
     def get_rate(
         self,
@@ -279,28 +297,27 @@ class PrefetchedFxRates:
         db: AsyncSession,
         pairs: list[tuple[str, str, date, date | None, date | None]],
     ) -> None:
-        """Fetch multiple rates in parallel or batch if possible."""
-        import asyncio
+        """Fetch multiple rates into the local prefetch cache."""
 
         async def _fetch_one(p: tuple[str, str, date, date | None, date | None]) -> None:
             base, quote, r_date, a_start, a_end = p
             if a_start and a_end:
-                rate = await get_average_rate(db, base, quote, a_start, a_end, fx_warnings=self._fx_warnings)
+                rate = await get_average_rate(
+                    db,
+                    base,
+                    quote,
+                    a_start,
+                    a_end,
+                    fx_warnings=self._fx_warnings,
+                    lazy_load=self._lazy_load,
+                )
             else:
-                rate = await get_exchange_rate(db, base, quote, r_date)
+                rate = await get_exchange_rate(db, base, quote, r_date, lazy_load=self._lazy_load)
             self.set_rate(base, quote, r_date, rate, a_start, a_end)
 
         unique_pairs = list(set(pairs))
         if not unique_pairs:
             return
 
-        try:
-            async with asyncio.TaskGroup() as tg:
-                for p in unique_pairs:
-                    tg.create_task(_fetch_one(p))
-        except ExceptionGroup as eg:
-            # Propagate the first FxRateError if present
-            for exc in eg.exceptions:
-                if isinstance(exc, FxRateError):
-                    raise exc
-            raise
+        for pair in unique_pairs:
+            await _fetch_one(pair)

--- a/apps/backend/src/services/market_data.py
+++ b/apps/backend/src/services/market_data.py
@@ -1,0 +1,308 @@
+"""Market data lookup helpers for report-side FX resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Any
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.logger import get_logger
+from src.models import FxRate
+
+logger = get_logger(__name__)
+
+_RATE_QUANT = Decimal("0.000001")
+_YAHOO_CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}=X"
+
+
+@dataclass(frozen=True)
+class FxRateObservation:
+    """Resolved FX rate observation from a provider or derivation path."""
+
+    base_currency: str
+    quote_currency: str
+    rate: Decimal
+    rate_date: date
+    source: str
+
+
+@dataclass(frozen=True)
+class _StoredFxRate:
+    rate: Decimal
+    rate_date: date
+    source: str
+
+
+def _normalize_currency(code: str) -> str:
+    return code.strip().upper()
+
+
+def _quantize_rate(rate: Decimal) -> Decimal:
+    return rate.quantize(_RATE_QUANT, rounding=ROUND_HALF_UP)
+
+
+def _date_to_epoch(value: date) -> int:
+    return int(datetime.combine(value, time.min, tzinfo=UTC).timestamp())
+
+
+async def _load_stored_rate(
+    db: AsyncSession,
+    base_currency: str,
+    quote_currency: str,
+    requested_date: date,
+) -> _StoredFxRate | None:
+    stmt = (
+        select(FxRate.rate, FxRate.rate_date, FxRate.source)
+        .where(FxRate.base_currency == base_currency)
+        .where(FxRate.quote_currency == quote_currency)
+        .where(FxRate.rate_date <= requested_date)
+        .order_by(FxRate.rate_date.desc())
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    row = result.one_or_none()
+    if row is None:
+        return None
+    rate = row.rate if isinstance(row.rate, Decimal) else Decimal(str(row.rate))
+    return _StoredFxRate(rate=_quantize_rate(rate), rate_date=row.rate_date, source=row.source)
+
+
+async def _load_stored_direct_or_inverse(
+    db: AsyncSession,
+    base_currency: str,
+    quote_currency: str,
+    requested_date: date,
+) -> FxRateObservation | None:
+    direct = await _load_stored_rate(db, base_currency, quote_currency, requested_date)
+    if direct is not None:
+        return FxRateObservation(
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            rate=direct.rate,
+            rate_date=direct.rate_date,
+            source=direct.source,
+        )
+
+    inverse = await _load_stored_rate(db, quote_currency, base_currency, requested_date)
+    if inverse is None:
+        return None
+
+    return FxRateObservation(
+        base_currency=base_currency,
+        quote_currency=quote_currency,
+        rate=_quantize_rate(Decimal("1") / inverse.rate),
+        rate_date=inverse.rate_date,
+        source=f"derived:inverse:{quote_currency}/{base_currency}",
+    )
+
+
+async def _derive_from_bridge_rates(
+    db: AsyncSession,
+    base_currency: str,
+    quote_currency: str,
+    requested_date: date,
+    bridge_currency: str,
+) -> FxRateObservation | None:
+    bridge = _normalize_currency(bridge_currency)
+    if bridge in {base_currency, quote_currency}:
+        return None
+
+    base_to_bridge = await _load_stored_direct_or_inverse(db, base_currency, bridge, requested_date)
+    bridge_to_quote = await _load_stored_direct_or_inverse(db, bridge, quote_currency, requested_date)
+    if base_to_bridge is None or bridge_to_quote is None:
+        return None
+
+    return FxRateObservation(
+        base_currency=base_currency,
+        quote_currency=quote_currency,
+        rate=_quantize_rate(base_to_bridge.rate * bridge_to_quote.rate),
+        rate_date=max(base_to_bridge.rate_date, bridge_to_quote.rate_date),
+        source=f"derived:bridge:{bridge}",
+    )
+
+
+async def _persist_fx_rate(db: AsyncSession, observation: FxRateObservation) -> Decimal:
+    base = _normalize_currency(observation.base_currency)
+    quote = _normalize_currency(observation.quote_currency)
+    rate = _quantize_rate(observation.rate)
+
+    existing = await _load_stored_rate(db, base, quote, observation.rate_date)
+    if existing is not None and existing.rate_date == observation.rate_date:
+        return existing.rate
+
+    db.add(
+        FxRate(
+            base_currency=base,
+            quote_currency=quote,
+            rate=rate,
+            rate_date=observation.rate_date,
+            source=observation.source[:50],
+        )
+    )
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        concurrent = await _load_stored_rate(db, base, quote, observation.rate_date)
+        if concurrent is not None and concurrent.rate_date == observation.rate_date:
+            return concurrent.rate
+        raise
+    logger.info(
+        "Persisted lazy FX rate",
+        base_currency=base,
+        quote_currency=quote,
+        rate_date=observation.rate_date.isoformat(),
+        source=observation.source[:50],
+    )
+    return rate
+
+
+async def resolve_missing_fx_rate(
+    db: AsyncSession,
+    base_currency: str,
+    quote_currency: str,
+    requested_date: date,
+) -> Decimal | None:
+    """Resolve a missing report FX rate through safe derivation or provider fetch."""
+    base = _normalize_currency(base_currency)
+    quote = _normalize_currency(quote_currency)
+    if base == quote:
+        return Decimal("1")
+
+    direct_or_inverse = await _load_stored_direct_or_inverse(db, base, quote, requested_date)
+    if direct_or_inverse is not None:
+        if direct_or_inverse.source.startswith("derived:inverse:"):
+            return await _persist_fx_rate(db, direct_or_inverse)
+        return direct_or_inverse.rate
+
+    bridge = await _derive_from_bridge_rates(
+        db,
+        base,
+        quote,
+        requested_date,
+        settings.market_data_fx_bridge_currency,
+    )
+    if bridge is not None:
+        return await _persist_fx_rate(db, bridge)
+
+    if not settings.market_data_lazy_fetch_enabled:
+        return None
+
+    provider_observation = await _fetch_yahoo_or_derived_fx_rate(base, quote, requested_date)
+    if provider_observation is not None:
+        return await _persist_fx_rate(db, provider_observation)
+
+    return None
+
+
+async def _fetch_yahoo_or_derived_fx_rate(
+    base_currency: str,
+    quote_currency: str,
+    requested_date: date,
+) -> FxRateObservation | None:
+    direct = await _fetch_yahoo_fx_rate(base_currency, quote_currency, requested_date)
+    if direct is not None:
+        return direct
+
+    inverse = await _fetch_yahoo_fx_rate(quote_currency, base_currency, requested_date)
+    if inverse is not None:
+        return FxRateObservation(
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            rate=_quantize_rate(Decimal("1") / inverse.rate),
+            rate_date=inverse.rate_date,
+            source="yahoo_finance:inverse",
+        )
+
+    bridge = _normalize_currency(settings.market_data_fx_bridge_currency)
+    if bridge in {base_currency, quote_currency}:
+        return None
+    base_to_bridge = await _fetch_yahoo_fx_rate(base_currency, bridge, requested_date)
+    bridge_to_quote = await _fetch_yahoo_fx_rate(bridge, quote_currency, requested_date)
+    if base_to_bridge is None or bridge_to_quote is None:
+        return None
+
+    return FxRateObservation(
+        base_currency=base_currency,
+        quote_currency=quote_currency,
+        rate=_quantize_rate(base_to_bridge.rate * bridge_to_quote.rate),
+        rate_date=max(base_to_bridge.rate_date, bridge_to_quote.rate_date),
+        source=f"yahoo_finance:bridge:{bridge}",
+    )
+
+
+async def _fetch_yahoo_fx_rate(
+    base_currency: str,
+    quote_currency: str,
+    requested_date: date,
+) -> FxRateObservation | None:
+    """Fetch the latest Yahoo Finance FX close on or before the requested date."""
+    symbol = f"{base_currency}{quote_currency}"
+    start = requested_date - timedelta(days=7)
+    end = requested_date + timedelta(days=1)
+    params = {
+        "period1": str(_date_to_epoch(start)),
+        "period2": str(_date_to_epoch(end)),
+        "interval": "1d",
+    }
+    headers = {"User-Agent": "finance-report-audit/1.0"}
+    url = _YAHOO_CHART_URL.format(symbol=symbol)
+
+    try:
+        async with httpx.AsyncClient(timeout=settings.market_data_yahoo_timeout_seconds, headers=headers) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "Yahoo Finance FX fetch failed",
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            requested_date=requested_date.isoformat(),
+            error=str(exc),
+        )
+        return None
+
+    return _parse_yahoo_fx_response(response.json(), base_currency, quote_currency, requested_date)
+
+
+def _parse_yahoo_fx_response(
+    payload: dict[str, Any],
+    base_currency: str,
+    quote_currency: str,
+    requested_date: date,
+) -> FxRateObservation | None:
+    results = payload.get("chart", {}).get("result") or []
+    if not results:
+        return None
+
+    result = results[0]
+    timestamps = result.get("timestamp") or []
+    closes = ((result.get("indicators") or {}).get("quote") or [{}])[0].get("close") or []
+
+    observations: list[FxRateObservation] = []
+    for timestamp, close in zip(timestamps, closes, strict=False):
+        if close is None:
+            continue
+        observed_date = datetime.fromtimestamp(int(timestamp), UTC).date()
+        if observed_date > requested_date:
+            continue
+        observations.append(
+            FxRateObservation(
+                base_currency=base_currency,
+                quote_currency=quote_currency,
+                rate=_quantize_rate(Decimal(str(close))),
+                rate_date=observed_date,
+                source="yahoo_finance",
+            )
+        )
+
+    if not observations:
+        return None
+    return max(observations, key=lambda item: item.rate_date)

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -20,7 +20,6 @@ from src.models import (
     Account,
     AccountType,
     Direction,
-    FxRate,
     JournalEntry,
     JournalEntryStatus,
     JournalLine,
@@ -28,7 +27,14 @@ from src.models import (
 from src.models.layer3 import ManagedPosition, ManualValuationLiquidityClass, PositionStatus
 from src.services import fx
 from src.services.assets import AssetService
-from src.services.fx import FxRateError, FxWarning, PrefetchedFxRates, convert_amount, get_average_rate
+from src.services.fx import (
+    FxRateError,
+    FxWarning,
+    PrefetchedFxRates,
+    convert_amount,
+    get_average_rate,
+    get_exchange_rate,
+)
 from src.services.fx_revaluation import RevaluationError, calculate_unrealized_fx_gains
 from src.services.portfolio import AssetNotFoundError, PortfolioService
 
@@ -173,21 +179,10 @@ async def _get_fx_rates_map(
             rates[source] = Decimal("1")
             continue
 
-        stmt = (
-            select(FxRate.rate)
-            .where(FxRate.base_currency == source)
-            .where(FxRate.quote_currency == target)
-            .where(FxRate.rate_date <= rate_date)
-            .order_by(FxRate.rate_date.desc())
-            .limit(1)
-        )
-        result = await db.execute(stmt)
-        rate = result.scalar_one_or_none()
-
-        if rate is None:
-            raise ReportError(f"No FX rate available for {source}/{target} on {rate_date}")
-
-        rates[source] = Decimal(str(rate)) if not isinstance(rate, Decimal) else rate
+        try:
+            rates[source] = await get_exchange_rate(db, source, target, rate_date, lazy_load=True)
+        except FxRateError as exc:
+            raise ReportError(str(exc)) from exc
 
     return rates
 
@@ -335,6 +330,7 @@ async def _aggregate_net_income_sql(
                 effective_start,
                 as_of_date,
                 fx_warnings=fx_warnings,
+                lazy_load=True,
             )
         except FxRateError as exc:
             raise ReportError(str(exc)) from exc
@@ -439,6 +435,7 @@ async def _build_portfolio_market_adjustment_lines(
                     currency=source_currency,
                     target_currency=target_currency,
                     rate_date=portfolio_eval_date,
+                    lazy_load=True,
                 )
                 cost_basis = await fx.convert_amount(
                     db,
@@ -446,6 +443,7 @@ async def _build_portfolio_market_adjustment_lines(
                     currency=source_currency,
                     target_currency=target_currency,
                     rate_date=position.acquisition_date,
+                    lazy_load=True,
                 )
             except FxRateError as exc:
                 raise ReportError(str(exc)) from exc
@@ -511,6 +509,7 @@ async def _build_manual_valuation_lines(
                     currency=source_currency,
                     target_currency=target_currency,
                     rate_date=as_of_date,
+                    lazy_load=True,
                 )
             except FxRateError as exc:
                 raise ReportError(str(exc)) from exc
@@ -697,7 +696,7 @@ async def generate_income_statement(
             fx_needs.append((line.currency, target_currency, entry.entry_date, period_key, month_end))
 
     # Batch pre-fetch all needed FX rates
-    fx_rates = PrefetchedFxRates(fx_warnings)
+    fx_rates = PrefetchedFxRates(fx_warnings, lazy_load=True)
     if fx_needs:
         try:
             await fx_rates.prefetch(db, fx_needs)
@@ -740,6 +739,7 @@ async def generate_income_statement(
                         average_start=start_date,
                         average_end=end_date,
                         fx_warnings=fx_warnings,
+                        lazy_load=True,
                     )
                 except FxRateError as exc:
                     logger.warning(
@@ -759,6 +759,7 @@ async def generate_income_statement(
                             currency=line.currency,
                             target_currency=target_currency,
                             rate_date=end_date,
+                            lazy_load=True,
                         )
                     except FxRateError as final_exc:
                         logger.error(
@@ -941,7 +942,7 @@ async def get_account_trend(
         if row.currency.upper() != target_currency:
             fx_needs.append((row.currency, target_currency, row.entry_date, None, None))
 
-    fx_rates = PrefetchedFxRates()
+    fx_rates = PrefetchedFxRates(lazy_load=True)
     if fx_needs:
         try:
             await fx_rates.prefetch(db, fx_needs)
@@ -1086,7 +1087,7 @@ async def get_category_breakdown(
         if row.currency.upper() != target_currency:
             fx_needs.append((row.currency, target_currency, today, start_date, today))
 
-    fx_rates = PrefetchedFxRates()
+    fx_rates = PrefetchedFxRates(lazy_load=True)
     if fx_needs:
         try:
             await fx_rates.prefetch(db, fx_needs)
@@ -1200,7 +1201,7 @@ async def generate_cash_flow(
         if row.currency.upper() != target_currency:
             fx_needs.append((row.currency, target_currency, end_date, None, None))
 
-    fx_rates = PrefetchedFxRates()
+    fx_rates = PrefetchedFxRates(lazy_load=True)
     if fx_needs:
         try:
             await fx_rates.prefetch(db, fx_needs)

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
+from src.config import settings
 from src.logger import get_logger
 from src.services.fx import clear_fx_cache
 
@@ -43,6 +44,12 @@ def cleanup_fx_cache():
     clear_fx_cache()
     yield
     clear_fx_cache()
+
+
+@pytest.fixture(autouse=True)
+def disable_external_market_data_fetch(monkeypatch):
+    """Keep tests deterministic unless a test explicitly enables provider fetches."""
+    monkeypatch.setattr(settings, "market_data_lazy_fetch_enabled", False, raising=False)
 
 
 # --- Helper to ensure 127.0.0.1 consistency ---

--- a/apps/backend/tests/market_data/test_fx.py
+++ b/apps/backend/tests/market_data/test_fx.py
@@ -3,11 +3,15 @@
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
+import httpx
 import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.config import settings
 from src.models import FxRate
-from src.services import fx as fx_service
+from src.services import fx as fx_service, market_data
 from src.services.fx import (
     FxRateError,
     convert_amount,
@@ -57,6 +61,456 @@ async def test_get_exchange_rate_fallback(db: AsyncSession):
     result = await get_exchange_rate(db, "USD", "SGD", date(2025, 1, 3))
 
     assert result == Decimal("1.320000")
+
+
+@pytest.mark.asyncio
+async def test_get_exchange_rate_lazy_derives_inverse(db: AsyncSession):
+    """[AC5.4.3] Lazy FX lookup should derive and persist inverse rates."""
+    db.add(
+        FxRate(
+            base_currency="SGD",
+            quote_currency="HKD",
+            rate=Decimal("5.800000"),
+            rate_date=date(2025, 6, 30),
+            source="test",
+        )
+    )
+    await db.commit()
+
+    result = await get_exchange_rate(db, "HKD", "SGD", date(2025, 6, 30), lazy_load=True)
+
+    assert result == Decimal("0.172414")
+    persisted = await db.execute(
+        select(FxRate).where(
+            FxRate.base_currency == "HKD",
+            FxRate.quote_currency == "SGD",
+            FxRate.rate_date == date(2025, 6, 30),
+        )
+    )
+    derived = persisted.scalar_one()
+    assert derived.rate == Decimal("0.172414")
+    assert derived.source == "derived:inverse:SGD/HKD"
+
+
+@pytest.mark.asyncio
+async def test_get_exchange_rate_lazy_fetches_provider_when_enabled(db: AsyncSession, monkeypatch):
+    """[AC5.4.3] Lazy FX lookup should persist provider rates when DB derivation is unavailable."""
+
+    async def fake_yahoo_fetch(base: str, quote: str, requested_date: date) -> market_data.FxRateObservation:
+        assert (base, quote, requested_date) == ("HKD", "SGD", date(2025, 6, 30))
+        return market_data.FxRateObservation(
+            base_currency=base,
+            quote_currency=quote,
+            rate=Decimal("0.173077"),
+            rate_date=requested_date,
+            source="yahoo_finance",
+        )
+
+    monkeypatch.setattr(settings, "market_data_lazy_fetch_enabled", True)
+    monkeypatch.setattr(market_data, "_fetch_yahoo_fx_rate", fake_yahoo_fetch)
+
+    result = await get_exchange_rate(db, "HKD", "SGD", date(2025, 6, 30), lazy_load=True)
+
+    assert result == Decimal("0.173077")
+    persisted = await db.execute(
+        select(FxRate).where(
+            FxRate.base_currency == "HKD",
+            FxRate.quote_currency == "SGD",
+            FxRate.rate_date == date(2025, 6, 30),
+        )
+    )
+    provider_rate = persisted.scalar_one()
+    assert provider_rate.rate == Decimal("0.173077")
+    assert provider_rate.source == "yahoo_finance"
+
+
+@pytest.mark.asyncio
+async def test_resolve_missing_fx_rate_same_currency_returns_identity(db: AsyncSession):
+    """[AC5.4.3] Lazy FX resolution should return identity for same-currency pairs."""
+    result = await market_data.resolve_missing_fx_rate(db, "sgd", "SGD", date(2025, 6, 30))
+
+    assert result == Decimal("1")
+
+
+@pytest.mark.asyncio
+async def test_resolve_missing_fx_rate_returns_stored_direct_rate(db: AsyncSession):
+    """[AC5.4.3] Lazy FX resolution should use an existing direct DB rate without persisting."""
+    db.add(
+        FxRate(
+            base_currency="HKD",
+            quote_currency="SGD",
+            rate=Decimal("0.173000"),
+            rate_date=date(2025, 6, 29),
+            source="test",
+        )
+    )
+    await db.commit()
+
+    result = await market_data.resolve_missing_fx_rate(db, "hkd", "sgd", date(2025, 6, 30))
+
+    assert result == Decimal("0.173000")
+
+
+@pytest.mark.asyncio
+async def test_resolve_missing_fx_rate_returns_none_when_provider_misses(db: AsyncSession, monkeypatch):
+    """[AC5.4.3] Lazy FX resolution should return None when derivation and provider fetch miss."""
+
+    async def fake_provider_fetch(_base: str, _quote: str, _requested_date: date) -> None:
+        return None
+
+    monkeypatch.setattr(settings, "market_data_lazy_fetch_enabled", True)
+    monkeypatch.setattr(market_data, "_fetch_yahoo_or_derived_fx_rate", fake_provider_fetch)
+
+    result = await market_data.resolve_missing_fx_rate(db, "HKD", "SGD", date(2025, 6, 30))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_persist_fx_rate_keeps_existing_same_day_rate(db: AsyncSession):
+    """[AC5.4.3] Lazy FX persistence should not overwrite an existing same-day rate."""
+    db.add(
+        FxRate(
+            base_currency="HKD",
+            quote_currency="SGD",
+            rate=Decimal("0.173000"),
+            rate_date=date(2025, 6, 30),
+            source="manual",
+        )
+    )
+    await db.commit()
+
+    result = await market_data._persist_fx_rate(
+        db,
+        market_data.FxRateObservation(
+            base_currency="hkd",
+            quote_currency="sgd",
+            rate=Decimal("0.180000"),
+            rate_date=date(2025, 6, 30),
+            source="yahoo_finance",
+        ),
+    )
+
+    assert result == Decimal("0.173000")
+    persisted = await db.execute(select(FxRate).where(FxRate.base_currency == "HKD", FxRate.quote_currency == "SGD"))
+    rate = persisted.scalar_one()
+    assert rate.rate == Decimal("0.173000")
+    assert rate.source == "manual"
+
+
+@pytest.mark.asyncio
+async def test_persist_fx_rate_handles_concurrent_insert():
+    """[AC5.4.3] Lazy FX persistence should return the concurrent same-day insert after IntegrityError."""
+
+    class Row:
+        rate = Decimal("0.173500")
+        rate_date = date(2025, 6, 30)
+        source = "concurrent"
+
+    class Result:
+        def __init__(self, row):
+            self._row = row
+
+        def one_or_none(self):
+            return self._row
+
+    class FakeSession:
+        def __init__(self):
+            self.execute_calls = 0
+            self.rolled_back = False
+            self.added = None
+
+        async def execute(self, _stmt):
+            self.execute_calls += 1
+            return Result(None if self.execute_calls == 1 else Row())
+
+        def add(self, value):
+            self.added = value
+
+        async def commit(self):
+            raise IntegrityError("insert fx", {}, Exception("duplicate"))
+
+        async def rollback(self):
+            self.rolled_back = True
+
+    session = FakeSession()
+
+    result = await market_data._persist_fx_rate(
+        session,
+        market_data.FxRateObservation(
+            base_currency="HKD",
+            quote_currency="SGD",
+            rate=Decimal("0.173077"),
+            rate_date=date(2025, 6, 30),
+            source="yahoo_finance",
+        ),
+    )
+
+    assert result == Decimal("0.173500")
+    assert session.rolled_back is True
+    assert session.added is not None
+
+
+@pytest.mark.asyncio
+async def test_persist_fx_rate_reraises_integrity_error_without_concurrent_rate():
+    """[AC5.4.3] Lazy FX persistence should re-raise an unexpected IntegrityError."""
+
+    class Result:
+        def one_or_none(self):
+            return None
+
+    class FakeSession:
+        async def execute(self, _stmt):
+            return Result()
+
+        def add(self, _value):
+            return None
+
+        async def commit(self):
+            raise IntegrityError("insert fx", {}, Exception("duplicate"))
+
+        async def rollback(self):
+            return None
+
+    with pytest.raises(IntegrityError):
+        await market_data._persist_fx_rate(
+            FakeSession(),
+            market_data.FxRateObservation(
+                base_currency="HKD",
+                quote_currency="SGD",
+                rate=Decimal("0.173077"),
+                rate_date=date(2025, 6, 30),
+                source="yahoo_finance",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_yahoo_or_derived_fx_rate_uses_inverse(monkeypatch):
+    """[AC5.4.3] Yahoo lazy fetch should derive inverse provider rates."""
+
+    async def fake_fetch(base: str, quote: str, requested_date: date) -> market_data.FxRateObservation | None:
+        if (base, quote, requested_date) == ("SGD", "HKD", date(2025, 6, 30)):
+            return market_data.FxRateObservation(
+                base_currency=base,
+                quote_currency=quote,
+                rate=Decimal("5.800000"),
+                rate_date=requested_date,
+                source="yahoo_finance",
+            )
+        return None
+
+    monkeypatch.setattr(market_data, "_fetch_yahoo_fx_rate", fake_fetch)
+
+    result = await market_data._fetch_yahoo_or_derived_fx_rate("HKD", "SGD", date(2025, 6, 30))
+
+    assert result == market_data.FxRateObservation(
+        base_currency="HKD",
+        quote_currency="SGD",
+        rate=Decimal("0.172414"),
+        rate_date=date(2025, 6, 30),
+        source="yahoo_finance:inverse",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_yahoo_or_derived_fx_rate_uses_bridge(monkeypatch):
+    """[AC5.4.3] Yahoo lazy fetch should derive bridge-provider rates."""
+
+    async def fake_fetch(base: str, quote: str, requested_date: date) -> market_data.FxRateObservation | None:
+        observations = {
+            ("HKD", "USD"): market_data.FxRateObservation(
+                base_currency="HKD",
+                quote_currency="USD",
+                rate=Decimal("0.128205"),
+                rate_date=date(2025, 6, 29),
+                source="yahoo_finance",
+            ),
+            ("USD", "SGD"): market_data.FxRateObservation(
+                base_currency="USD",
+                quote_currency="SGD",
+                rate=Decimal("1.350000"),
+                rate_date=date(2025, 6, 30),
+                source="yahoo_finance",
+            ),
+        }
+        assert requested_date == date(2025, 6, 30)
+        return observations.get((base, quote))
+
+    monkeypatch.setattr(settings, "market_data_fx_bridge_currency", "USD")
+    monkeypatch.setattr(market_data, "_fetch_yahoo_fx_rate", fake_fetch)
+
+    result = await market_data._fetch_yahoo_or_derived_fx_rate("HKD", "SGD", date(2025, 6, 30))
+
+    assert result == market_data.FxRateObservation(
+        base_currency="HKD",
+        quote_currency="SGD",
+        rate=Decimal("0.173077"),
+        rate_date=date(2025, 6, 30),
+        source="yahoo_finance:bridge:USD",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_yahoo_or_derived_fx_rate_skips_bridge_when_bridge_is_pair_currency(monkeypatch):
+    """[AC5.4.3] Yahoo lazy fetch should not bridge through the requested pair currencies."""
+
+    async def fake_fetch(_base: str, _quote: str, _requested_date: date) -> None:
+        return None
+
+    monkeypatch.setattr(settings, "market_data_fx_bridge_currency", "SGD")
+    monkeypatch.setattr(market_data, "_fetch_yahoo_fx_rate", fake_fetch)
+
+    result = await market_data._fetch_yahoo_or_derived_fx_rate("HKD", "SGD", date(2025, 6, 30))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_yahoo_or_derived_fx_rate_returns_none_when_bridge_leg_missing(monkeypatch):
+    """[AC5.4.3] Yahoo lazy fetch should return None when a bridge leg is unavailable."""
+
+    async def fake_fetch(base: str, quote: str, _requested_date: date) -> market_data.FxRateObservation | None:
+        if (base, quote) == ("HKD", "USD"):
+            return market_data.FxRateObservation(
+                base_currency="HKD",
+                quote_currency="USD",
+                rate=Decimal("0.128205"),
+                rate_date=date(2025, 6, 30),
+                source="yahoo_finance",
+            )
+        return None
+
+    monkeypatch.setattr(settings, "market_data_fx_bridge_currency", "USD")
+    monkeypatch.setattr(market_data, "_fetch_yahoo_fx_rate", fake_fetch)
+
+    result = await market_data._fetch_yahoo_or_derived_fx_rate("HKD", "SGD", date(2025, 6, 30))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_yahoo_fx_rate_success(monkeypatch):
+    """[AC5.4.3] Yahoo FX fetch should request a bounded daily chart window and parse a rate."""
+    calls = []
+    payload = {
+        "chart": {
+            "result": [
+                {
+                    "timestamp": [market_data._date_to_epoch(date(2025, 6, 29))],
+                    "indicators": {"quote": [{"close": [0.173077]}]},
+                }
+            ]
+        }
+    }
+
+    class FakeClient:
+        def __init__(self, *, timeout, headers):
+            self.timeout = timeout
+            self.headers = headers
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _traceback):
+            return False
+
+        async def get(self, url, params):
+            calls.append((self.timeout, self.headers, url, params))
+            return httpx.Response(200, json=payload, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(market_data.httpx, "AsyncClient", FakeClient)
+
+    result = await market_data._fetch_yahoo_fx_rate("HKD", "SGD", date(2025, 6, 30))
+
+    assert result == market_data.FxRateObservation(
+        base_currency="HKD",
+        quote_currency="SGD",
+        rate=Decimal("0.173077"),
+        rate_date=date(2025, 6, 29),
+        source="yahoo_finance",
+    )
+    timeout, headers, url, params = calls[0]
+    assert timeout == settings.market_data_yahoo_timeout_seconds
+    assert headers["User-Agent"] == "finance-report-audit/1.0"
+    assert url == "https://query1.finance.yahoo.com/v8/finance/chart/HKDSGD=X"
+    assert params["interval"] == "1d"
+
+
+@pytest.mark.asyncio
+async def test_fetch_yahoo_fx_rate_returns_none_on_http_error(monkeypatch):
+    """[AC5.4.3] Yahoo FX fetch should convert HTTP errors into cache misses."""
+
+    class FailingClient:
+        def __init__(self, *, timeout, headers):
+            self.timeout = timeout
+            self.headers = headers
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _traceback):
+            return False
+
+        async def get(self, url, params):
+            raise httpx.ConnectError("offline", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(market_data.httpx, "AsyncClient", FailingClient)
+
+    result = await market_data._fetch_yahoo_fx_rate("HKD", "SGD", date(2025, 6, 30))
+
+    assert result is None
+
+
+def test_parse_yahoo_fx_response_selects_latest_on_or_before_requested_date():
+    """[AC5.4.3] Yahoo parser should ignore null and future closes and select the latest eligible close."""
+    payload = {
+        "chart": {
+            "result": [
+                {
+                    "timestamp": [
+                        market_data._date_to_epoch(date(2025, 6, 28)),
+                        market_data._date_to_epoch(date(2025, 6, 29)),
+                        market_data._date_to_epoch(date(2025, 7, 1)),
+                    ],
+                    "indicators": {"quote": [{"close": [None, 0.1730774, 0.200000]}]},
+                }
+            ]
+        }
+    }
+
+    result = market_data._parse_yahoo_fx_response(payload, "HKD", "SGD", date(2025, 6, 30))
+
+    assert result == market_data.FxRateObservation(
+        base_currency="HKD",
+        quote_currency="SGD",
+        rate=Decimal("0.173077"),
+        rate_date=date(2025, 6, 29),
+        source="yahoo_finance",
+    )
+
+
+def test_parse_yahoo_fx_response_returns_none_for_empty_or_unusable_payloads():
+    """[AC5.4.3] Yahoo parser should return None when the payload has no usable close."""
+    assert market_data._parse_yahoo_fx_response({}, "HKD", "SGD", date(2025, 6, 30)) is None
+    assert (
+        market_data._parse_yahoo_fx_response(
+            {
+                "chart": {
+                    "result": [
+                        {
+                            "timestamp": [market_data._date_to_epoch(date(2025, 7, 1))],
+                            "indicators": {"quote": [{"close": [0.200000]}]},
+                        }
+                    ]
+                }
+            },
+            "HKD",
+            "SGD",
+            date(2025, 6, 30),
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/reporting/test_reporting_fx.py
+++ b/apps/backend/tests/reporting/test_reporting_fx.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import (
@@ -1051,6 +1052,87 @@ async def test_balance_sheet_net_income_fx_fallback(db: AsyncSession, multi_curr
 
     # Net income should be 100 USD * 1.35 = 135 SGD
     assert report["net_income"] == Decimal("135.00")
+
+
+@pytest.mark.asyncio
+async def test_reports_lazy_resolve_missing_hkd_sgd_from_bridge_rates(db: AsyncSession, test_user_id):
+    """[AC5.4.3] Reports derive and persist a missing HKD/SGD rate from bridge rates."""
+    hkd_cash = Account(user_id=test_user_id, name="HKD Cash", type=AccountType.ASSET, currency="HKD")
+    hkd_salary = Account(user_id=test_user_id, name="HKD Salary", type=AccountType.INCOME, currency="HKD")
+    db.add_all([hkd_cash, hkd_salary])
+    await db.flush()
+
+    db.add_all(
+        [
+            FxRate(
+                base_currency="USD",
+                quote_currency="HKD",
+                rate=Decimal("7.800000"),
+                rate_date=date(2025, 6, 30),
+                source="test",
+            ),
+            FxRate(
+                base_currency="USD",
+                quote_currency="SGD",
+                rate=Decimal("1.350000"),
+                rate_date=date(2025, 6, 30),
+                source="test",
+            ),
+        ]
+    )
+
+    entry = JournalEntry(
+        user_id=test_user_id,
+        entry_date=date(2025, 6, 30),
+        memo="HKD salary",
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=hkd_cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("780.00"),
+                currency="HKD",
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=hkd_salary.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("780.00"),
+                currency="HKD",
+            ),
+        ]
+    )
+    await db.commit()
+
+    income_statement = await generate_income_statement(
+        db,
+        test_user_id,
+        start_date=date(2025, 6, 1),
+        end_date=date(2025, 6, 30),
+        currency="SGD",
+    )
+    balance_sheet = await generate_balance_sheet(db, test_user_id, as_of_date=date(2025, 6, 30), currency="SGD")
+
+    assert income_statement["total_income"] == Decimal("135.00")
+    assert balance_sheet["total_assets"] == Decimal("135.00")
+    assert balance_sheet["net_income"] == Decimal("135.00")
+    assert balance_sheet["is_balanced"] is True
+
+    result = await db.execute(
+        select(FxRate).where(
+            FxRate.base_currency == "HKD",
+            FxRate.quote_currency == "SGD",
+            FxRate.rate_date == date(2025, 6, 30),
+        )
+    )
+    derived_rate = result.scalar_one()
+    assert derived_rate.rate == Decimal("0.173077")
+    assert derived_rate.source == "derived:bridge:USD"
 
 
 @pytest.mark.asyncio

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -985,6 +985,11 @@ groups:
         epic_name: reporting-visualization
         description: Balance Sheet Net Income FX Fallback
         mandatory: true
+      - id: AC5.4.3
+        epic: 5
+        epic_name: reporting-visualization
+        description: Report FX Lazy Resolution
+        mandatory: true
     AC5.5:
       - id: AC5.5.1
         epic: 5

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -49,7 +49,8 @@ Accounting Equation Verification: Reports must comply with accounting equation
 - [x] `services/fx.py` - Exchange rate service
   - [x] `get_exchange_rate()` - Get exchange rate
   - [x] `convert_to_base()` - Convert to base currency
-  - [x] Exchange rate caching (daily update)
+  - [x] Exchange rate caching and report-side lazy FX resolution
+  - [ ] Daily incremental FX sync (tracked by Issue #539)
 - [x] Report currency configuration
   - [x] Base currency setting (default SGD)
   - [x] Unified report conversion
@@ -123,6 +124,7 @@ Accounting Equation Verification: Reports must comply with accounting equation
 |----|-----------|---------------|------|----------|
 | AC5.4.1 | FX Fallbacks | `test_reporting_fx_fallbacks` | `reporting/test_reporting_fx.py` | P1 |
 | AC5.4.2 | Balance Sheet Net Income FX Fallback | `test_balance_sheet_net_income_fx_fallback` | `reporting/test_reporting_fx.py` | P1 |
+| AC5.4.3 | Report FX Lazy Resolution | `test_reports_lazy_resolve_missing_hkd_sgd_from_bridge_rates` | `reporting/test_reporting_fx.py` | P0 |
 
 ### AC5.5: Error Handling
 

--- a/docs/ssot/market_data.md
+++ b/docs/ssot/market_data.md
@@ -9,39 +9,35 @@
 
 | Dimension | Physical Location (SSOT) | Description |
 |-----------|--------------------------|-------------|
-| **Sync Logic** | `apps/backend/src/services/market_data.py` | Data fetching |
-| **Rate Storage** | `fx_rates` table | Historical rates |
-| **Price Storage** | `stock_prices` table | Historical prices |
+| **Report Lazy FX Resolution** | `apps/backend/src/services/market_data.py` | On-demand FX derivation/fetch for reports |
+| **FX Lookup API** | `apps/backend/src/services/fx.py` | DB lookup, in-process cache, optional lazy resolution |
+| **Rate Storage** | `fx_rates` table | Historical direct and derived rates |
+| **Scheduled Sync** | GitHub Issue #539 | Planned daily incremental FX/stock pipeline |
+| **Price Storage** | `stock_prices` table | Planned historical prices |
 
 ---
 
 ## 2. Data Sources
 
-### Primary: yfinance
-- **Type**: Python library (free)
-- **Data**: FX rates, stock prices
+### Primary: Yahoo Finance
+- **Type**: Yahoo Finance chart endpoint, compatible with yfinance currency symbols
+- **Data**: Report-side lazy FX rates
 - **Rate Limit**: Unofficial, ~2000 requests/hour
-- **Fallback**: Twelve Data
+- **Fallback**: Stored inverse or bridge rates before external fetch
 
-### Secondary: Twelve Data
+### Secondary: Twelve Data (Planned)
 - **Type**: REST API (API key required)
 - **Data**: FX rates, stock prices
 - **Rate Limit**: 800 requests/day (free tier)
-- **Use Case**: Fallback when yfinance fails
+- **Use Case**: Cross-source validation and scheduled sync fallback in Issue #539
 
-### Source Priority
+### Report Lazy Resolution Priority
 ```python
-MARKET_DATA_SOURCES = [
-    {"name": "yfinance", "priority": 1},
-    {"name": "twelve_data", "priority": 2},
-]
-
 async def get_fx_rate(base: str, quote: str, date: date) -> Decimal:
-    for source in sorted(MARKET_DATA_SOURCES, key=lambda x: x["priority"]):
-        try:
-            return await fetch_rate(source["name"], base, quote, date)
-        except SourceError:
-            continue
+    # 1. Existing direct DB row on or before date
+    # 2. Existing inverse DB row, persisted as derived direct row
+    # 3. Existing bridge rows via MARKET_DATA_FX_BRIDGE_CURRENCY, default USD
+    # 4. Yahoo Finance direct/inverse/bridge fetch when lazy fetch is enabled
     raise MarketDataUnavailable(f"No source available for {base}/{quote}")
 ```
 
@@ -53,11 +49,13 @@ async def get_fx_rate(base: str, quote: str, date: date) -> Decimal:
 - **Frequency**: Daily at 08:00 UTC
 - **Pairs**: USD/SGD, USD/CNY, USD/HKD, EUR/USD, GBP/USD
 - **History**: Keep 2 years of daily rates
+- **Status**: Planned in Issue #539. Report APIs currently use lazy resolution when a required rate is missing.
 
 ### Stock Prices
 - **Frequency**: Daily at 22:00 UTC (after US market close)
 - **Symbols**: User-configured holdings
 - **History**: Keep 2 years of daily prices
+- **Status**: Planned in Issue #539.
 
 ### Sync Workflow (via Activepieces)
 ```yaml
@@ -132,10 +130,12 @@ amount_usd = (amount_sgd * fx_rate).quantize(Decimal("0.01"))
 
 ## 6. Caching Strategy
 
-### Redis Cache
+### FX Cache
 - **Key format**: `fx:{base}:{quote}:{date}`
 - **TTL**: 24 hours
+- **Implementation**: In-process cache in `apps/backend/src/services/fx.py`
 - **Fallback**: Database lookup if cache miss
+- **Report lazy resolution**: `lazy_load=True` call sites may resolve a missing DB rate through inverse, bridge, or Yahoo Finance and persist the result to `fx_rates`.
 
 ```python
 async def get_fx_rate_cached(base: str, quote: str, date: date) -> Decimal:
@@ -152,10 +152,10 @@ async def get_fx_rate_cached(base: str, quote: str, date: date) -> Decimal:
         await redis.setex(cache_key, 86400, str(rate.rate))
         return rate.rate
     
-    # Fetch from source
-    rate = await fetch_from_source(base, quote, date)
+    # Report-only lazy fallback
+    rate = await resolve_missing_fx_rate(base, quote, date)
     await save_to_db(rate)
-    await redis.setex(cache_key, 86400, str(rate))
+    cache.set(cache_key, rate)
     return rate
 ```
 
@@ -167,10 +167,11 @@ async def get_fx_rate_cached(base: str, quote: str, date: date) -> Decimal:
 - **Pattern A**: Always store source name with rate for auditability
 - **Pattern B**: Use Decimal(6) for rates, Decimal(2) for converted amounts
 - **Pattern C**: Prefer historical rates over real-time for reporting
+- **Pattern D**: Persist derived report-side rates with `source` values such as `derived:inverse:SGD/HKD`, `derived:bridge:USD`, or `yahoo_finance`.
 
 ### ⛔ Prohibited Patterns
 - **Anti-pattern A**: **NEVER** hardcode exchange rates
-- **Anti-pattern B**: **NEVER** use single source without fallback
+- **Anti-pattern B**: **NEVER** silently invent rates when direct, inverse, bridge, and provider lookup all fail
 
 ---
 
@@ -178,9 +179,10 @@ async def get_fx_rate_cached(base: str, quote: str, date: date) -> Decimal:
 
 | Error | Action |
 |-------|--------|
-| Source timeout | Retry 3x, then try next source |
-| Missing rate for date | Use previous day's rate |
-| All sources failed | Log alert, use last known rate |
+| Missing direct rate | Try inverse and bridge rates from `fx_rates` |
+| Source timeout | Log warning and continue to report error handling |
+| Missing rate for date | Use the latest stored/provider date on or before the requested date |
+| All lazy paths failed | Raise `FxRateError`; report APIs surface a controlled `ReportError` |
 
 ---
 
@@ -188,10 +190,12 @@ async def get_fx_rate_cached(base: str, quote: str, date: date) -> Decimal:
 
 | Behavior | Test Method | Status |
 |----------|-------------|--------|
-| yfinance fetch | `test_yfinance_fx` | ⏳ Pending |
-| Twelve Data fallback | `test_twelve_data_fallback` | ⏳ Pending |
-| Cache hit/miss | `test_fx_cache` | ⏳ Pending |
-| Missing rate handling | `test_missing_rate` | ⏳ Pending |
+| Inverse lazy resolution | `test_get_exchange_rate_lazy_derives_inverse` | ✅ Implemented |
+| Provider lazy resolution | `test_get_exchange_rate_lazy_fetches_provider_when_enabled` | ✅ Implemented |
+| Report HKD/SGD bridge resolution | `test_reports_lazy_resolve_missing_hkd_sgd_from_bridge_rates` | ✅ Implemented |
+| Cache hit/miss | `test_fx_cache` | ✅ Implemented |
+| Twelve Data fallback | Issue #539 | ⏳ Planned |
+| Daily stock/FX sync | Issue #539 | ⏳ Planned |
 
 ---
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -34,6 +34,11 @@ def get_runtime_version(name: str) -> str:
     return str(toolchain["runtime"][name])
 
 
+def uv_run(*args: str) -> list[str]:
+    """Build a uv run command pinned to the SSOT Python runtime."""
+    return ["uv", "run", "--python", get_runtime_version("python"), *args]
+
+
 def get_compose_cmd() -> list[str]:
     """Detect container runtime (podman or docker) and return compose command."""
     requested = os.environ.get("CONTAINER_RUNTIME", "").strip().lower()
@@ -85,11 +90,11 @@ def cmd_dev(args):
         run([*compose_cmd, "--profile", "infra", "up", "-d"])
 
     if args.migrate:
-        run(["uv", "run", "alembic", "upgrade", "head"], cwd=BACKEND_DIR)
+        run(uv_run("python", "-m", "alembic", "upgrade", "head"), cwd=BACKEND_DIR)
         return
 
     if args.check:
-        run(["uv", "run", "python", "-m", "src.boot", "--mode=full"], cwd=BACKEND_DIR)
+        run(uv_run("python", "-m", "src.boot", "--mode=full"), cwd=BACKEND_DIR)
         return
 
     if args.backend:
@@ -109,15 +114,16 @@ def cmd_test(args, extra_args: list[str]):
         return
     if args.e2e:
         run(
-            ["uv", "run", "pytest", "-m", "e2e", "tests/e2e/"] + extra_args,
+            uv_run("python", "-m", "pytest", "-m", "e2e", "tests/e2e/")
+            + extra_args,
             cwd=BACKEND_DIR,
         )
         return
     if args.perf:
         run(
-            [
-                "uv",
-                "run",
+            uv_run(
+                "python",
+                "-m",
                 "locust",
                 "-f",
                 "tests/locustfile.py",
@@ -129,13 +135,13 @@ def cmd_test(args, extra_args: list[str]):
                 "--run-time",
                 "30s",
                 "--headless",
-            ],
+            ),
             cwd=BACKEND_DIR,
         )
         return
 
     if extra_args and extra_args[0].startswith("tests/"):
-        run(["uv", "run", "pytest"] + extra_args, cwd=BACKEND_DIR)
+        run(uv_run("python", "-m", "pytest") + extra_args, cwd=BACKEND_DIR)
         return
     lifecycle_args = []
     if args.fast:
@@ -155,12 +161,15 @@ def cmd_lint(args):
     """Run linting and formatting."""
     if args.backend or not args.frontend:
         if args.fix:
-            run(["uv", "run", "ruff", "format", "src/"], cwd=BACKEND_DIR)
-            run(["uv", "run", "ruff", "check", "src/", "--fix"], cwd=BACKEND_DIR)
-        else:
-            run(["uv", "run", "ruff", "check", "src/"], cwd=BACKEND_DIR)
+            run(uv_run("python", "-m", "ruff", "format", "src/"), cwd=BACKEND_DIR)
             run(
-                ["uv", "run", "ruff", "format", "src/", "--check"],
+                uv_run("python", "-m", "ruff", "check", "src/", "--fix"),
+                cwd=BACKEND_DIR,
+            )
+        else:
+            run(uv_run("python", "-m", "ruff", "check", "src/"), cwd=BACKEND_DIR)
+            run(
+                uv_run("python", "-m", "ruff", "format", "src/", "--check"),
                 cwd=BACKEND_DIR,
             )
 

--- a/scripts/dev_backend.py
+++ b/scripts/dev_backend.py
@@ -16,6 +16,7 @@ import signal
 import subprocess
 import sys
 import time
+import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -26,6 +27,18 @@ _started_resources: dict = {
     "uvicorn_proc": None,
     "stack_started": False,
 }
+
+
+def get_runtime_version(name: str) -> str:
+    """Read a runtime version from the repository toolchain contract."""
+    with (REPO_ROOT / "toolchain.toml").open("rb") as fh:
+        toolchain = tomllib.load(fh)
+    return str(toolchain["runtime"][name])
+
+
+def uv_run(*args: str) -> list[str]:
+    """Build a uv run command pinned to the SSOT Python runtime."""
+    return ["uv", "run", "--python", get_runtime_version("python"), *args]
 
 
 def get_compose_cmd() -> list[str]:
@@ -65,7 +78,7 @@ def check_database_ready() -> bool:
     print("  🚀 Running migrations...")
     try:
         subprocess.run(
-            ["uv", "run", "alembic", "upgrade", "head"],
+            uv_run("python", "-m", "alembic", "upgrade", "head"),
             cwd=REPO_ROOT / "apps" / "backend",
             check=True,
             capture_output=True,  # Capture output to avoid noise if it fails
@@ -123,9 +136,9 @@ def main():
     # Start uvicorn
     backend_dir = REPO_ROOT / "apps" / "backend"
     proc = subprocess.Popen(
-        [
-            "uv",
-            "run",
+        uv_run(
+            "python",
+            "-m",
             "uvicorn",
             "src.main:app",
             "--reload",
@@ -133,7 +146,7 @@ def main():
             "0.0.0.0",
             "--port",
             "8000",
-        ],
+        ),
         cwd=backend_dir,
     )
     _started_resources["uvicorn_proc"] = proc

--- a/scripts/test_lifecycle.py
+++ b/scripts/test_lifecycle.py
@@ -21,6 +21,7 @@ import signal
 import subprocess
 import sys
 import time
+import tomllib
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -46,6 +47,18 @@ GREEN = "\033[92m"
 YELLOW = "\033[93m"
 RED = "\033[91m"
 RESET = "\033[0m"
+
+
+def get_runtime_version(name: str) -> str:
+    """Read a runtime version from the repository toolchain contract."""
+    with (REPO_ROOT / "toolchain.toml").open("rb") as fh:
+        toolchain = tomllib.load(fh)
+    return str(toolchain["runtime"][name])
+
+
+def uv_run(*args: str) -> list[str]:
+    """Build a uv run command pinned to the SSOT Python runtime."""
+    return ["uv", "run", "--python", get_runtime_version("python"), *args]
 
 
 # === Isolation Utilities ===
@@ -453,7 +466,7 @@ def test_database(ephemeral=False):
 
     try:
         subprocess.run(
-            ["uv", "run", "alembic", "upgrade", "head"],
+            uv_run("python", "-m", "alembic", "upgrade", "head"),
             cwd=BACKEND_DIR,
             env=env,
             check=True,
@@ -622,7 +635,7 @@ def main():
             env["S3_ENDPOINT"] = "http://localhost:9000"
             env["S3_BUCKET"] = get_s3_bucket(namespace)
 
-            cmd = ["uv", "run", "pytest", "-v"] + pytest_args
+            cmd = uv_run("python", "-m", "pytest", "-v") + pytest_args
 
             log(f"   Command: {' '.join(cmd)}", YELLOW)
             result = subprocess.run(cmd, cwd=BACKEND_DIR, env=env)

--- a/scripts/tests/test_cli_and_dev_servers.py
+++ b/scripts/tests/test_cli_and_dev_servers.py
@@ -89,7 +89,16 @@ def test_AC16_11_17_cmd_test_e2e_route(monkeypatch):
         ),
         ["-q"],
     )
-    assert calls[0][0][:4] == ["uv", "run", "pytest", "-m"]
+    assert calls[0][0][:7] == [
+        "uv",
+        "run",
+        "--python",
+        "3.12.12",
+        "python",
+        "-m",
+        "pytest",
+    ]
+    assert "-m" in calls[0][0]
 
 
 def test_AC16_11_17_cmd_test_perf_route(monkeypatch):
@@ -110,7 +119,15 @@ def test_AC16_11_17_cmd_test_perf_route(monkeypatch):
         ),
         [],
     )
-    assert calls[0][0][:3] == ["uv", "run", "locust"]
+    assert calls[0][0][:7] == [
+        "uv",
+        "run",
+        "--python",
+        "3.12.12",
+        "python",
+        "-m",
+        "locust",
+    ]
 
 
 def test_AC16_11_17_cmd_test_backend_path_route(monkeypatch):
@@ -131,7 +148,15 @@ def test_AC16_11_17_cmd_test_backend_path_route(monkeypatch):
         ),
         ["tests/review/test_x.py"],
     )
-    assert calls[0][0][:3] == ["uv", "run", "pytest"]
+    assert calls[0][0][:7] == [
+        "uv",
+        "run",
+        "--python",
+        "3.12.12",
+        "python",
+        "-m",
+        "pytest",
+    ]
 
 
 def test_AC16_11_17_cmd_test_lifecycle_route(monkeypatch):
@@ -387,7 +412,19 @@ class TestCmdLint:
         cli.cmd_lint(SimpleNamespace(backend=True, frontend=False, fix=False))
 
         format_calls = [
-            call for call in calls if call["cmd"][:4] == ["uv", "run", "ruff", "format"]
+            call
+            for call in calls
+            if call["cmd"][:7]
+            == [
+                "uv",
+                "run",
+                "--python",
+                "3.12.12",
+                "python",
+                "-m",
+                "ruff",
+            ]
+            and "format" in call["cmd"]
         ]
         assert format_calls
         assert format_calls[0]["check"] is True


### PR DESCRIPTION
## Summary

Fix report-side FX resolution so dashboards can derive or lazily fetch missing rates instead of failing when direct FX rows are absent.

Closes #538

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-005 — Reporting and Visualization |
| **AC IDs** | AC5.4.3 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/market_data.md` — documents report-side lazy FX resolution, source priority, caching, and Issue #539 follow-up scope

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | Not separately preserved | Added AC5.4.3 tests for inverse/provider/report bridge FX lazy resolution |
| Green (passing test) | `89bf455` | Implemented report FX lazy resolution and Python-runtime-pinned lifecycle commands |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no enum changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (checked; no production template change required, optional backend defaults cover the new env vars)
- [x] `scripts/check_env_keys.py` passes
- [x] `scripts/check_manifest.py` passes
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
moon run :test
moon run :lint
uv run --with pytest --with pyyaml --with pdfplumber --with reportlab pytest scripts/tests/test_cli_and_dev_servers.py scripts/tests/test_lifecycle_and_pdf_scripts.py -q
uv run --with pyyaml python scripts/check_ac_traceability.py
uv run --with pyyaml python scripts/generate_ac_registry.py --check
uv run --with pyyaml python scripts/check_env_keys.py
uv run --with pyyaml python scripts/check_manifest.py
uv run --with pyyaml python scripts/lint_doc_consistency.py
```

---

## Screenshots / Evidence

Backend-only change. Local `moon run :test` passed with 1905 tests and 97.35% coverage.
