### PR TITLE
[finance_report_audit] Keep CSV inferred balances reviewable

### DIFF
--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -465,13 +465,21 @@ class ExtractionService:
             is_valid = balance_result["balance_valid"]
             has_inferred_csv_balances = extracted.get("balance_source") == "inferred_from_csv_transactions"
 
-            # For confidence score, we use the original extracted dict to maintain logic
-            confidence = compute_confidence_score(extracted, balance_result)
             if has_inferred_csv_balances:
-                confidence = min(confidence, 84)
+                confidence = compute_confidence_score(
+                    extracted,
+                    {
+                        **balance_result,
+                        "balance_valid": False,
+                        "balance_proof_available": False,
+                        "notes": CSV_INFERRED_BALANCE_REVIEW_NOTE,
+                    },
+                )
                 status = BankStatementStatus.PARSED
                 is_valid = False
             else:
+                # For confidence score, we use the original extracted dict to maintain logic.
+                confidence = compute_confidence_score(extracted, balance_result)
                 status = (
                     BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(confidence, is_valid)
                 )

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -35,6 +35,9 @@ from src.services.validation import (
 )
 
 logger = get_logger(__name__)
+CSV_INFERRED_BALANCE_REVIEW_NOTE = (
+    "CSV import does not include source statement opening/closing balances; manual review required"
+)
 
 
 class ExtractionError(Exception):
@@ -460,13 +463,23 @@ class ExtractionService:
                 net_transactions=net_transactions,
             )
             is_valid = balance_result["balance_valid"]
+            has_inferred_csv_balances = extracted.get("balance_source") == "inferred_from_csv_transactions"
 
             # For confidence score, we use the original extracted dict to maintain logic
             confidence = compute_confidence_score(extracted, balance_result)
-            status = BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(confidence, is_valid)
+            if has_inferred_csv_balances:
+                confidence = min(confidence, 84)
+                status = BankStatementStatus.PARSED
+                is_valid = False
+            else:
+                status = (
+                    BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(confidence, is_valid)
+                )
 
             statement.balance_validated = is_valid
-            if not is_valid:
+            if has_inferred_csv_balances:
+                statement.validation_error = CSV_INFERRED_BALANCE_REVIEW_NOTE
+            elif not is_valid:
                 statement.validation_error = balance_result["notes"]
             statement.confidence_score = confidence
             statement.status = status
@@ -1267,6 +1280,7 @@ class ExtractionService:
             "period_end": period_end.isoformat() if period_end else None,
             "opening_balance": "0.00",
             "closing_balance": str(inferred_closing_balance),
+            "balance_source": "inferred_from_csv_transactions",
             "transactions": transactions,
         }
 

--- a/apps/backend/src/services/validation.py
+++ b/apps/backend/src/services/validation.py
@@ -98,17 +98,18 @@ def compute_confidence_score(
     transactions = extracted.get("transactions", []) or []
 
     # Balance validation (35%)
-    if balance_result["balance_valid"]:
-        score += 35
-    else:
-        try:
-            diff = Decimal(str(balance_result.get("difference", "0") or "0"))
-            if diff <= Decimal("1.00"):
-                score += 25
-            elif diff <= Decimal("10.00"):
-                score += 17
-        except (ValueError, TypeError, InvalidOperation):
-            pass
+    if balance_result.get("balance_proof_available", True):
+        if balance_result["balance_valid"]:
+            score += 35
+        else:
+            try:
+                diff = Decimal(str(balance_result.get("difference", "0") or "0"))
+                if diff <= Decimal("1.00"):
+                    score += 25
+                elif diff <= Decimal("10.00"):
+                    score += 17
+            except (ValueError, TypeError, InvalidOperation):
+                pass
 
     # Field completeness (25%)
     required_fields_count = 5

--- a/apps/backend/tests/accounting/test_validation.py
+++ b/apps/backend/tests/accounting/test_validation.py
@@ -154,6 +154,30 @@ def test_compute_confidence_score_normalizes_signed_outflow_progression():
     assert score == 100
 
 
+def test_compute_confidence_score_without_balance_proof_gets_no_balance_component():
+    """AC3.2.5: Inferred balances do not earn source balance-validation confidence."""
+    extracted = {
+        "institution": "DBS",
+        "currency": "SGD",
+        "period_start": "2025-01-01",
+        "period_end": "2025-01-31",
+        "opening_balance": "0.00",
+        "closing_balance": "400.00",
+        "transactions": [
+            {"amount": "500.00", "direction": "IN", "currency": "SGD", "balance_after": "500.00"},
+            {"amount": "100.00", "direction": "OUT", "currency": "SGD", "balance_after": "400.00"},
+        ],
+    }
+
+    score = compute_confidence_score(
+        extracted,
+        {"balance_valid": True, "difference": "0.00", "balance_proof_available": False},
+        missing_fields=[],
+    )
+
+    assert score == 65
+
+
 def test_compute_confidence_score_invalid_difference() -> None:
     extracted = {
         "institution": "DBS",

--- a/apps/backend/tests/extraction/test_extraction_flow.py
+++ b/apps/backend/tests/extraction/test_extraction_flow.py
@@ -179,7 +179,7 @@ class TestExtractionServiceFlow:
         assert len(events) == 2
         assert stmt.status == BankStatementStatus.PARSED
         assert stmt.balance_validated is False
-        assert stmt.confidence_score < 85
+        assert stmt.confidence_score == 45
         assert stmt.validation_error == (
             "CSV import does not include source statement opening/closing balances; manual review required"
         )

--- a/apps/backend/tests/extraction/test_extraction_flow.py
+++ b/apps/backend/tests/extraction/test_extraction_flow.py
@@ -159,6 +159,32 @@ class TestExtractionServiceFlow:
             assert len(events) == 0
 
     @pytest.mark.asyncio
+    async def test_parse_document_csv_without_statement_balances_remains_reviewable(self, service, tmp_path):
+        """AC3.2.5: CSV transaction exports without statement balances remain reviewable."""
+        csv_file = tmp_path / "dbs-export.csv"
+        csv_file.write_bytes(
+            b"Transaction Date,Reference,Debit Amount,Credit Amount,Transaction Ref1\n"
+            b"15 Jan 2025,REF001,,500.00,SALARY\n"
+            b"16 Jan 2025,REF002,100.00,,GROCERIES\n"
+        )
+
+        stmt, events = await service.parse_document(
+            csv_file,
+            "DBS",
+            user_id=UUID("00000000-0000-0000-0000-000000000001"),
+            file_type="csv",
+            file_content=csv_file.read_bytes(),
+        )
+
+        assert len(events) == 2
+        assert stmt.status == BankStatementStatus.PARSED
+        assert stmt.balance_validated is False
+        assert stmt.confidence_score < 85
+        assert stmt.validation_error == (
+            "CSV import does not include source statement opening/closing balances; manual review required"
+        )
+
+    @pytest.mark.asyncio
     async def test_parse_document_unsupported_type(self, service, tmp_path):
         """[AC3.4.2] Test parse_document raises error for unsupported type."""
         txt_file = tmp_path / "test.txt"

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -527,6 +527,11 @@ groups:
         epic_name: statement-parsing
         description: Bank statement balance mismatches preserve validation_error details
         mandatory: true
+      - id: AC3.2.5
+        epic: 3
+        epic_name: statement-parsing
+        description: CSV transaction exports without statement balances remain reviewable
+        mandatory: true
     AC3.3:
       - id: AC3.3.1
         epic: 3

--- a/docs/analysis/test-ac-coverage-report.md
+++ b/docs/analysis/test-ac-coverage-report.md
@@ -1,6 +1,6 @@
 # AC Coverage Analysis Report
 
-> Generated: 2026-06-03 07:53:52 UTC by `tools/analyze_test_ac_coverage.py`
+> Generated: 2026-06-03 08:23:16 UTC by `tools/analyze_test_ac_coverage.py`
 > Snapshot: this checked-in report is a generated artifact. Regenerate it or inspect CI artifacts for current values; do not copy these counts into prose docs.
 
 ## Coverage accounting (EPIC-008 aligned)
@@ -17,10 +17,10 @@
 
 | Metric | Count |
 |---|---:|
-| Registered ACs | 1133 |
-| Active ACs | 973 |
+| Registered ACs | 1134 |
+| Active ACs | 974 |
 | Deprecated ACs excluded from coverage gate | 160 |
-| Covered by real test candidates | 973 (100.0%) |
+| Covered by real test candidates | 974 (100.0%) |
 | Placeholder-only assertions | 0 |
 | Stub-only placeholders (`_ac_stubs`) | 0 |
 | Active registered but untested | 0 |
@@ -32,7 +32,7 @@
 
 | Source | Files scanned | Unique AC refs (real) | Unique AC refs (placeholder) | Unique AC refs (stub) |
 |---|---:|---:|---:|---:|
-| backend | 180 | 713 | 0 | 0 |
+| backend | 180 | 714 | 0 | 0 |
 | frontend | 83 | 222 | 0 | 0 |
 | frontend_playwright | 3 | 12 | 0 | 0 |
 | tooling_tests | 54 | 262 | 0 | 0 |
@@ -44,7 +44,7 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|
 | EPIC-001 | phase0-setup | 29 | 2 | 27 | 0 | 0 | 0 | 100.0% |
 | EPIC-002 | double-entry-core | 62 | 15 | 47 | 0 | 0 | 0 | 100.0% |
-| EPIC-003 | statement-parsing | 63 | 20 | 43 | 0 | 0 | 0 | 100.0% |
+| EPIC-003 | statement-parsing | 64 | 20 | 44 | 0 | 0 | 0 | 100.0% |
 | EPIC-004 | reconciliation-engine | 44 | 21 | 23 | 0 | 0 | 0 | 100.0% |
 | EPIC-005 | reporting-visualization | 55 | 11 | 44 | 0 | 0 | 0 | 100.0% |
 | EPIC-006 | ai-advisor | 63 | 8 | 55 | 0 | 0 | 0 | 100.0% |

--- a/docs/project/EPIC-003.statement-parsing.md
+++ b/docs/project/EPIC-003.statement-parsing.md
@@ -134,6 +134,7 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 | AC3.2.2 | Balance Validation (Fail) | `test_balance_invalid` | `extraction/test_extraction.py` | P0 |
 | AC3.2.3 | Completeness Validation | `test_missing_required_fields_detected` | `extraction/test_pdf_parsing.py` | P1 |
 | AC3.2.4 | Bank statement balance mismatches preserve validation_error details | `test_parse_document_bank_balance_mismatch_records_validation_error` | `extraction/test_pdf_parsing.py` | P0 |
+| AC3.2.5 | CSV transaction exports without statement balances remain reviewable | `test_parse_document_csv_without_statement_balances_remains_reviewable` | `extraction/test_extraction_flow.py` | P0 |
 
 ### AC3.3: Confidence & Routing
 

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -81,6 +81,8 @@ CSV transaction exports that do not contain source statement opening and closing
 balances may use inferred balances for import continuity, but those inferred
 balances are not source balance proof. Such parses must remain reviewable and
 must not be auto-approved solely because `0 + transactions = inferred closing`.
+Their confidence score must not include the balance-validation component because
+no source statement balances were provided.
 
 **Parsing state note**: `currency`, `period_start`, `period_end`, `opening_balance`, `closing_balance`,
 `confidence_score`, and `balance_validated` are nullable while status is `parsing`.

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -77,6 +77,11 @@ preserve the mismatch note from the Decimal balance check. The statement must
 remain reviewable instead of silently hiding the reason it cannot be trusted for
 auto-accept.
 
+CSV transaction exports that do not contain source statement opening and closing
+balances may use inferred balances for import continuity, but those inferred
+balances are not source balance proof. Such parses must remain reviewable and
+must not be auto-approved solely because `0 + transactions = inferred closing`.
+
 **Parsing state note**: `currency`, `period_start`, `period_end`, `opening_balance`, `closing_balance`,
 `confidence_score`, and `balance_validated` are nullable while status is `parsing`.
 


### PR DESCRIPTION
## Summary
- Add AC3.2.5 coverage for provider-free CSV parse_document paths that infer balances from transaction exports.
- Mark CSV-inferred balances as review-only proof: keep parsed transactions reviewable, set balance_validated=false, cap confidence below auto-approve, and preserve a clear validation_error.
- Update EPIC-003, extraction SSOT, AC registry, and generated AC coverage report.

## Why
CSV transaction exports often lack source statement opening/closing balances. Using `0 + transactions = inferred closing` as balance proof can make an incomplete source look audit-grade. This keeps the data usable while preventing silent auto-approval/posting.

## TDD
- Red: 8752982 Add CSV inferred balance review coverage
- Green: ee13811 Keep CSV inferred balances reviewable

## Verification
- python3 -m compileall -q apps/backend/src/services/extraction.py apps/backend/tests/extraction/test_extraction_flow.py
- provider-free direct ExtractionService parse_document script for the same CSV input
- python3 tools/check_ac_traceability.py
- python3 tools/analyze_test_ac_coverage.py --check
- moon run :lint
- Blocked locally: moon run :test -- --fast apps/backend/tests/extraction/test_extraction_flow.py -k csv_without_statement_balances could not start test infra because local Podman socket refused connection before pytest. CI should run the container-backed test path.

## Issue Coverage
This is the final #417 statement parsing provider-free slice after #647 and #650.

Closes #417
