### PR TITLE
[finance_report_ui] Harden mobile review UX gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,7 @@ jobs:
 
     - name: Write coverage gate summary
       if: ${{ always() }}
+      continue-on-error: true
       run: |
         {
           echo "## Coverage Gate"

--- a/apps/frontend/playwright/mobile-ux.spec.ts
+++ b/apps/frontend/playwright/mobile-ux.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const baseEntry = {
+  id: "entry-mobile",
+  entry_date: "2026-06-01",
+  status: "posted",
+  source_type: "manual_adjustment",
+  memo: "Mobile review sample entry",
+  created_at: "2026-06-01T08:00:00Z",
+  lines: [
+    {
+      id: "line-debit",
+      account_id: "assets:cash:very-long-account-identifier-for-mobile",
+      direction: "DEBIT",
+      amount: "123456.78",
+      currency: "SGD",
+    },
+    {
+      id: "line-credit",
+      account_id: "income:salary:very-long-account-identifier-for-mobile",
+      direction: "CREDIT",
+      amount: "123456.78",
+      currency: "SGD",
+    },
+  ],
+};
+
+async function installMobileApiMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("finance_access_token", "mobile-review-token");
+    localStorage.setItem("finance_user_id", "mobile-user");
+    localStorage.setItem("finance_user_email", "mobile@example.com");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    let body: unknown = {};
+
+    if (path === "/api/ai/suggestions") {
+      body = {
+        items: [
+          {
+            suggestion_id: "suggestion-mobile",
+            transaction: "Long mobile transaction description from a bank statement",
+            suggested_category_or_match: "Meals and entertainment",
+            ai_score: 72,
+            ai_reasoning: "Merchant category and prior corrections suggest this classification.",
+          },
+        ],
+      };
+    } else if (path.startsWith("/api/journal-entries")) {
+      body = { items: [baseEntry], total: 1 };
+    } else if (path.startsWith("/api/transactions/") && path.endsWith("/audit")) {
+      body = { items: [] };
+    } else if (path === "/api/statements/pending-review") {
+      body = { items: [], total: 0 };
+    } else if (path === "/api/statements/stage2/queue") {
+      body = { pending_matches: [] };
+    } else if (path === "/api/accounts/processing/summary") {
+      body = { current_balance: "0.00", pending_total: "0.00" };
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+async function expectNoDocumentHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    scrollX: window.scrollX,
+  }));
+
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.scrollX).toBe(0);
+}
+
+async function gotoReady(page: Page, path: string) {
+  await page.goto(path, { waitUntil: "networkidle" });
+}
+
+test.use({
+  viewport: { width: 390, height: 844 },
+  isMobile: true,
+  hasTouch: true,
+});
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeEach(async ({ page }) => {
+  await installMobileApiMocks(page);
+});
+
+test("AC16.25.1 mobile review routes avoid document horizontal scrolling", async ({ page }) => {
+  await gotoReady(page, "/review/ai-suggestions");
+  await expect(page.getByTestId("ai-suggestions-mobile-list")).toBeVisible();
+  await expectNoDocumentHorizontalScroll(page);
+  await page.getByLabel("Open navigation menu").click();
+  await expect(page.getByRole("dialog", { name: "Finance Report" })).toBeVisible();
+  await expectNoDocumentHorizontalScroll(page);
+  await page.getByRole("button", { name: "Close panel" }).click();
+
+  await gotoReady(page, "/journal");
+  await page.getByText("Mobile review sample entry").click();
+  await expect(page.getByTestId("journal-lines-mobile")).toBeVisible();
+  await expectNoDocumentHorizontalScroll(page);
+});
+
+test("AC16.25.2 AI suggestions mobile cards expose feedback actions", async ({ page }) => {
+  await gotoReady(page, "/review/ai-suggestions");
+
+  const card = page.getByTestId("ai-suggestion-mobile-card-suggestion-mobile");
+  await expect(card).toBeVisible();
+  await expect(card.getByText("Long mobile transaction description")).toBeVisible();
+  await expect(card.getByLabel("Corrected value")).toBeVisible();
+  await expect(card.getByRole("button", { name: "Accept", exact: true })).toBeVisible();
+  await expect(card.getByRole("button", { name: "Reject", exact: true })).toBeVisible();
+  await expect(card.getByRole("button", { name: "Edit-then-Accept", exact: true })).toBeVisible();
+  await expectNoDocumentHorizontalScroll(page);
+});

--- a/apps/frontend/src/__tests__/detailViewComponents.test.tsx
+++ b/apps/frontend/src/__tests__/detailViewComponents.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { describe, expect, it, vi } from "vitest"
 
@@ -93,14 +93,43 @@ describe("JournalEntryDetailsModal", () => {
     expect(screen.getByText("No memo")).toBeInTheDocument()
 
     
-    expect(screen.getByText("a1")).toBeInTheDocument()
-    expect(screen.getByText("DEBIT")).toBeInTheDocument()
-    expect(screen.getByText("a2")).toBeInTheDocument()
-    expect(screen.getByText("CREDIT")).toBeInTheDocument()
+    expect(screen.getAllByText("a1").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("DEBIT").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("a2").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("CREDIT").length).toBeGreaterThan(0)
 
     
     expect(screen.getByText(/DR:/)).toBeInTheDocument()
     expect(screen.getByText(/CR:/)).toBeInTheDocument()
+  })
+
+  it("AC16.25.3 journal entry details mobile line cards expose all line fields", () => {
+    const lines: JournalLine[] = [
+      { id: "line-debit", account_id: "assets:cash:mobile", direction: "DEBIT", amount: 1234.56, currency: "SGD" },
+      { id: "line-credit", account_id: "income:salary:mobile", direction: "CREDIT", amount: 1234.56, currency: "SGD" },
+    ]
+    const entry: JournalEntry = {
+      id: "je-mobile",
+      entry_date: "2026-06-01",
+      memo: "Mobile detail entry",
+      source_type: "manual_adjustment",
+      status: "posted",
+      lines,
+      created_at: "2026-06-01T08:00:00Z",
+    }
+
+    render(<JournalEntryDetailsModal entry={entry} isOpen onClose={vi.fn()} />)
+
+    const mobileLines = screen.getByTestId("journal-lines-mobile")
+    const debitCard = within(mobileLines).getByTestId("journal-line-mobile-line-debit")
+    const creditCard = within(mobileLines).getByTestId("journal-line-mobile-line-credit")
+
+    expect(within(debitCard).getByText("assets:cash:mobile")).toBeInTheDocument()
+    expect(within(debitCard).getByText("DEBIT")).toBeInTheDocument()
+    expect(within(debitCard).getByText(/1,234\.56/)).toBeInTheDocument()
+    expect(within(debitCard).getByText("SGD")).toBeInTheDocument()
+    expect(within(creditCard).getByText("income:salary:mobile")).toBeInTheDocument()
+    expect(within(creditCard).getByText("CREDIT")).toBeInTheDocument()
   })
 
   it("handles different statuses rendering badge variants", () => {

--- a/apps/frontend/src/__tests__/rootLayout.test.tsx
+++ b/apps/frontend/src/__tests__/rootLayout.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 
-import RootLayout from "@/app/layout"
+import RootLayout, { metadata, viewport } from "@/app/layout"
 
 vi.mock("next/font/google", () => ({
   Inter: () => ({ variable: "--font-inter" }),
@@ -27,5 +27,18 @@ describe("RootLayout", () => {
     expect(screen.getByTestId("providers")).toBeInTheDocument()
     expect(screen.getByTestId("auth-guard")).toBeInTheDocument()
     expect(screen.getByText("Root Child")).toBeInTheDocument()
+  })
+
+  it("AC16.25.4 root layout metadata keeps viewport-only theme color", () => {
+    expect(metadata).not.toHaveProperty("themeColor")
+    expect(viewport.themeColor).toBe("#7c3aed")
+    expect(metadata.appleWebApp).toEqual({
+      capable: true,
+      title: "Finance Report",
+      statusBarStyle: "default",
+    })
+    expect(metadata.other).toEqual({
+      "mobile-web-app-capable": "yes",
+    })
   })
 })

--- a/apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx
+++ b/apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import AiSuggestionsPage from "@/app/(main)/review/ai-suggestions/page";
@@ -83,9 +83,9 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
 
     render(<AiSuggestionsPage />);
 
-    expect(await screen.findByText("CARD PURCHASE COFFEE")).toBeInTheDocument();
-    expect(screen.getByText("Expense - Food & Dining")).toBeInTheDocument();
-    expect(screen.getByText("Merchant name indicates dining.")).toBeInTheDocument();
+    expect((await screen.findAllByText("CARD PURCHASE COFFEE")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Expense - Food & Dining").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Merchant name indicates dining.").length).toBeGreaterThan(0);
   });
 
   it("AC18.5.4 — feedback POST on accept/reject/edit", async () => {
@@ -108,17 +108,64 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
 
     render(<AiSuggestionsPage />);
 
-    await screen.findByText("PAYNOW TRANSFER");
-    fireEvent.click(screen.getByRole("button", { name: "Accept" }));
-    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
-    fireEvent.change(screen.getByLabelText("Corrected value"), { target: { value: "Expense - Transport" } });
-    fireEvent.click(screen.getByRole("button", { name: "Edit-then-Accept" }));
+    await screen.findAllByText("PAYNOW TRANSFER");
+    const mobileCard = screen.getByTestId("ai-suggestion-mobile-card-00000000-0000-0000-0000-000000000012");
+    fireEvent.click(within(mobileCard).getByRole("button", { name: "Accept" }));
+    fireEvent.click(within(mobileCard).getByRole("button", { name: "Reject" }));
+    fireEvent.change(within(mobileCard).getByLabelText("Corrected value"), { target: { value: "Expense - Transport" } });
+    fireEvent.click(within(mobileCard).getByRole("button", { name: "Edit-then-Accept" }));
 
     await waitFor(() =>
       expect(mockedApiFetch).toHaveBeenCalledWith("/api/ai/feedback", {
         method: "POST",
         body: JSON.stringify({
           suggestion_id: "00000000-0000-0000-0000-000000000012",
+          action: "edit_accept",
+          corrected_value: { value: "Expense - Transport" },
+        }),
+      }),
+    );
+  });
+
+  it("AC16.25.2 — AI suggestions mobile cards expose feedback actions", async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce({
+        items: [
+          {
+            suggestion_id: "00000000-0000-0000-0000-000000000025",
+            transaction: "MOBILE CARD PURCHASE",
+            suggested_category_or_match: "Expense - Food & Dining",
+            ai_score: 72,
+            ai_reasoning: "Merchant category and prior corrections match dining.",
+          },
+        ],
+        total: 1,
+      })
+      .mockResolvedValueOnce({ id: "feedback-accept" })
+      .mockResolvedValueOnce({ id: "feedback-reject" })
+      .mockResolvedValueOnce({ id: "feedback-edit" });
+
+    render(<AiSuggestionsPage />);
+
+    const mobileList = await screen.findByTestId("ai-suggestions-mobile-list");
+    const mobileCard = within(mobileList).getByTestId(
+      "ai-suggestion-mobile-card-00000000-0000-0000-0000-000000000025",
+    );
+
+    expect(within(mobileCard).getByText("MOBILE CARD PURCHASE")).toBeInTheDocument();
+    expect(within(mobileCard).getByLabelText("Corrected value")).toBeInTheDocument();
+    fireEvent.click(within(mobileCard).getByRole("button", { name: "Accept" }));
+    fireEvent.click(within(mobileCard).getByRole("button", { name: "Reject" }));
+    fireEvent.change(within(mobileCard).getByLabelText("Corrected value"), {
+      target: { value: "Expense - Transport" },
+    });
+    fireEvent.click(within(mobileCard).getByRole("button", { name: "Edit-then-Accept" }));
+
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenCalledWith("/api/ai/feedback", {
+        method: "POST",
+        body: JSON.stringify({
+          suggestion_id: "00000000-0000-0000-0000-000000000025",
           action: "edit_accept",
           corrected_value: { value: "Expense - Transport" },
         }),

--- a/apps/frontend/src/app/(main)/review/ai-suggestions/page.tsx
+++ b/apps/frontend/src/app/(main)/review/ai-suggestions/page.tsx
@@ -12,6 +12,8 @@ interface AiSuggestion {
   ai_reasoning: string;
 }
 
+type FeedbackAction = "accept" | "reject" | "edit_accept";
+
 export default function AiSuggestionsPage() {
   const [suggestions, setSuggestions] = useState<AiSuggestion[]>([]);
   const [correctedValues, setCorrectedValues] = useState<Record<string, string>>({});
@@ -35,7 +37,7 @@ export default function AiSuggestionsPage() {
     fetchSuggestions();
   }, [fetchSuggestions]);
 
-  const submitFeedback = async (suggestion: AiSuggestion, action: "accept" | "reject" | "edit_accept") => {
+  const submitFeedback = async (suggestion: AiSuggestion, action: FeedbackAction) => {
     const corrected = correctedValues[suggestion.suggestion_id]?.trim();
     await apiFetch("/api/ai/feedback", {
       method: "POST",
@@ -47,16 +49,53 @@ export default function AiSuggestionsPage() {
     });
   };
 
+  const renderCorrectionInput = (suggestion: AiSuggestion, surface: "mobile" | "table") => {
+    const inputId = `corrected-${surface}-${suggestion.suggestion_id}`;
+
+    return (
+      <>
+        <label className="sr-only" htmlFor={inputId}>Corrected value</label>
+        <input
+          id={inputId}
+          aria-label="Corrected value"
+          className="input py-2 text-sm"
+          value={correctedValues[suggestion.suggestion_id] ?? ""}
+          onChange={(event) =>
+            setCorrectedValues((current) => ({
+              ...current,
+              [suggestion.suggestion_id]: event.target.value,
+            }))
+          }
+          placeholder="Optional correction"
+        />
+      </>
+    );
+  };
+
+  const renderActionButtons = (suggestion: AiSuggestion, className = "") => (
+    <div className={`grid grid-cols-2 gap-2 sm:flex sm:justify-end ${className}`}>
+      <button type="button" className="btn-primary text-xs whitespace-nowrap" onClick={() => submitFeedback(suggestion, "accept")}>
+        Accept
+      </button>
+      <button type="button" className="btn-secondary text-xs whitespace-nowrap" onClick={() => submitFeedback(suggestion, "reject")}>
+        Reject
+      </button>
+      <button type="button" className="btn-secondary col-span-2 text-xs whitespace-nowrap" onClick={() => submitFeedback(suggestion, "edit_accept")}>
+        Edit-then-Accept
+      </button>
+    </div>
+  );
+
   if (loading) {
     return (
-      <div className="p-6">
-        <div className="card p-8 text-center text-muted">Loading AI suggestions...</div>
+      <div className="p-4 md:p-6">
+        <div className="card p-6 text-center text-muted md:p-8">Loading AI suggestions...</div>
       </div>
     );
   }
 
   return (
-    <div className="p-6">
+    <div className="p-4 md:p-6">
       <div className="page-header">
         <h1 className="page-title">AI Suggestion Review Queue</h1>
         <p className="page-description">Review AI classifications and reconciliation matches in the 60-84 score band.</p>
@@ -68,59 +107,74 @@ export default function AiSuggestionsPage() {
         {suggestions.length === 0 ? (
           <div className="p-8 text-center text-muted">No pending AI suggestions</div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[760px] text-sm">
-              <thead className="bg-[var(--background-muted)]/50 border-b border-[var(--border)]">
-                <tr>
-                  <th className="text-left px-4 py-3">Transaction</th>
-                  <th className="text-left px-4 py-3">Suggestion</th>
-                  <th className="text-left px-4 py-3">AI Score</th>
-                  <th className="text-left px-4 py-3">AI Reasoning</th>
-                  <th className="text-left px-4 py-3">Corrected value</th>
-                  <th className="text-right px-4 py-3">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[var(--border)]">
-                {suggestions.map((suggestion) => (
-                  <tr key={suggestion.suggestion_id}>
-                    <td className="px-4 py-3 font-medium">{suggestion.transaction}</td>
-                    <td className="px-4 py-3">{suggestion.suggested_category_or_match}</td>
-                    <td className="px-4 py-3 text-[var(--warning)] font-semibold">{suggestion.ai_score}</td>
-                    <td className="px-4 py-3 text-muted">{suggestion.ai_reasoning}</td>
-                    <td className="px-4 py-3 min-w-[220px]">
-                      <label className="sr-only" htmlFor={`corrected-${suggestion.suggestion_id}`}>Corrected value</label>
-                      <input
-                        id={`corrected-${suggestion.suggestion_id}`}
-                        aria-label="Corrected value"
-                        className="input py-1 text-sm"
-                        value={correctedValues[suggestion.suggestion_id] ?? ""}
-                        onChange={(event) =>
-                          setCorrectedValues((current) => ({
-                            ...current,
-                            [suggestion.suggestion_id]: event.target.value,
-                          }))
-                        }
-                        placeholder="Optional correction"
-                      />
-                    </td>
-                    <td className="px-4 py-3 min-w-[220px]">
-                      <div className="flex justify-end gap-2">
-                        <button type="button" className="btn-primary text-xs whitespace-nowrap" onClick={() => submitFeedback(suggestion, "accept")}>
-                          Accept
-                        </button>
-                        <button type="button" className="btn-secondary text-xs whitespace-nowrap" onClick={() => submitFeedback(suggestion, "reject")}>
-                          Reject
-                        </button>
-                        <button type="button" className="btn-secondary text-xs whitespace-nowrap" onClick={() => submitFeedback(suggestion, "edit_accept")}>
-                          Edit-then-Accept
-                        </button>
-                      </div>
-                    </td>
+          <>
+            <div data-testid="ai-suggestions-mobile-list" className="divide-y divide-[var(--border)] md:hidden">
+              {suggestions.map((suggestion) => (
+                <article
+                  key={suggestion.suggestion_id}
+                  data-testid={`ai-suggestion-mobile-card-${suggestion.suggestion_id}`}
+                  className="space-y-4 p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-xs font-medium uppercase text-muted">Transaction</p>
+                      <p className="mt-1 break-words font-medium">{suggestion.transaction}</p>
+                    </div>
+                    <div className="flex-shrink-0 rounded-md bg-[var(--warning-muted)] px-2.5 py-1 text-sm font-semibold text-[var(--warning)]">
+                      {suggestion.ai_score}
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-3 text-sm">
+                    <div>
+                      <p className="text-xs font-medium uppercase text-muted">Suggestion</p>
+                      <p className="mt-1 break-words">{suggestion.suggested_category_or_match}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase text-muted">Reasoning</p>
+                      <p className="mt-1 break-words text-muted">{suggestion.ai_reasoning}</p>
+                    </div>
+                  </div>
+
+                  <div className="space-y-3">
+                    {renderCorrectionInput(suggestion, "mobile")}
+                    {renderActionButtons(suggestion)}
+                  </div>
+                </article>
+              ))}
+            </div>
+
+            <div className="hidden overflow-x-auto md:block">
+              <table className="w-full min-w-[760px] text-sm">
+                <thead className="bg-[var(--background-muted)]/50 border-b border-[var(--border)]">
+                  <tr>
+                    <th className="text-left px-4 py-3">Transaction</th>
+                    <th className="text-left px-4 py-3">Suggestion</th>
+                    <th className="text-left px-4 py-3">AI Score</th>
+                    <th className="text-left px-4 py-3">AI Reasoning</th>
+                    <th className="text-left px-4 py-3">Corrected value</th>
+                    <th className="text-right px-4 py-3">Actions</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody className="divide-y divide-[var(--border)]">
+                  {suggestions.map((suggestion) => (
+                    <tr key={suggestion.suggestion_id}>
+                      <td className="px-4 py-3 font-medium">{suggestion.transaction}</td>
+                      <td className="px-4 py-3">{suggestion.suggested_category_or_match}</td>
+                      <td className="px-4 py-3 text-[var(--warning)] font-semibold">{suggestion.ai_score}</td>
+                      <td className="px-4 py-3 text-muted">{suggestion.ai_reasoning}</td>
+                      <td className="px-4 py-3 min-w-[220px]">
+                        {renderCorrectionInput(suggestion, "table")}
+                      </td>
+                      <td className="px-4 py-3 min-w-[240px]">
+                        {renderActionButtons(suggestion)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
   title: "Finance Report",
   description: "Personal financial management",
   manifest: "/site.webmanifest",
-  themeColor: "#7c3aed",
   icons: {
     icon: "/icon.svg",
     apple: "/apple-touch-icon.png",
@@ -27,7 +26,6 @@ export const metadata: Metadata = {
   },
   other: {
     "mobile-web-app-capable": "yes",
-    "apple-mobile-web-app-capable": "yes",
   },
 };
 
@@ -35,6 +33,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
+  themeColor: "#7c3aed",
 };
 
 export default function RootLayout({

--- a/apps/frontend/src/components/journal/JournalEntryDetailsModal.tsx
+++ b/apps/frontend/src/components/journal/JournalEntryDetailsModal.tsx
@@ -68,7 +68,49 @@ export default function JournalEntryDetailsModal({
 
                 <div>
                     <h4 className="font-semibold mb-3">Lines</h4>
-                    <div className="border border-[var(--border)] rounded-lg overflow-x-auto">
+                    <div data-testid="journal-lines-mobile" className="space-y-3 md:hidden">
+                        {entry.lines.map((line) => (
+                            <div
+                                key={line.id}
+                                data-testid={`journal-line-mobile-${line.id}`}
+                                className="rounded-lg border border-[var(--border)] bg-[var(--background-card)] p-4"
+                            >
+                                <div className="flex items-start justify-between gap-3">
+                                    <div className="min-w-0">
+                                        <p className="text-xs font-medium uppercase text-muted">Account</p>
+                                        <p className="mt-1 break-all font-mono text-xs">{line.account_id}</p>
+                                    </div>
+                                    <span className={`badge flex-shrink-0 ${line.direction === "DEBIT" ? "badge-success" : "badge-error"}`}>
+                                        {line.direction}
+                                    </span>
+                                </div>
+                                <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                                    <div>
+                                        <p className="text-xs font-medium uppercase text-muted">Amount</p>
+                                        <p className={`mt-1 font-semibold ${line.direction === "DEBIT" ? "text-[var(--success)]" : "text-[var(--error)]"}`}>
+                                            {formatCurrencyLocale(line.amount, line.currency)}
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p className="text-xs font-medium uppercase text-muted">Currency</p>
+                                        <p className="mt-1 text-muted">{line.currency}</p>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                        <div className="rounded-lg border border-[var(--border)] bg-[var(--background-muted)]/30 p-4 text-sm">
+                            <p className="text-xs font-medium uppercase text-muted">Totals</p>
+                            <div className="mt-2 flex items-center justify-between gap-3 text-[var(--success)]">
+                                <span>DR</span>
+                                <span className="font-semibold">{formatCurrencyLocale(sumAmounts(totalDebits), baseCurrency)}</span>
+                            </div>
+                            <div className="mt-1 flex items-center justify-between gap-3 text-[var(--error)]">
+                                <span>CR</span>
+                                <span className="font-semibold">{formatCurrencyLocale(sumAmounts(totalCredits), baseCurrency)}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="hidden border border-[var(--border)] rounded-lg overflow-x-auto md:block">
                         <table className="w-full min-w-[640px] text-sm text-left">
                             <thead className="bg-[var(--background-muted)]/50 text-muted font-medium border-b border-[var(--border)]">
                                 <tr>

--- a/common/ssot/lint_doc_consistency.py
+++ b/common/ssot/lint_doc_consistency.py
@@ -16,8 +16,8 @@ Hard-fail checks enforced in CI:
      two registries (no dangling AC IDs in EPIC docs).
   5. Every AC ID present in either registry MUST appear at least once
      under apps/backend/tests/, apps/frontend/src/__tests__/,
-     tests/tooling/, or tests/e2e/, unless the AC is marked ``deprecated``
-     (full traceability).
+     apps/frontend/playwright/, tests/tooling/, or tests/e2e/, unless the
+     AC is marked ``deprecated`` (full traceability).
   6. Every ``ACx.y.z`` referenced from a test file MUST exist in one of
      the two registries AND its ``epic`` field MUST equal ``x`` (the
      epic prefix of the AC ID). Test fixtures under ``tests/tooling/``
@@ -78,6 +78,7 @@ TRACEABILITY_EXCEPTIONS = REPO_ROOT / "docs" / "analysis" / "traceability-except
 TEST_ROOTS = [
     REPO_ROOT / "apps" / "backend" / "tests",
     REPO_ROOT / "apps" / "frontend" / "src" / "__tests__",
+    REPO_ROOT / "apps" / "frontend" / "playwright",
     REPO_ROOT / "tests" / "tooling",
     REPO_ROOT / "tests" / "e2e",
 ]
@@ -87,6 +88,10 @@ NO_AC_SCAN_TARGETS: tuple[tuple[Path, tuple[str, ...]], ...] = (
     (
         REPO_ROOT / "apps" / "frontend" / "src",
         ("**/*.test.ts", "**/*.test.tsx"),
+    ),
+    (
+        REPO_ROOT / "apps" / "frontend" / "playwright",
+        ("**/*.spec.ts", "**/*.spec.tsx"),
     ),
     (REPO_ROOT / "tests" / "tooling", ("**/*.py",)),
     (REPO_ROOT / "tests" / "e2e", ("**/*.py",)),
@@ -300,6 +305,10 @@ def discover_no_ac_test_files(
             (
                 REPO_ROOT / "apps" / "frontend" / "src",
                 ("**/*.test.ts", "**/*.test.tsx"),
+            ),
+            (
+                REPO_ROOT / "apps" / "frontend" / "playwright",
+                ("**/*.spec.ts", "**/*.spec.tsx"),
             ),
             (REPO_ROOT / "tests" / "tooling", ("**/*.py",)),
             (REPO_ROOT / "tests" / "e2e", ("**/*.py",)),
@@ -525,7 +534,8 @@ def check_registry_to_tests(
                     message=(
                         f"{ac_id}: present in registry but not referenced "
                         "by any test under apps/backend/tests/, "
-                        "apps/frontend/src/__tests__/, or tests/tooling/"
+                        "apps/frontend/src/__tests__/, apps/frontend/playwright/, "
+                        "or tests/tooling/"
                     ),
                 )
             )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:3001}
       CORS_ORIGIN_REGEX: ${CORS_ORIGIN_REGEX:-https://.*\.zitian\.party}
       DEBUG: ${DEBUG:-false}
+      GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-unknown}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-finance-report-backend}
       OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-deployment.environment=development}

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2200,6 +2200,12 @@ groups:
         epic_name: testing-strategy
         description: Scheduled PR preview cleanup is limited to closed-PR reconciliation and no longer owns generic host hygiene.
         mandatory: true
+      - id: AC8.13.75
+        epic: 8
+        epic_name: testing-strategy
+        description: Reporting-only coverage gate summary cannot fail the final CI aggregation job if GitHub Step Summary
+          writes fail.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1
@@ -3821,6 +3827,29 @@ groups:
         epic_name: two-stage-review-ui
         description: Stage 2 batch approval routes accepted matches through the ledger-safe acceptance path, creating missing
           journal entries
+        mandatory: true
+    AC16.25:
+      - id: AC16.25.1
+        epic: 16
+        epic_name: two-stage-review-ui
+        description: Review, journal details, and mobile navigation surfaces do not create document-level horizontal scrolling
+          at phone width
+        mandatory: true
+      - id: AC16.25.2
+        epic: 16
+        epic_name: two-stage-review-ui
+        description: AI suggestion review queue exposes accept, reject, correction, and edit-accept actions directly in a
+          mobile card layout
+        mandatory: true
+      - id: AC16.25.3
+        epic: 16
+        epic_name: two-stage-review-ui
+        description: Journal entry details expose line account, direction, amount, and currency as mobile line cards
+        mandatory: true
+      - id: AC16.25.4
+        epic: 16
+        epic_name: two-stage-review-ui
+        description: Root layout keeps theme color in the viewport export and avoids duplicate iOS web-app capability metadata
         mandatory: true
   AC17:
     AC17.1:

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -114,6 +114,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.72**: Dokploy deploy diagnostics redact raw responses and log only allowlisted effective environment diffs.
 - **AC8.13.73**: VPS host hygiene is a credential-free local systemd timer for generic Docker and journal garbage.
 - **AC8.13.74**: Scheduled PR preview cleanup is limited to closed-PR reconciliation and no longer owns generic host hygiene.
+- **AC8.13.75**: Reporting-only coverage gate summary cannot fail the final CI aggregation job if GitHub Step Summary writes fail.
 
 Current test and AC coverage status is generated, not hand-maintained here.
 Use `docs/analysis/test-ac-coverage-report.md`,
@@ -470,6 +471,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.72 | Dokploy deploy diagnostics redact raw responses and log only allowlisted effective environment diffs | `test_AC8_13_72_*` | `tests/tooling/test_dokploy_redaction.py`, `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
 | AC8.13.73 | VPS host hygiene is a credential-free local systemd timer for generic Docker and journal garbage | `test_AC8_13_73_*` | `tests/tooling/test_vps_host_hygiene.py` | P0 |
 | AC8.13.74 | Scheduled PR preview cleanup is limited to closed-PR reconciliation and no longer owns generic host hygiene | `test_AC8_13_74_*` | `tests/tooling/test_pr_preview_lifecycle.py`, `tests/tooling/test_vps_host_hygiene.py` | P0 |
+| AC8.13.75 | Reporting-only coverage gate summary cannot fail the final CI aggregation job if GitHub Step Summary writes fail | `test_AC8_13_75_coverage_gate_summary_is_nonblocking` | `tests/tooling/test_post_merge_e2e_gates.py` | P1 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -656,6 +656,15 @@ delivery status table.
 | AC16.22.5 | Stage 1 tolerance is 0.001 USD (not 0.10 USD from Stage 2) | `test_validate_balance_chain_within_tolerance` | `review/test_statement_validation.py` | P0 |
 | AC16.22.6 | All service methods mutating `pending_review` enforce `user_id` ownership | `test_get_statement_for_update_wrong_user_raises` | `review/test_statement_validation.py` | P1 |
 
+### AC16.25 — Mobile Review UX Hardening
+
+| AC ID | Description | Test Function | File | Priority |
+|-------|-------------|---------------|------|----------|
+| AC16.25.1 | Review, journal details, and mobile navigation surfaces do not create document-level horizontal scrolling at phone widths | `AC16.25.1 mobile review routes avoid document horizontal scrolling` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 |
+| AC16.25.2 | AI suggestion review queue exposes accept, reject, correction, and edit-accept actions directly in a mobile card layout | `AC16.25.2 AI suggestions mobile cards expose feedback actions` | `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx` | P0 |
+| AC16.25.3 | Journal entry details expose line account, direction, amount, and currency as mobile line cards | `AC16.25.3 journal entry details mobile line cards expose all line fields` | `apps/frontend/src/__tests__/detailViewComponents.test.tsx` | P1 |
+| AC16.25.4 | Root layout keeps theme color in the viewport export and avoids duplicate iOS web-app capability metadata | `AC16.25.4 root layout metadata keeps viewport-only theme color` | `apps/frontend/src/__tests__/rootLayout.test.tsx` | P1 |
+
 
 ---
 

--- a/docs/ssot/frontend-patterns.md
+++ b/docs/ssot/frontend-patterns.md
@@ -76,13 +76,44 @@ Desktop sidebar and mobile drawer navigation share `components/navigation.ts` as
 - Mobile must not render desktop workspace tabs; phone navigation uses the drawer only.
 - Do not create separate reduced mobile menus that hide core routes.
 
-## 7. Security & Authentication
+## 7. Mobile Review Surfaces
+
+Review and journal workflows must be usable at phone widths without relying on
+document-level horizontal scrolling.
+
+**Rules:**
+- Key review routes and dialogs must keep `document.documentElement.scrollWidth`
+  less than or equal to `clientWidth` at 375-390 px viewports.
+- Desktop data tables may remain tables at `md` and wider breakpoints.
+- Phone layouts for action-heavy review queues should use stacked cards so
+  primary actions and correction inputs are visible without horizontal dragging.
+- Dense accounting details may keep desktop tables, but phone layouts must expose
+  account, direction, amount, and currency as readable line cards.
+- Use Playwright for route-level mobile overflow checks and component tests for
+  mobile card affordances.
+
+**Applied In:**
+- `app/(main)/review/ai-suggestions/page.tsx`
+- `components/journal/JournalEntryDetailsModal.tsx`
+- `playwright/mobile-ux.spec.ts`
+
+## 8. App Metadata & PWA Head Tags
+
+Root app metadata lives in `app/layout.tsx`.
+
+**Rules:**
+- Keep PWA manifest and icon metadata in the `metadata` export.
+- Keep viewport-related fields, including `themeColor`, in the `viewport` export.
+- Use `appleWebApp` for iOS web-app capability metadata; do not duplicate
+  `apple-mobile-web-app-capable` in `metadata.other`.
+
+## 9. Security & Authentication
 
 - **AuthGuard**: Protects all `(main)` routes. Unauthorized users are redirected to `/login`.
 - **Public Routes**: Only `/login` and `/ping-pong` are exempt from `AuthGuard`.
 - **Injection Protection**: The `apiFetch` wrapper is the primary defense against missing user context.
 
-## 8. Shared Types
+## 10. Shared Types
 
 To avoid duplication, shared interfaces are defined in `src/lib/types.ts`.
 
@@ -100,7 +131,7 @@ import { Account, AccountListResponse } from "@/lib/types";
 // components/accounts/AccountFormModal.tsx
 ```
 
-## 9. Brokerage Import Completion Path
+## 11. Brokerage Import Completion Path
 
 After a brokerage PDF is uploaded and parsed, users must be able to see the import status and navigate to their portfolio.
 
@@ -131,7 +162,7 @@ Upload PDF → Parsing (polling) → parsed/approved status
 - `src/__tests__/statementDetailPage.coverage.test.tsx` — AC17.8.1–AC17.8.3, AC17.8.5
 - `src/__tests__/portfolioPage.test.tsx` — AC17.8.4
 
-## 10. Dashboard First-Run Onboarding
+## 12. Dashboard First-Run Onboarding
 
 The Dashboard must give first-time users a direct path into the core flow instead of only rendering empty metrics.
 

--- a/tests/tooling/test_lint_doc_consistency.py
+++ b/tests/tooling/test_lint_doc_consistency.py
@@ -16,6 +16,17 @@ from unittest import mock
 from common.ssot import lint_doc_consistency as ldc
 
 
+def test_AC16_25_1_playwright_specs_are_traceability_test_roots() -> None:
+    """AC16.25.1: Frontend Playwright mobile specs count as AC proof."""
+    playwright_root = ldc.REPO_ROOT / "apps" / "frontend" / "playwright"
+
+    assert playwright_root in ldc.TEST_ROOTS
+    assert any(
+        base == playwright_root and "**/*.spec.ts" in patterns
+        for base, patterns in ldc.NO_AC_SCAN_TARGETS
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -889,6 +889,20 @@ def test_AC8_13_27_coveralls_uploads_are_reporting_only() -> None:
     assert "merge readiness follows the `finish` check" in readme
 
 
+def test_AC8_13_75_coverage_gate_summary_is_nonblocking() -> None:
+    """AC8.13.75: Coverage summary display cannot fail final CI aggregation."""
+    workflow = read(".github/workflows/ci.yml")
+
+    summary_block = workflow.split("- name: Write coverage gate summary", 1)[1].split(
+        "- name: Check job status", 1
+    )[0]
+
+    assert "if: ${{ always() }}" in summary_block
+    assert "continue-on-error: true" in summary_block
+    assert "Authoritative coverage gate" in summary_block
+    assert "reporting-only" in summary_block
+
+
 def test_AC8_13_66_coveralls_uploads_use_line_only_lcov() -> None:
     """AC8.13.66: Coveralls reports the same line-only metric as the CI gate."""
     workflow = read(".github/workflows/ci.yml")

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -41,6 +41,16 @@ def test_AC8_13_71_preview_env_contains_stable_metadata() -> None:
     assert env["COMPOSE_PROFILES"] == "infra,app"
 
 
+def test_AC8_13_71_root_compose_passes_git_sha_to_backend_runtime() -> None:
+    compose = (ROOT / "docker-compose.yml").read_text()
+    backend_block = compose.split("  backend:", 1)[1].split("  frontend:", 1)[0]
+
+    assert "GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-unknown}" in backend_block
+    assert backend_block.index("environment:") < backend_block.index(
+        "GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-unknown}"
+    )
+
+
 def test_AC8_13_71_dash_prefixed_environment_id_is_accepted() -> None:
     lifecycle = lifecycle_module()
 


### PR DESCRIPTION
## Summary

Hardens mobile review UX and CI metadata/reporting gates for EPIC-016 + EPIC-008 follow-up coverage.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-016 — Two-stage review UI; EPIC-008 — Testing strategy |
| **AC IDs** | AC16.25.1, AC16.25.2, AC16.25.3, AC16.25.4, AC8.13.71 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/frontend-patterns.md` — added mobile review surface rules and root metadata ownership rules

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | local red phase before implementation | Added failing component/tooling tests for mobile cards, journal line cards, metadata ownership, and coverage summary nonblocking behavior |
| Green (passing test) | `4cb4b34` | Implemented mobile card layouts, metadata/CI fixes, Playwright mobile route checks, and SSOT/AC traceability updates |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no SQLAlchemy enum changes
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` — N/A, no env var changes
- [x] `repo/` submodule updated for production config changes — N/A
- [x] `tools/check_env_keys.py` passes — N/A, no env var changes
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

---

## Testing

```bash
npm run lint
npm run test -- --run src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx src/__tests__/detailViewComponents.test.tsx src/__tests__/rootLayout.test.tsx
npm run build
npx playwright test playwright/mobile-ux.spec.ts --project=chromium
uv run --with pytest --with pyyaml pytest tests/tooling/test_post_merge_e2e_gates.py tests/tooling/test_lint_doc_consistency.py -q
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_manifest.py
uv run --with pyyaml python tools/lint_doc_consistency.py
python tools/check_ssot_ownership.py --verbose
```

Also ran `moon run :lint && moon run :test` locally before opening the PR. `moon run :lint` passed; `moon run :test` progressed into backend pytest and then stopped producing output with idle xdist workers, so I interrupted that local run and left final full-suite validation to GitHub Actions.

---

## Screenshots / Evidence

- Next build completed without the unsupported `themeColor` metadata warning.
- Playwright mobile regression passed for `/review/ai-suggestions`, journal details modal, and mobile navigation at phone width.
