### PR TITLE
[finance_report_audit] Fix framework policy review follow-ups

### DIFF
--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -312,7 +312,11 @@ class FrameworkPolicyDecision(BaseModel):
 
     @model_validator(mode="after")
     def validate_required_dimensions(self) -> "FrameworkPolicyDecision":
-        missing = [dimension.value for dimension in PolicyDimension if not getattr(self, dimension.value)]
+        missing = [
+            f"{self.domain.value}.{dimension.value}"
+            for dimension in PolicyDimension
+            if not getattr(self, dimension.value)
+        ]
         if missing:
             raise ValueError(f"missing required policy dimensions: {', '.join(missing)}")
         return self
@@ -373,7 +377,7 @@ class FrameworkPolicyResult(BaseModel):
     @model_validator(mode="after")
     def validate_decision_dimensions(self) -> "FrameworkPolicyResult":
         incomplete = [
-            decision.domain.value
+            f"{decision.domain.value}.{dimension.value}"
             for decision in self.decisions
             for dimension in PolicyDimension
             if not getattr(decision, dimension.value)

--- a/apps/backend/src/services/framework_policy.py
+++ b/apps/backend/src/services/framework_policy.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from datetime import date
 from decimal import Decimal
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import (
@@ -17,6 +18,7 @@ from src.models import (
     ManualValuationComponentType,
     ManualValuationSnapshot,
     MarketDataOverride,
+    StockPrice,
 )
 from src.models.layer2 import AssetType, AtomicPosition
 from src.schemas.reporting import (
@@ -83,10 +85,19 @@ def _rule(
             disclosure=disclosure,
         ),
         line_mappings=line_mappings,
-        required_evidence=required_evidence or ["source_anchor", "ledger_or_portfolio_anchor", "review_state"],
-        disclosure_requirements=disclosure_requirements or ["basis", "source_coverage", "valuation_or_cutoff"],
+        required_evidence=(
+            ["source_anchor", "ledger_or_portfolio_anchor", "review_state"]
+            if required_evidence is None
+            else required_evidence
+        ),
+        disclosure_requirements=(
+            ["basis", "source_coverage", "valuation_or_cutoff"]
+            if disclosure_requirements is None
+            else disclosure_requirements
+        ),
         blocker_conditions=blocker_conditions
-        or [
+        if blocker_conditions is not None
+        else [
             "missing_source_anchor",
             "pending_review",
             "missing_measurement_basis",
@@ -182,7 +193,7 @@ def _common_rules(framework_label: str) -> list[FrameworkPolicyMatrixRule]:
         _rule(
             domain=PolicyFactDomain.TRANSFER,
             supported_instrument_types=["internal_transfer", "broker_transfer", "cash_transfer", "fixture"],
-            recognition="Recognize transfers when both legs or explicit pending Processing evidence exist.",
+            recognition="Recognize transfers when both legs or explicit pending processing evidence exist.",
             measurement="Measure transfer legs at source cash amounts and FX translated report-currency equivalents.",
             classification="Internal movement, not income or expense.",
             presentation=f"{framework_label} cash-flow transfer reconciliation.",
@@ -269,21 +280,28 @@ def _gap_for_fact(fact: FrameworkPolicyFact) -> FrameworkPolicyGap:
 def _result_id(
     framework_id: PersonalReportingFrameworkId,
     *,
+    matrix_version: str,
     report_period_start: date,
     report_period_end: date,
     decisions: list[FrameworkPolicyDecision],
     gaps: list[FrameworkPolicyGap],
 ) -> str:
-    payload = "|".join(
-        [
-            framework_id.value,
-            report_period_start.isoformat(),
-            report_period_end.isoformat(),
-            ",".join(sorted(decision.domain.value for decision in decisions)),
-            ",".join(sorted(anchor.anchor_id for decision in decisions for anchor in decision.evidence_anchors)),
-            ",".join(sorted(f"{gap.fact_id}:{gap.code}" for gap in gaps)),
-            ",".join(sorted(anchor.anchor_id for gap in gaps for anchor in gap.evidence_anchors)),
-        ]
+    decision_payloads = [decision.model_dump(mode="json") for decision in decisions]
+    gap_payloads = [gap.model_dump(mode="json") for gap in gaps]
+    payload = json.dumps(
+        {
+            "framework_id": framework_id.value,
+            "matrix_version": matrix_version,
+            "report_period_start": report_period_start.isoformat(),
+            "report_period_end": report_period_end.isoformat(),
+            "decisions": sorted(
+                decision_payloads,
+                key=lambda decision: json.dumps(decision, sort_keys=True, separators=(",", ":")),
+            ),
+            "gaps": sorted(gap_payloads, key=lambda gap: json.dumps(gap, sort_keys=True, separators=(",", ":"))),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
     )
     digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
     return (
@@ -398,6 +416,7 @@ def derive_framework_policy_result(
     return FrameworkPolicyResult(
         result_id=_result_id(
             framework_id,
+            matrix_version=matrix.version,
             report_period_start=report_period_start,
             report_period_end=report_period_end,
             decisions=decisions,
@@ -454,16 +473,6 @@ async def framework_policy_facts_for_user(
             )
         )
 
-    price_result = await db.execute(
-        select(MarketDataOverride)
-        .where(MarketDataOverride.user_id == user_id)
-        .where(MarketDataOverride.price_date <= as_of_date)
-        .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
-    )
-    latest_price_by_identifier: dict[str, MarketDataOverride] = {}
-    for price in price_result.scalars().all():
-        latest_price_by_identifier.setdefault(price.asset_identifier, price)
-
     position_result = await db.execute(
         select(AtomicPosition)
         .where(AtomicPosition.user_id == user_id)
@@ -471,10 +480,37 @@ async def framework_policy_facts_for_user(
         .order_by(AtomicPosition.snapshot_date.desc(), AtomicPosition.created_at.desc())
     )
     seen_positions: set[str] = set()
+    latest_positions: list[AtomicPosition] = []
     for position in position_result.scalars().all():
-        if position.asset_identifier in seen_positions:
+        normalized_identifier = position.asset_identifier.strip().upper()
+        if normalized_identifier in seen_positions:
             continue
-        seen_positions.add(position.asset_identifier)
+        seen_positions.add(normalized_identifier)
+        latest_positions.append(position)
+
+    latest_override_by_identifier: dict[str, MarketDataOverride] = {}
+    latest_stock_price_by_identifier: dict[str, StockPrice] = {}
+    if seen_positions:
+        override_result = await db.execute(
+            select(MarketDataOverride)
+            .where(MarketDataOverride.user_id == user_id)
+            .where(func.upper(MarketDataOverride.asset_identifier).in_(seen_positions))
+            .where(MarketDataOverride.price_date <= as_of_date)
+            .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+        )
+        for override in override_result.scalars().all():
+            latest_override_by_identifier.setdefault(override.asset_identifier.strip().upper(), override)
+
+        stock_price_result = await db.execute(
+            select(StockPrice)
+            .where(func.upper(StockPrice.symbol).in_(seen_positions))
+            .where(StockPrice.price_date <= as_of_date)
+            .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc())
+        )
+        for stock_price in stock_price_result.scalars().all():
+            latest_stock_price_by_identifier.setdefault(stock_price.symbol.strip().upper(), stock_price)
+
+    for position in latest_positions:
         domain, instrument_type = _position_domain_and_instrument(position)
         anchors = [
             _anchor(
@@ -484,14 +520,27 @@ async def framework_policy_facts_for_user(
                 description=position.asset_identifier,
             )
         ]
-        price = latest_price_by_identifier.get(position.asset_identifier)
+        asset_identifier = position.asset_identifier.strip().upper()
+        override = latest_override_by_identifier.get(asset_identifier)
+        stock_price = latest_stock_price_by_identifier.get(asset_identifier)
+        price_candidates: list[tuple[date, int, MarketDataOverride | StockPrice]] = []
+        if stock_price is not None:
+            price_candidates.append((stock_price.price_date, 0, stock_price))
+        if override is not None:
+            price_candidates.append((override.price_date, 1, override))
+        price = (
+            max(price_candidates, key=lambda candidate: (candidate[0], candidate[1]))[2] if price_candidates else None
+        )
         if price is not None:
+            source_system = "market_data_override" if isinstance(price, MarketDataOverride) else "stock_price"
+            source_id = price.id
+            identifier = price.asset_identifier if isinstance(price, MarketDataOverride) else price.symbol
             anchors.append(
                 _anchor(
                     anchor_type="market_price",
-                    source_system="market_data_override",
-                    source_id=price.id,
-                    description=f"{price.asset_identifier} price dated {price.price_date.isoformat()}",
+                    source_system=source_system,
+                    source_id=source_id,
+                    description=f"{identifier} price dated {price.price_date.isoformat()}",
                 )
             )
         facts.append(

--- a/apps/backend/src/services/report_readiness.py
+++ b/apps/backend/src/services/report_readiness.py
@@ -30,6 +30,7 @@ from src.models import (
     ReconciliationStatus,
     ReportSnapshot,
     Stage1Status,
+    StockPrice,
 )
 from src.models.layer2 import AssetType
 from src.schemas.reporting import (
@@ -44,6 +45,7 @@ from src.services.fx import FxRateError, convert_amount
 
 PACKAGE_ID = "personal-financial-report-package"
 MARKET_DATA_STALE_AFTER_DAYS = 90
+FRAMEWORK_POLICY_ACTION_HREF = "/reports/package"
 
 
 def _blocker(
@@ -150,7 +152,7 @@ def framework_policy_readiness_blockers(
                     "Missing framework policy result",
                     1,
                     "A selected framework requires a structured policy result before trusted output can be generated.",
-                    "/reports/package/framework-policy",
+                    FRAMEWORK_POLICY_ACTION_HREF,
                 )
             )
         return blockers
@@ -162,7 +164,7 @@ def framework_policy_readiness_blockers(
                 "Framework policy result mismatch",
                 1,
                 "The available policy result does not match the selected reporting framework.",
-                "/reports/package/framework-policy",
+                FRAMEWORK_POLICY_ACTION_HREF,
             )
         )
 
@@ -173,7 +175,7 @@ def framework_policy_readiness_blockers(
                 "Missing framework policy result",
                 1,
                 "The selected framework produced no structured policy decisions or explicit policy gaps for the available package inputs.",
-                "/reports/package/framework-policy",
+                FRAMEWORK_POLICY_ACTION_HREF,
             )
         )
 
@@ -188,7 +190,7 @@ def framework_policy_readiness_blockers(
                 "Unsupported policy domain" if code == "unsupported_policy_domain" else "Framework policy gap",
                 count,
                 "A selected-framework policy gap must be remediated before the package can be trusted.",
-                "/reports/package/framework-policy",
+                FRAMEWORK_POLICY_ACTION_HREF,
             )
         )
 
@@ -204,7 +206,7 @@ def framework_policy_readiness_blockers(
                 "Incomplete framework policy decision",
                 missing_dimension_count,
                 "Every policy decision must include recognition, measurement, classification, presentation, and disclosure.",
-                "/reports/package/framework-policy",
+                FRAMEWORK_POLICY_ACTION_HREF,
             )
         )
 
@@ -281,24 +283,37 @@ async def _stale_market_data_count(db: AsyncSession, user_id: UUID, *, as_of_dat
     asset_identifiers = list(position_rows.scalars().all())
     if not asset_identifiers:
         return 0
+    normalized_asset_identifiers = [asset_identifier.strip().upper() for asset_identifier in asset_identifiers]
 
-    price_rows = await db.execute(
+    override_rows = await db.execute(
         select(MarketDataOverride)
         .where(MarketDataOverride.user_id == user_id)
-        .where(MarketDataOverride.asset_identifier.in_(asset_identifiers))
+        .where(func.upper(MarketDataOverride.asset_identifier).in_(normalized_asset_identifiers))
         .where(MarketDataOverride.price_date <= as_of_date)
         .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
     )
-    latest_price_by_identifier: dict[str, MarketDataOverride] = {}
-    for price in price_rows.scalars().all():
-        latest_price_by_identifier.setdefault(price.asset_identifier, price)
+    latest_price_date_by_identifier: dict[str, date] = {}
+    for override in override_rows.scalars().all():
+        latest_price_date_by_identifier.setdefault(override.asset_identifier.strip().upper(), override.price_date)
+
+    stock_price_rows = await db.execute(
+        select(StockPrice)
+        .where(func.upper(StockPrice.symbol).in_(normalized_asset_identifiers))
+        .where(StockPrice.price_date <= as_of_date)
+        .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc())
+    )
+    for stock_price in stock_price_rows.scalars().all():
+        matching_identifier = stock_price.symbol.strip().upper()
+        current_price_date = latest_price_date_by_identifier.get(matching_identifier)
+        if current_price_date is None or stock_price.price_date > current_price_date:
+            latest_price_date_by_identifier[matching_identifier] = stock_price.price_date
 
     freshness_cutoff = as_of_date - timedelta(days=MARKET_DATA_STALE_AFTER_DAYS)
     return sum(
         1
-        for asset_identifier in asset_identifiers
-        if latest_price_by_identifier.get(asset_identifier) is None
-        or latest_price_by_identifier[asset_identifier].price_date < freshness_cutoff
+        for asset_identifier in normalized_asset_identifiers
+        if latest_price_date_by_identifier.get(asset_identifier) is None
+        or latest_price_date_by_identifier[asset_identifier] < freshness_cutoff
     )
 
 
@@ -350,6 +365,15 @@ async def get_personal_report_package_readiness(
         db,
         select(func.count(MarketDataOverride.id)).where(MarketDataOverride.user_id == user_id),
     )
+    policy_account_count = await _count(
+        db,
+        select(func.count(Account.id)).where(
+            Account.user_id == user_id,
+            Account.is_active == True,  # noqa: E712
+            Account.is_system == False,  # noqa: E712
+            Account.type.in_([AccountType.ASSET, AccountType.LIABILITY, AccountType.INCOME]),
+        ),
+    )
 
     source_summary = {
         "statements": statement_count,
@@ -360,6 +384,7 @@ async def get_personal_report_package_readiness(
         "dividends": dividend_count,
         "market_prices": market_price_count,
     }
+    framework_policy_input_count = policy_account_count + position_count + manual_valuation_count + dividend_count
     report_input_count = (
         statement_count
         + journal_entry_count
@@ -541,6 +566,7 @@ async def get_personal_report_package_readiness(
         source_summary.update(
             {
                 "selected_framework_id": selected_framework_id.value,
+                "framework_policy_inputs": framework_policy_input_count,
                 "framework_policy_decisions": len(policy_result.decisions),
                 "framework_policy_gaps": len(policy_result.gaps),
             }
@@ -549,7 +575,7 @@ async def get_personal_report_package_readiness(
         framework_policy_readiness_blockers(
             framework_id=framework_id,
             policy_result=policy_result,
-            report_input_count=report_input_count,
+            report_input_count=framework_policy_input_count,
             missing_valuation_basis_count=missing_valuation_basis_count,
             stale_market_data_count=stale_market_data_count,
         )

--- a/apps/backend/tests/reporting/test_framework_package_integration.py
+++ b/apps/backend/tests/reporting/test_framework_package_integration.py
@@ -18,7 +18,9 @@ from src.models.layer3 import (
     ManualValuationSnapshot,
     PositionStatus,
 )
+from src.models.market_data import StockPrice
 from src.models.portfolio import DividendIncome, MarketDataOverride, PriceSource
+from src.models.statement import BankStatement, BankStatementStatus, Stage1Status
 from src.models.user import User
 from src.routers.reports import (
     personal_report_package_contract,
@@ -43,12 +45,7 @@ from src.services.framework_policy import (
 from src.services.report_readiness import framework_policy_readiness_blockers
 
 
-@pytest.fixture(autouse=True)
-def patch_database_connection():
-    """Pure contract tests in this module do not require an implicit database."""
-    yield
-
-
+@pytest.mark.no_db
 def test_AC5_14_1_package_contract_accepts_selected_framework_policy_endpoint() -> None:
     """AC5.14.1: Package contract consumes EPIC-020 policy result metadata, not raw market value rules."""
     response = personal_report_package_contract(framework_id=PersonalReportingFrameworkId.HKFRS_LIKE)
@@ -117,6 +114,50 @@ async def test_AC20_5_1_package_policy_api_derives_framework_result_from_facts(
     assert hk_line == "assets.financial_assets_at_fair_value"
     assert "atomic_position" in {anchor.anchor_type for anchor in hk_response.decisions[0].evidence_anchors}
     assert "market_price" in {anchor.anchor_type for anchor in hk_response.decisions[0].evidence_anchors}
+
+
+@pytest.mark.asyncio
+async def test_AC20_5_1_package_policy_uses_synced_stock_prices_when_no_manual_override(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC20.5.1: Policy facts use synced StockPrice rows when no manual override exists."""
+    report_date = date(2026, 5, 31)
+    position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=report_date,
+        asset_identifier="SYNCED",
+        broker="Framework Broker",
+        quantity=Decimal("10"),
+        market_value=Decimal("125.00"),
+        currency="SGD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=f"framework-synced-{uuid4()}",
+        source_documents={"documents": [{"doc_id": "synced-doc", "doc_type": "brokerage_statement"}]},
+    )
+    synced_price = StockPrice(
+        symbol="SYNCED",
+        price_date=report_date,
+        price=Decimal("12.500000"),
+        currency="SGD",
+        source="test_provider",
+    )
+    db.add_all([position, synced_price])
+    await db.flush()
+
+    response = await personal_report_package_framework_policy(
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        start_date=date(2026, 5, 1),
+        end_date=report_date,
+        as_of_date=report_date,
+        db=db,
+        user_id=test_user.id,
+    )
+
+    anchors = response.decisions[0].evidence_anchors
+    market_anchor = next(anchor for anchor in anchors if anchor.anchor_type == "market_price")
+    assert market_anchor.source_system == "stock_price"
+    assert market_anchor.source_id == str(synced_price.id)
 
 
 @pytest.mark.asyncio
@@ -194,6 +235,56 @@ async def test_AC19_7_1_readiness_consumes_framework_specific_evidence_blockers(
     assert blockers["stale_market_data"]["count"] == 1
 
 
+@pytest.mark.asyncio
+async def test_AC19_7_1_readiness_uses_freshest_stock_price_or_manual_override(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC19.7.1: Fresh synced StockPrice rows satisfy market-data freshness without manual overrides."""
+    report_date = date(2026, 5, 31)
+    position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=report_date,
+        asset_identifier="FRESH",
+        broker="Framework Broker",
+        quantity=Decimal("5"),
+        market_value=Decimal("50.00"),
+        currency="SGD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=f"framework-fresh-{uuid4()}",
+        source_documents={"documents": [{"doc_id": "fresh-doc", "doc_type": "brokerage_statement"}]},
+    )
+    stale_override = MarketDataOverride(
+        user_id=test_user.id,
+        asset_identifier="FRESH",
+        price_date=date(2025, 12, 31),
+        price=Decimal("9.00"),
+        currency="SGD",
+        source=PriceSource.MANUAL,
+    )
+    fresh_synced_price = StockPrice(
+        symbol="FRESH",
+        price_date=report_date,
+        price=Decimal("10.000000"),
+        currency="SGD",
+        source="test_provider",
+    )
+    db.add_all([position, stale_override, fresh_synced_price])
+    await db.flush()
+
+    response = await personal_report_package_readiness(
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        end_date=report_date,
+        as_of_date=report_date,
+        db=db,
+        user_id=test_user.id,
+    )
+    blockers = {blocker.code: blocker for blocker in response.blockers}
+
+    assert "stale_market_data" not in blockers
+
+
+@pytest.mark.no_db
 def test_AC20_6_1_ai_suggestions_require_reviewed_policy_fields_for_readiness() -> None:
     """AC20.6.1: AI suggestions and incomplete policy fields become readiness blocker codes."""
     decision = FrameworkPolicyDecision.model_construct(
@@ -235,6 +326,7 @@ def test_AC20_6_1_ai_suggestions_require_reviewed_policy_fields_for_readiness() 
     assert "framework_ai_suggestion_unreviewed" in blocker_codes
 
 
+@pytest.mark.no_db
 def test_AC19_7_1_selected_framework_requires_non_empty_policy_result() -> None:
     """AC19.7.1: Selected-framework readiness fails closed when no policy result can be derived."""
     empty_policy_result = FrameworkPolicyResult.model_construct(
@@ -259,6 +351,43 @@ def test_AC19_7_1_selected_framework_requires_non_empty_policy_result() -> None:
     assert {blocker["code"] for blocker in blockers} == {"missing_framework_policy_result"}
 
 
+@pytest.mark.asyncio
+async def test_AC19_7_1_statement_only_inputs_do_not_require_framework_policy_result(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC19.7.1: Statement-only package inputs do not require an empty framework policy result."""
+    report_date = date(2026, 5, 31)
+    statement = BankStatement(
+        user_id=test_user.id,
+        file_path=f"s3://test/{uuid4()}.csv",
+        file_hash=uuid4().hex,
+        original_filename=f"{uuid4()}.csv",
+        institution="Framework Bank",
+        period_start=date(2026, 5, 1),
+        period_end=report_date,
+        status=BankStatementStatus.APPROVED,
+        balance_validated=True,
+        validation_error=None,
+        stage1_status=Stage1Status.APPROVED,
+    )
+    db.add(statement)
+    await db.flush()
+
+    response = await personal_report_package_readiness(
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        end_date=report_date,
+        as_of_date=report_date,
+        db=db,
+        user_id=test_user.id,
+    )
+    blocker_codes = {blocker.code for blocker in response.blockers}
+
+    assert response.source_summary["statements"] == 1
+    assert "missing_framework_policy_result" not in blocker_codes
+
+
+@pytest.mark.no_db
 def test_AC20_5_1_manual_valuation_components_map_to_supported_policy_instruments() -> None:
     """AC20.5.1: Manual valuation facts map to supported matrix instruments instead of policy gaps."""
     fixtures = [
@@ -281,6 +410,7 @@ def test_AC20_5_1_manual_valuation_components_map_to_supported_policy_instrument
         assert _manual_domain_and_instrument(snapshot) == (expected_domain, expected_instrument)
 
 
+@pytest.mark.no_db
 def test_AC20_5_1_atomic_position_asset_types_map_to_policy_domains() -> None:
     """AC20.5.1: Atomic positions map to supported policy domains or explicit unsupported facts."""
     fixtures = [
@@ -299,6 +429,7 @@ def test_AC20_5_1_atomic_position_asset_types_map_to_policy_domains() -> None:
         assert _position_domain_and_instrument(position) == (expected_domain, expected_instrument)
 
 
+@pytest.mark.no_db
 def test_AC20_5_1_ledger_account_types_map_to_policy_domains() -> None:
     """AC20.5.1: Ledger accounts map to framework-neutral facts or stay out of policy derivation."""
     fixtures = [
@@ -417,6 +548,7 @@ async def test_AC20_5_1_framework_facts_include_ledger_manual_position_and_divid
     assert f"dividend_income:{dividend.id}" in fact_ids
 
 
+@pytest.mark.no_db
 def test_AC19_7_1_framework_policy_helper_emits_all_evidence_blocker_codes() -> None:
     """AC19.7.1: Readiness helper emits framework, policy gap, valuation, and market-data blockers."""
     policy_result = FrameworkPolicyResult.model_construct(
@@ -466,6 +598,18 @@ def test_AC19_7_1_framework_policy_helper_emits_all_evidence_blocker_codes() -> 
         "missing_valuation_basis",
         "stale_market_data",
     } <= blocker_codes
+    framework_blockers = [
+        blocker
+        for blocker in blockers
+        if blocker["code"]
+        in {
+            "missing_framework_policy_result",
+            "unsupported_policy_domain",
+            "framework_policy_missing_dimensions",
+        }
+    ]
+    assert framework_blockers
+    assert {blocker["action_href"] for blocker in framework_blockers} == {"/reports/package"}
     assert {
         blocker["code"]
         for blocker in framework_policy_readiness_blockers(

--- a/apps/backend/tests/reporting/test_framework_policy.py
+++ b/apps/backend/tests/reporting/test_framework_policy.py
@@ -18,13 +18,9 @@ from src.schemas.reporting import (
     PolicyProvenance,
     PolicyReviewState,
 )
-from src.services.framework_policy import derive_framework_policy_result, get_framework_policy_matrix
+from src.services.framework_policy import _result_id, _rule, derive_framework_policy_result, get_framework_policy_matrix
 
-
-@pytest.fixture(autouse=True)
-def patch_database_connection():
-    """Framework policy contract tests do not require a database."""
-    yield
+pytestmark = pytest.mark.no_db
 
 
 def _anchor(identifier: str = "statement:dbs-2026-05") -> FrameworkPolicyEvidenceAnchor:
@@ -64,6 +60,30 @@ def test_AC20_3_1_policy_result_schema_requires_all_policy_dimensions() -> None:
         )
 
 
+def test_AC20_3_1_policy_result_validation_names_missing_dimensions() -> None:
+    """AC20.3.1: Result-level dimension validation identifies fields, not only domains."""
+    incomplete_decision = FrameworkPolicyDecision.model_construct(
+        domain=PolicyFactDomain.CASH,
+        recognition="Recognize cash from reviewed source evidence.",
+        measurement="Measure cash at nominal amount.",
+        classification="Cash asset.",
+        presentation="Balance sheet cash.",
+        disclosure=None,
+        line_mappings={"balance_sheet": "assets.cash"},
+    )
+
+    with pytest.raises(ValidationError, match="cash.disclosure"):
+        FrameworkPolicyResult(
+            result_id="policy-result:test",
+            framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+            report_period_start=date(2026, 5, 1),
+            report_period_end=date(2026, 5, 31),
+            generated_at=date(2026, 6, 1),
+            required_statements=["balance_sheet"],
+            decisions=[incomplete_decision],
+        )
+
+
 def test_AC20_3_1_framework_schema_rejects_unsupported_framework_id() -> None:
     """AC20.3.1: Framework policy result schema is closed to unsupported framework IDs."""
     with pytest.raises(ValidationError):
@@ -76,6 +96,27 @@ def test_AC20_3_1_framework_schema_rejects_unsupported_framework_id() -> None:
             required_statements=["balance_sheet"],
             decisions=[],
         )
+
+
+def test_AC20_4_1_policy_rule_defaults_preserve_explicit_empty_lists() -> None:
+    """AC20.4.1: Matrix rule construction preserves explicit empty evidence/disclosure lists."""
+    rule = _rule(
+        domain=PolicyFactDomain.CASH,
+        supported_instrument_types=["cash"],
+        recognition="Recognize cash.",
+        measurement="Measure cash.",
+        classification="Cash asset.",
+        presentation="Cash line.",
+        disclosure="No additional disclosure.",
+        line_mappings={"balance_sheet": "assets.cash"},
+        required_evidence=[],
+        disclosure_requirements=[],
+        blocker_conditions=[],
+    )
+
+    assert rule.required_evidence == []
+    assert rule.disclosure_requirements == []
+    assert rule.blocker_conditions == []
 
 
 def test_AC20_4_1_policy_matrix_covers_required_v1_domains_and_dimensions() -> None:
@@ -133,6 +174,49 @@ def test_AC20_5_1_policy_derivation_is_deterministic_reviewed_and_read_only() ->
     assert first.gaps == []
     assert {decision.provenance for decision in first.decisions} == {PolicyProvenance.DETERMINISTIC_MATRIX}
     assert {decision.review_state for decision in first.decisions} == {PolicyReviewState.ACCEPTED}
+
+
+def test_AC20_5_1_policy_result_id_fingerprints_decision_content_and_matrix_version() -> None:
+    """AC20.5.1: Policy result IDs change when decision content or matrix version changes."""
+    decision = FrameworkPolicyDecision(
+        domain=PolicyFactDomain.CASH,
+        recognition="Recognize cash from reviewed source evidence.",
+        measurement="Measure cash at nominal amount.",
+        classification="Cash asset.",
+        presentation="Balance sheet cash.",
+        disclosure="Disclose source coverage.",
+        line_mappings={"balance_sheet": "assets.cash"},
+        evidence_anchors=[_anchor("source:cash")],
+    )
+    changed_decision = decision.model_copy(update={"presentation": "Changed cash presentation."})
+
+    base_id = _result_id(
+        PersonalReportingFrameworkId.US_GAAP_LIKE,
+        matrix_version="1.0",
+        report_period_start=date(2026, 5, 1),
+        report_period_end=date(2026, 5, 31),
+        decisions=[decision],
+        gaps=[],
+    )
+    changed_decision_id = _result_id(
+        PersonalReportingFrameworkId.US_GAAP_LIKE,
+        matrix_version="1.0",
+        report_period_start=date(2026, 5, 1),
+        report_period_end=date(2026, 5, 31),
+        decisions=[changed_decision],
+        gaps=[],
+    )
+    changed_version_id = _result_id(
+        PersonalReportingFrameworkId.US_GAAP_LIKE,
+        matrix_version="1.1",
+        report_period_start=date(2026, 5, 1),
+        report_period_end=date(2026, 5, 31),
+        decisions=[decision],
+        gaps=[],
+    )
+
+    assert base_id != changed_decision_id
+    assert base_id != changed_version_id
 
 
 def test_AC20_4_1_us_and_hk_matrix_differ_for_same_listed_security_fixture() -> None:

--- a/docs/ssot/framework-reporting.md
+++ b/docs/ssot/framework-reporting.md
@@ -81,7 +81,10 @@ Code-owned contract surfaces:
 - Matrix service: `apps/backend/src/services/framework_policy.py` owns the
   deterministic v1 US-like/HK-like matrix, builds framework-neutral facts from
   existing user accounts, atomic positions, manual valuations, dividends, and
-  market-data overrides, then derives read-only policy results.
+  market-data evidence from synced `StockPrice` rows and manual
+  `MarketDataOverride` rows, then derives read-only policy results. When both
+  price sources exist, the latest price date is used and same-date manual
+  overrides take precedence.
 - Package API: `GET /api/reports/package/framework-policy` returns the selected
   framework policy result consumed by package assembly. `GET
   /api/reports/package/contract` exposes supported framework IDs, the selected
@@ -91,7 +94,8 @@ Code-owned contract surfaces:
 - Proof: `apps/backend/tests/reporting/test_framework_policy.py` verifies that
   policy results reject missing dimensions, unsupported frameworks are closed
   out, supported domains carry all five policy dimensions, derivation is
-  deterministic/read-only, US/HK outputs can differ from the same fixture, and
+  deterministic/read-only, result IDs fingerprint the matrix version plus full
+  decision/gap content, US/HK outputs can differ from the same fixture, and
   unsupported instruments create explicit policy gaps instead of silently
   defaulting to market value.
   `apps/backend/tests/reporting/test_framework_package_integration.py` covers
@@ -163,7 +167,8 @@ Required framework-aware blocker codes:
 - `missing_valuation_basis`: manual/private valuation snapshots included in
   trusted totals lack an explicit valuation basis.
 - `stale_market_data`: listed security, ETF, mutual-fund, or bond positions
-  lack market prices dated within 90 days of the report date.
+  lack synced provider or manual override prices dated within 90 days of the
+  report date.
 
 Draft output may exist with blockers, but trusted output must expose the blocker
 state before presenting framework-specific statements as reliable.

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -269,6 +269,9 @@ Package readiness:
   - `state`: closed enum of `draft`, `processing`, `blocked`, `ready`,
     `generated`, or `stale`
   - `selected_framework_id` in `source_summary` when a framework is selected
+  - `framework_policy_inputs` in `source_summary`; this policy-specific count
+    includes accounts, positions, manual valuations, and dividends, and excludes
+    bank statements or journal entries that do not produce EPIC-020 policy facts
   - `framework_policy_decisions` and `framework_policy_gaps` in
     `source_summary` when framework policy is evaluated
   - `label` and `action_href`: primary UI state and next action; action links
@@ -317,9 +320,13 @@ Package readiness:
   - `missing_valuation_basis`: manual/private valuations lack explicit basis
     text before trusted totals.
   - `stale_market_data`: listed security, ETF, mutual-fund, or bond positions
-    lack prices dated within 90 days of the report date.
+    lack synced provider or manual override prices dated within 90 days of the
+    report date.
 - The readiness derivation must be read-only. Opening the reports page must not
   create Processing accounts or other readiness artifacts.
+- Framework policy blocker `action_href` values point to the existing
+  `/reports/package` frontend route. The framework policy API endpoint remains
+  backend-only unless a dedicated frontend route is explicitly added.
 
 Framework policy result:
 
@@ -331,9 +338,11 @@ Framework policy result:
   default to a trailing 365-day window ending at the selected as-of date.
 - Output: a read-only `FrameworkPolicyResult` with stable `result_id`,
   selected framework ID, report period, required statements, policy decisions,
-  line mappings, evidence anchors, and explicit gaps. The endpoint derives the
-  result from existing accounts, atomic positions, manual valuations, dividends,
-  and market-data overrides. It must not mutate source records, journal entries,
+  line mappings, evidence anchors, and explicit gaps. `result_id` fingerprints
+  the selected framework, matrix version, period, full decision content, and gap
+  content. The endpoint derives the result from existing accounts, atomic
+  positions, manual valuations, dividends, synced `StockPrice` rows, and manual
+  `MarketDataOverride` rows. It must not mutate source records, journal entries,
   portfolio lots, market data, or report snapshots.
 - Package assembly must consume this policy result and must not infer
   framework-specific report lines directly from raw portfolio market value.


### PR DESCRIPTION
## Summary
- Fixes actionable CR follow-ups from #686 and #688 for EPIC-020 framework policy/readiness work.
- Preserves explicit empty policy rule lists, fixes policy dimension error detail, and fingerprints policy result IDs with matrix version plus full decision/gap content.
- Uses synced StockPrice rows with manual MarketDataOverride precedence for policy evidence and readiness freshness.
- Routes framework blocker actions to the existing /reports/package frontend route and scopes missing policy-result readiness to policy-producing inputs.

## Tracking
- Parent: #675
- Follow-up for completed PRs: #686, #688
- Related closed issues: #676, #677, #678, #680
- Leaves #679 and #681 open for the next 1-2 PRs.

## Verification
- `moon run :lint`
- `cd apps/backend && uv run --python 3.12.12 python -m pytest -q --no-cov -m no_db tests/reporting/test_framework_policy.py tests/reporting/test_framework_package_integration.py`

## Local Test Limitation
- `moon run :test` could not start local DB infrastructure because Podman compose still points at an unreachable stale machine socket (`127.0.0.1:61270`) in this workspace. CI should run the DB-backed tests with its normal infrastructure.

## Notes
- Existing local `repo/` submodule difference was not staged or committed.
