### PR TITLE
[finance_report_ui] Add workflow notifications

### DIFF
--- a/apps/backend/src/services/workflow_events.py
+++ b/apps/backend/src/services/workflow_events.py
@@ -2,8 +2,9 @@
 
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from src.models import BankStatement
 from src.models.workflow import (
@@ -48,62 +49,29 @@ def build_workflow_dedupe_key(*, family: WorkflowEventFamily, source_type: str, 
     return f"{source_type}:{source_id}:{family.value}"
 
 
-async def upsert_workflow_event(
-    db: AsyncSession,
-    *,
-    user_id: UUID,
-    payload: WorkflowEventCreate,
-) -> WorkflowEvent:
-    """Create or update a deterministic workflow event without committing."""
-    result = await db.execute(
-        select(WorkflowEvent)
-        .where(WorkflowEvent.user_id == user_id)
-        .where(WorkflowEvent.dedupe_key == payload.dedupe_key)
-    )
-    event = result.scalar_one_or_none()
-    if event is None:
-        event = WorkflowEvent(
-            user_id=user_id,
-            occurred_at=payload.occurred_at,
-            family=payload.family,
-            severity=payload.severity,
-            status=WorkflowEventStatus.UNREAD,
-            title=payload.title,
-            summary=payload.summary,
-            source_type=payload.source_type,
-            source_id=payload.source_id,
-            action_href=payload.action_href,
-            report_impact=payload.report_impact,
-            dedupe_key=payload.dedupe_key,
-        )
-        db.add(event)
-    else:
-        event.occurred_at = payload.occurred_at
-        event.family = payload.family
-        event.severity = payload.severity
-        event.title = payload.title
-        event.summary = payload.summary
-        event.source_type = payload.source_type
-        event.source_id = payload.source_id
-        event.action_href = payload.action_href
-        event.report_impact = payload.report_impact
+def _apply_workflow_event_payload(event: WorkflowEvent, payload: WorkflowEventCreate) -> None:
+    event.occurred_at = payload.occurred_at
+    event.family = payload.family
+    event.severity = payload.severity
+    event.title = payload.title
+    event.summary = payload.summary
+    event.source_type = payload.source_type
+    event.source_id = payload.source_id
+    event.action_href = payload.action_href
+    event.report_impact = payload.report_impact
+    event.dedupe_key = payload.dedupe_key
 
-    await db.flush()
+
+def _workflow_event_from_payload(*, user_id: UUID, payload: WorkflowEventCreate) -> WorkflowEvent:
+    event = WorkflowEvent(user_id=user_id, status=WorkflowEventStatus.UNREAD)
+    _apply_workflow_event_payload(event, payload)
     return event
 
 
-async def derive_uploaded_statement_event(
-    db: AsyncSession,
-    statement: BankStatement,
-    *,
-    user_id: UUID,
-) -> WorkflowEvent:
-    """Upsert the initial uploaded-statement workflow event."""
-    if statement.user_id != user_id:
-        raise ValueError("statement.user_id must match user_id")
-
+def build_uploaded_statement_event_payload(statement: BankStatement) -> WorkflowEventCreate:
+    """Build the deterministic uploaded-statement workflow event payload."""
     family = WorkflowEventFamily.SOURCE_UPLOADED
-    payload = WorkflowEventCreate(
+    return WorkflowEventCreate(
         occurred_at=statement.created_at,
         family=family,
         severity=WorkflowEventSeverity.INFO,
@@ -119,27 +87,70 @@ async def derive_uploaded_statement_event(
             source_id=statement.id,
         ),
     )
+
+
+async def upsert_workflow_event(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    payload: WorkflowEventCreate,
+) -> WorkflowEvent:
+    """Create or update a deterministic workflow event without committing."""
+    result = await db.execute(
+        select(WorkflowEvent)
+        .where(WorkflowEvent.user_id == user_id)
+        .where(WorkflowEvent.dedupe_key == payload.dedupe_key)
+    )
+    event = result.scalar_one_or_none()
+    if event is None:
+        event = _workflow_event_from_payload(user_id=user_id, payload=payload)
+        db.add(event)
+    else:
+        _apply_workflow_event_payload(event, payload)
+
+    await db.flush()
+    return event
+
+
+async def derive_uploaded_statement_event(
+    db: AsyncSession,
+    statement: BankStatement,
+    *,
+    user_id: UUID,
+) -> WorkflowEvent:
+    """Upsert the initial uploaded-statement workflow event."""
+    if statement.user_id != user_id:
+        raise ValueError("statement.user_id must match user_id")
+
+    payload = build_uploaded_statement_event_payload(statement)
     return await upsert_workflow_event(db, user_id=user_id, payload=payload)
 
 
 async def sync_workflow_events_for_user(db: AsyncSession, *, user_id: UUID) -> None:
     """Derive deterministic workflow events from existing user-owned records."""
-    existing_uploaded_event = (
-        select(WorkflowEvent.id)
-        .where(WorkflowEvent.user_id == user_id)
-        .where(WorkflowEvent.source_type == "bank_statement")
-        .where(WorkflowEvent.source_id == BankStatement.id)
-        .where(WorkflowEvent.family == WorkflowEventFamily.SOURCE_UPLOADED)
-        .exists()
-    )
+    existing_event = aliased(WorkflowEvent)
     result = await db.execute(
-        select(BankStatement)
+        select(BankStatement, existing_event)
+        .outerjoin(
+            existing_event,
+            and_(
+                existing_event.user_id == user_id,
+                existing_event.family == WorkflowEventFamily.SOURCE_UPLOADED,
+                existing_event.source_type == "bank_statement",
+                existing_event.source_id == BankStatement.id,
+            ),
+        )
         .where(BankStatement.user_id == user_id)
-        .where(~existing_uploaded_event)
         .order_by(BankStatement.created_at.asc())
     )
-    for statement in result.scalars().all():
-        await derive_uploaded_statement_event(db, statement, user_id=user_id)
+    for statement, event in result.all():
+        payload = build_uploaded_statement_event_payload(statement)
+        if event is None:
+            db.add(_workflow_event_from_payload(user_id=user_id, payload=payload))
+        else:
+            _apply_workflow_event_payload(event, payload)
+
+    await db.flush()
 
 
 async def list_workflow_events(
@@ -200,10 +211,6 @@ async def get_workflow_status(db: AsyncSession, *, user_id: UUID) -> WorkflowSta
 
     active_filters = [WorkflowEvent.user_id == user_id, WorkflowEvent.status != WorkflowEventStatus.ARCHIVED]
 
-    async def count_where(*filters: object) -> int:
-        value = await db.scalar(select(func.count(WorkflowEvent.id)).where(*active_filters, *filters))
-        return int(value or 0)
-
     async def representative_event(*filters: object) -> WorkflowEvent | None:
         result = await db.execute(
             select(WorkflowEvent)
@@ -213,12 +220,35 @@ async def get_workflow_status(db: AsyncSession, *, user_id: UUID) -> WorkflowSta
         )
         return result.scalar_one_or_none()
 
-    active_count = await count_where()
-    unread_count = await count_where(WorkflowEvent.status == WorkflowEventStatus.UNREAD)
-    action_required_count = await count_where(WorkflowEvent.severity == WorkflowEventSeverity.ACTION_REQUIRED)
-    blocked_count = await count_where(WorkflowEvent.severity == WorkflowEventSeverity.BLOCKED)
-    processing_count = await count_where(WorkflowEvent.report_impact == WorkflowReportImpact.PROCESSING)
-    ready_count = await count_where(WorkflowEvent.report_impact == WorkflowReportImpact.READY)
+    aggregate_row = (
+        await db.execute(
+            select(
+                func.count(WorkflowEvent.id).label("active_count"),
+                func.count(WorkflowEvent.id)
+                .filter(WorkflowEvent.status == WorkflowEventStatus.UNREAD)
+                .label("unread_count"),
+                func.count(WorkflowEvent.id)
+                .filter(WorkflowEvent.severity == WorkflowEventSeverity.ACTION_REQUIRED)
+                .label("action_required_count"),
+                func.count(WorkflowEvent.id)
+                .filter(WorkflowEvent.severity == WorkflowEventSeverity.BLOCKED)
+                .label("blocked_count"),
+                func.count(WorkflowEvent.id)
+                .filter(WorkflowEvent.report_impact == WorkflowReportImpact.PROCESSING)
+                .label("processing_count"),
+                func.count(WorkflowEvent.id)
+                .filter(WorkflowEvent.report_impact == WorkflowReportImpact.READY)
+                .label("ready_count"),
+            ).where(*active_filters)
+        )
+    ).one()
+
+    active_count = int(aggregate_row.active_count or 0)
+    unread_count = int(aggregate_row.unread_count or 0)
+    action_required_count = int(aggregate_row.action_required_count or 0)
+    blocked_count = int(aggregate_row.blocked_count or 0)
+    processing_count = int(aggregate_row.processing_count or 0)
+    ready_count = int(aggregate_row.ready_count or 0)
 
     if blocked_count or package_readiness_state == WorkflowReportReadinessState.BLOCKED:
         blocked_event = await representative_event(WorkflowEvent.severity == WorkflowEventSeverity.BLOCKED)

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -46,9 +46,7 @@ def test_AC19_1_1_workflow_event_ssot_registers_manifest_owner() -> None:
 def test_AC19_3_8_workflow_notification_ssot_documents_frontend_surfaces() -> None:
     """AC19.3.8: workflow notification UI contract is documented in SSOT and EPIC."""
     ssot = (ROOT_DIR / "docs" / "ssot" / "workflow-events.md").read_text(encoding="utf-8")
-    epic = (ROOT_DIR / "docs" / "project" / "EPIC-019.event-driven-upload-to-report-ux.md").read_text(
-        encoding="utf-8"
-    )
+    epic = (ROOT_DIR / "docs" / "project" / "EPIC-019.event-driven-upload-to-report-ux.md").read_text(encoding="utf-8")
 
     for phrase in (
         "Header badge",
@@ -326,6 +324,41 @@ async def test_AC19_3_1_sync_refreshes_mutable_uploaded_event_fields_without_lif
 
 
 @pytest.mark.asyncio
+async def test_AC19_3_1_sync_uses_bounded_workflow_event_lookup(db, db_engine, test_user) -> None:
+    """AC19.3.1: derived sync avoids per-statement workflow event lookups."""
+    from sqlalchemy import event as sqlalchemy_event
+
+    for index in range(3):
+        db.add(
+            BankStatement(
+                user_id=test_user.id,
+                file_path=f"statements/bulk-{index}.csv",
+                file_hash=f"{index}" * 64,
+                original_filename=f"bulk-{index}.csv",
+                institution="Demo Bank",
+                status=BankStatementStatus.UPLOADED,
+            )
+        )
+    await db.commit()
+
+    statements: list[str] = []
+
+    def capture_sql(_conn, _cursor, statement, _parameters, _context, _executemany) -> None:
+        normalized = " ".join(statement.lower().split())
+        if normalized.startswith("select") and "workflow_events" in normalized:
+            statements.append(normalized)
+
+    sqlalchemy_event.listen(db_engine.sync_engine, "before_cursor_execute", capture_sql)
+    try:
+        await sync_workflow_events_for_user(db, user_id=test_user.id)
+    finally:
+        sqlalchemy_event.remove(db_engine.sync_engine, "before_cursor_execute", capture_sql)
+
+    assert len(statements) == 1
+    assert "join workflow_events" in statements[0]
+
+
+@pytest.mark.asyncio
 async def test_AC19_3_2_workflow_status_uses_single_aggregate_for_badge_counts(
     db,
     db_engine,
@@ -383,9 +416,7 @@ async def test_AC19_3_2_workflow_status_uses_single_aggregate_for_badge_counts(
 
     count_queries = [statement for statement in statements if "count(" in statement]
     representative_queries = [
-        statement
-        for statement in statements
-        if "select workflow_events." in statement and "count(" not in statement
+        statement for statement in statements if "select workflow_events." in statement and "count(" not in statement
     ]
 
     assert status.primary_state.value == "needs_action"

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -22,7 +22,9 @@ from src.models.workflow import (
 from src.schemas.workflow import WorkflowEventCreate, WorkflowEventResponse
 from src.services.workflow_events import (
     derive_uploaded_statement_event,
+    get_workflow_status,
     list_workflow_events,
+    sync_workflow_events_for_user,
     update_workflow_event_status,
     upsert_workflow_event,
 )
@@ -39,6 +41,27 @@ def test_AC19_1_1_workflow_event_ssot_registers_manifest_owner() -> None:
     assert "workflow_events:" in manifest
     assert "owner: docs/ssot/workflow-events.md" in manifest
     assert "docs/project/EPIC-019.event-driven-upload-to-report-ux.md" in manifest
+
+
+def test_AC19_3_8_workflow_notification_ssot_documents_frontend_surfaces() -> None:
+    """AC19.3.8: workflow notification UI contract is documented in SSOT and EPIC."""
+    ssot = (ROOT_DIR / "docs" / "ssot" / "workflow-events.md").read_text(encoding="utf-8")
+    epic = (ROOT_DIR / "docs" / "project" / "EPIC-019.event-driven-upload-to-report-ux.md").read_text(
+        encoding="utf-8"
+    )
+
+    for phrase in (
+        "Header badge",
+        "Event inbox",
+        "Status feed",
+        "Routine automation",
+        "WorkflowNotificationCenter",
+        "WorkflowStatusFeed",
+    ):
+        assert phrase in ssot
+
+    assert "AC19.3.1" in epic
+    assert "AC19.3.8" in epic
 
 
 def test_AC19_1_2_workflow_event_model_contract() -> None:
@@ -255,3 +278,116 @@ async def test_AC19_1_5_workflow_event_lifecycle_is_user_isolated(db, test_user)
     assert updated is not None
     assert updated.status == WorkflowEventStatus.ARCHIVED
     assert WorkflowEventResponse.model_validate(updated).status == WorkflowEventStatus.ARCHIVED
+
+
+@pytest.mark.asyncio
+async def test_AC19_3_1_sync_refreshes_mutable_uploaded_event_fields_without_lifecycle_reset(db, test_user) -> None:
+    """AC19.3.1: derived sync updates mutable display fields without lifecycle reset."""
+    statement = BankStatement(
+        user_id=test_user.id,
+        file_path="statements/original.csv",
+        file_hash="e" * 64,
+        original_filename="original.csv",
+        institution="Demo Bank",
+        status=BankStatementStatus.UPLOADED,
+    )
+    db.add(statement)
+    await db.flush()
+
+    await sync_workflow_events_for_user(db, user_id=test_user.id)
+    event = (
+        await db.execute(
+            select(WorkflowEvent)
+            .where(WorkflowEvent.user_id == test_user.id)
+            .where(WorkflowEvent.source_id == statement.id)
+        )
+    ).scalar_one()
+    event.status = WorkflowEventStatus.ARCHIVED
+    statement.original_filename = "renamed.csv"
+    await db.flush()
+
+    await sync_workflow_events_for_user(db, user_id=test_user.id)
+    events = (
+        (
+            await db.execute(
+                select(WorkflowEvent)
+                .where(WorkflowEvent.user_id == test_user.id)
+                .where(WorkflowEvent.source_id == statement.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(events) == 1
+    assert events[0].id == event.id
+    assert events[0].status == WorkflowEventStatus.ARCHIVED
+    assert "renamed.csv" in events[0].summary
+
+
+@pytest.mark.asyncio
+async def test_AC19_3_2_workflow_status_uses_single_aggregate_for_badge_counts(
+    db,
+    db_engine,
+    test_user,
+) -> None:
+    """AC19.3.2: status uses one aggregate count query and one winning representative query."""
+    from sqlalchemy import event as sqlalchemy_event
+
+    await upsert_workflow_event(
+        db,
+        user_id=test_user.id,
+        payload=WorkflowEventCreate(
+            family=WorkflowEventFamily.REVIEW_REQUIRED,
+            severity=WorkflowEventSeverity.ACTION_REQUIRED,
+            title="Review required",
+            summary="One statement needs confirmation.",
+            source_type="bank_statement",
+            source_id=uuid4(),
+            action_href="/review",
+            report_impact=WorkflowReportImpact.BLOCKED,
+            dedupe_key="bank-statement:review-required:aggregate",
+            occurred_at=datetime.now(UTC),
+        ),
+    )
+    await upsert_workflow_event(
+        db,
+        user_id=test_user.id,
+        payload=WorkflowEventCreate(
+            family=WorkflowEventFamily.REPORT_PROCESSING,
+            severity=WorkflowEventSeverity.INFO,
+            title="Report processing",
+            summary="Automation is running.",
+            source_type="report",
+            source_id=uuid4(),
+            action_href="/reports",
+            report_impact=WorkflowReportImpact.PROCESSING,
+            dedupe_key="report:processing:aggregate",
+            occurred_at=datetime.now(UTC),
+        ),
+    )
+    await db.commit()
+
+    statements: list[str] = []
+
+    def capture_sql(_conn, _cursor, statement, _parameters, _context, _executemany) -> None:
+        normalized = " ".join(statement.lower().split())
+        if "workflow_events" in normalized:
+            statements.append(normalized)
+
+    sqlalchemy_event.listen(db_engine.sync_engine, "before_cursor_execute", capture_sql)
+    try:
+        status = await get_workflow_status(db, user_id=test_user.id)
+    finally:
+        sqlalchemy_event.remove(db_engine.sync_engine, "before_cursor_execute", capture_sql)
+
+    count_queries = [statement for statement in statements if "count(" in statement]
+    representative_queries = [
+        statement
+        for statement in statements
+        if "select workflow_events." in statement and "count(" not in statement
+    ]
+
+    assert status.primary_state.value == "needs_action"
+    assert len(count_queries) == 1
+    assert len(representative_queries) == 1

--- a/apps/frontend/playwright/workflow-notifications.spec.ts
+++ b/apps/frontend/playwright/workflow-notifications.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const COLD_ROUTE_TIMEOUT_MS = 10_000;
+
+const workflowStatus = {
+  primary_state: "needs_action",
+  next_action: { type: "review_required", count: 1, href: "/review" },
+  report_readiness: { state: "blocked", blocking_count: 1, href: "/reports" },
+  event_counts: { unread: 2, action_required: 1, blocked: 1 },
+};
+
+const workflowEvents = {
+  total: 3,
+  items: [
+    {
+      id: "workflow-blocked",
+      user_id: "workflow-user",
+      occurred_at: "2026-06-03T08:00:00Z",
+      family: "reconciliation.blocked",
+      severity: "blocked",
+      status: "unread",
+      title: "Reconciliation blocked",
+      summary: "Match two transactions before reports can be trusted.",
+      source_type: "reconciliation",
+      source_id: "source-blocked",
+      action_href: "/reconciliation/unmatched",
+      report_impact: "blocked",
+      dedupe_key: "workflow:blocker",
+      created_at: "2026-06-03T08:00:00Z",
+      updated_at: "2026-06-03T08:00:00Z",
+    },
+    {
+      id: "workflow-review",
+      user_id: "workflow-user",
+      occurred_at: "2026-06-03T07:00:00Z",
+      family: "review.required",
+      severity: "action_required",
+      status: "unread",
+      title: "Review required",
+      summary: "Confirm one low-confidence statement extraction.",
+      source_type: "bank_statement",
+      source_id: "source-review",
+      action_href: "/review",
+      report_impact: "blocked",
+      dedupe_key: "workflow:review",
+      created_at: "2026-06-03T07:00:00Z",
+      updated_at: "2026-06-03T07:00:00Z",
+    },
+    {
+      id: "workflow-success",
+      user_id: "workflow-user",
+      occurred_at: "2026-06-03T06:00:00Z",
+      family: "ledger.auto_posted",
+      severity: "success",
+      status: "read",
+      title: "Safe entries posted",
+      summary: "Automation posted high-confidence entries.",
+      source_type: "journal",
+      source_id: "source-success",
+      action_href: "/journal",
+      report_impact: "ready",
+      dedupe_key: "workflow:success",
+      created_at: "2026-06-03T06:00:00Z",
+      updated_at: "2026-06-03T06:00:00Z",
+    },
+  ],
+};
+
+async function installWorkflowMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("finance_access_token", "workflow-smoke-token");
+    localStorage.setItem("finance_user_id", "workflow-user");
+    localStorage.setItem("finance_user_email", "workflow@example.com");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    let body: unknown = {};
+
+    if (path === "/api/workflow/status") {
+      body = workflowStatus;
+    } else if (path === "/api/workflow/events") {
+      body = workflowEvents;
+    } else if (path.startsWith("/api/workflow/events/")) {
+      body = workflowEvents.items[0];
+    } else if (path === "/api/accounts") {
+      body = { items: [{ id: "cash", name: "Cash", type: "ASSET", currency: "SGD", is_active: true }], total: 1 };
+    } else if (path === "/api/accounts/processing/summary") {
+      body = { pending_count: 0, pending_total: "0.00", current_balance: "0.00", currency: "SGD", oldest_pending_date: null };
+    } else if (path === "/api/statements") {
+      body = { items: [{ id: "statement", status: "approved" }], total: 1 };
+    } else if (path === "/api/statements/pending-review") {
+      body = { items: [{ id: "statement" }], total: 1 };
+    } else if (path === "/api/statements/stage2/queue") {
+      body = { pending_matches: [], consistency_checks: [], has_unresolved_checks: false };
+    } else if (path.startsWith("/api/reports/balance-sheet")) {
+      body = {
+        as_of_date: "2026-06-03",
+        currency: "SGD",
+        assets: [{ account_id: "cash", name: "Cash", type: "ASSET", amount: "1000.00" }],
+        liabilities: [],
+        equity: [],
+        total_assets: "1000.00",
+        total_liabilities: "0.00",
+        total_equity: "1000.00",
+        equation_delta: "0.00",
+        is_balanced: true,
+      };
+    } else if (path.startsWith("/api/reports/income-statement")) {
+      body = { start_date: "2026-01-01", end_date: "2026-06-03", currency: "SGD", income: [], expenses: [], total_income: "0.00", total_expenses: "0.00", net_income: "0.00", trends: [] };
+    } else if (path === "/api/income/annualized") {
+      body = { annualized_salary: "0.00", annualized_bonus: "0.00", annualized_dividend: "0.00", annualized_total: "0.00", currency: "SGD", as_of: "2026-06-03" };
+    } else if (path === "/api/assets/restricted") {
+      body = [];
+    } else if (path === "/api/reconciliation/stats") {
+      body = { total_transactions: 0, matched_transactions: 0, unmatched_transactions: 0, pending_review: 0, auto_accepted: 0, match_rate: 0, score_distribution: {} };
+    } else if (path === "/api/reconciliation/unmatched") {
+      body = { items: [], total: 0 };
+    } else if (path.startsWith("/api/journal-entries")) {
+      body = { items: [], total: 0 };
+    } else if (path === "/api/assets/restricted") {
+      body = [];
+    }
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+}
+
+async function expectNoDocumentHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    scrollX: window.scrollX,
+  }));
+
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.scrollX).toBe(0);
+}
+
+test.describe("AC19.3.7 workflow notification smoke", () => {
+  for (const scenario of [
+    { name: "desktop", viewport: { width: 1440, height: 1000 }, isMobile: false },
+    { name: "mobile", viewport: { width: 390, height: 844 }, isMobile: true },
+  ]) {
+    test(`${scenario.name} shows workflow badge, inbox, and dashboard status feed`, async ({ page }) => {
+      await page.setViewportSize(scenario.viewport);
+      await installWorkflowMocks(page);
+
+      await page.goto("/dashboard", { waitUntil: "networkidle" });
+      await expect(page.getByRole("heading", { name: "Workflow status" })).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
+      await expect(page.getByText("Review required")).toBeVisible();
+
+      await page.getByRole("button", { name: /Workflow events/i }).click();
+      await expect(page.getByRole("dialog", { name: "Workflow events" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Blocked" })).toBeVisible();
+      await expect(page.getByRole("link", { name: /Open Reconciliation blocked/i })).toHaveAttribute(
+        "href",
+        "/reconciliation/unmatched",
+      );
+
+      await expectNoDocumentHorizontalScroll(page);
+    });
+  }
+});

--- a/apps/frontend/playwright/workflow-notifications.spec.ts
+++ b/apps/frontend/playwright/workflow-notifications.spec.ts
@@ -108,6 +108,8 @@ async function installWorkflowMocks(page: Page) {
       };
     } else if (path.startsWith("/api/reports/income-statement")) {
       body = { start_date: "2026-01-01", end_date: "2026-06-03", currency: "SGD", income: [], expenses: [], total_income: "0.00", total_expenses: "0.00", net_income: "0.00", trends: [] };
+    } else if (path.startsWith("/api/reports/trend")) {
+      body = { points: [] };
     } else if (path === "/api/income/annualized") {
       body = { annualized_salary: "0.00", annualized_bonus: "0.00", annualized_dividend: "0.00", annualized_total: "0.00", currency: "SGD", as_of: "2026-06-03" };
     } else if (path === "/api/assets/restricted") {
@@ -118,8 +120,6 @@ async function installWorkflowMocks(page: Page) {
       body = { items: [], total: 0 };
     } else if (path.startsWith("/api/journal-entries")) {
       body = { items: [], total: 0 };
-    } else if (path === "/api/assets/restricted") {
-      body = [];
     }
 
     await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
@@ -151,9 +151,10 @@ test.describe("AC19.3.7 workflow notification smoke", () => {
       await expect(page.getByText("Review required")).toBeVisible();
 
       await page.getByRole("button", { name: /Workflow events/i }).click();
-      await expect(page.getByRole("dialog", { name: "Workflow events" })).toBeVisible();
-      await expect(page.getByRole("heading", { name: "Blocked" })).toBeVisible();
-      await expect(page.getByRole("link", { name: /Open Reconciliation blocked/i })).toHaveAttribute(
+      const dialog = page.getByRole("dialog", { name: "Workflow events" });
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByRole("heading", { name: "Blocked", exact: true })).toBeVisible();
+      await expect(dialog.getByRole("link", { name: /Open Reconciliation blocked/i })).toHaveAttribute(
         "href",
         "/reconciliation/unmatched",
       );

--- a/apps/frontend/src/__tests__/dashboardPage.test.tsx
+++ b/apps/frontend/src/__tests__/dashboardPage.test.tsx
@@ -59,6 +59,46 @@ function mockDashboardApi(overrides: Record<string, unknown> = {}) {
         : baseBalance
       return Promise.resolve(hasOverride("balance") ? overrides.balance : defaultBalance)
     }
+    if (path.startsWith("/api/workflow/status")) {
+      return Promise.resolve(
+        hasOverride("workflowStatus")
+          ? overrides.workflowStatus
+          : {
+              primary_state: "needs_action",
+              next_action: { type: "review_required", count: 1, href: "/review" },
+              report_readiness: { state: "blocked", blocking_count: 1, href: "/reports" },
+              event_counts: { unread: 2, action_required: 1, blocked: 0 },
+            },
+      )
+    }
+    if (path.startsWith("/api/workflow/events")) {
+      return Promise.resolve(
+        hasOverride("workflowEvents")
+          ? overrides.workflowEvents
+          : {
+              total: 1,
+              items: [
+                {
+                  id: "workflow-dashboard",
+                  user_id: "user-dashboard",
+                  occurred_at: "2026-06-03T08:00:00Z",
+                  family: "review.required",
+                  severity: "action_required",
+                  status: "unread",
+                  title: "Review required",
+                  summary: "A statement needs confirmation before reports are ready.",
+                  source_type: "bank_statement",
+                  source_id: "statement-dashboard",
+                  action_href: "/review",
+                  report_impact: "blocked",
+                  dedupe_key: "workflow:dashboard",
+                  created_at: "2026-06-03T08:00:00Z",
+                  updated_at: "2026-06-03T08:00:00Z",
+                },
+              ],
+            },
+      )
+    }
     if (path.startsWith("/api/reports/income-statement")) return Promise.resolve(hasOverride("income") ? overrides.income : baseIncome)
     if (path.startsWith("/api/income/annualized")) {
       return Promise.resolve(
@@ -168,6 +208,18 @@ describe("DashboardPage", () => {
     expect(screen.getByText("BarChartMock")).toBeInTheDocument()
     expect(screen.getByText("Recent Entries")).toBeInTheDocument()
     expect(screen.getByText("Unmatched Alerts")).toBeInTheDocument()
+  })
+
+  it("AC19.3.6 renders the workflow status feed on the dashboard landing surface", async () => {
+    mockDashboardApi()
+
+    render(<DashboardPage />)
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Workflow status" })).toBeInTheDocument())
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/workflow/status")
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/workflow/events?limit=5")
+    expect(screen.getByText("Review required")).toBeInTheDocument()
+    expect(screen.getByText("Report blocked")).toBeInTheDocument()
   })
 
   it("AC11.8.2/AC11.8.6/AC5.6.4 renders Annualized Income card with the four metric labels", async () => {

--- a/apps/frontend/src/__tests__/dashboardPage.test.tsx
+++ b/apps/frontend/src/__tests__/dashboardPage.test.tsx
@@ -25,9 +25,20 @@ vi.mock("@/components/charts/NetWorthTimeSeriesChart", () => ({
   NetWorthTimeSeriesChart: () => <div>NetWorthTimeSeriesMock</div>,
 }))
 
-vi.mock("@/lib/api", () => ({
-  apiFetch: vi.fn(),
-}))
+vi.mock("@/lib/api", () => {
+  const apiFetch = vi.fn()
+  return {
+    apiFetch,
+    fetchWorkflowStatus: () => apiFetch("/api/workflow/status"),
+    fetchWorkflowEvents: ({ limit }: { limit?: number } = {}) =>
+      apiFetch(`/api/workflow/events${limit ? `?limit=${limit}` : ""}`),
+    updateWorkflowEventStatus: (eventId: string, status: string) =>
+      apiFetch(`/api/workflow/events/${eventId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status }),
+      }),
+  }
+})
 
 const baseBalance = {
   assets: [{ account_id: "a1", name: "Cash", amount: 5000 }],

--- a/apps/frontend/src/__tests__/eventsPage.test.tsx
+++ b/apps/frontend/src/__tests__/eventsPage.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import EventsPage from "@/app/(main)/events/page"
+
+vi.mock("@/components/workflow/WorkflowNotifications", () => ({
+  WorkflowEventsPageContent: () => <div>Workflow events page content</div>,
+}))
+
+describe("EventsPage", () => {
+  it("AC19.3.5 renders the workflow events content surface", () => {
+    render(<EventsPage />)
+    expect(screen.getByText("Workflow events page content")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/__tests__/navigation.test.ts
+++ b/apps/frontend/src/__tests__/navigation.test.ts
@@ -6,6 +6,7 @@ describe("navigation metadata", () => {
   it("AC16.23.5 exposes the full primary navigation set for mobile and desktop", () => {
     expect(primaryNavItems.map((item) => item.label)).toEqual([
       "Dashboard",
+      "Events",
       "Accounts",
       "Journal",
       "Statements",

--- a/apps/frontend/src/__tests__/workflowApi.test.ts
+++ b/apps/frontend/src/__tests__/workflowApi.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+
+function makeFetchMock(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+    headers: { get: () => null },
+  })
+}
+
+describe("workflow API helpers", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    localStorageMock.clear()
+    vi.unstubAllGlobals()
+    vi.stubGlobal("localStorage", localStorageMock)
+  })
+
+  it("AC19.3.3 fetches typed workflow status through lib/api.ts", async () => {
+    const fetchMock = makeFetchMock(200, {
+      primary_state: "needs_action",
+      next_action: { type: "review_required", count: 2, href: "/review" },
+      report_readiness: { state: "blocked", blocking_count: 2, href: "/reports" },
+      event_counts: { unread: 3, action_required: 2, blocked: 1 },
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { fetchWorkflowStatus } = await import("@/lib/api")
+    const status = await fetchWorkflowStatus()
+
+    expect(status.primary_state).toBe("needs_action")
+    expect(status.event_counts.action_required).toBe(2)
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/workflow/status"),
+      expect.objectContaining({ headers: expect.any(Object) }),
+    )
+  })
+
+  it("AC19.3.3 fetches events with bounded limit and patches lifecycle state", async () => {
+    const fetchMock = makeFetchMock(200, { items: [], total: 0 })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { fetchWorkflowEvents, updateWorkflowEventStatus } = await import("@/lib/api")
+    await fetchWorkflowEvents({ status: "unread", limit: 20 })
+    await updateWorkflowEventStatus("event-1", "archived")
+
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/workflow/events?status=unread&limit=20")
+    expect(fetchMock.mock.calls[1][0]).toContain("/api/workflow/events/event-1")
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ status: "archived" }),
+      }),
+    )
+  })
+})

--- a/apps/frontend/src/__tests__/workflowSurfaces.test.tsx
+++ b/apps/frontend/src/__tests__/workflowSurfaces.test.tsx
@@ -1,0 +1,188 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  WorkflowNotificationCenter,
+  WorkflowStatusFeed,
+} from "@/components/workflow/WorkflowNotifications"
+import {
+  fetchWorkflowEvents,
+  fetchWorkflowStatus,
+  updateWorkflowEventStatus,
+} from "@/lib/api"
+import type {
+  WorkflowEventListResponse,
+  WorkflowStatusResponse,
+} from "@/lib/types"
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, className }: { href: string; children: ReactNode; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock("@/lib/api", () => ({
+  fetchWorkflowEvents: vi.fn(),
+  fetchWorkflowStatus: vi.fn(),
+  updateWorkflowEventStatus: vi.fn(),
+}))
+
+const statusNeedsAction: WorkflowStatusResponse = {
+  primary_state: "needs_action",
+  next_action: { type: "review_required", count: 2, href: "/review" },
+  report_readiness: { state: "blocked", blocking_count: 2, href: "/reports" },
+  event_counts: { unread: 3, action_required: 2, blocked: 1 },
+}
+
+const statusEmpty: WorkflowStatusResponse = {
+  primary_state: "empty",
+  next_action: { type: "upload", count: 0, href: "/statements/upload" },
+  report_readiness: { state: "none", blocking_count: 0, href: "/reports" },
+  event_counts: { unread: 0, action_required: 0, blocked: 0 },
+}
+
+const workflowEvents: WorkflowEventListResponse = {
+  total: 4,
+  items: [
+    {
+      id: "blocked-event",
+      user_id: "user-1",
+      occurred_at: "2026-06-03T08:00:00Z",
+      family: "reconciliation.blocked",
+      severity: "blocked",
+      status: "unread",
+      title: "Reconciliation blocked",
+      summary: "Two transactions need matching before the report can be trusted.",
+      source_type: "reconciliation",
+      source_id: "source-1",
+      action_href: "/reconciliation/unmatched",
+      report_impact: "blocked",
+      dedupe_key: "event:blocked",
+      created_at: "2026-06-03T08:00:00Z",
+      updated_at: "2026-06-03T08:00:00Z",
+    },
+    {
+      id: "review-event",
+      user_id: "user-1",
+      occurred_at: "2026-06-03T07:00:00Z",
+      family: "review.required",
+      severity: "action_required",
+      status: "unread",
+      title: "Review required",
+      summary: "A statement has low-confidence entries that need confirmation.",
+      source_type: "bank_statement",
+      source_id: "source-2",
+      action_href: "/review",
+      report_impact: "blocked",
+      dedupe_key: "event:review",
+      created_at: "2026-06-03T07:00:00Z",
+      updated_at: "2026-06-03T07:00:00Z",
+    },
+    {
+      id: "success-event",
+      user_id: "user-1",
+      occurred_at: "2026-06-03T06:00:00Z",
+      family: "ledger.auto_posted",
+      severity: "success",
+      status: "read",
+      title: "Safe entries posted",
+      summary: "Automation posted high-confidence entries.",
+      source_type: "journal",
+      source_id: "source-3",
+      action_href: "/journal",
+      report_impact: "ready",
+      dedupe_key: "event:success",
+      created_at: "2026-06-03T06:00:00Z",
+      updated_at: "2026-06-03T06:00:00Z",
+    },
+    {
+      id: "info-event",
+      user_id: "user-1",
+      occurred_at: "2026-06-03T05:00:00Z",
+      family: "source.uploaded",
+      severity: "info",
+      status: "read",
+      title: "Statement uploaded",
+      summary: "The file is queued for processing.",
+      source_type: "bank_statement",
+      source_id: "source-4",
+      action_href: "/statements/source-4",
+      report_impact: "processing",
+      dedupe_key: "event:info",
+      created_at: "2026-06-03T05:00:00Z",
+      updated_at: "2026-06-03T05:00:00Z",
+    },
+  ],
+}
+
+function renderWithQuery(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+describe("workflow notification surfaces", () => {
+  beforeEach(() => {
+    vi.mocked(fetchWorkflowStatus).mockReset()
+    vi.mocked(fetchWorkflowEvents).mockReset()
+    vi.mocked(updateWorkflowEventStatus).mockReset()
+    vi.mocked(fetchWorkflowStatus).mockResolvedValue(statusNeedsAction)
+    vi.mocked(fetchWorkflowEvents).mockResolvedValue(workflowEvents)
+    vi.mocked(updateWorkflowEventStatus).mockResolvedValue(workflowEvents.items[0])
+  })
+
+  it("AC19.3.4 shows the header badge from compact workflow counts and hides counts when quiet", async () => {
+    renderWithQuery(<WorkflowNotificationCenter />)
+
+    const button = await screen.findByRole("button", { name: /Workflow events/i })
+    expect(button).toHaveTextContent("3")
+    expect(button).toHaveAccessibleName(/2 actions/i)
+    expect(button).toHaveAccessibleName(/1 blocked/i)
+    expect(fetchWorkflowStatus).toHaveBeenCalledTimes(1)
+
+    vi.mocked(fetchWorkflowStatus).mockResolvedValue(statusEmpty)
+    renderWithQuery(<WorkflowNotificationCenter />)
+    await waitFor(() => expect(screen.getAllByRole("button", { name: /Workflow events/i })[1]).not.toHaveTextContent("0"))
+  })
+
+  it("AC19.3.5 groups inbox events by actionability and supports read/archive lifecycle actions", async () => {
+    renderWithQuery(<WorkflowNotificationCenter />)
+
+    fireEvent.click(await screen.findByRole("button", { name: /Workflow events/i }))
+    const dialog = await screen.findByRole("dialog", { name: "Workflow events" })
+
+    expect(within(dialog).getByRole("heading", { name: "Blocked" })).toBeInTheDocument()
+    expect(within(dialog).getByRole("heading", { name: "Action required" })).toBeInTheDocument()
+    expect(within(dialog).getByRole("heading", { name: "Routine automation" })).toBeInTheDocument()
+    expect(within(dialog).getByRole("link", { name: /Open Reconciliation blocked/i })).toHaveAttribute(
+      "href",
+      "/reconciliation/unmatched",
+    )
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Mark Reconciliation blocked as read" }))
+    await waitFor(() => expect(updateWorkflowEventStatus).toHaveBeenCalledWith("blocked-event", "read"))
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Archive Review required" }))
+    await waitFor(() => expect(updateWorkflowEventStatus).toHaveBeenCalledWith("review-event", "archived"))
+  })
+
+  it("AC19.3.6 renders status feed severity, readiness, routine summary, and empty no-action state", () => {
+    const { rerender } = render(<WorkflowStatusFeed status={statusNeedsAction} events={workflowEvents.items} />)
+
+    expect(screen.getByRole("heading", { name: "Workflow status" })).toBeInTheDocument()
+    expect(screen.getByText("Review required")).toBeInTheDocument()
+    expect(screen.getByText("Report blocked")).toBeInTheDocument()
+    expect(screen.getByText("Routine automation")).toBeInTheDocument()
+    expect(screen.getByText("2 routine events")).toBeInTheDocument()
+    expect(screen.queryByText(/audit/i)).not.toBeInTheDocument()
+
+    rerender(<WorkflowStatusFeed status={statusEmpty} events={[]} />)
+    expect(screen.getByText("No action required")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Upload statements" })).toHaveAttribute("href", "/statements/upload")
+  })
+})

--- a/apps/frontend/src/__tests__/workflowSurfaces.test.tsx
+++ b/apps/frontend/src/__tests__/workflowSurfaces.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   WorkflowNotificationCenter,
+  WorkflowEventsPageContent,
   WorkflowStatusFeed,
 } from "@/components/workflow/WorkflowNotifications"
 import {
@@ -140,8 +141,8 @@ describe("workflow notification surfaces", () => {
     renderWithQuery(<WorkflowNotificationCenter />)
 
     const button = await screen.findByRole("button", { name: /Workflow events/i })
-    expect(button).toHaveTextContent("3")
-    expect(button).toHaveAccessibleName(/2 actions/i)
+    await waitFor(() => expect(button).toHaveTextContent("3"))
+    await waitFor(() => expect(button).toHaveAccessibleName(/2 actions/i))
     expect(button).toHaveAccessibleName(/1 blocked/i)
     expect(fetchWorkflowStatus).toHaveBeenCalledTimes(1)
 
@@ -156,7 +157,7 @@ describe("workflow notification surfaces", () => {
     fireEvent.click(await screen.findByRole("button", { name: /Workflow events/i }))
     const dialog = await screen.findByRole("dialog", { name: "Workflow events" })
 
-    expect(within(dialog).getByRole("heading", { name: "Blocked" })).toBeInTheDocument()
+    await waitFor(() => expect(within(dialog).getByRole("heading", { name: "Blocked" })).toBeInTheDocument())
     expect(within(dialog).getByRole("heading", { name: "Action required" })).toBeInTheDocument()
     expect(within(dialog).getByRole("heading", { name: "Routine automation" })).toBeInTheDocument()
     expect(within(dialog).getByRole("link", { name: /Open Reconciliation blocked/i })).toHaveAttribute(
@@ -184,5 +185,44 @@ describe("workflow notification surfaces", () => {
     rerender(<WorkflowStatusFeed status={statusEmpty} events={[]} />)
     expect(screen.getByText("No action required")).toBeInTheDocument()
     expect(screen.getByRole("link", { name: "Upload statements" })).toHaveAttribute("href", "/statements/upload")
+  })
+
+  it("AC19.3.5 renders the events page loading and unavailable states", async () => {
+    vi.mocked(fetchWorkflowStatus).mockImplementation(() => new Promise(() => undefined))
+    vi.mocked(fetchWorkflowEvents).mockImplementation(() => new Promise(() => undefined))
+
+    const { unmount } = renderWithQuery(<WorkflowEventsPageContent />)
+
+    expect(screen.getByRole("heading", { name: "Events" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Upload statements" })).toHaveAttribute("href", "/statements/upload")
+    expect(screen.getByText("Loading workflow status...")).toBeInTheDocument()
+    expect(screen.getByText("Loading workflow events...")).toBeInTheDocument()
+
+    unmount()
+
+    vi.mocked(fetchWorkflowStatus).mockRejectedValue(new Error("status unavailable"))
+    vi.mocked(fetchWorkflowEvents).mockRejectedValue(new Error("events unavailable"))
+
+    renderWithQuery(<WorkflowEventsPageContent />)
+
+    expect(await screen.findByText("Workflow status is unavailable.")).toBeInTheDocument()
+    expect(await screen.findByText("Unable to load workflow events.")).toBeInTheDocument()
+  })
+
+  it("AC19.3.5 renders the events page status feed, inbox total, and lifecycle actions", async () => {
+    renderWithQuery(<WorkflowEventsPageContent />)
+
+    expect(await screen.findByRole("heading", { name: "Workflow status" })).toBeInTheDocument()
+    expect(screen.getByText("Workflow attention for upload, review, reconciliation, and reports")).toBeInTheDocument()
+    expect(screen.getByText("4 total")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Workflow events" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Blocked" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Open Reconciliation blocked/i })).toHaveAttribute(
+      "href",
+      "/reconciliation/unmatched",
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark Reconciliation blocked as read" }))
+    await waitFor(() => expect(updateWorkflowEventStatus).toHaveBeenCalledWith("blocked-event", "read"))
   })
 })

--- a/apps/frontend/src/app/(main)/dashboard/page.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Landmark, FileText, BookOpen } from "lucide-react";
 import ProcessingSummaryCard from "@/components/ProcessingSummaryCard";
+import { WorkflowStatusFeedPanel } from "@/components/workflow/WorkflowNotifications";
 
 import { apiFetch } from "@/lib/api";
 import { formatDateInput, formatDateDisplay, formatMonthLabel } from "@/lib/date";
@@ -313,6 +314,10 @@ export default function DashboardPage() {
           </div>
         </section>
       )}
+
+      <div className="mb-6">
+        <WorkflowStatusFeedPanel />
+      </div>
 
       {/* KPI Cards */}
       <div className="grid gap-4 md:grid-cols-4 mb-6">

--- a/apps/frontend/src/app/(main)/events/page.tsx
+++ b/apps/frontend/src/app/(main)/events/page.tsx
@@ -1,0 +1,5 @@
+import { WorkflowEventsPageContent } from "@/components/workflow/WorkflowNotifications";
+
+export default function EventsPage() {
+  return <WorkflowEventsPageContent />;
+}

--- a/apps/frontend/src/components/AppShell.tsx
+++ b/apps/frontend/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from "@/components/Sidebar";
 import { MobileNav } from "@/components/MobileNav";
 import { WorkspaceTabs } from "@/components/WorkspaceTabs";
 import { ToastProvider } from "@/components/ui/Toast";
+import { WorkflowNotificationCenter } from "@/components/workflow/WorkflowNotifications";
 
 interface AppShellProps {
     children: ReactNode;
@@ -24,11 +25,12 @@ function AppShellContent({ children }: AppShellProps) {
                     isCollapsed ? "md:ml-16" : "md:ml-64"
                 }`}
             >
-                <div className="flex min-w-0 items-center border-b border-border md:block md:border-none">
+                <div className="flex min-w-0 items-center border-b border-border bg-surface-card">
                     <MobileNav />
-                    <div className="hidden md:block min-w-0">
+                    <div className="hidden md:block min-w-0 flex-1">
                         <WorkspaceTabs />
                     </div>
+                    <WorkflowNotificationCenter />
                 </div>
 
                 <main className="min-h-[calc(100vh-4rem)]">

--- a/apps/frontend/src/components/navigation.ts
+++ b/apps/frontend/src/components/navigation.ts
@@ -1,5 +1,6 @@
 import {
     BarChart3,
+    Bell,
     BookOpen,
     ClipboardCheck,
     Clock,
@@ -27,6 +28,7 @@ export interface RouteConfig {
 
 export const primaryNavItems: NavItem[] = [
     { icon: LayoutDashboard, label: "Dashboard", href: "/dashboard", protected: true },
+    { icon: Bell, label: "Events", href: "/events", protected: true },
     { icon: Landmark, label: "Accounts", href: "/accounts", protected: true },
     { icon: BookOpen, label: "Journal", href: "/journal", protected: true },
     { icon: FileText, label: "Statements", href: "/statements", protected: true },
@@ -40,6 +42,7 @@ export const primaryNavItems: NavItem[] = [
 
 export const ROUTE_CONFIG: Record<string, RouteConfig> = {
     "/dashboard": { label: "Dashboard", Icon: LayoutDashboard },
+    "/events": { label: "Events", Icon: Bell },
     "/accounts": { label: "Accounts", Icon: Landmark },
     "/journal": { label: "Journal", Icon: BookOpen },
     "/statements": { label: "Statements", Icon: FileText },

--- a/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
+++ b/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
@@ -1,0 +1,562 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Archive,
+  Bell,
+  CheckCircle2,
+  CircleAlert,
+  CircleCheck,
+  ExternalLink,
+  Inbox,
+  Loader2,
+  ShieldAlert,
+} from "lucide-react";
+import Sheet from "@/components/ui/Sheet";
+import { Alert, Badge, EmptyState, IconButton } from "@/components/ui";
+import {
+  fetchWorkflowEvents,
+  fetchWorkflowStatus,
+  updateWorkflowEventStatus,
+} from "@/lib/api";
+import type {
+  WorkflowEventResponse,
+  WorkflowEventSeverity,
+  WorkflowEventStatus,
+  WorkflowStatusResponse,
+} from "@/lib/types";
+
+const STATUS_QUERY_KEY = ["workflow", "status"] as const;
+const EVENTS_QUERY_KEY = ["workflow", "events"] as const;
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function severityBadgeVariant(severity: WorkflowEventSeverity) {
+  if (severity === "blocked") return "error";
+  if (severity === "action_required" || severity === "warning") return "warning";
+  if (severity === "success") return "success";
+  return "info";
+}
+
+function severityIcon(severity: WorkflowEventSeverity) {
+  if (severity === "blocked") return ShieldAlert;
+  if (severity === "action_required" || severity === "warning") return CircleAlert;
+  if (severity === "success") return CircleCheck;
+  return CheckCircle2;
+}
+
+function labelFromSnake(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function sentenceFromSnake(value: string) {
+  return value.replace(/_/g, " ");
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function routineEvents(events: WorkflowEventResponse[]) {
+  return events.filter((event) => event.severity !== "blocked" && event.severity !== "action_required");
+}
+
+interface WorkflowEventGroupProps {
+  title: string;
+  events: WorkflowEventResponse[];
+  onStatusChange?: (eventId: string, status: WorkflowEventStatus) => void;
+  showActions?: boolean;
+}
+
+function WorkflowEventGroup({
+  title,
+  events,
+  onStatusChange,
+  showActions = true,
+}: WorkflowEventGroupProps) {
+  if (events.length === 0) return null;
+
+  return (
+    <section className="space-y-2" aria-label={title}>
+      <h3 className="text-sm font-semibold">{title}</h3>
+      <div className="space-y-2">
+        {events.map((event) => {
+          const Icon = severityIcon(event.severity);
+          return (
+            <article
+              key={event.id}
+              className={cx(
+                "rounded-md border p-3 text-sm",
+                event.severity === "blocked" && "border-status-error bg-status-error-muted",
+                event.severity === "action_required" && "border-status-warning bg-status-warning-muted",
+                event.severity !== "blocked" &&
+                  event.severity !== "action_required" &&
+                  "border-border bg-surface-card",
+              )}
+            >
+              <div className="flex min-w-0 items-start gap-3">
+                <Icon className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted" aria-hidden="true" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h4 className="font-medium">{event.title}</h4>
+                    <Badge variant={severityBadgeVariant(event.severity)}>{labelFromSnake(event.severity)}</Badge>
+                  </div>
+                  <p className="mt-1 text-sm text-muted">{event.summary}</p>
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <Link
+                      href={event.action_href}
+                      className="btn-secondary inline-flex items-center gap-1.5 px-3 py-1.5 text-xs"
+                    >
+                      <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                      Open {event.title}
+                    </Link>
+                    {showActions && event.status === "unread" && (
+                      <button
+                        type="button"
+                        className="btn-ghost px-3 py-1.5 text-xs"
+                        aria-label={`Mark ${event.title} as read`}
+                        onClick={() => onStatusChange?.(event.id, "read")}
+                      >
+                        Mark as read
+                      </button>
+                    )}
+                    {showActions && event.status !== "archived" && (
+                      <button
+                        type="button"
+                        className="btn-ghost px-3 py-1.5 text-xs"
+                        onClick={() => onStatusChange?.(event.id, "archived")}
+                      >
+                        Archive
+                        <span className="sr-only"> {event.title}</span>
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+interface WorkflowInboxProps {
+  events: WorkflowEventResponse[];
+  onStatusChange?: (eventId: string, status: WorkflowEventStatus) => void;
+}
+
+export function WorkflowInbox({ events, onStatusChange }: WorkflowInboxProps) {
+  const grouped = useMemo(
+    () => ({
+      blocked: events.filter((event) => event.severity === "blocked"),
+      actionRequired: events.filter((event) => event.severity === "action_required"),
+      routine: routineEvents(events),
+    }),
+    [events],
+  );
+
+  if (events.length === 0) {
+    return (
+      <EmptyState
+        title="No action required"
+        description="Workflow events will appear here when review or blockers need attention."
+        action={
+          <Link href="/statements/upload" className="btn-primary inline-flex">
+            Upload statements
+          </Link>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <WorkflowEventGroup title="Blocked" events={grouped.blocked} onStatusChange={onStatusChange} />
+      <WorkflowEventGroup title="Action required" events={grouped.actionRequired} onStatusChange={onStatusChange} />
+      <WorkflowEventGroup title="Routine automation" events={grouped.routine} onStatusChange={onStatusChange} />
+    </div>
+  );
+}
+
+export function WorkflowNotificationCenter() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [status, setStatus] = useState<WorkflowStatusResponse | null>(null);
+  const [events, setEvents] = useState<WorkflowEventResponse[]>([]);
+  const [eventsLoading, setEventsLoading] = useState(false);
+  const [eventsError, setEventsError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadStatus() {
+      try {
+        const nextStatus = await fetchWorkflowStatus();
+        if (!cancelled) setStatus(nextStatus);
+      } catch {
+        if (!cancelled) setStatus(null);
+      }
+    }
+
+    void loadStatus();
+    const interval = window.setInterval(loadStatus, 30000);
+    window.addEventListener("focus", loadStatus);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      window.removeEventListener("focus", loadStatus);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+
+    async function loadEvents() {
+      setEventsLoading(true);
+      setEventsError(false);
+      try {
+        const nextEvents = await fetchWorkflowEvents({ limit: 50 });
+        if (!cancelled) setEvents(nextEvents.items);
+      } catch {
+        if (!cancelled) setEventsError(true);
+      } finally {
+        if (!cancelled) setEventsLoading(false);
+      }
+    }
+
+    void loadEvents();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  async function updateEventLifecycle(eventId: string, nextStatus: WorkflowEventStatus) {
+    await updateWorkflowEventStatus(eventId, nextStatus);
+    const [nextStatusSummary, nextEvents] = await Promise.all([
+      fetchWorkflowStatus(),
+      fetchWorkflowEvents({ limit: 50 }),
+    ]);
+    setStatus(nextStatusSummary);
+    setEvents(nextEvents.items);
+  }
+
+  const counts = status?.event_counts ?? { unread: 0, action_required: 0, blocked: 0 };
+  const attentionCount = counts.blocked + counts.action_required;
+  const badgeCount = counts.unread || attentionCount;
+  const ariaLabel = [
+    "Workflow events",
+    counts.unread ? countLabel(counts.unread, "unread") : null,
+    counts.action_required ? countLabel(counts.action_required, "action") : null,
+    counts.blocked ? countLabel(counts.blocked, "blocked", "blocked") : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <div className="flex h-11 items-center justify-end px-2">
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className={cx(
+          "relative inline-flex h-9 w-9 items-center justify-center rounded-md border transition-colors",
+          attentionCount > 0
+            ? "border-status-warning bg-status-warning-muted text-status-warning"
+            : "border-border text-muted hover:bg-surface-muted hover:text-content",
+        )}
+        aria-label={ariaLabel || "Workflow events"}
+        title="Workflow events"
+      >
+        <Bell className="h-4 w-4" aria-hidden="true" />
+        {badgeCount > 0 && (
+          <span className="absolute -right-1 -top-1 inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-status-error px-1 text-[0.6875rem] font-semibold leading-5 text-content-inverse">
+            {badgeCount > 99 ? "99+" : badgeCount}
+          </span>
+        )}
+      </button>
+
+      <Sheet isOpen={isOpen} onClose={() => setIsOpen(false)} title="Workflow events" width="max-w-lg">
+        <div className="space-y-4">
+          {status && (
+            <WorkflowStatusSummary status={status} />
+          )}
+          {eventsLoading && (
+            <div className="flex items-center gap-2 text-sm text-muted" role="status">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              Loading workflow events...
+            </div>
+          )}
+          {eventsError && <Alert variant="error">Unable to load workflow events.</Alert>}
+          {!eventsLoading && !eventsError && (
+            <WorkflowInbox
+              events={events}
+              onStatusChange={(eventId, nextStatus) => {
+                void updateEventLifecycle(eventId, nextStatus);
+              }}
+            />
+          )}
+        </div>
+      </Sheet>
+    </div>
+  );
+}
+
+function WorkflowStatusSummary({ status }: { status: WorkflowStatusResponse }) {
+  return (
+    <div className="rounded-md border border-border bg-surface-muted p-3 text-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted">Current state</p>
+          <p className="font-semibold">{labelFromSnake(status.primary_state)}</p>
+        </div>
+        <Badge variant={status.report_readiness.state === "blocked" ? "error" : "info"}>
+          Report {sentenceFromSnake(status.report_readiness.state)}
+        </Badge>
+      </div>
+    </div>
+  );
+}
+
+export interface WorkflowStatusFeedProps {
+  status: WorkflowStatusResponse;
+  events: WorkflowEventResponse[];
+}
+
+export function WorkflowStatusFeed({ status, events }: WorkflowStatusFeedProps) {
+  const actionableEvents = events.filter(
+    (event) => event.severity === "blocked" || event.severity === "action_required",
+  );
+  const routineCount = routineEvents(events).length;
+  const primaryHref = status.next_action.href;
+  const primaryLabel = status.next_action.type === "upload" ? "Upload statements" : "Open next action";
+  const readinessLabel = `Report ${sentenceFromSnake(status.report_readiness.state)}`;
+
+  if (status.primary_state === "empty" && events.length === 0) {
+    return (
+      <section className="card p-5" aria-label="Workflow status">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Workflow status</h2>
+            <p className="mt-1 text-sm text-muted">No action required</p>
+          </div>
+          <Link href={primaryHref} className="btn-primary inline-flex justify-center text-sm">
+            Upload statements
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="card p-5" aria-label="Workflow status">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold">Workflow status</h2>
+          <p className="mt-1 text-sm text-muted">{labelFromSnake(status.primary_state)}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Badge variant={status.report_readiness.state === "blocked" ? "error" : "info"}>{readinessLabel}</Badge>
+            {status.event_counts.action_required > 0 && (
+              <Badge variant="warning">{countLabel(status.event_counts.action_required, "action")}</Badge>
+            )}
+            {status.event_counts.blocked > 0 && (
+              <Badge variant="error">{countLabel(status.event_counts.blocked, "blocked", "blocked")}</Badge>
+            )}
+          </div>
+        </div>
+        <Link href={primaryHref} className="btn-secondary inline-flex justify-center text-sm">
+          {primaryLabel}
+        </Link>
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_16rem]">
+        <div className="space-y-3">
+          {actionableEvents.slice(0, 3).map((event) => (
+            <article
+              key={event.id}
+              className={cx(
+                "rounded-md border p-3 text-sm",
+                event.severity === "blocked"
+                  ? "border-status-error bg-status-error-muted"
+                  : "border-status-warning bg-status-warning-muted",
+              )}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="font-medium">{event.title}</h3>
+                  <p className="mt-1 text-sm text-muted">{event.summary}</p>
+                </div>
+                <Link href={event.action_href} className="btn-secondary shrink-0 px-3 py-1.5 text-xs">
+                  Open
+                </Link>
+              </div>
+            </article>
+          ))}
+          {actionableEvents.length === 0 && (
+            <div className="rounded-md border border-border bg-surface-muted p-3 text-sm text-muted">
+              No action required
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-md border border-border bg-surface-muted p-3">
+          <div className="flex items-center gap-2">
+            <Inbox className="h-4 w-4 text-muted" aria-hidden="true" />
+            <h3 className="text-sm font-semibold">Routine automation</h3>
+          </div>
+          <p className="mt-2 text-sm text-muted">{countLabel(routineCount, "routine event")}</p>
+          {routineCount > 0 && (
+            <p className="mt-1 text-xs text-muted">
+              Latest: {routineEvents(events)[0]?.title}
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function WorkflowStatusFeedPanel() {
+  const [status, setStatus] = useState<WorkflowStatusResponse | null>(null);
+  const [events, setEvents] = useState<WorkflowEventResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadWorkflowFeed() {
+      setIsLoading(true);
+      setError(false);
+      try {
+        const [nextStatus, nextEvents] = await Promise.all([
+          fetchWorkflowStatus(),
+          fetchWorkflowEvents({ limit: 5 }),
+        ]);
+        if (!cancelled) {
+          setStatus(nextStatus);
+          setEvents(nextEvents.items);
+        }
+      } catch {
+        if (!cancelled) setError(true);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    void loadWorkflowFeed();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (isLoading) {
+    return (
+      <section className="card p-5" aria-label="Workflow status">
+        <div className="flex items-center gap-2 text-sm text-muted" role="status">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          Loading workflow status...
+        </div>
+      </section>
+    );
+  }
+
+  if (error || !status) {
+    return (
+      <section className="card p-5" aria-label="Workflow status">
+        <div className="alert-warning">Workflow status is unavailable.</div>
+      </section>
+    );
+  }
+
+  return <WorkflowStatusFeed status={status} events={events} />;
+}
+
+export function WorkflowArchiveButton({
+  event,
+  onArchive,
+}: {
+  event: WorkflowEventResponse;
+  onArchive: (eventId: string) => void;
+}) {
+  return <IconButton icon={Archive} label={`Archive ${event.title}`} onClick={() => onArchive(event.id)} />;
+}
+
+export function WorkflowEventsPageContent() {
+  const queryClient = useQueryClient();
+  const statusQuery = useQuery({
+    queryKey: STATUS_QUERY_KEY,
+    queryFn: fetchWorkflowStatus,
+  });
+  const eventsQuery = useQuery({
+    queryKey: [...EVENTS_QUERY_KEY, "page"],
+    queryFn: () => fetchWorkflowEvents({ limit: 100 }),
+  });
+  const lifecycleMutation = useMutation({
+    mutationFn: ({ eventId, status }: { eventId: string; status: WorkflowEventStatus }) =>
+      updateWorkflowEventStatus(eventId, status),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: STATUS_QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: EVENTS_QUERY_KEY });
+    },
+  });
+
+  return (
+    <div className="p-6">
+      <div className="page-header flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="page-title">Events</h1>
+          <p className="page-description">Workflow attention for upload, review, reconciliation, and reports</p>
+        </div>
+        <Link href="/statements/upload" className="btn-primary inline-flex justify-center text-sm">
+          Upload statements
+        </Link>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+        <div>
+          {statusQuery.isLoading || eventsQuery.isLoading ? (
+            <section className="card p-5" aria-label="Workflow status">
+              <div className="flex items-center gap-2 text-sm text-muted" role="status">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Loading workflow status...
+              </div>
+            </section>
+          ) : statusQuery.data && eventsQuery.data ? (
+            <WorkflowStatusFeed status={statusQuery.data} events={eventsQuery.data.items} />
+          ) : (
+            <section className="card p-5" aria-label="Workflow status">
+              <div className="alert-warning">Workflow status is unavailable.</div>
+            </section>
+          )}
+        </div>
+
+        <section className="card p-5" aria-label="Workflow event inbox">
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold">Workflow events</h2>
+            <Badge variant="muted">{eventsQuery.data?.total ?? 0} total</Badge>
+          </div>
+          {eventsQuery.isLoading && (
+            <div className="flex items-center gap-2 text-sm text-muted" role="status">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              Loading workflow events...
+            </div>
+          )}
+          {eventsQuery.isError && <Alert variant="error">Unable to load workflow events.</Alert>}
+          {eventsQuery.data && (
+            <WorkflowInbox
+              events={eventsQuery.data.items}
+              onStatusChange={(eventId, status) => lifecycleMutation.mutate({ eventId, status })}
+            />
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,4 +1,10 @@
 import { getAccessToken, getUserId } from "./auth";
+import type {
+  WorkflowEventListResponse,
+  WorkflowEventResponse,
+  WorkflowEventStatus,
+  WorkflowStatusResponse,
+} from "./types";
 
 /**
  * API base URL for backend requests.
@@ -236,4 +242,33 @@ export async function apiUpload<T>(
   }
 
   return (await res.json()) as T;
+}
+
+export interface FetchWorkflowEventsOptions {
+  status?: WorkflowEventStatus;
+  limit?: number;
+}
+
+export async function fetchWorkflowStatus(): Promise<WorkflowStatusResponse> {
+  return apiFetch<WorkflowStatusResponse>("/api/workflow/status");
+}
+
+export async function fetchWorkflowEvents(
+  options: FetchWorkflowEventsOptions = {}
+): Promise<WorkflowEventListResponse> {
+  const params = new URLSearchParams();
+  if (options.status) params.set("status", options.status);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  const query = params.toString();
+  return apiFetch<WorkflowEventListResponse>(`/api/workflow/events${query ? `?${query}` : ""}`);
+}
+
+export async function updateWorkflowEventStatus(
+  eventId: string,
+  status: WorkflowEventStatus
+): Promise<WorkflowEventResponse> {
+  return apiFetch<WorkflowEventResponse>(`/api/workflow/events/${eventId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ status }),
+  });
 }

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -254,6 +254,88 @@ export interface PersonalReportPackageTraceabilityResponse {
     completeness_warnings: PersonalReportPackageCompletenessWarning[];
 }
 
+export type WorkflowPrimaryState = "empty" | "processing" | "needs_action" | "blocked" | "ready";
+
+export type WorkflowNextActionType =
+    | "upload"
+    | "wait"
+    | "review_required"
+    | "resolve_blocker"
+    | "open_report"
+    | "none";
+
+export type WorkflowReportReadinessState = "none" | "processing" | "ready" | "blocked" | "stale";
+
+export type WorkflowEventFamily =
+    | "source.uploaded"
+    | "source.parsing.started"
+    | "source.parsing.completed"
+    | "source.parsing.failed"
+    | "record.validation.passed"
+    | "record.validation.failed"
+    | "ledger.auto_posted"
+    | "review.required"
+    | "review.completed"
+    | "reconciliation.blocked"
+    | "report.processing"
+    | "report.ready"
+    | "report.blocked"
+    | "report.generated";
+
+export type WorkflowEventSeverity = "info" | "success" | "warning" | "action_required" | "blocked";
+
+export type WorkflowEventStatus = "unread" | "read" | "archived";
+
+export type WorkflowReportImpact = "none" | "processing" | "ready" | "blocked" | "stale";
+
+export interface WorkflowNextActionResponse {
+    type: WorkflowNextActionType;
+    count: number;
+    href: string;
+}
+
+export interface WorkflowReportReadinessResponse {
+    state: WorkflowReportReadinessState;
+    blocking_count: number;
+    href: string;
+}
+
+export interface WorkflowEventCountsResponse {
+    unread: number;
+    action_required: number;
+    blocked: number;
+}
+
+export interface WorkflowStatusResponse {
+    primary_state: WorkflowPrimaryState;
+    next_action: WorkflowNextActionResponse;
+    report_readiness: WorkflowReportReadinessResponse;
+    event_counts: WorkflowEventCountsResponse;
+}
+
+export interface WorkflowEventResponse {
+    id: string;
+    user_id: string;
+    occurred_at: string;
+    family: WorkflowEventFamily;
+    severity: WorkflowEventSeverity;
+    status: WorkflowEventStatus;
+    title: string;
+    summary: string;
+    source_type: string;
+    source_id: string;
+    action_href: string;
+    report_impact: WorkflowReportImpact;
+    dedupe_key: string;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface WorkflowEventListResponse {
+    items: WorkflowEventResponse[];
+    total: number;
+}
+
 export interface AnnualizedIncomeScheduleIncome {
     annualized_salary: number | string;
     annualized_bonus: number | string;

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -312,6 +312,19 @@ workflow state exists.
 | AC19.2.5 | Status and events reads run deterministic derived sync without duplicating events or resetting read/archive lifecycle state | `test_AC19_2_5_workflow_reads_sync_derived_events_without_lifecycle_reset` | P0 |
 | AC19.2.6 | Workflow API router is mounted and documented in the workflow-events SSOT as the compact read path for later UI slices | `test_AC19_2_6_workflow_router_and_ssot_document_compact_read_path` | P0 |
 
+### AC19.3 — In-App Event Inbox, Header Badge, And Status Feed
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC19.3.1 | Deterministic sync refreshes mutable derived event fields for all user statements without duplicating events or resetting lifecycle state | `test_AC19_3_1_sync_refreshes_mutable_uploaded_event_fields_without_lifecycle_reset` | P0 |
+| AC19.3.2 | Workflow status uses one aggregate count query and only fetches a representative event for the winning branch | `test_AC19_3_2_workflow_status_uses_single_aggregate_for_badge_counts` | P0 |
+| AC19.3.3 | Frontend exposes typed workflow API helpers through `lib/api.ts` for status, events, and lifecycle patching | `workflowApi.test.ts` | P0 |
+| AC19.3.4 | Header/app-shell badge reflects unread/action-required/blocked counts from the compact workflow API and stays quiet when no attention is needed | `workflowSurfaces.test.tsx` | P0 |
+| AC19.3.5 | Event inbox groups events by blocked, action-required, and routine automation; it supports read/archive actions and direct action links | `workflowSurfaces.test.tsx` | P0 |
+| AC19.3.6 | Dashboard status feed renders primary state, report readiness, recent automation, blocker/action severity, and an empty no-action state without raw audit-log noise | `workflowSurfaces.test.tsx`, `dashboardPage.test.tsx` | P0 |
+| AC19.3.7 | Desktop and mobile Playwright smoke covers the workflow badge/inbox/feed without layout overflow | `workflow-notifications.spec.ts` | P0 |
+| AC19.3.8 | Workflow notification UI contract is documented in the workflow-events SSOT and EPIC-019 | `test_AC19_3_8_workflow_notification_ssot_documents_frontend_surfaces` | P0 |
+
 ### AC19.5 — Report Readiness and Blocker State
 
 | AC ID | Description | Verification | Priority |

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -20,8 +20,10 @@
 | Derivation/upsert service | `apps/backend/src/services/workflow_events.py` |
 | Compact status/events API | `apps/backend/src/routers/workflow.py` |
 | Report package readiness fact source | `GET /api/reports/package/readiness` in `apps/backend/src/services/report_readiness.py` |
+| Header badge, Event inbox, Status feed | `apps/frontend/src/components/workflow/WorkflowNotifications.tsx` |
+| Events page | `apps/frontend/src/app/(main)/events/page.tsx` |
 | Database migrations | `apps/backend/migrations/versions/0021_add_workflow_events.py`, `apps/backend/migrations/versions/0022_harden_workflow_contract.py` |
-| Contract tests | `apps/backend/tests/workflow/test_workflow_events.py`, `apps/backend/tests/api/test_workflow_router.py` |
+| Contract tests | `apps/backend/tests/workflow/test_workflow_events.py`, `apps/backend/tests/api/test_workflow_router.py`, `apps/frontend/src/__tests__/workflowApi.test.ts`, `apps/frontend/src/__tests__/workflowSurfaces.test.tsx`, `apps/frontend/playwright/workflow-notifications.spec.ts` |
 
 ---
 
@@ -248,7 +250,55 @@ lifecycle state. Missing or non-owned events return `404`.
 
 ---
 
-## 10. Initial Derivation
+## 10. In-App Notification Surfaces
+
+EPIC-019 notifications are in-app only. External push, email, Slack, browser
+push, proactive reminders, and event bus infrastructure are out of scope.
+
+The frontend notification surface is:
+
+```text
+WorkflowNotificationCenter
+  -> Header badge
+  -> Event inbox drawer
+
+WorkflowStatusFeed
+  -> Dashboard status feed
+  -> Events page status summary
+```
+
+Header badge rules:
+
+- It reads only `GET /api/workflow/status` through `lib/api.ts`.
+- It displays unread/action-required/blocked counts from `event_counts`.
+- It stays visually quiet when no workflow attention is required.
+- It opens the in-app Event inbox drawer.
+
+Event inbox rules:
+
+- It reads `GET /api/workflow/events` only after the user opens the drawer or
+  page.
+- It groups events by actionability: `Blocked`, `Action required`, and
+  `Routine automation`.
+- It supports lifecycle actions through `PATCH /api/workflow/events/{id}`.
+- Each event exposes exactly one primary internal action link from
+  `action_href`.
+- It must not show raw audit-log payloads, low-level ledger internals, or
+  source-table debugging fields as primary content.
+
+Status feed rules:
+
+- `WorkflowStatusFeed` summarizes the current upload-to-report state and report
+  readiness.
+- Blocked and action-required events are prominent.
+- Routine automation is summarized under `Routine automation` and is not the
+  primary attention driver.
+- Empty state says `No action required` and routes the user to upload when no
+  workflow state exists.
+
+---
+
+## 11. Initial Derivation
 
 The first implementation derives `source.uploaded` from `BankStatement` upload
 state. Workflow status and event reads run this deterministic sync before


### PR DESCRIPTION
## Summary

Add EPIC-019 workflow notification surfaces and resolve the actionable workflow status read-path review residuals from #654 and PR review.

Closes #637

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-019 — Event-Driven Upload-to-Report UX |
| **AC IDs** | AC19.3.1, AC19.3.2, AC19.3.3, AC19.3.4, AC19.3.5, AC19.3.6, AC19.3.7, AC19.3.8 |
| **AC Registry updated** | `docs/ac_registry.yaml` |

---

## SSOT Changes

- [x] `docs/ssot/workflow-events.md` — documents workflow notification frontend surfaces, header badge, Event inbox, Status feed, lifecycle actions, and in-app-only rules
- [ ] `docs/ssot/MANIFEST.yaml` — no new SSOT owner required
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `23979a8` | Added AC19.3 tests before workflow API helpers/components/feed existed; frontend failed on missing helpers/components and dashboard feed |
| 🟢 Green (passing test) | `be48e5a` | Implemented workflow status aggregate/read-path residuals, bounded derived sync, typed frontend helpers, badge/inbox/feed, Events route, SSOT updates, and workflow page coverage gate |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable: no new env vars)
- [x] `repo/` submodule updated/synced for production config changes (if applicable: no infra config changes; submodule is clean and synced to `origin/main` at `6e81bc3`)
- [x] `tools/check_env_keys.py` passes (if env vars changed: no env vars changed)
- [x] `tools/check_manifest.py` passes (covered by `moon run :lint`)
- [x] `tools/lint_doc_consistency.py` passes (covered by `moon run :lint`)

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner. N/A, no infra/runtime workflow changes.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys. N/A.
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged. N/A.
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials. N/A.
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule. N/A.
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene. N/A.

---

## Testing

```bash
# Frontend targeted tests
cd apps/frontend && npm test -- --run src/__tests__/workflowApi.test.ts src/__tests__/workflowSurfaces.test.tsx src/__tests__/eventsPage.test.tsx src/__tests__/dashboardPage.test.tsx src/__tests__/navigation.test.ts src/__tests__/shellAndAuth.test.tsx

# Frontend full unit suite
cd apps/frontend && npm test -- --run

# Frontend Playwright workflow smoke; local config builds before starting Next
cd apps/frontend && npx playwright test playwright/workflow-notifications.spec.ts

# Repo lint and AC registry
moon run :lint
./.venv/bin/python tools/generate_ac_registry.py --check

# Backend syntax check
./.venv/bin/python -m compileall -q apps/backend/src apps/backend/tests/workflow/test_workflow_events.py apps/backend/tests/api/test_workflow_router.py
```

Local backend DB tests and full repo test lifecycle are blocked by unavailable local database/Podman:

```text
uv run --python 3.12.12 pytest tests/workflow/test_workflow_events.py -k "AC19_3_1 or AC19_3_2"
ConnectionRefusedError: [Errno 61] Connect call failed ('127.0.0.1', 5432)

moon run :test
Cannot connect to Podman socket: dial tcp 127.0.0.1:61270: connect: connection refused
```

CI should run the Postgres-backed backend workflow/API tests.

---

## Screenshots / Evidence

Local Playwright smoke covers desktop and mobile workflow badge, inbox drawer, and dashboard status feed with mocked workflow API responses.
