### PR TITLE
[finance_report_vision] Define personal report package contract

### DIFF
--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -26,6 +26,7 @@ from src.schemas import (
     IncomeStatementResponse,
     NetWorthGranularity,
     NetWorthTimeSeriesResponse,
+    PersonalReportPackageContractResponse,
     TrendPeriod,
 )
 from src.services.market_data import ensure_market_data_fresh
@@ -97,6 +98,117 @@ class ReportType(str, Enum):
 
     BALANCE_SHEET = "balance-sheet"
     INCOME_STATEMENT = "income-statement"
+
+
+PERSONAL_REPORT_PACKAGE_CONTRACT: dict = {
+    "package_id": "personal-financial-report-package",
+    "version": "1.0",
+    "period_semantics": {
+        "start_date": "required for period sections",
+        "end_date": "required for period sections",
+        "as_of_date": "required for point-in-time sections",
+        "currency": "ISO-4217 code; defaults to base currency when omitted",
+        "decimal_serialization": "string",
+    },
+    "sections": [
+        {
+            "section_id": "balance_sheet",
+            "label": "Balance Sheet",
+            "owner_epic": "EPIC-005",
+            "period_type": "as_of",
+            "source_endpoint": "/api/reports/balance-sheet",
+            "status": "ready",
+            "decimal_total_fields": ["total_assets", "total_liabilities", "total_equity", "equation_delta"],
+        },
+        {
+            "section_id": "income_statement",
+            "label": "Income Statement",
+            "owner_epic": "EPIC-005",
+            "period_type": "period",
+            "source_endpoint": "/api/reports/income-statement",
+            "status": "ready",
+            "decimal_total_fields": ["total_income", "total_expenses", "net_income"],
+        },
+        {
+            "section_id": "cash_flow",
+            "label": "Cash Flow",
+            "owner_epic": "EPIC-005",
+            "period_type": "period",
+            "source_endpoint": "/api/reports/cash-flow",
+            "status": "ready",
+            "decimal_total_fields": [
+                "operating_activities",
+                "investing_activities",
+                "financing_activities",
+                "net_cash_flow",
+                "beginning_cash",
+                "ending_cash",
+            ],
+        },
+        {
+            "section_id": "investment_performance",
+            "label": "Investment Performance",
+            "owner_epic": "EPIC-017",
+            "period_type": "period_and_as_of",
+            "source_endpoint": "/api/portfolio/performance/report-schedule",
+            "status": "ready",
+            "decimal_total_fields": [
+                "xirr",
+                "time_weighted_return",
+                "money_weighted_return",
+                "realized_pnl",
+                "unrealized_pnl",
+                "dividend_income",
+            ],
+        },
+        {
+            "section_id": "annualized_income_long_term",
+            "label": "Annualized Income & Long-Term Compensation",
+            "owner_epic": "EPIC-011",
+            "period_type": "trailing_12_months_and_as_of",
+            "source_endpoint": "/api/reports/package/annualized-income-schedule",
+            "status": "planned",
+            "blocking_issue": "#566",
+            "decimal_total_fields": [
+                "annualized_salary",
+                "annualized_bonus",
+                "annualized_dividend",
+                "annualized_total",
+                "restricted_fair_value",
+            ],
+        },
+        {
+            "section_id": "notes",
+            "label": "Notes & Disclosures",
+            "owner_epic": "EPIC-005",
+            "period_type": "package",
+            "source_endpoint": "/api/reports/package/notes",
+            "status": "planned",
+            "blocking_issue": "#571",
+            "decimal_total_fields": [],
+        },
+        {
+            "section_id": "traceability_appendix",
+            "label": "Traceability Appendix",
+            "owner_epic": "EPIC-018",
+            "period_type": "package",
+            "source_endpoint": "/api/reports/package/traceability",
+            "status": "planned",
+            "blocking_issue": "#572",
+            "decimal_total_fields": [],
+        },
+    ],
+    "export_contract": {
+        "formats": ["json", "csv"],
+        "csv_columns": ["package_id", "section_id", "line_id", "label", "amount", "currency", "source_state"],
+    },
+}
+
+
+@router.get("/package/contract", response_model=PersonalReportPackageContractResponse)
+def personal_report_package_contract() -> PersonalReportPackageContractResponse:
+    """Return the stable package-level API/export contract."""
+    return PersonalReportPackageContractResponse(**PERSONAL_REPORT_PACKAGE_CONTRACT)
 
 
 @router.get("/balance-sheet", response_model=BalanceSheetResponse)

--- a/apps/backend/src/schemas/__init__.py
+++ b/apps/backend/src/schemas/__init__.py
@@ -65,6 +65,9 @@ from src.schemas.reporting import (
     IncomeStatementResponse,
     NetWorthGranularity,
     NetWorthTimeSeriesResponse,
+    PersonalReportPackageContractResponse,
+    PersonalReportPackageExportContract,
+    PersonalReportPackageSectionContract,
     TrendPeriod,
 )
 from src.schemas.review import (
@@ -151,6 +154,9 @@ __all__ = [
     "ManagedPositionResponse",
     "NetWorthGranularity",
     "NetWorthTimeSeriesResponse",
+    "PersonalReportPackageContractResponse",
+    "PersonalReportPackageExportContract",
+    "PersonalReportPackageSectionContract",
     "ParsedStatementPreview",
     "PingStateResponse",
     "ProcessingPendingItem",

--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -177,3 +177,34 @@ class CashFlowResponse(BaseModel):
     investing: list[CashFlowItem]
     financing: list[CashFlowItem]
     summary: CashFlowSummary
+
+
+class PersonalReportPackageSectionContract(BaseModel):
+    """Stable section contract for the personal financial-report package."""
+
+    section_id: str
+    label: str
+    owner_epic: str
+    period_type: str
+    source_endpoint: str
+    status: str
+    required: bool = True
+    blocking_issue: str | None = None
+    decimal_total_fields: list[str] = Field(default_factory=list)
+
+
+class PersonalReportPackageExportContract(BaseModel):
+    """Stable export contract for personal package consumers."""
+
+    formats: list[str]
+    csv_columns: list[str]
+
+
+class PersonalReportPackageContractResponse(BaseModel):
+    """Package-level API/export contract for the north-star report package."""
+
+    package_id: str
+    version: str
+    period_semantics: dict[str, str]
+    sections: list[PersonalReportPackageSectionContract]
+    export_contract: PersonalReportPackageExportContract

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -1,0 +1,73 @@
+"""Personal report package API contract coverage."""
+
+import pytest
+
+from src.routers.reports import personal_report_package_contract
+
+
+@pytest.fixture(autouse=True)
+def patch_database_connection():
+    """This contract endpoint is static and does not need a test database."""
+    yield
+
+
+def test_AC5_9_1_package_contract_endpoint_defines_required_sections():
+    """AC5.9.1: Package contract endpoint defines stable required sections."""
+    response = personal_report_package_contract()
+    payload = response.model_dump(mode="json")
+    assert payload["package_id"] == "personal-financial-report-package"
+    assert payload["version"] == "1.0"
+
+    sections = {section["section_id"]: section for section in payload["sections"]}
+    assert list(sections) == [
+        "balance_sheet",
+        "income_statement",
+        "cash_flow",
+        "investment_performance",
+        "annualized_income_long_term",
+        "notes",
+        "traceability_appendix",
+    ]
+
+    assert sections["balance_sheet"]["label"] == "Balance Sheet"
+    assert sections["balance_sheet"]["source_endpoint"] == "/api/reports/balance-sheet"
+    assert sections["investment_performance"]["owner_epic"] == "EPIC-017"
+    assert sections["annualized_income_long_term"]["blocking_issue"] == "#566"
+    assert sections["notes"]["blocking_issue"] == "#571"
+    assert sections["traceability_appendix"]["blocking_issue"] == "#572"
+
+
+def test_AC5_9_2_package_contract_marks_decimal_totals_and_period_semantics():
+    """AC5.9.2: Contract exposes Decimal-safe totals and date semantics."""
+    response = personal_report_package_contract()
+    payload = response.model_dump(mode="json")
+    assert payload["period_semantics"] == {
+        "start_date": "required for period sections",
+        "end_date": "required for period sections",
+        "as_of_date": "required for point-in-time sections",
+        "currency": "ISO-4217 code; defaults to base currency when omitted",
+        "decimal_serialization": "string",
+    }
+
+    sections = {section["section_id"]: section for section in payload["sections"]}
+    assert sections["balance_sheet"]["period_type"] == "as_of"
+    assert sections["income_statement"]["period_type"] == "period"
+    assert sections["cash_flow"]["period_type"] == "period"
+    assert sections["balance_sheet"]["decimal_total_fields"] == [
+        "total_assets",
+        "total_liabilities",
+        "total_equity",
+        "equation_delta",
+    ]
+    assert "annualized_total" in sections["annualized_income_long_term"]["decimal_total_fields"]
+
+    assert payload["export_contract"]["formats"] == ["json", "csv"]
+    assert payload["export_contract"]["csv_columns"] == [
+        "package_id",
+        "section_id",
+        "line_id",
+        "label",
+        "amount",
+        "currency",
+        "source_state",
+    ]

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import PersonalReportPackagePage from "@/app/(main)/reports/package/page"
+import { apiFetch } from "@/lib/api"
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}))
+
+const mockedApiFetch = vi.mocked(apiFetch)
+
+const contract = {
+  package_id: "personal-financial-report-package",
+  version: "1.0",
+  period_semantics: {
+    start_date: "required for period sections",
+    end_date: "required for period sections",
+    as_of_date: "required for point-in-time sections",
+    currency: "ISO-4217 code; defaults to base currency when omitted",
+    decimal_serialization: "string",
+  },
+  sections: [
+    { section_id: "balance_sheet", label: "Balance Sheet", owner_epic: "EPIC-005", source_endpoint: "/api/reports/balance-sheet", status: "ready" },
+    { section_id: "income_statement", label: "Income Statement", owner_epic: "EPIC-005", source_endpoint: "/api/reports/income-statement", status: "ready" },
+    { section_id: "cash_flow", label: "Cash Flow", owner_epic: "EPIC-005", source_endpoint: "/api/reports/cash-flow", status: "ready" },
+    { section_id: "investment_performance", label: "Investment Performance", owner_epic: "EPIC-017", source_endpoint: "/api/portfolio/performance/report-schedule", status: "ready" },
+    { section_id: "annualized_income_long_term", label: "Annualized Income & Long-Term Compensation", owner_epic: "EPIC-011", source_endpoint: "/api/reports/package/annualized-income-schedule", status: "planned" },
+    { section_id: "notes", label: "Notes & Disclosures", owner_epic: "EPIC-005", source_endpoint: "/api/reports/package/notes", status: "planned" },
+    { section_id: "traceability_appendix", label: "Traceability Appendix", owner_epic: "EPIC-018", source_endpoint: "/api/reports/package/traceability", status: "planned" },
+  ],
+  export_contract: {
+    formats: ["json", "csv"],
+    csv_columns: ["package_id", "section_id", "line_id", "label", "amount", "currency", "source_state"],
+  },
+}
+
+describe("PersonalReportPackagePage", () => {
+  it("AC5.9.3 renders personal package contract sections from API", async () => {
+    mockedApiFetch.mockResolvedValue(contract)
+
+    render(<PersonalReportPackagePage />)
+
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledWith("/api/reports/package/contract"))
+    expect(screen.getByText("Personal Report Package")).toBeInTheDocument()
+    expect(screen.getByText("personal-financial-report-package")).toBeInTheDocument()
+    expect(screen.getByText("balance_sheet")).toBeInTheDocument()
+    expect(screen.getByText("Balance Sheet")).toBeInTheDocument()
+    expect(screen.getByText("annualized_income_long_term")).toBeInTheDocument()
+    expect(screen.getByText("Annualized Income & Long-Term Compensation")).toBeInTheDocument()
+  })
+
+  it("AC5.9.4 renders export contract metadata", async () => {
+    mockedApiFetch.mockResolvedValue(contract)
+
+    render(<PersonalReportPackagePage />)
+
+    await waitFor(() => expect(screen.getByText("Export Contract")).toBeInTheDocument())
+    expect(screen.getByText("json, csv")).toBeInTheDocument()
+    expect(screen.getByText("package_id, section_id, line_id, label, amount, currency, source_state")).toBeInTheDocument()
+    expect(screen.getByText("string")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/__tests__/reportsPage.test.tsx
+++ b/apps/frontend/src/__tests__/reportsPage.test.tsx
@@ -15,7 +15,9 @@ describe("ReportsPage", () => {
     expect(screen.getByText("Balance Sheet")).toBeInTheDocument()
     expect(screen.getByText("Income Statement")).toBeInTheDocument()
     expect(screen.getByText("Cash Flow Statement")).toBeInTheDocument()
+    expect(screen.getByText("Personal Report Package")).toBeInTheDocument()
 
+    expect(screen.getByRole("link", { name: /Personal Report Package/i })).toHaveAttribute("href", "/reports/package")
     expect(screen.getByRole("link", { name: /Balance Sheet/i })).toHaveAttribute("href", "/reports/balance-sheet")
     expect(screen.getByRole("link", { name: /Income Statement/i })).toHaveAttribute("href", "/reports/income-statement")
     expect(screen.getByRole("link", { name: /Cash Flow Statement/i })).toHaveAttribute("href", "/reports/cash-flow")
@@ -41,6 +43,6 @@ describe("ReportsPage", () => {
 
     // SVG elements are rendered for each report card icon
     const svgs = document.querySelectorAll("svg")
-    expect(svgs.length).toBeGreaterThanOrEqual(3)
+    expect(svgs.length).toBeGreaterThanOrEqual(4)
   })
 })

--- a/apps/frontend/src/app/(main)/reports/package/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/package/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { apiFetch } from "@/lib/api";
+import type { PersonalReportPackageContractResponse } from "@/lib/types";
+
+export default function PersonalReportPackagePage() {
+    const [contract, setContract] = useState<PersonalReportPackageContractResponse | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        apiFetch<PersonalReportPackageContractResponse>("/api/reports/package/contract")
+            .then((data) => {
+                if (isMounted) setContract(data);
+            })
+            .catch((err) => {
+                if (isMounted) setError(err instanceof Error ? err.message : "Failed to load package contract.");
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
+
+    if (error) {
+        return <div className="p-6 text-[var(--error)]">{error}</div>;
+    }
+
+    if (!contract) {
+        return <div className="p-6 text-muted">Loading package contract...</div>;
+    }
+
+    return (
+        <div className="p-6">
+            <div className="page-header">
+                <h1 className="page-title">Personal Report Package</h1>
+                <p className="page-description">{contract.package_id}</p>
+            </div>
+
+            <div className="grid lg:grid-cols-2 gap-4 mb-6">
+                {contract.sections.map((section) => (
+                    <section key={section.section_id} className="card p-5">
+                        <div className="flex items-start justify-between gap-3">
+                            <div>
+                                <p className="text-xs font-mono text-muted">{section.section_id}</p>
+                                <h2 className="font-semibold mt-1">{section.label}</h2>
+                            </div>
+                            <span className="badge badge-muted">{section.status}</span>
+                        </div>
+                        <dl className="mt-4 space-y-2 text-sm">
+                            <div className="flex justify-between gap-3">
+                                <dt className="text-muted">Owner</dt>
+                                <dd className="font-medium">{section.owner_epic}</dd>
+                            </div>
+                            <div className="flex justify-between gap-3">
+                                <dt className="text-muted">Endpoint</dt>
+                                <dd className="font-mono text-xs text-right">{section.source_endpoint}</dd>
+                            </div>
+                            {section.blocking_issue ? (
+                                <div className="flex justify-between gap-3">
+                                    <dt className="text-muted">Follow-up</dt>
+                                    <dd className="font-medium">{section.blocking_issue}</dd>
+                                </div>
+                            ) : null}
+                        </dl>
+                    </section>
+                ))}
+            </div>
+
+            <section className="card p-5">
+                <h2 className="font-semibold">Export Contract</h2>
+                <dl className="mt-4 space-y-2 text-sm">
+                    <div className="flex justify-between gap-3">
+                        <dt className="text-muted">Formats</dt>
+                        <dd className="font-medium">{contract.export_contract.formats.join(", ")}</dd>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                        <dt className="text-muted">CSV Columns</dt>
+                        <dd className="font-mono text-xs text-right">{contract.export_contract.csv_columns.join(", ")}</dd>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                        <dt className="text-muted">Decimal Serialization</dt>
+                        <dd className="font-medium">{contract.period_semantics.decimal_serialization}</dd>
+                    </div>
+                </dl>
+            </section>
+        </div>
+    );
+}

--- a/apps/frontend/src/app/(main)/reports/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import { BarChart2, TrendingUp, DollarSign } from "lucide-react";
+import { BarChart2, TrendingUp, DollarSign, FileText } from "lucide-react";
 
 const reports = [
+    { id: "personal-package", title: "Personal Report Package", description: "Stable package contract for statements, schedules, notes, and traceability", icon: FileText, href: "/reports/package", available: true },
     { id: "balance-sheet", title: "Balance Sheet", description: "Assets, liabilities, and equity at a point in time", icon: BarChart2, href: "/reports/balance-sheet", available: true },
     { id: "income-statement", title: "Income Statement", description: "Revenue and expenses over a period", icon: TrendingUp, href: "/reports/income-statement", available: true },
     { id: "cash-flow", title: "Cash Flow Statement", description: "Cash movements by operating, investing, and financing activities", icon: DollarSign, href: "/reports/cash-flow", available: true },
@@ -15,7 +16,7 @@ export default function ReportsPage() {
                 <p className="page-description">Generate and view financial reports following standard accounting principles.</p>
             </div>
 
-            <div className="grid md:grid-cols-3 gap-4 mb-6">
+            <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-4 mb-6">
                 {reports.map((report) => (
                     <ReportCard key={report.id} report={report} />
                 ))}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -153,6 +153,29 @@ export interface IncomeStatementResponse {
     trends: IncomeStatementTrend[];
 }
 
+export interface PersonalReportPackageSectionContract {
+    section_id: string;
+    label: string;
+    owner_epic: string;
+    period_type?: string;
+    source_endpoint: string;
+    status: string;
+    required?: boolean;
+    blocking_issue?: string | null;
+    decimal_total_fields?: string[];
+}
+
+export interface PersonalReportPackageContractResponse {
+    package_id: string;
+    version: string;
+    period_semantics: Record<string, string>;
+    sections: PersonalReportPackageSectionContract[];
+    export_contract: {
+        formats: string[];
+        csv_columns: string[];
+    };
+}
+
 export interface AnnualizedIncomeResponse {
     annualized_salary: number | string;
     annualized_bonus: number | string;

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1185,6 +1185,27 @@ groups:
         description: Personal report package defines the investment_performance report section as a consumer of the EPIC-017
           schedule API
         mandatory: true
+    AC5.9:
+      - id: AC5.9.1
+        epic: 5
+        epic_name: reporting-visualization
+        description: Package contract endpoint defines required section IDs, labels, owners, and source endpoints
+        mandatory: true
+      - id: AC5.9.2
+        epic: 5
+        epic_name: reporting-visualization
+        description: Package contract exposes Decimal-safe total fields and explicit period/as-of semantics
+        mandatory: true
+      - id: AC5.9.3
+        epic: 5
+        epic_name: reporting-visualization
+        description: Frontend personal package page renders the contract section IDs and labels from the API contract
+        mandatory: true
+      - id: AC5.9.4
+        epic: 5
+        epic_name: reporting-visualization
+        description: Frontend/export contract surfaces stable export format and CSV columns for package consumers
+        mandatory: true
   AC6:
     AC6.1:
       - id: AC6.1.1
@@ -4323,12 +4344,14 @@ groups:
       - id: AC17.10.3
         epic: 17
         epic_name: portfolio-management
-        description: Investment performance schedule source links preserve brokerage statement, price source, ledger, transaction source, and report-section anchors
+        description: Investment performance schedule source links preserve brokerage statement, price source, ledger, transaction
+          source, and report-section anchors
         mandatory: true
       - id: AC17.10.4
         epic: 17
         epic_name: portfolio-management
-        description: Investment performance schedule data freshness marks the schedule stale when any holding lacks current as-of-date price evidence
+        description: Investment performance schedule data freshness marks the schedule stale when any holding lacks current
+          as-of-date price evidence
         mandatory: true
       - id: AC17.10.5
         epic: 17

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -167,11 +167,28 @@ method, dividends, realized/unrealized P&L, and return metric limitations.
 |----|-----------|---------------|------|----------|
 | AC5.8.1 | Personal report package defines the `investment_performance` report section as a consumer of the EPIC-017 schedule API | `AC5.8.1 renders investment performance report schedule from the schedule API`; `test_personal_financial_report_package_post_merge_journey`; `test_AC5_8_1_personal_report_package_consumes_investment_schedule_contract` | `apps/frontend/src/__tests__/portfolioPage.test.tsx`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
 
+### AC5.9: Personal Report Package Contract
+
+Issue [#570](https://github.com/wangzitian0/finance_report/issues/570)
+defines the package-level API/export contract before the annualized income,
+notes, traceability appendix, and representative fixture follow-up work lands.
+The contract owns stable section IDs, labels, period/as-of semantics, and
+Decimal-safe total field names. Supporting EPICs keep ownership of their
+calculations; this contract only describes how their outputs plug into one
+personal financial-report package.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.9.1 | Package contract endpoint defines required section IDs, labels, owners, and source endpoints | `test_AC5_9_1_package_contract_endpoint_defines_required_sections` | `api/test_personal_report_package_contract.py` | P0 |
+| AC5.9.2 | Package contract exposes Decimal-safe total fields and explicit period/as-of semantics | `test_AC5_9_2_package_contract_marks_decimal_totals_and_period_semantics` | `api/test_personal_report_package_contract.py` | P0 |
+| AC5.9.3 | Frontend personal package page renders the contract section IDs and labels from the API contract | `AC5.9.3 renders personal package contract sections from API` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
+| AC5.9.4 | Frontend/export contract surfaces stable export format and CSV columns for package consumers | `AC5.9.4 renders export contract metadata` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P1 |
+
 **Traceability Result**:
-- Total AC IDs: 19
+- Total AC IDs: 23
 - Requirements converted to AC IDs: 100% (EPIC-005 checklist + must-have standards)
 - Requirements with implemented test references: 100%
-- Test files: 5
+- Test files: 7
 
 ---
 
@@ -263,7 +280,8 @@ compliance.
 Remaining blocker breakdown after the #565 post-merge proof:
 
 - [#570](https://github.com/wangzitian0/finance_report/issues/570) defines the
-  package-level API/export contract and stable section IDs.
+  package-level API/export contract and stable section IDs through
+  `GET /api/reports/package/contract`.
 - [#564](https://github.com/wangzitian0/finance_report/issues/564) supplies the
   investment performance schedule input from EPIC-017.
 - [#566](https://github.com/wangzitian0/finance_report/issues/566) supplies the
@@ -282,8 +300,9 @@ Closure status:
 1. Done: #565 added the behavioral post-merge package journey and promoted
    `personal-financial-report-package` to `covered` in
    `docs/ssot/critical-proof-matrix.yaml`.
-2. Land the package contract (#570) so backend, frontend, export, and E2E
-   assertions share one shape.
+2. Done: #570 defines `GET /api/reports/package/contract` so backend,
+   frontend, export, and E2E assertions share stable package section IDs,
+   labels, period semantics, and Decimal-safe export fields.
 3. Done: deliver the investment-performance schedule input consumed by this
    package (#564, promoted by #596). Still open: annualized income/long-term
    compensation (#566).

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -165,6 +165,46 @@ The schedule must not mutate ledger state. It assembles existing portfolio,
 market-data, dividend, and journal-entry facts into a reporting payload that can
 be exported or embedded by EPIC-005.
 
+### 2.6 Personal Financial-Report Package Contract
+
+Issue [#570](https://github.com/wangzitian0/finance_report/issues/570) owns the
+stable package-level API/export contract. The contract defines how existing and
+future report sections plug into one personal financial-report package; it does
+not duplicate the calculation ownership of the supporting EPICs.
+
+Endpoint:
+`GET /api/reports/package/contract`
+
+Contract response:
+
+| Field | Rule |
+|---|---|
+| `package_id` | Always `personal-financial-report-package` |
+| `version` | Contract version, currently `1.0` |
+| `period_semantics` | Defines required `start_date`, `end_date`, `as_of_date`, `currency`, and `decimal_serialization` semantics |
+| `sections` | Stable ordered section contracts with `section_id`, label, owner EPIC, period type, source endpoint, status, optional blocking issue, and Decimal-safe total fields |
+| `export_contract` | Stable export formats and CSV column names for package consumers |
+
+Required section IDs:
+
+| Section ID | Owner | Source endpoint | Status |
+|---|---|---|---|
+| `balance_sheet` | EPIC-005 | `/api/reports/balance-sheet` | ready |
+| `income_statement` | EPIC-005 | `/api/reports/income-statement` | ready |
+| `cash_flow` | EPIC-005 | `/api/reports/cash-flow` | ready |
+| `investment_performance` | EPIC-017 | `/api/portfolio/performance/report-schedule` | ready |
+| `annualized_income_long_term` | EPIC-011 | `/api/reports/package/annualized-income-schedule` | planned by #566 |
+| `notes` | EPIC-005 | `/api/reports/package/notes` | planned by #571 |
+| `traceability_appendix` | EPIC-018 | `/api/reports/package/traceability` | planned by #572 |
+
+Export contract:
+
+- Formats: `json`, `csv`
+- CSV columns: `package_id`, `section_id`, `line_id`, `label`, `amount`,
+  `currency`, `source_state`
+- Decimal fields must serialize as strings so frontend, CSV export, and E2E
+  assertions do not lose money precision.
+
 ---
 
 ## 3. Multi-Currency Consolidation

--- a/docs/user-guide/reports.md
+++ b/docs/user-guide/reports.md
@@ -9,6 +9,22 @@ metrics live in generated reports such as
 
 ## Available Reports
 
+### Personal Report Package
+
+The personal financial-report package contract defines the stable report package
+shape used by backend, frontend, export, and E2E assertions.
+
+Contract endpoint:
+
+```bash
+curl "https://report.zitian.party/api/reports/package/contract"
+```
+
+The contract includes stable section IDs for balance sheet, income statement,
+cash-flow view, investment performance, annualized income and long-term
+compensation, notes, and traceability appendix. Decimal fields serialize as
+strings to preserve money precision in frontend and export consumers.
+
 ### Balance Sheet
 
 Shows your financial position at a point in time:


### PR DESCRIPTION
## Summary

Define the personal financial-report package API/export contract and add the frontend contract page.

Closes #570

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-005 — Reports & Visualization |
| **AC IDs** | AC5.9.1, AC5.9.2, AC5.9.3, AC5.9.4 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/reporting.md` — added the personal financial-report package contract endpoint, required section IDs, period semantics, and export columns.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `N/A` | Local pre-implementation targeted tests failed because `/reports/package/contract` and `/reports/package` did not exist. |
| 🟢 Green (passing test) | `5583a1a` | Implement package contract schema/endpoint, frontend page, AC registry, and docs. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — no database enum changes.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — not applicable.
- [x] `repo/` submodule updated for production config changes (if applicable) — not applicable.
- [x] `tools/check_env_keys.py` passes (if env vars changed) — not applicable.
- [x] `tools/check_manifest.py` passes (if SSOT files changed) — no manifest ownership change; reporting SSOT already owns report contracts.
- [x] `tools/lint_doc_consistency.py` passes — covered by targeted registry/traceability checks below.

### CI/CD, Runtime, and VPS Infra Audit

Not applicable: this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
cd apps/backend && uv run pytest -n 0 --no-cov tests/api/test_personal_report_package_contract.py
cd apps/frontend && npm test -- personalReportPackagePage.test.tsx reportsPage.test.tsx --run
cd apps/backend && uv run ruff check src tests/api/test_personal_report_package_contract.py
cd apps/frontend && npm run lint
moon run :lint
python tools/generate_ac_registry.py --check
python tools/check_ac_traceability.py
python tools/check_critical_proof_matrix.py
python tools/check_e2e_epic_traceability.py
```

Attempted full root test:

```bash
moon run :test
python3 tools/cli.py test
```

Local full test did not reach pytest/vitest execution because local Podman infra startup blocked on MinIO health wait and then reported `Unregistered namespace: issue_570_personal_report_package_5ccd893e` after termination. Targeted tests and repository gates above pass; GitHub CI should validate the full environment independently.

---

## Screenshots / Evidence

N/A
