### PR TITLE
[finance_report_hacker] Harden auth and ledger boundaries

### DIFF
--- a/apps/backend/src/boot.py
+++ b/apps/backend/src/boot.py
@@ -25,6 +25,8 @@ logger = get_logger(__name__)
 
 VAULT_SECRETS_FILE_PATH = "/secrets/.env"
 VAULT_SECRETS_STALENESS_THRESHOLD_SECONDS = 3600
+DEVELOPMENT_SECRET_KEY = "dev_secret_key_change_in_prod"
+PROTECTED_ENVIRONMENTS = frozenset({"staging", "production"})
 
 
 class BootMode(str, Enum):
@@ -167,6 +169,19 @@ class Bootloader:
         try:
             # Just accessing settings triggers validation
             _ = settings.database_url
+            environment = str(getattr(settings, "environment", "")).lower()
+            secret_key = getattr(settings, "secret_key", "")
+            if environment in PROTECTED_ENVIRONMENTS:
+                if not isinstance(secret_key, str) or not secret_key.strip():
+                    logger.error("SECRET_KEY is required in protected environments", environment=environment)
+                    return False
+                normalized_secret = secret_key.strip()
+                if normalized_secret == DEVELOPMENT_SECRET_KEY:
+                    logger.error("Default development SECRET_KEY is forbidden", environment=environment)
+                    return False
+                if len(normalized_secret.encode("utf-8")) < 32:
+                    logger.error("SECRET_KEY must be at least 32 bytes", environment=environment)
+                    return False
             return True
         except Exception as e:
             logger.error("Configuration load failed", error=str(e))

--- a/apps/backend/src/routers/users.py
+++ b/apps/backend/src/routers/users.py
@@ -2,52 +2,29 @@
 
 from uuid import UUID
 
-import bcrypt
 from fastapi import APIRouter, Query, status
 from sqlalchemy import func, select
 
-from src.deps import DbSession
+from src.deps import CurrentUserId, DbSession
 from src.models import User
 from src.schemas import UserCreate, UserListResponse, UserResponse, UserUpdate
 from src.utils import raise_bad_request, raise_not_found
 
 router = APIRouter(prefix="/users", tags=["users"])
 
-MOCK_USER_ID = UUID("00000000-0000-0000-0000-000000000001")
-
-
-def hash_password(password: str) -> str:
-    """Hash a password."""
-    salt = bcrypt.gensalt()
-    return bcrypt.hashpw(password.encode("utf-8"), salt).decode("utf-8")
-
-
-def get_current_user_id() -> UUID:
-    """Return mock user ID until authentication is implemented."""
-    return MOCK_USER_ID
-
 
 @router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 async def create_user(
     user_data: UserCreate,
-    db: DbSession = None,
+    user_id: CurrentUserId = None,
 ) -> UserResponse:
-    """Create a new user."""
-    result = await db.execute(select(User).where(User.email == user_data.email))
-    existing_user = result.scalar_one_or_none()
+    """Deprecated user creation route.
 
-    if existing_user:
-        raise_bad_request("Invalid registration data")
-
-    user = User(
-        email=user_data.email,
-        hashed_password=hash_password(user_data.password),
-    )
-    db.add(user)
-    await db.commit()
-    await db.refresh(user)
-
-    return UserResponse.model_validate(user)
+    Public registration is owned by /auth/register so this legacy route cannot
+    be used to create arbitrary users.
+    """
+    _ = (user_data, user_id)
+    raise_bad_request("Use /auth/register to create users")
 
 
 @router.get("", response_model=UserListResponse)
@@ -55,12 +32,14 @@ async def list_users(
     limit: int = Query(50, ge=1, le=100, description="Maximum items to return"),
     offset: int = Query(0, ge=0, description="Number of items to skip"),
     db: DbSession = None,
+    user_id: CurrentUserId = None,
 ) -> UserListResponse:
-    """List all users with pagination."""
-    count_result = await db.execute(select(func.count(User.id)))
+    """List the authenticated user's profile only."""
+    scoped_query = select(User).where(User.id == user_id)
+    count_result = await db.execute(select(func.count()).select_from(scoped_query.subquery()))
     total = count_result.scalar_one()
 
-    result = await db.execute(select(User).order_by(User.created_at.desc()).limit(limit).offset(offset))
+    result = await db.execute(scoped_query.order_by(User.created_at.desc()).limit(limit).offset(offset))
     users = result.scalars().all()
 
     return UserListResponse(
@@ -73,8 +52,12 @@ async def list_users(
 async def get_user(
     user_id: UUID,
     db: DbSession = None,
+    current_user_id: CurrentUserId = None,
 ) -> UserResponse:
-    """Get user by ID."""
+    """Get current user by ID without cross-user disclosure."""
+    if user_id != current_user_id:
+        raise_not_found("User")
+
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
 
@@ -89,8 +72,12 @@ async def update_user(
     user_id: UUID,
     user_data: UserUpdate,
     db: DbSession = None,
+    current_user_id: CurrentUserId = None,
 ) -> UserResponse:
-    """Update user details."""
+    """Update current user details without cross-user mutation."""
+    if user_id != current_user_id:
+        raise_not_found("User")
+
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
 

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -84,6 +84,10 @@ def validate_journal_posting_invariants(entry: JournalEntry) -> None:
 
     for line in entry.lines:
         account = line.account
+        if account is None:
+            raise ValidationError(f"Account {line.account_id} not found")
+        if account.user_id != entry.user_id:
+            raise ValidationError("Account does not belong to user")
         if account.is_system and entry.source_type != JournalEntrySourceType.SYSTEM:
             raise ValidationError(
                 "System accounts can only be used by system-generated entries. "
@@ -126,6 +130,7 @@ async def calculate_account_balance(db: AsyncSession, account_id: UUID, user_id:
         .join(JournalEntry)
         .where(JournalLine.account_id == account_id)
         .where(JournalLine.direction == Direction.DEBIT)
+        .where(JournalEntry.user_id == user_id)
         .where(JournalEntry.status.in_([JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED]))
     )
 
@@ -135,6 +140,7 @@ async def calculate_account_balance(db: AsyncSession, account_id: UUID, user_id:
         .join(JournalEntry)
         .where(JournalLine.account_id == account_id)
         .where(JournalLine.direction == Direction.CREDIT)
+        .where(JournalEntry.user_id == user_id)
         .where(JournalEntry.status.in_([JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED]))
     )
 
@@ -198,6 +204,7 @@ async def calculate_account_balances(
         .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
         .join(Account, JournalLine.account_id == Account.id)
         .where(Account.user_id == user_id)
+        .where(JournalEntry.user_id == user_id)
         .where(JournalLine.account_id.in_(account_ids))
         .where(JournalEntry.status.in_([JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED]))
         .group_by(JournalLine.account_id)
@@ -259,6 +266,28 @@ async def verify_accounting_equation(db: AsyncSession, user_id: UUID) -> bool:
     return abs(left_side - right_side) < Decimal("0.01")
 
 
+async def validate_line_account_ownership(
+    db: AsyncSession,
+    user_id: UUID,
+    account_ids: set[UUID],
+) -> dict[UUID, Account]:
+    """Load and validate that every line account belongs to the current user."""
+    if not account_ids:
+        return {}
+
+    result = await db.execute(select(Account).where(Account.id.in_(account_ids)))
+    accounts = {account.id: account for account in result.scalars().all()}
+
+    missing = account_ids - set(accounts)
+    if missing:
+        raise ValidationError(f"Account {next(iter(missing))} not found")
+
+    if any(account.user_id != user_id for account in accounts.values()):
+        raise ValidationError("Account does not belong to user")
+
+    return accounts
+
+
 async def create_journal_entry(
     db: AsyncSession,
     user_id: UUID,
@@ -268,6 +297,12 @@ async def create_journal_entry(
     source_type: JournalEntrySourceType = JournalEntrySourceType.MANUAL,
     source_id: UUID | None = None,
 ) -> JournalEntry:
+    await validate_line_account_ownership(
+        db,
+        user_id,
+        {line_data["account_id"] for line_data in lines_data},
+    )
+
     entry = JournalEntry(
         user_id=user_id,
         entry_date=entry_date,

--- a/apps/backend/tests/accounting/test_accounting.py
+++ b/apps/backend/tests/accounting/test_accounting.py
@@ -182,3 +182,31 @@ async def test_missing_currency_balances_as_base_currency():
     ]
 
     validate_journal_balance(lines)
+
+
+@pytest.mark.asyncio
+async def test_balance_validation_requires_fx_rate_for_foreign_currency_conversion():
+    """AC2.2.5: Balance conversion rejects non-base currency lines without fx_rate."""
+    lines = [
+        JournalLine(
+            id=uuid4(),
+            journal_entry_id=uuid4(),
+            account_id=uuid4(),
+            direction=Direction.DEBIT,
+            amount=Decimal("100.00"),
+            currency="USD",
+            fx_rate=None,
+        ),
+        JournalLine(
+            id=uuid4(),
+            journal_entry_id=uuid4(),
+            account_id=uuid4(),
+            direction=Direction.CREDIT,
+            amount=Decimal("100.00"),
+            currency="SGD",
+            fx_rate=None,
+        ),
+    ]
+
+    with pytest.raises(ValidationError, match="fx_rate required for currency USD"):
+        validate_journal_balance(lines)

--- a/apps/backend/tests/accounting/test_accounting_integration.py
+++ b/apps/backend/tests/accounting/test_accounting_integration.py
@@ -26,6 +26,7 @@ from src.models import (
 from src.services.accounting import (
     ValidationError,
     calculate_account_balance,
+    calculate_account_balances,
     create_journal_entry,
     post_journal_entry,
     verify_accounting_equation,
@@ -195,6 +196,141 @@ async def test_post_journal_entry_success(db: AsyncSession, bank_account, salary
 
     assert posted_entry.status == JournalEntryStatus.POSTED
     assert posted_entry.id == entry.id
+
+
+@pytest.mark.asyncio
+async def test_AC2_13_1_create_journal_entry_rejects_cross_user_account(
+    db: AsyncSession,
+    bank_account,
+    salary_account,
+    test_user_id,
+):
+    """AC2.13.1: Manual journal creation rejects lines using another user's account."""
+    other_user_id = uuid4()
+    other_account = Account(
+        user_id=other_user_id,
+        name="Other User Cash",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add(other_account)
+    await db.commit()
+    await db.refresh(other_account)
+
+    with pytest.raises(ValidationError, match="Account does not belong to user"):
+        await create_journal_entry(
+            db=db,
+            user_id=test_user_id,
+            entry_date=date.today(),
+            memo="Cross-user attempt",
+            lines_data=[
+                {"account_id": other_account.id, "direction": Direction.DEBIT, "amount": Decimal("10.00")},
+                {"account_id": salary_account.id, "direction": Direction.CREDIT, "amount": Decimal("10.00")},
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_AC2_13_2_post_journal_entry_rejects_cross_user_account(
+    db: AsyncSession,
+    bank_account,
+    salary_account,
+    test_user_id,
+):
+    """AC2.13.2: Posting validates that every line account belongs to the entry owner."""
+    other_user_id = uuid4()
+    other_account = Account(
+        user_id=other_user_id,
+        name="Other User Asset",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add(other_account)
+    await db.flush()
+
+    entry = JournalEntry(
+        user_id=test_user_id,
+        entry_date=date.today(),
+        memo="Cross-user draft",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.DRAFT,
+    )
+    db.add(entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=other_account.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("25.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=salary_account.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("25.00"),
+                currency="SGD",
+            ),
+        ]
+    )
+    await db.commit()
+
+    with pytest.raises(ValidationError, match="Account does not belong to user"):
+        await post_journal_entry(db, entry.id, test_user_id)
+
+
+@pytest.mark.asyncio
+async def test_AC2_13_3_balance_queries_ignore_cross_user_entry_headers(
+    db: AsyncSession,
+    bank_account,
+    salary_account,
+    test_user_id,
+):
+    """AC2.13.3: Balance aggregation requires account and entry ownership to match."""
+    other_user_id = uuid4()
+    other_account = Account(
+        user_id=other_user_id,
+        name="Other User Cash",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add(other_account)
+    await db.flush()
+
+    polluted_entry = JournalEntry(
+        user_id=test_user_id,
+        entry_date=date.today(),
+        memo="Pollution attempt",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(polluted_entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=polluted_entry.id,
+                account_id=other_account.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("99.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=polluted_entry.id,
+                account_id=salary_account.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("99.00"),
+                currency="SGD",
+            ),
+        ]
+    )
+    await db.commit()
+
+    balances = await calculate_account_balances(db, [other_account], other_user_id)
+
+    assert balances[other_account.id] == Decimal("0")
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/accounting/test_accounting_integration.py
+++ b/apps/backend/tests/accounting/test_accounting_integration.py
@@ -29,6 +29,8 @@ from src.services.accounting import (
     calculate_account_balances,
     create_journal_entry,
     post_journal_entry,
+    validate_journal_posting_invariants,
+    validate_line_account_ownership,
     verify_accounting_equation,
     void_journal_entry,
 )
@@ -231,6 +233,29 @@ async def test_AC2_13_1_create_journal_entry_rejects_cross_user_account(
 
 
 @pytest.mark.asyncio
+async def test_AC2_13_1_line_account_ownership_accepts_empty_line_set(
+    db: AsyncSession,
+    test_user_id,
+):
+    """AC2.13.1: Empty line account sets short-circuit without a database lookup."""
+    accounts = await validate_line_account_ownership(db, test_user_id, set())
+
+    assert accounts == {}
+
+
+@pytest.mark.asyncio
+async def test_AC2_13_1_line_account_ownership_rejects_missing_account(
+    db: AsyncSession,
+    test_user_id,
+):
+    """AC2.13.1: Journal lines cannot reference nonexistent accounts."""
+    missing_account_id = uuid4()
+
+    with pytest.raises(ValidationError, match=f"Account {missing_account_id} not found"):
+        await validate_line_account_ownership(db, test_user_id, {missing_account_id})
+
+
+@pytest.mark.asyncio
 async def test_AC2_13_2_post_journal_entry_rejects_cross_user_account(
     db: AsyncSession,
     bank_account,
@@ -279,6 +304,40 @@ async def test_AC2_13_2_post_journal_entry_rejects_cross_user_account(
 
     with pytest.raises(ValidationError, match="Account does not belong to user"):
         await post_journal_entry(db, entry.id, test_user_id)
+
+
+@pytest.mark.asyncio
+async def test_AC2_13_2_posting_invariants_reject_line_with_missing_account_relationship(
+    test_user_id,
+):
+    """AC2.13.2: Posting invariants require every line to resolve to an account."""
+    missing_account_id = uuid4()
+    entry = JournalEntry(
+        user_id=test_user_id,
+        entry_date=date.today(),
+        memo="Missing account",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.DRAFT,
+    )
+    entry.lines = [
+        JournalLine(
+            journal_entry_id=uuid4(),
+            account_id=missing_account_id,
+            direction=Direction.DEBIT,
+            amount=Decimal("25.00"),
+            currency="SGD",
+        ),
+        JournalLine(
+            journal_entry_id=uuid4(),
+            account_id=uuid4(),
+            direction=Direction.CREDIT,
+            amount=Decimal("25.00"),
+            currency="SGD",
+        ),
+    ]
+
+    with pytest.raises(ValidationError, match=f"Account {missing_account_id} not found"):
+        validate_journal_posting_invariants(entry)
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/auth/test_users_router.py
+++ b/apps/backend/tests/auth/test_users_router.py
@@ -8,10 +8,12 @@ mutate other users.
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import User
+from src.routers.users import get_user, update_user
 from src.schemas.user import UserCreate, UserUpdate
 
 pytestmark = pytest.mark.asyncio
@@ -77,6 +79,18 @@ async def test_AC1_8_1_get_user_by_id_hides_other_users(
     assert response.status_code == 404
 
 
+async def test_AC1_8_1_get_user_by_id_returns_not_found_when_current_user_record_is_missing(
+    db: AsyncSession,
+) -> None:
+    """AC1.8.1: A valid token cannot disclose a deleted current-user row."""
+    missing_user_id = uuid4()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_user(user_id=missing_user_id, db=db, current_user_id=missing_user_id)
+
+    assert exc_info.value.status_code == 404
+
+
 async def test_AC1_8_1_update_user_email_allows_current_user(client: AsyncClient, test_user: User) -> None:
     """AC1.8.1: Current user can update their own email."""
     response = await client.put(f"/users/{test_user.id}", json={"email": "updated-current@example.com"})
@@ -102,6 +116,23 @@ async def test_AC1_8_1_update_user_email_hides_other_users(
 
     assert response.status_code == 404
     assert other.email == "victim@example.com"
+
+
+async def test_AC1_8_1_update_user_returns_not_found_when_current_user_record_is_missing(
+    db: AsyncSession,
+) -> None:
+    """AC1.8.1: A valid token cannot recreate a deleted current-user row via update."""
+    missing_user_id = uuid4()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_user(
+            user_id=missing_user_id,
+            user_data=UserUpdate(email="deleted@example.com"),
+            db=db,
+            current_user_id=missing_user_id,
+        )
+
+    assert exc_info.value.status_code == 404
 
 
 async def test_AC1_8_1_update_user_duplicate_email_rejected(

--- a/apps/backend/tests/auth/test_users_router.py
+++ b/apps/backend/tests/auth/test_users_router.py
@@ -1,351 +1,148 @@
-"""AC1.8.1 - AC1.8.1: User Management Endpoint Tests
+"""AC1.8.1: Authenticated user management endpoint tests.
 
-These tests validate user management endpoints including CRUD operations,
-pagination, duplicate detection, password requirements, and response serialization.
+The public registration surface is /auth/register. The legacy /users router is
+kept only for authenticated current-user operations and must not expose or
+mutate other users.
 """
 
-from datetime import UTC
+from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import User
+from src.schemas.user import UserCreate, UserUpdate
+
+pytestmark = pytest.mark.asyncio
 
 
-@pytest.mark.asyncio
-async def test_create_user_success(client: AsyncClient) -> None:
-    """Test creating a new user successfully."""
-    payload = {
-        "email": "test@example.com",
-        "password": "securepassword123",
-    }
-    response = await client.post("/users", json=payload)
-    assert response.status_code == 201
-    data = response.json()
-    assert data["email"] == "test@example.com"
-    assert "id" in data
-    assert "hashed_password" not in data
-    assert "created_at" in data
-    assert "updated_at" in data
+async def test_AC1_8_1_users_endpoints_require_auth(public_client: AsyncClient, test_user: User) -> None:
+    """AC1.8.1: Legacy /users endpoints reject unauthenticated callers."""
+    other_id = uuid4()
+
+    responses = [
+        await public_client.post("/users", json={"email": "new@example.com", "password": "securepassword123"}),
+        await public_client.get("/users"),
+        await public_client.get(f"/users/{test_user.id}"),
+        await public_client.put(f"/users/{other_id}", json={"email": "updated@example.com"}),
+    ]
+
+    assert [response.status_code for response in responses] == [401, 401, 401, 401]
 
 
-@pytest.mark.asyncio
-async def test_create_user_duplicate_email(client: AsyncClient) -> None:
-    """Test that creating a user with existing email fails with generic message."""
-    payload = {
-        "email": "duplicate@example.com",
-        "password": "securepassword123",
-    }
-    # First user succeeds
-    response = await client.post("/users", json=payload)
-    assert response.status_code == 201
+async def test_AC1_8_1_create_user_route_no_longer_registers_users(client: AsyncClient) -> None:
+    """AC1.8.1: User registration is constrained to /auth/register."""
+    response = await client.post(
+        "/users",
+        json={"email": "legacy-create@example.com", "password": "securepassword123"},
+    )
 
-    # Second user with same email fails with generic message
-    response = await client.post("/users", json=payload)
     assert response.status_code == 400
-    assert "Invalid registration data" in response.json()["detail"]
+    assert response.json()["detail"] == "Use /auth/register to create users"
 
 
-@pytest.mark.asyncio
-async def test_create_user_invalid_password(client: AsyncClient) -> None:
-    """Test that creating user with short password fails validation."""
-    payload = {
-        "email": "test@example.com",
-        "password": "short",  # Less than 8 characters
-    }
-    response = await client.post("/users", json=payload)
-    assert response.status_code == 422  # Validation error
-
-
-@pytest.mark.asyncio
-async def test_create_user_invalid_email(client: AsyncClient) -> None:
-    """Test that creating user with invalid email format fails validation."""
-    payload = {
-        "email": "not-an-email",
-        "password": "securepassword123",
-    }
-    # Note: client uses ASGITransport which bypasses real network,
-    # but Pydantic EmailStr still validates format.
-    response = await client.post("/users", json=payload)
-    assert response.status_code == 422  # Validation error
-
-
-@pytest.mark.asyncio
-async def test_list_users_empty(client: AsyncClient) -> None:
-    """Test listing users when none exist."""
-    # The client fixture creates one test_user by default.
-    # So we expect 1 user, not 0.
+async def test_AC1_8_1_list_users_returns_only_current_user(client: AsyncClient, test_user: User) -> None:
+    """AC1.8.1: Listing users does not disclose other user records."""
     response = await client.get("/users")
+
     assert response.status_code == 200
     data = response.json()
-    assert len(data["items"]) == 1
     assert data["total"] == 1
+    assert [item["id"] for item in data["items"]] == [str(test_user.id)]
 
 
-@pytest.mark.asyncio
-async def test_list_users_with_data(client: AsyncClient) -> None:
-    """Test listing users after creating some."""
-    # Create 3 more users (total 4)
-    for i in range(3):
-        payload = {
-            "email": f"user{i}@example.com",
-            "password": "securepassword123",
-        }
-        await client.post("/users", json=payload)
+async def test_AC1_8_1_get_user_by_id_allows_current_user(client: AsyncClient, test_user: User) -> None:
+    """AC1.8.1: Current user can read their own profile through the legacy route."""
+    response = await client.get(f"/users/{test_user.id}")
 
-    response = await client.get("/users")
     assert response.status_code == 200
     data = response.json()
-    assert len(data["items"]) == 4
-    assert data["total"] == 4
+    assert data["id"] == str(test_user.id)
+    assert data["email"] == test_user.email
 
 
-@pytest.mark.asyncio
-async def test_list_users_pagination(client: AsyncClient) -> None:
-    """Test pagination parameters work correctly."""
-    # Create 5 users (total 6)
-    for i in range(5):
-        payload = {
-            "email": f"pageuser{i}@example.com",
-            "password": "securepassword123",
-        }
-        await client.post("/users", json=payload)
+async def test_AC1_8_1_get_user_by_id_hides_other_users(
+    client: AsyncClient,
+    db: AsyncSession,
+) -> None:
+    """AC1.8.1: User lookups do not disclose another user's profile."""
+    other = User(email="other-user@example.com", hashed_password="hashed")
+    db.add(other)
+    await db.commit()
+    await db.refresh(other)
 
-    # Get first page
-    response = await client.get("/users?limit=2&offset=0")
-    assert response.status_code == 200
-    data = response.json()
-    assert len(data["items"]) == 2
-    assert data["total"] == 6
+    response = await client.get(f"/users/{other.id}")
 
-    # Get second page
-    response = await client.get("/users?limit=2&offset=2")
-    assert response.status_code == 200
-    data = response.json()
-    assert len(data["items"]) == 2
-    assert data["total"] == 6
-
-
-@pytest.mark.asyncio
-async def test_get_user_by_id(client: AsyncClient) -> None:
-    """Test getting a user by their ID."""
-    # Create user
-    create_payload = {
-        "email": "getme@example.com",
-        "password": "securepassword123",
-    }
-    create_response = await client.post("/users", json=create_payload)
-    user_id = create_response.json()["id"]
-
-    # Get user
-    response = await client.get(f"/users/{user_id}")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["id"] == user_id
-    assert data["email"] == "getme@example.com"
-
-
-@pytest.mark.asyncio
-async def test_get_user_not_found(client: AsyncClient) -> None:
-    """Test getting a non-existent user returns generic 404 message."""
-    import uuid
-
-    fake_id = str(uuid.uuid4())
-    response = await client.get(f"/users/{fake_id}")
     assert response.status_code == 404
-    assert "not found" in response.json()["detail"].lower()
 
 
-@pytest.mark.asyncio
-async def test_update_user_email(client: AsyncClient) -> None:
-    """Test updating a user's email."""
-    # Create user
-    create_payload = {
-        "email": "update@example.com",
-        "password": "securepassword123",
-    }
-    create_response = await client.post("/users", json=create_payload)
-    user_id = create_response.json()["id"]
+async def test_AC1_8_1_update_user_email_allows_current_user(client: AsyncClient, test_user: User) -> None:
+    """AC1.8.1: Current user can update their own email."""
+    response = await client.put(f"/users/{test_user.id}", json={"email": "updated-current@example.com"})
 
-    # Update email
-    update_payload = {"email": "updated@example.com"}
-    response = await client.put(f"/users/{user_id}", json=update_payload)
     assert response.status_code == 200
     data = response.json()
-    assert data["email"] == "updated@example.com"
-    assert data["id"] == user_id
+    assert data["id"] == str(test_user.id)
+    assert data["email"] == "updated-current@example.com"
 
 
-@pytest.mark.asyncio
-async def test_update_user_duplicate_email(client: AsyncClient) -> None:
-    """Test that updating to an existing email fails with generic message."""
-    # Create two users
-    payload1 = {
-        "email": "user1@test.com",
-        "password": "securepassword123",
-    }
-    payload2 = {
-        "email": "user2@test.com",
-        "password": "securepassword123",
-    }
-    await client.post("/users", json=payload1)
-    user2_response = await client.post("/users", json=payload2)
-    user2_id = user2_response.json()["id"]
+async def test_AC1_8_1_update_user_email_hides_other_users(
+    client: AsyncClient,
+    db: AsyncSession,
+) -> None:
+    """AC1.8.1: Current user cannot mutate another user's email."""
+    other = User(email="victim@example.com", hashed_password="hashed")
+    db.add(other)
+    await db.commit()
+    await db.refresh(other)
 
-    # Try to update user2 with user1's email - should get generic error
-    update_payload = {"email": "user1@test.com"}
-    response = await client.put(f"/users/{user2_id}", json=update_payload)
+    response = await client.put(f"/users/{other.id}", json={"email": "taken-over@example.com"})
+    await db.refresh(other)
+
+    assert response.status_code == 404
+    assert other.email == "victim@example.com"
+
+
+async def test_AC1_8_1_update_user_duplicate_email_rejected(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC1.8.1: Current-user update still enforces email uniqueness."""
+    other = User(email="existing@example.com", hashed_password="hashed")
+    db.add(other)
+    await db.commit()
+
+    response = await client.put(f"/users/{test_user.id}", json={"email": "existing@example.com"})
+
     assert response.status_code == 400
-    assert "Invalid update data" in response.json()["detail"]
-
-
-@pytest.mark.asyncio
-async def test_update_user_not_found(client: AsyncClient) -> None:
-    """Test updating a non-existent user returns 404."""
-    import uuid
-
-    fake_id = str(uuid.uuid4())
-    response = await client.put(f"/users/{fake_id}", json={"email": "new@example.com"})
-    assert response.status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_password_is_hashed(client: AsyncClient) -> None:
-    """Test that passwords are stored as hashes, not plain text."""
-    payload = {
-        "email": "hash@example.com",
-        "password": "myplainpassword",
-    }
-    response = await client.post("/users", json=payload)
-    assert response.status_code == 201
-
-    # Verify response doesn't contain plain password
-    data = response.json()
-    assert data["email"] == "hash@example.com"
-    assert "password" not in data
-    assert "hashed_password" not in data  # Response schema doesn't expose it
-
-
-@pytest.mark.asyncio
-async def test_user_response_timezone_aware(client: AsyncClient) -> None:
-    """Test that response timestamps are timezone-aware."""
-    payload = {
-        "email": "timezone@example.com",
-        "password": "securepassword123",
-    }
-    response = await client.post("/users", json=payload)
-    assert response.status_code == 201
-    data = response.json()
-
-    # Check created_at is timezone-aware (contains Z or +00:00)
-    assert "Z" in data["created_at"] or "+00:00" in data["created_at"] or "T00:00:00+00:00" in data["created_at"]
+    assert response.json()["detail"] == "Invalid update data"
 
 
 class TestUserSchemas:
     """Unit tests for user schemas without database."""
 
-    def test_user_create_schema_valid(self):
-        """Test UserCreate schema with valid data."""
-        from src.schemas.user import UserCreate
-
+    def test_user_create_schema_valid(self) -> None:
         user = UserCreate(email="test@example.com", password="securepassword123")
         assert user.email == "test@example.com"
         assert user.password == "securepassword123"
 
-    def test_user_create_schema_invalid_email(self):
-        """Test UserCreate schema rejects invalid email."""
+    def test_user_create_schema_invalid_email(self) -> None:
         from pydantic import ValidationError
 
-        from src.schemas.user import UserCreate
-
-        try:
+        with pytest.raises(ValidationError):
             UserCreate(email="not-an-email", password="securepassword123")
-            assert False, "Should have raised ValidationError"
-        except ValidationError:
-            pass
 
-    def test_user_create_schema_short_password(self):
-        """Test UserCreate schema rejects short password."""
+    def test_user_create_schema_short_password(self) -> None:
         from pydantic import ValidationError
 
-        from src.schemas.user import UserCreate
-
-        try:
+        with pytest.raises(ValidationError):
             UserCreate(email="test@example.com", password="short")
-            assert False, "Should have raised ValidationError"
-        except ValidationError:
-            pass
 
-    def test_user_update_schema_optional_email(self):
-        """Test UserUpdate schema with optional email."""
-        from src.schemas.user import UserUpdate
+    def test_user_update_schema_optional_email(self) -> None:
+        update = UserUpdate()
+        assert update.email is None
 
-        user = UserUpdate()
-        assert user.email is None
-
-    def test_user_update_schema_with_email(self):
-        """Test UserUpdate schema with email provided."""
-        from src.schemas.user import UserUpdate
-
-        user = UserUpdate(email="new@example.com")
-        assert user.email == "new@example.com"
-
-    def test_user_response_schema(self):
-        """Test UserResponse schema."""
-        from datetime import datetime
-        from uuid import uuid4
-
-        from src.schemas.user import UserResponse
-
-        user_id = uuid4()
-        now = datetime.now(UTC)
-        user = UserResponse(
-            id=user_id,
-            email="test@example.com",
-            created_at=now,
-            updated_at=now,
-        )
-        assert user.id == user_id
-        assert user.email == "test@example.com"
-
-    def test_user_list_response_schema(self):
-        """Test UserListResponse schema."""
-        from datetime import datetime
-        from uuid import uuid4
-
-        from src.schemas.user import UserListResponse, UserResponse
-
-        now = datetime.now(UTC)
-        items = [
-            UserResponse(
-                id=uuid4(),
-                email="user1@example.com",
-                created_at=now,
-                updated_at=now,
-            ),
-            UserResponse(
-                id=uuid4(),
-                email="user2@example.com",
-                created_at=now,
-                updated_at=now,
-            ),
-        ]
-        response = UserListResponse(items=items, total=2)
-        assert len(response.items) == 2
-        assert response.total == 2
-
-    def test_user_response_timezone_conversion(self):
-        """Test UserResponse converts naive datetime to UTC."""
-        from datetime import datetime
-        from uuid import uuid4
-
-        from src.schemas.user import UserResponse
-
-        naive_dt = datetime(2026, 1, 12, 0, 0, 0)
-        user = UserResponse(
-            id=uuid4(),
-            email="test@example.com",
-            created_at=naive_dt,
-            updated_at=naive_dt,
-        )
-        # After validation, datetime should be timezone-aware
-        assert user.created_at.tzinfo is not None
-        assert user.updated_at.tzinfo is not None
+        update = UserUpdate(email="new@example.com")
+        assert update.email == "new@example.com"

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -152,6 +152,15 @@ class TestBootloaderStaticConfig:
 
         assert result is False
 
+    def test_AC1_10_1_static_config_rejects_blank_secret_key_in_production(self, mock_settings):
+        """AC1.10.1: Protected environments require a configured JWT secret."""
+        mock_settings.environment = "production"
+        mock_settings.secret_key = "   "
+
+        result = Bootloader._check_static_config()
+
+        assert result is False
+
     def test_AC1_10_1_static_config_allows_development_default_secret_key(self, mock_settings):
         """AC1.10.1: Local development keeps convenient defaults."""
         mock_settings.environment = "development"
@@ -415,6 +424,29 @@ class TestBootloaderOpenrouter:
 
             assert status.status == "ok"
             assert status.service == "ai_provider"
+
+    @pytest.mark.asyncio
+    async def test_check_openrouter_configured_catalog_skips_network_probe(self, mock_settings):
+        mock_settings.openrouter_api_key = "test-key"
+        mock_settings.ai_api_key = "test-key"
+        mock_settings.ai_model_catalog_source = "configured"
+
+        status = await Bootloader._check_openrouter()
+
+        assert status.status == "ok"
+        assert "Configured provider=" in status.message
+
+    @pytest.mark.asyncio
+    async def test_check_openrouter_remote_catalog_requires_base_url(self, mock_settings):
+        mock_settings.openrouter_api_key = "test-key"
+        mock_settings.ai_api_key = "test-key"
+        mock_settings.ai_base_url = None
+        mock_settings.openrouter_base_url = None
+
+        status = await Bootloader._check_openrouter()
+
+        assert status.status == "error"
+        assert status.message == "Base URL not configured"
 
     @pytest.mark.asyncio
     async def test_check_openrouter_auth_failure(self, mock_settings):

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -10,6 +10,7 @@ from src.boot import Bootloader, Bootloader as BootloaderClass, BootMode, Servic
 
 _ORIGINAL_CHECK_DATABASE = BootloaderClass._check_database
 ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+pytestmark = pytest.mark.no_db
 
 
 @pytest.fixture
@@ -131,6 +132,33 @@ class TestBootloader:
 class TestBootloaderStaticConfig:
     def test_check_static_config_success(self, mock_settings):
         result = Bootloader._check_static_config()
+        assert result is True
+
+    def test_AC1_10_1_static_config_rejects_default_secret_key_in_production(self, mock_settings):
+        """AC1.10.1: Production startup refuses the development JWT secret."""
+        mock_settings.environment = "production"
+        mock_settings.secret_key = "dev_secret_key_change_in_prod"
+
+        result = Bootloader._check_static_config()
+
+        assert result is False
+
+    def test_AC1_10_1_static_config_rejects_short_secret_key_in_staging(self, mock_settings):
+        """AC1.10.1: Staging startup requires a high-entropy JWT secret."""
+        mock_settings.environment = "staging"
+        mock_settings.secret_key = "short-secret"
+
+        result = Bootloader._check_static_config()
+
+        assert result is False
+
+    def test_AC1_10_1_static_config_allows_development_default_secret_key(self, mock_settings):
+        """AC1.10.1: Local development keeps convenient defaults."""
+        mock_settings.environment = "development"
+        mock_settings.secret_key = "dev_secret_key_change_in_prod"
+
+        result = Bootloader._check_static_config()
+
         assert result is True
 
     def test_check_static_config_failure(self):

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -2,9 +2,55 @@ export function shouldProxyApiToLocalBackend() {
     return process.env.NODE_ENV !== 'production' && (process.env.NEXT_PUBLIC_API_URL ?? '') === '';
 }
 
+const securityHeaders = [
+    {
+        key: 'Content-Security-Policy',
+        value: [
+            "default-src 'self'",
+            "base-uri 'self'",
+            "object-src 'none'",
+            "frame-ancestors 'none'",
+            "img-src 'self' data: blob:",
+            "font-src 'self' data:",
+            "style-src 'self' 'unsafe-inline'",
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+            "connect-src 'self' https://*.zitian.party",
+            "form-action 'self'",
+        ].join('; '),
+    },
+    {
+        key: 'Strict-Transport-Security',
+        value: 'max-age=31536000; includeSubDomains; preload',
+    },
+    {
+        key: 'X-Frame-Options',
+        value: 'DENY',
+    },
+    {
+        key: 'X-Content-Type-Options',
+        value: 'nosniff',
+    },
+    {
+        key: 'Referrer-Policy',
+        value: 'strict-origin-when-cross-origin',
+    },
+    {
+        key: 'Permissions-Policy',
+        value: 'camera=(), microphone=(), geolocation=(), payment=()',
+    },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
+    async headers() {
+        return [
+            {
+                source: '/:path*',
+                headers: securityHeaders,
+            },
+        ];
+    },
     async redirects() {
         return [
             {

--- a/apps/frontend/src/__tests__/api-urls.test.ts
+++ b/apps/frontend/src/__tests__/api-urls.test.ts
@@ -64,6 +64,27 @@ describe('API URL Configuration Scenarios', () => {
 
       expect(JSON.stringify(rewrites)).not.toContain('localhost:8000')
     })
+
+    it('AC1.10.2 configures browser security headers for localStorage bearer-token risk', async () => {
+      const { default: nextConfig } = await import('../../next.config.mjs')
+
+      expect(typeof nextConfig.headers).toBe('function')
+      const headerRules = typeof nextConfig.headers === 'function'
+        ? await nextConfig.headers()
+        : []
+      const headers = Object.fromEntries(
+        headerRules.flatMap((rule: { headers: Array<{ key: string; value: string }> }) =>
+          rule.headers.map((header) => [header.key, header.value])
+        )
+      )
+
+      expect(headers['Content-Security-Policy']).toContain("default-src 'self'")
+      expect(headers['Content-Security-Policy']).toContain("frame-ancestors 'none'")
+      expect(headers['Strict-Transport-Security']).toContain('max-age=31536000')
+      expect(headers['X-Frame-Options']).toBe('DENY')
+      expect(headers['Referrer-Policy']).toBe('strict-origin-when-cross-origin')
+      expect(headers['Permissions-Policy']).toContain('camera=()')
+    })
   })
 
   describe('PR Environment', () => {

--- a/docs/project/EPIC-001.phase0-setup.md
+++ b/docs/project/EPIC-001.phase0-setup.md
@@ -137,6 +137,13 @@ Set up a runnable Monorepo development environment, complete user authentication
 |----|-------------|---------------|------|
 | AC1.9.1 | A new user can register, log in, create first ledger accounts, post a first manual entry, and preserve the accounting equation | `test_AC1_9_1_first_run_registration_account_entry_journey` | `integration/test_onboarding_e2e.py` |
 
+### AC1.10: Auth & Browser Security Hardening
+
+| ID | Requirement | Test Function | File |
+|----|-------------|---------------|------|
+| AC1.10.1 | Staging and production startup reject missing, default, or short JWT `SECRET_KEY` values | `test_AC1_10_1_static_config_*` | `infra/test_boot.py` |
+| AC1.10.2 | Frontend responses include security headers that mitigate localStorage bearer-token exposure | `AC1.10.2 configures browser security headers for localStorage bearer-token risk` | `src/__tests__/api-urls.test.ts` |
+
 ## 📏 Acceptance Criteria
 
 ### 🟢 Must Have

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -205,6 +205,14 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 | AC2.12.2 | Accounting equation verification uses base-currency converted account balances | `test_AC2_12_2_accounting_equation_uses_base_currency_balances()` | `accounting/test_multicurrency_integrity.py` | P0 |
 | AC2.12.6 | Statement validation logic rejects invalid statement balance and transaction states | `test_validation.py` suite | `accounting/test_validation.py` | P0 |
 
+### AC2.13: User-Scoped Ledger Integrity
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC2.13.1 | Manual journal creation rejects lines using another user's account | `test_AC2_13_1_create_journal_entry_rejects_cross_user_account()` | `accounting/test_accounting_integration.py` | P0 |
+| AC2.13.2 | Posting validates that every line account belongs to the entry owner | `test_AC2_13_2_post_journal_entry_rejects_cross_user_account()` | `accounting/test_accounting_integration.py` | P0 |
+| AC2.13.3 | Balance aggregation requires account and entry ownership to match | `test_AC2_13_3_balance_queries_ignore_cross_user_entry_headers()` | `accounting/test_accounting_integration.py` | P0 |
+
 ## 📏 Acceptance Criteria
 
 > ℹ️ **Non-contiguous AC numbering**: Gaps in `AC2.x.y` numbers reflect deprecated or merged ACs preserved through generated registry indexes plus explicit overrides. Do **not** renumber. New ACs append to the next available index in this EPIC.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -239,10 +239,10 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 
 | Method | Path | Auth | Params | Request | Success responses | Summary |
 |---|---|---|---|---|---|---|
-| `GET` | `/users` | no | `limit` (query), `offset` (query) | - | `200` `ListResponse_UserResponse_` | List Users |
-| `POST` | `/users` | no | - | `UserCreate` | `201` `UserResponse` | Create User |
-| `GET` | `/users/{user_id}` | no | `user_id`* (path) | - | `200` `UserResponse` | Get User |
-| `PUT` | `/users/{user_id}` | no | `user_id`* (path) | `UserUpdate` | `200` `UserResponse` | Update User |
+| `GET` | `/users` | yes | `limit` (query), `offset` (query) | - | `200` `ListResponse_UserResponse_` | List Users |
+| `POST` | `/users` | yes | - | `UserCreate` | `201` `UserResponse` | Create User |
+| `GET` | `/users/{user_id}` | yes | `user_id`* (path) | - | `200` `UserResponse` | Get User |
+| `PUT` | `/users/{user_id}` | yes | `user_id`* (path) | `UserUpdate` | `200` `UserResponse` | Update User |
 
 ### workflow
 

--- a/docs/ssot/accounting.md
+++ b/docs/ssot/accounting.md
@@ -67,6 +67,7 @@ Debit and credit totals are valid only when their converted base amounts differ 
 - **Pattern B**: Use Decimal for precise calculations, tolerance < 0.01
 - **Pattern C**: Posted entries can only be voided, not directly modified
 - **Pattern D**: Multi-currency entries validate debit/credit balance after base-currency conversion.
+- **Pattern E**: Journal line account authorization is a domain invariant. Accounting services must validate that every `JournalLine.account_id` belongs to the same `user_id` as the `JournalEntry`; HTTP middleware is not sufficient because service calls and background tasks can write ledger records without a request object.
 
 ### ⛔ Prohibited Patterns
 
@@ -82,6 +83,7 @@ Debit and credit totals are valid only when their converted base amounts differ 
 - **Anti-pattern B**: **NEVER** allow unbalanced debit/credit entries. See: `apps/backend/tests/accounting/test_accounting_integration.py::test_post_unbalanced_entry_rejected`
 - **Anti-pattern C**: **NEVER** skip validation when writing posted status. See: `apps/backend/tests/accounting/test_accounting_integration.py::test_post_journal_entry_already_posted_fails`
 - **Anti-pattern E**: **NEVER** validate a multi-currency journal entry by comparing raw original-currency nominal amounts.
+- **Anti-pattern F**: **NEVER** create, post, or aggregate journal lines across user boundaries. Balance queries must require both `Account.user_id == user_id` and `JournalEntry.user_id == user_id`.
 
 <a id="async-tx-boundary"></a>
 
@@ -180,6 +182,7 @@ def void_entry(entry: JournalEntry, reason: str) -> JournalEntry:
 | Accounting equation | Integration test `test_accounting_equation` | ⏳ Pending |
 | Multi-currency base balance | Unit test `test_AC2_12_1_multicurrency_entry_balances_in_base_currency` | ✅ Implemented |
 | Accounting equation base conversion | Integration test `test_AC2_12_2_accounting_equation_uses_base_currency_balances` | ✅ Implemented |
+| User-scoped line ownership | Integration tests `test_AC2_13_1_*`, `test_AC2_13_2_*`, `test_AC2_13_3_*` | ✅ Implemented |
 | Void logic | Unit test `test_void_entry` | ⏳ Pending |
 
 ---

--- a/docs/ssot/auth.md
+++ b/docs/ssot/auth.md
@@ -13,9 +13,11 @@
 | User context dependency | `apps/backend/src/auth.py` | `get_current_user_id` JWT resolver |
 | Global security gate | `apps/backend/src/main.py` | CORS and security middleware configuration |
 | User registration API | `apps/backend/src/routers/auth.py` | Registration and login endpoints |
+| Legacy user profile API | `apps/backend/src/routers/users.py` | Authenticated current-user compatibility routes only |
 | User model | `apps/backend/src/models/user.py` | Persistence for valid user IDs |
 | Frontend auth context | `apps/frontend/src/lib/auth.ts` | User session management |
 | API fetch with auth | `apps/frontend/src/lib/api.ts` | Bearer token injection |
+| Frontend security headers | `apps/frontend/next.config.mjs` | CSP and browser security response headers |
 
 ---
 
@@ -94,6 +96,7 @@ sequenceDiagram
 **Scope**:
 - Accounts, journal entries, statements, reports, reconciliation, and chat endpoints.
 - Reconciliation endpoints **must** be authenticated and user-scoped via `get_current_user_id`. Unauthenticated access to reconciliation data is **prohibited**, including in MVP and test environments.
+- Legacy `/users` routes are not a public registration surface. Public registration is owned by `/auth/register`; `/users` may only expose authenticated current-user compatibility operations.
 
 ---
 
@@ -218,6 +221,15 @@ Authenticates user with email and password.
 - Constant-time password comparison
 - Rate limiting: 5 attempts per 15 minutes per IP
 - Generic error message (doesn't reveal if email exists)
+
+### Legacy `/users` Compatibility API
+
+The `/users` router is retained for compatibility only:
+
+- `POST /users` requires authentication and returns a migration error directing clients to `/auth/register`.
+- `GET /users` returns only the authenticated user's profile.
+- `GET /users/{user_id}` and `PUT /users/{user_id}` are allowed only when `user_id` matches the JWT subject; other user IDs return not found.
+- Unauthenticated access to any `/users` route returns `401 Unauthorized`.
 
 ### GET /api/auth/me
 
@@ -364,6 +376,14 @@ Before production deployment, ensure:
 4. **Rate limiting** - Configure appropriate limits for production traffic
 5. **Token lifetime** - Consider shorter expiration for sensitive operations
 6. **Monitoring** - Track failed auth attempts for security analysis
+
+The backend bootloader enforces the first requirement for staging and
+production by refusing to start with the development default secret, an empty
+secret, or a secret shorter than 32 bytes.
+
+The frontend must emit security headers, including a Content Security Policy
+with `frame-ancestors 'none'`, because the current token storage model uses
+`localStorage`.
 
 ---
 

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -408,10 +408,10 @@ def test_AC8_13_72_deploy_action_reads_effective_env_before_deploy(
     assert "MINIO_ROOT_PASSWORD" not in rendered_calls
 
 
-def test_AC8_13_98_existing_preview_compose_is_replaced_before_deploy(
+def test_AC8_13_98_existing_preview_compose_is_stopped_deployed_and_started(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC8.13.98: Existing PR previews are recreated to force fresh rollout state."""
+    """AC8.13.98: Existing PR previews restart around deploy."""
     lifecycle = lifecycle_module()
     calls: list[list[str]] = []
 
@@ -438,13 +438,6 @@ def test_AC8_13_98_existing_preview_compose_is_replaced_before_deploy(
                 cmd,
                 0,
                 stdout='{"compose":[{"name":"pr-591","composeId":"cmp-591"}]}',
-                stderr="",
-            )
-        if "compose.create" in rendered:
-            return subprocess.CompletedProcess(
-                cmd,
-                0,
-                stdout='{"composeId":"cmp-591-new"}',
                 stderr="",
             )
         if "compose.one" in rendered:
@@ -477,17 +470,15 @@ def test_AC8_13_98_existing_preview_compose_is_replaced_before_deploy(
     assert lifecycle.main_from_args(args) == 0
 
     rendered_calls = "\n".join(" ".join(call) for call in calls)
-    assert "compose.delete" in rendered_calls
-    assert "compose.create" in rendered_calls
+    assert "compose.delete" not in rendered_calls
+    assert "compose.create" not in rendered_calls
     assert "compose.update" in rendered_calls
     assert "compose.one" in rendered_calls
+    assert "compose.stop" in rendered_calls
     assert "compose.deploy" in rendered_calls
-    assert "compose.stop" not in rendered_calls
-    assert "compose.redeploy" not in rendered_calls
     assert "compose.start" in rendered_calls
-    assert rendered_calls.index("compose.delete") < rendered_calls.index("compose.create")
-    assert rendered_calls.index("compose.create") < rendered_calls.index("compose.update")
-    assert rendered_calls.index("compose.update") < rendered_calls.index("compose.deploy")
+    assert "compose.redeploy" not in rendered_calls
+    assert rendered_calls.index("compose.stop") < rendered_calls.index("compose.deploy")
     assert rendered_calls.index("compose.deploy") < rendered_calls.index("compose.start")
     assert "secret-key" not in rendered_calls
 

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -408,10 +408,10 @@ def test_AC8_13_72_deploy_action_reads_effective_env_before_deploy(
     assert "MINIO_ROOT_PASSWORD" not in rendered_calls
 
 
-def test_AC8_13_98_existing_preview_compose_is_stopped_redeployed_and_started(
+def test_AC8_13_98_existing_preview_compose_is_replaced_before_deploy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC8.13.98: Existing PR previews force a redeploy before restart."""
+    """AC8.13.98: Existing PR previews are recreated to force fresh rollout state."""
     lifecycle = lifecycle_module()
     calls: list[list[str]] = []
 
@@ -438,6 +438,13 @@ def test_AC8_13_98_existing_preview_compose_is_stopped_redeployed_and_started(
                 cmd,
                 0,
                 stdout='{"compose":[{"name":"pr-591","composeId":"cmp-591"}]}',
+                stderr="",
+            )
+        if "compose.create" in rendered:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout='{"composeId":"cmp-591-new"}',
                 stderr="",
             )
         if "compose.one" in rendered:
@@ -470,16 +477,17 @@ def test_AC8_13_98_existing_preview_compose_is_stopped_redeployed_and_started(
     assert lifecycle.main_from_args(args) == 0
 
     rendered_calls = "\n".join(" ".join(call) for call in calls)
-    assert "compose.delete" not in rendered_calls
-    assert "compose.create" not in rendered_calls
+    assert "compose.delete" in rendered_calls
+    assert "compose.create" in rendered_calls
     assert "compose.update" in rendered_calls
     assert "compose.one" in rendered_calls
-    assert "compose.stop" in rendered_calls
-    assert "compose.redeploy" in rendered_calls
-    assert "compose.start" in rendered_calls
-    assert "compose.deploy" not in rendered_calls
-    assert rendered_calls.index("compose.stop") < rendered_calls.index("compose.redeploy")
-    assert rendered_calls.index("compose.redeploy") < rendered_calls.index("compose.start")
+    assert "compose.deploy" in rendered_calls
+    assert "compose.stop" not in rendered_calls
+    assert "compose.redeploy" not in rendered_calls
+    assert "compose.start" not in rendered_calls
+    assert rendered_calls.index("compose.delete") < rendered_calls.index("compose.create")
+    assert rendered_calls.index("compose.create") < rendered_calls.index("compose.update")
+    assert rendered_calls.index("compose.update") < rendered_calls.index("compose.deploy")
     assert "secret-key" not in rendered_calls
 
 

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -484,10 +484,11 @@ def test_AC8_13_98_existing_preview_compose_is_replaced_before_deploy(
     assert "compose.deploy" in rendered_calls
     assert "compose.stop" not in rendered_calls
     assert "compose.redeploy" not in rendered_calls
-    assert "compose.start" not in rendered_calls
+    assert "compose.start" in rendered_calls
     assert rendered_calls.index("compose.delete") < rendered_calls.index("compose.create")
     assert rendered_calls.index("compose.create") < rendered_calls.index("compose.update")
     assert rendered_calls.index("compose.update") < rendered_calls.index("compose.deploy")
+    assert rendered_calls.index("compose.deploy") < rendered_calls.index("compose.start")
     assert "secret-key" not in rendered_calls
 
 

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -408,10 +408,10 @@ def test_AC8_13_72_deploy_action_reads_effective_env_before_deploy(
     assert "MINIO_ROOT_PASSWORD" not in rendered_calls
 
 
-def test_AC8_13_98_existing_preview_compose_is_stopped_deployed_and_started(
+def test_AC8_13_98_existing_preview_compose_is_stopped_redeployed_and_started(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC8.13.98: Existing PR previews restart around deploy."""
+    """AC8.13.98: Existing PR previews force a redeploy before restart."""
     lifecycle = lifecycle_module()
     calls: list[list[str]] = []
 
@@ -475,11 +475,11 @@ def test_AC8_13_98_existing_preview_compose_is_stopped_deployed_and_started(
     assert "compose.update" in rendered_calls
     assert "compose.one" in rendered_calls
     assert "compose.stop" in rendered_calls
-    assert "compose.deploy" in rendered_calls
+    assert "compose.redeploy" in rendered_calls
     assert "compose.start" in rendered_calls
-    assert "compose.redeploy" not in rendered_calls
-    assert rendered_calls.index("compose.stop") < rendered_calls.index("compose.deploy")
-    assert rendered_calls.index("compose.deploy") < rendered_calls.index("compose.start")
+    assert "compose.deploy" not in rendered_calls
+    assert rendered_calls.index("compose.stop") < rendered_calls.index("compose.redeploy")
+    assert rendered_calls.index("compose.redeploy") < rendered_calls.index("compose.start")
     assert "secret-key" not in rendered_calls
 
 

--- a/tools/_lib/dev/pr_preview_lifecycle.py
+++ b/tools/_lib/dev/pr_preview_lifecycle.py
@@ -417,15 +417,6 @@ def deploy_action(args: argparse.Namespace) -> int:
         compose_name=args.compose_name,
         pr_number=args.pr_number,
     )
-    if existing_compose:
-        delete_compose(config, compose_id=compose_id)
-        compose_id = create_compose(
-            config,
-            environment_id=args.environment_id,
-            compose_name=args.compose_name,
-            pr_number=args.pr_number,
-        )
-        existing_compose = False
     update_compose_source(
         config,
         compose_id=compose_id,
@@ -443,8 +434,11 @@ def deploy_action(args: argparse.Namespace) -> int:
             internal_domain=args.internal_domain,
         ),
     )
-    deploy_compose(config, compose_id=compose_id, force_redeploy=existing_compose)
-    start_compose(config, compose_id=compose_id)
+    if existing_compose:
+        stop_compose(config, compose_id=compose_id)
+    deploy_compose(config, compose_id=compose_id)
+    if existing_compose:
+        start_compose(config, compose_id=compose_id)
     if github_output := os.environ.get("GITHUB_OUTPUT"):
         with open(github_output, "a", encoding="utf-8") as output:
             output.write(f"compose_id={compose_id}\n")

--- a/tools/_lib/dev/pr_preview_lifecycle.py
+++ b/tools/_lib/dev/pr_preview_lifecycle.py
@@ -444,6 +444,7 @@ def deploy_action(args: argparse.Namespace) -> int:
         ),
     )
     deploy_compose(config, compose_id=compose_id, force_redeploy=existing_compose)
+    start_compose(config, compose_id=compose_id)
     if github_output := os.environ.get("GITHUB_OUTPUT"):
         with open(github_output, "a", encoding="utf-8") as output:
             output.write(f"compose_id={compose_id}\n")

--- a/tools/_lib/dev/pr_preview_lifecycle.py
+++ b/tools/_lib/dev/pr_preview_lifecycle.py
@@ -417,6 +417,15 @@ def deploy_action(args: argparse.Namespace) -> int:
         compose_name=args.compose_name,
         pr_number=args.pr_number,
     )
+    if existing_compose:
+        delete_compose(config, compose_id=compose_id)
+        compose_id = create_compose(
+            config,
+            environment_id=args.environment_id,
+            compose_name=args.compose_name,
+            pr_number=args.pr_number,
+        )
+        existing_compose = False
     update_compose_source(
         config,
         compose_id=compose_id,
@@ -434,11 +443,7 @@ def deploy_action(args: argparse.Namespace) -> int:
             internal_domain=args.internal_domain,
         ),
     )
-    if existing_compose:
-        stop_compose(config, compose_id=compose_id)
     deploy_compose(config, compose_id=compose_id, force_redeploy=existing_compose)
-    if existing_compose:
-        start_compose(config, compose_id=compose_id)
     if github_output := os.environ.get("GITHUB_OUTPUT"):
         with open(github_output, "a", encoding="utf-8") as output:
             output.write(f"compose_id={compose_id}\n")

--- a/tools/_lib/dev/pr_preview_lifecycle.py
+++ b/tools/_lib/dev/pr_preview_lifecycle.py
@@ -436,7 +436,7 @@ def deploy_action(args: argparse.Namespace) -> int:
     )
     if existing_compose:
         stop_compose(config, compose_id=compose_id)
-    deploy_compose(config, compose_id=compose_id)
+    deploy_compose(config, compose_id=compose_id, force_redeploy=existing_compose)
     if existing_compose:
         start_compose(config, compose_id=compose_id)
     if github_output := os.environ.get("GITHUB_OUTPUT"):


### PR DESCRIPTION
## Summary

Harden P0/P1 security boundaries for auth, user-scoped ledger integrity, production JWT secrets, and frontend browser security headers.

Closes #<!-- issue number -->

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-001 — Infrastructure & Authentication; EPIC-002 — Double-Entry Bookkeeping Core |
| **AC IDs** | AC1.8.1, AC1.10.1, AC1.10.2, AC2.13.1, AC2.13.2, AC2.13.3 |
| **AC source updated** | Owning EPIC docs updated; `docs/ac_registry.yaml` regenerated with no diff |

---

## SSOT Changes

- [x] `docs/ssot/auth.md` — documents legacy `/users` compatibility rules, production `SECRET_KEY` gate, and frontend security headers.
- [x] `docs/ssot/accounting.md` — documents user-scoped journal line ownership as an accounting domain invariant.
- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `423590a` | Tests were written first in the working tree for cross-user journal pollution, `/users` auth, production secret gate, and frontend security headers; not committed separately. |
| 🟢 Green (passing test) | `423590a` | Implemented service/domain checks, route restrictions, boot guard, and Next headers. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no enum changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (N/A; no env vars added)
- [x] `repo/` submodule updated for production config changes (user-authorized sync to latest infra2 main)
- [x] `tools/check_env_keys.py` passes (N/A; no env vars added)
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes (covered by `moon run :lint`)

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: N/A, no workflow/deploy tooling changes.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys.
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged.
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials.
- [x] Cleanup is scoped: N/A, no cleanup behavior changes.
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene: N/A, no infra runtime changes.

---

## Testing

```bash
uv run ruff check apps/backend/src/boot.py apps/backend/src/routers/users.py apps/backend/src/services/accounting.py apps/backend/tests/accounting/test_accounting_integration.py apps/backend/tests/auth/test_users_router.py apps/backend/tests/infra/test_boot.py
uv run pytest apps/backend/tests/infra/test_boot.py -q --no-cov -n0
uv run pytest apps/backend/tests/accounting/test_accounting_integration.py apps/backend/tests/auth/test_users_router.py --collect-only -q --no-cov -n0
npm test -- --run src/__tests__/api-urls.test.ts
npm run lint
uv run --with pyyaml python tools/check_ac_traceability.py
uv run --with pyyaml python tools/check_manifest.py
uv run --with pyyaml python tools/check_ssot_ownership.py
moon run :lint
```

`moon run :test` could not start locally because this machine has no working Podman/Docker socket:

```text
Cannot connect to Podman ... dial tcp 127.0.0.1:61270: connect: connection refused
Failed to start database.
```

---

## Screenshots / Evidence

_N/A_
