### PR TITLE
[finance_report_vision] Add Advisor Brief UX

### DIFF
--- a/apps/backend/src/routers/chat.py
+++ b/apps/backend/src/routers/chat.py
@@ -213,6 +213,8 @@ async def delete_session(
 async def suggestions(
     language: str | None = Query(default=None, pattern="^(en|zh)$"),
     message: str | None = Query(default=None, max_length=4000),
+    db: DbSession = None,
+    user_id: CurrentUserId = None,
 ) -> ChatSuggestionsResponse:
     """Return a suggested question list for the chat UI."""
     resolved_language = language or (detect_language(message) if message else "en")
@@ -231,4 +233,11 @@ async def suggestions(
         "\u6709\u6ca1\u6709\u5f02\u5e38\u7684\u6d88\u8d39\u8d8b\u52bf\uff1f",
     ]
     suggestions = suggestions_zh if resolved_language == "zh" else suggestions_en
-    return ChatSuggestionsResponse(suggestions=suggestions)
+    structured_suggestions = []
+    if db is not None and user_id is not None:
+        try:
+            context = await AIAdvisorService().get_advisor_context(db, user_id)
+            structured_suggestions = context.get("suggestions") or []
+        except Exception as exc:
+            logger.warning("Failed to load structured chat suggestions", error=str(exc))
+    return ChatSuggestionsResponse(suggestions=suggestions, structured_suggestions=structured_suggestions)

--- a/apps/backend/tests/ai/test_chat_router.py
+++ b/apps/backend/tests/ai/test_chat_router.py
@@ -49,6 +49,40 @@ async def test_chat_suggestions_auto_detect_en() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.no_db
+async def test_AC21_3_1_chat_suggestions_include_structured_advisor_facts() -> None:
+    """AC21.3.1: Chat suggestions expose structured advisor facts without LLM prose parsing."""
+    from src.routers.chat import suggestions
+
+    advisor_fact = {
+        "basis": "Report package is blocked by one review-required item.",
+        "confidence_tier": "blocked",
+        "source_refs": ["workflow.status", "report_package.readiness"],
+        "limitation": "The report should not be treated as final until review is complete.",
+        "next_action_href": "/reports/package",
+    }
+    mock_db = MagicMock()
+    mock_user_id = uuid4()
+
+    with patch("src.routers.chat.AIAdvisorService") as MockService:
+        mock_service = MagicMock()
+        mock_service.get_advisor_context = AsyncMock(return_value={"suggestions": [advisor_fact]})
+        MockService.return_value = mock_service
+
+        response = await suggestions(language="en", db=mock_db, user_id=mock_user_id)
+
+    assert response.suggestions
+    assert len(response.structured_suggestions) == 1
+    structured = response.structured_suggestions[0]
+    assert structured.basis == advisor_fact["basis"]
+    assert structured.confidence_tier == "blocked"
+    assert structured.source_refs == ["workflow.status", "report_package.readiness"]
+    assert structured.limitation == advisor_fact["limitation"]
+    assert structured.next_action_href == "/reports/package"
+    mock_service.get_advisor_context.assert_awaited_once_with(mock_db, mock_user_id)
+
+
+@pytest.mark.asyncio
 async def test_detect_language_chinese() -> None:
     """AC6.2.1: Detect Chinese language."""
     from src.services.ai_advisor import detect_language

--- a/apps/frontend/playwright/advisor-brief.spec.ts
+++ b/apps/frontend/playwright/advisor-brief.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const COLD_ROUTE_TIMEOUT_MS = 10_000;
+
+const workflowStatus = {
+  primary_state: "needs_action",
+  next_action: { type: "review_required", count: 1, href: "/review", label: "Review required" },
+  report_readiness: { state: "blocked", blocking_count: 1, href: "/reports/package" },
+  event_counts: { unread: 1, action_required: 1, blocked: 0 },
+};
+
+const workflowEvents = {
+  total: 1,
+  items: [
+    {
+      id: "advisor-brief-review",
+      user_id: "advisor-user",
+      session_id: "advisor-session",
+      occurred_at: "2026-06-03T08:00:00Z",
+      family: "review.required",
+      severity: "action_required",
+      status: "unread",
+      title: "Review required",
+      summary: "Confirm one low-confidence extraction before reports are ready.",
+      source_type: "bank_statement",
+      source_id: "statement-review",
+      action_href: "/review",
+      report_impact: "blocked",
+      dedupe_key: "advisor-brief:review",
+      created_at: "2026-06-03T08:00:00Z",
+      updated_at: "2026-06-03T08:00:00Z",
+    },
+  ],
+  sessions: [
+    {
+      id: "advisor-session",
+      status: "active",
+      title: "Advisor Brief session",
+      summary: "Current upload, processing, review, and report-readiness work.",
+      started_at: "2026-06-03T07:00:00Z",
+      last_event_at: "2026-06-03T08:00:00Z",
+      source_count: 2,
+      primary_state: "needs_action",
+      report_readiness: { state: "blocked", blocking_count: 1, href: "/reports/package" },
+      event_counts: { unread: 1, action_required: 1, blocked: 0 },
+    },
+  ],
+};
+
+const chatSuggestions = {
+  suggestions: ["How is my Advisor Brief?"],
+  structured_suggestions: [
+    {
+      basis: "Report package is blocked by one review-required item.",
+      confidence_tier: "blocked",
+      source_refs: ["workflow.status", "report_package.readiness"],
+      limitation: "Review the blocker before relying on this report.",
+      next_action_href: "/reports/package",
+    },
+    {
+      basis: "Market prices are stale for one portfolio holding.",
+      confidence_tier: "stale",
+      source_refs: ["market_data.freshness"],
+      limitation: "Portfolio value may be outdated until prices refresh.",
+      next_action_href: "/portfolio/prices/update",
+    },
+  ],
+};
+
+async function installAdvisorBriefMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("finance_access_token", "advisor-brief-token");
+    localStorage.setItem("finance_user_id", "advisor-user");
+    localStorage.setItem("finance_user_email", "advisor@example.com");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    let body: unknown = {};
+
+    if (path === "/api/chat/suggestions") {
+      body = chatSuggestions;
+    } else if (path === "/api/workflow/status") {
+      body = workflowStatus;
+    } else if (path === "/api/workflow/events") {
+      body = workflowEvents;
+    } else if (path === "/api/accounts" || path === "/api/statements" || path.startsWith("/api/journal-entries")) {
+      body = { items: [], total: 0 };
+    } else if (path === "/api/accounts/processing/summary") {
+      body = { pending_count: 0, pending_total: "0.00", current_balance: "0.00", currency: "SGD", oldest_pending_date: null };
+    } else if (path.startsWith("/api/reports/balance-sheet")) {
+      body = {
+        as_of_date: "2026-06-03",
+        currency: "SGD",
+        assets: [{ account_id: "cash", name: "Cash", type: "ASSET", amount: "1000.00" }],
+        liabilities: [],
+        equity: [],
+        total_assets: "1000.00",
+        total_liabilities: "0.00",
+        total_equity: "1000.00",
+        equation_delta: "0.00",
+        is_balanced: true,
+      };
+    } else if (path.startsWith("/api/reports/income-statement")) {
+      body = {
+        start_date: "2026-01-01",
+        end_date: "2026-06-03",
+        currency: "SGD",
+        income: [],
+        expenses: [],
+        total_income: "0.00",
+        total_expenses: "0.00",
+        net_income: "0.00",
+        trends: [],
+      };
+    } else if (path.startsWith("/api/reports/trend")) {
+      body = { points: [] };
+    } else if (path === "/api/income/annualized") {
+      body = { annualized_salary: "0.00", annualized_bonus: "0.00", annualized_dividend: "0.00", annualized_total: "0.00", currency: "SGD", as_of: "2026-06-03" };
+    } else if (path === "/api/assets/restricted") {
+      body = [];
+    } else if (path === "/api/reconciliation/stats") {
+      body = { total_transactions: 0, matched_transactions: 0, unmatched_transactions: 0, pending_review: 0, auto_accepted: 0, match_rate: 0, score_distribution: {} };
+    } else if (path === "/api/reconciliation/unmatched") {
+      body = { items: [], total: 0 };
+    }
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+}
+
+async function expectNoDocumentHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    scrollX: window.scrollX,
+  }));
+
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.scrollX).toBe(0);
+}
+
+test.describe("AC21.3.4 Advisor Brief responsive layout", () => {
+  for (const scenario of [
+    { name: "desktop", viewport: { width: 1440, height: 1000 } },
+    { name: "mobile", viewport: { width: 390, height: 844 } },
+  ]) {
+    test(`${scenario.name} advisor-brief desktop and mobile layouts avoid horizontal overflow`, async ({ page }) => {
+      await page.setViewportSize(scenario.viewport);
+      await installAdvisorBriefMocks(page);
+
+      await page.goto("/dashboard", { waitUntil: "networkidle" });
+
+      const brief = page.getByLabel("Advisor Brief");
+      await expect(brief.getByRole("heading", { name: "Advisor Brief" })).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
+      await expect(brief.getByText("Readiness blocker")).toBeVisible();
+      await expect(brief.getByText("Refresh market data")).toBeVisible();
+      await expect(brief.getByRole("link", { name: "Open next action" }).nth(0)).toHaveAttribute("href", "/reports/package");
+      await expect(brief.getByRole("link", { name: "Open next action" }).nth(1)).toHaveAttribute("href", "/portfolio/prices");
+      await expect(brief.getByRole("link", { name: "Ask about this" }).nth(0)).toHaveAttribute("href", /\/chat\?prompt=/);
+      await expectNoDocumentHorizontalScroll(page);
+    });
+  }
+});

--- a/apps/frontend/src/__tests__/advisorBrief.test.tsx
+++ b/apps/frontend/src/__tests__/advisorBrief.test.tsx
@@ -42,6 +42,13 @@ const advisorSuggestions: AdvisorSuggestion[] = [
     limitation: "Portfolio value may be outdated until prices refresh.",
     next_action_href: "/portfolio/prices/update",
   },
+  {
+    basis: "Manual evidence exists for one asset but it is not yet trusted.",
+    confidence_tier: "unsupported",
+    source_refs: [],
+    limitation: "Manual evidence needs an internal support path before it can drive report conclusions.",
+    next_action_href: "/assets?filter=manual",
+  },
 ];
 
 describe("AdvisorBrief", () => {
@@ -53,9 +60,11 @@ describe("AdvisorBrief", () => {
     expect(screen.getByText("Ready facts")).toBeInTheDocument();
     expect(screen.getByText("Needs review")).toBeInTheDocument();
     expect(screen.getByText("Refresh market data")).toBeInTheDocument();
+    expect(screen.getByText("Advisor signal")).toBeInTheDocument();
     expect(screen.getByText("Report package is blocked by one review-required item.")).toBeInTheDocument();
     expect(screen.getByText("Do not rely on the final report until review is complete.")).toBeInTheDocument();
     expect(screen.getByText("workflow.status")).toBeInTheDocument();
+    expect(screen.getByText("source unavailable")).toBeInTheDocument();
 
     const cards = screen.getAllByTestId(/advisor-brief-card-/);
     const cardLinks = cards.map((card) => within(card).getByRole("link", { name: "Open next action" }));
@@ -64,6 +73,7 @@ describe("AdvisorBrief", () => {
       "/reports",
       "/review",
       "/portfolio/prices",
+      "/assets",
     ]);
     expect(safeAdvisorHref("https://evil.example/review")).toBe("/dashboard");
     expect(safeAdvisorHref("/portfolio/prices/update?source=advisor")).toBe("/portfolio/prices");

--- a/apps/frontend/src/__tests__/advisorBrief.test.tsx
+++ b/apps/frontend/src/__tests__/advisorBrief.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AdvisorBrief, safeAdvisorHref } from "@/components/advisor/AdvisorBrief";
+import type { AdvisorSuggestion } from "@/lib/types";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const advisorSuggestions: AdvisorSuggestion[] = [
+  {
+    basis: "Report package is blocked by one review-required item.",
+    confidence_tier: "blocked",
+    source_refs: ["workflow.status", "report_package.readiness"],
+    limitation: "Do not rely on the final report until review is complete.",
+    next_action_href: "/reports/package",
+  },
+  {
+    basis: "Balance sheet and income statement are ready from posted ledger entries.",
+    confidence_tier: "deterministic",
+    source_refs: ["reports.balance_sheet", "reports.income_statement"],
+    limitation: "This only reflects posted and reconciled ledger data.",
+    next_action_href: "/reports",
+  },
+  {
+    basis: "Two reconciliation items still need source confirmation.",
+    confidence_tier: "review_required",
+    source_refs: ["reconciliation.stats"],
+    limitation: "Unreviewed items can still change report totals.",
+    next_action_href: "/review",
+  },
+  {
+    basis: "Market prices are stale for one portfolio holding.",
+    confidence_tier: "stale",
+    source_refs: ["market_data.freshness"],
+    limitation: "Portfolio value may be outdated until prices refresh.",
+    next_action_href: "/portfolio/prices/update",
+  },
+];
+
+describe("AdvisorBrief", () => {
+  it("AC21.3.2 test_AC21_3_2_advisor_brief_renders_structured_cards_and_safe_routes", () => {
+    render(<AdvisorBrief suggestions={advisorSuggestions} />);
+
+    expect(screen.getByLabelText("Advisor Brief")).toBeInTheDocument();
+    expect(screen.getByText("Readiness blocker")).toBeInTheDocument();
+    expect(screen.getByText("Ready facts")).toBeInTheDocument();
+    expect(screen.getByText("Needs review")).toBeInTheDocument();
+    expect(screen.getByText("Refresh market data")).toBeInTheDocument();
+    expect(screen.getByText("Report package is blocked by one review-required item.")).toBeInTheDocument();
+    expect(screen.getByText("Do not rely on the final report until review is complete.")).toBeInTheDocument();
+    expect(screen.getByText("workflow.status")).toBeInTheDocument();
+
+    const cards = screen.getAllByTestId(/advisor-brief-card-/);
+    const cardLinks = cards.map((card) => within(card).getByRole("link", { name: "Open next action" }));
+    expect(cardLinks.map((link) => link.getAttribute("href"))).toEqual([
+      "/reports/package",
+      "/reports",
+      "/review",
+      "/portfolio/prices",
+    ]);
+    expect(safeAdvisorHref("https://evil.example/review")).toBe("/dashboard");
+    expect(safeAdvisorHref("/portfolio/prices/update?source=advisor")).toBe("/portfolio/prices");
+    expect(within(cards[0]).getByRole("link", { name: "Ask about this" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/chat?prompt="),
+    );
+  });
+});

--- a/apps/frontend/src/__tests__/chatPanelComponent.test.tsx
+++ b/apps/frontend/src/__tests__/chatPanelComponent.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import type { ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import ChatPanel from "@/components/ChatPanel"
@@ -13,6 +14,10 @@ vi.mock("@/lib/api", () => ({
 
 vi.mock("@/lib/aiModels", () => ({
   fetchAiModels: vi.fn(),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => <a href={href} {...props}>{children}</a>,
 }))
 
 function streamingResponse(text: string): Response {
@@ -63,7 +68,18 @@ describe("ChatPanel", () => {
 
     mockedApiFetch.mockImplementation((path: string) => {
       if (path.includes("/api/chat/suggestions")) {
-        return Promise.resolve({ suggestions: ["How is cash flow?"] })
+        return Promise.resolve({
+          suggestions: ["How is cash flow?"],
+          structured_suggestions: [
+            {
+              basis: "Report package is blocked by one review-required item.",
+              confidence_tier: "blocked",
+              source_refs: ["workflow.status", "report_package.readiness"],
+              limitation: "Review the blocker before relying on this report.",
+              next_action_href: "/reports/package",
+            },
+          ],
+        })
       }
       if (path.includes("/api/chat/history")) {
         return Promise.resolve({ sessions: [{ id: "sess-1", title: "Cash flow review", message_count: 0, messages: [] }] })
@@ -87,6 +103,22 @@ describe("ChatPanel", () => {
 
     await waitFor(() => expect(mockedApiStream).toHaveBeenCalled())
     await waitFor(() => expect(screen.getByText("Assistant answer")).toBeInTheDocument())
+  })
+
+  it("AC21.3.3 test_AC21_3_3_chat_panel_renders_contextual_advisor_brief", async () => {
+    render(<ChatPanel variant="page" />)
+
+    const brief = await screen.findByLabelText("Advisor Brief")
+    expect(within(brief).getByText("Report package is blocked by one review-required item.")).toBeInTheDocument()
+    expect(within(brief).getByText("Review the blocker before relying on this report.")).toBeInTheDocument()
+    expect(within(brief).getByRole("link", { name: "Open next action" })).toHaveAttribute("href", "/reports/package")
+    expect(within(brief).getByRole("link", { name: "Ask about this" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/chat?prompt="),
+    )
+
+    fireEvent.click(screen.getByText("How is cash flow?"))
+    await waitFor(() => expect(mockedApiStream).toHaveBeenCalled())
   })
 
   it("AC16.20.5 starts a new conversation from the active session", async () => {

--- a/apps/frontend/src/__tests__/dashboardPage.test.tsx
+++ b/apps/frontend/src/__tests__/dashboardPage.test.tsx
@@ -71,6 +71,25 @@ function mockDashboardApi(overrides: Record<string, unknown> = {}) {
         : baseBalance
       return Promise.resolve(hasOverride("balance") ? overrides.balance : defaultBalance)
     }
+    if (path.startsWith("/api/chat/suggestions")) {
+      if (overrides.chatSuggestionsError) return Promise.reject(overrides.chatSuggestionsError)
+      return Promise.resolve(
+        hasOverride("chatSuggestions")
+          ? overrides.chatSuggestions
+          : {
+              suggestions: ["How is my report readiness?"],
+              structured_suggestions: [
+                {
+                  basis: "Report package is blocked by one review-required item.",
+                  confidence_tier: "blocked",
+                  source_refs: ["workflow.status", "report_package.readiness"],
+                  limitation: "Review the blocker before relying on this report.",
+                  next_action_href: "/reports/package",
+                },
+              ],
+            },
+      )
+    }
     if (path.startsWith("/api/workflow/status")) {
       return Promise.resolve(
         hasOverride("workflowStatus")
@@ -291,6 +310,32 @@ describe("DashboardPage", () => {
     const workflowHome = screen.getByLabelText("Upload-to-report home")
     const totalAssets = screen.getByText("Total Assets")
     expect(Boolean(workflowHome.compareDocumentPosition(totalAssets) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
+  })
+
+  it("AC21.3.3 test_AC21_3_3_dashboard_renders_advisor_brief_before_analytics", async () => {
+    mockDashboardApi()
+
+    render(<DashboardPage />)
+
+    const brief = await screen.findByLabelText("Advisor Brief")
+    expect(within(brief).getByText("Report package is blocked by one review-required item.")).toBeInTheDocument()
+    expect(within(brief).getByRole("link", { name: "Open next action" })).toHaveAttribute("href", "/reports/package")
+    expect(within(brief).getByRole("link", { name: "Ask about this" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/chat?prompt="),
+    )
+    const analytics = screen.getByLabelText("Dashboard analytics")
+    expect(Boolean(brief.compareDocumentPosition(analytics) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
+  })
+
+  it("AC21.3.3 keeps dashboard analytics usable when Advisor Brief suggestions are unavailable", async () => {
+    mockDashboardApi({ chatSuggestionsError: new Error("advisor suggestions failed") })
+
+    render(<DashboardPage />)
+
+    await waitForDashboardAnalyticsReady()
+    expect(screen.queryByLabelText("Advisor Brief")).not.toBeInTheDocument()
+    expect(screen.getByText("Total Assets")).toBeInTheDocument()
   })
 
   it("AC19.4.3 follows workflow next_action for blocker and upload primary CTAs", async () => {

--- a/apps/frontend/src/app/(main)/dashboard/page.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Landmark, FileText, BookOpen } from "lucide-react";
 import ProcessingSummaryCard from "@/components/ProcessingSummaryCard";
 import { UploadToReportHomePanel } from "@/components/workflow/WorkflowNotifications";
+import { AdvisorBrief } from "@/components/advisor/AdvisorBrief";
 
 import { apiFetch } from "@/lib/api";
 import { formatDateInput, formatDateDisplay, formatMonthLabel } from "@/lib/date";
@@ -15,8 +16,10 @@ import { PieChart } from "@/components/charts/PieChart";
 import { TrendChart } from "@/components/charts/TrendChart";
 import {
   AccountListResponse,
+  AdvisorSuggestion,
   BankStatementListResponse,
   BalanceSheetResponse,
+  ChatSuggestionsResponse,
   AnnualizedIncomeResponse,
   IncomeStatementResponse,
   JournalEntryListResponse,
@@ -121,6 +124,7 @@ export default function DashboardPage() {
   const [unmatched, setUnmatched] = useState<UnmatchedTransactionsResponse | null>(null);
   const [recentEntries, setRecentEntries] = useState<JournalEntryListResponse | null>(null);
   const [onboardingStatus, setOnboardingStatus] = useState<OnboardingStatus | null>(null);
+  const [advisorSuggestions, setAdvisorSuggestions] = useState<AdvisorSuggestion[]>([]);
   const [annualizedIncome, setAnnualizedIncome] = useState<AnnualizedIncomeResponse | null>(null);
   const [restrictedHoldings, setRestrictedHoldings] = useState<RestrictedHolding[]>([]);
   const [includeRestricted, setIncludeRestricted] = useState(false);
@@ -146,6 +150,7 @@ export default function DashboardPage() {
         accountData,
         statementData,
         postedJournalData,
+        chatSuggestionsData,
       ] = await Promise.all([
         apiFetch<BalanceSheetResponse>(`/api/reports/balance-sheet?include_restricted=${includeRestricted ? "true" : "false"}`),
         apiFetch<IncomeStatementResponse>(`/api/reports/income-statement?start_date=${incomeStart}&end_date=${incomeEnd}`),
@@ -157,6 +162,10 @@ export default function DashboardPage() {
         apiFetch<AccountListResponse>("/api/accounts?limit=1"),
         apiFetch<BankStatementListResponse>("/api/statements"),
         apiFetch<JournalEntryListResponse>("/api/journal-entries?status_filter=posted&limit=1"),
+        apiFetch<ChatSuggestionsResponse>("/api/chat/suggestions?language=en").catch(() => ({
+          suggestions: [],
+          structured_suggestions: [],
+        })),
       ]);
       setBalanceSheet(normalizeBalanceSheet(balanceData));
       setIncomeStatement(normalizeIncomeStatement(incomeData));
@@ -171,6 +180,7 @@ export default function DashboardPage() {
         approvedStatementCount: statementData?.items?.filter((statement) => statement.status === "approved").length ?? 0,
         postedEntryCount: postedJournalData?.total ?? 0,
       });
+      setAdvisorSuggestions(chatSuggestionsData?.structured_suggestions ?? []);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load dashboard data.");
@@ -234,6 +244,12 @@ export default function DashboardPage() {
       <div className="mb-6">
         <UploadToReportHomePanel />
       </div>
+
+      {advisorSuggestions.length > 0 ? (
+        <div className="mb-6">
+          <AdvisorBrief suggestions={advisorSuggestions} />
+        </div>
+      ) : null}
 
       <section className="mb-6" aria-label="Dashboard analytics">
         <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/frontend/src/components/ChatPanel.tsx
+++ b/apps/frontend/src/components/ChatPanel.tsx
@@ -6,6 +6,8 @@ import { MessageSquareText, PanelLeft } from "lucide-react";
 
 import { apiFetch, apiStream, apiDelete } from "@/lib/api";
 import { fetchAiModels } from "@/lib/aiModels";
+import type { AdvisorSuggestion, ChatSuggestionsResponse } from "@/lib/types";
+import { AdvisorBrief } from "@/components/advisor/AdvisorBrief";
 import Sheet from "@/components/ui/Sheet";
 
 const DISCLAIMER_EN = "The above analysis is for reference only.";
@@ -26,7 +28,6 @@ interface ChatSessionResponse {
   messages: ChatMessageResponse[];
 }
 interface ChatHistoryResponse { sessions: ChatSessionResponse[]; }
-interface ChatSuggestionsResponse { suggestions: string[]; }
 interface ChatPanelProps { variant?: "page" | "widget"; initialPrompt?: string | null; onClose?: () => void; }
 
 const getBrowserLanguage = () => typeof window === "undefined" ? "en" : navigator.language.toLowerCase().startsWith("zh") ? "zh" : "en";
@@ -44,6 +45,7 @@ export default function ChatPanel({ variant = "page", initialPrompt, onClose }: 
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [advisorSuggestions, setAdvisorSuggestions] = useState<AdvisorSuggestion[]>([]);
   const [chatSessions, setChatSessions] = useState<ChatSessionResponse[]>([]);
   const [sessionsOpen, setSessionsOpen] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(true);
@@ -60,8 +62,10 @@ export default function ChatPanel({ variant = "page", initialPrompt, onClose }: 
     try { 
       const data = await apiFetch<ChatSuggestionsResponse>(`/api/chat/suggestions?language=${language}`);
       setSuggestions(data.suggestions || []); 
+      setAdvisorSuggestions(data.structured_suggestions || []);
     } catch { 
       setSuggestions([]); 
+      setAdvisorSuggestions([]);
     }
   }, [language]);
 
@@ -306,6 +310,10 @@ await apiDelete(`/api/chat/session/${sessionId}`);
         <div className="mt-4 flex flex-wrap gap-2">
           {suggestions.map((s) => <button key={s} onClick={() => void sendMessage(s)} className="badge badge-muted hover:bg-[var(--accent-muted)] hover:text-[var(--accent)] transition-colors cursor-pointer">{s}</button>)}
         </div>
+      )}
+
+      {advisorSuggestions.length > 0 && variant === "page" && (
+        <AdvisorBrief suggestions={advisorSuggestions} compact className="mt-4" />
       )}
 
       {error && <div className="mt-4 alert-error">{error}</div>}

--- a/apps/frontend/src/components/advisor/AdvisorBrief.tsx
+++ b/apps/frontend/src/components/advisor/AdvisorBrief.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import Link from "next/link";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  DatabaseZap,
+  LineChart,
+  MessageSquareText,
+  ShieldAlert,
+} from "lucide-react";
+
+import type { AdvisorSuggestion } from "@/lib/types";
+
+const SAFE_ROUTE_FALLBACK = "/dashboard";
+
+const ROUTE_MAP: Array<[RegExp, string]> = [
+  [/^\/reports\/package(?:[/?#].*)?$/, "/reports/package"],
+  [/^\/review(?:[/?#].*)?$/, "/review"],
+  [/^\/reconciliation\/review-queue(?:[/?#].*)?$/, "/reconciliation/review-queue"],
+  [/^\/portfolio\/prices(?:\/update)?(?:[/?#].*)?$/, "/portfolio/prices"],
+  [/^\/portfolio(?:[/?#].*)?$/, "/portfolio"],
+  [/^\/assets(?:[/?#].*)?$/, "/assets"],
+  [/^\/reports(?:[/?#].*)?$/, "/reports"],
+  [/^\/statements\/upload(?:[/?#].*)?$/, "/statements/upload"],
+];
+
+export function safeAdvisorHref(href: string): string {
+  const trimmed = href.trim();
+  const match = ROUTE_MAP.find(([pattern]) => pattern.test(trimmed));
+  return match ? match[1] : SAFE_ROUTE_FALLBACK;
+}
+
+function titleForSuggestion(suggestion: AdvisorSuggestion): string {
+  const tier = suggestion.confidence_tier.toLowerCase();
+  if (tier.includes("blocked")) return "Readiness blocker";
+  if (tier.includes("stale")) return "Refresh market data";
+  if (tier.includes("review")) return "Needs review";
+  if (tier.includes("deterministic")) return "Ready facts";
+  return "Advisor signal";
+}
+
+function iconForSuggestion(suggestion: AdvisorSuggestion) {
+  const tier = suggestion.confidence_tier.toLowerCase();
+  if (tier.includes("blocked")) return AlertTriangle;
+  if (tier.includes("stale")) return LineChart;
+  if (tier.includes("review")) return ShieldAlert;
+  if (tier.includes("deterministic")) return CheckCircle2;
+  return DatabaseZap;
+}
+
+function promptForSuggestion(suggestion: AdvisorSuggestion): string {
+  return [
+    "Explain this Advisor Brief item using only the cited application facts.",
+    `Basis: ${suggestion.basis}`,
+    `Limitation: ${suggestion.limitation}`,
+    `Sources: ${suggestion.source_refs.join(", ") || "not provided"}`,
+    `Next action: ${safeAdvisorHref(suggestion.next_action_href)}`,
+  ].join("\n");
+}
+
+interface AdvisorBriefProps {
+  suggestions: AdvisorSuggestion[];
+  title?: string;
+  description?: string;
+  compact?: boolean;
+  className?: string;
+}
+
+export function AdvisorBrief({
+  suggestions,
+  title = "Advisor Brief",
+  description = "Application guidance from structured readiness, trust, workflow, market, portfolio, and cash-flow facts.",
+  compact = false,
+  className = "",
+}: AdvisorBriefProps) {
+  if (!suggestions.length) return null;
+
+  return (
+    <section className={`card p-5 ${className}`} aria-label="Advisor Brief" data-testid="advisor-brief">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-xs font-mono text-muted">advisor_brief</p>
+          <h2 className="mt-1 text-lg font-semibold">{title}</h2>
+          {!compact ? <p className="mt-2 max-w-3xl text-sm text-muted">{description}</p> : null}
+        </div>
+        <Link
+          href={`/chat?prompt=${encodeURIComponent("Summarize my current Advisor Brief and list the safest next action.")}`}
+          className="btn-secondary inline-flex shrink-0 items-center justify-center gap-2 text-sm"
+        >
+          <MessageSquareText className="h-4 w-4" aria-hidden="true" />
+          Ask AI
+        </Link>
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        {suggestions.map((suggestion, index) => {
+          const Icon = iconForSuggestion(suggestion);
+          const safeHref = safeAdvisorHref(suggestion.next_action_href);
+          const titleText = titleForSuggestion(suggestion);
+          return (
+            <article
+              key={`${suggestion.confidence_tier}-${suggestion.basis}-${index}`}
+              className="min-w-0 rounded-panel border border-border bg-surface-card p-4"
+              data-testid={`advisor-brief-card-${index}`}
+            >
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-control bg-accent-muted text-accent">
+                  <Icon className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-sm font-semibold">{titleText}</h3>
+                    <span className="badge badge-muted">{suggestion.confidence_tier}</span>
+                  </div>
+                  <p className="mt-2 break-words text-sm">{suggestion.basis}</p>
+                  <p className="mt-2 break-words text-xs text-muted">{suggestion.limitation}</p>
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {suggestion.source_refs.length ? (
+                  suggestion.source_refs.map((source) => (
+                    <span key={source} className="badge badge-info">
+                      {source}
+                    </span>
+                  ))
+                ) : (
+                  <span className="badge badge-muted">source unavailable</span>
+                )}
+              </div>
+
+              <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+                <Link href={safeHref} className="btn-primary text-center text-sm">
+                  Open next action
+                </Link>
+                <Link
+                  href={`/chat?prompt=${encodeURIComponent(promptForSuggestion(suggestion))}`}
+                  className="btn-secondary text-center text-sm"
+                >
+                  Ask about this
+                </Link>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -228,6 +228,19 @@ export interface PersonalReportPackageReadinessResponse {
   stale_since?: string | null;
 }
 
+export interface AdvisorSuggestion {
+  basis: string;
+  confidence_tier: string;
+  source_refs: string[];
+  limitation: string;
+  next_action_href: string;
+}
+
+export interface ChatSuggestionsResponse {
+  suggestions: string[];
+  structured_suggestions?: AdvisorSuggestion[];
+}
+
 export interface PersonalReportPackageNote {
   note_id: string;
   label: string;

--- a/docs/project/EPIC-021.application-ai-advisor.md
+++ b/docs/project/EPIC-021.application-ai-advisor.md
@@ -88,6 +88,15 @@ Not owned here:
 | AC21.2.2 | Prompt construction consumes structured advisor facts and must not describe blocked, stale, unreviewed, unsupported, or manual-trusted data as trusted | `test_AC21_2_2_prompt_consumes_structured_advisor_facts_without_trusting_blocked_state` | `apps/backend/tests/ai/test_ai_advisor_service.py` | P0 |
 | AC21.2.3 | Chat provider calls and persisted chat messages redact sensitive numeric fields while preserving read-only advisor behavior | `test_AC21_2_3_chat_stream_redacts_sensitive_numbers_before_provider_and_persistence` | `apps/backend/tests/ai/test_ai_advisor_service.py` | P0 |
 
+### AC21.3: Frontend Advisor Brief and Contextual Next Actions
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC21.3.1 | Chat suggestions endpoint exposes structured advisor suggestions to the frontend without relying on LLM prose parsing | `test_AC21_3_1_chat_suggestions_include_structured_advisor_facts` | `apps/backend/tests/ai/test_chat_router.py` | P0 |
+| AC21.3.2 | Advisor Brief renders blocked, ready, review-required, and stale-market-data cards with source basis, limitation, and safe internal action links | `test_AC21_3_2_advisor_brief_renders_structured_cards_and_safe_routes` | `apps/frontend/src/__tests__/advisorBrief.test.tsx` | P0 |
+| AC21.3.3 | Chat and dashboard surfaces expose contextual Ask AI links that seed a scoped prompt without losing existing chat behavior | `test_AC21_3_3_chat_panel_renders_contextual_advisor_brief`, `test_AC21_3_3_dashboard_renders_advisor_brief_before_analytics` | `apps/frontend/src/__tests__/chatPanelComponent.test.tsx`, `apps/frontend/src/__tests__/dashboardPage.test.tsx` | P0 |
+| AC21.3.4 | Advisor Brief keeps desktop and mobile layouts free of horizontal overflow | `advisor-brief desktop and mobile layouts avoid horizontal overflow` | `apps/frontend/playwright/advisor-brief.spec.ts` | P1 |
+
 ## Planned Implementation Slices
 
 These are issue-scoped follow-ups. They should add their own AC IDs only when
@@ -99,7 +108,8 @@ their tests are introduced.
    readiness, source trust, workflow blockers, pending review, market freshness,
    portfolio, and cash-flow state. This slice owns AC21.2.1 through AC21.2.3.
 3. PR3 - Frontend Advisor Brief: render structured cards, safe next-action
-   routes, and contextual chat entry points.
+   routes, and contextual chat entry points. This slice owns AC21.3.1 through
+   AC21.3.4.
 
 ## Tracking Issues
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -100,7 +100,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `POST` | `/chat` | yes | - | `ChatRequest` | `200` - | Chat Message |
 | `GET` | `/chat/history` | yes | `session_id` (query), `limit` (query) | - | `200` `ChatHistoryResponse` | Chat History |
 | `DELETE` | `/chat/session/{session_id}` | yes | `session_id`* (path) | - | `204` - | Delete Session |
-| `GET` | `/chat/suggestions` | no | `language` (query), `message` (query) | - | `200` `ChatSuggestionsResponse` | Suggestions |
+| `GET` | `/chat/suggestions` | yes | `language` (query), `message` (query) | - | `200` `ChatSuggestionsResponse` | Suggestions |
 
 ### corrections
 

--- a/docs/ssot/ai.md
+++ b/docs/ssot/ai.md
@@ -88,6 +88,13 @@ serialized structured facts and must preserve blocked, stale, unreviewed,
 unsupported, and manual-trusted limitations instead of converting them into
 trusted conclusions.
 
+Frontend Advisor Brief surfaces consume
+`GET /api/chat/suggestions.structured_suggestions`; they must render structured
+facts directly rather than parsing LLM prose. Any `next_action_href` shown to
+users must be normalized through the Advisor Brief safe-route allowlist before
+link rendering, and contextual chat entry links must seed scoped prompts through
+`/chat?prompt=...` without clearing the user's existing chat session.
+
 ### 2.4 Financial Suggestion Scope
 
 The assistant may surface explainable personal-finance suggestions from trusted


### PR DESCRIPTION
## Summary

Adds the frontend Advisor Brief and contextual next-action UX for structured AI Advisor facts.

Closes #713

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-021 — Application-Layer AI Advisor |
| **AC IDs** | AC21.3.1, AC21.3.2, AC21.3.3, AC21.3.4 |
| **AC source updated** | `docs/project/EPIC-021.application-ai-advisor.md` |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/ai.md` — documents frontend Advisor Brief consumption of `structured_suggestions`, safe-route normalization, and contextual `/chat?prompt=...` links
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | Working tree before implementation | Added AC21.3 tests before making the frontend/backend changes pass; not split into a separate commit |
| 🟢 Green (passing test) | `035597b` | Implemented structured suggestions, Advisor Brief UI, dashboard/chat entry points, and responsive Playwright coverage |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable; no env changes)
- [x] `repo/` submodule updated for production config changes (if applicable; no config changes, verified `repo` main equals `origin/main` at `e154dcef84e87504d2ce7ae5313475432c4b4a3b`)
- [x] `tools/check_env_keys.py` passes (if env vars changed; no env vars changed)
- [x] `tools/check_manifest.py` passes (if SSOT files changed; AI SSOT owner already exists in MANIFEST)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: create/update/deploy/delete/cleanup/reconcile paths share one tool or explicitly documented owner. Not applicable; no infra lifecycle changes.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys. Not applicable; no logging changes.
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged. Not applicable.
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials. Not applicable.
- [x] Cleanup is scoped: PR-preview cleanup removes only Dokploy compose/GHCR PR artifacts; Docker volume/container leftovers are handled by the Dokploy host hygiene schedule. Not applicable.
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene. Not applicable; no infra changes.

---

## Testing

```bash
moon run :lint
npm run test -- advisorBrief.test.tsx chatPanelComponent.test.tsx dashboardPage.test.tsx
uv run pytest tests/ai/test_chat_router.py -q --no-cov -k AC21_3_1
npm run test:e2e -- advisor-brief.spec.ts
npm run build
python3 tools/generate_ac_registry.py --check
python3 tools/analyze_test_ac_coverage.py --stdout --no-write
```

Local note: `moon run :test -- --smart` was attempted, but the local Podman machine exits after startup and `podman compose` cannot connect to the socket. The PR CI should run the full DB-backed gate.

---

## Screenshots / Evidence

- Playwright AC21.3.4 covers desktop and mobile Advisor Brief layouts and asserts no horizontal overflow.
- Frontend unit tests cover blocked, deterministic, review-required, and stale-market-data Advisor Brief cards plus safe internal routes.