### PR TITLE
[finance_report_infra] Fix doc epic nav coverage and exclude tmp from AC mismatch audit

### DIFF
--- a/common/ssot/audit_ac_epic_mismatches.py
+++ b/common/ssot/audit_ac_epic_mismatches.py
@@ -31,6 +31,7 @@ EXCL_DIRS = {
     ".venv",
     "venv",
     "_ac_stubs",
+    "tmp",
 }
 TEST_SUFFIXES = ("_test.py", ".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx")
 TEST_PREFIXES = ("test_",)

--- a/common/ssot/audit_ac_epic_mismatches.py
+++ b/common/ssot/audit_ac_epic_mismatches.py
@@ -55,7 +55,8 @@ def walk_tests() -> list[Path]:
     for p in ROOT.rglob("*"):
         if not p.is_file():
             continue
-        if any(part in EXCL_DIRS for part in p.parts):
+        rel = p.relative_to(ROOT)
+        if any(part in EXCL_DIRS for part in rel.parts):
             continue
         if not is_test_file(p):
             continue

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-05-29 12:26:22 UTC by `tools/analyze_test_ac_coverage.py`
+> Generated: 2026-05-29 13:18:03 UTC by `tools/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -33,7 +33,7 @@
 | Source | Files scanned | Unique AC refs (real) | Unique AC refs (placeholder) | Unique AC refs (stub) |
 |---|---:|---:|---:|---:|
 | backend | 172 | 677 | 0 | 0 |
-| frontend | 79 | 190 | 0 | 0 |
+| frontend | 80 | 191 | 0 | 0 |
 | tooling_tests | 49 | 229 | 23 | 0 |
 | e2e | 12 | 49 | 0 | 0 |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,17 @@ nav:
           - "EPIC-005: Reporting": project/EPIC-005.reporting-visualization.md
           - "EPIC-006: AI Advisor": project/EPIC-006.ai-advisor.md
           - "EPIC-007: Deployment": project/EPIC-007.deployment.md
+          - "EPIC-008: Comprehensive Testing Strategy (Smoke & E2E)": project/EPIC-008.testing-strategy.md
+          - "EPIC-009: PDF Fixture Generation for Testing": project/EPIC-009.pdf-fixture-generation.md
+          - "EPIC-010: SigNoz Logging Integration": project/EPIC-010.signoz-logging.md
+          - "EPIC-011: Asset Lifecycle Management": project/EPIC-011.asset-lifecycle.md
+          - "EPIC-012: Foundation Libraries Enhancement": project/EPIC-012.foundation-libs.md
+          - "EPIC-013: Statement Parsing V2": project/EPIC-013.statement-parsing-v2.md
+          - "EPIC-014: Test-Driven Documentation (TTD) Transformation": project/EPIC-014.ttd-transformation.md
+          - "EPIC-015: Processing Account Integration": project/EPIC-015.processing-account.md
+          - "EPIC-016: Two-Stage Review & Data Validation UI": project/EPIC-016.two-stage-review-ui.md
+          - "EPIC-017: Investment Portfolio Management (100% Self-Developed)": project/EPIC-017.portfolio-management.md
+          - "EPIC-018: AI-Driven Data Pipeline": project/EPIC-018.ai-driven-pipeline.md
 
 extra:
   social:

--- a/tests/tooling/test_audit_ac_epic_mismatches.py
+++ b/tests/tooling/test_audit_ac_epic_mismatches.py
@@ -156,6 +156,13 @@ class TestWalkTests:
             files = aam.walk_tests()
         assert any(f.name == "test_good.py" for f in files)
 
+    def test_finds_test_files_when_root_path_contains_tmp(self, tmp_path):
+        repo = tmp_path / "tmp" / "repo"
+        self._make_test_tree(repo)
+        with mock.patch.object(aam, "ROOT", repo):
+            files = aam.walk_tests()
+        assert any(f.name == "test_good.py" for f in files)
+
     def test_excludes_node_modules(self, tmp_path):
         self._make_test_tree(tmp_path)
         with mock.patch.object(aam, "ROOT", tmp_path):

--- a/tests/tooling/test_audit_ac_epic_mismatches.py
+++ b/tests/tooling/test_audit_ac_epic_mismatches.py
@@ -162,6 +162,15 @@ class TestWalkTests:
             files = aam.walk_tests()
         assert not any("node_modules" in f.parts for f in files)
 
+    def test_excludes_tmp_dir(self, tmp_path):
+        self._make_test_tree(tmp_path)
+        tmp = tmp_path / "tmp" / "tests"
+        tmp.mkdir(parents=True)
+        (tmp / "test_tmp.py").write_text("# AC1.1.1\n")
+        with mock.patch.object(aam, "ROOT", tmp_path):
+            files = aam.walk_tests()
+        assert not any("tmp" in f.relative_to(tmp_path).parts for f in files)
+
     def test_excludes_ac_stubs(self, tmp_path):
         stubs = tmp_path / "apps" / "backend" / "tests" / "_ac_stubs"
         stubs.mkdir(parents=True)


### PR DESCRIPTION
## Why
- EPIC navigation in mkdocs only listed EPIC-001..007, causing docs discoverability gap.
- AC/epic mismatch audit scanned tmp/ and surfaced fake actionable mismatches.

## What changed
- Add EPIC-008 to EPIC-018 to docs navigation.
- Exclude  from AC mismatch audit test file walk.
- Add regression test for tmp exclusion.

## Verification
- python -m pytest tests/tooling/test_audit_ac_epic_mismatches.py
- python tools/audit_ac_epic_mismatches.py