### PR TITLE
[finance_report_audit] Preserve bank statement validation errors

### DIFF
--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -466,7 +466,7 @@ class ExtractionService:
             status = BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(confidence, is_valid)
 
             statement.balance_validated = is_valid
-            if is_brokerage_payload and not is_valid:
+            if not is_valid:
                 statement.validation_error = balance_result["notes"]
             statement.confidence_score = confidence
             statement.status = status

--- a/apps/backend/tests/extraction/test_pdf_parsing.py
+++ b/apps/backend/tests/extraction/test_pdf_parsing.py
@@ -198,9 +198,9 @@ class TestInvalidParseNotPersisted:
                 )
 
     @pytest.mark.asyncio
-    async def test_balance_validation_failure_marks_status(self, service, tmp_path):
+    async def test_parse_document_bank_balance_mismatch_records_validation_error(self, service, tmp_path):
         """
-        CRITICAL #4: Balance validation failure should be reflected in status.
+        AC3.2.4: Bank statement balance mismatches preserve validation_error details.
         """
         pdf_file = tmp_path / "test.pdf"
         pdf_file.write_bytes(b"dummy")
@@ -234,6 +234,7 @@ class TestInvalidParseNotPersisted:
             # The status should NOT be APPROVED/PARSED for auto-accept path
             # Low score should route to manual review
             assert stmt.balance_validated is False or stmt.confidence_score < 85
+            assert stmt.validation_error == "Balance mismatch: expected 1100.00, got 2000.00"
 
     def test_validate_balance_returns_invalid_on_mismatch(self):
         """

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -522,6 +522,11 @@ groups:
         epic_name: statement-parsing
         description: Completeness Validation
         mandatory: true
+      - id: AC3.2.4
+        epic: 3
+        epic_name: statement-parsing
+        description: Bank statement balance mismatches preserve validation_error details
+        mandatory: true
     AC3.3:
       - id: AC3.3.1
         epic: 3

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-06-03 07:36:03 UTC by `tools/analyze_test_ac_coverage.py`
+> Generated: 2026-06-03 07:53:52 UTC by `tools/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 1131 |
-| Active ACs | 971 |
+| Registered ACs | 1133 |
+| Active ACs | 973 |
 | Deprecated ACs excluded from coverage gate | 160 |
-| Covered by real test candidates | 971 (100.0%) |
+| Covered by real test candidates | 973 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -32,10 +32,10 @@
 
 | Source | Files scanned | Unique AC refs (real) | Unique AC refs (placeholder) | Unique AC refs (stub) |
 |---|---:|---:|---:|---:|
-| backend | 180 | 712 | 0 | 0 |
+| backend | 180 | 713 | 0 | 0 |
 | frontend | 83 | 222 | 0 | 0 |
 | frontend_playwright | 3 | 12 | 0 | 0 |
-| tooling_tests | 54 | 261 | 0 | 0 |
+| tooling_tests | 54 | 262 | 0 | 0 |
 | e2e | 13 | 64 | 0 | 0 |
 
 ## Coverage by EPIC
@@ -44,12 +44,12 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|
 | EPIC-001 | phase0-setup | 29 | 2 | 27 | 0 | 0 | 0 | 100.0% |
 | EPIC-002 | double-entry-core | 62 | 15 | 47 | 0 | 0 | 0 | 100.0% |
-| EPIC-003 | statement-parsing | 62 | 20 | 42 | 0 | 0 | 0 | 100.0% |
+| EPIC-003 | statement-parsing | 63 | 20 | 43 | 0 | 0 | 0 | 100.0% |
 | EPIC-004 | reconciliation-engine | 44 | 21 | 23 | 0 | 0 | 0 | 100.0% |
 | EPIC-005 | reporting-visualization | 55 | 11 | 44 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 8 | 55 | 0 | 0 | 0 | 100.0% |
 | EPIC-007 | deployment | 39 | 0 | 39 | 0 | 0 | 0 | 100.0% |
-| EPIC-008 | testing-strategy | 142 | 6 | 136 | 0 | 0 | 0 | 100.0% |
+| EPIC-008 | testing-strategy | 143 | 6 | 137 | 0 | 0 | 0 | 100.0% |
 | EPIC-009 | pdf-fixture-generation | 37 | 1 | 36 | 0 | 0 | 0 | 100.0% |
 | EPIC-010 | signoz-logging | 25 | 0 | 25 | 0 | 0 | 0 | 100.0% |
 | EPIC-011 | asset-lifecycle | 53 | 0 | 53 | 0 | 0 | 0 | 100.0% |

--- a/docs/project/EPIC-003.statement-parsing.md
+++ b/docs/project/EPIC-003.statement-parsing.md
@@ -133,6 +133,7 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 | AC3.2.1 | Balance Validation (Pass) | `test_balance_valid` | `extraction/test_extraction.py` | P0 |
 | AC3.2.2 | Balance Validation (Fail) | `test_balance_invalid` | `extraction/test_extraction.py` | P0 |
 | AC3.2.3 | Completeness Validation | `test_missing_required_fields_detected` | `extraction/test_pdf_parsing.py` | P1 |
+| AC3.2.4 | Bank statement balance mismatches preserve validation_error details | `test_parse_document_bank_balance_mismatch_records_validation_error` | `extraction/test_pdf_parsing.py` | P0 |
 
 ### AC3.3: Confidence & Routing
 

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -72,6 +72,11 @@ The system is currently migrating to a 4-layer architecture. During Phase 2, dat
 | `balance_validated` | bool | Opening + txns ≈ closing |
 | `validation_error` | str | Optional validation failure details |
 
+When a parsed bank statement fails balance validation, `validation_error` must
+preserve the mismatch note from the Decimal balance check. The statement must
+remain reviewable instead of silently hiding the reason it cannot be trusted for
+auto-accept.
+
 **Parsing state note**: `currency`, `period_start`, `period_end`, `opening_balance`, `closing_balance`,
 `confidence_score`, and `balance_validated` are nullable while status is `parsing`.
 


### PR DESCRIPTION
## Summary
- Add AC3.2.4 coverage for bank statement balance mismatches preserving validation_error details.
- Preserve Decimal balance-check notes whenever parsed statements fail balance validation, matching the existing brokerage behavior.
- Update EPIC-003, extraction SSOT, AC registry, and generated AC coverage report.

## TDD
- Red: 0c3f004 Add bank statement validation error coverage
- Green: df99f65 Preserve bank balance validation errors

## Verification
- python3 -m compileall -q apps/backend/src/services/extraction.py apps/backend/tests/extraction/test_pdf_parsing.py
- python3 tools/check_ac_traceability.py
- python3 tools/analyze_test_ac_coverage.py --check
- moon run :lint
- Blocked locally: moon run :test -- --fast apps/backend/tests/extraction/test_pdf_parsing.py -k bank_balance_mismatch could not start test infra because the local Podman VM/socket repeatedly stopped/refused connection; CI should run the container-backed test path.

## Scope
- Related to #417.
- No overlap with #649, which is already claimed by finance_report_vision.
