### PR TITLE
[finance_report_infra] Harden post-merge report schedule evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
   PYTHON_VERSION: "3.12.12"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   PYTHON_VERSION: "3.12.12"
 
 jobs:

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -19,6 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   DOKPLOY_API_URL: https://cloud.zitian.party/api
   TEST_ENV_ID: -fzh5EGJN74I1AjNEpVUr
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -28,6 +28,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
   DOKPLOY_API_URL: https://cloud.zitian.party/api

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -25,6 +25,7 @@ on:
         type: boolean
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
   DOKPLOY_API_URL: https://cloud.zitian.party/api

--- a/.github/workflows/staging-ai-ocr-gate.yml
+++ b/.github/workflows/staging-ai-ocr-gate.yml
@@ -18,6 +18,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
   APP_URL: https://report-staging.zitian.party

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -22,6 +22,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
   DOKPLOY_API_URL: https://cloud.zitian.party/api

--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -12,7 +12,13 @@ from src.logger import get_logger
 from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition, PositionStatus
 from src.models.market_data import StockPrice
-from src.models.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType, MarketDataOverride
+from src.models.portfolio import (
+    DividendIncome,
+    InvestmentTransaction,
+    InvestmentTransactionType,
+    MarketDataOverride,
+    PriceSource,
+)
 from src.schemas.portfolio import (
     BrokerageImportRequest,
     BrokerageImportResponse,
@@ -100,6 +106,39 @@ def _source_document_links(source_documents: object) -> list[str]:
 
 def _freshness_link(asset_identifier: str, source_kind: str, source_id: object, evidence_date: date) -> str:
     return f"price_source:{source_kind}:{asset_identifier}:{source_id}:{evidence_date.isoformat()}"
+
+
+async def _report_preparation_holdings(
+    db: DbSession,
+    user_id: CurrentUserId,
+    as_of_date: date,
+) -> list[HoldingResponse]:
+    """Load current holdings only when post-period manual prices evidence report preparation."""
+    override_result = await db.execute(
+        select(MarketDataOverride)
+        .where(MarketDataOverride.user_id == user_id)
+        .where(MarketDataOverride.source == PriceSource.MANUAL)
+        .where(MarketDataOverride.price_date > as_of_date)
+        .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+    )
+    override_assets = {override.asset_identifier for override in override_result.scalars().all()}
+    if not override_assets:
+        return []
+
+    try:
+        current_holdings = await _portfolio_service.get_holdings(
+            db=db,
+            user_id=user_id,
+            include_disposed=True,
+        )
+    except (PortfolioNotFoundError, AssetNotFoundError):
+        return []
+
+    return [
+        holding
+        for holding in current_holdings
+        if holding.asset_identifier in override_assets and holding.status == PositionStatus.ACTIVE
+    ]
 
 
 @router.post("/brokerage/import", response_model=BrokerageImportResponse, status_code=status.HTTP_200_OK)
@@ -437,9 +476,13 @@ async def get_investment_performance_report_schedule(
 
     notes: list[str] = [
         "Cost basis uses the holding-level cost-basis method where available.",
-        "Market values use the latest available brokerage or market-data snapshot on or before the as-of date.",
+        (
+            "Market values use the latest available brokerage or market-data snapshot on or before the as-of date; "
+            "report-preparation overrides after the as-of date are disclosed when they evidence active holdings."
+        ),
     ]
 
+    used_report_preparation_evidence = False
     try:
         holdings = list(
             await _portfolio_service.get_holdings(
@@ -451,7 +494,17 @@ async def get_investment_performance_report_schedule(
         )
     except (PortfolioNotFoundError, AssetNotFoundError):
         holdings = []
-        notes.append("No portfolio holdings were available for the requested as-of date.")
+
+    if not holdings:
+        holdings = await _report_preparation_holdings(db=db, user_id=user_id, as_of_date=as_of_date)
+        used_report_preparation_evidence = bool(holdings)
+        if used_report_preparation_evidence:
+            notes.append(
+                "No holdings snapshot existed on or before the as-of date; the schedule used active holdings "
+                "with post-period manual market-data overrides as report-preparation evidence."
+            )
+        else:
+            notes.append("No portfolio holdings were available for the requested as-of date.")
 
     asset_identifiers = [holding.asset_identifier for holding in holdings]
     cost_basis_by_asset: dict[str, Decimal] = {}
@@ -565,12 +618,42 @@ async def get_investment_performance_report_schedule(
                     count=row.count,
                 )
             )
+    if used_report_preparation_evidence and not allocation_rows and holding_rows:
+        total_market_value = sum((row.market_value for row in holding_rows), Decimal("0.00"))
+        for dimension, attribute, fallback_category in [
+            ("sector", "sector", "Unclassified"),
+            ("geography", "geography", "Unclassified"),
+            ("asset_class", "asset_type", "Unclassified"),
+        ]:
+            grouped: dict[str, tuple[Decimal, int]] = {}
+            for holding, row in zip(holdings, holding_rows, strict=True):
+                category = getattr(holding, attribute) or fallback_category
+                current_value, current_count = grouped.get(category, (Decimal("0.00"), 0))
+                grouped[category] = (current_value + row.market_value, current_count + 1)
+            for category, (value, count) in grouped.items():
+                percentage = Decimal("0.00")
+                if total_market_value:
+                    percentage = (value / total_market_value * Decimal("100")).quantize(
+                        Decimal("0.01"), rounding=ROUND_HALF_UP
+                    )
+                allocation_rows.append(
+                    InvestmentPerformanceAllocationRow(
+                        dimension=dimension,
+                        category=category,
+                        value=_money(value),
+                        percentage=percentage,
+                        count=count,
+                    )
+                )
+        notes.append("Allocation rows use report-preparation holdings when as-of allocation snapshots are unavailable.")
 
+    latest_atomic_query = select(AtomicPosition).where(AtomicPosition.user_id == user_id)
+    if used_report_preparation_evidence and asset_identifiers:
+        latest_atomic_query = latest_atomic_query.where(AtomicPosition.asset_identifier.in_(asset_identifiers))
+    else:
+        latest_atomic_query = latest_atomic_query.where(AtomicPosition.snapshot_date <= as_of_date)
     latest_atomic_result = await db.execute(
-        select(AtomicPosition)
-        .where(AtomicPosition.user_id == user_id)
-        .where(AtomicPosition.snapshot_date <= as_of_date)
-        .order_by(AtomicPosition.snapshot_date.desc(), AtomicPosition.created_at.desc())
+        latest_atomic_query.order_by(AtomicPosition.snapshot_date.desc(), AtomicPosition.created_at.desc())
     )
     atomics = list(latest_atomic_result.scalars().all())
     latest_atomic_by_asset: dict[str, AtomicPosition] = {}
@@ -579,13 +662,26 @@ async def get_investment_performance_report_schedule(
         for link in _source_document_links(atomic.source_documents):
             source_links.add(link)
 
-    latest_override_result = await db.execute(
+    latest_override_query = (
         select(MarketDataOverride)
         .where(MarketDataOverride.user_id == user_id)
         .where(MarketDataOverride.price_date <= as_of_date)
-        .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+    )
+    latest_override_result = await db.execute(
+        latest_override_query.order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
     )
     overrides = list(latest_override_result.scalars().all())
+    if asset_identifiers:
+        report_preparation_override_result = await db.execute(
+            select(MarketDataOverride)
+            .where(MarketDataOverride.user_id == user_id)
+            .where(MarketDataOverride.asset_identifier.in_(asset_identifiers))
+            .where(MarketDataOverride.source == PriceSource.MANUAL)
+            .where(MarketDataOverride.price_date > as_of_date)
+            .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+        )
+        overrides.extend(report_preparation_override_result.scalars().all())
+        overrides.sort(key=lambda override: override.price_date, reverse=True)
     latest_override = overrides[0] if overrides else None
     latest_override_by_asset: dict[str, MarketDataOverride] = {}
     for override in overrides:

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -568,6 +568,78 @@ async def test_AC17_10_4_report_schedule_marks_stale_when_any_holding_price_is_s
 
 
 @pytest.mark.asyncio
+async def test_AC17_10_1_report_schedule_uses_manual_override_after_period_end(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+    investment_account,
+):
+    """AC17.10.1 AC17.10.2: Report-preparation overrides can evidence active holdings after period end."""
+    period_start = date(2026, 5, 2)
+    period_end = date(2026, 5, 19)
+    override_date = date(2026, 5, 31)
+    position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=investment_account.id,
+        asset_identifier="FULLERTON_SGD_MMF",
+        quantity=Decimal("100"),
+        cost_basis=Decimal("1000.00"),
+        currency="SGD",
+        acquisition_date=period_start,
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    atomic = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=override_date,
+        asset_identifier="FULLERTON_SGD_MMF",
+        broker="Moomoo",
+        quantity=Decimal("100"),
+        market_value=Decimal("1250.00"),
+        currency="SGD",
+        sector="Cash",
+        geography="SG",
+        asset_type="mutual_fund",
+        dedup_hash="fullerton_future_snapshot",
+        source_documents=[{"doc_id": "brokerage-doc-fullerton", "doc_type": "brokerage_statement"}],
+    )
+    db.add_all([position, atomic])
+    await db.commit()
+
+    price_response = await client.post(
+        "/portfolio/prices/update",
+        json={
+            "updates": [
+                {
+                    "asset_identifier": "FULLERTON_SGD_MMF",
+                    "price": "12.50",
+                    "currency": "SGD",
+                    "price_date": override_date.isoformat(),
+                }
+            ]
+        },
+    )
+    assert price_response.status_code == 200
+    assert price_response.json()["updated_count"] == 1
+
+    response = await client.get(
+        "/portfolio/performance/report-schedule"
+        f"?period_start={period_start.isoformat()}"
+        f"&period_end={period_end.isoformat()}"
+        f"&as_of_date={period_end.isoformat()}&currency=SGD"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["holdings"][0]["asset_identifier"] == "FULLERTON_SGD_MMF"
+    assert data["holdings"][0]["market_value"] == "1250.00"
+    assert {row["dimension"] for row in data["allocation"]} == {"asset_class", "geography", "sector"}
+    assert data["data_freshness"]["latest_price_date"] == override_date.isoformat()
+    assert data["data_freshness"]["manual_override_basis"] == (f"FULLERTON_SGD_MMF:{override_date.isoformat()}")
+    assert any(link.startswith("price_source:market_data_override:FULLERTON_SGD_MMF:") for link in data["source_links"])
+
+
+@pytest.mark.asyncio
 async def test_get_sector_allocation_empty(client: AsyncClient):
     """AC17.6.7: GET /portfolio/allocation/sector on empty portfolio returns [].
 

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -360,10 +360,17 @@ Response object:
 | `source_links` | Source document, brokerage import, price source, and ledger/report traceability anchors |
 | `notes` | Human-readable methods and limitations for cost basis, market prices, and return metrics |
 
+When no holding snapshot exists on or before the requested `as_of_date`, the
+report schedule may use active current holdings only if the same asset has a
+manual market-data override dated after `as_of_date`. This is report-preparation
+evidence for EPIC-005 packaging, not a mutation or relaxation of historical
+portfolio queries, and the response must disclose the override through notes,
+freshness metadata, and source links.
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC17.10.1 | Investment performance schedule API exposes report-ready metrics and rows | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
-| AC17.10.2 | Investment performance schedule API exposes data freshness, source links, and notes for report traceability | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+| AC17.10.1 | Investment performance schedule API exposes report-ready metrics and rows | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_AC17_10_1_report_schedule_uses_manual_override_after_period_end`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+| AC17.10.2 | Investment performance schedule API exposes data freshness, source links, and notes for report traceability | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_AC17_10_1_report_schedule_uses_manual_override_after_period_end`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
 | AC17.10.3 | Investment performance schedule source links preserve brokerage statement, price source, ledger, transaction source, and report-section anchors | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P0 |
 | AC17.10.4 | Investment performance schedule data freshness marks the schedule stale when any holding lacks current as-of-date price evidence | `test_AC17_10_4_report_schedule_marks_stale_when_any_holding_price_is_stale` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P0 |
 | AC17.10.5 | Investment performance XIRR solver does not convert monetary Decimal cash flows to float | `test_AC17_10_5_xirr_solver_does_not_float_monetary_cashflows` | `apps/backend/tests/portfolio/test_performance_service.py` | P0 |

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -199,6 +199,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - PR CI dry-runs staging image builds before merge. The `container-images` job uses `docker/build-push-action` for both backend and frontend images with `push: false` on pull requests, then `finish` fails if that validation job fails.
 - Main push CI is the only path that pushes SHA-tagged images. Registry login and image push are guarded by `github.event_name == 'push' && github.ref == 'refs/heads/main'`; registry availability and authorization remain post-merge external-service risks, but Dockerfile, build-context, and build-argument errors are caught before merge.
 - Frontend dependency installation uses `actions/setup-node@v4` with npm cache and deterministic `npm ci`.
+- GitHub JavaScript action runtime is explicitly validated on Node 24 by setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at the workflow level. This does not change the application toolchain `NODE_VERSION`; it only opts GitHub-hosted JavaScript actions into the runtime that GitHub will make the default.
 - Production release tag builds and dry-runs verify that the target SHA already
   has a successful `main` CI `finish` result, then run release lint and image
   build validation. They do not rerun the container-backed `moon run :test`

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -180,6 +180,14 @@ The schedule must not mutate ledger state. It assembles existing portfolio,
 market-data, dividend, and journal-entry facts into a reporting payload that can
 be exported or embedded by EPIC-005.
 
+If no holding snapshot exists on or before `as_of_date`, the schedule may use
+active current holdings only when the same asset has a manual market-data
+override dated after `as_of_date`. The response must disclose that
+report-preparation evidence in `notes`, expose the override in
+`data_freshness.manual_override_basis`, and include a `market_data_override`
+source link. This fallback is report-only evidence and must not mutate ledger
+state or weaken historical portfolio holding queries.
+
 ### 2.6 Annualized Income Dashboard Summary
 
 Endpoint:

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -610,6 +610,19 @@ def test_AC8_13_16_ci_change_classification_and_frontend_cache() -> None:
     assert "lightweight documentation" in environments.lower()
 
 
+def test_AC8_13_16_workflows_opt_into_node24_actions_runtime() -> None:
+    """AC8.13.16: JavaScript actions are validated against the Node 24 runtime before migration."""
+    workflow_paths = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+    assert workflow_paths
+    for workflow_path in workflow_paths:
+        workflow = workflow_path.read_text(encoding="utf-8")
+        assert 'FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"' in workflow, workflow_path.name
+
+    ci_cd = read("docs/ssot/ci-cd.md")
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in ci_cd
+    assert "GitHub JavaScript action runtime is explicitly validated on Node 24" in ci_cd
+
+
 def test_AC8_13_17_ac_traceability_runs_registry_generation_check() -> None:
     """AC8.13.17: AC traceability checks registry generation before audit output."""
     workflow = read(".github/workflows/ci.yml")


### PR DESCRIPTION
## Summary
- Allow the investment performance report schedule to use active current holdings only when post-period manual market-data overrides evidence report preparation.
- Preserve strict historical portfolio holding semantics outside the report schedule fallback.
- Opt all GitHub workflows into the Node 24 JavaScript action runtime ahead of GitHub's default runtime migration.

## MECE framing
- Backend/reporting: fix the staging AI/OCR failure where the personal report package schedule had no holdings after brokerage import plus a post-period price override.
- CI/runtime: remove the separate GitHub Actions Node 20 runtime migration risk by validating JavaScript actions on Node 24 now.
- Documentation/proof: update EPIC-017 and SSOT reporting/CI-CD so the behavior is owned and testable.
- Out of scope: no change to ledger mutation, global portfolio as-of queries, application Node toolchain, or staging latest-pending concurrency semantics.

## Benefit
- Restores the post-merge personal financial report package proof path while keeping historical valuation queries strict.
- Makes future GitHub Actions runtime migration fail left in PR CI instead of surprising staging or production lanes later.
- Keeps the CI/CD stage model aligned: fast deterministic workflow checks stay left; provider-backed staging evidence remains right-side and production-like.

## Verification
- `uv run pytest tests/tooling/test_post_merge_e2e_gates.py -q`
- `uv run pytest tests/tooling/test_post_merge_e2e_gates.py::test_AC8_13_16_ci_change_classification_and_frontend_cache tests/tooling/test_post_merge_e2e_gates.py::test_AC8_13_16_workflows_opt_into_node24_actions_runtime -q`
- `uv run --with pyyaml python tools/generate_ac_registry.py --check`
- `uv run ruff check apps/backend/src/routers/portfolio.py apps/backend/tests/portfolio/test_portfolio_router.py tests/tooling/test_post_merge_e2e_gates.py`
- `git diff --check`

Backend DB-targeted test was attempted locally, but local PostgreSQL was unavailable and the podman machine exited after start; GitHub CI is expected to run the container-backed proof.
