### PR TITLE
[finance_report_infra] [codex] Tighten semantic portfolio proof coverage

### DIFF
--- a/apps/backend/src/services/performance.py
+++ b/apps/backend/src/services/performance.py
@@ -1,6 +1,6 @@
 """Portfolio performance metrics service - XIRR, TWR, MWR calculations."""
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 from uuid import UUID
 
@@ -11,6 +11,7 @@ from src.config import settings
 from src.logger import get_logger
 from src.models.layer2 import AtomicPosition, AtomicTransaction, TransactionDirection
 from src.models.layer3 import ManagedPosition, PositionStatus
+from src.models.portfolio import DividendIncome
 from src.services import fx
 
 logger = get_logger(__name__)
@@ -366,6 +367,48 @@ async def calculate_money_weighted_return(
     """
     # MWR = XIRR (they are the same concept)
     return await calculate_xirr(db, user_id, as_of_date)
+
+
+async def calculate_dividend_yield(
+    db: AsyncSession,
+    user_id: UUID,
+    as_of_date: date | None = None,
+) -> Decimal:
+    """
+    Calculate trailing 12-month dividend yield.
+
+    Formula: annual dividends / current portfolio value.
+    """
+    if as_of_date is None:
+        as_of_date = date.today()
+
+    period_start = as_of_date - timedelta(days=365)
+    result = await db.execute(
+        select(DividendIncome).where(
+            DividendIncome.user_id == user_id,
+            DividendIncome.payment_date > period_start,
+            DividendIncome.payment_date <= as_of_date,
+        )
+    )
+    dividends = result.scalars().all()
+
+    annual_dividends = Decimal("0")
+    for dividend in dividends:
+        annual_dividends += await fx.convert_amount(
+            db,
+            dividend.amount,
+            dividend.currency,
+            settings.base_currency,
+            dividend.payment_date,
+        )
+
+    current_value = await _get_portfolio_value(db, user_id, as_of_date)
+    if current_value == Decimal("0"):
+        if annual_dividends == Decimal("0"):
+            return Decimal("0")
+        raise InsufficientDataError("Cannot calculate dividend yield with zero current portfolio value")
+
+    return (annual_dividends / current_value * Decimal("100")).quantize(Decimal("0.01"))
 
 
 async def _get_portfolio_value(

--- a/apps/backend/tests/portfolio/test_investment_accounting.py
+++ b/apps/backend/tests/portfolio/test_investment_accounting.py
@@ -114,7 +114,7 @@ async def test_sell_transaction_uses_fifo_and_records_realized_gain(
     chart,
     svc: InvestmentAccountingService,
 ):
-    """AC17.5.2/AC17.6.1: Sell transactions consume FIFO lots and record realized P&L."""
+    """AC17.1.2 AC17.5.2 AC17.6.1: Sell transactions consume FIFO lots and record realized P&L."""
     await svc.post_buy(
         db,
         user_id=test_user.id,
@@ -182,7 +182,7 @@ async def test_sell_transaction_uses_average_cost_for_realized_pnl(
     chart,
     svc: InvestmentAccountingService,
 ):
-    """AC17.5.2: Average cost basis is explicit and persisted on sell transactions."""
+    """AC17.1.4 AC17.5.2: Average cost basis is explicit and persisted on sell transactions."""
     await svc.post_buy(
         db,
         user_id=test_user.id,
@@ -233,7 +233,7 @@ async def test_sell_transaction_uses_lifo_loss_and_disposes_position(
     chart,
     svc: InvestmentAccountingService,
 ):
-    """AC17.5.2/AC17.6.1: LIFO sells can realize losses and close positions."""
+    """AC17.1.3 AC17.5.2 AC17.6.1: LIFO sells can realize losses and close positions."""
     await svc.post_buy(
         db,
         user_id=test_user.id,

--- a/apps/backend/tests/portfolio/test_performance_service.py
+++ b/apps/backend/tests/portfolio/test_performance_service.py
@@ -13,9 +13,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models.account import Account, AccountType
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
+from src.models.portfolio import DividendIncome
 from src.services.performance import (
     InsufficientDataError,
     XIRRCalculationError,
+    calculate_dividend_yield,
     calculate_money_weighted_return,
     calculate_time_weighted_return,
     calculate_xirr,
@@ -152,6 +154,57 @@ async def test_xirr_with_realistic_data(db: AsyncSession, test_user, portfolio_w
 
 
 @pytest.mark.asyncio
+async def test_AC5_6_1_xirr_matches_single_year_excel_case(db: AsyncSession, test_user, investment_account):
+    """AC5.6.1: XIRR is within 0.01 percentage points of a one-year Excel case."""
+    from src.models.layer2 import AtomicPosition, AtomicTransaction
+
+    start = date.today() - timedelta(days=365)
+    db.add(
+        AtomicTransaction(
+            user_id=test_user.id,
+            txn_date=start,
+            amount=Decimal("10000.00"),
+            currency="SGD",
+            direction=TransactionDirection.IN,
+            description="one-year XIRR deposit",
+            source_documents={},
+            dedup_hash="ac5_6_1_xirr_deposit",
+        )
+    )
+    db.add(
+        ManagedPosition(
+            user_id=test_user.id,
+            account_id=investment_account.id,
+            asset_identifier="XIRR10",
+            quantity=Decimal("100"),
+            cost_basis=Decimal("10000.00"),
+            currency="SGD",
+            acquisition_date=start,
+            status=PositionStatus.ACTIVE,
+            cost_basis_method=CostBasisMethod.FIFO,
+        )
+    )
+    db.add(
+        AtomicPosition(
+            user_id=test_user.id,
+            snapshot_date=date.today(),
+            asset_identifier="XIRR10",
+            broker="Test Broker",
+            quantity=Decimal("100"),
+            market_value=Decimal("11000.00"),
+            currency="SGD",
+            dedup_hash="ac5_6_1_xirr_snapshot",
+            source_documents={},
+        )
+    )
+    await db.flush()
+
+    xirr = await calculate_xirr(db, test_user.id)
+
+    assert abs(xirr - Decimal("10.00")) <= Decimal("0.01")
+
+
+@pytest.mark.asyncio
 async def test_time_weighted_return_empty_portfolio(db: AsyncSession, test_user):
     """AC17.3.3: TWR returns zero for empty portfolio.
 
@@ -183,6 +236,63 @@ async def test_time_weighted_return_with_period(db: AsyncSession, test_user, por
 
 
 @pytest.mark.asyncio
+async def test_AC5_6_2_time_weighted_return_matches_snapshot_period(
+    db: AsyncSession,
+    test_user,
+    investment_account,
+):
+    """AC5.6.2: TWR computes the exact period return from start/end snapshots."""
+    from src.models.layer2 import AtomicPosition
+
+    start = date.today() - timedelta(days=30)
+    end = date.today()
+    db.add(
+        ManagedPosition(
+            user_id=test_user.id,
+            account_id=investment_account.id,
+            asset_identifier="TWR",
+            quantity=Decimal("100"),
+            cost_basis=Decimal("10000.00"),
+            currency="SGD",
+            acquisition_date=start,
+            status=PositionStatus.ACTIVE,
+            cost_basis_method=CostBasisMethod.FIFO,
+        )
+    )
+    db.add_all(
+        [
+            AtomicPosition(
+                user_id=test_user.id,
+                snapshot_date=start,
+                asset_identifier="TWR",
+                broker="Test Broker",
+                quantity=Decimal("100"),
+                market_value=Decimal("10000.00"),
+                currency="SGD",
+                dedup_hash="ac5_6_2_twr_start",
+                source_documents={},
+            ),
+            AtomicPosition(
+                user_id=test_user.id,
+                snapshot_date=end,
+                asset_identifier="TWR",
+                broker="Test Broker",
+                quantity=Decimal("100"),
+                market_value=Decimal("11250.00"),
+                currency="SGD",
+                dedup_hash="ac5_6_2_twr_end",
+                source_documents={},
+            ),
+        ]
+    )
+    await db.flush()
+
+    twr = await calculate_time_weighted_return(db, test_user.id, start, end)
+
+    assert twr == Decimal("12.500")
+
+
+@pytest.mark.asyncio
 async def test_money_weighted_return_insufficient_data(db: AsyncSession, test_user):
     """AC17.3.5: MWR raises InsufficientDataError on empty portfolio.
 
@@ -204,6 +314,158 @@ async def test_money_weighted_return_with_data(db: AsyncSession, test_user, port
     assert isinstance(mwr, Decimal)
     # With total deposits 15000 and current value 12000, MWR should be negative
     assert mwr < Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_AC5_6_3_dividend_yield_uses_trailing_dividends_over_current_value(
+    db: AsyncSession,
+    test_user,
+    investment_account,
+):
+    """AC5.6.3: Dividend yield equals annual dividends divided by current value."""
+    from src.models.layer2 import AtomicPosition
+
+    today = date.today()
+    position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=investment_account.id,
+        asset_identifier="DIV",
+        quantity=Decimal("120"),
+        cost_basis=Decimal("10000.00"),
+        currency="SGD",
+        acquisition_date=today - timedelta(days=400),
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    db.add(position)
+    await db.flush()
+    db.add(
+        AtomicPosition(
+            user_id=test_user.id,
+            snapshot_date=today,
+            asset_identifier="DIV",
+            broker="Test Broker",
+            quantity=Decimal("120"),
+            market_value=Decimal("12000.00"),
+            currency="SGD",
+            dedup_hash="ac5_6_3_dividend_snapshot",
+            source_documents={},
+        )
+    )
+    db.add(
+        DividendIncome(
+            user_id=test_user.id,
+            position_id=position.id,
+            payment_date=today - timedelta(days=30),
+            amount=Decimal("240.00"),
+            currency="SGD",
+        )
+    )
+    await db.flush()
+
+    dividend_yield = await calculate_dividend_yield(db, test_user.id, today)
+
+    assert dividend_yield == Decimal("2.00")
+
+
+@pytest.mark.asyncio
+async def test_AC5_6_3_dividend_yield_empty_portfolio_returns_zero(db: AsyncSession, test_user):
+    """AC5.6.3: Dividend yield returns zero when no dividends or holdings exist."""
+    dividend_yield = await calculate_dividend_yield(db, test_user.id)
+
+    assert dividend_yield == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_AC5_6_3_dividend_yield_with_income_requires_current_value(
+    db: AsyncSession,
+    test_user,
+    investment_account,
+):
+    """AC5.6.3: Dividend yield refuses positive income with zero current value."""
+    today = date.today()
+    position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=investment_account.id,
+        asset_identifier="DIV-ZERO",
+        quantity=Decimal("120"),
+        cost_basis=Decimal("10000.00"),
+        currency="SGD",
+        acquisition_date=today - timedelta(days=400),
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    db.add(position)
+    await db.flush()
+    db.add(
+        DividendIncome(
+            user_id=test_user.id,
+            position_id=position.id,
+            payment_date=today - timedelta(days=30),
+            amount=Decimal("240.00"),
+            currency="SGD",
+        )
+    )
+    await db.flush()
+
+    with pytest.raises(InsufficientDataError):
+        await calculate_dividend_yield(db, test_user.id, today)
+
+
+@pytest.mark.asyncio
+async def test_AC5_6_6_money_weighted_return_matches_xirr_for_single_cashflow(
+    db: AsyncSession,
+    test_user,
+    investment_account,
+):
+    """AC5.6.6: MWR matches XIRR for a single cash-flow portfolio."""
+    from src.models.layer2 import AtomicPosition, AtomicTransaction
+
+    start = date.today() - timedelta(days=365)
+    db.add(
+        AtomicTransaction(
+            user_id=test_user.id,
+            txn_date=start,
+            amount=Decimal("10000.00"),
+            currency="SGD",
+            direction=TransactionDirection.IN,
+            description="single cashflow",
+            source_documents={},
+            dedup_hash="ac5_6_6_mwr_deposit",
+        )
+    )
+    db.add(
+        ManagedPosition(
+            user_id=test_user.id,
+            account_id=investment_account.id,
+            asset_identifier="MWR",
+            quantity=Decimal("100"),
+            cost_basis=Decimal("10000.00"),
+            currency="SGD",
+            acquisition_date=start,
+            status=PositionStatus.ACTIVE,
+            cost_basis_method=CostBasisMethod.FIFO,
+        )
+    )
+    db.add(
+        AtomicPosition(
+            user_id=test_user.id,
+            snapshot_date=date.today(),
+            asset_identifier="MWR",
+            broker="Test Broker",
+            quantity=Decimal("100"),
+            market_value=Decimal("11000.00"),
+            currency="SGD",
+            dedup_hash="ac5_6_6_mwr_snapshot",
+            source_documents={},
+        )
+    )
+    await db.flush()
+
+    xirr = await calculate_xirr(db, test_user.id)
+    mwr = await calculate_money_weighted_return(db, test_user.id)
+
+    assert mwr == xirr
 
 
 @pytest.mark.asyncio

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -147,12 +147,12 @@ Accounting Equation Verification: Reports must comply with accounting equation
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.6.1 | XIRR calculation accuracy ≤ 0.01% error vs Excel XIRR | `TBD` | `TBD (test to be implemented)` | P0 |
-| AC5.6.2 | Annualized return (TWR) computed correctly | `TBD` | `TBD (test to be implemented)` | P0 |
-| AC5.6.3 | Dividend yield = annual dividends / current value | `TBD` | `TBD (test to be implemented)` | P0 |
+| AC5.6.1 | XIRR calculation accuracy ≤ 0.01% error vs Excel XIRR | `test_AC5_6_1_xirr_matches_single_year_excel_case` | `portfolio/test_performance_service.py` | P0 |
+| AC5.6.2 | Annualized return (TWR) computed correctly | `test_AC5_6_2_time_weighted_return_matches_snapshot_period` | `portfolio/test_performance_service.py` | P0 |
+| AC5.6.3 | Dividend yield = annual dividends / current value | `test_AC5_6_3_dividend_yield_uses_trailing_dividends_over_current_value` | `portfolio/test_performance_service.py` | P0 |
 | AC5.6.4 | Annualized income KPI is surfaced through the dashboard/reporting path and delegates calculation ownership to AC11.8.1 | `test_annualized_income_endpoint_groups_last_12_month_income`, `AC11.8.2/AC11.8.6 renders Annualized Income card with the four metric labels` | `reporting/test_income_annualized_router.py`, `frontend/src/__tests__/dashboardPage.test.tsx` | P0 |
 | AC5.6.5 | Unrealized P&L reflected in balance sheet equity | `test_reporting_dashboard_fixture_exact_totals` | `reporting/test_reporting.py` | P0 |
-| AC5.6.6 | MWR (money-weighted return) matches XIRR for single cashflow | `TBD` | `TBD (test to be implemented)` | P1 |
+| AC5.6.6 | MWR (money-weighted return) matches XIRR for single cashflow | `test_AC5_6_6_money_weighted_return_matches_xirr_for_single_cashflow` | `portfolio/test_performance_service.py` | P1 |
 
 **Traceability Result**:
 - Total AC IDs: 19

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -654,7 +654,7 @@ delivery status table.
 | AC16.22.3 | Stage 2 `pending_review → accepted` transition blocked when unresolved checks exist | `test_batch_approve_matches_blocked_by_unresolved_checks` | `api/test_statements_router.py` | P0 |
 | AC16.22.4 | Journal entry created only on `accepted` transition, never on `pending_review` | `test_batch_approve_matches_creates_missing_entry_once` | `api/test_statements_router.py` | P0 |
 | AC16.22.5 | Stage 1 tolerance is 0.001 USD (not 0.10 USD from Stage 2) | `test_validate_balance_chain_within_tolerance` | `review/test_statement_validation.py` | P0 |
-| AC16.22.6 | All service methods mutating `pending_review` enforce `user_id` ownership | `TBD` | `TBD (test to be implemented)` | P1 |
+| AC16.22.6 | All service methods mutating `pending_review` enforce `user_id` ownership | `test_get_statement_for_update_wrong_user_raises` | `review/test_statement_validation.py` | P1 |
 
 
 ---

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -265,9 +265,9 @@ issues.
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC17.1.1 | Holdings Summary | `test_get_holdings_happy_path` | `portfolio/test_portfolio_service.py` | P0 |
-| AC17.1.2 | FIFO Cost Basis | `TBD` | `TBD (test to be implemented)` | P0 |
-| AC17.1.3 | LIFO Cost Basis | `TBD` | `TBD (test to be implemented)` | P0 |
-| AC17.1.4 | Average Cost Basis | `TBD` | `TBD (test to be implemented)` | P0 |
+| AC17.1.2 | FIFO Cost Basis | `test_sell_transaction_uses_fifo_and_records_realized_gain` | `portfolio/test_investment_accounting.py` | P0 |
+| AC17.1.3 | LIFO Cost Basis | `test_sell_transaction_uses_lifo_loss_and_disposes_position` | `portfolio/test_investment_accounting.py` | P0 |
+| AC17.1.4 | Average Cost Basis | `test_sell_transaction_uses_average_cost_for_realized_pnl` | `portfolio/test_investment_accounting.py` | P0 |
 | AC17.1.5 | Unrealized P&L Calculation | `test_unrealized_pnl_happy_path` | `portfolio/test_portfolio_service.py` | P0 |
 | AC17.1.6 | Manual Price Update | `test_update_prices_happy` | `portfolio/test_portfolio_service.py` | P1 |
 


### PR DESCRIPTION
## Summary

Tighten semantic AC proof coverage for portfolio performance and cost-basis behavior, and remove stale TBD proof mappings from EPIC tables.

Related #521

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-005 — Reporting & Visualization; EPIC-016 — Two-Stage Review UI; EPIC-017 — Portfolio Management |
| **AC IDs** | AC5.6.1, AC5.6.2, AC5.6.3, AC5.6.6, AC16.22.6, AC17.1.2, AC17.1.3, AC17.1.4 |
| **AC Registry updated** | N/A — generated registries unchanged; EPIC proof rows and behavioral tests updated |

---

## SSOT Changes

- [x] None — existing SSOT already covers the README -> EPIC -> E2E macro path and EPIC -> AC -> test micro path

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | N/A | Semantic coverage cleanup over existing ACs; separate red commit was not preserved |
| Green | d12d9f9 | Added behavioral tests and dividend-yield implementation; target suite passes |

---

## Engineering Audit

- [x] No `sa.Enum` changes
- [x] No `NEXT_PUBLIC_` variable changes
- [x] No `repo/` production config changes
- [x] No env var changes
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

---

## Testing

```bash
cd apps/backend && uv run ruff check src/services/performance.py tests/portfolio/test_performance_service.py tests/portfolio/test_investment_accounting.py tests/review/test_statement_validation.py
cd apps/backend && uv run python -m pytest tests/portfolio/test_performance_service.py tests/portfolio/test_investment_accounting.py tests/review/test_statement_validation.py -q --no-cov -n 0
python tools/generate_ac_registry.py --check
python tools/check_ac_traceability.py
python tools/check_critical_proof_matrix.py
python tools/check_e2e_epic_traceability.py
python tools/lint_doc_consistency.py
python tools/check_ssot_ownership.py
python tools/check_manifest.py
git diff --check
```

Target pytest result: `51 passed`.

---

## Screenshots / Evidence

N/A — backend test and documentation traceability change.