### PR TITLE
[finance_report_audit] Harden classification service idempotency

### DIFF
--- a/apps/backend/src/services/classification.py
+++ b/apps/backend/src/services/classification.py
@@ -158,6 +158,16 @@ class ClassificationService:
                     break
 
             if matched_rule:
+                existing_result = await db.execute(
+                    select(TransactionClassification)
+                    .where(TransactionClassification.atomic_txn_id == txn.id)
+                    .where(TransactionClassification.rule_version_id == matched_rule.id)
+                )
+                existing_classification = existing_result.scalar_one_or_none()
+                if existing_classification:
+                    results.append(existing_classification)
+                    continue
+
                 classification = TransactionClassification(
                     atomic_txn_id=txn.id,
                     rule_version_id=matched_rule.id,

--- a/apps/backend/tests/extraction/test_classification_service.py
+++ b/apps/backend/tests/extraction/test_classification_service.py
@@ -8,10 +8,11 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy import select
 
 from src.models.account import Account, AccountType
 from src.models.layer2 import AtomicTransaction, TransactionDirection
-from src.models.layer3 import ClassificationRule, RuleType
+from src.models.layer3 import ClassificationRule, RuleType, TransactionClassification
 from src.services.classification import ClassificationService
 
 
@@ -618,6 +619,7 @@ class TestClassificationService:
         assert len(results) == 0
 
     async def test_classification_priority_keyword_over_regex_over_ml(self, db, test_user):
+        """AC18.1.4 AC11.12.2: Rule type priority beats lower-priority AI/regex matches."""
         service = ClassificationService()
 
         keyword_account = Account(
@@ -694,6 +696,121 @@ class TestClassificationService:
 
         assert len(results) == 1
         assert results[0].account_id == keyword_account.id
+
+    async def test_same_type_rules_prefer_newer_version(self, db, test_user):
+        """AC11.12.2: Same-type matches choose the newest rule version deterministically."""
+        service = ClassificationService()
+
+        old_account = Account(
+            user_id=test_user.id,
+            name="Old Grocery Account",
+            type=AccountType.EXPENSE,
+            currency="SGD",
+            code="6817",
+        )
+        new_account = Account(
+            user_id=test_user.id,
+            name="New Grocery Account",
+            type=AccountType.EXPENSE,
+            currency="SGD",
+            code="6818",
+        )
+        db.add_all([old_account, new_account])
+        await db.flush()
+
+        old_rule = ClassificationRule(
+            user_id=test_user.id,
+            version_number=1,
+            effective_date=date(2024, 1, 1),
+            rule_name="Grocery Rule",
+            rule_type=RuleType.KEYWORD_MATCH,
+            rule_config={"keywords": ["grocery"]},
+            default_account_id=old_account.id,
+            created_by=test_user.id,
+        )
+        new_rule = ClassificationRule(
+            user_id=test_user.id,
+            version_number=2,
+            effective_date=date(2024, 2, 1),
+            rule_name="Grocery Rule",
+            rule_type=RuleType.KEYWORD_MATCH,
+            rule_config={"keywords": ["grocery"]},
+            default_account_id=new_account.id,
+            created_by=test_user.id,
+        )
+        db.add_all([old_rule, new_rule])
+        await db.flush()
+
+        txn = AtomicTransaction(
+            user_id=test_user.id,
+            txn_date=date(2024, 2, 15),
+            amount=Decimal("42.00"),
+            direction=TransactionDirection.OUT,
+            description="Grocery store",
+            currency="SGD",
+            dedup_hash="hash_same_type_newer_version",
+            source_documents=[],
+        )
+        db.add(txn)
+        await db.flush()
+
+        results = await service.apply_rules(db, test_user.id, [txn])
+
+        assert len(results) == 1
+        assert results[0].rule_version_id == new_rule.id
+        assert results[0].account_id == new_account.id
+
+    async def test_apply_rules_is_idempotent_for_existing_transaction_rule_version(self, db, test_user):
+        """AC11.12.1: Re-running the same rule does not duplicate Layer 3 classifications."""
+        service = ClassificationService()
+
+        account = Account(
+            user_id=test_user.id,
+            name="Idempotent Classification Account",
+            type=AccountType.EXPENSE,
+            currency="SGD",
+            code="6819",
+        )
+        db.add(account)
+        await db.flush()
+
+        rule = ClassificationRule(
+            user_id=test_user.id,
+            version_number=1,
+            effective_date=date(2024, 1, 1),
+            rule_name="Idempotent Keyword Rule",
+            rule_type=RuleType.KEYWORD_MATCH,
+            rule_config={"keywords": ["subscription"]},
+            default_account_id=account.id,
+            created_by=test_user.id,
+        )
+        txn = AtomicTransaction(
+            user_id=test_user.id,
+            txn_date=date(2024, 3, 15),
+            amount=Decimal("19.99"),
+            direction=TransactionDirection.OUT,
+            description="Software subscription",
+            currency="SGD",
+            dedup_hash="hash_classification_idempotency",
+            source_documents=[],
+        )
+        db.add_all([rule, txn])
+        await db.flush()
+
+        first_results = await service.apply_rules(db, test_user.id, [txn])
+        second_results = await service.apply_rules(db, test_user.id, [txn])
+
+        assert len(first_results) == 1
+        assert len(second_results) == 1
+        assert second_results[0].id == first_results[0].id
+
+        classification_result = await db.execute(
+            select(TransactionClassification)
+            .where(TransactionClassification.atomic_txn_id == txn.id)
+            .where(TransactionClassification.rule_version_id == rule.id)
+        )
+        classifications = classification_result.scalars().all()
+        assert len(classifications) == 1
 
     async def test_ml_model_rule_ignores_non_extraction_source(self, db, test_user):
         service = ClassificationService()

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -2683,6 +2683,17 @@ groups:
         description: The schedule includes ESOP/RSU/stock-option restricted holdings with valuation basis, vesting/unlock
           metadata, fair valu
         mandatory: true
+    AC11.12:
+      - id: AC11.12.1
+        epic: 11
+        epic_name: asset-lifecycle
+        description: Classification rule application is idempotent for the same transaction and rule version
+        mandatory: true
+      - id: AC11.12.2
+        epic: 11
+        epic_name: asset-lifecycle
+        description: Classification priority is deterministic across rule type and descending rule version
+        mandatory: true
   AC13:
     AC13.1:
       - id: AC13.1.1

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-06-03 04:08:32 UTC by `tools/analyze_test_ac_coverage.py`
+> Generated: 2026-06-03 07:36:03 UTC by `tools/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 1102 |
-| Active ACs | 942 |
+| Registered ACs | 1131 |
+| Active ACs | 971 |
 | Deprecated ACs excluded from coverage gate | 160 |
-| Covered by real test candidates | 942 (100.0%) |
+| Covered by real test candidates | 971 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -32,11 +32,11 @@
 
 | Source | Files scanned | Unique AC refs (real) | Unique AC refs (placeholder) | Unique AC refs (stub) |
 |---|---:|---:|---:|---:|
-| backend | 178 | 698 | 0 | 0 |
-| frontend | 82 | 212 | 0 | 0 |
-| frontend_playwright | 2 | 11 | 0 | 0 |
-| tooling_tests | 53 | 258 | 0 | 0 |
-| e2e | 13 | 60 | 0 | 0 |
+| backend | 180 | 712 | 0 | 0 |
+| frontend | 83 | 222 | 0 | 0 |
+| frontend_playwright | 3 | 12 | 0 | 0 |
+| tooling_tests | 54 | 261 | 0 | 0 |
+| e2e | 13 | 64 | 0 | 0 |
 
 ## Coverage by EPIC
 
@@ -44,20 +44,20 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|
 | EPIC-001 | phase0-setup | 29 | 2 | 27 | 0 | 0 | 0 | 100.0% |
 | EPIC-002 | double-entry-core | 62 | 15 | 47 | 0 | 0 | 0 | 100.0% |
-| EPIC-003 | statement-parsing | 60 | 20 | 40 | 0 | 0 | 0 | 100.0% |
-| EPIC-004 | reconciliation-engine | 41 | 21 | 20 | 0 | 0 | 0 | 100.0% |
-| EPIC-005 | reporting-visualization | 50 | 11 | 39 | 0 | 0 | 0 | 100.0% |
+| EPIC-003 | statement-parsing | 62 | 20 | 42 | 0 | 0 | 0 | 100.0% |
+| EPIC-004 | reconciliation-engine | 44 | 21 | 23 | 0 | 0 | 0 | 100.0% |
+| EPIC-005 | reporting-visualization | 55 | 11 | 44 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 8 | 55 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-008 | testing-strategy | 139 | 6 | 133 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 142 | 6 | 136 | 0 | 0 | 0 | 100.0% |
 | EPIC-009 | pdf-fixture-generation | 37 | 1 | 36 | 0 | 0 | 0 | 100.0% |
 | EPIC-010 | signoz-logging | 25 | 0 | 25 | 0 | 0 | 0 | 100.0% |
-| EPIC-011 | asset-lifecycle | 51 | 0 | 51 | 0 | 0 | 0 | 100.0% |
-| EPIC-012 | foundation-libs | 63 | 7 | 56 | 0 | 0 | 0 | 100.0% |
+| EPIC-011 | asset-lifecycle | 53 | 0 | 53 | 0 | 0 | 0 | 100.0% |
+| EPIC-012 | foundation-libs | 66 | 7 | 59 | 0 | 0 | 0 | 100.0% |
 | EPIC-013 | statement-parsing-v2 | 60 | 2 | 58 | 0 | 0 | 0 | 100.0% |
 | EPIC-014 | ttd-transformation | 6 | 0 | 6 | 0 | 0 | 0 | 100.0% |
 | EPIC-015 | processing-account | 31 | 0 | 31 | 0 | 0 | 0 | 100.0% |
-| EPIC-016 | two-stage-review-ui | 231 | 24 | 207 | 0 | 0 | 0 | 100.0% |
+| EPIC-016 | two-stage-review-ui | 242 | 24 | 218 | 0 | 0 | 0 | 100.0% |
 | EPIC-017 | portfolio-management | 91 | 43 | 48 | 0 | 0 | 0 | 100.0% |
 | EPIC-018 | ai-driven-pipeline | 24 | 0 | 24 | 0 | 0 | 0 | 100.0% |
 

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -2114,3 +2114,10 @@ representative fixture expansion needed before the overall
 |----|-----------|---------------|------|----------|
 | AC11.11.1 | `GET /api/reports/package/annualized-income-schedule` returns annualized salary, bonus, dividend, total income, currency, as-of date, and trailing-period boundaries for the personal report package | `test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restricted_treatment` | `reporting/test_annualized_income_schedule.py` | P0 |
 | AC11.11.2 | The schedule includes ESOP/RSU/stock-option restricted holdings with valuation basis, vesting/unlock metadata, fair value, and explicit liquid-versus-restricted net worth treatment | `test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restricted_treatment` | `reporting/test_annualized_income_schedule.py` | P0 |
+
+### Acceptance Criteria — Layer 3 Classification Service
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.12.1 | Re-applying the same rule version to the same atomic transaction is idempotent and returns the existing classification without inserting duplicates | `test_apply_rules_is_idempotent_for_existing_transaction_rule_version` | `extraction/test_classification_service.py` | P0 |
+| AC11.12.2 | Classification priority is deterministic across rule type and descending rule version | `test_classification_priority_keyword_over_regex_over_ml`, `test_same_type_rules_prefer_newer_version` | `extraction/test_classification_service.py` | P0 |

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -482,6 +482,18 @@ Reconciliation match table.
     **Constraints**:
     - `(user_id, dedup_hash)` unique
 
+    ### Layer 3: ClassificationRules and TransactionClassification (EPIC-011)
+    Versioned business rules map immutable Layer 2 transactions into report and posting categories.
+
+    | Table | Key Columns | Constraints | Operational Contract |
+    |-------|-------------|-------------|----------------------|
+    | classification_rules | user_id, rule_name, version_number, rule_type, rule_config, default_account_id | `(user_id, rule_name, version_number)` unique | Active rules are evaluated by deterministic priority, then descending version number. |
+    | transaction_classification | atomic_txn_id, rule_version_id, account_id, tags, confidence_score, status | `(atomic_txn_id, rule_version_id)` unique | Re-running the same rule version for the same transaction is idempotent: return the existing classification without inserting a duplicate or surfacing a database uniqueness error. |
+
+    **Constraints**:
+    - Rule priority is deterministic: keyword rules outrank regex rules, regex rules outrank ML rules, and newer versions win within the same rule type.
+    - One transaction can have multiple classifications only across different rule versions; one transaction plus one rule version has exactly one classification row.
+
     ### Layer 3: ManualValuationSnapshots (EPIC-011)
     User-entered valuation snapshots for net worth components that do not arrive from bank or broker statements.
 


### PR DESCRIPTION
## Summary

Harden Layer 3 classification reruns so applying the same rule version to the same atomic transaction is idempotent, and add AC-backed provider-free service coverage.

Refs #417

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-011 — Asset Lifecycle Management |
| **AC IDs** | AC11.12.1, AC11.12.2, AC18.1.4 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/schema.md` — documents Layer 3 classification priority and transaction/rule-version idempotency
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `462e6ce` | Adds AC11.12.1/AC11.12.2 coverage for idempotent classification reruns and same-type rule version priority before service implementation |
| 🟢 Green (passing test) | `a2af34b` | Reuses an existing TransactionClassification for the same atomic transaction and rule version instead of inserting a duplicate |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no enum/model change)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `tools/check_env_keys.py` passes (not applicable; no env var changes)
- [x] `tools/check_manifest.py` passes (not applicable; no MANIFEST change)
- [x] `tools/lint_doc_consistency.py` passes (covered by `moon run :lint`)

### CI/CD, Runtime, and VPS Infra Audit

Not applicable: this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
python3 -m compileall -q apps/backend/src/services/classification.py apps/backend/tests/extraction/test_classification_service.py
python3 tools/check_ac_traceability.py
python3 tools/analyze_test_ac_coverage.py --check
moon run :lint
```

Attempted targeted backend test:

```bash
moon run :test -- --fast apps/backend/tests/extraction/test_classification_service.py -k "idempotent or same_type_rules_prefer_newer_version"
```

Local result: blocked before pytest by local Podman machine connectivity (`unable to connect to Podman socket: 127.0.0.1:61270`). `podman machine start` returned success, but `podman info` still failed against the stale socket. CI should run the container-backed backend tests.

---

## Screenshots / Evidence

_N/A_
