### PR TITLE
[finance_report_audit] Integrate framework policy readiness and package API

### DIFF
--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -36,15 +36,18 @@ from src.schemas import (
     BreakdownType,
     CashFlowResponse,
     CategoryBreakdownResponse,
+    FrameworkPolicyResult,
     IncomeStatementResponse,
     NetWorthGranularity,
     NetWorthTimeSeriesResponse,
+    PersonalReportingFrameworkId,
     PersonalReportPackageContractResponse,
     PersonalReportPackageNotesResponse,
     PersonalReportPackageReadinessResponse,
     PersonalReportPackageTraceabilityResponse,
     TrendPeriod,
 )
+from src.services.framework_policy import derive_user_framework_policy_result
 from src.services.fx import FxRateError, convert_amount
 from src.services.market_data import ensure_market_data_fresh
 from src.services.report_readiness import get_personal_report_package_readiness
@@ -126,8 +129,15 @@ PERSONAL_REPORT_PACKAGE_CONTRACT: dict = {
         "end_date": "required for period sections",
         "as_of_date": "required for point-in-time sections",
         "currency": "ISO-4217 code; defaults to base currency when omitted",
+        "framework_id": "selected supported personal reporting framework",
         "decimal_serialization": "string",
     },
+    "supported_frameworks": [
+        "personal_us_gaap_like",
+        "personal_hkfrs_like",
+    ],
+    "selected_framework_id": None,
+    "framework_policy_endpoint": "/api/reports/package/framework-policy",
     "sections": [
         {
             "section_id": "balance_sheet",
@@ -721,19 +731,57 @@ def _annualized_income_bucket(account_name: str) -> str | None:
 
 
 @router.get("/package/contract", response_model=PersonalReportPackageContractResponse)
-def personal_report_package_contract() -> PersonalReportPackageContractResponse:
+def personal_report_package_contract(
+    framework_id: PersonalReportingFrameworkId | None = None,
+) -> PersonalReportPackageContractResponse:
     """Return the stable package-level API/export contract."""
-    return PersonalReportPackageContractResponse(**PERSONAL_REPORT_PACKAGE_CONTRACT)
+    payload = deepcopy(PERSONAL_REPORT_PACKAGE_CONTRACT)
+    payload["selected_framework_id"] = framework_id.value if framework_id is not None else None
+    return PersonalReportPackageContractResponse(**payload)
 
 
 @router.get("/package/readiness", response_model=PersonalReportPackageReadinessResponse)
 async def personal_report_package_readiness(
+    framework_id: PersonalReportingFrameworkId | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    as_of_date: date | None = None,
     db: DbSession = None,
     user_id: CurrentUserId = None,
 ) -> PersonalReportPackageReadinessResponse:
     """Return deterministic readiness and blocker state for the personal package."""
-    payload = await get_personal_report_package_readiness(db, user_id)
+    payload = await get_personal_report_package_readiness(
+        db,
+        user_id,
+        framework_id=framework_id,
+        report_period_start=start_date,
+        report_period_end=end_date,
+        as_of_date=as_of_date,
+    )
     return PersonalReportPackageReadinessResponse(**payload)
+
+
+@router.get("/package/framework-policy", response_model=FrameworkPolicyResult)
+async def personal_report_package_framework_policy(
+    framework_id: PersonalReportingFrameworkId = PersonalReportingFrameworkId.US_GAAP_LIKE,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    as_of_date: date | None = None,
+    db: DbSession = None,
+    user_id: CurrentUserId = None,
+) -> FrameworkPolicyResult:
+    """Return the selected framework policy result consumed by package assembly."""
+    report_as_of = as_of_date or end_date or date.today()
+    report_end = end_date or report_as_of
+    report_start = start_date or report_end - timedelta(days=365)
+    return await derive_user_framework_policy_result(
+        db,
+        user_id,
+        framework_id=framework_id,
+        report_period_start=report_start,
+        report_period_end=report_end,
+        as_of_date=report_as_of,
+    )
 
 
 @router.get("/package/notes", response_model=PersonalReportPackageNotesResponse)

--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -212,6 +212,9 @@ class PersonalReportPackageContractResponse(BaseModel):
     package_id: str
     version: str
     period_semantics: dict[str, str]
+    supported_frameworks: list[str] = Field(default_factory=list)
+    selected_framework_id: str | None = None
+    framework_policy_endpoint: str | None = None
     sections: list[PersonalReportPackageSectionContract]
     export_contract: PersonalReportPackageExportContract
 
@@ -357,6 +360,7 @@ class FrameworkPolicyMatrix(BaseModel):
 class FrameworkPolicyResult(BaseModel):
     """Read-only target-backward policy result consumed by readiness and reporting."""
 
+    result_id: str
     framework_id: PersonalReportingFrameworkId
     report_period_start: date
     report_period_end: date
@@ -414,7 +418,7 @@ class PersonalReportPackageReadinessResponse(BaseModel):
     action_href: str
     blocking_count: int
     blockers: list[PersonalReportPackageReadinessBlocker] = Field(default_factory=list)
-    source_summary: dict[str, int] = Field(default_factory=dict)
+    source_summary: dict[str, int | str] = Field(default_factory=dict)
     generated_at: datetime | None = None
     stale_since: datetime | None = None
 

--- a/apps/backend/src/services/framework_policy.py
+++ b/apps/backend/src/services/framework_policy.py
@@ -2,10 +2,26 @@
 
 from __future__ import annotations
 
+import hashlib
 from datetime import date
+from decimal import Decimal
+from uuid import UUID
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import (
+    Account,
+    AccountType,
+    DividendIncome,
+    ManualValuationComponentType,
+    ManualValuationSnapshot,
+    MarketDataOverride,
+)
+from src.models.layer2 import AssetType, AtomicPosition
 from src.schemas.reporting import (
     FrameworkPolicyDecision,
+    FrameworkPolicyEvidenceAnchor,
     FrameworkPolicyFact,
     FrameworkPolicyGap,
     FrameworkPolicyMatrix,
@@ -250,6 +266,92 @@ def _gap_for_fact(fact: FrameworkPolicyFact) -> FrameworkPolicyGap:
     )
 
 
+def _result_id(
+    framework_id: PersonalReportingFrameworkId,
+    *,
+    report_period_start: date,
+    report_period_end: date,
+    decisions: list[FrameworkPolicyDecision],
+    gaps: list[FrameworkPolicyGap],
+) -> str:
+    payload = "|".join(
+        [
+            framework_id.value,
+            report_period_start.isoformat(),
+            report_period_end.isoformat(),
+            ",".join(sorted(decision.domain.value for decision in decisions)),
+            ",".join(sorted(anchor.anchor_id for decision in decisions for anchor in decision.evidence_anchors)),
+            ",".join(sorted(f"{gap.fact_id}:{gap.code}" for gap in gaps)),
+            ",".join(sorted(anchor.anchor_id for gap in gaps for anchor in gap.evidence_anchors)),
+        ]
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return (
+        f"policy-result:{framework_id.value}:{report_period_start.isoformat()}:{report_period_end.isoformat()}:{digest}"
+    )
+
+
+def _anchor(
+    *,
+    anchor_type: str,
+    source_system: str,
+    source_id: object,
+    description: str | None = None,
+) -> FrameworkPolicyEvidenceAnchor:
+    return FrameworkPolicyEvidenceAnchor(
+        anchor_id=f"{anchor_type}:{source_id}",
+        anchor_type=anchor_type,
+        source_system=source_system,
+        source_id=str(source_id),
+        description=description,
+    )
+
+
+def _position_domain_and_instrument(position: AtomicPosition) -> tuple[PolicyFactDomain, str]:
+    if position.asset_type == AssetType.STOCK:
+        return PolicyFactDomain.LISTED_SECURITY, "listed_equity"
+    if position.asset_type == AssetType.ETF:
+        return PolicyFactDomain.LISTED_SECURITY, "etf"
+    if position.asset_type == AssetType.MUTUAL_FUND:
+        return PolicyFactDomain.FUND, "fund"
+    if position.asset_type == AssetType.CASH:
+        return PolicyFactDomain.CASH, "cash"
+    if position.asset_type == AssetType.PROPERTY:
+        return PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "property"
+    return (
+        PolicyFactDomain.UNSUPPORTED,
+        position.asset_type.value if position.asset_type is not None else "unknown_asset",
+    )
+
+
+def _manual_domain_and_instrument(snapshot: ManualValuationSnapshot) -> tuple[PolicyFactDomain, str]:
+    restricted_components = {
+        ManualValuationComponentType.ESOP,
+        ManualValuationComponentType.RSU,
+        ManualValuationComponentType.STOCK_OPTIONS,
+    }
+    liability_components = {
+        ManualValuationComponentType.MORTGAGE_BALANCE,
+        ManualValuationComponentType.TAX_PAYABLE,
+        ManualValuationComponentType.OTHER_LIABILITY,
+    }
+    if snapshot.component_type in restricted_components:
+        return PolicyFactDomain.RESTRICTED_COMPENSATION, snapshot.component_type.value
+    if snapshot.component_type in liability_components:
+        return PolicyFactDomain.LIABILITY, snapshot.component_type.value
+    return PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, snapshot.component_type.value
+
+
+def _account_domain_and_instrument(account: Account) -> tuple[PolicyFactDomain, str] | None:
+    if account.type == AccountType.ASSET:
+        return PolicyFactDomain.CASH, "bank_account"
+    if account.type == AccountType.LIABILITY:
+        return PolicyFactDomain.LIABILITY, "loan"
+    if account.type == AccountType.INCOME:
+        return PolicyFactDomain.DIVIDEND_INTEREST, "interest"
+    return None
+
+
 def derive_framework_policy_result(
     framework_id: PersonalReportingFrameworkId,
     *,
@@ -283,6 +385,13 @@ def derive_framework_policy_result(
         )
 
     return FrameworkPolicyResult(
+        result_id=_result_id(
+            framework_id,
+            report_period_start=report_period_start,
+            report_period_end=report_period_end,
+            decisions=decisions,
+            gaps=gaps,
+        ),
         framework_id=framework_id,
         report_period_start=report_period_start,
         report_period_end=report_period_end,
@@ -290,4 +399,182 @@ def derive_framework_policy_result(
         required_statements=_REQUIRED_STATEMENTS,
         decisions=decisions,
         gaps=gaps,
+    )
+
+
+async def framework_policy_facts_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    report_period_start: date,
+    report_period_end: date,
+    as_of_date: date,
+) -> list[FrameworkPolicyFact]:
+    """Build framework-neutral facts from existing source, ledger, and portfolio records."""
+    facts: list[FrameworkPolicyFact] = []
+
+    account_result = await db.execute(
+        select(Account).where(
+            Account.user_id == user_id,
+            Account.is_active == True,  # noqa: E712
+            Account.is_system == False,  # noqa: E712
+        )
+    )
+    for account in account_result.scalars().all():
+        mapping = _account_domain_and_instrument(account)
+        if mapping is None:
+            continue
+        domain, instrument_type = mapping
+        facts.append(
+            FrameworkPolicyFact(
+                fact_id=f"account:{account.id}",
+                domain=domain,
+                instrument_type=instrument_type,
+                currency=account.currency,
+                event_date=as_of_date,
+                anchors=[
+                    _anchor(
+                        anchor_type="account",
+                        source_system="canonical_ledger",
+                        source_id=account.id,
+                        description=account.name,
+                    )
+                ],
+            )
+        )
+
+    price_result = await db.execute(
+        select(MarketDataOverride)
+        .where(MarketDataOverride.user_id == user_id)
+        .where(MarketDataOverride.price_date <= as_of_date)
+        .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+    )
+    latest_price_by_identifier: dict[str, MarketDataOverride] = {}
+    for price in price_result.scalars().all():
+        latest_price_by_identifier.setdefault(price.asset_identifier, price)
+
+    position_result = await db.execute(
+        select(AtomicPosition)
+        .where(AtomicPosition.user_id == user_id)
+        .where(AtomicPosition.snapshot_date <= as_of_date)
+        .order_by(AtomicPosition.snapshot_date.desc(), AtomicPosition.created_at.desc())
+    )
+    seen_positions: set[str] = set()
+    for position in position_result.scalars().all():
+        if position.asset_identifier in seen_positions:
+            continue
+        seen_positions.add(position.asset_identifier)
+        domain, instrument_type = _position_domain_and_instrument(position)
+        anchors = [
+            _anchor(
+                anchor_type="atomic_position",
+                source_system="portfolio_subledger",
+                source_id=position.id,
+                description=position.asset_identifier,
+            )
+        ]
+        price = latest_price_by_identifier.get(position.asset_identifier)
+        if price is not None:
+            anchors.append(
+                _anchor(
+                    anchor_type="market_price",
+                    source_system="market_data_override",
+                    source_id=price.id,
+                    description=f"{price.asset_identifier} price dated {price.price_date.isoformat()}",
+                )
+            )
+        facts.append(
+            FrameworkPolicyFact(
+                fact_id=f"atomic_position:{position.id}",
+                domain=domain,
+                instrument_type=instrument_type,
+                amount=Decimal(position.market_value),
+                currency=position.currency,
+                event_date=position.snapshot_date,
+                anchors=anchors,
+            )
+        )
+
+    manual_result = await db.execute(
+        select(ManualValuationSnapshot)
+        .where(ManualValuationSnapshot.user_id == user_id)
+        .where(ManualValuationSnapshot.as_of_date <= as_of_date)
+        .order_by(ManualValuationSnapshot.as_of_date.desc(), ManualValuationSnapshot.created_at.desc())
+    )
+    seen_manual: set[tuple[ManualValuationComponentType, str]] = set()
+    for snapshot in manual_result.scalars().all():
+        manual_key = (snapshot.component_type, snapshot.source)
+        if manual_key in seen_manual:
+            continue
+        seen_manual.add(manual_key)
+        domain, instrument_type = _manual_domain_and_instrument(snapshot)
+        facts.append(
+            FrameworkPolicyFact(
+                fact_id=f"manual_valuation_snapshot:{snapshot.id}",
+                domain=domain,
+                instrument_type=instrument_type,
+                amount=Decimal(snapshot.value),
+                currency=snapshot.currency,
+                event_date=snapshot.as_of_date,
+                anchors=[
+                    _anchor(
+                        anchor_type="manual_valuation_snapshot",
+                        source_system="manual_valuation",
+                        source_id=snapshot.id,
+                        description=snapshot.source,
+                    )
+                ],
+            )
+        )
+
+    dividend_result = await db.execute(
+        select(DividendIncome)
+        .where(DividendIncome.user_id == user_id)
+        .where(DividendIncome.payment_date >= report_period_start)
+        .where(DividendIncome.payment_date <= report_period_end)
+    )
+    for dividend in dividend_result.scalars().all():
+        facts.append(
+            FrameworkPolicyFact(
+                fact_id=f"dividend_income:{dividend.id}",
+                domain=PolicyFactDomain.DIVIDEND_INTEREST,
+                instrument_type="dividend",
+                amount=Decimal(dividend.amount),
+                currency=dividend.currency,
+                event_date=dividend.payment_date,
+                anchors=[
+                    _anchor(
+                        anchor_type="dividend_income",
+                        source_system="portfolio_subledger",
+                        source_id=dividend.id,
+                    )
+                ],
+            )
+        )
+
+    return facts
+
+
+async def derive_user_framework_policy_result(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    framework_id: PersonalReportingFrameworkId,
+    report_period_start: date,
+    report_period_end: date,
+    as_of_date: date,
+) -> FrameworkPolicyResult:
+    """Derive the selected framework policy result from current user facts without writes."""
+    facts = await framework_policy_facts_for_user(
+        db,
+        user_id,
+        report_period_start=report_period_start,
+        report_period_end=report_period_end,
+        as_of_date=as_of_date,
+    )
+    return derive_framework_policy_result(
+        framework_id,
+        report_period_start=report_period_start,
+        report_period_end=report_period_end,
+        facts=facts,
     )

--- a/apps/backend/src/services/framework_policy.py
+++ b/apps/backend/src/services/framework_policy.py
@@ -325,21 +325,32 @@ def _position_domain_and_instrument(position: AtomicPosition) -> tuple[PolicyFac
 
 
 def _manual_domain_and_instrument(snapshot: ManualValuationSnapshot) -> tuple[PolicyFactDomain, str]:
-    restricted_components = {
-        ManualValuationComponentType.ESOP,
-        ManualValuationComponentType.RSU,
-        ManualValuationComponentType.STOCK_OPTIONS,
+    restricted_component_instruments = {
+        ManualValuationComponentType.ESOP: "esop",
+        ManualValuationComponentType.RSU: "rsu",
+        ManualValuationComponentType.STOCK_OPTIONS: "stock_option",
     }
-    liability_components = {
-        ManualValuationComponentType.MORTGAGE_BALANCE,
-        ManualValuationComponentType.TAX_PAYABLE,
-        ManualValuationComponentType.OTHER_LIABILITY,
+    liability_component_instruments = {
+        ManualValuationComponentType.MORTGAGE_BALANCE: "mortgage_liability",
+        ManualValuationComponentType.TAX_PAYABLE: "payable",
+        ManualValuationComponentType.OTHER_LIABILITY: "loan",
     }
-    if snapshot.component_type in restricted_components:
-        return PolicyFactDomain.RESTRICTED_COMPENSATION, snapshot.component_type.value
-    if snapshot.component_type in liability_components:
-        return PolicyFactDomain.LIABILITY, snapshot.component_type.value
-    return PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, snapshot.component_type.value
+    manual_asset_component_instruments = {
+        ManualValuationComponentType.PROPERTY_VALUE: "property",
+        ManualValuationComponentType.CPF_BALANCE: "manual_asset",
+        ManualValuationComponentType.LONG_TERM_SAVINGS: "manual_asset",
+        ManualValuationComponentType.TAX_REFUND: "manual_asset",
+        ManualValuationComponentType.INSURANCE_CASH_VALUE: "manual_asset",
+        ManualValuationComponentType.OTHER_ASSET: "manual_asset",
+    }
+    if snapshot.component_type in restricted_component_instruments:
+        return PolicyFactDomain.RESTRICTED_COMPENSATION, restricted_component_instruments[snapshot.component_type]
+    if snapshot.component_type in liability_component_instruments:
+        return PolicyFactDomain.LIABILITY, liability_component_instruments[snapshot.component_type]
+    return (
+        PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE,
+        manual_asset_component_instruments.get(snapshot.component_type, "manual_asset"),
+    )
 
 
 def _account_domain_and_instrument(account: Account) -> tuple[PolicyFactDomain, str] | None:

--- a/apps/backend/src/services/report_readiness.py
+++ b/apps/backend/src/services/report_readiness.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from uuid import UUID
 
@@ -31,9 +31,19 @@ from src.models import (
     ReportSnapshot,
     Stage1Status,
 )
+from src.models.layer2 import AssetType
+from src.schemas.reporting import (
+    FrameworkPolicyResult,
+    PersonalReportingFrameworkId,
+    PolicyDimension,
+    PolicyProvenance,
+    PolicyReviewState,
+)
+from src.services.framework_policy import derive_user_framework_policy_result
 from src.services.fx import FxRateError, convert_amount
 
 PACKAGE_ID = "personal-financial-report-package"
+MARKET_DATA_STALE_AFTER_DAYS = 90
 
 
 def _blocker(
@@ -96,8 +106,215 @@ async def _processing_account_balance(db: AsyncSession, user_id: UUID) -> Decima
     return total
 
 
-async def get_personal_report_package_readiness(db: AsyncSession, user_id: UUID) -> dict:
+def _normalize_framework_id(
+    framework_id: PersonalReportingFrameworkId | str | None,
+) -> PersonalReportingFrameworkId | None:
+    if framework_id is None:
+        return None
+    if isinstance(framework_id, PersonalReportingFrameworkId):
+        return framework_id
+    return PersonalReportingFrameworkId(framework_id)
+
+
+def framework_policy_readiness_blockers(
+    *,
+    framework_id: PersonalReportingFrameworkId | str | None,
+    policy_result: FrameworkPolicyResult | None,
+    report_input_count: int,
+    missing_valuation_basis_count: int,
+    stale_market_data_count: int,
+) -> list[dict[str, str | int]]:
+    """Translate selected-framework policy deficiencies into readiness blockers."""
+    blockers: list[dict[str, str | int]] = []
+    try:
+        selected_framework_id = _normalize_framework_id(framework_id)
+    except ValueError:
+        return [
+            _blocker(
+                "unsupported_framework",
+                "Unsupported framework",
+                1,
+                "The selected reporting framework is not supported for personal report generation.",
+                "/reports/package",
+            )
+        ]
+
+    if selected_framework_id is None:
+        return blockers
+
+    if policy_result is None:
+        if report_input_count:
+            blockers.append(
+                _blocker(
+                    "missing_framework_policy_result",
+                    "Missing framework policy result",
+                    1,
+                    "A selected framework requires a structured policy result before trusted output can be generated.",
+                    "/reports/package/framework-policy",
+                )
+            )
+        return blockers
+
+    if policy_result.framework_id != selected_framework_id:
+        blockers.append(
+            _blocker(
+                "missing_framework_policy_result",
+                "Framework policy result mismatch",
+                1,
+                "The available policy result does not match the selected reporting framework.",
+                "/reports/package/framework-policy",
+            )
+        )
+
+    if report_input_count and not policy_result.decisions and not policy_result.gaps:
+        blockers.append(
+            _blocker(
+                "missing_framework_policy_result",
+                "Missing framework policy result",
+                1,
+                "The selected framework produced no structured policy decisions or explicit policy gaps for the available package inputs.",
+                "/reports/package/framework-policy",
+            )
+        )
+
+    gap_counts: dict[str, int] = {}
+    for gap in policy_result.gaps:
+        if gap.blocker:
+            gap_counts[gap.code] = gap_counts.get(gap.code, 0) + 1
+    for code, count in sorted(gap_counts.items()):
+        blockers.append(
+            _blocker(
+                code,
+                "Unsupported policy domain" if code == "unsupported_policy_domain" else "Framework policy gap",
+                count,
+                "A selected-framework policy gap must be remediated before the package can be trusted.",
+                "/reports/package/framework-policy",
+            )
+        )
+
+    missing_dimension_count = sum(
+        1
+        for decision in policy_result.decisions
+        if any(not getattr(decision, dimension.value, None) for dimension in PolicyDimension)
+    )
+    if missing_dimension_count:
+        blockers.append(
+            _blocker(
+                "framework_policy_missing_dimensions",
+                "Incomplete framework policy decision",
+                missing_dimension_count,
+                "Every policy decision must include recognition, measurement, classification, presentation, and disclosure.",
+                "/reports/package/framework-policy",
+            )
+        )
+
+    unreviewed_ai_count = sum(
+        1
+        for decision in policy_result.decisions
+        if decision.provenance == PolicyProvenance.REVIEWED_AI_SUGGESTION
+        and (
+            decision.review_state != PolicyReviewState.ACCEPTED
+            or not decision.policy_field_name
+            or not decision.accepted_value
+            or not decision.evidence_anchors
+        )
+    )
+    if unreviewed_ai_count:
+        blockers.append(
+            _blocker(
+                "framework_ai_suggestion_unreviewed",
+                "Unreviewed AI policy suggestion",
+                unreviewed_ai_count,
+                "AI-suggested measurement or disclosure fields require source anchors, review acceptance, and accepted structured values.",
+                "/review",
+            )
+        )
+
+    if missing_valuation_basis_count:
+        blockers.append(
+            _blocker(
+                "missing_valuation_basis",
+                "Missing valuation basis",
+                missing_valuation_basis_count,
+                "Manual or private valuation facts need an explicit valuation basis before trusted totals can be generated.",
+                "/assets/manual-valuations",
+            )
+        )
+
+    if stale_market_data_count:
+        blockers.append(
+            _blocker(
+                "stale_market_data",
+                "Stale market data",
+                stale_market_data_count,
+                f"Listed security and fund positions need market prices dated within {MARKET_DATA_STALE_AFTER_DAYS} days of the report date.",
+                "/portfolio/market-data",
+            )
+        )
+
+    return blockers
+
+
+async def _missing_valuation_basis_count(db: AsyncSession, user_id: UUID, *, as_of_date: date) -> int:
+    rows = await db.execute(
+        select(ManualValuationSnapshot.notes)
+        .where(ManualValuationSnapshot.user_id == user_id)
+        .where(ManualValuationSnapshot.as_of_date <= as_of_date)
+    )
+    return sum(1 for notes in rows.scalars().all() if notes is None or not notes.strip())
+
+
+async def _stale_market_data_count(db: AsyncSession, user_id: UUID, *, as_of_date: date) -> int:
+    investable_asset_types = [
+        AssetType.STOCK,
+        AssetType.ETF,
+        AssetType.MUTUAL_FUND,
+        AssetType.BOND,
+    ]
+    position_rows = await db.execute(
+        select(AtomicPosition.asset_identifier)
+        .where(AtomicPosition.user_id == user_id)
+        .where(AtomicPosition.snapshot_date <= as_of_date)
+        .where(AtomicPosition.asset_type.in_(investable_asset_types))
+        .distinct()
+    )
+    asset_identifiers = list(position_rows.scalars().all())
+    if not asset_identifiers:
+        return 0
+
+    price_rows = await db.execute(
+        select(MarketDataOverride)
+        .where(MarketDataOverride.user_id == user_id)
+        .where(MarketDataOverride.asset_identifier.in_(asset_identifiers))
+        .where(MarketDataOverride.price_date <= as_of_date)
+        .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+    )
+    latest_price_by_identifier: dict[str, MarketDataOverride] = {}
+    for price in price_rows.scalars().all():
+        latest_price_by_identifier.setdefault(price.asset_identifier, price)
+
+    freshness_cutoff = as_of_date - timedelta(days=MARKET_DATA_STALE_AFTER_DAYS)
+    return sum(
+        1
+        for asset_identifier in asset_identifiers
+        if latest_price_by_identifier.get(asset_identifier) is None
+        or latest_price_by_identifier[asset_identifier].price_date < freshness_cutoff
+    )
+
+
+async def get_personal_report_package_readiness(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    framework_id: PersonalReportingFrameworkId | str | None = None,
+    report_period_start: date | None = None,
+    report_period_end: date | None = None,
+    as_of_date: date | None = None,
+) -> dict:
     """Return deterministic readiness for the personal financial-report package."""
+    report_as_of = as_of_date or report_period_end or date.today()
+    report_end = report_period_end or report_as_of
+    report_start = report_period_start or report_end - timedelta(days=365)
     statement_count = await _count(
         db,
         select(func.count(BankStatement.id)).where(BankStatement.user_id == user_id),
@@ -301,6 +518,42 @@ async def get_personal_report_package_readiness(db: AsyncSession, user_id: UUID)
                 "/accounts/coverage",
             )
         )
+
+    selected_framework_id: PersonalReportingFrameworkId | None = None
+    policy_result: FrameworkPolicyResult | None = None
+    missing_valuation_basis_count = 0
+    stale_market_data_count = 0
+    try:
+        selected_framework_id = _normalize_framework_id(framework_id)
+    except ValueError:
+        pass
+    if selected_framework_id is not None:
+        policy_result = await derive_user_framework_policy_result(
+            db,
+            user_id,
+            framework_id=selected_framework_id,
+            report_period_start=report_start,
+            report_period_end=report_end,
+            as_of_date=report_as_of,
+        )
+        missing_valuation_basis_count = await _missing_valuation_basis_count(db, user_id, as_of_date=report_as_of)
+        stale_market_data_count = await _stale_market_data_count(db, user_id, as_of_date=report_as_of)
+        source_summary.update(
+            {
+                "selected_framework_id": selected_framework_id.value,
+                "framework_policy_decisions": len(policy_result.decisions),
+                "framework_policy_gaps": len(policy_result.gaps),
+            }
+        )
+    blockers.extend(
+        framework_policy_readiness_blockers(
+            framework_id=framework_id,
+            policy_result=policy_result,
+            report_input_count=report_input_count,
+            missing_valuation_basis_count=missing_valuation_basis_count,
+            stale_market_data_count=stale_market_data_count,
+        )
+    )
 
     latest_snapshot_count = await _count(
         db,

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -95,6 +95,7 @@ def test_AC5_9_2_package_contract_marks_decimal_totals_and_period_semantics():
         "end_date": "required for period sections",
         "as_of_date": "required for point-in-time sections",
         "currency": "ISO-4217 code; defaults to base currency when omitted",
+        "framework_id": "selected supported personal reporting framework",
         "decimal_serialization": "string",
     }
 

--- a/apps/backend/tests/reporting/test_framework_package_integration.py
+++ b/apps/backend/tests/reporting/test_framework_package_integration.py
@@ -1,0 +1,247 @@
+"""Framework policy integration for package APIs and readiness."""
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.layer2 import AssetType, AtomicPosition
+from src.models.layer3 import (
+    ManualValuationComponentType,
+    ManualValuationLiquidityClass,
+    ManualValuationSnapshot,
+)
+from src.models.portfolio import MarketDataOverride, PriceSource
+from src.models.user import User
+from src.routers.reports import (
+    personal_report_package_contract,
+    personal_report_package_framework_policy,
+    personal_report_package_readiness,
+)
+from src.schemas.reporting import (
+    FrameworkPolicyDecision,
+    FrameworkPolicyResult,
+    PersonalReportingFrameworkId,
+    PolicyFactDomain,
+    PolicyProvenance,
+    PolicyReviewState,
+)
+from src.services.report_readiness import framework_policy_readiness_blockers
+
+
+@pytest.fixture(autouse=True)
+def patch_database_connection():
+    """Pure contract tests in this module do not require an implicit database."""
+    yield
+
+
+def test_AC5_14_1_package_contract_accepts_selected_framework_policy_endpoint() -> None:
+    """AC5.14.1: Package contract consumes EPIC-020 policy result metadata, not raw market value rules."""
+    response = personal_report_package_contract(framework_id=PersonalReportingFrameworkId.HKFRS_LIKE)
+    payload = response.model_dump(mode="json")
+
+    assert payload["selected_framework_id"] == "personal_hkfrs_like"
+    assert payload["supported_frameworks"] == ["personal_us_gaap_like", "personal_hkfrs_like"]
+    assert payload["framework_policy_endpoint"] == "/api/reports/package/framework-policy"
+    assert payload["period_semantics"]["framework_id"] == "selected supported personal reporting framework"
+
+
+@pytest.mark.asyncio
+async def test_AC20_5_1_package_policy_api_derives_framework_result_from_facts(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC20.5.1: Package policy API derives a read-only result from canonical portfolio facts."""
+    report_date = date(2026, 5, 31)
+    position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=report_date,
+        asset_identifier="HKAPI",
+        broker="Framework Broker",
+        quantity=Decimal("10"),
+        market_value=Decimal("125.00"),
+        currency="SGD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=f"framework-api-{uuid4()}",
+        source_documents={"documents": [{"doc_id": "framework-broker-doc", "doc_type": "brokerage_statement"}]},
+    )
+    price = MarketDataOverride(
+        user_id=test_user.id,
+        asset_identifier="HKAPI",
+        price_date=report_date,
+        price=Decimal("12.50"),
+        currency="SGD",
+        source=PriceSource.API,
+    )
+    db.add_all([position, price])
+    await db.flush()
+
+    us_response = await personal_report_package_framework_policy(
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        start_date=date(2026, 5, 1),
+        end_date=report_date,
+        as_of_date=report_date,
+        db=db,
+        user_id=test_user.id,
+    )
+    hk_response = await personal_report_package_framework_policy(
+        framework_id=PersonalReportingFrameworkId.HKFRS_LIKE,
+        start_date=date(2026, 5, 1),
+        end_date=report_date,
+        as_of_date=report_date,
+        db=db,
+        user_id=test_user.id,
+    )
+
+    assert us_response.result_id.startswith("policy-result:personal_us_gaap_like:")
+    assert hk_response.result_id.startswith("policy-result:personal_hkfrs_like:")
+    assert us_response.gaps == []
+    assert hk_response.gaps == []
+    us_line = us_response.decisions[0].line_mappings["balance_sheet"]
+    hk_line = hk_response.decisions[0].line_mappings["balance_sheet"]
+    assert us_line == "assets.marketable_securities"
+    assert hk_line == "assets.financial_assets_at_fair_value"
+    assert "atomic_position" in {anchor.anchor_type for anchor in hk_response.decisions[0].evidence_anchors}
+    assert "market_price" in {anchor.anchor_type for anchor in hk_response.decisions[0].evidence_anchors}
+
+
+@pytest.mark.asyncio
+async def test_AC19_7_1_readiness_consumes_framework_specific_evidence_blockers(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC19.7.1: Framework-selected readiness blocks policy gaps and evidence deficiencies."""
+    report_date = date(2026, 5, 31)
+    stale_position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=report_date,
+        asset_identifier="STALE",
+        broker="Framework Broker",
+        quantity=Decimal("5"),
+        market_value=Decimal("50.00"),
+        currency="SGD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=f"framework-stale-{uuid4()}",
+        source_documents={"documents": [{"doc_id": "stale-doc", "doc_type": "brokerage_statement"}]},
+    )
+    unsupported_position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=report_date,
+        asset_identifier="PRIVATE-TOKEN",
+        broker="Framework Broker",
+        quantity=Decimal("1"),
+        market_value=Decimal("500.00"),
+        currency="SGD",
+        asset_type=AssetType.OTHER,
+        dedup_hash=f"framework-token-{uuid4()}",
+        source_documents={"documents": [{"doc_id": "token-doc", "doc_type": "brokerage_statement"}]},
+    )
+    stale_price = MarketDataOverride(
+        user_id=test_user.id,
+        asset_identifier="STALE",
+        price_date=date(2025, 12, 31),
+        price=Decimal("10.00"),
+        currency="SGD",
+        source=PriceSource.MANUAL,
+    )
+    missing_basis = ManualValuationSnapshot(
+        user_id=test_user.id,
+        component_type=ManualValuationComponentType.PROPERTY_VALUE,
+        liquidity_class=ManualValuationLiquidityClass.ILLIQUID,
+        as_of_date=report_date,
+        value=Decimal("500000.00"),
+        currency="SGD",
+        source="Manual property estimate",
+        notes=None,
+    )
+    db.add_all([stale_position, unsupported_position, stale_price, missing_basis])
+    await db.flush()
+
+    response = await personal_report_package_readiness(
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        end_date=report_date,
+        as_of_date=report_date,
+        db=db,
+        user_id=test_user.id,
+    )
+    payload = response.model_dump(mode="json")
+    blockers = {blocker["code"]: blocker for blocker in payload["blockers"]}
+
+    assert payload["state"] == "blocked"
+    assert payload["source_summary"]["selected_framework_id"] == "personal_us_gaap_like"
+    assert payload["source_summary"]["framework_policy_gaps"] == 1
+    assert {
+        "unsupported_policy_domain",
+        "missing_valuation_basis",
+        "stale_market_data",
+    } <= set(blockers)
+    assert blockers["unsupported_policy_domain"]["count"] == 1
+    assert blockers["missing_valuation_basis"]["count"] == 1
+    assert blockers["stale_market_data"]["count"] == 1
+
+
+def test_AC20_6_1_ai_suggestions_require_reviewed_policy_fields_for_readiness() -> None:
+    """AC20.6.1: AI suggestions and incomplete policy fields become readiness blocker codes."""
+    decision = FrameworkPolicyDecision.model_construct(
+        domain=PolicyFactDomain.LISTED_SECURITY,
+        recognition="Recognize listed holding from broker evidence.",
+        measurement="AI-proposed fair-value measurement.",
+        classification="Marketable investment asset.",
+        presentation="Balance sheet investment line.",
+        disclosure=None,
+        line_mappings={"balance_sheet": "assets.marketable_securities"},
+        evidence_anchors=[],
+        provenance=PolicyProvenance.REVIEWED_AI_SUGGESTION,
+        confidence_tier="MEDIUM",
+        review_state=PolicyReviewState.PENDING_REVIEW,
+        policy_field_name="measurement_basis",
+        accepted_value=None,
+    )
+    policy_result = FrameworkPolicyResult.model_construct(
+        result_id="policy-result:ai-pending",
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        report_period_start=date(2026, 5, 1),
+        report_period_end=date(2026, 5, 31),
+        generated_at=date(2026, 5, 31),
+        required_statements=["balance_sheet"],
+        decisions=[decision],
+        gaps=[],
+    )
+
+    blockers = framework_policy_readiness_blockers(
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        policy_result=policy_result,
+        report_input_count=1,
+        missing_valuation_basis_count=0,
+        stale_market_data_count=0,
+    )
+    blocker_codes = {blocker["code"] for blocker in blockers}
+
+    assert "framework_policy_missing_dimensions" in blocker_codes
+    assert "framework_ai_suggestion_unreviewed" in blocker_codes
+
+
+def test_AC19_7_1_selected_framework_requires_non_empty_policy_result() -> None:
+    """AC19.7.1: Selected-framework readiness fails closed when no policy result can be derived."""
+    empty_policy_result = FrameworkPolicyResult.model_construct(
+        result_id="policy-result:empty",
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        report_period_start=date(2026, 5, 1),
+        report_period_end=date(2026, 5, 31),
+        generated_at=date(2026, 5, 31),
+        required_statements=["balance_sheet"],
+        decisions=[],
+        gaps=[],
+    )
+
+    blockers = framework_policy_readiness_blockers(
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        policy_result=empty_policy_result,
+        report_input_count=1,
+        missing_valuation_basis_count=0,
+        stale_market_data_count=0,
+    )
+
+    assert {blocker["code"] for blocker in blockers} == {"missing_framework_policy_result"}

--- a/apps/backend/tests/reporting/test_framework_package_integration.py
+++ b/apps/backend/tests/reporting/test_framework_package_integration.py
@@ -8,13 +8,17 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.models.account import Account, AccountType
 from src.models.layer2 import AssetType, AtomicPosition
 from src.models.layer3 import (
+    CostBasisMethod,
+    ManagedPosition,
     ManualValuationComponentType,
     ManualValuationLiquidityClass,
     ManualValuationSnapshot,
+    PositionStatus,
 )
-from src.models.portfolio import MarketDataOverride, PriceSource
+from src.models.portfolio import DividendIncome, MarketDataOverride, PriceSource
 from src.models.user import User
 from src.routers.reports import (
     personal_report_package_contract,
@@ -30,7 +34,12 @@ from src.schemas.reporting import (
     PolicyProvenance,
     PolicyReviewState,
 )
-from src.services.framework_policy import _manual_domain_and_instrument, _position_domain_and_instrument
+from src.services.framework_policy import (
+    _account_domain_and_instrument,
+    _manual_domain_and_instrument,
+    _position_domain_and_instrument,
+    framework_policy_facts_for_user,
+)
 from src.services.report_readiness import framework_policy_readiness_blockers
 
 
@@ -288,6 +297,124 @@ def test_AC20_5_1_atomic_position_asset_types_map_to_policy_domains() -> None:
     for asset_type, expected_domain, expected_instrument in fixtures:
         position = SimpleNamespace(asset_type=asset_type)
         assert _position_domain_and_instrument(position) == (expected_domain, expected_instrument)
+
+
+def test_AC20_5_1_ledger_account_types_map_to_policy_domains() -> None:
+    """AC20.5.1: Ledger accounts map to framework-neutral facts or stay out of policy derivation."""
+    fixtures = [
+        (AccountType.ASSET, (PolicyFactDomain.CASH, "bank_account")),
+        (AccountType.LIABILITY, (PolicyFactDomain.LIABILITY, "loan")),
+        (AccountType.INCOME, (PolicyFactDomain.DIVIDEND_INTEREST, "interest")),
+        (AccountType.EXPENSE, None),
+        (AccountType.EQUITY, None),
+    ]
+
+    for account_type, expected in fixtures:
+        account = SimpleNamespace(type=account_type)
+        assert _account_domain_and_instrument(account) == expected
+
+
+@pytest.mark.asyncio
+async def test_AC20_5_1_framework_facts_include_ledger_manual_position_and_dividend_sources(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC20.5.1: Policy facts derive from canonical sources with latest-source deduplication."""
+    report_date = date(2026, 5, 31)
+    account = Account(user_id=test_user.id, name="Framework Cash", type=AccountType.ASSET, currency="SGD")
+    expense_account = Account(user_id=test_user.id, name="Framework Expense", type=AccountType.EXPENSE, currency="SGD")
+    investment_account = Account(
+        user_id=test_user.id,
+        name="Framework Investment",
+        type=AccountType.ASSET,
+        currency="SGD",
+        is_system=True,
+    )
+    db.add_all([account, expense_account, investment_account])
+    await db.flush()
+
+    managed_position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=investment_account.id,
+        asset_identifier="DIVFACT",
+        quantity=Decimal("1"),
+        cost_basis=Decimal("10.00"),
+        currency="SGD",
+        acquisition_date=report_date,
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    db.add(managed_position)
+    await db.flush()
+
+    latest_position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=report_date,
+        asset_identifier="DEDUP",
+        broker="Framework Broker",
+        quantity=Decimal("2"),
+        market_value=Decimal("20.00"),
+        currency="SGD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=f"framework-position-latest-{uuid4()}",
+        source_documents={},
+    )
+    older_position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=date(2026, 4, 30),
+        asset_identifier="DEDUP",
+        broker="Framework Broker",
+        quantity=Decimal("1"),
+        market_value=Decimal("10.00"),
+        currency="SGD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=f"framework-position-older-{uuid4()}",
+        source_documents={},
+    )
+    latest_manual = ManualValuationSnapshot(
+        user_id=test_user.id,
+        component_type=ManualValuationComponentType.OTHER_ASSET,
+        liquidity_class=ManualValuationLiquidityClass.LIQUID,
+        as_of_date=report_date,
+        value=Decimal("120.00"),
+        currency="SGD",
+        source="Other asset schedule",
+    )
+    older_manual = ManualValuationSnapshot(
+        user_id=test_user.id,
+        component_type=ManualValuationComponentType.OTHER_ASSET,
+        liquidity_class=ManualValuationLiquidityClass.LIQUID,
+        as_of_date=date(2026, 4, 30),
+        value=Decimal("100.00"),
+        currency="SGD",
+        source="Other asset schedule",
+    )
+    dividend = DividendIncome(
+        user_id=test_user.id,
+        position_id=managed_position.id,
+        payment_date=report_date,
+        amount=Decimal("3.50"),
+        currency="SGD",
+    )
+    db.add_all([latest_position, older_position, latest_manual, older_manual, dividend])
+    await db.flush()
+
+    facts = await framework_policy_facts_for_user(
+        db,
+        test_user.id,
+        report_period_start=date(2026, 5, 1),
+        report_period_end=report_date,
+        as_of_date=report_date,
+    )
+
+    fact_ids = {fact.fact_id for fact in facts}
+    assert f"account:{account.id}" in fact_ids
+    assert f"account:{expense_account.id}" not in fact_ids
+    assert f"atomic_position:{latest_position.id}" in fact_ids
+    assert f"atomic_position:{older_position.id}" not in fact_ids
+    assert f"manual_valuation_snapshot:{latest_manual.id}" in fact_ids
+    assert f"manual_valuation_snapshot:{older_manual.id}" not in fact_ids
+    assert f"dividend_income:{dividend.id}" in fact_ids
 
 
 def test_AC19_7_1_framework_policy_helper_emits_all_evidence_blocker_codes() -> None:

--- a/apps/backend/tests/reporting/test_framework_package_integration.py
+++ b/apps/backend/tests/reporting/test_framework_package_integration.py
@@ -2,6 +2,7 @@
 
 from datetime import date
 from decimal import Decimal
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -22,12 +23,14 @@ from src.routers.reports import (
 )
 from src.schemas.reporting import (
     FrameworkPolicyDecision,
+    FrameworkPolicyGap,
     FrameworkPolicyResult,
     PersonalReportingFrameworkId,
     PolicyFactDomain,
     PolicyProvenance,
     PolicyReviewState,
 )
+from src.services.framework_policy import _manual_domain_and_instrument, _position_domain_and_instrument
 from src.services.report_readiness import framework_policy_readiness_blockers
 
 
@@ -245,3 +248,104 @@ def test_AC19_7_1_selected_framework_requires_non_empty_policy_result() -> None:
     )
 
     assert {blocker["code"] for blocker in blockers} == {"missing_framework_policy_result"}
+
+
+def test_AC20_5_1_manual_valuation_components_map_to_supported_policy_instruments() -> None:
+    """AC20.5.1: Manual valuation facts map to supported matrix instruments instead of policy gaps."""
+    fixtures = [
+        (ManualValuationComponentType.PROPERTY_VALUE, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "property"),
+        (ManualValuationComponentType.CPF_BALANCE, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "manual_asset"),
+        (ManualValuationComponentType.LONG_TERM_SAVINGS, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "manual_asset"),
+        (ManualValuationComponentType.TAX_REFUND, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "manual_asset"),
+        (ManualValuationComponentType.INSURANCE_CASH_VALUE, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "manual_asset"),
+        (ManualValuationComponentType.OTHER_ASSET, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "manual_asset"),
+        (ManualValuationComponentType.ESOP, PolicyFactDomain.RESTRICTED_COMPENSATION, "esop"),
+        (ManualValuationComponentType.RSU, PolicyFactDomain.RESTRICTED_COMPENSATION, "rsu"),
+        (ManualValuationComponentType.STOCK_OPTIONS, PolicyFactDomain.RESTRICTED_COMPENSATION, "stock_option"),
+        (ManualValuationComponentType.MORTGAGE_BALANCE, PolicyFactDomain.LIABILITY, "mortgage_liability"),
+        (ManualValuationComponentType.TAX_PAYABLE, PolicyFactDomain.LIABILITY, "payable"),
+        (ManualValuationComponentType.OTHER_LIABILITY, PolicyFactDomain.LIABILITY, "loan"),
+    ]
+
+    for component_type, expected_domain, expected_instrument in fixtures:
+        snapshot = SimpleNamespace(component_type=component_type)
+        assert _manual_domain_and_instrument(snapshot) == (expected_domain, expected_instrument)
+
+
+def test_AC20_5_1_atomic_position_asset_types_map_to_policy_domains() -> None:
+    """AC20.5.1: Atomic positions map to supported policy domains or explicit unsupported facts."""
+    fixtures = [
+        (AssetType.STOCK, PolicyFactDomain.LISTED_SECURITY, "listed_equity"),
+        (AssetType.ETF, PolicyFactDomain.LISTED_SECURITY, "etf"),
+        (AssetType.MUTUAL_FUND, PolicyFactDomain.FUND, "fund"),
+        (AssetType.CASH, PolicyFactDomain.CASH, "cash"),
+        (AssetType.PROPERTY, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "property"),
+        (AssetType.BOND, PolicyFactDomain.UNSUPPORTED, "bond"),
+        (AssetType.OTHER, PolicyFactDomain.UNSUPPORTED, "other"),
+        (None, PolicyFactDomain.UNSUPPORTED, "unknown_asset"),
+    ]
+
+    for asset_type, expected_domain, expected_instrument in fixtures:
+        position = SimpleNamespace(asset_type=asset_type)
+        assert _position_domain_and_instrument(position) == (expected_domain, expected_instrument)
+
+
+def test_AC19_7_1_framework_policy_helper_emits_all_evidence_blocker_codes() -> None:
+    """AC19.7.1: Readiness helper emits framework, policy gap, valuation, and market-data blockers."""
+    policy_result = FrameworkPolicyResult.model_construct(
+        result_id="policy-result:gap",
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        report_period_start=date(2026, 5, 1),
+        report_period_end=date(2026, 5, 31),
+        generated_at=date(2026, 5, 31),
+        required_statements=["balance_sheet"],
+        decisions=[
+            FrameworkPolicyDecision(
+                domain=PolicyFactDomain.CASH,
+                recognition="Recognize cash from reviewed source evidence.",
+                measurement="Measure cash at nominal amount.",
+                classification="Cash asset.",
+                presentation="Balance sheet cash.",
+                disclosure="Disclose source coverage.",
+                line_mappings={"balance_sheet": "assets.cash"},
+            )
+        ],
+        gaps=[
+            FrameworkPolicyGap(
+                code="unsupported_policy_domain",
+                fact_id="fact-private-token",
+                domain=PolicyFactDomain.UNSUPPORTED,
+                instrument_type="other",
+                blocker=True,
+                reason="Unsupported.",
+                remediation="Review policy rule.",
+                evidence_anchors=[],
+            )
+        ],
+    )
+
+    blockers = framework_policy_readiness_blockers(
+        framework_id=PersonalReportingFrameworkId.HKFRS_LIKE,
+        policy_result=policy_result,
+        report_input_count=1,
+        missing_valuation_basis_count=2,
+        stale_market_data_count=3,
+    )
+    blocker_codes = {blocker["code"] for blocker in blockers}
+
+    assert {
+        "missing_framework_policy_result",
+        "unsupported_policy_domain",
+        "missing_valuation_basis",
+        "stale_market_data",
+    } <= blocker_codes
+    assert {
+        blocker["code"]
+        for blocker in framework_policy_readiness_blockers(
+            framework_id="personal_cn_cas_like",
+            policy_result=None,
+            report_input_count=1,
+            missing_valuation_basis_count=0,
+            stale_market_data_count=0,
+        )
+    } == {"unsupported_framework"}

--- a/apps/backend/tests/reporting/test_framework_policy.py
+++ b/apps/backend/tests/reporting/test_framework_policy.py
@@ -68,6 +68,7 @@ def test_AC20_3_1_framework_schema_rejects_unsupported_framework_id() -> None:
     """AC20.3.1: Framework policy result schema is closed to unsupported framework IDs."""
     with pytest.raises(ValidationError):
         FrameworkPolicyResult(
+            result_id="policy-result:test",
             framework_id="cn_cas_like",
             report_period_start=date(2026, 5, 1),
             report_period_end=date(2026, 5, 31),

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -170,6 +170,9 @@ export interface PersonalReportPackageContractResponse {
     package_id: string;
     version: string;
     period_semantics: Record<string, string>;
+    supported_frameworks: string[];
+    selected_framework_id?: string | null;
+    framework_policy_endpoint?: string | null;
     sections: PersonalReportPackageSectionContract[];
     export_contract: {
         formats: string[];
@@ -193,7 +196,7 @@ export interface PersonalReportPackageReadinessResponse {
     action_href: string;
     blocking_count: number;
     blockers: PersonalReportPackageReadinessBlocker[];
-    source_summary: Record<string, number>;
+    source_summary: Record<string, number | string>;
     generated_at?: string | null;
     stale_since?: string | null;
 }

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,8 +5,8 @@
 
 - API title: `Finance Report API`
 - API version: `0.1.0`
-- Endpoint count: `114`
-- Schema count: `182`
+- Endpoint count: `115`
+- Schema count: `190`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 
@@ -27,7 +27,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `market-data` | 3 |
 | `portfolio` | 13 |
 | `reconciliation` | 11 |
-| `reports` | 14 |
+| `reports` | 15 |
 | `review` | 7 |
 | `statements` | 15 |
 | `untagged` | 3 |
@@ -180,9 +180,10 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `GET` | `/reports/income-statement` | yes | `start_date`* (query), `end_date`* (query), `currency` (query), `tags` (query), `account_type` (query) | - | `200` `IncomeStatementResponse` | Income Statement |
 | `GET` | `/reports/net-worth/timeseries` | yes | `from`* (query), `to`* (query), `granularity` (query), `currency` (query) | - | `200` `NetWorthTimeSeriesResponse` | Net Worth Timeseries |
 | `GET` | `/reports/package/annualized-income-schedule` | yes | `as_of_date` (query) | - | `200` `AnnualizedIncomeScheduleResponse` | Annualized Income Schedule |
-| `GET` | `/reports/package/contract` | no | - | - | `200` `PersonalReportPackageContractResponse` | Personal Report Package Contract |
+| `GET` | `/reports/package/contract` | no | `framework_id` (query) | - | `200` `PersonalReportPackageContractResponse` | Personal Report Package Contract |
+| `GET` | `/reports/package/framework-policy` | yes | `framework_id` (query), `start_date` (query), `end_date` (query), `as_of_date` (query) | - | `200` `FrameworkPolicyResult` | Personal Report Package Framework Policy |
 | `GET` | `/reports/package/notes` | no | - | - | `200` `PersonalReportPackageNotesResponse` | Personal Report Package Notes |
-| `GET` | `/reports/package/readiness` | yes | - | - | `200` `PersonalReportPackageReadinessResponse` | Personal Report Package Readiness |
+| `GET` | `/reports/package/readiness` | yes | `framework_id` (query), `start_date` (query), `end_date` (query), `as_of_date` (query) | - | `200` `PersonalReportPackageReadinessResponse` | Personal Report Package Readiness |
 | `GET` | `/reports/package/traceability` | yes | `start_date` (query), `end_date` (query), `as_of_date` (query) | - | `200` `PersonalReportPackageTraceabilityResponse` | Personal Report Package Traceability |
 | `GET` | `/reports/trend` | yes | `account_id`* (query), `period` (query), `currency` (query) | - | `200` `AccountTrendResponse` | Account Trend |
 | `GET` | `/reports/{report_type}/snapshots` | yes | `report_type`* (path) | - | `200` array[object] | List Report Snapshots |

--- a/docs/ssot/framework-reporting.md
+++ b/docs/ssot/framework-reporting.md
@@ -61,6 +61,7 @@ canonical ledger + portfolio facts + evidence readiness + framework target
 
 The result must include:
 
+- stable policy result ID.
 - framework ID and report period.
 - required statements and schedules.
 - report line mappings.
@@ -78,14 +79,24 @@ Code-owned contract surfaces:
   IDs, policy fact domains, required policy dimensions, evidence anchors,
   policy decisions, explicit gaps, matrices, and policy results.
 - Matrix service: `apps/backend/src/services/framework_policy.py` owns the
-  deterministic v1 US-like/HK-like matrix and derives read-only policy results
-  from framework-neutral facts.
+  deterministic v1 US-like/HK-like matrix, builds framework-neutral facts from
+  existing user accounts, atomic positions, manual valuations, dividends, and
+  market-data overrides, then derives read-only policy results.
+- Package API: `GET /api/reports/package/framework-policy` returns the selected
+  framework policy result consumed by package assembly. `GET
+  /api/reports/package/contract` exposes supported framework IDs, the selected
+  framework ID when provided, and the policy result endpoint. `GET
+  /api/reports/package/readiness` accepts the same selected framework inputs and
+  evaluates framework policy blockers before marking output trusted.
 - Proof: `apps/backend/tests/reporting/test_framework_policy.py` verifies that
   policy results reject missing dimensions, unsupported frameworks are closed
   out, supported domains carry all five policy dimensions, derivation is
   deterministic/read-only, US/HK outputs can differ from the same fixture, and
   unsupported instruments create explicit policy gaps instead of silently
   defaulting to market value.
+  `apps/backend/tests/reporting/test_framework_package_integration.py` covers
+  package API framework selection, DB-derived policy results, readiness
+  blockers, and reviewed AI policy-field requirements.
 
 ## 4. Minimum V1 Policy Matrix
 
@@ -136,6 +147,23 @@ framework requires evidence that is missing or unresolved, including:
 - stale market data without an explicit freshness disclosure.
 - AI-only measurement or disclosure suggestion that has not been accepted into
   structured policy fields.
+
+Required framework-aware blocker codes:
+
+- `unsupported_framework`: selected framework ID is outside the supported v1
+  enum.
+- `missing_framework_policy_result`: selected framework has report-supporting
+  inputs but no matching structured policy result.
+- `unsupported_policy_domain`: a framework-neutral fact has no deterministic
+  v1 rule for the selected framework.
+- `framework_policy_missing_dimensions`: a decision lacks recognition,
+  measurement, classification, presentation, or disclosure.
+- `framework_ai_suggestion_unreviewed`: AI-suggested policy fields are not
+  accepted structured fields with anchors and accepted values.
+- `missing_valuation_basis`: manual/private valuation snapshots included in
+  trusted totals lack an explicit valuation basis.
+- `stale_market_data`: listed security, ETF, mutual-fund, or bond positions
+  lack market prices dated within 90 days of the report date.
 
 Draft output may exist with blockers, but trusted output must expose the blocker
 state before presenting framework-specific statements as reliable.

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -223,7 +223,10 @@ Contract response:
 |---|---|
 | `package_id` | Always `personal-financial-report-package` |
 | `version` | Contract version, currently `1.0` |
-| `period_semantics` | Defines required `start_date`, `end_date`, `as_of_date`, `currency`, and `decimal_serialization` semantics |
+| `period_semantics` | Defines required `start_date`, `end_date`, `as_of_date`, `currency`, `framework_id`, and `decimal_serialization` semantics |
+| `supported_frameworks` | Supported personal reporting framework IDs for package output |
+| `selected_framework_id` | Selected framework ID when the request includes one; otherwise `null` |
+| `framework_policy_endpoint` | Endpoint that returns the selected framework policy result consumed by package assembly |
 | `sections` | Stable ordered section contracts with `section_id`, label, owner EPIC, period type, source endpoint, status, optional blocking issue, and Decimal-safe total fields |
 | `export_contract` | Stable export formats and CSV column names for package consumers |
 
@@ -250,6 +253,9 @@ Package readiness:
   - `package_id`: always `personal-financial-report-package`
   - `state`: closed enum of `draft`, `processing`, `blocked`, `ready`,
     `generated`, or `stale`
+  - `selected_framework_id` in `source_summary` when a framework is selected
+  - `framework_policy_decisions` and `framework_policy_gaps` in
+    `source_summary` when framework policy is evaluated
   - `label` and `action_href`: primary UI state and next action; action links
     must be internal relative routes
   - `blocking_count`: sum of blocker record counts
@@ -284,8 +290,38 @@ Package readiness:
     zero after each line is converted into the base reporting currency.
   - `missing_source_coverage`: active asset or liability account lacks approved
     statement coverage or explicit source anchoring.
+  - `unsupported_framework`: selected package framework is unsupported.
+  - `missing_framework_policy_result`: selected framework has package inputs but
+    no matching structured policy result.
+  - `unsupported_policy_domain`: selected framework cannot map a source fact to
+    a deterministic v1 policy decision.
+  - `framework_policy_missing_dimensions`: a policy decision lacks one of
+    recognition, measurement, classification, presentation, or disclosure.
+  - `framework_ai_suggestion_unreviewed`: AI-suggested policy fields have not
+    been accepted as anchored structured fields.
+  - `missing_valuation_basis`: manual/private valuations lack explicit basis
+    text before trusted totals.
+  - `stale_market_data`: listed security, ETF, mutual-fund, or bond positions
+    lack prices dated within 90 days of the report date.
 - The readiness derivation must be read-only. Opening the reports page must not
   create Processing accounts or other readiness artifacts.
+
+Framework policy result:
+
+- Endpoint: `GET /api/reports/package/framework-policy`
+- Owner: EPIC-020 for policy decisions; EPIC-005 consumes the result for
+  package assembly.
+- Inputs: `framework_id`, `start_date`, `end_date`, and `as_of_date`.
+  `framework_id` defaults to `personal_us_gaap_like`; omitted period dates
+  default to a trailing 365-day window ending at the selected as-of date.
+- Output: a read-only `FrameworkPolicyResult` with stable `result_id`,
+  selected framework ID, report period, required statements, policy decisions,
+  line mappings, evidence anchors, and explicit gaps. The endpoint derives the
+  result from existing accounts, atomic positions, manual valuations, dividends,
+  and market-data overrides. It must not mutate source records, journal entries,
+  portfolio lots, market data, or report snapshots.
+- Package assembly must consume this policy result and must not infer
+  framework-specific report lines directly from raw portfolio market value.
 
 Annualized income and long-term compensation schedule:
 


### PR DESCRIPTION
## Summary

Integrate selected framework policy results into personal report package APIs and make framework policy evidence gaps block readiness.

Closes #678
Closes #680

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-019 — Event-driven upload-to-report UX; EPIC-020 — Framework-aware personal financial reporting; EPIC-005 — Reporting & visualization |
| **AC IDs** | AC19.7.1, AC20.6.1, AC5.14.1, AC20.5.1 |
| **AC source updated** | Existing owning EPIC ACs; generated registry check passed |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/framework-reporting.md` — documents policy result IDs, package API integration, and framework-aware readiness blocker codes
- [x] `docs/ssot/reporting.md` — documents package contract framework fields, readiness framework source summary fields, blocker codes, and `/package/framework-policy`
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `N/A` | Tests were written first in the working tree; red state was not preserved as a separate commit. Initial local execution was blocked by Podman before pytest DB setup. |
| 🟢 Green (passing test) | `59e2612` | Implement framework policy package API, readiness blocker codes, and SSOT updates; no-DB focused tests and lint pass locally. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A, no env changes
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A, no infra/config changes; checked `repo` state only
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env changes
- [x] `tools/check_manifest.py` passes (if SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner. — N/A
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys. — N/A
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged. — N/A
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials. — N/A
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule. — N/A
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene. — N/A

---

## Testing

```bash
moon run :lint
cd apps/backend && uv run pytest tests/reporting/test_framework_policy.py tests/reporting/test_framework_package_integration.py -k 'not package_policy_api and not readiness_consumes' --no-cov -q
uv run --with pytest --with pyyaml --with pydantic pytest tests/tooling/test_framework_reporting_epic_contract.py -q
python tools/generate_ac_registry.py --check
python tools/check_manifest.py
python tools/lint_doc_consistency.py
```

Blocked locally by Podman socket, expected to run in CI:

```bash
moon run :test -- --fast
moon run :test -- apps/backend/tests/reporting/test_framework_package_integration.py --no-cov
```

Local blocker:

```text
Cannot connect to Podman socket: failed to connect: dial tcp 127.0.0.1:61270: connect: connection refused
```

---

## Screenshots / Evidence

_N/A_
