### PR TITLE
[finance_report_vision] Harden investment performance audit semantics

### DIFF
--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -11,6 +11,7 @@ from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
 from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition, PositionStatus
+from src.models.market_data import StockPrice
 from src.models.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType, MarketDataOverride
 from src.schemas.portfolio import (
     BrokerageImportRequest,
@@ -88,6 +89,10 @@ def _source_document_links(source_documents: object) -> list[str]:
             if doc_id:
                 links.append(f"{doc_type}:{doc_id}")
     return links
+
+
+def _freshness_link(asset_identifier: str, source_kind: str, source_id: object, evidence_date: date) -> str:
+    return f"price_source:{source_kind}:{asset_identifier}:{source_id}:{evidence_date.isoformat()}"
 
 
 @router.post("/brokerage/import", response_model=BrokerageImportResponse, status_code=status.HTTP_200_OK)
@@ -427,7 +432,7 @@ async def get_investment_performance_report_schedule(
         .where(InvestmentTransaction.transaction_date <= period_end)
     )
     realized_by_asset: dict[str, Decimal] = {}
-    source_links: set[str] = set()
+    source_links: set[str] = {"report_section:investment_performance"}
     for txn in realized_result.scalars().all():
         realized_by_asset[txn.asset_identifier] = realized_by_asset.get(txn.asset_identifier, Decimal("0.00")) + (
             txn.realized_pnl or Decimal("0.00")
@@ -496,8 +501,9 @@ async def get_investment_performance_report_schedule(
         .order_by(AtomicPosition.snapshot_date.desc(), AtomicPosition.created_at.desc())
     )
     atomics = list(latest_atomic_result.scalars().all())
-    latest_atomic = atomics[0] if atomics else None
+    latest_atomic_by_asset: dict[str, AtomicPosition] = {}
     for atomic in atomics:
+        latest_atomic_by_asset.setdefault(atomic.asset_identifier, atomic)
         for link in _source_document_links(atomic.source_documents):
             source_links.add(link)
 
@@ -507,12 +513,61 @@ async def get_investment_performance_report_schedule(
         .where(MarketDataOverride.price_date <= as_of_date)
         .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
     )
-    latest_override = latest_override_result.scalars().first()
+    overrides = list(latest_override_result.scalars().all())
+    latest_override = overrides[0] if overrides else None
+    latest_override_by_asset: dict[str, MarketDataOverride] = {}
+    for override in overrides:
+        latest_override_by_asset.setdefault(override.asset_identifier, override)
+
+    stock_prices: list[StockPrice] = []
+    if asset_identifiers:
+        stock_price_result = await db.execute(
+            select(StockPrice)
+            .where(StockPrice.symbol.in_(asset_identifiers))
+            .where(StockPrice.price_date <= as_of_date)
+            .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc())
+        )
+        stock_prices = list(stock_price_result.scalars().all())
+    latest_stock_price_by_asset: dict[str, StockPrice] = {}
+    for stock_price in stock_prices:
+        latest_stock_price_by_asset.setdefault(stock_price.symbol, stock_price)
+
+    price_dates: list[date] = []
+    providers: set[str] = set()
+    stale_holdings: list[str] = []
+    for asset_identifier in asset_identifiers:
+        override = latest_override_by_asset.get(asset_identifier)
+        stock_price = latest_stock_price_by_asset.get(asset_identifier)
+        atomic = latest_atomic_by_asset.get(asset_identifier)
+
+        candidates: list[tuple[date, str, object, str | None]] = []
+        if override is not None:
+            candidates.append((override.price_date, "market_data_override", override.id, override.source.value))
+        if stock_price is not None:
+            candidates.append((stock_price.price_date, "stock_price", stock_price.id, stock_price.source))
+        if atomic is not None:
+            candidates.append((atomic.snapshot_date, "atomic_position", atomic.id, atomic.broker))
+
+        if not candidates:
+            stale_holdings.append(asset_identifier)
+            continue
+
+        evidence_date, source_kind, source_id, provider = max(candidates, key=lambda candidate: candidate[0])
+        price_dates.append(evidence_date)
+        source_links.add(_freshness_link(asset_identifier, source_kind, source_id, evidence_date))
+        if provider:
+            providers.add(provider)
+        if evidence_date < as_of_date:
+            stale_holdings.append(asset_identifier)
+
+    latest_price_date = max(price_dates) if price_dates else None
+    market_data_provider = ", ".join(sorted(providers)) if providers else None
 
     data_freshness = InvestmentPerformanceDataFreshness(
-        latest_price_date=latest_atomic.snapshot_date if latest_atomic else None,
-        market_data_provider=latest_atomic.broker if latest_atomic else None,
-        stale=latest_atomic is None or latest_atomic.snapshot_date < as_of_date,
+        latest_price_date=latest_price_date,
+        market_data_provider=market_data_provider,
+        stale=bool(stale_holdings),
+        stale_holdings=sorted(stale_holdings),
         manual_override_basis=(
             f"{latest_override.asset_identifier}:{latest_override.price_date.isoformat()}"
             if latest_override is not None

--- a/apps/backend/src/schemas/portfolio.py
+++ b/apps/backend/src/schemas/portfolio.py
@@ -134,6 +134,7 @@ class InvestmentPerformanceDataFreshness(BaseModel):
     latest_price_date: date | None
     market_data_provider: str | None
     stale: bool
+    stale_holdings: list[str] = Field(default_factory=list)
     manual_override_basis: str | None = None
 
 

--- a/apps/backend/src/services/performance.py
+++ b/apps/backend/src/services/performance.py
@@ -1,7 +1,7 @@
 """Portfolio performance metrics service - XIRR, TWR, MWR calculations."""
 
 from datetime import date, timedelta
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from uuid import UUID
 
 from sqlalchemy import and_, func, select
@@ -194,8 +194,8 @@ def _xirr_newton(amounts: list[Decimal], days: list[int], guess: Decimal, max_it
     """
     Calculate XIRR using Newton's method with bisection fallback.
 
-    Accepts Decimal parameters and returns a Decimal result; uses float internally
-    for power and rate operations for performance and compatibility.
+    Accepts Decimal parameters and returns a Decimal result without converting
+    monetary cash flows to float.
 
     Args:
         amounts: Cash flow amounts (negative for outflows, positive for inflows)
@@ -209,24 +209,36 @@ def _xirr_newton(amounts: list[Decimal], days: list[int], guess: Decimal, max_it
     Raises:
         ValueError: If calculation fails to converge
     """
-    # Use float internally for the power/division operations (Decimal ** Decimal is slow
-    # and Decimal doesn't support fractional exponents natively), but convert result back.
-    rate = float(guess)
-    float_amounts = [float(a) for a in amounts]
-    float_tol = float(tolerance)
+    rate = guess
 
     for _ in range(max_iter):
-        npv = sum(cf / (1 + rate) ** (d / 365.0) for cf, d in zip(float_amounts, days))
-        d_npv = sum(-(d / 365.0) * cf / (1 + rate) ** (d / 365.0 + 1) for cf, d in zip(float_amounts, days))
-        if abs(d_npv) < 1e-10:
+        base = Decimal("1") + rate
+        if base <= Decimal("0"):
+            break
+
+        npv = sum(cf / _decimal_power(base, Decimal(day) / Decimal("365")) for cf, day in zip(amounts, days))
+        d_npv = sum(
+            -(Decimal(day) / Decimal("365")) * cf / _decimal_power(base, (Decimal(day) / Decimal("365")) + Decimal("1"))
+            for cf, day in zip(amounts, days)
+        )
+        if abs(d_npv) < Decimal("1e-10"):
             break
 
         new_rate = rate - npv / d_npv
-        if abs(new_rate - rate) < float_tol:
-            return Decimal(str(new_rate))
+        if abs(new_rate - rate) < tolerance:
+            return new_rate
 
         rate = new_rate
     return _xirr_bisection(amounts, days, max_iter=200, tolerance=tolerance)
+
+
+def _decimal_power(base: Decimal, exponent: Decimal) -> Decimal:
+    """Raise a positive Decimal base to a fractional Decimal exponent."""
+    if base <= Decimal("0"):
+        raise ValueError("XIRR rate must be greater than -100%")
+    with localcontext() as ctx:
+        ctx.prec = max(ctx.prec, 34)
+        return (base.ln() * exponent).exp()
 
 
 def _xirr_bisection(amounts: list[Decimal], days: list[int], max_iter: int, tolerance: Decimal) -> Decimal:
@@ -247,12 +259,11 @@ def _xirr_bisection(amounts: list[Decimal], days: list[int], max_iter: int, tole
     Raises:
         ValueError: If no root found in search range
     """
-    lo, hi = -0.99, 10.0
-    float_amounts = [float(a) for a in amounts]
-    float_tol = float(tolerance)
+    lo, hi = Decimal("-0.99"), Decimal("10.0")
 
-    def npv(rate: float) -> float:
-        return sum(cf / (1 + rate) ** (d / 365.0) for cf, d in zip(float_amounts, days))
+    def npv(rate: Decimal) -> Decimal:
+        base = Decimal("1") + rate
+        return sum(cf / _decimal_power(base, Decimal(day) / Decimal("365")) for cf, day in zip(amounts, days))
 
     npv_lo = npv(lo)
     npv_hi = npv(hi)
@@ -260,11 +271,11 @@ def _xirr_bisection(amounts: list[Decimal], days: list[int], max_iter: int, tole
     if npv_lo * npv_hi > 0:
         raise ValueError(f"No root in [{lo}, {hi}]: NPV({lo})={npv_lo:.4f}, NPV({hi})={npv_hi:.4f}")
     for _ in range(max_iter):
-        mid = (lo + hi) / 2
+        mid = (lo + hi) / Decimal("2")
         npv_mid = npv(mid)
 
-        if abs(npv_mid) < float_tol or (hi - lo) / 2 < float_tol:
-            return Decimal(str(mid))
+        if abs(npv_mid) < tolerance or (hi - lo) / Decimal("2") < tolerance:
+            return mid
 
         if npv_lo * npv_mid < 0:
             hi = mid
@@ -273,7 +284,7 @@ def _xirr_bisection(amounts: list[Decimal], days: list[int], max_iter: int, tole
             lo = mid
             npv_lo = npv_mid
 
-    return Decimal(str((lo + hi) / 2))
+    return (lo + hi) / Decimal("2")
 
 
 async def calculate_time_weighted_return(

--- a/apps/backend/tests/portfolio/test_performance_service.py
+++ b/apps/backend/tests/portfolio/test_performance_service.py
@@ -4,6 +4,7 @@ AC17.3 block: Performance metrics — XIRR, TWR, MWR calculations.
 AC5.6.1 AC5.6.2 AC5.6.3 AC5.6.6: Portfolio return and yield metric calculations.
 """
 
+import inspect
 from datetime import date, timedelta
 from decimal import Decimal
 
@@ -599,6 +600,18 @@ def test_xirr_bisection_no_root_raises():
     days = [0, 180, 365]
     with pytest.raises(ValueError, match="No root in"):
         _xirr_bisection(amounts, days, max_iter=200, tolerance=Decimal("1e-6"))
+
+
+def test_AC17_10_5_xirr_solver_does_not_float_monetary_cashflows():
+    """AC17.10.5: XIRR internals do not convert monetary Decimal cash flows to float."""
+    import src.services.performance as performance_module
+
+    solver_source = inspect.getsource(performance_module._xirr_newton) + inspect.getsource(
+        performance_module._xirr_bisection
+    )
+
+    assert "float_amounts" not in solver_source
+    assert "float(a) for a in amounts" not in solver_source
 
 
 def test_xirr_bisection_max_iter_returns():

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -3,12 +3,14 @@
 from datetime import date, timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.account import Account, AccountType
+from src.models.journal import JournalEntry, JournalEntrySourceType, JournalEntryStatus
 from src.models.layer2 import AtomicPosition, AtomicTransaction, TransactionDirection
 from src.models.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
 from src.models.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType
@@ -68,7 +70,15 @@ async def portfolio_with_data(db: AsyncSession, test_user, investment_account):
         geography="US",
         asset_type="stock",
         dedup_hash="aapl_test",
-        source_documents={},
+        source_documents={
+            "documents": [
+                {
+                    "doc_id": "brokerage-doc-aapl",
+                    "doc_type": "brokerage_statement",
+                    "broker": "Test Broker",
+                }
+            ]
+        },
     )
     db.add(atomic)
     await db.commit()
@@ -431,8 +441,18 @@ async def test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule(
     test_user,
     portfolio_with_data,
 ):
-    """AC17.10.1 AC17.10.2: report schedule exposes metrics, rows, freshness, sources, and notes."""
+    """AC17.10.1 AC17.10.2 AC17.10.3: schedule exposes metrics, rows, freshness, sources, and notes."""
     position = portfolio_with_data["position"]
+    source_id = uuid4()
+    journal_entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=date.today() - timedelta(days=5),
+        memo="Realized investment sale",
+        source_type=JournalEntrySourceType.AUTO_PARSED,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(journal_entry)
+    await db.flush()
     dividend = DividendIncome(
         user_id=test_user.id,
         position_id=position.id,
@@ -454,6 +474,8 @@ async def test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule(
         cost_basis=Decimal("500.00"),
         realized_pnl=Decimal("149.00"),
         cost_basis_method=CostBasisMethod.FIFO,
+        journal_entry_id=journal_entry.id,
+        source_id=source_id,
     )
     db.add_all([dividend, sell])
     await db.commit()
@@ -482,10 +504,67 @@ async def test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule(
     assert data["holdings"][0]["dividend_income"] == "42.50"
     assert data["allocation"]
     assert data["data_freshness"]["latest_price_date"] == as_of_date
-    assert "source_links" in data
+    assert set(data["source_links"]) >= {
+        "brokerage_statement:brokerage-doc-aapl",
+        f"investment_transaction_source:{source_id}",
+        f"journal_entry:{journal_entry.id}",
+        "report_section:investment_performance",
+    }
+    assert any(link.startswith("price_source:atomic_position:AAPL:") for link in data["source_links"])
     assert data["notes"]
     if data["time_weighted_return"] is None:
         assert any("TWR unavailable" in note for note in data["notes"])
+
+
+@pytest.mark.asyncio
+async def test_AC17_10_4_report_schedule_marks_stale_when_any_holding_price_is_stale(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+    investment_account,
+    portfolio_with_data,
+):
+    """AC17.10.4: freshness is stale when any holding lacks current as-of-date price evidence."""
+    stale_date = date.today() - timedelta(days=7)
+    position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=investment_account.id,
+        asset_identifier="MSFT",
+        quantity=Decimal("10"),
+        cost_basis=Decimal("2500.00"),
+        currency="SGD",
+        acquisition_date=stale_date,
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    atomic = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=stale_date,
+        asset_identifier="MSFT",
+        broker="Stale Broker",
+        quantity=Decimal("10"),
+        market_value=Decimal("2700.00"),
+        currency="SGD",
+        sector="Technology",
+        geography="US",
+        asset_type="stock",
+        dedup_hash="msft_stale_snapshot",
+        source_documents=[{"doc_id": "brokerage-doc-msft", "doc_type": "brokerage_statement"}],
+    )
+    db.add_all([position, atomic])
+    await db.commit()
+
+    as_of_date = date.today().isoformat()
+    response = await client.get(
+        "/portfolio/performance/report-schedule"
+        f"?period_start={date.today().replace(month=1, day=1).isoformat()}"
+        f"&period_end={as_of_date}&as_of_date={as_of_date}&currency=SGD"
+    )
+
+    assert response.status_code == 200
+    freshness = response.json()["data_freshness"]
+    assert freshness["stale"] is True
+    assert freshness["stale_holdings"] == ["MSFT"]
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/__tests__/portfolioPage.test.tsx
+++ b/apps/frontend/src/__tests__/portfolioPage.test.tsx
@@ -126,6 +126,7 @@ function mockPortfolioApi(holdings: PortfolioHolding[] = [mockHolding]) {
           latest_price_date: "2026-12-31",
           market_data_provider: "Test Broker",
           stale: false,
+          stale_holdings: [],
           manual_override_basis: null,
         },
         source_links: ["brokerage_statement:aapl"],

--- a/apps/frontend/src/components/portfolio/InvestmentPerformanceSchedule.tsx
+++ b/apps/frontend/src/components/portfolio/InvestmentPerformanceSchedule.tsx
@@ -55,6 +55,7 @@ export function InvestmentPerformanceSchedule({
         { label: "MWR", value: schedule.money_weighted_return },
         { label: "Dividend Yield", value: schedule.dividend_yield },
     ];
+    const staleHoldings = schedule.data_freshness.stale_holdings ?? [];
 
     return (
         <section className="card p-5 mb-6" aria-labelledby="investment-performance-schedule-title">
@@ -109,6 +110,9 @@ export function InvestmentPerformanceSchedule({
                         <p>Latest price date: {schedule.data_freshness.latest_price_date ?? "N/A"}</p>
                         <p>Provider: {schedule.data_freshness.market_data_provider ?? "N/A"}</p>
                         <p>Status: {schedule.data_freshness.stale ? "Stale" : "Current"}</p>
+                        {staleHoldings.length > 0 ? (
+                            <p>Stale holdings: {staleHoldings.join(", ")}</p>
+                        ) : null}
                         {schedule.data_freshness.manual_override_basis ? (
                             <p>Manual override: {schedule.data_freshness.manual_override_basis}</p>
                         ) : null}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -396,6 +396,7 @@ export interface InvestmentPerformanceDataFreshness {
     latest_price_date: string | null;
     market_data_provider: string | null;
     stale: boolean;
+    stale_holdings: string[];
     manual_override_basis?: string | null;
 }
 

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -4294,6 +4294,21 @@ groups:
         epic_name: portfolio-management
         description: Investment performance schedule API exposes data freshness, source links, and notes for report traceability
         mandatory: true
+      - id: AC17.10.3
+        epic: 17
+        epic_name: portfolio-management
+        description: Investment performance schedule source links preserve brokerage statement, price source, ledger, transaction source, and report-section anchors
+        mandatory: true
+      - id: AC17.10.4
+        epic: 17
+        epic_name: portfolio-management
+        description: Investment performance schedule data freshness marks the schedule stale when any holding lacks current as-of-date price evidence
+        mandatory: true
+      - id: AC17.10.5
+        epic: 17
+        epic_name: portfolio-management
+        description: Investment performance XIRR solver does not convert monetary Decimal cash flows to float
+        mandatory: true
   AC18:
     AC18.1:
       - id: AC18.1.1

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -356,7 +356,7 @@ Response object:
 | `realized_pnl`, `unrealized_pnl`, `dividend_income`, `dividend_yield` | Decimal-safe return components |
 | `holdings` | Per holding `{asset_identifier, quantity, cost_basis, market_value, unrealized_pnl, realized_pnl, dividend_income, currency}` rows |
 | `allocation` | Sector, geography, and asset-class allocation rows |
-| `data_freshness` | Market-data source, latest price date, stale flag, and manual override basis |
+| `data_freshness` | Market-data source, latest price date, stale flag, `stale_holdings` per-holding stale list, and manual override basis |
 | `source_links` | Source document, brokerage import, price source, and ledger/report traceability anchors |
 | `notes` | Human-readable methods and limitations for cost basis, market prices, and return metrics |
 
@@ -364,6 +364,9 @@ Response object:
 |----|-----------|---------------|------|----------|
 | AC17.10.1 | Investment performance schedule API exposes report-ready metrics and rows | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
 | AC17.10.2 | Investment performance schedule API exposes data freshness, source links, and notes for report traceability | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+| AC17.10.3 | Investment performance schedule source links preserve brokerage statement, price source, ledger, transaction source, and report-section anchors | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P0 |
+| AC17.10.4 | Investment performance schedule data freshness marks the schedule stale when any holding lacks current as-of-date price evidence | `test_AC17_10_4_report_schedule_marks_stale_when_any_holding_price_is_stale` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P0 |
+| AC17.10.5 | Investment performance XIRR solver does not convert monetary Decimal cash flows to float | `test_AC17_10_5_xirr_solver_does_not_float_monetary_cashflows` | `apps/backend/tests/portfolio/test_performance_service.py` | P0 |
 
 ### Brokerage PDF to Asset Report Proof Matrix
 

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -157,7 +157,7 @@ Response object:
 | `realized_pnl`, `unrealized_pnl`, `dividend_income`, `dividend_yield` | Decimal-safe schedule totals in `currency` |
 | `holdings` | Per holding rows with quantity, cost basis, market value, realized/unrealized P&L, dividend income, and source currency |
 | `allocation` | Sector, geography, and asset-class allocation rows whose percentages reconcile to the schedule market value |
-| `data_freshness` | Latest price date, market-data provider, stale flag, and manual override basis |
+| `data_freshness` | Latest price date, market-data provider, stale flag, `stale_holdings` per-holding stale list, and manual override basis |
 | `source_links` | Brokerage statement/import IDs, price source IDs, ledger entry IDs, and report anchors needed for source-to-ledger-to-report traceability |
 | `notes` | Methods and limitations for cost basis, price freshness, dividends, XIRR/TWR/MWR, and any manual overrides |
 

--- a/docs/user-guide/reports.md
+++ b/docs/user-guide/reports.md
@@ -66,7 +66,8 @@ money-weighted return, realized P&L, unrealized P&L, dividend income, dividend
 yield, holdings, allocation, data freshness, `source_links`, and `notes`.
 Those fields let the package explain how investment-performance values were
 calculated and how they trace back to brokerage statements, market prices, and
-ledger/report output.
+ledger/report output. `data_freshness.stale_holdings` lists holdings whose price
+evidence is older than the requested `as_of_date`.
 
 ## Dashboard Widgets
 

--- a/tests/tooling/test_investment_performance_report_contract.py
+++ b/tests/tooling/test_investment_performance_report_contract.py
@@ -31,6 +31,7 @@ def test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract() -> N
         "holdings",
         "allocation",
         "data_freshness",
+        "stale_holdings",
         "source_links",
         "notes",
     ]:


### PR DESCRIPTION
## Summary

Hardens the `investment-performance` report schedule so audit source links, per-holding freshness, and XIRR Decimal discipline meet the quality baseline.

Closes #601
Parent: #596

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-017 — Investment Portfolio Management |
| **AC IDs** | AC17.10.3, AC17.10.4, AC17.10.5 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — no ownership change
- [x] `docs/ssot/reporting.md` — documents `data_freshness.stale_holdings` and strengthened schedule freshness semantics
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `0d9d528` | Tests were written before implementation in the working tree, but not split into a separate red-phase commit. Added AC17.10.3/4/5 coverage for source links, per-holding freshness, and XIRR Decimal cash-flow handling. |
| 🟢 Green (passing test) | `0d9d528` | Implemented report schedule source anchors, per-holding freshness, frontend display/type updates, and Decimal XIRR internals. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — no enum changes
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env vars changed
- [x] `tools/check_manifest.py` passes (if SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

N/A — no workflow, deploy tooling, Dokploy runtime config, VPS host script, or log changes.

---

## Testing

```bash
moon run :lint
npm test -- --run src/__tests__/portfolioPage.test.tsx src/__tests__/performanceCard.test.tsx
pytest tests/tooling/test_investment_performance_report_contract.py tests/tooling/test_check_critical_proof_matrix.py -q
python tools/check_critical_proof_matrix.py
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_ac_traceability.py
uv run --with pyyaml python tools/check_e2e_epic_traceability.py
python tools/check_manifest.py
python tools/lint_doc_consistency.py
PYTHONPATH=apps/backend python - <<'PY'
import inspect
from decimal import Decimal
import src.services.performance as performance
source = inspect.getsource(performance._xirr_newton) + inspect.getsource(performance._xirr_bisection)
assert 'float_amounts' not in source
assert 'float(a) for a in amounts' not in source
result = performance._xirr_newton([Decimal('-10000'), Decimal('11200')], [0, 365], Decimal('0.1'), 100, Decimal('1e-6'))
assert abs(result - Decimal('0.12')) < Decimal('0.000001')
print(result)
PY
```

Backend DB-backed target tests could not complete locally because Podman failed before infra startup:

```text
Cannot connect to Podman ... ssh: handshake failed: EOF
```

Attempted target command:

```bash
python tools/_lib/dev/test_lifecycle.py --fast \
  apps/backend/tests/portfolio/test_portfolio_router.py::test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule \
  apps/backend/tests/portfolio/test_portfolio_router.py::test_AC17_10_4_report_schedule_marks_stale_when_any_holding_price_is_stale \
  apps/backend/tests/portfolio/test_performance_service.py::test_AC17_10_5_xirr_solver_does_not_float_monetary_cashflows
```

---

## Screenshots / Evidence

N/A — backend/report contract hardening with a small freshness display addition.