### PR TITLE
[finance_report_infra] docs(agents): require workspace scope in PR titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,8 @@ Full policy: **[docs/contributing/branch-policy.md](docs/contributing/branch-pol
 - ✅ Claim an issue in one place only: assign yourself, add a start comment with branch/worktree name.
 - ✅ `_infra` labels are local coordination tags only; they do not block GitHub assignment by themselves.
 - ✅ If naming conventions conflict with branch policy, prioritize branch/PR naming and adjust only workspace naming to keep uniqueness.
-- ✅ Use an `ongoing` label as a working lock for issue+PR pairs:
-  - Before starting: check Issue does not have `ongoing` and has no duplicate open PR on same scope.
-  - Start: assign yourself, add `ongoing`, and post a start comment containing branch/worktree name.
-  - Finish: remove `ongoing` only after branch is merged/abandoned or handed off.
-- ✅ If `ongoing` conflicts with a required naming convention or automation policy, keep branch/PR naming as authoritative and use label rules as supplemental coordination signal.
 - ✅ PR title must include workspace scope derived from directory suffix (for example `[finance_report_infra] ...`), and branch names for active work should remain scoped consistently.
+- ✅ Scope rule is local-only: only enforce title fixes for your own scope (`[finance_report_infra] ...` in this repository). Do not rewrite PRs clearly belonging to another scope.
 
 ## 🤖 Agent Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Full policy: **[docs/contributing/branch-policy.md](docs/contributing/branch-pol
   - Start: assign yourself, add `ongoing`, and post a start comment containing branch/worktree name.
   - Finish: remove `ongoing` only after branch is merged/abandoned or handed off.
 - ✅ If `ongoing` conflicts with a required naming convention or automation policy, keep branch/PR naming as authoritative and use label rules as supplemental coordination signal.
+- ✅ PR title must include workspace scope derived from directory suffix (for example `[finance_report_infra] ...`), and branch names for active work should remain scoped consistently.
 
 ## 🤖 Agent Architecture
 


### PR DESCRIPTION
## Summary
- Enforce in AGENTS: PR titles should include workspace scope derived from working directory suffix (for example: [finance_report_infra]).
- Keeps PR ownership clearer across cloned workspace windows.