### PR TITLE
[finance_report_infra] Left-shift CI fast feedback jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   backend:
     name: Backend Tests (Shard ${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
-    needs: [changes, backend-integration, backend-e2e-tier1]
+    needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
     strategy:
       fail-fast: false
@@ -415,7 +415,7 @@ jobs:
   frontend:
     name: Frontend Build & Test
     runs-on: ubuntu-latest
-    needs: [changes, backend-integration, backend-e2e-tier1]
+    needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
     
     steps:
@@ -502,7 +502,7 @@ jobs:
   container-images:
     name: Build Staging Images
     runs-on: ubuntu-latest
-    needs: [changes, backend-integration, backend-e2e-tier1]
+    needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
     permissions:
       contents: read

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2407,6 +2407,11 @@ groups:
         description: Personal financial report package macro proof is promoted to covered only when the representative fixture
           contract ACs are part of the critical proof matrix.
         mandatory: true
+      - id: AC8.13.86
+        epic: 8
+        epic_name: testing-strategy
+        description: CI fast feedback jobs start after change classification without waiting for behavior-only backend gates.
+        mandatory: true
   AC11:
     AC11.1:
       - id: AC11.1.1

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -123,6 +123,7 @@ E2E coverage is measured across three tiers of increasing fidelity:
 - **AC8.13.83**: Personal report package representative fixture contract defines bank cash, income/expense activity, brokerage holdings, manual property valuation, liability, restricted compensation, notes, traceability anchors, and exact Decimal expected outputs.
 - **AC8.13.84**: Personal report package post-merge E2E consumes the representative fixture contract instead of duplicating financial constants or expected totals inline.
 - **AC8.13.85**: Personal financial report package macro proof is promoted to covered only when the representative fixture contract ACs are part of the critical proof matrix.
+- **AC8.13.86**: CI fast feedback jobs start after change classification without waiting for behavior-only backend gates.
 
 ### 2.3.1 Test Stage Semantics and Left-Move Plan (Unit / Integration / E2E)
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -12,10 +12,14 @@
 The GitHub Actions workflow (`.github/workflows/ci.yml`) follows this job dependency order:
 
 ```
-changes (classify-changes) → backend-integration + backend-e2e-tier1 → backend shards + frontend → unified-coverage → finish
-               ↘ tooling-coverage ───────────────────────────────────────────↗
-               ↘ lint ───────────────────────────────────────────────────────↗
-               ↘ ac-traceability ────────────────────────────────────────────↗
+changes (classify-changes) → backend shards ───────┐
+               ↘ frontend ─────────────────────────┼→ unified-coverage → finish
+               ↘ tooling-coverage ─────────────────┘                      ↑
+               ↘ backend-integration ──────────────────────────────────────┤
+               ↘ backend-e2e-tier1 ────────────────────────────────────────┤
+               ↘ container-images ─────────────────────────────────────────┤
+               ↘ lint ─────────────────────────────────────────────────────┤
+               ↘ ac-traceability ──────────────────────────────────────────┘
 ```
 
 ### Job Details
@@ -24,11 +28,11 @@ changes (classify-changes) → backend-integration + backend-e2e-tier1 → backe
 |-----|---------|--------------|
 | **changes** | Detect whether changed paths require heavy backend/frontend/coverage jobs | None |
 | **lint** | Static analysis (backend `src tests` ruff check + format check, frontend lint) + manifest/doc/CI metrics contract checks | None (first job) |
-| **backend** (Shards 1-6) | Backend fast-path tests only: `-m "not slow and not e2e and not integration"` | `needs: [changes, backend-integration, backend-e2e-tier1]` |
+| **backend** (Shards 1-6) | Backend fast-path tests only: `-m "not slow and not e2e and not integration"` | `needs: [changes]` |
 | **backend-integration** | Backend integration stage (`-m "integration"`), deterministic service-backed behavior checks | `needs: [changes]` |
 | **backend-e2e-tier1** | Backend Tier-1 API E2E stage (`apps/backend/tests/e2e/test_core_journeys.py` with `-m e2e`), executed with explicit marker override | `needs: [changes]` |
-| **frontend** | Frontend build + Vitest + Playwright tests when heavy CI is required | `needs: [changes, backend-integration, backend-e2e-tier1]` |
-| **container-images** | Build backend and frontend staging images without pushing on PRs; push SHA-tagged images only on `main` | `needs: [changes, backend-integration, backend-e2e-tier1]` |
+| **frontend** | Frontend build + Vitest + Playwright tests when heavy CI is required | `needs: [changes]` |
+| **container-images** | Build backend and frontend staging images without pushing on PRs; push SHA-tagged images only on `main` | `needs: [changes]` |
 | **tooling-coverage** | Run root tooling tests with common/tools coverage and upload LCOV inputs | `needs: [changes]` |
 | **unified-coverage** | Merge backend, frontend, common, and tools LCOV inputs, audit source-tree/LCOV policy, calculate unified coverage, compare to baseline, update Coveralls when heavy CI is required | `needs: [changes, backend, frontend, tooling-coverage]` |
 | **ac-traceability** | Verify AC-to-test traceability for all PR/main changes, including docs-only changes | None |
@@ -40,7 +44,7 @@ changes (classify-changes) → backend-integration + backend-e2e-tier1 → backe
 2. **Change Classification**: Lightweight documentation, issue-template, markdown, and `.github/workflows/docs.yml` changes skip backend, frontend, and unified coverage. Runtime, test, tooling, CI, dependency, and coverage-policy changes run the full heavy path.
 3. **Stable Required Checks**: Heavy jobs are skipped through job-level conditions rather than removing the workflow, so required check names remain visible and mergeable.
 4. **AC Traceability Always Runs**: AC traceability is separate from unified coverage so docs-only AC/EPIC changes still get traceability validation. The job first runs `tools/generate_ac_registry.py --check` to ensure EPIC-defined ACs are registered without rewriting historical registry descriptions, then runs `tools/check_ac_traceability.py` as the fail-closed gate, then runs `tools/check_e2e_epic_traceability.py` to ensure product E2E root test functions carry function-level EPIC IDs, every project EPIC has product E2E ownership, the README EPIC map matches project EPIC files, and unclassified E2E-like assets outside declared roots fail CI, then runs `tools/check_critical_proof_matrix.py` to validate the small core proof matrix, then generates `AC-TEST-TRACEABILITY-AUDIT.md` into `$RUNNER_TEMP`; the audit is uploaded as a CI artifact together with the critical proof matrix report. The audit distinguishes CI-executed real test references from `_ac_stubs`, trivial placeholder assertions, pure `pass`, pure skipped tests, and real references that live only in non-required execution stages. `docs/ssot/test-execution-matrix.yaml` owns the path-to-stage mapping. CI fails on mandatory AC coverage that is missing, placeholder-only, stub-only, or real-only outside CI-required stages; full-strikethrough deprecated ACs are excluded from the mandatory gate. The macro gate fails README/matrix/owner-EPIC drift, E2E/EPIC ownership drift, and broad/reference-only critical proof anchors. The generated audit is uploaded as a CI artifact; checked-in archive copies were retired to reduce merge conflicts.
-5. **Backend stages are explicit and split**: Backend fast-path remains shard stage (`backend`) with `-m "not slow and not e2e and not integration"`. Integration (`backend-integration`) and API E2E (`backend-e2e-tier1`) are explicit behavior-only jobs and run before the heavier shard/frontend/image stages.
+5. **Backend stages are explicit and split**: Backend fast-path remains shard stage (`backend`) with `-m "not slow and not e2e and not integration"`. Fast feedback jobs start after `changes` only: backend shards, frontend build/test, image build validation, tooling coverage, lint, and AC traceability run in parallel with lint and do not wait for behavior-only backend gates. Behavior-only backend gates run in parallel as explicit `backend-integration` and `backend-e2e-tier1` stages and are aggregated by `finish`.
 6. **Coverage Debug Context Is Always Uploaded**: The `tooling-coverage` job uploads `coverage-tooling` with `coverage/common.lcov` and `coverage/tools.lcov`; the `unified-coverage` job downloads that artifact and uploads `unified-coverage-context` on success and failure. The unified artifact contains `coverage/backend.lcov`, `coverage/frontend.lcov`, `coverage/common.lcov`, `coverage/tools.lcov`, the current `unified-coverage.json`, and `coverage/coverage-context.txt` with raw line-count inputs, commit/event/run metadata, toolchain versions, and input hashes. Coverage regressions must be diagnosed from these artifacts before treating a percentage delta as nondeterminism.
 7. **CI Observability Artifacts Are Failure-Path Owned**: Backend shard, backend integration, backend Tier-1 E2E, frontend Vitest, frontend Playwright, tooling/common coverage, AC traceability, PR preview, staging, manual AI/OCR, production release, and scheduled cleanup gates publish CI observability artifacts with `if: always()`. These artifacts include JUnit XML where pytest or Vitest/Playwright can produce it, raw coverage/report inputs where relevant, and a small context file with repository/event/ref/SHA/run metadata plus target environment/version fields. Step summaries remain human-readable status pages; artifacts are the replayable evidence for both success and failure.
 8. **Coveralls Is Main-Only Reporting**: Pull requests do not call Coveralls and therefore do not publish external Coveralls status contexts. CI pass/fail is decided by local gates (`tools/check_ci_metrics_contract.py`, `tools/check_coverage_policy.py`, `tools/calculate_unified_coverage.py`) aggregated by `finish`. Main pushes upload only the unified line-only LCOV report to Coveralls for badge and trend reporting after the local coverage gate passes. Backend/frontend per-flag Coveralls uploads are intentionally absent so a single commit has one reporting denominator.
@@ -55,7 +59,7 @@ changes (classify-changes) → backend-integration + backend-e2e-tier1 → backe
 
 | Stage | Current execution | Scope in CI | Coverage effect | Left-move action |
 |---|---|---|---|---|
-| Unit (fast/shard) | `backend` job, 6 shards after integration/Tier-1 gates pass | `-m "not slow and not e2e and not integration"` | Feeds unified line coverage (backend component) | Keep as deterministic base and expand shards if needed |
+| Unit (fast/shard) | `backend` job, 6 shards immediately after change classification | `-m "not slow and not e2e and not integration"` | Feeds unified line coverage (backend component) | Keep as deterministic base and expand shards if needed |
 | Integration (backend marker) | `backend-integration` job (`-m "integration"`) | `apps/backend/tests/**/*` marker-scoped integration suites with service-backed env | Not part of unified line baseline yet | Add sharding when count growth justifies it; keep explicit marker gate in CI |
 | Tooling/common contracts | `tooling-coverage` job | `tests/tooling/` with `--cov=common --cov=tools` | Feeds unified line coverage (common/tools components) | Keep parallel to app tests so tooling failures and LCOV inputs are independently visible |
 | Tier 1 API E2E | `backend-e2e-tier1` job (`apps/backend/tests/e2e/test_core_journeys.py` with `-m "e2e"`) | Serial backend contract/HTTP/DB/S3 API behavioral paths with Postgres and MinIO bucket readiness | Behavioral proof only; AC traceability-backed | Stabilize a deterministic API subset first, then scale by marker or folder |
@@ -176,7 +180,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - PR preview environments deploy only for runtime app, compose, root E2E, dependency, Dockerfile/config, or preview-action changes. App test-only and app Markdown changes still run CI and AC gates without consuming a Dokploy preview slot.
 - Automatic staging deploys are scoped to runtime app, deploy, root E2E, dependency, Dockerfile/config, staging workflow, toolchain, or infra-submodule changes. App test-only changes, documentation, project archive, AC traceability, and other tooling-only changes keep CI/AC gates but do not consume the staging singleton.
 - Markdown outside the documented lightweight trees is treated as heavy; this prevents runtime-adjacent README or tooling documentation changes from being hidden by a global `*.md` skip.
-- Backend shards and AC traceability run in parallel with lint once change classification has finished, so lint remains visible without delaying independent test work.
+- Backend shards, frontend build/test, image build validation, tooling coverage, integration, Tier-1 API E2E, lint, and AC traceability run in parallel once change classification has finished. Left-side deterministic failures are visible without waiting for behavior-only backend gates.
 - 6-way parallel test sharding via `pytest-split`
 - Each shard: `pytest --splits 6 --group N`
 - Tooling/common coverage runs in parallel as `tooling-coverage`; `unified-coverage` downloads `coverage-tooling` and merges backend, frontend, common, and tools LCOV inputs post-run.

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -940,7 +940,7 @@ def test_AC8_13_25_backend_and_traceability_do_not_wait_for_lint() -> None:
         "  finish:", 1
     )[0]
 
-    assert "needs: [changes, backend-integration, backend-e2e-tier1]" in backend_block
+    assert "needs: [changes]" in backend_block
     assert "needs: [changes, lint]" not in backend_block
     assert (
         "needs: [changes, backend-integration, backend-e2e-tier1, lint]"
@@ -948,6 +948,30 @@ def test_AC8_13_25_backend_and_traceability_do_not_wait_for_lint() -> None:
     )
     assert "needs: [lint]" not in traceability_block
     assert "run in parallel with lint" in ci_cd
+
+
+def test_AC8_13_86_fast_feedback_jobs_do_not_wait_for_behavior_gates() -> None:
+    """AC8.13.86: CI fast feedback jobs start after change classification only."""
+    workflow = read(".github/workflows/ci.yml")
+    ci_cd = read("docs/ssot/ci-cd.md")
+
+    backend_block = workflow.split("  backend:", 1)[1].split(
+        "  backend-integration:", 1
+    )[0]
+    frontend_block = workflow.split("  frontend:", 1)[1].split(
+        "  container-images:", 1
+    )[0]
+    image_block = workflow.split("  container-images:", 1)[1].split(
+        "  tooling-coverage:", 1
+    )[0]
+
+    for block in (backend_block, frontend_block, image_block):
+        assert "needs: [changes]" in block
+        assert "backend-integration" not in block.split("steps:", 1)[0]
+        assert "backend-e2e-tier1" not in block.split("steps:", 1)[0]
+
+    assert "Fast feedback jobs start after `changes` only" in ci_cd
+    assert "Behavior-only backend gates run in parallel" in ci_cd
 
 
 def test_AC8_13_67_backend_tier1_api_e2e_scope_excludes_browser_e2e() -> None:


### PR DESCRIPTION
## Summary

Left-shifts CI fast feedback jobs so backend shards, frontend build/test, and staging image build validation start immediately after change classification instead of waiting for behavior-only backend gates.

Closes #408

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.86, AC8.13.25 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/ci-cd.md` — updated CI DAG, job dependency table, stage semantics, and left-move guidance for fast feedback jobs.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | `working-tree` | `test_AC8_13_86_fast_feedback_jobs_do_not_wait_for_behavior_gates` initially failed until the SSOT contract text matched the new dependency policy. |
| Green (passing test) | `81d3592` | Left-shifted CI fast feedback job dependencies and updated SSOT/AC coverage. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable; no DB model changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable; no frontend env changes)
- [x] `repo/` submodule updated for production config changes (not applicable; no production config changes)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes (SSOT manifest check passed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: no lifecycle ownership changes.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys.
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged.
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials.
- [x] Cleanup is scoped: no cleanup behavior changes.
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene (not applicable; DAG-only workflow dependency change covered by tooling contract tests).

---

## Testing

```bash
uv run --with pytest --with pyyaml pytest tests/tooling/test_post_merge_e2e_gates.py::test_AC8_13_25_backend_and_traceability_do_not_wait_for_lint tests/tooling/test_post_merge_e2e_gates.py::test_AC8_13_86_fast_feedback_jobs_do_not_wait_for_behavior_gates -q
uv run --with pytest --with pyyaml pytest tests/tooling/test_ci_change_classifier.py tests/tooling/test_post_merge_e2e_gates.py -q
python tools/generate_ac_registry.py --check
python -m common.ssot.check_ac_traceability --registry docs/ac_registry.yaml --infra-registry docs/infra_registry.yaml
uv run python tools/check_ci_metrics_contract.py
uv run --with pyyaml python tools/lint_doc_consistency.py
uv run --with pyyaml python tools/check_manifest.py
python tools/check_toolchain_contract.py
moon run :lint
```

`moon run :test` was attempted locally but could not start because the local Podman socket is unavailable (`connect: connection refused` at `127.0.0.1:61270`). CI provides the DB/container-backed validation.

---

## Screenshots / Evidence

N/A

---

## Notes

Issue B from the review maps to existing #532 (`ci: exercise production release path before manual production deploy`), so this PR intentionally does not modify production release provenance gates.
