### PR TITLE
[finance_report_audit] Integrate evidence graph traceability

### DIFF
--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -59,6 +59,7 @@ from src.schemas import (
     TrendPeriod,
 )
 from src.services.confidence_tier import derive_confidence_tier
+from src.services.evidence_lineage import EvidenceLineageService
 from src.services.framework_policy import derive_user_framework_policy_result
 from src.services.fx import FxRateError, convert_amount
 from src.services.market_data import ensure_market_data_fresh
@@ -803,6 +804,47 @@ def _journal_source_anchor_detail(
     }
 
 
+async def _evidence_graph_source_anchor_details(
+    db: DbSession,
+    user_id: CurrentUserId,
+    *,
+    line: JournalLine,
+    ledger_detail: dict,
+) -> list[dict]:
+    lineage = EvidenceLineageService()
+    steps = await lineage.get_upstream(
+        db,
+        user_id=user_id,
+        entity_type="journal_line",
+        entity_id=line.id,
+        node_kind="ledger_line",
+    )
+    details: list[dict] = []
+    for step in steps:
+        node = step.node
+        if node.node_kind not in {"source_document", "atomic_fact"}:
+            continue
+        source_type = str(node.properties.get("document_type") or node.entity_type)
+        details.append(
+            {
+                "identifier": _identifier(node.entity_type, node.entity_id),
+                "source_kind": node.entity_type,
+                "source_id": str(node.entity_id),
+                "source_type": source_type,
+                "amount": ledger_detail["amount"],
+                "currency": ledger_detail["currency"],
+                "review_state": ledger_detail["review_state"],
+                "confidence_tier": ledger_detail["confidence_tier"],
+                "contribution_basis": "evidence_graph_upstream",
+                "journal_entry_id": ledger_detail["journal_entry_id"],
+                "journal_line_id": ledger_detail["journal_line_id"],
+                "account_id": ledger_detail["account_id"],
+                "account_type": ledger_detail["account_type"],
+            }
+        )
+    return _dedupe_details(details)
+
+
 async def _personal_report_package_traceability_payload(
     *,
     start_date: date | None,
@@ -879,20 +921,29 @@ async def _personal_report_package_traceability_payload(
             statement_txn_ids=statement_txn_ids,
             atomic_txn_ids=atomic_txn_ids,
         )
+        graph_source_details = await _evidence_graph_source_anchor_details(
+            db,
+            user_id,
+            line=line,
+            ledger_detail=ledger_detail,
+        )
+        entry_source_details = [source_detail, *graph_source_details]
+        entry_source_identifiers = [
+            str(detail["identifier"]) for detail in entry_source_details if detail.get("identifier")
+        ]
         ledger_details.append(ledger_detail)
-        source_details.append(source_detail)
+        source_details.extend(entry_source_details)
         ledger_identifiers.extend(
             [
                 _identifier("journal_entry", entry.id),
                 _identifier("journal_line", line.id),
             ]
         )
-        source_identifier = str(source_detail["identifier"])
-        source_identifiers.append(source_identifier)
+        source_identifiers.extend(entry_source_identifiers)
         is_unknown_source = source_detail["source_kind"] == "unknown_source"
         if account.type == AccountType.INCOME:
-            income_source_identifiers.append(source_identifier)
-            income_source_details.append(source_detail)
+            income_source_identifiers.extend(entry_source_identifiers)
+            income_source_details.extend(entry_source_details)
             income_ledger_details.append(ledger_detail)
             if is_unknown_source:
                 unknown_source_line_ids.update(
@@ -902,14 +953,14 @@ async def _personal_report_package_traceability_payload(
                     }
                 )
         elif account.type == AccountType.EXPENSE:
-            expense_source_identifiers.append(source_identifier)
-            expense_source_details.append(source_detail)
+            expense_source_identifiers.extend(entry_source_identifiers)
+            expense_source_details.extend(entry_source_details)
             expense_ledger_details.append(ledger_detail)
             if is_unknown_source:
                 unknown_source_line_ids.add("income_statement.total_expenses")
         elif account.type == AccountType.ASSET:
-            cash_source_identifiers.append(source_identifier)
-            cash_source_details.append(source_detail)
+            cash_source_identifiers.extend(entry_source_identifiers)
+            cash_source_details.extend(entry_source_details)
             cash_ledger_details.append(ledger_detail)
             if is_unknown_source:
                 unknown_source_line_ids.update(

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -308,6 +308,14 @@ async def upload_statement(
 
     db.add(statement)
     try:
+        await db.flush()
+        from src.services.evidence_graph_integration import EvidenceGraphIntegrationService
+
+        await EvidenceGraphIntegrationService().record_statement_upload(
+            db,
+            user_id=user_id,
+            statement=statement,
+        )
         await db.commit()
         await db.refresh(statement)
     except Exception as exc:

--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -298,11 +298,14 @@ async def dual_write_layer2(
         )
 
         layer2_count = 0
+        from src.services.evidence_graph_integration import EvidenceGraphIntegrationService
+
+        evidence_graph = EvidenceGraphIntegrationService()
         for txn in transactions:
             direction_map = {"IN": TransactionDirection.IN, "OUT": TransactionDirection.OUT}
             l2_direction = direction_map.get(txn.direction, TransactionDirection.IN)
 
-            await dedup_service.upsert_atomic_transaction(
+            atomic_txn = await dedup_service.upsert_atomic_transaction(
                 db=db,
                 user_id=user_id,
                 txn_date=txn.txn_date,
@@ -313,6 +316,14 @@ async def dual_write_layer2(
                 source_doc_id=uploaded_doc.id,
                 source_doc_type=doc_type,
                 reference=txn.reference,
+            )
+            await evidence_graph.record_layer2_dual_write(
+                db,
+                user_id=user_id,
+                uploaded_document=uploaded_doc,
+                source_transaction=txn,
+                atomic_transaction=atomic_txn,
+                document_type=doc_type,
             )
             layer2_count += 1
 

--- a/apps/backend/src/services/evidence_graph_integration.py
+++ b/apps/backend/src/services/evidence_graph_integration.py
@@ -1,0 +1,352 @@
+"""Evidence graph adapters for source-to-ledger product workflows."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import inspect as sa_inspect, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.evidence import EvidenceNode
+from src.models.journal import JournalEntry, JournalLine
+from src.models.layer1 import DocumentType, UploadedDocument
+from src.models.layer2 import AtomicTransaction, TransactionDirection
+from src.models.statement import BankStatement, BankStatementTransaction
+from src.services.deduplication import DeduplicationService
+from src.services.evidence_lineage import EvidenceLineageService
+
+
+class EvidenceGraphIntegrationService:
+    """Small workflow adapters that dual-write business events into Evidence Graph."""
+
+    def __init__(self) -> None:
+        self.lineage = EvidenceLineageService()
+
+    async def record_statement_upload(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        statement: BankStatement,
+    ) -> EvidenceNode | None:
+        """Record the uploaded BankStatement as a source document node."""
+        if statement.id is None:
+            return None
+        return await self.lineage.upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="source_document",
+            entity_type="bank_statement",
+            entity_id=statement.id,
+            properties={
+                "file_hash": statement.file_hash,
+                "original_filename": statement.original_filename,
+                "institution": statement.institution,
+            },
+        )
+
+    async def record_statement_parse(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        statement: BankStatement,
+        transactions: list[BankStatementTransaction],
+    ) -> None:
+        """Record BankStatement -> BankStatementTransaction parse lineage."""
+        source_node = await self.record_statement_upload(db, user_id=user_id, statement=statement)
+        if source_node is None:
+            return
+        for transaction in transactions:
+            if transaction.id is None:
+                continue
+            extracted_node = await self._upsert_statement_transaction_node(
+                db,
+                user_id=user_id,
+                transaction=transaction,
+            )
+            await self.lineage.upsert_edge(
+                db,
+                user_id=user_id,
+                from_node_id=source_node.id,
+                to_node_id=extracted_node.id,
+                relation="parsed_into",
+                properties={"adapter": "statement_parse"},
+            )
+
+    async def record_statement_layer2_lineage(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        statement: BankStatement,
+        transactions: list[BankStatementTransaction],
+    ) -> None:
+        """Backfill parse-time Layer 2 edges once statement transactions have database UUIDs."""
+        result = await db.execute(
+            select(UploadedDocument)
+            .where(UploadedDocument.user_id == user_id)
+            .where(UploadedDocument.file_hash == statement.file_hash)
+            .order_by(UploadedDocument.created_at.desc(), UploadedDocument.id.desc())
+            .limit(1)
+        )
+        uploaded_document = result.scalar_one_or_none()
+        if uploaded_document is None:
+            return
+
+        for transaction in transactions:
+            atomic_transaction = await self._find_atomic_transaction_for_bank_txn(
+                db,
+                user_id=user_id,
+                transaction=transaction,
+            )
+            if atomic_transaction is None:
+                continue
+            await self.record_layer2_dual_write(
+                db,
+                user_id=user_id,
+                uploaded_document=uploaded_document,
+                source_transaction=transaction,
+                atomic_transaction=atomic_transaction,
+                document_type=uploaded_document.document_type,
+            )
+
+    async def record_layer2_dual_write(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        uploaded_document: UploadedDocument,
+        source_transaction: BankStatementTransaction,
+        atomic_transaction: AtomicTransaction,
+        document_type: DocumentType,
+    ) -> None:
+        """Record UploadedDocument -> BankStatementTransaction -> AtomicTransaction lineage."""
+        statement = await self._resolve_statement(db, source_transaction)
+        if statement is not None:
+            await self.record_statement_parse(
+                db,
+                user_id=user_id,
+                statement=statement,
+                transactions=[source_transaction],
+            )
+        source_node = await self.lineage.upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="source_document",
+            entity_type="uploaded_document",
+            entity_id=uploaded_document.id,
+            properties={
+                "document_type": document_type.value,
+                "original_filename": uploaded_document.original_filename,
+                "file_hash": uploaded_document.file_hash,
+            },
+        )
+
+        txn_id = source_transaction.id
+        if txn_id is None:
+            return
+
+        extracted_node = await self._upsert_statement_transaction_node(
+            db,
+            user_id=user_id,
+            transaction=source_transaction,
+        )
+        atomic_node = await self._upsert_atomic_transaction_node(
+            db,
+            user_id=user_id,
+            atomic_transaction=atomic_transaction,
+        )
+        await self.lineage.upsert_edge(
+            db,
+            user_id=user_id,
+            from_node_id=source_node.id,
+            to_node_id=extracted_node.id,
+            relation="parsed_into",
+            properties={"adapter": "layer2_dual_write"},
+        )
+        await self.lineage.upsert_edge(
+            db,
+            user_id=user_id,
+            from_node_id=extracted_node.id,
+            to_node_id=atomic_node.id,
+            relation="deduped_into",
+            properties={"dedup_hash": atomic_transaction.dedup_hash},
+        )
+
+    async def record_journal_posting(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        source_transaction: BankStatementTransaction,
+        journal_entry: JournalEntry,
+        atomic_transaction: AtomicTransaction | None = None,
+    ) -> None:
+        """Record BankStatementTransaction/AtomicTransaction -> JournalEntry -> JournalLine lineage."""
+        extracted_node = await self._upsert_statement_transaction_node(
+            db,
+            user_id=user_id,
+            transaction=source_transaction,
+        )
+        ledger_entry_node = await self.lineage.upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="ledger_entry",
+            entity_type="journal_entry",
+            entity_id=journal_entry.id,
+            properties={
+                "source_type": journal_entry.source_type.value,
+                "source_id": str(journal_entry.source_id) if journal_entry.source_id else None,
+                "status": journal_entry.status.value,
+            },
+        )
+        await self.lineage.upsert_edge(
+            db,
+            user_id=user_id,
+            from_node_id=extracted_node.id,
+            to_node_id=ledger_entry_node.id,
+            relation="posted_as",
+            properties={"adapter": "journal_posting"},
+        )
+
+        atomic_transaction = atomic_transaction or await self._find_atomic_transaction_for_bank_txn(
+            db,
+            user_id=user_id,
+            transaction=source_transaction,
+        )
+        if atomic_transaction is not None:
+            atomic_node = await self._upsert_atomic_transaction_node(
+                db,
+                user_id=user_id,
+                atomic_transaction=atomic_transaction,
+            )
+            await self.lineage.upsert_edge(
+                db,
+                user_id=user_id,
+                from_node_id=atomic_node.id,
+                to_node_id=ledger_entry_node.id,
+                relation="posted_as",
+                properties={"adapter": "journal_posting"},
+            )
+
+        for line in journal_entry.lines:
+            await self._record_journal_line(
+                db,
+                user_id=user_id,
+                journal_line=line,
+                ledger_entry_node_id=ledger_entry_node.id,
+            )
+
+    async def _record_journal_line(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        journal_line: JournalLine,
+        ledger_entry_node_id: UUID,
+    ) -> None:
+        ledger_line_node = await self.lineage.upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="ledger_line",
+            entity_type="journal_line",
+            entity_id=journal_line.id,
+            properties={
+                "journal_entry_id": str(journal_line.journal_entry_id),
+                "account_id": str(journal_line.account_id),
+                "direction": journal_line.direction.value,
+                "amount": str(journal_line.amount),
+                "currency": journal_line.currency,
+            },
+        )
+        await self.lineage.upsert_edge(
+            db,
+            user_id=user_id,
+            from_node_id=ledger_entry_node_id,
+            to_node_id=ledger_line_node.id,
+            relation="contains",
+            properties={"adapter": "journal_posting"},
+        )
+
+    async def _upsert_statement_transaction_node(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        transaction: BankStatementTransaction,
+    ) -> EvidenceNode:
+        statement = await self._resolve_statement(db, transaction)
+        properties = {
+            "statement_id": str(transaction.statement_id),
+            "txn_date": transaction.txn_date.isoformat(),
+            "direction": transaction.direction,
+            "amount": str(transaction.amount),
+            "currency": transaction.currency or (statement.currency if statement else None),
+            "reference": transaction.reference,
+        }
+        return await self.lineage.upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="extracted_record",
+            entity_type="bank_statement_transaction",
+            entity_id=transaction.id,
+            properties=properties,
+        )
+
+    async def _upsert_atomic_transaction_node(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        atomic_transaction: AtomicTransaction,
+    ) -> EvidenceNode:
+        return await self.lineage.upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="atomic_fact",
+            entity_type="atomic_transaction",
+            entity_id=atomic_transaction.id,
+            properties={
+                "dedup_hash": atomic_transaction.dedup_hash,
+                "txn_date": atomic_transaction.txn_date.isoformat(),
+                "direction": atomic_transaction.direction.value,
+                "amount": str(atomic_transaction.amount),
+                "currency": atomic_transaction.currency,
+            },
+        )
+
+    async def _find_atomic_transaction_for_bank_txn(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        transaction: BankStatementTransaction,
+    ) -> AtomicTransaction | None:
+        direction = TransactionDirection.IN if transaction.direction == "IN" else TransactionDirection.OUT
+        dedup_hash = DeduplicationService.calculate_transaction_hash(
+            user_id,
+            transaction.txn_date,
+            transaction.amount,
+            direction,
+            transaction.description,
+            transaction.reference,
+        )
+        result = await db.execute(
+            select(AtomicTransaction)
+            .where(AtomicTransaction.user_id == user_id)
+            .where(AtomicTransaction.dedup_hash == dedup_hash)
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def _resolve_statement(
+        self,
+        db: AsyncSession,
+        transaction: BankStatementTransaction,
+    ) -> BankStatement | None:
+        state = sa_inspect(transaction)
+        if "statement" not in state.unloaded and transaction.statement is not None:
+            return transaction.statement
+        result = await db.execute(select(BankStatement).where(BankStatement.id == transaction.statement_id).limit(1))
+        return result.scalar_one_or_none()

--- a/apps/backend/src/services/review_queue.py
+++ b/apps/backend/src/services/review_queue.py
@@ -449,6 +449,15 @@ async def create_entry_from_txn(
     db.add(entry)
     await db.flush()
     await db.refresh(entry, ["lines"])
+    from src.services.evidence_graph_integration import EvidenceGraphIntegrationService
+
+    await EvidenceGraphIntegrationService().record_journal_posting(
+        db,
+        user_id=user_id,
+        source_transaction=txn,
+        journal_entry=entry,
+        atomic_transaction=atomic_txn,
+    )
     return entry
 
 

--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -444,6 +444,22 @@ async def parse_statement_background(
 
             await update_progress(90)
 
+            from src.services.evidence_graph_integration import EvidenceGraphIntegrationService
+
+            evidence_graph = EvidenceGraphIntegrationService()
+            await evidence_graph.record_statement_parse(
+                session,
+                user_id=user_id,
+                statement=statement,
+                transactions=list(statement.transactions),
+            )
+            await evidence_graph.record_statement_layer2_lineage(
+                session,
+                user_id=user_id,
+                statement=statement,
+                transactions=list(statement.transactions),
+            )
+
             statement.confidence_score = parsed_statement.confidence_score
             statement.balance_validated = parsed_statement.balance_validated
             statement.validation_error = parsed_statement.validation_error

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -6,12 +6,14 @@ from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError
+from sqlalchemy import select
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import (
     Account,
     AccountType,
+    AtomicTransaction,
     BankStatement,
     BankStatementStatus,
     BankStatementTransaction,
@@ -30,8 +32,10 @@ from src.models import (
     ReportType,
     RuleType,
     Stage1Status,
+    UploadedDocument,
 )
 from src.models.journal import JournalEntrySourceType
+from src.models.layer1 import DocumentType
 from src.models.layer2 import AssetType, AtomicPosition
 from src.models.layer3 import (
     CostBasisMethod,
@@ -55,7 +59,9 @@ from src.routers.reports import (
     personal_report_package_traceability,
 )
 from src.schemas import PersonalReportPackageReadinessResponse
+from src.services.deduplication import dual_write_layer2
 from src.services.fx import FxRateError
+from src.services.review_queue import create_entry_from_txn
 
 
 @pytest.fixture(autouse=True)
@@ -1170,11 +1176,97 @@ def test_AC19_10_1_anchor_detail_helpers_keep_auditable_deduped_payloads():
 
 
 @pytest.mark.asyncio
+async def test_AC18_8_4_AC18_8_7_package_traceability_resolves_report_line_to_source_document(
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC18.8.4 AC18.8.7: Report traceability resolves a ledger-backed line to an Evidence Graph source document."""
+    report_date = date(2026, 5, 31)
+    bank = Account(user_id=test_user.id, name="Evidence Trace Bank", type=AccountType.ASSET, currency="SGD")
+    db.add(bank)
+    await db.flush()
+
+    statement = BankStatement(
+        user_id=test_user.id,
+        account_id=bank.id,
+        file_path="s3://trace/evidence-statement.csv",
+        file_hash=f"evidence-trace-{uuid4().hex}",
+        original_filename="evidence-statement.csv",
+        institution="Trace Bank",
+        currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=report_date,
+        status=BankStatementStatus.APPROVED,
+        balance_validated=True,
+        stage1_status=Stage1Status.APPROVED,
+    )
+    txn = BankStatementTransaction(
+        statement=statement,
+        txn_date=report_date,
+        description="Evidence graph income",
+        amount=Decimal("120.00"),
+        direction="IN",
+        currency="SGD",
+        reference="EG-INC",
+    )
+    db.add_all([statement, txn])
+    await db.flush()
+
+    await dual_write_layer2(
+        db=db,
+        user_id=test_user.id,
+        file_path=None,
+        file_hash=statement.file_hash,
+        original_filename=statement.original_filename,
+        institution=statement.institution,
+        transactions=[txn],
+        document_type=DocumentType.BANK_STATEMENT,
+    )
+    entry = await create_entry_from_txn(
+        db,
+        txn,
+        user_id=test_user.id,
+        auto_post=True,
+        source_type=JournalEntrySourceType.USER_CONFIRMED,
+        preloaded_statement=statement,
+        preloaded_bank_account=bank,
+    )
+    await db.commit()
+
+    uploaded_doc = (
+        await db.execute(select(UploadedDocument).where(UploadedDocument.user_id == test_user.id))
+    ).scalar_one()
+    atomic_txn = (
+        await db.execute(select(AtomicTransaction).where(AtomicTransaction.user_id == test_user.id))
+    ).scalar_one()
+
+    traceability = await personal_report_package_traceability(
+        start_date=date(2026, 5, 1),
+        end_date=report_date,
+        as_of_date=report_date,
+        db=db,
+        user_id=test_user.id,
+    )
+    lines = {line["line_id"]: line for line in traceability.model_dump(mode="json")["lines"]}
+    total_income = lines["income_statement.total_income"]
+
+    assert f"uploaded_document:{uploaded_doc.id}" in total_income["source_anchor"]["identifiers"]
+    assert f"atomic_transaction:{atomic_txn.id}" in total_income["source_anchor"]["identifiers"]
+    assert any(
+        detail["source_kind"] == "uploaded_document"
+        and detail["source_id"] == str(uploaded_doc.id)
+        and detail["contribution_basis"] == "evidence_graph_upstream"
+        for detail in total_income["source_anchor"]["details"]
+    )
+    assert any(detail["journal_entry_id"] == str(entry.id) for detail in total_income["ledger_anchor"]["details"])
+
+
+@pytest.mark.asyncio
 async def test_AC19_10_1_unknown_journal_source_ids_are_not_reported_as_statement_transactions(
     db: AsyncSession,
     test_user: User,
 ):
-    """AC19.10.1: Unknown journal source IDs remain explicit blockers, not fake statement anchors."""
+    """AC18.8.5 AC19.10.1: Unknown journal source IDs remain explicit blockers, not fake statement anchors."""
     report_date = date(2026, 5, 31)
     bank = Account(user_id=test_user.id, name="Unknown Source Bank", type=AccountType.ASSET, currency="SGD")
     income = Account(user_id=test_user.id, name="Unknown Source Income", type=AccountType.INCOME, currency="SGD")

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -26,6 +26,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from src.models import Account, AccountType, User
+from src.models.evidence import EvidenceEdge, EvidenceNode
 from src.models.journal import JournalEntry, JournalEntrySourceType, JournalEntryStatus
 from src.models.reconciliation import ReconciliationMatch, ReconciliationStatus
 from src.models.statement import (
@@ -3090,6 +3091,56 @@ async def test_create_entry_from_txn_auto_post_rejects_inactive_statement_accoun
         .where(JournalEntry.source_id == txn.id)
     )
     assert list(entry_result.scalars().all()) == []
+
+
+async def test_AC18_8_3_AC18_8_6_create_entry_from_txn_writes_statement_to_ledger_graph(
+    db,
+    test_user,
+):
+    """AC18.8.3 AC18.8.6 AC18.8.7: Statement posting records extracted->ledger entry->ledger line lineage."""
+    account = await create_statement_account(db, test_user.id, "DBS Evidence Graph Posting")
+    statement = build_statement(test_user.id, "hash_evidence_graph_posting", 90)
+    statement.status = BankStatementStatus.APPROVED
+    statement.account_id = account.id
+    db.add(statement)
+    await db.flush()
+
+    txn = BankStatementTransaction(
+        statement_id=statement.id,
+        txn_date=date(2025, 1, 21),
+        description="Evidence graph salary",
+        amount=Decimal("50.00"),
+        direction="IN",
+    )
+    db.add(txn)
+    await db.flush()
+
+    entry = await create_entry_from_txn(
+        db,
+        txn,
+        user_id=test_user.id,
+        auto_post=True,
+        source_type=JournalEntrySourceType.USER_CONFIRMED,
+    )
+    await db.commit()
+
+    assert entry.source_type == JournalEntrySourceType.USER_CONFIRMED
+    assert entry.source_id == txn.id
+
+    nodes = {
+        (node.node_kind, node.entity_type, node.entity_id): node
+        for node in (await db.execute(select(EvidenceNode).where(EvidenceNode.user_id == test_user.id))).scalars()
+    }
+    extracted_node = nodes[("extracted_record", "bank_statement_transaction", txn.id)]
+    ledger_entry_node = nodes[("ledger_entry", "journal_entry", entry.id)]
+    ledger_line_nodes = [nodes[("ledger_line", "journal_line", line.id)] for line in entry.lines]
+
+    edges = {
+        (edge.from_node_id, edge.to_node_id, edge.relation)
+        for edge in (await db.execute(select(EvidenceEdge).where(EvidenceEdge.user_id == test_user.id))).scalars()
+    }
+    assert (extracted_node.id, ledger_entry_node.id, "posted_as") in edges
+    assert {(ledger_entry_node.id, ledger_line_node.id, "contains") for ledger_line_node in ledger_line_nodes} <= edges
 
 
 async def test_batch_approve_matches_returns_400_on_amount_mismatch(db, test_user):

--- a/apps/backend/tests/extraction/test_dual_write_layer2.py
+++ b/apps/backend/tests/extraction/test_dual_write_layer2.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import select
 
+from src.models.evidence import EvidenceEdge, EvidenceNode
 from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.services.extraction import ExtractionService
@@ -194,6 +195,75 @@ class TestDualWriteLayer2:
         assert txn2.amount == Decimal("2500.00")
         assert txn2.direction == TransactionDirection.OUT
         assert txn2.reference == "RENT001"
+
+    async def test_AC18_8_1_AC18_8_2_dual_write_creates_source_to_atomic_graph_path(
+        self, db, test_user, sample_file_content, monkeypatch
+    ):
+        """AC18.8.1 AC18.8.2 AC18.8.7: Layer 1/2 dual-write records source->extracted->atomic lineage."""
+        monkeypatch.setattr("src.config.settings.enable_4_layer_write", True)
+        file_hash = hashlib.sha256(sample_file_content).hexdigest()
+
+        from src.models import BankStatement, BankStatementTransaction
+
+        statement = BankStatement(
+            user_id=test_user.id,
+            file_path="test_statement.pdf",
+            file_hash=file_hash,
+            original_filename="test_statement.pdf",
+            institution="DBS",
+            account_last4="1234",
+            currency="SGD",
+            period_start=date(2024, 1, 1),
+            period_end=date(2024, 1, 31),
+            opening_balance=Decimal("1000.00"),
+            closing_balance=Decimal("1500.00"),
+        )
+        txn = BankStatementTransaction(
+            statement=statement,
+            txn_date=date(2024, 1, 15),
+            description="Salary Deposit",
+            amount=Decimal("3000.00"),
+            direction="IN",
+            reference="SAL001",
+        )
+        db.add(statement)
+        db.add(txn)
+        await db.flush()
+
+        from src.services.deduplication import dual_write_layer2
+
+        await dual_write_layer2(
+            db=db,
+            user_id=test_user.id,
+            file_path=Path("test_statement.pdf"),
+            file_hash=file_hash,
+            original_filename="test_statement.pdf",
+            institution="DBS",
+            transactions=[txn],
+        )
+        await db.commit()
+
+        uploaded_doc = (
+            await db.execute(select(UploadedDocument).where(UploadedDocument.user_id == test_user.id))
+        ).scalar_one()
+        atomic_txn = (
+            await db.execute(select(AtomicTransaction).where(AtomicTransaction.user_id == test_user.id))
+        ).scalar_one()
+        nodes = {
+            (node.node_kind, node.entity_type, node.entity_id): node
+            for node in (await db.execute(select(EvidenceNode).where(EvidenceNode.user_id == test_user.id))).scalars()
+        }
+
+        source_node = nodes[("source_document", "uploaded_document", uploaded_doc.id)]
+        statement_node = nodes[("source_document", "bank_statement", statement.id)]
+        extracted_node = nodes[("extracted_record", "bank_statement_transaction", txn.id)]
+        atomic_node = nodes[("atomic_fact", "atomic_transaction", atomic_txn.id)]
+
+        edge_rows = list((await db.execute(select(EvidenceEdge).where(EvidenceEdge.user_id == test_user.id))).scalars())
+        edges = {(edge.from_node_id, edge.to_node_id, edge.relation) for edge in edge_rows}
+        assert (statement_node.id, extracted_node.id, "parsed_into") in edges
+        assert (source_node.id, extracted_node.id, "parsed_into") in edges
+        assert (extracted_node.id, atomic_node.id, "deduped_into") in edges
 
     async def test_dual_write_deduplication_on_reupload(
         self, db, test_user, mock_ai_response, sample_file_content, monkeypatch

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -282,6 +282,28 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
 | AC18.7.6 | Evidence lineage | Evidence lineage traversal enforces a default maximum depth and never walks unbounded graphs |
 | AC18.7.7 | Evidence lineage | Evidence Graph foundation tests cover node creation, edge creation, duplicate upsert behavior, upstream traversal, downstream traversal, depth limit, and cross-user isolation |
 
+### AC18.8: Evidence Graph Source-to-Report Integration
+
+MECE task frame:
+
+- Source capture: statement upload and parse create source document and extracted record nodes.
+- Atomic fact integration: Layer 2 dual-write creates atomic fact nodes and `deduped_into` edges from extracted records.
+- Ledger integration: statement posting creates ledger entry and ledger line nodes while preserving `JournalEntry.source_type/source_id`.
+- Report integration: package traceability can resolve at least one report line through graph lineage back to source documents.
+- Blocker handling: unsupported source IDs remain explicit blockers instead of fabricated source anchors.
+
+Dependencies: AC18.7 Evidence Graph foundation and existing Layer 1/2, journal posting, and package traceability services. Out of scope: UI lineage panel, historical backfill, graph database adoption, and replacing every legacy traceability resolver in one change.
+
+| AC ID | Phase | Description |
+|-------|-------|-------------|
+| AC18.8.1 | Evidence lineage integration | Statement upload and parse create a `source_document` node for the uploaded source and `extracted_record` nodes for parsed bank statement transactions linked by `parsed_into` edges |
+| AC18.8.2 | Evidence lineage integration | Layer 2 dual-write creates `atomic_fact` nodes for atomic transactions and `deduped_into` edges from the parsed transaction records that produced them |
+| AC18.8.3 | Evidence lineage integration | Journal posting creates `ledger_entry` and `ledger_line` nodes, links extracted or atomic transaction facts to the ledger entry with `posted_as`, and links the ledger entry to its lines with `contains` |
+| AC18.8.4 | Evidence lineage integration | `GET /api/reports/package/traceability` can resolve at least one report line from ledger anchors through Evidence Graph lineage back to source document anchors |
+| AC18.8.5 | Evidence lineage integration | Unknown or unsupported `JournalEntry.source_id` values produce explicit blocker codes and never fabricate statement, atomic, or document anchors |
+| AC18.8.6 | Evidence lineage integration | Existing `JournalEntry.source_type/source_id` semantics remain backward-compatible while Evidence Graph writes add supplemental audit lineage |
+| AC18.8.7 | Evidence lineage integration | Tests cover three end-to-end graph paths: source document downstream impact, bank statement transaction to ledger line, and report line to source document |
+
 ### AC18.6: Framework Measurement and Disclosure Suggestions
 
 | AC ID | Phase | Description |

--- a/docs/ssot/evidence-lineage.md
+++ b/docs/ssot/evidence-lineage.md
@@ -133,3 +133,35 @@ Foundation proof is owned by AC18.7 and must cover:
 - downstream traversal;
 - depth limit enforcement;
 - cross-user isolation.
+
+Integration proof is owned by AC18.8. The first product integration path is:
+
+```text
+UploadedDocument / BankStatement
+  -> BankStatementTransaction
+  -> AtomicTransaction
+  -> JournalEntry
+  -> JournalLine
+  -> report line anchor
+```
+
+The corresponding graph nodes and edges are:
+
+```text
+source_document(uploaded_document or bank_statement)
+  -parsed_into->
+extracted_record(bank_statement_transaction)
+  -deduped_into->
+atomic_fact(atomic_transaction)
+  -posted_as->
+ledger_entry(journal_entry)
+  -contains->
+ledger_line(journal_line)
+  -aggregated_into->
+report_line(package_traceability_line)
+```
+
+Report traceability may still use legacy `JournalEntry.source_type/source_id`
+as a compatibility fallback. When a legacy source ID cannot be resolved to an
+owned source, extracted, atomic, or graph node, the caller must return an
+explicit blocker state rather than fabricating a source anchor.


### PR DESCRIPTION
## Summary

Wire the Evidence Graph into the bank statement -> atomic fact -> ledger -> report traceability path.

Closes #725

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-018 — AI-Driven Data Pipeline |
| **AC IDs** | AC18.8.1, AC18.8.2, AC18.8.3, AC18.8.4, AC18.8.5, AC18.8.6, AC18.8.7 |
| **AC source updated** | Owning EPIC |

---

## SSOT Changes

- [x] `docs/ssot/evidence-lineage.md` — documents the source-to-report integration path and graph node/edge mapping.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `local red phase before 4057e05` | Added AC18.8 tests; target tests failed on missing evidence graph nodes/anchors before implementation. |
| 🟢 Green (passing test) | `4057e05` | Implemented Evidence Graph integration adapters and report graph-source resolver. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — no Enum changes.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A.
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A.
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env changes.
- [x] `tools/check_manifest.py` passes (if SSOT files changed) — N/A, existing SSOT concept updated.
- [x] `tools/lint_doc_consistency.py` passes — covered by `moon run :lint`.

### CI/CD, Runtime, and VPS Infra Audit

N/A — no workflow, deploy tooling, Dokploy runtime config, VPS host scripts, or log changes.

---

## Testing

```bash
moon run :lint
python tools/generate_ac_registry.py --check
python tools/check_ac_traceability.py
python tools/check_e2e_epic_traceability.py
python tools/check_critical_proof_matrix.py
pytest --no-cov -n0 apps/backend/tests/extraction/test_dual_write_layer2.py apps/backend/tests/services/test_evidence_lineage.py apps/backend/tests/api/test_personal_report_package_contract.py apps/backend/tests/api/test_statements_router.py::test_AC18_8_3_AC18_8_6_create_entry_from_txn_writes_statement_to_ledger_graph -q
pytest --no-cov -n0 apps/backend/tests/api/test_statements_router.py -q
```

`moon run :test` was attempted locally, but this machine could not connect to the Podman socket (`127.0.0.1:61270: connect: connection refused`), so the containerized test lifecycle could not start.

---

## Screenshots / Evidence

N/A — backend lineage integration only.
