### PR TITLE
[finance_report_ui] Fix UI report trust gaps

### DIFF
--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -892,7 +892,7 @@ async def annualized_income_schedule(
 async def balance_sheet(
     as_of_date: date | None = Query(default=None),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
-    include_restricted: bool = Query(default=True),
+    include_restricted: bool = Query(default=False),
     db: DbSession = None,
     user_id: CurrentUserId = None,
 ) -> BalanceSheetResponse:
@@ -1090,6 +1090,7 @@ async def export_report(
     start_date: date | None = Query(default=None),
     end_date: date | None = Query(default=None),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
+    include_restricted: bool = Query(default=False),
     db: DbSession = None,
     user_id: CurrentUserId = None,
 ) -> StreamingResponse:
@@ -1106,6 +1107,7 @@ async def export_report(
                 user_id,
                 as_of_date=report_date,
                 currency=currency,
+                include_restricted=include_restricted,
             )
             writer.writerow(["section", "account", "amount", "currency"])
             for section, lines in (

--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -183,6 +183,7 @@ class CashFlowResponse(BaseModel):
     investing: list[CashFlowItem]
     financing: list[CashFlowItem]
     summary: CashFlowSummary
+    fx_warnings: list[dict[str, str]] = Field(default_factory=list)
 
 
 class PersonalReportPackageSectionContract(BaseModel):

--- a/apps/backend/tests/reporting/test_reports_router.py
+++ b/apps/backend/tests/reporting/test_reports_router.py
@@ -87,6 +87,39 @@ async def test_balance_sheet_endpoint(client, test_data_setup_reports):
 
 
 @pytest.mark.asyncio
+async def test_AC5_16_1_balance_sheet_defaults_to_excluding_restricted_holdings(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC5.16.1: Balance sheet endpoint defaults restricted holdings to excluded."""
+
+    async def fake_generate_balance_sheet(*_args, **kwargs):
+        assert kwargs["include_restricted"] is False
+        return {
+            "as_of_date": date(2026, 1, 31),
+            "currency": "SGD",
+            "assets": [],
+            "liabilities": [],
+            "equity": [],
+            "total_assets": Decimal("0.00"),
+            "total_liabilities": Decimal("0.00"),
+            "total_equity": Decimal("0.00"),
+            "net_income": Decimal("0.00"),
+            "unrealized_fx_gain_loss": Decimal("0.00"),
+            "net_worth_adjustment_gain_loss": Decimal("0.00"),
+            "fx_warnings": [],
+            "equation_delta": Decimal("0.00"),
+            "is_balanced": True,
+        }
+
+    monkeypatch.setattr(reports_router, "generate_balance_sheet", fake_generate_balance_sheet)
+
+    response = await client.get("/reports/balance-sheet", params={"as_of_date": "2026-01-31", "currency": "SGD"})
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_income_statement_endpoint(client, test_data_setup_reports):
     """Test income statement endpoint."""
     await test_data_setup_reports()
@@ -113,6 +146,57 @@ async def test_cash_flow_endpoint(client, test_data_setup_reports):
     assert "operating" in data
     assert "investing" in data
     assert "financing" in data
+
+
+@pytest.mark.asyncio
+async def test_AC5_16_2_cash_flow_response_preserves_fx_warnings(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC5.16.2: Cash flow response model exposes partial FX warnings."""
+
+    async def fake_generate_cash_flow(*_args, **_kwargs):
+        return {
+            "start_date": date(2026, 1, 1),
+            "end_date": date(2026, 1, 31),
+            "currency": "SGD",
+            "operating": [],
+            "investing": [],
+            "financing": [],
+            "summary": {
+                "operating_activities": Decimal("0.00"),
+                "investing_activities": Decimal("0.00"),
+                "financing_activities": Decimal("0.00"),
+                "net_cash_flow": Decimal("0.00"),
+                "beginning_cash": Decimal("0.00"),
+                "ending_cash": Decimal("0.00"),
+            },
+            "fx_warnings": [
+                {
+                    "type": "spot_rate_fallback",
+                    "from_currency": "USD",
+                    "to_currency": "SGD",
+                    "date": "2026-01-31",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(reports_router, "generate_cash_flow", fake_generate_cash_flow)
+
+    response = await client.get(
+        "/reports/cash-flow",
+        params={"start_date": "2026-01-01", "end_date": "2026-01-31", "currency": "SGD"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["fx_warnings"] == [
+        {
+            "type": "spot_rate_fallback",
+            "from_currency": "USD",
+            "to_currency": "SGD",
+            "date": "2026-01-31",
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -201,6 +285,44 @@ async def test_export_endpoint(client, test_data_setup_reports):
     response_is = await client.get("/reports/export", params=params_is)
     assert response_is.status_code == 200
     assert "text/csv" in response_is.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_AC5_16_1_balance_sheet_export_honors_restricted_query(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC5.16.1: Balance-sheet CSV export uses the same restricted toggle as the page."""
+
+    async def fake_generate_balance_sheet(*_args, **kwargs):
+        assert kwargs["include_restricted"] is True
+        return {
+            "as_of_date": date(2026, 1, 31),
+            "currency": "SGD",
+            "assets": [],
+            "liabilities": [],
+            "equity": [],
+            "total_assets": Decimal("0.00"),
+            "total_liabilities": Decimal("0.00"),
+            "total_equity": Decimal("0.00"),
+            "equation_delta": Decimal("0.00"),
+            "is_balanced": True,
+        }
+
+    monkeypatch.setattr(reports_router, "generate_balance_sheet", fake_generate_balance_sheet)
+
+    response = await client.get(
+        "/reports/export",
+        params={
+            "report_type": "balance-sheet",
+            "format": "csv",
+            "as_of_date": "2026-01-31",
+            "currency": "SGD",
+            "include_restricted": "true",
+        },
+    )
+
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/__tests__/balanceSheetPage.test.tsx
+++ b/apps/frontend/src/__tests__/balanceSheetPage.test.tsx
@@ -45,6 +45,10 @@ describe("BalanceSheetPage", () => {
       total_assets: "1000",
       total_liabilities: "200",
       total_equity: "800",
+      net_income: "300",
+      unrealized_fx_gain_loss: "12",
+      net_worth_adjustment_gain_loss: "5",
+      fx_warnings: [{ type: "missing_fx_rate_partial_skip", from_currency: "USD", to_currency: "SGD", date: "2026-02-01" }],
       equation_delta: "0",
       is_balanced: true,
     })
@@ -55,7 +59,16 @@ describe("BalanceSheetPage", () => {
     expect(screen.getByRole("heading", { name: "Assets", level: 2 })).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Liabilities", level: 2 })).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Equity", level: 2 })).toBeInTheDocument()
+    expect(screen.getByText("Partial FX data used")).toBeInTheDocument()
+    expect(screen.getByText("Balance Equation Detail")).toBeInTheDocument()
+    expect(screen.getByText("Excluded by default")).toBeInTheDocument()
+    expect(mockedApiFetch).toHaveBeenCalledWith(expect.stringContaining("include_restricted=false"))
     expect(screen.getAllByText(/Total:/)).toHaveLength(3)
+
+    fireEvent.click(screen.getByLabelText("Include restricted holdings"))
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenLastCalledWith(expect.stringContaining("include_restricted=true")),
+    )
 
     const dateInput = container.querySelector('input[type="date"]')
     expect(dateInput).not.toBeNull()

--- a/apps/frontend/src/__tests__/cashFlowPage.test.tsx
+++ b/apps/frontend/src/__tests__/cashFlowPage.test.tsx
@@ -54,6 +54,7 @@ describe("CashFlowPage", () => {
         beginning_cash: "5000",
         ending_cash: "5900",
       },
+      fx_warnings: [{ type: "spot_rate_fallback", from_currency: "EUR", to_currency: "SGD", fallback_date: "2026-01-30" }],
     })
 
     render(<CashFlowPage />)
@@ -63,6 +64,7 @@ describe("CashFlowPage", () => {
     expect(screen.getByText("Operating Activities")).toBeInTheDocument()
     expect(screen.getByText("Investing Activities")).toBeInTheDocument()
     expect(screen.getByText("Financing Activities")).toBeInTheDocument()
+    expect(screen.getByText("Partial FX data used")).toBeInTheDocument()
     expect(screen.getByText("Sales")).toBeInTheDocument()
     expect(screen.getByText("Main ops")).toBeInTheDocument()
 

--- a/apps/frontend/src/__tests__/epic016Components.test.tsx
+++ b/apps/frontend/src/__tests__/epic016Components.test.tsx
@@ -64,7 +64,7 @@ describe("EPIC-016 Componentization Tests", () => {
             />
         );
         expect(screen.getByText("Resolve Conflicts")).toBeInTheDocument();
-        expect(screen.getByText(/Backend conflict detection is currently under development/)).toBeInTheDocument();
+        expect(screen.getByText("No conflicts detected for this statement.")).toBeInTheDocument();
     });
 
     it("mounts MobileNav and asserts primary affordance (AC16.23.6)", () => {

--- a/apps/frontend/src/__tests__/incomeStatementPage.test.tsx
+++ b/apps/frontend/src/__tests__/incomeStatementPage.test.tsx
@@ -49,6 +49,7 @@ describe("IncomeStatementPage", () => {
       total_income: "5000",
       total_expenses: "1200",
       net_income: "3800",
+      fx_warnings: [{ type: "missing_average_rate", from_currency: "USD", to_currency: "SGD", date: "2026-01-31" }],
       trends: [{ period_start: "2026-01-01", period_end: "2026-01-31", total_income: "5000", total_expenses: "1200", net_income: "3800" }],
       filters_applied: { tags: null, account_type: null },
     })
@@ -60,6 +61,7 @@ describe("IncomeStatementPage", () => {
     expect(screen.getByText("Total Expenses")).toBeInTheDocument()
     expect(screen.getByText("Net Income")).toBeInTheDocument()
     expect(screen.getByText("BarChartMock")).toBeInTheDocument()
+    expect(screen.getByText("Partial FX data used")).toBeInTheDocument()
     expect(screen.getByText("Salary")).toBeInTheDocument()
     expect(screen.getByText("Rent")).toBeInTheDocument()
     expect(screen.getByRole("link", { name: "AI Interpretation" })).toHaveAttribute(

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -157,11 +157,13 @@ const traceabilityAppendix = {
         state: "available",
         source_types: ["bank_statement", "manual_valuation_snapshot"],
         identifier_fields: ["statement_transaction_ids", "manual_valuation_snapshot_ids"],
+        identifiers: ["statement_transaction:txn-123", "manual_valuation_snapshot:val-456"],
       },
       ledger_anchor: {
         state: "available",
         entry_statuses: ["posted", "reconciled"],
         identifier_fields: ["journal_entry_ids", "journal_line_ids"],
+        identifiers: ["journal_entry:je-789", "journal_line:jl-101"],
       },
       review_state: "trusted_or_explicit_manual_input",
       confidence_tier: "TRUSTED",
@@ -177,11 +179,13 @@ const traceabilityAppendix = {
         state: "available",
         source_types: ["package_contract"],
         identifier_fields: ["note_id"],
+        identifiers: ["note:basis-of-preparation"],
       },
       ledger_anchor: {
         state: "not_applicable",
         entry_statuses: [],
         identifier_fields: [],
+        identifiers: [],
       },
       review_state: "not_applicable",
       confidence_tier: "UNAVAILABLE",
@@ -293,7 +297,7 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.getByText("This personal management report is not a regulated filing, not legal advice, and not tax advice.")).toBeInTheDocument()
   })
 
-  it("AC5.13.3 renders traceability appendix source, ledger, review, and confidence metadata", async () => {
+  it("AC5.13.3 AC5.16.3 renders traceability appendix source, ledger, review, confidence, and identifiers", async () => {
     mockPackageApi()
 
     render(<PersonalReportPackagePage />)
@@ -302,7 +306,9 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.getAllByText("Traceability Appendix").length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText("posted_reconciled_journal_lines_and_manual_valuations")).toBeInTheDocument()
     expect(screen.getByText("bank_statement, manual_valuation_snapshot")).toBeInTheDocument()
+    expect(screen.getByText("statement_transaction:txn-123, manual_valuation_snapshot:val-456")).toBeInTheDocument()
     expect(screen.getByText("posted, reconciled")).toBeInTheDocument()
+    expect(screen.getByText("journal_entry:je-789, journal_line:jl-101")).toBeInTheDocument()
     expect(screen.getByText("trusted_or_explicit_manual_input")).toBeInTheDocument()
     expect(screen.getByText("TRUSTED")).toBeInTheDocument()
     expect(screen.getByText("manual_only_source")).toBeInTheDocument()

--- a/apps/frontend/src/__tests__/reviewPages.test.tsx
+++ b/apps/frontend/src/__tests__/reviewPages.test.tsx
@@ -45,10 +45,12 @@ describe("Review pages data flows", () => {
             pdf_url: null,
             transactions: [],
         };
-        // first call for statement review
-        mockedApi.mockResolvedValueOnce(stmt);
-        // pending statements
-        mockedApi.mockResolvedValueOnce({ items: [{ id: "s1" }] });
+        mockedApi.mockImplementation((path: string) => {
+            if (path === "/api/statements/s1/review") return Promise.resolve(stmt);
+            if (path === "/api/statements/pending-review") return Promise.resolve({ items: [{ id: "s1" }] });
+            if (path === "/api/review/conflicts/s1") return Promise.resolve({ duplicates: [], transfer_pairs: [] });
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
 
         renderReviewComponent(<StatementReviewPage /> as any);
         expect(await screen.findByText("Back to Statements")).toBeInTheDocument();

--- a/apps/frontend/src/__tests__/reviewRunPage.test.tsx
+++ b/apps/frontend/src/__tests__/reviewRunPage.test.tsx
@@ -18,7 +18,7 @@ describe("RunReviewPage", () => {
         vi.clearAllMocks();
     });
 
-    it("AC16.24.1 and AC16.24.2 summarizes unresolved run checks and blocks approval", async () => {
+    it("AC16.24.1 AC16.24.2 AC16.31.3 summarizes unresolved run checks and blocks approval", async () => {
         const checks = [
             {
                 id: "c-transfer",
@@ -66,6 +66,8 @@ describe("RunReviewPage", () => {
         renderReviewComponent(<RunReviewPage /> as any);
 
         expect(await screen.findByText("Stage 2 Run Review")).toBeInTheDocument();
+        expect(screen.getByText("Review the current Stage 2 queue from this run context")).toBeInTheDocument();
+        expect(screen.getByText(/this page uses the shared Stage 2 queue endpoint/i)).toBeInTheDocument();
         expect(screen.getByText("run-123")).toBeInTheDocument();
         expect(screen.getByText("1 unresolved transfer")).toBeInTheDocument();
         expect(screen.getByText("1 duplicate")).toBeInTheDocument();

--- a/apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx
@@ -11,6 +11,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 const mockedApi = vi.mocked(apiFetch);
+const emptyConflicts = { duplicates: [], transfer_pairs: [] };
 
 describe("StatementReviewPage - coverage additions", () => {
     beforeEach(() => {
@@ -18,9 +19,12 @@ describe("StatementReviewPage - coverage additions", () => {
     });
 
     it("renders loading then empty transactions and handles retry/back link", async () => {
-        mockedApi.mockResolvedValueOnce(null as any); // first query returns falsy -> not found
-        // pending statements
-        mockedApi.mockResolvedValueOnce({ items: [] });
+        mockedApi.mockImplementation((path: string) => {
+            if (path === "/api/statements/s1/review") return Promise.resolve(null as any);
+            if (path === "/api/statements/pending-review") return Promise.resolve({ items: [] });
+            if (path === "/api/review/conflicts/s1") return Promise.resolve(emptyConflicts);
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
 
         renderReviewComponent(<StatementReviewPage /> as any);
 
@@ -48,13 +52,13 @@ describe("StatementReviewPage - coverage additions", () => {
             ],
         };
 
-        // statement fetch
-        mockedApi.mockResolvedValueOnce(stmt as any);
-        // pending statements
-        mockedApi.mockResolvedValueOnce({ items: [{ id: "s1" }] });
-
-        // mock edit mutation endpoint response
-        mockedApi.mockResolvedValueOnce({ success: true });
+        mockedApi.mockImplementation((path: string) => {
+            if (path === "/api/statements/s1/review") return Promise.resolve(stmt as any);
+            if (path === "/api/statements/pending-review") return Promise.resolve({ items: [{ id: "s1" }] });
+            if (path === "/api/review/conflicts/s1") return Promise.resolve(emptyConflicts);
+            if (path === "/api/statements/s1/review/edit") return Promise.resolve({ success: true });
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
 
         renderReviewComponent(<StatementReviewPage /> as any);
 
@@ -114,12 +118,19 @@ describe("StatementReviewPage - coverage additions", () => {
             balance_validation_result: null,
             pdf_url: null,
             transactions: [],
-            duplicate_candidates: [{ description: "dup", txn_date: "2024-01-01", amount: 10 }],
-            transfer_pair_candidates: [{ description: "pair", txn_date: "2024-01-02", amount: 20 }],
         };
 
-        mockedApi.mockResolvedValueOnce(stmt as any);
-        mockedApi.mockResolvedValueOnce({ items: [] });
+        mockedApi.mockImplementation((path: string) => {
+            if (path === "/api/statements/s1/review") return Promise.resolve(stmt as any);
+            if (path === "/api/statements/pending-review") return Promise.resolve({ items: [] });
+            if (path === "/api/review/conflicts/s1") {
+                return Promise.resolve({
+                    duplicates: [{ description: "dup", txn_date: "2024-01-01", amount: 10 }],
+                    transfer_pairs: [{ description: "pair", txn_date: "2024-01-02", amount: 20 }],
+                });
+            }
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
 
         renderReviewComponent(<StatementReviewPage /> as any);
 
@@ -149,14 +160,14 @@ describe("StatementReviewPage - coverage additions", () => {
             transactions: [],
         };
 
-        // initial data + pending statements
-        mockedApi.mockResolvedValueOnce(stmt as any);
-        mockedApi.mockResolvedValueOnce({ items: [] });
-
-        // approve endpoint
-        mockedApi.mockResolvedValueOnce({});
-        // reject endpoint
-        mockedApi.mockResolvedValueOnce({});
+        mockedApi.mockImplementation((path: string) => {
+            if (path === "/api/statements/s1/review") return Promise.resolve(stmt as any);
+            if (path === "/api/statements/pending-review") return Promise.resolve({ items: [] });
+            if (path === "/api/review/conflicts/s1") return Promise.resolve(emptyConflicts);
+            if (path === "/api/statements/s1/review/approve") return Promise.resolve({});
+            if (path === "/api/statements/s1/review/reject") return Promise.resolve({});
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
 
         renderReviewComponent(<StatementReviewPage /> as any);
 
@@ -226,10 +237,13 @@ describe("StatementReviewPage - coverage additions", () => {
             ],
         };
 
-        mockedApi
-            .mockResolvedValueOnce(stmt as any)
-            .mockResolvedValueOnce({ items: [{ id: "s1" }] })
-            .mockRejectedValueOnce(new Error("edit failed"));
+        mockedApi.mockImplementation((path: string) => {
+            if (path === "/api/statements/s1/review") return Promise.resolve(stmt as any);
+            if (path === "/api/statements/pending-review") return Promise.resolve({ items: [{ id: "s1" }] });
+            if (path === "/api/review/conflicts/s1") return Promise.resolve(emptyConflicts);
+            if (path === "/api/statements/s1/review/edit") return Promise.reject(new Error("edit failed"));
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
 
         renderReviewComponent(<StatementReviewPage /> as any);
 
@@ -264,6 +278,7 @@ describe("StatementReviewPage - coverage additions", () => {
         mockedApi.mockImplementation((path: string) => {
             if (path === "/api/statements/s1/review") return Promise.resolve(stmt as any);
             if (path === "/api/statements/pending-review") return Promise.resolve({ items: [{ id: "s1" }] });
+            if (path === "/api/review/conflicts/s1") return Promise.resolve(emptyConflicts);
             if (path === "/api/statements/s1/review/approve") return Promise.reject(new Error("approve failed"));
             if (path === "/api/statements/s1/review/reject") return Promise.reject(new Error("reject failed"));
             return Promise.reject(new Error(`Unexpected path ${path}`));

--- a/apps/frontend/src/__tests__/statementReviewPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementReviewPage.test.tsx
@@ -53,9 +53,9 @@ const baseStatement = {
             status: "draft",
         },
     ],
-    duplicate_candidates: [],
-    transfer_pair_candidates: [],
 };
+
+const emptyConflicts = { duplicates: [], transfer_pairs: [] };
 
 describe("AC16.1.2 AC16.1.3 Statement review page", () => {
     beforeEach(() => {
@@ -93,6 +93,10 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
                 return Promise.resolve({ items: [{ id: "s1" }], total: 1 });
             }
 
+            if (path === "/api/review/conflicts/s1") {
+                return Promise.resolve(emptyConflicts);
+            }
+
             return Promise.reject(new Error(`Unexpected path ${path}`));
         });
 
@@ -123,6 +127,10 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
                 return Promise.resolve({ items: [{ id: "s1" }], total: 1 });
             }
 
+            if (path === "/api/review/conflicts/s1") {
+                return Promise.resolve(emptyConflicts);
+            }
+
             return Promise.reject(new Error(`Unexpected path ${path}`));
         });
 
@@ -140,6 +148,10 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
 
             if (path === "/api/statements/pending-review") {
                 return Promise.resolve({ items: [{ id: "s1" }], total: 1 });
+            }
+
+            if (path === "/api/review/conflicts/s1") {
+                return Promise.resolve(emptyConflicts);
             }
 
             if (path === "/api/statements/s1/review/approve") {
@@ -170,6 +182,10 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
 
             if (path === "/api/statements/pending-review") {
                 return Promise.resolve({ items: [{ id: "s1" }], total: 1 });
+            }
+
+            if (path === "/api/review/conflicts/s1") {
+                return Promise.resolve(emptyConflicts);
             }
 
             if (path === "/api/statements/s1/review/reject") {
@@ -211,6 +227,10 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
                 });
             }
 
+            if (path === "/api/review/conflicts/s1") {
+                return Promise.resolve(emptyConflicts);
+            }
+
             return Promise.reject(new Error(`Unexpected path ${path}`));
         });
 
@@ -223,19 +243,26 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
         expect(pushMock).toHaveBeenNthCalledWith(2, "/statements/s2/review");
     });
 
-    it("AC16.23.3 opens the conflict dialog when duplicate or transfer-pair candidates exist", async () => {
+    it("AC16.23.3 AC16.31.1 opens the conflict dialog when duplicate or transfer-pair candidates exist", async () => {
         mockedApi.mockImplementation((path: string) => {
             if (path === "/api/statements/s1/review") {
+                return Promise.resolve(baseStatement);
+            }
+
+            if (path === "/api/statements/pending-review") {
+                return Promise.resolve({ items: [{ id: "s1" }], total: 1 });
+            }
+
+            if (path === "/api/review/conflicts/s1") {
                 return Promise.resolve({
-                    ...baseStatement,
-                    duplicate_candidates: [
+                    duplicates: [
                         {
                             description: "Duplicate salary",
                             txn_date: "2024-01-04",
                             amount: "20.00",
                         },
                     ],
-                    transfer_pair_candidates: [
+                    transfer_pairs: [
                         {
                             description: "Transfer to savings",
                             txn_date: "2024-01-05",
@@ -243,10 +270,6 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
                         },
                     ],
                 });
-            }
-
-            if (path === "/api/statements/pending-review") {
-                return Promise.resolve({ items: [{ id: "s1" }], total: 1 });
             }
 
             return Promise.reject(new Error(`Unexpected path ${path}`));
@@ -257,5 +280,36 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
         const dialog = await screen.findByRole("dialog", { name: "Resolve Conflicts" });
         expect(within(dialog).getByText("Duplicate Candidates")).toBeInTheDocument();
         expect(within(dialog).getByText("Transfer Pair Candidates")).toBeInTheDocument();
+        expect(mockedApi).toHaveBeenCalledWith("/api/review/conflicts/s1");
+    });
+
+    it("AC16.31.2 disables approval when opening balance validation fails", async () => {
+        mockedApi.mockImplementation((path: string) => {
+            if (path === "/api/statements/s1/review") {
+                return Promise.resolve({
+                    ...baseStatement,
+                    balance_validation_result: {
+                        ...baseStatement.balance_validation_result,
+                        opening_match: false,
+                        closing_match: true,
+                    },
+                });
+            }
+
+            if (path === "/api/statements/pending-review") {
+                return Promise.resolve({ items: [{ id: "s1" }], total: 1 });
+            }
+
+            if (path === "/api/review/conflicts/s1") {
+                return Promise.resolve(emptyConflicts);
+            }
+
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
+
+        renderReviewComponent(<StatementReviewPage /> as never);
+
+        const approveButton = await screen.findByRole("button", { name: "Approve" });
+        expect(approveButton).toBeDisabled();
     });
 });

--- a/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
+++ b/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
@@ -73,7 +73,7 @@ describe("UnmatchedBoard", () => {
     )
   })
 
-  it("AC16.20.4 supports flag and ignore actions", async () => {
+  it("AC16.20.4 AC16.31.4 supports local flag and hide actions", async () => {
     mockedApiFetch.mockResolvedValueOnce({
       items: [
         {
@@ -93,15 +93,16 @@ describe("UnmatchedBoard", () => {
 
     await waitFor(() => expect(screen.getByRole("heading", { name: "Unmatched Transactions" })).toBeInTheDocument())
 
-    fireEvent.click(screen.getByRole("button", { name: "Flag" }))
-    expect(screen.getByRole("button", { name: "Unflag" })).toBeInTheDocument()
+    expect(screen.getByText("Flags and hidden rows are local workspace triage only.")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Flag local" }))
+    expect(screen.getByRole("button", { name: "Unflag local" })).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole("button", { name: "Ignore" }))
+    fireEvent.click(screen.getByRole("button", { name: "Hide locally" }))
     await waitFor(() => expect(screen.queryAllByText("Card payment")).toHaveLength(0))
     expect(screen.getByText("Select a transaction to review")).toBeInTheDocument()
   })
 
-  it("creates all entries with batch action", async () => {
+  it("AC16.31.4 creates all entries only after confirming the batch action", async () => {
     mockedApiFetch
       .mockResolvedValueOnce({
         items: [
@@ -124,6 +125,9 @@ describe("UnmatchedBoard", () => {
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Create All Entries" })).toBeEnabled())
     fireEvent.click(screen.getByRole("button", { name: "Create All Entries" }))
+    const dialog = await screen.findByRole("dialog", { name: "Create All Entries" })
+    expect(dialog).toHaveTextContent("Create draft journal entries for 1 unmatched transaction?")
+    fireEvent.click(screen.getByRole("button", { name: "Create Entries" }))
 
     await waitFor(() =>
       expect(mockedApiFetch).toHaveBeenCalledWith("/api/reconciliation/unmatched/batch-create", {
@@ -171,10 +175,12 @@ describe("UnmatchedBoard", () => {
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Create All Entries" })).toBeEnabled())
     fireEvent.click(screen.getByRole("button", { name: "Create All Entries" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Create Entries" }))
     expect(await screen.findByText("Created 1 journal entry from unmatched transactions.")).toBeInTheDocument()
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Create All Entries" })).toBeEnabled())
     fireEvent.click(screen.getByRole("button", { name: "Create All Entries" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Create Entries" }))
     expect(await screen.findByText("bulk failed")).toBeInTheDocument()
     expect(screen.queryByText("Created 1 journal entry from unmatched transactions.")).not.toBeInTheDocument()
   })
@@ -204,10 +210,10 @@ describe("UnmatchedBoard", () => {
 
     render(<UnmatchedBoard />)
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "Unflag" })).toBeInTheDocument())
-    fireEvent.click(screen.getByRole("button", { name: "Unflag" }))
+    await waitFor(() => expect(screen.getByRole("button", { name: "Unflag local" })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole("button", { name: "Unflag local" }))
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "Flag" })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole("button", { name: "Flag local" })).toBeInTheDocument())
     expect(warnSpy).toHaveBeenCalledWith(
       "[UnmatchedBoard] Failed to save flagged state:",
       expect.any(Error),

--- a/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
@@ -7,6 +7,7 @@ import { API_URL, apiFetch } from "@/lib/api";
 import { formatDateInput } from "@/lib/date";
 import { formatCurrencyLocale } from "@/lib/currency";
 import { useCurrencies } from "@/hooks/useCurrencies";
+import { FxWarningBanner, type FxWarning } from "@/components/reports/FxWarningBanner";
 
 interface ReportLine {
   account_id: string;
@@ -25,6 +26,10 @@ interface BalanceSheetResponse {
   total_assets: number | string;
   total_liabilities: number | string;
   total_equity: number | string;
+  net_income?: number | string;
+  unrealized_fx_gain_loss?: number | string;
+  net_worth_adjustment_gain_loss?: number | string;
+  fx_warnings?: FxWarning[];
   equation_delta: number | string;
   is_balanced: boolean;
 }
@@ -48,6 +53,7 @@ export default function BalanceSheetPage() {
   const [report, setReport] = useState<BalanceSheetResponse | null>(null);
   const [asOfDate, setAsOfDate] = useState(() => formatDateInput(new Date()));
   const [currency, setCurrency] = useState("SGD");
+  const [includeRestricted, setIncludeRestricted] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -56,7 +62,12 @@ export default function BalanceSheetPage() {
   const fetchReport = useCallback(async () => {
     setLoading(true);
     try {
-      const data = await apiFetch<BalanceSheetResponse>(`/api/reports/balance-sheet?as_of_date=${asOfDate}&currency=${currency}`);
+      const params = new URLSearchParams({
+        as_of_date: asOfDate,
+        currency,
+        include_restricted: includeRestricted ? "true" : "false",
+      });
+      const data = await apiFetch<BalanceSheetResponse>(`/api/reports/balance-sheet?${params.toString()}`);
       setReport(data);
       setError(null);
       const rootIds = new Set<string>();
@@ -65,7 +76,7 @@ export default function BalanceSheetPage() {
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load balance sheet.");
     } finally { setLoading(false); }
-  }, [asOfDate, currency]);
+  }, [asOfDate, currency, includeRestricted]);
 
   useEffect(() => { fetchReport(); }, [fetchReport]);
 
@@ -73,7 +84,7 @@ export default function BalanceSheetPage() {
   const liabilitiesTree = useMemo(() => report ? buildTree(report.liabilities) : [], [report]);
   const equityTree = useMemo(() => report ? buildTree(report.equity) : [], [report]);
 
-  const exportUrl = `${API_URL}/api/reports/export?report_type=balance-sheet&format=csv&as_of_date=${asOfDate}&currency=${currency}`;
+  const exportUrl = `${API_URL}/api/reports/export?report_type=balance-sheet&format=csv&as_of_date=${asOfDate}&currency=${currency}&include_restricted=${includeRestricted ? "true" : "false"}`;
   const aiPrompt = useMemo(() => encodeURIComponent(`Explain my balance sheet as of ${asOfDate} in ${currency}. Highlight any risks.`), [asOfDate, currency]);
 
   const toggle = (id: string) => setExpanded((prev) => { const next = new Set(prev); next.has(id) ? next.delete(id) : next.add(id); return next; });
@@ -117,8 +128,14 @@ export default function BalanceSheetPage() {
       <div className="flex flex-wrap gap-3 mb-6 text-sm">
         <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">As of date</span><input type="date" value={asOfDate} onChange={(e) => setAsOfDate(e.target.value)} className="input w-auto" /></label>
         <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">Currency</span><select value={currency} onChange={(e) => setCurrency(e.target.value)} className="input w-auto">{currencies.map((c) => <option key={c} value={c}>{c}</option>)}</select></label>
+        <label className="self-end flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2">
+          <input type="checkbox" checked={includeRestricted} onChange={(e) => setIncludeRestricted(e.target.checked)} />
+          <span>Include restricted holdings</span>
+        </label>
         <span className={`self-end badge ${report?.is_balanced ? "badge-success" : "badge-warning"}`}>{report?.is_balanced ? "✓ Balanced" : "⚠ Drift"}</span>
       </div>
+
+      <FxWarningBanner warnings={report?.fx_warnings} />
 
       <div className="flex flex-col gap-2 mb-6">
         <span className="text-xs text-muted uppercase">Quick filters</span>
@@ -128,6 +145,32 @@ export default function BalanceSheetPage() {
           <Link href={`/reports/balance-sheet?as_of_date=${asOfDate}&currency=${currency}#liabilities`} className="px-3 py-1 rounded-full text-xs font-medium bg-[var(--background-muted)] text-muted hover:bg-[var(--error-muted)] hover:text-[var(--error)]">Liabilities</Link>
           <Link href={`/reports/balance-sheet?as_of_date=${asOfDate}&currency=${currency}#equity`} className="px-3 py-1 rounded-full text-xs font-medium bg-[var(--background-muted)] text-muted hover:bg-[var(--accent-muted)] hover:text-[var(--accent)]">Equity</Link>
         </div>
+      </div>
+
+      <div className="card p-5 mb-6">
+        <h2 className="font-semibold mb-3">Balance Equation Detail</h2>
+        <dl className="grid gap-3 text-sm md:grid-cols-5">
+          <div>
+            <dt className="text-xs text-muted uppercase">Net Income</dt>
+            <dd className="mt-1 font-medium">{report ? formatCurrencyLocale(report.net_income ?? 0, report.currency) : "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted uppercase">Unrealized FX</dt>
+            <dd className="mt-1 font-medium">{report ? formatCurrencyLocale(report.unrealized_fx_gain_loss ?? 0, report.currency) : "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted uppercase">Net Worth Adjustment</dt>
+            <dd className="mt-1 font-medium">{report ? formatCurrencyLocale(report.net_worth_adjustment_gain_loss ?? 0, report.currency) : "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted uppercase">Equation Delta</dt>
+            <dd className="mt-1 font-medium">{report ? formatCurrencyLocale(report.equation_delta, report.currency) : "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted uppercase">Restricted Treatment</dt>
+            <dd className="mt-1 font-medium">{includeRestricted ? "Included" : "Excluded by default"}</dd>
+          </div>
+        </dl>
       </div>
 
       <div className="grid gap-4 lg:grid-cols-3">

--- a/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { SankeyChart } from "@/components/charts/SankeyChart";
+import { FxWarningBanner, type FxWarning } from "@/components/reports/FxWarningBanner";
 import { API_URL, apiFetch } from "@/lib/api";
 import { formatDateInput } from "@/lib/date";
 import { compareAmounts, formatCurrencyLocale } from "@/lib/currency";
@@ -33,6 +34,7 @@ interface CashFlowResponse {
   investing: CashFlowItem[];
   financing: CashFlowItem[];
   summary: CashFlowSummary;
+  fx_warnings?: FxWarning[];
 }
 
 export default function CashFlowPage() {
@@ -104,6 +106,8 @@ export default function CashFlowPage() {
         <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">End date</span><input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className="input w-auto" /></label>
         <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">Currency</span><select value={currency} onChange={(e) => setCurrency(e.target.value)} className="input w-auto">{currencies.map((c) => <option key={c} value={c}>{c}</option>)}</select></label>
       </div>
+
+      <FxWarningBanner warnings={report?.fx_warnings} />
 
       {summary && (
         <div className="grid gap-4 md:grid-cols-3 mb-6">

--- a/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { API_URL, apiFetch } from "@/lib/api";
 import { BarChart } from "@/components/charts/BarChart";
+import { FxWarningBanner, type FxWarning } from "@/components/reports/FxWarningBanner";
 import { formatDateInput, formatMonthLabel } from "@/lib/date";
 import { amountToChartNumber, formatCurrencyLocale } from "@/lib/currency";
 import { useCurrencies } from "@/hooks/useCurrencies";
@@ -34,6 +35,7 @@ interface IncomeStatementResponse {
   total_income: number | string;
   total_expenses: number | string;
   net_income: number | string;
+  fx_warnings?: FxWarning[];
   trends: IncomeStatementTrend[];
   filters_applied?: {
     tags: string[] | null;
@@ -164,6 +166,8 @@ export default function IncomeStatementPage() {
           {report.filters_applied.tags?.map((t) => <span key={t} className="badge badge-muted mr-2">{t}</span>)}
         </div>
       )}
+
+      <FxWarningBanner warnings={report?.fx_warnings} />
 
       <div className="grid gap-4 md:grid-cols-3 mb-6">
         <div className="card p-5"><p className="text-xs text-muted uppercase">Total Income</p><p className="text-2xl font-semibold text-[var(--success)] mt-1">{report ? formatCurrencyLocale(report.total_income, report.currency) : "—"}</p></div>

--- a/apps/frontend/src/app/(main)/reports/package/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/package/page.tsx
@@ -17,6 +17,17 @@ function formatScheduleCurrency(value: number | string, currency: string): strin
     return formatCurrencyLocale(value, currency, "en-US", { maximumFractionDigits: 0 }).replace(/\u00a0/g, " ");
 }
 
+function renderAnchorDetail(primary: string, identifiers?: string[]) {
+    return (
+        <>
+            <p className="mt-1 text-xs text-muted">{primary}</p>
+            {identifiers?.length ? (
+                <p className="mt-1 max-w-xs break-words font-mono text-[11px] text-muted">{identifiers.join(", ")}</p>
+            ) : null}
+        </>
+    );
+}
+
 export default function PersonalReportPackagePage() {
     const [contract, setContract] = useState<PersonalReportPackageContractResponse | null>(null);
     const [readiness, setReadiness] = useState<PersonalReportPackageReadinessResponse | null>(null);
@@ -305,15 +316,17 @@ export default function PersonalReportPackagePage() {
                                     </td>
                                     <td className="py-3 pr-4">
                                         <p className="font-mono text-xs">{line.source_state}</p>
-                                        <p className="mt-1 text-xs text-muted">
-                                            {(line.source_anchor.source_types ?? []).join(", ") || line.source_anchor.state}
-                                        </p>
+                                        {renderAnchorDetail(
+                                            (line.source_anchor.source_types ?? []).join(", ") || line.source_anchor.state,
+                                            line.source_anchor.identifiers,
+                                        )}
                                     </td>
                                     <td className="py-3 pr-4">
                                         <p className="font-mono text-xs">{line.ledger_anchor.state}</p>
-                                        <p className="mt-1 text-xs text-muted">
-                                            {(line.ledger_anchor.entry_statuses ?? []).join(", ") || line.ledger_anchor.unavailable_reason}
-                                        </p>
+                                        {renderAnchorDetail(
+                                            (line.ledger_anchor.entry_statuses ?? []).join(", ") || line.ledger_anchor.unavailable_reason || line.ledger_anchor.state,
+                                            line.ledger_anchor.identifiers,
+                                        )}
                                     </td>
                                     <td className="py-3 pr-4 font-mono text-xs">{line.review_state}</td>
                                     <td className="py-3">

--- a/apps/frontend/src/app/(main)/statements/[id]/review/page.tsx
+++ b/apps/frontend/src/app/(main)/statements/[id]/review/page.tsx
@@ -42,9 +42,17 @@ interface StatementReview {
     balance_validation_result: BalanceValidationResult | null;
     pdf_url: string | null;
     transactions: Transaction[];
-    // TODO(epic-016-conflict-detection): Backend needs to expose these
-    duplicate_candidates?: any[];
-    transfer_pair_candidates?: any[];
+}
+
+interface ConflictCandidate {
+    description: string;
+    txn_date: string;
+    amount: string | number;
+}
+
+interface ReviewConflicts {
+    duplicates: ConflictCandidate[];
+    transfer_pairs: ConflictCandidate[];
 }
 
 interface Stage1ApprovalResponse {
@@ -74,7 +82,14 @@ export default function StatementReviewPage() {
         queryFn: () => apiFetch<{ items: Array<{ id: string }> }>("/api/statements/pending-review"),
     });
 
+    const { data: conflicts } = useQuery({
+        queryKey: ["statement-conflicts", statementId],
+        queryFn: () => apiFetch<ReviewConflicts>(`/api/review/conflicts/${statementId}`),
+    });
+
     const pendingStatements = pendingStatementsData?.items || [];
+    const duplicateCandidates = conflicts?.duplicates || [];
+    const transferPairCandidates = conflicts?.transfer_pairs || [];
 
     // Mutations
     const editMutation = useMutation({
@@ -167,10 +182,10 @@ export default function StatementReviewPage() {
     };
 
     useEffect(() => {
-        if (data?.duplicate_candidates?.length || data?.transfer_pair_candidates?.length) {
+        if (duplicateCandidates.length || transferPairCandidates.length) {
             setConflictDialogOpen(true);
         }
-    }, [data]);
+    }, [duplicateCandidates.length, transferPairCandidates.length]);
 
     if (loading) {
         return (
@@ -216,7 +231,9 @@ export default function StatementReviewPage() {
         );
     }
 
-    const balanceValid = data.balance_validation_result?.closing_match ?? false;
+    const balanceValid = Boolean(
+        data.balance_validation_result?.opening_match && data.balance_validation_result?.closing_match
+    );
 
     return (
         <div className="flex min-h-[calc(100vh-2rem)] flex-col p-4 md:p-6 2xl:h-[calc(100vh-2rem)]">
@@ -300,8 +317,8 @@ export default function StatementReviewPage() {
             <ConflictResolutionDialog 
                 isOpen={conflictDialogOpen}
                 onClose={() => setConflictDialogOpen(false)}
-                duplicateCandidates={data.duplicate_candidates || []}
-                transferPairCandidates={data.transfer_pair_candidates || []}
+                duplicateCandidates={duplicateCandidates}
+                transferPairCandidates={transferPairCandidates}
             />
 
             <ConfirmDialog

--- a/apps/frontend/src/components/reconciliation/UnmatchedBoard.tsx
+++ b/apps/frontend/src/components/reconciliation/UnmatchedBoard.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import { apiFetch } from "@/lib/api";
 
 interface BankTransactionSummary {
@@ -55,6 +56,7 @@ export default function UnmatchedBoard() {
   const [error, setError] = useState<string | null>(null);
   const [flagged, setFlagged] = useState<Set<string>>(() => loadFlaggedFromStorage());
   const [creatingAll, setCreatingAll] = useState(false);
+  const [confirmCreateAllOpen, setConfirmCreateAllOpen] = useState(false);
   const [batchCreatedCount, setBatchCreatedCount] = useState<number | null>(null);
 
   const refresh = useCallback(async () => {
@@ -85,6 +87,7 @@ export default function UnmatchedBoard() {
 
   const createAllEntries = async () => {
     setCreatingAll(true);
+    setConfirmCreateAllOpen(false);
     setBatchCreatedCount(null);
     try {
       const result = await apiFetch<BatchCreateEntriesResponse>("/api/reconciliation/unmatched/batch-create", {
@@ -138,12 +141,13 @@ export default function UnmatchedBoard() {
         <div>
           <h1 className="page-title">Unmatched Transactions</h1>
           <p className="page-description">Triage unmatched transactions and create manual journal entries</p>
+          <p className="mt-1 text-xs text-muted">Flags and hidden rows are local workspace triage only.</p>
         </div>
         <div className="flex items-center gap-3">
           <Link href="/reconciliation" className="btn-secondary text-sm">← Workbench</Link>
           <button
             type="button"
-            onClick={createAllEntries}
+            onClick={() => setConfirmCreateAllOpen(true)}
             disabled={creatingAll || items.length === 0}
             className="btn-primary text-sm"
           >
@@ -180,7 +184,7 @@ export default function UnmatchedBoard() {
                   </div>
                   <div className="text-right flex-shrink-0">
                     <div className="font-semibold text-[var(--accent)]">{item.amount?.toLocaleString()}</div>
-                    {flagged.has(item.id) && <span className="badge badge-warning text-[10px]">Flagged</span>}
+                    {flagged.has(item.id) && <span className="badge badge-warning text-[10px]">Flagged locally</span>}
                   </div>
                 </div>
               </button>
@@ -203,8 +207,8 @@ export default function UnmatchedBoard() {
               <div className="flex flex-wrap gap-2">
                 <button onClick={() => createEntry(selected.id)} disabled={creating === selected.id} className="btn-primary">{creating === selected.id ? "Creating..." : "Create Entry"}</button>
                 {aiPrompt && <Link href={`/chat?prompt=${aiPrompt}`} className="btn-secondary">Ask AI</Link>}
-                <button onClick={() => toggleFlag(selected.id)} className="btn-secondary">{flagged.has(selected.id) ? "Unflag" : "Flag"}</button>
-                <button onClick={() => removeFromList(selected.id)} className="btn-secondary">Ignore</button>
+                <button onClick={() => toggleFlag(selected.id)} className="btn-secondary">{flagged.has(selected.id) ? "Unflag local" : "Flag local"}</button>
+                <button onClick={() => removeFromList(selected.id)} className="btn-secondary">Hide locally</button>
               </div>
 
               {createdEntry && (
@@ -216,6 +220,16 @@ export default function UnmatchedBoard() {
           )}
         </div>
       </div>
+
+      <ConfirmDialog
+        isOpen={confirmCreateAllOpen}
+        onCancel={() => !creatingAll && setConfirmCreateAllOpen(false)}
+        onConfirm={() => createAllEntries()}
+        title="Create All Entries"
+        message={`Create draft journal entries for ${items.length} unmatched transaction${items.length === 1 ? "" : "s"}? Review local flags before continuing.`}
+        confirmLabel="Create Entries"
+        loading={creatingAll}
+      />
     </div>
   );
 }

--- a/apps/frontend/src/components/reports/FxWarningBanner.tsx
+++ b/apps/frontend/src/components/reports/FxWarningBanner.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+export interface FxWarning {
+  type: string;
+  message?: string;
+  from_currency?: string;
+  to_currency?: string;
+  date?: string;
+  fallback_date?: string;
+  source?: string;
+  [key: string]: string | undefined;
+}
+
+function formatWarning(warning: FxWarning): string {
+  if (warning.message) return warning.message;
+
+  const route = warning.from_currency && warning.to_currency
+    ? `${warning.from_currency} to ${warning.to_currency}`
+    : "FX conversion";
+  const date = warning.date ? ` on ${warning.date}` : "";
+  const fallback = warning.fallback_date ? `; using ${warning.fallback_date}` : "";
+
+  return `${warning.type}: ${route}${date}${fallback}`;
+}
+
+interface FxWarningBannerProps {
+  warnings?: FxWarning[];
+}
+
+export function FxWarningBanner({ warnings }: FxWarningBannerProps) {
+  if (!warnings?.length) return null;
+
+  return (
+    <div className="mb-6 rounded-md border border-[var(--warning)]/40 bg-[var(--warning-muted)] p-4 text-sm">
+      <p className="font-medium text-[var(--warning)]">Partial FX data used</p>
+      <ul className="mt-2 space-y-1 text-muted">
+        {warnings.map((warning, index) => (
+          <li key={`${warning.type}:${warning.date ?? index}`}>{formatWarning(warning)}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/review/ConflictResolutionDialog.tsx
+++ b/apps/frontend/src/components/review/ConflictResolutionDialog.tsx
@@ -58,7 +58,6 @@ export function ConflictResolutionDialog({
                     {duplicateCandidates.length === 0 && transferPairCandidates.length === 0 ? (
                         <div className="text-center py-8 text-muted">
                             <p>No conflicts detected for this statement.</p>
-                            <p className="text-xs mt-2 italic">Note: Backend conflict detection is currently under development.</p>
                         </div>
                     ) : (
                         <div className="space-y-6">

--- a/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
+++ b/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
@@ -399,7 +399,7 @@ export function Stage2ReviewQueue() {
                 <h1 className="page-title">{isRunReview ? "Stage 2 Run Review" : "Reconciliation Review Queue"}</h1>
                 <p className="page-description">
                     {isRunReview
-                        ? "Review batch-level consistency checks and approve all resolved matches as one run"
+                        ? "Review the current Stage 2 queue from this run context"
                         : "Review consistency checks and approve reconciliation matches"}
                 </p>
             </div>
@@ -445,7 +445,8 @@ export function Stage2ReviewQueue() {
                         <div>
                             <p className="text-sm font-medium">Run approval gate</p>
                             <p className="text-sm text-muted">
-                                Resolve transfer, duplicate, and anomaly checks and clear Processing Account pending transfers before approving the run.
+                                Resolve transfer, duplicate, and anomaly checks and clear Processing Account pending transfers before approving current pending matches.
+                                Run ID is shown as context; this page uses the shared Stage 2 queue endpoint.
                             </p>
                         </div>
                         <button

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -121,6 +121,17 @@ export interface ReportLine {
     amount: number | string;
 }
 
+export interface FxWarning {
+    type: string;
+    message?: string;
+    from_currency?: string;
+    to_currency?: string;
+    date?: string;
+    fallback_date?: string;
+    source?: string;
+    [key: string]: string | undefined;
+}
+
 export interface BalanceSheetResponse {
     as_of_date: string;
     currency: string;
@@ -130,6 +141,10 @@ export interface BalanceSheetResponse {
     total_assets: number | string;
     total_liabilities: number | string;
     total_equity: number | string;
+    net_income?: number | string;
+    unrealized_fx_gain_loss?: number | string;
+    net_worth_adjustment_gain_loss?: number | string;
+    fx_warnings?: FxWarning[];
     equation_delta: number | string;
     is_balanced: boolean;
 }
@@ -151,6 +166,7 @@ export interface IncomeStatementResponse {
     total_income: number | string;
     total_expenses: number | string;
     net_income: number | string;
+    fx_warnings?: FxWarning[];
     trends: IncomeStatementTrend[];
 }
 

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -262,6 +262,19 @@ changing the later PDF export scope tracked by
 |----|-----------|---------------|------|----------|
 | AC5.15.1 | Multi-currency posted entries generate balanced balance sheet, income statement, and cash-flow reports in base currency | `test_AC5_15_1_multicurrency_reporting_cycle_reconciles_bs_is_cf` | `integration/test_reporting_e2e.py` | P0 |
 
+### AC5.16: Report Trust Signals and Restricted-Asset Defaults
+
+The June 2026 UI/report audit found that core report pages were technically
+covered but did not render important trust signals already present in backend
+payloads. This group makes report default semantics and partial-data warnings
+visible to users.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.16.1 | Balance sheet defaults restricted holdings to excluded, exposes an include toggle, and renders equation component detail | `test_AC5_16_1_balance_sheet_defaults_to_excluding_restricted_holdings` / `AC16.14.2 / test_AC8_13_48 renders string totals and refetches by date` | `reporting/test_reports_router.py`, `frontend/src/__tests__/balanceSheetPage.test.tsx` | P0 |
+| AC5.16.2 | Balance sheet, income statement, and cash-flow report pages surface backend `fx_warnings` instead of silently rendering partial totals | `test_AC5_16_2_cash_flow_response_preserves_fx_warnings` / page warning assertions | `reporting/test_reports_router.py`, `frontend/src/__tests__/balanceSheetPage.test.tsx`, `frontend/src/__tests__/incomeStatementPage.test.tsx`, `frontend/src/__tests__/cashFlowPage.test.tsx` | P0 |
+| AC5.16.3 | Personal report package traceability renders concrete source and ledger identifiers when the appendix provides them | `AC5.13.3 renders traceability appendix source, ledger, review, and confidence metadata` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
+
 ## 📏 Acceptance Criteria
 
 ### 🟢 Must Have

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -471,6 +471,20 @@ The April 2026 FE/UI audit snapshot was removed from this EPIC. Current review U
 - [x] **AC16.24.3** Stage 2 run-level approval submits all pending matches through the batch approval API after checks are resolved
 - **AC16.24.4** - Stage 2 batch approval routes accepted matches through the ledger-safe acceptance path, creating missing journal entries or reconciling referenced entries without duplicating entries on retry
 
+### Acceptance Criteria — Feature (group 31, review contract hardening)
+
+The June 2026 UI audit found several high-line-coverage review tests that
+validated mocked UI-only state rather than backend-owned review contracts.
+These ACs close those gaps without changing the underlying reconciliation data
+model.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC16.31.1 | Stage 1 conflict dialog loads duplicate and transfer-pair candidates from `GET /api/review/conflicts/{statement_id}` instead of fake review payload fields | `AC16.23.3 opens the conflict dialog when duplicate or transfer-pair candidates exist` / `opens conflict dialog when duplicate/transfer candidates present` | `apps/frontend/src/__tests__/statementReviewPage.test.tsx`, `apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx` | P0 |
+| AC16.31.2 | Stage 1 approval is disabled unless both opening and closing balance validation match | `AC16.31.2 disables approval when opening balance validation fails` | `apps/frontend/src/__tests__/statementReviewPage.test.tsx` | P0 |
+| AC16.31.3 | Stage 2 run review page states that it uses the shared Stage 2 queue endpoint when no run-scoped queue API exists | `AC16.24.1 and AC16.24.2 summarizes unresolved run checks and blocks approval` | `apps/frontend/src/__tests__/reviewRunPage.test.tsx` | P0 |
+| AC16.31.4 | Unmatched transaction local flag/hide actions are labeled as local-only triage and batch create requires confirmation | `AC16.20.4 supports flag and ignore actions` / `creates all entries with batch action` | `apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx` | P0 |
+
 ### Acceptance Criteria — Feature (group 28, frontend UI system primitives)
 
 Issue [#612](https://github.com/wangzitian0/finance_report/issues/612)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -176,7 +176,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `GET` | `/reports/breakdown` | yes | `type`* (query), `period` (query), `currency` (query) | - | `200` `CategoryBreakdownResponse` | Category Breakdown |
 | `GET` | `/reports/cash-flow` | yes | `start_date`* (query), `end_date`* (query), `currency` (query) | - | `200` `CashFlowResponse` | Cash Flow |
 | `GET` | `/reports/currencies` | no | - | - | `200` array[string] | Get Available Currencies |
-| `GET` | `/reports/export` | yes | `report_type`* (query), `format` (query), `as_of_date` (query), `start_date` (query), `end_date` (query), `currency` (query) | - | `200` - | Export Report |
+| `GET` | `/reports/export` | yes | `report_type`* (query), `format` (query), `as_of_date` (query), `start_date` (query), `end_date` (query), `currency` (query), `include_restricted` (query) | - | `200` - | Export Report |
 | `GET` | `/reports/income-statement` | yes | `start_date`* (query), `end_date`* (query), `currency` (query), `tags` (query), `account_type` (query) | - | `200` `IncomeStatementResponse` | Income Statement |
 | `GET` | `/reports/net-worth/timeseries` | yes | `from`* (query), `to`* (query), `granularity` (query), `currency` (query) | - | `200` `NetWorthTimeSeriesResponse` | Net Worth Timeseries |
 | `GET` | `/reports/package/annualized-income-schedule` | yes | `as_of_date` (query) | - | `200` `AnnualizedIncomeScheduleResponse` | Annualized Income Schedule |

--- a/docs/ssot/reconciliation.md
+++ b/docs/ssot/reconciliation.md
@@ -334,6 +334,11 @@ The Stage 2 queue response must derive `confidence_tier` from the actual
 | 60-84 | MEDIUM |
 | < 60 or null | LOW |
 
+The `/review/run/[runId]` frontend page currently uses the shared global
+`/statements/stage2/queue` endpoint and shows `runId` as navigation context.
+Until a backend run-scoped queue contract is introduced, the UI must not imply
+that the queue payload is isolated to a persisted batch/run.
+
 **State Machine**:
 ```
 [*] --> pending: Check detected
@@ -351,6 +356,7 @@ pending --> flagged: Needs manual review
 | POST | `/statements/{id}/review/reject` | Reject and trigger re-parse |
 | POST | `/statements/{id}/review/edit` | Edit transactions and approve |
 | POST | `/statements/{id}/review/opening-balance` | Set manual opening balance |
+| GET | `/review/conflicts/{statement_id}` | Stage 1 duplicate and transfer-pair conflict candidates |
 | GET | `/statements/stage2/queue` | Stage 2 review queue (global) |
 | POST | `/statements/{id}/stage2/run-checks` | Run consistency checks for statement |
 | POST | `/statements/consistency-checks/{id}/resolve` | Resolve a check |

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -302,7 +302,9 @@ Annualized income and long-term compensation schedule:
 - Restricted compensation basis: latest as-of manual valuation snapshots for
   `esop`, `rsu`, and `stock_options` with `liquidity_class=restricted`.
 - Liquid net worth default: restricted holdings are excluded by default and are
-  only included through the balance-sheet restricted toggle.
+  only included through the balance-sheet restricted toggle. The
+  `/reports/balance-sheet` endpoint and Balance Sheet page must both default
+  `include_restricted=false`.
 - Decimal fields serialize as strings; restricted fair-value totals are reported
   in the schedule currency using the as-of FX rate. Per-holding source currency
   remains visible.
@@ -410,6 +412,11 @@ Reports are generated in a single base currency (user configurable, default: SGD
   the report returns an explicit partial warning such as
   `missing_fx_rate_partial_skip` or `missing_fx_revaluation_partial_skip`.
   Reports must never silently assume a 1:1 rate for a foreign currency.
+- Core report pages must render non-empty `fx_warnings` visibly before the
+  headline KPI/cards so users can see that totals are partial or fallback-based.
+- The Balance Sheet page must render equation component detail for
+  `net_income`, `unrealized_fx_gain_loss`,
+  `net_worth_adjustment_gain_loss`, and `equation_delta`.
 
 ```python
 def consolidate_amount(amount: Decimal, currency: str, target: str, date: date) -> Decimal:


### PR DESCRIPTION
## Summary

Fixes the UI/report trust gaps found in the review: report partial-data signals are visible, Stage 1 conflict detection uses the real backend endpoint, restricted holdings default correctly, and local-only/dangerous review actions are clearer.

Related #586

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-005 — Reporting & Visualization; EPIC-016 — Two-Stage Review & Data Validation UI |
| **AC IDs** | AC5.16.1, AC5.16.2, AC5.16.3, AC16.31.1, AC16.31.2, AC16.31.3, AC16.31.4 |
| **AC source updated** | Owning EPIC docs updated |

---

## SSOT Changes

- [x] `docs/ssot/reporting.md` — balance sheet restricted default, report FX warning visibility, and equation component detail
- [x] `docs/ssot/reconciliation.md` — real conflict endpoint and Stage 2 run page shared-queue semantics
- [x] `docs/reference/api.md` — regenerated API reference for `/reports/export include_restricted`

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | N/A | Single-commit PR; failing focused tests were authored in workspace before implementation rather than preserved as a separate commit. |
| Green | `2968402` | Implement UI/report trust fixes and pass focused/full frontend checks. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no enum changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable; no env changes)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `tools/check_env_keys.py` passes (not applicable; no env changes)
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Not applicable; this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
npm run test -- statementReviewPage.test.tsx statementReviewPage.coverage.test.tsx balanceSheetPage.test.tsx incomeStatementPage.test.tsx cashFlowPage.test.tsx personalReportPackagePage.test.tsx unmatchedBoardComponent.test.tsx reviewRunPage.test.tsx
npm run test:coverage
npm run test:e2e
npm run lint
npm run build
uv --project apps/backend run ruff check apps/backend/src/routers/reports.py apps/backend/src/schemas/reporting.py apps/backend/tests/reporting/test_reports_router.py
uv --project apps/backend run python - <<'PY'
from datetime import date
from decimal import Decimal
from src.schemas.reporting import CashFlowResponse
payload = CashFlowResponse(
    start_date=date(2026, 1, 1), end_date=date(2026, 1, 31), currency='SGD',
    operating=[], investing=[], financing=[],
    summary={
        'operating_activities': Decimal('0'), 'investing_activities': Decimal('0'),
        'financing_activities': Decimal('0'), 'net_cash_flow': Decimal('0'),
        'beginning_cash': Decimal('0'), 'ending_cash': Decimal('0'),
    },
    fx_warnings=[{'type': 'spot_rate_fallback'}],
)
assert payload.fx_warnings == [{'type': 'spot_rate_fallback'}]
PY
uv --project apps/backend run python tools/generate_ac_registry.py --check
uv --project apps/backend run python tools/check_manifest.py
uv --project apps/backend run python tools/lint_doc_consistency.py
uv --project apps/backend run python tools/generate_api_reference.py --check
moon run :lint
```

Blocked locally:

```bash
uv run pytest apps/backend/tests/reporting/test_reports_router.py -q
# blocked: local Postgres unavailable at 127.0.0.1:5432

moon run :test
# blocked: local Podman socket unavailable at 127.0.0.1:61270
```

---

## Screenshots / Evidence

N/A
