### PR TITLE
[finance_report_audit] Fix framework market data readiness review feedback

### DIFF
--- a/apps/backend/src/services/framework_policy.py
+++ b/apps/backend/src/services/framework_policy.py
@@ -504,7 +504,7 @@ async def framework_policy_facts_for_user(
 
         stock_price_result = await db.execute(
             select(StockPrice)
-            .where(func.upper(StockPrice.symbol).in_(seen_positions))
+            .where(StockPrice.symbol.in_(sorted(seen_positions)))
             .where(StockPrice.price_date <= as_of_date)
             .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc())
         )

--- a/apps/backend/src/services/report_readiness.py
+++ b/apps/backend/src/services/report_readiness.py
@@ -287,7 +287,7 @@ async def _stale_market_data_count(db: AsyncSession, user_id: UUID, *, as_of_dat
     asset_identifiers = list(position_rows.scalars().all())
     if not asset_identifiers:
         return 0
-    normalized_asset_identifiers = [asset_identifier.strip().upper() for asset_identifier in asset_identifiers]
+    normalized_asset_identifiers = sorted({asset_identifier.strip().upper() for asset_identifier in asset_identifiers})
 
     override_rows = await db.execute(
         select(MarketDataOverride)
@@ -302,7 +302,7 @@ async def _stale_market_data_count(db: AsyncSession, user_id: UUID, *, as_of_dat
 
     stock_price_rows = await db.execute(
         select(StockPrice)
-        .where(func.upper(StockPrice.symbol).in_(normalized_asset_identifiers))
+        .where(StockPrice.symbol.in_(normalized_asset_identifiers))
         .where(StockPrice.price_date <= as_of_date)
         .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc())
     )

--- a/apps/backend/tests/reporting/test_framework_package_integration.py
+++ b/apps/backend/tests/reporting/test_framework_package_integration.py
@@ -284,6 +284,65 @@ async def test_AC19_7_1_readiness_uses_freshest_stock_price_or_manual_override(
     assert "stale_market_data" not in blockers
 
 
+@pytest.mark.asyncio
+async def test_AC19_7_1_readiness_deduplicates_normalized_market_data_symbols(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC19.7.1: Normalized holdings dedupe while blank identifiers still block readiness."""
+    report_date = date(2026, 5, 31)
+    upper_position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=report_date,
+        asset_identifier="DUPCASE",
+        broker="Framework Broker",
+        quantity=Decimal("5"),
+        market_value=Decimal("50.00"),
+        currency="SGD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=f"framework-dup-upper-{uuid4()}",
+        source_documents={"documents": [{"doc_id": "dup-upper-doc", "doc_type": "brokerage_statement"}]},
+    )
+    lower_position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=report_date,
+        asset_identifier="dupcase",
+        broker="Framework Broker",
+        quantity=Decimal("5"),
+        market_value=Decimal("50.00"),
+        currency="SGD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=f"framework-dup-lower-{uuid4()}",
+        source_documents={"documents": [{"doc_id": "dup-lower-doc", "doc_type": "brokerage_statement"}]},
+    )
+    blank_position = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=report_date,
+        asset_identifier="   ",
+        broker="Framework Broker",
+        quantity=Decimal("5"),
+        market_value=Decimal("50.00"),
+        currency="SGD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=f"framework-blank-{uuid4()}",
+        source_documents={"documents": [{"doc_id": "blank-doc", "doc_type": "brokerage_statement"}]},
+    )
+    db.add_all([upper_position, lower_position, blank_position])
+    await db.flush()
+
+    response = await personal_report_package_readiness(
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        end_date=report_date,
+        as_of_date=report_date,
+        db=db,
+        user_id=test_user.id,
+    )
+    blockers = {blocker.code: blocker for blocker in response.blockers}
+
+    assert "stale_market_data" in blockers
+    assert blockers["stale_market_data"].count == 2
+
+
 @pytest.mark.no_db
 def test_AC20_6_1_ai_suggestions_require_reviewed_policy_fields_for_readiness() -> None:
     """AC20.6.1: AI suggestions and incomplete policy fields become readiness blocker codes."""


### PR DESCRIPTION
## Summary

Fixes the remaining actionable review comments from #694 for EPIC-020 framework market-data readiness and policy derivation.

## Changes

- Deduplicate normalized investable asset identifiers before counting stale market-data blockers, so case variants such as `AAPL` and `aapl` count as one holding.
- Query `StockPrice.symbol` directly with normalized uppercase symbols instead of wrapping the indexed column in `func.upper()`.
- Apply the same direct `StockPrice.symbol` lookup in framework policy fact derivation.
- Add regression coverage for duplicate case variants producing one stale market-data blocker.

## Review follow-up

Addresses the remaining unresolved #694 review threads:

- https://github.com/wangzitian0/finance_report/pull/694#discussion_r3360322743
- https://github.com/wangzitian0/finance_report/pull/694#discussion_r3360322764
- https://github.com/wangzitian0/finance_report/pull/694#discussion_r3360322771

## Validation

- `moon run :lint`
- `git diff --check`
- `cd apps/backend && uv run --python 3.12.12 python -m pytest -q --no-cov -m no_db tests/reporting/test_framework_package_integration.py tests/reporting/test_framework_policy.py`
- `cd apps/backend && uv run --python 3.12.12 python -m pytest -q --no-cov tests/reporting/test_framework_policy.py`

## Local limitation

- Full DB-backed `tests/reporting/test_framework_package_integration.py` cannot complete locally because Postgres at `127.0.0.1:5432` is not running in this workspace. GitHub CI should provide the authoritative DB-backed result.

## EPIC-020 status

EPIC-020 functional scope is complete and #675/#676/#677/#678/#679/#680/#681 are already closed. This PR is a small post-merge CR hygiene fix, not a scope expansion.