### PR TITLE
[finance_report_audit] Fix Stage 1 auto-post eligibility

### DIFF
--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -10,7 +10,7 @@ from uuid import UUID, uuid4
 import structlog
 from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile, status
 from fastapi.concurrency import run_in_threadpool
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import selectinload
 
 from src.config import settings
@@ -23,13 +23,8 @@ from src.models import (
     AccountType,
     BankStatement,
     BankStatementStatus,
-    BankStatementTransaction,
-    JournalEntry,
-    JournalEntrySourceType,
-    JournalEntryStatus,
-    ReconciliationMatch,
-    ReconciliationStatus,
 )
+from src.models.statement import Stage1Status
 from src.schemas import (
     BankStatementListResponse,
     BankStatementResponse,
@@ -50,9 +45,8 @@ from src.schemas.review import (
 from src.services import StorageError, StorageService
 from src.services.brokerage_positions import BrokeragePositionImportService
 from src.services.openrouter_models import ModelCatalogError, get_model_info, model_matches_modality
-from src.services.review_queue import create_entry_from_txn
-from src.services.source_type_priority import STATEMENT_SOURCE_TYPES, promote_entry_source_type
 from src.services.statement_parsing import parse_statement_background
+from src.services.statement_posting import auto_create_posted_entries_for_statement
 from src.services.statement_validation import (
     approve_statement as approve_statement_svc,
     edit_and_approve,
@@ -133,117 +127,6 @@ async def _queue_statement_reparse(
         if "." in statement.original_filename
         else "pdf",
         model_to_use=model_to_use,
-    )
-
-
-async def _auto_create_posted_entries_for_statement(
-    db: DbSession,
-    statement: BankStatement,
-    user_id: UUID,
-) -> int:
-    txn_ids = [txn.id for txn in statement.transactions]
-    if not txn_ids:
-        return 0
-
-    existing_entry_result = await db.execute(
-        select(JournalEntry)
-        .where(JournalEntry.user_id == user_id)
-        .where(JournalEntry.source_type.in_(STATEMENT_SOURCE_TYPES))
-        .where(JournalEntry.source_id.in_(txn_ids))
-        .where(JournalEntry.status != JournalEntryStatus.VOID)
-    )
-    existing_entries = list(existing_entry_result.scalars().all())
-    for entry in existing_entries:
-        promote_entry_source_type(entry, JournalEntrySourceType.USER_CONFIRMED)
-    existing_entry_txn_ids = {entry.source_id for entry in existing_entries}
-
-    transfer_match_result = await db.execute(
-        select(ReconciliationMatch)
-        .join(BankStatementTransaction, ReconciliationMatch.bank_txn_id == BankStatementTransaction.id)
-        .join(BankStatement, BankStatementTransaction.statement_id == BankStatement.id)
-        .where(ReconciliationMatch.bank_txn_id.in_(txn_ids))
-        .where(
-            ReconciliationMatch.status.in_([ReconciliationStatus.AUTO_ACCEPTED, ReconciliationStatus.ACCEPTED]),
-            ReconciliationMatch.superseded_by_id.is_(None),
-        )
-        .where(BankStatement.user_id == user_id)
-    )
-    transfer_txn_ids = {match.bank_txn_id for match in transfer_match_result.scalars().all() if match.journal_entry_ids}
-
-    txns_to_post = [
-        txn for txn in statement.transactions if txn.id not in existing_entry_txn_ids and txn.id not in transfer_txn_ids
-    ]
-    if not txns_to_post:
-        return 0
-
-    preloaded_bank_account = await _resolve_statement_posting_account(db, statement, user_id)
-
-    for txn in txns_to_post:
-        await create_entry_from_txn(
-            db,
-            txn,
-            user_id=user_id,
-            auto_post=True,
-            source_type=JournalEntrySourceType.USER_CONFIRMED,
-            preloaded_statement=statement,
-            preloaded_bank_account=preloaded_bank_account,
-        )
-
-    return len(txns_to_post)
-
-
-async def _resolve_statement_posting_account(
-    db: DbSession,
-    statement: BankStatement,
-    user_id: UUID,
-) -> Account:
-    """Resolve the asset account for automatic posting without generic fallback."""
-    if statement.account_id:
-        account_result = await db.execute(
-            select(Account).where(Account.id == statement.account_id).where(Account.user_id == user_id)
-        )
-        account = account_result.scalar_one_or_none()
-        if account:
-            return account
-        raise ValueError("Statement account mapping is invalid. Confirm the target account before posting.")
-
-    institution = (statement.institution or "").strip()
-    account_last4 = (statement.account_last4 or "").strip()
-    currency = (statement.currency or "").strip().upper()
-    if not institution or not account_last4 or not currency:
-        raise ValueError(
-            "Account mapping required before posting. Confirm the statement account because institution, "
-            "account_last4, or currency metadata is missing."
-        )
-
-    account_result = await db.execute(
-        select(Account)
-        .join(BankStatement, BankStatement.account_id == Account.id)
-        .where(Account.user_id == user_id)
-        .where(Account.type == AccountType.ASSET)
-        .where(Account.currency == currency)
-        .where(Account.is_active.is_(True))
-        .where(BankStatement.user_id == user_id)
-        .where(BankStatement.id != statement.id)
-        .where(BankStatement.account_id.is_not(None))
-        .where(func.lower(BankStatement.institution) == institution.lower())
-        .where(BankStatement.account_last4 == account_last4)
-        .where(func.upper(BankStatement.currency) == currency)
-    )
-    accounts_by_id = {account.id: account for account in account_result.scalars().all()}
-    if len(accounts_by_id) == 1:
-        account = next(iter(accounts_by_id.values()))
-        statement.account_id = account.id
-        await db.flush()
-        return account
-    if len(accounts_by_id) > 1:
-        raise ValueError(
-            "Ambiguous account mapping. Multiple accounts match this statement's institution, account_last4, "
-            "and currency; confirm the target account before posting."
-        )
-    raise ValueError(
-        "Account mapping required before posting. No confirmed account matches this statement's institution, "
-        "account_last4, and currency."
     )
 
 
@@ -564,13 +447,16 @@ async def list_pending_review(
     db: DbSession,
     user_id: CurrentUserId,
 ) -> BankStatementListResponse:
-    """List statements pending human review (confidence 60-84)."""
+    """List statements pending human review."""
+    pending_review_filter = or_(
+        BankStatement.stage1_status == Stage1Status.PENDING_REVIEW,
+        and_(BankStatement.confidence_score >= 60, BankStatement.confidence_score < 85),
+    )
     result = await db.execute(
         select(BankStatement)
         .where(BankStatement.user_id == user_id)
         .where(BankStatement.status == BankStatementStatus.PARSED)
-        .where(BankStatement.confidence_score >= 60)
-        .where(BankStatement.confidence_score < 85)
+        .where(pending_review_filter)
         .options(selectinload(BankStatement.transactions))
         .order_by(BankStatement.created_at.desc())
     )
@@ -581,8 +467,7 @@ async def list_pending_review(
         .select_from(BankStatement)
         .where(BankStatement.user_id == user_id)
         .where(BankStatement.status == BankStatementStatus.PARSED)
-        .where(BankStatement.confidence_score >= 60)
-        .where(BankStatement.confidence_score < 85)
+        .where(pending_review_filter)
     )
     total = total_result.scalar() or 0
 
@@ -925,7 +810,7 @@ async def approve_statement_stage1(
         statement = await approve_statement_svc(db, statement_id, user_id)
         if request and request.create_account_if_missing and not statement.account_id:
             await _create_statement_account_from_confirmation(db, statement, user_id)
-        created_count = await _auto_create_posted_entries_for_statement(db, statement, user_id)
+        created_count = await auto_create_posted_entries_for_statement(db, statement, user_id)
         await db.commit()
     except ValueError as e:
         await db.rollback()
@@ -981,7 +866,7 @@ async def edit_and_approve_statement(
     edits_data = [{**e.model_dump(), "txn_id": str(e.txn_id)} for e in request.edits]
     try:
         statement = await edit_and_approve(db, statement_id, user_id, edits_data)
-        created_count = await _auto_create_posted_entries_for_statement(db, statement, user_id)
+        created_count = await auto_create_posted_entries_for_statement(db, statement, user_id)
         await db.commit()
     except ValueError as e:
         await db.rollback()

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -10,7 +10,7 @@ from uuid import UUID, uuid4
 import structlog
 from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile, status
 from fastapi.concurrency import run_in_threadpool
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
 from src.config import settings
@@ -24,7 +24,6 @@ from src.models import (
     BankStatement,
     BankStatementStatus,
 )
-from src.models.statement import Stage1Status
 from src.schemas import (
     BankStatementListResponse,
     BankStatementResponse,
@@ -50,6 +49,7 @@ from src.services.statement_posting import auto_create_posted_entries_for_statem
 from src.services.statement_validation import (
     approve_statement as approve_statement_svc,
     edit_and_approve,
+    pending_stage1_review_filter,
     reject_statement as reject_statement_svc,
     set_opening_balance,
     validate_balance_chain,
@@ -448,15 +448,11 @@ async def list_pending_review(
     user_id: CurrentUserId,
 ) -> BankStatementListResponse:
     """List statements pending human review."""
-    pending_review_filter = or_(
-        BankStatement.stage1_status == Stage1Status.PENDING_REVIEW,
-        and_(BankStatement.confidence_score >= 60, BankStatement.confidence_score < 85),
-    )
     result = await db.execute(
         select(BankStatement)
         .where(BankStatement.user_id == user_id)
         .where(BankStatement.status == BankStatementStatus.PARSED)
-        .where(pending_review_filter)
+        .where(pending_stage1_review_filter())
         .options(selectinload(BankStatement.transactions))
         .order_by(BankStatement.created_at.desc())
     )
@@ -467,7 +463,7 @@ async def list_pending_review(
         .select_from(BankStatement)
         .where(BankStatement.user_id == user_id)
         .where(BankStatement.status == BankStatementStatus.PARSED)
-        .where(pending_review_filter)
+        .where(pending_stage1_review_filter())
     )
     total = total_result.scalar() or 0
 

--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -16,6 +16,7 @@ from src.logger import get_logger
 from src.models import BankStatement, BankStatementStatus
 from src.services import ExtractionError, ExtractionService, StorageError, StorageService
 from src.services.brokerage_positions import BrokeragePositionImportService, looks_like_brokerage_payload
+from src.services.statement_posting import try_auto_approve_high_confidence_statement
 
 if TYPE_CHECKING:
     pass
@@ -448,6 +449,8 @@ async def parse_statement_background(
             statement.status = parsed_statement.status
 
             await update_progress(100)
+            auto_posted_count = await try_auto_approve_high_confidence_statement(session, statement.id, user_id)
+            await session.commit()
             await import_brokerage_payload_if_present(
                 statement=statement,
                 db=session,
@@ -468,6 +471,7 @@ async def parse_statement_background(
                 progress=100,
                 duration_ms=round(duration * 1000, 2),
                 transactions_count=len(transactions),
+                auto_posted_count=auto_posted_count,
             )
         except Exception as exc:
             logger.exception(

--- a/apps/backend/src/services/statement_posting.py
+++ b/apps/backend/src/services/statement_posting.py
@@ -102,18 +102,31 @@ async def resolve_statement_posting_account(
     user_id: UUID,
 ) -> Account:
     """Resolve the asset account for automatic posting without generic fallback."""
+    currency = (statement.currency or "").strip().upper()
+    if not currency:
+        raise ValueError("Statement currency required before posting. Confirm the source currency before posting.")
+
     if statement.account_id:
         account_result = await db.execute(
             select(Account).where(Account.id == statement.account_id).where(Account.user_id == user_id)
         )
         account = account_result.scalar_one_or_none()
-        if account:
-            return account
-        raise ValueError("Statement account mapping is invalid. Confirm the target account before posting.")
+        if account is None:
+            raise ValueError("Statement account mapping is invalid. Confirm the target account before posting.")
+        if account.type != AccountType.ASSET or not account.is_active:
+            raise ValueError(
+                "Statement account mapping must reference an active asset account. "
+                "Confirm the target account before posting."
+            )
+        if account.currency != currency:
+            raise ValueError(
+                "Statement account mapping must match the statement currency. "
+                "Confirm the target account before posting."
+            )
+        return account
 
     institution = (statement.institution or "").strip()
     account_last4 = (statement.account_last4 or "").strip()
-    currency = (statement.currency or "").strip().upper()
     if not institution or not account_last4 or not currency:
         raise ValueError(
             "Account mapping required before posting. Confirm the statement account because institution, "
@@ -210,12 +223,12 @@ async def try_auto_approve_high_confidence_statement(
         return 0
 
     try:
-        approved = await approve_statement(db, statement_id, user_id)
-        created_count = await auto_create_posted_entries_for_statement(db, approved, user_id)
-        await db.flush()
+        async with db.begin_nested():
+            approved = await approve_statement(db, statement_id, user_id)
+            created_count = await auto_create_posted_entries_for_statement(db, approved, user_id)
+            await db.flush()
         return created_count
     except ValueError as exc:
-        await db.rollback()
         refreshed = await db.get(BankStatement, statement_id)
         if refreshed is not None:
             refreshed.status = BankStatementStatus.PARSED

--- a/apps/backend/src/services/statement_posting.py
+++ b/apps/backend/src/services/statement_posting.py
@@ -1,0 +1,225 @@
+"""Stage 1 statement posting guards and auto-approval helpers."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.models import (
+    Account,
+    AccountType,
+    BankStatement,
+    BankStatementStatus,
+    BankStatementTransaction,
+    JournalEntry,
+    JournalEntrySourceType,
+    JournalEntryStatus,
+    ReconciliationMatch,
+    ReconciliationStatus,
+)
+from src.models.statement import Stage1Status
+from src.services.review_queue import create_entry_from_txn
+from src.services.source_type_priority import STATEMENT_SOURCE_TYPES, promote_entry_source_type
+from src.services.statement_validation import approve_statement
+
+HIGH_CONFIDENCE_AUTO_APPROVE_THRESHOLD = 85
+
+
+def is_high_confidence_auto_approve_candidate(statement: BankStatement) -> bool:
+    """Return whether parsing confidence is high enough for automatic Stage 1 approval."""
+    return (
+        statement.status == BankStatementStatus.APPROVED
+        and statement.balance_validated is True
+        and statement.confidence_score is not None
+        and statement.confidence_score >= HIGH_CONFIDENCE_AUTO_APPROVE_THRESHOLD
+    )
+
+
+async def auto_create_posted_entries_for_statement(
+    db: AsyncSession,
+    statement: BankStatement,
+    user_id: UUID,
+) -> int:
+    """Create posted journal entries after Stage 1 approval, guarded by mapping and period safety."""
+    txn_ids = [txn.id for txn in statement.transactions]
+    if not txn_ids:
+        return 0
+
+    existing_entry_result = await db.execute(
+        select(JournalEntry)
+        .where(JournalEntry.user_id == user_id)
+        .where(JournalEntry.source_type.in_(STATEMENT_SOURCE_TYPES))
+        .where(JournalEntry.source_id.in_(txn_ids))
+        .where(JournalEntry.status != JournalEntryStatus.VOID)
+    )
+    existing_entries = list(existing_entry_result.scalars().all())
+    for entry in existing_entries:
+        promote_entry_source_type(entry, JournalEntrySourceType.USER_CONFIRMED)
+    existing_entry_txn_ids = {entry.source_id for entry in existing_entries}
+
+    transfer_match_result = await db.execute(
+        select(ReconciliationMatch)
+        .join(BankStatementTransaction, ReconciliationMatch.bank_txn_id == BankStatementTransaction.id)
+        .join(BankStatement, BankStatementTransaction.statement_id == BankStatement.id)
+        .where(ReconciliationMatch.bank_txn_id.in_(txn_ids))
+        .where(
+            ReconciliationMatch.status.in_([ReconciliationStatus.AUTO_ACCEPTED, ReconciliationStatus.ACCEPTED]),
+            ReconciliationMatch.superseded_by_id.is_(None),
+        )
+        .where(BankStatement.user_id == user_id)
+    )
+    transfer_txn_ids = {match.bank_txn_id for match in transfer_match_result.scalars().all() if match.journal_entry_ids}
+
+    txns_to_post = [
+        txn for txn in statement.transactions if txn.id not in existing_entry_txn_ids and txn.id not in transfer_txn_ids
+    ]
+    if not txns_to_post:
+        return 0
+
+    preloaded_bank_account = await resolve_statement_posting_account(db, statement, user_id)
+    await validate_statement_period_unique(db, statement, user_id, preloaded_bank_account.id)
+
+    for txn in txns_to_post:
+        await create_entry_from_txn(
+            db,
+            txn,
+            user_id=user_id,
+            auto_post=True,
+            source_type=JournalEntrySourceType.USER_CONFIRMED,
+            preloaded_statement=statement,
+            preloaded_bank_account=preloaded_bank_account,
+        )
+
+    return len(txns_to_post)
+
+
+async def resolve_statement_posting_account(
+    db: AsyncSession,
+    statement: BankStatement,
+    user_id: UUID,
+) -> Account:
+    """Resolve the asset account for automatic posting without generic fallback."""
+    if statement.account_id:
+        account_result = await db.execute(
+            select(Account).where(Account.id == statement.account_id).where(Account.user_id == user_id)
+        )
+        account = account_result.scalar_one_or_none()
+        if account:
+            return account
+        raise ValueError("Statement account mapping is invalid. Confirm the target account before posting.")
+
+    institution = (statement.institution or "").strip()
+    account_last4 = (statement.account_last4 or "").strip()
+    currency = (statement.currency or "").strip().upper()
+    if not institution or not account_last4 or not currency:
+        raise ValueError(
+            "Account mapping required before posting. Confirm the statement account because institution, "
+            "account_last4, or currency metadata is missing."
+        )
+
+    account_result = await db.execute(
+        select(Account)
+        .join(BankStatement, BankStatement.account_id == Account.id)
+        .where(Account.user_id == user_id)
+        .where(Account.type == AccountType.ASSET)
+        .where(Account.currency == currency)
+        .where(Account.is_active.is_(True))
+        .where(BankStatement.user_id == user_id)
+        .where(BankStatement.id != statement.id)
+        .where(BankStatement.status == BankStatementStatus.APPROVED)
+        .where(BankStatement.account_id.is_not(None))
+        .where(func.lower(BankStatement.institution) == institution.lower())
+        .where(BankStatement.account_last4 == account_last4)
+        .where(func.upper(BankStatement.currency) == currency)
+    )
+    accounts_by_id = {account.id: account for account in account_result.scalars().all()}
+    if len(accounts_by_id) == 1:
+        account = next(iter(accounts_by_id.values()))
+        statement.account_id = account.id
+        await db.flush()
+        return account
+    if len(accounts_by_id) > 1:
+        raise ValueError(
+            "Ambiguous account mapping. Multiple accounts match this statement's institution, account_last4, "
+            "and currency; confirm the target account before posting."
+        )
+    raise ValueError(
+        "Account mapping required before posting. No confirmed account matches this statement's institution, "
+        "account_last4, and currency."
+    )
+
+
+async def validate_statement_period_unique(
+    db: AsyncSession,
+    statement: BankStatement,
+    user_id: UUID,
+    account_id: UUID,
+) -> None:
+    """Block posted entries when the statement source period is missing, duplicated, or overlapping."""
+    if statement.period_start is None or statement.period_end is None:
+        raise ValueError("Statement period required before posting. Confirm the source date range before posting.")
+    if statement.period_start > statement.period_end:
+        raise ValueError("Statement period is invalid. Confirm the source date range before posting.")
+
+    currency = (statement.currency or "").strip().upper()
+    if not currency:
+        raise ValueError("Statement currency required before posting. Confirm the source currency before posting.")
+
+    overlap_result = await db.execute(
+        select(BankStatement)
+        .where(BankStatement.user_id == user_id)
+        .where(BankStatement.id != statement.id)
+        .where(BankStatement.account_id == account_id)
+        .where(BankStatement.status == BankStatementStatus.APPROVED)
+        .where(func.upper(BankStatement.currency) == currency)
+        .where(BankStatement.period_start.is_not(None))
+        .where(BankStatement.period_end.is_not(None))
+        .where(BankStatement.period_start <= statement.period_end)
+        .where(BankStatement.period_end >= statement.period_start)
+        .limit(1)
+    )
+    overlapping_statement = overlap_result.scalar_one_or_none()
+    if overlapping_statement:
+        raise ValueError(
+            "Statement period overlaps an approved statement for this account and currency. "
+            "Resolve the duplicate source date range before posting."
+        )
+
+
+async def try_auto_approve_high_confidence_statement(
+    db: AsyncSession,
+    statement_id: UUID,
+    user_id: UUID,
+) -> int:
+    """Auto-approve and post a high-confidence parsed statement when all posting guards pass.
+
+    If a high-confidence statement cannot be safely posted automatically, leave it in
+    Stage 1 pending review instead of failing parsing.
+    """
+    result = await db.execute(
+        select(BankStatement)
+        .where(BankStatement.id == statement_id)
+        .where(BankStatement.user_id == user_id)
+        .options(selectinload(BankStatement.transactions))
+    )
+    statement = result.scalar_one_or_none()
+    if statement is None or not is_high_confidence_auto_approve_candidate(statement):
+        return 0
+
+    try:
+        approved = await approve_statement(db, statement_id, user_id)
+        created_count = await auto_create_posted_entries_for_statement(db, approved, user_id)
+        await db.flush()
+        return created_count
+    except ValueError as exc:
+        await db.rollback()
+        refreshed = await db.get(BankStatement, statement_id)
+        if refreshed is not None:
+            refreshed.status = BankStatementStatus.PARSED
+            refreshed.stage1_status = Stage1Status.PENDING_REVIEW
+            refreshed.validation_error = str(exc)[:500]
+            await db.flush()
+        return 0

--- a/apps/backend/src/services/statement_validation.py
+++ b/apps/backend/src/services/statement_validation.py
@@ -12,6 +12,14 @@ from src.models.statement import Stage1Status
 BALANCE_TOLERANCE = Decimal("0.001")
 
 
+def pending_stage1_review_filter():
+    """Return the shared Stage 1 pending-review predicate for PARSED statements."""
+    return or_(
+        BankStatement.stage1_status == Stage1Status.PENDING_REVIEW,
+        BankStatement.stage1_status.is_(None),
+    )
+
+
 async def validate_balance_chain(
     db: AsyncSession,
     statement_id: UUID,
@@ -188,15 +196,11 @@ async def get_pending_stage1_review(
     limit: int = 50,
     offset: int = 0,
 ) -> list[BankStatement]:
-    pending_review_filter = or_(
-        BankStatement.stage1_status == Stage1Status.PENDING_REVIEW,
-        and_(BankStatement.confidence_score >= 60, BankStatement.confidence_score < 85),
-    )
     result = await db.execute(
         select(BankStatement)
         .where(BankStatement.user_id == user_id)
         .where(BankStatement.status == BankStatementStatus.PARSED)
-        .where(pending_review_filter)
+        .where(pending_stage1_review_filter())
         .order_by(BankStatement.created_at.desc())
         .limit(limit)
         .offset(offset)

--- a/apps/backend/src/services/statement_validation.py
+++ b/apps/backend/src/services/statement_validation.py
@@ -188,11 +188,15 @@ async def get_pending_stage1_review(
     limit: int = 50,
     offset: int = 0,
 ) -> list[BankStatement]:
+    pending_review_filter = or_(
+        BankStatement.stage1_status == Stage1Status.PENDING_REVIEW,
+        and_(BankStatement.confidence_score >= 60, BankStatement.confidence_score < 85),
+    )
     result = await db.execute(
         select(BankStatement)
         .where(BankStatement.user_id == user_id)
         .where(BankStatement.status == BankStatementStatus.PARSED)
-        .where(or_(BankStatement.stage1_status.is_(None), BankStatement.stage1_status == Stage1Status.PENDING_REVIEW))
+        .where(pending_review_filter)
         .order_by(BankStatement.created_at.desc())
         .limit(limit)
         .offset(offset)

--- a/apps/backend/src/services/validation.py
+++ b/apps/backend/src/services/validation.py
@@ -212,7 +212,7 @@ def route_by_threshold(score: int, balance_valid: bool) -> BankStatementStatus:
     if not balance_valid:
         return BankStatementStatus.UPLOADED
     if score >= 85:
-        return BankStatementStatus.PARSED
+        return BankStatementStatus.APPROVED
     if score >= 60:
         return BankStatementStatus.PARSED
     return BankStatementStatus.UPLOADED

--- a/apps/backend/tests/accounting/test_validation.py
+++ b/apps/backend/tests/accounting/test_validation.py
@@ -57,7 +57,7 @@ def test_compute_confidence_score_with_missing_fields():
 
 def test_route_by_threshold():
     """Routing uses thresholds and balance validity."""
-    assert route_by_threshold(90, True) == BankStatementStatus.PARSED
+    assert route_by_threshold(90, True) == BankStatementStatus.APPROVED
     assert route_by_threshold(70, True) == BankStatementStatus.PARSED
     assert route_by_threshold(50, True) == BankStatementStatus.UPLOADED
     assert route_by_threshold(90, False) == BankStatementStatus.UPLOADED

--- a/apps/backend/tests/ai/test_models_repr.py
+++ b/apps/backend/tests/ai/test_models_repr.py
@@ -83,7 +83,7 @@ def test_validation_route_by_threshold():
     from src.models.statement import BankStatementStatus
     from src.services.validation import route_by_threshold
 
-    assert route_by_threshold(85, True) == BankStatementStatus.PARSED
+    assert route_by_threshold(85, True) == BankStatementStatus.APPROVED
     assert route_by_threshold(60, True) == BankStatementStatus.PARSED
     assert route_by_threshold(50, False) == BankStatementStatus.UPLOADED
     assert route_by_threshold(50, True) == BankStatementStatus.UPLOADED

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -33,6 +33,7 @@ from src.models.statement import (
     BankStatementStatus,
     BankStatementTransaction,
     BankStatementTransactionStatus,
+    Stage1Status,
 )
 from src.routers import review as review_router, statements as statements_router
 from src.schemas import StatementDecisionRequest
@@ -46,6 +47,10 @@ from src.services import (
 from src.services.review_queue import create_entry_from_txn
 from src.services.source_type_priority import STATEMENT_SOURCE_TYPES
 from src.services.statement_parsing import handle_parse_failure
+from src.services.statement_posting import (
+    is_high_confidence_auto_approve_candidate,
+    try_auto_approve_high_confidence_statement,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -142,6 +147,23 @@ def build_statement(user_id, file_hash: str, confidence_score: int) -> BankState
         confidence_score=confidence_score,
         balance_validated=True,
     )
+
+
+async def test_is_high_confidence_auto_approve_candidate_requires_all_guards(test_user):
+    statement = build_statement(test_user.id, "hash_candidate_true", 85)
+    statement.status = BankStatementStatus.APPROVED
+    assert is_high_confidence_auto_approve_candidate(statement) is True
+
+    statement.confidence_score = 84
+    assert is_high_confidence_auto_approve_candidate(statement) is False
+
+    statement.confidence_score = 90
+    statement.balance_validated = False
+    assert is_high_confidence_auto_approve_candidate(statement) is False
+
+    statement.balance_validated = True
+    statement.status = BankStatementStatus.PARSED
+    assert is_high_confidence_auto_approve_candidate(statement) is False
 
 
 async def create_statement_account(db, user_id, name: str = "DBS Statement Account") -> Account:
@@ -1558,6 +1580,8 @@ async def test_approve_statement_stage1_auto_maps_unique_prior_confirmed_account
     statement = build_statement(test_user.id, "hash_s1_auto_map", 90)
     statement.status = BankStatementStatus.PARSED
     statement.account_id = None
+    statement.period_start = date(2025, 2, 1)
+    statement.period_end = date(2025, 2, 28)
     statement.closing_balance = Decimal("120.00")
     db.add(statement)
     await db.flush()
@@ -1565,7 +1589,7 @@ async def test_approve_statement_stage1_auto_maps_unique_prior_confirmed_account
 
     txn = BankStatementTransaction(
         statement_id=statement_id,
-        txn_date=date(2025, 1, 5),
+        txn_date=date(2025, 2, 5),
         description="Salary",
         amount=Decimal("20.00"),
         direction="IN",
@@ -1591,6 +1615,304 @@ async def test_approve_statement_stage1_auto_maps_unique_prior_confirmed_account
     )
     entry = entry_result.scalar_one()
     assert any(line.account_id == bank_account_id for line in entry.lines)
+
+
+async def test_auto_approve_high_confidence_statement_creates_posted_entries(db, test_user):
+    """AC3.3.1: High-confidence, balance-valid, uniquely mapped statements auto-approve and post."""
+    bank_account = await create_statement_account(db, test_user.id, "DBS Auto Approval")
+    statement = build_statement(test_user.id, "hash_s1_high_confidence_auto", 90)
+    statement.status = BankStatementStatus.APPROVED
+    statement.account_id = bank_account.id
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+
+    txn = BankStatementTransaction(
+        statement_id=statement.id,
+        txn_date=date(2025, 1, 8),
+        description="Salary",
+        amount=Decimal("20.00"),
+        direction="IN",
+    )
+    db.add(txn)
+    await db.flush()
+    txn_id = txn.id
+    await db.commit()
+
+    created_count = await try_auto_approve_high_confidence_statement(db, statement.id, test_user.id)
+    assert created_count == 1
+
+    await db.refresh(statement)
+    assert statement.status == BankStatementStatus.APPROVED
+
+    entry_result = await db.execute(
+        select(JournalEntry)
+        .where(JournalEntry.user_id == test_user.id)
+        .where(JournalEntry.source_type.in_(STATEMENT_SOURCE_TYPES))
+        .where(JournalEntry.source_id == txn_id)
+    )
+    assert entry_result.scalar_one().status == JournalEntryStatus.POSTED
+
+
+async def test_auto_approve_high_confidence_statement_returns_zero_for_non_candidate(db, test_user):
+    statement = build_statement(test_user.id, "hash_s1_high_confidence_non_candidate", 90)
+    statement.status = BankStatementStatus.PARSED
+    statement.closing_balance = Decimal("100.00")
+    db.add(statement)
+    await db.commit()
+
+    created_count = await try_auto_approve_high_confidence_statement(db, statement.id, test_user.id)
+
+    assert created_count == 0
+
+
+async def test_auto_approve_high_confidence_statement_falls_back_to_pending_review_on_guard_failure(db, test_user):
+    """AC3.3.1: Unsafe high-confidence statements remain reviewable instead of failing parsing."""
+    statement = build_statement(test_user.id, "hash_s1_high_confidence_guard_failure", 90)
+    statement.status = BankStatementStatus.APPROVED
+    statement.account_id = None
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+
+    db.add(
+        BankStatementTransaction(
+            statement_id=statement.id,
+            txn_date=date(2025, 1, 8),
+            description="Salary",
+            amount=Decimal("20.00"),
+            direction="IN",
+        )
+    )
+    await db.commit()
+
+    created_count = await try_auto_approve_high_confidence_statement(db, statement.id, test_user.id)
+
+    assert created_count == 0
+    await db.refresh(statement)
+    assert statement.status == BankStatementStatus.PARSED
+    assert statement.stage1_status == Stage1Status.PENDING_REVIEW
+    assert "Account mapping required" in (statement.validation_error or "")
+
+
+async def test_approve_statement_stage1_promotes_existing_statement_entries_without_reposting(db, test_user):
+    bank_account = await create_statement_account(db, test_user.id, "DBS Existing Entry Promotion")
+    statement = build_statement(test_user.id, "hash_s1_existing_entry_promotion", 90)
+    statement.status = BankStatementStatus.PARSED
+    statement.account_id = bank_account.id
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+
+    txn = BankStatementTransaction(
+        statement_id=statement.id,
+        txn_date=date(2025, 1, 8),
+        description="Salary",
+        amount=Decimal("20.00"),
+        direction="IN",
+    )
+    db.add(txn)
+    await db.flush()
+
+    existing_entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=txn.txn_date,
+        memo="Existing parsed entry",
+        source_type=JournalEntrySourceType.AUTO_PARSED,
+        source_id=txn.id,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(existing_entry)
+    await db.commit()
+
+    result = await statements_router.approve_statement_stage1(statement_id=statement.id, db=db, user_id=test_user.id)
+
+    assert result.journal_entries_created == 0
+    await db.refresh(existing_entry)
+    assert existing_entry.source_type == JournalEntrySourceType.USER_CONFIRMED
+
+    entries_result = await db.execute(
+        select(JournalEntry)
+        .where(JournalEntry.user_id == test_user.id)
+        .where(JournalEntry.source_type.in_(STATEMENT_SOURCE_TYPES))
+        .where(JournalEntry.source_id == txn.id)
+    )
+    assert len(entries_result.scalars().all()) == 1
+
+
+async def test_approve_statement_stage1_blocks_prior_unconfirmed_account_mapping(db, test_user):
+    """AC3.6.5: Stage 1 posting cannot auto-map from an unconfirmed prior statement."""
+    user_id = test_user.id
+    bank_account = await create_statement_account(db, user_id, "DBS Unconfirmed Prior")
+
+    prior = build_statement(user_id, "hash_s1_prior_unconfirmed", 95)
+    prior.status = BankStatementStatus.PARSED
+    prior.account_id = bank_account.id
+    db.add(prior)
+    await db.flush()
+
+    statement = build_statement(user_id, "hash_s1_unconfirmed_prior_target", 90)
+    statement.status = BankStatementStatus.PARSED
+    statement.account_id = None
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+
+    db.add(
+        BankStatementTransaction(
+            statement_id=statement.id,
+            txn_date=date(2025, 1, 8),
+            description="Salary",
+            amount=Decimal("20.00"),
+            direction="IN",
+        )
+    )
+    await db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.approve_statement_stage1(statement_id=statement.id, db=db, user_id=user_id)
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "No confirmed account matches" in str(exc.value.detail)
+
+
+async def test_approve_statement_stage1_blocks_overlapping_statement_period_before_posting(db, test_user):
+    """AC3.6.6: Stage 1 posting blocks duplicate or overlapping account/currency periods."""
+    user_id = test_user.id
+    bank_account = await create_statement_account(db, user_id, "DBS Period Guard")
+
+    prior = build_statement(user_id, "hash_s1_prior_period", 95)
+    prior.status = BankStatementStatus.APPROVED
+    prior.account_id = bank_account.id
+    prior.period_start = date(2025, 1, 1)
+    prior.period_end = date(2025, 1, 31)
+    db.add(prior)
+    await db.flush()
+
+    statement = build_statement(user_id, "hash_s1_period_overlap", 90)
+    statement.status = BankStatementStatus.PARSED
+    statement.account_id = bank_account.id
+    statement.period_start = date(2025, 1, 15)
+    statement.period_end = date(2025, 2, 15)
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+
+    db.add(
+        BankStatementTransaction(
+            statement_id=statement.id,
+            txn_date=date(2025, 1, 20),
+            description="Salary",
+            amount=Decimal("20.00"),
+            direction="IN",
+        )
+    )
+    await db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.approve_statement_stage1(statement_id=statement.id, db=db, user_id=user_id)
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Statement period overlaps" in str(exc.value.detail)
+
+    entry_result = await db.execute(
+        select(JournalEntry)
+        .where(JournalEntry.user_id == user_id)
+        .where(JournalEntry.source_type.in_(STATEMENT_SOURCE_TYPES))
+    )
+    assert entry_result.scalars().all() == []
+
+
+async def test_approve_statement_stage1_blocks_missing_statement_period_before_posting(db, test_user):
+    user_id = test_user.id
+    bank_account = await create_statement_account(db, user_id, "DBS Missing Period Guard")
+
+    statement = build_statement(user_id, "hash_s1_missing_period", 90)
+    statement.status = BankStatementStatus.PARSED
+    statement.account_id = bank_account.id
+    statement.period_start = None
+    statement.period_end = date(2025, 1, 31)
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+
+    db.add(
+        BankStatementTransaction(
+            statement_id=statement.id,
+            txn_date=date(2025, 1, 20),
+            description="Salary",
+            amount=Decimal("20.00"),
+            direction="IN",
+        )
+    )
+    await db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.approve_statement_stage1(statement_id=statement.id, db=db, user_id=user_id)
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Statement period required" in str(exc.value.detail)
+
+
+async def test_approve_statement_stage1_blocks_invalid_statement_period_before_posting(db, test_user):
+    user_id = test_user.id
+    bank_account = await create_statement_account(db, user_id, "DBS Invalid Period Guard")
+
+    statement = build_statement(user_id, "hash_s1_invalid_period", 90)
+    statement.status = BankStatementStatus.PARSED
+    statement.account_id = bank_account.id
+    statement.period_start = date(2025, 2, 1)
+    statement.period_end = date(2025, 1, 31)
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+
+    db.add(
+        BankStatementTransaction(
+            statement_id=statement.id,
+            txn_date=date(2025, 1, 20),
+            description="Salary",
+            amount=Decimal("20.00"),
+            direction="IN",
+        )
+    )
+    await db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.approve_statement_stage1(statement_id=statement.id, db=db, user_id=user_id)
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Statement period is invalid" in str(exc.value.detail)
+
+
+async def test_approve_statement_stage1_blocks_missing_statement_currency_before_posting(db, test_user):
+    user_id = test_user.id
+    bank_account = await create_statement_account(db, user_id, "DBS Missing Currency Guard")
+
+    statement = build_statement(user_id, "hash_s1_missing_currency", 90)
+    statement.status = BankStatementStatus.PARSED
+    statement.account_id = bank_account.id
+    statement.currency = ""
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+
+    db.add(
+        BankStatementTransaction(
+            statement_id=statement.id,
+            txn_date=date(2025, 1, 20),
+            description="Salary",
+            amount=Decimal("20.00"),
+            direction="IN",
+        )
+    )
+    await db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.approve_statement_stage1(statement_id=statement.id, db=db, user_id=user_id)
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Statement currency required" in str(exc.value.detail)
 
 
 async def test_approve_statement_stage1_blocks_unmapped_account_without_fallback(db, test_user):

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -1695,6 +1695,42 @@ async def test_auto_approve_high_confidence_statement_falls_back_to_pending_revi
     assert "Account mapping required" in (statement.validation_error or "")
 
 
+async def test_auto_approve_guard_failure_preserves_uncommitted_parse_data(db, test_user):
+    """AC3.3.1: Auto-approval guard fallback must not roll back parsed statement data."""
+    statement = build_statement(test_user.id, "hash_s1_guard_failure_preserves_parse", 90)
+    statement.status = BankStatementStatus.APPROVED
+    statement.account_id = None
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+
+    txn = BankStatementTransaction(
+        statement_id=statement.id,
+        txn_date=date(2025, 1, 8),
+        description="Uncommitted Salary",
+        amount=Decimal("20.00"),
+        direction="IN",
+    )
+    db.add(txn)
+    await db.flush()
+
+    created_count = await try_auto_approve_high_confidence_statement(db, statement.id, test_user.id)
+
+    assert created_count == 0
+
+    persisted_statement = await db.get(BankStatement, statement.id)
+    assert persisted_statement is not None
+    assert persisted_statement.status == BankStatementStatus.PARSED
+    assert persisted_statement.stage1_status == Stage1Status.PENDING_REVIEW
+    assert "Account mapping required" in (persisted_statement.validation_error or "")
+
+    txn_result = await db.execute(
+        select(BankStatementTransaction).where(BankStatementTransaction.statement_id == statement.id)
+    )
+    persisted_txn = txn_result.scalar_one()
+    assert persisted_txn.description == "Uncommitted Salary"
+
+
 async def test_approve_statement_stage1_promotes_existing_statement_entries_without_reposting(db, test_user):
     bank_account = await create_statement_account(db, test_user.id, "DBS Existing Entry Promotion")
     statement = build_statement(test_user.id, "hash_s1_existing_entry_promotion", 90)
@@ -2024,6 +2060,61 @@ async def test_approve_statement_stage1_blocks_invalid_explicit_account_mapping(
 
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
     assert "Statement account mapping is invalid" in str(exc.value.detail)
+
+
+@pytest.mark.parametrize(
+    ("account_type", "account_currency", "is_active", "expected_detail"),
+    [
+        (AccountType.LIABILITY, "SGD", True, "active asset account"),
+        (AccountType.ASSET, "USD", True, "statement currency"),
+        (AccountType.ASSET, "SGD", False, "active asset account"),
+    ],
+)
+async def test_approve_statement_stage1_blocks_unsafe_explicit_account_mapping(
+    db,
+    test_user,
+    account_type,
+    account_currency,
+    is_active,
+    expected_detail,
+):
+    """AC3.6.2: Explicit statement accounts must be active ASSET accounts in the statement currency."""
+    user_id = test_user.id
+    account = Account(
+        user_id=user_id,
+        name="Unsafe Explicit Account",
+        type=account_type,
+        currency=account_currency,
+        is_active=is_active,
+    )
+    db.add(account)
+    await db.flush()
+
+    statement = build_statement(user_id, f"hash_s1_unsafe_explicit_{account_type}_{account_currency}_{is_active}", 90)
+    statement.status = BankStatementStatus.PARSED
+    statement.account_id = account.id
+    statement.currency = "SGD"
+    statement.closing_balance = Decimal("120.00")
+    db.add(statement)
+    await db.flush()
+    statement_id = statement.id
+
+    db.add(
+        BankStatementTransaction(
+            statement_id=statement_id,
+            txn_date=date(2025, 1, 6),
+            description="Salary",
+            amount=Decimal("20.00"),
+            direction="IN",
+        )
+    )
+    await db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.approve_statement_stage1(statement_id=statement_id, db=db, user_id=user_id)
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert expected_detail in str(exc.value.detail)
 
 
 async def test_approve_statement_stage1_creates_account_with_explicit_confirmation(db, test_user):

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -554,7 +554,7 @@ async def test_list_and_transactions_flow(db, monkeypatch, storage_stub, model_c
 
 
 async def test_pending_review_and_decisions(db, monkeypatch, storage_stub, model_catalog_stub, test_user):
-    """AC3.5.10: Review queue filters by confidence and supports approve/reject."""
+    """AC3.5.10: Review queue includes reviewable parsed statements and supports approve/reject."""
     contents = [b"review-70", b"review-90"]
     scores = [70, 90]
     score_by_hash = {
@@ -603,12 +603,11 @@ async def test_pending_review_and_decisions(db, monkeypatch, storage_stub, model
     await wait_for_background_tasks()
 
     pending = await statements_router.list_pending_review(db=db, user_id=test_user.id)
-    assert pending.total == 1
-    # Pending list should contain only the lower-confidence statement.
-    assert pending.items[0].id == created_ids[0]
+    assert pending.total == 2
+    assert {item.id for item in pending.items} == set(created_ids)
 
     # Test approve
-    statement_id = pending.items[0].id
+    statement_id = created_ids[0]
 
     approved = await statements_router.approve_statement(
         statement_id=statement_id,

--- a/apps/backend/tests/extraction/test_extraction_flow.py
+++ b/apps/backend/tests/extraction/test_extraction_flow.py
@@ -155,7 +155,7 @@ class TestExtractionServiceFlow:
                 file_content=csv_file.read_bytes(),
             )
 
-            assert stmt.status == BankStatementStatus.PARSED  # High confidence as it validates
+            assert stmt.status == BankStatementStatus.PARSED  # Medium confidence requires review
             assert len(events) == 0
 
     @pytest.mark.asyncio

--- a/apps/backend/tests/extraction/test_pdf_parsing.py
+++ b/apps/backend/tests/extraction/test_pdf_parsing.py
@@ -408,7 +408,7 @@ class TestConfidenceRouting:
     def test_high_confidence_auto_accept(self):
         """Confidence >= 85 with valid balance should auto-accept."""
         status = route_by_threshold(90, balance_valid=True)
-        assert status == BankStatementStatus.PARSED
+        assert status == BankStatementStatus.APPROVED
 
     def test_medium_confidence_review(self):
         """Confidence 60-84 should require review."""

--- a/apps/backend/tests/review/test_statement_validation.py
+++ b/apps/backend/tests/review/test_statement_validation.py
@@ -301,9 +301,9 @@ class TestSetOpeningBalance:
 
 class TestGetPendingStage1Review:
     async def test_returns_parsed_statements(self, db, user_id):
-        """AC1.6.1 get_pending_stage1_review returns PARSED statements with null/PENDING stage1_status."""
-        # PARSED with no stage1_status (null) -> should be returned
-        stmt_pending = BankStatement(
+        """AC1.6.1 get_pending_stage1_review returns medium confidence or explicit pending statements."""
+        # Medium-confidence PARSED with no stage1_status -> should be returned
+        stmt_medium = BankStatement(
             id=uuid4(),
             user_id=user_id,
             file_path="pending.pdf",
@@ -312,6 +312,7 @@ class TestGetPendingStage1Review:
             institution="Test Bank",
             currency="USD",
             status=BankStatementStatus.PARSED,
+            confidence_score=70,
         )
         # PARSED with stage1_status=PENDING_REVIEW -> should be returned
         stmt_review = BankStatement(
@@ -324,6 +325,19 @@ class TestGetPendingStage1Review:
             currency="USD",
             status=BankStatementStatus.PARSED,
             stage1_status=Stage1Status.PENDING_REVIEW,
+            confidence_score=90,
+        )
+        # High-confidence PARSED without explicit pending_review is not a review item.
+        stmt_high = BankStatement(
+            id=uuid4(),
+            user_id=user_id,
+            file_path="high.pdf",
+            file_hash="hash_high",
+            original_filename="high.pdf",
+            institution="Test Bank",
+            currency="USD",
+            status=BankStatementStatus.PARSED,
+            confidence_score=90,
         )
         # APPROVED -> should NOT be returned
         stmt_approved = BankStatement(
@@ -337,13 +351,14 @@ class TestGetPendingStage1Review:
             status=BankStatementStatus.APPROVED,
             stage1_status=Stage1Status.APPROVED,
         )
-        db.add_all([stmt_pending, stmt_review, stmt_approved])
+        db.add_all([stmt_medium, stmt_review, stmt_high, stmt_approved])
         await db.flush()
 
         result = await get_pending_stage1_review(db, user_id)
         ids = {s.id for s in result}
-        assert stmt_pending.id in ids
+        assert stmt_medium.id in ids
         assert stmt_review.id in ids
+        assert stmt_high.id not in ids
         assert stmt_approved.id not in ids
 
     async def test_returns_empty_when_none_pending(self, db, user_id):

--- a/apps/backend/tests/review/test_statement_validation.py
+++ b/apps/backend/tests/review/test_statement_validation.py
@@ -301,7 +301,7 @@ class TestSetOpeningBalance:
 
 class TestGetPendingStage1Review:
     async def test_returns_parsed_statements(self, db, user_id):
-        """AC1.6.1 get_pending_stage1_review returns medium confidence or explicit pending statements."""
+        """AC1.6.1 get_pending_stage1_review returns explicit pending or legacy parsed statements."""
         # Medium-confidence PARSED with no stage1_status -> should be returned
         stmt_medium = BankStatement(
             id=uuid4(),
@@ -327,8 +327,8 @@ class TestGetPendingStage1Review:
             stage1_status=Stage1Status.PENDING_REVIEW,
             confidence_score=90,
         )
-        # High-confidence PARSED without explicit pending_review is not a review item.
-        stmt_high = BankStatement(
+        # Legacy high-confidence PARSED with no stage1_status should remain reviewable.
+        stmt_high_legacy = BankStatement(
             id=uuid4(),
             user_id=user_id,
             file_path="high.pdf",
@@ -351,14 +351,14 @@ class TestGetPendingStage1Review:
             status=BankStatementStatus.APPROVED,
             stage1_status=Stage1Status.APPROVED,
         )
-        db.add_all([stmt_medium, stmt_review, stmt_high, stmt_approved])
+        db.add_all([stmt_medium, stmt_review, stmt_high_legacy, stmt_approved])
         await db.flush()
 
         result = await get_pending_stage1_review(db, user_id)
         ids = {s.id for s in result}
         assert stmt_medium.id in ids
         assert stmt_review.id in ids
-        assert stmt_high.id not in ids
+        assert stmt_high_legacy.id in ids
         assert stmt_approved.id not in ids
 
     async def test_returns_empty_when_none_pending(self, db, user_id):

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -701,6 +701,16 @@ groups:
         epic_name: statement-parsing
         description: Explicit First-Upload Account Creation
         mandatory: true
+      - id: AC3.6.5
+        epic: 3
+        epic_name: statement-parsing
+        description: Prior Mapping Requires Confirmed Statement
+        mandatory: true
+      - id: AC3.6.6
+        epic: 3
+        epic_name: statement-parsing
+        description: Source Period Unique Before Posting
+        mandatory: true
     AC3.7:
       - id: AC3.7.1
         epic: 3

--- a/docs/project/EPIC-003.statement-parsing.md
+++ b/docs/project/EPIC-003.statement-parsing.md
@@ -138,7 +138,7 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC3.3.1 | High Confidence (Auto-Accept) | `test_high_confidence`, `test_auto_approve_high_confidence_statement_creates_posted_entries` | `extraction/test_extraction.py`, `api/test_statements_router.py` | P0 |
+| AC3.3.1 | High Confidence (Auto-Accept) | `test_high_confidence`, `test_auto_approve_high_confidence_statement_creates_posted_entries`, `test_auto_approve_guard_failure_preserves_uncommitted_parse_data` | `extraction/test_extraction.py`, `api/test_statements_router.py` | P0 |
 | AC3.3.2 | Medium Confidence (Review) | `test_medium_confidence` | `extraction/test_extraction.py` | P0 |
 | AC3.3.3 | Low Confidence (Manual) | `test_low_confidence_empty_transactions` | `extraction/test_extraction.py` | P0 |
 
@@ -163,7 +163,7 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC3.6.1 | Unique Prior Mapping | `test_approve_statement_stage1_auto_maps_unique_prior_confirmed_account` | `api/test_statements_router.py` | P0 |
-| AC3.6.2 | No Silent Fallback Posting | `test_approve_statement_stage1_blocks_unmapped_account_without_fallback`, `test_create_entry_from_txn_auto_post_requires_account_mapping` | `api/test_statements_router.py`, `reconciliation/test_review_queue.py` | P0 |
+| AC3.6.2 | No Silent Fallback Posting | `test_approve_statement_stage1_blocks_unmapped_account_without_fallback`, `test_approve_statement_stage1_blocks_unsafe_explicit_account_mapping`, `test_create_entry_from_txn_auto_post_requires_account_mapping` | `api/test_statements_router.py`, `reconciliation/test_review_queue.py` | P0 |
 | AC3.6.3 | Ambiguous Mapping Blocked | `test_approve_statement_stage1_blocks_ambiguous_account_mapping` | `api/test_statements_router.py` | P0 |
 | AC3.6.4 | Explicit First-Upload Account Creation | `test_approve_statement_stage1_creates_account_with_explicit_confirmation` | `api/test_statements_router.py` | P0 |
 | AC3.6.5 | Prior Mapping Requires Confirmed Statement | `test_approve_statement_stage1_blocks_prior_unconfirmed_account_mapping` | `api/test_statements_router.py` | P0 |

--- a/docs/project/EPIC-003.statement-parsing.md
+++ b/docs/project/EPIC-003.statement-parsing.md
@@ -138,7 +138,7 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC3.3.1 | High Confidence (Auto-Accept) | `test_high_confidence` | `extraction/test_extraction.py` | P0 |
+| AC3.3.1 | High Confidence (Auto-Accept) | `test_high_confidence`, `test_auto_approve_high_confidence_statement_creates_posted_entries` | `extraction/test_extraction.py`, `api/test_statements_router.py` | P0 |
 | AC3.3.2 | Medium Confidence (Review) | `test_medium_confidence` | `extraction/test_extraction.py` | P0 |
 | AC3.3.3 | Low Confidence (Manual) | `test_low_confidence_empty_transactions` | `extraction/test_extraction.py` | P0 |
 
@@ -166,6 +166,8 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 | AC3.6.2 | No Silent Fallback Posting | `test_approve_statement_stage1_blocks_unmapped_account_without_fallback`, `test_create_entry_from_txn_auto_post_requires_account_mapping` | `api/test_statements_router.py`, `reconciliation/test_review_queue.py` | P0 |
 | AC3.6.3 | Ambiguous Mapping Blocked | `test_approve_statement_stage1_blocks_ambiguous_account_mapping` | `api/test_statements_router.py` | P0 |
 | AC3.6.4 | Explicit First-Upload Account Creation | `test_approve_statement_stage1_creates_account_with_explicit_confirmation` | `api/test_statements_router.py` | P0 |
+| AC3.6.5 | Prior Mapping Requires Confirmed Statement | `test_approve_statement_stage1_blocks_prior_unconfirmed_account_mapping` | `api/test_statements_router.py` | P0 |
+| AC3.6.6 | Source Period Unique Before Posting | `test_approve_statement_stage1_blocks_overlapping_statement_period_before_posting` | `api/test_statements_router.py` | P0 |
 
 ### AC3.7: Account Statement Coverage
 | ID | Test Case | Test Function | File | Priority |

--- a/docs/ssot/confirmation-workflow.md
+++ b/docs/ssot/confirmation-workflow.md
@@ -68,7 +68,8 @@ The following diagram shows how a bank statement travels from upload through to 
 
 | From | Event | To | Guard |
 |------|-------|----|-------|
-| `parsed` | system auto-accept | `approved` | Score ≥ 85, balance delta ≤ 0.001 USD, confirmed account mapping, non-overlapping source period |
+| `parsed` | system auto-accept | `approved` | Score ≥ 85, balance delta ≤ 0.001 USD, confirmed active asset account in statement currency, non-overlapping source period |
+| `approved` | auto-post guard failure | `pending_review` | Guard failure during high-confidence auto-post; preserve parsed statement and transactions |
 | `pending_review` | `approve_statement()` | `approved` | Balance delta ≤ 0.001 USD |
 | `pending_review` | `reject_statement()` | `rejected` | — |
 | `pending_review` | `edit_and_approve()` | `approved` | Balance delta ≤ 0.001 USD after edits |
@@ -123,7 +124,7 @@ The following diagram shows how a bank statement travels from upload through to 
 | `POST /api/statements/{id}/review/approve` | `statement_id`, bearer token | stage1_status → approved; balance chain validation enforced (≤ 0.001 USD); queues to Stage 2 |
 | `POST /api/statements/{id}/review/reject` | `statement_id`, `reason`, bearer token | stage1_status → rejected; triggers re-parse |
 | `POST /api/statements/{id}/review/edit` | `statement_id`, edits, bearer token | Updates transactions, re-validates, approves if valid |
-| `GET /api/statements/pending-review` | bearer token | Returns `[BankStatement]` where `status=PARSED` and `confidence_score` is 60–84 (does **not** filter on `stage1_status`) |
+| `GET /api/statements/pending-review` | bearer token | Returns `[BankStatement]` where `status=PARSED` and either `stage1_status=PENDING_REVIEW` or `stage1_status` is null for legacy parsed rows |
 ### Stage 2 Endpoints (reconciliation + statements routers)
 
 | Endpoint | Input | Side Effect |

--- a/docs/ssot/confirmation-workflow.md
+++ b/docs/ssot/confirmation-workflow.md
@@ -41,7 +41,9 @@ The following diagram shows how a bank statement travels from upload through to 
                  │                                                       │
   Upload         │  BankStatement.stage1_status                          │
   ──────►  parsed│                                                       │
-                 │   pending_review ──► approved ──────────────────────►│──► Stage 2 queue
+                 │   score ≥ 85 + guards ──► approved ─────────────────►│──► Stage 2 queue
+                 │         │                                             │
+                 │   pending_review ──► approved ──────────────────────►│
                  │         │                                             │
                  │         └──► rejected ──► re-parse (loop)            │
                  │              (edit → re-validate → approved)         │
@@ -66,6 +68,7 @@ The following diagram shows how a bank statement travels from upload through to 
 
 | From | Event | To | Guard |
 |------|-------|----|-------|
+| `parsed` | system auto-accept | `approved` | Score ≥ 85, balance delta ≤ 0.001 USD, confirmed account mapping, non-overlapping source period |
 | `pending_review` | `approve_statement()` | `approved` | Balance delta ≤ 0.001 USD |
 | `pending_review` | `reject_statement()` | `rejected` | — |
 | `pending_review` | `edit_and_approve()` | `approved` | Balance delta ≤ 0.001 USD after edits |
@@ -87,6 +90,7 @@ The following diagram shows how a bank statement travels from upload through to 
 ### DO
 - ✅ Always pass `user_id` to service methods that mutate `pending_review` state (ownership check)
 - ✅ Validate balance chain (0.001 USD tolerance) before advancing Stage 1
+- ✅ Require confirmed account mapping and source-period uniqueness before Stage 1 auto-posting
 - ✅ Resolve all consistency checks before Stage 2 batch approval
 - ✅ Create journal entry only on `accepted` transition (never on `pending_review`)
 - ✅ Emit an audit log entry on every state transition

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -106,7 +106,7 @@ The system is currently migrating to a 4-layer architecture. During Phase 2, dat
 | Currency consistency | 5% |
 
 **Thresholds**:
-- ≥85: Auto-accept
+- ≥85: Auto-accept only after balance validation, account mapping, and source-period uniqueness pass
 - 60-84: Review queue
 - <60: Manual entry required
 
@@ -239,7 +239,7 @@ fallback account. Before Stage 1 approval creates posted journal entries, the
 statement must resolve to a user-owned asset account by one of these paths:
 
 1. The statement already has an explicit `account_id` selected by the user.
-2. A previous confirmed statement for the same user has exactly one account
+2. A previous approved statement for the same user has exactly one account
    matching `institution`, `account_last4`, and `currency`.
 3. The user explicitly confirms first-upload account creation during Stage 1
    approval; the created asset account is bound to the statement before posted
@@ -249,6 +249,12 @@ If no confident match exists, or multiple accounts match the same metadata, the
 approval flow must block posting with a clear account-mapping action item. Draft
 candidate entries may still use legacy defaults in manual workflows, but posted
 entries cannot silently use `Bank - Main`.
+
+Before posted entries are created, the statement must also have a complete
+`period_start`/`period_end` source range that does not duplicate or overlap any
+approved statement for the same account and currency. High-confidence statements
+that fail account or source-period eligibility remain in Stage 1 review instead
+of posting automatically.
 
 ## Account Coverage Contract
 

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -110,6 +110,10 @@ The system is currently migrating to a 4-layer architecture. During Phase 2, dat
 - 60-84: Review queue
 - <60: Manual entry required
 
+If a high-confidence statement fails any Stage 1 posting guard, the parser must
+preserve the extracted statement and transactions, set the statement to parsed
+pending review, and expose the guard reason for human correction.
+
 ## API Endpoints
 
 | Method | Path | Description |
@@ -118,7 +122,7 @@ The system is currently migrating to a 4-layer architecture. During Phase 2, dat
 | GET | `/api/statements` | Statement list |
 | GET | `/api/statements/{id}` | Get statement with transactions |
 | GET | `/api/statements/{id}/transactions` | Transaction list |
-| GET | `/api/statements/pending-review` | List items needing review |
+| GET | `/api/statements/pending-review` | List parsed items needing review, including legacy parsed rows with no `stage1_status` |
 | GET | `/api/accounts/coverage` | Account-level latest confirmed source date, stale status, and statement period continuity issues |
 | POST | `/api/statements/{id}/review/approve` | Stage 1 approve with balance-chain validation (canonical) |
 | POST | `/api/statements/{id}/review/reject` | Stage 1 reject (canonical) |
@@ -238,7 +242,8 @@ Automatic journal posting from imported statements must never use a generic
 fallback account. Before Stage 1 approval creates posted journal entries, the
 statement must resolve to a user-owned asset account by one of these paths:
 
-1. The statement already has an explicit `account_id` selected by the user.
+1. The statement already has an explicit `account_id` selected by the user, and
+   that account is user-owned, active, `ASSET`, and in the statement currency.
 2. A previous approved statement for the same user has exactly one account
    matching `institution`, `account_last4`, and `currency`.
 3. The user explicitly confirms first-upload account creation during Stage 1


### PR DESCRIPTION
## Summary
- Fixes #611.
- Implements Stage 1 high-confidence auto-approval/posting eligibility behind the same financial guards used by manual Stage 1 posting.
- Restricts prior account auto-mapping to approved prior statements only.
- Blocks posted journal entry creation when the statement source period overlaps an approved statement for the same account/currency.
- Keeps high-confidence statements in Stage 1 pending review when automatic eligibility fails.

## Root Cause
The code treated `confidence >= 85` as the same `PARSED` state as medium-confidence review items, while posting guards lived only in the router approval path. Account mapping also accepted any prior statement with `account_id`, and source-period overlap was only reported later by coverage instead of blocking posting.

## Tests
- `moon run :lint`
- `uv run ruff check src/services/statement_posting.py src/services/statement_parsing.py src/routers/statements.py tests/api/test_statements_router.py tests/ai/test_models_repr.py tests/accounting/test_validation.py tests/extraction/test_pdf_parsing.py tests/extraction/test_extraction_flow.py tests/review/test_statement_validation.py`
- `uv run python -m py_compile src/services/statement_posting.py src/services/statement_parsing.py src/routers/statements.py src/services/validation.py`
- `uv run python - <<'PY' ... route_by_threshold smoke check ... PY`

## Local Test Note
Targeted DB tests were attempted, but local Podman API calls to `podman ps` time out after 10 seconds on this machine, and the backend test database connection timed out at `127.0.0.1:5432`. CI should provide the authoritative database-backed test result.
