### PR TITLE
[finance_report_audit] Fix annualized income currency conversion

### DIFF
--- a/apps/backend/src/routers/income.py
+++ b/apps/backend/src/routers/income.py
@@ -10,6 +10,8 @@ from src.config import settings
 from src.deps import CurrentUserId, DbSession
 from src.models import Account, AccountType, Direction, JournalEntry, JournalEntryStatus, JournalLine
 from src.schemas.income import AnnualizedIncomeResponse
+from src.services.fx import FxRateError, convert_amount
+from src.utils import raise_bad_request
 
 router = APIRouter(prefix="/income", tags=["income"])
 
@@ -51,14 +53,27 @@ async def get_annualized_income(
         "dividend": Decimal("0.00"),
         "total": Decimal("0.00"),
     }
-    currency = settings.base_currency
+    currency = settings.base_currency.strip().upper()
     for line, account in result.all():
         signed_amount = line.amount if line.direction == Direction.CREDIT else -line.amount
+        source_currency = (line.currency or account.currency or currency).strip().upper()
+        try:
+            signed_amount = await convert_amount(
+                db,
+                amount=signed_amount,
+                currency=source_currency,
+                target_currency=currency,
+                rate_date=report_date,
+                average_start=start_date,
+                average_end=report_date,
+                lazy_load=True,
+            )
+        except FxRateError as exc:
+            raise_bad_request(str(exc), cause=exc)
         bucket = _income_bucket(account.name)
         if bucket:
             totals[bucket] += signed_amount
         totals["total"] += signed_amount
-        currency = line.currency or account.currency or currency
 
     return AnnualizedIncomeResponse(
         annualized_salary=totals["salary"].quantize(Decimal("0.01")),

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -44,6 +44,7 @@ from src.schemas import (
     PersonalReportPackageTraceabilityResponse,
     TrendPeriod,
 )
+from src.services.fx import FxRateError, convert_amount
 from src.services.market_data import ensure_market_data_fresh
 from src.services.reporting import (
     ReportError,
@@ -774,14 +775,27 @@ async def annualized_income_schedule(
         "dividend": Decimal("0.00"),
         "total": Decimal("0.00"),
     }
-    currency = settings.base_currency
+    currency = settings.base_currency.strip().upper()
     for line, account in income_result.all():
         signed_amount = line.amount if line.direction == Direction.CREDIT else -line.amount
+        source_currency = (line.currency or account.currency or currency).strip().upper()
+        try:
+            signed_amount = await convert_amount(
+                db,
+                amount=signed_amount,
+                currency=source_currency,
+                target_currency=currency,
+                rate_date=report_date,
+                average_start=start_date,
+                average_end=report_date,
+                lazy_load=True,
+            )
+        except FxRateError as exc:
+            raise_bad_request(str(exc), cause=exc)
         bucket = _annualized_income_bucket(account.name)
         if bucket:
             totals[bucket] += signed_amount
         totals["total"] += signed_amount
-        currency = line.currency or account.currency or currency
 
     restricted_types = (
         ManualValuationComponentType.ESOP,
@@ -802,24 +816,34 @@ async def annualized_income_schedule(
         key = (snapshot.component_type, snapshot.source, snapshot.currency)
         latest_holdings.setdefault(key, snapshot)
 
-    holdings = [
-        AnnualizedIncomeScheduleHolding(
-            ticker=snapshot.source,
-            compensation_type=snapshot.component_type.value,
-            fair_value=snapshot.value.quantize(Decimal("0.01")),
-            currency=snapshot.currency,
-            valuation_basis="manual_valuation_snapshot",
-            vesting_schedule=snapshot.notes,
-            unlock_date=snapshot.reminder_date,
-            liquidity_class=snapshot.liquidity_class.value,
-            net_worth_treatment="excluded_from_liquid_net_worth_by_default",
+    holdings: list[AnnualizedIncomeScheduleHolding] = []
+    restricted_total = Decimal("0.00")
+    for snapshot in latest_holdings.values():
+        holdings.append(
+            AnnualizedIncomeScheduleHolding(
+                ticker=snapshot.source,
+                compensation_type=snapshot.component_type.value,
+                fair_value=snapshot.value.quantize(Decimal("0.01")),
+                currency=snapshot.currency,
+                valuation_basis="manual_valuation_snapshot",
+                vesting_schedule=snapshot.notes,
+                unlock_date=snapshot.reminder_date,
+                liquidity_class=snapshot.liquidity_class.value,
+                net_worth_treatment="excluded_from_liquid_net_worth_by_default",
+            )
         )
-        for snapshot in latest_holdings.values()
-    ]
-    restricted_total = sum(
-        (holding.fair_value for holding in holdings if holding.currency == currency),
-        Decimal("0.00"),
-    ).quantize(Decimal("0.01"))
+        try:
+            restricted_total += await convert_amount(
+                db,
+                amount=snapshot.value,
+                currency=snapshot.currency,
+                target_currency=currency,
+                rate_date=report_date,
+                lazy_load=True,
+            )
+        except FxRateError as exc:
+            raise_bad_request(str(exc), cause=exc)
+    restricted_total = restricted_total.quantize(Decimal("0.01"))
 
     return AnnualizedIncomeScheduleResponse(
         section_id="annualized_income_long_term",

--- a/apps/backend/tests/reporting/test_annualized_income_schedule.py
+++ b/apps/backend/tests/reporting/test_annualized_income_schedule.py
@@ -7,7 +7,15 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models import Account, AccountType, Direction, JournalEntry, JournalEntryStatus, JournalLine
+from src.models import (
+    Account,
+    AccountType,
+    Direction,
+    FxRate,
+    JournalEntry,
+    JournalEntryStatus,
+    JournalLine,
+)
 from src.models.layer3 import ManualValuationComponentType, ManualValuationLiquidityClass, ManualValuationSnapshot
 from src.routers.reports import _annualized_income_bucket
 
@@ -132,3 +140,77 @@ async def test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restr
         "liquidity_class": "restricted",
         "net_worth_treatment": "excluded_from_liquid_net_worth_by_default",
     }
+
+
+@pytest.mark.asyncio
+async def test_AC5_11_3_AC11_11_3_annualized_schedule_converts_mixed_currency_totals(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+):
+    """AC5.11.3/AC11.11.3: Annualized package totals use one reporting currency."""
+    salary = Account(user_id=test_user.id, name="Salary Income", type=AccountType.INCOME, currency="SGD")
+    dividend = Account(user_id=test_user.id, name="Dividend Income", type=AccountType.INCOME, currency="USD")
+    db.add_all([salary, dividend])
+    await db.flush()
+
+    income_entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=date(2026, 5, 1),
+        memo="mixed currency trailing income",
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(income_entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=income_entry.id,
+                account_id=salary.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=income_entry.id,
+                account_id=dividend.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("10.00"),
+                currency="USD",
+            ),
+            FxRate(
+                base_currency="USD",
+                quote_currency="SGD",
+                rate=Decimal("1.500000"),
+                rate_date=date(2026, 5, 1),
+                source="test",
+            ),
+            ManualValuationSnapshot(
+                user_id=test_user.id,
+                component_type=ManualValuationComponentType.RSU,
+                liquidity_class=ManualValuationLiquidityClass.RESTRICTED,
+                as_of_date=date(2026, 5, 1),
+                value=Decimal("20.00"),
+                currency="USD",
+                source="USD-RSU",
+            ),
+        ]
+    )
+    await db.commit()
+
+    response = await client.get("/reports/package/annualized-income-schedule?as_of_date=2026-05-20")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["income"] == {
+        "annualized_salary": "100.00",
+        "annualized_bonus": "0.00",
+        "annualized_dividend": "15.00",
+        "annualized_total": "115.00",
+        "currency": "SGD",
+        "calculation_basis": "posted_or_reconciled_income_journal_lines_trailing_12_months",
+    }
+    assert data["restricted_fair_value_total"] == "30.00"
+    assert data["restricted_fair_value_total_currency"] == "SGD"
+    assert data["restricted_holdings"][0]["fair_value"] == "20.00"
+    assert data["restricted_holdings"][0]["currency"] == "USD"

--- a/apps/backend/tests/reporting/test_income_annualized_router.py
+++ b/apps/backend/tests/reporting/test_income_annualized_router.py
@@ -7,7 +7,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models import Account, AccountType, Direction, JournalEntry, JournalEntryStatus, JournalLine
+from src.models import Account, AccountType, Direction, FxRate, JournalEntry, JournalEntryStatus, JournalLine
 from src.models.layer3 import ManualValuationComponentType, ManualValuationLiquidityClass, ManualValuationSnapshot
 
 
@@ -90,6 +90,66 @@ async def test_annualized_income_endpoint_groups_last_12_month_income(
         "annualized_bonus": "15000.00",
         "annualized_dividend": "2400.00",
         "annualized_total": "137700.00",
+        "currency": "SGD",
+        "as_of": "2026-05-20",
+    }
+
+
+@pytest.mark.asyncio
+async def test_AC11_8_7_annualized_income_endpoint_converts_mixed_currency_totals(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+):
+    """AC11.8.7: Dashboard annualized income totals use one reporting currency."""
+    salary = Account(user_id=test_user.id, name="Salary Income", type=AccountType.INCOME, currency="SGD")
+    dividend = Account(user_id=test_user.id, name="Dividend Income", type=AccountType.INCOME, currency="USD")
+    db.add_all([salary, dividend])
+    await db.flush()
+
+    income_entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=date(2026, 5, 1),
+        memo="mixed currency dashboard income",
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(income_entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=income_entry.id,
+                account_id=salary.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=income_entry.id,
+                account_id=dividend.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("10.00"),
+                currency="USD",
+            ),
+            FxRate(
+                base_currency="USD",
+                quote_currency="SGD",
+                rate=Decimal("1.500000"),
+                rate_date=date(2026, 5, 1),
+                source="test",
+            ),
+        ]
+    )
+    await db.commit()
+
+    response = await client.get("/income/annualized?as_of=2026-05-20")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "annualized_salary": "100.00",
+        "annualized_bonus": "0.00",
+        "annualized_dividend": "15.00",
+        "annualized_total": "115.00",
         "currency": "SGD",
         "as_of": "2026-05-20",
     }

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -203,6 +203,7 @@ AC5.9. Supporting calculations remain owned by EPIC-011.
 |----|-----------|---------------|------|----------|
 | AC5.11.1 | Package contract marks `annualized_income_long_term` as ready and points to the schedule endpoint | `test_AC5_11_1_package_contract_marks_annualized_schedule_ready` | `api/test_personal_report_package_contract.py` | P0 |
 | AC5.11.2 | Frontend personal package page renders annualized income totals and restricted treatment from the schedule endpoint | `AC5.11.2 renders annualized income schedule values and restricted treatment` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
+| AC5.11.3 | Annualized income package schedule converts mixed-currency income and restricted totals into one reporting currency | `test_AC5_11_3_AC11_11_3_annualized_schedule_converts_mixed_currency_totals` | `reporting/test_annualized_income_schedule.py` | P0 |
 
 ### AC5.12: Personal Report Package Notes and Disclosure Basis
 

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -2074,6 +2074,7 @@ The following items were identified during the vision.md recovery audit as featu
 - [x] **AC11.8.4** Dashboard "Restricted Holdings" card lists restricted holdings separated from liquid net worth, with vesting timeline tooltip
 - [x] **AC11.8.5** Net worth calculation toggle on dashboard (`include_restricted=true|false`) re-fetches and updates total, defaulting to `false` (vision: liquid wealth is primary)
 - [x] **AC11.8.6** Frontend test mounts AnnualizedIncomeCard and asserts the four metric labels render
+- [x] **AC11.8.7** API endpoint `GET /api/income/annualized` converts mixed-currency annualized income totals into the dashboard reporting currency before aggregation
 
 **Priority**: P1 (high) — closes the largest "vision parity" gap after net worth time series.
 **Estimated effort**: 4-6 days backend (income aggregation + restricted-flag schema check) + 3-4 days frontend.
@@ -2114,6 +2115,7 @@ representative fixture expansion needed before the overall
 |----|-----------|---------------|------|----------|
 | AC11.11.1 | `GET /api/reports/package/annualized-income-schedule` returns annualized salary, bonus, dividend, total income, currency, as-of date, and trailing-period boundaries for the personal report package | `test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restricted_treatment` | `reporting/test_annualized_income_schedule.py` | P0 |
 | AC11.11.2 | The schedule includes ESOP/RSU/stock-option restricted holdings with valuation basis, vesting/unlock metadata, fair value, and explicit liquid-versus-restricted net worth treatment | `test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restricted_treatment` | `reporting/test_annualized_income_schedule.py` | P0 |
+| AC11.11.3 | Annualized income and restricted fair-value package totals are Decimal-safe and converted to the schedule reporting currency | `test_AC5_11_3_AC11_11_3_annualized_schedule_converts_mixed_currency_totals` | `reporting/test_annualized_income_schedule.py` | P0 |
 
 ### Acceptance Criteria — Layer 3 Classification Service
 

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -180,7 +180,20 @@ The schedule must not mutate ledger state. It assembles existing portfolio,
 market-data, dividend, and journal-entry facts into a reporting payload that can
 be exported or embedded by EPIC-005.
 
-### 2.6 Personal Financial-Report Package Contract
+### 2.6 Annualized Income Dashboard Summary
+
+Endpoint:
+`GET /api/income/annualized`
+
+The dashboard annualized income summary uses the same trailing 365-day window
+as the package schedule. It returns salary, bonus, dividend, total income,
+currency, and as-of date for quick dashboard display.
+
+Mixed-currency income lines must be converted into the dashboard reporting
+currency before bucket and total aggregation. Non-reporting-currency income
+uses the trailing-period average FX rate for the window.
+
+### 2.7 Personal Financial-Report Package Contract
 
 Issue [#570](https://github.com/wangzitian0/finance_report/issues/570) owns the
 stable package-level API/export contract. The contract defines how existing and
@@ -220,12 +233,17 @@ Annualized income and long-term compensation schedule:
 - Income basis: `POSTED` or `RECONCILED` income journal lines in the trailing
   period, bucketed into salary, bonus, dividend, and total by income account
   name.
+- Income totals are converted into the schedule reporting currency before
+  bucket aggregation. Mixed-currency income lines must not be added at raw
+  nominal amounts. Non-reporting-currency income uses the trailing-period
+  average FX rate for the schedule window.
 - Restricted compensation basis: latest as-of manual valuation snapshots for
   `esop`, `rsu`, and `stock_options` with `liquidity_class=restricted`.
 - Liquid net worth default: restricted holdings are excluded by default and are
   only included through the balance-sheet restricted toggle.
 - Decimal fields serialize as strings; restricted fair-value totals are reported
-  in the schedule currency and do not imply cross-currency conversion.
+  in the schedule currency using the as-of FX rate. Per-holding source currency
+  remains visible.
 
 Notes and disclosures:
 


### PR DESCRIPTION
## Summary

- Convert report-package annualized income lines into the schedule/base currency before salary, bonus, dividend, and total aggregation.
- Convert restricted compensation fair-value totals into the same schedule currency while keeping per-holding source currency visible.
- Apply the same mixed-currency annualized-income rule to the dashboard `/api/income/annualized` endpoint.
- Register AC5.11.3, AC11.11.3, and AC11.8.7 with focused tests and SSOT updates.

## Root Cause

Annualized income paths were adding raw `JournalLine.amount` values across currencies and letting the response currency be determined by the last processed income line. The package schedule also excluded restricted holdings whose source currency did not match that incidental final currency.

## Validation

- `moon run :lint -- --fix`
- `python3 -m py_compile apps/backend/src/routers/reports.py apps/backend/src/routers/income.py apps/backend/tests/reporting/test_annualized_income_schedule.py apps/backend/tests/reporting/test_income_annualized_router.py`
- `uv run --with pyyaml python tools/generate_ac_registry.py --check`
- `uv run --with pyyaml python tools/check_ac_traceability.py`
- `uv run --with pyyaml python tools/check_manifest.py`
- `uv run --python 3.12.12 python -m pytest -q tests/reporting/test_annualized_income_schedule.py tests/reporting/test_income_annualized_router.py --collect-only --no-cov`

Local DB-backed target test execution was blocked by local Podman connection failure (`dial tcp 127.0.0.1:61270: connect: connection refused`). GitHub CI should run the full database-backed proof.

Closes #656
