### PR TITLE
[finance_report_infra] Harden market data transaction boundaries

### DIFF
--- a/apps/backend/src/routers/market_data.py
+++ b/apps/backend/src/routers/market_data.py
@@ -106,7 +106,9 @@ async def sync_fx_endpoint(
             end_date=request.end_date,
             user_id=user_id,
         )
+        await db.commit()
     except ValueError as exc:
+        await db.rollback()
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
     return _response_from_result(result)
 
@@ -118,11 +120,16 @@ async def sync_stocks_endpoint(
     user_id: CurrentUserId,
 ) -> MarketDataSyncResponse:
     """Incrementally fill stock prices for explicit symbols or active holdings."""
-    result = await sync_stock_prices(
-        db,
-        symbols=request.symbols,
-        start_date=request.start_date,
-        end_date=request.end_date,
-        user_id=user_id,
-    )
+    try:
+        result = await sync_stock_prices(
+            db,
+            symbols=request.symbols,
+            start_date=request.start_date,
+            end_date=request.end_date,
+            user_id=user_id,
+        )
+        await db.commit()
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
     return _response_from_result(result)

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -363,6 +363,7 @@ async def balance_sheet(
             error=str(exc),
         )
         raise_bad_request(str(exc), cause=exc)
+    await db.commit()
     return BalanceSheetResponse(**report)
 
 
@@ -397,6 +398,7 @@ async def income_statement(
             error=str(exc),
         )
         raise_bad_request(str(exc), cause=exc)
+    await db.commit()
     return IncomeStatementResponse(**report)
 
 
@@ -427,6 +429,7 @@ async def cash_flow(
             error=str(exc),
         )
         raise_bad_request(str(exc), cause=exc)
+    await db.commit()
     return CashFlowResponse(**report)
 
 
@@ -457,6 +460,7 @@ async def account_trend(
             error=str(exc),
         )
         raise_bad_request(str(exc), cause=exc)
+    await db.commit()
     return AccountTrendResponse(**report)
 
 
@@ -490,6 +494,7 @@ async def net_worth_timeseries(
             error=str(exc),
         )
         raise_bad_request(str(exc), cause=exc)
+    await db.commit()
     return NetWorthTimeSeriesResponse(**report)
 
 
@@ -521,6 +526,7 @@ async def category_breakdown(
             error=str(exc),
         )
         raise_bad_request(str(exc), cause=exc)
+    await db.commit()
     return CategoryBreakdownResponse(**report)
 
 
@@ -590,6 +596,7 @@ async def export_report(
         )
         raise_bad_request(str(exc), cause=exc)
 
+    await db.commit()
     content = output.getvalue()
     output.close()
     return StreamingResponse(

--- a/apps/backend/src/services/market_data.py
+++ b/apps/backend/src/services/market_data.py
@@ -461,19 +461,19 @@ async def _persist_fx_rate(db: AsyncSession, observation: FxRateObservation) -> 
     if existing is not None:
         return existing.rate
 
-    db.add(
-        FxRate(
-            base_currency=base,
-            quote_currency=quote,
-            rate=rate,
-            rate_date=observation.rate_date,
-            source=observation.source[:50],
-        )
-    )
     try:
-        await db.flush()
+        async with db.begin_nested():
+            db.add(
+                FxRate(
+                    base_currency=base,
+                    quote_currency=quote,
+                    rate=rate,
+                    rate_date=observation.rate_date,
+                    source=observation.source[:50],
+                )
+            )
+            await db.flush()
     except IntegrityError:
-        await db.rollback()
         concurrent = await _load_stored_rate_on_date(db, base, quote, observation.rate_date)
         if concurrent is not None:
             return concurrent.rate
@@ -653,35 +653,36 @@ async def _upsert_sync_state(
 ) -> None:
     observed_now = now or datetime.now(UTC)
     state = await _load_sync_state(db, kind, scope)
-    if state is None:
-        db.add(
-            MarketDataSyncState(
-                kind=kind,
-                scope=scope,
-                last_success_at=observed_now,
-                last_success_date=last_success_date,
-                last_observation_date=last_observation_date,
-                created_at=observed_now,
-                updated_at=observed_now,
-            )
-        )
-    else:
-        state.last_success_at = observed_now
-        state.last_success_date = last_success_date
-        state.last_observation_date = last_observation_date
-        state.updated_at = observed_now
     try:
-        await db.flush()
+        async with db.begin_nested():
+            if state is None:
+                db.add(
+                    MarketDataSyncState(
+                        kind=kind,
+                        scope=scope,
+                        last_success_at=observed_now,
+                        last_success_date=last_success_date,
+                        last_observation_date=last_observation_date,
+                        created_at=observed_now,
+                        updated_at=observed_now,
+                    )
+                )
+            else:
+                state.last_success_at = observed_now
+                state.last_success_date = last_success_date
+                state.last_observation_date = last_observation_date
+                state.updated_at = observed_now
+            await db.flush()
     except IntegrityError:
-        await db.rollback()
         concurrent = await _load_sync_state(db, kind, scope)
         if concurrent is None:
             raise
-        concurrent.last_success_at = observed_now
-        concurrent.last_success_date = last_success_date
-        concurrent.last_observation_date = last_observation_date
-        concurrent.updated_at = observed_now
-        await db.flush()
+        async with db.begin_nested():
+            concurrent.last_success_at = observed_now
+            concurrent.last_success_date = last_success_date
+            concurrent.last_observation_date = last_observation_date
+            concurrent.updated_at = observed_now
+            await db.flush()
 
 
 async def _persist_stock_price(db: AsyncSession, observation: StockPriceObservation) -> Decimal:
@@ -693,19 +694,19 @@ async def _persist_stock_price(db: AsyncSession, observation: StockPriceObservat
     if existing is not None:
         return existing.price
 
-    db.add(
-        StockPrice(
-            symbol=symbol,
-            price=price,
-            currency=currency,
-            price_date=observation.price_date,
-            source=observation.source[:50],
-        )
-    )
     try:
-        await db.flush()
+        async with db.begin_nested():
+            db.add(
+                StockPrice(
+                    symbol=symbol,
+                    price=price,
+                    currency=currency,
+                    price_date=observation.price_date,
+                    source=observation.source[:50],
+                )
+            )
+            await db.flush()
     except IntegrityError:
-        await db.rollback()
         concurrent = await _load_stored_stock_price_on_date(db, symbol, observation.price_date)
         if concurrent is not None:
             return concurrent.price

--- a/apps/backend/src/services/market_data.py
+++ b/apps/backend/src/services/market_data.py
@@ -471,7 +471,7 @@ async def _persist_fx_rate(db: AsyncSession, observation: FxRateObservation) -> 
         )
     )
     try:
-        await db.commit()
+        await db.flush()
     except IntegrityError:
         await db.rollback()
         concurrent = await _load_stored_rate_on_date(db, base, quote, observation.rate_date)
@@ -671,7 +671,7 @@ async def _upsert_sync_state(
         state.last_observation_date = last_observation_date
         state.updated_at = observed_now
     try:
-        await db.commit()
+        await db.flush()
     except IntegrityError:
         await db.rollback()
         concurrent = await _load_sync_state(db, kind, scope)
@@ -681,7 +681,7 @@ async def _upsert_sync_state(
         concurrent.last_success_date = last_success_date
         concurrent.last_observation_date = last_observation_date
         concurrent.updated_at = observed_now
-        await db.commit()
+        await db.flush()
 
 
 async def _persist_stock_price(db: AsyncSession, observation: StockPriceObservation) -> Decimal:
@@ -703,7 +703,7 @@ async def _persist_stock_price(db: AsyncSession, observation: StockPriceObservat
         )
     )
     try:
-        await db.commit()
+        await db.flush()
     except IntegrityError:
         await db.rollback()
         concurrent = await _load_stored_stock_price_on_date(db, symbol, observation.price_date)

--- a/apps/backend/src/services/market_data_scheduler.py
+++ b/apps/backend/src/services/market_data_scheduler.py
@@ -35,6 +35,7 @@ async def run_daily_market_data_sync(
     async with session_factory() as session:
         fx_result = await sync_fx_rates(session)
         stock_result = await sync_stock_prices(session)
+        await session.commit()
     logger.info(
         "Daily market data sync completed",
         fx_requested=fx_result.requested,

--- a/apps/backend/tests/infra/test_transaction_boundaries.py
+++ b/apps/backend/tests/infra/test_transaction_boundaries.py
@@ -1,0 +1,186 @@
+"""EPIC-012 transaction-boundary guardrails."""
+
+from __future__ import annotations
+
+import ast
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import FxRate, StockPrice
+from src.services import market_data
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+SERVICE_ROOT = PROJECT_ROOT / "apps" / "backend" / "src" / "services"
+
+ALLOWED_SERVICE_COMMIT_BOUNDARIES = {
+    ("ai_advisor.py", "AIAdvisorService._stream_and_store"),
+    ("market_data_scheduler.py", "run_daily_market_data_sync"),
+    ("statement_parsing.py", "handle_parse_failure"),
+    ("statement_parsing.py", "import_brokerage_payload_if_present"),
+    ("statement_parsing.py", "parse_statement_background"),
+    ("statement_parsing.py", "parse_statement_background.update_progress"),
+    ("statement_parsing_supervisor.py", "reset_stale_parsing_jobs"),
+}
+
+
+class _CommitCallVisitor(ast.NodeVisitor):
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        self.stack: list[str] = []
+        self.calls: list[tuple[str, str, int]] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        self.stack.append(node.name)
+        self.generic_visit(node)
+        self.stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self._visit_callable(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        self._visit_callable(node)
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "commit":
+            self.calls.append((self.filename, ".".join(self.stack), node.lineno))
+        self.generic_visit(node)
+
+    def _visit_callable(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.stack.append(node.name)
+        self.generic_visit(node)
+        self.stack.pop()
+
+
+def _service_commit_calls() -> list[tuple[str, str, int]]:
+    calls: list[tuple[str, str, int]] = []
+    for path in sorted(SERVICE_ROOT.glob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        visitor = _CommitCallVisitor(path.name)
+        visitor.visit(tree)
+        calls.extend(visitor.calls)
+    return calls
+
+
+def test_service_commit_calls_are_documented_boundary_exceptions() -> None:
+    """AC12.26.1: service commit calls are limited to documented boundary exceptions."""
+    unexpected = [
+        f"{filename}:{lineno} in {qualname}"
+        for filename, qualname, lineno in _service_commit_calls()
+        if (filename, qualname) not in ALLOWED_SERVICE_COMMIT_BOUNDARIES
+    ]
+
+    assert unexpected == []
+
+
+@pytest.mark.asyncio
+async def test_market_data_fx_persistence_is_rollbackable_until_boundary_commit(db: AsyncSession) -> None:
+    """AC12.26.2: market-data persistence helpers flush but do not finalize transactions."""
+    rate = await market_data._persist_fx_rate(
+        db,
+        market_data.FxRateObservation(
+            base_currency="USD",
+            quote_currency="SGD",
+            rate=Decimal("1.350000"),
+            rate_date=date(2026, 1, 5),
+            source="test",
+        ),
+    )
+
+    assert rate == Decimal("1.350000")
+    await db.rollback()
+
+    persisted = await db.scalar(
+        select(FxRate)
+        .where(FxRate.base_currency == "USD")
+        .where(FxRate.quote_currency == "SGD")
+        .where(FxRate.rate_date == date(2026, 1, 5))
+    )
+    assert persisted is None
+
+
+@pytest.mark.asyncio
+async def test_market_data_sync_endpoint_commits_service_writes_at_router_boundary(
+    client: AsyncClient,
+    db: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC12.26.3: market-data sync endpoints commit service writes at the router boundary."""
+
+    async def fake_fetch(
+        _base_currency: str,
+        _quote_currency: str,
+        _start_date: date,
+        _end_date: date,
+    ) -> market_data.ValidatedMarketObservationSeries:
+        return market_data.ValidatedMarketObservationSeries(
+            observations=[
+                market_data.FxRateObservation(
+                    base_currency="USD",
+                    quote_currency="SGD",
+                    rate=Decimal("1.350000"),
+                    rate_date=date(2026, 1, 5),
+                    source="test",
+                )
+            ],
+            provider_success=True,
+        )
+
+    async def fake_stock_fetch(
+        _symbol: str,
+        _start_date: date,
+        _end_date: date,
+    ) -> market_data.ValidatedMarketObservationSeries:
+        return market_data.ValidatedMarketObservationSeries(
+            observations=[
+                market_data.StockPriceObservation(
+                    symbol="AAPL",
+                    price=Decimal("190.250000"),
+                    currency="USD",
+                    price_date=date(2026, 1, 5),
+                    source="test",
+                )
+            ],
+            provider_success=True,
+        )
+
+    monkeypatch.setattr(market_data, "_fetch_validated_fx_rate_series", fake_fetch)
+    monkeypatch.setattr(market_data, "_fetch_validated_stock_price_series", fake_stock_fetch)
+
+    fx_response = await client.post(
+        "/market-data/sync/fx",
+        json={
+            "pairs": ["USD/SGD"],
+            "start_date": "2026-01-05",
+            "end_date": "2026-01-05",
+        },
+    )
+    stock_response = await client.post(
+        "/market-data/sync/stocks",
+        json={
+            "symbols": ["AAPL"],
+            "start_date": "2026-01-05",
+            "end_date": "2026-01-05",
+        },
+    )
+
+    assert fx_response.status_code == 200
+    assert fx_response.json()["inserted"] == 1
+    assert stock_response.status_code == 200
+    assert stock_response.json()["inserted"] == 1
+    persisted = await db.scalar(
+        select(FxRate)
+        .where(FxRate.base_currency == "USD")
+        .where(FxRate.quote_currency == "SGD")
+        .where(FxRate.rate_date == date(2026, 1, 5))
+    )
+    assert persisted is not None
+    persisted_stock = await db.scalar(
+        select(StockPrice).where(StockPrice.symbol == "AAPL").where(StockPrice.price_date == date(2026, 1, 5))
+    )
+    assert persisted_stock is not None

--- a/apps/backend/tests/market_data/test_fx.py
+++ b/apps/backend/tests/market_data/test_fx.py
@@ -214,6 +214,13 @@ async def test_persist_fx_rate_handles_concurrent_insert():
         def one_or_none(self):
             return self._row
 
+    class NestedTransaction:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc_info):
+            return False
+
     class FakeSession:
         def __init__(self):
             self.execute_calls = 0
@@ -233,6 +240,9 @@ async def test_persist_fx_rate_handles_concurrent_insert():
         async def rollback(self):
             self.rolled_back = True
 
+        def begin_nested(self):
+            return NestedTransaction()
+
     session = FakeSession()
 
     result = await market_data._persist_fx_rate(
@@ -247,7 +257,7 @@ async def test_persist_fx_rate_handles_concurrent_insert():
     )
 
     assert result == Decimal("0.173500")
-    assert session.rolled_back is True
+    assert session.rolled_back is False
     assert session.added is not None
 
 
@@ -258,6 +268,13 @@ async def test_persist_fx_rate_reraises_integrity_error_without_concurrent_rate(
     class Result:
         def one_or_none(self):
             return None
+
+    class NestedTransaction:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc_info):
+            return False
 
     class FakeSession:
         async def execute(self, _stmt):
@@ -271,6 +288,9 @@ async def test_persist_fx_rate_reraises_integrity_error_without_concurrent_rate(
 
         async def rollback(self):
             return None
+
+        def begin_nested(self):
+            return NestedTransaction()
 
     with pytest.raises(IntegrityError):
         await market_data._persist_fx_rate(

--- a/apps/backend/tests/market_data/test_fx.py
+++ b/apps/backend/tests/market_data/test_fx.py
@@ -227,7 +227,7 @@ async def test_persist_fx_rate_handles_concurrent_insert():
         def add(self, value):
             self.added = value
 
-        async def commit(self):
+        async def flush(self):
             raise IntegrityError("insert fx", {}, Exception("duplicate"))
 
         async def rollback(self):
@@ -266,7 +266,7 @@ async def test_persist_fx_rate_reraises_integrity_error_without_concurrent_rate(
         def add(self, _value):
             return None
 
-        async def commit(self):
+        async def flush(self):
             raise IntegrityError("insert fx", {}, Exception("duplicate"))
 
         async def rollback(self):

--- a/apps/backend/tests/market_data/test_provider_parsers.py
+++ b/apps/backend/tests/market_data/test_provider_parsers.py
@@ -265,6 +265,13 @@ async def test_persist_stock_price_returns_concurrent_row_after_integrity_error(
 ) -> None:
     """AC11.10.1: Concurrent stock price inserts are resolved idempotently."""
 
+    class NestedTransaction:
+        async def __aenter__(self) -> "NestedTransaction":
+            return self
+
+        async def __aexit__(self, *_exc_info: object) -> bool:
+            return False
+
     class FakeDb:
         def add(self, _row: object) -> None:
             return None
@@ -274,6 +281,9 @@ async def test_persist_stock_price_returns_concurrent_row_after_integrity_error(
 
         async def rollback(self) -> None:
             return None
+
+        def begin_nested(self) -> NestedTransaction:
+            return NestedTransaction()
 
     calls = 0
 

--- a/apps/backend/tests/market_data/test_provider_parsers.py
+++ b/apps/backend/tests/market_data/test_provider_parsers.py
@@ -269,7 +269,7 @@ async def test_persist_stock_price_returns_concurrent_row_after_integrity_error(
         def add(self, _row: object) -> None:
             return None
 
-        async def commit(self) -> None:
+        async def flush(self) -> None:
             raise IntegrityError("insert", {}, Exception("duplicate"))
 
         async def rollback(self) -> None:

--- a/apps/backend/tests/market_data/test_scheduler.py
+++ b/apps/backend/tests/market_data/test_scheduler.py
@@ -23,7 +23,14 @@ def test_next_market_data_sync_at_uses_nightly_sgt_schedule() -> None:
 @pytest.mark.asyncio
 async def test_run_daily_market_data_sync_uses_sessionmaker(monkeypatch: pytest.MonkeyPatch) -> None:
     """AC11.10.10: Daily sync opens a DB session and runs FX then stock sync."""
-    session = object()
+
+    class FakeSession:
+        committed = False
+
+        async def commit(self) -> None:
+            self.committed = True
+
+    session = FakeSession()
     calls: list[tuple[str, object]] = []
 
     class FakeSessionMaker:
@@ -50,6 +57,7 @@ async def test_run_daily_market_data_sync_uses_sessionmaker(monkeypatch: pytest.
     await market_data_scheduler.run_daily_market_data_sync(sessionmaker=FakeSessionMaker())  # type: ignore[arg-type]
 
     assert calls == [("fx", session), ("stock", session)]
+    assert session.committed is True
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/market_data/test_sync.py
+++ b/apps/backend/tests/market_data/test_sync.py
@@ -663,7 +663,7 @@ async def test_persist_stock_price_reraises_integrity_error_without_concurrent_r
         def add(self, _row: object) -> None:
             return None
 
-        async def commit(self) -> None:
+        async def flush(self) -> None:
             raise IntegrityError("insert", {}, Exception("duplicate"))
 
         async def rollback(self) -> None:
@@ -698,14 +698,14 @@ async def test_upsert_sync_state_handles_concurrent_insert(monkeypatch: pytest.M
         updated_at = datetime(2026, 1, 4, tzinfo=UTC)
 
     class FakeDb:
-        commits = 0
+        flushes = 0
 
         def add(self, _row: object) -> None:
             return None
 
-        async def commit(self) -> None:
-            self.commits += 1
-            if self.commits == 1:
+        async def flush(self) -> None:
+            self.flushes += 1
+            if self.flushes == 1:
                 raise IntegrityError("insert", {}, Exception("duplicate"))
 
         async def rollback(self) -> None:
@@ -732,7 +732,7 @@ async def test_upsert_sync_state_handles_concurrent_insert(monkeypatch: pytest.M
         now=observed_now,
     )
 
-    assert db.commits == 2
+    assert db.flushes == 2
     assert state.last_success_at == observed_now
     assert state.last_success_date == date(2026, 1, 6)
 

--- a/apps/backend/tests/market_data/test_sync.py
+++ b/apps/backend/tests/market_data/test_sync.py
@@ -659,6 +659,13 @@ async def test_persist_stock_price_reraises_integrity_error_without_concurrent_r
 ) -> None:
     """AC11.10.1: Stock price persistence reraises unresolved concurrent insert errors."""
 
+    class NestedTransaction:
+        async def __aenter__(self) -> "NestedTransaction":
+            return self
+
+        async def __aexit__(self, *_exc_info: object) -> bool:
+            return False
+
     class FakeDb:
         def add(self, _row: object) -> None:
             return None
@@ -668,6 +675,9 @@ async def test_persist_stock_price_reraises_integrity_error_without_concurrent_r
 
         async def rollback(self) -> None:
             return None
+
+        def begin_nested(self) -> NestedTransaction:
+            return NestedTransaction()
 
     async def fake_load(*_args: object) -> None:
         return None
@@ -691,6 +701,13 @@ async def test_persist_stock_price_reraises_integrity_error_without_concurrent_r
 async def test_upsert_sync_state_handles_concurrent_insert(monkeypatch: pytest.MonkeyPatch) -> None:
     """AC11.10.9: Sync state upsert resolves concurrent inserts idempotently."""
 
+    class NestedTransaction:
+        async def __aenter__(self) -> "NestedTransaction":
+            return self
+
+        async def __aexit__(self, *_exc_info: object) -> bool:
+            return False
+
     class FakeState:
         last_success_at = datetime(2026, 1, 4, tzinfo=UTC)
         last_success_date = date(2026, 1, 4)
@@ -710,6 +727,9 @@ async def test_upsert_sync_state_handles_concurrent_insert(monkeypatch: pytest.M
 
         async def rollback(self) -> None:
             return None
+
+        def begin_nested(self) -> NestedTransaction:
+            return NestedTransaction()
 
     calls = 0
     state = FakeState()

--- a/apps/backend/tests/market_data/test_sync_router.py
+++ b/apps/backend/tests/market_data/test_sync_router.py
@@ -95,6 +95,31 @@ async def test_market_data_fx_sync_endpoint_rejects_invalid_pair(client: AsyncCl
 
 
 @pytest.mark.asyncio
+async def test_market_data_stock_sync_endpoint_rolls_back_service_value_error(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC12.26.3: Stock sync endpoint rolls back when the service rejects a request."""
+
+    async def fake_stock_sync(*_args, **_kwargs) -> market_data.MarketDataSyncResult:
+        raise ValueError("invalid symbol")
+
+    monkeypatch.setattr(market_data_router, "sync_stock_prices", fake_stock_sync)
+
+    response = await client.post(
+        "/market-data/sync/stocks",
+        json={
+            "symbols": ["BAD"],
+            "start_date": "2026-01-05",
+            "end_date": "2026-01-05",
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "invalid symbol"
+
+
+@pytest.mark.asyncio
 async def test_market_data_status_endpoint_returns_authenticated_scope_freshness(
     client: AsyncClient,
     db,

--- a/apps/backend/tests/market_data/test_sync_router.py
+++ b/apps/backend/tests/market_data/test_sync_router.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models import FxRate, MarketDataSyncState, StockPrice
 from src.routers import market_data as market_data_router, reports as reports_router
@@ -97,11 +99,22 @@ async def test_market_data_fx_sync_endpoint_rejects_invalid_pair(client: AsyncCl
 @pytest.mark.asyncio
 async def test_market_data_stock_sync_endpoint_rolls_back_service_value_error(
     client: AsyncClient,
+    db_engine,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """AC12.26.3: Stock sync endpoint rolls back when the service rejects a request."""
 
-    async def fake_stock_sync(*_args, **_kwargs) -> market_data.MarketDataSyncResult:
+    async def fake_stock_sync(db: AsyncSession, *_args, **_kwargs) -> market_data.MarketDataSyncResult:
+        db.add(
+            StockPrice(
+                symbol="BAD",
+                price=Decimal("1.000000"),
+                currency="USD",
+                price_date=date(2026, 1, 5),
+                source="test",
+            )
+        )
+        await db.flush()
         raise ValueError("invalid symbol")
 
     monkeypatch.setattr(market_data_router, "sync_stock_prices", fake_stock_sync)
@@ -117,6 +130,12 @@ async def test_market_data_stock_sync_endpoint_rolls_back_service_value_error(
 
     assert response.status_code == 422
     assert response.json()["detail"] == "invalid symbol"
+    sessionmaker = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with sessionmaker() as session:
+        persisted = await session.scalar(
+            select(StockPrice).where(StockPrice.symbol == "BAD").where(StockPrice.price_date == date(2026, 1, 5))
+        )
+    assert persisted is None
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/reporting/test_reports_router.py
+++ b/apps/backend/tests/reporting/test_reports_router.py
@@ -11,7 +11,8 @@ from decimal import Decimal
 from uuid import uuid4
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models import (
     Account,
@@ -21,6 +22,7 @@ from src.models import (
     JournalEntrySourceType,
     JournalEntryStatus,
     JournalLine,
+    StockPrice,
 )
 from src.routers import reports as reports_router
 from src.services.reporting import ReportError
@@ -128,11 +130,22 @@ async def test_trending_endpoint(client, test_data_setup_reports):
 @pytest.mark.asyncio
 async def test_net_worth_timeseries_endpoint_commits_boundary(
     client,
+    db_engine,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """AC12.26.2: Report endpoints commit flushed market-data writes at the router boundary."""
 
-    async def fake_timeseries(*_args, **_kwargs):
+    async def fake_timeseries(db: AsyncSession, *_args, **_kwargs):
+        db.add(
+            StockPrice(
+                symbol="REPORT",
+                price=Decimal("42.000000"),
+                currency="USD",
+                price_date=date(2026, 1, 31),
+                source="test",
+            )
+        )
+        await db.flush()
         return {
             "currency": "SGD",
             "granularity": "daily",
@@ -148,6 +161,12 @@ async def test_net_worth_timeseries_endpoint_commits_boundary(
 
     assert response.status_code == 200
     assert response.json()["points"] == []
+    sessionmaker = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with sessionmaker() as session:
+        persisted = await session.scalar(
+            select(StockPrice).where(StockPrice.symbol == "REPORT").where(StockPrice.price_date == date(2026, 1, 31))
+        )
+    assert persisted is not None
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/reporting/test_reports_router.py
+++ b/apps/backend/tests/reporting/test_reports_router.py
@@ -126,6 +126,31 @@ async def test_trending_endpoint(client, test_data_setup_reports):
 
 
 @pytest.mark.asyncio
+async def test_net_worth_timeseries_endpoint_commits_boundary(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC12.26.2: Report endpoints commit flushed market-data writes at the router boundary."""
+
+    async def fake_timeseries(*_args, **_kwargs):
+        return {
+            "currency": "SGD",
+            "granularity": "daily",
+            "points": [],
+        }
+
+    monkeypatch.setattr(reports_router, "get_net_worth_timeseries", fake_timeseries)
+
+    response = await client.get(
+        "/reports/net-worth/timeseries",
+        params={"from": "2026-01-01", "to": "2026-01-31", "granularity": "daily", "currency": "SGD"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["points"] == []
+
+
+@pytest.mark.asyncio
 async def test_breakdown_endpoint(client, test_data_setup_reports):
     """Test breakdown endpoint."""
     _, income = await test_data_setup_reports()

--- a/docs/infra_registry.yaml
+++ b/docs/infra_registry.yaml
@@ -871,6 +871,24 @@ groups:
         epic_name: foundation-libs
         description: UUID auto-serialization structlog processor remains EPIC-012 P2 backlog until implemented
         mandatory: true
+    AC12.26:
+      - id: AC12.26.1
+        epic: 12
+        epic_name: foundation-libs
+        description: Service modules only call commit() in documented background-task or streaming-response transaction-boundary
+          exceptions
+        mandatory: true
+      - id: AC12.26.2
+        epic: 12
+        epic_name: foundation-libs
+        description: Market-data persistence helpers use flush() so router/report/scheduler boundaries can roll back or commit
+          atomically
+        mandatory: true
+      - id: AC12.26.3
+        epic: 12
+        epic_name: foundation-libs
+        description: Market-data HTTP sync endpoints finalize service writes at the router boundary
+        mandatory: true
   AC14:
     AC14.1:
       - id: AC14.1.1

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -318,13 +318,21 @@ This EPIC addresses technical debt in the foundational libraries that all module
 |----|-----------|---------------|------|----------|
 | AC12.25.1 | UUID auto-serialization structlog processor remains EPIC-012 P2 backlog until implemented | `test_AC12_25_1_uuid_logging_residual_is_epic_owned` | `tests/tooling/test_archive_residual_epic_ownership.py` | P2 |
 
+### AC12.26: Transaction Boundary Ownership
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC12.26.1 | Service modules only call `commit()` in documented background-task or streaming-response transaction-boundary exceptions | `test_service_commit_calls_are_documented_boundary_exceptions` | `infra/test_transaction_boundaries.py` | P0 |
+| AC12.26.2 | Market-data persistence helpers use `flush()` so router/report/scheduler boundaries can roll back or commit atomically | `test_market_data_fx_persistence_is_rollbackable_until_boundary_commit` | `infra/test_transaction_boundaries.py` | P0 |
+| AC12.26.3 | Market-data HTTP sync endpoints finalize service writes at the router boundary | `test_market_data_sync_endpoint_commits_service_writes_at_router_boundary` | `infra/test_transaction_boundaries.py` | P0 |
+
 ## 📊 Progress Tracking
 
 | Phase | Task | Status | PR |
 |-------|------|--------|-----|
 | 0 | Audit & Documentation | ✅ Complete | This EPIC |
 | 1 | Distributed Tracing (H1) | ✅ Complete | Pending |
-| 2 | Transaction Boundaries (H2) | ⏳ Pending | - |
+| 2 | Transaction Boundaries (H2) | ⏳ In progress | AC12.26 |
 | 3 | Connection Pool Config (M1) | ✅ Complete | This PR |
 | 4 | Exception Hierarchy (M2) | ✅ Complete | This PR |
 | 5 | Rate Limiting (M3) | ✅ Complete | This PR |

--- a/docs/ssot/accounting.md
+++ b/docs/ssot/accounting.md
@@ -88,7 +88,7 @@ Debit and credit totals are valid only when their converted base amounts differ 
 - **Anti-pattern D**: **NEVER** call `db.commit()` in service-layer methods that receive a `db: AsyncSession` from a router.
     -   **Rule**: Services use `flush()` to assign IDs and validate constraints. Routers call `commit()` to finalize the transaction.
     -   **Documented Exceptions**:
-        1. **Background tasks** with own sessions (via `session_maker()`/`session_factory()`): These create their own `AsyncSession` and ARE the transaction boundary. Example: `statement_parsing.py::parse_statement_background()`, `statement_parsing_supervisor.py::reset_stale_parsing_jobs()`.
+        1. **Background tasks** with own sessions (via `session_maker()`/`session_factory()`): These create their own `AsyncSession` and ARE the transaction boundary. Example: `statement_parsing.py::parse_statement_background()`, `statement_parsing_supervisor.py::reset_stale_parsing_jobs()`, `market_data_scheduler.py::run_daily_market_data_sync()`.
         2. **Streaming generators** that outlive the router response: When a router returns `StreamingResponse`, the async generator runs after the router has returned. The generator must own the final `commit()` for data written during streaming. Example: `ai_advisor.py::_stream_and_store()` commits the assistant message after streaming completes.
     -   **Enforcement**: `apps/backend/tests/ai/test_commit_boundary.py` verifies flush-only behavior in AI advisor service methods.
 


### PR DESCRIPTION
## Summary

Hardens EPIC-012 transaction-boundary ownership for market-data persistence: service helpers now flush, while router/report/scheduler boundaries own commit/rollback.

Closes #622

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-012 — Foundation Libraries |
| **AC IDs** | AC12.26.1, AC12.26.2, AC12.26.3 |
| **AC Registry updated** | `docs/infra_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/accounting.md` — documents market-data scheduler as a session-owned background transaction-boundary exception
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `not preserved as standalone commit` | Added AC12.26 transaction-boundary tests before implementation; local DB-backed pytest was blocked by Podman/Postgres availability. |
| 🟢 Green (passing test) | `17e9ce3` | Implemented service flush semantics and boundary commits; static/lint/traceability gates pass. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no enum changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable; no frontend/env changes)
- [x] `repo/` submodule updated for production config changes (not applicable; no production config changes)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes (if SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner. (Not applicable; no lifecycle tooling changes.)
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys. (No log changes.)
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged. (No diagnostics changes.)
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials. (No VPS hygiene changes.)
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule. (No cleanup changes.)
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene. (Not applicable; no runtime infra lifecycle changes.)

---

## Testing

```bash
# Passed
moon run :lint
python tools/generate_ac_registry.py --check
python -m common.ssot.check_ac_traceability --registry docs/ac_registry.yaml --infra-registry docs/infra_registry.yaml
python tools/check_manifest.py
python tools/lint_doc_consistency.py
python -m common.ssot.check_critical_proof_matrix
uv run ruff check src/routers/market_data.py src/routers/reports.py src/services/market_data.py src/services/market_data_scheduler.py tests/infra/test_transaction_boundaries.py tests/market_data/test_fx.py tests/market_data/test_provider_parsers.py tests/market_data/test_scheduler.py tests/market_data/test_sync.py
uv run ruff format --check src/routers/market_data.py src/routers/reports.py src/services/market_data.py src/services/market_data_scheduler.py tests/infra/test_transaction_boundaries.py tests/market_data/test_fx.py tests/market_data/test_provider_parsers.py tests/market_data/test_scheduler.py tests/market_data/test_sync.py
python - <<'PY'
# AST service commit guardrail equivalent; reported unexpected []
PY
```

```bash
# Blocked locally by Podman/Postgres environment, not by test assertions
moon run :test
uv run pytest tests/infra/test_transaction_boundaries.py::test_service_commit_calls_are_documented_boundary_exceptions -q -n 0 --no-cov
uv run pytest tests/market_data/test_scheduler.py tests/market_data/test_fx.py::test_persist_fx_rate_handles_concurrent_insert tests/market_data/test_fx.py::test_persist_fx_rate_reraises_integrity_error_without_concurrent_rate tests/market_data/test_provider_parsers.py::test_persist_stock_price_returns_concurrent_row_after_integrity_error tests/market_data/test_sync.py::test_persist_stock_price_reraises_integrity_error_without_concurrent_row tests/market_data/test_sync.py::test_upsert_sync_state_handles_concurrent_insert -q -n 0 --no-cov
```

Local blocker details: `podman machine start` reports success, but `podman info` and compose still fail with `connect: connection refused` for the configured Podman socket/SSH port, so test DB startup cannot complete on this machine.

---

## Screenshots / Evidence

_N/A_
