### PR TITLE
[finance_report_ui] Add workflow action route aliases

### DIFF
--- a/apps/frontend/src/__tests__/workflowActionRoutes.test.tsx
+++ b/apps/frontend/src/__tests__/workflowActionRoutes.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+import AccountsProcessingAliasPage from "@/app/(main)/accounts/processing/page";
+import StatementUploadAliasPage from "@/app/(main)/statements/upload/page";
+
+const redirectMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  redirect: (path: string) => redirectMock(path),
+}));
+
+describe("workflow action route aliases", () => {
+  it("AC19.4.3 AC19.6.6 keeps workflow upload action href reachable", () => {
+    StatementUploadAliasPage();
+
+    expect(redirectMock).toHaveBeenCalledWith("/statements");
+  });
+
+  it("AC19.5.4 AC19.6.6 keeps Processing readiness blocker href reachable", () => {
+    AccountsProcessingAliasPage();
+
+    expect(redirectMock).toHaveBeenCalledWith("/processing");
+  });
+});

--- a/apps/frontend/src/app/(main)/accounts/processing/page.tsx
+++ b/apps/frontend/src/app/(main)/accounts/processing/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AccountsProcessingAliasPage() {
+  redirect("/processing");
+}

--- a/apps/frontend/src/app/(main)/statements/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/statements/upload/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function StatementUploadAliasPage() {
+  redirect("/statements");
+}

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -371,7 +371,7 @@ workflow state exists.
 | AC19.6.3 | Desktop sidebar renders Upload Pipeline, Reports, AI, and Advanced as the primary surface; advanced child links remain accessible and active-state aware | `sidebarAndTabs.test.tsx` | P0 |
 | AC19.6.4 | Mobile nav renders the same primary/advanced grouping, supports advanced route selection, closes the drawer on navigation, and avoids overflow | `mobileNav.coverage.test.tsx`, `workflow-navigation.spec.ts` | P0 |
 | AC19.6.5 | Sidebar attention indicators are derived from `/api/workflow/status` through `lib/api.ts`; direct `/api/statements/pending-review` and stage2 queue polling are removed from Sidebar | `sidebarAndTabs.test.tsx` | P0 |
-| AC19.6.6 | Workflow event action links and workspace route labels continue to deep-link into advanced review/reconciliation/processing/report destinations | `workflowSurfaces.test.tsx`, `sidebarAndTabs.test.tsx` | P0 |
+| AC19.6.6 | Workflow event action links and workspace route labels continue to deep-link into advanced review/reconciliation/processing/report destinations | `workflowSurfaces.test.tsx`, `sidebarAndTabs.test.tsx`, `workflowActionRoutes.test.tsx` | P0 |
 | AC19.6.7 | Desktop and mobile Playwright smoke covers the folded navigation and Advanced access without horizontal overflow | `workflow-navigation.spec.ts` | P0 |
 
 ### AC19.7 — Framework-Aware Evidence Readiness


### PR DESCRIPTION
## Summary

- Add frontend alias routes for workflow action hrefs already emitted by the backend: `/statements/upload` -> `/statements` and `/accounts/processing` -> `/processing`.
- Add AC19 route tests proving upload and processing action links are reachable.
- Update EPIC-019 proof text to include the new route alias test.

## Why

Workflow events and report-readiness blockers use action hrefs as the handoff from status to user action. These aliases keep the existing API contract stable while preventing those CTAs from landing on missing frontend routes.

## Validation

- `npm run lint`
- `npm test -- src/__tests__/workflowActionRoutes.test.tsx src/__tests__/workflowSurfaces.test.tsx src/__tests__/personalReportPackagePage.test.tsx src/__tests__/navigation.test.ts`
- `npm test`

## Notes

- EPIC-020 framework selection is intentionally out of scope.
- Existing local `repo` submodule dirty state was not staged or committed.
