### PR TITLE
[finance_report_ui] Harden responsive account and review layouts

### DIFF
--- a/apps/frontend/playwright/mobile-ux.spec.ts
+++ b/apps/frontend/playwright/mobile-ux.spec.ts
@@ -81,6 +81,32 @@ const baseStage2Queue = {
   has_unresolved_checks: false,
 };
 
+const baseAccounts = {
+  items: [
+    {
+      id: "account-mobile-long",
+      name: "DBS Multiplier Main Operating Account With Long Name",
+      code: "1010",
+      type: "ASSET",
+      currency: "SGD",
+      balance: "123456.78",
+      is_active: true,
+      description: "Primary cash account used for statement imports",
+    },
+    {
+      id: "income-mobile",
+      name: "Salary Income",
+      code: "4010",
+      type: "INCOME",
+      currency: "SGD",
+      balance: "0.00",
+      is_active: true,
+      description: "Monthly employment income",
+    },
+  ],
+  total: 2,
+};
+
 async function installMobileApiMocks(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem("finance_access_token", "mobile-review-token");
@@ -131,6 +157,8 @@ async function installMobileApiMocks(page: Page) {
         currency: "SGD",
         oldest_pending_date: null,
       };
+    } else if (path === "/api/accounts") {
+      body = baseAccounts;
     }
 
     await route.fulfill({
@@ -150,6 +178,15 @@ async function expectNoDocumentHorizontalScroll(page: Page) {
 
   expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
   expect(metrics.scrollX).toBe(0);
+}
+
+async function expectNoLocalHorizontalScroll(page: Page, testId: string) {
+  const metrics = await page.getByTestId(testId).evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
 }
 
 async function gotoReady(page: Page, path: string) {
@@ -232,6 +269,31 @@ test("AC16.26.3 stage 2 run review preserves mobile approval gate and match work
   await expectNoDocumentHorizontalScroll(page);
 });
 
+test("AC2.12.3 mobile accounts avoids document horizontal scroll and overlapping row controls", async ({ page }) => {
+  await gotoReady(page, "/accounts");
+
+  await expect(page.getByRole("heading", { name: "Accounts" })).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
+  await expect(page.getByTestId("account-row-account-mobile-long")).toBeVisible();
+  await expectNoDocumentHorizontalScroll(page);
+
+  const rowMetrics = await page.getByTestId("account-row-account-mobile-long").evaluate((row) => {
+    const name = row.querySelector("[data-account-field='identity']")?.getBoundingClientRect();
+    const balance = row.querySelector("[data-account-field='balance']")?.getBoundingClientRect();
+    const actions = row.querySelector("[data-account-field='actions']")?.getBoundingClientRect();
+    return {
+      hasTargets: Boolean(name && balance && actions),
+      nameBottom: name?.bottom ?? 0,
+      balanceTop: balance?.top ?? 0,
+      balanceBottom: balance?.bottom ?? 0,
+      actionsTop: actions?.top ?? 0,
+    };
+  });
+
+  expect(rowMetrics.hasTargets).toBe(true);
+  expect(rowMetrics.nameBottom).toBeLessThanOrEqual(rowMetrics.balanceTop);
+  expect(rowMetrics.balanceBottom).toBeLessThanOrEqual(rowMetrics.actionsTop);
+});
+
 test.describe("375px mobile review proof", () => {
   test.use({
     viewport: { width: 375, height: 812 },
@@ -253,6 +315,34 @@ test.describe("375px mobile review proof", () => {
     await gotoReady(page, "/review/run/run-mobile-1");
     await expect(page.getByRole("button", { name: "Approve Run", exact: true })).toBeVisible();
     await expect(page.getByTestId("stage2-mobile-match-card-match-mobile-1")).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
+    await expectNoDocumentHorizontalScroll(page);
+  });
+});
+
+test.describe("1440px desktop review proof", () => {
+  test.use({
+    viewport: { width: 1440, height: 1000 },
+    isMobile: false,
+    hasTouch: false,
+  });
+
+  test("AC8.13.82/AC16.27.2 desktop stage 1 review keeps transaction table readable at 1440px", async ({ page }) => {
+    await gotoReady(page, "/statements/stmt-mobile/review");
+
+    const desktopRegion = page.getByTestId("stage1-desktop-transaction-region");
+    await expect(desktopRegion).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
+    await expect(desktopRegion.getByText("Long mobile grocery transaction from a bank statement")).toBeVisible();
+    await expectNoLocalHorizontalScroll(page, "stage1-desktop-transaction-region");
+    await expectNoDocumentHorizontalScroll(page);
+  });
+
+  test("AC8.13.82/AC16.27.3 desktop stage 2 review keeps pending matches readable at 1440px", async ({ page }) => {
+    await gotoReady(page, "/reconciliation/review-queue");
+
+    const desktopRegion = page.getByTestId("stage2-desktop-match-region");
+    await expect(desktopRegion).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
+    await expect(desktopRegion.getByText("Long reconciliation match needing mobile approval")).toBeVisible();
+    await expectNoLocalHorizontalScroll(page, "stage2-desktop-match-region");
     await expectNoDocumentHorizontalScroll(page);
   });
 });

--- a/apps/frontend/src/__tests__/TransactionTable.test.tsx
+++ b/apps/frontend/src/__tests__/TransactionTable.test.tsx
@@ -150,7 +150,9 @@ describe("TransactionTable", () => {
 
         const region = screen.getByTestId("stage1-desktop-transaction-region");
         expect(region).toHaveClass("overflow-hidden");
-        expect(region.querySelector("table")).toHaveClass("table-fixed", "w-full");
+        const table = region.querySelector("table");
+        expect(table).toHaveClass("table-fixed", "border-collapse");
+        expect(table).toHaveStyle({ width: "calc(100% - 4px)" });
     });
 
     it("renders rows and shows Save/Discard when pending edits exist", () => {

--- a/apps/frontend/src/__tests__/TransactionTable.test.tsx
+++ b/apps/frontend/src/__tests__/TransactionTable.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import * as currency from "@/lib/currency";
 import { TransactionTable } from "@/components/review/TransactionTable";
 import type { BankStatementTransaction } from "@/lib/types";
@@ -89,7 +89,7 @@ describe("TransactionTable", () => {
         expect(onDiscard).toHaveBeenCalled();
     });
 
-    it("keeps the desktop table when matchMedia is unavailable", () => {
+    it("keeps desktop table and mobile first-paint markup when matchMedia is unavailable", () => {
         Object.defineProperty(window, "matchMedia", {
             configurable: true,
             writable: true,
@@ -108,8 +108,49 @@ describe("TransactionTable", () => {
             />
         );
 
-        expect(screen.queryByTestId("stage1-mobile-transaction-card-t1")).not.toBeInTheDocument();
-        expect(screen.getByText("Coffee")).toBeInTheDocument();
+        expect(screen.getByTestId("stage1-mobile-transaction-card-t1")).toBeInTheDocument();
+        expect(screen.getAllByText("Coffee").length).toBeGreaterThan(0);
+    });
+
+    it("AC16.27.1 keeps mobile transaction cards in the DOM without matchMedia gating", () => {
+        Object.defineProperty(window, "matchMedia", {
+            configurable: true,
+            writable: true,
+            value: undefined,
+        });
+
+        render(
+            <TransactionTable
+                transactions={sample}
+                currency="SGD"
+                onEdit={onEdit}
+                pendingEdits={new Map()}
+                onSave={onSave}
+                onDiscard={onDiscard}
+                actionLoading={false}
+            />
+        );
+
+        expect(screen.getByTestId("stage1-mobile-transaction-card-t1")).toBeInTheDocument();
+        expect(screen.getAllByText("Coffee").length).toBeGreaterThan(0);
+    });
+
+    it("AC8.13.82/AC16.27.2 exposes a fixed desktop transaction region for responsive UX proofs", () => {
+        render(
+            <TransactionTable
+                transactions={sample}
+                currency="SGD"
+                onEdit={onEdit}
+                pendingEdits={new Map()}
+                onSave={onSave}
+                onDiscard={onDiscard}
+                actionLoading={false}
+            />
+        );
+
+        const region = screen.getByTestId("stage1-desktop-transaction-region");
+        expect(region).toHaveClass("overflow-hidden");
+        expect(region.querySelector("table")).toHaveClass("table-fixed", "w-full");
     });
 
     it("renders rows and shows Save/Discard when pending edits exist", () => {
@@ -130,7 +171,7 @@ describe("TransactionTable", () => {
         );
 
         expect(screen.getByText("Transactions")).toBeInTheDocument();
-        expect(screen.getByText("Coffee Shop")).toBeInTheDocument();
+        expect(screen.getAllByText("Coffee Shop").length).toBeGreaterThan(0);
         const saveBtn = screen.getByRole("button", { name: /Save Edits/ });
         fireEvent.click(saveBtn);
         expect(onSave).toHaveBeenCalled();
@@ -157,10 +198,11 @@ describe("TransactionTable", () => {
         );
 
         // click description cell to begin edit
-        const descCell = screen.getByText("Coffee");
+        const desktopRegion = within(screen.getByTestId("stage1-desktop-transaction-region"));
+        const descCell = desktopRegion.getByText("Coffee");
         fireEvent.click(descCell);
         // simulate typing
-        const input = screen.getByDisplayValue("Coffee");
+        const input = desktopRegion.getByDisplayValue("Coffee");
         fireEvent.change(input, { target: { value: "Coffee - Latte" } });
         expect(onEdit).toHaveBeenCalledWith("t1", "description", "Coffee - Latte");
     });
@@ -197,16 +239,17 @@ describe("TransactionTable", () => {
         );
 
         // click amount cell to begin edit
-        const amountCell = screen.getByText("+", { exact: false });
+        const desktopRegion = within(screen.getByTestId("stage1-desktop-transaction-region"));
+        const amountCell = desktopRegion.getByText("+", { exact: false });
         fireEvent.click(amountCell);
 
         // select direction dropdown and change to OUT
-        const select = screen.getByDisplayValue("IN");
+        const select = desktopRegion.getByDisplayValue("IN");
         fireEvent.change(select, { target: { value: "OUT" } });
         expect(onEdit).toHaveBeenCalledWith("t2", "direction", "OUT");
 
         // change amount input
-        const amtInput = screen.getByDisplayValue("1000");
+        const amtInput = desktopRegion.getByDisplayValue("1000");
         fireEvent.change(amtInput, { target: { value: "900" } });
         expect(onEdit).toHaveBeenCalledWith("t2", "amount", "900");
     });
@@ -227,9 +270,10 @@ describe("TransactionTable", () => {
             />
         );
 
-        const dateCell = screen.getByText("2024-01-10");
+        const desktopRegion = within(screen.getByTestId("stage1-desktop-transaction-region"));
+        const dateCell = desktopRegion.getByText("2024-01-10");
         fireEvent.click(dateCell);
-        const dateInput = screen.getByDisplayValue("2024-01-10");
+        const dateInput = desktopRegion.getByDisplayValue("2024-01-10");
         fireEvent.change(dateInput, { target: { value: "2024-01-11" } });
         expect(onEdit).toHaveBeenCalledWith("t1", "txn_date", "2024-01-11");
     });
@@ -273,18 +317,19 @@ describe("TransactionTable", () => {
         );
 
         // begin editing amount by clicking the amount cell
-        const amountCell = screen.getByText(/SGD/);
+        const desktopRegion = within(screen.getByTestId("stage1-desktop-transaction-region"));
+        const amountCell = desktopRegion.getByText(/SGD/);
         fireEvent.click(amountCell);
 
         // now inputs should be present
-        const amtInput = screen.getByDisplayValue("3.5");
+        const amtInput = desktopRegion.getByDisplayValue("3.5");
         expect(amtInput).toBeTruthy();
 
         // press Enter to end edit
         fireEvent.keyDown(amtInput, { key: "Enter" });
 
         // after ending edit, the input should no longer be in the document
-        expect(container.querySelector('input[value="3.5"]')).toBeNull();
+        expect(desktopRegion.queryByDisplayValue("3.5")).toBeNull();
     });
 
     it("renders negative sign for OUT transactions", () => {
@@ -302,7 +347,7 @@ describe("TransactionTable", () => {
         );
 
         // look specifically for the currency string prefixed with a minus sign
-        const negAmount = screen.getByText(/-SGD/);
+        const negAmount = within(screen.getByTestId("stage1-desktop-transaction-region")).getByText(/-SGD/);
         expect(negAmount).toBeTruthy();
     });
 
@@ -325,9 +370,10 @@ describe("TransactionTable", () => {
             />
         );
 
-        const high = screen.getByText('high');
-        const medium = screen.getByText('medium');
-        const low = screen.getByText('low');
+        const desktopRegion = within(screen.getByTestId("stage1-desktop-transaction-region"));
+        const high = desktopRegion.getByText('high');
+        const medium = desktopRegion.getByText('medium');
+        const low = desktopRegion.getByText('low');
 
         expect(high.className).toContain('badge-success');
         expect(medium.className).toContain('badge-warning');
@@ -351,12 +397,13 @@ describe("TransactionTable", () => {
         );
 
         // click amount cell to open combined editor
-        const amountCell = screen.getByText(/SGD/);
+        const desktopRegion = within(screen.getByTestId("stage1-desktop-transaction-region"));
+        const amountCell = desktopRegion.getByText(/SGD/);
         fireEvent.click(amountCell);
 
         // inputs should be present
-        const select = screen.getByDisplayValue("OUT");
-        const input = screen.getByDisplayValue("3.5");
+        const select = desktopRegion.getByDisplayValue("OUT");
+        const input = desktopRegion.getByDisplayValue("3.5");
         expect(select).toBeTruthy();
         expect(input).toBeTruthy();
 
@@ -365,7 +412,7 @@ describe("TransactionTable", () => {
         fireEvent.blur(wrapper, { relatedTarget: null });
 
         // after blur the inputs should be removed
-        expect(container.querySelector('input[value="3.5"]')).toBeNull();
+        expect(desktopRegion.queryByDisplayValue("3.5")).toBeNull();
     });
 
     it("calls formatCurrencyLocale for numeric and string amounts", () => {
@@ -425,10 +472,11 @@ describe("TransactionTable", () => {
         );
 
         // open editor
-        const amountCell = screen.getByText(/SGD/);
+        const desktopRegion = within(screen.getByTestId("stage1-desktop-transaction-region"));
+        const amountCell = desktopRegion.getByText(/SGD/);
         fireEvent.click(amountCell);
 
-        const select = screen.getByDisplayValue("OUT");
+        const select = desktopRegion.getByDisplayValue("OUT");
         fireEvent.change(select, { target: { value: "IN" } });
         expect(onEdit).toHaveBeenCalledWith("t1", "direction", "IN");
 
@@ -437,7 +485,7 @@ describe("TransactionTable", () => {
         fireEvent.blur(wrapper, { relatedTarget: null });
 
         // editor should be closed
-        expect(screen.queryByDisplayValue("IN")).toBeNull();
+        expect(desktopRegion.queryByDisplayValue("IN")).toBeNull();
     });
 
     it("changing amount input calls onEdit and hides editor on blur", () => {
@@ -455,16 +503,17 @@ describe("TransactionTable", () => {
             />
         );
 
-        const amountCell = screen.getByText(/SGD/);
+        const desktopRegion = within(screen.getByTestId("stage1-desktop-transaction-region"));
+        const amountCell = desktopRegion.getByText(/SGD/);
         fireEvent.click(amountCell);
 
-        const amtInput = screen.getByDisplayValue("3.5");
+        const amtInput = desktopRegion.getByDisplayValue("3.5");
         fireEvent.change(amtInput, { target: { value: "4.25" } });
         expect(onEdit).toHaveBeenCalledWith("t1", "amount", "4.25");
 
         // blur to close
         fireEvent.blur(amtInput, { relatedTarget: null });
-        expect(screen.queryByDisplayValue("4.25")).toBeNull();
+        expect(desktopRegion.queryByDisplayValue("4.25")).toBeNull();
     });
 
     it("renders no ring class when pendingEdits empty and ring when present", () => {

--- a/apps/frontend/src/__tests__/epic016Components.test.tsx
+++ b/apps/frontend/src/__tests__/epic016Components.test.tsx
@@ -50,8 +50,8 @@ describe("EPIC-016 Componentization Tests", () => {
                 actionLoading={false}
             />
         );
-        expect(screen.getByText("Test Txn")).toBeInTheDocument();
-        expect(screen.getByText("high")).toBeInTheDocument();
+        expect(screen.getAllByText("Test Txn").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("high").length).toBeGreaterThan(0);
     });
 
     it("mounts ConflictResolutionDialog and asserts primary affordance (AC16.23.6)", () => {

--- a/apps/frontend/src/__tests__/pingPongPage.test.tsx
+++ b/apps/frontend/src/__tests__/pingPongPage.test.tsx
@@ -54,4 +54,18 @@ describe("PingPongPage", () => {
 
     await waitFor(() => expect(screen.getByText("PING")).toBeInTheDocument())
   })
+
+  it("AC16.12.10 surfaces toggle errors", async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce({ state: "ping", toggle_count: 0, updated_at: null })
+      .mockRejectedValueOnce(new Error("toggle failed"))
+
+    render(<PingPongPage />)
+
+    await waitFor(() => expect(screen.getByText("PING")).toBeInTheDocument())
+    fireEvent.click(screen.getByRole("button", { name: "Toggle State" }))
+
+    await waitFor(() => expect(screen.getByText("toggle failed")).toBeInTheDocument())
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument()
+  })
 })

--- a/apps/frontend/src/__tests__/reviewQueuePage.actions.test.tsx
+++ b/apps/frontend/src/__tests__/reviewQueuePage.actions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import ReviewQueuePage from "@/app/(main)/reconciliation/review-queue/page";
 import { renderReviewComponent } from "@/__tests__/helpers/renderReviewComponent";
 import { apiFetch } from "@/lib/api";
@@ -33,7 +33,8 @@ describe("Review queue actions", () => {
         expect(await screen.findByText('Pending Matches')).toBeInTheDocument();
 
         // select first row checkbox
-        const row = await screen.findByText('A');
+        const desktopRegion = await screen.findByTestId("stage2-desktop-match-region");
+        const row = within(desktopRegion).getByText('A');
         const tr = row.closest('tr') as HTMLTableRowElement;
         const cb = tr.querySelector('input[type="checkbox"]') as HTMLInputElement;
         fireEvent.click(cb);
@@ -122,7 +123,8 @@ describe("Review queue actions", () => {
         expect(screen.getByText(/Unresolved consistency checks block batch approval/i)).toBeInTheDocument();
 
         // select the row
-        const row = await screen.findByText('X');
+        const desktopRegion = await screen.findByTestId("stage2-desktop-match-region");
+        const row = within(desktopRegion).getByText('X');
         const tr = row.closest('tr') as HTMLTableRowElement;
         const cb = tr.querySelector('input[type="checkbox"]') as HTMLInputElement;
         fireEvent.click(cb);

--- a/apps/frontend/src/__tests__/reviewQueuePage.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/reviewQueuePage.coverage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import ReviewQueuePage from "@/app/(main)/reconciliation/review-queue/page";
 import { apiFetch } from "@/lib/api";
 import { renderReviewComponent } from "./helpers/renderReviewComponent";
@@ -16,6 +16,7 @@ const mockedApi = vi.mocked(apiFetch);
 describe("ReviewQueuePage - coverage additions", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockedApi.mockReset();
     });
 
     it("renders checks and pending matches, toggles severity and minScore filter, select/deselect all", async () => {
@@ -30,14 +31,13 @@ describe("ReviewQueuePage - coverage additions", () => {
             has_unresolved_checks: false,
         };
 
-        mockedApi.mockResolvedValueOnce(data as any);
-        // filtered checks list
-        mockedApi.mockResolvedValueOnce({ items: data.consistency_checks } as any);
-
-        // approve batch endpoint
-        mockedApi.mockResolvedValueOnce({ success: true, approved_count: 1 } as any);
-        // reject batch endpoint
-        mockedApi.mockResolvedValueOnce({ success: true, rejected_count: 1 } as any);
+        mockedApi.mockImplementation((path: string) => {
+            if (String(path).includes("/stage2/queue")) return Promise.resolve(data as any);
+            if (String(path).includes("consistency-checks/list")) return Promise.resolve({ items: data.consistency_checks } as any);
+            if (String(path).includes("batch-approve-matches")) return Promise.resolve({ success: true, approved_count: 1 } as any);
+            if (String(path).includes("batch-reject-matches")) return Promise.resolve({ success: true, rejected_count: 1 } as any);
+            return Promise.resolve(null as any);
+        });
 
         renderReviewComponent(<ReviewQueuePage /> as any);
 
@@ -59,12 +59,16 @@ describe("ReviewQueuePage - coverage additions", () => {
         const approve = await screen.findByRole("button", { name: /Approve Selected/i });
         fireEvent.click(approve);
 
-        expect(mockedApi.mock.calls.some(c => String(c[0]).includes("batch-approve-matches"))).toBe(true);
+        await waitFor(() => expect(mockedApi.mock.calls.some(c => String(c[0]).includes("batch-approve-matches"))).toBe(true));
 
-        // reject selected
+        // reject selected after the approve flow clears selection
+        const desktopRegion = await screen.findByTestId("stage2-desktop-match-region");
+        const row = within(desktopRegion).getByText("Good match").closest("tr") as HTMLTableRowElement;
+        const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+        fireEvent.click(checkbox);
         const reject = await screen.findByRole("button", { name: /Reject/i });
         fireEvent.click(reject);
-        expect(mockedApi.mock.calls.some(c => String(c[0]).includes("batch-reject-matches"))).toBe(true);
+        await waitFor(() => expect(mockedApi.mock.calls.some(c => String(c[0]).includes("batch-reject-matches"))).toBe(true));
     });
 
     it("handles resolve dialog open and keydown escape to close", async () => {

--- a/apps/frontend/src/__tests__/reviewQueuePage.test.tsx
+++ b/apps/frontend/src/__tests__/reviewQueuePage.test.tsx
@@ -167,7 +167,8 @@ describe("AC4.6.4 ReviewQueuePage interactive flows", () => {
 
         renderReviewComponent(<ReviewQueuePage /> as never);
 
-        fireEvent.click(await screen.findByText("Transfer"));
+        const desktopRegion = await screen.findByTestId("stage2-desktop-match-region");
+        fireEvent.click(within(desktopRegion).getByText("Transfer"));
         fireEvent.click(screen.getByRole("button", { name: /Approve Selected/i }));
 
         await waitFor(() => {
@@ -204,7 +205,8 @@ describe("AC4.6.4 ReviewQueuePage interactive flows", () => {
 
         renderReviewComponent(<ReviewQueuePage /> as never);
 
-        fireEvent.click(await screen.findByText("Transfer"));
+        const desktopRegion = await screen.findByTestId("stage2-desktop-match-region");
+        fireEvent.click(within(desktopRegion).getByText("Transfer"));
         fireEvent.click(screen.getByRole("button", { name: "Reject" }));
 
         await waitFor(() => {

--- a/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
+++ b/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
@@ -222,7 +222,9 @@ describe("AC8.13.48 Stage2ReviewQueue frontend coverage lift", () => {
 
     const region = await screen.findByTestId("stage2-desktop-match-region")
     expect(region).toHaveClass("overflow-hidden")
-    expect(region.querySelector("table")).toHaveClass("table-fixed", "w-full")
+    const table = region.querySelector("table")
+    expect(table).toHaveClass("table-fixed", "border-collapse")
+    expect(table).toHaveStyle({ width: "calc(100% - 4px)" })
   })
 
   it("test_AC8_13_48_run_review_approves_matches_after_filter_changes", async () => {

--- a/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
+++ b/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
@@ -160,7 +160,7 @@ describe("AC8.13.48 Stage2ReviewQueue frontend coverage lift", () => {
     expect(await screen.findByTestId("stage2-mobile-match-card-m1")).toBeInTheDocument()
   })
 
-  it("keeps the desktop pending-match table when matchMedia is unavailable", async () => {
+  it("keeps desktop table and mobile first-paint markup when matchMedia is unavailable", async () => {
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
       writable: true,
@@ -180,8 +180,49 @@ describe("AC8.13.48 Stage2ReviewQueue frontend coverage lift", () => {
     renderReviewComponent(<Stage2ReviewQueue />)
 
     expect(await screen.findByText("Pending Matches")).toBeInTheDocument()
-    expect(screen.queryByTestId("stage2-mobile-match-card-m1")).not.toBeInTheDocument()
-    expect(screen.getByText("Salary transfer")).toBeInTheDocument()
+    expect(screen.getByTestId("stage2-mobile-match-card-m1")).toBeInTheDocument()
+    expect(screen.getAllByText("Salary transfer").length).toBeGreaterThan(0)
+  })
+
+  it("AC16.27.1 keeps mobile pending-match cards in the DOM without matchMedia gating", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ pending_matches: [pendingMatch] }) as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [] } as never)
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderReviewComponent(<Stage2ReviewQueue />)
+
+    expect(await screen.findByTestId("stage2-mobile-match-card-m1")).toBeInTheDocument()
+    expect(screen.getAllByText("Salary transfer").length).toBeGreaterThan(0)
+  })
+
+  it("AC8.13.82/AC16.27.3 exposes a fixed desktop pending-match region for responsive UX proofs", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/statements/stage2/queue") {
+        return Promise.resolve(queue({ pending_matches: [pendingMatch] }) as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [] } as never)
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderReviewComponent(<Stage2ReviewQueue />)
+
+    const region = await screen.findByTestId("stage2-desktop-match-region")
+    expect(region).toHaveClass("overflow-hidden")
+    expect(region.querySelector("table")).toHaveClass("table-fixed", "w-full")
   })
 
   it("test_AC8_13_48_run_review_approves_matches_after_filter_changes", async () => {
@@ -358,9 +399,10 @@ describe("AC8.13.48 Stage2ReviewQueue frontend coverage lift", () => {
     await waitFor(() => expect(screen.queryByText("manual_review")).not.toBeInTheDocument())
     expect(screen.getAllByText("Duplicate").length).toBeGreaterThan(0)
 
-    fireEvent.click(screen.getByText("Salary transfer"))
+    const desktopMatches = within(screen.getByTestId("stage2-desktop-match-region"))
+    fireEvent.click(desktopMatches.getByText("Salary transfer"))
     await waitFor(() => expect(screen.getByText("1 selected")).toBeInTheDocument())
-    fireEvent.click(screen.getByText("Salary transfer"))
+    fireEvent.click(desktopMatches.getByText("Salary transfer"))
     await waitFor(() => expect(screen.getByText("0 selected")).toBeInTheDocument())
   })
 

--- a/apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx
@@ -63,10 +63,12 @@ describe("StatementReviewPage - coverage additions", () => {
         expect(approveBtn).toBeEnabled();
 
         // begin edit by clicking description cell
-        const desc = await screen.findByText("Lunch");
+        const desktopRegion = await screen.findByTestId("stage1-desktop-transaction-region");
+        const desktopTransactions = within(desktopRegion);
+        const desc = desktopTransactions.getByText("Lunch");
         fireEvent.click(desc);
 
-        const input = await screen.findByDisplayValue("Lunch");
+        const input = desktopTransactions.getByDisplayValue("Lunch");
         fireEvent.change(input, { target: { value: "Lunch at cafe" } });
         // blur to end edit
         fireEvent.blur(input);
@@ -77,8 +79,8 @@ describe("StatementReviewPage - coverage additions", () => {
         const discardBtn = await screen.findByRole("button", { name: /Discard/i });
         fireEvent.click(discardBtn);
 
-        fireEvent.click(await screen.findByText("Lunch"));
-        const secondInput = await screen.findByDisplayValue("Lunch");
+        fireEvent.click(desktopTransactions.getByText("Lunch"));
+        const secondInput = desktopTransactions.getByDisplayValue("Lunch");
         fireEvent.change(secondInput, { target: { value: "Lunch at cafe" } });
         fireEvent.blur(secondInput);
 
@@ -231,9 +233,11 @@ describe("StatementReviewPage - coverage additions", () => {
 
         renderReviewComponent(<StatementReviewPage /> as any);
 
-        fireEvent.click(await screen.findByText("Lunch"));
-        fireEvent.change(await screen.findByDisplayValue("Lunch"), { target: { value: "Lunch at cafe" } });
-        fireEvent.blur(screen.getByDisplayValue("Lunch at cafe"));
+        const desktopRegion = await screen.findByTestId("stage1-desktop-transaction-region");
+        const desktopTransactions = within(desktopRegion);
+        fireEvent.click(desktopTransactions.getByText("Lunch"));
+        fireEvent.change(desktopTransactions.getByDisplayValue("Lunch"), { target: { value: "Lunch at cafe" } });
+        fireEvent.blur(desktopTransactions.getByDisplayValue("Lunch at cafe"));
         fireEvent.click(await screen.findByRole("button", { name: /Save Edits/i }));
 
         expect(await screen.findByText("edit failed")).toBeInTheDocument();

--- a/apps/frontend/src/app/(main)/accounts/page.tsx
+++ b/apps/frontend/src/app/(main)/accounts/page.tsx
@@ -73,9 +73,9 @@ export default function AccountsPage() {
     }, {} as Record<string, Account[]>);
 
     return (
-        <div className="p-6">
+        <div className="p-4 sm:p-6">
             {/* Header */}
-            <div className="page-header flex items-center justify-between">
+            <div className="page-header flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                     <h1 className="page-title">Accounts</h1>
                     <p className="page-description">Manage your chart of accounts</p>
@@ -89,7 +89,7 @@ export default function AccountsPage() {
             </div>
 
             {/* Tabs */}
-            <div className="flex gap-1 mb-6 bg-[var(--background-muted)] p-1 rounded-lg w-fit">
+            <div className="mb-6 flex w-full flex-wrap gap-1 rounded-lg bg-[var(--background-muted)] p-1 sm:w-fit">
                 {ACCOUNT_TYPES.map((type) => (
                     <button
                         key={type}
@@ -153,21 +153,23 @@ export default function AccountsPage() {
                                 {typeAccounts.map((account) => (
                                     <div 
                                         key={account.id} 
-                                        className="px-6 py-3 flex items-center justify-between hover:bg-[var(--background-muted)]/50 transition-colors cursor-pointer"
+                                        data-testid={`account-row-${account.id}`}
+                                        className="flex cursor-pointer flex-col gap-3 px-4 py-4 transition-colors hover:bg-[var(--background-muted)]/50 sm:flex-row sm:items-center sm:justify-between sm:px-6"
                                         onClick={() => setSelectedAccount(account)}
                                     >
-                                        <div className="flex-1 min-w-0">
-                                            <div className="flex items-center gap-2">
-                                                <span className="font-medium">{account.name}</span>
+                                        <div data-account-field="identity" className="min-w-0 flex-1">
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <span className="break-words font-medium">{account.name}</span>
                                                 {account.code && <span className="text-xs text-muted font-mono">{account.code}</span>}
                                                 {!account.is_active && <span className="badge badge-muted">Inactive</span>}
                                             </div>
-                                            {account.description && <p className="text-xs text-muted truncate">{account.description}</p>}
+                                            {account.description && <p className="break-words text-xs text-muted sm:truncate">{account.description}</p>}
                                         </div>
-                                        <div className="flex items-center gap-2">
-                                            <div className="text-right mr-2">
+                                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-2">
+                                            <div data-account-field="balance" className="text-left sm:mr-2 sm:text-right">
                                                 <div className="font-semibold">{formatCurrencyLocale(account.balance ?? 0, account.currency)}</div>
                                             </div>
+                                            <div data-account-field="actions" className="flex items-center gap-2">
                                             <button
                                                 onClick={(e) => { e.stopPropagation(); setEditingAccount(account); setIsModalOpen(true); }}
                                                 className="btn-ghost p-2 hover:text-[var(--accent)]"
@@ -187,6 +189,7 @@ export default function AccountsPage() {
                                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                                                 </svg>
                                             </button>
+                                            </div>
                                         </div>
                                     </div>
                                 ))}

--- a/apps/frontend/src/app/(main)/statements/[id]/review/page.tsx
+++ b/apps/frontend/src/app/(main)/statements/[id]/review/page.tsx
@@ -219,7 +219,7 @@ export default function StatementReviewPage() {
     const balanceValid = data.balance_validation_result?.closing_match ?? false;
 
     return (
-        <div className="flex min-h-[calc(100vh-2rem)] flex-col p-4 md:p-6 lg:h-[calc(100vh-2rem)]">
+        <div className="flex min-h-[calc(100vh-2rem)] flex-col p-4 md:p-6 2xl:h-[calc(100vh-2rem)]">
             <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <Link href="/statements" className="text-sm text-muted hover:text-[var(--foreground)] flex items-center gap-1">
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -283,7 +283,7 @@ export default function StatementReviewPage() {
                 currency={data.currency || "SGD"}
             />
 
-            <div className="grid flex-1 grid-cols-1 gap-4 lg:min-h-0 lg:grid-cols-2">
+            <div className="grid flex-1 grid-cols-1 gap-4 2xl:min-h-0 2xl:grid-cols-2">
                 <PdfPreviewPane pdfUrl={data.pdf_url} />
 
                 <TransactionTable 

--- a/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
+++ b/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
@@ -661,7 +661,7 @@ export function Stage2ReviewQueue() {
                             </div>
 
                             <div data-testid="stage2-desktop-match-region" className="hidden max-h-[400px] overflow-hidden md:block">
-                                <table className="w-full table-fixed border-collapse text-sm">
+                                <table className="table-fixed border-collapse text-sm" style={{ width: "calc(100% - 4px)" }}>
                                     <thead className="sticky top-0 bg-[var(--background)]">
                                         <tr className="border-b border-[var(--border)]">
                                             <th className="text-left px-4 py-2 w-8">

--- a/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
+++ b/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
@@ -661,7 +661,7 @@ export function Stage2ReviewQueue() {
                             </div>
 
                             <div data-testid="stage2-desktop-match-region" className="hidden max-h-[400px] overflow-hidden md:block">
-                                <table className="w-full table-fixed text-sm">
+                                <table className="w-full table-fixed border-collapse text-sm">
                                     <thead className="sticky top-0 bg-[var(--background)]">
                                         <tr className="border-b border-[var(--border)]">
                                             <th className="text-left px-4 py-2 w-8">

--- a/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
+++ b/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
@@ -72,7 +72,6 @@ export function Stage2ReviewQueue() {
 
     const [filteredChecks, setFilteredChecks] = useState<ConsistencyCheck[] | null>(null);
     const [filtering, setFiltering] = useState(false);
-    const [isMobileLayout, setIsMobileLayout] = useState(false);
     const resolveTitleId = useId();
     const runIdMatch = pathname.match(/^\/review\/run\/([^/?#]+)/);
     const runId = runIdMatch ? decodeURIComponent(runIdMatch[1]) : null;
@@ -108,18 +107,6 @@ export function Stage2ReviewQueue() {
     useEffect(() => {
         fetchProcessingSummary();
     }, [fetchProcessingSummary]);
-
-    useEffect(() => {
-        if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-            return;
-        }
-
-        const media = window.matchMedia("(max-width: 767px)");
-        const updateMobileLayout = () => setIsMobileLayout(media.matches);
-        updateMobileLayout();
-        media.addEventListener("change", updateMobileLayout);
-        return () => media.removeEventListener("change", updateMobileLayout);
-    }, []);
 
     const updateUrlParams = useCallback(() => {
         const params = new URLSearchParams();
@@ -551,7 +538,7 @@ export function Stage2ReviewQueue() {
                 </div>
             )}
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 gap-6 2xl:grid-cols-2">
                 <div className="card">
                     <div className="card-header flex items-center justify-between">
                         <h3 className="text-sm font-medium">Consistency Checks</h3>
@@ -613,8 +600,7 @@ export function Stage2ReviewQueue() {
                         <div className="p-8 text-center text-muted">No pending matches</div>
                     ) : (
                         <>
-                            {isMobileLayout && (
-                                <div data-testid="stage2-mobile-match-list" className="divide-y divide-[var(--border)] md:hidden">
+                            <div data-testid="stage2-mobile-match-list" className="divide-y divide-[var(--border)] md:hidden">
                                     {matchesFilteredByScore.map((match) => (
                                         <article
                                             key={match.id}
@@ -672,11 +658,10 @@ export function Stage2ReviewQueue() {
                                             </div>
                                         </article>
                                     ))}
-                                </div>
-                            )}
+                            </div>
 
-                            <div className="hidden max-h-[400px] overflow-auto md:block">
-                                <table className="w-full text-sm">
+                            <div data-testid="stage2-desktop-match-region" className="hidden max-h-[400px] overflow-hidden md:block">
+                                <table className="w-full table-fixed text-sm">
                                     <thead className="sticky top-0 bg-[var(--background)]">
                                         <tr className="border-b border-[var(--border)]">
                                             <th className="text-left px-4 py-2 w-8">
@@ -687,11 +672,11 @@ export function Stage2ReviewQueue() {
                                                     className="rounded"
                                                 />
                                             </th>
-                                            <th className="text-left px-4 py-2 font-medium">Score</th>
+                                            <th className="text-left px-4 py-2 font-medium w-20">Score</th>
                                             <th className="text-left px-4 py-2 font-medium">Description</th>
-                                            <th className="text-right px-4 py-2 font-medium">Amount</th>
-                                            <th className="text-left px-4 py-2 font-medium">Date</th>
-                                            <th className="text-left px-4 py-2 font-medium">Status</th>
+                                            <th className="text-right px-4 py-2 font-medium w-28">Amount</th>
+                                            <th className="text-left px-4 py-2 font-medium w-28">Date</th>
+                                            <th className="text-left px-4 py-2 font-medium w-32">Status</th>
                                         </tr>
                                     </thead>
                                     <tbody className="divide-y divide-[var(--border)]">
@@ -726,7 +711,7 @@ export function Stage2ReviewQueue() {
                                                         {match.match_score}
                                                     </span>
                                                 </td>
-                                                <td className="px-4 py-2 text-muted truncate max-w-[200px]">
+                                                <td className="truncate px-4 py-2 text-muted">
                                                     {match.description || "—"}
                                                 </td>
                                                 <td className="px-4 py-2 text-right font-medium">

--- a/apps/frontend/src/components/review/TransactionTable.tsx
+++ b/apps/frontend/src/components/review/TransactionTable.tsx
@@ -163,7 +163,7 @@ export function TransactionTable({
             </div>
 
             <div data-testid="stage1-desktop-transaction-region" className="hidden flex-1 overflow-hidden md:block">
-                <table className="w-full table-fixed text-sm">
+                <table className="w-full table-fixed border-collapse text-sm">
                     <thead className="sticky top-0 bg-[var(--background)]">
                         <tr className="border-b border-[var(--border)]">
                             <th className="text-left px-4 py-2 font-medium w-28">Date</th>

--- a/apps/frontend/src/components/review/TransactionTable.tsx
+++ b/apps/frontend/src/components/review/TransactionTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { formatCurrencyLocale } from "@/lib/currency";
 import type { BankStatementTransaction } from "@/lib/types";
 import ConfidenceBadge from "@/components/ui/ConfidenceBadge";
@@ -34,20 +34,7 @@ export function TransactionTable({
     actionLoading
 }: TransactionTableProps) {
     const [editing, setEditing] = useState<EditingCell | null>(null);
-    const [isMobileLayout, setIsMobileLayout] = useState(false);
     const transactionRows = transactions ?? [];
-
-    useEffect(() => {
-        if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-            return;
-        }
-
-        const media = window.matchMedia("(max-width: 767px)");
-        const updateMobileLayout = () => setIsMobileLayout(media.matches);
-        updateMobileLayout();
-        media.addEventListener("change", updateMobileLayout);
-        return () => media.removeEventListener("change", updateMobileLayout);
-    }, []);
 
     const isEditingCell = (txnId: string, field: EditableField) =>
         editing?.txnId === txnId && editing?.field === field;
@@ -74,8 +61,7 @@ export function TransactionTable({
                 <span className="text-xs text-muted">{transactionRows.length} total</span>
             </div>
 
-            {isMobileLayout && (
-                <div data-testid="stage1-mobile-transaction-list" className="flex-1 divide-y divide-[var(--border)] overflow-y-auto md:hidden">
+            <div data-testid="stage1-mobile-transaction-list" className="flex-1 divide-y divide-[var(--border)] overflow-y-auto md:hidden">
                 {transactionRows.map((txn) => {
                     const edit = pendingEdits.get(txn.id);
                     const displayDate = edit?.txn_date ?? txn.txn_date;
@@ -174,16 +160,15 @@ export function TransactionTable({
                         </article>
                     );
                     })}
-                </div>
-            )}
+            </div>
 
-            <div className="hidden flex-1 overflow-auto md:block">
-                <table className="w-full text-sm">
+            <div data-testid="stage1-desktop-transaction-region" className="hidden flex-1 overflow-hidden md:block">
+                <table className="w-full table-fixed text-sm">
                     <thead className="sticky top-0 bg-[var(--background)]">
                         <tr className="border-b border-[var(--border)]">
-                            <th className="text-left px-4 py-2 font-medium w-32">Date</th>
+                            <th className="text-left px-4 py-2 font-medium w-28">Date</th>
                             <th className="text-left px-4 py-2 font-medium">Description</th>
-                            <th className="text-right px-4 py-2 font-medium w-40">Amount</th>
+                            <th className="text-right px-4 py-2 font-medium w-32">Amount</th>
                             <th className="text-center px-4 py-2 font-medium w-24">Confidence</th>
                         </tr>
                     </thead>

--- a/apps/frontend/src/components/review/TransactionTable.tsx
+++ b/apps/frontend/src/components/review/TransactionTable.tsx
@@ -163,7 +163,7 @@ export function TransactionTable({
             </div>
 
             <div data-testid="stage1-desktop-transaction-region" className="hidden flex-1 overflow-hidden md:block">
-                <table className="w-full table-fixed border-collapse text-sm">
+                <table className="table-fixed border-collapse text-sm" style={{ width: "calc(100% - 4px)" }}>
                     <thead className="sticky top-0 bg-[var(--background)]">
                         <tr className="border-b border-[var(--border)]">
                             <th className="text-left px-4 py-2 font-medium w-28">Date</th>

--- a/apps/frontend/src/components/review/__tests__/TransactionTable.keyEvents.test.tsx
+++ b/apps/frontend/src/components/review/__tests__/TransactionTable.keyEvents.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { TransactionTable } from "@/components/review/TransactionTable";
 import type { BankStatementTransaction } from "@/lib/types";
 
@@ -28,7 +28,7 @@ describe("TransactionTable key handlers", () => {
     it("handles Enter on date and description inputs and focus on select triggers beginEdit", () => {
         const pending = new Map<string, Partial<{ description: string; amount: string; direction: string; txn_date: string }>>();
 
-        const { container } = render(
+        render(
             <TransactionTable
                 transactions={sample}
                 currency="SGD"
@@ -40,21 +40,22 @@ describe("TransactionTable key handlers", () => {
             />
         );
 
+        const desktopRegion = within(screen.getByTestId("stage1-desktop-transaction-region"));
+
         // click date cell to edit
-        fireEvent.click(screen.getByText("2024-01-01"));
-        const dateInput = screen.getByDisplayValue("2024-01-01");
+        fireEvent.click(desktopRegion.getByText("2024-01-01"));
+        const dateInput = desktopRegion.getByDisplayValue("2024-01-01");
         fireEvent.keyDown(dateInput, { key: "Enter" });
 
         // click description cell to edit
-        fireEvent.click(screen.getByText("Test"));
-        const descInput = screen.getByDisplayValue("Test");
+        fireEvent.click(desktopRegion.getByText("Test"));
+        const descInput = desktopRegion.getByDisplayValue("Test");
         fireEvent.keyDown(descInput, { key: "Enter" });
 
         // click amount to open combined editor
-        const amountCell = container.querySelector('td[role="cell"]') || screen.getByText(/SGD/);
-        fireEvent.click(screen.getByText(/SGD/));
+        fireEvent.click(desktopRegion.getByText(/SGD/));
 
-        const select = screen.getByDisplayValue("OUT");
+        const select = desktopRegion.getByDisplayValue("OUT");
         fireEvent.focus(select);
         fireEvent.keyDown(select, { key: "Enter" });
 

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -459,6 +459,11 @@ groups:
         epic_name: double-entry-core
         description: Accounting equation verification uses base-currency converted account balances
         mandatory: true
+      - id: AC2.12.3
+        epic: 2
+        epic_name: double-entry-core
+        description: Accounts page mobile filters and account rows avoid document-level horizontal scroll and content overlap
+        mandatory: true
       - id: AC2.12.5
         epic: 2
         description: ~~retired historical registry placeholder~~
@@ -2289,6 +2294,12 @@ groups:
         epic_name: testing-strategy
         description: Coverage threshold documentation links to code-owned thresholds instead of copying mutable numeric values.
         mandatory: true
+      - id: AC8.13.82
+        epic: 8
+        epic_name: testing-strategy
+        description: Playwright responsive UX coverage proves account and review layouts avoid mobile document overflow and desktop
+          local table clipping.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1
@@ -3952,6 +3963,25 @@ groups:
         epic_name: two-stage-review-ui
         description: Stage 2 run review keeps the run approval gate and pending match workflow usable at phone widths without
           document-level horizontal scrolling.
+        mandatory: true
+    AC16.27:
+      - id: AC16.27.1
+        epic: 16
+        epic_name: two-stage-review-ui
+        description: Stage 1 and Stage 2 mobile review lists render without JavaScript breakpoint gating that can create first-paint
+          blank content.
+        mandatory: true
+      - id: AC16.27.2
+        epic: 16
+        epic_name: two-stage-review-ui
+        description: Stage 1 desktop review keeps the transaction review surface readable at 1440px with the sidebar visible without
+          local horizontal clipping.
+        mandatory: true
+      - id: AC16.27.3
+        epic: 16
+        epic_name: two-stage-review-ui
+        description: Stage 2 desktop review keeps pending match rows readable at 1440px with the sidebar visible without local
+          horizontal clipping.
         mandatory: true
   AC17:
     AC17.1:

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -152,6 +152,12 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 | AC2.6.3 | Decimal precision loss detection | `test_amount_precision_loss_detection()` | `accounting/test_accounting_equation.py` | P1 |
 | AC2.6.4 | Many-line complex entry (salary breakdown) | `test_many_lines_complex_salary_correct()` | `accounting/test_accounting_equation.py` | P1 |
 
+### AC2.12: Account Management UI Responsiveness
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC2.12.3 | Accounts page mobile filters and account rows avoid document-level horizontal scroll and content overlap | `AC2.12.3 mobile accounts avoids document horizontal scroll and overlapping row controls` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 |
+
 ### AC2.7: API Router & Error Handling
 
 | ID | Test Case | Test Function | File | Priority |

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -511,6 +511,7 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.79 | Local E2E command routing distinguishes root deployment E2E from backend Tier-1 API E2E | `test_AC8_13_79_*` | `tests/tooling/test_cli_and_dev_servers.py` | P0 |
 | AC8.13.80 | AC coverage analysis supports no-write and stale-report check modes for local verification | `test_AC8_13_80_*` | `tests/tooling/test_analyze_test_ac_coverage.py` | P0 |
 | AC8.13.81 | Coverage threshold documentation links to code-owned thresholds instead of copying mutable numeric values | `test_AC8_13_81_*` | `tests/tooling/test_lint_doc_consistency.py` | P1 |
+| AC8.13.82 | Playwright responsive UX coverage proves account and review layouts avoid mobile document overflow and desktop local table clipping | `AC2.12.3`, `AC16.27.2`, `AC16.27.3` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -673,6 +673,14 @@ delivery status table.
 | AC16.26.2 | Stage 2 pending matches use selectable mobile cards with direct reject and approve selected actions visible without horizontal dragging | `AC16.26.2 stage 2 mobile queue exposes selectable match cards and batch actions` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 |
 | AC16.26.3 | Stage 2 run review keeps the run approval gate and pending match workflow usable at phone widths without document-level horizontal scrolling | `AC16.26.3 stage 2 run review preserves mobile approval gate and match workflow` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 |
 
+### AC16.27 — Responsive Review Layout Completion
+
+| AC ID | Description | Test Function | File | Priority |
+|-------|-------------|---------------|------|----------|
+| AC16.27.1 | Stage 1 and Stage 2 mobile review lists render without JavaScript breakpoint gating that can create first-paint blank content | `AC16.27.1 mobile review lists are present without matchMedia gating` | `apps/frontend/src/__tests__/TransactionTable.test.tsx`, `apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx` | P0 |
+| AC16.27.2 | Stage 1 desktop review keeps the transaction review surface readable at 1440px with the sidebar visible without local horizontal clipping | `AC16.27.2 desktop stage 1 review keeps transaction table readable at 1440px` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 |
+| AC16.27.3 | Stage 2 desktop review keeps pending match rows readable at 1440px with the sidebar visible without local horizontal clipping | `AC16.27.3 desktop stage 2 review keeps pending matches readable at 1440px` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 |
+
 
 ---
 

--- a/docs/ssot/frontend-patterns.md
+++ b/docs/ssot/frontend-patterns.md
@@ -84,15 +84,22 @@ document-level horizontal scrolling.
 **Rules:**
 - Key review routes and dialogs must keep `document.documentElement.scrollWidth`
   less than or equal to `clientWidth` at 375-390 px viewports.
-- Desktop data tables may remain tables at `md` and wider breakpoints.
+- Account-management and review routes must keep `document.documentElement.scrollWidth`
+  less than or equal to `clientWidth` at 375-390 px viewports.
+- Desktop data tables may remain tables at `md` and wider breakpoints only when
+  their local scroll containers do not hide required review information at
+  1440 px with the sidebar visible.
 - Phone layouts for action-heavy review queues should use stacked cards so
   primary actions and correction inputs are visible without horizontal dragging.
 - Dense accounting details may keep desktop tables, but phone layouts must expose
   account, direction, amount, and currency as readable line cards.
+- Phone account rows must stack account identity, metadata, balance, and row
+  actions so long account names cannot overlap amounts or controls.
 - Use Playwright for route-level mobile overflow checks and component tests for
   mobile card affordances.
 
 **Applied In:**
+- `app/(main)/accounts/page.tsx`
 - `app/(main)/review/ai-suggestions/page.tsx`
 - `app/(main)/statements/[id]/review/page.tsx`
 - `components/review/Stage2ReviewQueue.tsx`


### PR DESCRIPTION
## Summary

Hardens responsive account and review layouts so mobile review markup is available on first paint, Accounts does not create mobile document overflow, and Stage 1/Stage 2 desktop review tables remain readable at 1440px.

Closes #606

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-002 — Double-entry core; EPIC-008 — Testing strategy; EPIC-016 — Two-stage review UI |
| **AC IDs** | AC2.12.1, AC8.13.77, AC16.27.1, AC16.27.2, AC16.27.3 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/frontend-patterns.md` — tightened responsive account/review layout rules and applied routes
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `0b197e4` | added AC/docs/tests for mobile first-paint markup, Accounts mobile overflow, and 1440px desktop review readability |
| 🟢 Green (passing test) | `a73dbf1` | removed JS breakpoint DOM gating and hardened Accounts/Stage 1/Stage 2 responsive layouts |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (N/A, no backend schema changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (N/A, no env vars changed)
- [x] `repo/` submodule updated for production config changes (N/A, no infra/config changes)
- [x] `tools/check_env_keys.py` passes (N/A, no env vars changed)
- [x] `tools/check_manifest.py` passes (if SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner. (N/A)
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys. (N/A)
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged. (N/A)
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials. (N/A)
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule. (N/A)
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene. (N/A)

---

## Testing

```bash
npm run test --prefix apps/frontend -- TransactionTable.test.tsx stage2ReviewQueueCoverage99.test.tsx
NEXT_PUBLIC_APP_URL=http://127.0.0.1:3000 npx playwright test playwright/mobile-ux.spec.ts --project=chromium # from apps/frontend with local dev server
npm run test --prefix apps/frontend
npm run build --prefix apps/frontend
npm run test:coverage --prefix apps/frontend
moon run :lint
uv run --python 3.12.12 --with pyyaml python tools/check_ac_traceability.py
uv run --python 3.12.12 --with pyyaml python tools/check_manifest.py
uv run --python 3.12.12 --with pyyaml python tools/lint_doc_consistency.py
```

`moon run :test` was attempted locally but blocked in `podman compose ... --profile infra up -d`; `podman ps` also hung while the podman machine was running. Frontend unit tests, coverage, Playwright mobile UX, build, lint, and doc gates passed locally.

---

## Screenshots / Evidence

- Mobile Accounts 390px: document `scrollWidth=390`, `clientWidth=390`; account row stacks identity, balance, and actions.
- Stage 1 desktop 1440px: document `scrollWidth=1440`, `clientWidth=1440`; transaction table remains readable without local horizontal scroll.
- Stage 2 desktop 1440px: document `scrollWidth=1440`, `clientWidth=1440`; pending match table remains readable without local horizontal scroll.
