### PR TITLE
[finance_report_infra] Harden CI concurrency and staging audit summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.event_name == 'push' && github.sha || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/apps/backend/migrations/versions/0023_stmt_extract_metadata.py
+++ b/apps/backend/migrations/versions/0023_stmt_extract_metadata.py
@@ -1,0 +1,21 @@
+"""add statement extraction metadata"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0023_stmt_extract_metadata"
+down_revision = "0022_harden_workflow_contract"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "bank_statements",
+        sa.Column("extraction_metadata", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("bank_statements", "extraction_metadata")

--- a/apps/backend/src/models/statement.py
+++ b/apps/backend/src/models/statement.py
@@ -84,6 +84,11 @@ class BankStatement(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     parsing_progress: Mapped[int | None] = mapped_column(Integer, default=0, nullable=True)
     balance_validated: Mapped[bool | None] = mapped_column(default=None, nullable=True)
     validation_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    extraction_metadata: Mapped[dict | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        default=None,
+    )
     stage1_status: Mapped[Stage1Status | None] = mapped_column(
         SQLEnum(
             Stage1Status,

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -23,6 +23,7 @@ from src.models import (
     AccountType,
     BankStatement,
     BankStatementStatus,
+    UploadedDocument,
 )
 from src.schemas import (
     BankStatementListResponse,
@@ -544,6 +545,55 @@ def _brokerage_payload_from_statement(statement: BankStatement) -> dict:
     }
 
 
+def _extract_brokerage_payload_from_metadata(metadata: dict | None) -> dict | None:
+    """Return the structured extraction payload stored in Layer 1 metadata."""
+    if not isinstance(metadata, dict):
+        return None
+    for key in ("extraction_payload", "parsed_payload", "payload"):
+        payload = metadata.get(key)
+        if isinstance(payload, dict):
+            return payload
+    return metadata if any(key in metadata for key in ("positions", "holdings", "securities")) else None
+
+
+def _enrich_brokerage_payload_from_statement(payload: dict, statement: BankStatement) -> dict:
+    """Backfill statement metadata into a recovered extraction payload."""
+    enriched = dict(payload)
+    enriched.setdefault("institution", statement.institution)
+    statement_payload = enriched.get("statement") if isinstance(enriched.get("statement"), dict) else {}
+    statement_payload = dict(statement_payload)
+    statement_payload.setdefault("institution", statement.institution)
+    statement_payload.setdefault("period_end", statement.period_end.isoformat() if statement.period_end else None)
+    statement_payload.setdefault("currency", statement.currency)
+    enriched["statement"] = statement_payload
+    return enriched
+
+
+async def _brokerage_payload_from_persisted_extraction(
+    db,
+    *,
+    statement: BankStatement,
+    user_id: UUID,
+) -> dict | None:
+    """Load the persisted OCR extraction payload for statement-scoped imports."""
+    payload = _extract_brokerage_payload_from_metadata(statement.extraction_metadata)
+    if payload is not None:
+        return _enrich_brokerage_payload_from_statement(payload, statement)
+
+    result = await db.execute(
+        select(UploadedDocument)
+        .where(UploadedDocument.user_id == user_id)
+        .where(UploadedDocument.file_hash == statement.file_hash)
+    )
+    uploaded_document = result.scalar_one_or_none()
+    if uploaded_document is None:
+        return None
+    payload = _extract_brokerage_payload_from_metadata(uploaded_document.extraction_metadata)
+    if payload is None:
+        return None
+    return _enrich_brokerage_payload_from_statement(payload, statement)
+
+
 def _brokerage_import_not_ready_reason(statement: BankStatement) -> str:
     """Explain why a brokerage statement cannot be imported yet."""
     status_value = statement.status.value if hasattr(statement.status, "value") else str(statement.status)
@@ -587,7 +637,9 @@ async def import_brokerage_statement_positions(
     if statement.status not in (BankStatementStatus.PARSED, BankStatementStatus.APPROVED):
         raise_bad_request(_brokerage_import_not_ready_reason(statement))
 
-    payload = _brokerage_payload_from_statement(statement)
+    payload = await _brokerage_payload_from_persisted_extraction(db, statement=statement, user_id=user_id)
+    if payload is None:
+        payload = _brokerage_payload_from_statement(statement)
     request_id = _current_request_id()
     logger.info(
         "statement.brokerage_import.started",

--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -225,6 +225,7 @@ class DeduplicationService:
         file_hash: str,
         original_filename: str,
         document_type: DocumentType,
+        extraction_metadata: dict[str, Any] | None = None,
     ) -> UploadedDocument:
         """Create Layer 1 document metadata record.
 
@@ -236,6 +237,7 @@ class DeduplicationService:
             file_hash=file_hash,
             original_filename=original_filename,
             document_type=document_type,
+            extraction_metadata=extraction_metadata,
         )
         db.add(doc)
         await db.flush()
@@ -259,6 +261,8 @@ async def dual_write_layer2(
     original_filename: str,
     institution: str,
     transactions: list[BankStatementTransaction],
+    document_type: DocumentType | None = None,
+    extraction_metadata: dict[str, Any] | None = None,
 ) -> None:
     """Write parsed data to Layer 1/2 tables (Phase 2 dual write).
 
@@ -280,7 +284,7 @@ async def dual_write_layer2(
         "uob": DocumentType.BANK_STATEMENT,
         "posb": DocumentType.BANK_STATEMENT,
     }
-    doc_type = doc_type_map.get(institution.lower(), DocumentType.BANK_STATEMENT)
+    doc_type = document_type or doc_type_map.get(institution.lower(), DocumentType.BANK_STATEMENT)
 
     try:
         uploaded_doc = await dedup_service.create_uploaded_document(
@@ -290,6 +294,7 @@ async def dual_write_layer2(
             file_hash=file_hash,
             original_filename=original_filename,
             document_type=doc_type,
+            extraction_metadata=extraction_metadata,
         )
 
         layer2_count = 0

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -15,7 +15,7 @@ import httpx
 
 from src.config import settings
 from src.logger import get_logger
-from src.models import BankStatement, BankStatementStatus, BankStatementTransaction, ConfidenceLevel
+from src.models import BankStatement, BankStatementStatus, BankStatementTransaction, ConfidenceLevel, DocumentType
 from src.prompts import get_parsing_prompt
 from src.services.brokerage_positions import looks_like_brokerage_payload
 from src.services.deduplication import DeduplicationService, dual_write_layer2
@@ -379,6 +379,8 @@ class ExtractionService:
                 ),
             )
             statement._extracted_payload = extracted
+            if is_brokerage_payload:
+                statement.extraction_metadata = {"extraction_payload": extracted}
 
             transactions = []
             net_transactions = Decimal("0.00")
@@ -509,6 +511,10 @@ class ExtractionService:
                     original_filename=original_filename or (file_path.name if file_path else "unknown"),
                     institution=final_institution,
                     transactions=transactions,
+                    document_type=(
+                        DocumentType.BROKERAGE_STATEMENT if is_brokerage_payload else DocumentType.BANK_STATEMENT
+                    ),
+                    extraction_metadata={"extraction_payload": extracted} if is_brokerage_payload else None,
                 )
 
             return statement, transactions

--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -428,6 +428,7 @@ async def parse_statement_background(
             statement.period_end = parsed_statement.period_end
             statement.opening_balance = parsed_statement.opening_balance
             statement.closing_balance = parsed_statement.closing_balance
+            statement.extraction_metadata = parsed_statement.extraction_metadata
             await session.commit()
 
             await update_progress(80)

--- a/apps/backend/tests/extraction/test_dual_write_layer2.py
+++ b/apps/backend/tests/extraction/test_dual_write_layer2.py
@@ -103,6 +103,52 @@ class TestDualWriteLayer2:
         assert uploaded_doc.file_hash == file_hash
         assert uploaded_doc.original_filename == "test_statement.pdf"
         assert uploaded_doc.document_type == DocumentType.BANK_STATEMENT
+        assert uploaded_doc.extraction_metadata is None
+
+    async def test_dual_write_persists_brokerage_extraction_metadata(
+        self, db, test_user, sample_file_content, monkeypatch
+    ):
+        """AC17.4.7: Brokerage dual-write keeps structured OCR positions available for import."""
+        monkeypatch.setattr("src.config.settings.enable_4_layer_write", True)
+
+        service = ExtractionService()
+        file_hash = hashlib.sha256(sample_file_content).hexdigest()
+        brokerage_response = {
+            "institution": "Moomoo",
+            "currency": "SGD",
+            "period_start": "2026-05-01",
+            "period_end": "2026-05-31",
+            "positions": [
+                {
+                    "symbol": "Fullerton SGD Money Market Fund",
+                    "quantity": "1",
+                    "market_value": "1250.50",
+                    "currency": "SGD",
+                }
+            ],
+            "transactions": [],
+        }
+
+        with patch.object(service, "extract_financial_data", return_value=brokerage_response):
+            statement, transactions = await service.parse_document(
+                file_path=Path("moomoo-statement.pdf"),
+                institution="Moomoo",
+                user_id=test_user.id,
+                file_content=sample_file_content,
+                file_hash=file_hash,
+                original_filename="moomoo-statement.pdf",
+                db=db,
+            )
+
+        await db.commit()
+
+        result = await db.execute(select(UploadedDocument).where(UploadedDocument.user_id == test_user.id))
+        uploaded_doc = result.scalar_one()
+
+        assert transactions == []
+        assert statement.extraction_metadata == {"extraction_payload": brokerage_response}
+        assert uploaded_doc.document_type == DocumentType.BROKERAGE_STATEMENT
+        assert uploaded_doc.extraction_metadata == {"extraction_payload": brokerage_response}
 
     async def test_dual_write_creates_atomic_transactions(
         self, db, test_user, mock_ai_response, sample_file_content, monkeypatch

--- a/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
+++ b/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
@@ -167,6 +167,7 @@ async def test_parse_document_preserves_brokerage_payload_for_background_import(
     assert statement.opening_balance is None
     assert statement.closing_balance is None
     assert statement._extracted_payload == payload
+    assert statement.extraction_metadata == {"extraction_payload": payload}
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -9,7 +9,12 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import select
 
-from src.models import BankStatement, BankStatementStatus, BankStatementTransaction, ConfidenceLevel
+from src.models import (
+    BankStatement,
+    BankStatementStatus,
+    BankStatementTransaction,
+    ConfidenceLevel,
+)
 from src.models.layer2 import AssetType, AtomicPosition
 from src.models.layer3 import ManagedPosition
 from src.routers.statements import _brokerage_payload_from_statement
@@ -395,6 +400,62 @@ async def test_statement_scoped_brokerage_import_uses_parsed_transactions(client
     )
     statement_id = statement.id
     db.add(statement)
+    await db.commit()
+
+    response = await client.post(f"/statements/{statement_id}/brokerage/import")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["broker"] == "Moomoo"
+    assert data["parsed_positions"] == 1
+    assert data["created_atomic_positions"] == 1
+    assert data["reconcile_created"] == 1
+
+    positions = (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == test_user.id))).scalars().all()
+    assert len(positions) == 1
+    assert positions[0].asset_identifier == "Fullerton SGD Money Market Fund"
+    assert positions[0].market_value == Decimal("1250.50")
+
+
+@pytest.mark.asyncio
+async def test_statement_scoped_brokerage_import_uses_persisted_extraction_positions(client, db, test_user):
+    """AC8.13.10/AC17.4.7: Statement import recovers structured OCR positions from metadata."""
+    file_hash = "issue-653-moomoo-structured"
+    statement = BankStatement(
+        id=uuid4(),
+        user_id=test_user.id,
+        file_path="statements/moomoo/structured.pdf",
+        file_hash=file_hash,
+        original_filename="moomoo-structured.pdf",
+        institution="Moomoo",
+        account_last4="1582",
+        currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 31),
+        opening_balance=None,
+        closing_balance=None,
+        status=BankStatementStatus.PARSED,
+        confidence_score=95,
+        balance_validated=False,
+        extraction_metadata={
+            "extraction_payload": {
+                "institution": "Moomoo",
+                "statement": {"period_end": "2026-05-31", "currency": "SGD"},
+                "positions": [
+                    {
+                        "symbol": "Fullerton SGD Money Market Fund",
+                        "quantity": "1",
+                        "market_value": "1250.50",
+                        "currency": "SGD",
+                        "asset_type": "money_market",
+                    }
+                ],
+            }
+        },
+        transactions=[],
+    )
+    db.add(statement)
+    statement_id = statement.id
     await db.commit()
 
     response = await client.post(f"/statements/{statement_id}/brokerage/import")

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -81,6 +81,13 @@ Coverage regression detection is enforced locally against
 `unified-coverage.json`; Coveralls remains main-only reporting and does not
 decide CI pass/fail.
 
+CI concurrency is deliberately different for PRs and `main`. Pull request runs
+share a PR ref-scoped concurrency group and cancel superseded in-progress runs
+to keep author feedback current. Pushes to `main` use a SHA-scoped concurrency
+group, so rapid consecutive merges do not cancel or replace a pending main CI
+run for an earlier merge commit. `workflow_dispatch` uses the run ID to keep
+manual validations independent.
+
 Lightweight changes do not repeat the heavy path on either PRs or `main`.
 Lightweight means all changed files are limited to documentation, markdown,
 issue templates, or `.github/workflows/docs.yml`. Other workflow changes are not

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -168,7 +168,8 @@ Parsing priority:
 4. For Interactive Brokers, consume structured position rows from CSV/PDF extraction payloads.
 
 Import entry points:
-- Automatic: successful statement background parsing inspects the structured extraction payload. If it contains brokerage `positions`, `holdings`, or `securities`, or if broker detection recognizes the filename/institution/content, the parser calls `BrokeragePositionImportService` with the current statement ID as `source_document_id`.
+- Automatic: successful statement background parsing stores brokerage OCR output in `BankStatement.extraction_metadata`, inspects the structured extraction payload, and imports positions when it contains brokerage `positions`, `holdings`, or `securities`, or when broker detection recognizes the filename/institution/content. The parser calls `BrokeragePositionImportService` with the current statement ID as `source_document_id`.
+- Statement-scoped manual: `POST /statements/{id}/brokerage/import` first reads the persisted `BankStatement.extraction_metadata` payload, then falls back to Layer 1 `UploadedDocument.extraction_metadata`, and finally reconstructs cash events from parsed statement transactions. This keeps structured holdings importable even when a brokerage PDF has no bank-style transaction rows.
 - Manual/API: `POST /portfolio/brokerage/import` remains available for parsed payload backfills and tests.
 
 Import behavior:

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -362,6 +362,7 @@ Statement header table for imported statements.
 | confidence_score | INT |  | Extraction confidence (nullable while parsing) |
 | balance_validated | BOOLEAN |  | Balance check result (nullable while parsing) |
 | validation_error | TEXT | | Validation notes |
+| extraction_metadata | JSONB | | Durable parser handoff metadata, including structured brokerage OCR positions used by statement-scoped imports |
 | created_at | TIMESTAMP | NOT NULL | Creation time |
 | updated_at | TIMESTAMP | NOT NULL | Update time |
 

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -235,6 +235,20 @@ def test_AC8_13_13_staging_deploy_fast_fail_guardrails() -> None:
     assert "22-minute E2E step timeout" in ci_cd
 
 
+def test_AC8_13_13_main_ci_keeps_each_merge_commit_run() -> None:
+    """AC8.13.13: Main push CI uses SHA-scoped concurrency."""
+    workflow = read(".github/workflows/ci.yml")
+    ci_cd = read("docs/ssot/ci-cd.md")
+
+    assert (
+        "group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.event_name == 'push' && github.sha || github.run_id }}"
+        in workflow
+    )
+    assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in workflow
+    assert "Pushes to `main` use a SHA-scoped concurrency" in ci_cd
+    assert "do not cancel or replace a pending main CI" in ci_cd
+
+
 def test_AC8_13_14_staging_ai_ocr_gate_is_separate_deploy_job() -> None:
     """AC8.13.14: Provider-backed AI/OCR gate runs outside deploy health."""
     deploy_workflow = read(".github/workflows/staging-deploy.yml")


### PR DESCRIPTION
## Summary

Fixes the two CI/CD review findings from the stage review:

- Prevent main push CI runs from replacing pending merge-commit validations by using SHA-scoped concurrency for `push` events while keeping PR runs PR ref-scoped and cancelable.
- Align automatic and manual staging AI/OCR audit summaries with the current replay inventory counts (`9` uploads, `9` parse completions, `4` brokerage imports, `2` report verifications) via the staging gate contract.
- Persist brokerage OCR extraction metadata on `BankStatement` and reuse it in `POST /statements/{id}/brokerage/import`, so structured holdings remain importable even when a brokerage PDF has no bank-style transaction rows. Layer 1 extraction metadata remains a fallback for 4-layer-enabled paths.

## Why

The CI/CD model should preserve the intended left-to-right validation gradient:

- Left side: PR runs stay fast and current by canceling superseded PR ref runs.
- Main: each merge commit gets its own CI concurrency key, so rapid merges no longer cancel pending main CI validations.
- Right side: staging AI/OCR summaries now report the same expected proof inventory as the gate actually runs, and statement-scoped brokerage import can recover the original structured OCR positions instead of degrading to an empty transaction-only payload.

## Verification

- `uv run --project apps/backend python -m py_compile apps/backend/src/models/statement.py apps/backend/src/routers/statements.py apps/backend/src/services/deduplication.py apps/backend/src/services/extraction.py apps/backend/src/services/statement_parsing.py apps/backend/migrations/versions/0023_stmt_extract_metadata.py apps/backend/tests/portfolio/test_brokerage_position_parsing.py apps/backend/tests/extraction/test_dual_write_layer2.py apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py`
- `cd apps/backend && uv run ruff check src tests`
- `cd apps/backend && uv run ruff format src tests --check`
- `cd apps/backend && uv run alembic heads`
- `uv run --with pytest --with pyyaml pytest tests/tooling/test_post_merge_e2e_gates.py -q`
- `uv run python tools/check_ci_metrics_contract.py`
- `uv run --with pyyaml python tools/lint_doc_consistency.py`
- `uv run --with pyyaml python tools/check_manifest.py`
- `python tools/generate_ac_registry.py --check`
- `python -m common.ssot.check_ac_traceability --registry docs/ac_registry.yaml --infra-registry docs/infra_registry.yaml`
- `git diff --check`

Local DB-backed backend tests could not run because PostgreSQL at `127.0.0.1:5432` is not running in this workspace; GitHub CI is expected to cover those tests.
