### PR TITLE
[finance_report_vision] Simplify vision direction

### DIFF
--- a/docs/ssot/ai.md
+++ b/docs/ssot/ai.md
@@ -43,7 +43,20 @@ The advisor only reads summarized, posted/reconciled data:
 - Reconciliation stats and unmatched counts
 - User session context (last 10 rounds max)
 
-### 2.3 Data Handling Policy
+### 2.3 Financial Suggestion Scope
+
+The assistant may surface explainable personal-finance suggestions from trusted
+summary data, known data gaps, and pending review actions. Supported suggestion
+classes include cash-flow observations, unusual income or expense movement,
+portfolio concentration flags, stale market-data warnings, missing source
+documents, report-readiness blockers, and questions the user should answer
+before relying on a report.
+
+Suggestions are read-only. They must identify the source basis or limitation
+behind the suggestion and must not execute trades, mutate ledger data, provide
+legal or tax advice, or present regulated investment advice as a conclusion.
+
+### 2.4 Data Handling Policy
 
 - No ledger mutations, no write endpoints used.
 - Only summarized data is sent to the LLM (no full account numbers or raw files).

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -6,6 +6,21 @@ This document defines the Single Source of Truth for the document extraction fea
 
 The extraction pipeline parses financial statements (PDFs, images, CSVs) with the configured AI provider. PDF/image uploads use `OCR_MODEL` (default `glm-4.6v`) as the OCR-capable model. When `OCR_MODEL` is a separate model from `VISION_MODEL`, the service uses the provider layout parser first, then structures Markdown with `PRIMARY_MODEL` (default `glm-5.1`). When `OCR_MODEL` equals `VISION_MODEL`, the service skips layout parsing and uses the shared vision OCR path directly. Z.AI PDF vision extraction renders the uploaded PDF bytes into a bounded set of in-memory PNG `image_url` payloads; short-lived external URLs are used only when no bytes are available. Inline base64 PDF payloads are reserved for dedicated layout parsing and non-Z.AI compatibility. JSON extraction disables GLM thinking by default and caps output tokens to keep provider latency bounded. Uploads immediately create a `parsing` record, and a background worker updates the statement once parsing completes.
 
+## Upload-First Product Contract
+
+The user-facing input model is upload-first: users provide supported source
+documents and exports, and the system converts them into reviewed records before
+ledger/report use. Supported upload classes include bank statements, brokerage
+statements or settlement notes, CSV exports, ESOP/RSU grant or vesting
+documents, property appraisals, insurance or liability statements, and other
+future document types registered through the schema and AC workflow.
+
+Extraction owns parsing, source metadata, validation results, and lineage back
+to the original file. Downstream automation such as market-data refresh,
+portfolio valuation, ESOP schedule presentation, recurring accrual treatment,
+and report preparation is delegated to the owning SSOT documents and must not
+weaken extraction confidence or balance-validation rules.
+
 ## Data Flow
 
 ```mermaid

--- a/docs/ssot/market_data.md
+++ b/docs/ssot/market_data.md
@@ -18,6 +18,18 @@
 | **Price Storage** | `stock_prices` table | Historical daily stock prices |
 | **Sync State Storage** | `market_data_sync_state` table | Last successful provider sync timestamp by FX pair or stock symbol |
 
+## 1.1 Product Automation Contract
+
+Report and dashboard preparation may automatically refresh FX rates and stock
+prices for currencies and symbols observed in trusted user data. Automatic
+market-data refresh is supporting evidence for valuation and reporting; it does
+not replace source documents, brokerage statements, or user-confirmed ledger
+facts.
+
+Every persisted FX rate or price must retain its source and date. If market
+data is unavailable or stale, reports and assistant suggestions must expose that
+limitation instead of inventing a value.
+
 ---
 
 ## 2. Data Sources

--- a/docs/ssot/processing_account.md
+++ b/docs/ssot/processing_account.md
@@ -17,7 +17,7 @@
 
 ## 2. Problem Statement (Vision Context)
 
-From `vision.md` Decision 5:
+From the `vision.md` `decision-5-processing-account` anchor:
 
 **Problem**: Bank A transfers out on Day 1, Bank B receives on Day 3. Where are the funds on Day 2?
 

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -15,6 +15,21 @@
 | **Report Templates** | `apps/frontend/src/app/reports/` | Report pages and layouts |
 | **Visual Components** | `apps/frontend/src/components/charts/` | Chart components |
 
+## 1.1 Automated Report Preparation Contract
+
+Reports are prepared from trusted ledger facts, reviewed records, owned
+valuation snapshots, and market data with explicit source basis. Once the user
+has uploaded supported source documents, report preparation should assemble the
+required sections automatically wherever deterministic rules and registered ACs
+exist.
+
+Automation examples include multi-currency conversion, investment valuation,
+annualized income, ESOP/RSU and other long-term compensation schedules, fixed
+recurring expense accrual or pre-deduction presentation, report-readiness
+blockers, notes, and source links. If an input is missing, stale, ambiguous, or
+outside the implemented contract, the report must disclose the limitation or
+block readiness instead of silently filling the gap.
+
 ---
 
 ## 2. Report Types

--- a/vision.md
+++ b/vision.md
@@ -3,13 +3,28 @@
 ## Terminal Goal
 
 **A generated personal financial-report package backed by an accurate asset
-dashboard.**
+dashboard and an explainable financial assistant.**
 
 The final product should generate a self-hosted personal financial report
 package whose structure is inspired by US GAAP and Hong Kong listed-company
 reporting: statements, schedules, notes, and source traceability. It is a
 personal management report, not a regulated filing, audit opinion, legal
-advice, or tax advice.
+advice, tax advice, or regulated investment advice.
+
+## Product Promise
+
+The user should only need to upload financial source documents, such as bank
+statements, brokerage statements, settlement notes, ESOP/RSU plan documents,
+property or liability statements, CSV exports, and other supported records.
+
+After upload, the system should automate the rest where the behavior can be
+made trustworthy: extraction, validation, deduplication, reconciliation, FX and
+stock-price refresh, ESOP and long-term compensation schedules, recurring fixed
+expense accruals or pre-deductions, dashboard updates, and report-package
+preparation.
+
+Human review remains part of the product when source data is missing,
+ambiguous, material, or inconsistent.
 
 At any time, the system should help answer:
 
@@ -20,13 +35,16 @@ At any time, the system should help answer:
 - How are my investments performing?
 - What is my annualized income across salary, ESOP, dividends, and other
   long-term components?
+- What financial suggestions should my assistant surface from trusted data,
+  known limitations, and pending actions?
 
 ## Core Challenge
 
 Financial data is scattered across banks, brokers, statements, PDFs, CSVs, and
 manual records. Manual entry can omit data; automated extraction can be wrong.
 
-The product exists to make asset data trustworthy, auditable, and explainable.
+The product exists to make asset data trustworthy, auditable, explainable, and
+useful for personal financial decisions.
 
 ## Product Principles
 
@@ -35,7 +53,8 @@ The product exists to make asset data trustworthy, auditable, and explainable.
 - AI may parse, classify, explain, and suggest; it must not become the source of
   record.
 - Deterministic logic owns core bookkeeping and report calculations.
-- Human review should reduce uncertainty without hiding important details.
+- Automation should reduce user effort without hiding uncertainty.
+- Human review should focus on uncertainty, exceptions, and material judgments.
 - Self-hosting and data ownership are first-class constraints.
 - Every workflow should preserve traceability from source document to ledger to
   report.
@@ -51,7 +70,7 @@ raw source
   -> human confirmation
   -> reconciliation and deduplication
   -> trusted ledger knowledge
-  -> dashboard and reports
+  -> dashboard, assistant, and reports
 ```
 
 Only trusted or explicitly reviewed data should drive conclusions that claim to
@@ -71,79 +90,79 @@ Use this when product or architecture choices are ambiguous:
 
 If the answer is unclear, choose the smaller step that improves proof quality.
 
-## Strategic Decisions
+## Directional Commitments
+
+These commitments describe product direction. Implementation contracts belong
+in `docs/ssot/`; delivery scope belongs in `docs/project/`.
 
 ### Personal Report Package Is The North-Star Output
 
 Dashboards are working surfaces; the durable product output is a generated
-personal financial-report package. The package should include balance sheet,
-income statement, cash-flow view, investment schedules, annualized income and
-long-term compensation schedules, notes, and source-to-ledger-to-report
-traceability.
-
-US GAAP and Hong Kong listed-company reporting are reference structures for
-coverage, naming, and disclosure discipline. The system must not claim filing
-compliance unless that scope is explicitly registered, tested, and reviewed.
+personal financial-report package with report sections, schedules, notes, and
+source-to-ledger-to-report traceability. Reporting contracts are owned by
+`docs/ssot/reporting.md` and `docs/ssot/framework-reporting.md`.
 
 <a id="decision-1-portfolio-self-developed"></a>
 
 ### Portfolio Is Native
 
-Portfolio management is part of the system, not an external integration layer.
-The product should support holdings, cost basis, dividends, allocation, and
-performance metrics while remaining tied to the accounting model.
+Portfolio management is part of the system, not an outsourced portfolio SaaS.
+Holdings, cost basis, dividends, allocation, performance, and restricted
+compensation must remain tied to the accounting and reporting model. Detailed
+contracts are owned by `docs/ssot/assets.md` and `docs/ssot/reporting.md`.
 
 <a id="decision-2-event-middle-layer"></a>
 <a id="decision-3-record-layer"></a>
 
-### Record Layer Before Ledger Knowledge
+### Uploaded Sources Become Reviewed Records Before Ledger Knowledge
 
-Source documents should be reviewed as records before they become trusted
-ledger facts. A record carries source metadata, validation results, and
-traceability back to the original file.
+Uploaded documents should become traceable records before they become trusted
+ledger facts. The upload, extraction, record, workflow-event, and review
+contracts are owned by `docs/ssot/extraction.md`,
+`docs/ssot/workflow-events.md`, and `docs/ssot/confirmation-workflow.md`.
 
 <a id="decision-4-two-stage-review"></a>
 
-### Two-Stage Review
+### Review Separates Source Accuracy From Batch Consistency
 
-Review should separate:
-
-1. **Record-level review**: did this source parse correctly?
-2. **Run-level review**: does the whole batch reconcile consistently?
-
-This keeps local parse errors from being mixed with cross-document consistency
-questions.
+Review should separate whether a source parsed correctly from whether the full
+batch reconciles consistently. Detailed review-state rules are owned by
+`docs/ssot/confirmation-workflow.md` and `docs/ssot/reconciliation.md`.
 
 <a id="decision-5-processing-account"></a>
 
-### Processing Account For In-Transit Funds
+### In-Transit Funds Must Stay Visible
 
-Transfers can leave one account before arriving in another. A virtual
-Processing account makes in-transit funds visible instead of letting money
-appear to disappear.
+Transfers can leave one account before arriving in another. In-transit value
+must remain visible and reconcilable instead of disappearing from net worth.
+The detailed Processing account contract is owned by
+`docs/ssot/processing_account.md`.
 
 ### Manual Data Is Explicitly Trusted
 
 Some assets and liabilities cannot be verified by imported statements. Manual
-records are trusted because the user explicitly supplied them, but they should
-remain clearly labeled as manual/trusted data.
+records are trusted because the user explicitly supplied them, but they must
+remain clearly labeled as manual data. Source-type priority is owned by
+`docs/ssot/source-type-priority.md`.
 
 <a id="decision-7-tech-stack"></a>
 
-### FastAPI + Next.js + PostgreSQL
+### The Stack Must Stay Self-Hostable
 
-The current stack exists because the domain needs transactional control,
-Decimal-safe accounting, explicit schemas, and a self-hostable deployment model.
+The stack should support transactional control, Decimal-safe accounting,
+explicit schemas, private deployment, and reproducible CI. Runtime and
+environment contracts are owned by `docs/ssot/development.md`,
+`docs/ssot/schema.md`, and `docs/ssot/deployment.md`.
 
 ## Non-Goals
 
 - Replacing accounting logic with LLMs.
 - Regulated US/HK filing compliance, XBRL filing, audit opinions, legal advice,
-  or tax advice.
+  tax advice, or regulated investment advice.
 - <a id="non-goals-not-budgeting-app"></a>Becoming a consumer budgeting app
   centered on bank OAuth aggregation.
-- <a id="non-goals-not-robo-advisor"></a>Trading, portfolio optimization, or
-  robo-advisory automation.
+- <a id="non-goals-not-robo-advisor"></a>Automated trading, portfolio
+  optimization, or robo-advisory execution.
 
 ## Relationship To Project Documents
 
@@ -152,4 +171,5 @@ This file does not own project status. Current implementation status lives in
 registries plus tests.
 
 Vision changes should be rare and directional. Implementation details should be
-captured as EPIC -> AC -> test, or as code-owned contracts referenced by docs.
+captured as EPIC -> AC -> test, or as code-owned contracts referenced by
+`docs/ssot/`.


### PR DESCRIPTION
## Summary

Simplifies the project vision into directional product commitments and moves implementation-level details into the owning SSOT documents.

Closes #N/A

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | N/A — Vision and SSOT documentation cleanup |
| **AC IDs** | N/A |
| **AC source updated** | N/A — no feature/infra acceptance criteria changed |

---

## SSOT Changes

- [x] `docs/ssot/ai.md` — defines read-only financial suggestion scope and safety boundaries for the assistant
- [x] `docs/ssot/extraction.md` — documents the upload-first input contract and extraction ownership
- [x] `docs/ssot/market_data.md` — documents automatic FX/stock refresh as source-backed supporting evidence
- [x] `docs/ssot/reporting.md` — documents automated report preparation scope and limitation disclosure
- [x] `docs/ssot/processing_account.md` — updates the vision reference wording to the retained anchor

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | N/A | Documentation-only directional cleanup; no behavior or AC contract changed |
| 🟢 Green (passing test) | `18ce8d6` | Simplify vision direction and align SSOT ownership |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no code/schema change
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A
- [x] `tools/check_manifest.py` passes (if SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner. — N/A
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys. — N/A
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged. — N/A
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials. — N/A
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule. — N/A
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene. — N/A

---

## Testing

```bash
python tools/check_manifest.py
python tools/lint_doc_consistency.py
git diff --check
uv run --with 'mkdocs-material>=9.5.0' --with 'pymdown-extensions>=10.0' mkdocs build --clean
moon run :lint
```

`moon run :test` was attempted, but the local Podman machine repeatedly returned to `stopped`; the test database could not start before project tests ran.

---

## Screenshots / Evidence

N/A — documentation-only change.
