### PR TITLE
[finance_report_audit] Add evidence graph foundation

### DIFF
--- a/apps/backend/migrations/versions/0025_add_evidence_lineage.py
+++ b/apps/backend/migrations/versions/0025_add_evidence_lineage.py
@@ -1,0 +1,79 @@
+"""add evidence lineage graph"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0025_add_evidence_lineage"
+down_revision = "0024_add_workflow_sessions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table("evidence_nodes",
+        sa.Column("node_kind", sa.String(length=50), nullable=False),
+        sa.Column("entity_type", sa.String(length=100), nullable=False),
+        sa.Column("entity_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "properties",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "node_kind", "entity_type", "entity_id", name="uq_evidence_nodes_user_entity"),
+    )
+    op.create_index("idx_evidence_nodes_user_entity", "evidence_nodes", ["user_id", "entity_type", "entity_id"])
+    op.create_index("idx_evidence_nodes_user_kind", "evidence_nodes", ["user_id", "node_kind"])
+
+    op.create_table("evidence_edges",
+        sa.Column("from_node_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("to_node_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("relation", sa.String(length=100), nullable=False),
+        sa.Column(
+            "properties",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["from_node_id"], ["evidence_nodes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["to_node_id"], ["evidence_nodes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "from_node_id", "to_node_id", "relation", name="uq_evidence_edges_user_relation"),
+    )
+    op.create_index("idx_evidence_edges_user_from", "evidence_edges", ["user_id", "from_node_id"])
+    op.create_index("idx_evidence_edges_user_to", "evidence_edges", ["user_id", "to_node_id"])
+    op.create_index(
+        "idx_evidence_edges_user_relation_from",
+        "evidence_edges",
+        ["user_id", "relation", "from_node_id"],
+    )
+    op.create_index(
+        "idx_evidence_edges_user_relation_to",
+        "evidence_edges",
+        ["user_id", "relation", "to_node_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_evidence_edges_user_relation_to", table_name="evidence_edges")
+    op.drop_index("idx_evidence_edges_user_relation_from", table_name="evidence_edges")
+    op.drop_index("idx_evidence_edges_user_to", table_name="evidence_edges")
+    op.drop_index("idx_evidence_edges_user_from", table_name="evidence_edges")
+    op.drop_table("evidence_edges")
+    op.drop_index("idx_evidence_nodes_user_kind", table_name="evidence_nodes")
+    op.drop_index("idx_evidence_nodes_user_entity", table_name="evidence_nodes")
+    op.drop_table("evidence_nodes")

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -4,6 +4,7 @@ from src.models.account import Account, AccountType
 from src.models.chat import ChatMessage, ChatMessageRole, ChatSession, ChatSessionStatus
 from src.models.consistency_check import CheckStatus, CheckType, ConsistencyCheck
 from src.models.correction import CorrectionLog
+from src.models.evidence import EvidenceEdge, EvidenceNode
 from src.models.journal import (
     Direction,
     JournalAuditLog,
@@ -90,6 +91,8 @@ __all__ = [
     "Direction",
     "DocumentStatus",
     "DocumentType",
+    "EvidenceEdge",
+    "EvidenceNode",
     "FxRate",
     "JournalEntry",
     "JournalAuditLog",

--- a/apps/backend/src/models/evidence.py
+++ b/apps/backend/src/models/evidence.py
@@ -1,0 +1,72 @@
+"""Evidence graph models for audit lineage."""
+
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.database import Base
+from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
+
+
+class EvidenceNode(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
+    """Auditable state node in the evidence graph."""
+
+    __tablename__ = "evidence_nodes"
+    __table_args__ = (
+        UniqueConstraint("user_id", "node_kind", "entity_type", "entity_id", name="uq_evidence_nodes_user_entity"),
+        Index("idx_evidence_nodes_user_entity", "user_id", "entity_type", "entity_id"),
+        Index("idx_evidence_nodes_user_kind", "user_id", "node_kind"),
+    )
+
+    node_kind: Mapped[str] = mapped_column(String(50), nullable=False)
+    entity_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    entity_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    properties: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+
+    outgoing_edges: Mapped[list["EvidenceEdge"]] = relationship(
+        back_populates="from_node",
+        foreign_keys="EvidenceEdge.from_node_id",
+        cascade="all, delete-orphan",
+    )
+    incoming_edges: Mapped[list["EvidenceEdge"]] = relationship(
+        back_populates="to_node",
+        foreign_keys="EvidenceEdge.to_node_id",
+        cascade="all, delete-orphan",
+    )
+
+
+class EvidenceEdge(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
+    """Transformation edge connecting two evidence nodes."""
+
+    __tablename__ = "evidence_edges"
+    __table_args__ = (
+        UniqueConstraint("user_id", "from_node_id", "to_node_id", "relation", name="uq_evidence_edges_user_relation"),
+        Index("idx_evidence_edges_user_from", "user_id", "from_node_id"),
+        Index("idx_evidence_edges_user_to", "user_id", "to_node_id"),
+        Index("idx_evidence_edges_user_relation_from", "user_id", "relation", "from_node_id"),
+        Index("idx_evidence_edges_user_relation_to", "user_id", "relation", "to_node_id"),
+    )
+
+    from_node_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("evidence_nodes.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    to_node_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("evidence_nodes.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    relation: Mapped[str] = mapped_column(String(100), nullable=False)
+    properties: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+
+    from_node: Mapped[EvidenceNode] = relationship(
+        back_populates="outgoing_edges",
+        foreign_keys=[from_node_id],
+    )
+    to_node: Mapped[EvidenceNode] = relationship(
+        back_populates="incoming_edges",
+        foreign_keys=[to_node_id],
+    )

--- a/apps/backend/src/services/evidence_lineage.py
+++ b/apps/backend/src/services/evidence_lineage.py
@@ -1,0 +1,259 @@
+"""Evidence graph foundation service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.evidence import EvidenceEdge, EvidenceNode
+
+DEFAULT_MAX_DEPTH = 6
+
+
+@dataclass(frozen=True)
+class EvidenceTraversalStep:
+    """Single hop returned by evidence graph traversal."""
+
+    depth: int
+    edge: EvidenceEdge
+    node: EvidenceNode
+
+
+class EvidenceLineageService:
+    """User-scoped evidence graph node, edge, and traversal operations."""
+
+    async def upsert_node(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        node_kind: str,
+        entity_type: str,
+        entity_id: UUID,
+        properties: dict | None = None,
+    ) -> EvidenceNode:
+        """Create or update a node keyed by user, node kind, and entity identity."""
+        result = await db.execute(
+            select(EvidenceNode)
+            .where(EvidenceNode.user_id == user_id)
+            .where(EvidenceNode.node_kind == node_kind)
+            .where(EvidenceNode.entity_type == entity_type)
+            .where(EvidenceNode.entity_id == entity_id)
+            .limit(1)
+        )
+        node = result.scalar_one_or_none()
+        if node is None:
+            node = EvidenceNode(
+                user_id=user_id,
+                node_kind=node_kind,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                properties=properties or {},
+            )
+            db.add(node)
+        elif properties is not None:
+            node.properties = properties
+
+        await db.flush()
+        return node
+
+    async def get_node_for_entity(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        entity_type: str,
+        entity_id: UUID,
+        node_kind: str | None = None,
+    ) -> EvidenceNode | None:
+        """Resolve one user-owned evidence node for an entity identity."""
+        query = (
+            select(EvidenceNode)
+            .where(EvidenceNode.user_id == user_id)
+            .where(EvidenceNode.entity_type == entity_type)
+            .where(EvidenceNode.entity_id == entity_id)
+        )
+        if node_kind is not None:
+            query = query.where(EvidenceNode.node_kind == node_kind)
+
+        result = await db.execute(query.order_by(EvidenceNode.created_at.asc(), EvidenceNode.id.asc()).limit(1))
+        return result.scalar_one_or_none()
+
+    async def upsert_edge(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        from_node_id: UUID,
+        to_node_id: UUID,
+        relation: str,
+        properties: dict | None = None,
+    ) -> EvidenceEdge:
+        """Create or update a user-scoped edge between two nodes."""
+        from_node = await self._get_node_by_id(db, node_id=from_node_id)
+        to_node = await self._get_node_by_id(db, node_id=to_node_id)
+        if from_node is None or to_node is None:
+            raise ValueError("from_node_id and to_node_id must reference existing evidence nodes")
+        if from_node.user_id != user_id or to_node.user_id != user_id:
+            raise ValueError("evidence edge endpoints must belong to the same user")
+
+        result = await db.execute(
+            select(EvidenceEdge)
+            .where(EvidenceEdge.user_id == user_id)
+            .where(EvidenceEdge.from_node_id == from_node_id)
+            .where(EvidenceEdge.to_node_id == to_node_id)
+            .where(EvidenceEdge.relation == relation)
+            .limit(1)
+        )
+        edge = result.scalar_one_or_none()
+        if edge is None:
+            edge = EvidenceEdge(
+                user_id=user_id,
+                from_node_id=from_node_id,
+                to_node_id=to_node_id,
+                relation=relation,
+                properties=properties or {},
+            )
+            db.add(edge)
+        elif properties is not None:
+            edge.properties = properties
+
+        await db.flush()
+        return edge
+
+    async def get_downstream(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        entity_type: str,
+        entity_id: UUID,
+        node_kind: str | None = None,
+        max_depth: int | None = DEFAULT_MAX_DEPTH,
+    ) -> list[EvidenceTraversalStep]:
+        """Traverse user-scoped evidence edges from an entity toward derived states."""
+        start = await self.get_node_for_entity(
+            db,
+            user_id=user_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            node_kind=node_kind,
+        )
+        if start is None:
+            return []
+        return await self._traverse(
+            db, user_id=user_id, start_node_id=start.id, direction="downstream", max_depth=max_depth
+        )
+
+    async def get_upstream(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        entity_type: str,
+        entity_id: UUID,
+        node_kind: str | None = None,
+        max_depth: int | None = DEFAULT_MAX_DEPTH,
+    ) -> list[EvidenceTraversalStep]:
+        """Traverse user-scoped evidence edges from an entity back to source states."""
+        start = await self.get_node_for_entity(
+            db,
+            user_id=user_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            node_kind=node_kind,
+        )
+        if start is None:
+            return []
+        return await self._traverse(
+            db, user_id=user_id, start_node_id=start.id, direction="upstream", max_depth=max_depth
+        )
+
+    async def _get_node_by_id(self, db: AsyncSession, *, node_id: UUID) -> EvidenceNode | None:
+        result = await db.execute(select(EvidenceNode).where(EvidenceNode.id == node_id).limit(1))
+        return result.scalar_one_or_none()
+
+    async def _traverse(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        start_node_id: UUID,
+        direction: str,
+        max_depth: int | None,
+    ) -> list[EvidenceTraversalStep]:
+        depth_limit = self._depth_limit(max_depth)
+        if depth_limit == 0:
+            return []
+
+        steps: list[EvidenceTraversalStep] = []
+        frontier = {start_node_id}
+        visited = {start_node_id}
+
+        for depth in range(1, depth_limit + 1):
+            if not frontier:
+                break
+
+            if direction == "downstream":
+                edge_query = (
+                    select(EvidenceEdge)
+                    .where(EvidenceEdge.user_id == user_id)
+                    .where(EvidenceEdge.from_node_id.in_(frontier))
+                    .order_by(EvidenceEdge.created_at.asc(), EvidenceEdge.id.asc())
+                )
+                next_node_attr = "to_node_id"
+            else:
+                edge_query = (
+                    select(EvidenceEdge)
+                    .where(EvidenceEdge.user_id == user_id)
+                    .where(EvidenceEdge.to_node_id.in_(frontier))
+                    .order_by(EvidenceEdge.created_at.asc(), EvidenceEdge.id.asc())
+                )
+                next_node_attr = "from_node_id"
+
+            edges = list((await db.execute(edge_query)).scalars().all())
+            next_node_ids = {getattr(edge, next_node_attr) for edge in edges}
+            nodes = await self._get_nodes_for_user(db, user_id=user_id, node_ids=next_node_ids - visited)
+            node_by_id = {node.id: node for node in nodes}
+
+            frontier = set()
+            for edge in edges:
+                next_node_id = getattr(edge, next_node_attr)
+                node = node_by_id.get(next_node_id)
+                if node is None:
+                    continue
+                steps.append(EvidenceTraversalStep(depth=depth, edge=edge, node=node))
+                frontier.add(next_node_id)
+                visited.add(next_node_id)
+
+        return steps
+
+    async def _get_nodes_for_user(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        node_ids: set[UUID],
+    ) -> list[EvidenceNode]:
+        if not node_ids:
+            return []
+        result = await db.execute(
+            select(EvidenceNode)
+            .where(EvidenceNode.user_id == user_id)
+            .where(EvidenceNode.id.in_(node_ids))
+            .order_by(EvidenceNode.created_at.asc(), EvidenceNode.id.asc())
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    def _depth_limit(max_depth: int | None) -> int:
+        if max_depth is None:
+            return DEFAULT_MAX_DEPTH
+        if max_depth < 0:
+            raise ValueError("max_depth must be non-negative")
+        if max_depth > DEFAULT_MAX_DEPTH:
+            raise ValueError("max_depth exceeds default evidence traversal bound")
+        return max_depth

--- a/apps/backend/src/services/market_data.py
+++ b/apps/backend/src/services/market_data.py
@@ -631,11 +631,19 @@ async def _sync_scope_status(
     last_success_at = _normalize_utc(state.last_success_at) if state is not None else fallback_success_at
     latest_observation_date = await _latest_observation_date(db, kind, scope)
     last_success_date = state.last_success_date if state is not None else latest_observation_date
-    last_observation_date = state.last_observation_date if state is not None else latest_observation_date
+    last_observation_date = (
+        state.last_observation_date
+        if state is not None and state.last_observation_date is not None
+        else latest_observation_date
+    )
     return MarketDataScopeStatus(
         kind=kind,
         scope=scope,
-        fresh=last_success_at is not None and last_success_at >= now - _FRESHNESS_THRESHOLD,
+        fresh=(
+            last_success_at is not None
+            and last_success_at >= now - _FRESHNESS_THRESHOLD
+            and last_observation_date is not None
+        ),
         last_success_at=last_success_at,
         last_success_date=last_success_date,
         last_observation_date=last_observation_date,

--- a/apps/backend/tests/infra/test_evidence_lineage_contract.py
+++ b/apps/backend/tests/infra/test_evidence_lineage_contract.py
@@ -1,0 +1,35 @@
+"""Evidence Graph foundation contract tests."""
+
+from pathlib import Path
+
+import pytest
+
+from src.models.evidence import EvidenceEdge, EvidenceNode
+
+REPO_ROOT = Path(__file__).parents[4]
+SSOT_PATH = REPO_ROOT / "docs" / "ssot" / "evidence-lineage.md"
+
+pytestmark = pytest.mark.no_db
+
+
+def test_AC18_7_1_evidence_lineage_ssot_defines_graph_semantics():
+    """AC18.7.1: Evidence lineage SSOT defines node, edge, identity, and traversal semantics."""
+    source = SSOT_PATH.read_text()
+
+    assert "node = auditable state" in source
+    assert "edge = transformation or calculation process" in source
+    assert "user_id + node_kind + entity_type + entity_id" in source
+    assert "user_id + from_node_id + to_node_id + relation" in source
+    assert "The default maximum traversal depth is 6" in source
+
+
+def test_AC18_7_3_evidence_lineage_models_expose_jsonb_user_owned_graph_tables():
+    """AC18.7.3: Evidence lineage models expose user-owned graph tables with JSONB properties."""
+    assert EvidenceNode.__tablename__ == "evidence_nodes"
+    assert EvidenceEdge.__tablename__ == "evidence_edges"
+    assert EvidenceNode.__table__.c.user_id.foreign_keys
+    assert EvidenceEdge.__table__.c.user_id.foreign_keys
+    assert EvidenceNode.__table__.c.properties.type.__class__.__name__ == "JSONB"
+    assert EvidenceEdge.__table__.c.properties.type.__class__.__name__ == "JSONB"
+    assert "uq_evidence_nodes_user_entity" in {constraint.name for constraint in EvidenceNode.__table__.constraints}
+    assert "uq_evidence_edges_user_relation" in {constraint.name for constraint in EvidenceEdge.__table__.constraints}

--- a/apps/backend/tests/infra/test_evidence_lineage_migration_contract.py
+++ b/apps/backend/tests/infra/test_evidence_lineage_migration_contract.py
@@ -1,0 +1,24 @@
+"""Evidence Graph migration contract tests."""
+
+from pathlib import Path
+
+import pytest
+
+BACKEND_DIR = Path(__file__).parent.parent.parent
+MIGRATION_PATH = BACKEND_DIR / "migrations" / "versions" / "0025_add_evidence_lineage.py"
+
+pytestmark = pytest.mark.no_db
+
+
+def test_AC18_7_2_evidence_lineage_migration_creates_tables_and_indexes():
+    """AC18.7.2: Evidence lineage migration creates graph tables and traversal indexes."""
+    source = MIGRATION_PATH.read_text()
+
+    assert 'op.create_table("evidence_nodes"' in source
+    assert 'op.create_table("evidence_edges"' in source
+    assert "uq_evidence_nodes_user_entity" in source
+    assert "uq_evidence_edges_user_relation" in source
+    assert "idx_evidence_edges_user_from" in source
+    assert "idx_evidence_edges_user_to" in source
+    assert "idx_evidence_edges_user_relation_from" in source
+    assert "idx_evidence_edges_user_relation_to" in source

--- a/apps/backend/tests/market_data/test_sync.py
+++ b/apps/backend/tests/market_data/test_sync.py
@@ -996,3 +996,72 @@ async def test_market_data_sync_state_updates_when_provider_has_no_rows(
     )
     assert state is not None
     assert state.last_success_date == date(2026, 1, 11)
+
+
+@pytest.mark.asyncio
+async def test_market_data_status_requires_observation_date_for_freshness(
+    db: AsyncSession,
+) -> None:
+    """AC11.10.11: Freshness status requires data evidence, not only a recent provider call."""
+    observed_at = datetime(2026, 1, 11, tzinfo=UTC)
+    db.add(
+        MarketDataSyncState(
+            kind="stock",
+            scope="AAPL",
+            last_success_at=observed_at,
+            last_success_date=date(2026, 1, 11),
+            last_observation_date=None,
+            created_at=observed_at,
+            updated_at=observed_at,
+        )
+    )
+    await db.commit()
+
+    status = await market_data.get_market_data_status(
+        db,
+        symbols=["AAPL"],
+        now=datetime(2026, 1, 11, 1, 0, tzinfo=UTC),
+    )
+
+    assert len(status) == 1
+    assert status[0].fresh is False
+    assert status[0].last_observation_date is None
+
+
+@pytest.mark.asyncio
+async def test_market_data_status_falls_back_to_persisted_observation_date(
+    db: AsyncSession,
+) -> None:
+    """AC11.10.11: Status backfills older sync states from persisted price evidence."""
+    observed_at = datetime(2026, 1, 11, tzinfo=UTC)
+    db.add_all(
+        [
+            StockPrice(
+                symbol="AAPL",
+                price=Decimal("190.000000"),
+                currency="USD",
+                price_date=date(2026, 1, 10),
+                source="test",
+            ),
+            MarketDataSyncState(
+                kind="stock",
+                scope="AAPL",
+                last_success_at=observed_at,
+                last_success_date=date(2026, 1, 11),
+                last_observation_date=None,
+                created_at=observed_at,
+                updated_at=observed_at,
+            ),
+        ]
+    )
+    await db.commit()
+
+    status = await market_data.get_market_data_status(
+        db,
+        symbols=["AAPL"],
+        now=datetime(2026, 1, 11, 1, 0, tzinfo=UTC),
+    )
+
+    assert len(status) == 1
+    assert status[0].fresh is True
+    assert status[0].last_observation_date == date(2026, 1, 10)

--- a/apps/backend/tests/services/test_evidence_lineage.py
+++ b/apps/backend/tests/services/test_evidence_lineage.py
@@ -1,0 +1,225 @@
+"""Evidence Graph foundation service tests."""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.services.evidence_lineage import DEFAULT_MAX_DEPTH, EvidenceLineageService
+
+
+@pytest.mark.asyncio
+async def test_AC18_7_4_node_and_edge_upserts_are_idempotent(db: AsyncSession):
+    """AC18.7.4: Evidence lineage service supports idempotent node and edge upsert."""
+    service = EvidenceLineageService()
+    user_id = uuid4()
+    source_entity_id = uuid4()
+    record_entity_id = uuid4()
+
+    source = await service.upsert_node(
+        db,
+        user_id=user_id,
+        node_kind="source_document",
+        entity_type="bank_statement",
+        entity_id=source_entity_id,
+        properties={"label": "May statement"},
+    )
+    source_again = await service.upsert_node(
+        db,
+        user_id=user_id,
+        node_kind="source_document",
+        entity_type="bank_statement",
+        entity_id=source_entity_id,
+        properties={"label": "May statement updated"},
+    )
+    record = await service.upsert_node(
+        db,
+        user_id=user_id,
+        node_kind="extracted_record",
+        entity_type="bank_statement_transaction",
+        entity_id=record_entity_id,
+    )
+
+    edge = await service.upsert_edge(
+        db,
+        user_id=user_id,
+        from_node_id=source.id,
+        to_node_id=record.id,
+        relation="parsed_into",
+        properties={"parser": "fixture"},
+    )
+    edge_again = await service.upsert_edge(
+        db,
+        user_id=user_id,
+        from_node_id=source.id,
+        to_node_id=record.id,
+        relation="parsed_into",
+        properties={"parser": "fixture-v2"},
+    )
+
+    assert source_again.id == source.id
+    assert source_again.properties == {"label": "May statement updated"}
+    assert edge_again.id == edge.id
+    assert edge_again.properties == {"parser": "fixture-v2"}
+
+
+@pytest.mark.asyncio
+async def test_AC18_7_5_traversal_resolves_upstream_and_downstream_by_entity(db: AsyncSession):
+    """AC18.7.5: Evidence lineage traverses upstream and downstream within user scope."""
+    service = EvidenceLineageService()
+    user_id = uuid4()
+    source_entity_id = uuid4()
+    extracted_entity_id = uuid4()
+    atomic_entity_id = uuid4()
+
+    source = await service.upsert_node(
+        db,
+        user_id=user_id,
+        node_kind="source_document",
+        entity_type="bank_statement",
+        entity_id=source_entity_id,
+    )
+    extracted = await service.upsert_node(
+        db,
+        user_id=user_id,
+        node_kind="extracted_record",
+        entity_type="bank_statement_transaction",
+        entity_id=extracted_entity_id,
+    )
+    atomic = await service.upsert_node(
+        db,
+        user_id=user_id,
+        node_kind="atomic_fact",
+        entity_type="atomic_transaction",
+        entity_id=atomic_entity_id,
+    )
+    await service.upsert_edge(
+        db, user_id=user_id, from_node_id=source.id, to_node_id=extracted.id, relation="parsed_into"
+    )
+    await service.upsert_edge(
+        db,
+        user_id=user_id,
+        from_node_id=extracted.id,
+        to_node_id=atomic.id,
+        relation="deduped_into",
+    )
+
+    downstream = await service.get_downstream(
+        db,
+        user_id=user_id,
+        entity_type="bank_statement",
+        entity_id=source_entity_id,
+    )
+    upstream = await service.get_upstream(
+        db,
+        user_id=user_id,
+        entity_type="atomic_transaction",
+        entity_id=atomic_entity_id,
+    )
+
+    assert [(step.depth, step.edge.relation, step.node.entity_type) for step in downstream] == [
+        (1, "parsed_into", "bank_statement_transaction"),
+        (2, "deduped_into", "atomic_transaction"),
+    ]
+    assert [(step.depth, step.edge.relation, step.node.entity_type) for step in upstream] == [
+        (1, "deduped_into", "bank_statement_transaction"),
+        (2, "parsed_into", "bank_statement"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_AC18_7_6_traversal_enforces_depth_limit(db: AsyncSession):
+    """AC18.7.6: Evidence lineage traversal never walks unbounded graphs."""
+    service = EvidenceLineageService()
+    user_id = uuid4()
+    entity_ids = [uuid4(), uuid4(), uuid4()]
+    first = await service.upsert_node(
+        db,
+        user_id=user_id,
+        node_kind="source_document",
+        entity_type="source",
+        entity_id=entity_ids[0],
+    )
+    second = await service.upsert_node(
+        db,
+        user_id=user_id,
+        node_kind="extracted_record",
+        entity_type="middle",
+        entity_id=entity_ids[1],
+    )
+    third = await service.upsert_node(
+        db,
+        user_id=user_id,
+        node_kind="atomic_fact",
+        entity_type="leaf",
+        entity_id=entity_ids[2],
+    )
+    await service.upsert_edge(db, user_id=user_id, from_node_id=first.id, to_node_id=second.id, relation="parsed_into")
+    await service.upsert_edge(db, user_id=user_id, from_node_id=second.id, to_node_id=third.id, relation="deduped_into")
+
+    one_hop = await service.get_downstream(
+        db,
+        user_id=user_id,
+        entity_type="source",
+        entity_id=entity_ids[0],
+        max_depth=1,
+    )
+
+    assert DEFAULT_MAX_DEPTH == 6
+    assert [(step.depth, step.node.entity_type) for step in one_hop] == [(1, "middle")]
+
+
+@pytest.mark.asyncio
+async def test_AC18_7_5_cross_user_edges_and_traversal_are_blocked(db: AsyncSession):
+    """AC18.7.5 AC18.7.7: Evidence lineage enforces user-scoped graph isolation."""
+    service = EvidenceLineageService()
+    user_a = uuid4()
+    user_b = uuid4()
+    shared_entity_id = uuid4()
+    source_a = await service.upsert_node(
+        db,
+        user_id=user_a,
+        node_kind="source_document",
+        entity_type="bank_statement",
+        entity_id=shared_entity_id,
+    )
+    source_b = await service.upsert_node(
+        db,
+        user_id=user_b,
+        node_kind="source_document",
+        entity_type="bank_statement",
+        entity_id=shared_entity_id,
+    )
+    target_a = await service.upsert_node(
+        db,
+        user_id=user_a,
+        node_kind="extracted_record",
+        entity_type="bank_statement_transaction",
+        entity_id=uuid4(),
+    )
+
+    with pytest.raises(ValueError, match="same user"):
+        await service.upsert_edge(
+            db,
+            user_id=user_a,
+            from_node_id=source_b.id,
+            to_node_id=target_a.id,
+            relation="parsed_into",
+        )
+
+    await service.upsert_edge(
+        db,
+        user_id=user_a,
+        from_node_id=source_a.id,
+        to_node_id=target_a.id,
+        relation="parsed_into",
+    )
+    user_b_downstream = await service.get_downstream(
+        db,
+        user_id=user_b,
+        entity_type="bank_statement",
+        entity_id=shared_entity_id,
+    )
+
+    assert source_a.id != source_b.id
+    assert user_b_downstream == []

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -270,6 +270,18 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
 | AC18.4.3 | 4 | AI CSV parsing handles unknown institutions as fallback |
 | AC18.4.4 | 4 | Income statements include applied Layer 3 classification coverage |
 
+### AC18.7: Evidence Graph Foundation
+
+| AC ID | Phase | Description |
+|-------|-------|-------------|
+| AC18.7.1 | Evidence lineage | Evidence Graph SSOT defines nodes as auditable states, edges as transformation processes, allowed foundation node/edge fields, traversal direction, and append-only edge rules |
+| AC18.7.2 | Evidence lineage | Alembic migration creates `evidence_nodes` and `evidence_edges` with user-scoped entity lookup and edge traversal indexes |
+| AC18.7.3 | Evidence lineage | SQLAlchemy models expose `EvidenceNode` and `EvidenceEdge` with JSONB properties and user-owned isolation |
+| AC18.7.4 | Evidence lineage | Evidence lineage service supports idempotent node and edge upsert keyed by user, entity identity, node kind, relation, and edge endpoints |
+| AC18.7.5 | Evidence lineage | Evidence lineage service resolves entity nodes and traverses upstream and downstream paths only within the authenticated user scope |
+| AC18.7.6 | Evidence lineage | Evidence lineage traversal enforces a default maximum depth and never walks unbounded graphs |
+| AC18.7.7 | Evidence lineage | Evidence Graph foundation tests cover node creation, edge creation, duplicate upsert behavior, upstream traversal, downstream traversal, depth limit, and cross-user isolation |
+
 ### AC18.6: Framework Measurement and Disclosure Suggestions
 
 | AC ID | Phase | Description |
@@ -358,3 +370,4 @@ rather than duplicated.
 These non-EPIC docs are part of this EPIC's maintained surface:
 
 - [../ssot/source-type-priority.md](../ssot/source-type-priority.md) — confidence and source trust hierarchy used by AI-assisted flows.
+- [../ssot/evidence-lineage.md](../ssot/evidence-lineage.md) — generic Evidence Graph contract for source-to-report audit lineage.

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -194,6 +194,14 @@ concepts:
       - docs/ssot/confirmation-workflow.md
       - docs/ssot/reporting.md
 
+  evidence_lineage:
+    owner: docs/ssot/evidence-lineage.md
+    description: Generic Evidence Graph for source-to-ledger-to-report audit lineage.
+    cross_refs:
+      - docs/project/EPIC-018.ai-driven-pipeline.md
+      - docs/ssot/workflow-events.md
+      - docs/ssot/reporting.md
+
   # ── Observability ──────────────────────────────────────────────────────
   observability_logging:
     owner: docs/ssot/observability.md

--- a/docs/ssot/evidence-lineage.md
+++ b/docs/ssot/evidence-lineage.md
@@ -1,0 +1,135 @@
+# Evidence Lineage
+
+> **SSOT Key**: `evidence_lineage`
+> **Owner EPIC**: EPIC-018
+> **Purpose**: Define the generic Evidence Graph used to audit how source facts become ledger and report facts.
+
+## Scope
+
+Evidence lineage is a PostgreSQL-backed adjacency-list graph. It records
+auditable states and the transformation processes between them.
+
+```text
+node = auditable state
+edge = transformation or calculation process
+```
+
+This layer does not replace double-entry bookkeeping. Journal entries and
+journal lines remain the accounting source of truth. Evidence lineage records
+how source, extracted, atomic, ledger, and report entities are connected.
+
+## Tables
+
+The foundation owns two generic tables:
+
+```text
+evidence_nodes
+- id
+- user_id
+- node_kind
+- entity_type
+- entity_id
+- properties jsonb
+- created_at
+- updated_at
+```
+
+```text
+evidence_edges
+- id
+- user_id
+- from_node_id
+- to_node_id
+- relation
+- properties jsonb
+- created_at
+- updated_at
+```
+
+`properties` is only for small audit metadata such as confidence summaries,
+algorithm names, score snapshots, or source labels. Large OCR text, PDFs, CSV
+content, and provider payloads must stay in their owning business tables or
+object storage.
+
+## Node Kinds
+
+Initial node kinds are:
+
+- `source_document`
+- `extracted_record`
+- `atomic_fact`
+- `review_decision`
+- `ledger_entry`
+- `ledger_line`
+- `report_line`
+- `package_snapshot`
+
+New node kinds are allowed when a new business workflow needs a distinct
+auditable state. They must be documented in the owning EPIC before use.
+
+## Relations
+
+Initial relation names are process-oriented:
+
+- `parsed_into`
+- `deduped_into`
+- `reviewed_as`
+- `posted_as`
+- `contains`
+- `aggregated_into`
+- `included_in`
+- `supports`
+- `superseded_by`
+- `corrected_by`
+
+Do not use generic relations such as `related_to` for product lineage. The
+relation should explain why one state can support or transform into the next.
+
+## Identity
+
+A node is uniquely identified by:
+
+```text
+user_id + node_kind + entity_type + entity_id
+```
+
+An edge is idempotent by:
+
+```text
+user_id + from_node_id + to_node_id + relation
+```
+
+Business tables keep their own primary keys. Evidence lineage references them
+through `entity_type` and `entity_id` so future tables can join the graph
+without schema changes to the graph foundation.
+
+## Traversal
+
+All traversal queries must:
+
+- require `user_id`;
+- support upstream direction through `to_node_id`;
+- support downstream direction through `from_node_id`;
+- enforce a bounded maximum depth;
+- avoid loading large `properties` payloads into high-frequency UI summaries.
+
+The default maximum traversal depth is 6. Callers may request a smaller depth.
+Larger depths require a deliberate service-level override and test coverage.
+
+## Append-Only Edges
+
+Edges are append-oriented audit facts. Corrections should normally add
+`corrected_by` or `superseded_by` edges instead of mutating historical lineage.
+Foundation upsert is allowed only to keep identical writes idempotent.
+
+## Proof
+
+Foundation proof is owned by AC18.7 and must cover:
+
+- node creation;
+- edge creation;
+- duplicate upsert behavior;
+- upstream traversal;
+- downstream traversal;
+- depth limit enforcement;
+- cross-user isolation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - Market Data: ssot/market_data.md
       - Source Type Priority: ssot/source-type-priority.md
       - Workflow Events: ssot/workflow-events.md
+      - Evidence Lineage: ssot/evidence-lineage.md
       - Database Schema: ssot/schema.md
       - Observability: ssot/observability.md
       - Observability Logging: ssot/observability-logging.md


### PR DESCRIPTION
## Summary

Add the Evidence Graph foundation for user-scoped source-to-report audit lineage.

Closes #724

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-018 — AI-Driven Pipeline |
| **AC IDs** | AC18.7.1, AC18.7.2, AC18.7.3, AC18.7.4, AC18.7.5, AC18.7.6, AC18.7.7 |
| **AC source updated** | `docs/project/EPIC-018.ai-driven-pipeline.md` |

---

## SSOT Changes

- [x] `docs/ssot/MANIFEST.yaml` — added `evidence_lineage` concept ownership
- [x] `docs/ssot/evidence-lineage.md` — added Evidence Graph node, edge, identity, traversal, and proof contract
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | working tree before implementation | `tests/services/test_evidence_lineage.py` failed because `src.services.evidence_lineage` did not exist; migration contract failed before `0025_add_evidence_lineage.py` existed |
| Green (passing test) | `8430e6e` | Implemented migration, models, service, SSOT, and AC contract tests; focused tests pass |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter; this PR adds no new `sa.Enum`
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes
- [ ] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Not applicable; this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
uv run pytest -o addopts='' tests/services/test_evidence_lineage.py tests/infra/test_evidence_lineage_contract.py tests/infra/test_evidence_lineage_migration_contract.py
moon run :lint
python tools/generate_ac_registry.py --check
python tools/check_manifest.py && python tools/check_ssot_ownership.py && python tools/check_ac_traceability.py
```

`moon run :test` is currently blocked on this workstation before tests start because Podman cannot connect to its socket:

```text
Cannot connect to Podman ... dial tcp 127.0.0.1:61270: connect: connection refused
```

---

## Screenshots / Evidence

N/A

