### PR TITLE
[finance_report_ui] Build upload-first dashboard entry surface

### DIFF
--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -77,7 +77,8 @@ def test_AC19_4_1_upload_first_home_ssot_documents_dashboard_contract() -> None:
 
     assert "AC19.4.1" in epic
     assert "AC19.4.7" in epic
-    assert "metrics are secondary analytics below the workflow entry surface" in epic
+    assert "secondary analytics below the workflow entry surface" in epic
+    assert "must not block upload, event, or report readiness actions" in epic
 
 
 def test_AC19_1_2_workflow_event_model_contract() -> None:

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -62,6 +62,24 @@ def test_AC19_3_8_workflow_notification_ssot_documents_frontend_surfaces() -> No
     assert "AC19.3.8" in epic
 
 
+def test_AC19_4_1_upload_first_home_ssot_documents_dashboard_contract() -> None:
+    """AC19.4.1: /dashboard is the upload-first home and metrics are secondary."""
+    ssot = (ROOT_DIR / "docs" / "ssot" / "workflow-events.md").read_text(encoding="utf-8")
+    epic = (ROOT_DIR / "docs" / "project" / "EPIC-019.event-driven-upload-to-report-ux.md").read_text(encoding="utf-8")
+
+    for phrase in (
+        "`/dashboard` is the authenticated home for the upload-to-report workflow",
+        "UploadToReportHome",
+        "Dashboard first viewport",
+        "Secondary dashboard metric loading or failure must not hide the workflow",
+    ):
+        assert phrase in ssot
+
+    assert "AC19.4.1" in epic
+    assert "AC19.4.7" in epic
+    assert "metrics are secondary analytics below the workflow entry surface" in epic
+
+
 def test_AC19_1_2_workflow_event_model_contract() -> None:
     """AC19.1.2: workflow_events model exposes lifecycle, dedupe, and read indexes."""
     table = WorkflowEvent.__table__

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -77,8 +77,9 @@ def test_AC19_4_1_upload_first_home_ssot_documents_dashboard_contract() -> None:
 
     assert "AC19.4.1" in epic
     assert "AC19.4.7" in epic
-    assert "secondary analytics below the workflow entry surface" in epic
-    assert "must not block upload, event, or report readiness actions" in epic
+    normalized_epic = " ".join(epic.split())
+    assert "secondary analytics below the workflow entry surface" in normalized_epic
+    assert "must not block upload, event, or report readiness actions" in normalized_epic
 
 
 def test_AC19_1_2_workflow_event_model_contract() -> None:

--- a/apps/frontend/playwright/upload-first-dashboard.spec.ts
+++ b/apps/frontend/playwright/upload-first-dashboard.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const COLD_ROUTE_TIMEOUT_MS = 10_000;
+
+const workflowStatus = {
+  primary_state: "needs_action",
+  next_action: { type: "review_required", count: 1, href: "/review" },
+  report_readiness: { state: "blocked", blocking_count: 1, href: "/reports" },
+  event_counts: { unread: 2, action_required: 1, blocked: 0 },
+};
+
+const workflowEvents = {
+  total: 2,
+  items: [
+    {
+      id: "upload-home-review",
+      user_id: "upload-home-user",
+      occurred_at: "2026-06-03T08:00:00Z",
+      family: "review.required",
+      severity: "action_required",
+      status: "unread",
+      title: "Review required",
+      summary: "Confirm one low-confidence extraction before reports are ready.",
+      source_type: "bank_statement",
+      source_id: "statement-review",
+      action_href: "/review",
+      report_impact: "blocked",
+      dedupe_key: "upload-home:review",
+      created_at: "2026-06-03T08:00:00Z",
+      updated_at: "2026-06-03T08:00:00Z",
+    },
+    {
+      id: "upload-home-posted",
+      user_id: "upload-home-user",
+      occurred_at: "2026-06-03T07:00:00Z",
+      family: "ledger.auto_posted",
+      severity: "success",
+      status: "read",
+      title: "Safe entries posted",
+      summary: "Automation posted high-confidence entries.",
+      source_type: "journal",
+      source_id: "journal-posted",
+      action_href: "/journal",
+      report_impact: "ready",
+      dedupe_key: "upload-home:posted",
+      created_at: "2026-06-03T07:00:00Z",
+      updated_at: "2026-06-03T07:00:00Z",
+    },
+  ],
+};
+
+async function installDashboardMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("finance_access_token", "upload-home-token");
+    localStorage.setItem("finance_user_id", "upload-home-user");
+    localStorage.setItem("finance_user_email", "upload-home@example.com");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    let body: unknown = {};
+
+    if (path === "/api/workflow/status") {
+      body = workflowStatus;
+    } else if (path === "/api/workflow/events") {
+      body = workflowEvents;
+    } else if (path === "/api/accounts" || path === "/api/statements" || path.startsWith("/api/journal-entries")) {
+      body = { items: [], total: 0 };
+    } else if (path === "/api/accounts/processing/summary") {
+      body = { pending_count: 0, pending_total: "0.00", current_balance: "0.00", currency: "SGD", oldest_pending_date: null };
+    } else if (path.startsWith("/api/reports/balance-sheet")) {
+      body = {
+        as_of_date: "2026-06-03",
+        currency: "SGD",
+        assets: [{ account_id: "cash", name: "Cash", type: "ASSET", amount: "1000.00" }],
+        liabilities: [],
+        equity: [],
+        total_assets: "1000.00",
+        total_liabilities: "0.00",
+        total_equity: "1000.00",
+        equation_delta: "0.00",
+        is_balanced: true,
+      };
+    } else if (path.startsWith("/api/reports/income-statement")) {
+      body = { start_date: "2026-01-01", end_date: "2026-06-03", currency: "SGD", income: [], expenses: [], total_income: "0.00", total_expenses: "0.00", net_income: "0.00", trends: [] };
+    } else if (path.startsWith("/api/reports/trend")) {
+      body = { points: [] };
+    } else if (path === "/api/income/annualized") {
+      body = { annualized_salary: "0.00", annualized_bonus: "0.00", annualized_dividend: "0.00", annualized_total: "0.00", currency: "SGD", as_of: "2026-06-03" };
+    } else if (path === "/api/assets/restricted") {
+      body = [];
+    } else if (path === "/api/reconciliation/stats") {
+      body = { total_transactions: 0, matched_transactions: 0, unmatched_transactions: 0, pending_review: 0, auto_accepted: 0, match_rate: 0, score_distribution: {} };
+    } else if (path === "/api/reconciliation/unmatched") {
+      body = { items: [], total: 0 };
+    }
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+}
+
+async function expectNoDocumentHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    scrollX: window.scrollX,
+  }));
+
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.scrollX).toBe(0);
+}
+
+test.describe("AC19.4.7 upload-first dashboard smoke", () => {
+  for (const scenario of [
+    { name: "desktop", viewport: { width: 1440, height: 1000 } },
+    { name: "mobile", viewport: { width: 390, height: 844 } },
+  ]) {
+    test(`${scenario.name} renders upload-to-report home before secondary analytics`, async ({ page }) => {
+      await page.setViewportSize(scenario.viewport);
+      await installDashboardMocks(page);
+
+      await page.goto("/dashboard", { waitUntil: "networkidle" });
+
+      const uploadHome = page.getByLabel("Upload-to-report home");
+      await expect(uploadHome.getByRole("heading", { name: "Upload to report" })).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
+      await expect(uploadHome.getByRole("link", { name: "Review required", exact: true })).toHaveAttribute("href", "/review");
+      await expect(uploadHome.getByRole("link", { name: "Report readiness" })).toHaveAttribute("href", "/reports");
+      await expect(uploadHome.getByRole("heading", { name: "Routine automation" })).toBeVisible();
+
+      const homeBox = await uploadHome.boundingBox();
+      const analyticsBox = await page.getByLabel("Dashboard analytics").boundingBox();
+      expect(homeBox).not.toBeNull();
+      expect(analyticsBox).not.toBeNull();
+      expect(homeBox!.y).toBeLessThan(analyticsBox!.y);
+      await expectNoDocumentHorizontalScroll(page);
+    });
+  }
+});

--- a/apps/frontend/playwright/workflow-notifications.spec.ts
+++ b/apps/frontend/playwright/workflow-notifications.spec.ts
@@ -148,7 +148,7 @@ test.describe("AC19.3.7 workflow notification smoke", () => {
 
       await page.goto("/dashboard", { waitUntil: "networkidle" });
       await expect(page.getByRole("heading", { name: "Workflow status" })).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
-      await expect(page.getByText("Review required")).toBeVisible();
+      await expect(page.getByRole("link", { name: "Review required", exact: true })).toHaveAttribute("href", "/review");
 
       await page.getByRole("button", { name: /Workflow events/i }).click();
       const dialog = page.getByRole("dialog", { name: "Workflow events" });

--- a/apps/frontend/src/__tests__/dashboardPage.test.tsx
+++ b/apps/frontend/src/__tests__/dashboardPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -6,7 +6,7 @@ import DashboardPage from "@/app/(main)/dashboard/page"
 import { apiFetch } from "@/lib/api"
 
 vi.mock("next/link", () => ({
-  default: ({ href, children }: { href: string; children: ReactNode }) => <a href={href}>{children}</a>,
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => <a href={href} {...props}>{children}</a>,
 }))
 
 vi.mock("@/components/charts/BarChart", () => ({
@@ -64,6 +64,7 @@ function mockDashboardApi(overrides: Record<string, unknown> = {}) {
   let trendCalls = 0
   mockedApiFetch.mockImplementation((path: string) => {
     if (path.startsWith("/api/reports/balance-sheet")) {
+      if (overrides.balanceError) return Promise.reject(overrides.balanceError)
       const includeRestricted = path.includes("include_restricted=true")
       const defaultBalance = includeRestricted
         ? { ...baseBalance, total_assets: 17500, total_equity: 16500 }
@@ -105,6 +106,23 @@ function mockDashboardApi(overrides: Record<string, unknown> = {}) {
                   dedupe_key: "workflow:dashboard",
                   created_at: "2026-06-03T08:00:00Z",
                   updated_at: "2026-06-03T08:00:00Z",
+                },
+                {
+                  id: "workflow-routine-dashboard",
+                  user_id: "user-dashboard",
+                  occurred_at: "2026-06-03T07:00:00Z",
+                  family: "ledger.auto_posted",
+                  severity: "success",
+                  status: "read",
+                  title: "Safe entries posted",
+                  summary: "Automation posted high-confidence entries.",
+                  source_type: "journal",
+                  source_id: "journal-dashboard",
+                  action_href: "/journal",
+                  report_impact: "ready",
+                  dedupe_key: "workflow:routine-dashboard",
+                  created_at: "2026-06-03T07:00:00Z",
+                  updated_at: "2026-06-03T07:00:00Z",
                 },
               ],
             },
@@ -191,7 +209,8 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />)
 
-    expect(screen.getByText("Loading dashboard...")).toBeInTheDocument()
+    expect(screen.getByText("Loading upload-to-report workflow...")).toBeInTheDocument()
+    expect(screen.getByText("Loading dashboard analytics...")).toBeInTheDocument()
   })
 
   it("AC16.12.2 renders error fallback and retry action on failure", async () => {
@@ -199,10 +218,12 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />)
 
-    await waitFor(() => expect(screen.getByText("Unable to Load Dashboard")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Upload to report")).toBeInTheDocument())
+    expect(screen.getByText("Workflow status is unavailable. You can still upload files or open reports.")).toBeInTheDocument()
+    expect(screen.getByText("Dashboard analytics unavailable")).toBeInTheDocument()
     expect(screen.getByText("dashboard failed")).toBeInTheDocument()
     const callCountBeforeRetry = mockedApiFetch.mock.calls.length
-    fireEvent.click(screen.getByRole("button", { name: "Retry Connection" }))
+    fireEvent.click(screen.getByRole("button", { name: "Retry analytics" }))
     await waitFor(() => expect(mockedApiFetch.mock.calls.length).toBeGreaterThan(callCountBeforeRetry))
   })
 
@@ -211,7 +232,7 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />)
 
-    await waitFor(() => expect(screen.getByText("Dashboard")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Financial analytics")).toBeInTheDocument())
     expect(screen.getByText("Total Assets")).toBeInTheDocument()
     expect(screen.getByText("Total Liabilities")).toBeInTheDocument()
     expect(screen.getByText("Net Assets")).toBeInTheDocument()
@@ -229,8 +250,86 @@ describe("DashboardPage", () => {
     await waitFor(() => expect(screen.getByRole("heading", { name: "Workflow status" })).toBeInTheDocument())
     expect(mockedApiFetch).toHaveBeenCalledWith("/api/workflow/status")
     expect(mockedApiFetch).toHaveBeenCalledWith("/api/workflow/events?limit=5")
-    expect(screen.getByText("Review required")).toBeInTheDocument()
-    expect(screen.getByText("Report blocked")).toBeInTheDocument()
+    expect(screen.getAllByText("Review required").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText("Report blocked").length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("AC19.4.2 renders the upload-to-report home before secondary dashboard metrics", async () => {
+    mockDashboardApi()
+
+    render(<DashboardPage />)
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Upload to report" })).toBeInTheDocument())
+    const workflowHome = screen.getByLabelText("Upload-to-report home")
+    const totalAssets = screen.getByText("Total Assets")
+    expect(Boolean(workflowHome.compareDocumentPosition(totalAssets) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
+  })
+
+  it("AC19.4.3 follows workflow next_action for blocker and upload primary CTAs", async () => {
+    mockDashboardApi()
+
+    const { unmount } = render(<DashboardPage />)
+
+    await waitFor(() => {
+      const uploadHome = within(screen.getByLabelText("Upload-to-report home"))
+      expect(uploadHome.getAllByRole("link", { name: /Review required/i })[0]).toHaveAttribute("href", "/review")
+    })
+    unmount()
+    mockedApiFetch.mockReset()
+
+    mockDashboardApi({
+      workflowStatus: {
+        primary_state: "empty",
+        next_action: { type: "upload", count: 0, href: "/statements/upload" },
+        report_readiness: { state: "none", blocking_count: 0, href: "/reports" },
+        event_counts: { unread: 0, action_required: 0, blocked: 0 },
+      },
+      workflowEvents: { total: 0, items: [] },
+    })
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      const uploadHome = within(screen.getByLabelText("Upload-to-report home"))
+      expect(uploadHome.getAllByRole("link", { name: /Upload statements/i })[0]).toHaveAttribute("href", "/statements/upload")
+    })
+  })
+
+  it("AC19.4.4 renders report readiness above analytics with blocker count and link", async () => {
+    mockDashboardApi()
+
+    render(<DashboardPage />)
+
+    await waitFor(() => expect(screen.getByLabelText("Report readiness")).toHaveAttribute("href", "/reports"))
+    expect(screen.getAllByText("Report blocked").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText("1 blocker")).toBeInTheDocument()
+    const readiness = screen.getByLabelText("Report readiness")
+    const totalAssets = screen.getByText("Total Assets")
+    expect(Boolean(readiness.compareDocumentPosition(totalAssets) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
+  })
+
+  it("AC19.4.5 shows actionable recent events and summarizes routine automation", async () => {
+    mockDashboardApi()
+
+    render(<DashboardPage />)
+
+    await waitFor(() => expect(screen.getByText("Action required")).toBeInTheDocument())
+    expect(screen.getAllByText("Review required").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByRole("heading", { name: "Routine automation" })).toBeInTheDocument()
+    expect(screen.getByText("1 routine event")).toBeInTheDocument()
+    expect(screen.getByText("Safe entries posted")).toBeInTheDocument()
+  })
+
+  it("AC19.4.6 keeps upload-to-report home visible when secondary analytics fail", async () => {
+    mockDashboardApi({ balanceError: new Error("balance failed") })
+
+    render(<DashboardPage />)
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Upload to report" })).toBeInTheDocument())
+    const uploadHome = within(screen.getByLabelText("Upload-to-report home"))
+    expect(uploadHome.getAllByRole("link", { name: /Review required/i })[0]).toHaveAttribute("href", "/review")
+    expect(screen.getByText("Dashboard analytics unavailable")).toBeInTheDocument()
+    expect(screen.getByText("balance failed")).toBeInTheDocument()
   })
 
   it("AC11.8.2/AC11.8.6/AC5.6.4 renders Annualized Income card with the four metric labels", async () => {
@@ -299,7 +398,7 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />)
 
-    await waitFor(() => expect(screen.getByText("Dashboard")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Financial analytics")).toBeInTheDocument())
     expect(screen.getByText("No assets to chart yet.")).toBeInTheDocument()
     expect(screen.getByText("No income data available.")).toBeInTheDocument()
     expect(screen.getByText("No recent journal entries.")).toBeInTheDocument()
@@ -348,7 +447,7 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />)
 
-    await waitFor(() => expect(screen.getByText("Dashboard")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Financial analytics")).toBeInTheDocument())
     expect(screen.getByText(/No trend data/)).toBeInTheDocument()
     expect(screen.getByText("No assets to chart yet.")).toBeInTheDocument()
     expect(screen.getByText("No income data available.")).toBeInTheDocument()
@@ -384,7 +483,7 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />)
 
-    await waitFor(() => expect(screen.getByText("Dashboard")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Financial analytics")).toBeInTheDocument())
     const selector = screen.getByRole("combobox") as HTMLSelectElement
     expect(selector).toBeInTheDocument()
     expect(screen.getByText("Top Asset")).toBeInTheDocument()
@@ -403,7 +502,7 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />)
 
-    await waitFor(() => expect(screen.getByText("Dashboard")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Financial analytics")).toBeInTheDocument())
     await waitFor(() => expect(screen.getByText(/No trend data/)).toBeInTheDocument())
     expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to fetch trend data:", expect.any(Error))
 
@@ -466,7 +565,7 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />)
 
-    await waitFor(() => expect(screen.getByText("Dashboard")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Financial analytics")).toBeInTheDocument())
     expect(screen.queryByLabelText("Getting started")).not.toBeInTheDocument()
     expect(screen.getByText("Total Assets")).toBeInTheDocument()
   })

--- a/apps/frontend/src/__tests__/workflowSurfaces.test.tsx
+++ b/apps/frontend/src/__tests__/workflowSurfaces.test.tsx
@@ -1,11 +1,12 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
-import type { ReactNode } from "react"
+import type { AnchorHTMLAttributes, ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   WorkflowNotificationCenter,
   WorkflowEventsPageContent,
+  UploadToReportHome,
   WorkflowStatusFeed,
 } from "@/components/workflow/WorkflowNotifications"
 import {
@@ -19,8 +20,8 @@ import type {
 } from "@/lib/types"
 
 vi.mock("next/link", () => ({
-  default: ({ href, children, className }: { href: string; children: ReactNode; className?: string }) => (
-    <a href={href} className={className}>
+  default: ({ href, children, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
       {children}
     </a>
   ),
@@ -185,6 +186,84 @@ describe("workflow notification surfaces", () => {
     rerender(<WorkflowStatusFeed status={statusEmpty} events={[]} />)
     expect(screen.getByText("No action required")).toBeInTheDocument()
     expect(screen.getByRole("link", { name: "Upload statements" })).toHaveAttribute("href", "/statements/upload")
+  })
+
+  it("AC19.4.2 renders the upload-to-report home as the first workflow entry surface", () => {
+    render(<UploadToReportHome status={statusNeedsAction} events={workflowEvents.items} />)
+
+    expect(screen.getByRole("region", { name: "Upload-to-report home" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Upload to report" })).toBeInTheDocument()
+    expect(screen.getByText("Review the required action so automation can continue.")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /^Review required$/i })).toHaveAttribute("href", "/review")
+    expect(screen.getByRole("link", { name: "Report readiness" })).toHaveAttribute("href", "/reports")
+    expect(screen.getByRole("heading", { name: "Workflow status" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Blocked" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Action required" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Routine automation" })).toBeInTheDocument()
+    expect(screen.getByText("2 routine events")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Archive/i })).not.toBeInTheDocument()
+  })
+
+  it("AC19.4.3 keeps the upload-first CTA and quiet state aligned to workflow next action", () => {
+    render(<UploadToReportHome status={statusEmpty} events={[]} />)
+
+    expect(screen.getByText("Upload files to start the automated reporting workflow.")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Upload statements/i })).toHaveAttribute("href", "/statements/upload")
+    expect(screen.getAllByText("Report none")[0]).toBeInTheDocument()
+    expect(screen.getByText("0 blockers")).toBeInTheDocument()
+    expect(screen.getByText("No action required")).toBeInTheDocument()
+    expect(screen.getByText("0 routine events")).toBeInTheDocument()
+  })
+
+  it("AC19.4.4 exposes ready, processing, and stale report readiness states above analytics", () => {
+    const { rerender } = render(
+      <UploadToReportHome
+        status={{
+          primary_state: "ready",
+          next_action: { type: "open_report", count: 0, href: "/reports" },
+          report_readiness: { state: "ready", blocking_count: 0, href: "/reports" },
+          event_counts: { unread: 0, action_required: 0, blocked: 0 },
+        }}
+        events={workflowEvents.items.slice(2)}
+      />,
+    )
+
+    expect(screen.getByText("Reports are ready to inspect.")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Open reports/i })).toHaveAttribute("href", "/reports")
+    expect(screen.getAllByText("Report ready")[0]).toBeInTheDocument()
+
+    rerender(
+      <UploadToReportHome
+        status={{
+          primary_state: "processing",
+          next_action: { type: "wait", count: 0, href: "/events" },
+          report_readiness: { state: "processing", blocking_count: 0, href: "/reports" },
+          event_counts: { unread: 1, action_required: 0, blocked: 0 },
+        }}
+        events={[workflowEvents.items[3]]}
+      />,
+    )
+
+    expect(screen.getByText("Automation is processing uploaded source files.")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /View processing/i })).toHaveAttribute("href", "/events")
+    expect(screen.getAllByText("Report processing")[0]).toBeInTheDocument()
+
+    rerender(
+      <UploadToReportHome
+        status={{
+          primary_state: "blocked",
+          next_action: { type: "resolve_blocker", count: 1, href: "/reconciliation/unmatched" },
+          report_readiness: { state: "stale", blocking_count: 1, href: "/reports" },
+          event_counts: { unread: 1, action_required: 0, blocked: 1 },
+        }}
+        events={[workflowEvents.items[0]]}
+      />,
+    )
+
+    expect(screen.getByText("A blocker is holding report readiness.")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Resolve blocker/i })).toHaveAttribute("href", "/reconciliation/unmatched")
+    expect(screen.getAllByText("Report stale")[0]).toBeInTheDocument()
+    expect(screen.getByText("1 blocker")).toBeInTheDocument()
   })
 
   it("AC19.3.5 renders the events page loading and unavailable states", async () => {

--- a/apps/frontend/src/app/(main)/dashboard/page.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Landmark, FileText, BookOpen } from "lucide-react";
 import ProcessingSummaryCard from "@/components/ProcessingSummaryCard";
-import { WorkflowStatusFeedPanel } from "@/components/workflow/WorkflowNotifications";
+import { UploadToReportHomePanel } from "@/components/workflow/WorkflowNotifications";
 
 import { apiFetch } from "@/lib/api";
 import { formatDateInput, formatDateDisplay, formatMonthLabel } from "@/lib/date";
@@ -229,62 +229,50 @@ export default function DashboardPage() {
     ];
   }, [isCoreFlowComplete, onboardingStatus]);
 
-  if (loading) {
-    return (
-      <div className="p-6 flex items-center justify-center min-h-[60vh]">
-        <div className="text-center text-muted">
-          <div className="inline-block w-6 h-6 border-2 border-current border-t-transparent rounded-full animate-spin mb-2" />
-          <p className="text-sm">Loading dashboard...</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="p-6">
-        <div className="card p-8 text-center max-w-lg mx-auto">
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--error-muted)] text-[var(--error)] mb-4">
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          </div>
-          <h1 className="text-xl font-semibold mb-2">Unable to Load Dashboard</h1>
-          <p className="text-muted mb-4 text-sm">{error}</p>
-          <div className="grid gap-3 sm:grid-cols-3 mb-6">
-            <Link href="/accounts" className="card p-4 hover:border-[var(--accent)] transition-colors text-center">
-              <Landmark className="w-8 h-8 mx-auto mb-1 text-[var(--accent)]" aria-hidden="true" />
-              <span className="text-sm font-medium">Accounts</span>
-            </Link>
-            <Link href="/statements" className="card p-4 hover:border-[var(--accent)] transition-colors text-center">
-              <FileText className="w-8 h-8 mx-auto mb-1 text-[var(--accent)]" aria-hidden="true" />
-              <span className="text-sm font-medium">Statements</span>
-            </Link>
-            <Link href="/journal" className="card p-4 hover:border-[var(--accent)] transition-colors text-center">
-              <BookOpen className="w-8 h-8 mx-auto mb-1 text-[var(--accent)]" aria-hidden="true" />
-              <span className="text-sm font-medium">Journal</span>
-            </Link>
-          </div>
-          <button onClick={fetchData} className="btn-secondary">Retry Connection</button>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="p-6">
-      {/* Header */}
-      <div className="page-header flex items-center justify-between">
-        <div>
-          <h1 className="page-title">Dashboard</h1>
-          <p className="page-description">Track net assets, cash momentum, and reconciliation risk</p>
-        </div>
-        <div className="flex gap-2">
-          <Link href="/reports/balance-sheet" className="btn-secondary text-sm">Balance Sheet</Link>
-          <Link href="/reports/income-statement" className="btn-secondary text-sm">Income Statement</Link>
-        </div>
+      <div className="mb-6">
+        <UploadToReportHomePanel />
       </div>
 
+      <section className="mb-6" aria-label="Dashboard analytics">
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Financial analytics</h2>
+            <p className="text-sm text-muted">Secondary metrics, charts, and reconciliation details</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link href="/reports/balance-sheet" className="btn-secondary text-sm">Balance Sheet</Link>
+            <Link href="/reports/income-statement" className="btn-secondary text-sm">Income Statement</Link>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="card p-5" role="status" aria-label="Dashboard analytics loading">
+            <div className="flex items-center gap-2 text-sm text-muted">
+              <div className="h-4 w-4 rounded-full border-2 border-current border-t-transparent animate-spin" />
+              Loading dashboard analytics...
+            </div>
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="card p-5" role="alert" aria-label="Dashboard analytics unavailable">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <h3 className="font-semibold">Dashboard analytics unavailable</h3>
+                <p className="mt-1 text-sm text-muted">{error}</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button onClick={fetchData} className="btn-secondary text-sm">Retry analytics</button>
+                <Link href="/statements/upload" className="btn-primary text-sm">Upload statements</Link>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!loading && !error && (
+          <>
       {showOnboarding && (
         <section className="card p-5 mb-6 border-[var(--accent)]/40" aria-label="Getting started">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
@@ -314,10 +302,6 @@ export default function DashboardPage() {
           </div>
         </section>
       )}
-
-      <div className="mb-6">
-        <WorkflowStatusFeedPanel />
-      </div>
 
       {/* KPI Cards */}
       <div className="grid gap-4 md:grid-cols-4 mb-6">
@@ -560,6 +544,9 @@ export default function DashboardPage() {
           </div>
         </div>
       </div>
+          </>
+        )}
+      </section>
     </div>
   );
 }

--- a/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
+++ b/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  Archive,
   ArrowRight,
   Bell,
   CheckCircle2,
@@ -18,7 +17,7 @@ import {
   ShieldAlert,
 } from "lucide-react";
 import Sheet from "@/components/ui/Sheet";
-import { Alert, Badge, EmptyState, IconButton, type BadgeVariant } from "@/components/ui";
+import { Alert, Badge, EmptyState, type BadgeVariant } from "@/components/ui";
 import {
   fetchWorkflowEvents,
   fetchWorkflowStatus,
@@ -623,73 +622,6 @@ export function UploadToReportHomePanel() {
   }
 
   return <UploadToReportHome status={status} events={events} />;
-}
-
-export function WorkflowStatusFeedPanel() {
-  const [status, setStatus] = useState<WorkflowStatusResponse | null>(null);
-  const [events, setEvents] = useState<WorkflowEventResponse[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function loadWorkflowFeed() {
-      setIsLoading(true);
-      setError(false);
-      try {
-        const [nextStatus, nextEvents] = await Promise.all([
-          fetchWorkflowStatus(),
-          fetchWorkflowEvents({ limit: 5 }),
-        ]);
-        if (!cancelled) {
-          setStatus(nextStatus);
-          setEvents(nextEvents.items);
-        }
-      } catch {
-        if (!cancelled) setError(true);
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    }
-
-    void loadWorkflowFeed();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  if (isLoading) {
-    return (
-      <section className="card p-5" aria-label="Workflow status">
-        <div className="flex items-center gap-2 text-sm text-muted" role="status">
-          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-          Loading workflow status...
-        </div>
-      </section>
-    );
-  }
-
-  if (error || !status) {
-    return (
-      <section className="card p-5" aria-label="Workflow status">
-        <div className="alert-warning">Workflow status is unavailable.</div>
-      </section>
-    );
-  }
-
-  return <WorkflowStatusFeed status={status} events={events} />;
-}
-
-export function WorkflowArchiveButton({
-  event,
-  onArchive,
-}: {
-  event: WorkflowEventResponse;
-  onArchive: (eventId: string) => void;
-}) {
-  return <IconButton icon={Archive} label={`Archive ${event.title}`} onClick={() => onArchive(event.id)} />;
 }
 
 export function WorkflowEventsPageContent() {

--- a/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
+++ b/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
@@ -5,17 +5,20 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Archive,
+  ArrowRight,
   Bell,
   CheckCircle2,
   CircleAlert,
   CircleCheck,
   ExternalLink,
+  FileCheck2,
   Inbox,
   Loader2,
+  UploadCloud,
   ShieldAlert,
 } from "lucide-react";
 import Sheet from "@/components/ui/Sheet";
-import { Alert, Badge, EmptyState, IconButton } from "@/components/ui";
+import { Alert, Badge, EmptyState, IconButton, type BadgeVariant } from "@/components/ui";
 import {
   fetchWorkflowEvents,
   fetchWorkflowStatus,
@@ -63,6 +66,30 @@ function countLabel(count: number, singular: string, plural = `${singular}s`) {
 
 function routineEvents(events: WorkflowEventResponse[]) {
   return events.filter((event) => event.severity !== "blocked" && event.severity !== "action_required");
+}
+
+function nextActionLabel(status: WorkflowStatusResponse) {
+  if (status.next_action.type === "upload") return "Upload statements";
+  if (status.next_action.type === "review_required") return "Review required";
+  if (status.next_action.type === "resolve_blocker") return "Resolve blocker";
+  if (status.next_action.type === "open_report") return "Open reports";
+  if (status.next_action.type === "wait") return "View processing";
+  return "Open workflow";
+}
+
+function workflowStateCopy(status: WorkflowStatusResponse) {
+  if (status.primary_state === "blocked") return "A blocker is holding report readiness.";
+  if (status.primary_state === "needs_action") return "Review the required action so automation can continue.";
+  if (status.primary_state === "processing") return "Automation is processing uploaded source files.";
+  if (status.primary_state === "ready") return "Reports are ready to inspect.";
+  return "Upload files to start the automated reporting workflow.";
+}
+
+function readinessVariant(state: WorkflowStatusResponse["report_readiness"]["state"]): BadgeVariant {
+  if (state === "blocked" || state === "stale") return "error";
+  if (state === "processing") return "warning";
+  if (state === "ready") return "success";
+  return "info";
 }
 
 interface WorkflowEventGroupProps {
@@ -419,6 +446,183 @@ export function WorkflowStatusFeed({ status, events }: WorkflowStatusFeedProps) 
       </div>
     </section>
   );
+}
+
+export function UploadToReportHome({ status, events }: WorkflowStatusFeedProps) {
+  const groupedEvents = {
+    blocked: events.filter((event) => event.severity === "blocked"),
+    actionRequired: events.filter((event) => event.severity === "action_required"),
+    routine: routineEvents(events),
+  };
+  const primaryLabel = nextActionLabel(status);
+  const readinessLabel = `Report ${sentenceFromSnake(status.report_readiness.state)}`;
+  const blockerLabel = countLabel(status.report_readiness.blocking_count, "blocker");
+  const primaryIsUpload = status.next_action.type === "upload";
+
+  return (
+    <section className="space-y-4" aria-label="Upload-to-report home">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
+        <div className="card p-5">
+          <p className="text-xs uppercase tracking-wide text-muted">Upload-to-report workflow</p>
+          <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold">Upload to report</h1>
+              <p className="mt-2 max-w-2xl text-sm text-muted">{workflowStateCopy(status)}</p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Badge variant={severityBadgeVariant(status.primary_state === "blocked" ? "blocked" : "info")}>
+                  {labelFromSnake(status.primary_state)}
+                </Badge>
+                {status.event_counts.action_required > 0 && (
+                  <Badge variant="warning">{countLabel(status.event_counts.action_required, "action")}</Badge>
+                )}
+                {status.event_counts.blocked > 0 && (
+                  <Badge variant="error">{countLabel(status.event_counts.blocked, "blocked", "blocked")}</Badge>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row lg:flex-col">
+              <Link
+                href={status.next_action.href}
+                className="btn-primary inline-flex items-center justify-center gap-2 text-sm"
+              >
+                {primaryIsUpload ? (
+                  <UploadCloud className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                )}
+                {primaryLabel}
+              </Link>
+              <Link href="/events" className="btn-secondary inline-flex items-center justify-center gap-2 text-sm">
+                <Inbox className="h-4 w-4" aria-hidden="true" />
+                View events
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <Link
+          href={status.report_readiness.href}
+          className="card block p-5 transition-colors hover:border-[var(--accent)]"
+          aria-label="Report readiness"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted">Report readiness</p>
+              <h2 className="mt-2 text-lg font-semibold">{readinessLabel}</h2>
+            </div>
+            <FileCheck2 className="h-5 w-5 text-muted" aria-hidden="true" />
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Badge variant={readinessVariant(status.report_readiness.state)}>{readinessLabel}</Badge>
+            <Badge variant={status.report_readiness.blocking_count > 0 ? "error" : "muted"}>{blockerLabel}</Badge>
+          </div>
+          <p className="mt-3 text-sm text-muted">Open the report readiness path for blockers, processing state, or generated output.</p>
+        </Link>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,0.45fr)]">
+        <section className="card p-5" aria-label="Workflow status">
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold">Workflow status</h2>
+              <p className="mt-1 text-sm text-muted">Required actions and blockers stay visible before analytics.</p>
+            </div>
+            <Badge variant="muted">{events.length} recent</Badge>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <WorkflowEventGroup title="Blocked" events={groupedEvents.blocked.slice(0, 2)} showActions={false} />
+            <WorkflowEventGroup title="Action required" events={groupedEvents.actionRequired.slice(0, 2)} showActions={false} />
+          </div>
+          {groupedEvents.blocked.length === 0 && groupedEvents.actionRequired.length === 0 && (
+            <div className="rounded-md border border-border bg-surface-muted p-3 text-sm text-muted">
+              No action required
+            </div>
+          )}
+        </section>
+
+        <section className="card p-5" aria-label="Routine automation">
+          <div className="flex items-center gap-2">
+            <CircleCheck className="h-4 w-4 text-muted" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Routine automation</h2>
+          </div>
+          <p className="mt-3 text-sm text-muted">{countLabel(groupedEvents.routine.length, "routine event")}</p>
+          {groupedEvents.routine.length > 0 && (
+            <div className="mt-3 rounded-md border border-border bg-surface-muted p-3 text-sm">
+              <p className="font-medium">{groupedEvents.routine[0].title}</p>
+              <p className="mt-1 text-muted">{groupedEvents.routine[0].summary}</p>
+            </div>
+          )}
+        </section>
+      </div>
+    </section>
+  );
+}
+
+export function UploadToReportHomePanel() {
+  const [status, setStatus] = useState<WorkflowStatusResponse | null>(null);
+  const [events, setEvents] = useState<WorkflowEventResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadUploadHome() {
+      setIsLoading(true);
+      setError(false);
+      try {
+        const [nextStatus, nextEvents] = await Promise.all([
+          fetchWorkflowStatus(),
+          fetchWorkflowEvents({ limit: 5 }),
+        ]);
+        if (!cancelled) {
+          setStatus(nextStatus);
+          setEvents(nextEvents.items);
+        }
+      } catch {
+        if (!cancelled) setError(true);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    void loadUploadHome();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (isLoading) {
+    return (
+      <section className="card p-5" aria-label="Upload-to-report home">
+        <div className="flex items-center gap-2 text-sm text-muted" role="status">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          Loading upload-to-report workflow...
+        </div>
+      </section>
+    );
+  }
+
+  if (error || !status) {
+    return (
+      <section className="card p-5" aria-label="Upload-to-report home">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold">Upload to report</h1>
+            <p className="mt-1 text-sm text-muted">Workflow status is unavailable. You can still upload files or open reports.</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link href="/statements/upload" className="btn-primary text-sm">Upload statements</Link>
+            <Link href="/reports" className="btn-secondary text-sm">Open reports</Link>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return <UploadToReportHome status={status} events={events} />;
 }
 
 export function WorkflowStatusFeedPanel() {

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -200,8 +200,9 @@ Make upload the first-class product entry. The user should see:
 - Required action summary.
 - Report readiness summary.
 
-This can start by replacing or reshaping the current dashboard with an
-Upload-to-Report home, without deleting existing dashboard metrics.
+`/dashboard` is the authenticated Upload-to-Report home. Existing dashboard
+metrics remain available, but they are secondary analytics below the workflow
+entry surface and must not block upload, event, or report readiness actions.
 
 **Why this works:** it aligns first-screen behavior with the core use case:
 upload files and let the system work.
@@ -328,6 +329,18 @@ workflow state exists.
 | AC19.3.6 | Dashboard status feed renders primary state, report readiness, recent automation, blocker/action severity, and an empty no-action state without raw audit-log noise | `workflowSurfaces.test.tsx`, `dashboardPage.test.tsx` | P0 |
 | AC19.3.7 | Desktop and mobile Playwright smoke covers the workflow badge/inbox/feed without layout overflow | `workflow-notifications.spec.ts` | P0 |
 | AC19.3.8 | Workflow notification UI contract is documented in the workflow-events SSOT and EPIC-019 | `test_AC19_3_8_workflow_notification_ssot_documents_frontend_surfaces` | P0 |
+
+### AC19.4 — Upload-First Entry Surface
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC19.4.1 | EPIC-019 and workflow-events SSOT define `/dashboard` as the upload-first authenticated home, with dashboard metrics as secondary analytics | `test_AC19_4_1_upload_first_home_ssot_documents_dashboard_contract` | P0 |
+| AC19.4.2 | The first dashboard viewport renders the upload-to-report workflow home before KPI, chart, and activity content | `dashboardPage.test.tsx` | P0 |
+| AC19.4.3 | The dashboard primary CTA follows `workflow.status.next_action.href` and labels upload as the default action when no higher-priority blocker/action exists | `dashboardPage.test.tsx` | P0 |
+| AC19.4.4 | Report readiness state and blocker count are visible above secondary dashboard metrics and link to the readiness/report action path | `dashboardPage.test.tsx` | P0 |
+| AC19.4.5 | Recent workflow events are visible, grouped by actionability, and routine automation is summarized without dominating the page | `dashboardPage.test.tsx` | P0 |
+| AC19.4.6 | Secondary dashboard metric API failure does not hide the workflow home; the analytics section renders an isolated retry/error state | `dashboardPage.test.tsx` | P0 |
+| AC19.4.7 | Desktop and mobile Playwright smoke covers the upload-first dashboard entry without layout overflow | `upload-first-dashboard.spec.ts` | P0 |
 
 ### AC19.5 — Report Readiness and Blocker State
 

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -21,6 +21,7 @@
 | Compact status/events API | `apps/backend/src/routers/workflow.py` |
 | Report package readiness fact source | `GET /api/reports/package/readiness` in `apps/backend/src/services/report_readiness.py` |
 | Header badge, Event inbox, Status feed | `apps/frontend/src/components/workflow/WorkflowNotifications.tsx` |
+| Upload-to-Report home | `apps/frontend/src/app/(main)/dashboard/page.tsx` |
 | Events page | `apps/frontend/src/app/(main)/events/page.tsx` |
 | Database migrations | `apps/backend/migrations/versions/0021_add_workflow_events.py`, `apps/backend/migrations/versions/0022_harden_workflow_contract.py` |
 | Contract tests | `apps/backend/tests/workflow/test_workflow_events.py`, `apps/backend/tests/api/test_workflow_router.py`, `apps/frontend/src/__tests__/workflowApi.test.ts`, `apps/frontend/src/__tests__/workflowSurfaces.test.tsx`, `apps/frontend/playwright/workflow-notifications.spec.ts` |
@@ -265,6 +266,10 @@ WorkflowNotificationCenter
 WorkflowStatusFeed
   -> Dashboard status feed
   -> Events page status summary
+
+UploadToReportHome
+  -> Dashboard first viewport
+  -> Secondary analytics boundary
 ```
 
 Header badge rules:
@@ -295,6 +300,23 @@ Status feed rules:
   primary attention driver.
 - Empty state says `No action required` and routes the user to upload when no
   workflow state exists.
+
+Upload-to-Report home rules:
+
+- `/dashboard` is the authenticated home for the upload-to-report workflow.
+- The first viewport renders workflow state, the primary next action, report
+  readiness, and recent workflow events before KPI, chart, reconciliation, or
+  activity analytics.
+- The primary CTA uses `workflow.status.next_action.href`. Upload is the
+  default label only when no higher-priority blocker or action-required state
+  wins the workflow priority.
+- Report readiness appears above secondary analytics and links to the report or
+  readiness action route from the workflow status contract.
+- Routine automation is summarized; blocked and action-required events remain
+  visually prominent.
+- Secondary dashboard metric loading or failure must not hide the workflow
+  home. Analytics render below the workflow surface with an isolated loading,
+  empty, retry, or error state.
 
 ---
 

--- a/tests/e2e/test_four_asset_net_worth_golden_path.py
+++ b/tests/e2e/test_four_asset_net_worth_golden_path.py
@@ -482,7 +482,10 @@ async def test_four_asset_as_of_net_worth_golden_path(
 
     await page.goto(_get_url("/dashboard"))
     await page.wait_for_load_state("networkidle")
-    await expect(page.get_by_role("heading", name="Dashboard")).to_be_visible(
+    await expect(page.get_by_role("heading", name="Upload to report")).to_be_visible(
+        timeout=10_000
+    )
+    await expect(page.get_by_label("Dashboard analytics")).to_be_visible(
         timeout=10_000
     )
     include_checkbox = page.get_by_label("Include restricted holdings")

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -763,7 +763,8 @@ async def test_personal_financial_report_package_post_merge_journey(authenticate
 
     await page.goto(_get_url("/dashboard"))
     await page.wait_for_load_state("networkidle")
-    await expect(page.get_by_role("heading", name="Dashboard")).to_be_visible(timeout=10_000)
+    await expect(page.get_by_role("heading", name="Upload to report")).to_be_visible(timeout=10_000)
+    await expect(page.get_by_label("Dashboard analytics")).to_be_visible(timeout=10_000)
 
     await page.goto(
         _get_url(

--- a/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
+++ b/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
@@ -275,7 +275,8 @@ async def test_statement_upload_to_dashboard_vision_hard_gate(authenticated_page
 
     await page.goto(_get_url("/dashboard"))
     await page.wait_for_load_state("networkidle")
-    await expect(page.get_by_role("heading", name="Dashboard")).to_be_visible(timeout=10_000)
+    await expect(page.get_by_role("heading", name="Upload to report")).to_be_visible(timeout=10_000)
+    await expect(page.get_by_label("Dashboard analytics")).to_be_visible(timeout=10_000)
     await expect(
         page.locator(".card")
         .filter(has_text="Processing")


### PR DESCRIPTION
## Summary

Builds the EPIC-019 upload-first `/dashboard` home surface so workflow state, next action, recent events, and report readiness appear before secondary dashboard analytics.

Closes #638

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-019 — Event-Driven Upload-to-Report UX |
| **AC IDs** | AC19.4.1, AC19.4.2, AC19.4.3, AC19.4.4, AC19.4.5, AC19.4.6, AC19.4.7 |
| **AC source updated** | Owning EPIC |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/workflow-events.md` — documents `/dashboard` as the upload-first home, primary CTA/readiness rules, routine automation treatment, and isolated secondary analytics failure handling.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `abaf2a2` | Registers AC19.4, adds dashboard component tests and Playwright smoke before implementation. |
| 🟢 Green (passing test) | `a4042d5` | Implements `UploadToReportHomePanel` and resilient `/dashboard` analytics boundary. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no DB enum changes.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A, no env changes.
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A, no config changes.
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env changes.
- [x] `tools/check_manifest.py` passes (if SSOT files changed) — Existing `workflow-events` SSOT owner unchanged; AC traceability/checks passed.
- [x] `tools/lint_doc_consistency.py` passes — Covered by `moon run :lint`.

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner. — N/A.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys. — N/A.
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged. — N/A.
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials. — N/A.
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule. — N/A.
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene. — N/A.

---

## Testing

```bash
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_ac_traceability.py
npm test -- dashboardPage.test.tsx
npm test -- workflowSurfaces.test.tsx workflowApi.test.ts
npm test
npm run lint
npm run test:e2e -- upload-first-dashboard.spec.ts
moon run :lint
```

Attempted but blocked by local infra:

```bash
moon run :test
```

`moon run :test` failed before test execution because local Podman was unavailable: `unable to connect to Podman socket: dial tcp 127.0.0.1:61270: connect: connection refused`.

---

## Screenshots / Evidence

- Playwright desktop/mobile smoke for `/dashboard` passed: `2 passed (20.4s)`.
- Full frontend Vitest suite passed: `86 passed`, `570 tests`.
