### PR TITLE
[finance_report_vision] feat: add investment performance report schedule

### DIFF
--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -9,14 +9,19 @@ from sqlalchemy import select
 
 from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
+from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition, PositionStatus
-from src.models.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType
+from src.models.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType, MarketDataOverride
 from src.schemas.portfolio import (
     BrokerageImportRequest,
     BrokerageImportResponse,
     CostBasisMethodUpdateRequest,
     DividendEventResponse,
     HoldingResponse,
+    InvestmentPerformanceAllocationRow,
+    InvestmentPerformanceDataFreshness,
+    InvestmentPerformanceHoldingRow,
+    InvestmentPerformanceReportScheduleResponse,
     PortfolioSummaryDashboardResponse,
     PriceUpdateRequest as SchemaPriceUpdateRequest,
     RealizedLotResponse,
@@ -55,6 +60,34 @@ class PriceUpdateRequest(BaseModel):
 
 class PriceUpdateBatchRequest(BaseModel):
     updates: list[PriceUpdateRequest]
+
+
+def _money(value: Decimal) -> Decimal:
+    return Decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _percent(value: Decimal | None) -> Decimal | None:
+    if value is None:
+        return None
+    return Decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _source_document_links(source_documents: object) -> list[str]:
+    if isinstance(source_documents, list):
+        docs = source_documents
+    elif isinstance(source_documents, dict):
+        docs = source_documents.get("documents") or source_documents.get("source_documents") or [source_documents]
+    else:
+        docs = []
+
+    links: list[str] = []
+    for doc in docs:
+        if isinstance(doc, dict):
+            doc_type = doc.get("doc_type") or doc.get("type") or "source"
+            doc_id = doc.get("doc_id") or doc.get("id") or doc.get("source_id")
+            if doc_id:
+                links.append(f"{doc_type}:{doc_id}")
+    return links
 
 
 @router.post("/brokerage/import", response_model=BrokerageImportResponse, status_code=status.HTTP_200_OK)
@@ -296,6 +329,217 @@ async def get_performance(
     mwr = mwr.quantize(_two_dp, rounding=ROUND_HALF_UP)
     logger.info("Performance calculated", xirr=float(xirr), twr=float(twr), mwr=float(mwr))
     return PerformanceMetricsResponse(xirr=xirr, time_weighted_return=twr, money_weighted_return=mwr)
+
+
+@router.get("/performance/report-schedule", response_model=InvestmentPerformanceReportScheduleResponse)
+async def get_investment_performance_report_schedule(
+    db: DbSession,
+    user_id: CurrentUserId,
+    period_start: date | None = Query(None, description="Report period start date (default: Jan 1 of period end year)"),
+    period_end: date | None = Query(None, description="Report period end date (default: today)"),
+    as_of_date: date | None = Query(None, description="Valuation date (default: period_end)"),
+    currency: str = Query(default="SGD", min_length=3, max_length=3),
+) -> InvestmentPerformanceReportScheduleResponse:
+    """Build the report-ready investment performance schedule consumed by EPIC-005."""
+    period_end = period_end or date.today()
+    period_start = period_start or date(period_end.year, 1, 1)
+    as_of_date = as_of_date or period_end
+
+    if period_start > period_end:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="period_start must be <= period_end"
+        )
+
+    if as_of_date < period_end:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="as_of_date must be >= period_end")
+
+    if currency != "SGD":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Investment performance report schedule currently supports SGD presentation currency",
+        )
+
+    notes: list[str] = [
+        "Cost basis uses the holding-level cost-basis method where available.",
+        "Market values use the latest available brokerage or market-data snapshot on or before the as-of date.",
+    ]
+
+    try:
+        holdings = list(
+            await _portfolio_service.get_holdings(
+                db=db,
+                user_id=user_id,
+                as_of_date=as_of_date,
+                include_disposed=True,
+            )
+        )
+    except (PortfolioNotFoundError, AssetNotFoundError):
+        holdings = []
+        notes.append("No portfolio holdings were available for the requested as-of date.")
+
+    asset_identifiers = [holding.asset_identifier for holding in holdings]
+    cost_basis_by_asset: dict[str, Decimal] = {}
+    if asset_identifiers:
+        position_result = await db.execute(
+            select(ManagedPosition)
+            .where(ManagedPosition.user_id == user_id)
+            .where(ManagedPosition.asset_identifier.in_(asset_identifiers))
+        )
+        cost_basis_by_asset = {
+            position.asset_identifier: position.cost_basis for position in position_result.scalars().all()
+        }
+
+    async def _metric_or_note(metric_name: str, calculation):
+        try:
+            return await calculation()
+        except InsufficientDataError as exc:
+            notes.append(f"{metric_name} unavailable: {exc}")
+            return None
+        except PerformanceError as exc:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+
+    xirr = await _metric_or_note(
+        "XIRR", lambda: performance.calculate_xirr(db=db, user_id=user_id, as_of_date=as_of_date)
+    )
+    twr = await _metric_or_note(
+        "TWR",
+        lambda: performance.calculate_time_weighted_return(
+            db=db,
+            user_id=user_id,
+            period_start=period_start,
+            period_end=period_end,
+        ),
+    )
+    mwr = await _metric_or_note(
+        "MWR",
+        lambda: performance.calculate_money_weighted_return(db=db, user_id=user_id, as_of_date=as_of_date),
+    )
+    dividend_yield = await _metric_or_note(
+        "Dividend yield",
+        lambda: performance.calculate_dividend_yield(db=db, user_id=user_id, as_of_date=as_of_date),
+    )
+
+    realized_result = await db.execute(
+        select(InvestmentTransaction)
+        .where(InvestmentTransaction.user_id == user_id)
+        .where(InvestmentTransaction.transaction_type == InvestmentTransactionType.SELL)
+        .where(InvestmentTransaction.transaction_date >= period_start)
+        .where(InvestmentTransaction.transaction_date <= period_end)
+    )
+    realized_by_asset: dict[str, Decimal] = {}
+    source_links: set[str] = set()
+    for txn in realized_result.scalars().all():
+        realized_by_asset[txn.asset_identifier] = realized_by_asset.get(txn.asset_identifier, Decimal("0.00")) + (
+            txn.realized_pnl or Decimal("0.00")
+        )
+        if txn.journal_entry_id:
+            source_links.add(f"journal_entry:{txn.journal_entry_id}")
+        if txn.source_id:
+            source_links.add(f"investment_transaction_source:{txn.source_id}")
+
+    dividend_result = await db.execute(
+        select(DividendIncome, ManagedPosition)
+        .join(ManagedPosition, DividendIncome.position_id == ManagedPosition.id)
+        .where(DividendIncome.user_id == user_id)
+        .where(ManagedPosition.user_id == user_id)
+        .where(DividendIncome.payment_date >= period_start)
+        .where(DividendIncome.payment_date <= period_end)
+    )
+    dividend_by_asset: dict[str, Decimal] = {}
+    for dividend, position in dividend_result.all():
+        dividend_by_asset[position.asset_identifier] = (
+            dividend_by_asset.get(
+                position.asset_identifier,
+                Decimal("0.00"),
+            )
+            + dividend.amount
+        )
+
+    holding_rows: list[InvestmentPerformanceHoldingRow] = []
+    for holding in holdings:
+        cost_basis = _money(cost_basis_by_asset.get(holding.asset_identifier, holding.cost_basis))
+        market_value = _money(holding.market_value)
+        holding_rows.append(
+            InvestmentPerformanceHoldingRow(
+                asset_identifier=holding.asset_identifier,
+                quantity=holding.quantity,
+                cost_basis=cost_basis,
+                market_value=market_value,
+                unrealized_pnl=_money(market_value - cost_basis),
+                realized_pnl=_money(realized_by_asset.get(holding.asset_identifier, Decimal("0.00"))),
+                dividend_income=_money(dividend_by_asset.get(holding.asset_identifier, Decimal("0.00"))),
+                currency=holding.currency,
+            )
+        )
+
+    allocation_rows: list[InvestmentPerformanceAllocationRow] = []
+    for dimension, loader in [
+        ("sector", allocation.get_sector_allocation),
+        ("geography", allocation.get_geography_allocation),
+        ("asset_class", allocation.get_asset_class_allocation),
+    ]:
+        for row in await loader(db=db, user_id=user_id, as_of_date=as_of_date):
+            allocation_rows.append(
+                InvestmentPerformanceAllocationRow(
+                    dimension=dimension,
+                    category=row.category,
+                    value=_money(row.value),
+                    percentage=_money(row.percentage),
+                    count=row.count,
+                )
+            )
+
+    latest_atomic_result = await db.execute(
+        select(AtomicPosition)
+        .where(AtomicPosition.user_id == user_id)
+        .where(AtomicPosition.snapshot_date <= as_of_date)
+        .order_by(AtomicPosition.snapshot_date.desc(), AtomicPosition.created_at.desc())
+    )
+    atomics = list(latest_atomic_result.scalars().all())
+    latest_atomic = atomics[0] if atomics else None
+    for atomic in atomics:
+        for link in _source_document_links(atomic.source_documents):
+            source_links.add(link)
+
+    latest_override_result = await db.execute(
+        select(MarketDataOverride)
+        .where(MarketDataOverride.user_id == user_id)
+        .where(MarketDataOverride.price_date <= as_of_date)
+        .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+    )
+    latest_override = latest_override_result.scalars().first()
+
+    data_freshness = InvestmentPerformanceDataFreshness(
+        latest_price_date=latest_atomic.snapshot_date if latest_atomic else None,
+        market_data_provider=latest_atomic.broker if latest_atomic else None,
+        stale=latest_atomic is None or latest_atomic.snapshot_date < as_of_date,
+        manual_override_basis=(
+            f"{latest_override.asset_identifier}:{latest_override.price_date.isoformat()}"
+            if latest_override is not None
+            else None
+        ),
+    )
+    if data_freshness.stale:
+        notes.append("One or more market values use stale data relative to the requested as-of date.")
+
+    return InvestmentPerformanceReportScheduleResponse(
+        period_start=period_start,
+        period_end=period_end,
+        as_of_date=as_of_date,
+        currency=currency,
+        xirr=_percent(xirr),
+        time_weighted_return=_percent(twr),
+        money_weighted_return=_percent(mwr),
+        realized_pnl=_money(sum(realized_by_asset.values(), Decimal("0.00"))),
+        unrealized_pnl=_money(sum((row.unrealized_pnl for row in holding_rows), Decimal("0.00"))),
+        dividend_income=_money(sum(dividend_by_asset.values(), Decimal("0.00"))),
+        dividend_yield=_percent(dividend_yield),
+        holdings=holding_rows,
+        allocation=allocation_rows,
+        data_freshness=data_freshness,
+        source_links=sorted(source_links),
+        notes=notes,
+    )
 
 
 @router.get("/allocation/sector", response_model=list[AllocationBreakdownResponse])

--- a/apps/backend/src/schemas/portfolio.py
+++ b/apps/backend/src/schemas/portfolio.py
@@ -105,6 +105,59 @@ class PortfolioSummaryDashboardResponse(PortfolioSummaryResponse):
     dividend_income_ytd: Annotated[Decimal, Field(decimal_places=2)]
 
 
+class InvestmentPerformanceHoldingRow(BaseModel):
+    """Per-holding row for the investment performance report schedule."""
+
+    asset_identifier: str
+    quantity: Annotated[Decimal, Field(decimal_places=6)]
+    cost_basis: Annotated[Decimal, Field(decimal_places=2)]
+    market_value: Annotated[Decimal, Field(decimal_places=2)]
+    unrealized_pnl: Annotated[Decimal, Field(decimal_places=2)]
+    realized_pnl: Annotated[Decimal, Field(decimal_places=2)]
+    dividend_income: Annotated[Decimal, Field(decimal_places=2)]
+    currency: Annotated[str, Field(min_length=3, max_length=3)]
+
+
+class InvestmentPerformanceAllocationRow(BaseModel):
+    """Allocation row for one report-schedule dimension."""
+
+    dimension: str
+    category: str
+    value: Annotated[Decimal, Field(decimal_places=2)]
+    percentage: Annotated[Decimal, Field(decimal_places=2)]
+    count: int
+
+
+class InvestmentPerformanceDataFreshness(BaseModel):
+    """Market data freshness metadata for the report schedule."""
+
+    latest_price_date: date | None
+    market_data_provider: str | None
+    stale: bool
+    manual_override_basis: str | None = None
+
+
+class InvestmentPerformanceReportScheduleResponse(BaseModel):
+    """Report-ready investment performance schedule consumed by EPIC-005."""
+
+    period_start: date
+    period_end: date
+    as_of_date: date
+    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    xirr: Annotated[Decimal | None, Field(decimal_places=2)]
+    time_weighted_return: Annotated[Decimal | None, Field(decimal_places=2)]
+    money_weighted_return: Annotated[Decimal | None, Field(decimal_places=2)]
+    realized_pnl: Annotated[Decimal, Field(decimal_places=2)]
+    unrealized_pnl: Annotated[Decimal, Field(decimal_places=2)]
+    dividend_income: Annotated[Decimal, Field(decimal_places=2)]
+    dividend_yield: Annotated[Decimal | None, Field(decimal_places=2)]
+    holdings: list[InvestmentPerformanceHoldingRow]
+    allocation: list[InvestmentPerformanceAllocationRow]
+    data_freshness: InvestmentPerformanceDataFreshness
+    source_links: list[str]
+    notes: list[str]
+
+
 class DividendEventResponse(BaseModel):
     """Dividend event shown on a holding detail page."""
 

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -425,6 +425,70 @@ async def test_get_performance_with_period(client: AsyncClient, portfolio_with_d
 
 
 @pytest.mark.asyncio
+async def test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+    portfolio_with_data,
+):
+    """AC17.10.1 AC17.10.2: report schedule exposes metrics, rows, freshness, sources, and notes."""
+    position = portfolio_with_data["position"]
+    dividend = DividendIncome(
+        user_id=test_user.id,
+        position_id=position.id,
+        payment_date=date.today() - timedelta(days=10),
+        amount=Decimal("42.50"),
+        currency="SGD",
+    )
+    sell = InvestmentTransaction(
+        user_id=test_user.id,
+        position_id=position.id,
+        transaction_date=date.today() - timedelta(days=5),
+        transaction_type=InvestmentTransactionType.SELL,
+        asset_identifier="AAPL",
+        quantity=Decimal("5"),
+        unit_price=Decimal("130.00"),
+        gross_amount=Decimal("650.00"),
+        fees=Decimal("1.00"),
+        currency="SGD",
+        cost_basis=Decimal("500.00"),
+        realized_pnl=Decimal("149.00"),
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    db.add_all([dividend, sell])
+    await db.commit()
+
+    period_start = (date.today() - timedelta(days=90)).isoformat()
+    as_of_date = date.today().isoformat()
+    response = await client.get(
+        "/portfolio/performance/report-schedule"
+        f"?period_start={period_start}&period_end={as_of_date}&as_of_date={as_of_date}&currency=SGD"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["period_start"] == period_start
+    assert data["period_end"] == as_of_date
+    assert data["as_of_date"] == as_of_date
+    assert data["currency"] == "SGD"
+    for key in ["xirr", "time_weighted_return", "money_weighted_return", "dividend_yield"]:
+        assert key in data
+        assert data[key] is None or isinstance(data[key], str)
+    assert data["realized_pnl"] == "149.00"
+    assert data["dividend_income"] == "42.50"
+    assert data["unrealized_pnl"] == "2000.00"
+    assert data["holdings"][0]["asset_identifier"] == "AAPL"
+    assert data["holdings"][0]["realized_pnl"] == "149.00"
+    assert data["holdings"][0]["dividend_income"] == "42.50"
+    assert data["allocation"]
+    assert data["data_freshness"]["latest_price_date"] == as_of_date
+    assert "source_links" in data
+    assert data["notes"]
+    if data["time_weighted_return"] is None:
+        assert any("TWR unavailable" in note for note in data["notes"])
+
+
+@pytest.mark.asyncio
 async def test_get_sector_allocation_empty(client: AsyncClient):
     """AC17.6.7: GET /portfolio/allocation/sector on empty portfolio returns [].
 

--- a/apps/frontend/src/__tests__/portfolioPage.test.tsx
+++ b/apps/frontend/src/__tests__/portfolioPage.test.tsx
@@ -91,9 +91,45 @@ function mockPortfolioApi(holdings: PortfolioHolding[] = [mockHolding]) {
         holdings_count: holdings.length,
         active_positions_count: holdings.filter((h) => h.status === "active").length,
         disposed_positions_count: holdings.filter((h) => h.status === "disposed").length,
-        currency: "USD",
+        currency: "SGD",
         realized_pnl_ytd: "149.00",
         dividend_income_ytd: "42.50",
+      })
+    }
+    if (path.startsWith("/api/portfolio/performance/report-schedule")) {
+      return Promise.resolve({
+        period_start: "2026-01-01",
+        period_end: "2026-12-31",
+        as_of_date: "2026-12-31",
+        currency: "USD",
+        xirr: "12.50",
+        time_weighted_return: "8.30",
+        money_weighted_return: "10.10",
+        realized_pnl: "149.00",
+        unrealized_pnl: "300.00",
+        dividend_income: "42.50",
+        dividend_yield: "2.36",
+        holdings: [
+          {
+            asset_identifier: "AAPL",
+            quantity: "10.000000",
+            cost_basis: "1500.00",
+            market_value: "1800.00",
+            unrealized_pnl: "300.00",
+            realized_pnl: "149.00",
+            dividend_income: "42.50",
+            currency: "SGD",
+          },
+        ],
+        allocation: [{ dimension: "sector", category: "Technology", value: "1800.00", percentage: "100.00", count: 1 }],
+        data_freshness: {
+          latest_price_date: "2026-12-31",
+          market_data_provider: "Test Broker",
+          stale: false,
+          manual_override_basis: null,
+        },
+        source_links: ["brokerage_statement:aapl"],
+        notes: ["Cost basis uses FIFO where available."],
       })
     }
     if (path.startsWith("/api/portfolio/holdings")) {
@@ -229,8 +265,21 @@ describe("PortfolioPage", () => {
 
     await waitFor(() => expect(screen.getByText("Realized P&L YTD")).toBeInTheDocument())
     expect(screen.getByText("Dividend Income YTD")).toBeInTheDocument()
-    expect(screen.getByText("$149.00")).toBeInTheDocument()
-    expect(screen.getByText("$42.50")).toBeInTheDocument()
+    expect(screen.getAllByText("$149.00").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText("$42.50").length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("AC5.8.1 renders investment performance report schedule from the schedule API", async () => {
+    mockPortfolioApi()
+
+    render(<PortfolioPage />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByText("investment_performance")).toBeInTheDocument())
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/portfolio/performance/report-schedule")
+    expect(screen.getByText(/Report section/)).toBeInTheDocument()
+    expect(screen.getByText("Source Links")).toBeInTheDocument()
+    expect(screen.getByText("brokerage_statement:aapl")).toBeInTheDocument()
+    expect(screen.getByText("Cost basis uses FIFO where available.")).toBeInTheDocument()
   })
 
   it("AC17.8.4 does not show total portfolio value banner when no active holdings", async () => {

--- a/apps/frontend/src/app/(main)/portfolio/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/page.tsx
@@ -10,7 +10,9 @@ import { PortfolioHolding, PortfolioSummaryResponse } from "@/lib/types";
 import { PerformanceCard } from "@/components/portfolio/PerformanceCard";
 import { HoldingsTable } from "@/components/portfolio/HoldingsTable";
 import { AllocationChart } from "@/components/portfolio/AllocationChart";
+import { InvestmentPerformanceSchedule } from "@/components/portfolio/InvestmentPerformanceSchedule";
 import { formatCurrencyLocale, sumAmounts } from "@/lib/currency";
+import type { InvestmentPerformanceReportSchedule } from "@/lib/types";
 
 export default function PortfolioPage() {
     const [showDisposed, setShowDisposed] = useState(false);
@@ -33,6 +35,26 @@ export default function PortfolioPage() {
     const { data: summary } = useQuery({
         queryKey: ["portfolio-summary", asOfDate],
         queryFn: () => apiFetch<PortfolioSummaryResponse>(`/api/portfolio/summary${asOfDate ? `?as_of_date=${asOfDate}` : ""}`),
+    });
+    const {
+        data: performanceSchedule,
+        isLoading: isPerformanceScheduleLoading,
+        error: performanceScheduleError,
+    } = useQuery({
+        queryKey: ["portfolio-performance-report-schedule", asOfDate],
+        queryFn: () => {
+            if (!asOfDate) {
+                return apiFetch<InvestmentPerformanceReportSchedule>("/api/portfolio/performance/report-schedule");
+            }
+            const yearStart = `${asOfDate.slice(0, 4)}-01-01`;
+            const params = new URLSearchParams({
+                period_start: yearStart,
+                period_end: asOfDate,
+                as_of_date: asOfDate,
+                currency: "SGD",
+            });
+            return apiFetch<InvestmentPerformanceReportSchedule>(`/api/portfolio/performance/report-schedule?${params}`);
+        },
     });
 
     const activeHoldings = holdings?.filter((h) => h.status === "active") ?? [];
@@ -86,6 +108,12 @@ export default function PortfolioPage() {
                 <AllocationChart type="sector" title="Sector Allocation" />
                 <AllocationChart type="geography" title="Geography Allocation" />
             </div>
+
+            <InvestmentPerformanceSchedule
+                schedule={performanceSchedule}
+                isLoading={isPerformanceScheduleLoading}
+                error={performanceScheduleError}
+            />
 
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between mb-4">
                 <h2 className="text-lg font-semibold">Holdings</h2>

--- a/apps/frontend/src/components/portfolio/InvestmentPerformanceSchedule.tsx
+++ b/apps/frontend/src/components/portfolio/InvestmentPerformanceSchedule.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { FileText, Link2 } from "lucide-react";
+
+import { formatCurrencyLocale, formatAmount } from "@/lib/currency";
+import type { InvestmentPerformanceReportSchedule } from "@/lib/types";
+
+function formatPercent(value: string | null): string {
+    if (value === null) return "N/A";
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return "N/A";
+    const sign = numeric > 0 ? "+" : "";
+    return `${sign}${formatAmount(value, 2)}%`;
+}
+
+function metricClass(value: string | null): string {
+    if (value === null) return "text-muted";
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric === 0) return "";
+    return numeric > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
+}
+
+interface InvestmentPerformanceScheduleProps {
+    schedule?: InvestmentPerformanceReportSchedule;
+    isLoading?: boolean;
+    error?: unknown;
+}
+
+export function InvestmentPerformanceSchedule({
+    schedule,
+    isLoading = false,
+    error = null,
+}: InvestmentPerformanceScheduleProps) {
+    if (isLoading) {
+        return (
+            <div className="card p-5 mb-6" aria-busy="true">
+                <p className="text-xs text-muted uppercase">Investment Performance Report Schedule</p>
+                <div className="mt-4 h-5 w-5 rounded-full border-2 border-current border-t-transparent text-muted animate-spin" />
+            </div>
+        );
+    }
+
+    if (error || !schedule) {
+        return (
+            <div className="card p-5 mb-6">
+                <p className="text-xs text-muted uppercase">Investment Performance Report Schedule</p>
+                <p className="mt-3 text-sm text-muted">Unable to load investment performance schedule</p>
+            </div>
+        );
+    }
+
+    const metrics = [
+        { label: "XIRR", value: schedule.xirr },
+        { label: "TWR", value: schedule.time_weighted_return },
+        { label: "MWR", value: schedule.money_weighted_return },
+        { label: "Dividend Yield", value: schedule.dividend_yield },
+    ];
+
+    return (
+        <section className="card p-5 mb-6" aria-labelledby="investment-performance-schedule-title">
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div>
+                    <div className="flex items-center gap-2">
+                        <FileText className="h-4 w-4 text-[var(--accent)]" aria-hidden="true" />
+                        <h2 id="investment-performance-schedule-title" className="text-base font-semibold">
+                            Investment Performance Report Schedule
+                        </h2>
+                    </div>
+                    <p className="mt-1 text-xs text-muted">
+                        Report section <span className="font-mono text-[var(--foreground)]">investment_performance</span>
+                    </p>
+                </div>
+                <div className="text-xs text-muted md:text-right">
+                    <p>{schedule.period_start} to {schedule.period_end}</p>
+                    <p>As of {schedule.as_of_date} - {schedule.currency}</p>
+                </div>
+            </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                {metrics.map((metric) => (
+                    <div key={metric.label} className="rounded border border-[var(--border)] p-3">
+                        <p className="text-xs text-muted uppercase">{metric.label}</p>
+                        <p className={`mt-1 text-lg font-semibold ${metricClass(metric.value)}`}>
+                            {formatPercent(metric.value)}
+                        </p>
+                    </div>
+                ))}
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-3">
+                <div className="rounded border border-[var(--border)] p-3">
+                    <p className="text-xs text-muted uppercase">Realized P&L</p>
+                    <p className="mt-1 font-semibold">{formatCurrencyLocale(schedule.realized_pnl, schedule.currency)}</p>
+                </div>
+                <div className="rounded border border-[var(--border)] p-3">
+                    <p className="text-xs text-muted uppercase">Unrealized P&L</p>
+                    <p className="mt-1 font-semibold">{formatCurrencyLocale(schedule.unrealized_pnl, schedule.currency)}</p>
+                </div>
+                <div className="rounded border border-[var(--border)] p-3">
+                    <p className="text-xs text-muted uppercase">Dividend Income</p>
+                    <p className="mt-1 font-semibold">{formatCurrencyLocale(schedule.dividend_income, schedule.currency)}</p>
+                </div>
+            </div>
+
+            <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                <div>
+                    <p className="text-xs text-muted uppercase">Data Freshness</p>
+                    <div className="mt-2 text-sm">
+                        <p>Latest price date: {schedule.data_freshness.latest_price_date ?? "N/A"}</p>
+                        <p>Provider: {schedule.data_freshness.market_data_provider ?? "N/A"}</p>
+                        <p>Status: {schedule.data_freshness.stale ? "Stale" : "Current"}</p>
+                        {schedule.data_freshness.manual_override_basis ? (
+                            <p>Manual override: {schedule.data_freshness.manual_override_basis}</p>
+                        ) : null}
+                    </div>
+                </div>
+                <div>
+                    <div className="flex items-center gap-2">
+                        <Link2 className="h-4 w-4 text-muted" aria-hidden="true" />
+                        <p className="text-xs text-muted uppercase">Source Links</p>
+                    </div>
+                    <ul className="mt-2 space-y-1 text-sm">
+                        {schedule.source_links.length > 0 ? (
+                            schedule.source_links.slice(0, 4).map((link) => <li key={link} className="break-all font-mono">{link}</li>)
+                        ) : (
+                            <li className="text-muted">No source links available</li>
+                        )}
+                    </ul>
+                </div>
+            </div>
+
+            {schedule.notes.length > 0 ? (
+                <div className="mt-4">
+                    <p className="text-xs text-muted uppercase">Notes</p>
+                    <ul className="mt-2 list-disc pl-5 text-sm text-muted">
+                        {schedule.notes.map((note) => <li key={note}>{note}</li>)}
+                    </ul>
+                </div>
+            ) : null}
+        </section>
+    );
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -373,6 +373,51 @@ export interface PerformanceMetrics {
     money_weighted_return: string;
 }
 
+export interface InvestmentPerformanceHoldingRow {
+    asset_identifier: string;
+    quantity: string;
+    cost_basis: string;
+    market_value: string;
+    unrealized_pnl: string;
+    realized_pnl: string;
+    dividend_income: string;
+    currency: string;
+}
+
+export interface InvestmentPerformanceAllocationRow {
+    dimension: "sector" | "geography" | "asset_class" | string;
+    category: string;
+    value: string;
+    percentage: string;
+    count: number;
+}
+
+export interface InvestmentPerformanceDataFreshness {
+    latest_price_date: string | null;
+    market_data_provider: string | null;
+    stale: boolean;
+    manual_override_basis?: string | null;
+}
+
+export interface InvestmentPerformanceReportSchedule {
+    period_start: string;
+    period_end: string;
+    as_of_date: string;
+    currency: string;
+    xirr: string | null;
+    time_weighted_return: string | null;
+    money_weighted_return: string | null;
+    realized_pnl: string;
+    unrealized_pnl: string;
+    dividend_income: string;
+    dividend_yield: string | null;
+    holdings: InvestmentPerformanceHoldingRow[];
+    allocation: InvestmentPerformanceAllocationRow[];
+    data_freshness: InvestmentPerformanceDataFreshness;
+    source_links: string[];
+    notes: string[];
+}
+
 export interface AllocationBreakdown {
     category: string;
     value: string;

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1178,6 +1178,13 @@ groups:
         epic_name: reporting-visualization
         description: Frontend unit test mounts NetWorthTimeSeries component and asserts chart container exists
         mandatory: true
+    AC5.8:
+      - id: AC5.8.1
+        epic: 5
+        epic_name: reporting-visualization
+        description: Personal report package defines the investment_performance report section as a consumer of the EPIC-017
+          schedule API
+        mandatory: true
   AC6:
     AC6.1:
       - id: AC6.1.1
@@ -4226,6 +4233,17 @@ groups:
         epic: 17
         epic_name: portfolio-management
         description: Portfolio page exposes an as-of date selector and passes it to /api/portfolio/holdings
+        mandatory: true
+    AC17.10:
+      - id: AC17.10.1
+        epic: 17
+        epic_name: portfolio-management
+        description: Investment performance schedule API exposes report-ready metrics and rows
+        mandatory: true
+      - id: AC17.10.2
+        epic: 17
+        epic_name: portfolio-management
+        description: Investment performance schedule API exposes data freshness, source links, and notes for report traceability
         mandatory: true
   AC18:
     AC18.1:

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -165,7 +165,7 @@ method, dividends, realized/unrealized P&L, and return metric limitations.
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.8.1 | Personal report package defines the `investment_performance` report section as a consumer of the EPIC-017 schedule API | `test_AC5_8_1_personal_report_package_consumes_investment_schedule_contract` | `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+| AC5.8.1 | Personal report package defines the `investment_performance` report section as a consumer of the EPIC-017 schedule API | `AC5.8.1 renders investment performance report schedule from the schedule API`; `test_personal_financial_report_package_post_merge_journey`; `test_AC5_8_1_personal_report_package_consumes_investment_schedule_contract` | `apps/frontend/src/__tests__/portfolioPage.test.tsx`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
 
 **Traceability Result**:
 - Total AC IDs: 19

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -154,6 +154,19 @@ Accounting Equation Verification: Reports must comply with accounting equation
 | AC5.6.5 | Unrealized P&L reflected in balance sheet equity | `test_reporting_dashboard_fixture_exact_totals` | `reporting/test_reporting.py` | P0 |
 | AC5.6.6 | MWR (money-weighted return) matches XIRR for single cashflow | `test_AC5_6_6_money_weighted_return_matches_xirr_for_single_cashflow` | `portfolio/test_performance_service.py` | P1 |
 
+### AC5.8: Personal Report Package Investment Performance Consumption
+
+EPIC-005 consumes the EPIC-017 schedule endpoint
+`GET /api/portfolio/performance/report-schedule` as the
+`investment_performance` report section in the personal financial-report
+package. The report section must preserve `source_links` and `notes` from the
+schedule payload so the package can explain market-data freshness, cost-basis
+method, dividends, realized/unrealized P&L, and return metric limitations.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.8.1 | Personal report package defines the `investment_performance` report section as a consumer of the EPIC-017 schedule API | `test_AC5_8_1_personal_report_package_consumes_investment_schedule_contract` | `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+
 **Traceability Result**:
 - Total AC IDs: 19
 - Requirements converted to AC IDs: 100% (EPIC-005 checklist + must-have standards)

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -333,6 +333,34 @@ issues.
 | AC17.9.2 | Portfolio holdings API returns date-bounded snapshot quantities for explicit `as_of_date` requests | `test_get_holdings_explicit_date_uses_historical_snapshot_quantity` | `portfolio/test_portfolio_router.py` | P0 |
 | AC17.9.3 | Portfolio page exposes an as-of date selector and passes it to `/api/portfolio/holdings` | `AC17.9.3 passes selected as-of date to holdings API` | `frontend/src/__tests__/portfolioPage.test.tsx` | P0 |
 
+### AC17.10: Investment Performance Report Schedule API
+
+This API contract is the EPIC-017-owned schedule input for the personal
+financial-report package tracked by #564. It is intentionally separate from
+the dashboard-only `/api/portfolio/performance` summary so EPIC-005 can consume
+a stable, report-ready payload with source traceability and explanation fields.
+
+Endpoint:
+`GET /api/portfolio/performance/report-schedule?period_start=YYYY-MM-DD&period_end=YYYY-MM-DD&as_of_date=YYYY-MM-DD&currency=SGD`
+
+Response object:
+
+| Field | Meaning |
+|---|---|
+| `period_start`, `period_end`, `as_of_date`, `currency` | Schedule boundary and presentation currency |
+| `xirr`, `time_weighted_return`, `money_weighted_return` | Portfolio performance metrics as percentages |
+| `realized_pnl`, `unrealized_pnl`, `dividend_income`, `dividend_yield` | Decimal-safe return components |
+| `holdings` | Per holding `{asset_identifier, quantity, cost_basis, market_value, unrealized_pnl, realized_pnl, dividend_income, currency}` rows |
+| `allocation` | Sector, geography, and asset-class allocation rows |
+| `data_freshness` | Market-data source, latest price date, stale flag, and manual override basis |
+| `source_links` | Source document, brokerage import, price source, and ledger/report traceability anchors |
+| `notes` | Human-readable methods and limitations for cost basis, market prices, and return metrics |
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC17.10.1 | Investment performance schedule API exposes report-ready metrics and rows | `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+| AC17.10.2 | Investment performance schedule API exposes data freshness, source links, and notes for report traceability | `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+
 ### Brokerage PDF to Asset Report Proof Matrix
 
 This is the detailed EPIC-017 counterpart to the README core proof path. It

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -343,6 +343,10 @@ a stable, report-ready payload with source traceability and explanation fields.
 Endpoint:
 `GET /api/portfolio/performance/report-schedule?period_start=YYYY-MM-DD&period_end=YYYY-MM-DD&as_of_date=YYYY-MM-DD&currency=SGD`
 
+When dates are omitted, the API defaults to year-to-date reporting using
+`period_end=today`, `period_start=January 1` of the period-end year, and
+`as_of_date=period_end`.
+
 Response object:
 
 | Field | Meaning |
@@ -358,8 +362,8 @@ Response object:
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC17.10.1 | Investment performance schedule API exposes report-ready metrics and rows | `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `tests/tooling/test_investment_performance_report_contract.py` | P0 |
-| AC17.10.2 | Investment performance schedule API exposes data freshness, source links, and notes for report traceability | `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+| AC17.10.1 | Investment performance schedule API exposes report-ready metrics and rows | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+| AC17.10.2 | Investment performance schedule API exposes data freshness, source links, and notes for report traceability | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
 
 ### Brokerage PDF to Asset Report Proof Matrix
 

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -135,6 +135,32 @@ Shows cash movements by category.
 └─────────────────────────────────────────────┘
 ```
 
+### 2.5 Investment Performance Schedule
+
+The investment performance schedule is the report-ready portfolio input for the
+personal financial-report package and is owned by EPIC-017. EPIC-005 consumes it
+as the `investment_performance` report section.
+
+Endpoint:
+`GET /api/portfolio/performance/report-schedule?period_start=YYYY-MM-DD&period_end=YYYY-MM-DD&as_of_date=YYYY-MM-DD&currency=SGD`
+
+Response object:
+
+| Field | Rule |
+|---|---|
+| `period_start`, `period_end`, `as_of_date`, `currency` | Echo the requested reporting period, valuation date, and presentation currency |
+| `xirr`, `time_weighted_return`, `money_weighted_return` | Decimal-safe percentage metrics; return `null` with a note when input data is insufficient |
+| `realized_pnl`, `unrealized_pnl`, `dividend_income`, `dividend_yield` | Decimal-safe schedule totals in `currency` |
+| `holdings` | Per holding rows with quantity, cost basis, market value, realized/unrealized P&L, dividend income, and source currency |
+| `allocation` | Sector, geography, and asset-class allocation rows whose percentages reconcile to the schedule market value |
+| `data_freshness` | Latest price date, market-data provider, stale flag, and manual override basis |
+| `source_links` | Brokerage statement/import IDs, price source IDs, ledger entry IDs, and report anchors needed for source-to-ledger-to-report traceability |
+| `notes` | Methods and limitations for cost basis, price freshness, dividends, XIRR/TWR/MWR, and any manual overrides |
+
+The schedule must not mutate ledger state. It assembles existing portfolio,
+market-data, dividend, and journal-entry facts into a reporting payload that can
+be exported or embedded by EPIC-005.
+
 ---
 
 ## 3. Multi-Currency Consolidation

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -144,6 +144,10 @@ as the `investment_performance` report section.
 Endpoint:
 `GET /api/portfolio/performance/report-schedule?period_start=YYYY-MM-DD&period_end=YYYY-MM-DD&as_of_date=YYYY-MM-DD&currency=SGD`
 
+If dates are omitted, the schedule defaults to year-to-date: `period_end`
+defaults to today, `period_start` defaults to January 1 of the period-end year,
+and `as_of_date` defaults to `period_end`.
+
 Response object:
 
 | Field | Rule |

--- a/docs/user-guide/reports.md
+++ b/docs/user-guide/reports.md
@@ -50,6 +50,24 @@ Shows how cash moves in and out:
 !!! info "Status"
     Cash flow statement is planned for Phase 2.
 
+### Investment Performance
+
+The personal financial-report package includes an `investment_performance`
+report section once the EPIC-017 schedule is implemented. The section consumes:
+
+`GET /api/portfolio/performance/report-schedule`
+
+```bash
+curl "https://report.zitian.party/api/portfolio/performance/report-schedule?period_start=2026-01-01&period_end=2026-12-31&as_of_date=2026-12-31&currency=SGD"
+```
+
+The report section is designed to show XIRR, time-weighted return,
+money-weighted return, realized P&L, unrealized P&L, dividend income, dividend
+yield, holdings, allocation, data freshness, `source_links`, and `notes`.
+Those fields let the package explain how investment-performance values were
+calculated and how they trace back to brokerage statements, market prices, and
+ledger/report output.
+
 ## Dashboard Widgets
 
 ### Account Balances

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -320,9 +320,11 @@ async def _create_manual_snapshot(
 async def test_personal_financial_report_package_post_merge_journey(authenticated_page_unique: Page) -> None:
     """EPIC-005 EPIC-008 EPIC-011 EPIC-017.
 
-    AC5.1.1 AC5.1.4 AC5.2.3 AC5.3.1 AC11.8.3 AC11.9.1 AC11.9.2 AC11.9.3:
+    AC5.1.1 AC5.1.4 AC5.2.3 AC5.3.1 AC5.8.1 AC11.8.3 AC11.9.1 AC11.9.2 AC11.9.3
+    AC17.10.1 AC17.10.2:
     one complete fresh-user report package with bank data, brokerage import,
-    manual valuation, restricted notes, and source traceability.
+    investment performance schedule, manual valuation, restricted notes, and
+    source traceability.
     """
     page = authenticated_page_unique
     fixture_rows = _read_fixture_rows()
@@ -428,6 +430,32 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         )
         brokerage_value = sum((_money(item["market_value"]) for item in holdings), Decimal("0.00"))
         assert brokerage_value > Decimal("0.00"), f"brokerage holdings have no value: {holdings}"
+
+        schedule_response = await client.get(
+            _api_url(
+                "/portfolio/performance/report-schedule"
+                f"?period_start={fixture_period_start.isoformat()}"
+                f"&period_end={fixture_period_end.isoformat()}"
+                f"&as_of_date={fixture_period_end.isoformat()}&currency=SGD"
+            )
+        )
+        assert schedule_response.status_code == 200, (
+            f"investment performance schedule failed: {schedule_response.status_code} {schedule_response.text}"
+        )
+        schedule = schedule_response.json()
+        assert schedule["period_start"] == fixture_period_start.isoformat()
+        assert schedule["period_end"] == fixture_period_end.isoformat()
+        assert schedule["as_of_date"] == fixture_period_end.isoformat()
+        assert schedule["currency"] == "SGD"
+        assert schedule["holdings"], f"investment schedule has no holdings: {schedule}"
+        assert _money(schedule["unrealized_pnl"]) >= Decimal("0.00")
+        assert "data_freshness" in schedule
+        assert schedule["source_links"], f"investment schedule missing source links: {schedule}"
+        assert schedule["notes"], f"investment schedule missing notes: {schedule}"
+
+        await page.goto(_get_url("/portfolio"))
+        await expect(page.get_by_text("Investment Performance Report Schedule")).to_be_visible()
+        await expect(page.get_by_text("investment_performance")).to_be_visible()
 
         property_snapshot = await _create_manual_snapshot(
             client,

--- a/tests/tooling/test_investment_performance_report_contract.py
+++ b/tests/tooling/test_investment_performance_report_contract.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract() -> None:
+    """AC17.10.1 AC17.10.2: EPIC-017 owns the investment performance schedule API contract."""
+    epic = read("docs/project/EPIC-017.portfolio-management.md")
+    reporting = read("docs/ssot/reporting.md")
+
+    for text in (epic, reporting):
+        assert "GET /api/portfolio/performance/report-schedule" in text
+        assert "period_start" in text
+        assert "period_end" in text
+        assert "as_of_date" in text
+        assert "currency" in text
+
+    for field in [
+        "xirr",
+        "time_weighted_return",
+        "money_weighted_return",
+        "realized_pnl",
+        "unrealized_pnl",
+        "dividend_income",
+        "dividend_yield",
+        "holdings",
+        "allocation",
+        "data_freshness",
+        "source_links",
+        "notes",
+    ]:
+        assert field in epic
+        assert field in reporting
+
+
+def test_AC5_8_1_personal_report_package_consumes_investment_schedule_contract() -> None:
+    """AC5.8.1: EPIC-005 owns package consumption of the investment performance schedule."""
+    epic = read("docs/project/EPIC-005.reporting-visualization.md")
+    user_guide = read("docs/user-guide/reports.md")
+
+    for text in (epic, user_guide):
+        assert "investment-performance" in text
+        assert "GET /api/portfolio/performance/report-schedule" in text
+        assert "investment_performance" in text
+        assert "report section" in text
+        assert "source_links" in text
+        assert "notes" in text


### PR DESCRIPTION
## Summary

Implements the investment performance report schedule end to end for issue #564:

- Adds `GET /api/portfolio/performance/report-schedule` with report-ready metrics, holding rows, allocation rows, data freshness, source links, and notes.
- Adds the Portfolio page consumer UI for the `investment_performance` report section.
- Adds backend, frontend, tooling-contract, and E2E traceability coverage for AC17.10.1, AC17.10.2, and AC5.8.1.
- Updates EPIC and SSOT docs for the implemented endpoint defaults and proof paths.

Refs #564. Does not close #564 because `investment-performance` should remain partial until the post-merge deployed proof path is validated and the critical proof matrix can be promoted.
Refs #521.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| EPIC | EPIC-017 Portfolio Management; EPIC-005 Reporting and Visualization |
| AC IDs | AC17.10.1, AC17.10.2, AC5.8.1 |
| AC Registry | Already registered in `docs/ac_registry.yaml` |

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|------------|-------------|
| Red | `f09024a` | Added AC-registered contract tests before the SSOT/API contract existed. |
| Green | `1cd8071` | Added the SSOT and user-guide API contract so contract tests passed. |
| Implementation | `9561260` | Added backend API, frontend consumer, backend unit test, frontend unit test, E2E trace, and EPIC/SSOT proof updates. |

---

## Engineering Audit

- [x] MECE task frame: backend API, FE consumer, unit tests, E2E trace, SSOT/EPIC proof updates.
- [x] No infra/config changes; `repo/` submodule sync not applicable.
- [x] No DB enum changes; explicit enum naming not applicable.
- [x] No `NEXT_PUBLIC_` changes; Docker bake not applicable.
- [x] No raw frontend `fetch()`; Portfolio page uses `lib/api.ts` via `apiFetch`.
- [x] Monetary values use `Decimal` in backend implementation.
- [x] `investment-performance` critical proof status intentionally remains partial pending deployed proof.

---

## Local Verification

```bash
moon run :lint
npm test -- --run src/__tests__/portfolioPage.test.tsx src/__tests__/performanceCard.test.tsx
uv run --with pytest pytest tests/tooling/test_investment_performance_report_contract.py -q
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_ac_traceability.py
uv run --with pyyaml python tools/lint_doc_consistency.py
python tools/check_critical_proof_matrix.py --output /tmp/critical-proof-564-fe.md
python tools/check_e2e_epic_traceability.py --output /tmp/e2e-epic-564-fe.md
git diff --check
```

A targeted backend router test passed earlier in this branch before the local Podman backend degraded:

```bash
PYTEST_ADDOPTS=--no-cov uv run --python 3.12.12 python -m pytest -n0 tests/portfolio/test_portfolio_router.py::test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule -q
```

After a full `moon run :test` attempt, local Podman/Postgres stopped responding: the full run stalled with no pytest progress, and a later targeted backend rerun did not enter the test body because `tests/conftest.py` blocked while opening the asyncpg connection. GitHub CI is the authoritative full-suite verification for this pushed commit.

---

## Screenshots / Evidence

No screenshot required; this PR adds a compact Portfolio page report schedule section plus API/test coverage. GitHub CI must pass before this PR is considered ready to merge.