### PR TITLE
fix: preserve production release version proof

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -121,6 +121,8 @@ jobs:
           context: ./apps/backend
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.version.outputs.tag }}
+          build-args: |
+            GIT_COMMIT_SHA=${{ steps.version.outputs.tag }}
 
       - name: Build Frontend
         uses: docker/build-push-action@v5
@@ -217,6 +219,8 @@ jobs:
           context: ./apps/backend
           push: false
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.version.outputs.tag }}
+          build-args: |
+            GIT_COMMIT_SHA=${{ steps.version.outputs.tag }}
 
       - name: Build Frontend Image Without Push
         uses: docker/build-push-action@v5

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2159,6 +2159,11 @@ groups:
         description: Coveralls uploads strip branch counters so external percentages track the line-only unified coverage
           gate.
         mandatory: true
+      - id: AC8.13.67
+        epic: 8
+        epic_name: testing-strategy
+        description: Production release preserves deployed version metadata from image build through Dokploy runtime health.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -106,6 +106,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.64**: Production release verifies DB, S3, API, frontend, and SigNoz health before completing deploy.
 - **AC8.13.65**: Production release reuses successful main CI proof instead of rerunning container-backed tests in the release lane.
 - **AC8.13.66**: Coveralls uploads strip branch counters so external percentages track the line-only unified coverage gate.
+- **AC8.13.67**: Production release preserves deployed version metadata from image build through Dokploy runtime health.
 
 Current test and AC coverage status is generated, not hand-maintained here.
 Use `docs/analysis/test-ac-coverage-report.md`,
@@ -443,6 +444,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.64 | Production release verifies DB, S3, API, frontend, and SigNoz health before completing deploy | `test_AC8_13_64_*` | `tests/tooling/test_production_infra_smoke.py`, `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.65 | Production release reuses successful main CI proof instead of rerunning container-backed tests in the release lane | `test_AC8_13_52_production_release_dry_run_does_not_mutate_production`, `test_AC8_13_9_production_release_runs_prod_safe_e2e_smoke` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.66 | Coveralls uploads strip branch counters so external percentages track the line-only unified coverage gate | `test_AC8_13_66_*` | `tests/tooling/test_build_unified_lcov.py`, `tests/tooling/test_strip_lcov_branches.py`, `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+| AC8.13.67 | Production release preserves deployed version metadata from image build through Dokploy runtime health | `test_AC8_13_67_production_release_preserves_version_metadata` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -217,6 +217,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Manual `workflow_dispatch` with `dry_run=true` verifies the target SHA's successful `main` CI result, runs release lint, and builds production images with `push: false`.
 - The dry-run uses production frontend build arguments without changing Dokploy or production tags, and does not enter the `production` environment or push GHCR images. Its summary reports the validated ref/tag and states that production mutation was skipped.
 - Tag pushes remain the only automatic path that pushes versioned release images. Manual dispatch with `dry_run=false` remains the production deploy path for an existing version.
+- Production backend release images bake `GIT_COMMIT_SHA` from the release tag, and Dokploy deploys also inject the same runtime `GIT_COMMIT_SHA` so `/api/health` can prove the deployed version even after a same-tag redeploy.
 - Production deploys run `tools/production_infra_smoke.py` after health check. That gate verifies the deployed version, `/api/health` dependency checks for database and S3, read-only `/api/ping`, frontend reachability, and the shared SigNoz health/version endpoints before production smoke and read-only E2E run.
 
 The remaining higher-risk CI and post-merge optimization candidates are tracked

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -102,6 +102,12 @@ git push origin v1.2.3
 # → Actions → Production Release → Run workflow → dry_run=true
 ```
 
+Production app deploys must keep the image tag, Dokploy runtime
+`GIT_COMMIT_SHA`, and `/api/health.git_sha` aligned. The release workflow bakes
+the tag into backend images, and `tools/dokploy_deploy.sh` refreshes
+`IAC_CONFIG_HASH` on every deploy attempt so Dokploy restarts the app even when
+redeploying the same tag.
+
 **Hotfix flow**:
 ```bash
 git checkout -b hotfix/bug v1.2.3

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -508,6 +508,40 @@ def test_AC8_13_9_production_release_runs_prod_safe_e2e_smoke() -> None:
         assert mutating_token not in prod_smoke
 
 
+def test_AC8_13_67_production_release_preserves_version_metadata() -> None:
+    """AC8.13.67: Production release preserves deployed version metadata."""
+    workflow = read(".github/workflows/production-release.yml")
+    deploy_script = read("tools/_lib/shell/dokploy_deploy.sh")
+    app_compose = read("repo/finance_report/finance_report/10.app/compose.yaml")
+
+    backend_build_blocks = re.findall(
+        r"- name: Build Backend(?: Image Without Push)?\n(?:(?!\n      - name:).)*",
+        workflow,
+        flags=re.S,
+    )
+    assert len(backend_build_blocks) == 2
+    for block in backend_build_blocks:
+        assert "context: ./apps/backend" in block
+        assert "build-args:" in block
+        assert "GIT_COMMIT_SHA=${{ steps.version.outputs.tag }}" in block
+
+    config_hash_update = (
+        'new_env=$(update_env_var "$new_env" "IAC_CONFIG_HASH" '
+        '"deploy-${IMAGE_TAG}-$(date +%s)")'
+    )
+    assert config_hash_update in deploy_script
+    assert deploy_script.count('update_env_var "$new_env" "IAC_CONFIG_HASH"') == 1
+    assert deploy_script.index(config_hash_update) < deploy_script.index(
+        'dokploy_api_call "POST" "compose.update"'
+    )
+    assert "models-${IMAGE_TAG}" not in deploy_script
+
+    assert "GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-unknown}" in app_compose
+    assert app_compose.index("backend:") < app_compose.index(
+        "GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-unknown}"
+    )
+
+
 def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     """AC8.13.7: Post-merge AI/OCR E2E is a single-provider-access gate."""
     workflow = read(".github/workflows/staging-deploy.yml")
@@ -548,10 +582,7 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
         'update_env_var "$new_env" "VISION_MODEL" "$DEPLOY_VISION_MODEL_OVERRIDE"'
         in deploy_script
     )
-    assert (
-        'update_env_var "$new_env" "IAC_CONFIG_HASH" "models-${IMAGE_TAG}-$(date +%s)"'
-        in deploy_script
-    )
+    assert 'update_env_var "$new_env" "IAC_CONFIG_HASH"' in deploy_script
     assert '-m "(smoke or e2e) and not llm" -n 4' in workflow
     assert "PARSING_TIMEOUT_MS: 480000" in workflow
     assert "github.event.workflow_run.conclusion == 'success'" in workflow

--- a/tools/_lib/shell/dokploy_deploy.sh
+++ b/tools/_lib/shell/dokploy_deploy.sh
@@ -89,6 +89,7 @@ new_env=$(update_env_var "$new_env" "GIT_COMMIT_SHA" "$IMAGE_TAG")
 new_env=$(update_env_var "$new_env" "NEXT_PUBLIC_APP_URL" "$APP_URL")
 new_env=$(update_env_var "$new_env" "COMPOSE_PROFILES" "app")
 new_env=$(update_env_var "$new_env" "TRAEFIK_ENABLE" "true")
+new_env=$(update_env_var "$new_env" "IAC_CONFIG_HASH" "deploy-${IMAGE_TAG}-$(date +%s)")
 
 if [[ -n "${DEPLOY_PRIMARY_MODEL_OVERRIDE:-}" ]]; then
   new_env=$(update_env_var "$new_env" "PRIMARY_MODEL" "$DEPLOY_PRIMARY_MODEL_OVERRIDE")
@@ -100,10 +101,6 @@ fi
 
 if [[ -n "${DEPLOY_VISION_MODEL_OVERRIDE:-}" ]]; then
   new_env=$(update_env_var "$new_env" "VISION_MODEL" "$DEPLOY_VISION_MODEL_OVERRIDE")
-fi
-
-if [[ -n "${DEPLOY_PRIMARY_MODEL_OVERRIDE:-}" || -n "${DEPLOY_OCR_MODEL_OVERRIDE:-}" || -n "${DEPLOY_VISION_MODEL_OVERRIDE:-}" ]]; then
-  new_env=$(update_env_var "$new_env" "IAC_CONFIG_HASH" "models-${IMAGE_TAG}-$(date +%s)")
 fi
 
 # Traefik routing configuration


### PR DESCRIPTION
## Summary

- bake the release tag into backend production images via `GIT_COMMIT_SHA`
- refresh Dokploy `IAC_CONFIG_HASH` on every deploy attempt so same-tag redeploys restart app services
- add `AC8.13.67` coverage for release version metadata from image build through runtime health
- update the infra2 submodule to wangzitian0/infra2#174, which injects `GIT_COMMIT_SHA` into the backend runtime environment

Closes #560

## Validation

- `uv run --with pytest --with pyyaml pytest tests/tooling/test_post_merge_e2e_gates.py tests/tooling/test_issue_459_infra_contracts.py -q`
- `uv run --all-extras --dev python -m pytest tests/infra/test_observability_contract.py -q -n 0 --no-cov` from `apps/backend`
- `uv run --with pyyaml python tools/generate_ac_registry.py --check`
- `uv run --with pyyaml python tools/check_ac_traceability.py`
- `uv run --with pyyaml python tools/check_critical_proof_matrix.py`
- `uv run --with pyyaml python tools/lint_doc_consistency.py`
- `uv run --with pyyaml python tools/check_manifest.py`
- `uv run --with pyyaml python tools/check_ssot_ownership.py`
- `moon run :lint`

## Deployment Note

Merge order matters: merge wangzitian0/infra2#174 before this PR is used for a production redeploy, because Dokploy clones infra2 `main` for the production compose file.
