### PR TITLE
Cover report-time market data refresh E2E

### DIFF
--- a/apps/backend/src/routers/market_data.py
+++ b/apps/backend/src/routers/market_data.py
@@ -2,11 +2,17 @@
 
 from datetime import date
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from src.deps import CurrentUserId, DbSession
-from src.services.market_data import MarketDataSyncResult, sync_fx_rates, sync_stock_prices
+from src.services.market_data import (
+    MarketDataScopeStatus,
+    MarketDataSyncResult,
+    get_market_data_status,
+    sync_fx_rates,
+    sync_stock_prices,
+)
 
 router = APIRouter(prefix="/market-data", tags=["market-data"])
 
@@ -44,8 +50,45 @@ class MarketDataSyncResponse(BaseModel):
     disagreements: list[ProviderDisagreementResponse]
 
 
+class MarketDataStatusResponse(BaseModel):
+    """Read-only market data freshness status for authenticated users."""
+
+    kind: str
+    scope: str
+    fresh: bool
+    last_success_at: str | None
+    last_success_date: str | None
+    last_observation_date: str | None
+
+
 def _response_from_result(result: MarketDataSyncResult) -> MarketDataSyncResponse:
     return MarketDataSyncResponse.model_validate(result.to_dict())
+
+
+def _status_response(status_result: MarketDataScopeStatus) -> MarketDataStatusResponse:
+    return MarketDataStatusResponse.model_validate(status_result.to_dict())
+
+
+@router.get("/status", response_model=list[MarketDataStatusResponse], status_code=status.HTTP_200_OK)
+async def market_data_status_endpoint(
+    db: DbSession,
+    user_id: CurrentUserId,
+    pairs: list[str] | None = Query(default=None, description="FX pairs in BASE/QUOTE format"),
+    symbols: list[str] | None = Query(default=None, description="Stock symbols"),
+    include_default_fx: bool = Query(default=False),
+) -> list[MarketDataStatusResponse]:
+    """Return read-only market data freshness status for observed or explicit scopes."""
+    try:
+        statuses = await get_market_data_status(
+            db,
+            pairs=pairs,
+            symbols=symbols,
+            user_id=user_id,
+            include_default_fx=include_default_fx,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    return [_status_response(item) for item in statuses]
 
 
 @router.post("/sync/fx", response_model=MarketDataSyncResponse, status_code=status.HTTP_200_OK)

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -57,11 +57,13 @@ async def _ensure_report_market_data_fresh(
     user_id: CurrentUserId,
     *,
     currency: str | None,
+    end_date: date,
 ) -> None:
     has_report_subjects = await db.scalar(select(Account.id).where(Account.user_id == user_id).limit(1))
     await ensure_market_data_fresh(
         db,
         user_id=user_id,
+        end_date=end_date,
         include_default_fx=False,
         extra_fx_pairs=_target_currency_pair(currency) if has_report_subjects is not None else [],
     )
@@ -107,11 +109,12 @@ async def balance_sheet(
 ) -> BalanceSheetResponse:
     """Get balance sheet as of date."""
     try:
-        await _ensure_report_market_data_fresh(db, user_id, currency=currency)
+        report_date = as_of_date or date.today()
+        await _ensure_report_market_data_fresh(db, user_id, currency=currency, end_date=report_date)
         report = await generate_balance_sheet(
             db,
             user_id,
-            as_of_date=as_of_date or date.today(),
+            as_of_date=report_date,
             currency=currency,
             include_restricted=include_restricted,
         )
@@ -138,7 +141,7 @@ async def income_statement(
 ) -> IncomeStatementResponse:
     """Get income statement for a period with optional filtering."""
     try:
-        await _ensure_report_market_data_fresh(db, user_id, currency=currency)
+        await _ensure_report_market_data_fresh(db, user_id, currency=currency, end_date=end_date)
         report = await generate_income_statement(
             db,
             user_id,
@@ -170,7 +173,7 @@ async def cash_flow(
 ) -> CashFlowResponse:
     """Get cash flow statement for a period."""
     try:
-        await _ensure_report_market_data_fresh(db, user_id, currency=currency)
+        await _ensure_report_market_data_fresh(db, user_id, currency=currency, end_date=end_date)
         report = await generate_cash_flow(
             db,
             user_id,
@@ -200,7 +203,7 @@ async def account_trend(
 ) -> AccountTrendResponse:
     """Get account trend data."""
     try:
-        await _ensure_report_market_data_fresh(db, user_id, currency=currency)
+        await _ensure_report_market_data_fresh(db, user_id, currency=currency, end_date=date.today())
         report = await get_account_trend(
             db,
             user_id,
@@ -231,7 +234,7 @@ async def net_worth_timeseries(
 ) -> NetWorthTimeSeriesResponse:
     """Get daily or monthly net worth time-series."""
     try:
-        await _ensure_report_market_data_fresh(db, user_id, currency=currency)
+        await _ensure_report_market_data_fresh(db, user_id, currency=currency, end_date=to_date)
         report = await get_net_worth_timeseries(
             db,
             user_id,
@@ -264,7 +267,7 @@ async def category_breakdown(
     """Get income or expense category breakdown."""
     account_type = AccountType.INCOME if breakdown_type == BreakdownType.INCOME else AccountType.EXPENSE
     try:
-        await _ensure_report_market_data_fresh(db, user_id, currency=currency)
+        await _ensure_report_market_data_fresh(db, user_id, currency=currency, end_date=date.today())
         report = await get_category_breakdown(
             db,
             user_id,
@@ -300,12 +303,13 @@ async def export_report(
     writer = csv.writer(output)
 
     try:
-        await _ensure_report_market_data_fresh(db, user_id, currency=currency)
         if report_type == ReportType.BALANCE_SHEET:
+            report_date = as_of_date or date.today()
+            await _ensure_report_market_data_fresh(db, user_id, currency=currency, end_date=report_date)
             report = await generate_balance_sheet(
                 db,
                 user_id,
-                as_of_date=as_of_date or date.today(),
+                as_of_date=report_date,
                 currency=currency,
             )
             writer.writerow(["section", "account", "amount", "currency"])
@@ -323,6 +327,7 @@ async def export_report(
         elif report_type == ReportType.INCOME_STATEMENT:
             if not start_date or not end_date:
                 raise_bad_request("start_date and end_date are required for income statement export")
+            await _ensure_report_market_data_fresh(db, user_id, currency=currency, end_date=end_date)
             report = await generate_income_statement(
                 db,
                 user_id,

--- a/apps/backend/src/services/market_data.py
+++ b/apps/backend/src/services/market_data.py
@@ -139,6 +139,28 @@ class MarketDataFreshnessResult:
 
 
 @dataclass(frozen=True)
+class MarketDataScopeStatus:
+    """Read-only freshness status for one market data scope."""
+
+    kind: str
+    scope: str
+    fresh: bool
+    last_success_at: datetime | None
+    last_success_date: date | None
+    last_observation_date: date | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "scope": self.scope,
+            "fresh": self.fresh,
+            "last_success_at": self.last_success_at.isoformat() if self.last_success_at else None,
+            "last_success_date": self.last_success_date.isoformat() if self.last_success_date else None,
+            "last_observation_date": self.last_observation_date.isoformat() if self.last_observation_date else None,
+        }
+
+
+@dataclass(frozen=True)
 class _StoredFxRate:
     rate: Decimal
     rate_date: date
@@ -548,13 +570,76 @@ async def _fallback_last_success_at(db: AsyncSession, kind: str, scope: str) -> 
     return _normalize_utc(value) if value is not None else None
 
 
-async def _is_sync_scope_fresh(db: AsyncSession, kind: str, scope: str, now: datetime) -> bool:
+async def _latest_observation_date_on_or_before(
+    db: AsyncSession,
+    kind: str,
+    scope: str,
+    observed_date: date,
+) -> date | None:
+    if kind == "fx":
+        base, quote_currency = _parse_fx_pair(scope)
+        return await db.scalar(
+            select(func.max(FxRate.rate_date))
+            .where(FxRate.base_currency == base)
+            .where(FxRate.quote_currency == quote_currency)
+            .where(FxRate.rate_date <= observed_date)
+        )
+    return await db.scalar(
+        select(func.max(StockPrice.price_date))
+        .where(StockPrice.symbol == _normalize_symbol(scope))
+        .where(StockPrice.price_date <= observed_date)
+    )
+
+
+async def _is_sync_scope_fresh(
+    db: AsyncSession,
+    kind: str,
+    scope: str,
+    now: datetime,
+    *,
+    required_observation_date: date | None = None,
+) -> bool:
     state = await _load_sync_state(db, kind, scope)
     if state is not None:
-        return _normalize_utc(state.last_success_at) >= now - _FRESHNESS_THRESHOLD
+        fresh = _normalize_utc(state.last_success_at) >= now - _FRESHNESS_THRESHOLD
+    else:
+        fallback = await _fallback_last_success_at(db, kind, scope)
+        fresh = fallback is not None and fallback >= now - _FRESHNESS_THRESHOLD
 
-    fallback = await _fallback_last_success_at(db, kind, scope)
-    return fallback is not None and fallback >= now - _FRESHNESS_THRESHOLD
+    if not fresh or required_observation_date is None:
+        return fresh
+
+    return await _latest_observation_date_on_or_before(db, kind, scope, required_observation_date) is not None
+
+
+async def _latest_observation_date(db: AsyncSession, kind: str, scope: str) -> date | None:
+    if kind == "fx":
+        base, quote_currency = _parse_fx_pair(scope)
+        return await _latest_fx_rate_date(db, base, quote_currency)
+    return await _latest_stock_price_date(db, scope)
+
+
+async def _sync_scope_status(
+    db: AsyncSession,
+    *,
+    kind: str,
+    scope: str,
+    now: datetime,
+) -> MarketDataScopeStatus:
+    state = await _load_sync_state(db, kind, scope)
+    fallback_success_at = await _fallback_last_success_at(db, kind, scope) if state is None else None
+    last_success_at = _normalize_utc(state.last_success_at) if state is not None else fallback_success_at
+    latest_observation_date = await _latest_observation_date(db, kind, scope)
+    last_success_date = state.last_success_date if state is not None else latest_observation_date
+    last_observation_date = state.last_observation_date if state is not None else latest_observation_date
+    return MarketDataScopeStatus(
+        kind=kind,
+        scope=scope,
+        fresh=last_success_at is not None and last_success_at >= now - _FRESHNESS_THRESHOLD,
+        last_success_at=last_success_at,
+        last_success_date=last_success_date,
+        last_observation_date=last_observation_date,
+    )
 
 
 async def _upsert_sync_state(
@@ -859,23 +944,47 @@ async def ensure_market_data_fresh(
         if base == quote_currency:
             continue
         scope = _fx_scope(base, quote_currency)
-        if not await _is_sync_scope_fresh(db, "fx", scope, checked_at):
+        if not await _is_sync_scope_fresh(
+            db,
+            "fx",
+            scope,
+            checked_at,
+            required_observation_date=sync_end,
+        ):
             stale_pairs.append(scope)
 
     stock_symbols = await _active_stock_symbols(db, user_id)
     stale_symbols: list[str] = []
     for symbol in stock_symbols:
         scope = _stock_scope(symbol)
-        if not await _is_sync_scope_fresh(db, "stock", scope, checked_at):
+        if not await _is_sync_scope_fresh(
+            db,
+            "stock",
+            scope,
+            checked_at,
+            required_observation_date=sync_end,
+        ):
             stale_symbols.append(scope)
 
     fx_result = (
-        await sync_fx_rates(db, pairs=stale_pairs, end_date=sync_end, user_id=user_id)
+        await sync_fx_rates(
+            db,
+            pairs=stale_pairs,
+            start_date=_default_start_date(sync_end),
+            end_date=sync_end,
+            user_id=user_id,
+        )
         if stale_pairs
         else MarketDataSyncResult(kind="fx")
     )
     stock_result = (
-        await sync_stock_prices(db, symbols=stale_symbols, end_date=sync_end, user_id=user_id)
+        await sync_stock_prices(
+            db,
+            symbols=stale_symbols,
+            start_date=_default_start_date(sync_end),
+            end_date=sync_end,
+            user_id=user_id,
+        )
         if stale_symbols
         else MarketDataSyncResult(kind="stock")
     )
@@ -888,6 +997,55 @@ async def ensure_market_data_fresh(
             stock_inserted=stock_result.inserted,
         )
     return MarketDataFreshnessResult(checked_at=checked_at, fx=fx_result, stock=stock_result)
+
+
+async def get_market_data_status(
+    db: AsyncSession,
+    *,
+    pairs: Sequence[str] | None = None,
+    symbols: Sequence[str] | None = None,
+    user_id: UUID | None = None,
+    include_default_fx: bool = False,
+    now: datetime | None = None,
+) -> list[MarketDataScopeStatus]:
+    """Return read-only sync freshness status for explicit or observed scopes."""
+    checked_at = _normalize_utc(now or datetime.now(UTC))
+    statuses: list[MarketDataScopeStatus] = []
+
+    sync_pairs = (
+        list(pairs) if pairs is not None else await _observed_fx_pairs(db, user_id, include_default=include_default_fx)
+    )
+    for raw_pair in sorted(set(sync_pairs)):
+        base, quote_currency = _parse_fx_pair(raw_pair)
+        if base == quote_currency:
+            continue
+        statuses.append(
+            await _sync_scope_status(
+                db,
+                kind="fx",
+                scope=_fx_scope(base, quote_currency),
+                now=checked_at,
+            )
+        )
+
+    sync_symbols = (
+        sorted({_normalize_symbol(symbol) for symbol in symbols})
+        if symbols is not None
+        else await _active_stock_symbols(db, user_id)
+    )
+    for symbol in sync_symbols:
+        if not symbol:
+            continue
+        statuses.append(
+            await _sync_scope_status(
+                db,
+                kind="stock",
+                scope=_stock_scope(symbol),
+                now=checked_at,
+            )
+        )
+
+    return statuses
 
 
 async def _fetch_validated_fx_rate_series(

--- a/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
+++ b/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
@@ -17,6 +17,8 @@ from src.services.brokerage_positions import looks_like_brokerage_payload, parse
 from src.services.extraction import ExtractionService
 from src.services.statement_parsing import import_brokerage_payload_if_present, parse_statement_background
 
+_BRIDGE_ASSET_IDENTIFIER = "BRIDGE_TEST_STOCK"
+
 
 def _parsed_statement(user_id, file_hash: str) -> BankStatement:
     return BankStatement(
@@ -45,7 +47,7 @@ def _brokerage_payload() -> dict:
         "statement": {"period_end": "2026-05-18", "currency": "SGD"},
         "positions": [
             {
-                "symbol": "AAPL",
+                "symbol": _BRIDGE_ASSET_IDENTIFIER,
                 "snapshot_date": date(2026, 5, 18),
                 "quantity": "10",
                 "market_value": "1900.25",
@@ -396,10 +398,10 @@ async def test_parse_statement_background_imports_brokerage_positions(client, db
     assert refreshed.balance_validated is True
     assert refreshed.validation_error is None
     assert len(atomic_rows) == 1
-    assert atomic_rows[0].asset_identifier == "AAPL"
+    assert atomic_rows[0].asset_identifier == _BRIDGE_ASSET_IDENTIFIER
     assert atomic_rows[0].source_documents["documents"][0]["doc_id"] == str(statement_id)
     assert len(managed_rows) == 1
-    assert managed_rows[0].asset_identifier == "AAPL"
+    assert managed_rows[0].asset_identifier == _BRIDGE_ASSET_IDENTIFIER
     assert managed_rows[0].quantity == Decimal("10")
 
     holdings_response = await client.get(
@@ -409,12 +411,16 @@ async def test_parse_statement_background_imports_brokerage_positions(client, db
     assert holdings_response.status_code == 200
     holdings = holdings_response.json()
     assert len(holdings) == 1
-    assert holdings[0]["asset_identifier"] == "AAPL"
+    assert holdings[0]["asset_identifier"] == _BRIDGE_ASSET_IDENTIFIER
     assert holdings[0]["account_name"] == "Moomoo"
     assert Decimal(str(holdings[0]["quantity"])) == Decimal("10.00000000")
     assert Decimal(str(holdings[0]["market_value"])) == Decimal("1900.25")
     assert holdings[0]["currency"] == "SGD"
 
+    async def skip_report_market_data_refresh(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("src.routers.reports.ensure_market_data_fresh", skip_report_market_data_refresh)
     balance_response = await client.get(
         "/reports/balance-sheet",
         params={"as_of_date": "2026-05-18", "currency": "SGD"},

--- a/apps/backend/tests/market_data/test_sync.py
+++ b/apps/backend/tests/market_data/test_sync.py
@@ -846,6 +846,86 @@ async def test_market_data_freshness_sync_runs_once_after_24h(
 
 
 @pytest.mark.asyncio
+async def test_market_data_freshness_backfills_report_date_when_latest_price_is_newer(
+    db: AsyncSession,
+    test_user,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC11.10.9: Fresh sync state does not skip a missing historical report-date price."""
+    account = Account(
+        user_id=test_user.id,
+        name="Historical Brokerage",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add(account)
+    await db.flush()
+    db.add_all(
+        [
+            ManagedPosition(
+                user_id=test_user.id,
+                account_id=account.id,
+                asset_identifier="IBM",
+                quantity=Decimal("1"),
+                cost_basis=Decimal("100.00"),
+                currency="SGD",
+                acquisition_date=date(2024, 1, 1),
+                status=PositionStatus.ACTIVE,
+                cost_basis_method=CostBasisMethod.FIFO,
+            ),
+            StockPrice(
+                symbol="IBM",
+                price=Decimal("200.000000"),
+                currency="USD",
+                price_date=date(2026, 1, 6),
+                source="future_seed",
+            ),
+            MarketDataSyncState(
+                kind="stock",
+                scope="IBM",
+                last_success_at=datetime(2026, 1, 6, 8, 0, tzinfo=UTC),
+                last_success_date=date(2026, 1, 6),
+                last_observation_date=date(2026, 1, 6),
+                created_at=datetime(2026, 1, 6, 8, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 6, 8, 0, tzinfo=UTC),
+            ),
+        ]
+    )
+    await db.commit()
+
+    requested_ranges: list[tuple[str, date, date]] = []
+
+    async def fake_stock_fetch(
+        symbol: str, start_date: date, end_date: date
+    ) -> market_data.ValidatedMarketObservationSeries:
+        requested_ranges.append((symbol, start_date, end_date))
+        return market_data.ValidatedMarketObservationSeries(
+            observations=[
+                market_data.StockPriceObservation(
+                    symbol=symbol,
+                    price=Decimal("150.000000"),
+                    currency="USD",
+                    price_date=end_date,
+                    source="test_primary",
+                )
+            ]
+        )
+
+    monkeypatch.setattr(market_data, "_fetch_validated_stock_price_series", fake_stock_fetch)
+
+    result = await market_data.ensure_market_data_fresh(
+        db,
+        user_id=test_user.id,
+        end_date=date(2024, 6, 3),
+        now=datetime(2026, 1, 6, 9, 0, tzinfo=UTC),
+    )
+
+    assert result.triggered is True
+    assert requested_ranges == [("IBM", date(2024, 5, 28), date(2024, 6, 3))]
+    assert result.stock.inserted == 1
+
+
+@pytest.mark.asyncio
 async def test_market_data_freshness_skips_same_currency_pair(
     db: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/backend/tests/market_data/test_sync_router.py
+++ b/apps/backend/tests/market_data/test_sync_router.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from httpx import AsyncClient
 
+from src.models import FxRate, MarketDataSyncState, StockPrice
 from src.routers import market_data as market_data_router, reports as reports_router
 from src.services import market_data
 
@@ -94,6 +95,65 @@ async def test_market_data_fx_sync_endpoint_rejects_invalid_pair(client: AsyncCl
 
 
 @pytest.mark.asyncio
+async def test_market_data_status_endpoint_returns_authenticated_scope_freshness(
+    client: AsyncClient,
+    db,
+) -> None:
+    """AC11.10.11: Authenticated users can inspect market data freshness without triggering sync."""
+    observed_at = datetime(2026, 1, 6, tzinfo=UTC)
+    db.add_all(
+        [
+            FxRate(
+                base_currency="USD",
+                quote_currency="SGD",
+                rate=Decimal("1.350000"),
+                rate_date=date(2026, 1, 5),
+                source="test",
+            ),
+            StockPrice(
+                symbol="IBM",
+                price=Decimal("160.000000"),
+                currency="USD",
+                price_date=date(2026, 1, 5),
+                source="test",
+            ),
+            MarketDataSyncState(
+                kind="fx",
+                scope="USD/SGD",
+                last_success_at=observed_at,
+                last_success_date=date(2026, 1, 5),
+                last_observation_date=date(2026, 1, 5),
+                created_at=observed_at,
+                updated_at=observed_at,
+            ),
+            MarketDataSyncState(
+                kind="stock",
+                scope="IBM",
+                last_success_at=observed_at,
+                last_success_date=date(2026, 1, 5),
+                last_observation_date=date(2026, 1, 5),
+                created_at=observed_at,
+                updated_at=observed_at,
+            ),
+        ]
+    )
+    await db.commit()
+
+    response = await client.get(
+        "/market-data/status",
+        params=[("pairs", "USD/SGD"), ("symbols", "IBM")],
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert {(item["kind"], item["scope"]) for item in payload} == {
+        ("fx", "USD/SGD"),
+        ("stock", "IBM"),
+    }
+    assert all(item["last_success_date"] == "2026-01-05" for item in payload)
+
+
+@pytest.mark.asyncio
 async def test_report_endpoint_runs_market_data_freshness_check(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -102,9 +162,10 @@ async def test_report_endpoint_runs_market_data_freshness_check(
     calls: list[str] = []
 
     async def fake_ensure(
-        _db, *, user_id, include_default_fx: bool, extra_fx_pairs: list[str]
+        _db, *, user_id, end_date: date, include_default_fx: bool, extra_fx_pairs: list[str]
     ) -> market_data.MarketDataFreshnessResult:
         calls.append(str(user_id))
+        assert end_date == date(2026, 1, 6)
         assert include_default_fx is False
         assert extra_fx_pairs == []
         return market_data.MarketDataFreshnessResult(
@@ -147,7 +208,7 @@ def test_report_target_currency_pair_includes_requested_non_base_currency() -> N
 
 
 def test_market_data_provider_e2e_gate_is_declared() -> None:
-    """AC11.10.7: Provider-backed stock and lazy FX E2E gate is wired as critical."""
+    """AC11.10.11: Provider-backed user-view E2E gate is wired as critical."""
     repo_root = Path(__file__).resolve().parents[4]
     e2e_source = (repo_root / "tests/e2e/test_market_data_price_paths.py").read_text()
 
@@ -155,5 +216,6 @@ def test_market_data_provider_e2e_gate_is_declared() -> None:
     assert "@pytest.mark.tier3" in e2e_source
     assert "@pytest.mark.critical" in e2e_source
     assert "RUN_MARKET_DATA_PROVIDER_E2E" in e2e_source
-    assert "/market-data/sync/stocks" in e2e_source
+    assert "/market-data/status" in e2e_source
+    assert "/market-data/sync/stocks" not in e2e_source
     assert "/reports/balance-sheet" in e2e_source

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2300,6 +2300,11 @@ groups:
         epic_name: asset-lifecycle
         description: Backend scheduler runs daily market data sync at the nightly Asia/Singapore close-refresh window
         mandatory: true
+      - id: AC11.10.11
+        epic: 11
+        epic_name: asset-lifecycle
+        description: Staging E2E covers report-time market data refresh from an authenticated ordinary-user path without manual sync
+        mandatory: true
   AC13:
     AC13.1:
       - id: AC13.1.1

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -1238,9 +1238,10 @@ DR  Equity:APIC                 $1,250
 | AC11.10.8 | Long historical market data sync uses bounded range provider requests instead of per-day provider calls | `test_sync_stock_prices_fetches_decade_range_once()` | `market_data/test_sync.py` | P0 |
 | AC11.10.9 | Report reads check market data freshness and trigger at most one immediate refresh when the last successful sync is older than 24 hours | `test_market_data_freshness_sync_runs_once_after_24h()` | `market_data/test_sync.py` | P0 |
 | AC11.10.10 | Backend scheduler runs daily market data sync at the nightly Asia/Singapore close-refresh window | `test_next_market_data_sync_at_uses_nightly_sgt_schedule()` | `market_data/test_scheduler.py` | P0 |
+| AC11.10.11 | Staging E2E covers report-time market data refresh from an authenticated ordinary-user path without manual sync | `test_market_data_provider_sync_feeds_fx_and_stock_price_paths()` | `tests/e2e/test_market_data_price_paths.py` | P0 |
 
 **Test Coverage Summary**:
-- Total AC IDs: 28
+- Total AC IDs: 29
 - Requirements converted to AC IDs: 100% (EPIC-011 P0 implementation)
 - Requirements with test references: 100%
 - Test files: 2 (`test_asset_service.py`, `test_assets_router.py`)

--- a/docs/ssot/critical-proof-matrix.yaml
+++ b/docs/ssot/critical-proof-matrix.yaml
@@ -133,7 +133,7 @@ proofs:
 
   - id: market-data-provider-price-path
     scope: behavioral
-    ci_tier: pr_ci
+    ci_tier: post_merge_environment
     issue: "#539"
     file: tests/e2e/test_market_data_price_paths.py
     test: test_market_data_provider_sync_feeds_fx_and_stock_price_paths
@@ -143,3 +143,4 @@ proofs:
       - critical
     ac_ids:
       - AC11.10.7
+      - AC11.10.11

--- a/docs/ssot/market_data.md
+++ b/docs/ssot/market_data.md
@@ -13,6 +13,7 @@
 | **FX Lookup API** | `apps/backend/src/services/fx.py` | DB lookup, in-process cache, optional lazy resolution |
 | **Rate Storage** | `fx_rates` table | Historical direct and derived rates |
 | **Market Data Sync** | `apps/backend/src/services/market_data.py` | Incremental FX/stock sync and provider validation |
+| **Market Data Status** | `GET /api/market-data/status` | Authenticated read-only freshness status for ordinary-user E2E and support diagnostics |
 | **Market Data Scheduler** | `apps/backend/src/services/market_data_scheduler.py` | Daily 22:00 Asia/Singapore background sync |
 | **Price Storage** | `stock_prices` table | Historical daily stock prices |
 | **Sync State Storage** | `market_data_sync_state` table | Last successful provider sync timestamp by FX pair or stock symbol |
@@ -61,7 +62,8 @@ async def get_fx_rate(base: str, quote: str, date: date) -> Decimal:
 ### Sync Workflow
 - The backend starts `run_market_data_scheduler()` in FastAPI lifespan and runs FX plus stock sync once per day at 22:00 Asia/Singapore.
 - Manual and E2E callers can still use `POST /api/market-data/sync/fx` and `POST /api/market-data/sync/stocks`.
-- Report endpoints call `ensure_market_data_fresh()` before report generation. If the relevant FX pair, requested non-base report currency, or active stock symbol has no successful provider sync in the last 24 hours, the backend sends one immediate incremental provider request and records the new sync state, including successful no-row responses such as weekends or market holidays.
+- Report endpoints call `ensure_market_data_fresh()` before report generation with the report's own effective end date. If the relevant FX pair, requested non-base report currency, or active stock symbol has no successful provider sync in the last 24 hours, the backend sends one immediate incremental provider request and records the new sync state, including successful no-row responses such as weekends or market holidays.
+- Authenticated users can call `GET /api/market-data/status` with explicit `pairs` and `symbols` query parameters, or with no explicit scopes to inspect observed user scopes. The endpoint is read-only and does not trigger provider requests.
 - Sync fetches provider chart/CSV data by bounded date range per pair or symbol, then inserts only missing daily rows. It does not issue one provider request per calendar day.
 
 ---
@@ -211,6 +213,7 @@ async def get_fx_rate_cached(base: str, quote: str, date: date) -> Decimal:
 | Provider-backed stock and lazy FX E2E | `test_market_data_provider_sync_feeds_fx_and_stock_price_paths` | ✅ Implemented |
 | Long-history range sync | `test_sync_stock_prices_fetches_decade_range_once` | ✅ Implemented |
 | Report-time 24h freshness check | `test_market_data_freshness_sync_runs_once_after_24h`, `test_report_endpoint_runs_market_data_freshness_check` | ✅ Implemented |
+| Ordinary-user staging report refresh | `test_market_data_provider_sync_feeds_fx_and_stock_price_paths`, `test_market_data_status_endpoint_returns_authenticated_scope_freshness` | ✅ Implemented |
 | Nightly scheduler | `test_next_market_data_sync_at_uses_nightly_sgt_schedule` | ✅ Implemented |
 
 ---

--- a/tests/e2e/test_market_data_price_paths.py
+++ b/tests/e2e/test_market_data_price_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import uuid
 from datetime import date
 from decimal import Decimal
 
@@ -18,6 +19,15 @@ MARKET_DATA_E2E_DATE = date.fromisoformat(
 MARKET_DATA_PROVIDER_E2E_ENABLED = os.getenv(
     "RUN_MARKET_DATA_PROVIDER_E2E", ""
 ).lower() in {"1", "true", "yes"}
+MARKET_DATA_E2E_SYMBOL_CANDIDATES = tuple(
+    symbol.strip().upper()
+    for symbol in os.getenv(
+        "MARKET_DATA_E2E_SYMBOL_CANDIDATES",
+        "IBM,ORCL,INTC,CSCO,KO,PEP,WMT,DIS,V,MA,ADBE,CRM",
+    ).split(",")
+    if symbol.strip()
+)
+STALE_BROKERAGE_MARKET_VALUE = Decimal("20.00")
 
 
 def _api_url(path: str) -> str:
@@ -26,6 +36,38 @@ def _api_url(path: str) -> str:
 
 def _money(value: object) -> Decimal:
     return Decimal(str(value)).quantize(Decimal("0.01"))
+
+
+async def _market_data_status_by_scope(
+    client: httpx.AsyncClient,
+    *,
+    symbols: tuple[str, ...],
+) -> dict[tuple[str, str], dict]:
+    params: list[tuple[str, str]] = [("pairs", "USD/SGD")]
+    params.extend(("symbols", symbol) for symbol in symbols)
+    response = await client.get(_api_url("/market-data/status"), params=params)
+    assert response.status_code == 200, (
+        f"market data status failed: {response.status_code} {response.text}"
+    )
+    return {(item["kind"], item["scope"]): item for item in response.json()}
+
+
+def _select_stale_or_first_symbol(status_by_scope: dict[tuple[str, str], dict]) -> str:
+    for symbol in MARKET_DATA_E2E_SYMBOL_CANDIDATES:
+        status = status_by_scope.get(("stock", symbol))
+        if status is None or not status["fresh"]:
+            return symbol
+    return MARKET_DATA_E2E_SYMBOL_CANDIDATES[0]
+
+
+def _market_valuation_lines(report: dict, broker_name: str) -> list[dict]:
+    return [
+        line
+        for line in report.get("assets", [])
+        if isinstance(line, dict)
+        and broker_name.lower() in str(line.get("name", "")).lower()
+        and "market valuation adjustment" in str(line.get("name", "")).lower()
+    ]
 
 
 @pytest.mark.e2e
@@ -38,27 +80,36 @@ def _money(value: object) -> Decimal:
 async def test_market_data_provider_sync_feeds_fx_and_stock_price_paths(
     shared_auth_state: AuthState,
 ) -> None:
-    """AC11.10.7: Lazy FX and stock sync feed portfolio and report valuation paths."""
+    """AC11.10.7 AC11.10.11: Reports auto-refresh provider FX and stock data from a user path."""
     headers = {"Authorization": f"Bearer {shared_auth_state.access_token}"}
     async with httpx.AsyncClient(
         headers=headers, verify=False, timeout=120.0
     ) as client:
+        before_status = await _market_data_status_by_scope(
+            client,
+            symbols=MARKET_DATA_E2E_SYMBOL_CANDIDATES,
+        )
+        symbol = _select_stale_or_first_symbol(before_status)
+        broker_name = f"Market Data User E2E {symbol}"
         import_response = await client.post(
             _api_url("/portfolio/brokerage/import"),
             json={
-                "filename": "market-data-provider-e2e.json",
-                "source_document_id": f"market-data-provider-e2e-{shared_auth_state.user_id}",
+                "filename": f"market-data-user-e2e-{symbol.lower()}.json",
+                "source_document_id": (
+                    f"market-data-user-e2e-{shared_auth_state.user_id}-{uuid.uuid4()}"
+                ),
                 "payload": {
-                    "institution": "Market Data Provider E2E",
+                    "institution": broker_name,
                     "statement": {
                         "period_end": MARKET_DATA_E2E_DATE.isoformat(),
                         "currency": "USD",
                     },
                     "positions": [
                         {
-                            "symbol": "AAPL",
+                            "symbol": symbol,
+                            "broker": broker_name,
                             "quantity": "2",
-                            "market_value": "20.00",
+                            "market_value": str(STALE_BROKERAGE_MARKET_VALUE),
                             "currency": "USD",
                         }
                     ],
@@ -70,20 +121,28 @@ async def test_market_data_provider_sync_feeds_fx_and_stock_price_paths(
         )
         assert import_response.json()["parsed_positions"] == 1
 
-        stock_response = await client.post(
-            _api_url("/market-data/sync/stocks"),
-            json={
-                "symbols": ["AAPL"],
-                "start_date": MARKET_DATA_E2E_DATE.isoformat(),
-                "end_date": MARKET_DATA_E2E_DATE.isoformat(),
-            },
+        report_response = await client.get(
+            _api_url(
+                f"/reports/balance-sheet?as_of_date={MARKET_DATA_E2E_DATE.isoformat()}&currency=SGD"
+            )
         )
-        assert stock_response.status_code == 200, (
-            f"stock sync failed: {stock_response.status_code} {stock_response.text}"
+        assert report_response.status_code == 200, (
+            f"balance sheet failed through report-time market data refresh: "
+            f"{report_response.status_code} {report_response.text}"
         )
-        stock_payload = stock_response.json()
-        assert stock_payload["inserted"] + stock_payload["skipped"] >= 1, stock_payload
-        assert stock_payload["disagreements"] == []
+        report = report_response.json()
+        assert report["is_balanced"] is True
+        assert _money(report["total_assets"]) > STALE_BROKERAGE_MARKET_VALUE, report
+
+        after_status = await _market_data_status_by_scope(client, symbols=(symbol,))
+        stock_status = after_status.get(("stock", symbol))
+        fx_status = after_status.get(("fx", "USD/SGD"))
+        assert stock_status is not None, after_status
+        assert fx_status is not None, after_status
+        assert stock_status["fresh"] is True, stock_status
+        assert fx_status["fresh"] is True, fx_status
+        assert stock_status["last_observation_date"] is not None, stock_status
+        assert fx_status["last_observation_date"] is not None, fx_status
 
         holdings_response = await client.get(
             _api_url(
@@ -94,22 +153,16 @@ async def test_market_data_provider_sync_feeds_fx_and_stock_price_paths(
             f"holdings failed: {holdings_response.status_code} {holdings_response.text}"
         )
         holdings = holdings_response.json()
-        aapl = next(
-            (item for item in holdings if item["asset_identifier"] == "AAPL"), None
+        selected_holding = next(
+            (item for item in holdings if item["asset_identifier"] == symbol), None
         )
-        assert aapl is not None, f"AAPL holding missing: {holdings}"
-        assert _money(aapl["market_value"]) > Decimal("20.00"), (
-            f"synced stock price did not replace stale brokerage snapshot: {aapl}"
+        assert selected_holding is not None, f"{symbol} holding missing: {holdings}"
+        assert _money(selected_holding["market_value"]) > STALE_BROKERAGE_MARKET_VALUE, (
+            f"synced stock price did not replace stale brokerage snapshot: {selected_holding}"
         )
 
-        report_response = await client.get(
-            _api_url(
-                f"/reports/balance-sheet?as_of_date={MARKET_DATA_E2E_DATE.isoformat()}&currency=SGD"
-            )
+        valuation_lines = _market_valuation_lines(report, broker_name)
+        assert valuation_lines, (
+            f"balance sheet did not expose the refreshed brokerage valuation line; "
+            f"broker={broker_name}; report={report}"
         )
-        assert report_response.status_code == 200, (
-            f"balance sheet failed through lazy FX resolution: {report_response.status_code} {report_response.text}"
-        )
-        report = report_response.json()
-        assert _money(report["total_assets"]) > Decimal("20.00"), report
-        assert report["is_balanced"] is True


### PR DESCRIPTION
## Summary

Covers report-time market data refresh from an authenticated ordinary-user staging path without manually calling market-data sync endpoints.

Follow-up to #539 / #549

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-011 — Asset Lifecycle |
| **AC IDs** | AC11.10.7, AC11.10.9, AC11.10.11 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/market_data.md` — documents ordinary-user status checks and report-date freshness behavior
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | working tree before `4112b90` | Added E2E/router tests exposing the old manual-sync-only coverage gap |
| 🟢 Green (passing test) | `4112b90` | Added report-time refresh status API, report-date freshness wiring, and passing tests |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable; no frontend env changes)
- [x] `repo/` submodule updated for production config changes (if applicable; verified already at latest `85a15cd`)
- [x] `tools/check_env_keys.py` passes (if env vars changed; no env vars changed)
- [x] `tools/check_manifest.py` passes (if SSOT files changed; no manifest ownership change)
- [x] `tools/lint_doc_consistency.py` passes

---

## Testing

```bash
cd apps/backend && uv run --python 3.12.12 python -m pytest tests/market_data -q --no-cov
cd apps/backend && uv run --python 3.12.12 python -m pytest tests/api/test_reports_router.py tests/reporting/test_reports_router.py tests/reporting/test_reports_errors.py tests/market_data/test_sync_router.py -q --no-cov
cd apps/backend && uv run --python 3.12.12 python -m ruff check src tests/market_data
cd apps/backend && uv run --python 3.12.12 python -m ruff format --check src tests/market_data
uv run --with pyyaml python tools/check_ac_traceability.py
uv run --with pyyaml python tools/check_critical_proof_matrix.py
moon run :lint -- --backend
moon run :test -- tests/market_data --no-cov
```

---

## Screenshots / Evidence

Backend/API only; PR test environment and staging E2E should validate this on GitHub.
