### PR TITLE
[finance_report_ui] Define workflow event model

### DIFF
--- a/apps/backend/migrations/versions/0021_add_workflow_events.py
+++ b/apps/backend/migrations/versions/0021_add_workflow_events.py
@@ -1,0 +1,117 @@
+"""add workflow events read model"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0021_add_workflow_events"
+down_revision = "0020_add_market_data_sync_state"
+branch_labels = None
+depends_on = None
+
+
+FAMILY_VALUES = (
+    "source.uploaded",
+    "source.parsing.started",
+    "source.parsing.completed",
+    "source.parsing.failed",
+    "record.validation.passed",
+    "record.validation.failed",
+    "ledger.auto_posted",
+    "review.required",
+    "review.completed",
+    "reconciliation.blocked",
+    "report.processing",
+    "report.ready",
+    "report.blocked",
+    "report.generated",
+)
+SEVERITY_VALUES = ("info", "success", "warning", "action_required", "blocked")
+STATUS_VALUES = ("unread", "read", "archived")
+
+
+def _create_enum_if_missing(name: str, values: tuple[str, ...]) -> None:
+    quoted_values = ", ".join(f"'{value}'" for value in values)
+    op.execute(
+        f"DO $$ BEGIN CREATE TYPE {name} AS ENUM ({quoted_values}); "
+        "EXCEPTION WHEN duplicate_object THEN null; END $$;"
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    _create_enum_if_missing("workflow_event_family_enum", FAMILY_VALUES)
+    _create_enum_if_missing("workflow_event_severity_enum", SEVERITY_VALUES)
+    _create_enum_if_missing("workflow_event_status_enum", STATUS_VALUES)
+
+    if not inspector.has_table("workflow_events"):
+        op.create_table(
+            "workflow_events",
+            sa.Column("id", sa.UUID(), nullable=False),
+            sa.Column("user_id", sa.UUID(), nullable=False),
+            sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column(
+                "family",
+                postgresql.ENUM(*FAMILY_VALUES, name="workflow_event_family_enum", create_type=False),
+                nullable=False,
+            ),
+            sa.Column(
+                "severity",
+                postgresql.ENUM(*SEVERITY_VALUES, name="workflow_event_severity_enum", create_type=False),
+                nullable=False,
+            ),
+            sa.Column(
+                "status",
+                postgresql.ENUM(*STATUS_VALUES, name="workflow_event_status_enum", create_type=False),
+                nullable=False,
+            ),
+            sa.Column("title", sa.String(length=160), nullable=False),
+            sa.Column("summary", sa.Text(), nullable=False),
+            sa.Column("source_type", sa.String(length=50), nullable=False),
+            sa.Column("source_id", sa.UUID(), nullable=False),
+            sa.Column("action_href", sa.String(length=500), nullable=False),
+            sa.Column("report_impact", sa.String(length=50), nullable=False),
+            sa.Column("dedupe_key", sa.String(length=255), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("user_id", "dedupe_key", name="uq_workflow_events_user_dedupe_key"),
+        )
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_workflow_events_user_id "
+        "ON workflow_events (user_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_workflow_events_user_status_occurred "
+        "ON workflow_events (user_id, status, occurred_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_workflow_events_user_severity_occurred "
+        "ON workflow_events (user_id, severity, occurred_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_workflow_events_user_family_occurred "
+        "ON workflow_events (user_id, family, occurred_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_workflow_events_user_source "
+        "ON workflow_events (user_id, source_type, source_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_workflow_events_user_source")
+    op.execute("DROP INDEX IF EXISTS idx_workflow_events_user_family_occurred")
+    op.execute("DROP INDEX IF EXISTS idx_workflow_events_user_severity_occurred")
+    op.execute("DROP INDEX IF EXISTS idx_workflow_events_user_status_occurred")
+    op.execute("DROP INDEX IF EXISTS ix_workflow_events_user_id")
+    op.drop_table("workflow_events")
+    op.execute("DROP TYPE IF EXISTS workflow_event_status_enum")
+    op.execute("DROP TYPE IF EXISTS workflow_event_severity_enum")
+    op.execute("DROP TYPE IF EXISTS workflow_event_family_enum")

--- a/apps/backend/migrations/versions/0022_harden_workflow_contract.py
+++ b/apps/backend/migrations/versions/0022_harden_workflow_contract.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "0022_harden_workflow_event_contract"
+revision = "0022_harden_workflow_contract"
 down_revision = "0021_add_workflow_events"
 branch_labels = None
 depends_on = None

--- a/apps/backend/migrations/versions/0022_harden_workflow_event_contract.py
+++ b/apps/backend/migrations/versions/0022_harden_workflow_event_contract.py
@@ -1,0 +1,58 @@
+"""harden workflow event contract"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0022_harden_workflow_event_contract"
+down_revision = "0021_add_workflow_events"
+branch_labels = None
+depends_on = None
+
+
+REPORT_IMPACT_VALUES = ("none", "processing", "ready", "blocked", "stale")
+
+
+def _create_enum_if_missing(name: str, values: tuple[str, ...]) -> None:
+    quoted_values = ", ".join(f"'{value}'" for value in values)
+    op.execute(
+        f"DO $$ BEGIN CREATE TYPE {name} AS ENUM ({quoted_values}); "
+        "EXCEPTION WHEN duplicate_object THEN null; END $$;"
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("workflow_events"):
+        return
+
+    _create_enum_if_missing("workflow_report_impact_enum", REPORT_IMPACT_VALUES)
+    op.execute(
+        "ALTER TABLE workflow_events "
+        "ALTER COLUMN report_impact TYPE workflow_report_impact_enum "
+        "USING report_impact::workflow_report_impact_enum"
+    )
+    op.execute(
+        "DO $$ BEGIN "
+        "ALTER TABLE workflow_events ADD CONSTRAINT ck_workflow_events_action_href_internal "
+        "CHECK (action_href LIKE '/%' AND action_href NOT LIKE '//%' AND action_href NOT LIKE '%://%'); "
+        "EXCEPTION WHEN duplicate_object THEN null; END $$;"
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("workflow_events"):
+        op.execute("DROP TYPE IF EXISTS workflow_report_impact_enum")
+        return
+
+    op.execute("ALTER TABLE workflow_events DROP CONSTRAINT IF EXISTS ck_workflow_events_action_href_internal")
+    op.execute(
+        "ALTER TABLE workflow_events "
+        "ALTER COLUMN report_impact TYPE VARCHAR(50) "
+        "USING report_impact::text"
+    )
+    op.execute("DROP TYPE IF EXISTS workflow_report_impact_enum")

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -47,6 +47,7 @@ from src.models.statement import (
     Stage1Status,
 )
 from src.models.user import AiFeedback, User
+from src.models.workflow import WorkflowEvent, WorkflowEventFamily, WorkflowEventSeverity, WorkflowEventStatus
 
 # Alias for SSOT compatibility (account_events table / statements table naming)
 AccountEvent = BankStatementTransaction
@@ -113,4 +114,8 @@ __all__ = [
     "TransactionDirection",
     "UploadedDocument",
     "User",
+    "WorkflowEvent",
+    "WorkflowEventFamily",
+    "WorkflowEventSeverity",
+    "WorkflowEventStatus",
 ]

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -47,7 +47,13 @@ from src.models.statement import (
     Stage1Status,
 )
 from src.models.user import AiFeedback, User
-from src.models.workflow import WorkflowEvent, WorkflowEventFamily, WorkflowEventSeverity, WorkflowEventStatus
+from src.models.workflow import (
+    WorkflowEvent,
+    WorkflowEventFamily,
+    WorkflowEventSeverity,
+    WorkflowEventStatus,
+    WorkflowReportImpact,
+)
 
 # Alias for SSOT compatibility (account_events table / statements table naming)
 AccountEvent = BankStatementTransaction
@@ -118,4 +124,5 @@ __all__ = [
     "WorkflowEventFamily",
     "WorkflowEventSeverity",
     "WorkflowEventStatus",
+    "WorkflowReportImpact",
 ]

--- a/apps/backend/src/models/workflow.py
+++ b/apps/backend/src/models/workflow.py
@@ -1,0 +1,100 @@
+"""User-facing workflow event read model."""
+
+from datetime import UTC, datetime
+from enum import Enum
+from uuid import UUID
+
+from sqlalchemy import DateTime, Enum as SQLEnum, Index, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.database import Base
+from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
+
+
+class WorkflowEventFamily(str, Enum):
+    """Product-level workflow event families."""
+
+    SOURCE_UPLOADED = "source.uploaded"
+    SOURCE_PARSING_STARTED = "source.parsing.started"
+    SOURCE_PARSING_COMPLETED = "source.parsing.completed"
+    SOURCE_PARSING_FAILED = "source.parsing.failed"
+    RECORD_VALIDATION_PASSED = "record.validation.passed"
+    RECORD_VALIDATION_FAILED = "record.validation.failed"
+    LEDGER_AUTO_POSTED = "ledger.auto_posted"
+    REVIEW_REQUIRED = "review.required"
+    REVIEW_COMPLETED = "review.completed"
+    RECONCILIATION_BLOCKED = "reconciliation.blocked"
+    REPORT_PROCESSING = "report.processing"
+    REPORT_READY = "report.ready"
+    REPORT_BLOCKED = "report.blocked"
+    REPORT_GENERATED = "report.generated"
+
+
+class WorkflowEventSeverity(str, Enum):
+    """User-facing actionability level."""
+
+    INFO = "info"
+    SUCCESS = "success"
+    WARNING = "warning"
+    ACTION_REQUIRED = "action_required"
+    BLOCKED = "blocked"
+
+
+class WorkflowEventStatus(str, Enum):
+    """User-visible event lifecycle."""
+
+    UNREAD = "unread"
+    READ = "read"
+    ARCHIVED = "archived"
+
+
+class WorkflowEvent(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
+    """User-facing workflow event projection for upload-to-report state."""
+
+    __tablename__ = "workflow_events"
+    __table_args__ = (
+        UniqueConstraint("user_id", "dedupe_key", name="uq_workflow_events_user_dedupe_key"),
+        Index("idx_workflow_events_user_status_occurred", "user_id", "status", "occurred_at"),
+        Index("idx_workflow_events_user_severity_occurred", "user_id", "severity", "occurred_at"),
+        Index("idx_workflow_events_user_family_occurred", "user_id", "family", "occurred_at"),
+        Index("idx_workflow_events_user_source", "user_id", "source_type", "source_id"),
+    )
+
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    family: Mapped[WorkflowEventFamily] = mapped_column(
+        SQLEnum(
+            WorkflowEventFamily,
+            name="workflow_event_family_enum",
+            values_callable=lambda obj: [e.value for e in obj],
+        ),
+        nullable=False,
+    )
+    severity: Mapped[WorkflowEventSeverity] = mapped_column(
+        SQLEnum(
+            WorkflowEventSeverity,
+            name="workflow_event_severity_enum",
+            values_callable=lambda obj: [e.value for e in obj],
+        ),
+        nullable=False,
+    )
+    status: Mapped[WorkflowEventStatus] = mapped_column(
+        SQLEnum(
+            WorkflowEventStatus,
+            name="workflow_event_status_enum",
+            values_callable=lambda obj: [e.value for e in obj],
+        ),
+        nullable=False,
+        default=WorkflowEventStatus.UNREAD,
+    )
+    title: Mapped[str] = mapped_column(String(160), nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    source_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    source_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    action_href: Mapped[str] = mapped_column(String(500), nullable=False)
+    report_impact: Mapped[str] = mapped_column(String(50), nullable=False, default="none")
+    dedupe_key: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/apps/backend/src/models/workflow.py
+++ b/apps/backend/src/models/workflow.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from uuid import UUID
 
-from sqlalchemy import DateTime, Enum as SQLEnum, Index, String, Text, UniqueConstraint
+from sqlalchemy import CheckConstraint, DateTime, Enum as SQLEnum, Index, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -49,12 +49,26 @@ class WorkflowEventStatus(str, Enum):
     ARCHIVED = "archived"
 
 
+class WorkflowReportImpact(str, Enum):
+    """Impact of the event on report readiness."""
+
+    NONE = "none"
+    PROCESSING = "processing"
+    READY = "ready"
+    BLOCKED = "blocked"
+    STALE = "stale"
+
+
 class WorkflowEvent(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """User-facing workflow event projection for upload-to-report state."""
 
     __tablename__ = "workflow_events"
     __table_args__ = (
         UniqueConstraint("user_id", "dedupe_key", name="uq_workflow_events_user_dedupe_key"),
+        CheckConstraint(
+            "action_href LIKE '/%' AND action_href NOT LIKE '//%' AND action_href NOT LIKE '%://%'",
+            name="ck_workflow_events_action_href_internal",
+        ),
         Index("idx_workflow_events_user_status_occurred", "user_id", "status", "occurred_at"),
         Index("idx_workflow_events_user_severity_occurred", "user_id", "severity", "occurred_at"),
         Index("idx_workflow_events_user_family_occurred", "user_id", "family", "occurred_at"),
@@ -96,5 +110,13 @@ class WorkflowEvent(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     source_type: Mapped[str] = mapped_column(String(50), nullable=False)
     source_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
     action_href: Mapped[str] = mapped_column(String(500), nullable=False)
-    report_impact: Mapped[str] = mapped_column(String(50), nullable=False, default="none")
+    report_impact: Mapped[WorkflowReportImpact] = mapped_column(
+        SQLEnum(
+            WorkflowReportImpact,
+            name="workflow_report_impact_enum",
+            values_callable=lambda obj: [e.value for e in obj],
+        ),
+        nullable=False,
+        default=WorkflowReportImpact.NONE,
+    )
     dedupe_key: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/apps/backend/src/schemas/__init__.py
+++ b/apps/backend/src/schemas/__init__.py
@@ -96,7 +96,12 @@ from src.schemas.user import (
     UserResponse,
     UserUpdate,
 )
-from src.schemas.workflow import WorkflowEventCreate, WorkflowEventResponse, WorkflowEventStatusUpdate
+from src.schemas.workflow import (
+    WorkflowEventCreate,
+    WorkflowEventResponse,
+    WorkflowEventStatusUpdate,
+    WorkflowReportImpact,
+)
 
 from .extraction import (
     BankStatementListResponse,
@@ -209,4 +214,5 @@ __all__ = [
     "WorkflowEventCreate",
     "WorkflowEventResponse",
     "WorkflowEventStatusUpdate",
+    "WorkflowReportImpact",
 ]

--- a/apps/backend/src/schemas/__init__.py
+++ b/apps/backend/src/schemas/__init__.py
@@ -96,6 +96,7 @@ from src.schemas.user import (
     UserResponse,
     UserUpdate,
 )
+from src.schemas.workflow import WorkflowEventCreate, WorkflowEventResponse, WorkflowEventStatusUpdate
 
 from .extraction import (
     BankStatementListResponse,
@@ -205,4 +206,7 @@ __all__ = [
     "UserResponse",
     "UserUpdate",
     "VoidJournalEntryRequest",
+    "WorkflowEventCreate",
+    "WorkflowEventResponse",
+    "WorkflowEventStatusUpdate",
 ]

--- a/apps/backend/src/schemas/workflow.py
+++ b/apps/backend/src/schemas/workflow.py
@@ -1,0 +1,62 @@
+"""Schemas for user-facing workflow events."""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+from src.models.workflow import WorkflowEventFamily, WorkflowEventSeverity, WorkflowEventStatus
+
+
+def _validate_internal_action_href(value: str) -> str:
+    if not value.startswith("/") or value.startswith("//") or "://" in value:
+        raise ValueError("action_href must be an internal relative path")
+    return value
+
+
+class WorkflowEventCreate(BaseModel):
+    """Input contract for deterministic workflow event upserts."""
+
+    family: WorkflowEventFamily
+    severity: WorkflowEventSeverity
+    title: str = Field(min_length=1, max_length=160)
+    summary: str = Field(min_length=1)
+    source_type: str = Field(min_length=1, max_length=50)
+    source_id: UUID
+    action_href: str = Field(min_length=1, max_length=500)
+    report_impact: str = Field(min_length=1, max_length=50)
+    dedupe_key: str = Field(min_length=1, max_length=255)
+    occurred_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @field_validator("action_href")
+    @classmethod
+    def validate_action_href(cls, value: str) -> str:
+        return _validate_internal_action_href(value)
+
+
+class WorkflowEventStatusUpdate(BaseModel):
+    """Lifecycle update payload for user-visible workflow events."""
+
+    status: WorkflowEventStatus
+
+
+class WorkflowEventResponse(BaseModel):
+    """User-facing workflow event response contract."""
+
+    id: UUID
+    user_id: UUID
+    occurred_at: datetime
+    family: WorkflowEventFamily
+    severity: WorkflowEventSeverity
+    status: WorkflowEventStatus
+    title: str
+    summary: str
+    source_type: str
+    source_id: UUID
+    action_href: str
+    report_impact: str
+    dedupe_key: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/apps/backend/src/schemas/workflow.py
+++ b/apps/backend/src/schemas/workflow.py
@@ -5,7 +5,12 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
-from src.models.workflow import WorkflowEventFamily, WorkflowEventSeverity, WorkflowEventStatus
+from src.models.workflow import (
+    WorkflowEventFamily,
+    WorkflowEventSeverity,
+    WorkflowEventStatus,
+    WorkflowReportImpact,
+)
 
 
 def _validate_internal_action_href(value: str) -> str:
@@ -24,7 +29,7 @@ class WorkflowEventCreate(BaseModel):
     source_type: str = Field(min_length=1, max_length=50)
     source_id: UUID
     action_href: str = Field(min_length=1, max_length=500)
-    report_impact: str = Field(min_length=1, max_length=50)
+    report_impact: WorkflowReportImpact
     dedupe_key: str = Field(min_length=1, max_length=255)
     occurred_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
@@ -54,7 +59,7 @@ class WorkflowEventResponse(BaseModel):
     source_type: str
     source_id: UUID
     action_href: str
-    report_impact: str
+    report_impact: WorkflowReportImpact
     dedupe_key: str
     created_at: datetime
     updated_at: datetime

--- a/apps/backend/src/services/workflow_events.py
+++ b/apps/backend/src/services/workflow_events.py
@@ -1,0 +1,121 @@
+"""Deterministic user-facing workflow event derivation."""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import BankStatement
+from src.models.workflow import WorkflowEvent, WorkflowEventFamily, WorkflowEventSeverity, WorkflowEventStatus
+from src.schemas.workflow import WorkflowEventCreate
+
+
+def build_workflow_dedupe_key(*, family: WorkflowEventFamily, source_type: str, source_id: UUID) -> str:
+    """Build the stable per-user dedupe key for a source-derived workflow event."""
+    return f"{source_type}:{source_id}:{family.value}"
+
+
+async def upsert_workflow_event(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    payload: WorkflowEventCreate,
+) -> WorkflowEvent:
+    """Create or update a deterministic workflow event without committing."""
+    result = await db.execute(
+        select(WorkflowEvent)
+        .where(WorkflowEvent.user_id == user_id)
+        .where(WorkflowEvent.dedupe_key == payload.dedupe_key)
+    )
+    event = result.scalar_one_or_none()
+    if event is None:
+        event = WorkflowEvent(
+            user_id=user_id,
+            occurred_at=payload.occurred_at,
+            family=payload.family,
+            severity=payload.severity,
+            status=WorkflowEventStatus.UNREAD,
+            title=payload.title,
+            summary=payload.summary,
+            source_type=payload.source_type,
+            source_id=payload.source_id,
+            action_href=payload.action_href,
+            report_impact=payload.report_impact,
+            dedupe_key=payload.dedupe_key,
+        )
+        db.add(event)
+    else:
+        event.occurred_at = payload.occurred_at
+        event.family = payload.family
+        event.severity = payload.severity
+        event.title = payload.title
+        event.summary = payload.summary
+        event.source_type = payload.source_type
+        event.source_id = payload.source_id
+        event.action_href = payload.action_href
+        event.report_impact = payload.report_impact
+
+    await db.flush()
+    return event
+
+
+async def derive_uploaded_statement_event(
+    db: AsyncSession,
+    statement: BankStatement,
+    *,
+    user_id: UUID,
+) -> WorkflowEvent:
+    """Upsert the initial uploaded-statement workflow event."""
+    family = WorkflowEventFamily.SOURCE_UPLOADED
+    payload = WorkflowEventCreate(
+        occurred_at=statement.created_at,
+        family=family,
+        severity=WorkflowEventSeverity.INFO,
+        title="Statement uploaded",
+        summary=f"{statement.original_filename} was uploaded and is ready for processing.",
+        source_type="bank_statement",
+        source_id=statement.id,
+        action_href=f"/statements/{statement.id}",
+        report_impact="processing",
+        dedupe_key=build_workflow_dedupe_key(
+            family=family,
+            source_type="bank_statement",
+            source_id=statement.id,
+        ),
+    )
+    return await upsert_workflow_event(db, user_id=user_id, payload=payload)
+
+
+async def list_workflow_events(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    status: WorkflowEventStatus | None = None,
+    limit: int = 50,
+) -> list[WorkflowEvent]:
+    """List user-scoped workflow events for inbox/status consumers."""
+    stmt = select(WorkflowEvent).where(WorkflowEvent.user_id == user_id)
+    if status is not None:
+        stmt = stmt.where(WorkflowEvent.status == status)
+    stmt = stmt.order_by(WorkflowEvent.occurred_at.desc(), WorkflowEvent.created_at.desc()).limit(limit)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_workflow_event_status(
+    db: AsyncSession,
+    *,
+    event_id: UUID,
+    user_id: UUID,
+    status: WorkflowEventStatus,
+) -> WorkflowEvent | None:
+    """Update read/archive lifecycle state for one user-scoped event."""
+    result = await db.execute(
+        select(WorkflowEvent).where(WorkflowEvent.id == event_id).where(WorkflowEvent.user_id == user_id)
+    )
+    event = result.scalar_one_or_none()
+    if event is None:
+        return None
+    event.status = status
+    await db.flush()
+    return event

--- a/apps/backend/src/services/workflow_events.py
+++ b/apps/backend/src/services/workflow_events.py
@@ -6,7 +6,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import BankStatement
-from src.models.workflow import WorkflowEvent, WorkflowEventFamily, WorkflowEventSeverity, WorkflowEventStatus
+from src.models.workflow import (
+    WorkflowEvent,
+    WorkflowEventFamily,
+    WorkflowEventSeverity,
+    WorkflowEventStatus,
+    WorkflowReportImpact,
+)
 from src.schemas.workflow import WorkflowEventCreate
 
 
@@ -66,6 +72,9 @@ async def derive_uploaded_statement_event(
     user_id: UUID,
 ) -> WorkflowEvent:
     """Upsert the initial uploaded-statement workflow event."""
+    if statement.user_id != user_id:
+        raise ValueError("statement.user_id must match user_id")
+
     family = WorkflowEventFamily.SOURCE_UPLOADED
     payload = WorkflowEventCreate(
         occurred_at=statement.created_at,
@@ -76,7 +85,7 @@ async def derive_uploaded_statement_event(
         source_type="bank_statement",
         source_id=statement.id,
         action_href=f"/statements/{statement.id}",
-        report_impact="processing",
+        report_impact=WorkflowReportImpact.PROCESSING,
         dedupe_key=build_workflow_dedupe_key(
             family=family,
             source_type="bank_statement",

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -1,0 +1,198 @@
+"""Workflow event contract tests for EPIC-019."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import func, inspect, select
+
+from src.models import BankStatement, BankStatementStatus, User
+from src.models.workflow import (
+    WorkflowEvent,
+    WorkflowEventFamily,
+    WorkflowEventSeverity,
+    WorkflowEventStatus,
+)
+from src.schemas.workflow import WorkflowEventCreate, WorkflowEventResponse
+from src.services.workflow_events import (
+    derive_uploaded_statement_event,
+    list_workflow_events,
+    update_workflow_event_status,
+    upsert_workflow_event,
+)
+
+ROOT_DIR = Path(__file__).resolve().parents[4]
+
+
+def test_AC19_1_1_workflow_event_ssot_registers_manifest_owner() -> None:
+    """AC19.1.1: workflow event SSOT is registered as a single manifest owner."""
+    manifest_path = ROOT_DIR / "docs" / "ssot" / "MANIFEST.yaml"
+    with open(manifest_path, encoding="utf-8") as fh:
+        manifest = fh.read()
+
+    assert "workflow_events:" in manifest
+    assert "owner: docs/ssot/workflow-events.md" in manifest
+    assert "docs/project/EPIC-019.event-driven-upload-to-report-ux.md" in manifest
+
+
+def test_AC19_1_2_workflow_event_model_contract() -> None:
+    """AC19.1.2: workflow_events model exposes lifecycle, dedupe, and read indexes."""
+    table = WorkflowEvent.__table__
+    assert table.name == "workflow_events"
+
+    enum_names = {
+        table.c.family.type.name,
+        table.c.severity.type.name,
+        table.c.status.type.name,
+    }
+    assert enum_names == {
+        "workflow_event_family_enum",
+        "workflow_event_severity_enum",
+        "workflow_event_status_enum",
+    }
+
+    unique_constraints = {
+        tuple(constraint.columns.keys()): constraint.name
+        for constraint in table.constraints
+        if constraint.__class__.__name__ == "UniqueConstraint"
+    }
+    assert unique_constraints[("user_id", "dedupe_key")] == "uq_workflow_events_user_dedupe_key"
+
+    indexes = {index.name: tuple(index.columns.keys()) for index in table.indexes}
+    assert indexes["idx_workflow_events_user_status_occurred"] == ("user_id", "status", "occurred_at")
+    assert indexes["idx_workflow_events_user_severity_occurred"] == ("user_id", "severity", "occurred_at")
+    assert indexes["idx_workflow_events_user_family_occurred"] == ("user_id", "family", "occurred_at")
+    assert indexes["idx_workflow_events_user_source"] == ("user_id", "source_type", "source_id")
+
+    mapper_columns = {column.key for column in inspect(WorkflowEvent).columns}
+    assert {
+        "id",
+        "user_id",
+        "occurred_at",
+        "family",
+        "severity",
+        "status",
+        "title",
+        "summary",
+        "source_type",
+        "source_id",
+        "action_href",
+        "report_impact",
+        "dedupe_key",
+        "created_at",
+        "updated_at",
+    }.issubset(mapper_columns)
+
+
+def test_AC19_1_3_workflow_event_schema_rejects_external_action_href() -> None:
+    """AC19.1.3: workflow event schemas only allow internal relative action links."""
+    valid = WorkflowEventCreate(
+        family=WorkflowEventFamily.SOURCE_UPLOADED,
+        severity=WorkflowEventSeverity.INFO,
+        title="Statement uploaded",
+        summary="Processing will start shortly.",
+        source_type="bank_statement",
+        source_id=uuid4(),
+        action_href="/statements/123",
+        report_impact="processing",
+        dedupe_key="bank-statement:123:source.uploaded",
+        occurred_at=datetime.now(UTC),
+    )
+    assert valid.action_href == "/statements/123"
+
+    for href in ("https://example.com/review", "//example.com/review", "javascript:alert(1)", "statements/123"):
+        with pytest.raises(ValidationError):
+            WorkflowEventCreate(
+                family=WorkflowEventFamily.SOURCE_UPLOADED,
+                severity=WorkflowEventSeverity.INFO,
+                title="Statement uploaded",
+                summary="Processing will start shortly.",
+                source_type="bank_statement",
+                source_id=uuid4(),
+                action_href=href,
+                report_impact="processing",
+                dedupe_key=f"bad:{href}",
+                occurred_at=datetime.now(UTC),
+            )
+
+
+@pytest.mark.asyncio
+async def test_AC19_1_4_upsert_uploaded_statement_event_is_deterministic(db, test_user) -> None:
+    """AC19.1.4: uploaded statement event derivation is deterministic and idempotent."""
+    statement = BankStatement(
+        user_id=test_user.id,
+        file_path="statements/demo.csv",
+        file_hash="a" * 64,
+        original_filename="demo.csv",
+        institution="Demo Bank",
+        status=BankStatementStatus.UPLOADED,
+    )
+    db.add(statement)
+    await db.flush()
+
+    first = await derive_uploaded_statement_event(db, statement, user_id=test_user.id)
+    second = await derive_uploaded_statement_event(db, statement, user_id=test_user.id)
+    await db.flush()
+
+    assert first.id == second.id
+    assert first.family == WorkflowEventFamily.SOURCE_UPLOADED
+    assert first.severity == WorkflowEventSeverity.INFO
+    assert first.status == WorkflowEventStatus.UNREAD
+    assert first.action_href == f"/statements/{statement.id}"
+    assert first.report_impact == "processing"
+
+    count = await db.scalar(select(func.count(WorkflowEvent.id)).where(WorkflowEvent.user_id == test_user.id))
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_AC19_1_5_workflow_event_lifecycle_is_user_isolated(db, test_user) -> None:
+    """AC19.1.5: workflow event reads and lifecycle changes are scoped by user_id."""
+    other_user = User(email=f"other-{uuid4()}@example.com", hashed_password="hashed")
+    db.add(other_user)
+    await db.flush()
+
+    event = await upsert_workflow_event(
+        db,
+        user_id=test_user.id,
+        payload=WorkflowEventCreate(
+            family=WorkflowEventFamily.REVIEW_REQUIRED,
+            severity=WorkflowEventSeverity.ACTION_REQUIRED,
+            title="Review required",
+            summary="One statement needs confirmation.",
+            source_type="bank_statement",
+            source_id=uuid4(),
+            action_href="/review",
+            report_impact="blocked",
+            dedupe_key="bank-statement:review-required:test",
+            occurred_at=datetime.now(UTC),
+        ),
+    )
+    await db.flush()
+
+    assert [item.id for item in await list_workflow_events(db, user_id=test_user.id)] == [event.id]
+    assert await list_workflow_events(db, user_id=other_user.id) == []
+
+    assert (
+        await update_workflow_event_status(
+            db,
+            event_id=event.id,
+            user_id=other_user.id,
+            status=WorkflowEventStatus.READ,
+        )
+        is None
+    )
+
+    updated = await update_workflow_event_status(
+        db,
+        event_id=event.id,
+        user_id=test_user.id,
+        status=WorkflowEventStatus.ARCHIVED,
+    )
+    assert updated is not None
+    assert updated.status == WorkflowEventStatus.ARCHIVED
+    assert WorkflowEventResponse.model_validate(updated).status == WorkflowEventStatus.ARCHIVED

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -16,6 +17,7 @@ from src.models.workflow import (
     WorkflowEventFamily,
     WorkflowEventSeverity,
     WorkflowEventStatus,
+    WorkflowReportImpact,
 )
 from src.schemas.workflow import WorkflowEventCreate, WorkflowEventResponse
 from src.services.workflow_events import (
@@ -48,12 +50,19 @@ def test_AC19_1_2_workflow_event_model_contract() -> None:
         table.c.family.type.name,
         table.c.severity.type.name,
         table.c.status.type.name,
+        table.c.report_impact.type.name,
     }
     assert enum_names == {
         "workflow_event_family_enum",
         "workflow_event_severity_enum",
         "workflow_event_status_enum",
+        "workflow_report_impact_enum",
     }
+
+    check_constraints = {
+        constraint.name for constraint in table.constraints if constraint.__class__.__name__ == "CheckConstraint"
+    }
+    assert "ck_workflow_events_action_href_internal" in check_constraints
 
     unique_constraints = {
         tuple(constraint.columns.keys()): constraint.name
@@ -98,11 +107,12 @@ def test_AC19_1_3_workflow_event_schema_rejects_external_action_href() -> None:
         source_type="bank_statement",
         source_id=uuid4(),
         action_href="/statements/123",
-        report_impact="processing",
+        report_impact=WorkflowReportImpact.PROCESSING,
         dedupe_key="bank-statement:123:source.uploaded",
         occurred_at=datetime.now(UTC),
     )
     assert valid.action_href == "/statements/123"
+    assert valid.report_impact == WorkflowReportImpact.PROCESSING
 
     for href in ("https://example.com/review", "//example.com/review", "javascript:alert(1)", "statements/123"):
         with pytest.raises(ValidationError):
@@ -114,10 +124,45 @@ def test_AC19_1_3_workflow_event_schema_rejects_external_action_href() -> None:
                 source_type="bank_statement",
                 source_id=uuid4(),
                 action_href=href,
-                report_impact="processing",
+                report_impact=WorkflowReportImpact.PROCESSING,
                 dedupe_key=f"bad:{href}",
                 occurred_at=datetime.now(UTC),
             )
+
+    with pytest.raises(ValidationError):
+        WorkflowEventCreate(
+            family=WorkflowEventFamily.REPORT_READY,
+            severity=WorkflowEventSeverity.SUCCESS,
+            title="Report ready",
+            summary="The report can be opened.",
+            source_type="report",
+            source_id=uuid4(),
+            action_href="/reports/current",
+            report_impact="published",
+            dedupe_key="report:current:report.ready",
+            occurred_at=datetime.now(UTC),
+        )
+
+    with pytest.raises(ValidationError):
+        WorkflowEventResponse.model_validate(
+            SimpleNamespace(
+                id=uuid4(),
+                user_id=uuid4(),
+                occurred_at=datetime.now(UTC),
+                family=WorkflowEventFamily.REPORT_READY,
+                severity=WorkflowEventSeverity.SUCCESS,
+                status=WorkflowEventStatus.UNREAD,
+                title="Report ready",
+                summary="The report can be opened.",
+                source_type="report",
+                source_id=uuid4(),
+                action_href="/reports/current",
+                report_impact="published",
+                dedupe_key="report:current:report.ready",
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+        )
 
 
 @pytest.mark.asyncio
@@ -143,7 +188,7 @@ async def test_AC19_1_4_upsert_uploaded_statement_event_is_deterministic(db, tes
     assert first.severity == WorkflowEventSeverity.INFO
     assert first.status == WorkflowEventStatus.UNREAD
     assert first.action_href == f"/statements/{statement.id}"
-    assert first.report_impact == "processing"
+    assert first.report_impact == WorkflowReportImpact.PROCESSING
 
     count = await db.scalar(select(func.count(WorkflowEvent.id)).where(WorkflowEvent.user_id == test_user.id))
     assert count == 1
@@ -156,6 +201,20 @@ async def test_AC19_1_5_workflow_event_lifecycle_is_user_isolated(db, test_user)
     db.add(other_user)
     await db.flush()
 
+    statement = BankStatement(
+        user_id=test_user.id,
+        file_path="statements/owned.csv",
+        file_hash="b" * 64,
+        original_filename="owned.csv",
+        institution="Demo Bank",
+        status=BankStatementStatus.UPLOADED,
+    )
+    db.add(statement)
+    await db.flush()
+
+    with pytest.raises(ValueError, match="statement.user_id must match user_id"):
+        await derive_uploaded_statement_event(db, statement, user_id=other_user.id)
+
     event = await upsert_workflow_event(
         db,
         user_id=test_user.id,
@@ -167,7 +226,7 @@ async def test_AC19_1_5_workflow_event_lifecycle_is_user_isolated(db, test_user)
             source_type="bank_statement",
             source_id=uuid4(),
             action_href="/review",
-            report_impact="blocked",
+            report_impact=WorkflowReportImpact.BLOCKED,
             dedupe_key="bank-statement:review-required:test",
             occurred_at=datetime.now(UTC),
         ),

--- a/common/ssot/generate_ac_registry.py
+++ b/common/ssot/generate_ac_registry.py
@@ -26,7 +26,7 @@ OUTPUT_INFRA = "docs/infra_registry.yaml"
 OUTPUT = OUTPUT_FEATURE
 
 # EPIC classification: which EPICs are feature vs infra
-FEATURE_EPICS = {1, 2, 3, 4, 5, 6, 8, 11, 13, 15, 16, 17, 18}
+FEATURE_EPICS = {1, 2, 3, 4, 5, 6, 8, 11, 13, 15, 16, 17, 18, 19}
 INFRA_EPICS = {7, 9, 10, 12, 14}
 
 # EPIC-016 sub-classification: these AC16.XX.x groups route to infra
@@ -51,6 +51,7 @@ EPIC_NAMES: dict[int, str] = {
     16: "two-stage-review-ui",
     17: "portfolio-management",
     18: "ai-driven-pipeline",
+    19: "event-driven-upload-to-report-ux",
 }
 
 

--- a/common/ssot/generate_ac_registry.py
+++ b/common/ssot/generate_ac_registry.py
@@ -91,7 +91,7 @@ def _extract_ac_definition(line: str) -> tuple[str, int, str] | None:
         if not match:
             return None
         desc = _clean_description(cells[1] if len(cells) > 1 else "")
-        return match.group(1), int(match.group(2)), desc[:120]
+        return match.group(1), int(match.group(2)), desc
 
     match = re.match(
         r"^(?:[-*]\s*)?(?:\*\*)?(AC(\d+)\.(\d+)\.(\d+))(?:\*\*)?\s*[:|-]\s*(.+)$",
@@ -103,7 +103,7 @@ def _extract_ac_definition(line: str) -> tuple[str, int, str] | None:
     ac_id = match.group(1)
     ac_epic = int(match.group(2))
     desc = _clean_description(match.group(5))
-    return ac_id, ac_epic, desc[:120]
+    return ac_id, ac_epic, desc
 
 
 def _require_yaml() -> None:

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2393,7 +2393,8 @@ groups:
         epic: 8
         epic_name: testing-strategy
         description: Personal report package representative fixture contract defines bank cash, income and expense activity,
-          brokerage holdings, manual property valuation, liability, restricted compensation, notes, traceability anchors, and exact Decimal expected outputs.
+          brokerage holdings, manual property valuation, liability, restricted compensation, notes, traceability anchors,
+          and exact Decimal expected outputs.
         mandatory: true
       - id: AC8.13.84
         epic: 8
@@ -3983,7 +3984,8 @@ groups:
       - id: AC16.22.7
         epic: 16
         epic_name: two-stage-review-ui
-        description: Stage 1 approval tolerance and extraction/reconciliation scoring tolerance remain separate documented policies
+        description: Stage 1 approval tolerance and extraction/reconciliation scoring tolerance remain separate documented
+          policies
         mandatory: true
     AC16.23:
       - id: AC16.23.1
@@ -4162,32 +4164,33 @@ groups:
       - id: AC16.30.1
         epic: 16
         epic_name: two-stage-review-ui
-        description: IconButton keeps its required label as the authoritative accessible name so callers cannot override or remove
-          it through passthrough props.
+        description: IconButton keeps its required label as the authoritative accessible name so callers cannot override or
+          remove it through passthrough props.
         mandatory: true
       - id: AC16.30.2
         epic: 16
         epic_name: two-stage-review-ui
-        description: The design-token follow-ups from issues 612 and 613 are resolved; border tokens are documented, core recipes
-          use border-border, alert variants use semantic status token classes, and SSOT examples use accurate fence language.
+        description: The design-token follow-ups from issues 612 and 613 are resolved; border tokens are documented, core
+          recipes use border-border, alert variants use semantic status token classes, and SSOT examples use accurate fence
+          language.
         mandatory: true
       - id: AC16.30.3
         epic: 16
         epic_name: two-stage-review-ui
-        description: WorkspaceTabs uses one coherent navigation/list semantic model with aria-current for the active route while
-          preserving keyboard navigation between open workspace pages.
+        description: WorkspaceTabs uses one coherent navigation/list semantic model with aria-current for the active route
+          while preserving keyboard navigation between open workspace pages.
         mandatory: true
       - id: AC16.30.4
         epic: 16
         epic_name: two-stage-review-ui
-        description: Component tests cover keyboard and ARIA behavior for dialog, sheet, toast, workspace navigation, and icon-only
-          controls.
+        description: Component tests cover keyboard and ARIA behavior for dialog, sheet, toast, workspace navigation, and
+          icon-only controls.
         mandatory: true
       - id: AC16.30.5
         epic: 16
         epic_name: two-stage-review-ui
-        description: Playwright visual smoke covers desktop and mobile representative app-shell, accounts, statements, and review
-          pages with stable visual anchors and nonblank screenshots.
+        description: Playwright visual smoke covers desktop and mobile representative app-shell, accounts, statements, and
+          review pages with stable visual anchors and nonblank screenshots.
         mandatory: true
       - id: AC16.30.6
         epic: 16
@@ -4802,4 +4805,34 @@ groups:
         epic_name: ai-driven-pipeline
         description: 'Frontend tests: mount ConfidenceBadge for each tier; mount AI Suggestion Queue and assert Accept/Reject
           buttons render; '
+        mandatory: true
+  AC19:
+    AC19.1:
+      - id: AC19.1.1
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: Workflow event SSOT defines event families, severity/actionability, lifecycle states, dedupe rules, internal
+          action link
+        mandatory: true
+      - id: AC19.1.2
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: Backend model defines a user-scoped workflow_events read model with explicit enum names, lifecycle status,
+          UNIQUE(user_i
+        mandatory: true
+      - id: AC19.1.3
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: Pydantic schemas validate the workflow event contract and reject external action_href values
+        mandatory: true
+      - id: AC19.1.4
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: Workflow event service deterministically upserts a derived event from existing statement/upload state
+          without duplicatin
+        mandatory: true
+      - id: AC19.1.5
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: Workflow event reads and lifecycle changes are user isolated
         mandatory: true

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -4812,13 +4812,13 @@ groups:
         epic: 19
         epic_name: event-driven-upload-to-report-ux
         description: Workflow event SSOT defines event families, severity/actionability, lifecycle states, dedupe rules, internal
-          action link
+          action links, indexes, and relationship to audit logs
         mandatory: true
       - id: AC19.1.2
         epic: 19
         epic_name: event-driven-upload-to-report-ux
         description: Backend model defines a user-scoped workflow_events read model with explicit enum names, lifecycle status,
-          UNIQUE(user_i
+          UNIQUE(user_id, dedupe_key), and badge/inbox read indexes
         mandatory: true
       - id: AC19.1.3
         epic: 19
@@ -4829,7 +4829,7 @@ groups:
         epic: 19
         epic_name: event-driven-upload-to-report-ux
         description: Workflow event service deterministically upserts a derived event from existing statement/upload state
-          without duplicatin
+          without duplicating on rerun
         mandatory: true
       - id: AC19.1.5
         epic: 19

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -286,6 +286,18 @@ users and debugging workflows still have full access to accounting details.
 This order avoids a cosmetic navigation reshuffle before the underlying
 workflow state exists.
 
+## Acceptance Criteria
+
+### AC19.1 — Product Workflow Event Model
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC19.1.1 | Workflow event SSOT defines event families, severity/actionability, lifecycle states, dedupe rules, internal action links, indexes, and relationship to audit logs | `test_AC19_1_1_workflow_event_ssot_registers_manifest_owner` | P0 |
+| AC19.1.2 | Backend model defines a user-scoped `workflow_events` read model with explicit enum names, lifecycle status, `UNIQUE(user_id, dedupe_key)`, and badge/inbox read indexes | `test_AC19_1_2_workflow_event_model_contract` | P0 |
+| AC19.1.3 | Pydantic schemas validate the workflow event contract and reject external `action_href` values | `test_AC19_1_3_workflow_event_schema_rejects_external_action_href` | P0 |
+| AC19.1.4 | Workflow event service deterministically upserts a derived event from existing statement/upload state without duplicating on rerun | `test_AC19_1_4_upsert_uploaded_statement_event_is_deterministic` | P0 |
+| AC19.1.5 | Workflow event reads and lifecycle changes are user isolated | `test_AC19_1_5_workflow_event_lifecycle_is_user_isolated` | P0 |
+
 ## How To Build It
 
 ### Backend

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -148,6 +148,14 @@ concepts:
       - docs/ssot/reconciliation.md
       - docs/ssot/processing_account.md
 
+  workflow_events:
+    owner: docs/ssot/workflow-events.md
+    description: User-facing upload-to-report workflow event read model.
+    cross_refs:
+      - docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+      - docs/ssot/confirmation-workflow.md
+      - docs/ssot/reporting.md
+
   # ── Observability ──────────────────────────────────────────────────────
   observability_logging:
     owner: docs/ssot/observability.md

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -70,6 +70,7 @@ contracts is tracked in
 | [source-type-priority.md](./source-type-priority.md) | `source-type-priority` | Trust hierarchy rationale; priority should migrate to code/common |
 | [confirmation-workflow.md](./confirmation-workflow.md) | `confirmation-workflow` | Review lifecycle rationale; state machine should migrate to code/common |
 | [processing_account.md](./processing_account.md) | `processing_account` | In-transit funds model and proof references |
+| [workflow-events.md](./workflow-events.md) | `workflow-events` | User-facing upload-to-report workflow event read model |
 
 ## Proof Reports
 

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -18,7 +18,7 @@
 | Event model | `apps/backend/src/models/workflow.py` |
 | Event schemas | `apps/backend/src/schemas/workflow.py` |
 | Derivation/upsert service | `apps/backend/src/services/workflow_events.py` |
-| Database migration | `apps/backend/migrations/versions/0021_add_workflow_events.py` |
+| Database migrations | `apps/backend/migrations/versions/0021_add_workflow_events.py`, `apps/backend/migrations/versions/0022_harden_workflow_event_contract.py` |
 | Contract tests | `apps/backend/tests/workflow/test_workflow_events.py` |
 
 ---
@@ -136,12 +136,15 @@ Required database rules:
 - `INDEX(user_id, severity, occurred_at)`
 - `INDEX(user_id, family, occurred_at)`
 - `INDEX(user_id, source_type, source_id)`
+- `CHECK(action_href)` only allows internal relative routes: starts with `/`,
+  does not start with `//`, and does not contain `://`.
 
 All database enum types must have explicit names:
 
 - `workflow_event_family_enum`
 - `workflow_event_severity_enum`
 - `workflow_event_status_enum`
+- `workflow_report_impact_enum`
 
 ---
 

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -18,7 +18,7 @@
 | Event model | `apps/backend/src/models/workflow.py` |
 | Event schemas | `apps/backend/src/schemas/workflow.py` |
 | Derivation/upsert service | `apps/backend/src/services/workflow_events.py` |
-| Database migrations | `apps/backend/migrations/versions/0021_add_workflow_events.py`, `apps/backend/migrations/versions/0022_harden_workflow_event_contract.py` |
+| Database migrations | `apps/backend/migrations/versions/0021_add_workflow_events.py`, `apps/backend/migrations/versions/0022_harden_workflow_contract.py` |
 | Contract tests | `apps/backend/tests/workflow/test_workflow_events.py` |
 
 ---

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -1,0 +1,215 @@
+# Workflow Events SSOT
+
+> **SSOT Key**: `workflow-events`
+> **Authority**: This document defines the user-facing workflow event read
+> model used by EPIC-019. Workflow events describe product attention state; they
+> do not replace audit logs, ledger state, reconciliation state, or report
+> traceability.
+> **Cross-references**: [confirmation-workflow.md](./confirmation-workflow.md),
+> [reconciliation.md](./reconciliation.md), [reporting.md](./reporting.md),
+> [schema.md](./schema.md), [EPIC-019](../project/EPIC-019.event-driven-upload-to-report-ux.md)
+
+---
+
+## 1. Source of Truth
+
+| Concern | Location |
+|---|---|
+| Event model | `apps/backend/src/models/workflow.py` |
+| Event schemas | `apps/backend/src/schemas/workflow.py` |
+| Derivation/upsert service | `apps/backend/src/services/workflow_events.py` |
+| Database migration | `apps/backend/migrations/versions/0021_add_workflow_events.py` |
+| Contract tests | `apps/backend/tests/workflow/test_workflow_events.py` |
+
+---
+
+## 2. Purpose
+
+Workflow events are the product read model for the upload-to-report journey.
+They answer:
+
+- What happened?
+- Does the user need to act?
+- Where should the user go next?
+- Does this affect report readiness?
+
+They are intentionally separate from:
+
+- `JournalAuditLog`, which is audit proof for journal mutations.
+- `JournalLine.event_type`, which is accounting metadata.
+- `BankStatement.status` and `BankStatement.stage1_status`, which are
+  statement processing and Stage 1 review state.
+- `ReconciliationMatch.status`, which is Stage 2 matching state.
+- Report package traceability, which proves report line support.
+
+Workflow events may summarize those sources, but they do not own them.
+
+---
+
+## 3. Event Families
+
+Initial event families:
+
+```text
+source.uploaded
+source.parsing.started
+source.parsing.completed
+source.parsing.failed
+record.validation.passed
+record.validation.failed
+ledger.auto_posted
+review.required
+review.completed
+reconciliation.blocked
+report.processing
+report.ready
+report.blocked
+report.generated
+```
+
+The code owner is `WorkflowEventFamily` in
+`apps/backend/src/models/workflow.py`.
+
+---
+
+## 4. Severity And Actionability
+
+| Severity | Meaning | UI treatment |
+|---|---|---|
+| `info` | Routine progress; no immediate user action | Low prominence |
+| `success` | Automation completed successfully | Summarizable/collapsible |
+| `warning` | User may need awareness, but not necessarily blocked | Medium prominence |
+| `action_required` | User input is required to continue | Badge/inbox prominent |
+| `blocked` | Report or workflow progress is blocked | Highest prominence |
+
+Successful automation should not create noisy primary UI. `action_required` and
+`blocked` events are the main attention drivers.
+
+---
+
+## 5. Lifecycle
+
+Workflow event lifecycle is user-visible only:
+
+```text
+unread -> read -> archived
+```
+
+Rules:
+
+- New or newly-derived events start as `unread`.
+- Rerunning deterministic derivation must not reset an existing read or
+  archived event to unread.
+- Archive hides an event from default inbox views but does not delete proof or
+  underlying business state.
+- Lifecycle changes are scoped by `user_id`.
+
+---
+
+## 6. Persistence Contract
+
+The read model table is `workflow_events`.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `id` | Event identity |
+| `user_id` | Owner and isolation boundary |
+| `occurred_at` | Product event time |
+| `family` | Stable workflow family |
+| `severity` | User-facing actionability |
+| `status` | User-visible lifecycle |
+| `title` | Short UI label |
+| `summary` | Plain-language explanation |
+| `source_type` | Source domain, for example `bank_statement` |
+| `source_id` | Source record id |
+| `action_href` | Internal route for the next action or detail view |
+| `report_impact` | `none`, `processing`, `ready`, `blocked`, or `stale` |
+| `dedupe_key` | Stable deterministic key for idempotent upsert |
+| `created_at` / `updated_at` | Model timestamps |
+
+Required database rules:
+
+- `UNIQUE(user_id, dedupe_key)`
+- `INDEX(user_id, status, occurred_at)`
+- `INDEX(user_id, severity, occurred_at)`
+- `INDEX(user_id, family, occurred_at)`
+- `INDEX(user_id, source_type, source_id)`
+
+All database enum types must have explicit names:
+
+- `workflow_event_family_enum`
+- `workflow_event_severity_enum`
+- `workflow_event_status_enum`
+
+---
+
+## 7. Dedupe Rules
+
+`dedupe_key` must be deterministic for the same user-visible event. Source
+derived events use:
+
+```text
+{source_type}:{source_id}:{family}
+```
+
+Examples:
+
+```text
+bank_statement:4ab1...:source.uploaded
+bank_statement:4ab1...:review.required
+```
+
+Rerunning derivation updates mutable display fields, but it must not create
+duplicates or reset lifecycle status.
+
+---
+
+## 8. Action Links
+
+`action_href` must be an internal relative route. Valid examples:
+
+```text
+/statements/{statement_id}
+/review
+/reconciliation/review-queue
+/reconciliation/unmatched
+/reports/package
+```
+
+Invalid examples:
+
+```text
+https://example.com/review
+//example.com/review
+javascript:alert(1)
+statements/{statement_id}
+```
+
+External push, email, Slack, browser push, and proactive reminders are out of
+scope for EPIC-019.
+
+---
+
+## 9. Read Path Rules
+
+Header badges and global attention indicators must not load the full event
+list. They should use compact status/count APIs owned by #636.
+
+Event inbox and status feed views may use paginated event lists. Default lists
+must be user-scoped, ordered by recent `occurred_at`, and bounded by a limit.
+
+---
+
+## 10. Initial Derivation
+
+The first implementation derives `source.uploaded` from `BankStatement` upload
+state. This proves the contract without introducing a full workflow API or UI.
+
+Future slices may add deterministic derivation for:
+
+- Stage 1 review required/completed.
+- Reconciliation blockers.
+- Processing-account blockers.
+- Report processing/ready/blocked state.


### PR DESCRIPTION
## Summary

Define EPIC-019 workflow event read model contract for user-facing upload-to-report events.

Closes #635

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-019 — Event-Driven Upload-to-Report UX |
| **AC IDs** | AC19.1.1, AC19.1.2, AC19.1.3, AC19.1.4, AC19.1.5 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/MANIFEST.yaml` — added `workflow_events` concept owner
- [x] `docs/ssot/workflow-events.md` — defines workflow event families, severity, lifecycle, dedupe, action links, indexes, and audit-log boundary
- [x] `docs/ssot/README.md` — indexes workflow-events SSOT

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `b3300ae` | Added AC19.1.x contract tests before implementation; local red failed with missing `src.models.workflow` module. |
| 🟢 Green (passing test) | `e8a7436` | Implemented workflow event model/schema/service/migration to satisfy the contract. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (N/A; no frontend env vars)
- [x] `repo/` submodule updated for production config changes (N/A; no config/submodule changes)
- [x] `tools/check_env_keys.py` passes (N/A; no env vars changed)
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

N/A. This PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_ac_traceability.py
uv run --with pyyaml python tools/check_e2e_epic_traceability.py --output /tmp/E2E-EPIC-TRACEABILITY.md
uv run --with pyyaml --python 3.12.12 python tools/check_manifest.py
uv run --with pyyaml --python 3.12.12 python tools/lint_doc_consistency.py
cd apps/backend && uv run python -m compileall -q src tests/workflow/test_workflow_events.py
cd apps/backend && uv run pytest tests/workflow/test_workflow_events.py --collect-only -q
moon run :lint
```

Attempted:

```bash
moon run :test
```

Local full test run is blocked because this machine cannot connect to Podman (`podman compose ... connect: connection refused`). CI provides the Postgres service and must verify the DB-backed workflow tests.

---

## Screenshots / Evidence

N/A — backend contract and SSOT change only.
