### PR TITLE
[finance_report_ui] Fold workflow navigation into advanced drill-downs

### DIFF
--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -82,6 +82,25 @@ def test_AC19_4_1_upload_first_home_ssot_documents_dashboard_contract() -> None:
     assert "must not block upload, event, or report readiness actions" in normalized_epic
 
 
+def test_AC19_6_1_workflow_navigation_ssot_documents_primary_and_advanced_groups() -> None:
+    """AC19.6.1: workflow navigation IA is documented in SSOT and EPIC."""
+    ssot = (ROOT_DIR / "docs" / "ssot" / "workflow-events.md").read_text(encoding="utf-8")
+    epic = (ROOT_DIR / "docs" / "project" / "EPIC-019.event-driven-upload-to-report-ux.md").read_text(encoding="utf-8")
+
+    for phrase in (
+        "Primary navigation:",
+        "Upload -> /dashboard",
+        "Advanced navigation:",
+        "Statements -> /statements",
+        "AI Settings -> /chat",
+        "Navigation attention indicators must use `GET /api/workflow/status` through",
+    ):
+        assert phrase in ssot
+
+    assert "AC19.6.1" in epic
+    assert "AC19.6.7" in epic
+
+
 def test_AC19_1_2_workflow_event_model_contract() -> None:
     """AC19.1.2: workflow_events model exposes lifecycle, dedupe, and read indexes."""
     table = WorkflowEvent.__table__

--- a/apps/frontend/playwright/workflow-navigation.spec.ts
+++ b/apps/frontend/playwright/workflow-navigation.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const COLD_ROUTE_TIMEOUT_MS = 10_000;
+
+const workflowStatus = {
+  primary_state: "needs_action",
+  next_action: { type: "review_required", count: 2, href: "/review" },
+  report_readiness: { state: "blocked", blocking_count: 1, href: "/reports" },
+  event_counts: { unread: 4, action_required: 2, blocked: 1 },
+};
+
+async function installNavigationMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("finance_access_token", "workflow-navigation-token");
+    localStorage.setItem("finance_user_id", "workflow-navigation-user");
+    localStorage.setItem("finance_user_email", "workflow-navigation@example.com");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    let body: unknown = {};
+
+    if (path === "/api/workflow/status") {
+      body = workflowStatus;
+    } else if (path === "/api/workflow/events") {
+      body = { items: [], total: 0 };
+    } else if (path.startsWith("/api/reports/balance-sheet")) {
+      body = {
+        as_of_date: "2026-06-04",
+        currency: "SGD",
+        assets: [],
+        liabilities: [],
+        equity: [],
+        total_assets: "0.00",
+        total_liabilities: "0.00",
+        total_equity: "0.00",
+        equation_delta: "0.00",
+        is_balanced: true,
+      };
+    } else if (path.startsWith("/api/reports/income-statement")) {
+      body = {
+        start_date: "2026-01-01",
+        end_date: "2026-06-04",
+        currency: "SGD",
+        income: [],
+        expenses: [],
+        total_income: "0.00",
+        total_expenses: "0.00",
+        net_income: "0.00",
+        trends: [],
+      };
+    } else if (path.startsWith("/api/reports/trend")) {
+      body = { points: [] };
+    } else if (path === "/api/income/annualized") {
+      body = {
+        annualized_salary: "0.00",
+        annualized_bonus: "0.00",
+        annualized_dividend: "0.00",
+        annualized_total: "0.00",
+        currency: "SGD",
+        as_of: "2026-06-04",
+      };
+    } else if (path === "/api/assets/restricted") {
+      body = [];
+    } else if (path === "/api/reconciliation/stats") {
+      body = {
+        total_transactions: 0,
+        matched_transactions: 0,
+        unmatched_transactions: 0,
+        pending_review: 0,
+        auto_accepted: 0,
+        match_rate: 0,
+        score_distribution: {},
+      };
+    } else if (path === "/api/reconciliation/unmatched") {
+      body = { items: [], total: 0 };
+    } else if (path === "/api/accounts") {
+      body = { items: [], total: 0 };
+    } else if (path === "/api/statements") {
+      body = { items: [], total: 0 };
+    } else if (path.startsWith("/api/journal-entries")) {
+      body = { items: [], total: 0 };
+    }
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+}
+
+async function expectNoDocumentHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    scrollX: window.scrollX,
+  }));
+
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.scrollX).toBe(0);
+}
+
+test.describe("AC19.6.7 workflow navigation folding", () => {
+  test.beforeEach(async ({ page }) => {
+    await installNavigationMocks(page);
+  });
+
+  test("desktop exposes primary workflow nav and advanced drill-downs", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto("/dashboard", { waitUntil: "networkidle" });
+
+    const nav = page.getByRole("navigation", { name: "Sidebar navigation" });
+    await expect(nav.getByRole("link", { name: "Upload" })).toHaveAttribute("href", "/dashboard");
+    await expect(nav.getByRole("link", { name: /Events.*4/ })).toHaveAttribute("href", "/events");
+    await expect(nav.getByRole("link", { name: "Reports" })).toHaveAttribute("href", "/reports");
+    await expect(nav.getByRole("link", { name: "Portfolio" })).toHaveAttribute("href", "/portfolio");
+    await expect(nav.getByRole("button", { name: /Advanced.*3/ })).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
+
+    await nav.getByRole("button", { name: /Advanced/ }).click();
+    await expect(nav.getByRole("link", { name: "Statements" })).toHaveAttribute("href", "/statements");
+    await expect(nav.getByRole("link", { name: "Review" })).toHaveAttribute("href", "/review");
+    await expect(nav.getByRole("link", { name: "Reconciliation" })).toHaveAttribute("href", "/reconciliation");
+    await expect(nav.getByRole("link", { name: "Processing" })).toHaveAttribute("href", "/processing");
+    await expect(nav.getByRole("link", { name: "AI Settings" })).toHaveAttribute("href", "/chat");
+    await expectNoDocumentHorizontalScroll(page);
+  });
+
+  test("mobile exposes the same primary and advanced route access", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/dashboard", { waitUntil: "networkidle" });
+
+    await page.getByLabel("Open navigation menu").click();
+    const dialog = page.getByRole("dialog", { name: "Finance Report" });
+    await expect(dialog.getByRole("link", { name: "Upload" })).toHaveAttribute("href", "/dashboard");
+    await expect(dialog.getByRole("link", { name: "Events" })).toHaveAttribute("href", "/events");
+    await expect(dialog.getByRole("link", { name: "Reports" })).toHaveAttribute("href", "/reports");
+    await expect(dialog.getByRole("link", { name: "Portfolio" })).toHaveAttribute("href", "/portfolio");
+
+    await dialog.getByRole("button", { name: "Advanced" }).click();
+    await expect(dialog.getByRole("link", { name: "Statements" })).toHaveAttribute("href", "/statements");
+    await expect(dialog.getByRole("link", { name: "Review" })).toHaveAttribute("href", "/review");
+    await expect(dialog.getByRole("link", { name: "AI Settings" })).toHaveAttribute("href", "/chat");
+    await expectNoDocumentHorizontalScroll(page);
+  });
+});

--- a/apps/frontend/src/__tests__/mobileNav.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/mobileNav.coverage.test.tsx
@@ -1,14 +1,20 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { fireEvent, screen } from "@testing-library/react";
 import { MobileNav } from "@/components/MobileNav";
 import { renderReviewComponent } from "./helpers/renderReviewComponent";
 
+let pathnameMock = "/dashboard";
+
 vi.mock("next/navigation", () => ({
-    usePathname: () => "/dashboard",
+    usePathname: () => pathnameMock,
     useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
 }));
 
 describe("MobileNav coverage (AC16.23.6)", () => {
+    beforeEach(() => {
+        pathnameMock = "/dashboard";
+    });
+
     it("AC19.6.4 opens workflow mobile nav, exposes Advanced drill-downs, and closes via link click", () => {
         renderReviewComponent(<MobileNav />);
         const trigger = screen.getByLabelText("Open navigation menu");
@@ -39,5 +45,17 @@ describe("MobileNav coverage (AC16.23.6)", () => {
         fireEvent.click(screen.getByRole("button", { name: /advanced/i }));
         fireEvent.click(screen.getByRole("link", { name: /review/i }));
         expect(screen.queryByRole("link", { name: /review/i })).not.toBeInTheDocument();
+    });
+
+    it("AC19.6.4 highlights active advanced routes in mobile navigation", () => {
+        pathnameMock = "/review/run/run-1";
+        renderReviewComponent(<MobileNav />);
+
+        fireEvent.click(screen.getByLabelText("Open navigation menu"));
+        const advancedButton = screen.getByRole("button", { name: /advanced/i });
+        expect(advancedButton.className).toContain("accent-muted");
+        fireEvent.click(advancedButton);
+        const reviewLink = screen.getByRole("link", { name: /review/i });
+        expect(reviewLink.className).toContain("accent-muted");
     });
 });

--- a/apps/frontend/src/__tests__/mobileNav.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/mobileNav.coverage.test.tsx
@@ -9,28 +9,35 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("MobileNav coverage (AC16.23.6)", () => {
-    it("AC16.23.5 opens a full mobile nav drawer with active highlighting, closes via close button, and closes via link click", () => {
+    it("AC19.6.4 opens workflow mobile nav, exposes Advanced drill-downs, and closes via link click", () => {
         renderReviewComponent(<MobileNav />);
         const trigger = screen.getByLabelText("Open navigation menu");
         fireEvent.click(trigger);
-        const dashboardLink = screen.getByRole("link", { name: /dashboard/i });
-        expect(dashboardLink).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /accounts/i })).toHaveAttribute("href", "/accounts");
-        expect(screen.getByRole("link", { name: /journal/i })).toHaveAttribute("href", "/journal");
+        const uploadLink = screen.getByRole("link", { name: /upload/i });
+        expect(uploadLink).toHaveAttribute("href", "/dashboard");
+        expect(screen.getByRole("link", { name: /events/i })).toHaveAttribute("href", "/events");
+        expect(screen.getByRole("link", { name: /reports/i })).toHaveAttribute("href", "/reports");
+        expect(screen.getByRole("link", { name: /portfolio/i })).toHaveAttribute("href", "/portfolio");
+        expect(screen.queryByRole("link", { name: /accounts/i })).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /advanced/i })).toBeInTheDocument();
+        expect(uploadLink.className).toContain("accent-muted");
+
+        fireEvent.click(screen.getByRole("button", { name: /advanced/i }));
         expect(screen.getByRole("link", { name: /statements/i })).toHaveAttribute("href", "/statements");
         expect(screen.getByRole("link", { name: /review/i })).toHaveAttribute("href", "/review");
-        expect(screen.getByRole("link", { name: /portfolio/i })).toHaveAttribute("href", "/portfolio");
-        expect(screen.getByRole("link", { name: /reports/i })).toHaveAttribute("href", "/reports");
+        expect(screen.getByRole("link", { name: /accounts/i })).toHaveAttribute("href", "/accounts");
+        expect(screen.getByRole("link", { name: /journal/i })).toHaveAttribute("href", "/journal");
         expect(screen.getByRole("link", { name: /reconciliation/i })).toHaveAttribute("href", "/reconciliation");
         expect(screen.getByRole("link", { name: /processing/i })).toHaveAttribute("href", "/processing");
-        expect(screen.getByRole("link", { name: /ai advisor/i })).toHaveAttribute("href", "/chat");
-        expect(dashboardLink.className).toContain("accent-muted");
+        expect(screen.getByRole("link", { name: /ai settings/i })).toHaveAttribute("href", "/chat");
 
         const closeBtn = screen.getByText("Close panel").closest("button")!;
         fireEvent.click(closeBtn);
-        expect(screen.queryByRole("link", { name: /dashboard/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: /upload/i })).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByLabelText("Open navigation menu"));
+        fireEvent.click(screen.getByRole("button", { name: /advanced/i }));
         fireEvent.click(screen.getByRole("link", { name: /review/i }));
+        expect(screen.queryByRole("link", { name: /review/i })).not.toBeInTheDocument();
     });
 });

--- a/apps/frontend/src/__tests__/navigation.test.ts
+++ b/apps/frontend/src/__tests__/navigation.test.ts
@@ -38,6 +38,7 @@ describe("navigation metadata", () => {
     expect(getRouteConfig("/review/run/123").label).toBe("Review");
     expect(getRouteConfig("/reconciliation/unmatched").label).toBe("Unmatched");
     expect(getRouteConfig("/processing").label).toBe("Processing");
+    expect(getRouteConfig("/chat").label).toBe("AI Settings");
     expect(getRouteConfig("/custom-report_page").label).toBe("Custom Report Page");
     expect(getRouteConfig("/").Icon).toBe(DEFAULT_ROUTE_ICON);
   });

--- a/apps/frontend/src/__tests__/navigation.test.ts
+++ b/apps/frontend/src/__tests__/navigation.test.ts
@@ -1,27 +1,43 @@
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_ROUTE_ICON, getRouteConfig, primaryNavItems } from "@/components/navigation";
+import {
+  DEFAULT_ROUTE_ICON,
+  advancedNavItems,
+  getRouteConfig,
+  primaryWorkflowNavItems,
+} from "@/components/navigation";
 
 describe("navigation metadata", () => {
-  it("AC16.23.5 exposes the full primary navigation set for mobile and desktop", () => {
-    expect(primaryNavItems.map((item) => item.label)).toEqual([
-      "Dashboard",
+  it("AC19.6.2 exposes primary workflow navigation separately from advanced drill-downs", () => {
+    expect(primaryWorkflowNavItems.map((item) => item.label)).toEqual([
+      "Upload",
       "Events",
-      "Accounts",
-      "Journal",
+      "Reports",
+      "Portfolio",
+    ]);
+    expect(primaryWorkflowNavItems.map((item) => item.href)).toEqual([
+      "/dashboard",
+      "/events",
+      "/reports",
+      "/portfolio",
+    ]);
+    expect(advancedNavItems.map((item) => item.label)).toEqual([
       "Statements",
       "Review",
-      "Portfolio",
-      "Reports",
+      "Accounts",
+      "Journal",
       "Reconciliation",
       "Processing",
-      "AI Advisor",
+      "AI Settings",
     ]);
   });
 
-  it("AC16.19.4 resolves exact, parent, and derived route labels", () => {
+  it("AC16.19.4 AC19.6.6 resolves exact, parent, and advanced deep-link route labels", () => {
     expect(getRouteConfig("/reports/balance-sheet").label).toBe("Balance Sheet");
     expect(getRouteConfig("/reports/balance-sheet/detail").label).toBe("Balance Sheet");
+    expect(getRouteConfig("/review/run/123").label).toBe("Review");
+    expect(getRouteConfig("/reconciliation/unmatched").label).toBe("Unmatched");
+    expect(getRouteConfig("/processing").label).toBe("Processing");
     expect(getRouteConfig("/custom-report_page").label).toBe("Custom Report Page");
     expect(getRouteConfig("/").Icon).toBe(DEFAULT_ROUTE_ICON);
   });

--- a/apps/frontend/src/__tests__/sidebarAndTabs.test.tsx
+++ b/apps/frontend/src/__tests__/sidebarAndTabs.test.tsx
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Sidebar } from "@/components/Sidebar"
 import { WorkspaceTabs } from "@/components/WorkspaceTabs"
-import { apiFetch } from "@/lib/api"
+import { apiFetch, fetchWorkflowStatus } from "@/lib/api"
+import type { WorkflowStatusResponse } from "@/lib/types"
 
 const pushMock = vi.fn()
 const toggleSidebarMock = vi.fn()
@@ -14,6 +15,7 @@ const clearUserMock = vi.fn()
 const getUserEmailMock = vi.fn()
 const isAuthenticatedMock = vi.fn()
 const mockedApiFetch = vi.mocked(apiFetch)
+const mockedFetchWorkflowStatus = vi.mocked(fetchWorkflowStatus)
 
 let pathnameMock = "/dashboard"
 
@@ -34,7 +36,15 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/lib/api", () => ({
   apiFetch: vi.fn(),
+  fetchWorkflowStatus: vi.fn(),
 }))
+
+const defaultWorkflowStatus: WorkflowStatusResponse = {
+  primary_state: "needs_action",
+  next_action: { type: "review_required", count: 2, href: "/review" },
+  report_readiness: { state: "blocked", blocking_count: 1, href: "/reports" },
+  event_counts: { unread: 4, action_required: 2, blocked: 1 },
+}
 
 let workspaceMockData = {
     isCollapsed: false,
@@ -51,8 +61,6 @@ vi.mock("@/hooks/useWorkspace", () => ({
 }))
 
 describe("Sidebar and WorkspaceTabs", () => {
-  const expectedReviewBadgeCountFromMocks = "3"
-
   beforeEach(() => {
     pushMock.mockReset()
     toggleSidebarMock.mockReset()
@@ -63,21 +71,12 @@ describe("Sidebar and WorkspaceTabs", () => {
     getUserEmailMock.mockReset()
     isAuthenticatedMock.mockReset()
     mockedApiFetch.mockReset()
+    mockedFetchWorkflowStatus.mockReset()
     pathnameMock = "/dashboard"
     getUserEmailMock.mockReturnValue("user@example.com")
     isAuthenticatedMock.mockReturnValue(true)
-    mockedApiFetch.mockImplementation(async (path: string) => {
-      if (path === "/api/statements/pending-review") {
-        return { items: [{ id: "s1" }, { id: "s2" }], total: 2 }
-      }
-      if (path === "/api/statements/stage2/queue") {
-        return { pending_matches: [{ id: "m1", status: "pending_review" }, { id: "m2", status: "accepted" }] }
-      }
-      if (path === "/api/accounts/processing/summary") {
-        return { pending_count: 0, pending_total: "0.00", current_balance: "0.00", currency: "SGD", oldest_pending_date: null }
-      }
-      return {}
-    })
+    mockedApiFetch.mockResolvedValue({})
+    mockedFetchWorkflowStatus.mockResolvedValue(defaultWorkflowStatus)
     workspaceMockData = {
       isCollapsed: false,
       toggleSidebar: toggleSidebarMock,
@@ -92,10 +91,9 @@ describe("Sidebar and WorkspaceTabs", () => {
   it("AC16.19.3 shows auth-aware sidebar actions and logout behavior", async () => {
     render(<Sidebar />)
 
-    await waitFor(() => expect(screen.getByText("Dashboard")).toBeInTheDocument())
-    const reviewLink = await screen.findByRole("link", { name: /Review/i })
-    expect(reviewLink).toHaveAttribute("href", "/review")
-    expect(screen.getByText(expectedReviewBadgeCountFromMocks)).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole("link", { name: /Upload/i })).toBeInTheDocument())
+    expect(screen.getByRole("link", { name: /Events/i })).toHaveAttribute("href", "/events")
+    expect(screen.getByRole("button", { name: /Advanced/i })).toBeInTheDocument()
     expect(screen.getByText("user@example.com")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument()
 
@@ -104,24 +102,18 @@ describe("Sidebar and WorkspaceTabs", () => {
     expect(pushMock).toHaveBeenCalledWith("/login")
   })
 
-  it("AC15.7.3 exposes Processing Account in sidebar", async () => {
-    mockedApiFetch.mockImplementation(async (path: string) => {
-      if (path === "/api/statements/pending-review") {
-        return { items: [], total: 0 }
-      }
-      if (path === "/api/statements/stage2/queue") {
-        return { pending_matches: [] }
-      }
-      if (path === "/api/accounts/processing/summary") {
-        return { pending_count: 4, pending_total: "1250.00", current_balance: "0.00", currency: "SGD", oldest_pending_date: "2026-05-01" }
-      }
-      return {}
-    })
-
+  it("AC19.6.3 exposes advanced accounting surfaces behind the Advanced group", async () => {
     render(<Sidebar />)
 
-    const processingLink = await screen.findByRole("link", { name: /Processing/i })
+    fireEvent.click(await screen.findByRole("button", { name: /Advanced/i }))
+    expect(screen.getByRole("link", { name: /Statements/i })).toHaveAttribute("href", "/statements")
+    expect(screen.getByRole("link", { name: /Review/i })).toHaveAttribute("href", "/review")
+    expect(screen.getByRole("link", { name: /Accounts/i })).toHaveAttribute("href", "/accounts")
+    expect(screen.getByRole("link", { name: /Journal/i })).toHaveAttribute("href", "/journal")
+    expect(screen.getByRole("link", { name: /Reconciliation/i })).toHaveAttribute("href", "/reconciliation")
+    const processingLink = screen.getByRole("link", { name: /Processing/i })
     expect(processingLink).toHaveAttribute("href", "/processing")
+    expect(screen.getByRole("link", { name: /AI Settings/i })).toHaveAttribute("href", "/chat")
   })
 
   it("AC16.19.4 adds and manages workspace tabs from route changes", async () => {
@@ -158,40 +150,33 @@ describe("Sidebar and WorkspaceTabs", () => {
     })))
   });
 
-  it("AC16.19.12 sidebar nav shows Portfolio label for /assets route", () => {
+  it("AC16.19.12 sidebar nav shows Portfolio label for /assets route", async () => {
     render(<Sidebar />)
-    expect(screen.getByText("Portfolio")).toBeInTheDocument()
+    expect(await screen.findByText("Portfolio")).toBeInTheDocument()
     expect(screen.queryByText("Assets")).not.toBeInTheDocument()
   })
 
-  it("AC15.7.6 shows Processing between Reconciliation and AI Advisor", async () => {
+  it("AC15.7.6 AC19.6.3 shows Processing between Reconciliation and AI Settings in Advanced", async () => {
     render(<Sidebar />)
 
+    fireEvent.click(await screen.findByRole("button", { name: /Advanced/i }))
     await waitFor(() => expect(screen.getByText("Processing")).toBeInTheDocument())
     const labels = screen.getAllByRole("link").map((link) => link.textContent ?? "")
     expect(labels.indexOf("Reconciliation")).toBeLessThan(labels.indexOf("Processing"))
-    expect(labels.indexOf("Processing")).toBeLessThan(labels.indexOf("AI Advisor"))
+    expect(labels.indexOf("Processing")).toBeLessThan(labels.indexOf("AI Settings"))
   })
 
-  it("AC15.7.7 shows a sidebar warning when Processing Account balance is non-zero", async () => {
-    mockedApiFetch.mockImplementation(async (path: string) => {
-      if (path === "/api/statements/pending-review") {
-        return { items: [], total: 0 }
-      }
-      if (path === "/api/statements/stage2/queue") {
-        return { pending_matches: [] }
-      }
-      if (path === "/api/accounts/processing/summary") {
-        return { pending_count: 1, pending_total: "100.00", current_balance: "100.00", currency: "SGD", oldest_pending_date: "2026-05-01" }
-      }
-      return {}
-    })
-
+  it("AC15.7.7 AC19.6.5 derives sidebar attention badges from workflow status instead of local processing or review polling", async () => {
     render(<Sidebar />)
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Processing Account has unresolved balance")).toBeInTheDocument()
+      expect(mockedFetchWorkflowStatus).toHaveBeenCalledTimes(1)
     })
+    expect(screen.getByRole("link", { name: /Events 4/i })).toHaveAttribute("href", "/events")
+    expect(screen.getByRole("button", { name: /Advanced 3/i })).toBeInTheDocument()
+    expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/statements/pending-review")
+    expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/statements/stage2/queue")
+    expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/accounts/processing/summary")
   })
 
   it("AC16.19.13 WorkspaceTabs labels /assets tab as Portfolio from ROUTE_CONFIG", async () => {

--- a/apps/frontend/src/__tests__/sidebarAndTabs.test.tsx
+++ b/apps/frontend/src/__tests__/sidebarAndTabs.test.tsx
@@ -116,6 +116,15 @@ describe("Sidebar and WorkspaceTabs", () => {
     expect(screen.getByRole("link", { name: /AI Settings/i })).toHaveAttribute("href", "/chat")
   })
 
+  it("AC19.6.3 opens Advanced automatically for active advanced routes", async () => {
+    pathnameMock = "/review/run/run-1"
+    render(<Sidebar />)
+
+    const advancedButton = await screen.findByRole("button", { name: /Advanced/i })
+    expect(advancedButton).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByRole("link", { name: /Review/i })).toHaveAttribute("href", "/review")
+  })
+
   it("AC16.19.4 adds and manages workspace tabs from route changes", async () => {
     pathnameMock = "/reports/balance-sheet"
     render(<WorkspaceTabs />)
@@ -177,6 +186,18 @@ describe("Sidebar and WorkspaceTabs", () => {
     expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/statements/pending-review")
     expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/statements/stage2/queue")
     expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/accounts/processing/summary")
+  })
+
+  it("AC19.6.5 clears sidebar workflow badges when workflow status is unavailable", async () => {
+    mockedFetchWorkflowStatus.mockRejectedValue(new Error("workflow unavailable"))
+
+    render(<Sidebar />)
+
+    await waitFor(() => {
+      expect(mockedFetchWorkflowStatus).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByRole("link", { name: /^Events$/i })).toHaveAttribute("href", "/events")
+    expect(screen.getByRole("button", { name: /^Advanced$/i })).toBeInTheDocument()
   })
 
   it("AC16.19.13 WorkspaceTabs labels /assets tab as Portfolio from ROUTE_CONFIG", async () => {

--- a/apps/frontend/src/__tests__/sidebarAndTabs.test.tsx
+++ b/apps/frontend/src/__tests__/sidebarAndTabs.test.tsx
@@ -180,9 +180,9 @@ describe("Sidebar and WorkspaceTabs", () => {
 
     await waitFor(() => {
       expect(mockedFetchWorkflowStatus).toHaveBeenCalledTimes(1)
+      expect(screen.getByRole("link", { name: /Events 4/i })).toHaveAttribute("href", "/events")
+      expect(screen.getByRole("button", { name: /Advanced 3/i })).toBeInTheDocument()
     })
-    expect(screen.getByRole("link", { name: /Events 4/i })).toHaveAttribute("href", "/events")
-    expect(screen.getByRole("button", { name: /Advanced 3/i })).toBeInTheDocument()
     expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/statements/pending-review")
     expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/statements/stage2/queue")
     expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/accounts/processing/summary")

--- a/apps/frontend/src/components/MobileNav.tsx
+++ b/apps/frontend/src/components/MobileNav.tsx
@@ -3,13 +3,19 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Menu } from "lucide-react";
+import { ChevronDown, FolderOpen, Menu } from "lucide-react";
 import Sheet from "@/components/ui/Sheet";
-import { primaryNavItems } from "@/components/navigation";
+import { advancedNavItems, primaryWorkflowNavItems } from "@/components/navigation";
 
 export function MobileNav() {
     const [isOpen, setIsOpen] = useState(false);
+    const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
     const pathname = usePathname();
+    const isAdvancedActive = advancedNavItems.some((item) => pathname === item.href || pathname.startsWith(item.href + "/"));
+    const closeNavigation = () => {
+        setIsOpen(false);
+        setIsAdvancedOpen(false);
+    };
 
     return (
         <div className="md:hidden">
@@ -23,12 +29,12 @@ export function MobileNav() {
 
             <Sheet
                 isOpen={isOpen}
-                onClose={() => setIsOpen(false)}
+                onClose={closeNavigation}
                 title="Finance Report"
                 width="max-w-xs"
             >
-                <nav className="space-y-1">
-                    {primaryNavItems.map((item) => {
+                <nav className="space-y-1" aria-label="Mobile navigation">
+                    {primaryWorkflowNavItems.map((item) => {
                         const Icon = item.icon;
                         const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
                         
@@ -36,7 +42,7 @@ export function MobileNav() {
                             <Link
                                 key={item.href}
                                 href={item.href}
-                                onClick={() => setIsOpen(false)}
+                                onClick={closeNavigation}
                                 className={`
                                     flex items-center gap-3 px-3 py-4 rounded-md transition-colors text-base font-medium
                                     ${isActive 
@@ -45,11 +51,60 @@ export function MobileNav() {
                                     }
                                 `}
                             >
-                                <Icon className="w-6 h-6" />
+                                <Icon className="w-6 h-6" aria-hidden="true" />
                                 {item.label}
                             </Link>
                         );
                     })}
+
+                    <div className="pt-1">
+                        <button
+                            type="button"
+                            onClick={() => setIsAdvancedOpen((open) => !open)}
+                            className={`
+                                flex w-full items-center gap-3 rounded-md px-3 py-4 text-base font-medium transition-colors
+                                ${isAdvancedActive
+                                    ? "bg-[var(--accent-muted)] text-[var(--accent)]"
+                                    : "text-muted hover:bg-[var(--background-muted)] hover:text-[var(--foreground)]"
+                                }
+                            `}
+                            aria-expanded={isAdvancedOpen}
+                        >
+                            <FolderOpen className="h-6 w-6" aria-hidden="true" />
+                            <span>Advanced</span>
+                            <ChevronDown
+                                className={`ml-auto h-5 w-5 transition-transform ${isAdvancedOpen ? "rotate-180" : ""}`}
+                                aria-hidden="true"
+                            />
+                        </button>
+
+                        {isAdvancedOpen && (
+                            <div className="mt-1 space-y-1 pl-3">
+                                {advancedNavItems.map((item) => {
+                                    const Icon = item.icon;
+                                    const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
+
+                                    return (
+                                        <Link
+                                            key={item.href}
+                                            href={item.href}
+                                            onClick={closeNavigation}
+                                            className={`
+                                                flex items-center gap-3 rounded-md px-3 py-3 text-base font-medium transition-colors
+                                                ${isActive
+                                                    ? "bg-[var(--accent-muted)] text-[var(--accent)]"
+                                                    : "text-muted hover:bg-[var(--background-muted)] hover:text-[var(--foreground)]"
+                                                }
+                                            `}
+                                        >
+                                            <Icon className="h-5 w-5" aria-hidden="true" />
+                                            {item.label}
+                                        </Link>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </div>
                 </nav>
             </Sheet>
         </div>

--- a/apps/frontend/src/components/Sidebar.tsx
+++ b/apps/frontend/src/components/Sidebar.tsx
@@ -5,12 +5,10 @@ import { useRouter, usePathname } from "next/navigation";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { clearUser, getUserEmail, isAuthenticated } from "@/lib/auth";
-import { apiFetch } from "@/lib/api";
-import { isAmountZero } from "@/lib/currency";
-import type { ProcessingSummaryResponse } from "@/lib/types";
-import { primaryNavItems } from "@/components/navigation";
+import { fetchWorkflowStatus } from "@/lib/api";
+import { advancedNavItems, primaryWorkflowNavItems, type NavItem } from "@/components/navigation";
 import { useState, useEffect } from "react";
-import { LogIn, LogOut, Zap } from "lucide-react";
+import { ChevronDown, FolderOpen, LogIn, LogOut, Zap } from "lucide-react";
 
 // Hide dev routes in production
 const IS_DEV = process.env.NODE_ENV === "development";
@@ -21,8 +19,11 @@ export function Sidebar() {
     const { isCollapsed, toggleSidebar } = useWorkspace();
     const [userEmail, setUserEmail] = useState<string | null>(null);
     const [isAuth, setIsAuth] = useState(false);
-    const [pendingReviewCount, setPendingReviewCount] = useState(0);
-    const [hasProcessingBalanceWarning, setHasProcessingBalanceWarning] = useState(false);
+    const [workflowBadgeCount, setWorkflowBadgeCount] = useState(0);
+    const [advancedAttentionCount, setAdvancedAttentionCount] = useState(0);
+    const [isAdvancedOpen, setIsAdvancedOpen] = useState(() =>
+        advancedNavItems.some((item) => pathname === item.href || pathname.startsWith(item.href + "/")),
+    );
 
     useEffect(() => {
         setUserEmail(getUserEmail());
@@ -31,64 +32,89 @@ export function Sidebar() {
 
     useEffect(() => {
         if (!isAuth) {
-            setPendingReviewCount(0);
+            setWorkflowBadgeCount(0);
+            setAdvancedAttentionCount(0);
             return;
         }
 
-        const fetchPendingReviewCount = async () => {
+        const fetchWorkflowAttention = async () => {
             try {
-                const [stage1, stage2] = await Promise.all([
-                    apiFetch<{ items: Array<{ id: string }>; total: number }>("/api/statements/pending-review"),
-                    apiFetch<{ pending_matches: Array<{ id: string; status: string }> }>("/api/statements/stage2/queue"),
-                ]);
-
-                const stage2Pending = stage2.pending_matches.filter((match) => match.status === "pending_review").length;
-                setPendingReviewCount((stage1.total || 0) + stage2Pending);
+                const status = await fetchWorkflowStatus();
+                const attentionCount = status.event_counts.blocked + status.event_counts.action_required;
+                setWorkflowBadgeCount(status.event_counts.unread || attentionCount);
+                setAdvancedAttentionCount(attentionCount);
             } catch {
-                setPendingReviewCount(0);
+                setWorkflowBadgeCount(0);
+                setAdvancedAttentionCount(0);
             }
         };
 
-        fetchPendingReviewCount();
-        const refreshInterval = window.setInterval(fetchPendingReviewCount, 30000);
-        window.addEventListener("focus", fetchPendingReviewCount);
+        void fetchWorkflowAttention();
+        const refreshInterval = window.setInterval(fetchWorkflowAttention, 30000);
+        window.addEventListener("focus", fetchWorkflowAttention);
 
         return () => {
             window.clearInterval(refreshInterval);
-            window.removeEventListener("focus", fetchPendingReviewCount);
+            window.removeEventListener("focus", fetchWorkflowAttention);
         };
     }, [isAuth]);
 
     useEffect(() => {
-        if (!isAuth) {
-            setHasProcessingBalanceWarning(false);
-            return;
+        if (advancedNavItems.some((item) => pathname === item.href || pathname.startsWith(item.href + "/"))) {
+            setIsAdvancedOpen(true);
         }
-
-        const fetchProcessingSummary = async () => {
-            try {
-                const summary = await apiFetch<ProcessingSummaryResponse>("/api/accounts/processing/summary");
-                const balance = summary.current_balance ?? summary.pending_total ?? "0.00";
-                setHasProcessingBalanceWarning(!isAmountZero(balance, 0));
-            } catch {
-                setHasProcessingBalanceWarning(false);
-            }
-        };
-
-        fetchProcessingSummary();
-        const refreshInterval = window.setInterval(fetchProcessingSummary, 30000);
-        window.addEventListener("focus", fetchProcessingSummary);
-
-        return () => {
-            window.clearInterval(refreshInterval);
-            window.removeEventListener("focus", fetchProcessingSummary);
-        };
-    }, [isAuth]);
+    }, [pathname]);
 
     const handleLogout = () => {
         clearUser();
         router.push("/login");
     };
+
+    const renderNavLink = (item: NavItem, badgeCount = 0, inset = false) => {
+        const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
+        const IconComponent = item.icon;
+        const label = badgeCount > 0 ? `${item.label} ${badgeCount}` : item.label;
+
+        return (
+            <Link
+                key={item.href}
+                href={item.href}
+                className={`
+                    relative flex items-center gap-2.5 rounded-md min-h-[44px]
+                    transition-colors text-sm
+                    ${inset ? "px-2.5 py-2.5" : "px-2.5 py-3"}
+                    ${isActive
+                        ? "bg-[var(--accent-muted)] text-[var(--accent)]"
+                        : "text-muted hover:bg-[var(--background-muted)] hover:text-[var(--foreground)]"
+                    }
+                    ${isCollapsed ? "justify-center" : ""}
+                `}
+                title={isCollapsed ? label : undefined}
+                aria-label={isCollapsed ? label : undefined}
+            >
+                <span className="relative flex h-5 w-5 flex-shrink-0 items-center justify-center">
+                    <IconComponent className="w-5 h-5" aria-hidden="true" />
+                    {isCollapsed && badgeCount > 0 && (
+                        <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-[var(--warning)] ring-2 ring-[var(--background-card)]" />
+                    )}
+                </span>
+                {!isCollapsed && (
+                    <>
+                        <span className="font-medium">{item.label}</span>
+                        {badgeCount > 0 && (
+                            <span className="ml-auto inline-flex min-w-[1.5rem] items-center justify-center rounded-full bg-[var(--warning)] px-1.5 py-0.5 text-xs font-semibold text-white">
+                                {badgeCount > 99 ? "99+" : badgeCount}
+                            </span>
+                        )}
+                    </>
+                )}
+            </Link>
+        );
+    };
+
+    const visiblePrimaryItems = primaryWorkflowNavItems.filter(item => isAuth || !item.protected);
+    const visibleAdvancedItems = advancedNavItems.filter(item => isAuth || !item.protected);
+    const isAdvancedActive = visibleAdvancedItems.some((item) => pathname === item.href || pathname.startsWith(item.href + "/"));
 
     return (
         <aside
@@ -133,52 +159,58 @@ export function Sidebar() {
 
             {/* Navigation */}
             <nav className="p-2 space-y-0.5" aria-label="Sidebar navigation">
-                {primaryNavItems.filter(item => isAuth || !item.protected).map((item) => {
-                    const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
-                    const IconComponent = item.icon;
-                    const badgeCount = item.href === "/review" ? pendingReviewCount : 0;
-                    const showProcessingWarning = item.href === "/processing" && hasProcessingBalanceWarning;
-                    return (
-                        <Link
-                            key={item.href}
-                            href={item.href}
+                {visiblePrimaryItems.map((item) => renderNavLink(
+                    item,
+                    item.href === "/events" ? workflowBadgeCount : 0,
+                ))}
+
+                {visibleAdvancedItems.length > 0 && (
+                    <div className="pt-1">
+                        <button
+                            type="button"
+                            onClick={() => setIsAdvancedOpen((open) => !open)}
                             className={`
-                relative flex items-center gap-2.5 px-2.5 py-3 rounded-md min-h-[44px]
-                transition-colors text-sm
-                ${isActive
+                                relative flex w-full items-center gap-2.5 rounded-md px-2.5 py-3 min-h-[44px]
+                                text-sm transition-colors
+                                ${isAdvancedActive
                                     ? "bg-[var(--accent-muted)] text-[var(--accent)]"
                                     : "text-muted hover:bg-[var(--background-muted)] hover:text-[var(--foreground)]"
                                 }
-                ${isCollapsed ? "justify-center" : ""}
-              `}
-                            title={isCollapsed ? item.label : undefined}
-                            aria-label={isCollapsed ? item.label : undefined}
+                                ${isCollapsed ? "justify-center" : ""}
+                            `}
+                            title={isCollapsed ? `Advanced${advancedAttentionCount > 0 ? ` ${advancedAttentionCount}` : ""}` : undefined}
+                            aria-label={`Advanced${advancedAttentionCount > 0 ? ` ${advancedAttentionCount}` : ""}`}
+                            aria-expanded={isAdvancedOpen}
                         >
                             <span className="relative flex h-5 w-5 flex-shrink-0 items-center justify-center">
-                                <IconComponent className="w-5 h-5" aria-hidden="true" />
-                                {showProcessingWarning && (
-                                    <span
-                                        className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-[var(--warning)] ring-2 ring-[var(--background-card)]"
-                                        aria-label="Processing Account has unresolved balance"
-                                    />
+                                <FolderOpen className="w-5 h-5" aria-hidden="true" />
+                                {isCollapsed && advancedAttentionCount > 0 && (
+                                    <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-[var(--warning)] ring-2 ring-[var(--background-card)]" />
                                 )}
                             </span>
                             {!isCollapsed && (
                                 <>
-                                    <span className="font-medium">{item.label}</span>
-                                    {badgeCount > 0 && (
+                                    <span className="font-medium">Advanced</span>
+                                    {advancedAttentionCount > 0 && (
                                         <span className="ml-auto inline-flex min-w-[1.5rem] items-center justify-center rounded-full bg-[var(--warning)] px-1.5 py-0.5 text-xs font-semibold text-white">
-                                            {badgeCount}
+                                            {advancedAttentionCount > 99 ? "99+" : advancedAttentionCount}
                                         </span>
                                     )}
-                                    {showProcessingWarning && (
-                                        <span className="ml-auto h-2.5 w-2.5 rounded-full bg-[var(--warning)]" aria-hidden="true" />
-                                    )}
+                                    <ChevronDown
+                                        className={`h-4 w-4 transition-transform ${isAdvancedOpen ? "rotate-180" : ""}`}
+                                        aria-hidden="true"
+                                    />
                                 </>
                             )}
-                        </Link>
-                    );
-                })}
+                        </button>
+
+                        {isAdvancedOpen && (
+                            <div className={`mt-1 space-y-0.5 ${isCollapsed ? "" : "pl-3"}`}>
+                                {visibleAdvancedItems.map((item) => renderNavLink(item, 0, true))}
+                            </div>
+                        )}
+                    </div>
+                )}
             </nav>
 
             {/* Bottom Section */}

--- a/apps/frontend/src/components/navigation.ts
+++ b/apps/frontend/src/components/navigation.ts
@@ -9,6 +9,7 @@ import {
     LayoutDashboard,
     Link2,
     MessageSquare,
+    UploadCloud,
     Wallet,
     Zap,
     type LucideIcon,
@@ -26,18 +27,21 @@ export interface RouteConfig {
     Icon: LucideIcon;
 }
 
-export const primaryNavItems: NavItem[] = [
-    { icon: LayoutDashboard, label: "Dashboard", href: "/dashboard", protected: true },
+export const primaryWorkflowNavItems: NavItem[] = [
+    { icon: UploadCloud, label: "Upload", href: "/dashboard", protected: true },
     { icon: Bell, label: "Events", href: "/events", protected: true },
-    { icon: Landmark, label: "Accounts", href: "/accounts", protected: true },
-    { icon: BookOpen, label: "Journal", href: "/journal", protected: true },
+    { icon: BarChart3, label: "Reports", href: "/reports", protected: true },
+    { icon: Wallet, label: "Portfolio", href: "/portfolio", protected: true },
+];
+
+export const advancedNavItems: NavItem[] = [
     { icon: FileText, label: "Statements", href: "/statements", protected: true },
     { icon: ClipboardCheck, label: "Review", href: "/review", protected: true },
-    { icon: Wallet, label: "Portfolio", href: "/portfolio", protected: true },
-    { icon: BarChart3, label: "Reports", href: "/reports", protected: true },
+    { icon: Landmark, label: "Accounts", href: "/accounts", protected: true },
+    { icon: BookOpen, label: "Journal", href: "/journal", protected: true },
     { icon: Link2, label: "Reconciliation", href: "/reconciliation", protected: true },
     { icon: Clock, label: "Processing", href: "/processing", protected: true },
-    { icon: MessageSquare, label: "AI Advisor", href: "/chat", protected: true },
+    { icon: MessageSquare, label: "AI Settings", href: "/chat", protected: true },
 ];
 
 export const ROUTE_CONFIG: Record<string, RouteConfig> = {

--- a/apps/frontend/src/components/navigation.ts
+++ b/apps/frontend/src/components/navigation.ts
@@ -62,7 +62,7 @@ export const ROUTE_CONFIG: Record<string, RouteConfig> = {
     "/reconciliation/unmatched": { label: "Unmatched", Icon: Link2 },
     "/reconciliation/review-queue": { label: "Review Queue", Icon: Link2 },
     "/processing": { label: "Processing", Icon: Clock },
-    "/chat": { label: "AI Advisor", Icon: MessageSquare },
+    "/chat": { label: "AI Settings", Icon: MessageSquare },
     "/ping-pong": { label: "Ping-Pong", Icon: Zap },
 };
 

--- a/docs/project/EPIC-015.processing-account.md
+++ b/docs/project/EPIC-015.processing-account.md
@@ -325,13 +325,13 @@ assert abs(assets - liabilities_equity) < Decimal("0.01")  # ✅ PASSED
 - [x] **AC15.7.3** Card click-through navigates to `/processing` listing pending transfers (existing or new page) with line items `{from_account, to_account, amount, initiated_date, days_outstanding}`
 - [x] **AC15.7.4** Pending entries older than 7 days render a warning badge on the listing row
 - [x] **AC15.7.5** Frontend test mounts ProcessingSummaryCard and asserts `pending_count` + `pending_total` labels render
-- [x] **AC15.7.6** Sidebar navigation exposes a Processing entry between Reconciliation and AI Advisor
+- [x] **AC15.7.6** Sidebar navigation exposes a Processing entry between Reconciliation and AI Settings
 - [x] **AC15.7.7** Sidebar Processing entry shows a warning indicator when Processing Account current balance is non-zero
 - [x] **AC15.7.8** Dashboard Processing card shows the signed current balance and a non-zero balance warning
 
 | AC ID | Description | Test | Path | Priority |
 |-------|-------------|------|------|----------|
-| AC15.7.6 | Sidebar navigation exposes a Processing entry between Reconciliation and AI Advisor | `AC15.7.6 shows Processing between Reconciliation and AI Advisor` | `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx` | P1 |
+| AC15.7.6 | Sidebar navigation exposes a Processing entry between Reconciliation and AI Settings | `AC15.7.6 AC19.6.3 shows Processing between Reconciliation and AI Settings in Advanced` | `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx` | P1 |
 | AC15.7.7 | Sidebar Processing entry shows a warning indicator when Processing Account current balance is non-zero | `AC15.7.7 shows a sidebar warning when Processing Account balance is non-zero` | `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx` | P1 |
 | AC15.7.8 | Dashboard Processing card shows the signed current balance and a non-zero balance warning | `shows the current Processing Account balance when transfers are unresolved` | `apps/frontend/src/components/__tests__/ProcessingSummaryCard.test.tsx` | P1 |
 

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -354,6 +354,18 @@ workflow state exists.
 | AC19.5.6 | Package readiness fails deterministically when duplicate Processing system accounts would otherwise make blockers non-deterministic | `test_AC19_5_6_package_readiness_rejects_duplicate_processing_accounts` | P0 |
 | AC19.5.7 | Package readiness converts Processing Account journal lines into base reporting currency before deciding whether the in-transit balance nets to zero | `test_AC19_5_7_package_readiness_converts_processing_balance_before_zero_check` | P0 |
 
+### AC19.6 — Navigation Folding And Advanced Drill-Down
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC19.6.1 | EPIC-019 and workflow-events SSOT define the canonical primary/advanced navigation IA and document `/dashboard` as the Upload primary entry | `test_AC19_6_1_workflow_navigation_ssot_documents_primary_and_advanced_groups` | P0 |
+| AC19.6.2 | Frontend navigation exports separate primary workflow nav and advanced nav groups while preserving route config for all existing advanced deep links | `navigation.test.ts` | P0 |
+| AC19.6.3 | Desktop sidebar renders Upload, Events, Reports, Portfolio, and Advanced as the primary surface; advanced child links remain accessible and active-state aware | `sidebarAndTabs.test.tsx` | P0 |
+| AC19.6.4 | Mobile nav renders the same primary/advanced grouping, supports advanced route selection, closes the drawer on navigation, and avoids overflow | `mobileNav.coverage.test.tsx`, `workflow-navigation.spec.ts` | P0 |
+| AC19.6.5 | Sidebar attention indicators are derived from `/api/workflow/status` through `lib/api.ts`; direct `/api/statements/pending-review` and stage2 queue polling are removed from Sidebar | `sidebarAndTabs.test.tsx` | P0 |
+| AC19.6.6 | Workflow event action links and workspace route labels continue to deep-link into advanced review/reconciliation/processing/report destinations | `workflowSurfaces.test.tsx`, `sidebarAndTabs.test.tsx` | P0 |
+| AC19.6.7 | Desktop and mobile Playwright smoke covers the folded navigation and Advanced access without horizontal overflow | `workflow-navigation.spec.ts` | P0 |
+
 ## How To Build It
 
 ### Backend

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -23,8 +23,11 @@
 | Header badge, Event inbox, Status feed | `apps/frontend/src/components/workflow/WorkflowNotifications.tsx` |
 | Upload-to-Report home | `apps/frontend/src/app/(main)/dashboard/page.tsx` |
 | Events page | `apps/frontend/src/app/(main)/events/page.tsx` |
+| Workflow navigation IA | `apps/frontend/src/components/navigation.ts` |
+| Desktop workflow navigation | `apps/frontend/src/components/Sidebar.tsx` |
+| Mobile workflow navigation | `apps/frontend/src/components/MobileNav.tsx` |
 | Database migrations | `apps/backend/migrations/versions/0021_add_workflow_events.py`, `apps/backend/migrations/versions/0022_harden_workflow_contract.py` |
-| Contract tests | `apps/backend/tests/workflow/test_workflow_events.py`, `apps/backend/tests/api/test_workflow_router.py`, `apps/frontend/src/__tests__/workflowApi.test.ts`, `apps/frontend/src/__tests__/workflowSurfaces.test.tsx`, `apps/frontend/playwright/workflow-notifications.spec.ts` |
+| Contract tests | `apps/backend/tests/workflow/test_workflow_events.py`, `apps/backend/tests/api/test_workflow_router.py`, `apps/frontend/src/__tests__/navigation.test.ts`, `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx`, `apps/frontend/src/__tests__/mobileNav.coverage.test.tsx`, `apps/frontend/src/__tests__/workflowApi.test.ts`, `apps/frontend/src/__tests__/workflowSurfaces.test.tsx`, `apps/frontend/playwright/workflow-notifications.spec.ts`, `apps/frontend/playwright/workflow-navigation.spec.ts` |
 
 ---
 
@@ -320,7 +323,51 @@ Upload-to-Report home rules:
 
 ---
 
-## 11. Initial Derivation
+## 11. Workflow Navigation
+
+EPIC-019 owns the product-level navigation model for the upload-to-report
+journey. The primary navigation must express the workflow, not the internal
+accounting pipeline.
+
+Primary navigation:
+
+```text
+Upload -> /dashboard
+Events -> /events
+Reports -> /reports
+Portfolio -> /portfolio
+Advanced
+```
+
+Advanced navigation:
+
+```text
+Statements -> /statements
+Review -> /review
+Accounts -> /accounts
+Journal -> /journal
+Reconciliation -> /reconciliation
+Processing -> /processing
+AI Settings -> /chat
+```
+
+Rules:
+
+- `/dashboard` remains the authenticated upload-to-report home and is labeled
+  as Upload in primary navigation.
+- Advanced is a navigation group, not a new backend workflow concept.
+- Advanced pages are not removed. Direct routes and event `action_href` links
+  into review, reconciliation, processing, statements, reports, and package
+  readiness must continue to work.
+- Desktop and mobile navigation must expose the same primary and advanced
+  groups.
+- Navigation attention indicators must use `GET /api/workflow/status` through
+  `lib/api.ts`. Sidebar-local review queue polling must not calculate separate
+  review badge semantics.
+
+---
+
+## 12. Initial Derivation
 
 The first implementation derives `source.uploaded` from `BankStatement` upload
 state. Workflow status and event reads run this deterministic sync before


### PR DESCRIPTION
## Summary

Fold EPIC-019 navigation into Upload / Events / Reports / Portfolio / Advanced, preserve advanced drill-down routes, and derive sidebar attention badges from workflow status.

Closes #640

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-019 — Event-Driven Upload-to-Report UX |
| **AC IDs** | AC19.6.1, AC19.6.2, AC19.6.3, AC19.6.4, AC19.6.5, AC19.6.6, AC19.6.7 |
| **AC source updated** | Owning EPIC |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/workflow-events.md` — documents workflow navigation IA, primary/advanced groups, and workflow-status-owned attention semantics
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | `local-before-implementation` | `npm test -- navigation.test.ts sidebarAndTabs.test.tsx mobileNav.coverage.test.tsx` failed on old flat Dashboard/module nav and missing workflow-status sidebar badge |
| Green (passing test) | `2951b30` | Implemented primary/advanced nav groups and workflow-status attention semantics |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable; no DB enum changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable; no env var changes)
- [x] `repo/` submodule updated for production config changes (not applicable; no config changes; checked `repo` HEAD matches `origin/main`)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes (not required; no manifest changes)
- [x] `tools/lint_doc_consistency.py` passes via `moon run :lint`

### CI/CD, Runtime, and VPS Infra Audit

Not applicable; this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_ac_traceability.py
npm test -- navigation.test.ts sidebarAndTabs.test.tsx mobileNav.coverage.test.tsx workflowSurfaces.test.tsx
npm run lint
npm run test:e2e -- workflow-navigation.spec.ts
moon run :lint
```

Blocked locally:

```bash
moon run :test
# Fails before tests start because local Podman socket refuses connection:
# dial tcp 127.0.0.1:61270: connect: connection refused
```

Also attempted the backend AC19.6.1 test directly; it could not start because local PostgreSQL on `127.0.0.1:5432` was unavailable in this workspace.

---

## Screenshots / Evidence

Playwright smoke passed for desktop and mobile folded navigation:

```bash
npm run test:e2e -- workflow-navigation.spec.ts
# 2 passed
```
