### PR TITLE
ci: remove nonblocking deploy noise

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -123,12 +123,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Check Deployment Dependencies
-        env:
-          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
-          DOKPLOY_API_URL: ${{ env.DOKPLOY_API_URL }}
-        run: echo "Deployment deps check skipped (integrated into deploy script)"
-
       - name: Check if compose exists
         id: check
         run: |

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -259,12 +259,6 @@ jobs:
           done
           echo "✅ Images verified"
 
-      - name: Check Deployment Dependencies
-        env:
-          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
-          DOKPLOY_API_URL: ${{ env.DOKPLOY_API_URL }}
-        run: echo "Deployment deps check skipped (integrated into deploy script)"
-
       - name: Deploy & Health Check
         env:
           IMAGE_TAG: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -260,12 +260,6 @@ jobs:
             --tag "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:staging" \
             "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.get_sha.outputs.short_sha }}"
 
-      - name: Check Deployment Dependencies
-        env:
-          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
-          DOKPLOY_API_URL: ${{ env.DOKPLOY_API_URL }}
-        run: echo "Deployment deps check skipped (integrated into deploy script)"
-
       - name: Deploy to Staging
         env:
           IMAGE_TAG: ${{ steps.get_sha.outputs.short_sha }}
@@ -334,27 +328,6 @@ jobs:
             pytest tests/e2e -v -m "(smoke or e2e) and not llm" -n 4
 
           echo "✅ Staging deploy health gate passed!"
-
-      - name: Performance Benchmark
-        continue-on-error: true  # Don't block deploy, but report issues
-        run: |
-          echo "Running API performance benchmark..."
-          BASE_URL="https://report-staging.zitian.party"
-          
-          # Test key endpoints
-          for endpoint in /api/health /api/ping; do
-            response_time=$(curl -sf -w "%{time_total}" -o /dev/null "$BASE_URL$endpoint" 2>/dev/null || echo "failed")
-            
-            if [ "$response_time" = "failed" ]; then
-              echo "::warning::$endpoint - Failed to connect"
-            elif (( $(echo "$response_time > 2.0" | bc -l 2>/dev/null || echo 0) )); then
-              echo "::warning::$endpoint - Slow: ${response_time}s (> 2s threshold)"
-            else
-              echo "✅ $endpoint - ${response_time}s"
-            fi
-          done
-          
-          echo "Performance benchmark complete."
 
   ai-ocr-gate:
     name: Staging AI/OCR Gate

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2043,6 +2043,12 @@ groups:
         epic_name: testing-strategy
         description: Config validation command entry points run from tools/ while shared implementations live under common/config/.
         mandatory: true
+      - id: AC8.13.60
+        epic: 8
+        epic_name: testing-strategy
+        description: Deploy workflows do not keep no-op dependency checks or warning-only performance probes that cannot block
+          release risk.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -99,6 +99,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.57**: SSOT and AC command entry points run from `tools/` while shared implementations live under `common/ssot/`.
 - **AC8.13.58**: CI and toolchain command entry points run from `tools/` while shared implementations live under `common/ci/`.
 - **AC8.13.59**: Config validation command entry points run from `tools/` while shared implementations live under `common/config/`.
+- **AC8.13.60**: Deploy workflows do not keep no-op dependency checks or warning-only performance probes that cannot block release risk.
 
 Current test and AC coverage status is generated, not hand-maintained here.
 Use `docs/analysis/test-ac-coverage-report.md`,
@@ -429,6 +430,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.57 | SSOT and AC command entry points run from `tools/` while shared implementations live under `common/ssot/` | `test_AC8_13_57_*` | `tests/tooling/test_common_tooling_modules.py`, `tests/tooling/test_ci_metrics_contract.py`, `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.58 | CI and toolchain command entry points run from `tools/` while shared implementations live under `common/ci/` | `test_AC8_13_58_*` | `tests/tooling/test_common_tooling_modules.py`, `tests/tooling/test_toolchain_contract.py`, `tests/tooling/test_ci_change_classifier.py`, `tests/tooling/test_github_workflow_timing_summary.py`, `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.59 | Config validation command entry points run from `tools/` while shared implementations live under `common/config/` | `test_AC8_13_59_*` | `tests/tooling/test_common_tooling_modules.py`, `tests/tooling/test_check_env_keys.py`, `tests/tooling/test_validate_schemas.py` | P0 |
+| AC8.13.60 | Deploy workflows do not keep no-op dependency checks or warning-only performance probes that cannot block release risk | `test_AC8_13_60_deploy_workflows_have_no_nonblocking_noop_gates` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.
@@ -541,7 +543,7 @@ finance_report AC coverage.
    - **Coverage**: AC8.13.1–5 (PDF upload, parse polling, transactions, approve, balance sheet)
    - **Hard-gate rule**: When `STRICT_E2E_GATES=true`, critical E2E skips are converted to failures; `status=rejected` fails instead of skips and reports the statement id, validation error, parsing progress, confidence, and selected model. The separate post-merge `Staging AI/OCR Gate` is the provider-backed AI/OCR gate.
    - **Provider budget rule**: Tests marked `llm` run serially in `.github/workflows/staging-ai-ocr-gate.yml`, not under the staging deploy `-n 4` parallel phase. PR preview E2E excludes `llm` tests and does not inject `ZAI_API_KEY`, so automated GLM/OCR provider calls are centralized in the staging AI/OCR gate. Staging pins `PRIMARY_MODEL=glm-5.1`, `OCR_MODEL=glm-4.6v`, and `VISION_MODEL=glm-4.6v` for the AI/OCR gate. The gate waits for the same SHA's `CI` push run to succeed before spending provider quota.
-   - **Fast-fail guardrail**: Staging post-merge workflows use GitHub concurrency without canceling a running validation. GitHub retains one running run and one latest pending run per group, so rapid pushes are batched to the latest pending commit rather than interrupting the active deploy/gate. The deploy job is capped at 30 minutes, the deploy E2E step is capped at 22 minutes, and phase timing logs identify smoke and core non-LLM E2E latency. Provider-backed OCR parsing runs afterward in the separate `Staging AI/OCR Gate`.
+   - **Fast-fail guardrail**: Staging post-merge workflows use GitHub concurrency without canceling a running validation. GitHub retains one running run and one latest pending run per group, so rapid pushes are batched to the latest pending commit rather than interrupting the active deploy/gate. The deploy-health job is capped at 75 minutes, the deploy E2E step is capped at 22 minutes, and phase timing logs identify smoke and core non-LLM E2E latency. Provider-backed OCR parsing runs afterward in the separate `Staging AI/OCR Gate`.
    - **Route diagnostics**: If staging `/api/health` remains 404, `tools/health_check.sh` probes `/api/ping` and `/` and identifies a likely Traefik API route miss or web-route shadow before failing the deploy.
 
 3. **Multi-Brokerage Upload to Portfolio Value (Tier 3)** (`test_brokerage_upload_to_portfolio_value.py`):

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -192,6 +192,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - The automatic AI/OCR job has a 30-minute job timeout, while the provider-backed pytest step remains capped at 22 minutes.
 - Staging deploys may set `DEPLOY_PRIMARY_MODEL_OVERRIDE`, `DEPLOY_OCR_MODEL_OVERRIDE`, and `DEPLOY_VISION_MODEL_OVERRIDE`; the current post-merge gate pins `PRIMARY_MODEL=glm-5.1`, `OCR_MODEL=glm-4.6v`, and `VISION_MODEL=glm-4.6v`.
 - Repeated `/api/health` 404 responses are treated as route failures, not generic backend failures: the health script probes `/api/ping` and `/` so logs distinguish a missing or shadowed Traefik API route from an unhealthy backend container.
+- Deploy dependency preflight lives in `tools/dokploy_deploy.sh` and the shared shell helpers it delegates to. Workflow-only no-op dependency checks and warning-only post-deploy performance probes are intentionally absent; deploy workflows keep only gates that can fail on release risk: image availability/build, Dokploy rollout, health, smoke, E2E, and provider-backed AI/OCR validation.
 - The post-merge workflow appends a GitHub Step Summary after deploy health and AI/OCR finish, making queue time, serial execution time, and slow jobs visible without manually scraping logs.
 
 **Post-merge staging AI/OCR gate** (`.github/workflows/staging-ai-ocr-gate.yml`):

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -165,7 +165,7 @@ def test_AC8_13_14_staging_ai_ocr_gate_is_separate_deploy_job() -> None:
     assert (
         '-v -m "llm"'
         not in deploy_workflow.split("name: End-to-End Tests", 1)[1].split(
-            "Performance Benchmark", 1
+            "ai-ocr-gate:", 1
         )[0]
     )
     assert "name: Staging AI/OCR Gate" in ai_workflow
@@ -293,6 +293,25 @@ def test_AC8_13_55_post_merge_staging_is_scoped_to_deploy_relevant_paths() -> No
         "Documentation, project archive, AC traceability, and other tooling-only changes keep CI/AC gates but do not consume the staging singleton"
         in ci_cd
     )
+
+
+def test_AC8_13_60_deploy_workflows_have_no_nonblocking_noop_gates() -> None:
+    """AC8.13.60: Deploy gates do not keep no-op or warning-only checks."""
+    workflows = [
+        read(".github/workflows/staging-deploy.yml"),
+        read(".github/workflows/production-release.yml"),
+        read(".github/workflows/pr-test.yml"),
+    ]
+    ci_cd = read("docs/ssot/ci-cd.md")
+
+    for workflow in workflows:
+        assert "Check Deployment Dependencies" not in workflow
+        assert "Deployment deps check skipped" not in workflow
+
+    staging = workflows[0]
+    assert "Performance Benchmark" not in staging
+    assert "Don't block deploy, but report issues" not in staging
+    assert "Deploy dependency preflight lives in `tools/dokploy_deploy.sh`" in ci_cd
 
 
 def test_AC8_13_52_production_release_dry_run_does_not_mutate_production() -> None:
@@ -791,7 +810,7 @@ def test_AC8_13_46_pr_preview_non_llm_gate_matches_staging_strict_parallelism() 
         "- name: Rollback on E2E Failure", 1
     )[0]
     staging_block = staging.split("- name: End-to-End Tests", 1)[1].split(
-        "- name: Performance Benchmark", 1
+        "\n  ai-ocr-gate:", 1
     )[0]
 
     for block in (preview_block, staging_block):


### PR DESCRIPTION
## Summary

Remove deploy workflow checks that only emitted no-op or warning-only output and could not block release risk.

Related #408

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Comprehensive Testing Strategy |
| **AC IDs** | AC8.13.60 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/ci-cd.md` — documents that deploy dependency preflight lives in `tools/dokploy_deploy.sh` and deploy workflows keep only risk-blocking gates
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (local) | `uncommitted` | Added AC8.13.60 workflow hygiene assertion before final cleanup verification |
| Green | `8d65969` | Removed no-op deploy dependency checks and warning-only staging performance benchmark |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable; no SQLAlchemy changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `scripts/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `scripts/check_manifest.py` passes (covered by `moon run :lint` before rebase)
- [x] `scripts/lint_doc_consistency.py` passes (covered by `moon run :lint` before rebase)

---

## Testing

```bash
uv run --with pytest --with pyyaml pytest tests/tooling/test_post_merge_e2e_gates.py -q
actionlint .github/workflows/*.yml
python tools/generate_ac_registry.py --check
uv run ruff check tests/tooling/test_post_merge_e2e_gates.py
uv run ruff format tests/tooling/test_post_merge_e2e_gates.py --check
uv run --with pyyaml python tools/check_ac_traceability.py
uv run --with pyyaml python tools/check_critical_proof_matrix.py
git diff --check
```

Before the rebase, `moon run :lint` passed. `moon run :test` was attempted locally but Podman failed before tests started with `proxy already running`; the transient containers and volumes created by that attempt were removed.

---

## Screenshots / Evidence

_N/A_
