### PR TITLE
[finance_report_audit] Add framework-aware personal reporting epic

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ registries, and generated reports rather than duplicated here.
 | [EPIC-017](docs/project/EPIC-017.portfolio-management.md) | Portfolio management |
 | [EPIC-018](docs/project/EPIC-018.ai-driven-pipeline.md) | AI-driven pipeline |
 | [EPIC-019](docs/project/EPIC-019.event-driven-upload-to-report-ux.md) | Event-driven upload-to-report UX |
+| [EPIC-020](docs/project/EPIC-020.framework-aware-personal-reporting.md) | Framework-aware personal financial reporting |
 
 Known proof-quality caveats:
 

--- a/common/ssot/generate_ac_registry.py
+++ b/common/ssot/generate_ac_registry.py
@@ -27,7 +27,7 @@ OVERRIDES = "docs/ac_registry_overrides.yaml"
 OUTPUT = OUTPUT_FEATURE
 
 # EPIC classification: which EPICs are feature vs infra
-FEATURE_EPICS = {1, 2, 3, 4, 5, 6, 8, 11, 13, 15, 16, 17, 18, 19}
+FEATURE_EPICS = {1, 2, 3, 4, 5, 6, 8, 11, 13, 15, 16, 17, 18, 19, 20}
 INFRA_EPICS = {7, 9, 10, 12, 14}
 
 # EPIC-016 sub-classification: these AC16.XX.x groups route to infra
@@ -53,6 +53,7 @@ EPIC_NAMES: dict[int, str] = {
     17: "portfolio-management",
     18: "ai-driven-pipeline",
     19: "event-driven-upload-to-report-ux",
+    20: "framework-aware-personal-reporting",
 }
 
 

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -360,6 +360,20 @@ retained in [#548](https://github.com/wangzitian0/finance_report/issues/548):
 
 **Implementation Summary**: Current implementation truth is owned by the code paths listed above, [accounting.md](../ssot/accounting.md), [schema.md](../ssot/schema.md), and the AC2.* tests. Archive implementation notes are historical only and are not part of the active README -> EPIC -> AC -> test chain.
 
+## Framework Boundary
+
+EPIC-002 owns canonical double-entry facts only. Journal entries, account
+balances, source links, currency, and Decimal invariants are framework-neutral
+inputs to [EPIC-020](EPIC-020.framework-aware-personal-reporting.md). US-like
+or HK-like recognition, measurement, classification, presentation, and
+disclosure decisions must not be embedded into posting logic.
+
+### AC2.13: Framework-Neutral Ledger Boundary
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC2.13.1 | Canonical ledger documentation declares that double-entry posting is framework-neutral and that US/HK policy decisions belong to EPIC-020 | `test_AC2_13_1_canonical_ledger_is_framework_neutral` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
 ---
 
 ## 📝 Technical Debt
@@ -396,11 +410,10 @@ These non-EPIC docs are part of this EPIC's maintained surface:
 
 **✅ Your Answer**: Use US GAAP Taxonomy standard
 
-**Decision**: Adopt US GAAP Taxonomy standard coding
-- Follow international financial reporting standards
-- Account model `code` field must comply with GAAP Taxonomy
-- Frontend provides code lookup/selection tool
-- Support custom aliases (user-friendly names)
+**Current decision**: Account codes are canonical user ledger identifiers, not
+the authoritative US GAAP, HKFRS, or CAS taxonomy. Framework-specific report
+line mappings are owned by EPIC-020. Frontend lookup can offer familiar code
+aliases, but posting and balance validation must remain framework-neutral.
 
 ### Q2: Multi-Currency Strategy
 > **Question**: Should v1 support multi-currency entries? Or only support single base currency?  

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -408,7 +408,8 @@ These non-EPIC docs are part of this EPIC's maintained surface:
 > **Question**: Should we enforce 1xxx-5xxx account codes? Or allow user customization?  
 > **Impact**: Affects Account model `code` field validation rules
 
-**✅ Your Answer**: Use US GAAP Taxonomy standard
+**✅ Your Answer**: Use canonical framework-neutral account codes, with
+framework-specific taxonomy and report-line mapping owned by EPIC-020.
 
 **Current decision**: Account codes are canonical user ledger identifiers, not
 the authoritative US GAAP, HKFRS, or CAS taxonomy. Framework-specific report

--- a/docs/project/EPIC-003.statement-parsing.md
+++ b/docs/project/EPIC-003.statement-parsing.md
@@ -24,7 +24,6 @@ EPIC-003 owns source capture. It extracts settlement, statement, PDF, and CSV
 facts with source metadata, period boundaries, currencies, balances, and raw
 line anchors needed by downstream evidence checks. It does not decide US-like
 or HK-like report classification, measurement, presentation, or disclosure.
-It does not decide US-like or HK-like report classification.
 
 ---
 

--- a/docs/project/EPIC-003.statement-parsing.md
+++ b/docs/project/EPIC-003.statement-parsing.md
@@ -18,6 +18,14 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 
 - `source-ledger-report-traceability`
 
+## Framework Boundary
+
+EPIC-003 owns source capture. It extracts settlement, statement, PDF, and CSV
+facts with source metadata, period boundaries, currencies, balances, and raw
+line anchors needed by downstream evidence checks. It does not decide US-like
+or HK-like report classification, measurement, presentation, or disclosure.
+It does not decide US-like or HK-like report classification.
+
 ---
 
 ## 👥 Multi-Role Review
@@ -200,6 +208,12 @@ Upload → Free LLM (NVIDIA, etc) → JSON → Validation → BankStatementTrans
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC3.9.1 | Parsing cases that fail audit are recorded in an SSOT registry without expanding deterministic parser scope or committing real documents | `test_AC3_9_1_extraction_failed_case_registry_preserves_audit_cases_without_parser_expansion` | `tests/tooling/test_extraction_failed_case_registry.py` | P0 |
+
+### AC3.10: Settlement Evidence Capture Boundary
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC3.10.1 | Statement parsing owns fact-forward settlement evidence capture and must preserve source metadata needed by framework readiness while leaving US/HK policy decisions to EPIC-020 | `test_AC3_10_1_statement_parsing_is_source_capture_not_framework_policy` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
 
 ## 📏 Acceptance Criteria
 

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -238,6 +238,18 @@ to audit each report line.
 | AC5.13.4 | Post-merge package proof fails trusted totals without source/ledger anchors or explicit manual inputs | `test_personal_financial_report_package_post_merge_journey` | `tests/e2e/test_personal_financial_report_package.py` | P0 |
 | AC5.13.5 | Package traceability endpoint returns current-user dynamic source identifiers and excludes unrelated-user anchors | `test_AC5_13_5_package_traceability_returns_dynamic_current_user_identifiers` | `api/test_personal_report_package_contract.py` | P0 |
 
+### AC5.14: Framework Policy Result Consumption
+
+EPIC-005 assembles report packages from framework policy results owned by
+[EPIC-020](EPIC-020.framework-aware-personal-reporting.md). It renders
+statements, notes, exports, and traceability; it must not own US/HK
+recognition, measurement, or classification rules.
+It must not own US/HK recognition rules.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.14.1 | Reporting docs declare that EPIC-005 consumes framework policy results for US/HK package output and does not own framework-specific accounting decisions | `test_AC5_14_1_reporting_assembles_framework_policy_results_only` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
 ## 📏 Acceptance Criteria
 
 ### 🟢 Must Have
@@ -318,10 +330,12 @@ Scope owned here:
   tracked by [#566](https://github.com/wangzitian0/finance_report/issues/566).
 - Integration of EPIC-017 investment performance schedules tracked by
   [#564](https://github.com/wangzitian0/finance_report/issues/564).
+- Integration of EPIC-020 framework policy results for US-like and HK-like
+  personal report package variants.
 
-US GAAP and Hong Kong listed-company reporting are reference structures for
-coverage and naming discipline. This EPIC does not claim regulated filing
-compliance.
+US GAAP and Hong Kong listed-company reporting are target reference structures
+for coverage and naming discipline through EPIC-020. This EPIC renders personal
+management reports and does not claim regulated filing compliance.
 
 Remaining blocker breakdown after the #565 post-merge proof:
 

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -244,7 +244,6 @@ EPIC-005 assembles report packages from framework policy results owned by
 [EPIC-020](EPIC-020.framework-aware-personal-reporting.md). It renders
 statements, notes, exports, and traceability; it must not own US/HK
 recognition, measurement, or classification rules.
-It must not own US/HK recognition rules.
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -79,6 +79,13 @@ now better managed by code, SSOT files, and generated proof.
 | Portfolio UI surfaces | `apps/frontend/src/app/(main)/portfolio`, frontend tests |
 | Current proof and execution stage | AC registries, `tools/check_ac_traceability.py`, [test-execution-matrix.yaml](../ssot/test-execution-matrix.yaml) |
 
+Framework boundary: EPIC-017 supplies portfolio facts, not final framework
+accounting conclusions. Holdings, lots, cost basis, dividends, fees, prices,
+freshness, and source links are inputs to EPIC-020. Whether a US-like or HK-like
+personal report presents a valuation change in a specific statement line or
+disclosure belongs to EPIC-020 and EPIC-005 assembly.
+EPIC-017 owns portfolio facts, not final framework accounting conclusions.
+
 Future scope such as additional brokers, complex corporate actions, options,
 futures, crypto, and real-time market streaming needs explicit ACs before it can
 be treated as current work.
@@ -225,6 +232,12 @@ redacted, and Decimal-safe.
 | AC17.12.2 | Portfolio audit fixture contract pins sanitized trade, dividend, fee, and valuation activity rows, derives expected totals from fixture rows and positions, and covers parser support for Moomoo margin history rows | `test_AC17_12_2_portfolio_fixture_pins_activity_rows_without_raw_documents`, `test_AC17_12_2_parse_moomoo_margin_history_rows_as_equity_position_snapshot` | `tests/tooling/test_portfolio_audit_fixture_contract.py`, `portfolio/test_brokerage_position_parsing.py` | P0 |
 | AC17.12.3 | Personal report package fixture consumes expanded portfolio expected outputs instead of keeping one-position brokerage constants inline | `test_AC17_12_3_personal_package_references_expanded_portfolio_fixture_contract` | `tests/tooling/test_portfolio_audit_fixture_contract.py` | P0 |
 
+### AC17.13: Portfolio Fact Boundary for Framework Reporting
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC17.13.1 | Portfolio management owns holdings, lots, dividends, fees, prices, freshness, and source links as framework policy inputs, but does not own final US/HK report presentation decisions | `test_AC17_13_1_portfolio_supplies_facts_not_framework_conclusions` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
 ### Brokerage PDF to Asset Report Proof Matrix
 
 This is the detailed EPIC-017 counterpart to the README core proof path. It
@@ -284,6 +297,7 @@ scope decisions are:
 | Brokerage statements are uploaded and parsed through the statement pipeline | AC17.4, EPIC-003/EPIC-013 extraction SSOT |
 | Manual price update remains valid for low-frequency holdings; provider sync is governed separately | AC17.1.6, [market_data.md](../ssot/market_data.md), AC11.10 |
 | Report-ready investment schedule is consumed by the personal report package | AC17.10 and EPIC-005 package contract |
+| Framework-specific report presentation for portfolio facts is not owned here | [framework-reporting.md](../ssot/framework-reporting.md), EPIC-020, AC17.13 |
 
 Current proof status comes from generated registries, traceability checks, tests,
 critical proof matrix rows, and CI artifacts. Open product questions should be

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -84,7 +84,6 @@ accounting conclusions. Holdings, lots, cost basis, dividends, fees, prices,
 freshness, and source links are inputs to EPIC-020. Whether a US-like or HK-like
 personal report presents a valuation change in a specific statement line or
 disclosure belongs to EPIC-020 and EPIC-005 assembly.
-EPIC-017 owns portfolio facts, not final framework accounting conclusions.
 
 Future scope such as additional brokers, complex corporate actions, options,
 futures, crypto, and real-time market streaming needs explicit ACs before it can

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -80,6 +80,7 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
 | EPIC-013 (Statement Parsing V2) | Builds on V2's confidence scoring framework |
 | EPIC-016 (Two-Stage Review) | **Complementary** — AI automates what it can, EPIC-016 handles human review for what AI can't confidently classify |
 | EPIC-017 (Portfolio) | Independent — no direct dependency |
+| EPIC-020 (Framework-aware reporting) | AI may suggest measurement/disclosure evidence, but EPIC-020 owns deterministic policy and trusted report boundaries |
 
 ---
 
@@ -268,6 +269,12 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
 | AC18.4.2 | 4 | `ReportSnapshot` (Layer 4) generated and queryable via API |
 | AC18.4.3 | 4 | AI CSV parsing handles unknown institutions as fallback |
 | AC18.4.4 | 4 | Income statements include applied Layer 3 classification coverage |
+
+### AC18.6: Framework Measurement and Disclosure Suggestions
+
+| AC ID | Phase | Description |
+|-------|-------|-------------|
+| AC18.6.1 | Framework reporting | AI-generated measurement or disclosure suggestions for US/HK personal report packages must remain structured, source-anchored, confidence-scored, and reviewed before EPIC-020 or EPIC-005 can treat them as trusted report inputs |
 
 ---
 

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -366,6 +366,12 @@ workflow state exists.
 | AC19.6.6 | Workflow event action links and workspace route labels continue to deep-link into advanced review/reconciliation/processing/report destinations | `workflowSurfaces.test.tsx`, `sidebarAndTabs.test.tsx` | P0 |
 | AC19.6.7 | Desktop and mobile Playwright smoke covers the folded navigation and Advanced access without horizontal overflow | `workflow-navigation.spec.ts` | P0 |
 
+### AC19.7 — Framework-Aware Evidence Readiness
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC19.7.1 | Report readiness must evaluate framework-specific evidence blockers from EPIC-020, including missing settlement coverage, unresolved review, stale market data, missing valuation basis, and AI-only unreviewed policy suggestions before marking US/HK personal reports trusted | `test_AC19_7_1_readiness_consumes_framework_specific_evidence_blockers` | P0 |
+
 ## How To Build It
 
 ### Backend

--- a/docs/project/EPIC-020.framework-aware-personal-reporting.md
+++ b/docs/project/EPIC-020.framework-aware-personal-reporting.md
@@ -124,9 +124,9 @@ Not owned here:
 - Policy result schema: [#676](https://github.com/wangzitian0/finance_report/issues/676)
 - US/HK policy matrix v1: [#677](https://github.com/wangzitian0/finance_report/issues/677)
 - Framework-aware readiness blockers: [#678](https://github.com/wangzitian0/finance_report/issues/678)
-- Report package API integration: [#679](https://github.com/wangzitian0/finance_report/issues/679)
-- US/HK golden fixture proof: [#680](https://github.com/wangzitian0/finance_report/issues/680)
-- Framework selection UI and exports: [#681](https://github.com/wangzitian0/finance_report/issues/681)
+- Framework selection UI and exports: [#679](https://github.com/wangzitian0/finance_report/issues/679)
+- Report package API integration: [#680](https://github.com/wangzitian0/finance_report/issues/680)
+- US/HK golden fixture proof: [#681](https://github.com/wangzitian0/finance_report/issues/681)
 
 ## Related
 

--- a/docs/project/EPIC-020.framework-aware-personal-reporting.md
+++ b/docs/project/EPIC-020.framework-aware-personal-reporting.md
@@ -1,0 +1,137 @@
+# EPIC-020: Framework-Aware Personal Financial Reporting
+
+> **Status ownership**: Scope owner only; live delivery status is tracked by
+> GitHub issues, AC registries, and executable tests.
+> **Vision Anchor**: `decision-filter-accuracy-auditability`
+> **Phase**: Target-backward report policy
+> **Priority**: P0 for US/HK framework selection on personal financial reports
+> **Dependencies**: EPIC-002, EPIC-003, EPIC-005, EPIC-017, EPIC-018, EPIC-019
+
+---
+
+## Objective
+
+Define the target-backward accounting policy layer that lets a user upload all
+settlement evidence and generate a personal financial-report package by choosing
+`personal_us_gaap_like` or `personal_hkfrs_like`.
+
+This EPIC does not claim statutory US GAAP, SEC, HKEX, or HKFRS filing
+compliance. It owns framework-aware personal management reporting: deterministic
+recognition, measurement, classification, presentation, and disclosure rules
+that borrow discipline from US and Hong Kong reporting frameworks.
+
+## Macro Proof Ownership
+
+- `personal-financial-report-package`
+
+## MECE Audit Architecture
+
+The six audit lanes are mutually exclusive by question and collectively cover
+the stated product goal.
+
+| Lane | Direction | Owner | EPIC-020 dependency |
+|---|---|---|---|
+| Source capture | Fact-forward | EPIC-003 / EPIC-013 | Consumes parsed settlement facts and source metadata |
+| Evidence control | Fact-forward | EPIC-019, with EPIC-004 reconciliation signals | Consumes readiness blockers and review state |
+| Canonical ledger | Fact-forward | EPIC-002 | Consumes framework-neutral journal entries and balances |
+| Portfolio subledger | Fact-forward | EPIC-017 | Consumes holdings, lots, dividends, fees, and valuation evidence |
+| Framework policy | Target-backward | EPIC-020 | Owns US/HK target policy and required evidence |
+| Report assembly | Target-backward | EPIC-005 | Produces statements, notes, exports, and traceability from policy results |
+
+EPIC-018 is a cross-cutting AI capability. It can suggest measurement and
+disclosure evidence, but trusted output must be deterministic, reviewed, and
+traceable.
+
+## Scope
+
+Owned here:
+
+- Supported framework IDs: `personal_us_gaap_like` and `personal_hkfrs_like`.
+- Framework target package requirements: required statements, schedules, notes,
+  line mappings, and blocker conditions.
+- Policy matrix for recognition, measurement, classification, presentation, and
+  disclosure.
+- Read-only policy result contract consumed by EPIC-005.
+- Required evidence definitions that EPIC-019 readiness must evaluate.
+- AI boundary rules for measurement/disclosure suggestions.
+
+Not owned here:
+
+- Parsing settlement files (EPIC-003 / EPIC-013).
+- It does not parse settlements.
+- Reconciliation scoring or review UI (EPIC-004 / EPIC-016).
+- Posting canonical journal entries (EPIC-002).
+- Maintaining portfolio lots, holdings, or market data (EPIC-017 / EPIC-011).
+- Rendering report pages or exports (EPIC-005).
+- AI prompt execution or model integration (EPIC-018).
+
+## Acceptance Criteria
+
+### AC20.1: Framework Target Registry
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC20.1.1 | Framework reporting SSOT defines `personal_us_gaap_like` and `personal_hkfrs_like`, excludes CN/CAS v1, and states that outputs are personal management reports rather than statutory filings | `test_AC20_1_1_framework_registry_defines_us_hk_personal_targets` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
+### AC20.2: MECE Direction Ownership
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC20.2.1 | Framework reporting SSOT and EPIC-020 define the six-lane fact-forward/target-backward architecture with distinct owners and outputs | `test_AC20_2_1_mece_direction_matrix_declares_distinct_owner_lanes` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
+### AC20.3: Target-backward Report Requirements
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC20.3.1 | Framework target package requirements enumerate required statements, report line mappings, policy dimensions, evidence anchors, disclosure requirements, and blocker conditions before report assembly | `test_AC20_3_1_framework_target_contract_is_report_output_backward` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
+### AC20.4: Personal Finance Policy Matrix
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC20.4.1 | The v1 policy matrix covers cash, listed securities, funds, dividends, brokerage fees, FX, restricted compensation, property, mortgage, and private/manual assets across recognition, measurement, classification, presentation, and disclosure | `test_AC20_4_1_policy_matrix_covers_personal_finance_domains` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
+### AC20.5: Read-Only Policy Result
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC20.5.1 | Framework policy consumes canonical ledger, portfolio facts, evidence readiness, and framework target without mutating source records, journal entries, portfolio lots, market data, or report snapshots | `test_AC20_5_1_policy_layer_is_read_only_between_facts_and_report` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
+### AC20.6: AI Measurement and Disclosure Boundary
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC20.6.1 | AI measurement/disclosure suggestions can affect trusted output only after becoming structured fields with source anchor, confidence tier, review state, policy field name, and accepted value | `test_AC20_6_1_ai_suggestions_require_structured_reviewed_policy_fields` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
+### AC20.7: Framework-Differentiated Proof Path
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC20.7.1 | The same settlement and portfolio fixture must be able to produce US-like and HK-like personal report packages with framework-specific line mappings, notes, source anchors, and readiness blockers | `test_AC20_7_1_same_fixture_must_drive_framework_differentiated_reports` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+
+## Implementation Order
+
+1. Define the framework policy result schema and SSOT contract.
+2. Add framework-aware readiness blockers before adding rendered output.
+3. Add policy matrix tests over the expanded settlement/portfolio fixture.
+4. Add report assembly consumption tests for US-like and HK-like outputs.
+5. Expose framework selection in the package API and UI after backend proof is
+   deterministic.
+
+## Tracking Issues
+
+- Umbrella: [#675](https://github.com/wangzitian0/finance_report/issues/675)
+- Policy result schema: [#676](https://github.com/wangzitian0/finance_report/issues/676)
+- US/HK policy matrix v1: [#677](https://github.com/wangzitian0/finance_report/issues/677)
+- Framework-aware readiness blockers: [#678](https://github.com/wangzitian0/finance_report/issues/678)
+- Report package API integration: [#679](https://github.com/wangzitian0/finance_report/issues/679)
+- US/HK golden fixture proof: [#680](https://github.com/wangzitian0/finance_report/issues/680)
+- Framework selection UI and exports: [#681](https://github.com/wangzitian0/finance_report/issues/681)
+
+## Related
+
+- [framework-reporting.md](../ssot/framework-reporting.md)
+- [reporting.md](../ssot/reporting.md)
+- [accounting.md](../ssot/accounting.md)
+- [EPIC-005](./EPIC-005.reporting-visualization.md)
+- [EPIC-017](./EPIC-017.portfolio-management.md)

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -67,6 +67,7 @@ owning source instead of copying:
 | [EPIC-017](./EPIC-017.portfolio-management.md) | Portfolio management |
 | [EPIC-018](./EPIC-018.ai-driven-pipeline.md) | AI-driven pipeline |
 | [EPIC-019](./EPIC-019.event-driven-upload-to-report-ux.md) | Event-driven upload-to-report UX |
+| [EPIC-020](./EPIC-020.framework-aware-personal-reporting.md) | Framework-aware personal financial reporting |
 
 ## Current Audit Reports
 

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -136,6 +136,14 @@ concepts:
       - docs/ssot/accounting.md
       - docs/ssot/market_data.md
 
+  framework_reporting:
+    owner: docs/ssot/framework-reporting.md
+    description: US-like and HK-like target-backward policy layer for personal report packages.
+    cross_refs:
+      - docs/ssot/reporting.md
+      - docs/ssot/accounting.md
+      - docs/project/EPIC-020.framework-aware-personal-reporting.md
+
   net_worth_valuation_snapshots:
     owner: docs/ssot/assets.md#manual-valuation-snapshots
     description: Point-in-time manual valuation snapshots for non-ledger net worth components.

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -65,6 +65,7 @@ contracts is tracked in
 | [pdf-fixtures.md](./pdf-fixtures.md) | `pdf_fixtures` | Synthetic PDF fixture commands, local-only input policy, and font fallback |
 | [reconciliation.md](./reconciliation.md) | `reconciliation` | Matching rationale; thresholds should migrate to code/common |
 | [reporting.md](./reporting.md) | `reporting` | Report calculation rationale and proof links |
+| [framework-reporting.md](./framework-reporting.md) | `framework_reporting` | US/HK target-backward policy layer for personal report packages |
 | [ai.md](./ai.md) | `ai` | AI advisor policy and safety rationale |
 | [assets.md](./assets.md) | `assets` | Asset lifecycle rationale and code/test links |
 | [market_data.md](./market_data.md) | `market_data` | Market data source rationale and fallback policy |

--- a/docs/ssot/critical-proof-matrix.yaml
+++ b/docs/ssot/critical-proof-matrix.yaml
@@ -14,6 +14,7 @@ outcomes:
       - EPIC-011
       - EPIC-017
       - EPIC-018
+      - EPIC-020
     issue: "#567"
     proof_ids:
       - personal-financial-report-package-post-merge

--- a/docs/ssot/framework-reporting.md
+++ b/docs/ssot/framework-reporting.md
@@ -1,0 +1,135 @@
+# Framework-Aware Personal Reporting SSOT
+
+> **SSOT Key**: `framework_reporting`
+> **Core Definition**: Target-backward accounting framework policy for
+> US-like and HK-like personal financial-report packages.
+
+---
+
+## 1. Objective
+
+The product goal is:
+
+```text
+Upload all settlement evidence -> choose US-like or HK-like framework ->
+generate a trusted personal financial-report package.
+```
+
+This is not a statutory filing, audit opinion, tax filing, or listed-company
+annual report. The framework names mean personal management reports that borrow
+recognition, measurement, presentation, and disclosure discipline from US GAAP
+and HKFRS-style reporting.
+
+Supported v1 framework IDs:
+
+- `personal_us_gaap_like`
+- `personal_hkfrs_like`
+
+Explicitly out of scope for v1:
+
+- CN/CAS framework output.
+- SEC, HKEX, XBRL, audit opinion, consolidated issuer reporting, or regulated
+  filing compliance.
+
+## 2. Direction Matrix
+
+The architecture uses both fact-forward and target-backward reasoning. Each lane
+has a different question, owner, and proof responsibility.
+
+| Lane | Direction | Owner | Question | Output |
+|---|---|---|---|---|
+| Source capture | Fact-forward | EPIC-003 / EPIC-013 | What did the settlement, statement, PDF, or CSV say? | Parsed facts with source metadata |
+| Evidence control | Fact-forward | EPIC-019, with EPIC-004 reconciliation signals | Is the evidence complete, reviewed, and conflict-free enough for a trusted report? | Readiness state and blockers |
+| Canonical ledger | Fact-forward | EPIC-002 | How do facts become balanced double-entry records? | Framework-neutral journal entries and account balances |
+| Portfolio subledger | Fact-forward | EPIC-017 | What are the investment holdings, lots, dividends, fees, and valuation facts? | Portfolio facts and valuation evidence |
+| Framework policy | Target-backward | EPIC-020 | What must a US-like or HK-like report require from the facts? | Recognition, measurement, classification, presentation, and disclosure policy result |
+| Report assembly | Target-backward | EPIC-005 | How is the policy result rendered as a complete personal report package? | Statements, schedules, notes, export, and traceability appendix |
+
+EPIC-018 is cross-cutting. AI can help identify measurement evidence and draft
+disclosure suggestions, but it does not own trusted monetary results or final
+framework policy decisions.
+
+## 3. Framework Policy Contract
+
+For each supported framework and report period, the policy layer must derive a
+structured result from canonical facts:
+
+```text
+canonical ledger + portfolio facts + evidence readiness + framework target
+  -> framework policy result
+```
+
+The result must include:
+
+- framework ID and report period.
+- required statements and schedules.
+- report line mappings.
+- recognition basis per source event type.
+- measurement basis per asset/liability/income category.
+- disclosure requirements and blocker conditions.
+- source, ledger, portfolio, valuation, and review anchors.
+
+The policy layer is read-only. It must not mutate source records, journal
+entries, portfolio lots, market data, or report snapshots.
+
+## 4. Minimum V1 Policy Matrix
+
+The first framework matrix must cover these personal finance domains:
+
+| Domain | Required policy dimensions |
+|---|---|
+| Cash and bank accounts | Classification, period cutoff, source coverage |
+| Listed equities and ETFs | Measurement basis, unrealized gain presentation, stale price disclosure |
+| Funds and money-market products | Classification, valuation source, liquidity disclosure |
+| Dividends and interest | Recognition date, income line mapping, withholding/tax note hooks |
+| Brokerage fees | Cost basis or expense treatment, cash-flow presentation |
+| FX | Transaction-date, average-rate, and period-end-rate usage by statement type |
+| RSU, ESOP, and options | Recognition trigger, restriction/liquidity treatment, valuation evidence |
+| Property, mortgage, and private/manual assets | Valuation basis, source date, confidence, and trusted-total blocker rules |
+
+## 5. AI Boundary
+
+AI may produce structured suggestions for measurement and disclosure, including:
+
+- likely asset category.
+- proposed valuation basis.
+- source uncertainty.
+- disclosure draft text.
+- fair-value evidence hints.
+
+Those suggestions can influence trusted output only after they are transformed
+into deterministic structured fields with:
+
+- source anchor.
+- confidence tier.
+- review state.
+- policy field name.
+- accepted value.
+
+The report assembly layer must never calculate trusted monetary totals from free-form AI text.
+
+## 6. Readiness and Blockers
+
+Framework-aware report readiness must block trusted output when any selected
+framework requires evidence that is missing or unresolved, including:
+
+- missing settlement/source coverage for an in-scope account or broker.
+- overlapping or duplicate source periods.
+- balance mismatch or unresolved parsing validation failure.
+- pending review or reconciliation blocker.
+- missing valuation basis for manual/private assets included in trusted totals.
+- stale market data without an explicit freshness disclosure.
+- AI-only measurement or disclosure suggestion that has not been accepted into
+  structured policy fields.
+
+Draft output may exist with blockers, but trusted output must expose the blocker
+state before presenting framework-specific statements as reliable.
+
+## 7. Relationship To Existing Reporting
+
+EPIC-005 remains the report package assembler. It consumes the policy result and
+renders statements, notes, exports, and traceability. It does not own
+recognition, measurement, or framework-specific classification rules.
+
+EPIC-020 owns framework target policy. It does not parse settlements, post
+journal entries, maintain lots, or render UI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Statement Extraction: ssot/extraction.md
       - PDF Fixtures: ssot/pdf-fixtures.md
       - Reporting: ssot/reporting.md
+      - Framework Reporting: ssot/framework-reporting.md
       - AI Advisor: ssot/ai.md
       - Assets: ssot/assets.md
       - Market Data: ssot/market_data.md
@@ -137,6 +138,7 @@ nav:
           - "EPIC-017: Investment Portfolio Management (100% Self-Developed)": project/EPIC-017.portfolio-management.md
           - "EPIC-018: AI-Driven Data Pipeline": project/EPIC-018.ai-driven-pipeline.md
           - "EPIC-019: Event-Driven Upload to Report UX": project/EPIC-019.event-driven-upload-to-report-ux.md
+          - "EPIC-020: Framework-Aware Personal Reporting": project/EPIC-020.framework-aware-personal-reporting.md
 
 extra:
   social:

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -326,7 +326,7 @@ async def _create_manual_snapshot(
 async def test_personal_financial_report_package_post_merge_journey(
     authenticated_page_unique: Page,
 ) -> None:
-    """EPIC-005 EPIC-008 EPIC-011 EPIC-017.
+    """EPIC-005 EPIC-008 EPIC-011 EPIC-017 EPIC-020.
 
     AC5.1.1 AC5.1.4 AC5.2.3 AC5.3.1 AC5.8.1 AC5.12.4 AC5.13.4 AC5.13.5
     AC11.8.3 AC11.9.1 AC11.9.2 AC11.9.3 AC11.11.1 AC11.11.2 AC17.10.1 AC17.10.2

--- a/tests/tooling/test_framework_reporting_epic_contract.py
+++ b/tests/tooling/test_framework_reporting_epic_contract.py
@@ -147,7 +147,8 @@ def test_AC3_10_1_statement_parsing_is_source_capture_not_framework_policy() -> 
     assert "Framework Boundary" in epic
     assert "source capture" in epic
     assert "period boundaries" in epic
-    assert "does not decide US-like or HK-like report classification" in epic
+    assert "It does not decide US-like" in epic
+    assert "classification, measurement, presentation, or disclosure" in epic
 
 
 def test_AC5_14_1_reporting_assembles_framework_policy_results_only() -> None:
@@ -156,7 +157,8 @@ def test_AC5_14_1_reporting_assembles_framework_policy_results_only() -> None:
 
     assert "Framework Policy Result Consumption" in epic
     assert "assembles report packages from framework policy results" in epic
-    assert "must not own US/HK recognition" in epic
+    assert "must not own US/HK" in epic
+    assert "recognition, measurement, or classification rules" in epic
     assert "Integration of EPIC-020 framework policy results" in epic
 
 
@@ -166,7 +168,8 @@ def test_AC17_13_1_portfolio_supplies_facts_not_framework_conclusions() -> None:
 
     assert "Framework boundary" in epic
     assert "supplies portfolio facts" in epic
-    assert "not final framework accounting conclusions" in epic
+    assert "inputs to EPIC-020" in epic
+    assert "belongs to EPIC-020 and EPIC-005 assembly" in epic
     assert "does not own final US/HK report presentation decisions" in epic
 
 

--- a/tests/tooling/test_framework_reporting_epic_contract.py
+++ b/tests/tooling/test_framework_reporting_epic_contract.py
@@ -180,8 +180,8 @@ def test_AC18_6_1_ai_suggestions_are_reviewed_before_trusted_framework_use() -> 
     assert "structured, source-anchored, confidence-scored, and reviewed" in epic
 
 
-def test_AC19_6_1_readiness_consumes_framework_specific_evidence_blockers() -> None:
-    """AC19.6.1: Readiness consumes framework-specific blockers before trusted reports."""
+def test_AC19_7_1_readiness_consumes_framework_specific_evidence_blockers() -> None:
+    """AC19.7.1: Readiness consumes framework-specific blockers before trusted reports."""
     epic = read("docs/project/EPIC-019.event-driven-upload-to-report-ux.md")
     ssot = read(FRAMEWORK_SSOT)
 

--- a/tests/tooling/test_framework_reporting_epic_contract.py
+++ b/tests/tooling/test_framework_reporting_epic_contract.py
@@ -1,0 +1,197 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+FRAMEWORK_SSOT = "docs/ssot/framework-reporting.md"
+EPIC_020 = "docs/project/EPIC-020.framework-aware-personal-reporting.md"
+
+
+def test_AC20_1_1_framework_registry_defines_us_hk_personal_targets() -> None:
+    """AC20.1.1: Framework registry defines US/HK personal targets without statutory claims."""
+    ssot = read(FRAMEWORK_SSOT)
+    epic = read(EPIC_020)
+
+    for text in (ssot, epic):
+        assert "personal_us_gaap_like" in text
+        assert "personal_hkfrs_like" in text
+        assert "not a statutory filing" in text.lower() or "does not claim statutory" in text.lower()
+    assert "CN/CAS framework output" in ssot
+    assert "Explicitly out of scope for v1" in ssot
+
+
+def test_AC20_2_1_mece_direction_matrix_declares_distinct_owner_lanes() -> None:
+    """AC20.2.1: Six-lane fact-forward and target-backward ownership is explicit."""
+    ssot = read(FRAMEWORK_SSOT)
+    epic = read(EPIC_020)
+
+    for lane in (
+        "Source capture",
+        "Evidence control",
+        "Canonical ledger",
+        "Portfolio subledger",
+        "Framework policy",
+        "Report assembly",
+    ):
+        assert lane in ssot
+        assert lane in epic
+    assert ssot.count("Fact-forward") >= 4
+    assert ssot.count("Target-backward") >= 2
+    assert "mutually exclusive" in epic
+    assert "collectively cover" in epic
+
+
+def test_AC20_3_1_framework_target_contract_is_report_output_backward() -> None:
+    """AC20.3.1: Framework target contract works backward from report outputs."""
+    ssot = read(FRAMEWORK_SSOT)
+    epic = read(EPIC_020)
+
+    assert "required statements and schedules" in ssot
+    assert "report line mappings" in ssot
+    assert "disclosure requirements and blocker conditions" in ssot
+    assert "evidence anchors" in epic
+    assert "Target-backward Report Requirements" in epic
+
+
+def test_AC20_4_1_policy_matrix_covers_personal_finance_domains() -> None:
+    """AC20.4.1: Policy matrix covers core personal finance domains and policy dimensions."""
+    ssot = read(FRAMEWORK_SSOT)
+    epic = read(EPIC_020)
+
+    for domain in (
+        "Cash and bank accounts",
+        "Listed equities and ETFs",
+        "Funds and money-market products",
+        "Dividends and interest",
+        "Brokerage fees",
+        "FX",
+        "RSU, ESOP, and options",
+        "Property, mortgage, and private/manual assets",
+    ):
+        assert domain in ssot
+    for dimension in (
+        "recognition",
+        "measurement",
+        "classification",
+        "presentation",
+        "disclosure",
+    ):
+        assert dimension in ssot.lower()
+        assert dimension in epic.lower()
+
+
+def test_AC20_5_1_policy_layer_is_read_only_between_facts_and_report() -> None:
+    """AC20.5.1: Policy consumes facts and must not mutate source ledgers or reports."""
+    ssot = read(FRAMEWORK_SSOT)
+    epic = read(EPIC_020)
+
+    assert "read-only" in ssot
+    for immutable_surface in (
+        "source records",
+        "journal entries",
+        "portfolio lots",
+        "market data",
+        "report snapshots",
+    ):
+        assert immutable_surface in ssot
+    assert "does not parse settlements" in ssot
+    assert "does not parse settlements" in epic
+
+
+def test_AC20_6_1_ai_suggestions_require_structured_reviewed_policy_fields() -> None:
+    """AC20.6.1: AI suggestions need structured fields and review before trusted output."""
+    ssot = read(FRAMEWORK_SSOT)
+    epic = read(EPIC_020)
+
+    for required_field in (
+        "source anchor",
+        "confidence tier",
+        "review state",
+        "policy field name",
+        "accepted value",
+    ):
+        assert required_field in ssot
+    assert "must never calculate trusted monetary totals from free-form AI text" in ssot
+    assert "AI Measurement and Disclosure Boundary" in epic
+
+
+def test_AC20_7_1_same_fixture_must_drive_framework_differentiated_reports() -> None:
+    """AC20.7.1: Same fixture must support US-like and HK-like differentiated reports."""
+    epic = read(EPIC_020)
+
+    assert "same settlement and portfolio fixture" in epic
+    assert "US-like and HK-like personal report packages" in epic
+    assert "framework-specific line mappings" in epic
+    assert "readiness blockers" in epic
+
+
+def test_AC2_13_1_canonical_ledger_is_framework_neutral() -> None:
+    """AC2.13.1: Canonical ledger remains framework-neutral."""
+    epic = read("docs/project/EPIC-002.double-entry-core.md")
+
+    assert "Framework Boundary" in epic
+    assert "framework-neutral" in epic
+    assert "must not be embedded into posting logic" in epic
+    assert "Account codes are canonical user ledger identifiers" in epic
+
+
+def test_AC3_10_1_statement_parsing_is_source_capture_not_framework_policy() -> None:
+    """AC3.10.1: Statement parsing captures evidence and leaves framework policy to EPIC-020."""
+    epic = read("docs/project/EPIC-003.statement-parsing.md")
+
+    assert "Framework Boundary" in epic
+    assert "source capture" in epic
+    assert "period boundaries" in epic
+    assert "does not decide US-like or HK-like report classification" in epic
+
+
+def test_AC5_14_1_reporting_assembles_framework_policy_results_only() -> None:
+    """AC5.14.1: Reporting assembles framework policy results without owning policy."""
+    epic = read("docs/project/EPIC-005.reporting-visualization.md")
+
+    assert "Framework Policy Result Consumption" in epic
+    assert "assembles report packages from framework policy results" in epic
+    assert "must not own US/HK recognition" in epic
+    assert "Integration of EPIC-020 framework policy results" in epic
+
+
+def test_AC17_13_1_portfolio_supplies_facts_not_framework_conclusions() -> None:
+    """AC17.13.1: Portfolio supplies facts but not US/HK report conclusions."""
+    epic = read("docs/project/EPIC-017.portfolio-management.md")
+
+    assert "Framework boundary" in epic
+    assert "supplies portfolio facts" in epic
+    assert "not final framework accounting conclusions" in epic
+    assert "does not own final US/HK report presentation decisions" in epic
+
+
+def test_AC18_6_1_ai_suggestions_are_reviewed_before_trusted_framework_use() -> None:
+    """AC18.6.1: AI framework suggestions stay structured and reviewed."""
+    epic = read("docs/project/EPIC-018.ai-driven-pipeline.md")
+
+    assert "EPIC-020 (Framework-aware reporting)" in epic
+    assert "AI may suggest measurement/disclosure evidence" in epic
+    assert "AC18.6.1" in epic
+    assert "structured, source-anchored, confidence-scored, and reviewed" in epic
+
+
+def test_AC19_6_1_readiness_consumes_framework_specific_evidence_blockers() -> None:
+    """AC19.6.1: Readiness consumes framework-specific blockers before trusted reports."""
+    epic = read("docs/project/EPIC-019.event-driven-upload-to-report-ux.md")
+    ssot = read(FRAMEWORK_SSOT)
+
+    assert "Framework-Aware Evidence Readiness" in epic
+    assert "framework-specific evidence blockers from EPIC-020" in epic
+    for blocker in (
+        "missing settlement coverage",
+        "stale market data",
+        "missing valuation basis",
+        "AI-only unreviewed policy suggestions",
+    ):
+        assert blocker in epic
+    assert "Framework-aware report readiness must block trusted output" in ssot


### PR DESCRIPTION
## Summary

Adds EPIC-020 and the framework-reporting SSOT so settlement-driven personal financial reports can be designed from US-like or HK-like target requirements backward.

Refs #675, #676, #677, #678, #679, #680, #681

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-020 — Framework-Aware Personal Financial Reporting |
| **AC IDs** | AC20.1.1, AC20.2.1, AC20.3.1, AC20.4.1, AC20.5.1, AC20.6.1, AC20.7.1, AC2.13.1, AC3.10.1, AC5.14.1, AC17.13.1, AC18.6.1, AC19.7.1 |
| **AC source updated** | Owning EPIC docs and generated AC registry metadata |

---

## SSOT Changes

- [x] `docs/ssot/MANIFEST.yaml` — added `framework_reporting` concept owner
- [x] `docs/ssot/framework-reporting.md` — added US-like/HK-like target-backward policy layer
- [x] `docs/ssot/README.md` — linked framework-reporting SSOT
- [x] `docs/ssot/critical-proof-matrix.yaml` — added EPIC-020 ownership to personal financial report package proof

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | `0ab9bfe32ca27c501b41d8cd9828b94b419330f0` | Added framework reporting contract tests before EPIC-020 and SSOT implementation existed |
| Green (passing test) | `d6c5fa90b7fa2e990dc89e8421fcad31a190a5b1` | Added EPIC-020, SSOT, registry/nav links, and existing EPIC boundary adjustments |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no SQLAlchemy changes
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` — N/A, no env changes
- [x] `repo/` submodule updated for production config changes — N/A
- [x] `tools/check_env_keys.py` passes — N/A, no env vars changed
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

N/A — this PR changes EPIC/SSOT/test documentation contracts only.

---

## Testing

```bash
pytest tests/tooling/test_framework_reporting_epic_contract.py -q
python tools/generate_ac_registry.py --check
python tools/check_manifest.py
python tools/check_ssot_ownership.py
python tools/check_ac_traceability.py --report-only
python tools/check_e2e_epic_traceability.py --report-only
python tools/check_critical_proof_matrix.py
python tools/analyze_test_ac_coverage.py --no-write --stdout
python tools/lint_doc_consistency.py
moon run :lint
```

All commands above passed locally after rebasing onto latest `origin/main`.

`moon run :test` was attempted twice locally but did not reach test execution because Podman could not connect to the machine socket at `127.0.0.1:61270`; `podman machine start` reported success, but `podman machine inspect` still showed the machine as `stopped`. CI should provide the authoritative full-suite result.

---

## Screenshots / Evidence

N/A — documentation and tooling contract change only.