### PR TITLE
[finance_report_infra] Fix staging alert issue context

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -551,6 +551,7 @@ jobs:
       issues: write
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       STAGING_ALERT_TITLE: "[staging-alert] Post-merge staging deploy failing"
       STAGING_HEALTH_URL: https://report-staging.zitian.party/api/health
       STAGING_APP_URL: https://report-staging.zitian.party

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -448,6 +448,7 @@ def test_AC8_13_91_post_merge_staging_failure_opens_rolling_alert_issue() -> Non
     assert "staging-deploy-alert:" in workflow
     assert "name: Staging Deploy Alert" in workflow
     assert "issues: write" in workflow
+    assert "GH_REPO: ${{ github.repository }}" in workflow
     assert "STAGING_ALERT_TITLE: \"[staging-alert] Post-merge staging deploy failing\"" in workflow
     assert "github.event_name == 'workflow_run'" in workflow
     assert "github.event.workflow_run.conclusion == 'success'" in workflow
@@ -472,6 +473,9 @@ def test_AC8_13_91_post_merge_staging_failure_opens_rolling_alert_issue() -> Non
     assert "STAGING_APP_URL: https://report-staging.zitian.party" in workflow
     assert "App URL: ${STAGING_APP_URL}" in workflow
     assert "DOKPLOY_API_KEY" not in workflow.split("staging-deploy-alert:", 1)[1]
+    assert "actions/checkout" not in workflow.split("staging-deploy-alert:", 1)[1].split(
+        "post-merge-summary:", 1
+    )[0]
     assert "persistent GitHub Issue alert" in ci_cd
     assert "AC8.13.91" in epic
 


### PR DESCRIPTION
## Summary

Fix the post-merge staging alert job so `gh issue` can create/update the rolling alert without a checkout. The previous merged workflow failed with `fatal: not a git repository` because the job intentionally does not checkout code and did not set `GH_REPO`.

Closes N/A

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Comprehensive Testing Strategy |
| **AC IDs** | AC8.13.91 |
| **AC source updated** | N/A — existing AC |

---

## SSOT Changes

- [x] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red / Green | local working sequence | Added/updated the workflow contract assertion for `GH_REPO`, then patched the alert job env. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `tools/check_env_keys.py` passes (not applicable)
- [x] `tools/check_manifest.py` passes (not applicable)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

- [x] Lifecycle ownership is unchanged.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys.
- [x] API/CLI diagnostics show only allowlisted status fields.
- [x] VPS host hygiene is unchanged.
- [x] Cleanup scope is unchanged.
- [x] Proof command includes focused workflow alert contract tests.

---

## Testing

```bash
pytest tests/tooling/test_post_merge_e2e_gates.py::test_AC8_13_91_post_merge_staging_failure_opens_rolling_alert_issue -q
pytest tests/tooling/test_post_merge_e2e_gates.py -q
python - <<'PY'
from pathlib import Path
import yaml
for path in Path(".github/workflows").glob("*.yml"):
    yaml.safe_load(path.read_text())
print("workflow yaml ok")
PY
python tools/check_ac_traceability.py
python tools/lint_doc_consistency.py
python tools/generate_ac_registry.py --check
git diff --check
```

---

## Screenshots / Evidence

Failing merged run: https://github.com/wangzitian0/finance_report/actions/runs/26951237225/job/79517878700
