### PR TITLE
[finance_report_ui] Add workflow status API

### DIFF
--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -41,6 +41,7 @@ from src.routers import (
     statements,
     user_settings,
     users,
+    workflow,
 )
 from src.routers.reconciliation import router as reconciliation_router
 from src.schemas import PingStateResponse
@@ -274,6 +275,7 @@ app.include_router(reconciliation_router)
 app.include_router(users.router)
 app.include_router(user_settings.router)
 app.include_router(portfolio.router)
+app.include_router(workflow.router)
 
 
 # --- Health & Demo Endpoints ---

--- a/apps/backend/src/routers/workflow.py
+++ b/apps/backend/src/routers/workflow.py
@@ -1,0 +1,72 @@
+"""Workflow status and event API router."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from src.deps import CurrentUserId, DbSession
+from src.models.workflow import WorkflowEventStatus
+from src.schemas.workflow import (
+    WorkflowEventListResponse,
+    WorkflowEventResponse,
+    WorkflowEventStatusUpdate,
+    WorkflowStatusResponse,
+)
+from src.services.workflow_events import (
+    get_workflow_status,
+    list_workflow_events_response,
+    update_workflow_event_status,
+)
+
+router = APIRouter(prefix="/workflow", tags=["workflow"])
+
+
+@router.get("/status", response_model=WorkflowStatusResponse)
+async def get_workflow_status_endpoint(
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> WorkflowStatusResponse:
+    """Return the compact user-scoped upload-to-report workflow status."""
+    response = await get_workflow_status(db, user_id=user_id)
+    await db.commit()
+    return response
+
+
+@router.get("/events", response_model=WorkflowEventListResponse)
+async def list_workflow_events_endpoint(
+    db: DbSession,
+    user_id: CurrentUserId,
+    status_filter: WorkflowEventStatus | None = Query(default=None, alias="status"),
+    limit: int = Query(default=50, ge=1, le=100),
+) -> WorkflowEventListResponse:
+    """Return a bounded user-scoped workflow event list."""
+    response = await list_workflow_events_response(
+        db,
+        user_id=user_id,
+        status=status_filter,
+        limit=limit,
+    )
+    await db.commit()
+    return response
+
+
+@router.patch("/events/{event_id}", response_model=WorkflowEventResponse)
+async def update_workflow_event_status_endpoint(
+    event_id: UUID,
+    payload: WorkflowEventStatusUpdate,
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> WorkflowEventResponse:
+    """Update one user-owned workflow event lifecycle state."""
+    event = await update_workflow_event_status(
+        db,
+        event_id=event_id,
+        user_id=user_id,
+        status=payload.status,
+    )
+    if event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workflow event not found")
+
+    await db.commit()
+    await db.refresh(event)
+    return WorkflowEventResponse.model_validate(event)

--- a/apps/backend/src/schemas/__init__.py
+++ b/apps/backend/src/schemas/__init__.py
@@ -97,10 +97,18 @@ from src.schemas.user import (
     UserUpdate,
 )
 from src.schemas.workflow import (
+    WorkflowEventCountsResponse,
     WorkflowEventCreate,
+    WorkflowEventListResponse,
     WorkflowEventResponse,
     WorkflowEventStatusUpdate,
+    WorkflowNextActionResponse,
+    WorkflowNextActionType,
+    WorkflowPrimaryState,
     WorkflowReportImpact,
+    WorkflowReportReadinessResponse,
+    WorkflowReportReadinessState,
+    WorkflowStatusResponse,
 )
 
 from .extraction import (
@@ -212,7 +220,15 @@ __all__ = [
     "UserUpdate",
     "VoidJournalEntryRequest",
     "WorkflowEventCreate",
+    "WorkflowEventCountsResponse",
+    "WorkflowEventListResponse",
     "WorkflowEventResponse",
     "WorkflowEventStatusUpdate",
+    "WorkflowNextActionResponse",
+    "WorkflowNextActionType",
+    "WorkflowPrimaryState",
     "WorkflowReportImpact",
+    "WorkflowReportReadinessResponse",
+    "WorkflowReportReadinessState",
+    "WorkflowStatusResponse",
 ]

--- a/apps/backend/src/schemas/workflow.py
+++ b/apps/backend/src/schemas/workflow.py
@@ -1,6 +1,7 @@
 """Schemas for user-facing workflow events."""
 
 from datetime import UTC, datetime
+from enum import Enum
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
@@ -45,6 +46,80 @@ class WorkflowEventStatusUpdate(BaseModel):
     status: WorkflowEventStatus
 
 
+class WorkflowPrimaryState(str, Enum):
+    """Compact upload-to-report state for primary UI surfaces."""
+
+    EMPTY = "empty"
+    PROCESSING = "processing"
+    NEEDS_ACTION = "needs_action"
+    BLOCKED = "blocked"
+    READY = "ready"
+
+
+class WorkflowNextActionType(str, Enum):
+    """Primary next action exposed by the workflow status endpoint."""
+
+    UPLOAD = "upload"
+    WAIT = "wait"
+    REVIEW_REQUIRED = "review_required"
+    RESOLVE_BLOCKER = "resolve_blocker"
+    OPEN_REPORT = "open_report"
+    NONE = "none"
+
+
+class WorkflowReportReadinessState(str, Enum):
+    """Compact report readiness summary for upload/report surfaces."""
+
+    NONE = "none"
+    PROCESSING = "processing"
+    READY = "ready"
+    BLOCKED = "blocked"
+    STALE = "stale"
+
+
+class WorkflowNextActionResponse(BaseModel):
+    """Next user action derived from current workflow events."""
+
+    type: WorkflowNextActionType
+    count: int = Field(ge=0)
+    href: str
+
+    @field_validator("href")
+    @classmethod
+    def validate_href(cls, value: str) -> str:
+        return _validate_internal_action_href(value)
+
+
+class WorkflowReportReadinessResponse(BaseModel):
+    """Report readiness summary derived from workflow event impacts."""
+
+    state: WorkflowReportReadinessState
+    blocking_count: int = Field(ge=0)
+    href: str
+
+    @field_validator("href")
+    @classmethod
+    def validate_href(cls, value: str) -> str:
+        return _validate_internal_action_href(value)
+
+
+class WorkflowEventCountsResponse(BaseModel):
+    """Header and inbox counters that do not require loading the full event list."""
+
+    unread: int = Field(ge=0)
+    action_required: int = Field(ge=0)
+    blocked: int = Field(ge=0)
+
+
+class WorkflowStatusResponse(BaseModel):
+    """Compact user-scoped workflow status response."""
+
+    primary_state: WorkflowPrimaryState
+    next_action: WorkflowNextActionResponse
+    report_readiness: WorkflowReportReadinessResponse
+    event_counts: WorkflowEventCountsResponse
+
+
 class WorkflowEventResponse(BaseModel):
     """User-facing workflow event response contract."""
 
@@ -65,3 +140,10 @@ class WorkflowEventResponse(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class WorkflowEventListResponse(BaseModel):
+    """Bounded workflow event list response."""
+
+    items: list[WorkflowEventResponse]
+    total: int = Field(ge=0)

--- a/apps/backend/src/services/workflow_events.py
+++ b/apps/backend/src/services/workflow_events.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import BankStatement
@@ -13,7 +13,18 @@ from src.models.workflow import (
     WorkflowEventStatus,
     WorkflowReportImpact,
 )
-from src.schemas.workflow import WorkflowEventCreate
+from src.schemas.workflow import (
+    WorkflowEventCountsResponse,
+    WorkflowEventCreate,
+    WorkflowEventListResponse,
+    WorkflowEventResponse,
+    WorkflowNextActionResponse,
+    WorkflowNextActionType,
+    WorkflowPrimaryState,
+    WorkflowReportReadinessResponse,
+    WorkflowReportReadinessState,
+    WorkflowStatusResponse,
+)
 
 
 def build_workflow_dedupe_key(*, family: WorkflowEventFamily, source_type: str, source_id: UUID) -> str:
@@ -95,20 +106,187 @@ async def derive_uploaded_statement_event(
     return await upsert_workflow_event(db, user_id=user_id, payload=payload)
 
 
+async def sync_workflow_events_for_user(db: AsyncSession, *, user_id: UUID) -> None:
+    """Derive deterministic workflow events from existing user-owned records."""
+    existing_uploaded_event = (
+        select(WorkflowEvent.id)
+        .where(WorkflowEvent.user_id == user_id)
+        .where(WorkflowEvent.source_type == "bank_statement")
+        .where(WorkflowEvent.source_id == BankStatement.id)
+        .where(WorkflowEvent.family == WorkflowEventFamily.SOURCE_UPLOADED)
+        .exists()
+    )
+    result = await db.execute(
+        select(BankStatement)
+        .where(BankStatement.user_id == user_id)
+        .where(~existing_uploaded_event)
+        .order_by(BankStatement.created_at.asc())
+    )
+    for statement in result.scalars().all():
+        await derive_uploaded_statement_event(db, statement, user_id=user_id)
+
+
 async def list_workflow_events(
     db: AsyncSession,
     *,
     user_id: UUID,
     status: WorkflowEventStatus | None = None,
     limit: int = 50,
+    include_archived: bool = False,
 ) -> list[WorkflowEvent]:
     """List user-scoped workflow events for inbox/status consumers."""
     stmt = select(WorkflowEvent).where(WorkflowEvent.user_id == user_id)
     if status is not None:
         stmt = stmt.where(WorkflowEvent.status == status)
+    elif not include_archived:
+        stmt = stmt.where(WorkflowEvent.status != WorkflowEventStatus.ARCHIVED)
     stmt = stmt.order_by(WorkflowEvent.occurred_at.desc(), WorkflowEvent.created_at.desc()).limit(limit)
     result = await db.execute(stmt)
     return list(result.scalars().all())
+
+
+async def list_workflow_events_response(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    status: WorkflowEventStatus | None = None,
+    limit: int = 50,
+) -> WorkflowEventListResponse:
+    """Return a bounded event list plus total count for the same filter."""
+    await sync_workflow_events_for_user(db, user_id=user_id)
+
+    filters = [WorkflowEvent.user_id == user_id]
+    if status is not None:
+        filters.append(WorkflowEvent.status == status)
+    else:
+        filters.append(WorkflowEvent.status != WorkflowEventStatus.ARCHIVED)
+
+    total = await db.scalar(select(func.count(WorkflowEvent.id)).where(*filters))
+    events = await list_workflow_events(
+        db,
+        user_id=user_id,
+        status=status,
+        limit=limit,
+        include_archived=False,
+    )
+    return WorkflowEventListResponse(
+        items=[WorkflowEventResponse.model_validate(event) for event in events],
+        total=int(total or 0),
+    )
+
+
+async def get_workflow_status(db: AsyncSession, *, user_id: UUID) -> WorkflowStatusResponse:
+    """Return the compact workflow status for primary UI surfaces."""
+    await sync_workflow_events_for_user(db, user_id=user_id)
+
+    active_filters = [WorkflowEvent.user_id == user_id, WorkflowEvent.status != WorkflowEventStatus.ARCHIVED]
+
+    async def count_where(*filters: object) -> int:
+        value = await db.scalar(select(func.count(WorkflowEvent.id)).where(*active_filters, *filters))
+        return int(value or 0)
+
+    async def representative_event(*filters: object) -> WorkflowEvent | None:
+        result = await db.execute(
+            select(WorkflowEvent)
+            .where(*active_filters, *filters)
+            .order_by(WorkflowEvent.occurred_at.desc(), WorkflowEvent.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    active_count = await count_where()
+    unread_count = await count_where(WorkflowEvent.status == WorkflowEventStatus.UNREAD)
+    action_required_count = await count_where(WorkflowEvent.severity == WorkflowEventSeverity.ACTION_REQUIRED)
+    blocked_count = await count_where(WorkflowEvent.severity == WorkflowEventSeverity.BLOCKED)
+    processing_count = await count_where(WorkflowEvent.report_impact == WorkflowReportImpact.PROCESSING)
+    ready_count = await count_where(WorkflowEvent.report_impact == WorkflowReportImpact.READY)
+    stale_count = await count_where(WorkflowEvent.report_impact == WorkflowReportImpact.STALE)
+    report_blocking_count = await count_where(WorkflowEvent.report_impact == WorkflowReportImpact.BLOCKED)
+
+    if blocked_count:
+        blocked_event = await representative_event(WorkflowEvent.severity == WorkflowEventSeverity.BLOCKED)
+        primary_state = WorkflowPrimaryState.BLOCKED
+        next_action = WorkflowNextActionResponse(
+            type=WorkflowNextActionType.RESOLVE_BLOCKER,
+            count=blocked_count,
+            href=blocked_event.action_href if blocked_event else "/reports",
+        )
+    elif action_required_count:
+        action_required_event = await representative_event(
+            WorkflowEvent.severity == WorkflowEventSeverity.ACTION_REQUIRED
+        )
+        primary_state = WorkflowPrimaryState.NEEDS_ACTION
+        next_action = WorkflowNextActionResponse(
+            type=WorkflowNextActionType.REVIEW_REQUIRED,
+            count=action_required_count,
+            href=action_required_event.action_href if action_required_event else "/review",
+        )
+    elif processing_count:
+        primary_state = WorkflowPrimaryState.PROCESSING
+        next_action = WorkflowNextActionResponse(
+            type=WorkflowNextActionType.WAIT,
+            count=processing_count,
+            href="/statements",
+        )
+    elif ready_count:
+        primary_state = WorkflowPrimaryState.READY
+        next_action = WorkflowNextActionResponse(
+            type=WorkflowNextActionType.OPEN_REPORT,
+            count=ready_count,
+            href="/reports",
+        )
+    elif active_count:
+        primary_state = WorkflowPrimaryState.READY
+        next_action = WorkflowNextActionResponse(type=WorkflowNextActionType.NONE, count=0, href="/events")
+    else:
+        primary_state = WorkflowPrimaryState.EMPTY
+        next_action = WorkflowNextActionResponse(
+            type=WorkflowNextActionType.UPLOAD,
+            count=0,
+            href="/statements/upload",
+        )
+
+    if report_blocking_count:
+        readiness = WorkflowReportReadinessResponse(
+            state=WorkflowReportReadinessState.BLOCKED,
+            blocking_count=report_blocking_count,
+            href="/reports",
+        )
+    elif processing_count:
+        readiness = WorkflowReportReadinessResponse(
+            state=WorkflowReportReadinessState.PROCESSING,
+            blocking_count=0,
+            href="/reports",
+        )
+    elif stale_count:
+        readiness = WorkflowReportReadinessResponse(
+            state=WorkflowReportReadinessState.STALE,
+            blocking_count=0,
+            href="/reports",
+        )
+    elif ready_count:
+        readiness = WorkflowReportReadinessResponse(
+            state=WorkflowReportReadinessState.READY,
+            blocking_count=0,
+            href="/reports",
+        )
+    else:
+        readiness = WorkflowReportReadinessResponse(
+            state=WorkflowReportReadinessState.NONE,
+            blocking_count=0,
+            href="/reports",
+        )
+
+    return WorkflowStatusResponse(
+        primary_state=primary_state,
+        next_action=next_action,
+        report_readiness=readiness,
+        event_counts=WorkflowEventCountsResponse(
+            unread=unread_count,
+            action_required=action_required_count,
+            blocked=blocked_count,
+        ),
+    )
 
 
 async def update_workflow_event_status(

--- a/apps/backend/tests/api/test_workflow_router.py
+++ b/apps/backend/tests/api/test_workflow_router.py
@@ -1,0 +1,370 @@
+"""Workflow status API tests for EPIC-019."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.auth import get_current_user_id
+from src.main import app
+from src.models import BankStatement, BankStatementStatus, User
+from src.models.workflow import (
+    WorkflowEvent,
+    WorkflowEventFamily,
+    WorkflowEventSeverity,
+    WorkflowEventStatus,
+    WorkflowReportImpact,
+)
+from src.schemas.workflow import (
+    WorkflowEventCreate,
+    WorkflowEventListResponse,
+    WorkflowNextActionType,
+    WorkflowPrimaryState,
+    WorkflowReportReadinessState,
+    WorkflowStatusResponse,
+)
+from src.services.workflow_events import upsert_workflow_event
+
+pytestmark = pytest.mark.asyncio
+
+ROOT_DIR = Path(__file__).resolve().parents[4]
+
+
+async def _create_event(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    family: WorkflowEventFamily,
+    severity: WorkflowEventSeverity,
+    report_impact: WorkflowReportImpact,
+    action_href: str,
+    title: str,
+    occurred_at: datetime | None = None,
+    status: WorkflowEventStatus = WorkflowEventStatus.UNREAD,
+    source_id: UUID | None = None,
+) -> WorkflowEvent:
+    source_id = source_id or uuid4()
+    event = await upsert_workflow_event(
+        db,
+        user_id=user_id,
+        payload=WorkflowEventCreate(
+            family=family,
+            severity=severity,
+            title=title,
+            summary=f"{title} summary",
+            source_type="workflow_test",
+            source_id=source_id,
+            action_href=action_href,
+            report_impact=report_impact,
+            dedupe_key=f"workflow-test:{source_id}:{family.value}",
+            occurred_at=occurred_at or datetime.now(UTC),
+        ),
+    )
+    event.status = status
+    await db.flush()
+    return event
+
+
+async def _get_as_user(public_client: AsyncClient, user_id: UUID, path: str) -> dict:
+    app.dependency_overrides[get_current_user_id] = lambda: user_id
+    try:
+        response = await public_client.get(path)
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+
+    assert response.status_code == 200
+    return response.json()
+
+
+async def test_AC19_2_1_workflow_status_schema_contract() -> None:
+    """AC19.2.1: workflow status schemas expose stable contracts for UI consumers."""
+    status = WorkflowStatusResponse(
+        primary_state=WorkflowPrimaryState.NEEDS_ACTION,
+        next_action={
+            "type": WorkflowNextActionType.REVIEW_REQUIRED,
+            "count": 2,
+            "href": "/review?source=events",
+        },
+        report_readiness={
+            "state": WorkflowReportReadinessState.BLOCKED,
+            "blocking_count": 1,
+            "href": "/reports",
+        },
+        event_counts={"unread": 4, "action_required": 2, "blocked": 1},
+    )
+
+    assert status.model_dump(mode="json") == {
+        "primary_state": "needs_action",
+        "next_action": {
+            "type": "review_required",
+            "count": 2,
+            "href": "/review?source=events",
+        },
+        "report_readiness": {
+            "state": "blocked",
+            "blocking_count": 1,
+            "href": "/reports",
+        },
+        "event_counts": {"unread": 4, "action_required": 2, "blocked": 1},
+    }
+
+
+async def test_AC19_2_2_workflow_status_endpoint_returns_priority_summaries(
+    public_client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC19.2.2: GET /workflow/status returns user-scoped summary states with priority rules."""
+    empty = await _get_as_user(public_client, test_user.id, "/workflow/status")
+    assert empty["primary_state"] == "empty"
+    assert empty["next_action"] == {"type": "upload", "count": 0, "href": "/statements/upload"}
+    assert empty["report_readiness"] == {"state": "none", "blocking_count": 0, "href": "/reports"}
+    assert empty["event_counts"] == {"unread": 0, "action_required": 0, "blocked": 0}
+
+    statement = BankStatement(
+        user_id=test_user.id,
+        file_path="statements/status-demo.csv",
+        file_hash="c" * 64,
+        original_filename="status-demo.csv",
+        institution="Demo Bank",
+        status=BankStatementStatus.UPLOADED,
+    )
+    db.add(statement)
+    await db.commit()
+
+    processing = await _get_as_user(public_client, test_user.id, "/workflow/status")
+    assert processing["primary_state"] == "processing"
+    assert processing["next_action"] == {"type": "wait", "count": 1, "href": "/statements"}
+    assert processing["report_readiness"] == {"state": "processing", "blocking_count": 0, "href": "/reports"}
+    assert processing["event_counts"] == {"unread": 1, "action_required": 0, "blocked": 0}
+
+    await _create_event(
+        db,
+        user_id=test_user.id,
+        family=WorkflowEventFamily.REVIEW_REQUIRED,
+        severity=WorkflowEventSeverity.ACTION_REQUIRED,
+        report_impact=WorkflowReportImpact.BLOCKED,
+        action_href="/review?source=events",
+        title="Review required",
+    )
+    await db.commit()
+
+    needs_action = await _get_as_user(public_client, test_user.id, "/workflow/status")
+    assert needs_action["primary_state"] == "needs_action"
+    assert needs_action["next_action"] == {"type": "review_required", "count": 1, "href": "/review?source=events"}
+    assert needs_action["report_readiness"] == {"state": "blocked", "blocking_count": 1, "href": "/reports"}
+    assert needs_action["event_counts"] == {"unread": 2, "action_required": 1, "blocked": 0}
+
+    await _create_event(
+        db,
+        user_id=test_user.id,
+        family=WorkflowEventFamily.RECONCILIATION_BLOCKED,
+        severity=WorkflowEventSeverity.BLOCKED,
+        report_impact=WorkflowReportImpact.BLOCKED,
+        action_href="/reconciliation/unmatched",
+        title="Reconciliation blocked",
+    )
+    await db.commit()
+
+    blocked = await _get_as_user(public_client, test_user.id, "/workflow/status")
+    assert blocked["primary_state"] == "blocked"
+    assert blocked["next_action"] == {"type": "resolve_blocker", "count": 1, "href": "/reconciliation/unmatched"}
+    assert blocked["report_readiness"] == {"state": "blocked", "blocking_count": 2, "href": "/reports"}
+    assert blocked["event_counts"] == {"unread": 3, "action_required": 1, "blocked": 1}
+
+    ready_user = User(email=f"ready-{uuid4()}@example.com", hashed_password="hashed")
+    db.add(ready_user)
+    await db.flush()
+    await _create_event(
+        db,
+        user_id=ready_user.id,
+        family=WorkflowEventFamily.REPORT_READY,
+        severity=WorkflowEventSeverity.SUCCESS,
+        report_impact=WorkflowReportImpact.READY,
+        action_href="/reports",
+        title="Report ready",
+    )
+    await db.commit()
+
+    ready = await _get_as_user(public_client, ready_user.id, "/workflow/status")
+    assert ready["primary_state"] == "ready"
+    assert ready["next_action"] == {"type": "open_report", "count": 1, "href": "/reports"}
+    assert ready["report_readiness"] == {"state": "ready", "blocking_count": 0, "href": "/reports"}
+    assert ready["event_counts"] == {"unread": 1, "action_required": 0, "blocked": 0}
+
+
+async def test_AC19_2_3_workflow_events_endpoint_lists_bounded_user_events(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC19.2.3: GET /workflow/events returns bounded active events and supports status filtering."""
+    other_user = User(email=f"other-{uuid4()}@example.com", hashed_password="hashed")
+    db.add(other_user)
+    await db.flush()
+
+    now = datetime.now(UTC)
+    archived = await _create_event(
+        db,
+        user_id=test_user.id,
+        family=WorkflowEventFamily.SOURCE_UPLOADED,
+        severity=WorkflowEventSeverity.INFO,
+        report_impact=WorkflowReportImpact.PROCESSING,
+        action_href="/statements/archived",
+        title="Archived event",
+        occurred_at=now - timedelta(minutes=3),
+        status=WorkflowEventStatus.ARCHIVED,
+    )
+    older = await _create_event(
+        db,
+        user_id=test_user.id,
+        family=WorkflowEventFamily.REPORT_PROCESSING,
+        severity=WorkflowEventSeverity.INFO,
+        report_impact=WorkflowReportImpact.PROCESSING,
+        action_href="/reports",
+        title="Older active event",
+        occurred_at=now - timedelta(minutes=2),
+    )
+    newer = await _create_event(
+        db,
+        user_id=test_user.id,
+        family=WorkflowEventFamily.REVIEW_REQUIRED,
+        severity=WorkflowEventSeverity.ACTION_REQUIRED,
+        report_impact=WorkflowReportImpact.BLOCKED,
+        action_href="/review",
+        title="Newer active event",
+        occurred_at=now - timedelta(minutes=1),
+    )
+    await _create_event(
+        db,
+        user_id=other_user.id,
+        family=WorkflowEventFamily.REPORT_BLOCKED,
+        severity=WorkflowEventSeverity.BLOCKED,
+        report_impact=WorkflowReportImpact.BLOCKED,
+        action_href="/reports",
+        title="Other user event",
+        occurred_at=now,
+    )
+    await db.commit()
+
+    response = await client.get("/workflow/events")
+    assert response.status_code == 200
+    data = WorkflowEventListResponse.model_validate(response.json())
+    assert data.total == 2
+    assert [item.id for item in data.items] == [newer.id, older.id]
+
+    limited = await client.get("/workflow/events?limit=1")
+    assert limited.status_code == 200
+    limited_data = WorkflowEventListResponse.model_validate(limited.json())
+    assert limited_data.total == 2
+    assert [item.id for item in limited_data.items] == [newer.id]
+
+    archived_response = await client.get("/workflow/events?status=archived")
+    assert archived_response.status_code == 200
+    archived_data = WorkflowEventListResponse.model_validate(archived_response.json())
+    assert archived_data.total == 1
+    assert [item.id for item in archived_data.items] == [archived.id]
+
+
+async def test_AC19_2_4_workflow_event_patch_is_user_scoped(
+    client: AsyncClient,
+    public_client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC19.2.4: PATCH /workflow/events/{id} updates only the authenticated user's event."""
+    other_user = User(email=f"patch-other-{uuid4()}@example.com", hashed_password="hashed")
+    db.add(other_user)
+    await db.flush()
+
+    event = await _create_event(
+        db,
+        user_id=test_user.id,
+        family=WorkflowEventFamily.REVIEW_REQUIRED,
+        severity=WorkflowEventSeverity.ACTION_REQUIRED,
+        report_impact=WorkflowReportImpact.BLOCKED,
+        action_href="/review",
+        title="Patch owned event",
+    )
+    await db.commit()
+
+    response = await client.patch(f"/workflow/events/{event.id}", json={"status": "read"})
+    assert response.status_code == 200
+    assert response.json()["status"] == "read"
+
+    app.dependency_overrides[get_current_user_id] = lambda: other_user.id
+    try:
+        forbidden = await public_client.patch(f"/workflow/events/{event.id}", json={"status": "archived"})
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+
+    assert forbidden.status_code == 404
+    await db.refresh(event)
+    assert event.status == WorkflowEventStatus.READ
+
+    missing = await client.patch(f"/workflow/events/{uuid4()}", json={"status": "read"})
+    assert missing.status_code == 404
+
+
+async def test_AC19_2_5_workflow_reads_sync_derived_events_without_lifecycle_reset(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC19.2.5: workflow reads derive statement events idempotently without lifecycle reset."""
+    statement = BankStatement(
+        user_id=test_user.id,
+        file_path="statements/idempotent.csv",
+        file_hash="d" * 64,
+        original_filename="idempotent.csv",
+        institution="Demo Bank",
+        status=BankStatementStatus.UPLOADED,
+    )
+    db.add(statement)
+    await db.commit()
+
+    first = await client.get("/workflow/events")
+    assert first.status_code == 200
+    first_data = WorkflowEventListResponse.model_validate(first.json())
+    assert first_data.total == 1
+    event_id = first_data.items[0].id
+
+    patch = await client.patch(f"/workflow/events/{event_id}", json={"status": "archived"})
+    assert patch.status_code == 200
+
+    second = await client.get("/workflow/status")
+    assert second.status_code == 200
+
+    events = (
+        (
+            await db.execute(
+                select(WorkflowEvent)
+                .where(WorkflowEvent.user_id == test_user.id)
+                .where(WorkflowEvent.source_id == statement.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(events) == 1
+    assert events[0].id == event_id
+    assert events[0].status == WorkflowEventStatus.ARCHIVED
+
+
+async def test_AC19_2_6_workflow_router_and_ssot_document_compact_read_path() -> None:
+    """AC19.2.6: workflow router is mounted and documented as the compact read path."""
+    route_paths = {route.path for route in app.routes}
+    assert "/workflow/status" in route_paths
+    assert "/workflow/events" in route_paths
+    assert "/workflow/events/{event_id}" in route_paths
+
+    ssot = (ROOT_DIR / "docs" / "ssot" / "workflow-events.md").read_text(encoding="utf-8")
+    assert "GET /workflow/status" in ssot
+    assert "GET /workflow/events" in ssot
+    assert "PATCH /workflow/events/{event_id}" in ssot

--- a/docs/ac_registry.yaml
+++ b/docs/ac_registry.yaml
@@ -4875,3 +4875,40 @@ groups:
         epic_name: event-driven-upload-to-report-ux
         description: Workflow event reads and lifecycle changes are user isolated
         mandatory: true
+    AC19.2:
+      - id: AC19.2.1
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: Workflow status schemas define stable primary state, next action, report readiness, and event count response
+          contracts for later UI consumers
+        mandatory: true
+      - id: AC19.2.2
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: GET /workflow/status returns user-scoped empty, processing, needs-action, blocked, and ready summaries
+          with deterministic priority rules
+        mandatory: true
+      - id: AC19.2.3
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: GET /workflow/events returns bounded, user-scoped, deduplicated events, excludes archived events by default,
+          and supports status filtering
+        mandatory: true
+      - id: AC19.2.4
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: PATCH /workflow/events/{id} updates only the authenticated user's event lifecycle and returns 404 for
+          missing or non-owned events
+        mandatory: true
+      - id: AC19.2.5
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: Status and events reads run deterministic derived sync without duplicating events or resetting read/archive
+          lifecycle state
+        mandatory: true
+      - id: AC19.2.6
+        epic: 19
+        epic_name: event-driven-upload-to-report-ux
+        description: Workflow API router is mounted and documented in the workflow-events SSOT as the compact read path for
+          later UI slices
+        mandatory: true

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -132,10 +132,13 @@ inbox, and report readiness without forcing every page to duplicate logic.
 Initial API shape:
 
 ```text
-GET /api/workflow/status
-GET /api/workflow/events
-PATCH /api/workflow/events/{id}
+GET /workflow/status
+GET /workflow/events
+PATCH /workflow/events/{id}
 ```
+
+Frontend callers use the existing `/api/*` proxy convention, so #637 should
+call `/api/workflow/status` and `/api/workflow/events` through `lib/api.ts`.
 
 Representative status payload:
 
@@ -297,6 +300,17 @@ workflow state exists.
 | AC19.1.3 | Pydantic schemas validate the workflow event contract and reject external `action_href` values | `test_AC19_1_3_workflow_event_schema_rejects_external_action_href` | P0 |
 | AC19.1.4 | Workflow event service deterministically upserts a derived event from existing statement/upload state without duplicating on rerun | `test_AC19_1_4_upsert_uploaded_statement_event_is_deterministic` | P0 |
 | AC19.1.5 | Workflow event reads and lifecycle changes are user isolated | `test_AC19_1_5_workflow_event_lifecycle_is_user_isolated` | P0 |
+
+### AC19.2 — Workflow Status API
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC19.2.1 | Workflow status schemas define stable primary state, next action, report readiness, and event count response contracts for later UI consumers | `test_AC19_2_1_workflow_status_schema_contract` | P0 |
+| AC19.2.2 | `GET /workflow/status` returns user-scoped empty, processing, needs-action, blocked, and ready summaries with deterministic priority rules | `test_AC19_2_2_workflow_status_endpoint_returns_priority_summaries` | P0 |
+| AC19.2.3 | `GET /workflow/events` returns bounded, user-scoped, deduplicated events, excludes archived events by default, and supports status filtering | `test_AC19_2_3_workflow_events_endpoint_lists_bounded_user_events` | P0 |
+| AC19.2.4 | `PATCH /workflow/events/{id}` updates only the authenticated user's event lifecycle and returns 404 for missing or non-owned events | `test_AC19_2_4_workflow_event_patch_is_user_scoped` | P0 |
+| AC19.2.5 | Status and events reads run deterministic derived sync without duplicating events or resetting read/archive lifecycle state | `test_AC19_2_5_workflow_reads_sync_derived_events_without_lifecycle_reset` | P0 |
+| AC19.2.6 | Workflow API router is mounted and documented in the workflow-events SSOT as the compact read path for later UI slices | `test_AC19_2_6_workflow_router_and_ssot_document_compact_read_path` | P0 |
 
 ## How To Build It
 

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -18,8 +18,9 @@
 | Event model | `apps/backend/src/models/workflow.py` |
 | Event schemas | `apps/backend/src/schemas/workflow.py` |
 | Derivation/upsert service | `apps/backend/src/services/workflow_events.py` |
+| Compact status/events API | `apps/backend/src/routers/workflow.py` |
 | Database migrations | `apps/backend/migrations/versions/0021_add_workflow_events.py`, `apps/backend/migrations/versions/0022_harden_workflow_contract.py` |
-| Contract tests | `apps/backend/tests/workflow/test_workflow_events.py` |
+| Contract tests | `apps/backend/tests/workflow/test_workflow_events.py`, `apps/backend/tests/api/test_workflow_router.py` |
 
 ---
 
@@ -203,12 +204,45 @@ list. They should use compact status/count APIs owned by #636.
 Event inbox and status feed views may use paginated event lists. Default lists
 must be user-scoped, ordered by recent `occurred_at`, and bounded by a limit.
 
+The compact workflow API is:
+
+```text
+GET /workflow/status
+GET /workflow/events
+PATCH /workflow/events/{event_id}
+```
+
+`GET /workflow/status` returns:
+
+- `primary_state`: `empty`, `processing`, `needs_action`, `blocked`, or
+  `ready`.
+- `next_action`: `upload`, `wait`, `review_required`, `resolve_blocker`,
+  `open_report`, or `none`, plus a count and internal route.
+- `report_readiness`: `none`, `processing`, `ready`, `blocked`, or `stale`,
+  plus a blocking count and `/reports` route.
+- `event_counts`: unread, action-required, and blocked counts.
+
+Primary state priority is:
+
+```text
+blocked > needs_action > processing > ready > empty
+```
+
+`GET /workflow/events` returns `{ items, total }`. It excludes archived events
+by default, supports a `status` filter when archived events are explicitly
+requested, and enforces a bounded `limit`.
+
+`PATCH /workflow/events/{event_id}` updates only the authenticated user's event
+lifecycle state. Missing or non-owned events return `404`.
+
 ---
 
 ## 10. Initial Derivation
 
 The first implementation derives `source.uploaded` from `BankStatement` upload
-state. This proves the contract without introducing a full workflow API or UI.
+state. Workflow status and event reads run this deterministic sync before
+returning data. Repeated reads must not duplicate events or reset read/archive
+lifecycle state.
 
 Future slices may add deterministic derivation for:
 


### PR DESCRIPTION
## Summary

Add the EPIC-019 workflow status/events backend API so later UI slices can consume one compact upload-to-report state source.

Closes #636

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-019 — Event-Driven Upload-to-Report UX |
| **AC IDs** | AC19.2.1, AC19.2.2, AC19.2.3, AC19.2.4, AC19.2.5, AC19.2.6 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/workflow-events.md` — documents compact workflow status/events read path, route contract, priority rules, archive default, and deterministic derived sync behavior.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `2deaf21` | Added AC19.2 API/schema/router tests before the workflow status schemas and router existed; local run failed on missing `WorkflowEventListResponse`. |
| 🟢 Green (passing test) | `99a667d` | Implemented workflow status schemas, service aggregation, event list/lifecycle router, route mount, and SSOT updates. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A, no frontend env vars changed
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A, no production config changes; verified `repo/` matches `infra2` `origin/main` at `6e81bc3`
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A
- [x] `tools/check_manifest.py` passes (if SSOT files changed) — N/A, existing `workflow-events` manifest owner unchanged
- [x] `tools/lint_doc_consistency.py` passes — covered by `moon run :lint`

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner. — N/A
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys. — N/A
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged. — N/A
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials. — N/A
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule. — N/A
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene. — N/A

---

## Testing

```bash
# Passed
moon run :lint
./.venv/bin/python tools/generate_ac_registry.py --check
cd apps/backend && .venv/bin/python -m compileall -q src tests/api/test_workflow_router.py tests/workflow/test_workflow_events.py
cd apps/backend && .venv/bin/python - <<'PY'
from src.main import app
from src.schemas.workflow import WorkflowStatusResponse, WorkflowPrimaryState, WorkflowNextActionType, WorkflowReportReadinessState
route_paths = {route.path for route in app.routes}
assert '/workflow/status' in route_paths
assert '/workflow/events' in route_paths
assert '/workflow/events/{event_id}' in route_paths
status = WorkflowStatusResponse(
    primary_state=WorkflowPrimaryState.NEEDS_ACTION,
    next_action={'type': WorkflowNextActionType.REVIEW_REQUIRED, 'count': 2, 'href': '/review?source=events'},
    report_readiness={'state': WorkflowReportReadinessState.BLOCKED, 'blocking_count': 1, 'href': '/reports'},
    event_counts={'unread': 4, 'action_required': 2, 'blocked': 1},
)
assert status.model_dump(mode='json')['event_counts']['blocked'] == 1
PY

# Blocked locally by Podman socket; CI should run these with infra available
moon run :test -- --fast
cd apps/backend && .venv/bin/python -m pytest tests/api/test_workflow_router.py -q -n 0 --no-cov
```

Local DB-backed tests could not start because Podman is installed but its socket is unavailable:

```text
unable to connect to Podman socket: dial tcp 127.0.0.1:61270: connect: connection refused
```

---

## Screenshots / Evidence

N/A — backend API and SSOT change only.
