### PR TITLE
[finance_report_vision] Harden product source trust proof

### DIFF
--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -361,6 +361,10 @@ PERSONAL_REPORT_PACKAGE_TRACEABILITY: dict = {
             },
             "review_state": "trusted_or_explicit_manual_input",
             "confidence_tier": "TRUSTED",
+            "source_classes": ["bank_statement", "brokerage_statement", "manual_record"],
+            "proof_level": "hybrid",
+            "anchor_count": 0,
+            "blocker_codes": [],
         },
         {
             "line_id": "income_statement.total_income",
@@ -381,6 +385,10 @@ PERSONAL_REPORT_PACKAGE_TRACEABILITY: dict = {
             },
             "review_state": "trusted_or_reviewed",
             "confidence_tier": "TRUSTED",
+            "source_classes": ["bank_statement", "manual_record"],
+            "proof_level": "deterministic_pr",
+            "anchor_count": 0,
+            "blocker_codes": [],
         },
         {
             "line_id": "income_statement.total_expenses",
@@ -401,6 +409,10 @@ PERSONAL_REPORT_PACKAGE_TRACEABILITY: dict = {
             },
             "review_state": "trusted_or_reviewed",
             "confidence_tier": "TRUSTED",
+            "source_classes": ["bank_statement", "manual_record"],
+            "proof_level": "deterministic_pr",
+            "anchor_count": 0,
+            "blocker_codes": [],
         },
         {
             "line_id": "cash_flow.net_cash_flow",
@@ -421,6 +433,10 @@ PERSONAL_REPORT_PACKAGE_TRACEABILITY: dict = {
             },
             "review_state": "trusted_or_reviewed",
             "confidence_tier": "TRUSTED",
+            "source_classes": ["bank_statement", "csv_export", "manual_record"],
+            "proof_level": "deterministic_pr",
+            "anchor_count": 0,
+            "blocker_codes": [],
         },
         {
             "line_id": "investment_performance.market_value",
@@ -441,6 +457,10 @@ PERSONAL_REPORT_PACKAGE_TRACEABILITY: dict = {
             },
             "review_state": "market_data_fresh_or_disclosed_stale",
             "confidence_tier": "HIGH",
+            "source_classes": ["brokerage_statement"],
+            "proof_level": "hybrid",
+            "anchor_count": 0,
+            "blocker_codes": ["stale_market_data"],
         },
         {
             "line_id": "annualized_income_long_term.annualized_total",
@@ -461,6 +481,10 @@ PERSONAL_REPORT_PACKAGE_TRACEABILITY: dict = {
             },
             "review_state": "trusted_or_reviewed",
             "confidence_tier": "TRUSTED",
+            "source_classes": ["bank_statement", "csv_export", "manual_record"],
+            "proof_level": "deterministic_pr",
+            "anchor_count": 0,
+            "blocker_codes": [],
         },
         {
             "line_id": "annualized_income_long_term.restricted_fair_value_total",
@@ -482,6 +506,10 @@ PERSONAL_REPORT_PACKAGE_TRACEABILITY: dict = {
             },
             "review_state": "explicit_manual_input",
             "confidence_tier": "MEDIUM",
+            "source_classes": ["esop_rsu_plan", "manual_record"],
+            "proof_level": "manual_trusted",
+            "anchor_count": 0,
+            "blocker_codes": ["manual_only_source"],
         },
         {
             "line_id": "notes.non_compliance_statement",
@@ -503,6 +531,10 @@ PERSONAL_REPORT_PACKAGE_TRACEABILITY: dict = {
             },
             "review_state": "not_applicable",
             "confidence_tier": "UNAVAILABLE",
+            "source_classes": [],
+            "proof_level": "static_contract",
+            "anchor_count": 0,
+            "blocker_codes": [],
         },
     ],
     "completeness_warnings": [
@@ -578,6 +610,9 @@ def _add_anchor_identifiers(
     if line is None:
         return
     line[anchor_name]["identifiers"] = _dedupe_identifiers([*line[anchor_name].get("identifiers", []), *identifiers])
+    source_count = len(line.get("source_anchor", {}).get("identifiers", []))
+    ledger_count = len(line.get("ledger_anchor", {}).get("identifiers", []))
+    line["anchor_count"] = source_count + ledger_count
 
 
 async def _personal_report_package_traceability_payload(

--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -403,6 +403,17 @@ class PersonalReportPackageReadinessBlocker(BaseModel):
         return _validate_internal_action_href(value)
 
 
+class PersonalReportPackageSourceTrustSummary(BaseModel):
+    """Source-class trust summary for package readiness consumers."""
+
+    source_classes: list[str] = Field(default_factory=list)
+    deterministic_pr_source_classes: list[str] = Field(default_factory=list)
+    post_merge_llm_ocr_source_classes: list[str] = Field(default_factory=list)
+    manual_trusted_source_classes: list[str] = Field(default_factory=list)
+    gap_source_classes: list[str] = Field(default_factory=list)
+    blocker_codes: list[str] = Field(default_factory=list)
+
+
 class PersonalReportPackageReadinessState(str, Enum):
     """Allowed states for the personal report package readiness contract."""
 
@@ -424,6 +435,9 @@ class PersonalReportPackageReadinessResponse(BaseModel):
     blocking_count: int
     blockers: list[PersonalReportPackageReadinessBlocker] = Field(default_factory=list)
     source_summary: dict[str, int | str] = Field(default_factory=dict)
+    source_trust_summary: PersonalReportPackageSourceTrustSummary = Field(
+        default_factory=PersonalReportPackageSourceTrustSummary
+    )
     generated_at: datetime | None = None
     stale_since: datetime | None = None
 
@@ -479,6 +493,10 @@ class PersonalReportPackageTraceabilityLine(BaseModel):
     ledger_anchor: PersonalReportPackageTraceabilityAnchor
     review_state: str
     confidence_tier: str
+    source_classes: list[str] = Field(default_factory=list)
+    proof_level: str = "unclassified"
+    anchor_count: int = 0
+    blocker_codes: list[str] = Field(default_factory=list)
 
 
 class PersonalReportPackageCompletenessWarning(BaseModel):

--- a/apps/backend/src/services/report_readiness.py
+++ b/apps/backend/src/services/report_readiness.py
@@ -48,6 +48,10 @@ MARKET_DATA_STALE_AFTER_DAYS = 90
 FRAMEWORK_POLICY_ACTION_HREF = "/reports/package"
 
 
+def _sorted(values: set[str]) -> list[str]:
+    return sorted(values)
+
+
 def _blocker(
     code: str,
     label: str,
@@ -385,6 +389,30 @@ async def get_personal_report_package_readiness(
         "market_prices": market_price_count,
     }
     framework_policy_input_count = policy_account_count + position_count + manual_valuation_count + dividend_count
+    source_classes: set[str] = set()
+    deterministic_pr_source_classes: set[str] = set()
+    post_merge_llm_ocr_source_classes: set[str] = set()
+    manual_trusted_source_classes: set[str] = set()
+    gap_source_classes: set[str] = set()
+    if statement_count:
+        source_classes.update({"bank_statement", "csv_export"})
+        deterministic_pr_source_classes.update({"bank_statement", "csv_export"})
+        post_merge_llm_ocr_source_classes.add("bank_statement")
+    if position_count:
+        source_classes.add("brokerage_statement")
+        deterministic_pr_source_classes.add("brokerage_statement")
+        post_merge_llm_ocr_source_classes.add("brokerage_statement")
+    if manual_valuation_count:
+        source_classes.update({"property_statement", "liability_statement", "esop_rsu_plan", "manual_record"})
+        deterministic_pr_source_classes.update(
+            {"property_statement", "liability_statement", "esop_rsu_plan", "manual_record"}
+        )
+        manual_trusted_source_classes.update(
+            {"property_statement", "liability_statement", "esop_rsu_plan", "manual_record"}
+        )
+    if journal_entry_count:
+        source_classes.add("manual_record")
+        deterministic_pr_source_classes.add("manual_record")
     report_input_count = (
         statement_count
         + journal_entry_count
@@ -580,6 +608,13 @@ async def get_personal_report_package_readiness(
             stale_market_data_count=stale_market_data_count,
         )
     )
+    blocker_codes = {str(blocker["code"]) for blocker in blockers}
+    if "missing_source_coverage" in blocker_codes:
+        gap_source_classes.add("manual_record")
+    if "pending_review" in blocker_codes or "balance_mismatch" in blocker_codes:
+        gap_source_classes.add("bank_statement")
+    if "stale_market_data" in blocker_codes:
+        gap_source_classes.add("brokerage_statement")
 
     latest_snapshot_count = await _count(
         db,
@@ -648,6 +683,14 @@ async def get_personal_report_package_readiness(
         "blocking_count": sum(int(blocker["count"]) for blocker in blockers),
         "blockers": blockers,
         "source_summary": source_summary,
+        "source_trust_summary": {
+            "source_classes": _sorted(source_classes),
+            "deterministic_pr_source_classes": _sorted(deterministic_pr_source_classes),
+            "post_merge_llm_ocr_source_classes": _sorted(post_merge_llm_ocr_source_classes),
+            "manual_trusted_source_classes": _sorted(manual_trusted_source_classes),
+            "gap_source_classes": _sorted(gap_source_classes),
+            "blocker_codes": sorted(blocker_codes),
+        },
         "generated_at": latest_snapshot_updated_at,
         "stale_since": source_updated_at if state == "stale" else None,
     }

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -617,6 +617,109 @@ async def test_AC19_5_3_package_readiness_state_priority_and_snapshot_freshness(
 
 
 @pytest.mark.asyncio
+async def test_AC19_9_1_package_readiness_reports_source_trust_summary(
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC19.9.1 AC8.14.3: Package readiness reports deterministic source trust coverage."""
+    report_date = date(2026, 5, 31)
+    await _ready_source_account(db, test_user.id)
+    db.add(
+        Account(
+            user_id=test_user.id,
+            name="Uncovered Trust Liability",
+            type=AccountType.LIABILITY,
+            currency="SGD",
+        )
+    )
+    db.add(
+        JournalEntry(
+            user_id=test_user.id,
+            entry_date=report_date,
+            memo="Manual source trust anchor",
+            source_type=JournalEntrySourceType.MANUAL,
+            status=JournalEntryStatus.POSTED,
+        )
+    )
+    db.add(
+        AtomicPosition(
+            user_id=test_user.id,
+            snapshot_date=report_date,
+            asset_identifier="TRUST",
+            broker="Trust Broker",
+            quantity=Decimal("10"),
+            market_value=Decimal("125.00"),
+            currency="SGD",
+            asset_type=AssetType.STOCK,
+            dedup_hash=f"trust-{uuid4()}",
+            source_documents={"documents": [{"doc_id": "trust-brokerage-doc", "doc_type": "brokerage_statement"}]},
+        )
+    )
+    db.add_all(
+        [
+            ManualValuationSnapshot(
+                user_id=test_user.id,
+                component_type=ManualValuationComponentType.PROPERTY_VALUE,
+                liquidity_class=ManualValuationLiquidityClass.ILLIQUID,
+                as_of_date=report_date,
+                value=Decimal("500000.00"),
+                currency="SGD",
+                source="Trust Property",
+                notes="Independent appraisal basis",
+            ),
+            ManualValuationSnapshot(
+                user_id=test_user.id,
+                component_type=ManualValuationComponentType.RSU,
+                liquidity_class=ManualValuationLiquidityClass.RESTRICTED,
+                as_of_date=report_date,
+                value=Decimal("42000.00"),
+                currency="SGD",
+                source="Trust RSU",
+                notes="25% annual vesting",
+            ),
+            MarketDataOverride(
+                user_id=test_user.id,
+                asset_identifier="TRUST",
+                price_date=report_date,
+                price=Decimal("12.50"),
+                currency="SGD",
+                source=PriceSource.MANUAL,
+            ),
+        ]
+    )
+    await db.flush()
+
+    response = await personal_report_package_readiness(db=db, user_id=test_user.id)
+    payload = response.model_dump(mode="json")
+    trust = payload["source_trust_summary"]
+
+    assert {
+        "bank_statement",
+        "brokerage_statement",
+        "property_statement",
+        "liability_statement",
+        "esop_rsu_plan",
+        "csv_export",
+        "manual_record",
+    } <= set(trust["source_classes"])
+    assert {
+        "bank_statement",
+        "brokerage_statement",
+        "property_statement",
+        "liability_statement",
+        "esop_rsu_plan",
+        "csv_export",
+        "manual_record",
+    } <= set(trust["deterministic_pr_source_classes"])
+    assert {"bank_statement", "brokerage_statement"} <= set(trust["post_merge_llm_ocr_source_classes"])
+    assert {"property_statement", "liability_statement", "esop_rsu_plan", "manual_record"} <= set(
+        trust["manual_trusted_source_classes"]
+    )
+    assert "missing_source_coverage" in trust["blocker_codes"]
+    assert "manual_record" in trust["gap_source_classes"]
+
+
+@pytest.mark.asyncio
 async def test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors():
     """AC5.13.1: Package traceability endpoint returns source-to-ledger anchors per report line."""
     response = await personal_report_package_traceability()
@@ -640,6 +743,9 @@ async def test_AC5_13_1_package_traceability_endpoint_returns_section_line_ancho
     assert "manual_valuation_snapshot_ids" in total_assets["source_anchor"]["identifier_fields"]
     assert total_assets["review_state"] == "trusted_or_explicit_manual_input"
     assert total_assets["confidence_tier"] == "TRUSTED"
+    assert total_assets["source_classes"] == ["bank_statement", "brokerage_statement", "manual_record"]
+    assert total_assets["proof_level"] == "hybrid"
+    assert total_assets["anchor_count"] == 0
 
 
 @pytest.mark.asyncio
@@ -667,6 +773,9 @@ async def test_AC5_13_2_package_traceability_declares_completeness_warnings():
         assert line["ledger_anchor"]["state"] in {"available", "not_applicable", "unavailable"}
         assert line["review_state"]
         assert line["confidence_tier"] in {"TRUSTED", "HIGH", "MEDIUM", "LOW", "UNAVAILABLE"}
+        assert line["proof_level"]
+        assert isinstance(line["source_classes"], list)
+        assert isinstance(line["blocker_codes"], list)
 
 
 @pytest.mark.asyncio
@@ -798,6 +907,7 @@ async def test_AC5_13_5_package_traceability_returns_dynamic_current_user_identi
     total_assets = lines["balance_sheet.total_assets"]
     assert f"statement_transaction:{statement_txn_id}" in total_assets["source_anchor"]["identifiers"]
     assert f"manual_valuation_snapshot:{manual.id}" in total_assets["source_anchor"]["identifiers"]
+    assert total_assets["anchor_count"] > 0
     assert f"atomic_position:{atomic.id}" in total_assets["source_anchor"]["identifiers"]
     assert f"journal_entry:{entry.id}" in total_assets["ledger_anchor"]["identifiers"]
 

--- a/apps/backend/tests/integration/test_reporting_e2e.py
+++ b/apps/backend/tests/integration/test_reporting_e2e.py
@@ -57,7 +57,7 @@ async def test_AC5_15_1_multicurrency_reporting_cycle_reconciles_bs_is_cf(
     db: AsyncSession,
     test_user,
 ) -> None:
-    """AC5.15.1: Multi-currency entries generate balanced BS, IS, and CF reports in base currency."""
+    """AC5.15.1 AC8.14.4: Structured/manual facts deterministically generate BS, IS, and CF reports."""
     user_id = test_user.id
     period_start = date(2026, 1, 1)
     period_end = date(2026, 1, 31)

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -110,6 +110,14 @@ const readiness = {
     dividends: 1,
     market_prices: 1,
   },
+  source_trust_summary: {
+    source_classes: ["bank_statement", "brokerage_statement", "property_statement", "liability_statement", "esop_rsu_plan", "csv_export", "manual_record"],
+    deterministic_pr_source_classes: ["bank_statement", "brokerage_statement", "property_statement", "liability_statement", "esop_rsu_plan", "csv_export", "manual_record"],
+    post_merge_llm_ocr_source_classes: ["bank_statement", "brokerage_statement"],
+    manual_trusted_source_classes: ["property_statement", "liability_statement", "esop_rsu_plan", "manual_record"],
+    gap_source_classes: ["manual_record"],
+    blocker_codes: ["missing_source_coverage", "pending_review"],
+  },
   generated_at: null,
   stale_since: null,
 }
@@ -167,6 +175,10 @@ const traceabilityAppendix = {
       },
       review_state: "trusted_or_explicit_manual_input",
       confidence_tier: "TRUSTED",
+      source_classes: ["bank_statement", "manual_record"],
+      proof_level: "hybrid",
+      anchor_count: 4,
+      blocker_codes: [],
     },
     {
       line_id: "notes.non_compliance_statement",
@@ -189,6 +201,10 @@ const traceabilityAppendix = {
       },
       review_state: "not_applicable",
       confidence_tier: "UNAVAILABLE",
+      source_classes: [],
+      proof_level: "static_contract",
+      anchor_count: 1,
+      blocker_codes: [],
     },
   ],
   completeness_warnings: [
@@ -254,6 +270,23 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.queryByText("Pending source review")).not.toBeInTheDocument()
   })
 
+  it("AC19.9.2 renders compact source trust summary before traceability details", async () => {
+    mockPackageApi()
+
+    render(<PersonalReportPackagePage />)
+
+    const sourceTrust = await screen.findByText("Source Trust")
+    await waitFor(() => expect(screen.getAllByText("traceability_appendix").length).toBeGreaterThanOrEqual(2))
+    const traceability = screen.getAllByText("traceability_appendix").at(-1)!
+    expect(traceability).toBeDefined()
+    expect(sourceTrust.compareDocumentPosition(traceability) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(screen.getByText("7 classes")).toBeInTheDocument()
+    expect(screen.getByText("bank_statement, brokerage_statement, property_statement, liability_statement, esop_rsu_plan, csv_export, manual_record")).toBeInTheDocument()
+    expect(screen.getByText("bank_statement, brokerage_statement")).toBeInTheDocument()
+    expect(screen.getByText("property_statement, liability_statement, esop_rsu_plan, manual_record")).toBeInTheDocument()
+    expect(screen.getByText("missing_source_coverage, pending_review")).toBeInTheDocument()
+  })
+
   it("AC5.9.4 renders export contract metadata", async () => {
     mockPackageApi()
 
@@ -297,7 +330,7 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.getByText("This personal management report is not a regulated filing, not legal advice, and not tax advice.")).toBeInTheDocument()
   })
 
-  it("AC5.13.3 AC5.16.3 renders traceability appendix source, ledger, review, confidence, and identifiers", async () => {
+  it("AC5.13.3 AC5.16.3 AC5.16.4 renders traceability appendix source, ledger, review, confidence, and identifiers", async () => {
     mockPackageApi()
 
     render(<PersonalReportPackagePage />)
@@ -311,6 +344,8 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.getByText("journal_entry:je-789, journal_line:jl-101")).toBeInTheDocument()
     expect(screen.getByText("trusted_or_explicit_manual_input")).toBeInTheDocument()
     expect(screen.getByText("TRUSTED")).toBeInTheDocument()
+    expect(screen.getByText("hybrid")).toBeInTheDocument()
+    expect(screen.getByText("4 anchors")).toBeInTheDocument()
     expect(screen.getByText("manual_only_source")).toBeInTheDocument()
     expect(screen.getByText("explicit_manual_input_required")).toBeInTheDocument()
   })

--- a/apps/frontend/src/app/(main)/reports/package/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/package/page.tsx
@@ -17,6 +17,10 @@ function formatScheduleCurrency(value: number | string, currency: string): strin
     return formatCurrencyLocale(value, currency, "en-US", { maximumFractionDigits: 0 }).replace(/\u00a0/g, " ");
 }
 
+function renderCsv(values?: string[]): string {
+    return values && values.length ? values.join(", ") : "none";
+}
+
 function renderAnchorDetail(primary: string, identifiers?: string[]) {
     return (
         <>
@@ -130,6 +134,54 @@ export default function PersonalReportPackagePage() {
                     </div>
                 ) : null}
             </section>
+
+            {readiness.source_trust_summary ? (
+                <section className="card p-5 mb-6" aria-label="Source trust summary">
+                    <div className="flex items-start justify-between gap-3">
+                        <div>
+                            <p className="text-xs font-mono text-muted">source_trust_summary</p>
+                            <h2 className="font-semibold mt-1">Source Trust</h2>
+                        </div>
+                        <span className="badge badge-muted">
+                            {readiness.source_trust_summary.source_classes.length} classes
+                        </span>
+                    </div>
+                    <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+                        <div>
+                            <dt className="text-xs text-muted">Deterministic PR</dt>
+                            <dd className="mt-1 font-mono text-xs">
+                                {renderCsv(readiness.source_trust_summary.deterministic_pr_source_classes)}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-xs text-muted">Post-merge LLM/OCR</dt>
+                            <dd className="mt-1 font-mono text-xs">
+                                {renderCsv(readiness.source_trust_summary.post_merge_llm_ocr_source_classes)}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-xs text-muted">Manual Trusted</dt>
+                            <dd className="mt-1 font-mono text-xs">
+                                {renderCsv(readiness.source_trust_summary.manual_trusted_source_classes)}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-xs text-muted">Trust Gaps</dt>
+                            <dd className="mt-1 font-mono text-xs">
+                                {renderCsv(readiness.source_trust_summary.gap_source_classes)}
+                            </dd>
+                        </div>
+                    </dl>
+                    {readiness.source_trust_summary.blocker_codes.length ? (
+                        <div className="mt-4">
+                            <p className="text-xs text-muted">Blocker Codes</p>
+                            <p className="mt-1 font-mono text-xs">
+                                {readiness.source_trust_summary.blocker_codes.join(", ")}
+                            </p>
+                        </div>
+                    ) : null}
+                </section>
+            ) : null}
 
             <div className="grid lg:grid-cols-2 gap-4 mb-6">
                 {contract.sections.map((section) => (
@@ -330,7 +382,14 @@ export default function PersonalReportPackagePage() {
                                     </td>
                                     <td className="py-3 pr-4 font-mono text-xs">{line.review_state}</td>
                                     <td className="py-3">
-                                        <span className="badge badge-muted">{line.confidence_tier}</span>
+                                        <div className="flex flex-col gap-2">
+                                            <span className="badge badge-muted">{line.confidence_tier}</span>
+                                            <span className="font-mono text-xs text-muted">{line.proof_level ?? "unclassified"}</span>
+                                            <span className="font-mono text-xs text-muted">{line.anchor_count ?? 0} anchors</span>
+                                            {line.blocker_codes?.length ? (
+                                                <span className="font-mono text-xs text-muted">{line.blocker_codes.join(", ")}</span>
+                                            ) : null}
+                                        </div>
                                     </td>
                                 </tr>
                             ))}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -213,6 +213,14 @@ export interface PersonalReportPackageReadinessResponse {
     blocking_count: number;
     blockers: PersonalReportPackageReadinessBlocker[];
     source_summary: Record<string, number | string>;
+    source_trust_summary?: {
+        source_classes: string[];
+        deterministic_pr_source_classes: string[];
+        post_merge_llm_ocr_source_classes: string[];
+        manual_trusted_source_classes: string[];
+        gap_source_classes: string[];
+        blocker_codes: string[];
+    };
     generated_at?: string | null;
     stale_since?: string | null;
 }
@@ -255,6 +263,10 @@ export interface PersonalReportPackageTraceabilityLine {
     ledger_anchor: PersonalReportPackageTraceabilityAnchor;
     review_state: string;
     confidence_tier: string;
+    source_classes?: string[];
+    proof_level?: string;
+    anchor_count?: number;
+    blocker_codes?: string[];
 }
 
 export interface PersonalReportPackageCompletenessWarning {

--- a/common/ssot/check_critical_proof_matrix.py
+++ b/common/ssot/check_critical_proof_matrix.py
@@ -32,6 +32,7 @@ REGISTRY_PATHS = (
 VALID_SCOPES = {"behavioral", "static_contract", "manual_gate"}
 VALID_CI_TIERS = {"pr_ci", "post_merge_environment", "manual"}
 VALID_OUTCOME_STATUSES = {"covered", "partial", "gap"}
+VALID_TRUST_MODES = {"deterministic_pr", "llm_ocr_post_merge", "hybrid"}
 REQUIRED_OUTCOME_IDS = {
     "personal-financial-report-package",
     "asset-distribution-net-worth",
@@ -71,6 +72,9 @@ class ProofResult:
     test: str
     ac_ids: list[str]
     status: str
+    trust_mode: str = ""
+    source_classes: list[str] = field(default_factory=list)
+    mirror_proof_id: str = ""
     errors: list[str] = field(default_factory=list)
 
 
@@ -265,9 +269,20 @@ def _validate_proof(
     scope = str(proof.get("scope", ""))
     ci_tier = str(proof.get("ci_tier", ""))
     ac_ids = [str(ac_id) for ac_id in proof.get("ac_ids", [])]
+    trust_mode = str(proof.get("trust_mode", ""))
+    source_classes = [str(source_class) for source_class in proof.get("source_classes", [])]
+    mirror_proof_id = str(proof.get("mirror_proof_id", ""))
     rel_file = str(proof.get("file", ""))
     test_name = str(proof.get("test", ""))
     errors = list(shape_errors)
+
+    if trust_mode:
+        if trust_mode not in VALID_TRUST_MODES:
+            errors.append(f"{proof_id}: invalid trust_mode {trust_mode!r}")
+        if not source_classes:
+            errors.append(f"{proof_id}: source_classes are required when trust_mode is set")
+        if trust_mode == "llm_ocr_post_merge" and not mirror_proof_id:
+            errors.append(f"{proof_id}: llm_ocr_post_merge proof requires mirror_proof_id")
 
     for ac_id in ac_ids:
         if ac_id not in registry_ids:
@@ -282,6 +297,9 @@ def _validate_proof(
             test=test_name,
             ac_ids=ac_ids,
             status="fail" if errors else "manual",
+            trust_mode=trust_mode,
+            source_classes=source_classes,
+            mirror_proof_id=mirror_proof_id,
             errors=errors,
         )
 
@@ -297,14 +315,34 @@ def _validate_proof(
     if not path.exists():
         errors.append(f"{proof_id}: file does not exist: {rel_file}")
         return ProofResult(
-            proof_id, scope, ci_tier, rel_file, test_name, ac_ids, "fail", errors
+            proof_id,
+            scope,
+            ci_tier,
+            rel_file,
+            test_name,
+            ac_ids,
+            "fail",
+            trust_mode,
+            source_classes,
+            mirror_proof_id,
+            errors,
         )
 
     anchor = _find_anchor(path, test_name)
     if anchor is None:
         errors.append(f"{proof_id}: test anchor not found: {test_name}")
         return ProofResult(
-            proof_id, scope, ci_tier, rel_file, test_name, ac_ids, "fail", errors
+            proof_id,
+            scope,
+            ci_tier,
+            rel_file,
+            test_name,
+            ac_ids,
+            "fail",
+            trust_mode,
+            source_classes,
+            mirror_proof_id,
+            errors,
         )
 
     stable_refs = set(AC_PATTERN.findall(anchor.stable_text))
@@ -337,6 +375,9 @@ def _validate_proof(
         test=test_name,
         ac_ids=ac_ids,
         status="fail" if errors else scope,
+        trust_mode=trust_mode,
+        source_classes=source_classes,
+        mirror_proof_id=mirror_proof_id,
         errors=errors,
     )
 
@@ -347,13 +388,31 @@ def validate_matrix(repo_root: Path, matrix_path: Path) -> list[ProofResult]:
     if not isinstance(proofs, list) or not proofs:
         raise ValueError(f"{matrix_path} must define a non-empty proofs list")
     registry_ids = _load_registry_ids(repo_root)
-    return [
+    results = [
         _validate_proof(
             proof, repo_root=repo_root, registry_ids=registry_ids, index=index
         )
         for index, proof in enumerate(proofs)
         if isinstance(proof, dict)
     ]
+    by_id = {result.proof_id: result for result in results}
+    for result in results:
+        if not result.mirror_proof_id:
+            continue
+        mirror = by_id.get(result.mirror_proof_id)
+        if mirror is None:
+            result.errors.append(f"{result.proof_id}: unknown mirror_proof_id {result.mirror_proof_id}")
+            continue
+        if mirror.trust_mode != "deterministic_pr" or mirror.ci_tier != "pr_ci":
+            result.errors.append(
+                f"{result.proof_id}: mirror proof {result.mirror_proof_id} must be deterministic_pr in pr_ci"
+            )
+        missing_classes = sorted(set(result.source_classes) - set(mirror.source_classes))
+        if missing_classes:
+            result.errors.append(
+                f"{result.proof_id}: mirror proof {result.mirror_proof_id} missing source classes: {', '.join(missing_classes)}"
+            )
+    return results
 
 
 def _validate_outcome(
@@ -623,16 +682,18 @@ def render_report(
         "",
         "## Proofs",
         "",
-        "| ID | Scope | CI tier | AC IDs | Test anchor | Status |",
-        "|---|---|---|---|---|---|",
+        "| ID | Scope | CI tier | Trust mode | Source classes | AC IDs | Test anchor | Status |",
+        "|---|---|---|---|---|---|---|---|",
     ]
     for result in results:
         ac_cell = ", ".join(f"`{ac_id}`" for ac_id in result.ac_ids)
         anchor = f"`{result.file}::{result.test}`" if result.file else "_manual_"
         status = "fail" if result.errors else result.scope
+        source_cell = ", ".join(f"`{source_class}`" for source_class in result.source_classes) or "-"
+        trust_cell = result.trust_mode or "-"
         lines.append(
             f"| `{result.proof_id}` | {result.scope} | {result.ci_tier} | "
-            f"{ac_cell} | {anchor} | {status} |"
+            f"{trust_cell} | {source_cell} | {ac_cell} | {anchor} | {status} |"
         )
 
     if outcomes is not None:

--- a/common/ssot/check_source_coverage_matrix.py
+++ b/common/ssot/check_source_coverage_matrix.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Validate source coverage matrix for product trust."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MATRIX = REPO_ROOT / "docs" / "ssot" / "source-coverage-matrix.yaml"
+VALID_PROOF_LEVELS = {"pr_deterministic", "post_merge_llm_ocr", "manual_trusted", "gap"}
+ISSUE_RE = re.compile(r"^#\d+$")
+EPIC_RE = re.compile(r"^EPIC-\d{3}$")
+
+
+@dataclass
+class SourceCoverageResult:
+    source_id: str
+    proof_levels: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return payload
+
+
+def _validate_source(source: dict[str, Any], repo_root: Path) -> SourceCoverageResult:
+    source_id = str(source.get("id", ""))
+    errors: list[str] = []
+    proof_levels = [str(level) for level in source.get("proof_levels", [])]
+
+    required = {
+        "id",
+        "owner_epics",
+        "supported_formats",
+        "supported_institutions",
+        "proof_levels",
+        "ingestion_path",
+        "review_requirement",
+        "traceability_target",
+        "test_anchors",
+    }
+    missing = sorted(required - set(source))
+    if missing:
+        errors.append(f"{source_id or '<missing id>'}: missing keys: {', '.join(missing)}")
+
+    if not source_id:
+        errors.append("source class missing id")
+    owner_epics = source.get("owner_epics", [])
+    if not isinstance(owner_epics, list) or not owner_epics:
+        errors.append(f"{source_id}: owner_epics must be a non-empty list")
+    else:
+        for epic in owner_epics:
+            if not EPIC_RE.fullmatch(str(epic)):
+                errors.append(f"{source_id}: invalid owner EPIC {epic!r}")
+            elif not sorted((repo_root / "docs" / "project").glob(f"{epic}.*.md")):
+                errors.append(f"{source_id}: owner EPIC does not exist: {epic}")
+
+    if not proof_levels:
+        errors.append(f"{source_id}: proof_levels must be non-empty")
+    unknown = sorted(set(proof_levels) - VALID_PROOF_LEVELS)
+    if unknown:
+        errors.append(f"{source_id}: unknown proof levels: {', '.join(unknown)}")
+    if "gap" in proof_levels and not ISSUE_RE.fullmatch(str(source.get("gap_issue", ""))):
+        errors.append(f"{source_id}: gap proof level requires gap_issue like #696")
+    if proof_levels == ["post_merge_llm_ocr"] and source.get("requires_pr_deterministic_mirror") is not False:
+        errors.append(f"{source_id}: post_merge_llm_ocr cannot be the only proof level")
+
+    anchors = source.get("test_anchors", [])
+    if not isinstance(anchors, list) or not anchors:
+        errors.append(f"{source_id}: test_anchors must be a non-empty list")
+    else:
+        for anchor in anchors:
+            file_name = str(anchor).split("::", 1)[0]
+            if not (repo_root / file_name).exists():
+                errors.append(f"{source_id}: test anchor file does not exist: {file_name}")
+
+    return SourceCoverageResult(source_id=source_id, proof_levels=proof_levels, errors=errors)
+
+
+def validate_source_coverage(repo_root: Path, matrix_path: Path) -> list[SourceCoverageResult]:
+    payload = _load(matrix_path)
+    required_classes = [str(item) for item in payload.get("required_source_classes", [])]
+    sources = payload.get("source_classes", [])
+    results: list[SourceCoverageResult] = []
+    if not isinstance(sources, list):
+        return [SourceCoverageResult("__matrix__", errors=["source_classes must be a list"])]
+
+    by_id: dict[str, dict[str, Any]] = {}
+    duplicates: set[str] = set()
+    for source in sources:
+        if not isinstance(source, dict):
+            results.append(SourceCoverageResult("__source__", errors=["source entry must be a mapping"]))
+            continue
+        source_id = str(source.get("id", ""))
+        if source_id in by_id:
+            duplicates.add(source_id)
+        by_id[source_id] = source
+        results.append(_validate_source(source, repo_root))
+
+    missing = sorted(set(required_classes) - set(by_id))
+    unknown = sorted(set(by_id) - set(required_classes))
+    global_errors: list[str] = []
+    if missing:
+        global_errors.append(f"missing required source classes: {', '.join(missing)}")
+    if unknown:
+        global_errors.append(f"unknown source classes: {', '.join(unknown)}")
+    if duplicates:
+        global_errors.append(f"duplicate source classes: {', '.join(sorted(duplicates))}")
+    if global_errors:
+        results.append(SourceCoverageResult("__matrix__", errors=global_errors))
+    return results
+
+
+def render_report(results: list[SourceCoverageResult]) -> str:
+    errors = [error for result in results for error in result.errors]
+    lines = [
+        "# Source Coverage Matrix Report",
+        "",
+        "| Source | Proof levels | Validation |",
+        "|---|---|---|",
+    ]
+    for result in results:
+        if result.source_id.startswith("__") and not result.errors:
+            continue
+        lines.append(
+            f"| `{result.source_id}` | {', '.join(result.proof_levels) or '-'} | "
+            f"{'fail' if result.errors else 'ok'} |"
+        )
+    lines.extend(["", "## Errors", ""])
+    lines.extend(f"- {error}" for error in errors) if errors else lines.append("No source coverage errors found.")
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate source coverage matrix.")
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--matrix", type=Path, default=DEFAULT_MATRIX)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    matrix_path = args.matrix if args.matrix.is_absolute() else repo_root / args.matrix
+    results = validate_source_coverage(repo_root, matrix_path)
+    report = render_report(results)
+    print(report)
+    errors = [error for result in results for error in result.errors]
+    if errors:
+        for error in errors:
+            print(f"::error title=Source coverage matrix::{error}", file=sys.stderr)
+        return 1
+    print(f"Source coverage matrix passed: {len([result for result in results if not result.source_id.startswith('__')])} source class(es) validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -274,6 +274,7 @@ visible to users.
 | AC5.16.1 | Balance sheet defaults restricted holdings to excluded, exposes an include toggle, and renders equation component detail | `test_AC5_16_1_balance_sheet_defaults_to_excluding_restricted_holdings` / `AC16.14.2 / test_AC8_13_48 renders string totals and refetches by date` | `reporting/test_reports_router.py`, `frontend/src/__tests__/balanceSheetPage.test.tsx` | P0 |
 | AC5.16.2 | Balance sheet, income statement, and cash-flow report pages surface backend `fx_warnings` instead of silently rendering partial totals | `test_AC5_16_2_cash_flow_response_preserves_fx_warnings` / page warning assertions | `reporting/test_reports_router.py`, `frontend/src/__tests__/balanceSheetPage.test.tsx`, `frontend/src/__tests__/incomeStatementPage.test.tsx`, `frontend/src/__tests__/cashFlowPage.test.tsx` | P0 |
 | AC5.16.3 | Personal report package traceability renders concrete source and ledger identifiers when the appendix provides them | `AC5.13.3 renders traceability appendix source, ledger, review, and confidence metadata` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
+| AC5.16.4 | Personal report package traceability lines expose source classes, proof level, anchor count, and blocker codes for report-line confidence review | `test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors`, `test_AC5_13_2_package_traceability_declares_completeness_warnings` | `api/test_personal_report_package_contract.py` | P0 |
 
 ## 📏 Acceptance Criteria
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -363,6 +363,15 @@ job inventories or scenario counts into this EPIC.
 | AC8.13.90 | Frontend exposes `/frontend-version.json` with deployed `git_sha`/`version` metadata for PR preview readiness checks | `AC8.13.90 returns deployed frontend version metadata for PR preview readiness` | `frontendVersionRoute.test.ts` | P0 |
 | AC8.13.91 | Main post-merge staging deploy failures open or update a persistent GitHub Issue alert, and the next successful staging run closes it | `test_AC8_13_91_post_merge_staging_failure_opens_rolling_alert_issue` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 
+### AC8.14: Product Trust Proof Mirrors
+
+| AC ID | Test Case | Test Function | File | Priority |
+|---|---|---|---|---|
+| AC8.14.1 | Critical proof matrix classifies product proof paths by trust mode and source classes | `test_valid_behavioral_static_and_manual_entries_pass` / `test_AC8_14_2_llm_ocr_mirror_must_be_pr_deterministic` | `tests/tooling/test_check_critical_proof_matrix.py` | P0 |
+| AC8.14.2 | Critical post-merge LLM/OCR product proofs must name a PR deterministic mirror proof for the same source classes | `test_AC8_14_2_llm_ocr_proof_requires_deterministic_pr_mirror`, `test_AC8_14_2_llm_ocr_mirror_must_be_pr_deterministic` | `tests/tooling/test_check_critical_proof_matrix.py` | P0 |
+| AC8.14.3 | Personal report package critical proof has a deterministic PR mirror covering bank, brokerage, manual valuation, restricted-compensation, CSV, and manual-record source classes | `test_AC8_14_3_personal_package_has_deterministic_source_trust_mirror` | `tests/tooling/test_personal_report_package_fixture_contract.py` | P0 |
+| AC8.14.4 | Backend reporting integration acts as a deterministic PR mirror from structured/manual source facts through ledger and core statements | `test_AC5_15_1_multicurrency_reporting_cycle_reconciles_bs_is_cf` | `apps/backend/tests/integration/test_reporting_e2e.py` | P0 |
+
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.
 - Current AC counts, covered/untested totals, and placeholder/stub exclusions are

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -203,6 +203,14 @@ Expected routing behavior remains threshold-based (See: `docs/ssot/reconciliatio
 | AC13.10.5 | source_type cannot be downgraded | `test_source_type_no_downgrade` | `apps/backend/tests/reconciliation/test_source_type.py` | P1 |
 | AC13.10.6 | All four source_type values accepted by API | `test_all_four_source_type_values_accepted_by_api` | `apps/backend/tests/reconciliation/test_source_type.py` | P1 |
 
+### AC13.12: Source Coverage Matrix
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC13.12.1 | Source coverage matrix covers every source class named by vision.md with owner EPICs, proof levels, ingestion path, review requirement, traceability target, and test anchors | `test_AC13_12_1_source_coverage_matrix_covers_vision_source_classes` | `tests/tooling/test_source_coverage_matrix.py` | P0 |
+| AC13.12.2 | Source coverage matrix rejects source classes whose only proof level is post-merge LLM/OCR unless an explicit exception is recorded | `test_AC13_12_2_source_coverage_matrix_rejects_llm_only_sources` | `tests/tooling/test_source_coverage_matrix.py` | P0 |
+| AC13.12.3 | Source coverage matrix requires a gap issue for any source class still classified as a gap | `test_AC13_12_3_source_coverage_matrix_requires_gap_issue` | `tests/tooling/test_source_coverage_matrix.py` | P0 |
+
 ---
 
 ## 📌 Future Work (from Vision Recovery Audit)

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -393,6 +393,13 @@ workflow state exists.
 | AC19.8.7 | Report readiness has route-level Playwright smoke coverage before package output | `report-readiness.spec.ts` | P1 |
 | AC19.8.8 | CR cleanup fixes mixed-currency investment schedule fallback, missing Processing FX readiness blocker coverage, stale SSOT paths, and stale navigation docs | `test_AC19_8_8_investment_schedule_fallback_holding_cost_basis_converts_currency`, `test_AC19_8_8_package_readiness_blocks_when_processing_fx_conversion_fails`, `report-readiness.spec.ts` | P0 |
 
+### AC19.9 — Source Trust Readiness
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC19.9.1 | Personal report package readiness returns source trust summary by source class, deterministic PR proof availability, post-merge LLM/OCR coverage, manual-trusted classes, gaps, and blocker codes | `test_AC19_9_1_package_readiness_reports_source_trust_summary` | P0 |
+| AC19.9.2 | Personal report package page renders a compact source trust summary before detailed package output | `AC19.9.2 renders compact source trust summary before traceability details` | P0 |
+
 ## How To Build It
 
 ### Backend

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -6,7 +6,7 @@
 - API title: `Finance Report API`
 - API version: `0.1.0`
 - Endpoint count: `115`
-- Schema count: `190`
+- Schema count: `191`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -111,6 +111,14 @@ concepts:
       - docs/ssot/extraction.md
       - docs/project/EPIC-003.statement-parsing.md
 
+  source_coverage_matrix:
+    owner: docs/ssot/source-coverage-matrix.yaml
+    description: Machine-readable source-class coverage, proof level, review requirement, and traceability target registry.
+    cross_refs:
+      - vision.md
+      - docs/ssot/extraction.md
+      - docs/project/EPIC-013.statement-parsing-v2.md
+
   pdf_fixtures:
     owner: docs/ssot/pdf-fixtures.md
     description: Synthetic PDF fixture commands, local-only real-PDF handling, committed template policy, and font fallback.

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -73,12 +73,14 @@ contracts is tracked in
 | [confirmation-workflow.md](./confirmation-workflow.md) | `confirmation-workflow` | Review lifecycle rationale; state machine should migrate to code/common |
 | [processing_account.md](./processing_account.md) | `processing_account` | In-transit funds model and proof references |
 | [workflow-events.md](./workflow-events.md) | `workflow-events` | User-facing upload-to-report workflow event read model |
+| [source-coverage-matrix.yaml](./source-coverage-matrix.yaml) | `source_coverage_matrix` | Machine-readable source-class coverage, proof levels, review requirements, and traceability targets |
 
 ## Proof Reports
 
 | Report | Purpose |
 |---|---|
 | [critical-proof-matrix.yaml](./critical-proof-matrix.yaml) | Bidirectional README -> EPIC -> E2E macro outcome contract |
+| `python tools/check_source_coverage_matrix.py` | Source-class coverage and proof-level contract |
 | `python tools/analyze_test_ac_coverage.py --no-write --stdout` | Live local AC-to-test coverage report |
 | [unified-coverage.json](https://github.com/wangzitian0/finance_report/blob/main/unified-coverage.json) | Current committed coverage baseline |
 

--- a/docs/ssot/critical-proof-matrix.yaml
+++ b/docs/ssot/critical-proof-matrix.yaml
@@ -82,6 +82,10 @@ proofs:
   - id: dbs-pdf-full-journey
     scope: behavioral
     ci_tier: post_merge_environment
+    trust_mode: llm_ocr_post_merge
+    source_classes:
+      - bank_statement
+    mirror_proof_id: structured-source-reporting-pr
     issue: "#443"
     file: tests/e2e/test_statement_full_journey.py
     test: test_dbs_statement_full_journey
@@ -100,6 +104,10 @@ proofs:
   - id: deterministic-upload-to-dashboard
     scope: behavioral
     ci_tier: post_merge_environment
+    trust_mode: hybrid
+    source_classes:
+      - bank_statement
+      - csv_export
     issue: "#420"
     file: tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
     test: test_statement_upload_to_dashboard_vision_hard_gate
@@ -117,6 +125,10 @@ proofs:
   - id: brokerage-pdf-to-portfolio-value
     scope: behavioral
     ci_tier: post_merge_environment
+    trust_mode: llm_ocr_post_merge
+    source_classes:
+      - brokerage_statement
+    mirror_proof_id: personal-package-source-trust-pr
     issue: "#404"
     file: tests/e2e/test_brokerage_upload_to_portfolio_value.py
     test: test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value
@@ -131,6 +143,14 @@ proofs:
   - id: four-asset-as-of-net-worth
     scope: behavioral
     ci_tier: post_merge_environment
+    trust_mode: llm_ocr_post_merge
+    source_classes:
+      - bank_statement
+      - brokerage_statement
+      - property_statement
+      - liability_statement
+      - manual_record
+    mirror_proof_id: personal-package-source-trust-pr
     issue: "#444"
     file: tests/e2e/test_four_asset_net_worth_golden_path.py
     test: test_four_asset_as_of_net_worth_golden_path
@@ -151,6 +171,9 @@ proofs:
   - id: market-data-provider-price-path
     scope: behavioral
     ci_tier: post_merge_environment
+    trust_mode: hybrid
+    source_classes:
+      - brokerage_statement
     issue: "#539"
     file: tests/e2e/test_market_data_price_paths.py
     test: test_market_data_provider_sync_feeds_fx_and_stock_price_paths
@@ -165,6 +188,16 @@ proofs:
   - id: personal-financial-report-package-post-merge
     scope: behavioral
     ci_tier: post_merge_environment
+    trust_mode: llm_ocr_post_merge
+    source_classes:
+      - bank_statement
+      - brokerage_statement
+      - property_statement
+      - liability_statement
+      - esop_rsu_plan
+      - csv_export
+      - manual_record
+    mirror_proof_id: personal-package-source-trust-pr
     issue: "#573"
     file: tests/e2e/test_personal_financial_report_package.py
     test: test_personal_financial_report_package_post_merge_journey
@@ -198,3 +231,37 @@ proofs:
       - AC8.13.85
       - AC8.13.87
       - AC8.13.88
+
+  - id: structured-source-reporting-pr
+    scope: behavioral
+    ci_tier: pr_ci
+    trust_mode: deterministic_pr
+    source_classes:
+      - bank_statement
+      - csv_export
+      - manual_record
+    issue: "#696"
+    file: apps/backend/tests/integration/test_reporting_e2e.py
+    test: test_AC5_15_1_multicurrency_reporting_cycle_reconciles_bs_is_cf
+    ac_ids:
+      - AC5.15.1
+      - AC8.14.4
+
+  - id: personal-package-source-trust-pr
+    scope: behavioral
+    ci_tier: pr_ci
+    trust_mode: deterministic_pr
+    source_classes:
+      - bank_statement
+      - brokerage_statement
+      - property_statement
+      - liability_statement
+      - esop_rsu_plan
+      - csv_export
+      - manual_record
+    issue: "#696"
+    file: apps/backend/tests/api/test_personal_report_package_contract.py
+    test: test_AC19_9_1_package_readiness_reports_source_trust_summary
+    ac_ids:
+      - AC19.9.1
+      - AC8.14.3

--- a/docs/ssot/source-coverage-matrix.yaml
+++ b/docs/ssot/source-coverage-matrix.yaml
@@ -1,0 +1,106 @@
+version: "1.0"
+description: >
+  Product source coverage matrix for the source classes named by vision.md.
+  This matrix separates deterministic PR proof from post-merge LLM/OCR proof
+  and manual-trusted inputs. It must not contain real financial documents.
+
+required_source_classes:
+  - bank_statement
+  - brokerage_statement
+  - settlement_note
+  - esop_rsu_plan
+  - property_statement
+  - liability_statement
+  - csv_export
+  - manual_record
+
+source_classes:
+  - id: bank_statement
+    owner_epics: [EPIC-003, EPIC-013, EPIC-016]
+    supported_formats: [pdf, csv]
+    supported_institutions: [DBS/POSB, CMB, Maybank, Wise, OCBC, MariBank, GXS]
+    proof_levels: [pr_deterministic, post_merge_llm_ocr]
+    ingestion_path: /api/statements/upload
+    review_requirement: stage1_review_or_auto_post_guard
+    traceability_target: source_document_to_journal_entry_to_report_line
+    test_anchors:
+      - apps/backend/tests/extraction/test_extraction.py::test_dbs_fixture_structure
+      - apps/backend/tests/integration/test_reporting_e2e.py::test_AC5_15_1_multicurrency_reporting_cycle_reconciles_bs_is_cf
+
+  - id: brokerage_statement
+    owner_epics: [EPIC-013, EPIC-017]
+    supported_formats: [pdf, csv, structured_payload]
+    supported_institutions: [generic_brokerage, Moomoo, IBKR, Futu]
+    proof_levels: [pr_deterministic, post_merge_llm_ocr]
+    ingestion_path: /api/statements/upload
+    review_requirement: brokerage_position_import_traceability
+    traceability_target: brokerage_payload_to_atomic_position_to_portfolio_report_line
+    test_anchors:
+      - apps/backend/tests/portfolio/test_portfolio_router.py::test_brokerage_import_creates_atomic_positions
+      - tests/e2e/test_brokerage_upload_to_portfolio_value.py::test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value
+
+  - id: settlement_note
+    owner_epics: [EPIC-013, EPIC-017]
+    supported_formats: [pdf, csv, structured_payload]
+    supported_institutions: [generic_brokerage]
+    proof_levels: [pr_deterministic]
+    ingestion_path: /api/portfolio/brokerage/import
+    review_requirement: settlement_facts_must_be_structured_or_reviewed
+    traceability_target: settlement_payload_to_lot_fee_dividend_policy_fact
+    test_anchors:
+      - apps/backend/tests/reporting/test_framework_policy.py::test_AC20_4_1_us_and_hk_matrix_differ_for_same_listed_security_fixture
+
+  - id: esop_rsu_plan
+    owner_epics: [EPIC-011, EPIC-005]
+    supported_formats: [manual_evidence, structured_payload]
+    supported_institutions: [employer_plan_document]
+    proof_levels: [pr_deterministic, manual_trusted]
+    ingestion_path: /api/assets/valuation-snapshots
+    review_requirement: explicit_manual_input_with_vesting_or_unlock_basis
+    traceability_target: manual_restricted_compensation_to_annualized_schedule
+    test_anchors:
+      - apps/backend/tests/api/test_personal_report_package_contract.py::test_AC19_9_1_package_readiness_reports_source_trust_summary
+
+  - id: property_statement
+    owner_epics: [EPIC-011, EPIC-005]
+    supported_formats: [manual_evidence, structured_payload]
+    supported_institutions: [appraisal, property_statement]
+    proof_levels: [pr_deterministic, manual_trusted]
+    ingestion_path: /api/assets/valuation-snapshots
+    review_requirement: explicit_manual_input_with_valuation_basis_and_as_of_date
+    traceability_target: manual_property_valuation_to_balance_sheet_line
+    test_anchors:
+      - apps/backend/tests/api/test_personal_report_package_contract.py::test_AC19_9_1_package_readiness_reports_source_trust_summary
+
+  - id: liability_statement
+    owner_epics: [EPIC-011, EPIC-005]
+    supported_formats: [manual_evidence, structured_payload]
+    supported_institutions: [loan_statement, credit_card_statement, mortgage_statement]
+    proof_levels: [pr_deterministic, manual_trusted]
+    ingestion_path: /api/assets/valuation-snapshots
+    review_requirement: explicit_manual_input_or_approved_statement_coverage
+    traceability_target: liability_source_to_balance_sheet_liability_line
+    test_anchors:
+      - apps/backend/tests/api/test_personal_report_package_contract.py::test_AC19_9_1_package_readiness_reports_source_trust_summary
+
+  - id: csv_export
+    owner_epics: [EPIC-003, EPIC-013, EPIC-008]
+    supported_formats: [csv]
+    supported_institutions: [bank_export, brokerage_export, wallet_export]
+    proof_levels: [pr_deterministic]
+    ingestion_path: /api/statements/upload
+    review_requirement: csv_schema_validation_and_stage1_review
+    traceability_target: csv_row_to_journal_entry_to_report_line
+    test_anchors:
+      - tests/e2e/test_vision_upload_to_dashboard_hard_gate.py::test_statement_upload_to_dashboard_vision_hard_gate
+
+  - id: manual_record
+    owner_epics: [EPIC-002, EPIC-011, EPIC-005]
+    supported_formats: [api_entry, manual_evidence]
+    supported_institutions: [user_supplied]
+    proof_levels: [pr_deterministic, manual_trusted]
+    ingestion_path: /api/journal-entries
+    review_requirement: explicit_user_input_and_decimal_balanced_entry
+    traceability_target: manual_entry_to_ledger_to_report_line
+    test_anchors:
+      - apps/backend/tests/integration/test_reporting_e2e.py::test_AC5_15_1_multicurrency_reporting_cycle_reconciles_bs_is_cf

--- a/tests/tooling/test_check_critical_proof_matrix.py
+++ b/tests/tooling/test_check_critical_proof_matrix.py
@@ -85,6 +85,18 @@ groups:
         epic_name: testing-strategy
         description: critical proof matrix validates README and owner EPIC closure
         mandatory: true
+  AC8.14:
+    AC8.14:
+      - id: AC8.14.1
+        epic: 8
+        epic_name: testing-strategy
+        description: critical proof matrix classifies source trust mode
+        mandatory: true
+      - id: AC8.14.2
+        epic: 8
+        epic_name: testing-strategy
+        description: LLM/OCR critical proof requires deterministic PR mirror
+        mandatory: true
 """.strip()
         + "\n",
         encoding="utf-8",
@@ -169,6 +181,8 @@ proofs:
   - id: core-flow
     scope: behavioral
     ci_tier: post_merge_environment
+    trust_mode: hybrid
+    source_classes: [bank_statement]
     file: tests/e2e/test_core.py
     test: test_core_flow
     required_markers: [e2e, critical]
@@ -176,6 +190,8 @@ proofs:
   - id: static-contract
     scope: static_contract
     ci_tier: pr_ci
+    trust_mode: deterministic_pr
+    source_classes: [bank_statement]
     file: tests/tooling/test_contract.py
     test: test_contract_shape
     ac_ids: [AC8.13.41]
@@ -199,6 +215,106 @@ proofs:
     assert "Behavioral proof | 1" in report
     assert "Static/doc check | 1" in report
     assert "Manual-only gate | 1" in report
+    assert "Trust mode" in report
+
+
+def test_AC8_14_2_llm_ocr_proof_requires_deterministic_pr_mirror(tmp_path: Path) -> None:
+    """AC8.14.2: LLM/OCR critical proof must name a deterministic PR mirror."""
+    _write_registry(tmp_path)
+    test_dir = tmp_path / "tests" / "e2e"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_core.py").write_text(
+        """
+import pytest
+
+@pytest.mark.e2e
+@pytest.mark.critical
+@pytest.mark.llm
+async def test_core_flow():
+    \"\"\"AC8.13.1 AC8.14.2: LLM path proof.\"\"\"
+    assert True
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    matrix_path = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+proofs:
+  - id: llm-flow
+    scope: behavioral
+    ci_tier: post_merge_environment
+    trust_mode: llm_ocr_post_merge
+    source_classes: [bank_statement]
+    file: tests/e2e/test_core.py
+    test: test_core_flow
+    required_markers: [e2e, critical, llm]
+    ac_ids: [AC8.13.1, AC8.14.2]
+""",
+    )
+
+    results = matrix.validate_matrix(tmp_path, matrix_path)
+    errors = [error for result in results for error in result.errors]
+    assert "llm-flow: llm_ocr_post_merge proof requires mirror_proof_id" in errors
+
+
+def test_AC8_14_2_llm_ocr_mirror_must_be_pr_deterministic(tmp_path: Path) -> None:
+    """AC8.14.2: LLM/OCR mirrors must be deterministic PR proofs for the same sources."""
+    _write_registry(tmp_path)
+    (tmp_path / "tests" / "e2e").mkdir(parents=True)
+    (tmp_path / "apps" / "backend" / "tests").mkdir(parents=True)
+    (tmp_path / "tests" / "e2e" / "test_core.py").write_text(
+        """
+import pytest
+
+@pytest.mark.e2e
+@pytest.mark.critical
+@pytest.mark.llm
+async def test_core_flow():
+    \"\"\"AC8.13.1 AC8.14.2: LLM path proof.\"\"\"
+    assert True
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "apps" / "backend" / "tests" / "test_mirror.py").write_text(
+        """
+def test_mirror_flow():
+    \"\"\"AC8.14.1 AC8.14.2: deterministic mirror proof.\"\"\"
+    assert True
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    matrix_path = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+proofs:
+  - id: deterministic-mirror
+    scope: behavioral
+    ci_tier: pr_ci
+    trust_mode: deterministic_pr
+    source_classes: [bank_statement]
+    file: apps/backend/tests/test_mirror.py
+    test: test_mirror_flow
+    ac_ids: [AC8.14.1, AC8.14.2]
+  - id: llm-flow
+    scope: behavioral
+    ci_tier: post_merge_environment
+    trust_mode: llm_ocr_post_merge
+    source_classes: [bank_statement]
+    mirror_proof_id: deterministic-mirror
+    file: tests/e2e/test_core.py
+    test: test_core_flow
+    required_markers: [e2e, critical, llm]
+    ac_ids: [AC8.13.1, AC8.14.2]
+""",
+    )
+
+    results = matrix.validate_matrix(tmp_path, matrix_path)
+    assert [error for result in results for error in result.errors] == []
 
 
 def test_file_level_ac_reference_does_not_satisfy_core_proof(tmp_path: Path) -> None:

--- a/tests/tooling/test_personal_report_package_fixture_contract.py
+++ b/tests/tooling/test_personal_report_package_fixture_contract.py
@@ -139,3 +139,27 @@ def test_AC8_13_88_personal_package_e2e_consumes_audit_grade_expected_outputs() 
     assert 'schedule["data_freshness"]["latest_price_date"]' in journey
     assert "latest_price_date >= expected.market_price_date" in journey
     assert "assert _has_dynamic_traceability_identifiers(traceability)" in journey
+
+
+def test_AC8_14_3_personal_package_has_deterministic_source_trust_mirror() -> None:
+    """AC8.14.3: Package LLM/OCR critical proof has a deterministic source-trust mirror."""
+    matrix = yaml.safe_load(read("docs/ssot/critical-proof-matrix.yaml"))
+    proofs = {proof["id"]: proof for proof in matrix["proofs"]}
+
+    post_merge = proofs["personal-financial-report-package-post-merge"]
+    mirror = proofs[post_merge["mirror_proof_id"]]
+    expected_sources = {
+        "bank_statement",
+        "brokerage_statement",
+        "property_statement",
+        "liability_statement",
+        "esop_rsu_plan",
+        "csv_export",
+        "manual_record",
+    }
+
+    assert post_merge["trust_mode"] == "llm_ocr_post_merge"
+    assert mirror["trust_mode"] == "deterministic_pr"
+    assert mirror["ci_tier"] == "pr_ci"
+    assert expected_sources <= set(mirror["source_classes"])
+    assert "AC8.14.3" in mirror["ac_ids"]

--- a/tests/tooling/test_source_coverage_matrix.py
+++ b/tests/tooling/test_source_coverage_matrix.py
@@ -1,0 +1,308 @@
+"""Source coverage matrix contract tests."""
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from common.ssot.check_source_coverage_matrix import SourceCoverageResult
+from common.ssot import check_source_coverage_matrix as source_matrix
+
+
+def _write_repo_fixture(tmp_path: Path) -> Path:
+    (tmp_path / "docs" / "project").mkdir(parents=True)
+    (tmp_path / "docs" / "project" / "EPIC-003.statement-parsing.md").write_text("# EPIC-003\n", encoding="utf-8")
+    anchor = tmp_path / "tests" / "e2e" / "test_source.py"
+    anchor.parent.mkdir(parents=True)
+    anchor.write_text("def test_source():\n    pass\n", encoding="utf-8")
+    return anchor
+
+
+def _write_matrix(tmp_path: Path, content: str) -> Path:
+    matrix = tmp_path / "matrix.yaml"
+    matrix.parent.mkdir(parents=True, exist_ok=True)
+    matrix.write_text(dedent(content).strip() + "\n", encoding="utf-8")
+    return matrix
+
+
+def _valid_source_yaml(source_id: str = "bank_statement") -> str:
+    return f"""  - id: {source_id}
+    owner_epics: [EPIC-003]
+    supported_formats: [pdf]
+    supported_institutions: [DBS]
+    proof_levels: [pr_deterministic]
+    ingestion_path: /api/statements/upload
+    review_requirement: review
+    traceability_target: source_to_report
+    test_anchors:
+      - tests/e2e/test_source.py::test_source"""
+
+
+def test_AC13_12_1_source_coverage_matrix_covers_vision_source_classes() -> None:
+    """AC13.12.1: Source coverage matrix covers every source class named by vision."""
+    results = source_matrix.validate_source_coverage(
+        source_matrix.REPO_ROOT,
+        source_matrix.DEFAULT_MATRIX,
+    )
+    errors = [error for result in results for error in result.errors]
+    assert errors == []
+
+    sources = {
+        result.source_id: set(result.proof_levels)
+        for result in results
+        if not result.source_id.startswith("__")
+    }
+    assert {
+        "bank_statement",
+        "brokerage_statement",
+        "settlement_note",
+        "esop_rsu_plan",
+        "property_statement",
+        "liability_statement",
+        "csv_export",
+        "manual_record",
+    } == set(sources)
+    assert "pr_deterministic" in sources["bank_statement"]
+    assert "manual_trusted" in sources["esop_rsu_plan"]
+
+
+def test_AC13_12_2_source_coverage_matrix_rejects_llm_only_sources(tmp_path: Path) -> None:
+    """AC13.12.2: LLM/OCR-only source coverage fails without an explicit exception."""
+    _write_repo_fixture(tmp_path)
+    matrix = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+required_source_classes: [bank_statement]
+source_classes:
+  - id: bank_statement
+    owner_epics: [EPIC-003]
+    supported_formats: [pdf]
+    supported_institutions: [DBS]
+    proof_levels: [post_merge_llm_ocr]
+    ingestion_path: /api/statements/upload
+    review_requirement: review
+    traceability_target: source_to_report
+    test_anchors:
+      - tests/e2e/test_source.py::test_source
+""",
+    )
+
+    results = source_matrix.validate_source_coverage(tmp_path, matrix)
+    errors = [error for result in results for error in result.errors]
+    assert "bank_statement: post_merge_llm_ocr cannot be the only proof level" in errors
+
+
+def test_AC13_12_3_source_coverage_matrix_requires_gap_issue(tmp_path: Path) -> None:
+    """AC13.12.3: Gap source coverage must carry an explicit issue reference."""
+    _write_repo_fixture(tmp_path)
+    matrix = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+required_source_classes: [settlement_note]
+source_classes:
+  - id: settlement_note
+    owner_epics: [EPIC-003]
+    supported_formats: [pdf]
+    supported_institutions: [generic_brokerage]
+    proof_levels: [gap]
+    ingestion_path: /api/statements/upload
+    review_requirement: review
+    traceability_target: source_to_report
+    test_anchors:
+      - tests/e2e/test_source.py::test_source
+""",
+    )
+
+    results = source_matrix.validate_source_coverage(tmp_path, matrix)
+    errors = [error for result in results for error in result.errors]
+    assert "settlement_note: gap proof level requires gap_issue like #696" in errors
+
+
+def test_AC13_12_1_source_coverage_matrix_rejects_invalid_shape_and_global_drift(tmp_path: Path) -> None:
+    """AC13.12.1: Matrix validation rejects malformed entries and source-class drift."""
+    _write_repo_fixture(tmp_path)
+    matrix = _write_matrix(
+        tmp_path,
+        f"""
+version: "1.0"
+required_source_classes: [bank_statement, csv_export]
+source_classes:
+{_valid_source_yaml("bank_statement")}
+{_valid_source_yaml("bank_statement")}
+  - not_a_mapping
+{_valid_source_yaml("unexpected_source")}
+""",
+    )
+
+    results = source_matrix.validate_source_coverage(tmp_path, matrix)
+    errors = [error for result in results for error in result.errors]
+
+    assert "source entry must be a mapping" in errors
+    assert "missing required source classes: csv_export" in errors
+    assert "unknown source classes: unexpected_source" in errors
+    assert "duplicate source classes: bank_statement" in errors
+
+
+def test_AC13_12_1_source_coverage_matrix_rejects_source_field_errors(tmp_path: Path) -> None:
+    """AC13.12.1: Source entries must carry valid owners, anchors, proof levels, and IDs."""
+    matrix = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+required_source_classes: [bank_statement]
+source_classes:
+  - supported_formats: [pdf]
+    supported_institutions: [DBS]
+    proof_levels: [unknown_level]
+    ingestion_path: /api/statements/upload
+    review_requirement: review
+    traceability_target: source_to_report
+    test_anchors:
+      - missing.py::test_missing
+  - id: bank_statement
+    owner_epics: [BAD-1, EPIC-999]
+    supported_formats: [pdf]
+    supported_institutions: [DBS]
+    proof_levels: []
+    ingestion_path: /api/statements/upload
+    review_requirement: review
+    traceability_target: source_to_report
+    test_anchors: []
+""",
+    )
+
+    results = source_matrix.validate_source_coverage(tmp_path, matrix)
+    errors = [error for result in results for error in result.errors]
+
+    assert "<missing id>: missing keys: id, owner_epics" in errors
+    assert "source class missing id" in errors
+    assert ": owner_epics must be a non-empty list" in errors
+    assert ": unknown proof levels: unknown_level" in errors
+    assert ": test anchor file does not exist: missing.py" in errors
+    assert "bank_statement: invalid owner EPIC 'BAD-1'" in errors
+    assert "bank_statement: owner EPIC does not exist: EPIC-999" in errors
+    assert "bank_statement: proof_levels must be non-empty" in errors
+    assert "bank_statement: test_anchors must be a non-empty list" in errors
+
+
+def test_AC13_12_1_source_coverage_matrix_rejects_non_mapping_and_non_list_sources(tmp_path: Path) -> None:
+    """AC13.12.1: Matrix root and source_classes must have the expected YAML shape."""
+    scalar_matrix = _write_matrix(tmp_path, "[]")
+    with pytest.raises(ValueError, match="must contain a YAML mapping"):
+        source_matrix.validate_source_coverage(tmp_path, scalar_matrix)
+
+    non_list_matrix = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+required_source_classes: [bank_statement]
+source_classes: invalid
+""",
+    )
+
+    results = source_matrix.validate_source_coverage(tmp_path, non_list_matrix)
+    assert results == [SourceCoverageResult("__matrix__", errors=["source_classes must be a list"])]
+
+
+def test_AC13_12_2_source_coverage_matrix_allows_explicit_llm_only_exception(tmp_path: Path) -> None:
+    """AC13.12.2: Explicit exceptions can document rare LLM/OCR-only post-merge gates."""
+    _write_repo_fixture(tmp_path)
+    matrix = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+required_source_classes: [bank_statement]
+source_classes:
+  - id: bank_statement
+    owner_epics: [EPIC-003]
+    supported_formats: [pdf]
+    supported_institutions: [DBS]
+    proof_levels: [post_merge_llm_ocr]
+    requires_pr_deterministic_mirror: false
+    ingestion_path: /api/statements/upload
+    review_requirement: review
+    traceability_target: source_to_report
+    test_anchors:
+      - tests/e2e/test_source.py::test_source
+""",
+    )
+
+    results = source_matrix.validate_source_coverage(tmp_path, matrix)
+    errors = [error for result in results for error in result.errors]
+    assert errors == []
+
+
+def test_AC13_12_3_source_coverage_matrix_accepts_gap_with_issue(tmp_path: Path) -> None:
+    """AC13.12.3: Gap entries are accepted when they point to an explicit issue."""
+    _write_repo_fixture(tmp_path)
+    matrix = _write_matrix(
+        tmp_path,
+        """
+version: "1.0"
+required_source_classes: [settlement_note]
+source_classes:
+  - id: settlement_note
+    owner_epics: [EPIC-003]
+    supported_formats: [pdf]
+    supported_institutions: [generic_brokerage]
+    proof_levels: [gap]
+    gap_issue: "#696"
+    ingestion_path: /api/statements/upload
+    review_requirement: review
+    traceability_target: source_to_report
+    test_anchors:
+      - tests/e2e/test_source.py::test_source
+""",
+    )
+
+    results = source_matrix.validate_source_coverage(tmp_path, matrix)
+    assert [error for result in results for error in result.errors] == []
+
+
+def test_AC13_12_1_source_coverage_matrix_report_and_cli_paths(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC13.12.1: Source coverage checker reports both passing and failing CLI outcomes."""
+    _write_repo_fixture(tmp_path)
+    matrix = _write_matrix(
+        tmp_path,
+        f"""
+version: "1.0"
+required_source_classes: [bank_statement]
+source_classes:
+{_valid_source_yaml("bank_statement")}
+""",
+    )
+    failing_matrix = _write_matrix(
+        tmp_path / "failing",
+        """
+version: "1.0"
+required_source_classes: [bank_statement]
+source_classes: invalid
+""",
+    )
+
+    assert "No source coverage errors found." in source_matrix.render_report(
+        [SourceCoverageResult("bank_statement", ["pr_deterministic"], [])]
+    )
+    assert "- broken" in source_matrix.render_report([SourceCoverageResult("bank_statement", errors=["broken"])])
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["check_source_coverage_matrix.py", "--repo-root", str(tmp_path), "--matrix", str(matrix)],
+    )
+    assert source_matrix.main() == 0
+    assert "Source coverage matrix passed: 1 source class(es) validated." in capsys.readouterr().out
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["check_source_coverage_matrix.py", "--repo-root", str(tmp_path), "--matrix", str(failing_matrix)],
+    )
+    assert source_matrix.main() == 1
+    captured = capsys.readouterr()
+    assert "source_classes must be a list" in captured.out
+    assert "::error title=Source coverage matrix::source_classes must be a list" in captured.err

--- a/tools/check_source_coverage_matrix.py
+++ b/tools/check_source_coverage_matrix.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Command wrapper for source coverage matrix validation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.ssot.check_source_coverage_matrix import main  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add an SSOT source coverage matrix and validator for bank, brokerage, settlement, ESOP/RSU, property, liability, CSV, and manual-record sources.
- Classify critical proof paths by trust mode and require deterministic PR mirrors for LLM/OCR post-merge proofs.
- Expose source trust summary and traceability confidence metadata in the personal report package backend and frontend.

## Scope
- Product trust hardening only.
- Does not change production deployment, environment, observability, or infra runtime behavior.
- Does not expand EPIC-020 framework work.

## Verification
- `moon run :lint`
- `python tools/check_source_coverage_matrix.py`
- `python tools/check_critical_proof_matrix.py`
- `python tools/check_ac_traceability.py`
- `python tools/check_ssot_ownership.py`
- `python tools/check_manifest.py`
- `python tools/analyze_test_ac_coverage.py --no-write --stdout`
- `python -m pytest tests/tooling/test_source_coverage_matrix.py tests/tooling/test_check_critical_proof_matrix.py tests/tooling/test_personal_report_package_fixture_contract.py -q`
- `npm test -- --run src/__tests__/personalReportPackagePage.test.tsx` in `apps/frontend`
- `python -m pytest apps/backend/tests/api/test_personal_report_package_contract.py::test_AC5_9_1_package_contract_endpoint_defines_required_sections apps/backend/tests/api/test_personal_report_package_contract.py::test_AC5_9_2_package_contract_marks_decimal_totals_and_period_semantics apps/backend/tests/api/test_personal_report_package_contract.py::test_AC19_5_1_package_readiness_rejects_unknown_state_and_external_action_links -q --no-cov`

## Local limitation
- `moon run :test` could not complete locally because Podman is installed but its socket is not running: `connect tcp 127.0.0.1:61270: connection refused`. Backend DB-backed tests should run in GitHub CI where the test lifecycle can start Postgres.

Closes #696