### PR TITLE
[finance_report_vision] Define annualized income package schedule

### DIFF
--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import csv
-from datetime import date
+from datetime import date, timedelta
+from decimal import Decimal
 from enum import Enum
 from io import StringIO
 from uuid import UUID
@@ -15,9 +16,18 @@ from sqlalchemy import select, union
 from src.config import settings
 from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
-from src.models import Account, AccountType, FxRate
+from src.models import Account, AccountType, Direction, FxRate, JournalEntry, JournalEntryStatus, JournalLine
+from src.models.layer3 import (
+    ManualValuationComponentType,
+    ManualValuationLiquidityClass,
+    ManualValuationSnapshot,
+)
 from src.schemas import (
     AccountTrendResponse,
+    AnnualizedIncomeScheduleHolding,
+    AnnualizedIncomeScheduleIncome,
+    AnnualizedIncomeScheduleNetWorthTreatment,
+    AnnualizedIncomeScheduleResponse,
     BalanceSheetResponse,
     BreakdownPeriod,
     BreakdownType,
@@ -167,8 +177,8 @@ PERSONAL_REPORT_PACKAGE_CONTRACT: dict = {
             "owner_epic": "EPIC-011",
             "period_type": "trailing_12_months_and_as_of",
             "source_endpoint": "/api/reports/package/annualized-income-schedule",
-            "status": "planned",
-            "blocking_issue": "#566",
+            "status": "ready",
+            "blocking_issue": None,
             "decimal_total_fields": [
                 "annualized_salary",
                 "annualized_bonus",
@@ -205,10 +215,125 @@ PERSONAL_REPORT_PACKAGE_CONTRACT: dict = {
 }
 
 
+def _annualized_income_bucket(account_name: str) -> str | None:
+    normalized = account_name.casefold()
+    if "salary" in normalized or "payroll" in normalized:
+        return "salary"
+    if "bonus" in normalized:
+        return "bonus"
+    if "dividend" in normalized:
+        return "dividend"
+    return None
+
+
 @router.get("/package/contract", response_model=PersonalReportPackageContractResponse)
 def personal_report_package_contract() -> PersonalReportPackageContractResponse:
     """Return the stable package-level API/export contract."""
     return PersonalReportPackageContractResponse(**PERSONAL_REPORT_PACKAGE_CONTRACT)
+
+
+@router.get("/package/annualized-income-schedule", response_model=AnnualizedIncomeScheduleResponse)
+async def annualized_income_schedule(
+    as_of_date: date | None = Query(default=None),
+    db: DbSession = None,
+    user_id: CurrentUserId = None,
+) -> AnnualizedIncomeScheduleResponse:
+    """Return report-ready annualized income and restricted compensation schedule."""
+    report_date = as_of_date or date.today()
+    start_date = report_date - timedelta(days=365)
+    income_result = await db.execute(
+        select(JournalLine, Account)
+        .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
+        .join(Account, JournalLine.account_id == Account.id)
+        .where(JournalEntry.user_id == user_id)
+        .where(JournalEntry.entry_date > start_date)
+        .where(JournalEntry.entry_date <= report_date)
+        .where(JournalEntry.status.in_([JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED]))
+        .where(Account.type == AccountType.INCOME)
+    )
+
+    totals = {
+        "salary": Decimal("0.00"),
+        "bonus": Decimal("0.00"),
+        "dividend": Decimal("0.00"),
+        "total": Decimal("0.00"),
+    }
+    currency = settings.base_currency
+    for line, account in income_result.all():
+        signed_amount = line.amount if line.direction == Direction.CREDIT else -line.amount
+        bucket = _annualized_income_bucket(account.name)
+        if bucket:
+            totals[bucket] += signed_amount
+        totals["total"] += signed_amount
+        currency = line.currency or account.currency or currency
+
+    restricted_types = (
+        ManualValuationComponentType.ESOP,
+        ManualValuationComponentType.RSU,
+        ManualValuationComponentType.STOCK_OPTIONS,
+    )
+    restricted_result = await db.execute(
+        select(ManualValuationSnapshot)
+        .where(ManualValuationSnapshot.user_id == user_id)
+        .where(ManualValuationSnapshot.as_of_date <= report_date)
+        .where(ManualValuationSnapshot.component_type.in_(restricted_types))
+        .where(ManualValuationSnapshot.liquidity_class == ManualValuationLiquidityClass.RESTRICTED)
+        .order_by(ManualValuationSnapshot.as_of_date.desc(), ManualValuationSnapshot.created_at.desc())
+    )
+
+    latest_holdings: dict[tuple[ManualValuationComponentType, str, str], ManualValuationSnapshot] = {}
+    for snapshot in restricted_result.scalars().all():
+        key = (snapshot.component_type, snapshot.source, snapshot.currency)
+        latest_holdings.setdefault(key, snapshot)
+
+    holdings = [
+        AnnualizedIncomeScheduleHolding(
+            ticker=snapshot.source,
+            compensation_type=snapshot.component_type.value,
+            fair_value=snapshot.value.quantize(Decimal("0.01")),
+            currency=snapshot.currency,
+            valuation_basis="manual_valuation_snapshot",
+            vesting_schedule=snapshot.notes,
+            unlock_date=snapshot.reminder_date,
+            liquidity_class=snapshot.liquidity_class.value,
+            net_worth_treatment="excluded_from_liquid_net_worth_by_default",
+        )
+        for snapshot in latest_holdings.values()
+    ]
+    restricted_total = sum(
+        (holding.fair_value for holding in holdings if holding.currency == currency),
+        Decimal("0.00"),
+    ).quantize(Decimal("0.01"))
+
+    return AnnualizedIncomeScheduleResponse(
+        section_id="annualized_income_long_term",
+        label="Annualized Income & Long-Term Compensation",
+        as_of_date=report_date,
+        trailing_period_start=start_date,
+        trailing_period_end=report_date,
+        trailing_period_days=365,
+        income=AnnualizedIncomeScheduleIncome(
+            annualized_salary=totals["salary"].quantize(Decimal("0.01")),
+            annualized_bonus=totals["bonus"].quantize(Decimal("0.01")),
+            annualized_dividend=totals["dividend"].quantize(Decimal("0.01")),
+            annualized_total=totals["total"].quantize(Decimal("0.01")),
+            currency=currency,
+            calculation_basis="posted_or_reconciled_income_journal_lines_trailing_12_months",
+        ),
+        restricted_holdings=holdings,
+        restricted_fair_value_total=restricted_total,
+        restricted_fair_value_total_currency=currency,
+        net_worth_treatment=AnnualizedIncomeScheduleNetWorthTreatment(
+            liquid_net_worth_default="exclude_restricted_holdings",
+            restricted_wealth_basis="manual_valuation_snapshot_fair_value",
+            include_restricted_query="/api/reports/balance-sheet?include_restricted=true",
+            exclude_restricted_query="/api/reports/balance-sheet?include_restricted=false",
+        ),
+        notes=[
+            "Personal management report only; not tax advice.",
+            "Restricted holdings are excluded from liquid net worth by default.",
+        ],
+    )
 
 
 @router.get("/balance-sheet", response_model=BalanceSheetResponse)

--- a/apps/backend/src/schemas/__init__.py
+++ b/apps/backend/src/schemas/__init__.py
@@ -55,6 +55,10 @@ from src.schemas.reconciliation import (
 )
 from src.schemas.reporting import (
     AccountTrendResponse,
+    AnnualizedIncomeScheduleHolding,
+    AnnualizedIncomeScheduleIncome,
+    AnnualizedIncomeScheduleNetWorthTreatment,
+    AnnualizedIncomeScheduleResponse,
     BalanceSheetResponse,
     BreakdownPeriod,
     BreakdownType,
@@ -114,6 +118,10 @@ __all__ = [
     "AccountResponse",
     "AccountTrendResponse",
     "AccountUpdate",
+    "AnnualizedIncomeScheduleHolding",
+    "AnnualizedIncomeScheduleIncome",
+    "AnnualizedIncomeScheduleNetWorthTreatment",
+    "AnnualizedIncomeScheduleResponse",
     "AnomalyResponse",
     "AuthResponse",
     "BalanceSheetResponse",

--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -208,3 +208,54 @@ class PersonalReportPackageContractResponse(BaseModel):
     period_semantics: dict[str, str]
     sections: list[PersonalReportPackageSectionContract]
     export_contract: PersonalReportPackageExportContract
+
+
+class AnnualizedIncomeScheduleIncome(BaseModel):
+    """Trailing income totals for the personal report package."""
+
+    annualized_salary: Decimal
+    annualized_bonus: Decimal
+    annualized_dividend: Decimal
+    annualized_total: Decimal
+    currency: str = Field(min_length=3, max_length=3)
+    calculation_basis: str
+
+
+class AnnualizedIncomeScheduleHolding(BaseModel):
+    """Restricted long-term compensation holding for the personal report package."""
+
+    ticker: str
+    compensation_type: str
+    fair_value: Decimal
+    currency: str = Field(min_length=3, max_length=3)
+    valuation_basis: str
+    vesting_schedule: str | None = None
+    unlock_date: date | None = None
+    liquidity_class: str
+    net_worth_treatment: str
+
+
+class AnnualizedIncomeScheduleNetWorthTreatment(BaseModel):
+    """Net-worth presentation semantics for restricted compensation."""
+
+    liquid_net_worth_default: str
+    restricted_wealth_basis: str
+    include_restricted_query: str
+    exclude_restricted_query: str
+
+
+class AnnualizedIncomeScheduleResponse(BaseModel):
+    """Report-ready annualized income and long-term compensation schedule."""
+
+    section_id: str
+    label: str
+    as_of_date: date
+    trailing_period_start: date
+    trailing_period_end: date
+    trailing_period_days: int
+    income: AnnualizedIncomeScheduleIncome
+    restricted_holdings: list[AnnualizedIncomeScheduleHolding]
+    restricted_fair_value_total: Decimal
+    restricted_fair_value_total_currency: str = Field(min_length=3, max_length=3)
+    net_worth_treatment: AnnualizedIncomeScheduleNetWorthTreatment
+    notes: list[str]

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -32,7 +32,6 @@ def test_AC5_9_1_package_contract_endpoint_defines_required_sections():
     assert sections["balance_sheet"]["label"] == "Balance Sheet"
     assert sections["balance_sheet"]["source_endpoint"] == "/api/reports/balance-sheet"
     assert sections["investment_performance"]["owner_epic"] == "EPIC-017"
-    assert sections["annualized_income_long_term"]["blocking_issue"] == "#566"
     assert sections["notes"]["blocking_issue"] == "#571"
     assert sections["traceability_appendix"]["blocking_issue"] == "#572"
 
@@ -71,3 +70,15 @@ def test_AC5_9_2_package_contract_marks_decimal_totals_and_period_semantics():
         "currency",
         "source_state",
     ]
+
+
+def test_AC5_11_1_package_contract_marks_annualized_schedule_ready():
+    """AC5.11.1: Annualized income package section points to the ready schedule endpoint."""
+    response = personal_report_package_contract()
+    payload = response.model_dump(mode="json")
+
+    sections = {section["section_id"]: section for section in payload["sections"]}
+    section = sections["annualized_income_long_term"]
+    assert section["status"] == "ready"
+    assert section["blocking_issue"] is None
+    assert section["source_endpoint"] == "/api/reports/package/annualized-income-schedule"

--- a/apps/backend/tests/reporting/test_annualized_income_schedule.py
+++ b/apps/backend/tests/reporting/test_annualized_income_schedule.py
@@ -1,0 +1,134 @@
+"""Report package annualized income and long-term compensation schedule tests."""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import Account, AccountType, Direction, JournalEntry, JournalEntryStatus, JournalLine
+from src.models.layer3 import ManualValuationComponentType, ManualValuationLiquidityClass, ManualValuationSnapshot
+from src.routers.reports import _annualized_income_bucket
+
+
+def test_AC11_11_1_income_bucket_maps_report_package_income_accounts():
+    """AC11.11.1: Schedule income bucket mapping covers report package income labels."""
+    assert _annualized_income_bucket("Salary Income") == "salary"
+    assert _annualized_income_bucket("Monthly Payroll") == "salary"
+    assert _annualized_income_bucket("Annual Bonus") == "bonus"
+    assert _annualized_income_bucket("Dividend Income") == "dividend"
+    assert _annualized_income_bucket("Consulting Income") is None
+
+
+@pytest.mark.asyncio
+async def test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restricted_treatment(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+):
+    """AC11.11.1 AC11.11.2: Report package schedule includes income and restricted holdings."""
+    salary = Account(user_id=test_user.id, name="Salary Income", type=AccountType.INCOME, currency="SGD")
+    bonus = Account(user_id=test_user.id, name="Annual Bonus", type=AccountType.INCOME, currency="SGD")
+    dividend = Account(user_id=test_user.id, name="Dividend Income", type=AccountType.INCOME, currency="SGD")
+    db.add_all([salary, bonus, dividend])
+    await db.flush()
+
+    income_entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=date(2026, 5, 1),
+        memo="trailing income",
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(income_entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=income_entry.id,
+                account_id=salary.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("120000.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=income_entry.id,
+                account_id=bonus.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("15000.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=income_entry.id,
+                account_id=dividend.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("2400.00"),
+                currency="SGD",
+            ),
+        ]
+    )
+    db.add_all(
+        [
+            ManualValuationSnapshot(
+                user_id=test_user.id,
+                component_type=ManualValuationComponentType.RSU,
+                liquidity_class=ManualValuationLiquidityClass.RESTRICTED,
+                as_of_date=date(2026, 5, 1),
+                value=Decimal("12500.00"),
+                currency="SGD",
+                source="SHOP-RSU",
+                notes="25% annual vesting",
+                reminder_date=date(2027, 1, 1),
+            ),
+            ManualValuationSnapshot(
+                user_id=test_user.id,
+                component_type=ManualValuationComponentType.ESOP,
+                liquidity_class=ManualValuationLiquidityClass.RESTRICTED,
+                as_of_date=date(2026, 4, 15),
+                value=Decimal("85000.00"),
+                currency="SGD",
+                source="ACME ESOP",
+                notes="4-year vesting",
+                reminder_date=date(2028, 4, 15),
+            ),
+        ]
+    )
+    await db.commit()
+
+    response = await client.get("/reports/package/annualized-income-schedule?as_of_date=2026-05-20")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["section_id"] == "annualized_income_long_term"
+    assert data["as_of_date"] == "2026-05-20"
+    assert data["trailing_period_start"] == "2025-05-20"
+    assert data["trailing_period_end"] == "2026-05-20"
+    assert data["trailing_period_days"] == 365
+    assert data["income"] == {
+        "annualized_salary": "120000.00",
+        "annualized_bonus": "15000.00",
+        "annualized_dividend": "2400.00",
+        "annualized_total": "137400.00",
+        "currency": "SGD",
+        "calculation_basis": "posted_or_reconciled_income_journal_lines_trailing_12_months",
+    }
+    assert data["restricted_fair_value_total"] == "97500.00"
+    assert data["net_worth_treatment"]["liquid_net_worth_default"] == "exclude_restricted_holdings"
+    assert data["net_worth_treatment"]["restricted_wealth_basis"] == "manual_valuation_snapshot_fair_value"
+    assert data["notes"] == [
+        "Personal management report only; not tax advice.",
+        "Restricted holdings are excluded from liquid net worth by default.",
+    ]
+
+    holdings = {holding["ticker"]: holding for holding in data["restricted_holdings"]}
+    assert holdings["SHOP-RSU"] == {
+        "ticker": "SHOP-RSU",
+        "compensation_type": "rsu",
+        "fair_value": "12500.00",
+        "currency": "SGD",
+        "valuation_basis": "manual_valuation_snapshot",
+        "vesting_schedule": "25% annual vesting",
+        "unlock_date": "2027-01-01",
+        "liquidity_class": "restricted",
+        "net_worth_treatment": "excluded_from_liquid_net_worth_by_default",
+    }

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -25,7 +25,7 @@ const contract = {
     { section_id: "income_statement", label: "Income Statement", owner_epic: "EPIC-005", source_endpoint: "/api/reports/income-statement", status: "ready" },
     { section_id: "cash_flow", label: "Cash Flow", owner_epic: "EPIC-005", source_endpoint: "/api/reports/cash-flow", status: "ready" },
     { section_id: "investment_performance", label: "Investment Performance", owner_epic: "EPIC-017", source_endpoint: "/api/portfolio/performance/report-schedule", status: "ready" },
-    { section_id: "annualized_income_long_term", label: "Annualized Income & Long-Term Compensation", owner_epic: "EPIC-011", source_endpoint: "/api/reports/package/annualized-income-schedule", status: "planned" },
+    { section_id: "annualized_income_long_term", label: "Annualized Income & Long-Term Compensation", owner_epic: "EPIC-011", source_endpoint: "/api/reports/package/annualized-income-schedule", status: "ready" },
     { section_id: "notes", label: "Notes & Disclosures", owner_epic: "EPIC-005", source_endpoint: "/api/reports/package/notes", status: "planned" },
     { section_id: "traceability_appendix", label: "Traceability Appendix", owner_epic: "EPIC-018", source_endpoint: "/api/reports/package/traceability", status: "planned" },
   ],
@@ -35,9 +35,59 @@ const contract = {
   },
 }
 
+const annualizedSchedule = {
+  section_id: "annualized_income_long_term",
+  label: "Annualized Income & Long-Term Compensation",
+  as_of_date: "2026-05-20",
+  trailing_period_start: "2025-05-20",
+  trailing_period_end: "2026-05-20",
+  trailing_period_days: 365,
+  income: {
+    annualized_salary: "120000.00",
+    annualized_bonus: "15000.00",
+    annualized_dividend: "2400.00",
+    annualized_total: "137400.00",
+    currency: "SGD",
+    calculation_basis: "posted_or_reconciled_income_journal_lines_trailing_12_months",
+  },
+  restricted_holdings: [
+    {
+      ticker: "SHOP-RSU",
+      compensation_type: "rsu",
+      fair_value: "12500.00",
+      currency: "SGD",
+      valuation_basis: "manual_valuation_snapshot",
+      vesting_schedule: "25% annual vesting",
+      unlock_date: "2027-01-01",
+      liquidity_class: "restricted",
+      net_worth_treatment: "excluded_from_liquid_net_worth_by_default",
+    },
+  ],
+  restricted_fair_value_total: "12500.00",
+  restricted_fair_value_total_currency: "SGD",
+  net_worth_treatment: {
+    liquid_net_worth_default: "exclude_restricted_holdings",
+    restricted_wealth_basis: "manual_valuation_snapshot_fair_value",
+    include_restricted_query: "/api/reports/balance-sheet?include_restricted=true",
+    exclude_restricted_query: "/api/reports/balance-sheet?include_restricted=false",
+  },
+  notes: [
+    "Personal management report only; not tax advice.",
+    "Restricted holdings are excluded from liquid net worth by default.",
+  ],
+}
+
+function mockPackageApi() {
+  mockedApiFetch.mockImplementation((path: string) => {
+    if (path === "/api/reports/package/contract") return Promise.resolve(contract)
+    if (path === "/api/reports/package/annualized-income-schedule") return Promise.resolve(annualizedSchedule)
+    return Promise.reject(new Error(`Unexpected path ${path}`))
+  })
+}
+
 describe("PersonalReportPackagePage", () => {
   it("AC5.9.3 renders personal package contract sections from API", async () => {
-    mockedApiFetch.mockResolvedValue(contract)
+    mockPackageApi()
 
     render(<PersonalReportPackagePage />)
 
@@ -46,12 +96,12 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.getByText("personal-financial-report-package")).toBeInTheDocument()
     expect(screen.getByText("balance_sheet")).toBeInTheDocument()
     expect(screen.getByText("Balance Sheet")).toBeInTheDocument()
-    expect(screen.getByText("annualized_income_long_term")).toBeInTheDocument()
+    expect(screen.getAllByText("annualized_income_long_term").length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText("Annualized Income & Long-Term Compensation")).toBeInTheDocument()
   })
 
   it("AC5.9.4 renders export contract metadata", async () => {
-    mockedApiFetch.mockResolvedValue(contract)
+    mockPackageApi()
 
     render(<PersonalReportPackagePage />)
 
@@ -59,5 +109,24 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.getByText("json, csv")).toBeInTheDocument()
     expect(screen.getByText("package_id, section_id, line_id, label, amount, currency, source_state")).toBeInTheDocument()
     expect(screen.getByText("string")).toBeInTheDocument()
+  })
+
+  it("AC5.11.2 renders annualized income schedule values and restricted treatment", async () => {
+    mockPackageApi()
+
+    render(<PersonalReportPackagePage />)
+
+    await waitFor(() => expect(screen.getByText("Annualized Income Schedule")).toBeInTheDocument())
+    expect(screen.getByText("SGD 137,400")).toBeInTheDocument()
+    expect(screen.getByText("Salary")).toBeInTheDocument()
+    expect(screen.getByText("SGD 120,000")).toBeInTheDocument()
+    expect(screen.getByText("Bonus")).toBeInTheDocument()
+    expect(screen.getByText("SGD 15,000")).toBeInTheDocument()
+    expect(screen.getByText("Dividend")).toBeInTheDocument()
+    expect(screen.getByText("SGD 2,400")).toBeInTheDocument()
+    expect(screen.getByText("SHOP-RSU")).toBeInTheDocument()
+    expect(screen.getByText("SGD 12,500")).toBeInTheDocument()
+    expect(screen.getByText("exclude_restricted_holdings")).toBeInTheDocument()
+    expect(screen.getByText("Personal management report only; not tax advice.")).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/app/(main)/reports/package/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/package/page.tsx
@@ -3,21 +3,32 @@
 import { useEffect, useState } from "react";
 
 import { apiFetch } from "@/lib/api";
-import type { PersonalReportPackageContractResponse } from "@/lib/types";
+import { formatCurrencyLocale } from "@/lib/currency";
+import type { AnnualizedIncomeScheduleResponse, PersonalReportPackageContractResponse } from "@/lib/types";
+
+function formatScheduleCurrency(value: number | string, currency: string): string {
+    return formatCurrencyLocale(value, currency, "en-US", { maximumFractionDigits: 0 }).replace(/\u00a0/g, " ");
+}
 
 export default function PersonalReportPackagePage() {
     const [contract, setContract] = useState<PersonalReportPackageContractResponse | null>(null);
+    const [annualizedSchedule, setAnnualizedSchedule] = useState<AnnualizedIncomeScheduleResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
         let isMounted = true;
 
-        apiFetch<PersonalReportPackageContractResponse>("/api/reports/package/contract")
-            .then((data) => {
-                if (isMounted) setContract(data);
+        Promise.all([
+            apiFetch<PersonalReportPackageContractResponse>("/api/reports/package/contract"),
+            apiFetch<AnnualizedIncomeScheduleResponse>("/api/reports/package/annualized-income-schedule"),
+        ])
+            .then(([contractData, scheduleData]) => {
+                if (!isMounted) return;
+                setContract(contractData);
+                setAnnualizedSchedule(scheduleData);
             })
             .catch((err) => {
-                if (isMounted) setError(err instanceof Error ? err.message : "Failed to load package contract.");
+                if (isMounted) setError(err instanceof Error ? err.message : "Failed to load package data.");
             });
 
         return () => {
@@ -29,7 +40,7 @@ export default function PersonalReportPackagePage() {
         return <div className="p-6 text-[var(--error)]">{error}</div>;
     }
 
-    if (!contract) {
+    if (!contract || !annualizedSchedule) {
         return <div className="p-6 text-muted">Loading package contract...</div>;
     }
 
@@ -69,6 +80,98 @@ export default function PersonalReportPackagePage() {
                     </section>
                 ))}
             </div>
+
+            <section className="card p-5 mb-6">
+                <div className="flex items-start justify-between gap-3">
+                    <div>
+                        <p className="text-xs font-mono text-muted">{annualizedSchedule.section_id}</p>
+                        <h2 className="font-semibold mt-1">Annualized Income Schedule</h2>
+                    </div>
+                    <span className="badge badge-muted">{annualizedSchedule.trailing_period_days} days</span>
+                </div>
+                <div className="mt-4 grid md:grid-cols-4 gap-3">
+                    <div>
+                        <p className="text-xs text-muted">Total</p>
+                        <p className="mt-1 font-semibold">
+                            {formatScheduleCurrency(annualizedSchedule.income.annualized_total, annualizedSchedule.income.currency)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-xs text-muted">Salary</p>
+                        <p className="mt-1 font-semibold">
+                            {formatScheduleCurrency(annualizedSchedule.income.annualized_salary, annualizedSchedule.income.currency)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-xs text-muted">Bonus</p>
+                        <p className="mt-1 font-semibold">
+                            {formatScheduleCurrency(annualizedSchedule.income.annualized_bonus, annualizedSchedule.income.currency)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-xs text-muted">Dividend</p>
+                        <p className="mt-1 font-semibold">
+                            {formatScheduleCurrency(annualizedSchedule.income.annualized_dividend, annualizedSchedule.income.currency)}
+                        </p>
+                    </div>
+                </div>
+                <div className="mt-5 grid lg:grid-cols-2 gap-4">
+                    <div>
+                        <h3 className="text-sm font-semibold">Restricted Holdings</h3>
+                        <div className="mt-3 space-y-2">
+                            {annualizedSchedule.restricted_holdings.map((holding) => (
+                                <div key={`${holding.compensation_type}:${holding.ticker}`} className="border border-[var(--border)] rounded p-3">
+                                    <div className="flex items-start justify-between gap-3">
+                                        <div>
+                                            <p className="font-medium">{holding.ticker}</p>
+                                            <p className="text-xs text-muted">{holding.compensation_type}</p>
+                                        </div>
+                                        <p className="font-semibold">
+                                            {formatScheduleCurrency(holding.fair_value, holding.currency)}
+                                        </p>
+                                    </div>
+                                    <dl className="mt-3 space-y-1 text-xs">
+                                        {holding.vesting_schedule ? (
+                                            <div className="flex justify-between gap-3">
+                                                <dt className="text-muted">Vesting</dt>
+                                                <dd>{holding.vesting_schedule}</dd>
+                                            </div>
+                                        ) : null}
+                                        {holding.unlock_date ? (
+                                            <div className="flex justify-between gap-3">
+                                                <dt className="text-muted">Unlock</dt>
+                                                <dd>{holding.unlock_date}</dd>
+                                            </div>
+                                        ) : null}
+                                    </dl>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                    <div>
+                        <h3 className="text-sm font-semibold">Net Worth Treatment</h3>
+                        <dl className="mt-3 space-y-2 text-sm">
+                            <div className="flex justify-between gap-3">
+                                <dt className="text-muted">Liquid Default</dt>
+                                <dd className="font-mono text-xs text-right">
+                                    {annualizedSchedule.net_worth_treatment.liquid_net_worth_default}
+                                </dd>
+                            </div>
+                            <div className="flex justify-between gap-3">
+                                <dt className="text-muted">Restricted Basis</dt>
+                                <dd className="font-mono text-xs text-right">
+                                    {annualizedSchedule.net_worth_treatment.restricted_wealth_basis}
+                                </dd>
+                            </div>
+                        </dl>
+                        <ul className="mt-4 space-y-1 text-sm text-muted">
+                            {annualizedSchedule.notes.map((note) => (
+                                <li key={note}>{note}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            </section>
 
             <section className="card p-5">
                 <h2 className="font-semibold">Export Contract</h2>

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -177,6 +177,49 @@ export interface PersonalReportPackageContractResponse {
     };
 }
 
+export interface AnnualizedIncomeScheduleIncome {
+    annualized_salary: number | string;
+    annualized_bonus: number | string;
+    annualized_dividend: number | string;
+    annualized_total: number | string;
+    currency: string;
+    calculation_basis: string;
+}
+
+export interface AnnualizedIncomeScheduleHolding {
+    ticker: string;
+    compensation_type: string;
+    fair_value: number | string;
+    currency: string;
+    valuation_basis: string;
+    vesting_schedule?: string | null;
+    unlock_date?: string | null;
+    liquidity_class: string;
+    net_worth_treatment: string;
+}
+
+export interface AnnualizedIncomeScheduleNetWorthTreatment {
+    liquid_net_worth_default: string;
+    restricted_wealth_basis: string;
+    include_restricted_query: string;
+    exclude_restricted_query: string;
+}
+
+export interface AnnualizedIncomeScheduleResponse {
+    section_id: string;
+    label: string;
+    as_of_date: string;
+    trailing_period_start: string;
+    trailing_period_end: string;
+    trailing_period_days: number;
+    income: AnnualizedIncomeScheduleIncome;
+    restricted_holdings: AnnualizedIncomeScheduleHolding[];
+    restricted_fair_value_total: number | string;
+    restricted_fair_value_total_currency: string;
+    net_worth_treatment: AnnualizedIncomeScheduleNetWorthTreatment;
+    notes: string[];
+}
+
 export interface AnnualizedIncomeResponse {
     annualized_salary: number | string;
     annualized_bonus: number | string;

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -1228,6 +1228,18 @@ groups:
         epic_name: reporting-visualization
         description: Cash-flow operating, investing, and financing totals preserve inflow/outflow signs
         mandatory: true
+    AC5.11:
+      - id: AC5.11.1
+        epic: 5
+        epic_name: reporting-visualization
+        description: Package contract marks annualized_income_long_term as ready and points to the schedule endpoint
+        mandatory: true
+      - id: AC5.11.2
+        epic: 5
+        epic_name: reporting-visualization
+        description: Frontend personal package page renders annualized income totals and restricted treatment from the schedule
+          endpoint
+        mandatory: true
   AC6:
     AC6.1:
       - id: AC6.1.1
@@ -2551,6 +2563,19 @@ groups:
         epic_name: asset-lifecycle
         description: Staging E2E covers report-time market data refresh from an authenticated ordinary-user path without manual
           sync
+        mandatory: true
+    AC11.11:
+      - id: AC11.11.1
+        epic: 11
+        epic_name: asset-lifecycle
+        description: 'GET /api/reports/package/annualized-income-schedule returns annualized salary, bonus, dividend, total
+          income, currency, '
+        mandatory: true
+      - id: AC11.11.2
+        epic: 11
+        epic_name: asset-lifecycle
+        description: The schedule includes ESOP/RSU/stock-option restricted holdings with valuation basis, vesting/unlock
+          metadata, fair valu
         mandatory: true
   AC13:
     AC13.1:

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -191,11 +191,23 @@ personal financial-report package.
 | AC5.10.1 | Cash-flow statement beginning cash, ending cash, and net cash flow use cumulative cash balances | `test_AC5_10_1_cash_flow_uses_cumulative_cash_balances()` | `reporting/test_financial_logic_audit.py` | P0 |
 | AC5.10.2 | Cash-flow operating, investing, and financing totals preserve inflow/outflow signs | `test_AC5_10_2_cash_flow_activity_totals_preserve_signs()` | `reporting/test_financial_logic_audit.py` | P0 |
 
+### AC5.11: Personal Report Package Annualized Income Schedule Consumption
+
+Issue [#566](https://github.com/wangzitian0/finance_report/issues/566)
+supplies the report-ready annualized income and long-term compensation schedule
+that plugs into the `annualized_income_long_term` package section defined by
+AC5.9. Supporting calculations remain owned by EPIC-011.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.11.1 | Package contract marks `annualized_income_long_term` as ready and points to the schedule endpoint | `test_AC5_11_1_package_contract_marks_annualized_schedule_ready` | `api/test_personal_report_package_contract.py` | P0 |
+| AC5.11.2 | Frontend personal package page renders annualized income totals and restricted treatment from the schedule endpoint | `AC5.11.2 renders annualized income schedule values and restricted treatment` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
+
 **Traceability Result**:
-- Total AC IDs: 23
+- Total AC IDs: 25
 - Requirements converted to AC IDs: 100% (EPIC-005 checklist + must-have standards)
 - Requirements with implemented test references: 100%
-- Test files: 7
+- Test files: 8
 
 ---
 
@@ -286,13 +298,14 @@ compliance.
 
 Remaining blocker breakdown after the #565 post-merge proof:
 
-- [#570](https://github.com/wangzitian0/finance_report/issues/570) defines the
+- [#570](https://github.com/wangzitian0/finance_report/issues/570) defined the
   package-level API/export contract and stable section IDs through
   `GET /api/reports/package/contract`.
 - [#564](https://github.com/wangzitian0/finance_report/issues/564) supplies the
   investment performance schedule input from EPIC-017.
 - [#566](https://github.com/wangzitian0/finance_report/issues/566) supplies the
-  annualized income and long-term compensation schedule input from EPIC-011.
+  annualized income and long-term compensation schedule input from EPIC-011
+  through `GET /api/reports/package/annualized-income-schedule`.
 - [#571](https://github.com/wangzitian0/finance_report/issues/571) codifies the
   standards-inspired note and disclosure taxonomy without claiming regulated
   filing compliance.
@@ -311,11 +324,12 @@ Closure status:
    frontend, export, and E2E assertions share stable package section IDs,
    labels, period semantics, and Decimal-safe export fields.
 3. Done: deliver the investment-performance schedule input consumed by this
-   package (#564, promoted by #596). Still open: annualized income/long-term
-   compensation (#566).
-4. Deliver explanation outputs for the package output shape: notes/disclosures
+   package (#564, promoted by #596).
+4. Done: deliver the annualized income and long-term compensation schedule
+   input consumed by this package (#566).
+5. Deliver explanation outputs for the package output shape: notes/disclosures
    (#571) and traceability appendix (#572).
-5. Build deterministic fixture coverage (#573) against the same contract and
+6. Build deterministic fixture coverage (#573) against the same contract and
    schedules, then extend the #565 guard as those package sections become
    report-ready.
 

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -2092,7 +2092,7 @@ For #521 closure, this EPIC should be sequenced as:
 
 1. Consume the package section contract from `#570`.
 2. Finalize annualized income and long-term compensation schedule data
-   (`#566`).
+   (`#566`, done via `GET /api/reports/package/annualized-income-schedule`).
 3. Land supporting explanation assets:
    - report notes (`#571`)
    - traceability appendix (`#572`)
@@ -2103,3 +2103,13 @@ For #521 closure, this EPIC should be sequenced as:
 `#570`, `#571`, and `#572` are shared package prerequisites with EPIC-005;
 `#566` and `#573` are specifically the issue chain to close
 `annualized-income-long-term` in `docs/ssot/critical-proof-matrix.yaml`.
+`#566` supplies the report-ready schedule contract; `#573` remains responsible
+for the representative fixture and E2E proof needed before that macro can move
+from `partial` to `covered`.
+
+### Acceptance Criteria — Report Package Annualized Income Schedule
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.11.1 | `GET /api/reports/package/annualized-income-schedule` returns annualized salary, bonus, dividend, total income, currency, as-of date, and trailing-period boundaries for the personal report package | `test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restricted_treatment` | `reporting/test_annualized_income_schedule.py` | P0 |
+| AC11.11.2 | The schedule includes ESOP/RSU/stock-option restricted holdings with valuation basis, vesting/unlock metadata, fair value, and explicit liquid-versus-restricted net worth treatment | `test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restricted_treatment` | `reporting/test_annualized_income_schedule.py` | P0 |

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -208,9 +208,24 @@ Required section IDs:
 | `income_statement` | EPIC-005 | `/api/reports/income-statement` | ready |
 | `cash_flow` | EPIC-005 | `/api/reports/cash-flow` | ready |
 | `investment_performance` | EPIC-017 | `/api/portfolio/performance/report-schedule` | ready |
-| `annualized_income_long_term` | EPIC-011 | `/api/reports/package/annualized-income-schedule` | planned by #566 |
+| `annualized_income_long_term` | EPIC-011 | `/api/reports/package/annualized-income-schedule` | ready |
 | `notes` | EPIC-005 | `/api/reports/package/notes` | planned by #571 |
 | `traceability_appendix` | EPIC-018 | `/api/reports/package/traceability` | planned by #572 |
+
+Annualized income and long-term compensation schedule:
+
+- Endpoint: `GET /api/reports/package/annualized-income-schedule`
+- Period semantics: trailing 365 days ending at `as_of_date`; when omitted,
+  `as_of_date` defaults to the request date.
+- Income basis: `POSTED` or `RECONCILED` income journal lines in the trailing
+  period, bucketed into salary, bonus, dividend, and total by income account
+  name.
+- Restricted compensation basis: latest as-of manual valuation snapshots for
+  `esop`, `rsu`, and `stock_options` with `liquidity_class=restricted`.
+- Liquid net worth default: restricted holdings are excluded by default and are
+  only included through the balance-sheet restricted toggle.
+- Decimal fields serialize as strings; restricted fair-value totals are reported
+  in the schedule currency and do not imply cross-currency conversion.
 
 Export contract:
 

--- a/docs/user-guide/reports.md
+++ b/docs/user-guide/reports.md
@@ -25,6 +25,18 @@ cash-flow view, investment performance, annualized income and long-term
 compensation, notes, and traceability appendix. Decimal fields serialize as
 strings to preserve money precision in frontend and export consumers.
 
+Annualized income and long-term compensation schedule endpoint:
+
+```bash
+curl "https://report.zitian.party/api/reports/package/annualized-income-schedule?as_of_date=2026-05-20"
+```
+
+This schedule reports trailing-12-month salary, bonus, dividend, and total
+income from posted or reconciled income journal lines. It also lists restricted
+ESOP/RSU/stock-option manual valuation snapshots with valuation basis,
+vesting/unlock metadata, and the default net-worth treatment that excludes
+restricted holdings from liquid net worth.
+
 ### Balance Sheet
 
 Shows your financial position at a point in time:


### PR DESCRIPTION
## Summary

Define the report-ready annualized income and long-term compensation schedule for the personal financial-report package.

Closes #566

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-011 — Asset Lifecycle; EPIC-005 — Reporting Visualization |
| **AC IDs** | AC11.11.1, AC11.11.2, AC5.11.1, AC5.11.2 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/reporting.md` — marks `annualized_income_long_term` ready and defines the annualized income/restricted compensation schedule contract

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `uncommitted-red-phase` | Added AC5.10/AC11.11 tests first; frontend failed on missing `Annualized Income Schedule`, contract test failed while section was `planned`, DB endpoint test could not execute locally because Postgres was unavailable |
| 🟢 Green (passing test) | `9698746` | Implement schedule endpoint, contract readiness, frontend rendering, AC registry, and SSOT docs |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no new SQLAlchemy enum added)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes (not applicable; no MANIFEST change)
- [x] `tools/lint_doc_consistency.py` passes (covered by AC/SSOT checks below)

### CI/CD, Runtime, and VPS Infra Audit

Not applicable; this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
moon run :lint
cd apps/frontend && npm test -- personalReportPackagePage.test.tsx --run
cd apps/frontend && npm run lint -- --file src/app/\(main\)/reports/package/page.tsx --file src/lib/types.ts --file src/__tests__/personalReportPackagePage.test.tsx
cd apps/backend && uv run pytest -n 0 --no-cov tests/api/test_personal_report_package_contract.py
cd apps/backend && uv run ruff check src/routers/reports.py src/schemas/reporting.py src/schemas/__init__.py tests/api/test_personal_report_package_contract.py tests/reporting/test_annualized_income_schedule.py
python tools/generate_ac_registry.py --check
python tools/check_ac_traceability.py
python tools/check_critical_proof_matrix.py
```

Local limitation:

```bash
cd apps/backend && uv run pytest -n 0 --no-cov tests/reporting/test_annualized_income_schedule.py
```

This DB endpoint test could not complete locally because the workstation Postgres on `127.0.0.1:5432` timed out and the local `podman ps` query hung. CI should run it with managed test infra.

---

## Screenshots / Evidence

_N/A_



