### PR TITLE
[finance_report_vision] test: close personal report package fixture proof

### DIFF
--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+from copy import deepcopy
 from datetime import date, timedelta
 from decimal import Decimal
 from enum import Enum
@@ -16,7 +17,16 @@ from sqlalchemy import select, union
 from src.config import settings
 from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
-from src.models import Account, AccountType, Direction, FxRate, JournalEntry, JournalEntryStatus, JournalLine
+from src.models import (
+    Account,
+    AccountType,
+    BankStatement,
+    Direction,
+    FxRate,
+    JournalEntry,
+    JournalEntryStatus,
+    JournalLine,
+)
 from src.models.layer3 import (
     ManualValuationComponentType,
     ManualValuationLiquidityClass,
@@ -529,6 +539,102 @@ PERSONAL_REPORT_PACKAGE_TRACEABILITY: dict = {
 }
 
 
+def _sorted_unique_identifiers(values: list[object]) -> list[str]:
+    return sorted({str(value) for value in values if value is not None})
+
+
+def _line_by_id(payload: dict, line_id: str) -> dict:
+    return next(line for line in payload["lines"] if line["line_id"] == line_id)
+
+
+async def _enrich_package_traceability_identifiers(
+    payload: dict,
+    *,
+    db: DbSession | None,
+    user_id: CurrentUserId | None,
+    start_date: date | None,
+    end_date: date | None,
+    as_of_date: date | None,
+) -> dict:
+    """Attach concrete source, ledger, and manual valuation IDs when request context is available."""
+    if db is None or user_id is None:
+        return payload
+
+    journal_filters = [
+        JournalEntry.user_id == user_id,
+        JournalEntry.status.in_([JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED]),
+    ]
+    if start_date is not None:
+        journal_filters.append(JournalEntry.entry_date >= start_date)
+    if end_date is not None:
+        journal_filters.append(JournalEntry.entry_date <= end_date)
+    elif as_of_date is not None:
+        journal_filters.append(JournalEntry.entry_date <= as_of_date)
+
+    journal_result = await db.execute(
+        select(JournalEntry.id, JournalEntry.source_id, JournalLine.id)
+        .join(JournalLine, JournalLine.journal_entry_id == JournalEntry.id)
+        .where(*journal_filters)
+    )
+    journal_rows = journal_result.all()
+    journal_entry_ids = _sorted_unique_identifiers([row[0] for row in journal_rows])
+    source_ids = _sorted_unique_identifiers([row[1] for row in journal_rows])
+    journal_line_ids = _sorted_unique_identifiers([row[2] for row in journal_rows])
+    ledger_identifiers = _sorted_unique_identifiers([*journal_entry_ids, *journal_line_ids])
+
+    manual_filters = [ManualValuationSnapshot.user_id == user_id]
+    if as_of_date is not None:
+        manual_filters.append(ManualValuationSnapshot.as_of_date <= as_of_date)
+    manual_result = await db.execute(select(ManualValuationSnapshot).where(*manual_filters))
+    manual_snapshots = list(manual_result.scalars().all())
+    manual_ids = _sorted_unique_identifiers([snapshot.id for snapshot in manual_snapshots])
+    restricted_ids = _sorted_unique_identifiers(
+        [
+            snapshot.id
+            for snapshot in manual_snapshots
+            if snapshot.component_type
+            in (
+                ManualValuationComponentType.ESOP,
+                ManualValuationComponentType.RSU,
+                ManualValuationComponentType.STOCK_OPTIONS,
+            )
+            and snapshot.liquidity_class == ManualValuationLiquidityClass.RESTRICTED
+        ]
+    )
+
+    statement_filters = [BankStatement.user_id == user_id]
+    if start_date is not None:
+        statement_filters.append(BankStatement.period_end >= start_date)
+    if end_date is not None:
+        statement_filters.append(BankStatement.period_start <= end_date)
+    elif as_of_date is not None:
+        statement_filters.append(BankStatement.period_start <= as_of_date)
+    statement_result = await db.execute(select(BankStatement.id).where(*statement_filters))
+    statement_ids = _sorted_unique_identifiers([row[0] for row in statement_result.all()])
+
+    source_identifiers = _sorted_unique_identifiers([*statement_ids, *source_ids])
+    total_asset_source_identifiers = _sorted_unique_identifiers([*source_identifiers, *manual_ids])
+
+    for line_id in (
+        "income_statement.total_income",
+        "income_statement.total_expenses",
+        "cash_flow.net_cash_flow",
+        "annualized_income_long_term.annualized_total",
+    ):
+        line = _line_by_id(payload, line_id)
+        line["source_anchor"]["identifiers"] = source_identifiers
+        line["ledger_anchor"]["identifiers"] = ledger_identifiers
+
+    total_assets = _line_by_id(payload, "balance_sheet.total_assets")
+    total_assets["source_anchor"]["identifiers"] = total_asset_source_identifiers
+    total_assets["ledger_anchor"]["identifiers"] = ledger_identifiers
+
+    restricted = _line_by_id(payload, "annualized_income_long_term.restricted_fair_value_total")
+    restricted["source_anchor"]["identifiers"] = restricted_ids
+
+    return payload
+
+
 def _annualized_income_bucket(account_name: str) -> str | None:
     normalized = account_name.casefold()
     if "salary" in normalized or "payroll" in normalized:
@@ -553,9 +659,23 @@ def personal_report_package_notes() -> PersonalReportPackageNotesResponse:
 
 
 @router.get("/package/traceability", response_model=PersonalReportPackageTraceabilityResponse)
-def personal_report_package_traceability() -> PersonalReportPackageTraceabilityResponse:
+async def personal_report_package_traceability(
+    start_date: date | None = Query(default=None),
+    end_date: date | None = Query(default=None),
+    as_of_date: date | None = Query(default=None),
+    db: DbSession = None,
+    user_id: CurrentUserId = None,
+) -> PersonalReportPackageTraceabilityResponse:
     """Return the package-level source-ledger-report traceability appendix."""
-    return PersonalReportPackageTraceabilityResponse(**PERSONAL_REPORT_PACKAGE_TRACEABILITY)
+    payload = await _enrich_package_traceability_identifiers(
+        deepcopy(PERSONAL_REPORT_PACKAGE_TRACEABILITY),
+        db=db,
+        user_id=user_id,
+        start_date=start_date,
+        end_date=end_date,
+        as_of_date=as_of_date,
+    )
+    return PersonalReportPackageTraceabilityResponse(**payload)
 
 
 @router.get("/package/annualized-income-schedule", response_model=AnnualizedIncomeScheduleResponse)

--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -239,6 +239,7 @@ class PersonalReportPackageTraceabilityAnchor(BaseModel):
     source_types: list[str] = Field(default_factory=list)
     entry_statuses: list[str] = Field(default_factory=list)
     identifier_fields: list[str] = Field(default_factory=list)
+    identifiers: list[str] = Field(default_factory=list)
     unavailable_reason: str | None = None
 
 

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -1,7 +1,24 @@
 """Personal report package API contract coverage."""
 
-import pytest
+from datetime import date
+from decimal import Decimal
 
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import (
+    Account,
+    AccountType,
+    BankStatement,
+    BankStatementStatus,
+    BankStatementTransaction,
+    Direction,
+    JournalEntry,
+    JournalEntrySourceType,
+    JournalEntryStatus,
+    JournalLine,
+)
+from src.models.layer3 import ManualValuationComponentType, ManualValuationLiquidityClass, ManualValuationSnapshot
 from src.routers.reports import (
     personal_report_package_contract,
     personal_report_package_notes,
@@ -131,9 +148,10 @@ def test_AC5_12_2_package_contract_marks_notes_ready():
     assert section["source_endpoint"] == "/api/reports/package/notes"
 
 
-def test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors():
+@pytest.mark.asyncio
+async def test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors():
     """AC5.13.1: Package traceability endpoint returns source-to-ledger anchors per report line."""
-    response = personal_report_package_traceability()
+    response = await personal_report_package_traceability()
     payload = response.model_dump(mode="json")
 
     assert payload["section_id"] == "traceability_appendix"
@@ -156,9 +174,10 @@ def test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors():
     assert total_assets["confidence_tier"] == "TRUSTED"
 
 
-def test_AC5_13_2_package_traceability_declares_completeness_warnings():
+@pytest.mark.asyncio
+async def test_AC5_13_2_package_traceability_declares_completeness_warnings():
     """AC5.13.2: Traceability appendix exposes explicit completeness states where anchors are unavailable."""
-    response = personal_report_package_traceability()
+    response = await personal_report_package_traceability()
     payload = response.model_dump(mode="json")
 
     lines = {line["line_id"]: line for line in payload["lines"]}
@@ -180,3 +199,106 @@ def test_AC5_13_2_package_traceability_declares_completeness_warnings():
         assert line["ledger_anchor"]["state"] in {"available", "not_applicable", "unavailable"}
         assert line["review_state"]
         assert line["confidence_tier"] in {"TRUSTED", "HIGH", "MEDIUM", "LOW", "UNAVAILABLE"}
+
+
+@pytest.mark.asyncio
+async def test_AC8_13_85_package_traceability_returns_dynamic_identifiers(
+    client,
+    db: AsyncSession,
+    test_user,
+):
+    """AC8.13.85: Package traceability anchors include concrete source, ledger, and manual IDs."""
+    bank_account = Account(user_id=test_user.id, name="Package Bank", type=AccountType.ASSET, currency="SGD")
+    income_account = Account(user_id=test_user.id, name="Salary Income", type=AccountType.INCOME, currency="SGD")
+    db.add_all([bank_account, income_account])
+    await db.flush()
+
+    statement = BankStatement(
+        user_id=test_user.id,
+        account_id=bank_account.id,
+        file_path="/tmp/package_fixture.csv",
+        file_hash="package-fixture-hash",
+        original_filename="package_fixture.csv",
+        institution="Package Fixture Bank",
+        account_last4="1234",
+        currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 31),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("1000.00"),
+        status=BankStatementStatus.APPROVED,
+        balance_validated=True,
+    )
+    db.add(statement)
+    await db.flush()
+
+    transaction = BankStatementTransaction(
+        statement_id=statement.id,
+        txn_date=date(2026, 5, 2),
+        description="Package salary",
+        amount=Decimal("1000.00"),
+        direction="IN",
+        currency="SGD",
+    )
+    db.add(transaction)
+    await db.flush()
+
+    entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=date(2026, 5, 2),
+        memo="Package salary",
+        source_type=JournalEntrySourceType.USER_CONFIRMED,
+        source_id=transaction.id,
+        status=JournalEntryStatus.RECONCILED,
+    )
+    db.add(entry)
+    await db.flush()
+    bank_line = JournalLine(
+        journal_entry_id=entry.id,
+        account_id=bank_account.id,
+        direction=Direction.DEBIT,
+        amount=Decimal("1000.00"),
+        currency="SGD",
+    )
+    income_line = JournalLine(
+        journal_entry_id=entry.id,
+        account_id=income_account.id,
+        direction=Direction.CREDIT,
+        amount=Decimal("1000.00"),
+        currency="SGD",
+    )
+    restricted_snapshot = ManualValuationSnapshot(
+        user_id=test_user.id,
+        component_type=ManualValuationComponentType.RSU,
+        liquidity_class=ManualValuationLiquidityClass.RESTRICTED,
+        as_of_date=date(2026, 5, 31),
+        value=Decimal("42000.00"),
+        currency="SGD",
+        source="ACME RSU",
+        notes="RSU vesting 25% annually",
+    )
+    db.add_all([bank_line, income_line, restricted_snapshot])
+    await db.commit()
+
+    response = await client.get(
+        "/reports/package/traceability",
+        params={
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-31",
+            "as_of_date": "2026-05-31",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    lines = {line["line_id"]: line for line in payload["lines"]}
+    total_income = lines["income_statement.total_income"]
+    assert str(statement.id) in total_income["source_anchor"]["identifiers"]
+    assert str(transaction.id) in total_income["source_anchor"]["identifiers"]
+    assert str(entry.id) in total_income["ledger_anchor"]["identifiers"]
+    assert str(bank_line.id) in total_income["ledger_anchor"]["identifiers"]
+    assert str(income_line.id) in total_income["ledger_anchor"]["identifiers"]
+
+    restricted = lines["annualized_income_long_term.restricted_fair_value_total"]
+    assert str(restricted_snapshot.id) in restricted["source_anchor"]["identifiers"]
+    assert restricted["ledger_anchor"]["state"] == "not_applicable"

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -200,6 +200,7 @@ export interface PersonalReportPackageTraceabilityAnchor {
     source_types?: string[];
     entry_statuses?: string[];
     identifier_fields?: string[];
+    identifiers?: string[];
     unavailable_reason?: string | null;
 }
 

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2369,6 +2369,26 @@ groups:
         description: Playwright responsive UX coverage proves account and review layouts avoid mobile document overflow and
           desktop local table clipping.
         mandatory: true
+      - id: AC8.13.83
+        epic: 8
+        epic_name: testing-strategy
+        description: Representative package fixture exposes exact Decimal expected outputs.
+        mandatory: true
+      - id: AC8.13.84
+        epic: 8
+        epic_name: testing-strategy
+        description: Fixture covers required sections, notes, traceability lines, and warnings.
+        mandatory: true
+      - id: AC8.13.85
+        epic: 8
+        epic_name: testing-strategy
+        description: Traceability appendix returns concrete source, ledger, and manual IDs.
+        mandatory: true
+      - id: AC8.13.86
+        epic: 8
+        epic_name: testing-strategy
+        description: Critical package E2E consumes the fixture and fails on package drift.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1
@@ -4119,32 +4139,33 @@ groups:
       - id: AC16.30.1
         epic: 16
         epic_name: two-stage-review-ui
-        description: IconButton keeps its required label as the authoritative accessible name so callers cannot override or remove
-          it through passthrough props.
+        description: IconButton keeps its required label as the authoritative accessible name so callers cannot override or
+          remove it through passthrough props.
         mandatory: true
       - id: AC16.30.2
         epic: 16
         epic_name: two-stage-review-ui
-        description: The design-token follow-ups from issues 612 and 613 are resolved; border tokens are documented, core recipes
-          use border-border, alert variants use semantic status token classes, and SSOT examples use accurate fence language.
+        description: The design-token follow-ups from issues 612 and 613 are resolved; border tokens are documented, core
+          recipes use border-border, alert variants use semantic status token classes, and SSOT examples use accurate fence
+          language.
         mandatory: true
       - id: AC16.30.3
         epic: 16
         epic_name: two-stage-review-ui
-        description: WorkspaceTabs uses one coherent navigation/list semantic model with aria-current for the active route while
-          preserving keyboard navigation between open workspace pages.
+        description: WorkspaceTabs uses one coherent navigation/list semantic model with aria-current for the active route
+          while preserving keyboard navigation between open workspace pages.
         mandatory: true
       - id: AC16.30.4
         epic: 16
         epic_name: two-stage-review-ui
-        description: Component tests cover keyboard and ARIA behavior for dialog, sheet, toast, workspace navigation, and icon-only
-          controls.
+        description: Component tests cover keyboard and ARIA behavior for dialog, sheet, toast, workspace navigation, and
+          icon-only controls.
         mandatory: true
       - id: AC16.30.5
         epic: 16
         epic_name: two-stage-review-ui
-        description: Playwright visual smoke covers desktop and mobile representative app-shell, accounts, statements, and review
-          pages with stable visual anchors and nonblank screenshots.
+        description: Playwright visual smoke covers desktop and mobile representative app-shell, accounts, statements, and
+          review pages with stable visual anchors and nonblank screenshots.
         mandatory: true
       - id: AC16.30.6
         epic: 16

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-06-03 04:08:32 UTC by `tools/analyze_test_ac_coverage.py`
+> Generated: 2026-06-03 07:18:27 UTC by `tools/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 1102 |
-| Active ACs | 942 |
+| Registered ACs | 1122 |
+| Active ACs | 962 |
 | Deprecated ACs excluded from coverage gate | 160 |
-| Covered by real test candidates | 942 (100.0%) |
+| Covered by real test candidates | 962 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -32,11 +32,11 @@
 
 | Source | Files scanned | Unique AC refs (real) | Unique AC refs (placeholder) | Unique AC refs (stub) |
 |---|---:|---:|---:|---:|
-| backend | 178 | 698 | 0 | 0 |
-| frontend | 82 | 212 | 0 | 0 |
-| frontend_playwright | 2 | 11 | 0 | 0 |
-| tooling_tests | 53 | 258 | 0 | 0 |
-| e2e | 13 | 60 | 0 | 0 |
+| backend | 178 | 703 | 0 | 0 |
+| frontend | 83 | 222 | 0 | 0 |
+| frontend_playwright | 3 | 12 | 0 | 0 |
+| tooling_tests | 54 | 260 | 0 | 0 |
+| e2e | 14 | 65 | 0 | 0 |
 
 ## Coverage by EPIC
 
@@ -44,12 +44,12 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|
 | EPIC-001 | phase0-setup | 29 | 2 | 27 | 0 | 0 | 0 | 100.0% |
 | EPIC-002 | double-entry-core | 62 | 15 | 47 | 0 | 0 | 0 | 100.0% |
-| EPIC-003 | statement-parsing | 60 | 20 | 40 | 0 | 0 | 0 | 100.0% |
+| EPIC-003 | statement-parsing | 62 | 20 | 42 | 0 | 0 | 0 | 100.0% |
 | EPIC-004 | reconciliation-engine | 41 | 21 | 20 | 0 | 0 | 0 | 100.0% |
-| EPIC-005 | reporting-visualization | 50 | 11 | 39 | 0 | 0 | 0 | 100.0% |
+| EPIC-005 | reporting-visualization | 54 | 11 | 43 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 8 | 55 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-008 | testing-strategy | 139 | 6 | 133 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 143 | 6 | 137 | 0 | 0 | 0 | 100.0% |
 | EPIC-009 | pdf-fixture-generation | 37 | 1 | 36 | 0 | 0 | 0 | 100.0% |
 | EPIC-010 | signoz-logging | 25 | 0 | 25 | 0 | 0 | 0 | 100.0% |
 | EPIC-011 | asset-lifecycle | 51 | 0 | 51 | 0 | 0 | 0 | 100.0% |
@@ -57,7 +57,7 @@
 | EPIC-013 | statement-parsing-v2 | 60 | 2 | 58 | 0 | 0 | 0 | 100.0% |
 | EPIC-014 | ttd-transformation | 6 | 0 | 6 | 0 | 0 | 0 | 100.0% |
 | EPIC-015 | processing-account | 31 | 0 | 31 | 0 | 0 | 0 | 100.0% |
-| EPIC-016 | two-stage-review-ui | 231 | 24 | 207 | 0 | 0 | 0 | 100.0% |
+| EPIC-016 | two-stage-review-ui | 241 | 24 | 217 | 0 | 0 | 0 | 100.0% |
 | EPIC-017 | portfolio-management | 91 | 43 | 48 | 0 | 0 | 0 | 100.0% |
 | EPIC-018 | ai-driven-pipeline | 24 | 0 | 24 | 0 | 0 | 0 | 100.0% |
 

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -364,12 +364,13 @@ Closure status:
    input consumed by this package (#566).
 5. Done: deliver notes/disclosures for the package output shape (#571).
 6. Done: deliver the traceability appendix for the package output shape (#572).
-7. Build deterministic fixture coverage (#573) against the same contract and
-   schedules, then extend the #565 guard as those package sections become
-   report-ready.
+7. Done: #573 builds deterministic representative fixture coverage against the
+   same contract and schedules, and the #565 guard now consumes the fixture
+   contract for exact totals, notes, traceability anchors, and package section
+   completeness.
 
-The macro outcome remains `partial` until representative fixture coverage
-(#573) closes.
+The macro outcome is `covered` in `docs/ssot/critical-proof-matrix.yaml` once
+the #573 representative fixture proof is present.
 
 ## 📄 Owned Documentation Surfaces
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -106,6 +106,10 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.80**: AC coverage analysis supports no-write and stale-report check modes for local verification.
 - **AC8.13.81**: Coverage threshold documentation links to code-owned thresholds instead of copying mutable numeric values.
 - **AC8.13.60**: Deploy workflows do not keep no-op dependency checks or warning-only performance probes that cannot block release risk.
+- **AC8.13.83**: Representative package fixture exposes exact Decimal expected outputs.
+- **AC8.13.84**: Fixture covers required sections, notes, traceability lines, and warnings.
+- **AC8.13.85**: Traceability appendix returns concrete source, ledger, and manual IDs.
+- **AC8.13.86**: Critical package E2E consumes the fixture and fails on package drift.
 - **AC8.13.61**: Visual regression residual is explicitly owned by EPIC-008 as a P3 future testing capability.
 - **AC8.13.62**: Test observability residuals are explicitly owned by EPIC-008 with current replacements and future dashboard/notification/trend scope.
 - **AC8.13.64**: Production release verifies DB, S3, API, frontend, and SigNoz health before completing deploy.
@@ -512,6 +516,10 @@ These scenarios represent the "Vertical Slices" of user value.
 | AC8.13.80 | AC coverage analysis supports no-write and stale-report check modes for local verification | `test_AC8_13_80_*` | `tests/tooling/test_analyze_test_ac_coverage.py` | P0 |
 | AC8.13.81 | Coverage threshold documentation links to code-owned thresholds instead of copying mutable numeric values | `test_AC8_13_81_*` | `tests/tooling/test_lint_doc_consistency.py` | P1 |
 | AC8.13.82 | Playwright responsive UX coverage proves account and review layouts avoid mobile document overflow and desktop local table clipping | `AC2.12.3`, `AC16.27.2`, `AC16.27.3` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 |
+| AC8.13.83 | Representative package fixture exposes exact Decimal expected outputs | `test_AC8_13_83_personal_report_package_fixture_has_exact_decimal_expected_outputs` | `tests/tooling/test_personal_report_package_fixture_contract.py` | P0 |
+| AC8.13.84 | Fixture covers required sections, notes, traceability lines, and warnings | `test_AC8_13_84_personal_report_package_fixture_covers_required_package_sections`, `test_personal_financial_report_package_post_merge_journey` | `tests/tooling/test_personal_report_package_fixture_contract.py`, `tests/e2e/test_personal_financial_report_package.py` | P0 |
+| AC8.13.85 | Traceability appendix returns concrete source, ledger, and manual IDs | `test_AC8_13_85_package_traceability_returns_dynamic_identifiers`, `test_personal_financial_report_package_post_merge_journey` | `apps/backend/tests/api/test_personal_report_package_contract.py`, `tests/e2e/test_personal_financial_report_package.py` | P0 |
+| AC8.13.86 | Critical package E2E consumes the fixture and fails on package drift | `test_personal_financial_report_package_post_merge_journey` | `tests/e2e/test_personal_financial_report_package.py` | P0 |
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.
@@ -626,9 +634,9 @@ finance_report AC coverage.
      2. Package content inputs: [#564](https://github.com/wangzitian0/finance_report/issues/564), [#566](https://github.com/wangzitian0/finance_report/issues/566)
      3. Explanatory output layers: [#571](https://github.com/wangzitian0/finance_report/issues/571), [#572](https://github.com/wangzitian0/finance_report/issues/572)
      4. Representative fixture contract: [#573](https://github.com/wangzitian0/finance_report/issues/573)
-   - **Prerequisite fixture**: [#573](https://github.com/wangzitian0/finance_report/issues/573) owns the representative fresh-user fixture contract: bank cash, income/expense activity, brokerage holdings, market prices, dividends, manual valuation, liability, restricted holdings, reviewed sources, exact expected totals, notes, and traceability anchors.
+   - **Representative fixture**: [#573](https://github.com/wangzitian0/finance_report/issues/573) owns the representative fresh-user fixture contract: bank cash, income/expense activity, brokerage holdings, market prices, dividends, manual valuation, liability, restricted holdings, reviewed sources, exact expected totals, notes, and traceability anchors.
    - **Contract dependencies**: [#570](https://github.com/wangzitian0/finance_report/issues/570) owns section/API shape, [#571](https://github.com/wangzitian0/finance_report/issues/571) owns notes/disclosures, and [#572](https://github.com/wangzitian0/finance_report/issues/572) owns the traceability appendix.
-   - **Closure rule**: Partial. `personal-financial-report-package` points to `personal-financial-report-package-post-merge` as its baseline proof, and remains `partial` in `docs/ssot/critical-proof-matrix.yaml` until #573 closes.
+   - **Closure rule**: Covered. `personal-financial-report-package` points to `personal-financial-report-package-post-merge`, and the #573 fixture contract expands the baseline proof into representative exact-output package coverage.
 
 1. **Statement Upload Parsing** (`test_statement_upload_e2e.py`):
    - **Status**: ✅ Fixed (Tier 3 assertion now blocks immediate AI/OCR rejection)

--- a/docs/ssot/critical-proof-matrix.yaml
+++ b/docs/ssot/critical-proof-matrix.yaml
@@ -7,7 +7,7 @@ description: >
 outcomes:
   - id: personal-financial-report-package
     question: "Can I generate one auditable personal financial-report package with statements, schedules, notes, and source traceability?"
-    status: partial
+    status: covered
     owner_epics:
       - EPIC-005
       - EPIC-008
@@ -180,6 +180,10 @@ proofs:
       - AC5.8.1
       - AC5.12.4
       - AC5.13.4
+      - AC8.13.83
+      - AC8.13.84
+      - AC8.13.85
+      - AC8.13.86
       - AC11.8.3
       - AC11.9.1
       - AC11.9.2

--- a/tests/e2e/personal_report_package_fixture.py
+++ b/tests/e2e/personal_report_package_fixture.py
@@ -1,0 +1,197 @@
+"""Reusable representative fixture contract for the personal report package E2E."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+
+def _money(value: object) -> Decimal:
+    return Decimal(str(value)).quantize(Decimal("0.01"))
+
+
+@dataclass(frozen=True)
+class BankTransactionFixture:
+    txn_date: date
+    description: str
+    amount: Decimal
+
+
+@dataclass(frozen=True)
+class ManualValuationFixture:
+    component_type: str
+    value: Decimal
+    source: str
+    notes: str
+
+
+@dataclass(frozen=True)
+class PersonalReportPackageFixture:
+    """Deterministic package-completeness fixture and exact expected outputs."""
+
+    institution: str
+    brokerage_source: str
+    brokerage_institution: str
+    currency: str
+    bank_transactions: tuple[BankTransactionFixture, ...]
+    property_value: ManualValuationFixture
+    mortgage_balance: ManualValuationFixture
+    esop: ManualValuationFixture
+    rsu: ManualValuationFixture
+    stock_options: ManualValuationFixture
+    required_sections: frozenset[str]
+    required_note_ids: frozenset[str]
+    required_traceability_lines: frozenset[str]
+    required_traceability_warnings: frozenset[str]
+
+    @property
+    def period_start(self) -> date:
+        return min(row.txn_date for row in self.bank_transactions)
+
+    @property
+    def period_end(self) -> date:
+        return max(row.txn_date for row in self.bank_transactions)
+
+    @property
+    def transaction_count(self) -> int:
+        return len(self.bank_transactions)
+
+    @property
+    def income(self) -> Decimal:
+        return _money(sum((row.amount for row in self.bank_transactions if row.amount > 0), Decimal("0.00")))
+
+    @property
+    def expenses(self) -> Decimal:
+        return _money(sum((-row.amount for row in self.bank_transactions if row.amount < 0), Decimal("0.00")))
+
+    @property
+    def net_income(self) -> Decimal:
+        return _money(self.income - self.expenses)
+
+    @property
+    def bank_cash(self) -> Decimal:
+        return self.net_income
+
+    @property
+    def restricted_fair_value_total(self) -> Decimal:
+        return _money(self.esop.value + self.rsu.value + self.stock_options.value)
+
+    @property
+    def mortgage_liability(self) -> Decimal:
+        return self.mortgage_balance.value
+
+    @property
+    def net_worth_adjustment_gain_loss(self) -> Decimal:
+        return _money(
+            self.property_value.value
+            + self.restricted_fair_value_total
+            - self.mortgage_balance.value
+        )
+
+    def total_assets(self, brokerage_value: Decimal) -> Decimal:
+        return _money(
+            brokerage_value
+            + self.property_value.value
+            + self.restricted_fair_value_total
+            + self.bank_cash
+        )
+
+    def write_bank_csv(self, directory: Path) -> Path:
+        path = directory / "personal_report_package_bank_statement.csv"
+        with path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["Date", "Description", "Amount"])
+            for row in self.bank_transactions:
+                writer.writerow([row.txn_date.isoformat(), row.description, str(row.amount)])
+        return path
+
+
+PERSONAL_REPORT_PACKAGE_FIXTURE = PersonalReportPackageFixture(
+    institution="Personal Report Package Bank",
+    brokerage_source="moomoo",
+    brokerage_institution="Moomoo Personal Package",
+    currency="SGD",
+    bank_transactions=(
+        BankTransactionFixture(date(2026, 5, 2), "Salary", Decimal("5000.00")),
+        BankTransactionFixture(date(2026, 5, 3), "Freelance", Decimal("600.00")),
+        BankTransactionFixture(date(2026, 5, 5), "Rent", Decimal("-1500.00")),
+        BankTransactionFixture(date(2026, 5, 12), "Groceries", Decimal("-250.00")),
+        BankTransactionFixture(date(2026, 5, 18), "Utilities", Decimal("-120.00")),
+        BankTransactionFixture(date(2026, 5, 19), "Travel", Decimal("-3730.00")),
+    ),
+    property_value=ManualValuationFixture(
+        component_type="property_value",
+        value=Decimal("1100000.00"),
+        source="Family Home",
+        notes="Independent appraisal report reference A-12",
+    ),
+    mortgage_balance=ManualValuationFixture(
+        component_type="mortgage_balance",
+        value=Decimal("360000.00"),
+        source="Home Loan",
+        notes="Loan reference 2026-01",
+    ),
+    esop=ManualValuationFixture(
+        component_type="esop",
+        value=Decimal("85000.00"),
+        source="ACME ESOP",
+        notes="ESOP vesting starts over 4 years",
+    ),
+    rsu=ManualValuationFixture(
+        component_type="rsu",
+        value=Decimal("42000.00"),
+        source="ACME RSU",
+        notes="RSU vesting 25% annually",
+    ),
+    stock_options=ManualValuationFixture(
+        component_type="stock_options",
+        value=Decimal("29000.00"),
+        source="ACME Options",
+        notes="Stock options cliff vest at 3 years",
+    ),
+    required_sections=frozenset(
+        {
+            "balance_sheet",
+            "income_statement",
+            "cash_flow",
+            "investment_performance",
+            "annualized_income_long_term",
+            "notes",
+            "traceability_appendix",
+        }
+    ),
+    required_note_ids=frozenset(
+        {
+            "basis-of-preparation",
+            "reporting-period-and-currency",
+            "valuation-basis",
+            "investment-market-data",
+            "source-confidence-review",
+            "restricted-asset-treatment",
+        }
+    ),
+    required_traceability_lines=frozenset(
+        {
+            "balance_sheet.total_assets",
+            "income_statement.total_income",
+            "income_statement.total_expenses",
+            "cash_flow.net_cash_flow",
+            "investment_performance.market_value",
+            "annualized_income_long_term.annualized_total",
+            "annualized_income_long_term.restricted_fair_value_total",
+            "notes.non_compliance_statement",
+        }
+    ),
+    required_traceability_warnings=frozenset(
+        {
+            "missing_source_anchor",
+            "manual_only_source",
+            "stale_market_data",
+            "duplicate_source_coverage",
+            "overlapping_statement_period",
+        }
+    ),
+)

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -25,42 +25,12 @@ from uuid import uuid4
 
 import httpx
 import pytest
-from playwright.async_api import Page, expect
-
 from conftest import fail_or_skip_ai_ocr_gate
+from personal_report_package_fixture import PERSONAL_REPORT_PACKAGE_FIXTURE
+from playwright.async_api import Page, expect
 
 APP_URL: str = os.getenv("APP_URL", "http://localhost:3000")
 PARSING_TIMEOUT_MS: int = int(os.getenv("PARSING_TIMEOUT_MS", "480000"))
-
-FIXTURE_PATH: Path = (
-    Path(__file__).resolve().parents[2]
-    / "tests"
-    / "e2e"
-    / "fixtures"
-    / "vision_hard_gate_statement.csv"
-)
-BANK_INSTITUTION = "Personal Report Package Bank"
-BROKERAGE_SOURCE = "moomoo"
-BROKERAGE_INSTITUTION = "Moomoo Personal Package"
-
-PROPERTY_VALUE = Decimal("1100000.00")
-MORTGAGE_BALANCE = Decimal("360000.00")
-ESOP_VALUE = Decimal("85000.00")
-RSU_VALUE = Decimal("42000.00")
-STOCK_OPTIONS_VALUE = Decimal("29000.00")
-
-PROPERTY_SOURCE = "Family Home"
-MORTGAGE_SOURCE = "Home Loan"
-ESOP_SOURCE = "ACME ESOP"
-RSU_SOURCE = "ACME RSU"
-STOCK_OPTIONS_SOURCE = "ACME Options"
-ESOP_NOTES = "ESOP vesting starts over 4 years"
-RSU_NOTES = "RSU vesting 25% annually"
-STOCK_OPTIONS_NOTES = "Stock options cliff vest at 3 years"
-PROPERTY_NOTES = "Independent appraisal report reference A-12"
-MORTGAGE_NOTES = "Loan reference 2026-01"
-
-
 
 def _api_url(path: str) -> str:
     return f"{APP_URL.rstrip('/')}/api{path}"
@@ -72,32 +42,6 @@ def _get_url(path: str) -> str:
 
 def _money(value: object) -> Decimal:
     return Decimal(str(value)).quantize(Decimal("0.01"))
-
-
-def _read_fixture_rows() -> list[dict[str, str]]:
-    assert FIXTURE_PATH.exists(), f"fixture missing: {FIXTURE_PATH}"
-    with FIXTURE_PATH.open(newline="", encoding="utf-8") as fh:
-        rows = list(csv.DictReader(fh))
-    assert rows, f"fixture has no rows: {FIXTURE_PATH}"
-    return rows
-
-
-def _fixture_period(rows: list[dict[str, str]]) -> tuple[date, date]:
-    dates = sorted(date.fromisoformat(row["Date"]) for row in rows)
-    assert dates, "fixture period is empty"
-    return dates[0], dates[-1]
-
-
-def _fixture_totals(rows: list[dict[str, str]]) -> dict[str, object]:
-    amounts = [_money(row["Amount"]) for row in rows]
-    total_income = sum((amount for amount in amounts if amount > 0), Decimal("0.00"))
-    total_expenses = sum((-amount for amount in amounts if amount < 0), Decimal("0.00"))
-    return {
-        "transaction_count": len(rows),
-        "income": total_income,
-        "expenses": total_expenses,
-        "net_income": total_income - total_expenses,
-    }
 
 
 async def _auth_headers(page: Page) -> dict[str, str]:
@@ -197,7 +141,7 @@ def _get_pdf_path(source: str) -> Path:
 
 def _unique_pdf_copy(src: Path) -> Path:
     tmp = Path(tempfile.mkdtemp())
-    suffix = int((time() * 1000)) % 1_000_000
+    suffix = int(time() * 1000) % 1_000_000
     dest = tmp / f"{src.stem}_{suffix}{src.suffix}"
     shutil.copy2(src, dest)
     with dest.open("ab") as fh:
@@ -317,10 +261,14 @@ async def _create_manual_snapshot(
 @pytest.mark.tier3
 @pytest.mark.critical
 @pytest.mark.llm
-async def test_personal_financial_report_package_post_merge_journey(authenticated_page_unique: Page) -> None:
+async def test_personal_financial_report_package_post_merge_journey(
+    authenticated_page_unique: Page,
+    tmp_path: Path,
+) -> None:
     """EPIC-005 EPIC-008 EPIC-011 EPIC-017.
 
     AC5.1.1 AC5.1.4 AC5.2.3 AC5.3.1 AC5.8.1 AC5.12.4 AC5.13.4
+    AC8.13.83 AC8.13.84 AC8.13.85 AC8.13.86
     AC11.8.3 AC11.9.1 AC11.9.2 AC11.9.3 AC11.11.1 AC11.11.2 AC17.10.1 AC17.10.2:
     one complete fresh-user report package with bank data, brokerage import,
     investment performance schedule, annualized income and restricted
@@ -328,20 +276,28 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
     traceability.
     """
     page = authenticated_page_unique
-    fixture_rows = _read_fixture_rows()
-    fixture_period_start, fixture_period_end = _fixture_period(fixture_rows)
-    expected = _fixture_totals(fixture_rows)
+    fixture = PERSONAL_REPORT_PACKAGE_FIXTURE
+    bank_fixture_path = fixture.write_bank_csv(tmp_path)
+    fixture_period_start = fixture.period_start
+    fixture_period_end = fixture.period_end
 
     headers = await _auth_headers(page)
 
     async with httpx.AsyncClient(headers=headers, verify=False, timeout=120.0) as client:
-        bank_statement_id = await _upload_bank_csv(client, FIXTURE_PATH, institution=BANK_INSTITUTION)
+        contract_response = await client.get(_api_url("/reports/package/contract"))
+        assert contract_response.status_code == 200, (
+            f"package contract failed: {contract_response.status_code} {contract_response.text}"
+        )
+        contract_sections = {section["section_id"] for section in contract_response.json()["sections"]}
+        assert fixture.required_sections <= contract_sections
+
+        bank_statement_id = await _upload_bank_csv(client, bank_fixture_path, institution=fixture.institution)
         parsed_bank = await _wait_for_parsed_statement(
             client,
             bank_statement_id,
             gate_name="bank CSV",
         )
-        assert len(parsed_bank.get("transactions") or []) == expected["transaction_count"]
+        assert len(parsed_bank.get("transactions") or []) == fixture.transaction_count
 
         approve_response = await client.post(
             _api_url(f"/statements/{bank_statement_id}/review/approve"),
@@ -351,15 +307,15 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
             f"bank stage 1 approve failed: {approve_response.status_code} {approve_response.text}"
         )
         approve_payload = approve_response.json()
-        assert approve_payload["journal_entries_created"] == expected["transaction_count"]
+        assert approve_payload["journal_entries_created"] == fixture.transaction_count
 
         journal_response = await client.get(_api_url("/journal-entries?limit=20"))
         assert journal_response.status_code == 200, (
             f"journal entry check failed: {journal_response.status_code} {journal_response.text}"
         )
         journal_payload = journal_response.json()
-        assert journal_payload["total"] == expected["transaction_count"]
-        assert len(journal_payload["items"]) == expected["transaction_count"]
+        assert journal_payload["total"] == fixture.transaction_count
+        assert len(journal_payload["items"]) == fixture.transaction_count
         _assert_traceability(parsed_bank["transactions"], journal_payload["items"])
 
         first_reconciliation = await client.post(
@@ -370,8 +326,8 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
             f"first reconciliation failed: {first_reconciliation.status_code} {first_reconciliation.text}"
         )
         assert first_reconciliation.json() == {
-            "matches_created": expected["transaction_count"],
-            "auto_accepted": expected["transaction_count"],
+            "matches_created": fixture.transaction_count,
+            "auto_accepted": fixture.transaction_count,
             "pending_review": 0,
             "unmatched": 0,
         }
@@ -401,8 +357,8 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         model = await _default_image_model(client)
         brokerage_statement_id = await _upload_brokerage_pdf(
             client,
-            source=BROKERAGE_SOURCE,
-            institution=BROKERAGE_INSTITUTION,
+            source=fixture.brokerage_source,
+            institution=fixture.brokerage_institution,
             model=model,
         )
         parsed_brokerage = await _wait_for_parsed_statement(
@@ -437,7 +393,7 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
                 "/portfolio/performance/report-schedule"
                 f"?period_start={fixture_period_start.isoformat()}"
                 f"&period_end={fixture_period_end.isoformat()}"
-                f"&as_of_date={fixture_period_end.isoformat()}&currency=SGD"
+                f"&as_of_date={fixture_period_end.isoformat()}&currency={fixture.currency}"
             )
         )
         assert schedule_response.status_code == 200, (
@@ -447,7 +403,7 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         assert schedule["period_start"] == fixture_period_start.isoformat()
         assert schedule["period_end"] == fixture_period_end.isoformat()
         assert schedule["as_of_date"] == fixture_period_end.isoformat()
-        assert schedule["currency"] == "SGD"
+        assert schedule["currency"] == fixture.currency
         assert schedule["holdings"], f"investment schedule has no holdings: {schedule}"
         assert _money(schedule["unrealized_pnl"]) >= Decimal("0.00")
         assert "data_freshness" in schedule
@@ -460,43 +416,43 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
 
         property_snapshot = await _create_manual_snapshot(
             client,
-            component_type="property_value",
+            component_type=fixture.property_value.component_type,
             as_of_date=fixture_period_end,
-            value=PROPERTY_VALUE,
-            source=PROPERTY_SOURCE,
-            notes=PROPERTY_NOTES,
+            value=fixture.property_value.value,
+            source=fixture.property_value.source,
+            notes=fixture.property_value.notes,
         )
         mortgage_snapshot = await _create_manual_snapshot(
             client,
-            component_type="mortgage_balance",
+            component_type=fixture.mortgage_balance.component_type,
             as_of_date=fixture_period_end,
-            value=MORTGAGE_BALANCE,
-            source=MORTGAGE_SOURCE,
-            notes=MORTGAGE_NOTES,
+            value=fixture.mortgage_balance.value,
+            source=fixture.mortgage_balance.source,
+            notes=fixture.mortgage_balance.notes,
         )
         esop_snapshot = await _create_manual_snapshot(
             client,
-            component_type="esop",
+            component_type=fixture.esop.component_type,
             as_of_date=fixture_period_end,
-            value=ESOP_VALUE,
-            source=ESOP_SOURCE,
-            notes=ESOP_NOTES,
+            value=fixture.esop.value,
+            source=fixture.esop.source,
+            notes=fixture.esop.notes,
         )
         rsu_snapshot = await _create_manual_snapshot(
             client,
-            component_type="rsu",
+            component_type=fixture.rsu.component_type,
             as_of_date=fixture_period_end,
-            value=RSU_VALUE,
-            source=RSU_SOURCE,
-            notes=RSU_NOTES,
+            value=fixture.rsu.value,
+            source=fixture.rsu.source,
+            notes=fixture.rsu.notes,
         )
         stock_options_snapshot = await _create_manual_snapshot(
             client,
-            component_type="stock_options",
+            component_type=fixture.stock_options.component_type,
             as_of_date=fixture_period_end,
-            value=STOCK_OPTIONS_VALUE,
-            source=STOCK_OPTIONS_SOURCE,
-            notes=STOCK_OPTIONS_NOTES,
+            value=fixture.stock_options.value,
+            source=fixture.stock_options.source,
+            notes=fixture.stock_options.notes,
         )
 
         assert property_snapshot["liquidity_class"] == "illiquid"
@@ -518,11 +474,17 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         values_by_type_source = {
             (item["component_type"], item["source"]): _money(item["value"]) for item in manual_components["items"]
         }
-        assert values_by_type_source[("property_value", PROPERTY_SOURCE)] == PROPERTY_VALUE
-        assert values_by_type_source[("mortgage_balance", MORTGAGE_SOURCE)] == MORTGAGE_BALANCE
-        assert values_by_type_source[("esop", ESOP_SOURCE)] == ESOP_VALUE
-        assert values_by_type_source[("rsu", RSU_SOURCE)] == RSU_VALUE
-        assert values_by_type_source[("stock_options", STOCK_OPTIONS_SOURCE)] == STOCK_OPTIONS_VALUE
+        assert values_by_type_source[(fixture.property_value.component_type, fixture.property_value.source)] == (
+            fixture.property_value.value
+        )
+        assert values_by_type_source[(fixture.mortgage_balance.component_type, fixture.mortgage_balance.source)] == (
+            fixture.mortgage_balance.value
+        )
+        assert values_by_type_source[(fixture.esop.component_type, fixture.esop.source)] == fixture.esop.value
+        assert values_by_type_source[(fixture.rsu.component_type, fixture.rsu.source)] == fixture.rsu.value
+        assert values_by_type_source[(fixture.stock_options.component_type, fixture.stock_options.source)] == (
+            fixture.stock_options.value
+        )
 
         snapshots_response = await client.get(
             f"/assets/valuation-snapshots?as_of_date={fixture_period_end.isoformat()}"
@@ -532,9 +494,9 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         )
         snapshots = snapshots_response.json()["items"]
         notes_by_source = {snapshot["source"]: snapshot["notes"] for snapshot in snapshots}
-        assert notes_by_source[ESOP_SOURCE] == ESOP_NOTES
-        assert notes_by_source[RSU_SOURCE] == RSU_NOTES
-        assert notes_by_source[STOCK_OPTIONS_SOURCE] == STOCK_OPTIONS_NOTES
+        assert notes_by_source[fixture.esop.source] == fixture.esop.notes
+        assert notes_by_source[fixture.rsu.source] == fixture.rsu.notes
+        assert notes_by_source[fixture.stock_options.source] == fixture.stock_options.notes
 
         restricted_response = await client.get(
             f"/assets/restricted?as_of_date={fixture_period_end.isoformat()}"
@@ -544,14 +506,14 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         )
         restricted_holdings = restricted_response.json()
         assert {item["ticker"] for item in restricted_holdings} == {
-            ESOP_SOURCE,
-            RSU_SOURCE,
-            STOCK_OPTIONS_SOURCE,
+            fixture.esop.source,
+            fixture.rsu.source,
+            fixture.stock_options.source,
         }
         schedules_by_ticker = {item["ticker"]: item["vesting_schedule"] for item in restricted_holdings}
-        assert schedules_by_ticker[ESOP_SOURCE] == ESOP_NOTES
-        assert schedules_by_ticker[RSU_SOURCE] == RSU_NOTES
-        assert schedules_by_ticker[STOCK_OPTIONS_SOURCE] == STOCK_OPTIONS_NOTES
+        assert schedules_by_ticker[fixture.esop.source] == fixture.esop.notes
+        assert schedules_by_ticker[fixture.rsu.source] == fixture.rsu.notes
+        assert schedules_by_ticker[fixture.stock_options.source] == fixture.stock_options.notes
 
         annualized_response = await client.get(
             _api_url(
@@ -565,21 +527,19 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         assert annualized["section_id"] == "annualized_income_long_term"
         assert annualized["as_of_date"] == fixture_period_end.isoformat()
         assert annualized["trailing_period_days"] == 365
-        assert _money(annualized["income"]["annualized_total"]) == _money(expected["income"])
-        assert annualized["income"]["currency"] == "SGD"
+        assert _money(annualized["income"]["annualized_total"]) == fixture.income
+        assert annualized["income"]["currency"] == fixture.currency
         assert annualized["income"]["calculation_basis"] == (
             "posted_or_reconciled_income_journal_lines_trailing_12_months"
         )
-        assert _money(annualized["restricted_fair_value_total"]) == (
-            ESOP_VALUE + RSU_VALUE + STOCK_OPTIONS_VALUE
-        )
+        assert _money(annualized["restricted_fair_value_total"]) == fixture.restricted_fair_value_total
         assert annualized["net_worth_treatment"]["liquid_net_worth_default"] == (
             "exclude_restricted_holdings"
         )
         annualized_holdings = {holding["ticker"]: holding for holding in annualized["restricted_holdings"]}
-        assert annualized_holdings[ESOP_SOURCE]["vesting_schedule"] == ESOP_NOTES
-        assert annualized_holdings[RSU_SOURCE]["vesting_schedule"] == RSU_NOTES
-        assert annualized_holdings[STOCK_OPTIONS_SOURCE]["vesting_schedule"] == STOCK_OPTIONS_NOTES
+        assert annualized_holdings[fixture.esop.source]["vesting_schedule"] == fixture.esop.notes
+        assert annualized_holdings[fixture.rsu.source]["vesting_schedule"] == fixture.rsu.notes
+        assert annualized_holdings[fixture.stock_options.source]["vesting_schedule"] == fixture.stock_options.notes
         assert {holding["compensation_type"] for holding in annualized_holdings.values()} == {
             "esop",
             "rsu",
@@ -593,21 +553,21 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         package_notes = notes_response.json()
         assert package_notes["section_id"] == "notes"
         package_note_ids = {note["note_id"] for note in package_notes["notes"]}
-        assert {
-            "basis-of-preparation",
-            "reporting-period-and-currency",
-            "valuation-basis",
-            "investment-market-data",
-            "source-confidence-review",
-            "restricted-asset-treatment",
-        } <= package_note_ids
+        assert fixture.required_note_ids <= package_note_ids
         assert "not a regulated filing" in package_notes["non_compliance_statement"]
         assert "not legal advice" in package_notes["non_compliance_statement"]
         assert "not tax advice" in package_notes["non_compliance_statement"]
         assert "US GAAP compliant" not in package_notes["non_compliance_statement"]
         assert "HKEX filing" not in package_notes["non_compliance_statement"]
 
-        traceability_response = await client.get(_api_url("/reports/package/traceability"))
+        traceability_response = await client.get(
+            _api_url(
+                "/reports/package/traceability"
+                f"?start_date={fixture_period_start.isoformat()}"
+                f"&end_date={fixture_period_end.isoformat()}"
+                f"&as_of_date={fixture_period_end.isoformat()}"
+            )
+        )
         assert traceability_response.status_code == 200, (
             f"package traceability failed: {traceability_response.status_code} {traceability_response.text}"
         )
@@ -615,6 +575,7 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         assert traceability["section_id"] == "traceability_appendix"
         assert traceability["status"] == "ready"
         traceability_lines = {line["line_id"]: line for line in traceability["lines"]}
+        assert fixture.required_traceability_lines <= set(traceability_lines)
         trusted_total_line_ids = {
             "balance_sheet.total_assets",
             "income_statement.total_income",
@@ -628,12 +589,17 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
             assert line["source_anchor"]["state"] == "available"
             assert line["ledger_anchor"]["state"] == "available"
             assert line["ledger_anchor"]["entry_statuses"] == ["posted", "reconciled"]
+            assert line["source_anchor"]["identifiers"]
+            assert line["ledger_anchor"]["identifiers"]
             assert line["confidence_tier"] == "TRUSTED"
         assert traceability_lines["annualized_income_long_term.restricted_fair_value_total"]["ledger_anchor"][
             "state"
         ] == "not_applicable"
+        assert traceability_lines["annualized_income_long_term.restricted_fair_value_total"]["source_anchor"][
+            "identifiers"
+        ]
         warning_codes = {warning["code"] for warning in traceability["completeness_warnings"]}
-        assert {"missing_source_anchor", "manual_only_source", "stale_market_data"} <= warning_codes
+        assert fixture.required_traceability_warnings <= warning_codes
 
         manual_components_exclusive = await client.get(
             _api_url(
@@ -647,23 +613,14 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
         sources_exclusive = {
             (item["component_type"], item["source"]) for item in manual_components_exclusive_payload["items"]
         }
-        assert ("esop", ESOP_SOURCE) not in sources_exclusive
-        assert ("rsu", RSU_SOURCE) not in sources_exclusive
-        assert ("stock_options", STOCK_OPTIONS_SOURCE) not in sources_exclusive
+        assert (fixture.esop.component_type, fixture.esop.source) not in sources_exclusive
+        assert (fixture.rsu.component_type, fixture.rsu.source) not in sources_exclusive
+        assert (fixture.stock_options.component_type, fixture.stock_options.source) not in sources_exclusive
 
-        expected_bank_cash = _money(expected["income"]) - _money(expected["expenses"])
-        expected_assets = (
-            brokerage_value
-            + PROPERTY_VALUE
-            + ESOP_VALUE
-            + RSU_VALUE
-            + STOCK_OPTIONS_VALUE
-            + expected_bank_cash
-        ).quantize(Decimal("0.01"))
-        expected_liabilities = MORTGAGE_BALANCE
-        expected_net_worth_adjustment = (
-            PROPERTY_VALUE + ESOP_VALUE + RSU_VALUE + STOCK_OPTIONS_VALUE - MORTGAGE_BALANCE
-        ).quantize(Decimal("0.01"))
+        expected_bank_cash = fixture.bank_cash
+        expected_assets = fixture.total_assets(brokerage_value)
+        expected_liabilities = fixture.mortgage_liability
+        expected_net_worth_adjustment = fixture.net_worth_adjustment_gain_loss
 
         assert _money(manual_components["total_assets"]) == expected_assets
         assert _money(manual_components["total_liabilities"]) == expected_liabilities
@@ -671,7 +628,8 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
 
         balance_payload = await client.get(
             _api_url(
-                f"/reports/balance-sheet?as_of_date={fixture_period_end.isoformat()}&currency=SGD&include_restricted=true"
+                f"/reports/balance-sheet?as_of_date={fixture_period_end.isoformat()}"
+                f"&currency={fixture.currency}&include_restricted=true"
             )
         )
         assert balance_payload.status_code == 200, (
@@ -689,27 +647,29 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
 
         income_payload = await client.get(
             _api_url(
-                f"/reports/income-statement?start_date={fixture_period_start.isoformat()}&end_date={fixture_period_end.isoformat()}&currency=SGD"
+                f"/reports/income-statement?start_date={fixture_period_start.isoformat()}"
+                f"&end_date={fixture_period_end.isoformat()}&currency={fixture.currency}"
             )
         )
         assert income_payload.status_code == 200, (
             f"income statement failed: {income_payload.status_code} {income_payload.text}"
         )
         income = income_payload.json()
-        assert _money(income["total_income"]) == expected["income"]
-        assert _money(income["total_expenses"]) == expected["expenses"]
-        assert _money(income["net_income"]) == expected["net_income"]
+        assert _money(income["total_income"]) == fixture.income
+        assert _money(income["total_expenses"]) == fixture.expenses
+        assert _money(income["net_income"]) == fixture.net_income
 
         cash_flow_payload = await client.get(
             _api_url(
-                f"/reports/cash-flow?start_date={fixture_period_start.isoformat()}&end_date={fixture_period_end.isoformat()}&currency=SGD"
+                f"/reports/cash-flow?start_date={fixture_period_start.isoformat()}"
+                f"&end_date={fixture_period_end.isoformat()}&currency={fixture.currency}"
             )
         )
         assert cash_flow_payload.status_code == 200, (
             f"cash flow failed: {cash_flow_payload.status_code} {cash_flow_payload.text}"
         )
         cash_flow = cash_flow_payload.json()
-        assert _money(cash_flow["summary"]["net_cash_flow"]) == _money(expected["net_income"])
+        assert _money(cash_flow["summary"]["net_cash_flow"]) == fixture.net_income
         assert _money(cash_flow["summary"]["beginning_cash"]) == Decimal("0.00")
         assert _money(cash_flow["summary"]["ending_cash"]) == _money(expected_bank_cash)
 
@@ -719,7 +679,7 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
                 "report_type": "balance-sheet",
                 "format": "csv",
                 "as_of_date": fixture_period_end.isoformat(),
-                "currency": "SGD",
+                "currency": fixture.currency,
             },
         )
         assert bs_export.status_code == 200, f"balance-sheet export failed: {bs_export.status_code} {bs_export.text}"
@@ -738,7 +698,7 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
                 "format": "csv",
                 "start_date": fixture_period_start.isoformat(),
                 "end_date": fixture_period_end.isoformat(),
-                "currency": "SGD",
+                "currency": fixture.currency,
             },
         )
         assert income_export.status_code == 200, (
@@ -755,7 +715,7 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
 
     await page.goto(
         _get_url(
-            f"/reports/balance-sheet?as_of_date={fixture_period_end.isoformat()}&currency=SGD"
+            f"/reports/balance-sheet?as_of_date={fixture_period_end.isoformat()}&currency={fixture.currency}"
         )
     )
     await page.wait_for_load_state("networkidle")
@@ -763,7 +723,8 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
 
     await page.goto(
         _get_url(
-            f"/reports/income-statement?start_date={fixture_period_start.isoformat()}&end_date={fixture_period_end.isoformat()}&currency=SGD"
+            f"/reports/income-statement?start_date={fixture_period_start.isoformat()}"
+            f"&end_date={fixture_period_end.isoformat()}&currency={fixture.currency}"
         )
     )
     await page.wait_for_load_state("networkidle")
@@ -771,7 +732,8 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
 
     await page.goto(
         _get_url(
-            f"/reports/cash-flow?start_date={fixture_period_start.isoformat()}&end_date={fixture_period_end.isoformat()}&currency=SGD"
+            f"/reports/cash-flow?start_date={fixture_period_start.isoformat()}"
+            f"&end_date={fixture_period_end.isoformat()}&currency={fixture.currency}"
         )
     )
     await page.wait_for_load_state("networkidle")

--- a/tests/tooling/test_personal_report_package_fixture_contract.py
+++ b/tests/tooling/test_personal_report_package_fixture_contract.py
@@ -1,0 +1,62 @@
+"""Representative personal report package fixture contract tests."""
+
+from decimal import Decimal
+
+from tests.e2e.personal_report_package_fixture import PERSONAL_REPORT_PACKAGE_FIXTURE
+
+
+def test_AC8_13_83_personal_report_package_fixture_has_exact_decimal_expected_outputs() -> None:
+    """AC8.13.83: Representative package fixture exposes exact Decimal-safe expected outputs."""
+    fixture = PERSONAL_REPORT_PACKAGE_FIXTURE
+
+    assert fixture.transaction_count == 6
+    assert fixture.period_start.isoformat() == "2026-05-02"
+    assert fixture.period_end.isoformat() == "2026-05-19"
+    assert fixture.income == Decimal("5600.00")
+    assert fixture.expenses == Decimal("5600.00")
+    assert fixture.net_income == Decimal("0.00")
+    assert fixture.bank_cash == Decimal("0.00")
+    assert fixture.restricted_fair_value_total == Decimal("156000.00")
+    assert fixture.mortgage_liability == Decimal("360000.00")
+    assert fixture.net_worth_adjustment_gain_loss == Decimal("896000.00")
+    assert fixture.total_assets(Decimal("1234.56")) == Decimal("1257234.56")
+
+
+def test_AC8_13_84_personal_report_package_fixture_covers_required_package_sections() -> None:
+    """AC8.13.84: Fixture contract covers package sections, notes, and traceability appendix anchors."""
+    fixture = PERSONAL_REPORT_PACKAGE_FIXTURE
+
+    assert fixture.required_sections == {
+        "balance_sheet",
+        "income_statement",
+        "cash_flow",
+        "investment_performance",
+        "annualized_income_long_term",
+        "notes",
+        "traceability_appendix",
+    }
+    assert {
+        "basis-of-preparation",
+        "reporting-period-and-currency",
+        "valuation-basis",
+        "investment-market-data",
+        "source-confidence-review",
+        "restricted-asset-treatment",
+    } <= fixture.required_note_ids
+    assert {
+        "balance_sheet.total_assets",
+        "income_statement.total_income",
+        "income_statement.total_expenses",
+        "cash_flow.net_cash_flow",
+        "investment_performance.market_value",
+        "annualized_income_long_term.annualized_total",
+        "annualized_income_long_term.restricted_fair_value_total",
+        "notes.non_compliance_statement",
+    } <= fixture.required_traceability_lines
+    assert {
+        "missing_source_anchor",
+        "manual_only_source",
+        "stale_market_data",
+        "duplicate_source_coverage",
+        "overlapping_statement_period",
+    } <= fixture.required_traceability_warnings


### PR DESCRIPTION
## Summary

Adds the representative personal financial-report package fixture proof and promotes the macro outcome to covered.

Closes #573

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy; EPIC-005 — Financial Reports & Visualization |
| **AC IDs** | AC8.13.83, AC8.13.84, AC8.13.85, AC8.13.86, AC5.13.4 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/critical-proof-matrix.yaml` — promotes `personal-financial-report-package` to `covered` and anchors #573 ACs to the post-merge proof
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `dcb7ca4` | Adds AC8.13.83-86 fixture contract, E2E assertions, and dynamic traceability identifier expectations before backend enrichment |
| 🟢 Green (passing test) | `b768eb0` | Adds traceability `identifiers`, dynamic package appendix enrichment, and covered macro proof status |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable; no env changes)
- [x] `repo/` submodule updated for production config changes (if applicable; no config changes)
- [x] `tools/check_env_keys.py` passes (if env vars changed; no env changes)
- [x] `tools/check_manifest.py` passes (if SSOT files changed; not required for critical-proof matrix update)
- [x] `tools/lint_doc_consistency.py` passes (covered by `moon run :lint` and traceability checks)

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner. (N/A)
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys. (N/A)
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged. (N/A)
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials. (N/A)
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule. (N/A)
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene. (N/A)

---

## Testing

```bash
moon run :lint
python tools/check_ac_traceability.py
python tools/generate_ac_registry.py --check
python tools/check_critical_proof_matrix.py
python tools/check_e2e_epic_traceability.py
python -m pytest tests/tooling/test_personal_report_package_fixture_contract.py tests/tooling/test_check_critical_proof_matrix.py -q
cd apps/frontend && npm test -- --run src/__tests__/personalReportPackagePage.test.tsx
cd apps/backend && uv run pytest tests/api/test_personal_report_package_contract.py -q --no-cov -k 'not AC8_13_85'
```

Local limitation: `CONTAINER_RUNTIME=podman python tools/test_lifecycle.py --fast tests/api/test_personal_report_package_contract.py` could not run the DB-backed `AC8.13.85` test because local podman reported `unable to connect to Podman socket` after `podman machine start`. CI should run with container services available.

---

## Screenshots / Evidence

N/A
