### PR TITLE
[finance_report_infra] Harden Dokploy host hygiene cleanup

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -373,8 +373,8 @@ jobs:
             All temporary resources for this PR have been released:
 
             - **Dokploy Stack**: \`${{ needs.setup.outputs.compose_name }}\` ✓ deleted
-            - **Docker Volumes**: Cleaned (postgres_data, minio_data)
             - **GHCR Images**: Deleted (backend:pr-${{ needs.setup.outputs.pr_number }}, frontend:pr-${{ needs.setup.outputs.pr_number }})
+            - **Host Docker leftovers**: Managed by the Dokploy host hygiene schedule
 
             _Cleanup completed successfully._`;
 

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -546,3 +546,13 @@ def test_AC8_13_71_close_cleanup_checks_out_lifecycle_tool() -> None:
     )
     assert "VPS_SSH_KEY" not in cleanup_block
     assert "ssh-keyscan" not in cleanup_block
+
+
+def test_AC8_13_74_close_cleanup_notice_does_not_claim_host_volume_cleanup() -> None:
+    workflow = (ROOT / ".github/workflows/pr-test.yml").read_text()
+
+    cleanup_block = workflow.split("  cleanup:", 1)[1]
+    assert "Docker Volumes" not in cleanup_block
+    assert "postgres_data, minio_data" not in cleanup_block
+    assert "Host Docker leftovers" in cleanup_block
+    assert "Dokploy host hygiene schedule" in cleanup_block

--- a/tests/tooling/test_vps_host_hygiene.py
+++ b/tests/tooling/test_vps_host_hygiene.py
@@ -85,12 +85,40 @@ def test_AC8_13_73_hygiene_script_runs_real_prune_commands_without_credentials()
     assert 'docker network prune -f --filter "until=240h"' in script
     assert 'journalctl --vacuum-time="30d" --vacuum-size="512M"' in script
     assert ': > "$log_path"' in script
-    assert 'docker rm -f "$container_name"' in script
+    assert 'docker rm -f "$container_name" || true' in script
     assert 'docker rm -f "$non_preview_container" || true' in script
     assert 'docker volume rm "$volume_name" || true' in script
+    assert 'date -u -d "$created_at" +%s 2>/dev/null || echo 0' not in script
+    assert 'parse_utc_epoch "$created_at" || true' in script
+    assert "Skipping deletion because timestamp is missing or unparseable" in script
     assert "docker container prune" not in script
     assert "[dry-run]" not in script
     assert "GITHUB" not in script
+
+
+def test_AC8_13_73_hygiene_script_skips_unparseable_resource_timestamps() -> None:
+    hygiene = hygiene_module()
+
+    script = hygiene.build_hygiene_script(
+        dry_run=False,
+        container_prune_until="48h",
+        builder_prune_until="72h",
+        image_prune_until="240h",
+        network_prune_until="240h",
+        journal_vacuum_time="30d",
+        journal_vacuum_size="512M",
+        docker_log_truncate_size_mib=50,
+        disk_warning_percent=80,
+        disk_error_percent=90,
+        pr_preview_max_age_days=3,
+        pr_preview_keep_recent=3,
+    )
+
+    assert "parse_utc_epoch() {" in script
+    assert 'created_epoch="$(parse_utc_epoch "$created_at" || true)"' in script
+    assert 'if [ -z "$created_epoch" ]; then' in script
+    assert "return 1" in script
+    assert "continue" in script
 
 
 def test_AC8_13_73_hygiene_script_is_shell_parseable() -> None:
@@ -173,7 +201,25 @@ def test_AC8_13_73_dokploy_schedule_payload_is_server_job_with_retention() -> No
     assert payload["script"] == script
     assert "PR_PREVIEW_MAX_AGE_DAYS='3'" in str(payload["command"])
     assert "PR_PREVIEW_KEEP_RECENT='3'" in str(payload["command"])
+    assert "within 3 days" in str(payload["description"])
+    assert "most recent 3 PRs" in str(payload["description"])
     assert "VPS_SSH_KEY" not in json.dumps(payload)
+
+
+def test_AC8_13_73_dokploy_schedule_payload_describes_overridden_retention() -> None:
+    hygiene = hygiene_module()
+
+    payload = hygiene.build_schedule_payload(
+        server_id="srv-1",
+        script="echo clean",
+        pr_preview_max_age_days=7,
+        pr_preview_keep_recent=5,
+    )
+
+    assert "within 7 days" in str(payload["description"])
+    assert "most recent 5 PRs" in str(payload["description"])
+    assert "within 3 days" not in str(payload["description"])
+    assert "most recent 3 PRs" not in str(payload["description"])
 
 
 def test_AC8_13_73_ensure_schedule_updates_existing_named_job(monkeypatch) -> None:

--- a/tools/_lib/dev/vps_host_hygiene.py
+++ b/tools/_lib/dev/vps_host_hygiene.py
@@ -87,13 +87,24 @@ def build_hygiene_script(
             "  is_recent_pr() {",
             '    printf "%s\\n" "$recent_prs" | grep -qx "$1"',
             "  }",
+            "  parse_utc_epoch() {",
+            '    timestamp="$1"',
+            '    if [ -z "$timestamp" ]; then',
+            "      return 1",
+            "    fi",
+            '    date -u -d "$timestamp" +%s 2>/dev/null',
+            "  }",
             "  should_delete_pr_resource() {",
             '    pr_number="$1"',
             '    created_at="$2"',
             '    if is_recent_pr "$pr_number"; then',
             "      return 1",
             "    fi",
-            '    created_epoch="$(date -u -d "$created_at" +%s 2>/dev/null || echo 0)"',
+            '    created_epoch="$(parse_utc_epoch "$created_at" || true)"',
+            '    if [ -z "$created_epoch" ]; then',
+            '      echo "::warning::Skipping deletion because timestamp is missing or unparseable for PR ${pr_number}"',
+            "      return 1",
+            "    fi",
             '    [ "$created_epoch" -lt "$cutoff_epoch" ]',
             "  }",
             "  docker ps -a --format '{{.Names}}' | "
@@ -106,7 +117,7 @@ def build_hygiene_script(
             (
                 '      echo "[dry-run] docker rm -f ${container_name}"'
                 if dry_run
-                else '      docker rm -f "$container_name"'
+                else '      docker rm -f "$container_name" || true'
             ),
             "    fi",
             "  done",
@@ -141,7 +152,11 @@ def build_hygiene_script(
             '    status="$(docker inspect --format "{{.State.Status}}" "$non_preview_container" 2>/dev/null || echo "")"',
             '    case "$status" in exited|created|dead) ;; *) continue ;; esac',
             '    created_at="$(docker inspect --format "{{.Created}}" "$non_preview_container" 2>/dev/null || echo "")"',
-            '    created_epoch="$(date -u -d "$created_at" +%s 2>/dev/null || echo 0)"',
+            '    created_epoch="$(parse_utc_epoch "$created_at" || true)"',
+            '    if [ -z "$created_epoch" ]; then',
+            '      echo "::warning::Skipping deletion because timestamp is missing or unparseable for container ${non_preview_container}"',
+            "      continue",
+            "    fi",
             '    if [ "$created_epoch" -lt "$container_cutoff_epoch" ]; then',
             (
                 '      echo "[dry-run] docker rm -f ${non_preview_container}"'
@@ -247,12 +262,15 @@ def build_schedule_payload(
     timezone: str = DEFAULT_TIMEZONE,
     enabled: bool = True,
     schedule_id: str = "",
+    pr_preview_max_age_days: int = 3,
+    pr_preview_keep_recent: int = 3,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "name": name,
         "description": (
             "Finance Report VPS host hygiene. Keeps PR preview resources created "
-            "within 3 days or among the most recent 3 PRs; prunes older host garbage."
+            f"within {pr_preview_max_age_days} days or among the most recent "
+            f"{pr_preview_keep_recent} PRs; prunes older host garbage."
         ),
         "cronExpression": cron_expression,
         "shellType": "bash",
@@ -311,6 +329,8 @@ def ensure_dokploy_schedule(
     cron_expression: str,
     timezone: str,
     enabled: bool,
+    pr_preview_max_age_days: int = 3,
+    pr_preview_keep_recent: int = 3,
 ) -> str:
     schedule_id = find_schedule_id_by_name(config, server_id=server_id, name=name)
     payload = build_schedule_payload(
@@ -321,6 +341,8 @@ def ensure_dokploy_schedule(
         timezone=timezone,
         enabled=enabled,
         schedule_id=schedule_id or "",
+        pr_preview_max_age_days=pr_preview_max_age_days,
+        pr_preview_keep_recent=pr_preview_keep_recent,
     )
     endpoint = "schedule.update" if schedule_id else "schedule.create"
     body = dokploy_api_call(config, "POST", endpoint, payload=payload)
@@ -386,6 +408,8 @@ def main(argv: list[str] | None = None) -> int:
                     cron_expression=args.cron_expression,
                     timezone=args.timezone,
                     enabled=not args.disabled,
+                    pr_preview_max_age_days=args.pr_preview_max_age_days,
+                    pr_preview_keep_recent=args.pr_preview_keep_recent,
                 ),
                 indent=2,
                 sort_keys=True,
@@ -405,6 +429,8 @@ def main(argv: list[str] | None = None) -> int:
             cron_expression=args.cron_expression,
             timezone=args.timezone,
             enabled=not args.disabled,
+            pr_preview_max_age_days=args.pr_preview_max_age_days,
+            pr_preview_keep_recent=args.pr_preview_keep_recent,
         )
         return 0
 


### PR DESCRIPTION
## Summary

Hardens Dokploy host hygiene cleanup after PR #600 review feedback by avoiding unsafe timestamp fallbacks, tolerating cleanup races, and correcting cleanup notice ownership.

Closes N/A

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.73, AC8.13.74 |
| **AC Registry updated** | N/A |

---

## SSOT Changes

- [x] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | N/A — local red before final commit | `pytest tests/tooling/test_vps_host_hygiene.py -q` failed on unsafe timestamp fallback, missing race tolerance, and static schedule description; targeted workflow notice test also failed before the wording fix. |
| 🟢 Green (passing test) | `e34ae80` | Harden host hygiene script and cleanup notice; focused tests pass. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable)
- [x] `repo/` submodule updated for production config changes (if applicable)
- [x] `tools/check_env_keys.py` passes (if env vars changed)
- [x] `tools/check_manifest.py` passes (if SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys.
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged.
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials.
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule.
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene.

---

## Testing

```bash
pytest tests/tooling/test_vps_host_hygiene.py tests/tooling/test_pr_preview_lifecycle.py tests/tooling/test_cleanup_pr_preview_resources.py -q
ruff check tools/_lib/dev/vps_host_hygiene.py tests/tooling/test_vps_host_hygiene.py tests/tooling/test_pr_preview_lifecycle.py
ruff format --check tools/_lib/dev/vps_host_hygiene.py tests/tooling/test_vps_host_hygiene.py tests/tooling/test_pr_preview_lifecycle.py
python tools/check_ac_traceability.py
python tools/check_manifest.py
moon run :lint
```

---

## Screenshots / Evidence

N/A
