### PR TITLE
[finance_report_infra] Align Vault app-token lifecycle

### DIFF
--- a/common/shell/common.sh
+++ b/common/shell/common.sh
@@ -301,10 +301,23 @@ mask_secrets() {
 
 # Verify a Dokploy-provided VAULT_APP_TOKEN before triggering deployment.
 # This catches expired tokens before compose redeploy turns into a route-level 404.
+print_vault_app_token_repair_hint() {
+  local repair_env="${1:-staging}"
+
+  {
+    echo "Repair VAULT_APP_TOKEN from infra2:"
+    echo "  cd /path/to/infra2"
+    echo "  export VAULT_ROOT_TOKEN=\"\$(op read 'op://Infra2/dexluuvzg5paff3cltmtnlnosm/Token')\""
+    echo "  DEPLOY_ENV=${repair_env} invoke vault.setup-tokens --project=finance_report --service=app"
+    echo "Do not add VAULT_ROOT_TOKEN to GitHub Actions; finance_report deploy only preflights the token."
+  } >&2
+}
+
 verify_vault_app_token() {
   local env_content="$1"
   local context="${2:-Vault token preflight}"
   local min_ttl_seconds="${3:-86400}"
+  local repair_env="${4:-staging}"
   local token=""
   local vault_addr=""
   local lookup_file
@@ -322,6 +335,7 @@ verify_vault_app_token() {
 
   if [[ -z "$token" ]]; then
     echo "ERROR: $context failed: VAULT_APP_TOKEN is missing" >&2
+    print_vault_app_token_repair_hint "$repair_env"
     return 1
   fi
 
@@ -348,6 +362,7 @@ verify_vault_app_token() {
 
   if ! check_http_code "$http_code" "200" "$context" 2>/dev/null; then
     echo "ERROR: $context failed: VAULT_APP_TOKEN is invalid or expired (HTTP $http_code)" >&2
+    print_vault_app_token_repair_hint "$repair_env"
     rm -f "$lookup_file" "$error_file"
     return 1
   fi
@@ -365,11 +380,13 @@ verify_vault_app_token() {
 
   if [[ "$renewable" != "true" ]]; then
     echo "ERROR: $context failed: VAULT_APP_TOKEN is not renewable" >&2
+    print_vault_app_token_repair_hint "$repair_env"
     return 1
   fi
 
   if ! [[ "$ttl" =~ ^[0-9]+$ ]] || (( ttl < min_ttl_seconds )); then
     echo "ERROR: $context failed: VAULT_APP_TOKEN ttl ${ttl}s is below required ${min_ttl_seconds}s" >&2
+    print_vault_app_token_repair_hint "$repair_env"
     return 1
   fi
 

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -178,7 +178,7 @@ entrypoint:
 
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
-| Stuck "Waiting for secrets" | Vault token expired | `invoke vault.setup-tokens --project=finance_report` |
+| Stuck "Waiting for secrets" | Vault token expired | `DEPLOY_ENV=staging invoke vault.setup-tokens --project=finance_report --service=app` from infra2 |
 | 6 min timeout | Migration failed | Check SigNoz for CHECKPOINT-2 errors |
 | "Image not found" | Tag not built | `git push origin v1.2.3` to trigger build |
 | 502 Bad Gateway | Backend crashed | Check CHECKPOINT-3 in SigNoz logs |
@@ -189,20 +189,26 @@ entrypoint:
 
 | Property | Value |
 |----------|-------|
-| Token TTL | 768 hours (~32 days) |
+| Token period | 168 hours (7 days), renewable by vault-agent |
 | Secrets file path | `/secrets/.env` |
 | Staleness threshold | 1 hour (bootloader warning) |
 
-**Regenerate tokens** (when expired):
+`VAULT_APP_TOKEN` is owned by infra2. Finance Report deploys only preflight the
+Dokploy token and must not receive `VAULT_ROOT_TOKEN`.
+
+**Repair app token** (when expired):
 
 ```bash
 # From local machine with infra2 repo
 cd /path/to/infra2
-invoke vault.setup-tokens --project=finance_report
-
-# Restart vault-agent to pick up new token
-ssh root@$VPS_HOST "docker restart finance_report-vault-agent-staging"
+export VAULT_ROOT_TOKEN="$(op read 'op://Infra2/dexluuvzg5paff3cltmtnlnosm/Token')"
+DEPLOY_ENV=staging invoke vault.setup-tokens --project=finance_report --service=app
 ```
+
+The infra2 task updates the matching Dokploy compose env, triggers redeploy,
+tracks the new accessor, and revokes the previous accessor after a successful
+Dokploy update. For database sidecars use `--service=postgres` or
+`--service=redis`.
 
 **Monitoring**: Bootloader `_check_vault_secrets()` runs in FULL mode and reports:
 1. Missing secrets file → Warning with regeneration instructions

--- a/tests/tooling/test_issue_489_deployment_contracts.py
+++ b/tests/tooling/test_issue_489_deployment_contracts.py
@@ -99,7 +99,7 @@ def test_postgres_and_redis_iac_services_have_vault_gated_runtime_contracts() ->
             "deployer": "PostgresDeployer",
             "image": "postgres:16-alpine",
             "secret_key": "POSTGRES_PASSWORD",
-            "policy_path": "secret/data/finance_report/+/postgres",
+            "policy_path": "secret/data/finance_report/{{env}}/postgres",
             "health_token": "pg_isready -U postgres -d finance_report",
             "data_path": "/data/finance_report/postgres",
             "port": 5432,
@@ -109,7 +109,7 @@ def test_postgres_and_redis_iac_services_have_vault_gated_runtime_contracts() ->
             "deployer": "RedisDeployer",
             "image": "redis:alpine",
             "secret_key": "PASSWORD",
-            "policy_path": "secret/data/finance_report/+/redis",
+            "policy_path": "secret/data/finance_report/{{env}}/redis",
             "health_token": 'redis-cli -a "$$PASSWORD" ping',
             "data_path": "/data/finance_report/redis",
             "port": 6379,
@@ -232,9 +232,10 @@ def test_app_iac_wires_vault_secrets_health_and_traefik_routes() -> None:
     assert "printf" in app_template
 
     paths = policy_paths(app_dir / "vault-policy.hcl")
-    assert "secret/data/finance_report/+/app" in paths
-    assert "secret/data/finance_report/+/postgres" in paths
-    assert "secret/data/finance_report/+/redis" in paths
+    assert "secret/data/finance_report/{{env}}/app" in paths
+    assert "secret/data/finance_report/{{env}}/postgres" in paths
+    assert "secret/data/finance_report/{{env}}/redis" in paths
+    assert not any("/+/" in path for path in paths)
     assert "auth/token/lookup-self" in paths
 
     attrs = class_attrs(app_dir / "deploy.py", "AppDeployer")
@@ -287,7 +288,9 @@ def test_pr_preview_deploy_gate_exercises_health_smoke_e2e_and_storage_paths() -
     assert "EXPECTED_SHA: ${{ github.sha }}" in readiness_block
     assert 'expected_sha = os.environ["EXPECTED_SHA"]' in readiness_block
     assert 'payload.get("git_sha") or payload.get("version")' in readiness_block
-    assert "Existing deployment is still serving; waiting for rollout" in readiness_block
+    assert (
+        "Existing deployment is still serving; waiting for rollout" in readiness_block
+    )
     assert 'url = os.environ["APP_URL"] + "/api/health"' in workflow
     assert "bash tools/smoke_test.sh" in workflow
     assert 'pytest tests/e2e -v -m "(smoke or e2e) and not llm"' in workflow

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -46,7 +46,9 @@ def test_AC8_13_50_critical_proof_e2e_files_are_epic_owned() -> None:
     }
     assert [path for path in proof_files if path not in epic_rows] == []
     assert {
-        path: [ac_id for ac_id in ac_ids if not row_covers_ac_id(epic_rows[path], ac_id)]
+        path: [
+            ac_id for ac_id in ac_ids if not row_covers_ac_id(epic_rows[path], ac_id)
+        ]
         for path, ac_ids in proof_files.items()
         if any(not row_covers_ac_id(epic_rows[path], ac_id) for ac_id in ac_ids)
     } == {}
@@ -57,7 +59,10 @@ def test_AC8_13_50_product_e2e_files_are_epic_owned() -> None:
     epic = read("docs/project/EPIC-008.testing-strategy.md")
     product_e2e_files = sorted(
         path.relative_to(ROOT).as_posix()
-        for root in [ROOT / "tests" / "e2e", ROOT / "apps" / "backend" / "tests" / "e2e"]
+        for root in [
+            ROOT / "tests" / "e2e",
+            ROOT / "apps" / "backend" / "tests" / "e2e",
+        ]
         for path in root.glob("test_*.py")
     )
 
@@ -143,9 +148,15 @@ def test_AC8_13_11_deploy_preflights_vault_token_before_redeploy() -> None:
     assert "VAULT_APP_TOKEN is not renewable" in common
     assert "ttl ${ttl}s is below required" in common
     assert (
-        'verify_vault_app_token "$current_env" "Dokploy VAULT_APP_TOKEN preflight" 172800'
+        "DEPLOY_ENV=${repair_env} invoke vault.setup-tokens --project=finance_report --service=app"
+        in common
+    )
+    assert "Do not add VAULT_ROOT_TOKEN to GitHub Actions" in common
+    assert (
+        'verify_vault_app_token "$current_env" "Dokploy VAULT_APP_TOKEN preflight" 172800 "$vault_repair_env"'
         in deploy_script
     )
+    assert 'vault_repair_env="staging"' in deploy_script
     assert deploy_script.index("verify_vault_app_token") < deploy_script.index(
         'dokploy_api_call "POST" "compose.update"'
     )
@@ -842,7 +853,10 @@ def test_AC8_13_25_backend_and_traceability_do_not_wait_for_lint() -> None:
 
     assert "needs: [changes, backend-integration, backend-e2e-tier1]" in backend_block
     assert "needs: [changes, lint]" not in backend_block
-    assert "needs: [changes, backend-integration, backend-e2e-tier1, lint]" not in backend_block
+    assert (
+        "needs: [changes, backend-integration, backend-e2e-tier1, lint]"
+        not in backend_block
+    )
     assert "needs: [lint]" not in traceability_block
     assert "run in parallel with lint" in ci_cd
 
@@ -853,9 +867,9 @@ def test_AC8_13_67_backend_tier1_api_e2e_scope_excludes_browser_e2e() -> None:
     pyproject = read("apps/backend/pyproject.toml")
     ci_cd = read("docs/ssot/ci-cd.md")
 
-    tier1_block = workflow.split("  backend-e2e-tier1:", 1)[1].split(
-        "  frontend:", 1
-    )[0]
+    tier1_block = workflow.split("  backend-e2e-tier1:", 1)[1].split("  frontend:", 1)[
+        0
+    ]
 
     assert "tests/e2e/test_core_journeys.py" in tier1_block
     assert "tests/e2e/test_auth_flows.py" not in tier1_block
@@ -937,13 +951,11 @@ def test_AC8_13_66_coveralls_uploads_use_line_only_lcov() -> None:
     )
     assert (
         "tools/strip_lcov_branches.py coverage/backend.lcov "
-        "coverage/coveralls-backend.lcov"
-        in workflow
+        "coverage/coveralls-backend.lcov" in workflow
     )
     assert (
         "tools/strip_lcov_branches.py coverage/frontend.lcov "
-        "coverage/coveralls-frontend.lcov"
-        in workflow
+        "coverage/coveralls-frontend.lcov" in workflow
     )
     assert "file: coverage/coveralls-unified.lcov" in workflow
     assert "file: coverage/coveralls-backend.lcov" in workflow
@@ -1036,7 +1048,9 @@ def test_AC8_13_38_pr_preview_dokploy_responses_are_not_logged() -> None:
     ci_cd = read("docs/ssot/ci-cd.md")
     lifecycle = read("tools/_lib/dev/pr_preview_lifecycle.py")
 
-    assert "PR preview Dokploy API responses are parsed for required fields only" in ci_cd
+    assert (
+        "PR preview Dokploy API responses are parsed for required fields only" in ci_cd
+    )
     assert "Deploy preview lifecycle" in preview
     assert "Cleanup preview lifecycle" in preview
     assert "Rollback on E2E Failure" in preview
@@ -1065,7 +1079,7 @@ def test_AC8_13_72_staging_deploy_proves_health_sha_after_dokploy_trigger() -> N
         "- name: Setup E2E Tests", 1
     )[0]
 
-    assert 'IMAGE_TAG: ${{ steps.get_sha.outputs.short_sha }}' in deploy_block
+    assert "IMAGE_TAG: ${{ steps.get_sha.outputs.short_sha }}" in deploy_block
     assert "bash tools/dokploy_deploy.sh" in deploy_block
     assert "bash tools/health_check.sh" in deploy_block
     assert deploy_block.index("bash tools/dokploy_deploy.sh") < deploy_block.index(
@@ -1073,7 +1087,10 @@ def test_AC8_13_72_staging_deploy_proves_health_sha_after_dokploy_trigger() -> N
     )
     assert '"https://report-staging.zitian.party/api/health"' in deploy_block
     assert '"$IMAGE_TAG"' in deploy_block
-    assert "actual_sha=$(echo \"$health_response\" | jq -r '.git_sha // .version // \"\"')" in health_check
+    assert (
+        'actual_sha=$(echo "$health_response" | jq -r \'.git_sha // .version // ""\')'
+        in health_check
+    )
     assert "Git SHA Mismatch" in health_check
     assert "exit 1" in health_check
 

--- a/tools/_lib/shell/dokploy_deploy.sh
+++ b/tools/_lib/shell/dokploy_deploy.sh
@@ -81,7 +81,11 @@ fi
 current_env=$(safe_jq '.env // empty' "$env_response" "environment fetch") || exit 1
 
 mask_secrets "$current_env"
-verify_vault_app_token "$current_env" "Dokploy VAULT_APP_TOKEN preflight" 172800
+vault_repair_env="production"
+if [[ "$APP_URL" == *"-staging"* ]]; then
+  vault_repair_env="staging"
+fi
+verify_vault_app_token "$current_env" "Dokploy VAULT_APP_TOKEN preflight" 172800 "$vault_repair_env"
 
 new_env="$current_env"
 new_env=$(update_env_var "$new_env" "IMAGE_TAG" "$IMAGE_TAG")


### PR DESCRIPTION
## Summary
- Advance the `repo/` infra2 submodule to infra2 PR #175 (`6e81bc3`) so Finance Report consumes the hardened Vault app-token lifecycle.
- Keep Finance Report deploys as Vault consumers only: Dokploy `VAULT_APP_TOKEN` is preflighted, and failures point to the exact infra2 repair command instead of adding `VAULT_ROOT_TOKEN` to GitHub Actions.
- Update deployment SSOT and tooling tests for env-scoped Vault policy paths and targeted `--service=app` token repair.

## Why this lifecycle is stable
- infra2 owns token creation, policy scope, Dokploy injection, accessor tracking, old accessor revoke, and scheduled/audit repair.
- finance_report only validates the token before redeploy and fails fast with the infra2 repair command.
- GitHub Actions does not hold `VAULT_ROOT_TOKEN`.

## Verification
- `uv run pytest tests/tooling/test_issue_489_deployment_contracts.py tests/tooling/test_dokploy_redaction.py tests/tooling/test_post_merge_e2e_gates.py -q`
- `uv run ruff check tests/tooling/test_issue_489_deployment_contracts.py tests/tooling/test_post_merge_e2e_gates.py`
- `uv run ruff format --check tests/tooling/test_issue_489_deployment_contracts.py tests/tooling/test_post_merge_e2e_gates.py`
- `bash tools/check_repo_submodule.sh`
- `bash -n common/shell/common.sh tools/_lib/shell/dokploy_deploy.sh`
- `git diff --check HEAD~1..HEAD`

## Local full-tooling note
- Attempted `uv run --with pytest --with pdfplumber --with pyyaml --with reportlab python -m pytest tests/tooling -q`; local collection still requires additional project/runtime packages such as `python-dotenv` and `sqlalchemy`. The focused tests above cover this PR's changed contracts.
