### PR TITLE
[codex] Close E2E proof traceability gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ from project intent to executable proof without reading archive fragments.
 | EPIC scope | `docs/project/EPIC-*.md` | Scope, ACs, owned docs, known gaps | AC registries |
 | AC registry | `docs/ac_registry.yaml`, `docs/infra_registry.yaml` | Generated acceptance criteria inventory | `scripts/generate_ac_registry.py --check` |
 | SSOT index | `docs/ssot/README.md`, `docs/ssot/MANIFEST.yaml` | Technical truth ownership map | `scripts/check_ssot_ownership.py` |
-| Testing proof | `docs/analysis/test-ac-coverage-report.md`, `unified-coverage.json` | Checked-in AC-to-test snapshot and coverage baseline | `scripts/check_ac_traceability.py`, `scripts/coverage_policy.py` |
+| Testing proof | `docs/analysis/test-ac-coverage-report.md`, `unified-coverage.json` | Checked-in AC-to-test snapshot and coverage baseline | `scripts/check_ac_traceability.py`, `common/coverage/policy.py` |
 
 Implementation facts should be code-owned where possible. Prose SSOT documents
 explain rationale and link to code, tests, generated registries, or issues
@@ -61,7 +61,7 @@ Use these sources instead:
 - Live local AC coverage: `python scripts/analyze_test_ac_coverage.py --stdout`
 - Traceability gate: `python scripts/check_ac_traceability.py`
 - Coverage baseline data: `unified-coverage.json`
-- Coverage policy owner: `scripts/coverage_policy.py`
+- Coverage policy owner: `common/coverage/policy.py`
 
 Important caveat: the current AC coverage analyzer excludes `_ac_stubs`,
 trivial placeholder assertions, pure `pass`, and pure skipped tests from

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-05-28 13:28:05 UTC by `scripts/analyze_test_ac_coverage.py`
+> Generated: 2026-05-28 15:27:54 UTC by `scripts/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 1005 |
-| Active ACs | 1002 |
+| Registered ACs | 1006 |
+| Active ACs | 1003 |
 | Deprecated ACs excluded from coverage gate | 3 |
-| Covered by real test candidates | 1002 (100.0%) |
+| Covered by real test candidates | 1003 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -32,11 +32,10 @@
 
 | Source | Files scanned | Unique AC refs (real) | Unique AC refs (placeholder) | Unique AC refs (stub) |
 |---|---:|---:|---:|---:|
-| backend | 168 | 652 | 0 | 0 |
+| backend | 168 | 653 | 0 | 0 |
 | frontend | 80 | 190 | 7 | 0 |
-| scripts_tests | 47 | 211 | 23 | 0 |
-| e2e | 11 | 22 | 0 | 0 |
-| repo_e2e | 18 | 0 | 0 | 0 |
+| scripts_tests | 46 | 211 | 23 | 0 |
+| e2e | 11 | 47 | 0 | 0 |
 
 ## Coverage by EPIC
 
@@ -46,7 +45,7 @@
 | EPIC-002 | double-entry-core | 59 | 0 | 59 | 0 | 0 | 0 | 100.0% |
 | EPIC-003 | statement-parsing | 47 | 0 | 47 | 0 | 0 | 0 | 100.0% |
 | EPIC-004 | reconciliation-engine | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-005 | reporting-visualization | 36 | 0 | 36 | 0 | 0 | 0 | 100.0% |
+| EPIC-005 | reporting-visualization | 37 | 0 | 37 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 0 | 63 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
 | EPIC-008 | testing-strategy | 111 | 0 | 111 | 0 | 0 | 0 | 100.0% |

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -2,6 +2,7 @@
 
 > Generated from the issue #475 audit on 2026-05-21.
 > Updated for issue #511 on 2026-05-26.
+> Updated for E2E AC ownership cleanup on 2026-05-28.
 
 The project proof chain is `README.md -> docs/project/EPIC-*.md ->
 docs/*_registry.yaml -> tests`. Tests that assert product behavior should carry
@@ -117,18 +118,6 @@ explicit AC IDs for the behavior.
 | `scripts/tests/test_seed_fx_rates.py` | `docs/ssot/market_data.md` |
 | `scripts/tests/test_validate_schemas.py` | `docs/ssot/schema.md` |
 
-### Needs AC Triage
-
-These files assert broad E2E behavior. They remain outside AC proof until EPICs
-assign current AC IDs or replace them with narrower AC-owned tests.
-
-| Path | Owner |
-|---|---|
-| `tests/e2e/test_auth_flows.py` | EPIC-008 |
-| `tests/e2e/test_core_journeys.py` | EPIC-008 |
-| `tests/e2e/test_e2e_flows.py` | EPIC-008 |
-| `tests/e2e/test_version_check.py` | EPIC-008 |
-
 ## Source Direct-Test Heuristic Exceptions
 
 The following source files do not have direct filename-matched tests. They are
@@ -148,6 +137,8 @@ router, or generated-fixture flows.
 ## Rule
 
 New tests for user-visible behavior must include an AC reference. New helper,
-fixture, broad legacy E2E, or pure contract tests without AC references must be
-added to this file in the same PR, with an SSOT or EPIC owner. This allow-list
-is enforced by `scripts/lint_doc_consistency.py`.
+fixture, or pure contract tests without AC references must be added to this file
+in the same PR, with an SSOT or EPIC owner. Product E2E tests under
+`tests/e2e/test_*.py` or `apps/backend/tests/e2e/test_*.py` are not eligible
+for this allow-list; attach AC IDs or remove the obsolete test. This policy is
+enforced by `scripts/lint_doc_consistency.py`.

--- a/docs/project/AUDITS.md
+++ b/docs/project/AUDITS.md
@@ -11,16 +11,12 @@ reports for current metrics.
 | [../analysis/ac-epic-mismatch-report.md](../analysis/ac-epic-mismatch-report.md) | Current AC-to-EPIC mismatch triage, separated into actionable and fixture-only refs |
 | [../analysis/traceability-exceptions.md](../analysis/traceability-exceptions.md) | Classified helper/SSOT tests and source surfaces that are not AC proof |
 
-Current generated AC snapshot:
+Current generated AC snapshot values are owned by:
 
-- 984 registered ACs
-- 981 active ACs
-- 3 deprecated ACs excluded from the coverage gate
-- 981 active ACs with real test-candidate references
-- 0 active registered ACs without real test reference
-- 0 stub-only placeholders
-- 0 invalid AC refs in real tests
-- 0 actionable AC-to-EPIC mismatches
+- `docs/analysis/test-ac-coverage-report.md`
+- `docs/analysis/ac-epic-mismatch-report.md`
+- `python scripts/analyze_test_ac_coverage.py --stdout`
+- `python scripts/check_ac_traceability.py`
 
 Placeholder assertion, pure-pass, pure-skip, and stub-only detection are enforced
 by the AC traceability gate before the generated audit artifact is uploaded.

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -95,10 +95,10 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.53**: Common shared tooling owns SSOT, coverage, and isolation helpers while scripts remain command wrappers.
 - **AC8.13.54**: Critical proof matrix fails when README macro outcomes, matrix outcomes, or owner EPIC reverse declarations drift.
 
-**Current state (2026-02-23):**
-- **Tier 1**: 41 tests in `test_core_journeys.py` covering 45 ACs → **91.8% AC pass rate** (45/49)
-- **Tier 2**: Not yet implemented (planned: `tests/e2e/` with `APP_URL`)
-- **Tier 3**: 3 Playwright test files, all skip without `FRONTEND_URL`
+Current test and AC coverage status is generated, not hand-maintained here.
+Use `docs/analysis/test-ac-coverage-report.md`,
+`docs/analysis/ac-epic-mismatch-report.md`, and CI artifacts for live proof
+counts.
 
 ### 2.4 Synthetic Test Data (PDF Generation)
 
@@ -433,43 +433,39 @@ These scenarios represent the "Vertical Slices" of user value.
 
 ---
 
-## 5. Historical Implementation Snapshot
+## 5. E2E Suite Ownership
 
-This section records the implementation shape captured during the 2026-02-23
-testing-strategy audit. It is not the live source for current test counts or
-coverage status; use the generated coverage report and CI artifacts for that.
+Current test counts and coverage percentages belong to generated reports and CI
+artifacts, not this EPIC. This section records which suites are allowed to
+serve as E2E proof surfaces.
 
-### 5.1 Implemented Test Files
+### 5.1 E2E Test Files
 
-| File | Type | Tier | Tests | Coverage |
-|------|------|------|-------|----------|
-| `tests/e2e/test_core_journeys.py` | API E2E | Tier 1 | 41 | Health, accounts CRUD, journal entries, reports, reconciliation, auth, statement upload/flow, CI/CD integration, traceability |
-| `tests/e2e/test_statement_upload_e2e.py` | Playwright | Tier 3 | 2 | Statement upload + model selection (skips without `FRONTEND_URL`) |
-| `tests/e2e/test_statement_full_journey.py` | Playwright | Tier 3 | 1 | Full journey: DBS PDF upload → parse polling → detail/transactions → approve → balance sheet (AC8.13.1–5) |
-| `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | API E2E | Tier 3 | 1 | Issue #404 hard gate: Moomoo + Futu PDF upload → real OCR parsing → brokerage import → holdings + balance sheet value (AC8.13.10) |
-| `tests/e2e/test_vision_upload_to_dashboard_hard_gate.py` | Playwright/API | Tier 3 | 3 | Deterministic vision gate: fresh-user CSV upload → Stage 1 auto-post → reconciliation idempotency → Stage 2 cleared state → processing visibility → exact dashboard/report totals (AC8.13.28–32) |
-| `tests/e2e/test_four_asset_net_worth_golden_path.py` | Browser/API E2E | Tier 3 | 1 | Issue #444 hard gate: fresh-user bank CSV upload → Stage 1/Stage 2 posting → brokerage PDF import → property/mortgage/ESOP manual snapshots → exact as-of net worth and dashboard/report totals (AC8.13.42) |
-| `tests/e2e/test_production_readonly_smoke.py` | Playwright/API | Tier 3 | 3 | Production-safe read-only smoke: health, auth boundary, browser shell, optional credential-gated dashboard |
-| `tests/e2e/test_e2e_flows.py` | Playwright | Tier 3 | 3 | Navigation, registration, reports view (skips without `FRONTEND_URL`) |
-| `tests/e2e/test_auth_flows.py` | Playwright | Tier 3 | 2 | Authentication flows (skips without `FRONTEND_URL`) |
-| `tests/e2e/conftest.py` | Fixtures | — | — | Shared session user, browser context, auth injection |
-| `scripts/smoke_test.sh` | Shell Smoke | — | — | 200+ lines of basic connectivity tests |
+| File | Role | AC Ownership |
+|------|------|--------------|
+| `apps/backend/tests/e2e/test_core_journeys.py` | Backend Tier 1 scenario/API coverage | AC8.1-AC8.10 |
+| `apps/backend/tests/e2e/test_auth_flows.py` | Backend auth flow coverage | AC8.2, AC8.7 |
+| `apps/backend/tests/e2e/test_e2e_flows.py` | Backend report/navigation flow coverage | AC8.2, AC8.6 |
+| `tests/e2e/test_statement_upload_e2e.py` | Statement upload readiness E2E | AC8.4.2, AC8.4.3 |
+| `tests/e2e/test_statement_full_journey.py` | Full statement hard gate | AC8.13.1-AC8.13.8 |
+| `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | Brokerage portfolio hard gate | AC8.13.10, AC8.13.18, AC8.13.19 |
+| `tests/e2e/test_vision_upload_to_dashboard_hard_gate.py` | Deterministic upload-to-dashboard hard gate | AC8.13.28-AC8.13.32 |
+| `tests/e2e/test_four_asset_net_worth_golden_path.py` | Four-asset net-worth hard gate | AC8.13.42 |
+| `tests/e2e/test_production_readonly_smoke.py` | Production-safe read-only smoke | AC8.13.9 |
+| `tests/e2e/test_core_journeys.py` | Supplemental post-merge API smoke | AC8.1, AC8.3, AC8.4, AC8.7, AC8.8, AC8.10, AC1.5, AC6.5, AC6.11 |
+| `tests/e2e/test_e2e_flows.py` | Supplemental browser route/auth smoke | AC8.13.9, AC8.10.8, AC16.12.6, AC1.7.1 |
+| `tests/e2e/test_auth_flows.py` | Supplemental frontend auth/API-path smoke | AC8.10.8, AC8.10.9, AC16.12.5, AC16.12.6, AC1.7.1 |
+| `tests/e2e/test_version_check.py` | Deployment version smoke | AC8.13.36, AC8.13.39 |
 
-### 5.2 Scenario Coverage (Must-Have Requirements)
+Product E2E files under `tests/e2e/test_*.py` and
+`apps/backend/tests/e2e/test_*.py` must carry AC references directly. They are
+not eligible for `docs/analysis/traceability-exceptions.md`; only fixtures and
+shared harness files such as `tests/e2e/conftest.py` may use that exception
+path. The `repo/e2e_regressions/` tree belongs to the `repo/` infra2 submodule
+and is managed by the infrastructure submodule sync process, not by
+finance_report AC coverage.
 
-| Requirement | Status | Test Location |
-|-------------|--------|---------------|
-| Health endpoint reachable | ✅ Passing | `test_core_journeys.py::test_api_health_check` |
-| User can create account | ✅ Passing | `test_core_journeys.py::test_create_cash_account`, `test_accounts_crud_api` |
-| User can create journal entry | ✅ Passing | `test_core_journeys.py::test_simple_expense_entry`, `test_journal_entry_crud` |
-| Statement upload triggers AI | ✅ Passing | `test_core_journeys.py::test_statement_upload_csv` (Tier 1 CSV upload) |
-| Reconciliation engine runs | ✅ Passing | `test_core_journeys.py::test_reconciliation_engine_runs` |
-| Unbalanced entry rejected | ✅ Passing | `test_core_journeys.py::test_unbalanced_journal_entry_rejection` |
-| Reports API accessible | ✅ Passing | `test_core_journeys.py::test_balance_sheet_report`, `test_income_statement_report`, `test_cash_flow_report` |
-| Authentication validation | ✅ Passing | `test_core_journeys.py::test_api_authentication_failures`, `test_unauthorized_access_blocked` |
-| User registration flow | ✅ Passing | `test_core_journeys.py::test_register_and_login_flow` |
-
-### 5.3 Tier 1 Test → AC Mapping (Complete)
+### 5.2 Tier 1 Test -> AC Mapping (Complete)
 
 | Test Function | ACs Covered | Description |
 |---------------|-------------|-------------|
@@ -515,14 +511,14 @@ coverage status; use the generated coverage report and CI artifacts for that.
 | `test_traceability_user_registration` | AC8.10.8 | Dedicated: POST /auth/register |
 | `test_traceability_authentication_validation` | AC8.10.9 | Dedicated: invalid login → 400/401 |
 
-### 5.4 CI/CD Integration Status
+### 5.3 CI/CD Integration Status
 
 - ✅ **PR Workflow**: `.github/workflows/pr-test.yml` runs E2E tests on every PR
 - ✅ **Smoke Tests**: `scripts/smoke_test.sh` integrated into PR pipeline
 - ✅ **Critical Test Check**: `scripts/check_critical_tests.py` validates test results
 - ✅ **Environment Isolation**: Each PR gets isolated DB/Redis/MinIO via Dokploy
 
-### 5.5 Known Gaps
+### 5.4 Known Gaps
 
 1. **Statement Upload Parsing** (`test_statement_upload_e2e.py`):
    - **Status**: ✅ Fixed (Tier 3 assertion now blocks immediate AI/OCR rejection)
@@ -555,14 +551,13 @@ coverage status; use the generated coverage report and CI artifacts for that.
    - **Coverage**: Health payload, anonymous auth boundary, browser shell/login route, optional credential-gated dashboard
    - **Allowed skip**: Authenticated dashboard check may skip only when `PROD_SMOKE_EMAIL` / `PROD_SMOKE_PASSWORD` are not configured; it must not mutate production data
 
-4. **Tier 2 (HTTP E2E)**: Not yet implemented. Would test against deployed PR environments.
+6. **Tier 2 (HTTP E2E)**: Not yet implemented. Would test against deployed PR environments.
 
-5. **100 Scenario Coverage**:
-   - **Current**: 13 scenarios checked in Section 3 (of 100)
-   - **Gap**: 87 scenarios from Phase 1-6 not yet automated
-   - **Priority**: Low (core flows are covered, remaining are nice-to-have)
+7. **Scenario coverage tracking**: Section 3 remains a planning checklist.
+   Current proof counts belong to generated reports and CI artifacts, not this
+   prose list.
 
-### 5.6 Running Tests
+### 5.5 Running Tests
 
 ```bash
 # Run all E2E tests locally

--- a/scripts/analyze_test_ac_coverage.py
+++ b/scripts/analyze_test_ac_coverage.py
@@ -6,7 +6,6 @@ This analyzer scans AC references (``ACx.y.z``) in:
 - ``apps/frontend/src/**/*.test.ts(x)``
 - ``scripts/tests/**/*.py``
 - ``tests/e2e/**/*.py``
-- ``repo/e2e_regressions/**/*.py`` (when present)
 
 Coverage accounting follows EPIC-008 rules:
 - Only references from real (non-``_ac_stubs`` and non-placeholder) tests count
@@ -46,7 +45,6 @@ SCAN_TARGETS: tuple[tuple[str, Path, tuple[str, ...]], ...] = (
     ),
     ("scripts_tests", REPO_ROOT / "scripts" / "tests", ("**/*.py",)),
     ("e2e", REPO_ROOT / "tests" / "e2e", ("**/*.py",)),
-    ("repo_e2e", REPO_ROOT / "repo" / "e2e_regressions", ("**/*.py",)),
 )
 
 

--- a/scripts/lint_doc_consistency.py
+++ b/scripts/lint_doc_consistency.py
@@ -15,8 +15,8 @@ Hard-fail checks enforced in CI:
   4. Every AC ID referenced in an EPIC file MUST exist in one of the
      two registries (no dangling AC IDs in EPIC docs).
   5. Every AC ID present in either registry MUST appear at least once
-     under apps/backend/tests/, apps/frontend/src/__tests__/, or
-     scripts/tests/, unless the AC is marked ``deprecated``
+     under apps/backend/tests/, apps/frontend/src/__tests__/,
+     scripts/tests/, or tests/e2e/, unless the AC is marked ``deprecated``
      (full traceability).
   6. Every ``ACx.y.z`` referenced from a test file MUST exist in one of
      the two registries AND its ``epic`` field MUST equal ``x`` (the
@@ -29,6 +29,8 @@ Hard-fail checks enforced in CI:
      environment gates.
   8. Every test file without an ``ACx.y.z`` reference MUST be listed in
      docs/analysis/traceability-exceptions.md.
+  9. Product E2E test files MUST NOT be listed as traceability exceptions;
+     attach AC IDs to the test or remove the obsolete file instead.
 
 The script exits 0 on success and 1 on any violation.
 
@@ -77,6 +79,7 @@ TEST_ROOTS = [
     REPO_ROOT / "apps" / "backend" / "tests",
     REPO_ROOT / "apps" / "frontend" / "src" / "__tests__",
     REPO_ROOT / "scripts" / "tests",
+    REPO_ROOT / "tests" / "e2e",
 ]
 
 NO_AC_SCAN_TARGETS: tuple[tuple[Path, tuple[str, ...]], ...] = (
@@ -90,6 +93,10 @@ NO_AC_SCAN_TARGETS: tuple[tuple[Path, tuple[str, ...]], ...] = (
 )
 
 CHECK6_TEST_ROOTS = [r for r in TEST_ROOTS if r != REPO_ROOT / "scripts" / "tests"]
+E2E_PRODUCT_TEST_EXCEPTION_PREFIXES = (
+    "tests/e2e/test_",
+    "apps/backend/tests/e2e/test_",
+)
 
 # Allow-list of AC IDs that may appear in test fixtures without a
 # matching registry entry. Keep this list tight; every entry should be
@@ -351,6 +358,31 @@ def check_no_ac_test_exceptions(
                     message=(
                         f"{rel}: test/support file has no AC reference and is "
                         "not classified in docs/analysis/traceability-exceptions.md"
+                    ),
+                )
+            )
+    return violations
+
+
+def check_no_e2e_product_test_exceptions(
+    exception_path: Path | None = None,
+) -> list[Violation]:
+    """Check #9: product E2E tests must be owned by AC IDs, not exceptions."""
+    if exception_path is None:
+        exception_path = REPO_ROOT / "docs" / "analysis" / "traceability-exceptions.md"
+
+    violations: list[Violation] = []
+    for rel in sorted(load_traceability_exception_paths(exception_path)):
+        if "*" in rel:
+            continue
+        if rel.endswith(".py") and rel.startswith(E2E_PRODUCT_TEST_EXCEPTION_PREFIXES):
+            violations.append(
+                Violation(
+                    check="check9_no_e2e_product_test_exceptions",
+                    message=(
+                        f"{rel}: product E2E tests cannot be classified as "
+                        "traceability exceptions; attach EPIC/AC IDs or remove "
+                        "the obsolete test"
                     ),
                 )
             )
@@ -642,6 +674,7 @@ def main() -> int:
     violations.extend(check_test_id_epic_alignment(all_acs, test_refs))
     violations.extend(check_proof_placement_policy())
     violations.extend(check_no_ac_test_exceptions())
+    violations.extend(check_no_e2e_product_test_exceptions())
 
     if args.verbose or violations:
         print("=" * 72)

--- a/scripts/tests/test_analyze_test_ac_coverage.py
+++ b/scripts/tests/test_analyze_test_ac_coverage.py
@@ -86,14 +86,12 @@ groups:
         backend = repo_root / "apps" / "backend" / "tests"
         frontend = repo_root / "apps" / "frontend" / "src" / "__tests__"
         e2e = repo_root / "tests" / "e2e"
-        repo_e2e = repo_root / "repo" / "e2e_regressions"
         scripts_tests = repo_root / "scripts" / "tests"
         stubs = backend / "_ac_stubs"
 
         backend.mkdir(parents=True, exist_ok=True)
         frontend.mkdir(parents=True, exist_ok=True)
         e2e.mkdir(parents=True, exist_ok=True)
-        repo_e2e.mkdir(parents=True, exist_ok=True)
         scripts_tests.mkdir(parents=True, exist_ok=True)
         stubs.mkdir(parents=True, exist_ok=True)
 
@@ -112,10 +110,6 @@ groups:
             encoding="utf-8",
         )
         (e2e / "test_core.py").write_text(
-            "# AC2.2.1\n",
-            encoding="utf-8",
-        )
-        (repo_e2e / "test_regression.py").write_text(
             "# AC2.2.1\n",
             encoding="utf-8",
         )
@@ -146,7 +140,6 @@ groups:
         assert result.source_placeholder_ref_counts["frontend"] == 2
         assert result.source_file_counts["scripts_tests"] == 2
         assert result.source_file_counts["e2e"] == 1
-        assert result.source_file_counts["repo_e2e"] == 1
 
         assert result.covered_ids == {"AC1.1.1", "AC1.1.2", "AC2.2.1", "AC6.6.6"}
         assert result.deprecated_ids == {"AC7.7.7"}

--- a/scripts/tests/test_lint_doc_consistency.py
+++ b/scripts/tests/test_lint_doc_consistency.py
@@ -323,6 +323,37 @@ class TestNoAcTestExceptions:
         assert violations[0].check == "check8_no_ac_test_exceptions"
         assert "tests/test_legacy.py" in violations[0].message
 
+    def test_e2e_product_test_exception_fails(self, tmp_path):
+        exceptions = tmp_path / "docs" / "analysis" / "traceability-exceptions.md"
+        exceptions.parent.mkdir(parents=True)
+        exceptions.write_text(
+            "| `tests/e2e/test_legacy_flow.py` | EPIC-008 |\n"
+            "| `tests/e2e/conftest.py` | Shared fixtures |\n"
+            "| `apps/backend/tests/e2e/test_legacy_api.py` | EPIC-008 |\n",
+            encoding="utf-8",
+        )
+
+        violations = ldc.check_no_e2e_product_test_exceptions(exceptions)
+
+        assert [v.check for v in violations] == [
+            "check9_no_e2e_product_test_exceptions",
+            "check9_no_e2e_product_test_exceptions",
+        ]
+        messages = "\n".join(v.message for v in violations)
+        assert "tests/e2e/test_legacy_flow.py" in messages
+        assert "apps/backend/tests/e2e/test_legacy_api.py" in messages
+        assert all("conftest.py" not in v.message for v in violations)
+
+    def test_e2e_product_exception_policy_glob_is_not_a_file(self, tmp_path):
+        exceptions = tmp_path / "docs" / "analysis" / "traceability-exceptions.md"
+        exceptions.parent.mkdir(parents=True)
+        exceptions.write_text(
+            "Policy applies to `tests/e2e/test_*.py` files.\n",
+            encoding="utf-8",
+        )
+
+        assert ldc.check_no_e2e_product_test_exceptions(exceptions) == []
+
 
 # ---------------------------------------------------------------------------
 # collect_ac_refs_in_epics

--- a/tests/e2e/test_auth_flows.py
+++ b/tests/e2e/test_auth_flows.py
@@ -1,6 +1,13 @@
 """
 Authentication Flow E2E Tests.
 
+EPIC/AC ownership:
+- AC8.10.8: user registration flow
+- AC8.10.9: authentication validation
+- AC16.12.5: login page submits login payload
+- AC16.12.6: login page toggles register mode and switches endpoint
+- AC1.7.1: register endpoint accepts valid user payload
+
 These tests verify the frontend-to-backend auth flows:
 - User registration
 - User login
@@ -30,6 +37,8 @@ def get_url(path: str) -> str:
 @pytest.mark.asyncio
 async def test_registration_api_path(page: Page):
     """
+    AC8.10.8 AC16.12.6 AC1.7.1
+
     Verify registration form submits to correct API path.
     
     This test will FAIL if NEXT_PUBLIC_API_URL has /api suffix,
@@ -81,6 +90,8 @@ async def test_registration_api_path(page: Page):
 @pytest.mark.asyncio
 async def test_login_api_path(page: Page):
     """
+    AC8.10.9 AC16.12.5
+
     Verify login form submits to correct API path.
     
     This test will FAIL if NEXT_PUBLIC_API_URL has /api suffix.
@@ -117,6 +128,8 @@ async def test_login_api_path(page: Page):
 @pytest.mark.asyncio
 async def test_full_registration_flow(page: Page):
     """
+    AC8.10.8 AC16.12.6 AC1.7.1
+
     Full E2E test: Register a new user and verify redirect to dashboard.
     
     This test creates real data and should only run on staging/dev.

--- a/tests/e2e/test_core_journeys.py
+++ b/tests/e2e/test_core_journeys.py
@@ -1,6 +1,19 @@
 """
 Core Application Journey Tests (Finance Report).
 
+EPIC/AC ownership:
+- AC8.10.1 / AC8.8.1: health endpoint smoke
+- AC8.8.2 / AC8.10.2: accounts CRUD
+- AC8.8.3 / AC8.10.3: journal entry lifecycle
+- AC8.8.4 / AC8.10.7: reports API
+- AC8.8.5 / AC8.10.5: reconciliation API
+- AC8.7.1 / AC8.10.9: authentication failures
+- AC8.4.2: statement listing endpoints
+- AC6.11.1: AI model catalog endpoint
+- AC6.5.1: chat suggestions endpoint
+- AC1.5.4: ping toggle endpoint
+- AC8.3.4 / AC8.10.6: unbalanced journal entry rejection
+
 Covers:
 - Smoke Tests (Public pages, API health) - Run everywhere.
 - E2E Tests (User flows, Data mutation) - Run on Staging/Dev only.
@@ -41,7 +54,7 @@ def app_url():
 @pytest.mark.smoke
 @pytest.mark.api
 async def test_api_health_check(app_url):
-    """Verify the API health endpoint is up."""
+    """AC8.10.1 AC8.8.1: Verify the API health endpoint is up."""
     # verify=False is intentional for dev/staging self-signed certs
     async with httpx.AsyncClient(verify=False, timeout=API_TIMEOUT) as client:
         # Try both common health paths just in case
@@ -59,7 +72,7 @@ async def test_api_health_check(app_url):
 
 @pytest.mark.smoke
 async def test_homepage_loads(app_url):
-    """Verify the homepage is accessible (returns 200 or 302)."""
+    """AC8.1.3: Verify the homepage is accessible (returns 200 or 302)."""
     async with httpx.AsyncClient(verify=False, timeout=API_TIMEOUT) as client:
         response = await client.get(f"{app_url}/")
         assert response.status_code < 400, f"Homepage returned {response.status_code}"
@@ -71,7 +84,7 @@ async def test_homepage_loads(app_url):
 @pytest.mark.e2e
 @SKIP_UI
 async def test_dashboard_ui_load(page: Page, app_url):
-    """Verify Dashboard UI loads."""
+    """AC8.13.9: Verify the dashboard route loads for read-only smoke."""
     await page.goto(f"{app_url}/dashboard")
 
     # We expect some key element to be present.
@@ -90,6 +103,8 @@ async def test_dashboard_ui_load(page: Page, app_url):
 @SKIP_WRITE
 async def test_ping_toggle_via_api(app_url):
     """
+    AC1.5.4
+
     Scenario: Toggle ping/pong state via API (no auth required).
     Environment: Staging/Dev Only.
     """
@@ -116,6 +131,8 @@ async def test_ping_toggle_via_api(app_url):
 @pytest.mark.api
 async def test_api_authentication_failures(app_url):
     """
+    AC8.7.1 AC8.10.9
+
     Scenario: Verify API endpoints return 401 without valid authentication.
     Environment: All (security validation).
     - GET /accounts without auth header (should return 401; 429 accepted if rate-limited)
@@ -140,6 +157,8 @@ async def test_api_authentication_failures(app_url):
 @SKIP_WRITE
 async def test_accounts_crud_api(app_url, shared_auth_state):
     """
+    AC8.8.2 AC8.10.2
+
     Scenario: Full CRUD lifecycle for accounts via API.
     Environment: Staging/Dev Only.
 
@@ -215,6 +234,8 @@ async def test_accounts_crud_api(app_url, shared_auth_state):
 @SKIP_WRITE
 async def test_journal_entry_lifecycle_api(app_url, shared_auth_state):
     """
+    AC8.8.3 AC8.10.3
+
     Scenario: Create, post, and void a journal entry via API.
     Environment: Staging/Dev Only.
 
@@ -333,6 +354,8 @@ async def test_journal_entry_lifecycle_api(app_url, shared_auth_state):
 @pytest.mark.api
 async def test_reports_api(app_url, shared_auth_state):
     """
+    AC8.8.4 AC8.10.7
+
     Scenario: Fetch all financial reports via API.
     Environment: All (read-only).
 
@@ -387,6 +410,8 @@ async def test_reports_api(app_url, shared_auth_state):
 @pytest.mark.api
 async def test_reconciliation_api(app_url, shared_auth_state):
     """
+    AC8.8.5 AC8.10.5
+
     Scenario: Test reconciliation endpoints via API.
     Environment: All (read-only operations).
 
@@ -428,6 +453,8 @@ async def test_reconciliation_api(app_url, shared_auth_state):
 @pytest.mark.api
 async def test_statements_api(app_url, shared_auth_state):
     """
+    AC8.4.2
+
     Scenario: Test statement listing endpoints via API.
     Environment: All (read-only operations).
 
@@ -453,6 +480,8 @@ async def test_statements_api(app_url, shared_auth_state):
 @pytest.mark.api
 async def test_ai_models_api(app_url, shared_auth_state):
     """
+    AC6.11.1
+
     Scenario: Test AI models listing endpoint.
     Environment: All (read-only).
 
@@ -473,6 +502,8 @@ async def test_ai_models_api(app_url, shared_auth_state):
 @pytest.mark.api
 async def test_chat_suggestions_api(app_url, shared_auth_state):
     """
+    AC6.5.1
+
     Scenario: Test chat suggestions endpoint.
     Environment: All (read-only).
 
@@ -491,6 +522,8 @@ async def test_chat_suggestions_api(app_url, shared_auth_state):
 @SKIP_WRITE
 async def test_unbalanced_journal_entry_rejection(app_url, shared_auth_state):
     """
+    AC8.3.4 AC8.10.6
+
     Scenario: Verify unbalanced journal entries are rejected (accounting red line).
     Environment: Staging/Dev Only.
 

--- a/tests/e2e/test_e2e_flows.py
+++ b/tests/e2e/test_e2e_flows.py
@@ -2,27 +2,19 @@
 End-to-End Functional Flow Tests (Finance Report).
 
 Covers:
-- Scenario 1: Basic UI Navigation & Loading.
-- Scenario 2: Statement Upload, Parsing (LLM simulation), and Cleanup.
-- Scenario 3: Report Generation View.
-- Scenario 4: Reconciliation Match Approval.
-- Scenario 5: Account/Journal Entry lifecycle.
-- Scenario 6: User Registration Flow.
+- AC8.13.9: read-only route smoke for protected pages.
+- AC16.12.11: reports page route smoke.
+- AC8.10.8 / AC16.12.6 / AC1.7.1: user registration flow.
 """
 
 import os
-import sys
 import uuid
 import pytest
-import subprocess
-from pathlib import Path
 from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError, expect
 
 # --- Configuration ---
 
 APP_URL = os.getenv("APP_URL", "http://localhost:3000")
-PARSING_TIMEOUT = 60000  # LLM parsing can be slow
-EXPECTED_TXN_COUNT = 15
 AUTH_REDIRECT_TIMEOUT = 10000
 
 
@@ -62,7 +54,7 @@ async def setup_e2e(page: Page):
 @pytest.mark.smoke
 @pytest.mark.e2e
 async def test_full_navigation(page: Page):
-    """[Scenario 1] Verify all main pages load or redirect to login."""
+    """AC8.13.9: Verify main routes load or redirect to login without 500s."""
     pages = [
         "/dashboard",
         "/accounts",
@@ -89,87 +81,8 @@ async def test_full_navigation(page: Page):
 
 
 @pytest.mark.e2e
-@pytest.mark.skip(
-    reason="AI parsing backend issue: statements being rejected instead of parsed (0 txns). See PR #142 comments. Needs separate backend fix."
-)
-async def test_statement_upload_parsing_flow(authenticated_page: Page, tmp_path):
-    """
-    [Scenario 2] Upload a statement, wait for parsing, and then delete it.
-    Uses the generate_pdf_fixtures.py script to create a real PDF.
-
-    This is a CRITICAL test - it validates the core AI parsing functionality.
-    Uses authenticated_page fixture to ensure user is logged in.
-
-    NOTE: Temporarily not marked as @pytest.mark.critical due to backend AI
-    parsing issue. Will restore critical marker once backend is fixed.
-    """
-    page = authenticated_page
-
-    root_dir = Path(__file__).parent.parent.parent
-    script_path = root_dir / "scripts" / "pdf_fixtures" / "generate_pdf_fixtures.py"
-
-    if not script_path.exists():
-        pytest.fail(
-            f"PDF fixture generator not found at {script_path}. "
-            "Ensure scripts/pdf_fixtures/generate_pdf_fixtures.py exists."
-        )
-
-    output_dir = tmp_path
-
-    cmd = [sys.executable, str(script_path), str(output_dir)]
-    try:
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
-    except subprocess.CalledProcessError as e:
-        pytest.fail(
-            f"PDF fixture generation failed: {e.stderr}\n"
-            f"Command: {' '.join(cmd)}\n"
-            f"This is unexpected - reportlab should be installed in CI."
-        )
-
-    target_pdf = output_dir / "e2e_dbs_statement.pdf"
-    if not target_pdf.exists():
-        pytest.fail(f"Generated PDF not found at {target_pdf}")
-
-    try:
-        await page.goto(get_url("/statements"))
-        await page.wait_for_load_state("networkidle")
-
-        if "/login" in page.url:
-            pytest.fail(
-                f"Redirected to login despite using authenticated_page fixture. "
-                f"Current URL: {page.url}. "
-                f"Check if auth tokens are being properly injected."
-            )
-
-        await page.get_by_label("Bank / Institution").fill("DBS E2E Test")
-        await page.set_input_files("input[type='file']", str(target_pdf))
-
-        # 3. Click Upload
-        async with page.expect_response("**/api/statements/upload"):
-            await page.get_by_role("button", name="Upload & Parse Statement").click()
-
-        # 4. Verify List
-        await expect(page.get_by_text("DBS E2E Test").first).to_be_visible()
-
-        # 5. Wait for Parsing (AI processing - this is the critical part!)
-        row = page.locator("a", has=page.get_by_text("DBS E2E Test")).first
-        await expect(row).to_contain_text(
-            f"{EXPECTED_TXN_COUNT} txns", timeout=PARSING_TIMEOUT
-        )
-        await expect(row).to_contain_text("parsed", ignore_case=True)
-
-    finally:
-        # 6. Cleanup
-        row = page.locator("a", has=page.get_by_text("DBS E2E Test")).first
-        if await row.count() > 0:
-            page.once("dialog", lambda dialog: dialog.accept())
-            await row.get_by_title("Delete Statement").click()
-            await expect(page.get_by_text("DBS E2E Test")).not_to_be_visible()
-
-
-@pytest.mark.e2e
 async def test_reports_view(page: Page):
-    """[Scenario 3] Reports Page renders or redirects to login."""
+    """AC8.13.9 AC16.12.11: Reports page renders or redirects to login."""
     await page.goto(get_url("/reports"), wait_until="domcontentloaded")
 
     # Wait a moment for potential AuthGuard redirect
@@ -184,43 +97,11 @@ async def test_reports_view(page: Page):
 
 
 @pytest.mark.e2e
-async def test_account_deletion_constraint(page: Page):
-    """[Scenario 5] Account Deletion Constraints (Negative Test)."""
-    await page.goto(get_url("/accounts"), wait_until="domcontentloaded")
-
-    # Wait for redirect if not logged in
-    await wait_for_optional_login_redirect(page)
-
-    if "/login" in page.url:
-        pytest.skip("Skipping functional account test - redirected to login")
-
-    try:
-        await page.get_by_role("button", name="Add Account").click()
-        await page.fill("input[placeholder='Account Name']", "E2E Constraint Test")
-        await page.select_option("select", label="ASSET")
-        await page.get_by_role("button", name="Create Account").click()
-
-        await expect(page.get_by_text("E2E Constraint Test")).to_be_visible()
-
-        # UI flow for deletion constraint validation (with Journal Entry) is complex
-        # and currently under development for E2E.
-        pytest.skip(
-            "Full account deletion constraint UI flow not fully implemented in E2E yet"
-        )
-
-    finally:
-        # Cleanup
-        await page.goto(get_url("/accounts"), wait_until="domcontentloaded")
-        row = page.locator("div", has=page.get_by_text("E2E Constraint Test")).first
-        if await row.count() > 0:
-            page.once("dialog", lambda dialog: dialog.accept())
-            await row.get_by_title("Delete Account").click()
-
-
-@pytest.mark.e2e
 async def test_registration_flow(page: Page):
     """
-    [Scenario 6] User Registration Flow.
+    AC8.10.8 AC16.12.6 AC1.7.1
+
+    User Registration Flow.
     Verifies that the API URL configuration is correct (no double /api/ issue).
     """
     await page.goto(get_url("/login"))

--- a/tests/e2e/test_version_check.py
+++ b/tests/e2e/test_version_check.py
@@ -1,6 +1,8 @@
 """
 Version verification test.
-Ensures the deployed application matches the source code version (Git SHA).
+
+AC8.13.36 AC8.13.39: Ensures the deployed application matches the source
+code version (Git SHA).
 """
 
 import pytest
@@ -14,7 +16,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.smoke
 @pytest.mark.e2e
 async def test_deployed_version_matches_source(config: TestConfig):
-    """Verify that the deployed /health endpoint returns the expected Git SHA."""
+    """AC8.13.36 AC8.13.39: /health returns the expected Git SHA."""
     if not config.EXPECTED_SHA:
         logger.warning("Skipping version check: EXPECTED_SHA not set in environment")
         pytest.skip("EXPECTED_SHA not set")


### PR DESCRIPTION
## Summary

Close the remaining E2E traceability escape hatch after the README -> EPIC -> E2E and EPIC -> AC -> test proof-loop changes.

- Forbid product E2E tests from `docs/analysis/traceability-exceptions.md`.
- Add explicit AC ownership to the remaining top-level `tests/e2e/test_*.py` smoke suites.
- Remove obsolete skipped E2E scenarios that were no longer executable proof.
- Replace stale EPIC-008 test-count prose with current E2E suite ownership and refresh the generated AC coverage report.
- Exclude `repo/e2e_regressions` from finance_report AC coverage because it belongs to the `repo/` infra2 submodule sync process, not this repo's product E2E proof surface.

Closes N/A

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing strategy & E2E gates |
| **AC IDs** | AC8.13.53, AC8.13.54 plus existing E2E-owned AC references |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [x] None — existing SSOT already covers proof placement, AC traceability, and critical proof matrix ownership

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | N/A | Existing linter allowed product E2E files to remain in traceability exceptions |
| Green | `db28663` | Product E2E exceptions are blocked; remaining top-level E2E files carry AC refs; infra2 submodule E2E is excluded from finance_report AC coverage |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `scripts/check_env_keys.py` passes (not applicable; env vars unchanged)
- [x] `scripts/check_manifest.py` passes (SSOT files unchanged)
- [x] `scripts/lint_doc_consistency.py` passes

---

## Testing

```bash
git diff --check
python scripts/check_critical_proof_matrix.py
python scripts/lint_doc_consistency.py
python scripts/check_ssot_ownership.py
python scripts/generate_ac_registry.py --check
python scripts/check_ac_traceability.py
python scripts/analyze_test_ac_coverage.py --output docs/analysis/test-ac-coverage-report.md
python scripts/audit_ac_epic_mismatches.py --output docs/analysis/ac-epic-mismatch-report.md
pytest scripts/tests/test_analyze_test_ac_coverage.py scripts/tests/test_lint_doc_consistency.py scripts/tests/test_check_critical_proof_matrix.py -q
pytest scripts/tests/test_lint_doc_consistency.py scripts/tests/test_check_critical_proof_matrix.py scripts/tests/test_check_ssot_ownership.py -q
pytest tests/e2e/test_auth_flows.py tests/e2e/test_core_journeys.py tests/e2e/test_e2e_flows.py tests/e2e/test_version_check.py --collect-only -q
moon run :lint
```

`moon run :test` was attempted locally, but Podman failed before tests ran with `proxy already running` / internal libpod startup errors while starting the temporary DB/MinIO namespace. Temporary containers were removed.

---

## Screenshots / Evidence

N/A
