### PR TITLE
[codex] Codify personal report package proof plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Deploy Staging](https://github.com/wangzitian0/finance_report/actions/workflows/staging-deploy.yml/badge.svg?branch=main)](https://github.com/wangzitian0/finance_report/actions/workflows/staging-deploy.yml)
 [![Docs](https://github.com/wangzitian0/finance_report/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/wangzitian0/finance_report/actions/workflows/docs.yml)
 
-Personal finance system for accurate, auditable asset reporting: double-entry
-bookkeeping, statement import, reconciliation, reports, AI-assisted review, and
-portfolio tracking.
+Personal finance system for accurate, auditable asset reporting and generated
+personal financial-report packages: double-entry bookkeeping, statement import,
+reconciliation, reports, AI-assisted review, and portfolio tracking.
 
 ## Operating Model
 
@@ -113,6 +113,8 @@ Do not hand-maintain open/closed blocker lists here. GitHub issue state and
 labels are the source of truth for current tracker status.
 
 - Macro proof tracker: [#521](https://github.com/wangzitian0/finance_report/issues/521)
+- Personal report package tracker:
+  [#563](https://github.com/wangzitian0/finance_report/issues/563)
 - Related live work is tracked with labels such as `flow: upload-to-report`,
   `flow: net-worth`, and `scope: valuation`.
 - If a stable proof path is needed in docs, write a parseable matrix and attach
@@ -130,6 +132,7 @@ The macro outcome set is closed and parseable:
 
 | Outcome ID | Purpose |
 |---|---|
+| `personal-financial-report-package` | Generated personal report package with statements, schedules, notes, and source traceability |
 | `asset-distribution-net-worth` | Asset distribution, liabilities, and as-of net worth |
 | `monthly-income-spending` | Current-period income, expenses, and net income |
 | `investment-performance` | Portfolio import, valuation, and performance proof path |

--- a/common/ssot/check_critical_proof_matrix.py
+++ b/common/ssot/check_critical_proof_matrix.py
@@ -33,6 +33,7 @@ VALID_SCOPES = {"behavioral", "static_contract", "manual_gate"}
 VALID_CI_TIERS = {"pr_ci", "post_merge_environment", "manual"}
 VALID_OUTCOME_STATUSES = {"covered", "partial", "gap"}
 REQUIRED_OUTCOME_IDS = {
+    "personal-financial-report-package",
     "asset-distribution-net-worth",
     "monthly-income-spending",
     "investment-performance",

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -23,6 +23,7 @@ Accounting Equation Verification: Reports must comply with accounting equation
 
 ## Macro Proof Ownership
 
+- `personal-financial-report-package`
 - `asset-distribution-net-worth`
 - `monthly-income-spending`
 - `investment-performance`
@@ -223,6 +224,28 @@ Accounting Equation Verification: Reports must comply with accounting equation
 
 - [ ] Performance tests with high transaction volumes (stress testing) are missing.
 - [ ] Tests for partial date ranges (fiscal year boundaries) are missing.
+
+## Personal Financial Report Package Plan
+
+The north-star package is tracked by
+[#563](https://github.com/wangzitian0/finance_report/issues/563). EPIC-005 is
+the primary product owner for assembling the generated package tracked by
+[#567](https://github.com/wangzitian0/finance_report/issues/567).
+
+Scope owned here:
+
+- Balance sheet, income statement, cash-flow view, and report export assembly.
+- Report notes that identify methods, currencies, periods, and data freshness.
+- Package-level navigation from dashboard/report pages to source-backed report
+  outputs.
+- Integration of EPIC-011 annualized income and long-term compensation schedules
+  tracked by [#566](https://github.com/wangzitian0/finance_report/issues/566).
+- Integration of EPIC-017 investment performance schedules tracked by
+  [#564](https://github.com/wangzitian0/finance_report/issues/564).
+
+US GAAP and Hong Kong listed-company reporting are reference structures for
+coverage and naming discipline. This EPIC does not claim regulated filing
+compliance.
 
 ## 📄 Owned Documentation Surfaces
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -12,6 +12,7 @@ This epic defines the strategy for **Smoke Testing** and **End-to-End (E2E) Test
 
 ## Macro Proof Ownership
 
+- `personal-financial-report-package`
 - `asset-distribution-net-worth`
 - `monthly-income-spending`
 - `investment-performance`
@@ -546,6 +547,11 @@ finance_report AC coverage.
 - ✅ **Environment Isolation**: Each PR gets isolated DB/Redis/MinIO via Dokploy
 
 ### 5.4 Known Gaps
+
+0. **Personal Financial Report Package Post-Merge E2E**:
+   - **Status**: Planned and tracked by [#565](https://github.com/wangzitian0/finance_report/issues/565)
+   - **Scope**: Fresh-user post-merge proof that generates one personal report package from trusted source data and verifies statements, schedules, notes, and source traceability.
+   - **Closure rule**: `personal-financial-report-package` remains `partial` in `docs/ssot/critical-proof-matrix.yaml` until this journey has a behavioral E2E proof under `tests/e2e/` and the matrix points at that proof.
 
 1. **Statement Upload Parsing** (`test_statement_upload_e2e.py`):
    - **Status**: ✅ Fixed (Tier 3 assertion now blocks immediate AI/OCR rejection)

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -31,6 +31,7 @@
 
 ## Macro Proof Ownership
 
+- `personal-financial-report-package`
 - `asset-distribution-net-worth`
 - `annualized-income-long-term`
 
@@ -2076,3 +2077,14 @@ The following items were identified during the vision.md recovery audit as featu
 
 **Priority**: P1 (high) — closes the largest "vision parity" gap after net worth time series.
 **Estimated effort**: 4-6 days backend (income aggregation + restricted-flag schema check) + 3-4 days frontend.
+
+### Personal Report Package Dependency
+
+[#566](https://github.com/wangzitian0/finance_report/issues/566) owns the
+annualized income and long-term compensation proof path needed by the personal
+financial-report package tracked in
+[#563](https://github.com/wangzitian0/finance_report/issues/563). This EPIC
+must supply report-ready schedules for salary, dividends, ESOP/RSU, restricted
+holdings, vesting/unlock dates, valuation basis, and liquid-versus-restricted
+net worth treatment. EPIC-005 owns final package assembly; EPIC-008 owns the
+post-merge E2E proof.

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -32,6 +32,7 @@ Build a **100% self-developed** investment portfolio management system with comp
 
 ## Macro Proof Ownership
 
+- `personal-financial-report-package`
 - `asset-distribution-net-worth`
 - `investment-performance`
 - `annualized-income-long-term`
@@ -352,6 +353,17 @@ Provider-backed gate details live in
 [EPIC-008](EPIC-008.testing-strategy.md#tier-3-e2e-implementation) and
 [CI/CD SSOT](../ssot/ci-cd.md#post-merge-staging-aiocr-gate). The README keeps
 the compact entry-point version of this matrix.
+
+### Personal Report Package Dependency
+
+[#564](https://github.com/wangzitian0/finance_report/issues/564) owns the
+investment performance schedule proof path needed by the personal
+financial-report package tracked in
+[#563](https://github.com/wangzitian0/finance_report/issues/563). This EPIC
+must supply holdings, cost basis, realized and unrealized P&L, dividends,
+allocation, and as-of valuation schedules in a form that EPIC-005 can assemble
+into the generated package. EPIC-008 owns the post-merge E2E proof tracked by
+[#565](https://github.com/wangzitian0/finance_report/issues/565).
 
 **Traceability Result**:
 - Total AC IDs: 27

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -17,7 +17,18 @@ Maximize AI utilization across the entire data pipeline from statement upload to
 
 ## Macro Proof Ownership
 
+- `personal-financial-report-package`
 - `source-ledger-report-traceability`
+
+## Personal Report Package Traceability Inputs
+
+The personal financial-report package tracked by
+[#563](https://github.com/wangzitian0/finance_report/issues/563) and
+[#567](https://github.com/wangzitian0/finance_report/issues/567) depends on this
+EPIC for source confidence, extraction provenance, review status, and
+source-to-ledger-to-report traceability notes. AI remains a parsing and
+explanation layer; deterministic ledger and reporting logic remain the source
+of record.
 
 **Current Pipeline (Before)**:
 ```

--- a/docs/ssot/critical-proof-matrix.yaml
+++ b/docs/ssot/critical-proof-matrix.yaml
@@ -5,6 +5,17 @@ description: >
   traceability remains a separate hygiene gate.
 
 outcomes:
+  - id: personal-financial-report-package
+    question: "Can I generate one auditable personal financial-report package with statements, schedules, notes, and source traceability?"
+    status: partial
+    owner_epics:
+      - EPIC-005
+      - EPIC-008
+      - EPIC-011
+      - EPIC-017
+      - EPIC-018
+    issue: "#563"
+
   - id: asset-distribution-net-worth
     question: "How much money do I have, and where is it distributed?"
     status: covered

--- a/tests/tooling/test_check_critical_proof_matrix.py
+++ b/tests/tooling/test_check_critical_proof_matrix.py
@@ -28,6 +28,7 @@ This EPIC owns the following macro outcomes from `docs/ssot/critical-proof-matri
 - `investment-performance`
 - `annualized-income-long-term`
 - `source-ledger-report-traceability`
+- `personal-financial-report-package`
 """.strip()
         + "\n",
         encoding="utf-8",
@@ -48,6 +49,7 @@ Checker: tools/check_critical_proof_matrix.py
 | `investment-performance` | investment performance |
 | `annualized-income-long-term` | annualized long-term income |
 | `source-ledger-report-traceability` | source to report traceability |
+| `personal-financial-report-package` | personal report package |
 """.strip()
         + "\n",
         encoding="utf-8",
@@ -121,6 +123,10 @@ outcomes:
     status: gap
     owner_epics: [EPIC-008]
     issue: "#521"
+  - id: personal-financial-report-package
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#563"
 """
     matrix_path.write_text(rendered + "\n", encoding="utf-8")
     return matrix_path
@@ -471,6 +477,10 @@ outcomes:
     status: gap
     owner_epics: [EPIC-008]
     issue: "#521"
+  - id: personal-financial-report-package
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#563"
 """,
     )
 
@@ -481,6 +491,7 @@ outcomes:
         "investment-performance",
         "annualized-income-long-term",
         "source-ledger-report-traceability",
+        "personal-financial-report-package",
     ]
     assert not validation.errors
 
@@ -546,6 +557,10 @@ outcomes:
     status: gap
     owner_epics: [EPIC-008]
     issue: "#521"
+  - id: personal-financial-report-package
+    status: gap
+    owner_epics: [EPIC-008]
+    issue: "#563"
   - id: surprise-outcome
     status: gap
     owner_epics: [EPIC-008]
@@ -566,7 +581,7 @@ outcomes:
     )
     assert any("gap outcome requires issue like #521" in error for error in errors)
     assert any("invalid status 'unknown'" in error for error in errors)
-    assert any("outcome[6] must be a mapping" in error for error in errors)
+    assert any("outcome[7] must be a mapping" in error for error in errors)
     assert any(
         "README.md missing macro outcome id `monthly-income-spending`" in error
         for error in errors
@@ -593,6 +608,7 @@ Checker: tools/check_critical_proof_matrix.py
 | `investment-performance` | investment performance |
 | `annualized-income-long-term` | annualized income |
 | `source-ledger-report-traceability` | source traceability |
+| `personal-financial-report-package` | personal report package |
 | `surprise-outcome` | not in the matrix |
 """.strip()
         + "\n",
@@ -734,7 +750,7 @@ proofs:
     stdout = capsys.readouterr().out
     assert "Wrote critical proof matrix report" in stdout
     assert (
-        "Critical proof matrix passed: 1 proof path(s), 5 macro outcome(s) validated."
+        "Critical proof matrix passed: 1 proof path(s), 6 macro outcome(s) validated."
         in stdout
     )
     assert "| `core-flow` | behavioral | pr_ci |" in output_path.read_text(

--- a/vision.md
+++ b/vision.md
@@ -2,10 +2,19 @@
 
 ## Terminal Goal
 
-**An accurate asset dashboard.**
+**A generated personal financial-report package backed by an accurate asset
+dashboard.**
+
+The final product should generate a self-hosted personal financial report
+package whose structure is inspired by US GAAP and Hong Kong listed-company
+reporting: statements, schedules, notes, and source traceability. It is a
+personal management report, not a regulated filing, audit opinion, legal
+advice, or tax advice.
 
 At any time, the system should help answer:
 
+- Can I generate one auditable personal report package from trusted source
+  data?
 - How much money do I have, and where is it distributed?
 - How much did I earn and spend this month?
 - How are my investments performing?
@@ -64,6 +73,18 @@ If the answer is unclear, choose the smaller step that improves proof quality.
 
 ## Strategic Decisions
 
+### Personal Report Package Is The North-Star Output
+
+Dashboards are working surfaces; the durable product output is a generated
+personal financial-report package. The package should include balance sheet,
+income statement, cash-flow view, investment schedules, annualized income and
+long-term compensation schedules, notes, and source-to-ledger-to-report
+traceability.
+
+US GAAP and Hong Kong listed-company reporting are reference structures for
+coverage, naming, and disclosure discipline. The system must not claim filing
+compliance unless that scope is explicitly registered, tested, and reviewed.
+
 <a id="decision-1-portfolio-self-developed"></a>
 
 ### Portfolio Is Native
@@ -117,6 +138,8 @@ Decimal-safe accounting, explicit schemas, and a self-hostable deployment model.
 ## Non-Goals
 
 - Replacing accounting logic with LLMs.
+- Regulated US/HK filing compliance, XBRL filing, audit opinions, legal advice,
+  or tax advice.
 - <a id="non-goals-not-budgeting-app"></a>Becoming a consumer budgeting app
   centered on bank OAuth aggregation.
 - <a id="non-goals-not-robo-advisor"></a>Trading, portfolio optimization, or


### PR DESCRIPTION
## Summary

Codifies the personal financial-report package as the north-star macro outcome and wires it through README, the critical proof matrix, owner EPICs, issues, and matrix checker tests.

Refs #563, #564, #565, #566, #567. Updates #521.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-005 primary; EPIC-008, EPIC-011, EPIC-017, EPIC-018 supporting |
| **AC IDs** | AC8.13.50, AC8.13.54 |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [x] `docs/ssot/critical-proof-matrix.yaml` - added `personal-financial-report-package` as a partial macro outcome owned by EPIC-005/008/011/017/018 and tracked by #563.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | N/A | Existing critical-proof-matrix checker tests already enforce the closed README -> EPIC -> E2E outcome set. |
| Green | `8282b77` | Added the new outcome to the checker, fixtures, matrix, README table, and owner EPIC reverse declarations. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name=\"..._enum\"` parameter: N/A, no database model change.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV`: N/A, no env change.
- [x] `repo/` submodule updated for production config changes: N/A, no infra/config change.
- [x] `tools/check_env_keys.py` passes.
- [x] `tools/check_manifest.py` passes.
- [x] `tools/lint_doc_consistency.py` passes.

---

## Testing

```bash
python -m pytest tests/tooling/test_check_critical_proof_matrix.py tests/tooling/test_post_merge_e2e_gates.py -q
python -m pytest tests/tooling/test_lint_doc_consistency.py -q
python tools/check_critical_proof_matrix.py
python tools/generate_ac_registry.py --check
python tools/check_ac_traceability.py
python tools/lint_doc_consistency.py
python tools/check_ssot_ownership.py
python tools/check_manifest.py
python tools/check_env_keys.py
git diff --check
moon run :lint
```

`moon run :test` did not reach pytest locally because another worktree has Podman containers bound to the default local infra ports (`127.0.0.1:5432`, `9000`, `9001`), causing this branch's isolated infra startup to fail with `proxy already running`. I did not stop those unrelated containers; PR CI should run the full environment cleanly.

---

## Screenshots / Evidence

N/A - documentation/tooling governance change.