### PR TITLE
ci: verify production infrastructure after deploy

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -38,6 +38,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       packages: write
     
@@ -76,18 +77,30 @@ jobs:
         run: npm ci
         working-directory: apps/frontend
 
-      - name: Verify Codebase
+      - name: Verify source CI passed
         env:
-          DATABASE_URL: postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/finance_report_test
-          S3_ACCESS_KEY: minio
-          S3_SECRET_KEY: minio_local_secret
-          S3_ENDPOINT: http://127.0.0.1:9000
-          S3_BUCKET: statements
-          CONTAINER_RUNTIME: docker
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Ensure release is built from clean state
+          run_id="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow ci.yml \
+              --commit "$GITHUB_SHA" \
+              --limit 20 \
+              --json databaseId,status,conclusion,event,headBranch \
+              --jq '[.[] | select(.event == "push" and .headBranch == "main" and .status == "completed" and .conclusion == "success")][0].databaseId // ""'
+          )"
+          if [ -z "$run_id" ]; then
+            echo "::error::No successful main CI run found for $GITHUB_SHA"
+            exit 1
+          fi
+          echo "Using successful main CI run: $run_id"
+
+      - name: Verify Release Codebase
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
           moon run :lint
-          moon run :test
           
           # Clean up artifacts before build
           rm -rf .venv
@@ -129,6 +142,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - uses: actions/checkout@v4
@@ -169,17 +183,30 @@ jobs:
         run: npm ci
         working-directory: apps/frontend
 
-      - name: Verify Codebase
+      - name: Verify source CI passed
         env:
-          DATABASE_URL: postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/finance_report_test
-          S3_ACCESS_KEY: minio
-          S3_SECRET_KEY: minio_local_secret
-          S3_ENDPOINT: http://127.0.0.1:9000
-          S3_BUCKET: statements
-          CONTAINER_RUNTIME: docker
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow ci.yml \
+              --commit "$GITHUB_SHA" \
+              --limit 20 \
+              --json databaseId,status,conclusion,event,headBranch \
+              --jq '[.[] | select(.event == "push" and .headBranch == "main" and .status == "completed" and .conclusion == "success")][0].databaseId // ""'
+          )"
+          if [ -z "$run_id" ]; then
+            echo "::error::No successful main CI run found for $GITHUB_SHA"
+            exit 1
+          fi
+          echo "Using successful main CI run: $run_id"
+
+      - name: Verify Release Codebase
+        env:
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           moon run :lint
-          moon run :test
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
@@ -275,6 +302,13 @@ jobs:
             "production" \
             24 \
             "$IMAGE_TAG"
+
+      - name: Production Infrastructure Smoke
+        run: |
+          python tools/production_infra_smoke.py \
+            --base-url "https://report.zitian.party" \
+            --expected-sha "${{ steps.version.outputs.tag }}" \
+            --signoz-url "https://signoz.zitian.party"
 
       - name: Smoke Tests
         run: bash tools/smoke_test.sh https://report.zitian.party production

--- a/common/ci/production_infra_smoke.py
+++ b/common/ci/production_infra_smoke.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Production infrastructure smoke checks for release workflows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+class SmokeFailure(AssertionError):
+    """Raised when a production infrastructure smoke check fails."""
+
+
+@dataclass(frozen=True)
+class HttpResponse:
+    """Minimal HTTP response data used by smoke checks."""
+
+    status: int
+    body: str
+
+
+Fetcher = Callable[[str, float], HttpResponse]
+
+
+def _join_url(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+def fetch_url(url: str, timeout: float) -> HttpResponse:
+    """Fetch a URL with a small user agent and return status plus body."""
+    request = Request(url, headers={"User-Agent": "finance-report-prod-smoke/1.0"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            return HttpResponse(status=response.status, body=body)
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return HttpResponse(status=exc.code, body=body)
+    except URLError as exc:
+        raise SmokeFailure(f"Cannot reach {url}: {exc}") from exc
+
+
+def _require_success(name: str, response: HttpResponse) -> None:
+    if not 200 <= response.status < 400:
+        snippet = response.body[:300].replace("\n", " ")
+        raise SmokeFailure(f"{name} returned HTTP {response.status}: {snippet}")
+
+
+def _parse_json(name: str, response: HttpResponse) -> dict[str, Any]:
+    _require_success(name, response)
+    try:
+        payload = json.loads(response.body)
+    except json.JSONDecodeError as exc:
+        raise SmokeFailure(
+            f"{name} did not return JSON: {response.body[:300]}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise SmokeFailure(f"{name} returned non-object JSON")
+    return payload
+
+
+def _sha_matches(actual: str, expected: str) -> bool:
+    return (
+        actual == expected or actual.startswith(expected) or expected.startswith(actual)
+    )
+
+
+def verify_health(
+    base_url: str,
+    *,
+    expected_sha: str | None,
+    timeout: float,
+    fetcher: Fetcher = fetch_url,
+) -> list[str]:
+    """Verify production health exposes version plus DB and object-storage checks."""
+    payload = _parse_json(
+        "Production health", fetcher(_join_url(base_url, "/api/health"), timeout)
+    )
+
+    if payload.get("status") != "healthy":
+        raise SmokeFailure(f"Production health status is not healthy: {payload}")
+
+    git_sha = str(payload.get("git_sha") or payload.get("version") or "")
+    if not git_sha:
+        raise SmokeFailure("Production health payload is missing git_sha/version")
+    if expected_sha and not _sha_matches(git_sha, expected_sha):
+        raise SmokeFailure(
+            f"Production version mismatch: expected {expected_sha}, got {git_sha}"
+        )
+
+    checks = payload.get("checks")
+    if not isinstance(checks, dict):
+        raise SmokeFailure("Production health payload is missing checks object")
+
+    required_checks = ("database", "s3")
+    failed = [name for name in required_checks if checks.get(name) is not True]
+    if failed:
+        raise SmokeFailure(f"Production health dependency checks failed: {failed}")
+
+    return [
+        f"health status healthy ({git_sha})",
+        "database check true",
+        "s3 check true",
+    ]
+
+
+def verify_public_runtime(
+    base_url: str,
+    *,
+    timeout: float,
+    fetcher: Fetcher = fetch_url,
+) -> list[str]:
+    """Verify production public runtime endpoints without mutating data."""
+    ping = _parse_json(
+        "Production ping", fetcher(_join_url(base_url, "/api/ping"), timeout)
+    )
+    if "state" not in ping or "toggle_count" not in ping:
+        raise SmokeFailure(f"Production ping payload is incomplete: {ping}")
+
+    _require_success(
+        "Production frontend", fetcher(base_url.rstrip("/") + "/", timeout)
+    )
+    return ["ping API read-only check", "frontend shell reachable"]
+
+
+def verify_signoz(
+    signoz_url: str,
+    *,
+    timeout: float,
+    fetcher: Fetcher = fetch_url,
+) -> list[str]:
+    """Verify the shared SigNoz control plane is reachable."""
+    health = _parse_json(
+        "SigNoz health", fetcher(_join_url(signoz_url, "/api/v1/health"), timeout)
+    )
+    if health.get("status") != "ok":
+        raise SmokeFailure(f"SigNoz health is not ok: {health}")
+
+    version = _parse_json(
+        "SigNoz version", fetcher(_join_url(signoz_url, "/api/v1/version"), timeout)
+    )
+    if version.get("setupCompleted") is not True:
+        raise SmokeFailure(f"SigNoz setup is not complete: {version}")
+
+    return [f"signoz health ok ({version.get('version', 'unknown version')})"]
+
+
+def run_checks(
+    *,
+    base_url: str,
+    expected_sha: str | None,
+    signoz_url: str | None,
+    timeout: float,
+    fetcher: Fetcher = fetch_url,
+) -> list[str]:
+    """Run production infrastructure smoke checks and return passed check labels."""
+    passed: list[str] = []
+    passed.extend(
+        verify_health(
+            base_url,
+            expected_sha=expected_sha,
+            timeout=timeout,
+            fetcher=fetcher,
+        )
+    )
+    passed.extend(verify_public_runtime(base_url, timeout=timeout, fetcher=fetcher))
+    if signoz_url:
+        passed.extend(verify_signoz(signoz_url, timeout=timeout, fetcher=fetcher))
+    return passed
+
+
+def write_summary(passed: list[str]) -> None:
+    """Append smoke results to GitHub Step Summary when available."""
+    summary_path = os.getenv("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    with open(summary_path, "a", encoding="utf-8") as summary:
+        summary.write("## Production Infrastructure Smoke\n\n")
+        for label in passed:
+            summary.write(f"- OK: {label}\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--expected-sha", default=None)
+    parser.add_argument("--signoz-url", default=None)
+    parser.add_argument("--timeout", type=float, default=15.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        passed = run_checks(
+            base_url=args.base_url,
+            expected_sha=args.expected_sha,
+            signoz_url=args.signoz_url,
+            timeout=args.timeout,
+        )
+    except SmokeFailure as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    for label in passed:
+        print(f"OK: {label}")
+    write_summary(passed)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2076,6 +2076,17 @@ groups:
         description: Performance testing residual is explicitly owned by EPIC-008 with current Locust/staging coverage and
           future P95 trend gate scope.
         mandatory: true
+      - id: AC8.13.64
+        epic: 8
+        epic_name: testing-strategy
+        description: Production release verifies DB, S3, API, frontend, and SigNoz health before completing deploy.
+        mandatory: true
+      - id: AC8.13.65
+        epic: 8
+        epic_name: testing-strategy
+        description: Production release reuses successful main CI proof instead of rerunning container-backed tests in the
+          release lane.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -103,6 +103,8 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.61**: Visual regression residual is explicitly owned by EPIC-008 as a P3 future testing capability.
 - **AC8.13.62**: Test observability residuals are explicitly owned by EPIC-008 with current replacements and future dashboard/notification/trend scope.
 - **AC8.13.63**: Performance testing residual is explicitly owned by EPIC-008 with current Locust/staging coverage and future P95 trend gate scope.
+- **AC8.13.64**: Production release verifies DB, S3, API, frontend, and SigNoz health before completing deploy.
+- **AC8.13.65**: Production release reuses successful main CI proof instead of rerunning container-backed tests in the release lane.
 
 Current test and AC coverage status is generated, not hand-maintained here.
 Use `docs/analysis/test-ac-coverage-report.md`,
@@ -437,6 +439,8 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.61 | Visual regression residual is explicitly owned by EPIC-008 as a P3 future testing capability | `test_AC8_13_61_visual_regression_residual_is_epic_owned` | `tests/tooling/test_archive_residual_epic_ownership.py` | P3 |
 | AC8.13.62 | Test observability residuals are explicitly owned by EPIC-008 with current replacements and future dashboard/notification/trend scope | `test_AC8_13_62_test_observability_residual_is_epic_owned` | `tests/tooling/test_archive_residual_epic_ownership.py` | P2 |
 | AC8.13.63 | Performance testing residual is explicitly owned by EPIC-008 with current Locust/staging coverage and future P95 trend gate scope | `test_AC8_13_63_performance_testing_residual_is_epic_owned` | `tests/tooling/test_archive_residual_epic_ownership.py` | P2 |
+| AC8.13.64 | Production release verifies DB, S3, API, frontend, and SigNoz health before completing deploy | `test_AC8_13_64_*` | `tests/tooling/test_production_infra_smoke.py`, `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+| AC8.13.65 | Production release reuses successful main CI proof instead of rerunning container-backed tests in the release lane | `test_AC8_13_52_production_release_dry_run_does_not_mutate_production`, `test_AC8_13_9_production_release_runs_prod_safe_e2e_smoke` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -165,9 +165,10 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - PR CI dry-runs staging image builds before merge. The `container-images` job uses `docker/build-push-action` for both backend and frontend images with `push: false` on pull requests, then `finish` fails if that validation job fails.
 - Main push CI is the only path that pushes SHA-tagged images. Registry login and image push are guarded by `github.event_name == 'push' && github.ref == 'refs/heads/main'`; registry availability and authorization remain post-merge external-service risks, but Dockerfile, build-context, and build-argument errors are caught before merge.
 - Frontend dependency installation uses `actions/setup-node@v4` with npm cache and deterministic `npm ci`.
-- Production release tag builds set `CONTAINER_RUNTIME=docker` during `moon run :test`
-  so the release verification path uses the GitHub-hosted Docker daemon instead
-  of auto-selecting an unavailable Podman socket.
+- Production release tag builds and dry-runs verify that the target SHA already
+  has a successful `main` CI `finish` result, then run release lint and image
+  build validation. They do not rerun the container-backed `moon run :test`
+  lifecycle in the release lane.
 - The `finish` job appends a GitHub Step Summary from `tools/github_workflow_timing_summary.py` with queue delay, execution window, run wall time, longest completed job, and per-job durations.
 - Coveralls uploads are reporting-only and do not block CI pass/fail when local deterministic gates pass.
 - The asynchronous Coveralls status contexts include `coverage/coveralls`, `coverage/coveralls (push)`, `Coveralls - unified`, `Coveralls - backend`, and `Coveralls - frontend`. CI does not normalize or require those external contexts. The repository ruleset must require the `finish` check, which aggregates local deterministic gates, rather than Coveralls contexts.
@@ -212,9 +213,10 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - GLM/OCR CI traffic uses `AI_BASE_URL=https://api.z.ai/api/coding/paas/v4`; the URL remains an env override so the base provider can be replaced without code changes.
 
 **Production release dry-run** (`.github/workflows/production-release.yml`):
-- Manual `workflow_dispatch` with `dry_run=true` runs the same release prerequisite checks (`moon run :lint`, `moon run :test` with `CONTAINER_RUNTIME=docker`) and production image builds with `push: false`.
+- Manual `workflow_dispatch` with `dry_run=true` verifies the target SHA's successful `main` CI result, runs release lint, and builds production images with `push: false`.
 - The dry-run uses production frontend build arguments without changing Dokploy or production tags, and does not enter the `production` environment or push GHCR images. Its summary reports the validated ref/tag and states that production mutation was skipped.
 - Tag pushes remain the only automatic path that pushes versioned release images. Manual dispatch with `dry_run=false` remains the production deploy path for an existing version.
+- Production deploys run `tools/production_infra_smoke.py` after health check. That gate verifies the deployed version, `/api/health` dependency checks for database and S3, read-only `/api/ping`, frontend reachability, and the shared SigNoz health/version endpoints before production smoke and read-only E2E run.
 
 The remaining higher-risk CI and post-merge optimization candidates are tracked
 in the delivery-engine recommendation note instead of being mixed into routine

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -77,8 +77,8 @@ Triggers:
   - Manual dispatch:   Deploy to production
   - Manual dry-run:    Validate release prerequisites without deploy
 
-Build job:  Tag → Install backend/frontend toolchains → Verify with Docker test lifecycle → Build backend + frontend → Push to GHCR
-Dry-run:    Manual → Verify with Docker test lifecycle → Build production images with push=false → Skip Dokploy
+Build job:  Tag → Verify successful main CI for SHA → Release lint → Build backend + frontend → Push to GHCR
+Dry-run:    Manual → Verify successful main CI for SHA → Release lint → Build production images with push=false → Skip Dokploy
 Deploy job: Verify images → Deploy → Health (4min) → Smoke test
 
 URL: https://report.zitian.party

--- a/tests/tooling/test_cleanup_pr_preview_resources.py
+++ b/tests/tooling/test_cleanup_pr_preview_resources.py
@@ -1,8 +1,12 @@
 """AC8.13.38: Scheduled PR preview cleanup coverage."""
 
+import argparse
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -10,17 +14,19 @@ from tools._lib.dev import cleanup_pr_preview_resources as cleanup  # noqa: E402
 
 
 def test_AC8_13_38_run_command_uses_checked_text_subprocess(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls = []
+    calls: list[dict[str, object]] = []
 
-    def fake_run(**kwargs):
+    def fake_run(*_args: object, **kwargs: object) -> SimpleNamespace:
         calls.append(kwargs)
         return SimpleNamespace(stdout="ok\n", stderr="", returncode=0)
 
-    monkeypatch.setattr(cleanup.subprocess, "run", lambda *args, **kwargs: fake_run(**kwargs))
+    monkeypatch.setattr(cleanup.subprocess, "run", fake_run)
 
-    result = cleanup.run_command(["gh", "pr", "list"], input_text="payload", check=False)
+    result = cleanup.run_command(
+        ["gh", "pr", "list"], input_text="payload", check=False
+    )
 
     assert result.stdout == "ok\n"
     assert calls == [
@@ -33,28 +39,64 @@ def test_AC8_13_38_run_command_uses_checked_text_subprocess(
     ]
 
 
-def test_AC8_13_38_ssh_command_includes_optional_identity_file() -> None:
-    assert cleanup.ssh_command("vps.example", "deployer", "/tmp/key", "uptime") == [
+def test_AC8_13_38_parse_and_list_open_pr_numbers_uses_github_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    def run_command_stub(
+        cmd: list[str],
+        *,
+        input_text: str | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="\n498\n\n554\n", stderr="")
+
+    monkeypatch.setattr(cleanup, "run_command", run_command_stub)
+
+    assert cleanup.parse_open_pr_numbers("\n434\n\n 498 \n") == {434, 498}
+    assert cleanup.list_open_pr_numbers() == {498, 554}
+    assert commands == [
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "1000",
+            "--json",
+            "number",
+            "--jq",
+            ".[].number",
+        ]
+    ]
+
+
+def test_AC8_13_38_ssh_command_supports_optional_identity_file() -> None:
+    assert cleanup.ssh_command("cloud.zitian.party", "root", None, "docker ps") == [
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "root@cloud.zitian.party",
+        "docker ps",
+    ]
+
+    assert cleanup.ssh_command(
+        "cloud.zitian.party",
+        "deploy",
+        "/tmp/key",
+        "docker ps",
+    ) == [
         "ssh",
         "-o",
         "StrictHostKeyChecking=accept-new",
         "-i",
         "/tmp/key",
-        "deployer@vps.example",
-        "uptime",
+        "deploy@cloud.zitian.party",
+        "docker ps",
     ]
-
-
-def test_AC8_13_38_parse_and_list_open_pr_numbers(monkeypatch) -> None:
-    assert cleanup.parse_open_pr_numbers("\n434\n\n 498 \n") == {434, 498}
-
-    monkeypatch.setattr(
-        cleanup,
-        "run_command",
-        lambda cmd: SimpleNamespace(stdout="434\n498\n"),
-    )
-
-    assert cleanup.list_open_pr_numbers() == {434, 498}
 
 
 def test_AC8_13_38_parse_preview_resources_groups_by_pr() -> None:
@@ -63,43 +105,58 @@ def test_AC8_13_38_parse_preview_resources_groups_by_pr() -> None:
             "finance-report-backend-pr-434\tcompose-old",
             "finance-report-frontend-pr-434\tcompose-old",
             "finance-report-db-pr-498\tcompose-open",
+            "finance-report-minio-pr-499\t<no value>",
             "unrelated\tcompose-other",
         ]
     )
 
     resources = cleanup.parse_preview_resources(output)
 
-    assert sorted(resources) == [434, 498]
+    assert sorted(resources) == [434, 498, 499]
     assert resources[434].containers == {
         "finance-report-backend-pr-434",
         "finance-report-frontend-pr-434",
     }
     assert resources[434].compose_projects == {"compose-old"}
+    assert resources[499].compose_projects == set()
 
 
-def test_AC8_13_38_list_remote_preview_resources_uses_safe_ssh_command(monkeypatch) -> None:
-    calls = []
+def test_AC8_13_38_list_remote_preview_resources_uses_safe_ssh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
 
-    def fake_run_command(cmd):
-        calls.append(cmd)
-        return SimpleNamespace(stdout="finance-report-minio-pr-434\t<no value>\n")
+    def run_command_stub(
+        cmd: list[str],
+        *,
+        input_text: str | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        observed["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="finance-report-minio-pr-434\t<no value>\n",
+            stderr="",
+        )
 
-    monkeypatch.setattr(cleanup, "run_command", fake_run_command)
+    monkeypatch.setattr(cleanup, "run_command", run_command_stub)
 
-    resources = cleanup.list_remote_preview_resources("vps.example", "root", None)
+    resources = cleanup.list_remote_preview_resources(
+        "cloud.zitian.party",
+        "root",
+        "/tmp/key",
+    )
 
     assert sorted(resources) == [434]
     assert resources[434].containers == {"finance-report-minio-pr-434"}
     assert resources[434].compose_projects == set()
-    assert calls == [
-        [
-            "ssh",
-            "-o",
-            "StrictHostKeyChecking=accept-new",
-            "root@vps.example",
-            "docker ps -a --format '{{.Names}}\\t{{.Label \"com.docker.compose.project\"}}'",
-        ]
-    ]
+    assert observed["cmd"] == cleanup.ssh_command(
+        "cloud.zitian.party",
+        "root",
+        "/tmp/key",
+        "docker ps -a --format '{{.Names}}\\t{{.Label \"com.docker.compose.project\"}}'",
+    )
 
 
 def test_AC8_13_38_select_stale_resources_preserves_open_prs() -> None:
@@ -116,6 +173,7 @@ def test_AC8_13_38_select_stale_resources_preserves_open_prs() -> None:
 def test_AC8_13_38_remote_cleanup_script_targets_only_stale_projects() -> None:
     resources = cleanup.parse_preview_resources(
         "finance-report-backend-pr-434\tcompose-old\n"
+        "finance-report-frontend-pr-434\tbad project name\n"
         "finance-report-backend-pr-498\tcompose-open\n"
     )
     stale = cleanup.select_stale_resources(resources, {498})
@@ -133,50 +191,85 @@ def test_AC8_13_38_remote_cleanup_script_targets_only_stale_projects() -> None:
     assert "PROJECTS='compose-old'" in script
     assert "pr-${pr}" in script
     assert "compose-open" not in script
+    assert "bad project name" not in script
     assert "[dry-run] docker builder prune -af --filter until=24h" in script
     assert "[dry-run] docker image prune -af --filter until=168h" in script
 
 
-def test_AC8_13_38_remote_cleanup_script_prunes_without_dry_run() -> None:
-    resources = cleanup.parse_preview_resources(
+def test_AC8_13_38_remote_cleanup_script_can_run_real_prune_commands() -> None:
+    stale = cleanup.parse_preview_resources(
         "finance-report-backend-pr-434\tcompose-old\n"
         "finance-report-frontend-pr-435\tcompose;unsafe\n"
     )
 
     script = cleanup.build_remote_cleanup_script(
-        resources,
+        stale,
         dry_run=False,
         prune_build_cache=True,
         prune_images=True,
-        builder_prune_until="12h",
-        image_prune_until="72h",
+        builder_prune_until="48h",
+        image_prune_until="240h",
     )
 
     assert "PROJECTS='compose-old'" in script
     assert "compose;unsafe" not in script
-    assert 'docker builder prune -af --filter "until=12h"' in script
-    assert 'docker image prune -af --filter "until=72h"' in script
-    assert "echo [dry-run]" not in script
+    assert "[dry-run]" not in script
+    assert 'docker builder prune -af --filter "until=48h"' in script
+    assert 'docker image prune -af --filter "until=240h"' in script
 
 
-def test_AC8_13_38_cleanup_executes_remote_script_and_returns_status(
-    monkeypatch,
-    capsys,
+def test_AC8_13_38_remote_cleanup_script_can_skip_optional_prunes() -> None:
+    script = cleanup.build_remote_cleanup_script(
+        {},
+        dry_run=False,
+        prune_build_cache=False,
+        prune_images=False,
+        builder_prune_until="48h",
+        image_prune_until="240h",
+    )
+
+    assert "PRS=''" in script
+    assert "PROJECTS=''" in script
+    assert "docker builder prune" not in script
+    assert "docker image prune" not in script
+    assert "docker system df" in script
+
+
+def test_AC8_13_38_cleanup_orchestrates_stale_remote_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    run_calls = []
-    resources = cleanup.parse_preview_resources("finance-report-backend-pr-434\tcompose-old\n")
+    commands: list[tuple[list[str], str | None, bool]] = []
 
-    monkeypatch.setattr(cleanup, "list_open_pr_numbers", lambda: {498})
-    monkeypatch.setattr(cleanup, "list_remote_preview_resources", lambda *_args: resources)
+    def run_command_stub(
+        cmd: list[str],
+        *,
+        input_text: str | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        commands.append((cmd, input_text, check))
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="498\n", stderr="")
+        if "docker ps -a" in cmd[-1]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "finance-report-backend-pr-434\tcompose-old\n"
+                    "finance-report-backend-pr-498\tcompose-open\n"
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            cmd,
+            7,
+            stdout="remote stdout\n",
+            stderr="remote stderr\n",
+        )
 
-    def fake_run_command(cmd, *, input_text=None, check=True):
-        run_calls.append((cmd, input_text, check))
-        return SimpleNamespace(stdout="cleaned\n", stderr="warn\n", returncode=7)
-
-    monkeypatch.setattr(cleanup, "run_command", fake_run_command)
-
-    args = SimpleNamespace(
-        host="vps.example",
+    monkeypatch.setattr(cleanup, "run_command", run_command_stub)
+    args = argparse.Namespace(
+        host="cloud.zitian.party",
         user="root",
         ssh_key="/tmp/key",
         dry_run=True,
@@ -190,64 +283,63 @@ def test_AC8_13_38_cleanup_executes_remote_script_and_returns_status(
 
     out = capsys.readouterr()
     assert "Open PRs: [498]" in out.out
+    assert "Preview PRs on VPS: [434, 498]" in out.out
     assert "Stale preview PRs: [434]" in out.out
-    assert "cleaned" in out.out
-    assert "warn" in out.err
-    assert run_calls[0][0] == [
-        "ssh",
-        "-o",
-        "StrictHostKeyChecking=accept-new",
-        "-i",
-        "/tmp/key",
-        "root@vps.example",
-        "sh -s",
-    ]
-    assert "PRS='434'" in run_calls[0][1]
-    assert run_calls[0][2] is False
+    assert "remote stdout" in out.out
+    assert "remote stderr" in out.err
+    assert commands[-1][2] is False
+    assert "PRS='434'" in str(commands[-1][1])
+    assert "docker image prune" not in str(commands[-1][1])
 
 
-def test_AC8_13_38_main_parses_cli_flags(monkeypatch) -> None:
-    captured = []
+def test_AC8_13_38_main_parses_cleanup_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
 
-    def fake_cleanup(args):
-        captured.append(args)
+    def cleanup_stub(args: argparse.Namespace) -> int:
+        observed["args"] = args
         return 3
 
-    monkeypatch.setattr(cleanup, "cleanup", fake_cleanup)
+    monkeypatch.setattr(cleanup, "cleanup", cleanup_stub)
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "cleanup_pr_preview_resources.py",
             "--host",
-            "vps.example",
+            "cloud.zitian.party",
             "--user",
-            "deployer",
+            "deploy",
             "--ssh-key",
             "/tmp/key",
             "--dry-run",
             "--no-prune-build-cache",
             "--no-prune-images",
             "--builder-prune-until",
-            "12h",
-            "--image-prune-until",
             "72h",
+            "--image-prune-until",
+            "360h",
         ],
     )
 
     assert cleanup.main() == 3
-    assert captured[0].host == "vps.example"
-    assert captured[0].user == "deployer"
-    assert captured[0].ssh_key == "/tmp/key"
-    assert captured[0].dry_run is True
-    assert captured[0].no_prune_build_cache is True
-    assert captured[0].no_prune_images is True
-    assert captured[0].builder_prune_until == "12h"
-    assert captured[0].image_prune_until == "72h"
+    args = observed["args"]
+    assert isinstance(args, argparse.Namespace)
+    assert args.host == "cloud.zitian.party"
+    assert args.user == "deploy"
+    assert args.ssh_key == "/tmp/key"
+    assert args.dry_run is True
+    assert args.no_prune_build_cache is True
+    assert args.no_prune_images is True
+    assert args.builder_prune_until == "72h"
+    assert args.image_prune_until == "360h"
 
 
 def test_AC8_13_38_workflow_runs_on_schedule_and_manual_dispatch() -> None:
-    workflow = (Path(__file__).resolve().parents[2] / ".github/workflows/pr-preview-cleanup.yml").read_text()
+    workflow = (
+        Path(__file__).resolve().parents[2] / ".github/workflows/pr-preview-cleanup.yml"
+    ).read_text()
 
     assert 'cron: "37 */6 * * *"' in workflow
     assert "workflow_dispatch:" in workflow

--- a/tests/tooling/test_common_tooling_modules.py
+++ b/tests/tooling/test_common_tooling_modules.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
+import runpy
 import sys
 from pathlib import Path
 
@@ -14,6 +16,12 @@ sys.path.insert(0, str(ROOT))
 from common.coverage import policy as coverage_policy  # noqa: E402
 from common.ssot import ac_registry_format, ac_traceability_refs  # noqa: E402
 from common import test_isolation  # noqa: E402
+
+
+def _module_is_available(module_name: str) -> bool:
+    if module_name in sys.modules:
+        return True
+    return importlib.util.find_spec(module_name) is not None
 
 
 def test_AC8_13_53_common_ssot_helpers_are_the_authoritative_imports():
@@ -77,7 +85,10 @@ def test_AC8_13_56_tools_coverage_component_is_a_governed_source_root():
     assert component.source_subdir == "tools"
     assert component.ci_lcov_path == "coverage/tools.lcov"
     assert "tools/calculate_unified_coverage.py" in component.expected_sources(ROOT)
-    assert "tools/_lib/coverage/calculate_unified_coverage.py" in component.expected_sources(ROOT)
+    assert (
+        "tools/_lib/coverage/calculate_unified_coverage.py"
+        in component.expected_sources(ROOT)
+    )
     assert "tools/_lib/dev/test_lifecycle.py" in component.expected_sources(ROOT)
 
 
@@ -96,14 +107,21 @@ def test_AC8_13_56_coverage_tools_delegate_to_common_implementations():
     )
     assert (
         calc_tool.main
-        is importlib.import_module("tools._lib.coverage.calculate_unified_coverage").main
+        is importlib.import_module(
+            "tools._lib.coverage.calculate_unified_coverage"
+        ).main
     )
     assert (
-        analyzer_tool.main is importlib.import_module("tools._lib.coverage.analyzer").main
+        analyzer_tool.main
+        is importlib.import_module("tools._lib.coverage.analyzer").main
     )
-    assert merge_tool.main is importlib.import_module("tools._lib.coverage.merge_lcov").main
     assert (
-        policy_tool.main is importlib.import_module("tools._lib.coverage.check_policy").main
+        merge_tool.main
+        is importlib.import_module("tools._lib.coverage.merge_lcov").main
+    )
+    assert (
+        policy_tool.main
+        is importlib.import_module("tools._lib.coverage.check_policy").main
     )
     assert (
         metrics_tool.main is importlib.import_module("common.ci.metrics_contract").main
@@ -114,7 +132,10 @@ def test_AC8_13_56_coverage_tools_delegate_to_common_implementations():
     ("tool_module", "implementation_module"),
     [
         ("tools.analyze_pdf_fixture", "tools._lib.pdf_fixtures.analyzers.analyze_pdf"),
-        ("tools.generate_pdf_fixtures", "tools._lib.pdf_fixtures.generate_pdf_fixtures"),
+        (
+            "tools.generate_pdf_fixtures",
+            "tools._lib.pdf_fixtures.generate_pdf_fixtures",
+        ),
         ("tools.generate_fixtures", "tools._lib.fixtures.generate_fixtures"),
         ("tools.generate_test_pdfs", "tools._lib.fixtures.generate_test_pdfs"),
         ("tools.sanitize_fixtures", "tools._lib.fixtures.sanitize_fixtures"),
@@ -172,6 +193,7 @@ def test_AC8_13_58_ci_tools_delegate_to_common_implementations():
         "tools.github_workflow_timing_summary": (
             "tools._lib.ci.github_workflow_timing_summary"
         ),
+        "tools.production_infra_smoke": "common.ci.production_infra_smoke",
     }
 
     for tool_module, common_module in command_modules.items():
@@ -218,6 +240,41 @@ def test_AC8_13_58_shell_tools_delegate_to_common_shell_implementations():
         assert len(wrapper.splitlines()) <= 5
         assert implementation.startswith("#!")
         assert "tools/_lib/shell/$(basename" not in implementation
+
+
+def test_AC8_13_56_python_tool_wrappers_bootstrap_repo_root_when_run_directly():
+    """AC8.13.56: Python tool wrappers are executable without preset PYTHONPATH."""
+    optional_dependency_wrappers = {
+        "analyze_pdf_fixture.py": "pdfplumber",
+        "generate_fixtures.py": "dotenv",
+        "generate_pdf_fixtures.py": "reportlab",
+        "generate_test_pdfs.py": "reportlab",
+        "seed_fx_rates.py": "sqlalchemy",
+    }
+    wrappers = sorted(
+        path for path in (ROOT / "tools").glob("*.py") if path.name != "__init__.py"
+    )
+
+    assert wrappers
+    for wrapper in wrappers:
+        optional_dependency = optional_dependency_wrappers.get(wrapper.name)
+        if optional_dependency and not _module_is_available(optional_dependency):
+            continue
+
+        original_sys_path = list(sys.path)
+        try:
+            sys.path[:] = [entry for entry in sys.path if entry != str(ROOT)]
+
+            module_globals = runpy.run_path(
+                wrapper.as_posix(),
+                run_name=f"_tool_wrapper_{wrapper.stem}",
+            )
+
+            assert sys.path[0] == str(ROOT)
+            assert module_globals["ROOT_DIR"] == ROOT
+            assert callable(module_globals["main"])
+        finally:
+            sys.path[:] = original_sys_path
 
 
 def test_AC8_13_53_common_isolation_names_are_stable_and_bounded():
@@ -267,6 +324,8 @@ def test_AC8_13_53_common_isolation_handles_error_and_registry_edges(tmp_path):
     cache_dir = tmp_path / "cache"
     active_file = cache_dir / "active.json"
     test_isolation.register_namespace("feature_x", active_file, cache_dir)
-    assert test_isolation.load_active_namespaces(active_file, cache_dir) == ["feature_x"]
+    assert test_isolation.load_active_namespaces(active_file, cache_dir) == [
+        "feature_x"
+    ]
     test_isolation.unregister_namespace("feature_x", active_file, cache_dir)
     assert test_isolation.load_active_namespaces(active_file, cache_dir) == []

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -315,7 +315,7 @@ def test_AC8_13_60_deploy_workflows_have_no_nonblocking_noop_gates() -> None:
 
 
 def test_AC8_13_52_production_release_dry_run_does_not_mutate_production() -> None:
-    """AC8.13.52: Production release dry-run validates without deploying."""
+    """AC8.13.52 AC8.13.65: Production dry-run validates without deploying."""
     workflow = read(".github/workflows/production-release.yml")
     ci_cd = read("docs/ssot/ci-cd.md")
 
@@ -323,9 +323,12 @@ def test_AC8_13_52_production_release_dry_run_does_not_mutate_production() -> No
     assert "Validate release prerequisites without deploying production" in workflow
     assert "dry-run:" in workflow
     assert "github.event_name == 'workflow_dispatch' && inputs.dry_run" in workflow
-    assert "CONTAINER_RUNTIME: docker" in workflow
     assert "moon run :lint" in workflow
-    assert "moon run :test" in workflow
+    assert "moon run :test" not in workflow
+    assert "Verify source CI passed" in workflow
+    assert "--workflow ci.yml" in workflow
+    assert '--commit "$GITHUB_SHA"' in workflow
+    assert '.headBranch == "main"' in workflow
     assert "push: false" in workflow
     assert "Production mutation skipped" in workflow
     dry_run_section = workflow.split("dry-run:", 1)[1].split("\n  deploy:", 1)[0]
@@ -428,11 +431,14 @@ def test_AC8_13_9_production_release_runs_prod_safe_e2e_smoke() -> None:
     assert "Install frontend dependencies" in workflow
     assert "cache-dependency-path: apps/frontend/package-lock.json" in workflow
     assert "working-directory: apps/frontend" in workflow
-    assert "CONTAINER_RUNTIME: docker" in workflow
+    assert "Verify source CI passed" in workflow
     assert workflow.index("Install frontend dependencies") < workflow.index(
         "moon run :lint"
     )
     assert "Setup E2E Tests" in workflow
+    assert "Production Infrastructure Smoke" in workflow
+    assert "tools/production_infra_smoke.py" in workflow
+    assert "--signoz-url" in workflow
     assert "test_production_readonly_smoke.py" in workflow
     assert "TEST_ENV: production" in workflow
     assert "@pytest.mark.prod_safe" in prod_smoke

--- a/tests/tooling/test_production_infra_smoke.py
+++ b/tests/tooling/test_production_infra_smoke.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+import common.ci.production_infra_smoke as production_infra_smoke
+from common.ci.production_infra_smoke import (
+    HttpResponse,
+    SmokeFailure,
+    fetch_url,
+    main,
+    run_checks,
+    verify_signoz,
+    write_summary,
+)
+
+
+def test_AC8_13_64_production_infra_smoke_requires_db_s3_and_signoz() -> None:
+    """AC8.13.64: Production infra smoke proves DB, S3, and SigNoz health."""
+
+    def fetcher(url: str, timeout: float) -> HttpResponse:
+        assert timeout == 5
+        if url.endswith("/api/health"):
+            return HttpResponse(
+                200,
+                '{"status":"healthy","git_sha":"v0.1.3",'
+                '"checks":{"database":true,"s3":true}}',
+            )
+        if url.endswith("/api/ping"):
+            return HttpResponse(200, '{"state":"ping","toggle_count":1}')
+        if url.endswith("/api/v1/health"):
+            return HttpResponse(200, '{"status":"ok"}')
+        if url.endswith("/api/v1/version"):
+            return HttpResponse(
+                200,
+                '{"version":"v0.105.1","setupCompleted":true}',
+            )
+        return HttpResponse(200, "<html></html>")
+
+    passed = run_checks(
+        base_url="https://report.zitian.party",
+        expected_sha="v0.1.3",
+        signoz_url="https://signoz.zitian.party",
+        timeout=5,
+        fetcher=fetcher,
+    )
+
+    assert "database check true" in passed
+    assert "s3 check true" in passed
+    assert "signoz health ok (v0.105.1)" in passed
+
+
+def test_AC8_13_64_production_infra_smoke_fails_when_db_is_down() -> None:
+    """AC8.13.64: Production infra smoke fails on unhealthy DB checks."""
+
+    def fetcher(url: str, timeout: float) -> HttpResponse:
+        if url.endswith("/api/health"):
+            return HttpResponse(
+                200,
+                '{"status":"healthy","git_sha":"v0.1.3",'
+                '"checks":{"database":false,"s3":true}}',
+            )
+        return HttpResponse(200, "{}")
+
+    with pytest.raises(SmokeFailure, match="database"):
+        run_checks(
+            base_url="https://report.zitian.party",
+            expected_sha="v0.1.3",
+            signoz_url=None,
+            timeout=5,
+            fetcher=fetcher,
+        )
+
+
+def test_AC8_13_64_production_infra_smoke_fails_when_signoz_is_down() -> None:
+    """AC8.13.64: Production infra smoke fails when SigNoz health is not ok."""
+
+    def fetcher(url: str, timeout: float) -> HttpResponse:
+        if url.endswith("/api/health"):
+            return HttpResponse(
+                200,
+                '{"status":"healthy","git_sha":"v0.1.3",'
+                '"checks":{"database":true,"s3":true}}',
+            )
+        if url.endswith("/api/ping"):
+            return HttpResponse(200, '{"state":"ping","toggle_count":1}')
+        if url.endswith("/api/v1/health"):
+            return HttpResponse(503, '{"status":"error"}')
+        return HttpResponse(200, "<html></html>")
+
+    with pytest.raises(SmokeFailure, match="SigNoz health"):
+        run_checks(
+            base_url="https://report.zitian.party",
+            expected_sha="v0.1.3",
+            signoz_url="https://signoz.zitian.party",
+            timeout=5,
+            fetcher=fetcher,
+        )
+
+
+@pytest.mark.parametrize(
+    ("health_body", "expected_sha", "message"),
+    [
+        (
+            '{"status":"degraded","git_sha":"v0.1.3",'
+            '"checks":{"database":true,"s3":true}}',
+            "v0.1.3",
+            "status is not healthy",
+        ),
+        (
+            '{"status":"healthy","checks":{"database":true,"s3":true}}',
+            "v0.1.3",
+            "missing git_sha/version",
+        ),
+        (
+            '{"status":"healthy","git_sha":"old-sha",'
+            '"checks":{"database":true,"s3":true}}',
+            "new-sha",
+            "version mismatch",
+        ),
+        (
+            '{"status":"healthy","git_sha":"v0.1.3"}',
+            "v0.1.3",
+            "missing checks object",
+        ),
+        (
+            '{"status":"healthy","git_sha":"v0.1.3",'
+            '"checks":{"database":true,"s3":false}}',
+            "v0.1.3",
+            "s3",
+        ),
+    ],
+)
+def test_AC8_13_64_production_infra_smoke_rejects_bad_health_payloads(
+    health_body: str,
+    expected_sha: str,
+    message: str,
+) -> None:
+    """AC8.13.64: Production infra smoke rejects incomplete health proofs."""
+
+    def fetcher(url: str, timeout: float) -> HttpResponse:
+        assert url.endswith("/api/health")
+        return HttpResponse(200, health_body)
+
+    with pytest.raises(SmokeFailure, match=message):
+        run_checks(
+            base_url="https://report.zitian.party",
+            expected_sha=expected_sha,
+            signoz_url=None,
+            timeout=5,
+            fetcher=fetcher,
+        )
+
+
+@pytest.mark.parametrize(
+    ("url_suffix", "response", "message"),
+    [
+        ("/api/health", HttpResponse(200, "not-json"), "did not return JSON"),
+        ("/api/health", HttpResponse(200, "[]"), "non-object JSON"),
+        (
+            "/api/ping",
+            HttpResponse(200, '{"state":"ping"}'),
+            "ping payload is incomplete",
+        ),
+        ("/", HttpResponse(500, "server error"), "frontend returned HTTP 500"),
+    ],
+)
+def test_AC8_13_64_production_infra_smoke_rejects_bad_runtime_responses(
+    url_suffix: str,
+    response: HttpResponse,
+    message: str,
+) -> None:
+    """AC8.13.64: Production infra smoke rejects broken public runtime responses."""
+
+    def fetcher(url: str, timeout: float) -> HttpResponse:
+        if url.endswith(url_suffix):
+            return response
+        if url.endswith("/api/health"):
+            return HttpResponse(
+                200,
+                '{"status":"healthy","git_sha":"v0.1.3",'
+                '"checks":{"database":true,"s3":true}}',
+            )
+        if url.endswith("/api/ping"):
+            return HttpResponse(200, '{"state":"ping","toggle_count":1}')
+        return HttpResponse(200, "<html></html>")
+
+    with pytest.raises(SmokeFailure, match=message):
+        run_checks(
+            base_url="https://report.zitian.party",
+            expected_sha="v0.1.3",
+            signoz_url=None,
+            timeout=5,
+            fetcher=fetcher,
+        )
+
+
+@pytest.mark.parametrize(
+    ("health_response", "version_response", "message"),
+    [
+        (
+            HttpResponse(200, '{"status":"bad"}'),
+            HttpResponse(200, '{"version":"v0.105.1","setupCompleted":true}'),
+            "SigNoz health is not ok",
+        ),
+        (
+            HttpResponse(200, '{"status":"ok"}'),
+            HttpResponse(200, '{"version":"v0.105.1","setupCompleted":false}'),
+            "SigNoz setup is not complete",
+        ),
+    ],
+)
+def test_AC8_13_64_production_infra_smoke_rejects_bad_signoz_payloads(
+    health_response: HttpResponse,
+    version_response: HttpResponse,
+    message: str,
+) -> None:
+    """AC8.13.64: Production infra smoke rejects incomplete SigNoz proofs."""
+
+    def fetcher(url: str, timeout: float) -> HttpResponse:
+        if url.endswith("/api/v1/health"):
+            return health_response
+        return version_response
+
+    with pytest.raises(SmokeFailure, match=message):
+        verify_signoz(
+            "https://signoz.zitian.party",
+            timeout=5,
+            fetcher=fetcher,
+        )
+
+
+def test_AC8_13_64_production_infra_smoke_writes_github_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.64: Production infra smoke publishes concise GitHub summaries."""
+
+    summary_path = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+
+    write_summary(["database check true", "s3 check true"])
+
+    assert summary_path.read_text() == (
+        "## Production Infrastructure Smoke\n\n"
+        "- OK: database check true\n"
+        "- OK: s3 check true\n"
+    )
+
+
+def test_AC8_13_64_production_infra_smoke_cli_reports_success(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AC8.13.64: Production infra smoke CLI returns success after proof checks."""
+
+    def run_checks_stub(**kwargs: object) -> list[str]:
+        assert kwargs["base_url"] == "https://report.zitian.party"
+        assert kwargs["expected_sha"] == "v0.1.3"
+        assert kwargs["signoz_url"] == "https://signoz.zitian.party"
+        assert kwargs["timeout"] == 3.0
+        return ["database check true"]
+
+    monkeypatch.setattr(production_infra_smoke, "run_checks", run_checks_stub)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    assert (
+        main(
+            [
+                "--base-url",
+                "https://report.zitian.party",
+                "--expected-sha",
+                "v0.1.3",
+                "--signoz-url",
+                "https://signoz.zitian.party",
+                "--timeout",
+                "3",
+            ]
+        )
+        == 0
+    )
+
+    assert "OK: database check true" in capsys.readouterr().out
+
+
+def test_AC8_13_64_production_infra_smoke_cli_reports_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AC8.13.64: Production infra smoke CLI returns failure on proof gaps."""
+
+    def run_checks_stub(**kwargs: object) -> list[str]:
+        raise SmokeFailure("database down")
+
+    monkeypatch.setattr(production_infra_smoke, "run_checks", run_checks_stub)
+
+    assert main(["--base-url", "https://report.zitian.party"]) == 1
+    assert "ERROR: database down" in capsys.readouterr().err
+
+
+def test_AC8_13_64_production_infra_smoke_fetch_url_success_and_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.64: Production infra smoke preserves HTTP status and body."""
+
+    class Response:
+        status = 204
+
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"ok"
+
+    def urlopen_success(request: object, timeout: float) -> Response:
+        return Response()
+
+    monkeypatch.setattr(production_infra_smoke, "urlopen", urlopen_success)
+    assert fetch_url("https://report.zitian.party/api/health", 5) == HttpResponse(
+        204,
+        "ok",
+    )
+
+    error = HTTPError(
+        "https://report.zitian.party/api/health",
+        503,
+        "Service Unavailable",
+        {},
+        io.BytesIO(b"down"),
+    )
+
+    def urlopen_http_error(request: object, timeout: float) -> Response:
+        raise error
+
+    monkeypatch.setattr(production_infra_smoke, "urlopen", urlopen_http_error)
+    assert fetch_url("https://report.zitian.party/api/health", 5) == HttpResponse(
+        503,
+        "down",
+    )
+
+
+def test_AC8_13_64_production_infra_smoke_fetch_url_wraps_url_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC8.13.64: Production infra smoke reports unreachable production URLs."""
+
+    def urlopen_url_error(request: object, timeout: float) -> None:
+        raise URLError("timeout")
+
+    monkeypatch.setattr(production_infra_smoke, "urlopen", urlopen_url_error)
+
+    with pytest.raises(SmokeFailure, match="Cannot reach"):
+        fetch_url("https://report.zitian.party/api/health", 5)

--- a/tools/production_infra_smoke.py
+++ b/tools/production_infra_smoke.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Command wrapper for production infrastructure smoke checks."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.ci.production_infra_smoke import main  # noqa: E402
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Harden the production release lane: reuse successful main CI proof instead of rerunning container-backed tests in release, then add a post-deploy production infrastructure smoke gate for DB, S3, API, frontend, and SigNoz.

Related #408

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Comprehensive Testing Strategy |
| **AC IDs** | AC8.13.61, AC8.13.62 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/ci-cd.md` — production release reuses main CI proof and documents the post-deploy infrastructure smoke gate
- [x] `docs/ssot/deployment.md` — release flow now describes CI-proof reuse instead of Docker test lifecycle reruns
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (local) | `uncommitted` | Added AC8.13.61/62 tests for production infra smoke and release-lane CI proof reuse before final workflow verification |
| Green | `ca6f5d1` | Added production infra smoke implementation, wired it into production release deploy, and removed release-lane `moon run :test` reruns |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable; no DB model changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable; no infra config/env var changes)
- [x] `scripts/check_env_keys.py` passes (not applicable; tools path now owns this check)
- [x] `scripts/check_manifest.py` passes (covered by `moon run :lint`)
- [x] `scripts/lint_doc_consistency.py` passes (covered by `moon run :lint`)

---

## Testing

```bash
uv run --with pytest --with pyyaml pytest tests/tooling/test_production_infra_smoke.py tests/tooling/test_post_merge_e2e_gates.py tests/tooling/test_common_tooling_modules.py -q
uv run ruff check common/ci/production_infra_smoke.py tools/production_infra_smoke.py tests/tooling/test_production_infra_smoke.py tests/tooling/test_post_merge_e2e_gates.py tests/tooling/test_common_tooling_modules.py
uv run ruff format common/ci/production_infra_smoke.py tools/production_infra_smoke.py tests/tooling/test_production_infra_smoke.py tests/tooling/test_post_merge_e2e_gates.py tests/tooling/test_common_tooling_modules.py --check
python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_ac_traceability.py
uv run --with pyyaml python tools/check_critical_proof_matrix.py
actionlint .github/workflows/*.yml
python tools/production_infra_smoke.py --base-url https://report.zitian.party --expected-sha 38c4422 --signoz-url https://signoz.zitian.party
moon run :lint
```

The old production dry-run on `main` was cancelled after it stayed in the obsolete `moon run :test` release-lane step; this PR removes that release-lane container test rerun and relies on successful main CI instead.

---

## Screenshots / Evidence

Current production infra smoke output:

```text
OK: health status healthy (38c4422)
OK: database check true
OK: s3 check true
OK: ping API read-only check
OK: frontend shell reachable
OK: signoz health ok (v0.105.1)
```
