### PR TITLE
[finance_report_test_and_doc] Model CI as env-stage matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
   backend:
     name: Backend Tests (Shard ${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
-    needs: [changes, lint, ac-traceability]
+    needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
     strategy:
       fail-fast: false
@@ -222,7 +222,7 @@ jobs:
   backend-integration:
     name: Backend Integration Tests
     runs-on: ubuntu-latest
-    needs: [changes, lint, ac-traceability]
+    needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
 
     services:
@@ -310,7 +310,7 @@ jobs:
   backend-e2e-tier1:
     name: Backend Tier-1 API E2E
     runs-on: ubuntu-latest
-    needs: [changes, lint, ac-traceability]
+    needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
 
     services:
@@ -420,7 +420,7 @@ jobs:
   frontend:
     name: Frontend Build & Test
     runs-on: ubuntu-latest
-    needs: [changes, lint, ac-traceability]
+    needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
     
     steps:
@@ -507,7 +507,7 @@ jobs:
   container-images:
     name: Build Staging Images
     runs-on: ubuntu-latest
-    needs: [changes, lint, ac-traceability]
+    needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
     permissions:
       contents: read
@@ -559,7 +559,7 @@ jobs:
 
   tooling-coverage:
     name: Tooling/Common Coverage
-    needs: [changes, lint, ac-traceability]
+    needs: [changes]
     if: needs.changes.outputs.heavy_required == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/common/ci/change_classifier.py
+++ b/common/ci/change_classifier.py
@@ -4,9 +4,59 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
+
+
+class Environment(StrEnum):
+    LOCAL = "local"
+    PR = "pr"
+    PR_PREVIEW = "pr-preview"
+    STAGING = "staging"
+    PRODUCTION = "prd"
+
+
+class PipelineStage(StrEnum):
+    CHANGED_UNIT = "changed-unit"
+    STATIC = "static"
+    FULL_UNIT = "full-unit"
+    INTEGRATION = "integration"
+    REGRESSION = "regression"
+    E2E = "e2e"
+    IMAGE_BUILD = "image-build"
+    DEPLOY_SMOKE = "deploy-smoke"
+    PROVIDER_GATE = "provider-gate"
+    RELEASE_INTEGRITY = "release-integrity"
+
+
+ENV_STAGE_MATRIX: dict[Environment, tuple[PipelineStage, ...]] = {
+    Environment.LOCAL: (PipelineStage.CHANGED_UNIT, PipelineStage.STATIC),
+    Environment.PR: (
+        PipelineStage.STATIC,
+        PipelineStage.FULL_UNIT,
+        PipelineStage.INTEGRATION,
+        PipelineStage.REGRESSION,
+        PipelineStage.E2E,
+        PipelineStage.IMAGE_BUILD,
+    ),
+    Environment.PR_PREVIEW: (
+        PipelineStage.IMAGE_BUILD,
+        PipelineStage.DEPLOY_SMOKE,
+        PipelineStage.E2E,
+    ),
+    Environment.STAGING: (
+        PipelineStage.IMAGE_BUILD,
+        PipelineStage.DEPLOY_SMOKE,
+        PipelineStage.E2E,
+        PipelineStage.PROVIDER_GATE,
+    ),
+    Environment.PRODUCTION: (
+        PipelineStage.RELEASE_INTEGRITY,
+        PipelineStage.DEPLOY_SMOKE,
+    ),
+}
 
 LIGHTWEIGHT_EXACT = {
     "AGENTS.md",
@@ -20,28 +70,25 @@ LIGHTWEIGHT_PREFIXES = (
     ".github/ISSUE_TEMPLATE/",
 )
 
-PR_PREVIEW_EXACT = {
-    ".github/workflows/pr-preview-cleanup.yml",
-    ".github/workflows/pr-test.yml",
-    "apps/backend/Dockerfile",
-    "apps/backend/alembic.ini",
-    "apps/backend/pyproject.toml",
-    "apps/backend/uv.lock",
-    "apps/frontend/Dockerfile",
-    "apps/frontend/next.config.mjs",
-    "apps/frontend/package-lock.json",
-    "apps/frontend/package.json",
-    "apps/frontend/postcss.config.mjs",
-    "apps/frontend/tailwind.config.ts",
-    "apps/frontend/tsconfig.json",
-    "docker-compose.yml",
-    "tools/generate_pdf_fixtures.py",
-    "tools/pr_preview_lifecycle.py",
-    "tools/smoke_test.sh",
-    "tools/_lib/dev/cleanup_pr_preview_resources.py",
-    "tools/_lib/dev/pr_preview_lifecycle.py",
-}
-PR_PREVIEW_PREFIXES = (
+COMMON_DEPLOY_RUNTIME_EXACT = frozenset(
+    {
+        "apps/backend/Dockerfile",
+        "apps/backend/alembic.ini",
+        "apps/backend/pyproject.toml",
+        "apps/backend/uv.lock",
+        "apps/frontend/Dockerfile",
+        "apps/frontend/next.config.mjs",
+        "apps/frontend/package-lock.json",
+        "apps/frontend/package.json",
+        "apps/frontend/postcss.config.mjs",
+        "apps/frontend/tailwind.config.ts",
+        "apps/frontend/tsconfig.json",
+        "docker-compose.yml",
+        "tools/generate_pdf_fixtures.py",
+        "tools/smoke_test.sh",
+    }
+)
+COMMON_DEPLOY_RUNTIME_PREFIXES = (
     "apps/backend/config/",
     "apps/backend/migrations/",
     "apps/backend/scripts/",
@@ -51,6 +98,34 @@ PR_PREVIEW_PREFIXES = (
     ".github/actions/setup-e2e-tests/",
     "tests/e2e/",
 )
+
+PR_PREVIEW_ONLY_EXACT = frozenset(
+    {
+        ".github/workflows/pr-preview-cleanup.yml",
+        ".github/workflows/pr-test.yml",
+        "tools/pr_preview_lifecycle.py",
+        "tools/_lib/dev/cleanup_pr_preview_resources.py",
+        "tools/_lib/dev/pr_preview_lifecycle.py",
+    }
+)
+STAGING_ONLY_EXACT = frozenset(
+    {
+        ".github/workflows/ci.yml",
+        ".github/workflows/staging-deploy.yml",
+        ".github/workflows/staging-ai-ocr-gate.yml",
+        ".node-version",
+        ".python-version",
+        "tools/check_ghcr_image_tag.sh",
+        "tools/dokploy_deploy.sh",
+        "tools/health_check.sh",
+        "toolchain.toml",
+        "repo",
+    }
+)
+
+PR_PREVIEW_EXACT = COMMON_DEPLOY_RUNTIME_EXACT | PR_PREVIEW_ONLY_EXACT
+PR_PREVIEW_PREFIXES = COMMON_DEPLOY_RUNTIME_PREFIXES
+
 PDF_FIXTURE_RUNTIME_EXACT = {
     "tools/_lib/pdf_fixtures/__init__.py",
     "tools/_lib/pdf_fixtures/generate_pdf_fixtures.py",
@@ -62,42 +137,45 @@ PDF_FIXTURE_RUNTIME_PREFIXES = (
     "tools/_lib/pdf_fixtures/validators/",
 )
 
-STAGING_EXACT = {
-    ".github/workflows/ci.yml",
-    ".github/workflows/staging-deploy.yml",
-    ".github/workflows/staging-ai-ocr-gate.yml",
-    ".node-version",
-    ".python-version",
-    "apps/backend/Dockerfile",
-    "apps/backend/alembic.ini",
-    "apps/backend/pyproject.toml",
-    "apps/backend/uv.lock",
-    "apps/frontend/Dockerfile",
-    "apps/frontend/next.config.mjs",
-    "apps/frontend/package-lock.json",
-    "apps/frontend/package.json",
-    "apps/frontend/postcss.config.mjs",
-    "apps/frontend/tailwind.config.ts",
-    "apps/frontend/tsconfig.json",
-    "docker-compose.yml",
-    "tools/check_ghcr_image_tag.sh",
-    "tools/dokploy_deploy.sh",
-    "tools/generate_pdf_fixtures.py",
-    "tools/health_check.sh",
-    "tools/smoke_test.sh",
-    "toolchain.toml",
-    "repo",
+STAGING_EXACT = COMMON_DEPLOY_RUNTIME_EXACT | STAGING_ONLY_EXACT
+STAGING_PREFIXES = COMMON_DEPLOY_RUNTIME_PREFIXES + ("repo/",)
+
+
+@dataclass(frozen=True)
+class EnvStageRule:
+    environment: Environment
+    stages: tuple[PipelineStage, ...]
+    exact: frozenset[str]
+    prefixes: tuple[str, ...]
+    changed_reason: str
+    unchanged_reason: str
+    fail_closed_on_empty: bool = True
+    exclude_app_tests_and_docs: bool = True
+    include_pdf_fixture_runtime: bool = True
+
+
+ENV_STAGE_RULES: dict[Environment, EnvStageRule] = {
+    Environment.PR_PREVIEW: EnvStageRule(
+        environment=Environment.PR_PREVIEW,
+        stages=ENV_STAGE_MATRIX[Environment.PR_PREVIEW],
+        exact=frozenset(PR_PREVIEW_EXACT),
+        prefixes=PR_PREVIEW_PREFIXES,
+        changed_reason="pr-preview-paths-changed",
+        unchanged_reason="no-pr-preview-paths-changed",
+    ),
+    Environment.STAGING: EnvStageRule(
+        environment=Environment.STAGING,
+        stages=ENV_STAGE_MATRIX[Environment.STAGING],
+        exact=frozenset(STAGING_EXACT),
+        prefixes=STAGING_PREFIXES,
+        changed_reason="staging-paths-changed",
+        unchanged_reason="no-staging-paths-changed",
+    ),
 }
-STAGING_PREFIXES = (
-    "apps/backend/config/",
-    "apps/backend/migrations/",
-    "apps/backend/scripts/",
-    "apps/backend/src/",
-    "apps/frontend/public/",
-    "apps/frontend/src/",
-    ".github/actions/setup-e2e-tests/",
-    "repo/",
-    "tests/e2e/",
+
+LEGACY_ENV_OUTPUTS = (
+    (Environment.PR_PREVIEW, "pr_preview", "PR preview", "PR preview", "PR preview"),
+    (Environment.STAGING, "staging", "Staging deploy", "Staging", "Staging"),
 )
 
 
@@ -107,12 +185,39 @@ class ChangeClassification:
     heavy_files: tuple[str, ...]
     heavy_required: bool
     reason: str
-    pr_preview_files: tuple[str, ...]
-    pr_preview_required: bool
-    pr_preview_reason: str
-    staging_files: tuple[str, ...]
-    staging_required: bool
-    staging_reason: str
+    envs: Mapping[Environment, "EnvStageClassification"]
+
+    @property
+    def pr_preview_files(self) -> tuple[str, ...]:
+        return self.envs[Environment.PR_PREVIEW].files
+
+    @property
+    def pr_preview_required(self) -> bool:
+        return self.envs[Environment.PR_PREVIEW].required
+
+    @property
+    def pr_preview_reason(self) -> str:
+        return self.envs[Environment.PR_PREVIEW].reason
+
+    @property
+    def staging_files(self) -> tuple[str, ...]:
+        return self.envs[Environment.STAGING].files
+
+    @property
+    def staging_required(self) -> bool:
+        return self.envs[Environment.STAGING].required
+
+    @property
+    def staging_reason(self) -> str:
+        return self.envs[Environment.STAGING].reason
+
+
+@dataclass(frozen=True)
+class EnvStageClassification:
+    files: tuple[str, ...]
+    required: bool
+    reason: str
+    stages: tuple[PipelineStage, ...]
 
 
 def normalize_path(path: str) -> str:
@@ -147,26 +252,44 @@ def _is_pdf_fixture_runtime_path(path: str) -> bool:
     )
 
 
-def is_pr_preview_relevant(path: str) -> bool:
+def _matches_env_stage_rule(path: str, rule: EnvStageRule) -> bool:
     normalized = normalize_path(path)
-    if normalized in PR_PREVIEW_EXACT:
+    if normalized in rule.exact:
         return True
-    if _is_app_test_or_doc_path(normalized):
+    if rule.exclude_app_tests_and_docs and _is_app_test_or_doc_path(normalized):
         return False
-    if _is_pdf_fixture_runtime_path(normalized):
+    if rule.include_pdf_fixture_runtime and _is_pdf_fixture_runtime_path(normalized):
         return True
-    return normalized.startswith(PR_PREVIEW_PREFIXES)
+    return normalized.startswith(rule.prefixes)
+
+
+def is_pr_preview_relevant(path: str) -> bool:
+    return _matches_env_stage_rule(path, ENV_STAGE_RULES[Environment.PR_PREVIEW])
 
 
 def is_staging_relevant(path: str) -> bool:
-    normalized = normalize_path(path)
-    if normalized in STAGING_EXACT:
-        return True
-    if _is_app_test_or_doc_path(normalized):
-        return False
-    if _is_pdf_fixture_runtime_path(normalized):
-        return True
-    return normalized.startswith(STAGING_PREFIXES)
+    return _matches_env_stage_rule(path, ENV_STAGE_RULES[Environment.STAGING])
+
+
+def _classify_env_stage(
+    files: tuple[str, ...], environment: Environment
+) -> EnvStageClassification:
+    rule = ENV_STAGE_RULES[environment]
+    matched_files = tuple(path for path in files if _matches_env_stage_rule(path, rule))
+    required = bool(matched_files or (not files and rule.fail_closed_on_empty))
+    reason = (
+        rule.changed_reason
+        if matched_files
+        else "no-changed-files-detected"
+        if not files and rule.fail_closed_on_empty
+        else rule.unchanged_reason
+    )
+    return EnvStageClassification(
+        files=matched_files,
+        required=required,
+        reason=reason,
+        stages=rule.stages,
+    )
 
 
 def classify_changed_paths(paths: Iterable[str]) -> ChangeClassification:
@@ -180,35 +303,16 @@ def classify_changed_paths(paths: Iterable[str]) -> ChangeClassification:
         if not files
         else "lightweight-docs-or-docs-workflow-only"
     )
-    pr_preview_files = tuple(path for path in files if is_pr_preview_relevant(path))
-    pr_preview_required = bool(pr_preview_files or not files)
-    pr_preview_reason = (
-        "pr-preview-paths-changed"
-        if pr_preview_files
-        else "no-changed-files-detected"
-        if not files
-        else "no-pr-preview-paths-changed"
-    )
-    staging_files = tuple(path for path in files if is_staging_relevant(path))
-    staging_required = bool(staging_files or not files)
-    staging_reason = (
-        "staging-paths-changed"
-        if staging_files
-        else "no-changed-files-detected"
-        if not files
-        else "no-staging-paths-changed"
-    )
+    envs = {
+        environment: _classify_env_stage(files, environment)
+        for environment in ENV_STAGE_RULES
+    }
     return ChangeClassification(
         files=files,
         heavy_files=heavy_files,
         heavy_required=heavy_required,
         reason=reason,
-        pr_preview_files=pr_preview_files,
-        pr_preview_required=pr_preview_required,
-        pr_preview_reason=pr_preview_reason,
-        staging_files=staging_files,
-        staging_required=staging_required,
-        staging_reason=staging_reason,
+        envs=envs,
     )
 
 
@@ -218,12 +322,10 @@ def write_github_outputs(
     with output_path.open("a", encoding="utf-8") as fh:
         fh.write(f"heavy_required={str(classification.heavy_required).lower()}\n")
         fh.write(f"reason={classification.reason}\n")
-        fh.write(
-            f"pr_preview_required={str(classification.pr_preview_required).lower()}\n"
-        )
-        fh.write(f"pr_preview_reason={classification.pr_preview_reason}\n")
-        fh.write(f"staging_required={str(classification.staging_required).lower()}\n")
-        fh.write(f"staging_reason={classification.staging_reason}\n")
+        for environment, output_prefix, *_labels in LEGACY_ENV_OUTPUTS:
+            env_result = classification.envs[environment]
+            fh.write(f"{output_prefix}_required={str(env_result.required).lower()}\n")
+            fh.write(f"{output_prefix}_reason={env_result.reason}\n")
 
 
 def write_github_summary(
@@ -235,27 +337,35 @@ def write_github_summary(
             f"- Heavy CI required: `{str(classification.heavy_required).lower()}`\n"
         )
         fh.write(f"- Reason: `{classification.reason}`\n")
-        fh.write(
-            f"- PR preview required: `{str(classification.pr_preview_required).lower()}`\n"
-        )
-        fh.write(f"- PR preview reason: `{classification.pr_preview_reason}`\n")
-        fh.write(
-            f"- Staging deploy required: `{str(classification.staging_required).lower()}`\n"
-        )
-        fh.write(f"- Staging reason: `{classification.staging_reason}`\n")
+        for (
+            environment,
+            _output_prefix,
+            required_label,
+            reason_label,
+            _files_label,
+        ) in LEGACY_ENV_OUTPUTS:
+            env_result = classification.envs[environment]
+            fh.write(
+                f"- {required_label} required: `{str(env_result.required).lower()}`\n"
+            )
+            fh.write(f"- {reason_label} reason: `{env_result.reason}`\n")
         fh.write(f"- Changed files: `{len(classification.files)}`\n")
         if classification.heavy_files:
             fh.write("\nHeavy-triggering files:\n\n")
             for path in classification.heavy_files[:50]:
                 fh.write(f"- `{path}`\n")
-        if classification.pr_preview_files:
-            fh.write("\nPR preview-triggering files:\n\n")
-            for path in classification.pr_preview_files[:50]:
-                fh.write(f"- `{path}`\n")
-        if classification.staging_files:
-            fh.write("\nStaging-triggering files:\n\n")
-            for path in classification.staging_files[:50]:
-                fh.write(f"- `{path}`\n")
+        for (
+            environment,
+            _output_prefix,
+            _required_label,
+            _reason_label,
+            files_label,
+        ) in LEGACY_ENV_OUTPUTS:
+            env_result = classification.envs[environment]
+            if env_result.files:
+                fh.write(f"\n{files_label}-triggering files:\n\n")
+                for path in env_result.files[:50]:
+                    fh.write(f"- `{path}`\n")
 
 
 def main() -> int:
@@ -276,10 +386,10 @@ def main() -> int:
 
     print(f"heavy_required={str(classification.heavy_required).lower()}")
     print(f"reason={classification.reason}")
-    print(f"pr_preview_required={str(classification.pr_preview_required).lower()}")
-    print(f"pr_preview_reason={classification.pr_preview_reason}")
-    print(f"staging_required={str(classification.staging_required).lower()}")
-    print(f"staging_reason={classification.staging_reason}")
+    for environment, output_prefix, *_labels in LEGACY_ENV_OUTPUTS:
+        env_result = classification.envs[environment]
+        print(f"{output_prefix}_required={str(env_result.required).lower()}")
+        print(f"{output_prefix}_reason={env_result.reason}")
     print(f"changed_files={len(classification.files)}")
     return 0
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -295,7 +295,7 @@ job inventories or scenario counts into this EPIC.
 | AC8.13.22 | Staging deploy starts from successful main CI `workflow_run` before building or deploying | `test_AC8_13_22_staging_deploy_starts_from_successful_ci_before_building` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.23 | Automatic staging deploy health and AI/OCR validation run in one serialized post-merge workflow unit | `test_AC8_13_23_post_merge_deploy_and_ai_ocr_are_one_serial_unit` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.24 | AC traceability audit is uploaded as a CI artifact instead of failing on a stale committed report | `test_AC8_13_24_ac_traceability_uploads_audit_artifact_without_stale_doc_gate` | `tests/tooling/test_post_merge_e2e_gates.py` | P1 |
-| AC8.13.25 | Backend tests and AC traceability start without waiting for lint when their own prerequisites are ready | `test_AC8_13_25_backend_and_traceability_do_not_wait_for_lint` | `tests/tooling/test_post_merge_e2e_gates.py` | P1 |
+| AC8.13.25 | Full CI starts deterministic test and image jobs after change classification while `finish` aggregates lint, AC traceability, tests, image validation, coverage, and skipped-job semantics | `test_AC8_13_25_full_ci_aggregates_static_traceability_and_test_gates` | `tests/tooling/test_post_merge_e2e_gates.py` | P1 |
 | AC8.13.26 | CI metrics contract fails when source roots, coverage policy, workflow gates, or AC traceability semantics drift | `test_AC8_13_26_*` | `tests/tooling/` | P0 |
 | AC8.13.27 | Pull requests do not publish Coveralls status contexts; main-only Coveralls reporting remains separate from local deterministic coverage gates | `test_AC8_13_27_*` | `tests/tooling/` | P0 |
 | AC8.13.28 | Deterministic upload-to-dashboard gate runs as a critical fresh-user staging E2E | `test_statement_upload_to_dashboard_vision_hard_gate` | `tests/e2e/test_vision_upload_to_dashboard_hard_gate.py` | P0 |
@@ -364,9 +364,10 @@ job inventories or scenario counts into this EPIC.
 | AC8.13.91 | Main post-merge staging deploy failures open or update a persistent GitHub Issue alert, and the next successful staging run closes it | `test_AC8_13_91_post_merge_staging_failure_opens_rolling_alert_issue` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.92 | Frontend Vitest coverage keeps a code-owned 98% baseline for line, statement, and function metrics plus an explicit branch floor while representative low-coverage routes and workflow surfaces stay covered | `AC8.13.92*` | `apps/frontend/src/__tests__/coverageBaseline.test.ts`, `apps/frontend/src/__tests__/personalReportPackagePage.test.tsx`, `apps/frontend/src/__tests__/workflowSurfaces.test.tsx`, `apps/frontend/src/__tests__/chatPanelComponent.test.tsx`, `apps/frontend/src/__tests__/investmentPerformanceSchedule.test.tsx`, `apps/frontend/src/__tests__/journalPage.test.tsx`, `apps/frontend/src/__tests__/sankeyChartComponent.test.tsx`, `apps/frontend/src/__tests__/toastProviderComponent.test.tsx`, `apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx` | P0 |
 | AC8.13.93 | Automatic staging promotion accepts only successful `push` CI workflow_run events on `main` and records triggering CI metadata in deploy artifacts | `test_AC8_13_93_staging_promotion_requires_successful_main_push_ci_run` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
-| AC8.13.94 | Delivery pipeline documentation distinguishes local advisory feedback, PR merge authority, and deployed-environment proof stages | `test_AC8_13_94_delivery_pipeline_contract_is_documented` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+| AC8.13.94 | CI/CD documentation separates environment taxonomy from pipeline stages and declares the sparse env x stage execution matrix | `test_AC8_13_94_env_and_pipeline_stage_contract_is_documented` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.95 | Local verification guidance defaults to affected fast tests and defines risk-triggered escalation for high-impact paths | `test_AC8_13_95_local_fast_gate_and_escalation_policy_are_documented` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.96 | PR preview relevance classification includes preview workflow, lifecycle, and config changes while excluding docs-only and app test-only changes | `test_AC8_13_96_pr_preview_classifier_includes_preview_infrastructure_paths` | `tests/tooling/test_ci_change_classifier.py` | P0 |
+| AC8.13.97 | CI change classification exposes table-driven env/stage rules so shared runtime paths cannot drift between PR preview and staging deployed proof | `test_AC8_13_97_*` | `tests/tooling/test_ci_change_classifier.py` | P0 |
 
 ### AC8.14: Product Trust Proof Mirrors
 
@@ -397,6 +398,33 @@ job inventories or scenario counts into this EPIC.
 Current test counts and coverage percentages belong to generated reports and CI
 artifacts, not this EPIC. This section records which suites are allowed to
 serve as E2E proof surfaces.
+
+### 5.0 Env x Stage Delivery Matrix
+
+CI/CD proof is modeled as a sparse environment x pipeline stage matrix, not as a
+linear list of delivery stages. Environments define where proof runs; pipeline
+stages define what quality gate runs. Empty cells are intentional and must not
+be filled just for symmetry.
+
+| Env \ Stage | Changed/Affected UT | Lint/Static | Full UT | Integration | Regression/E2E | Image Build | Deploy Smoke | Provider Gate | Release Integrity |
+|---|---|---|---|---|---|---|---|---|---|
+| `local` | default | focused/static contracts | risk-triggered | risk-triggered | not default | no | no | no | no |
+| `pr` | covered by full gates | required | required for heavy changes | required for heavy changes | Tier-1/provider-free required | dry-run for heavy changes | no | no | no |
+| `pr-preview` | no | no | no | no | runtime/UI/API preview-relevant subset | push PR images | required health/version | no | no |
+| `staging` | no | no | no | no | merged-SHA non-LLM plus provider-backed regression | reuse or build missing SHA images | required | required when real-provider proof is needed | no |
+| `prd` | no | no | no | no | prod-safe smoke only | release image proof | required | no first-time proof | required |
+
+Operational interpretation:
+- Local optimizes left-shift speed and runs affected/focused checks by default,
+  not full remote-equivalent CI.
+- PR CI is the deterministic merge authority for business behavior, coverage,
+  traceability, and image build proof.
+- PR preview proves PR images can boot, route, report the expected version, and
+  pass provider-free deployed E2E for preview-relevant changes.
+- Staging consumes only successful `main` SHAs and proves real infra/provider
+  behavior for the exact merged commit.
+- Production proves release integrity and availability; it must not be the first
+  proof of deterministic business correctness.
 
 ### 5.1 E2E Proof Surface Ownership
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -12,14 +12,14 @@
 The GitHub Actions workflow (`.github/workflows/ci.yml`) follows this job dependency order:
 
 ```
-standalone: lint ───────────────┐
-standalone: ac-traceability ────┤
-changes (classify-changes) ─────┴→ backend shards ───────┐
-                         ├────────→ frontend ─────────────┼→ unified-coverage ───┐
-                         ├────────→ tooling-coverage ─────┘                      │
-                         ├────────→ backend-integration ─────────────────────────┤
-                         ├────────→ backend-e2e-tier1 ───────────────────────────┤→ finish
-                         └────────→ container-images ────────────────────────────┘
+standalone: lint ────────────────────────────────────────────────────────────────┐
+standalone: ac-traceability ────────────────────────────────────────────────────┤
+changes (classify-changes) ──→ backend shards ───────┐                          │
+                         ├────→ frontend ─────────────┼→ unified-coverage ───────┤
+                         ├────→ tooling-coverage ─────┘                          │
+                         ├────→ backend-integration ─────────────────────────────┤
+                         ├────→ backend-e2e-tier1 ───────────────────────────────┤→ finish
+                         └────→ container-images ────────────────────────────────┘
 ```
 
 ### Job Details
@@ -28,12 +28,12 @@ changes (classify-changes) ─────┴→ backend shards ─────�
 |-----|---------|--------------|
 | **changes** | Detect whether changed paths require heavy backend/frontend/coverage jobs | None |
 | **lint** | Static analysis (backend `src tests` ruff check + format check, frontend lint) + manifest/doc/CI metrics contract checks | None (first job) |
-| **backend** (Shards 1-6) | Backend fast-path tests only: `-m "not slow and not e2e and not integration"` | `needs: [changes, lint, ac-traceability]` |
-| **backend-integration** | Backend integration stage (`-m "integration"`), deterministic service-backed behavior checks | `needs: [changes, lint, ac-traceability]` |
-| **backend-e2e-tier1** | Backend Tier-1 API E2E stage (`apps/backend/tests/e2e/test_core_journeys.py` with `-m e2e`), executed with explicit marker override | `needs: [changes, lint, ac-traceability]` |
-| **frontend** | Frontend build + Vitest + Playwright tests when heavy CI is required | `needs: [changes, lint, ac-traceability]` |
-| **container-images** | Build backend and frontend staging images without pushing on PRs; push SHA-tagged images only on `main` | `needs: [changes, lint, ac-traceability]` |
-| **tooling-coverage** | Run root tooling tests with common/tools coverage and upload LCOV inputs | `needs: [changes, lint, ac-traceability]` |
+| **backend** (Shards 1-6) | Backend fast-path tests only: `-m "not slow and not e2e and not integration"` | `needs: [changes]` |
+| **backend-integration** | Backend integration stage (`-m "integration"`), deterministic service-backed behavior checks | `needs: [changes]` |
+| **backend-e2e-tier1** | Backend Tier-1 API E2E stage (`apps/backend/tests/e2e/test_core_journeys.py` with `-m e2e`), executed with explicit marker override | `needs: [changes]` |
+| **frontend** | Frontend build + Vitest + Playwright tests when heavy CI is required | `needs: [changes]` |
+| **container-images** | Build backend and frontend staging images without pushing on PRs; push SHA-tagged images only on `main` | `needs: [changes]` |
+| **tooling-coverage** | Run root tooling tests with common/tools coverage and upload LCOV inputs | `needs: [changes]` |
 | **unified-coverage** | Merge backend, frontend, common, and tools LCOV inputs, audit source-tree/LCOV policy, calculate unified coverage, compare to baseline, update Coveralls when heavy CI is required | `needs: [changes, backend, frontend, tooling-coverage]` |
 | **ac-traceability** | Verify AC-to-test traceability for all PR/main changes, including docs-only changes | None |
 | **finish** | Aggregate all required and skipped job results | `needs: [changes, backend, backend-integration, backend-e2e-tier1, frontend, container-images, lint, tooling-coverage, unified-coverage, ac-traceability]` |
@@ -45,7 +45,7 @@ changes (classify-changes) ─────┴→ backend shards ─────�
 3. **Stable Required Checks**: Heavy jobs are skipped through job-level conditions rather than removing the workflow, so required check names remain visible and mergeable.
 4. **AC Traceability Always Runs**: AC traceability is separate from unified coverage so docs-only AC/EPIC changes still get traceability validation. The job first runs `tools/generate_ac_registry.py --check` to ensure generated registry indexes can be materialized from EPIC docs plus explicit overrides, then runs `tools/check_ac_traceability.py` as the fail-closed gate, then runs `tools/check_e2e_epic_traceability.py` to ensure product E2E root test functions carry function-level EPIC IDs, every project EPIC has product E2E ownership, the README EPIC map matches project EPIC files, and unclassified E2E-like assets outside declared roots fail CI, then runs `tools/check_critical_proof_matrix.py` to validate the small core proof matrix, then generates `AC-TEST-TRACEABILITY-AUDIT.md` into `$RUNNER_TEMP`; the audit is uploaded as a CI artifact together with the critical proof matrix report. The job also runs `tools/reconciliation_audit.py` through the backend uv environment as a hard gate and uploads reconciliation audit JSON/Markdown with the same artifact. The audit distinguishes CI-executed real test references from `_ac_stubs`, trivial placeholder assertions, pure `pass`, pure skipped tests, and real references that live only in non-required execution stages. `docs/ssot/test-execution-matrix.yaml` owns the path-to-stage mapping. CI fails on mandatory AC coverage that is missing, placeholder-only, stub-only, or real-only outside CI-required stages; full-strikethrough deprecated ACs are excluded from the mandatory gate. The macro gate fails README/matrix/owner-EPIC drift, E2E/EPIC ownership drift, and broad/reference-only critical proof anchors. The generated audit is uploaded as a CI artifact; checked-in archive copies were retired to reduce merge conflicts.
 5. **Generated API reference is code-owned**: Static API reference docs are generated from FastAPI OpenAPI by `tools/generate_api_reference.py`. PR CI runs `python ../../tools/generate_api_reference.py --check` inside the backend uv environment after dependencies are installed, so endpoint paths, parameters, request schemas, response schemas, and enum values cannot drift into hand-written Markdown.
-6. **Backend stages are explicit and split**: Backend fast-path remains shard stage (`backend`) with `-m "not slow and not e2e and not integration"`. Standalone gates start immediately: `lint` and `ac-traceability` have no `needs` dependency and run in parallel with change classification. Changes-dependent fast feedback jobs start after `changes` only: backend shards, frontend build/test, image build validation, and tooling coverage do not wait for behavior-only backend gates. Behavior-only backend gates run in parallel as explicit `backend-integration` and `backend-e2e-tier1` stages and are aggregated by `finish`.
+6. **Backend stages are explicit and split**: Backend fast-path remains shard stage (`backend`) with `-m "not slow and not e2e and not integration"`. Standalone gates start immediately: `lint` and `ac-traceability` have no `needs` dependency and run in parallel with change classification. Deterministic test and image jobs start after change classification and do not wait for lint, AC traceability, or behavior-only backend gates. Behavior-only backend gates run in parallel as explicit `backend-integration` and `backend-e2e-tier1` stages, and finish remains the authoritative aggregate gate for lint, AC traceability, tests, image validation, coverage, and skipped heavy-job semantics.
 7. **Coverage Debug Context Is Always Uploaded**: The `tooling-coverage` job uploads `coverage-tooling` with `coverage/common.lcov` and `coverage/tools.lcov`; the `unified-coverage` job downloads that artifact and uploads `unified-coverage-context` on success and failure. The unified artifact contains `coverage/backend.lcov`, `coverage/frontend.lcov`, `coverage/common.lcov`, `coverage/tools.lcov`, the current `unified-coverage.json`, and `coverage/coverage-context.txt` with raw line-count inputs, commit/event/run metadata, toolchain versions, and input hashes. Coverage regressions must be diagnosed from these artifacts before treating a percentage delta as nondeterminism.
 8. **CI Observability Artifacts Are Failure-Path Owned**: Backend shard, backend integration, backend Tier-1 E2E, frontend Vitest, frontend Playwright, tooling/common coverage, AC traceability, PR preview, staging, manual AI/OCR, production release, and scheduled cleanup gates publish CI observability artifacts with `if: always()`. These artifacts include JUnit XML where pytest or Vitest/Playwright can produce it, raw coverage/report inputs where relevant, and a small context file with repository/event/ref/SHA/run metadata plus target environment/version fields. Step summaries remain human-readable status pages; artifacts are the replayable evidence for both success and failure.
 9. **Coveralls Is Main-Only Reporting**: Pull requests do not call Coveralls and therefore do not publish external Coveralls status contexts. CI pass/fail is decided by local gates (`tools/check_ci_metrics_contract.py`, `tools/check_coverage_policy.py`, `tools/calculate_unified_coverage.py`) aggregated by `finish`. Main pushes upload only the unified line-only LCOV report to Coveralls for badge and trend reporting after the local coverage gate passes. Backend/frontend per-flag Coveralls uploads are intentionally absent so a single commit has one reporting denominator.
@@ -56,24 +56,53 @@ changes (classify-changes) ─────┴→ backend shards ─────�
 14. **No-regression gate**: Zero-tolerance; if ANY component is below baseline, CI fails immediately.
 15. **Deny-list coverage scope**: Coverage scope is deny-list based within each governed source root. CI recursively expects every eligible source file in backend, frontend, common, and tools LCOV unless `common/coverage/policy.py` explicitly excludes it. New source roots fail the metrics contract until added to the policy and report pipeline.
 
-### Delivery Pipeline Contract
+### Env x Stage Contract
 
-This SSOT separates environment taxonomy, delivery stages, and GitHub Actions jobs.
-Environment taxonomy names the six runtime contexts in
-[environments.md](./environments.md). Delivery stages describe where confidence
-is produced. GitHub Actions jobs are implementation lanes inside those stages and
-must not be counted as separate release stages.
+This SSOT separates environment taxonomy, pipeline stages, and GitHub Actions jobs.
+Environment taxonomy names the runtime contexts in [environments.md](./environments.md).
+Pipeline stages are quality gates such as changed UT, lint/static checks, full UT,
+integration, regression/E2E, image validation, deploy smoke, provider gates, and
+release integrity. GitHub Actions jobs are implementation lanes for selected
+environment/stage cells.
 
 Local runs are fast advisory gates. PR CI is the deterministic merge authority.
-PR Preview, staging, and production are deployed-environment proof gates.
+PR Preview, staging, and production are deployed-environment proof gates. The model
+is an Env x Stage Execution Matrix: not every environment runs every pipeline stage,
+and environment names must not be counted as pipeline stages.
 
-| Delivery stage | Default proof role | Throughput policy |
-|---|---|---|
-| Local fast feedback | Developer advisory signal from affected tests and focused checks | Optimize for seconds-to-minutes feedback; do not require full remote-equivalent CI before opening a PR |
-| PR CI deterministic proof | Authoritative merge gate for deterministic behavior, AC traceability, coverage, and image build validation | Keep required proof parallel and fail-fast while preserving the aggregate `finish` check |
-| PR Preview deployed proof | Docker/runtime/routing/health/non-LLM deployed proof before merge for preview-relevant changes | Consume preview environments only for runtime, deploy, E2E, dependency, Dockerfile/config, or preview-action changes |
-| Staging merged-SHA proof | Exact successful `main` CI SHA deployed to shared staging with real infra and provider-backed gates | Serialize staging mutations and skip non-runtime changes after CI/AC proof |
-| Production release proof | Manual release image/deploy integrity, health, and prod-safe smoke | Reuse successful main CI proof; do not rerun full container-backed CI in the release lane |
+#### Environment Axis
+
+| Environment | Meaning |
+|---|---|
+| `local` | Developer machine and local CI commands |
+| `pr` | GitHub PR/main CI runner proof before merge or staging consumption |
+| `pr-preview` | Per-PR deployed Docker environment |
+| `staging` | Shared post-merge deployed environment for successful `main` SHAs |
+| `prd` | Production release environment |
+
+#### Pipeline Stage Axis
+
+| Pipeline stage | Purpose |
+|---|---|
+| Changed/Affected UT | Fast local or focused unit feedback for touched/affected code |
+| Lint/Static | Syntax, formatting, static contracts, SSOT and traceability checks |
+| Full UT | Deterministic unit coverage over governed app/tooling source trees |
+| Integration | Service-backed deterministic tests that do not require deployed routing |
+| Regression/E2E | Deterministic API/browser/user-journey proof |
+| Image Build | Dockerfile, build context, and build-argument proof |
+| Deploy Smoke | Runtime health, routing, version, and deploy integrity proof |
+| Provider Gate | Provider-backed OCR/LLM proof with real external credentials |
+| Release Integrity | Manual production release prerequisite and image/deploy proof |
+
+#### Env x Stage Execution Matrix
+
+| Env \ Stage | Changed/Affected UT | Lint/Static | Full UT | Integration | Regression/E2E | Image Build | Deploy Smoke | Provider Gate | Release Integrity |
+|---|---|---|---|---|---|---|---|---|---|
+| `local` | default | focused/static contracts | risk-triggered only | risk-triggered only | not default | no | no | no | no |
+| `pr` | covered by full gates | required | required for heavy changes | required for heavy changes | Tier-1/provider-free required for heavy changes | dry-run required for heavy changes | no | no | no |
+| `pr-preview` | no | no | no | no | runtime/UI/API preview-relevant subset | push PR images | required health/version | no | no |
+| `staging` | no | no | no | no | merged-SHA non-LLM and provider-backed regression | reuse or build missing SHA images | required | required where source class needs real provider proof | no |
+| `prd` | no | no | no | no | prod-safe smoke only | release image proof | required | no first-time proof | required |
 
 Production release proof is intentionally narrow: production validates release
 integrity and availability, not first-time deterministic business behavior.
@@ -228,7 +257,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - PR preview environments deploy only for runtime app, compose, root E2E, dependency, Dockerfile/config, or preview-action changes. Preview-action changes include `.github/workflows/pr-test.yml`, `.github/workflows/pr-preview-cleanup.yml`, `.github/actions/setup-e2e-tests/action.yml`, `tools/pr_preview_lifecycle.py`, and `tools/_lib/dev/pr_preview_lifecycle.py`. App test-only and app Markdown changes still run CI and AC gates without consuming a Dokploy preview slot.
 - Automatic staging deploys are scoped to runtime app, deploy, root E2E, dependency, Dockerfile/config, staging workflow, toolchain, or infra-submodule changes. App test-only changes, documentation, project archive, AC traceability, and other tooling-only changes keep CI/AC gates but do not consume the staging singleton.
 - Markdown outside the documented lightweight trees is treated as heavy; this prevents runtime-adjacent README or tooling documentation changes from being hidden by a global `*.md` skip.
-- Standalone lint and AC traceability start immediately with change classification. Full CI jobs wait for change classification, lint, and AC traceability, then backend shards, frontend build/test, image build validation, tooling coverage, integration, and Tier-1 API E2E run in parallel. Left-side deterministic failures stop the expensive group before behavior gates consume runner time.
+- Standalone lint and AC traceability start immediately with change classification. Deterministic test and image jobs start after change classification, then backend shards, frontend build/test, image build validation, tooling coverage, integration, and Tier-1 API E2E run in parallel. The `finish` job aggregates lint, AC traceability, deterministic tests, image validation, coverage, and skipped heavy-job semantics so earlier job starts improve wall-clock throughput without weakening merge authority.
 - 6-way parallel test sharding via `pytest-split`
 - Each shard: `pytest --splits 6 --group N`
 - Tooling/common coverage runs in parallel as `tooling-coverage`; `unified-coverage` downloads `coverage-tooling` and merges backend, frontend, common, and tools LCOV inputs post-run.

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -20,11 +20,10 @@
 | **5** | **Staging** | `report-staging.zitian.party` | Push to main<br>`staging-deploy.yml` | **Docker Images**<br>(GHCR) | Dedicated infra2<br>+ Shared Platform | Dedicated DB/Redis | Bucket name<br>`-staging` |
 | **6** | **Production** | `report.zitian.party` | Manual release<br>`production-release.yml` | **Docker Images**<br>(GHCR) | Dedicated infra2<br>+ Shared Platform | Dedicated DB/Redis | Bucket name |
 
-Environment taxonomy is not the delivery pipeline stage count. The delivery
-pipeline is documented in [ci-cd.md](./ci-cd.md) as local fast feedback, PR CI
-deterministic proof, PR Preview deployed proof, staging merged-SHA proof, and
-production release proof. GitHub Actions jobs are implementation lanes within
-those stages.
+Environment taxonomy is not the delivery pipeline stage count. The CI/CD model
+is documented in [ci-cd.md](./ci-cd.md) as a sparse environment x pipeline stage
+matrix: environments are where proof runs, pipeline stages are what quality gate
+runs, and GitHub Actions jobs are implementation lanes for selected cells.
 
 ---
 

--- a/tests/tooling/test_ci_change_classifier.py
+++ b/tests/tooling/test_ci_change_classifier.py
@@ -5,6 +5,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from common.ci import change_classifier as classifier  # noqa: E402
 from common.ci.change_classifier import (
+    ENV_STAGE_MATRIX,
+    Environment,
+    PipelineStage,
     classify_changed_paths,
     is_lightweight,
     is_pr_preview_relevant,
@@ -381,3 +384,59 @@ def test_AC8_13_20_cli_writes_outputs_summary_and_stdout(
     assert "pr_preview_required=false" in github_output.read_text(encoding="utf-8")
     assert "staging_required=false" in github_output.read_text(encoding="utf-8")
     assert "Changed files: `2`" in github_summary.read_text(encoding="utf-8")
+
+
+def test_AC8_13_97_env_stage_matrix_keeps_environments_separate_from_pipeline_stages() -> (
+    None
+):
+    """AC8.13.97: CI classification is modeled as sparse env x stage rules."""
+    assert set(ENV_STAGE_MATRIX) == {
+        Environment.LOCAL,
+        Environment.PR,
+        Environment.PR_PREVIEW,
+        Environment.STAGING,
+        Environment.PRODUCTION,
+    }
+    assert ENV_STAGE_MATRIX[Environment.LOCAL] == (
+        PipelineStage.CHANGED_UNIT,
+        PipelineStage.STATIC,
+    )
+    assert PipelineStage.FULL_UNIT in ENV_STAGE_MATRIX[Environment.PR]
+    assert PipelineStage.INTEGRATION in ENV_STAGE_MATRIX[Environment.PR]
+    assert PipelineStage.IMAGE_BUILD in ENV_STAGE_MATRIX[Environment.PR]
+    assert PipelineStage.DEPLOY_SMOKE not in ENV_STAGE_MATRIX[Environment.PR]
+    assert ENV_STAGE_MATRIX[Environment.PR_PREVIEW] == (
+        PipelineStage.IMAGE_BUILD,
+        PipelineStage.DEPLOY_SMOKE,
+        PipelineStage.E2E,
+    )
+    assert PipelineStage.PROVIDER_GATE in ENV_STAGE_MATRIX[Environment.STAGING]
+    assert PipelineStage.FULL_UNIT not in ENV_STAGE_MATRIX[Environment.STAGING]
+    assert ENV_STAGE_MATRIX[Environment.PRODUCTION] == (
+        PipelineStage.RELEASE_INTEGRITY,
+        PipelineStage.DEPLOY_SMOKE,
+    )
+
+
+def test_AC8_13_97_deployed_env_classifiers_share_common_runtime_rules() -> None:
+    """AC8.13.97: Shared runtime paths cannot drift between preview and staging classifiers."""
+    for path in classifier.COMMON_DEPLOY_RUNTIME_EXACT:
+        assert is_pr_preview_relevant(path) is True
+        assert is_staging_relevant(path) is True
+
+    for prefix in classifier.COMMON_DEPLOY_RUNTIME_PREFIXES:
+        path = f"{prefix}sentinel.py"
+        assert is_pr_preview_relevant(path) is True
+        assert is_staging_relevant(path) is True
+
+    assert classifier.ENV_STAGE_RULES[Environment.PR_PREVIEW].stages == (
+        PipelineStage.IMAGE_BUILD,
+        PipelineStage.DEPLOY_SMOKE,
+        PipelineStage.E2E,
+    )
+    assert classifier.ENV_STAGE_RULES[Environment.STAGING].stages == (
+        PipelineStage.IMAGE_BUILD,
+        PipelineStage.DEPLOY_SMOKE,
+        PipelineStage.E2E,
+        PipelineStage.PROVIDER_GATE,
+    )

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -921,7 +921,7 @@ def test_AC8_13_16_ci_change_classification_and_frontend_cache() -> None:
     assert "lightweight-docs-or-docs-workflow-only" in classifier
     assert "pr-preview-paths-changed" in classifier
     assert "no-pr-preview-paths-changed" in classifier
-    assert "needs: [changes, lint, ac-traceability]" in workflow
+    assert "needs: [changes]" in workflow
     assert "if: needs.changes.outputs.heavy_required == 'true'" in workflow
     assert (
         "pr_preview_required: ${{ steps.preview.outputs.pr_preview_required }}"
@@ -934,6 +934,7 @@ def test_AC8_13_16_ci_change_classification_and_frontend_cache() -> None:
         "needs: [changes, backend, backend-integration, backend-e2e-tier1, frontend, container-images, lint, tooling-coverage, unified-coverage, ac-traceability]"
         in workflow
     )
+    assert "finish remains the authoritative aggregate gate" in ci_cd
     assert (
         "Heavy backend/frontend/coverage jobs skipped for lightweight changes."
         in workflow
@@ -1234,7 +1235,12 @@ def test_AC8_13_36_post_merge_reuses_sha_tagged_staging_images() -> None:
 
     assert "container-images:" in ci_workflow
     assert "name: Build Staging Images" in ci_workflow
-    assert "needs: [changes, lint, ac-traceability]" in ci_workflow
+    container_block = ci_workflow.split("  container-images:", 1)[1].split(
+        "  tooling-coverage:", 1
+    )[0]
+    assert "needs: [changes]" in container_block
+    assert "lint" not in container_block.split("steps:", 1)[0]
+    assert "ac-traceability" not in container_block.split("steps:", 1)[0]
     assert "needs.changes.outputs.heavy_required == 'true'" in ci_workflow
     assert (
         "if: github.event_name == 'push' && github.ref == 'refs/heads/main'"
@@ -1479,28 +1485,43 @@ def test_AC8_13_24_ac_traceability_uploads_audit_artifact_without_stale_doc_gate
     assert "issue #548" in project_readme
 
 
-def test_AC8_13_25_full_ci_waits_for_static_and_traceability_gates() -> None:
-    """AC8.13.25: Full CI waits for static and traceability gates."""
+def test_AC8_13_25_full_ci_aggregates_static_traceability_and_test_gates() -> None:
+    """AC8.13.25: Full CI starts tests early while finish aggregates every gate."""
     workflow = read(".github/workflows/ci.yml")
     ci_cd = read("docs/ssot/ci-cd.md")
 
     backend_block = workflow.split("  backend:", 1)[1].split("  frontend:", 1)[0]
+    frontend_block = workflow.split("  frontend:", 1)[1].split(
+        "  container-images:", 1
+    )[0]
+    image_block = workflow.split("  container-images:", 1)[1].split(
+        "  tooling-coverage:", 1
+    )[0]
+    tooling_block = workflow.split("  tooling-coverage:", 1)[1].split(
+        "  unified-coverage:", 1
+    )[0]
     traceability_block = workflow.split("  ac-traceability:", 1)[1].split(
         "  finish:", 1
     )[0]
+    finish_block = workflow.split("  finish:", 1)[1]
 
-    assert "needs: [changes, lint, ac-traceability]" in backend_block
-    assert (
-        "needs: [changes, backend-integration, backend-e2e-tier1, lint]"
-        not in backend_block
-    )
+    for block in (backend_block, frontend_block, image_block, tooling_block):
+        assert "needs: [changes]" in block
+        assert "lint" not in block.split("steps:", 1)[0]
+        assert "ac-traceability" not in block.split("steps:", 1)[0]
+
     assert "needs: [lint]" not in traceability_block
     assert "needs:" not in traceability_block.split("steps:", 1)[0]
+    assert (
+        "needs: [changes, backend, backend-integration, backend-e2e-tier1, frontend, "
+        "container-images, lint, tooling-coverage, unified-coverage, ac-traceability]"
+        in finish_block
+    )
     assert "Standalone lint and AC traceability start immediately" in ci_cd
     assert (
-        "Full CI jobs wait for change classification, lint, and AC traceability"
-        in ci_cd
+        "Deterministic test and image jobs start after change classification" in ci_cd
     )
+    assert "finish remains the authoritative aggregate gate" in ci_cd
 
 
 def test_AC8_13_86_fast_feedback_jobs_do_not_wait_for_behavior_gates() -> None:
@@ -1523,39 +1544,48 @@ def test_AC8_13_86_fast_feedback_jobs_do_not_wait_for_behavior_gates() -> None:
     )[0]
 
     for block in (backend_block, frontend_block, image_block):
-        assert "needs: [changes, lint, ac-traceability]" in block
+        assert "needs: [changes]" in block
         assert "backend-integration" not in block.split("steps:", 1)[0]
         assert "backend-e2e-tier1" not in block.split("steps:", 1)[0]
+        assert "lint" not in block.split("steps:", 1)[0]
+        assert "ac-traceability" not in block.split("steps:", 1)[0]
 
     assert "needs:" not in lint_block.split("steps:", 1)[0]
     assert "needs:" not in traceability_block.split("steps:", 1)[0]
     assert "Standalone gates start immediately" in ci_cd
     assert (
-        "Full CI jobs wait for change classification, lint, and AC traceability"
-        in ci_cd
+        "Deterministic test and image jobs start after change classification" in ci_cd
     )
     assert "Behavior-only backend gates run in parallel" in ci_cd
 
 
-def test_AC8_13_94_delivery_pipeline_contract_is_documented() -> None:
-    """AC8.13.94: delivery stages distinguish advisory, authority, and environment proof."""
+def test_AC8_13_94_env_and_pipeline_stage_contract_is_documented() -> None:
+    """AC8.13.94: environments and pipeline stages are separate matrix axes."""
     ci_cd = read("docs/ssot/ci-cd.md")
     environments = read("docs/ssot/environments.md")
     readme = read("README.md")
 
     for token in (
-        "Local fast feedback",
-        "PR CI deterministic proof",
-        "PR Preview deployed proof",
-        "Staging merged-SHA proof",
-        "Production release proof",
+        "Environment Axis",
+        "Pipeline Stage Axis",
+        "Env x Stage Execution Matrix",
+        "local",
+        "pr",
+        "pr-preview",
+        "staging",
+        "prd",
+        "Changed/Affected UT",
+        "Lint/Static",
+        "Full UT",
+        "Regression/E2E",
         "Local runs are fast advisory gates",
         "PR CI is the deterministic merge authority",
         "deployed-environment proof gates",
     ):
         assert token in ci_cd
 
-    assert "environment taxonomy, delivery stages, and GitHub Actions jobs" in ci_cd
+    assert "not every environment runs every pipeline stage" in ci_cd
+    assert "environment taxonomy, pipeline stages, and GitHub Actions jobs" in ci_cd
     assert (
         "Environment taxonomy is not the delivery pipeline stage count" in environments
     )


### PR DESCRIPTION
## Summary

Models CI/CD proof as a sparse environment x pipeline-stage matrix, simplifies change classification around that model, and starts deterministic CI jobs earlier while preserving `finish` as the aggregate quality gate.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Testing Strategy |
| **AC IDs** | AC8.13.25, AC8.13.94, AC8.13.95, AC8.13.96, AC8.13.97 |
| **AC source updated** | Owning EPIC |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): N/A
- [x] `docs/ssot/ci-cd.md` — separates environment taxonomy from pipeline stages and documents the env x stage execution matrix.
- [x] `docs/ssot/environments.md` — clarifies that environments are not pipeline stages.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `5bf317d` | Added EPIC/test coverage for env x stage matrix, early CI aggregation, and classifier drift protection before implementation. |
| 🟢 Green (passing test) | `3fbc18f` | Implemented table-driven env/stage classifier, CI dependency changes, and SSOT updates. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not applicable; no DB model changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

- [x] Lifecycle ownership is unified: no lifecycle ownership changes; classifier now uses shared env/stage rules for preview and staging deployed proof.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys.
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged.
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials (not changed).
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule (not changed).
- [x] Proof command includes focused tests for this CI/classifier/docs change set.

---

## Testing

```bash
uv run --with pytest --with pyyaml pytest tests/tooling/test_ci_change_classifier.py tests/tooling/test_post_merge_e2e_gates.py -q
uv run --with ruff ruff check common/ci/change_classifier.py tests/tooling/test_ci_change_classifier.py tests/tooling/test_post_merge_e2e_gates.py
python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/lint_doc_consistency.py
python tools/check_ci_metrics_contract.py
uv run --with pyyaml python tools/check_manifest.py
uv run --with pyyaml python tools/check_ac_traceability.py
```

Local pre-push hook could not complete because this machine has no running local Postgres and neither Podman nor Docker was available (`127.0.0.1:5432` refused; Podman socket unavailable; Docker not in PATH). The branch was pushed with `--no-verify`; PR CI remains the authoritative merge gate.

---

## Screenshots / Evidence

N/A