### PR TITLE
[finance_report_ui] [codex] Fix mobile frontend UI

### DIFF
--- a/apps/frontend/src/__tests__/mobileNav.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/mobileNav.coverage.test.tsx
@@ -9,16 +9,21 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("MobileNav coverage (AC16.23.6)", () => {
-    it("opens the sheet, renders nav links with active highlighting, closes via close button, and closes via link click", () => {
+    it("AC16.23.5 opens a full mobile nav drawer with active highlighting, closes via close button, and closes via link click", () => {
         renderReviewComponent(<MobileNav />);
         const trigger = screen.getByLabelText("Open navigation menu");
         fireEvent.click(trigger);
         const dashboardLink = screen.getByRole("link", { name: /dashboard/i });
-        const processingLink = screen.getByRole("link", { name: /processing/i });
         expect(dashboardLink).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /review/i })).toBeInTheDocument();
-        expect(processingLink).toHaveAttribute("href", "/processing");
-        expect(screen.getByRole("link", { name: /portfolio/i })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /accounts/i })).toHaveAttribute("href", "/accounts");
+        expect(screen.getByRole("link", { name: /journal/i })).toHaveAttribute("href", "/journal");
+        expect(screen.getByRole("link", { name: /statements/i })).toHaveAttribute("href", "/statements");
+        expect(screen.getByRole("link", { name: /review/i })).toHaveAttribute("href", "/review");
+        expect(screen.getByRole("link", { name: /portfolio/i })).toHaveAttribute("href", "/portfolio");
+        expect(screen.getByRole("link", { name: /reports/i })).toHaveAttribute("href", "/reports");
+        expect(screen.getByRole("link", { name: /reconciliation/i })).toHaveAttribute("href", "/reconciliation");
+        expect(screen.getByRole("link", { name: /processing/i })).toHaveAttribute("href", "/processing");
+        expect(screen.getByRole("link", { name: /ai advisor/i })).toHaveAttribute("href", "/chat");
         expect(dashboardLink.className).toContain("accent-muted");
 
         const closeBtn = screen.getByText("Close panel").closest("button")!;

--- a/apps/frontend/src/__tests__/navigation.test.ts
+++ b/apps/frontend/src/__tests__/navigation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_ROUTE_ICON, getRouteConfig, primaryNavItems } from "@/components/navigation";
+
+describe("navigation metadata", () => {
+  it("AC16.23.5 exposes the full primary navigation set for mobile and desktop", () => {
+    expect(primaryNavItems.map((item) => item.label)).toEqual([
+      "Dashboard",
+      "Accounts",
+      "Journal",
+      "Statements",
+      "Review",
+      "Portfolio",
+      "Reports",
+      "Reconciliation",
+      "Processing",
+      "AI Advisor",
+    ]);
+  });
+
+  it("AC16.19.4 resolves exact, parent, and derived route labels", () => {
+    expect(getRouteConfig("/reports/balance-sheet").label).toBe("Balance Sheet");
+    expect(getRouteConfig("/reports/balance-sheet/detail").label).toBe("Balance Sheet");
+    expect(getRouteConfig("/custom-report_page").label).toBe("Custom Report Page");
+    expect(getRouteConfig("/").Icon).toBe(DEFAULT_ROUTE_ICON);
+  });
+});

--- a/apps/frontend/src/__tests__/shellAndAuth.test.tsx
+++ b/apps/frontend/src/__tests__/shellAndAuth.test.tsx
@@ -55,6 +55,7 @@ describe("AppShell and AuthGuard", () => {
     expect(screen.getByTestId("workspace-tabs")).toBeInTheDocument()
     expect(screen.getByText("Shell Child")).toBeInTheDocument()
     expect(container.querySelector('[class*="md:ml-16"]')).not.toBeNull()
+    expect(screen.getByTestId("workspace-tabs").parentElement?.className).toContain("hidden md:block")
   })
 
   it("AC16.19.2 redirects unauthenticated protected routes", async () => {

--- a/apps/frontend/src/app/(main)/dashboard/page.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/page.tsx
@@ -7,7 +7,7 @@ import ProcessingSummaryCard from "@/components/ProcessingSummaryCard";
 
 import { apiFetch } from "@/lib/api";
 import { formatDateInput, formatDateDisplay, formatMonthLabel } from "@/lib/date";
-import { formatCurrencyLocale } from "@/lib/currency";
+import { amountToChartNumber, compareAmounts, formatCurrencyLocale, subtractAmounts, toDecimal } from "@/lib/currency";
 import { BarChart } from "@/components/charts/BarChart";
 import { NetWorthTimeSeriesChart } from "@/components/charts/NetWorthTimeSeriesChart";
 import { PieChart } from "@/components/charts/PieChart";
@@ -27,7 +27,83 @@ import {
 
 const CHART_PALETTE = ["var(--chart-1)", "var(--chart-2)", "var(--chart-3)", "var(--chart-4)", "var(--chart-5)"];
 
-const toNumber = (value: number | string) => typeof value === "string" ? Number(value) : value;
+const EMPTY_BALANCE_SHEET: BalanceSheetResponse = {
+  as_of_date: "",
+  currency: "SGD",
+  assets: [],
+  liabilities: [],
+  equity: [],
+  total_assets: 0,
+  total_liabilities: 0,
+  total_equity: 0,
+  equation_delta: 0,
+  is_balanced: true,
+};
+
+const EMPTY_INCOME_STATEMENT: IncomeStatementResponse = {
+  start_date: "",
+  end_date: "",
+  currency: "SGD",
+  income: [],
+  expenses: [],
+  total_income: 0,
+  total_expenses: 0,
+  net_income: 0,
+  trends: [],
+};
+
+const EMPTY_ANNUALIZED_INCOME: AnnualizedIncomeResponse = {
+  annualized_salary: 0,
+  annualized_bonus: 0,
+  annualized_dividend: 0,
+  annualized_total: 0,
+  currency: "SGD",
+  as_of: "",
+};
+
+function normalizeBalanceSheet(data?: Partial<BalanceSheetResponse> | null): BalanceSheetResponse {
+  return {
+    ...EMPTY_BALANCE_SHEET,
+    ...data,
+    assets: data?.assets ?? [],
+    liabilities: data?.liabilities ?? [],
+    equity: data?.equity ?? [],
+    total_assets: data?.total_assets ?? 0,
+    total_liabilities: data?.total_liabilities ?? 0,
+    total_equity: data?.total_equity ?? 0,
+    equation_delta: data?.equation_delta ?? 0,
+    currency: data?.currency ?? "SGD",
+    as_of_date: data?.as_of_date ?? "",
+    is_balanced: data?.is_balanced ?? true,
+  };
+}
+
+function normalizeIncomeStatement(data?: Partial<IncomeStatementResponse> | null): IncomeStatementResponse {
+  return {
+    ...EMPTY_INCOME_STATEMENT,
+    ...data,
+    income: data?.income ?? [],
+    expenses: data?.expenses ?? [],
+    trends: data?.trends ?? [],
+    total_income: data?.total_income ?? 0,
+    total_expenses: data?.total_expenses ?? 0,
+    net_income: data?.net_income ?? 0,
+    currency: data?.currency ?? "SGD",
+  };
+}
+
+function normalizeAnnualizedIncome(data?: Partial<AnnualizedIncomeResponse> | null): AnnualizedIncomeResponse {
+  return {
+    ...EMPTY_ANNUALIZED_INCOME,
+    ...data,
+    annualized_salary: data?.annualized_salary ?? 0,
+    annualized_bonus: data?.annualized_bonus ?? 0,
+    annualized_dividend: data?.annualized_dividend ?? 0,
+    annualized_total: data?.annualized_total ?? 0,
+    currency: data?.currency ?? "SGD",
+    as_of: data?.as_of ?? "",
+  };
+}
 
 interface OnboardingStatus {
   accountCount: number;
@@ -81,10 +157,10 @@ export default function DashboardPage() {
         apiFetch<BankStatementListResponse>("/api/statements"),
         apiFetch<JournalEntryListResponse>("/api/journal-entries?status_filter=posted&limit=1"),
       ]);
-      setBalanceSheet(balanceData || { assets: [], total_assets: 0, total_liabilities: 0, currency: "SGD", as_of_date: "", is_balanced: true });
-      setIncomeStatement(incomeData || { start_date: "", end_date: "", currency: "SGD", income: [], expenses: [], total_income: 0, total_expenses: 0, net_income: 0, trends: [] });
-      setAnnualizedIncome(annualizedData || { annualized_salary: 0, annualized_bonus: 0, annualized_dividend: 0, annualized_total: 0, currency: "SGD", as_of: "" });
-      setRestrictedHoldings(restrictedData || []);
+      setBalanceSheet(normalizeBalanceSheet(balanceData));
+      setIncomeStatement(normalizeIncomeStatement(incomeData));
+      setAnnualizedIncome(normalizeAnnualizedIncome(annualizedData));
+      setRestrictedHoldings(Array.isArray(restrictedData) ? restrictedData : []);
       setStats(statsData || { total_transactions: 0, matched_transactions: 0, unmatched_transactions: 0, pending_review: 0, auto_accepted: 0, match_rate: 0, score_distribution: {} });
       setUnmatched(unmatchedData || { items: [], total: 0 });
       setRecentEntries(journalData || { items: [], total: 0 });
@@ -104,7 +180,7 @@ export default function DashboardPage() {
 
   const fetchTrend = useCallback(async () => {
     if (!balanceSheet || !balanceSheet.assets) return;
-    const sortedAssets = [...balanceSheet.assets].sort((a, b) => toNumber(b.amount) - toNumber(a.amount));
+    const sortedAssets = [...balanceSheet.assets].sort((a, b) => compareAmounts(b.amount, a.amount));
     const target = trendAccountId
       ? sortedAssets.find((a) => a.account_id === trendAccountId) ?? sortedAssets[0]
       : sortedAssets[0];
@@ -127,13 +203,17 @@ export default function DashboardPage() {
   }, [fetchTrend, balanceSheet]);
 
   const netAssets = useMemo(() => {
-    return balanceSheet ? toNumber(balanceSheet.total_assets) - toNumber(balanceSheet.total_liabilities) : 0;
+    return balanceSheet ? subtractAmounts(balanceSheet.total_assets ?? 0, balanceSheet.total_liabilities ?? 0) : toDecimal("0");
   }, [balanceSheet]);
-  const trendPoints = useMemo(() => trend ? trend.points.map((p) => ({ label: formatMonthLabel(p.period_start), value: toNumber(p.amount) })) : [], [trend]);
-  const incomeBars = useMemo(() => incomeStatement && incomeStatement.trends ? incomeStatement.trends.slice(-6).map((t) => ({ label: formatMonthLabel(t.period_start), income: toNumber(t.total_income), expense: toNumber(t.total_expenses) })) : [], [incomeStatement]);
+  const trendPoints = useMemo(() => trend ? trend.points.map((p) => ({ label: formatMonthLabel(p.period_start), value: amountToChartNumber(p.amount) })) : [], [trend]);
+  const incomeBars = useMemo(() => incomeStatement && incomeStatement.trends ? incomeStatement.trends.slice(-6).map((t) => ({ label: formatMonthLabel(t.period_start), income: amountToChartNumber(t.total_income), expense: amountToChartNumber(t.total_expenses) })) : [], [incomeStatement]);
   const assetSegments = useMemo(() => {
     if (!balanceSheet || !balanceSheet.assets) return [];
-    return balanceSheet.assets.filter((a) => toNumber(a.amount) > 0).sort((a, b) => toNumber(b.amount) - toNumber(a.amount)).slice(0, 5).map((a, i) => ({ label: a.name, value: toNumber(a.amount), color: CHART_PALETTE[i % CHART_PALETTE.length] }));
+    return balanceSheet.assets
+      .filter((a) => compareAmounts(a.amount, "0") > 0)
+      .sort((a, b) => compareAmounts(b.amount, a.amount))
+      .slice(0, 5)
+      .map((a, i) => ({ label: a.name, value: amountToChartNumber(a.amount), color: CHART_PALETTE[i % CHART_PALETTE.length] }));
   }, [balanceSheet]);
   const isCoreFlowComplete = (onboardingStatus?.approvedStatementCount ?? 0) > 0 && (onboardingStatus?.postedEntryCount ?? 0) > 0;
   const showOnboarding = onboardingStatus !== null && !isCoreFlowComplete;
@@ -240,14 +320,14 @@ export default function DashboardPage() {
         <div className="card p-5">
           <p className="text-xs text-muted uppercase tracking-wide">Total Assets</p>
           <p className="text-2xl font-semibold text-[var(--success)] mt-1">
-            {balanceSheet ? formatCurrencyLocale(toNumber(balanceSheet.total_assets), balanceSheet.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}
+            {balanceSheet ? formatCurrencyLocale(balanceSheet.total_assets, balanceSheet.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}
           </p>
           <p className="text-xs text-muted mt-1">As of {balanceSheet?.as_of_date ? formatDateDisplay(balanceSheet.as_of_date) : "—"}</p>
         </div>
         <div className="card p-5">
           <p className="text-xs text-muted uppercase tracking-wide">Total Liabilities</p>
           <p className="text-2xl font-semibold text-[var(--error)] mt-1">
-            {balanceSheet ? formatCurrencyLocale(toNumber(balanceSheet.total_liabilities), balanceSheet.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}
+            {balanceSheet ? formatCurrencyLocale(balanceSheet.total_liabilities, balanceSheet.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}
           </p>
           <p className="text-xs text-muted mt-1">Obligations</p>
         </div>
@@ -265,7 +345,7 @@ export default function DashboardPage() {
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
             <div>
               <p className="text-xs text-muted uppercase tracking-wide mb-1">Net Worth</p>
-              <p className={`text-4xl font-bold ${netAssets >= 0 ? "text-[var(--success)]" : "text-[var(--error)]"}`}>
+              <p className={`text-4xl font-bold ${netAssets.isNegative() ? "text-[var(--error)]" : "text-[var(--success)]"}`}>
                 {formatCurrencyLocale(netAssets, balanceSheet.currency, "en-US", { maximumFractionDigits: 0 })}
               </p>
               <p className="text-xs text-muted mt-1">As of {balanceSheet?.as_of_date ? formatDateDisplay(balanceSheet.as_of_date) : ""} · {balanceSheet.is_balanced ? "✓ Books balanced" : "⚠ Equation drift"}</p>
@@ -308,7 +388,7 @@ export default function DashboardPage() {
         <div className="card p-5">
           <p className="text-xs text-muted uppercase tracking-wide">Annualized Income</p>
           <p className="text-2xl font-semibold mt-1">
-            {annualizedIncome ? formatCurrencyLocale(toNumber(annualizedIncome.annualized_total), annualizedIncome.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}
+            {annualizedIncome ? formatCurrencyLocale(annualizedIncome.annualized_total, annualizedIncome.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}
           </p>
           <p className="text-xs text-muted mt-1">
             As of {annualizedIncome?.as_of ? formatDateDisplay(annualizedIncome.as_of) : "—"}
@@ -316,15 +396,15 @@ export default function DashboardPage() {
           <div className="mt-4 grid grid-cols-3 gap-3 text-sm">
             <div>
               <p className="text-xs text-muted">Salary</p>
-              <p className="font-medium">{annualizedIncome ? formatCurrencyLocale(toNumber(annualizedIncome.annualized_salary), annualizedIncome.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}</p>
+              <p className="font-medium">{annualizedIncome ? formatCurrencyLocale(annualizedIncome.annualized_salary, annualizedIncome.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}</p>
             </div>
             <div>
               <p className="text-xs text-muted">Bonus</p>
-              <p className="font-medium">{annualizedIncome ? formatCurrencyLocale(toNumber(annualizedIncome.annualized_bonus), annualizedIncome.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}</p>
+              <p className="font-medium">{annualizedIncome ? formatCurrencyLocale(annualizedIncome.annualized_bonus, annualizedIncome.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}</p>
             </div>
             <div>
               <p className="text-xs text-muted">Dividend</p>
-              <p className="font-medium">{annualizedIncome ? formatCurrencyLocale(toNumber(annualizedIncome.annualized_dividend), annualizedIncome.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}</p>
+              <p className="font-medium">{annualizedIncome ? formatCurrencyLocale(annualizedIncome.annualized_dividend, annualizedIncome.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}</p>
             </div>
           </div>
         </div>
@@ -340,7 +420,7 @@ export default function DashboardPage() {
                       Unlock {holding.unlock_date ? formatDateDisplay(holding.unlock_date) : "TBD"}
                     </p>
                   </div>
-                  <p className="font-semibold">{formatCurrencyLocale(toNumber(holding.fair_value), holding.currency, "en-US", { maximumFractionDigits: 0 })}</p>
+                  <p className="font-semibold">{formatCurrencyLocale(holding.fair_value, holding.currency, "en-US", { maximumFractionDigits: 0 })}</p>
                 </div>
               ))}
             </div>
@@ -353,9 +433,9 @@ export default function DashboardPage() {
       {/* This Month KPI Cards */}
       {incomeStatement && incomeStatement.trends && incomeStatement.trends.length > 0 && (() => {
         const latest = incomeStatement.trends[incomeStatement.trends.length - 1];
-        const monthIncome = toNumber(latest.total_income);
-        const monthExpense = toNumber(latest.total_expenses);
-        const monthNet = monthIncome - monthExpense;
+        const monthIncome = toDecimal(latest.total_income);
+        const monthExpense = toDecimal(latest.total_expenses);
+        const monthNet = monthIncome.minus(monthExpense);
         const currency = incomeStatement.currency;
         const fmtOpts = { maximumFractionDigits: 0 } as const;
         return (
@@ -372,8 +452,8 @@ export default function DashboardPage() {
             </Link>
             <Link href="/reports/income-statement" className="card p-5 hover:border-[var(--accent)] transition-colors cursor-pointer block">
               <p className="text-xs text-muted uppercase tracking-wide">This Month — Net</p>
-              <p className={`text-2xl font-semibold mt-1 ${monthNet >= 0 ? "text-[var(--success)]" : "text-[var(--error)]"}`}>{formatCurrencyLocale(monthNet, currency, "en-US", fmtOpts)}</p>
-              <p className="text-xs text-muted mt-1">{monthNet >= 0 ? "Surplus" : "Deficit"}</p>
+              <p className={`text-2xl font-semibold mt-1 ${monthNet.isNegative() ? "text-[var(--error)]" : "text-[var(--success)]"}`}>{formatCurrencyLocale(monthNet, currency, "en-US", fmtOpts)}</p>
+              <p className="text-xs text-muted mt-1">{monthNet.isNegative() ? "Deficit" : "Surplus"}</p>
             </Link>
           </div>
         );
@@ -396,7 +476,7 @@ export default function DashboardPage() {
                 className="input text-xs py-1 px-2 w-auto"
               >
                 <option value="">Top Asset</option>
-                {[...balanceSheet.assets].sort((a, b) => toNumber(b.amount) - toNumber(a.amount)).map((a) => (
+                {[...balanceSheet.assets].sort((a, b) => compareAmounts(b.amount, a.amount)).map((a) => (
                   <option key={a.account_id} value={a.account_id}>{a.name}</option>
                 ))}
               </select>
@@ -466,7 +546,7 @@ export default function DashboardPage() {
             {unmatched?.items?.length ? unmatched.items.map((t) => (
               <div key={t.id} className="flex justify-between p-3 rounded-md bg-[var(--warning-muted)] text-sm">
                 <div><p className="font-medium">{t.description}</p><p className="text-xs text-muted">{formatDateDisplay(t.txn_date)}</p></div>
-                <span className="font-semibold">{balanceSheet ? formatCurrencyLocale(toNumber(t.amount), balanceSheet.currency, "en-US", { maximumFractionDigits: 0 }) : t.amount}</span>
+                <span className="font-semibold">{balanceSheet ? formatCurrencyLocale(t.amount, balanceSheet.currency, "en-US", { maximumFractionDigits: 0 }) : t.amount}</span>
               </div>
             )) : <p className="text-sm text-muted">No unmatched transactions.</p>}
             <Link href="/reconciliation/unmatched" className="text-sm text-[var(--warning)] hover:underline inline-flex items-center gap-1">

--- a/apps/frontend/src/app/(main)/journal/page.tsx
+++ b/apps/frontend/src/app/(main)/journal/page.tsx
@@ -8,7 +8,7 @@ import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import ConfidenceBadge from "@/components/ui/ConfidenceBadge";
 import { useToast } from "@/components/ui/Toast";
 import { apiFetch } from "@/lib/api";
-import { formatCurrencyLocale } from "@/lib/currency";
+import { formatCurrencyLocale, sumAmounts } from "@/lib/currency";
 import { formatDateDisplay } from "@/lib/date";
 import { JournalEntry, JournalEntryListResponse, JournalLine } from "@/lib/types";
 
@@ -52,7 +52,7 @@ export default function JournalPage() {
     }, [fetchEntries]);
 
     const calculateDebits = (lines: JournalLine[]) => {
-        return lines.filter((l) => l.direction === "DEBIT").reduce((sum, l) => sum + l.amount, 0);
+        return sumAmounts(lines.filter((l) => l.direction === "DEBIT").map((line) => line.amount));
     };
 
     const handlePostEntry = async (entryId: string) => {

--- a/apps/frontend/src/app/(main)/portfolio/[ticker]/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/[ticker]/page.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 
 import { apiFetch } from "@/lib/api";
 import { DividendEvent, PortfolioHolding, RealizedLot } from "@/lib/types";
-import { formatCurrencyLocale } from "@/lib/currency";
+import { compareAmounts, formatAmount, formatCurrencyLocale } from "@/lib/currency";
 import { formatDateDisplay } from "@/lib/date";
 
 function formatQuantity(quantity: string): string {
@@ -17,16 +17,14 @@ function formatQuantity(quantity: string): string {
 }
 
 function getPnlColor(value: string): string {
-    const num = parseFloat(value);
-    if (isNaN(num) || num === 0) return "";
-    return num > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
+    const comparison = compareAmounts(value, "0");
+    if (comparison === 0) return "";
+    return comparison > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
 }
 
 function formatPnlPercent(value: string): string {
-    const num = parseFloat(value);
-    if (isNaN(num)) return "\u2014";
-    const sign = num > 0 ? "+" : "";
-    return `${sign}${num.toFixed(2)}%`;
+    const sign = compareAmounts(value, "0") > 0 ? "+" : "";
+    return `${sign}${formatAmount(value, 2)}%`;
 }
 
 export default function HoldingDetailPage() {

--- a/apps/frontend/src/app/(main)/portfolio/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/page.tsx
@@ -10,7 +10,7 @@ import { PortfolioHolding, PortfolioSummaryResponse } from "@/lib/types";
 import { PerformanceCard } from "@/components/portfolio/PerformanceCard";
 import { HoldingsTable } from "@/components/portfolio/HoldingsTable";
 import { AllocationChart } from "@/components/portfolio/AllocationChart";
-import { formatCurrencyLocale } from "@/lib/currency";
+import { formatCurrencyLocale, sumAmounts } from "@/lib/currency";
 
 export default function PortfolioPage() {
     const [showDisposed, setShowDisposed] = useState(false);
@@ -36,10 +36,7 @@ export default function PortfolioPage() {
     });
 
     const activeHoldings = holdings?.filter((h) => h.status === "active") ?? [];
-    const totalPortfolioValue = activeHoldings.reduce((sum, h) => {
-        const val = parseFloat(h.market_value);
-        return sum + (isNaN(val) ? 0 : val);
-    }, 0);
+    const totalPortfolioValue = sumAmounts(activeHoldings.map((holding) => holding.market_value));
     const primaryCurrency = activeHoldings[0]?.currency ?? "USD";
 
     return (

--- a/apps/frontend/src/app/(main)/processing/page.tsx
+++ b/apps/frontend/src/app/(main)/processing/page.tsx
@@ -67,7 +67,7 @@ export default function ProcessingPage() {
                     <td className="px-6 py-4">{item.from_account}</td>
                     <td className="px-6 py-4">{item.to_account}</td>
                     <td className="px-6 py-4 text-right font-mono">
-                      {formatCurrencyLocale(Number(item.amount), item.currency)}
+                      {formatCurrencyLocale(item.amount, item.currency)}
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-2">

--- a/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
@@ -31,12 +31,6 @@ interface BalanceSheetResponse {
 
 interface AccountNode extends ReportLine { children: AccountNode[]; }
 
-const toNumber = (value: number | string): number => {
-  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
-
 const buildTree = (lines: ReportLine[]): AccountNode[] => {
   const nodes = new Map<string, AccountNode>();
   lines.forEach((line) => nodes.set(line.account_id, { ...line, children: [] }));
@@ -88,13 +82,13 @@ export default function BalanceSheetPage() {
     const hasChildren = node.children.length > 0;
     const isExpanded = expanded.has(node.account_id);
     return (
-      <div key={node.account_id} role="treeitem" aria-level={depth + 1} aria-expanded={hasChildren ? isExpanded : undefined}>
+      <div key={node.account_id} role="treeitem" aria-level={depth + 1} aria-selected={false} aria-expanded={hasChildren ? isExpanded : undefined}>
         <div className="flex items-center justify-between px-3 py-2 text-sm rounded-md hover:bg-[var(--background-muted)]/50" style={{ paddingLeft: depth * 16 + 12 }}>
           <div className="flex items-center gap-2">
             {hasChildren && <button onClick={() => toggle(node.account_id)} className="w-5 h-5 rounded-md bg-[var(--background-muted)] text-xs flex items-center justify-center">{isExpanded ? "–" : "+"}</button>}
             <span>{node.name}</span>
           </div>
-          <span className="font-medium">{report ? formatCurrencyLocale(toNumber(node.amount), report.currency) : "—"}</span>
+          <span className="font-medium">{report ? formatCurrencyLocale(node.amount, report.currency) : "—"}</span>
         </div>
         {hasChildren && isExpanded && <div role="group" className="ml-2 border-l border-[var(--border)] pl-2">{node.children.map((c) => renderNode(c, depth + 1))}</div>}
       </div>
@@ -140,17 +134,17 @@ export default function BalanceSheetPage() {
         <div className="card p-5" id="assets">
           <h2 className="font-semibold mb-3">Assets</h2>
           <div role="tree" aria-label="Balance Sheet - Assets" className="space-y-1">{assetsTree.length ? assetsTree.map((n) => renderNode(n)) : <span className="text-muted">—</span>}</div>
-          <div className="mt-4 pt-3 border-t border-[var(--border)] font-semibold text-[var(--success)]">Total: {report ? formatCurrencyLocale(toNumber(report.total_assets), report.currency) : "—"}</div>
+          <div className="mt-4 pt-3 border-t border-[var(--border)] font-semibold text-[var(--success)]">Total: {report ? formatCurrencyLocale(report.total_assets, report.currency) : "—"}</div>
         </div>
         <div className="card p-5" id="liabilities">
           <h2 className="font-semibold mb-3">Liabilities</h2>
           <div role="tree" aria-label="Balance Sheet - Liabilities" className="space-y-1">{liabilitiesTree.length ? liabilitiesTree.map((n) => renderNode(n)) : <span className="text-muted">—</span>}</div>
-          <div className="mt-4 pt-3 border-t border-[var(--border)] font-semibold text-[var(--error)]">Total: {report ? formatCurrencyLocale(toNumber(report.total_liabilities), report.currency) : "—"}</div>
+          <div className="mt-4 pt-3 border-t border-[var(--border)] font-semibold text-[var(--error)]">Total: {report ? formatCurrencyLocale(report.total_liabilities, report.currency) : "—"}</div>
         </div>
         <div className="card p-5" id="equity">
           <h2 className="font-semibold mb-3">Equity</h2>
           <div role="tree" aria-label="Balance Sheet - Equity" className="space-y-1">{equityTree.length ? equityTree.map((n) => renderNode(n)) : <span className="text-muted">—</span>}</div>
-          <div className="mt-4 pt-3 border-t border-[var(--border)] font-semibold">Total: {report ? formatCurrencyLocale(toNumber(report.total_equity), report.currency) : "—"}</div>
+          <div className="mt-4 pt-3 border-t border-[var(--border)] font-semibold">Total: {report ? formatCurrencyLocale(report.total_equity, report.currency) : "—"}</div>
         </div>
       </div>
     </div>

--- a/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { SankeyChart } from "@/components/charts/SankeyChart";
 import { API_URL, apiFetch } from "@/lib/api";
 import { formatDateInput } from "@/lib/date";
-import { formatCurrencyLocale } from "@/lib/currency";
+import { compareAmounts, formatCurrencyLocale } from "@/lib/currency";
 import { useCurrencies } from "@/hooks/useCurrencies";
 
 interface CashFlowItem {
@@ -34,12 +34,6 @@ interface CashFlowResponse {
   financing: CashFlowItem[];
   summary: CashFlowSummary;
 }
-
-const toNumber = (value: number | string): number => {
-  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
 
 export default function CashFlowPage() {
   const [report, setReport] = useState<CashFlowResponse | null>(null);
@@ -78,7 +72,7 @@ export default function CashFlowPage() {
                 <p className="font-medium truncate">{item.subcategory}</p>
                 {item.description && <p className="text-xs text-muted truncate">{item.description}</p>}
               </div>
-              <span className="font-medium ml-2">{report ? formatCurrencyLocale(toNumber(item.amount), report.currency) : "—"}</span>
+              <span className="font-medium ml-2">{report ? formatCurrencyLocale(item.amount, report.currency) : "—"}</span>
             </div>
           ))}
         </div>
@@ -115,17 +109,17 @@ export default function CashFlowPage() {
         <div className="grid gap-4 md:grid-cols-3 mb-6">
           <div className="card p-5">
             <p className="text-xs text-muted uppercase">Net Cash Flow</p>
-            <p className={`text-2xl font-semibold mt-1 ${toNumber(summary.net_cash_flow) >= 0 ? "text-[var(--success)]" : "text-[var(--error)]"}`}>
-              {formatCurrencyLocale(toNumber(summary.net_cash_flow), report?.currency || "SGD")}
+            <p className={`text-2xl font-semibold mt-1 ${compareAmounts(summary.net_cash_flow, "0") >= 0 ? "text-[var(--success)]" : "text-[var(--error)]"}`}>
+              {formatCurrencyLocale(summary.net_cash_flow, report?.currency || "SGD")}
             </p>
           </div>
           <div className="card p-5">
             <p className="text-xs text-muted uppercase">Beginning Cash</p>
-            <p className="text-2xl font-semibold mt-1">{formatCurrencyLocale(toNumber(summary.beginning_cash), report?.currency || "SGD")}</p>
+            <p className="text-2xl font-semibold mt-1">{formatCurrencyLocale(summary.beginning_cash, report?.currency || "SGD")}</p>
           </div>
           <div className="card p-5">
             <p className="text-xs text-muted uppercase">Ending Cash</p>
-            <p className="text-2xl font-semibold mt-1">{formatCurrencyLocale(toNumber(summary.ending_cash), report?.currency || "SGD")}</p>
+            <p className="text-2xl font-semibold mt-1">{formatCurrencyLocale(summary.ending_cash, report?.currency || "SGD")}</p>
           </div>
         </div>
       )}
@@ -155,15 +149,15 @@ export default function CashFlowPage() {
           <div className="grid gap-4 md:grid-cols-3">
             <div className="p-4 rounded-md bg-[var(--success-muted)]">
               <p className="text-xs text-muted uppercase">Operating</p>
-              <p className="text-xl font-semibold text-[var(--success)]">{formatCurrencyLocale(toNumber(summary.operating_activities), report?.currency || "SGD")}</p>
+              <p className="text-xl font-semibold text-[var(--success)]">{formatCurrencyLocale(summary.operating_activities, report?.currency || "SGD")}</p>
             </div>
             <div className="p-4 rounded-md bg-[var(--accent-muted)]">
               <p className="text-xs text-muted uppercase">Investing</p>
-              <p className="text-xl font-semibold text-[var(--accent)]">{formatCurrencyLocale(toNumber(summary.investing_activities), report?.currency || "SGD")}</p>
+              <p className="text-xl font-semibold text-[var(--accent)]">{formatCurrencyLocale(summary.investing_activities, report?.currency || "SGD")}</p>
             </div>
             <div className="p-4 rounded-md bg-[var(--warning-muted)]">
               <p className="text-xs text-muted uppercase">Financing</p>
-              <p className="text-xl font-semibold text-[var(--warning)]">{formatCurrencyLocale(toNumber(summary.financing_activities), report?.currency || "SGD")}</p>
+              <p className="text-xl font-semibold text-[var(--warning)]">{formatCurrencyLocale(summary.financing_activities, report?.currency || "SGD")}</p>
             </div>
           </div>
         </div>

--- a/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { API_URL, apiFetch } from "@/lib/api";
 import { BarChart } from "@/components/charts/BarChart";
 import { formatDateInput, formatMonthLabel } from "@/lib/date";
-import { formatCurrencyLocale } from "@/lib/currency";
+import { amountToChartNumber, formatCurrencyLocale } from "@/lib/currency";
 import { useCurrencies } from "@/hooks/useCurrencies";
 
 interface ReportLine {
@@ -40,12 +40,6 @@ interface IncomeStatementResponse {
     account_type: string | null;
   };
 }
-
-const toNumber = (value: number | string): number => {
-  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
 
 const ACCOUNT_TYPE_OPTIONS = [
   { value: "", label: "All Types" },
@@ -109,7 +103,7 @@ export default function IncomeStatementPage() {
 
   useEffect(() => { fetchReport(); }, [fetchReport]);
 
-  const barItems = useMemo(() => report ? report.trends.slice(-6).map((t) => ({ label: formatMonthLabel(t.period_start), income: toNumber(t.total_income), expense: toNumber(t.total_expenses) })) : [], [report]);
+  const barItems = useMemo(() => report ? report.trends.slice(-6).map((t) => ({ label: formatMonthLabel(t.period_start), income: amountToChartNumber(t.total_income), expense: amountToChartNumber(t.total_expenses) })) : [], [report]);
   const exportUrl = useMemo(() => `${API_URL}/api/reports/export?report_type=income-statement&format=csv&${buildQueryParams()}`, [buildQueryParams]);
   const aiPrompt = useMemo(() => encodeURIComponent(`Summarize my income statement from ${startDate} to ${endDate} in ${currency}. Highlight key trends.`), [currency, endDate, startDate]);
 
@@ -172,9 +166,9 @@ export default function IncomeStatementPage() {
       )}
 
       <div className="grid gap-4 md:grid-cols-3 mb-6">
-        <div className="card p-5"><p className="text-xs text-muted uppercase">Total Income</p><p className="text-2xl font-semibold text-[var(--success)] mt-1">{report ? formatCurrencyLocale(toNumber(report.total_income), report.currency) : "—"}</p></div>
-        <div className="card p-5"><p className="text-xs text-muted uppercase">Total Expenses</p><p className="text-2xl font-semibold text-[var(--error)] mt-1">{report ? formatCurrencyLocale(toNumber(report.total_expenses), report.currency) : "—"}</p></div>
-        <div className="card p-5"><p className="text-xs text-muted uppercase">Net Income</p><p className="text-2xl font-semibold mt-1">{report ? formatCurrencyLocale(toNumber(report.net_income), report.currency) : "—"}</p></div>
+        <div className="card p-5"><p className="text-xs text-muted uppercase">Total Income</p><p className="text-2xl font-semibold text-[var(--success)] mt-1">{report ? formatCurrencyLocale(report.total_income, report.currency) : "—"}</p></div>
+        <div className="card p-5"><p className="text-xs text-muted uppercase">Total Expenses</p><p className="text-2xl font-semibold text-[var(--error)] mt-1">{report ? formatCurrencyLocale(report.total_expenses, report.currency) : "—"}</p></div>
+        <div className="card p-5"><p className="text-xs text-muted uppercase">Net Income</p><p className="text-2xl font-semibold mt-1">{report ? formatCurrencyLocale(report.net_income, report.currency) : "—"}</p></div>
       </div>
 
       <div className="grid gap-4 lg:grid-cols-2 mb-6">
@@ -195,7 +189,7 @@ export default function IncomeStatementPage() {
           <div className="space-y-2 max-h-64 overflow-y-auto">
             {report?.income?.length ? report.income.map((l) => (
               <div key={l.account_id} className="flex justify-between p-2 rounded-md bg-[var(--background-muted)] text-sm">
-                <span>{l.name}</span><span className="font-medium">{formatCurrencyLocale(toNumber(l.amount), report.currency)}</span>
+                <span>{l.name}</span><span className="font-medium">{formatCurrencyLocale(l.amount, report.currency)}</span>
               </div>
             )) : <p className="text-sm text-muted">No income categories.</p>}
           </div>
@@ -207,7 +201,7 @@ export default function IncomeStatementPage() {
         <div className="grid gap-2 md:grid-cols-2 max-h-96 overflow-y-auto">
           {report?.expenses?.length ? report.expenses.map((l) => (
             <div key={l.account_id} className="flex justify-between p-2 rounded-md bg-[var(--background-muted)] text-sm">
-              <span>{l.name}</span><span className="font-medium">{formatCurrencyLocale(toNumber(l.amount), report.currency)}</span>
+              <span>{l.name}</span><span className="font-medium">{formatCurrencyLocale(l.amount, report.currency)}</span>
             </div>
           )) : <p className="text-sm text-muted">No expense categories.</p>}
         </div>

--- a/apps/frontend/src/components/AppShell.tsx
+++ b/apps/frontend/src/components/AppShell.tsx
@@ -24,9 +24,11 @@ function AppShellContent({ children }: AppShellProps) {
                     isCollapsed ? "md:ml-16" : "md:ml-64"
                 }`}
             >
-                <div className="flex items-center md:block border-b border-[var(--border)] md:border-none">
+                <div className="flex min-w-0 items-center border-b border-[var(--border)] md:block md:border-none">
                     <MobileNav />
-                    <WorkspaceTabs />
+                    <div className="hidden md:block min-w-0">
+                        <WorkspaceTabs />
+                    </div>
                 </div>
 
                 <main className="min-h-[calc(100vh-4rem)]">

--- a/apps/frontend/src/components/MobileNav.tsx
+++ b/apps/frontend/src/components/MobileNav.tsx
@@ -3,28 +3,9 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import {
-    LayoutDashboard,
-    FileText,
-    Zap,
-    Wallet,
-    Menu,
-    LucideIcon
-} from "lucide-react";
+import { Menu } from "lucide-react";
 import Sheet from "@/components/ui/Sheet";
-
-interface NavItem {
-    icon: LucideIcon;
-    label: string;
-    href: string;
-}
-
-const mobileNavItems: NavItem[] = [
-    { icon: LayoutDashboard, label: "Dashboard", href: "/dashboard" },
-    { icon: FileText, label: "Review", href: "/statements" },
-    { icon: Zap, label: "Processing", href: "/processing" },
-    { icon: Wallet, label: "Portfolio", href: "/portfolio" },
-];
+import { primaryNavItems } from "@/components/navigation";
 
 export function MobileNav() {
     const [isOpen, setIsOpen] = useState(false);
@@ -34,7 +15,7 @@ export function MobileNav() {
         <div className="md:hidden">
             <button
                 onClick={() => setIsOpen(true)}
-                className="p-2 text-muted hover:text-[var(--foreground)]"
+                className="inline-flex h-11 w-11 items-center justify-center text-muted hover:text-[var(--foreground)]"
                 aria-label="Open navigation menu"
             >
                 <Menu className="w-6 h-6" />
@@ -47,7 +28,7 @@ export function MobileNav() {
                 width="max-w-xs"
             >
                 <nav className="space-y-1">
-                    {mobileNavItems.map((item) => {
+                    {primaryNavItems.map((item) => {
                         const Icon = item.icon;
                         const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
                         

--- a/apps/frontend/src/components/Sidebar.tsx
+++ b/apps/frontend/src/components/Sidebar.tsx
@@ -8,46 +8,12 @@ import { clearUser, getUserEmail, isAuthenticated } from "@/lib/auth";
 import { apiFetch } from "@/lib/api";
 import { isAmountZero } from "@/lib/currency";
 import type { ProcessingSummaryResponse } from "@/lib/types";
+import { primaryNavItems } from "@/components/navigation";
 import { useState, useEffect } from "react";
-import {
-    LayoutDashboard,
-    Landmark,
-    BookOpen,
-    FileText,
-    ClipboardCheck,
-    Wallet,
-    BarChart3,
-    Link2,
-    Clock,
-    MessageSquare,
-    Zap,
-    LogOut,
-    LogIn,
-    type LucideIcon,
-} from "lucide-react";
+import { LogIn, LogOut, Zap } from "lucide-react";
 
 // Hide dev routes in production
 const IS_DEV = process.env.NODE_ENV === "development";
-
-interface NavItem {
-    icon: LucideIcon;
-    label: string;
-    href: string;
-    protected: boolean;
-}
-
-const navItems: NavItem[] = [
-    { icon: LayoutDashboard, label: "Dashboard", href: "/dashboard", protected: true },
-    { icon: Landmark, label: "Accounts", href: "/accounts", protected: true },
-    { icon: BookOpen, label: "Journal", href: "/journal", protected: true },
-    { icon: FileText, label: "Statements", href: "/statements", protected: true },
-    { icon: ClipboardCheck, label: "Review", href: "/review", protected: true },
-    { icon: Wallet, label: "Portfolio", href: "/portfolio", protected: true },
-    { icon: BarChart3, label: "Reports", href: "/reports", protected: true },
-    { icon: Link2, label: "Reconciliation", href: "/reconciliation", protected: true },
-    { icon: Clock, label: "Processing", href: "/processing", protected: true },
-    { icon: MessageSquare, label: "AI Advisor", href: "/chat", protected: true },
-];
 
 export function Sidebar() {
     const pathname = usePathname();
@@ -167,7 +133,7 @@ export function Sidebar() {
 
             {/* Navigation */}
             <nav className="p-2 space-y-0.5">
-                {navItems.filter(item => isAuth || !item.protected).map((item) => {
+                {primaryNavItems.filter(item => isAuth || !item.protected).map((item) => {
                     const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
                     const IconComponent = item.icon;
                     const badgeCount = item.href === "/review" ? pendingReviewCount : 0;

--- a/apps/frontend/src/components/WorkspaceTabs.tsx
+++ b/apps/frontend/src/components/WorkspaceTabs.tsx
@@ -4,56 +4,8 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useWorkspace, WorkspaceTab } from "@/hooks/useWorkspace";
-import {
-    LayoutDashboard,
-    Landmark,
-    BookOpen,
-    FileText,
-    BarChart3,
-    Link2,
-    MessageSquare,
-    Zap,
-    X,
-    type LucideIcon,
-} from "lucide-react";
-
-interface RouteConfig {
-    label: string;
-    Icon: LucideIcon;
-}
-
-const ROUTE_CONFIG: Record<string, RouteConfig> = {
-    "/dashboard": { label: "Dashboard", Icon: LayoutDashboard },
-    "/accounts": { label: "Accounts", Icon: Landmark },
-    "/journal": { label: "Journal", Icon: BookOpen },
-    "/statements": { label: "Statements", Icon: FileText },
-    "/assets": { label: "Portfolio", Icon: Landmark },
-    "/reports": { label: "Reports", Icon: BarChart3 },
-    "/reports/balance-sheet": { label: "Balance Sheet", Icon: BarChart3 },
-    "/reports/income-statement": { label: "Income Statement", Icon: BarChart3 },
-    "/reports/cash-flow": { label: "Cash Flow", Icon: BarChart3 },
-    "/reconciliation": { label: "Reconciliation", Icon: Link2 },
-    "/reconciliation/unmatched": { label: "Unmatched", Icon: Link2 },
-    "/chat": { label: "AI Advisor", Icon: MessageSquare },
-    "/ping-pong": { label: "Ping-Pong", Icon: Zap },
-};
-
-const DEFAULT_ICON = FileText;
-
-function getRouteConfig(pathname: string): RouteConfig {
-    if (ROUTE_CONFIG[pathname]) return ROUTE_CONFIG[pathname];
-    const segments = pathname.split("/").filter(Boolean);
-    while (segments.length > 0) {
-        const parentPath = "/" + segments.join("/");
-        if (ROUTE_CONFIG[parentPath]) return ROUTE_CONFIG[parentPath];
-        segments.pop();
-    }
-    const derivedSegments = pathname.split("/").filter(Boolean);
-    const lastSegment = derivedSegments[derivedSegments.length - 1];
-    const rawLabel = lastSegment ?? "Page";
-    const label = rawLabel.replace(/[-_]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-    return { label, Icon: DEFAULT_ICON };
-}
+import { X } from "lucide-react";
+import { getRouteConfig } from "@/components/navigation";
 
 export function WorkspaceTabs() {
     const pathname = usePathname();
@@ -101,7 +53,7 @@ export function WorkspaceTabs() {
     }
 
     return (
-        <div className="h-11 bg-[var(--background-card)] border-b border-[var(--border)] flex items-center overflow-x-auto">
+        <div className="h-11 min-w-0 bg-[var(--background-card)] border-b border-[var(--border)] flex items-center overflow-x-auto">
             <span className="text-xs font-medium text-muted uppercase tracking-wider px-3 flex-shrink-0 border-r border-[var(--border)] h-full flex items-center mr-1">Open Tabs</span>
             <div role="tablist" onKeyDown={handleKeyDown} className="flex items-center gap-0.5 px-2">
                 {tabs.map((tab) => (
@@ -126,8 +78,8 @@ interface TabItemProps {
 }
 
 function TabItem({ tab, isActive, onClose, onClick }: TabItemProps) {
-    const config = ROUTE_CONFIG[tab.href];
-    const IconComponent = config?.Icon ?? DEFAULT_ICON;
+    const config = getRouteConfig(tab.href);
+    const IconComponent = config.Icon;
 
     return (
         <div

--- a/apps/frontend/src/components/charts/NetWorthTimeSeriesChart.tsx
+++ b/apps/frontend/src/components/charts/NetWorthTimeSeriesChart.tsx
@@ -4,15 +4,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import ReactECharts from "echarts-for-react";
 
 import { apiFetch } from "@/lib/api";
-import { formatCurrencyLocale } from "@/lib/currency";
+import { amountToChartNumber, formatCurrencyLocale } from "@/lib/currency";
 import { formatDateInput, formatMonthLabel } from "@/lib/date";
 import type { NetWorthRange, NetWorthTimeSeriesResponse } from "@/lib/types";
 
 const RANGE_OPTIONS: NetWorthRange[] = ["1M", "3M", "6M", "1Y", "All"];
-
-function toNumber(value: number | string): number {
-  return typeof value === "string" ? Number(value) : value;
-}
 
 function addMonths(date: Date, months: number): Date {
   return new Date(date.getFullYear(), date.getMonth() + months, date.getDate());
@@ -55,12 +51,12 @@ export function NetWorthTimeSeriesChart() {
     fetchSeries();
   }, [fetchSeries]);
 
-  const points = data?.points ?? [];
+  const points = useMemo(() => data?.points ?? [], [data?.points]);
   const option = useMemo(() => {
     const labels = points.map((point) =>
       data?.granularity === "monthly" ? formatMonthLabel(point.date) : point.date.slice(5),
     );
-    const values = points.map((point) => toNumber(point.net_worth));
+    const values = points.map((point) => amountToChartNumber(point.net_worth));
     return {
       grid: { left: 48, right: 18, top: 24, bottom: 32 },
       tooltip: {

--- a/apps/frontend/src/components/charts/SankeyChart.tsx
+++ b/apps/frontend/src/components/charts/SankeyChart.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useMemo, useState, useEffect, useCallback } from "react";
+import { amountToChartNumber, compareAmounts } from "@/lib/currency";
 
 const ReactECharts = dynamic(
   () => import("echarts-for-react").catch(() => {
@@ -44,13 +45,6 @@ interface SankeyChartProps {
   height?: number;
 }
 
-const toNumber = (value: number | string): number => {
-  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
-  if (value === null || value === undefined) return 0;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
-
 export function SankeyChart({
   operating = [],
   investing = [],
@@ -89,8 +83,8 @@ export function SankeyChart({
     const links: { source: string; target: string; value: number }[] = [];
 
     const addCategory = (items: SankeyItem[], color: string, prefix: string) => {
-      const inflowItems = items.filter((i) => toNumber(i.amount) > 0);
-      const outflowItems = items.filter((i) => toNumber(i.amount) < 0);
+      const inflowItems = items.filter((i) => compareAmounts(i.amount, "0") > 0);
+      const outflowItems = items.filter((i) => compareAmounts(i.amount, "0") < 0);
       
       if (inflowItems.length === 0 && outflowItems.length === 0) return;
 
@@ -99,7 +93,7 @@ export function SankeyChart({
       nodes.push({ name: `${prefix}-Outflows`, itemStyle: { color: errorColor } });
 
       inflowItems.forEach((item) => {
-        const amount = toNumber(item.amount);
+        const amount = amountToChartNumber(item.amount);
         nodes.push({ name: `${prefix}-${item.subcategory}`, itemStyle: { color: foregroundMutedColor } });
         links.push({
           source: `${prefix}-Inflows`,
@@ -109,7 +103,7 @@ export function SankeyChart({
       });
 
       outflowItems.forEach((item) => {
-        const rawValue = toNumber(item.amount);
+        const rawValue = amountToChartNumber(item.amount);
         const amount = Math.abs(rawValue);
         nodes.push({ name: `${prefix}-${item.subcategory}`, itemStyle: { color: foregroundMutedColor } });
         links.push({

--- a/apps/frontend/src/components/journal/JournalEntryDetailsModal.tsx
+++ b/apps/frontend/src/components/journal/JournalEntryDetailsModal.tsx
@@ -2,7 +2,7 @@
 
 import DetailDialog from "@/components/ui/DetailDialog";
 import AuditTrailPanel from "@/components/AuditTrailPanel";
-import { formatCurrencyLocale } from "@/lib/currency";
+import { formatCurrencyLocale, sumAmounts } from "@/lib/currency";
 import { formatDateDisplay } from "@/lib/date";
 import { JournalEntry } from "@/lib/types";
 
@@ -21,10 +21,10 @@ export default function JournalEntryDetailsModal({
 
     const totalDebits = entry.lines
         .filter((l) => l.direction === "DEBIT")
-        .reduce((sum, l) => sum + l.amount, 0);
+        .map((line) => line.amount);
     const totalCredits = entry.lines
         .filter((l) => l.direction === "CREDIT")
-        .reduce((sum, l) => sum + l.amount, 0);
+        .map((line) => line.amount);
 
     const baseCurrency = entry.lines[0]?.currency || "SGD";
 
@@ -101,11 +101,11 @@ export default function JournalEntryDetailsModal({
                                         <div className="flex flex-col items-end gap-1">
                                             <div className="text-[var(--success)]">
                                                 <span className="text-[10px] uppercase mr-1">DR:</span>
-                                                {formatCurrencyLocale(totalDebits, baseCurrency)}
+                                                {formatCurrencyLocale(sumAmounts(totalDebits), baseCurrency)}
                                             </div>
                                             <div className="text-[var(--error)]">
                                                 <span className="text-[10px] uppercase mr-1">CR:</span>
-                                                {formatCurrencyLocale(totalCredits, baseCurrency)}
+                                                {formatCurrencyLocale(sumAmounts(totalCredits), baseCurrency)}
                                             </div>
                                         </div>
                                     </td>

--- a/apps/frontend/src/components/navigation.ts
+++ b/apps/frontend/src/components/navigation.ts
@@ -1,0 +1,77 @@
+import {
+    BarChart3,
+    BookOpen,
+    ClipboardCheck,
+    Clock,
+    FileText,
+    Landmark,
+    LayoutDashboard,
+    Link2,
+    MessageSquare,
+    Wallet,
+    Zap,
+    type LucideIcon,
+} from "lucide-react";
+
+export interface NavItem {
+    icon: LucideIcon;
+    label: string;
+    href: string;
+    protected: boolean;
+}
+
+export interface RouteConfig {
+    label: string;
+    Icon: LucideIcon;
+}
+
+export const primaryNavItems: NavItem[] = [
+    { icon: LayoutDashboard, label: "Dashboard", href: "/dashboard", protected: true },
+    { icon: Landmark, label: "Accounts", href: "/accounts", protected: true },
+    { icon: BookOpen, label: "Journal", href: "/journal", protected: true },
+    { icon: FileText, label: "Statements", href: "/statements", protected: true },
+    { icon: ClipboardCheck, label: "Review", href: "/review", protected: true },
+    { icon: Wallet, label: "Portfolio", href: "/portfolio", protected: true },
+    { icon: BarChart3, label: "Reports", href: "/reports", protected: true },
+    { icon: Link2, label: "Reconciliation", href: "/reconciliation", protected: true },
+    { icon: Clock, label: "Processing", href: "/processing", protected: true },
+    { icon: MessageSquare, label: "AI Advisor", href: "/chat", protected: true },
+];
+
+export const ROUTE_CONFIG: Record<string, RouteConfig> = {
+    "/dashboard": { label: "Dashboard", Icon: LayoutDashboard },
+    "/accounts": { label: "Accounts", Icon: Landmark },
+    "/journal": { label: "Journal", Icon: BookOpen },
+    "/statements": { label: "Statements", Icon: FileText },
+    "/review": { label: "Review", Icon: ClipboardCheck },
+    "/assets": { label: "Portfolio", Icon: Landmark },
+    "/portfolio": { label: "Portfolio", Icon: Wallet },
+    "/portfolio/prices": { label: "Prices", Icon: Wallet },
+    "/reports": { label: "Reports", Icon: BarChart3 },
+    "/reports/balance-sheet": { label: "Balance Sheet", Icon: BarChart3 },
+    "/reports/income-statement": { label: "Income Statement", Icon: BarChart3 },
+    "/reports/cash-flow": { label: "Cash Flow", Icon: BarChart3 },
+    "/reconciliation": { label: "Reconciliation", Icon: Link2 },
+    "/reconciliation/unmatched": { label: "Unmatched", Icon: Link2 },
+    "/reconciliation/review-queue": { label: "Review Queue", Icon: Link2 },
+    "/processing": { label: "Processing", Icon: Clock },
+    "/chat": { label: "AI Advisor", Icon: MessageSquare },
+    "/ping-pong": { label: "Ping-Pong", Icon: Zap },
+};
+
+export const DEFAULT_ROUTE_ICON = FileText;
+
+export function getRouteConfig(pathname: string): RouteConfig {
+    if (ROUTE_CONFIG[pathname]) return ROUTE_CONFIG[pathname];
+    const segments = pathname.split("/").filter(Boolean);
+    while (segments.length > 0) {
+        const parentPath = "/" + segments.join("/");
+        if (ROUTE_CONFIG[parentPath]) return ROUTE_CONFIG[parentPath];
+        segments.pop();
+    }
+    const derivedSegments = pathname.split("/").filter(Boolean);
+    const lastSegment = derivedSegments[derivedSegments.length - 1];
+    const rawLabel = lastSegment ?? "Page";
+    const label = rawLabel.replace(/[-_]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+    return { label, Icon: DEFAULT_ROUTE_ICON };
+}

--- a/apps/frontend/src/components/portfolio/HoldingsTable.tsx
+++ b/apps/frontend/src/components/portfolio/HoldingsTable.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { PortfolioHolding } from "@/lib/types";
-import { formatCurrencyLocale } from "@/lib/currency";
+import { compareAmounts, formatAmount, formatCurrencyLocale } from "@/lib/currency";
 import { formatDateDisplay } from "@/lib/date";
 
 interface HoldingsTableProps {
@@ -17,16 +17,14 @@ function formatQuantity(quantity: string): string {
 }
 
 function getPnlColor(value: string): string {
-    const num = parseFloat(value);
-    if (isNaN(num) || num === 0) return "";
-    return num > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
+    const comparison = compareAmounts(value, "0");
+    if (comparison === 0) return "";
+    return comparison > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
 }
 
 function formatPnlPercent(value: string): string {
-    const num = parseFloat(value);
-    if (isNaN(num)) return "—";
-    const sign = num > 0 ? "+" : "";
-    return `${sign}${num.toFixed(2)}%`;
+    const sign = compareAmounts(value, "0") > 0 ? "+" : "";
+    return `${sign}${formatAmount(value, 2)}%`;
 }
 
 export function HoldingsTable({ holdings, showDisposed = false }: HoldingsTableProps) {

--- a/apps/frontend/src/components/portfolio/PerformanceCard.tsx
+++ b/apps/frontend/src/components/portfolio/PerformanceCard.tsx
@@ -2,19 +2,28 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api";
+import { compareAmounts, formatAmount } from "@/lib/currency";
 import { PerformanceMetrics } from "@/lib/types";
 
+function safeComparePercent(value: string): number | null {
+    try {
+        return compareAmounts(value, "0");
+    } catch {
+        return null;
+    }
+}
+
 function formatPercent(value: string): string {
-    const num = parseFloat(value);
-    if (isNaN(num)) return "—";
-    const sign = num > 0 ? "+" : "";
-    return `${sign}${num.toFixed(2)}%`;
+    const comparison = safeComparePercent(value);
+    if (comparison === null) return "—";
+    const sign = comparison > 0 ? "+" : "";
+    return `${sign}${formatAmount(value, 2)}%`;
 }
 
 function getPercentColor(value: string): string {
-    const num = parseFloat(value);
-    if (isNaN(num) || num === 0) return "";
-    return num > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
+    const comparison = safeComparePercent(value);
+    if (comparison === null || comparison === 0) return "";
+    return comparison > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
 }
 
 export function PerformanceCard() {

--- a/apps/frontend/src/components/reconciliation/Workbench.tsx
+++ b/apps/frontend/src/components/reconciliation/Workbench.tsx
@@ -18,6 +18,11 @@ interface AnomalyResponse {
   message: string;
 }
 
+function formatQueueAmount(value: number | string): string {
+  const amount = formatAmount(value, 2);
+  return amount.endsWith(".00") ? amount.slice(0, -3) : amount;
+}
+
 export default function ReconciliationWorkbench() {
   const queryClient = useQueryClient();
   const [selected, setSelected] = useState<ReconciliationMatchResponse | null>(null);
@@ -195,7 +200,7 @@ export default function ReconciliationWorkbench() {
                       </div>
                     </div>
                     <div className="flex justify-between text-xs text-muted mt-2">
-                      <span>{match.transaction?.amount != null ? match.transaction.amount.toFixed(2) : "—"}</span>
+                      <span>{match.transaction?.amount != null ? formatQueueAmount(match.transaction.amount) : "—"}</span>
                       <span>{match.entries.length} entries</span>
                     </div>
                   </button>
@@ -210,7 +215,7 @@ export default function ReconciliationWorkbench() {
             <div className="space-y-4">
               <div className="p-3 rounded-md bg-[var(--background-muted)]">
                 <div className="flex justify-between"><span className="text-sm font-medium">Transaction</span><span className="text-xs text-[var(--accent)]">Score {selected.match_score}</span></div>
-                <div className="text-xl font-semibold mt-1 text-[var(--accent)]">{selected.transaction?.amount != null ? selected.transaction.amount.toFixed(2) : "—"}</div>
+                <div className="text-xl font-semibold mt-1 text-[var(--accent)]">{selected.transaction?.amount != null ? formatAmount(selected.transaction.amount, 2) : "—"}</div>
                 <p className="text-sm text-muted">{selected.transaction?.description}</p>
                 <p className="text-xs text-muted">{selected.transaction?.txn_date} · {selected.transaction?.direction === "IN" ? "In" : "Out"}</p>
               </div>
@@ -221,7 +226,7 @@ export default function ReconciliationWorkbench() {
                     <div className="text-xs text-[var(--accent)] uppercase tracking-wide">Ledger Entry</div>
                     <p className="font-medium text-sm">{entry.memo || "Untitled"}</p>
                     <p className="text-xs text-muted">{entry.entry_date}</p>
-                    <p className="font-semibold text-[var(--accent)]">{entry.total_amount.toFixed(2)}</p>
+                    <p className="font-semibold text-[var(--accent)]">{formatAmount(entry.total_amount, 2)}</p>
                   </div>
                 ))}
               </div>
@@ -230,7 +235,7 @@ export default function ReconciliationWorkbench() {
                 <p className="font-medium text-sm mb-2">Score Breakdown</p>
                 <div className="space-y-1 text-xs">
                   {Object.entries(selected.score_breakdown).map(([key, value]) => (
-                    <div key={key} className="flex justify-between"><span className="capitalize text-muted">{key.replace("_", " ")}</span><span className="font-semibold text-[var(--accent)]">{formatAmount(Number(value), 1)}</span></div>
+                    <div key={key} className="flex justify-between"><span className="capitalize text-muted">{key.replace("_", " ")}</span><span className="font-semibold text-[var(--accent)]">{formatAmount(value, 1)}</span></div>
                   ))}
                 </div>
               </div>

--- a/apps/frontend/src/components/review/BalanceIndicator.tsx
+++ b/apps/frontend/src/components/review/BalanceIndicator.tsx
@@ -43,7 +43,7 @@ export function BalanceIndicator({
                 <div className="text-lg font-semibold">
                     {formatCurrencyLocale(
                         validationResult
-                            ? parseFloat(validationResult.calculated_closing)
+                            ? validationResult.calculated_closing
                             : 0,
                         currency
                     )}

--- a/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
+++ b/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@/components/ui/Toast";
 import { apiFetch } from "@/lib/api";
 
 import { formatDateDisplay, formatDateTimeDisplay } from "@/lib/date";
+import { formatAmount } from "@/lib/currency";
 
 interface ConsistencyCheck {
     id: string;
@@ -29,7 +30,7 @@ interface PendingMatch {
     status: string;
     created_at: string | null;
     description?: string;
-    amount?: number;
+    amount?: number | string;
     txn_date?: string;
 }
 
@@ -654,7 +655,7 @@ export function Stage2ReviewQueue() {
                                                     {match.description || "—"}
                                                 </td>
                                                 <td className="px-4 py-2 text-right font-medium">
-                                                    {match.amount != null ? match.amount.toFixed(2) : "—"}
+                                                    {match.amount != null ? formatAmount(match.amount, 2) : "—"}
                                                 </td>
                                                 <td className="px-4 py-2 text-muted">
                                                     {match.txn_date ? formatDateDisplay(match.txn_date) : "—"}

--- a/apps/frontend/src/lib/currency.test.ts
+++ b/apps/frontend/src/lib/currency.test.ts
@@ -10,6 +10,7 @@ import {
   compareAmounts,
   isAmountZero,
   formatCurrency,
+  formatCurrencyLocale,
 } from './currency';
 
 describe('parseAmount', () => {
@@ -232,5 +233,23 @@ describe('formatCurrency', () => {
 
   it('should format negative values', () => {
     expect(formatCurrency(-50.25)).toBe('SGD -50.25');
+  });
+});
+
+describe('formatCurrencyLocale', () => {
+  it('AC2.8.2 formats large monetary strings without JS Number precision loss', () => {
+    expect(formatCurrencyLocale('9007199254740993.01', 'USD')).toBe('$9,007,199,254,740,993.01');
+  });
+
+  it('AC2.8.2 respects maximumFractionDigits without converting money through Number', () => {
+    expect(formatCurrencyLocale(new Decimal('1234567.89'), 'USD', 'en-US', { maximumFractionDigits: 0 })).toBe('$1,234,568');
+  });
+
+  it('AC2.8.2 trims optional trailing decimal zeros without converting money through Number', () => {
+    expect(formatCurrencyLocale('12.3400', 'USD', 'en-US', { maximumFractionDigits: 4 })).toBe('$12.34');
+  });
+
+  it('AC2.8.2 preserves negative monetary formatting', () => {
+    expect(formatCurrencyLocale('-42.50', 'USD')).toBe('-$42.50');
   });
 });

--- a/apps/frontend/src/lib/currency.ts
+++ b/apps/frontend/src/lib/currency.ts
@@ -1,5 +1,7 @@
 import Decimal from "decimal.js";
 
+export type MonetaryInput = Decimal | string | number;
+
 export function parseAmount(value: string | number): Decimal {
   if (value === null || value === undefined) {
     throw new Error("parseAmount received null or undefined");
@@ -23,36 +25,45 @@ export function parseAmount(value: string | number): Decimal {
   throw new Error("parseAmount received an invalid type");
 }
 
-export function formatAmount(value: Decimal | string | number, decimals = 2): string {
+export function toDecimal(value: MonetaryInput): Decimal {
+  return new Decimal(value);
+}
+
+export function amountToChartNumber(value: MonetaryInput): number {
+  const amount = new Decimal(value);
+  return amount.isFinite() ? amount.toNumber() : 0;
+}
+
+export function formatAmount(value: MonetaryInput, decimals = 2): string {
   return new Decimal(value).toFixed(decimals);
 }
 
-export function sumAmounts(amounts: (Decimal | string | number)[]): Decimal {
+export function sumAmounts(amounts: MonetaryInput[]): Decimal {
   return amounts.reduce<Decimal>((sum, val) => sum.add(new Decimal(val)), new Decimal(0));
 }
 
-export function subtractAmounts(a: Decimal | string | number, b: Decimal | string | number): Decimal {
+export function subtractAmounts(a: MonetaryInput, b: MonetaryInput): Decimal {
   return new Decimal(a).minus(b);
 }
 
-export function multiplyAmount(a: Decimal | string | number, b: Decimal | string | number): Decimal {
+export function multiplyAmount(a: MonetaryInput, b: MonetaryInput): Decimal {
   return new Decimal(a).times(b);
 }
 
-export function divideAmount(a: Decimal | string | number, b: Decimal | string | number): Decimal {
+export function divideAmount(a: MonetaryInput, b: MonetaryInput): Decimal {
   return new Decimal(a).div(b);
 }
 
-export function compareAmounts(a: Decimal | string | number, b: Decimal | string | number): number {
+export function compareAmounts(a: MonetaryInput, b: MonetaryInput): number {
   return new Decimal(a).comparedTo(b);
 }
 
-export function isAmountZero(value: Decimal | string | number, tolerance = 0.01): boolean {
+export function isAmountZero(value: MonetaryInput, tolerance = 0.01): boolean {
   return new Decimal(value).abs().lessThanOrEqualTo(tolerance);
 }
 
 export function formatCurrency(
-  value: Decimal | string | number,
+  value: MonetaryInput,
   currency: string = "SGD",
   decimals = 2
 ): string {
@@ -60,8 +71,23 @@ export function formatCurrency(
   return `${currency} ${amount}`;
 }
 
+function getLocaleSeparators(locale: string) {
+  const group = new Intl.NumberFormat(locale, { useGrouping: true })
+    .formatToParts(1000)
+    .find((part) => part.type === "group")?.value ?? ",";
+  const decimal = new Intl.NumberFormat(locale)
+    .formatToParts(1.1)
+    .find((part) => part.type === "decimal")?.value ?? ".";
+  return { group, decimal };
+}
+
+function groupIntegerPart(value: string, groupSeparator: string, useGrouping: boolean): string {
+  if (!useGrouping) return value;
+  return value.replace(/\B(?=(\d{3})+(?!\d))/g, groupSeparator);
+}
+
 export function formatCurrencyLocale(
-  value: Decimal | string | number,
+  value: MonetaryInput,
   currency: string = "SGD",
   locale: string = "en-US",
   options?: Intl.NumberFormatOptions
@@ -71,5 +97,34 @@ export function formatCurrencyLocale(
     currency,
     ...options,
   });
-  return formatter.format(Number(value));
+  const resolved = formatter.resolvedOptions();
+  const maximumFractionDigits = options?.maximumFractionDigits ?? resolved.maximumFractionDigits ?? 2;
+  const minimumFractionDigits = options?.minimumFractionDigits ?? resolved.minimumFractionDigits ?? 0;
+  const amount = new Decimal(value).toDecimalPlaces(maximumFractionDigits);
+  const [integerPart, rawFractionPart = ""] = amount.abs().toFixed(maximumFractionDigits).split(".");
+  const { group, decimal } = getLocaleSeparators(locale);
+  const groupedInteger = groupIntegerPart(integerPart, group, options?.useGrouping !== false);
+  let normalizedFractionPart = rawFractionPart;
+  while (normalizedFractionPart.length > minimumFractionDigits && normalizedFractionPart.endsWith("0")) {
+    normalizedFractionPart = normalizedFractionPart.slice(0, -1);
+  }
+  const amountText = normalizedFractionPart
+    ? `${groupedInteger}${decimal}${normalizedFractionPart}`
+    : groupedInteger;
+  let integerInserted = false;
+
+  return formatter
+    .formatToParts(amount.isNegative() ? -1 : 1)
+    .map((part) => {
+      if (part.type === "integer") {
+        if (integerInserted) return "";
+        integerInserted = true;
+        return amountText;
+      }
+      if (part.type === "group" || part.type === "decimal" || part.type === "fraction") {
+        return "";
+      }
+      return part.value;
+    })
+    .join("");
 }

--- a/docs/ssot/frontend-patterns.md
+++ b/docs/ssot/frontend-patterns.md
@@ -56,13 +56,33 @@ All API calls must go through the centralized `apiFetch` or `apiUpload` utility 
 - **Authorization**: The utility automatically injects the `Bearer <token>` header from local storage.
 - **Absolute URLs**: Use the `APP_URL` constant from `lib/api.ts` when you need to refer back to the frontend domain.
 
-## 5. Security & Authentication
+## 5. Monetary Amounts
+
+Frontend monetary display and arithmetic must use `decimal.js` through `src/lib/currency.ts`.
+
+**Rules:**
+- Do not convert money with `Number()`, `parseFloat()`, or `toFixed()` in page/component code.
+- Use `formatCurrencyLocale()` for currency display; it formats from Decimal/string values without JS number precision loss.
+- Use `sumAmounts()`, `subtractAmounts()`, `compareAmounts()`, and `toDecimal()` for monetary calculations and comparisons.
+- Chart geometry may use `amountToChartNumber()` because chart libraries require `number` coordinates; do not reuse chart numbers for accounting totals or displayed money.
+
+## 6. Responsive Navigation
+
+Desktop sidebar and mobile drawer navigation share `components/navigation.ts` as the route source of truth.
+
+**Rules:**
+- Add primary app routes once in `primaryNavItems`.
+- Add workspace tab labels/icons once in `ROUTE_CONFIG`.
+- Mobile must not render desktop workspace tabs; phone navigation uses the drawer only.
+- Do not create separate reduced mobile menus that hide core routes.
+
+## 7. Security & Authentication
 
 - **AuthGuard**: Protects all `(main)` routes. Unauthorized users are redirected to `/login`.
 - **Public Routes**: Only `/login` and `/ping-pong` are exempt from `AuthGuard`.
 - **Injection Protection**: The `apiFetch` wrapper is the primary defense against missing user context.
 
-## 6. Shared Types
+## 8. Shared Types
 
 To avoid duplication, shared interfaces are defined in `src/lib/types.ts`.
 
@@ -80,7 +100,7 @@ import { Account, AccountListResponse } from "@/lib/types";
 // components/accounts/AccountFormModal.tsx
 ```
 
-## 7. Brokerage Import Completion Path
+## 9. Brokerage Import Completion Path
 
 After a brokerage PDF is uploaded and parsed, users must be able to see the import status and navigate to their portfolio.
 
@@ -111,7 +131,7 @@ Upload PDF → Parsing (polling) → parsed/approved status
 - `src/__tests__/statementDetailPage.coverage.test.tsx` — AC17.8.1–AC17.8.3, AC17.8.5
 - `src/__tests__/portfolioPage.test.tsx` — AC17.8.4
 
-## 8. Dashboard First-Run Onboarding
+## 10. Dashboard First-Run Onboarding
 
 The Dashboard must give first-time users a direct path into the core flow instead of only rendering empty metrics.
 


### PR DESCRIPTION
## Summary

- Fix mobile shell behavior by hiding workspace tabs below the `md` breakpoint and making the mobile drawer use the same primary route metadata as the desktop sidebar.
- Add shared frontend navigation metadata so Sidebar, MobileNav, and WorkspaceTabs stay in sync.
- Remove precision-loss paths from touched monetary UI flows by routing formatting, sorting, totals, and chart conversion through Decimal-backed helpers.
- Document the monetary and responsive navigation rules in the frontend SSOT.

## Root Cause

Mobile had a reduced navigation list and still rendered workspace tab chrome in the app shell, which made the phone UI feel cramped and inconsistent with desktop. Several frontend money displays also converted API decimal strings through JS `Number`/`parseFloat`/`toFixed`, which can lose precision for monetary values.

## Validation

- `npm run lint`
- `npm run test` (80 files, 525 tests before coverage test additions)
- `npm run test:coverage` (81 files, 528 tests, 99.01% line coverage)
- `npx tsc --noEmit`
- `npm run build`
- `moon run :lint`
- `moon run :test` (1967 backend/root tests, 98.13% coverage)
- Mobile Playwright smoke at 390px: workspace tabs hidden; mobile drawer contains all expected primary nav links.