### PR TITLE
[finance_report_audit] Implement Evidence Graph lazy materialization

### DIFF
--- a/apps/backend/src/routers/evidence.py
+++ b/apps/backend/src/routers/evidence.py
@@ -14,9 +14,26 @@ from src.schemas.evidence import (
     EvidenceLineageNode,
     EvidenceLineageResponse,
 )
+from src.services.evidence_graph_materialization import EvidenceGraphMaterializationService
 from src.services.evidence_lineage import DEFAULT_MAX_DEPTH, EvidenceLineageService, EvidenceTraversalStep
 
 router = APIRouter(prefix="/evidence", tags=["evidence"])
+
+_LAZY_MATERIALIZATION_ENTITY_TYPES = {
+    "journal_line",
+    "journal_entry",
+    "bank_statement_transaction",
+    "bank_statement",
+    "uploaded_document",
+    "atomic_transaction",
+}
+_LAZY_MATERIALIZATION_NODE_KINDS = {
+    "ledger_line",
+    "ledger_entry",
+    "extracted_record",
+    "source_document",
+    "atomic_fact",
+}
 
 
 @router.get("/lineage", response_model=EvidenceLineageResponse)
@@ -38,6 +55,27 @@ async def get_evidence_lineage(
         entity_id=entity_id,
         node_kind=node_kind,
     )
+    materialization_blockers: list[EvidenceLineageBlocker] = []
+    if _should_attempt_lazy_materialization(entity_type=entity_type, node_kind=node_kind, anchor=anchor):
+        materialization = await EvidenceGraphMaterializationService().materialize_for_entity(
+            db,
+            user_id=user_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            node_kind=node_kind,
+        )
+        materialization_blockers = [
+            EvidenceLineageBlocker(code=blocker.code, message=blocker.message) for blocker in materialization.blockers
+        ]
+        if materialization.has_writes:
+            await db.commit()
+        anchor = await lineage.get_node_for_entity(
+            db,
+            user_id=user_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            node_kind=node_kind,
+        )
     if anchor is None:
         return EvidenceLineageResponse(
             anchor=None,
@@ -48,7 +86,8 @@ async def get_evidence_lineage(
                     code="graph_node_missing",
                     message="No owned Evidence Graph node exists for this entity identity.",
                 )
-            ],
+            ]
+            + _visible_missing_anchor_blockers(materialization_blockers),
             max_depth=max_depth,
         )
 
@@ -82,9 +121,26 @@ async def get_evidence_lineage(
         anchor=_node_dto(anchor),
         nodes=[_node_dto(node) for node in nodes],
         edges=edges,
-        blockers=[],
+        blockers=materialization_blockers,
         max_depth=max_depth,
     )
+
+
+def _should_attempt_lazy_materialization(
+    *,
+    entity_type: str,
+    node_kind: str | None,
+    anchor: EvidenceNode | None,
+) -> bool:
+    if anchor is not None:
+        return False
+    return entity_type in _LAZY_MATERIALIZATION_ENTITY_TYPES or node_kind in _LAZY_MATERIALIZATION_NODE_KINDS
+
+
+def _visible_missing_anchor_blockers(
+    materialization_blockers: list[EvidenceLineageBlocker],
+) -> list[EvidenceLineageBlocker]:
+    return [blocker for blocker in materialization_blockers if blocker.code != "entity_missing"]
 
 
 def _node_dto(node: EvidenceNode) -> EvidenceLineageNode:

--- a/apps/backend/src/routers/evidence.py
+++ b/apps/backend/src/routers/evidence.py
@@ -27,12 +27,13 @@ _LAZY_MATERIALIZATION_ENTITY_TYPES = {
     "uploaded_document",
     "atomic_transaction",
 }
-_LAZY_MATERIALIZATION_NODE_KINDS = {
-    "ledger_line",
-    "ledger_entry",
-    "extracted_record",
-    "source_document",
-    "atomic_fact",
+_LAZY_MATERIALIZATION_ENTITY_NODE_KINDS = {
+    "journal_line": {"ledger_line"},
+    "journal_entry": {"ledger_entry"},
+    "bank_statement_transaction": {"extracted_record"},
+    "bank_statement": {"source_document"},
+    "uploaded_document": {"source_document"},
+    "atomic_transaction": {"atomic_fact"},
 }
 
 
@@ -134,7 +135,12 @@ def _should_attempt_lazy_materialization(
 ) -> bool:
     if anchor is not None:
         return False
-    return entity_type in _LAZY_MATERIALIZATION_ENTITY_TYPES or node_kind in _LAZY_MATERIALIZATION_NODE_KINDS
+    expected_node_kinds = _LAZY_MATERIALIZATION_ENTITY_NODE_KINDS.get(entity_type)
+    if expected_node_kinds is None:
+        return False
+    if node_kind is not None and node_kind not in expected_node_kinds:
+        return False
+    return True
 
 
 def _visible_missing_anchor_blockers(

--- a/apps/backend/src/services/evidence_graph_materialization.py
+++ b/apps/backend/src/services/evidence_graph_materialization.py
@@ -1,0 +1,943 @@
+"""Lazy Evidence Graph materialization and consistency checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from uuid import UUID
+
+from sqlalchemy import exists, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased, selectinload
+
+from src.models.evidence import EvidenceEdge, EvidenceNode
+from src.models.journal import JournalEntry, JournalEntrySourceType, JournalLine
+from src.models.layer1 import UploadedDocument
+from src.models.layer2 import AtomicTransaction, TransactionDirection
+from src.models.statement import BankStatement, BankStatementTransaction
+from src.services.deduplication import DeduplicationService
+from src.services.evidence_lineage import EvidenceLineageService
+from src.services.source_type_priority import STATEMENT_SOURCE_TYPES
+
+DEFAULT_MATERIALIZATION_WRITE_CAP = 25
+
+
+@dataclass(frozen=True)
+class EvidenceMaterializationBlocker:
+    """Explicit blocker returned when deterministic graph materialization cannot proceed."""
+
+    code: str
+    message: str
+
+
+@dataclass
+class EvidenceMaterializationResult:
+    """Summary of one bounded materialization attempt."""
+
+    created_nodes: int = 0
+    created_edges: int = 0
+    blockers: list[EvidenceMaterializationBlocker] = field(default_factory=list)
+
+    @property
+    def has_writes(self) -> bool:
+        return self.created_nodes > 0 or self.created_edges > 0
+
+    @property
+    def write_count(self) -> int:
+        return self.created_nodes + self.created_edges
+
+
+@dataclass(frozen=True)
+class EvidenceConsistencyFinding:
+    """Read-only consistency finding for Evidence Graph drift."""
+
+    code: str
+    severity: str
+    entity_type: str
+    entity_id: UUID
+    message: str
+
+
+@dataclass(frozen=True)
+class EvidenceConsistencyReport:
+    """Read-only drift report for operator checks."""
+
+    findings: list[EvidenceConsistencyFinding]
+
+
+class EvidenceGraphMaterializationService:
+    """Repair missing graph projection rows from deterministic business relationships."""
+
+    def __init__(self) -> None:
+        self.lineage = EvidenceLineageService()
+
+    async def materialize_for_entity(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        entity_type: str,
+        entity_id: UUID,
+        node_kind: str | None = None,
+        max_writes: int = DEFAULT_MATERIALIZATION_WRITE_CAP,
+    ) -> EvidenceMaterializationResult:
+        """Materialize one local graph path for an owned entity identity."""
+        result = EvidenceMaterializationResult()
+        if max_writes <= 0:
+            self._add_blocker(
+                result,
+                "materialization_write_cap_reached",
+                "Request-time Evidence Graph materialization write cap was reached.",
+            )
+            return result
+
+        if entity_type == "journal_line" or node_kind == "ledger_line":
+            await self._materialize_journal_line(db, user_id=user_id, line_id=entity_id, result=result, cap=max_writes)
+        elif entity_type == "journal_entry" or node_kind == "ledger_entry":
+            await self._materialize_journal_entry(
+                db, user_id=user_id, entry_id=entity_id, result=result, cap=max_writes
+            )
+        elif entity_type == "bank_statement_transaction" or node_kind == "extracted_record":
+            await self._materialize_statement_transaction(
+                db, user_id=user_id, transaction_id=entity_id, result=result, cap=max_writes
+            )
+        elif entity_type == "bank_statement":
+            await self._materialize_statement(
+                db, user_id=user_id, statement_id=entity_id, result=result, cap=max_writes
+            )
+        elif entity_type == "uploaded_document":
+            await self._materialize_uploaded_document(
+                db, user_id=user_id, document_id=entity_id, result=result, cap=max_writes
+            )
+        elif entity_type == "atomic_transaction" or node_kind == "atomic_fact":
+            await self._materialize_atomic_transaction(
+                db, user_id=user_id, atomic_id=entity_id, result=result, cap=max_writes
+            )
+        else:
+            self._add_blocker(result, "unsupported_provenance", f"Unsupported Evidence Graph entity: {entity_type}.")
+        return result
+
+    async def detect_consistency_drift(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID | None = None,
+    ) -> EvidenceConsistencyReport:
+        """Return a read-only consistency report without repairing graph rows."""
+        findings: list[EvidenceConsistencyFinding] = []
+        await self._detect_missing_journal_line_nodes(db, user_id=user_id, findings=findings)
+        await self._detect_orphan_nodes(db, user_id=user_id, findings=findings)
+        await self._detect_dangling_edges(db, user_id=user_id, findings=findings)
+        await self._detect_cross_user_edges(db, user_id=user_id, findings=findings)
+        return EvidenceConsistencyReport(findings=findings)
+
+    async def _materialize_journal_line(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        line_id: UUID,
+        result: EvidenceMaterializationResult,
+        cap: int,
+    ) -> None:
+        row = (
+            await db.execute(
+                select(JournalLine, JournalEntry)
+                .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
+                .where(JournalLine.id == line_id)
+                .options(selectinload(JournalLine.journal_entry))
+                .limit(1)
+            )
+        ).first()
+        if row is None:
+            self._add_blocker(result, "entity_missing", "Journal line does not exist.")
+            return
+        line, entry = row
+        if entry.user_id != user_id:
+            self._add_blocker(result, "cross_user_lineage_blocked", "Journal line belongs to a different user.")
+            return
+        entry = (
+            await db.execute(
+                select(JournalEntry)
+                .where(JournalEntry.id == line.journal_entry_id)
+                .options(selectinload(JournalEntry.lines))
+                .limit(1)
+            )
+        ).scalar_one()
+        await self._materialize_journal_entry(db, user_id=user_id, entry=entry, result=result, cap=cap)
+
+    async def _materialize_journal_entry(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        result: EvidenceMaterializationResult,
+        cap: int,
+        entry_id: UUID | None = None,
+        entry: JournalEntry | None = None,
+    ) -> EvidenceNode | None:
+        if entry is None:
+            entry = (
+                await db.execute(
+                    select(JournalEntry)
+                    .where(JournalEntry.id == entry_id)
+                    .options(selectinload(JournalEntry.lines))
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+        if entry is None:
+            self._add_blocker(result, "entity_missing", "Journal entry does not exist.")
+            return None
+        if entry.user_id != user_id:
+            self._add_blocker(result, "cross_user_lineage_blocked", "Journal entry belongs to a different user.")
+            return None
+
+        ledger_entry = await self._upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="ledger_entry",
+            entity_type="journal_entry",
+            entity_id=entry.id,
+            properties={
+                "source_type": entry.source_type.value,
+                "source_id": str(entry.source_id) if entry.source_id else None,
+                "status": entry.status.value,
+            },
+            result=result,
+            cap=cap,
+        )
+        if ledger_entry is None:
+            return None
+
+        for line in entry.lines:
+            ledger_line = await self._upsert_node(
+                db,
+                user_id=user_id,
+                node_kind="ledger_line",
+                entity_type="journal_line",
+                entity_id=line.id,
+                properties={
+                    "journal_entry_id": str(line.journal_entry_id),
+                    "account_id": str(line.account_id),
+                    "direction": line.direction.value,
+                    "amount": str(line.amount),
+                    "currency": line.currency,
+                },
+                result=result,
+                cap=cap,
+            )
+            if ledger_line is None:
+                return ledger_entry
+            edge = await self._upsert_edge(
+                db,
+                user_id=user_id,
+                from_node_id=ledger_entry.id,
+                to_node_id=ledger_line.id,
+                relation="contains",
+                properties={"adapter": "lazy_materialization"},
+                result=result,
+                cap=cap,
+            )
+            if edge is None:
+                return ledger_entry
+
+        await self._materialize_entry_source(
+            db, user_id=user_id, entry=entry, ledger_entry=ledger_entry, result=result, cap=cap
+        )
+        return ledger_entry
+
+    async def _materialize_entry_source(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        entry: JournalEntry,
+        ledger_entry: EvidenceNode,
+        result: EvidenceMaterializationResult,
+        cap: int,
+    ) -> None:
+        if entry.source_id is None:
+            return
+
+        transaction = await self._get_owned_statement_transaction(db, user_id=user_id, transaction_id=entry.source_id)
+        if transaction is not None:
+            extracted = await self._materialize_statement_transaction(
+                db,
+                user_id=user_id,
+                transaction=transaction,
+                result=result,
+                cap=cap,
+            )
+            if extracted is not None:
+                await self._upsert_edge(
+                    db,
+                    user_id=user_id,
+                    from_node_id=extracted.id,
+                    to_node_id=ledger_entry.id,
+                    relation="posted_as",
+                    properties={"adapter": "lazy_materialization"},
+                    result=result,
+                    cap=cap,
+                )
+            atomic = await self._find_atomic_transaction_for_bank_txn(db, user_id=user_id, transaction=transaction)
+            if atomic is not None:
+                atomic_node = await self._materialize_atomic_transaction(
+                    db,
+                    user_id=user_id,
+                    atomic=atomic,
+                    result=result,
+                    cap=cap,
+                )
+                if atomic_node is not None:
+                    await self._upsert_edge(
+                        db,
+                        user_id=user_id,
+                        from_node_id=atomic_node.id,
+                        to_node_id=ledger_entry.id,
+                        relation="posted_as",
+                        properties={"adapter": "lazy_materialization"},
+                        result=result,
+                        cap=cap,
+                    )
+            return
+
+        atomic = await self._get_owned_atomic_transaction(db, user_id=user_id, atomic_id=entry.source_id)
+        if atomic is not None:
+            atomic_node = await self._materialize_atomic_transaction(
+                db,
+                user_id=user_id,
+                atomic=atomic,
+                result=result,
+                cap=cap,
+            )
+            if atomic_node is not None:
+                await self._upsert_edge(
+                    db,
+                    user_id=user_id,
+                    from_node_id=atomic_node.id,
+                    to_node_id=ledger_entry.id,
+                    relation="posted_as",
+                    properties={"adapter": "lazy_materialization"},
+                    result=result,
+                    cap=cap,
+                )
+            return
+
+        if entry.source_type in STATEMENT_SOURCE_TYPES:
+            self._add_blocker(result, "entity_missing", "Journal entry source_id does not resolve to an owned source.")
+        elif entry.source_type not in {
+            JournalEntrySourceType.MANUAL,
+            JournalEntrySourceType.SYSTEM,
+            JournalEntrySourceType.FX_REVALUATION,
+        }:
+            self._add_blocker(
+                result,
+                "unsupported_provenance",
+                f"Unsupported journal source type for Evidence Graph materialization: {entry.source_type.value}.",
+            )
+
+    async def _materialize_statement_transaction(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        result: EvidenceMaterializationResult,
+        cap: int,
+        transaction_id: UUID | None = None,
+        transaction: BankStatementTransaction | None = None,
+    ) -> EvidenceNode | None:
+        if transaction is None:
+            transaction = await self._get_owned_statement_transaction(
+                db, user_id=user_id, transaction_id=transaction_id
+            )
+        if transaction is None:
+            self._add_blocker(result, "entity_missing", "Bank statement transaction does not exist for this user.")
+            return None
+
+        statement = await self._get_owned_statement(db, user_id=user_id, statement_id=transaction.statement_id)
+        source = None
+        if statement is not None:
+            source = await self._materialize_statement(
+                db,
+                user_id=user_id,
+                statement=statement,
+                result=result,
+                cap=cap,
+                include_transactions=False,
+            )
+        extracted = await self._upsert_statement_transaction_node(
+            db,
+            user_id=user_id,
+            transaction=transaction,
+            statement=statement,
+            result=result,
+            cap=cap,
+        )
+        if extracted is None:
+            return None
+        if source is not None:
+            await self._upsert_edge(
+                db,
+                user_id=user_id,
+                from_node_id=source.id,
+                to_node_id=extracted.id,
+                relation="parsed_into",
+                properties={"adapter": "lazy_materialization"},
+                result=result,
+                cap=cap,
+            )
+
+        uploaded_document = None
+        if statement is not None:
+            uploaded_document = await self._get_uploaded_document_by_hash(
+                db, user_id=user_id, file_hash=statement.file_hash
+            )
+        if uploaded_document is not None:
+            uploaded_source = await self._materialize_uploaded_document(
+                db,
+                user_id=user_id,
+                document=uploaded_document,
+                result=result,
+                cap=cap,
+            )
+            if uploaded_source is not None:
+                await self._upsert_edge(
+                    db,
+                    user_id=user_id,
+                    from_node_id=uploaded_source.id,
+                    to_node_id=extracted.id,
+                    relation="parsed_into",
+                    properties={"adapter": "lazy_materialization"},
+                    result=result,
+                    cap=cap,
+                )
+
+        atomic = await self._find_atomic_transaction_for_bank_txn(db, user_id=user_id, transaction=transaction)
+        if atomic is not None:
+            atomic_node = await self._materialize_atomic_transaction(
+                db,
+                user_id=user_id,
+                atomic=atomic,
+                result=result,
+                cap=cap,
+            )
+            if atomic_node is not None:
+                await self._upsert_edge(
+                    db,
+                    user_id=user_id,
+                    from_node_id=extracted.id,
+                    to_node_id=atomic_node.id,
+                    relation="deduped_into",
+                    properties={"dedup_hash": atomic.dedup_hash, "adapter": "lazy_materialization"},
+                    result=result,
+                    cap=cap,
+                )
+        return extracted
+
+    async def _materialize_statement(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        result: EvidenceMaterializationResult,
+        cap: int,
+        statement_id: UUID | None = None,
+        statement: BankStatement | None = None,
+        include_transactions: bool = True,
+    ) -> EvidenceNode | None:
+        if statement is None:
+            statement = await self._get_owned_statement(db, user_id=user_id, statement_id=statement_id)
+        if statement is None:
+            self._add_blocker(result, "entity_missing", "Bank statement does not exist for this user.")
+            return None
+        source = await self._upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="source_document",
+            entity_type="bank_statement",
+            entity_id=statement.id,
+            properties={
+                "file_hash": statement.file_hash,
+                "original_filename": statement.original_filename,
+                "institution": statement.institution,
+            },
+            result=result,
+            cap=cap,
+        )
+        if source is None or not include_transactions:
+            return source
+        transactions = (
+            (
+                await db.execute(
+                    select(BankStatementTransaction)
+                    .where(BankStatementTransaction.statement_id == statement.id)
+                    .order_by(BankStatementTransaction.created_at.asc(), BankStatementTransaction.id.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for transaction in transactions:
+            extracted = await self._upsert_statement_transaction_node(
+                db,
+                user_id=user_id,
+                transaction=transaction,
+                statement=statement,
+                result=result,
+                cap=cap,
+            )
+            if extracted is None:
+                return source
+            edge = await self._upsert_edge(
+                db,
+                user_id=user_id,
+                from_node_id=source.id,
+                to_node_id=extracted.id,
+                relation="parsed_into",
+                properties={"adapter": "lazy_materialization"},
+                result=result,
+                cap=cap,
+            )
+            if edge is None:
+                return source
+        return source
+
+    async def _materialize_uploaded_document(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        result: EvidenceMaterializationResult,
+        cap: int,
+        document_id: UUID | None = None,
+        document: UploadedDocument | None = None,
+    ) -> EvidenceNode | None:
+        if document is None:
+            document = (
+                await db.execute(
+                    select(UploadedDocument)
+                    .where(UploadedDocument.user_id == user_id)
+                    .where(UploadedDocument.id == document_id)
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+        if document is None:
+            self._add_blocker(result, "entity_missing", "Uploaded document does not exist for this user.")
+            return None
+        return await self._upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="source_document",
+            entity_type="uploaded_document",
+            entity_id=document.id,
+            properties={
+                "document_type": document.document_type.value,
+                "original_filename": document.original_filename,
+                "file_hash": document.file_hash,
+            },
+            result=result,
+            cap=cap,
+        )
+
+    async def _materialize_atomic_transaction(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        result: EvidenceMaterializationResult,
+        cap: int,
+        atomic_id: UUID | None = None,
+        atomic: AtomicTransaction | None = None,
+    ) -> EvidenceNode | None:
+        if atomic is None:
+            atomic = await self._get_owned_atomic_transaction(db, user_id=user_id, atomic_id=atomic_id)
+        if atomic is None:
+            self._add_blocker(result, "entity_missing", "Atomic transaction does not exist for this user.")
+            return None
+        return await self._upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="atomic_fact",
+            entity_type="atomic_transaction",
+            entity_id=atomic.id,
+            properties={
+                "dedup_hash": atomic.dedup_hash,
+                "txn_date": atomic.txn_date.isoformat(),
+                "direction": atomic.direction.value,
+                "amount": str(atomic.amount),
+                "currency": atomic.currency,
+            },
+            result=result,
+            cap=cap,
+        )
+
+    async def _upsert_statement_transaction_node(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        transaction: BankStatementTransaction,
+        statement: BankStatement | None,
+        result: EvidenceMaterializationResult,
+        cap: int,
+    ) -> EvidenceNode | None:
+        return await self._upsert_node(
+            db,
+            user_id=user_id,
+            node_kind="extracted_record",
+            entity_type="bank_statement_transaction",
+            entity_id=transaction.id,
+            properties={
+                "statement_id": str(transaction.statement_id),
+                "txn_date": transaction.txn_date.isoformat(),
+                "direction": transaction.direction,
+                "amount": str(transaction.amount),
+                "currency": transaction.currency or (statement.currency if statement else None),
+                "reference": transaction.reference,
+            },
+            result=result,
+            cap=cap,
+        )
+
+    async def _upsert_node(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        node_kind: str,
+        entity_type: str,
+        entity_id: UUID,
+        properties: dict,
+        result: EvidenceMaterializationResult,
+        cap: int,
+    ) -> EvidenceNode | None:
+        existing = await self.lineage.get_node_for_entity(
+            db,
+            user_id=user_id,
+            node_kind=node_kind,
+            entity_type=entity_type,
+            entity_id=entity_id,
+        )
+        if existing is None and result.write_count >= cap:
+            self._add_blocker(
+                result,
+                "materialization_write_cap_reached",
+                "Request-time Evidence Graph materialization write cap was reached.",
+            )
+            return None
+        node = await self.lineage.upsert_node(
+            db,
+            user_id=user_id,
+            node_kind=node_kind,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            properties=properties,
+        )
+        if existing is None:
+            result.created_nodes += 1
+        return node
+
+    async def _upsert_edge(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        from_node_id: UUID,
+        to_node_id: UUID,
+        relation: str,
+        properties: dict,
+        result: EvidenceMaterializationResult,
+        cap: int,
+    ) -> EvidenceEdge | None:
+        existing = (
+            await db.execute(
+                select(EvidenceEdge)
+                .where(EvidenceEdge.user_id == user_id)
+                .where(EvidenceEdge.from_node_id == from_node_id)
+                .where(EvidenceEdge.to_node_id == to_node_id)
+                .where(EvidenceEdge.relation == relation)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if existing is None and result.write_count >= cap:
+            self._add_blocker(
+                result,
+                "materialization_write_cap_reached",
+                "Request-time Evidence Graph materialization write cap was reached.",
+            )
+            return None
+        edge = await self.lineage.upsert_edge(
+            db,
+            user_id=user_id,
+            from_node_id=from_node_id,
+            to_node_id=to_node_id,
+            relation=relation,
+            properties=properties,
+        )
+        if existing is None:
+            result.created_edges += 1
+        return edge
+
+    async def _get_owned_statement_transaction(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        transaction_id: UUID | None,
+    ) -> BankStatementTransaction | None:
+        if transaction_id is None:
+            return None
+        return (
+            await db.execute(
+                select(BankStatementTransaction)
+                .join(BankStatement, BankStatementTransaction.statement_id == BankStatement.id)
+                .where(BankStatement.user_id == user_id)
+                .where(BankStatementTransaction.id == transaction_id)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+    async def _get_owned_statement(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        statement_id: UUID | None,
+    ) -> BankStatement | None:
+        if statement_id is None:
+            return None
+        return (
+            await db.execute(
+                select(BankStatement)
+                .where(BankStatement.user_id == user_id)
+                .where(BankStatement.id == statement_id)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+    async def _get_uploaded_document_by_hash(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        file_hash: str,
+    ) -> UploadedDocument | None:
+        return (
+            await db.execute(
+                select(UploadedDocument)
+                .where(UploadedDocument.user_id == user_id)
+                .where(UploadedDocument.file_hash == file_hash)
+                .order_by(UploadedDocument.created_at.desc(), UploadedDocument.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+    async def _get_owned_atomic_transaction(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        atomic_id: UUID | None,
+    ) -> AtomicTransaction | None:
+        if atomic_id is None:
+            return None
+        return (
+            await db.execute(
+                select(AtomicTransaction)
+                .where(AtomicTransaction.user_id == user_id)
+                .where(AtomicTransaction.id == atomic_id)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+    async def _find_atomic_transaction_for_bank_txn(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        transaction: BankStatementTransaction,
+    ) -> AtomicTransaction | None:
+        direction = TransactionDirection.IN if transaction.direction == "IN" else TransactionDirection.OUT
+        dedup_hash = DeduplicationService.calculate_transaction_hash(
+            user_id,
+            transaction.txn_date,
+            transaction.amount,
+            direction,
+            transaction.description,
+            transaction.reference,
+        )
+        return (
+            await db.execute(
+                select(AtomicTransaction)
+                .where(AtomicTransaction.user_id == user_id)
+                .where(AtomicTransaction.dedup_hash == dedup_hash)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+    async def _detect_missing_journal_line_nodes(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID | None,
+        findings: list[EvidenceConsistencyFinding],
+    ) -> None:
+        query = select(JournalLine.id).join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
+        if user_id is not None:
+            query = query.where(JournalEntry.user_id == user_id)
+        query = query.where(
+            ~exists()
+            .where(EvidenceNode.user_id == JournalEntry.user_id)
+            .where(EvidenceNode.node_kind == "ledger_line")
+            .where(EvidenceNode.entity_type == "journal_line")
+            .where(EvidenceNode.entity_id == JournalLine.id)
+        )
+        for line_id in (await db.execute(query.limit(100))).scalars().all():
+            findings.append(
+                EvidenceConsistencyFinding(
+                    code="graph_node_missing",
+                    severity="medium",
+                    entity_type="journal_line",
+                    entity_id=line_id,
+                    message="Journal line exists without a ledger_line Evidence Graph node.",
+                )
+            )
+
+    async def _detect_orphan_nodes(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID | None,
+        findings: list[EvidenceConsistencyFinding],
+    ) -> None:
+        query = select(EvidenceNode)
+        if user_id is not None:
+            query = query.where(EvidenceNode.user_id == user_id)
+        for node in (await db.execute(query.limit(200))).scalars().all():
+            if await self._business_entity_exists(db, node=node):
+                continue
+            findings.append(
+                EvidenceConsistencyFinding(
+                    code="orphan_graph_node",
+                    severity="high",
+                    entity_type=node.entity_type,
+                    entity_id=node.entity_id,
+                    message="Evidence Graph node points to a missing or cross-user business entity.",
+                )
+            )
+
+    async def _detect_cross_user_edges(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID | None,
+        findings: list[EvidenceConsistencyFinding],
+    ) -> None:
+        from_node = aliased(EvidenceNode)
+        to_node = aliased(EvidenceNode)
+        query = (
+            select(EvidenceEdge, from_node, to_node)
+            .join(from_node, EvidenceEdge.from_node_id == from_node.id)
+            .join(to_node, EvidenceEdge.to_node_id == to_node.id)
+        )
+        if user_id is not None:
+            query = query.where(EvidenceEdge.user_id == user_id)
+        rows = (await db.execute(query.limit(200))).all()
+        for edge, source, target in rows:
+            if edge.user_id == source.user_id == target.user_id:
+                continue
+            findings.append(
+                EvidenceConsistencyFinding(
+                    code="cross_user_lineage_blocked",
+                    severity="high",
+                    entity_type="evidence_edge",
+                    entity_id=edge.id,
+                    message="Evidence Graph edge user does not match both endpoint users.",
+                )
+            )
+
+    async def _detect_dangling_edges(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID | None,
+        findings: list[EvidenceConsistencyFinding],
+    ) -> None:
+        from_node = aliased(EvidenceNode)
+        to_node = aliased(EvidenceNode)
+        query = (
+            select(EvidenceEdge, from_node.id, to_node.id)
+            .outerjoin(from_node, EvidenceEdge.from_node_id == from_node.id)
+            .outerjoin(to_node, EvidenceEdge.to_node_id == to_node.id)
+        )
+        if user_id is not None:
+            query = query.where(EvidenceEdge.user_id == user_id)
+        rows = (await db.execute(query.limit(200))).all()
+        for edge, from_node_id, to_node_id in rows:
+            if from_node_id is not None and to_node_id is not None:
+                continue
+            findings.append(
+                EvidenceConsistencyFinding(
+                    code="dangling_graph_edge",
+                    severity="high",
+                    entity_type="evidence_edge",
+                    entity_id=edge.id,
+                    message="Evidence Graph edge points to a missing endpoint node.",
+                )
+            )
+
+    async def _business_entity_exists(self, db: AsyncSession, *, node: EvidenceNode) -> bool:
+        if node.entity_type == "journal_line":
+            row = (
+                await db.execute(
+                    select(JournalLine.id)
+                    .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
+                    .where(JournalLine.id == node.entity_id)
+                    .where(JournalEntry.user_id == node.user_id)
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            return row is not None
+        if node.entity_type == "journal_entry":
+            row = (
+                await db.execute(
+                    select(JournalEntry.id)
+                    .where(JournalEntry.id == node.entity_id)
+                    .where(JournalEntry.user_id == node.user_id)
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            return row is not None
+        if node.entity_type == "bank_statement_transaction":
+            row = (
+                await db.execute(
+                    select(BankStatementTransaction.id)
+                    .join(BankStatement, BankStatementTransaction.statement_id == BankStatement.id)
+                    .where(BankStatementTransaction.id == node.entity_id)
+                    .where(BankStatement.user_id == node.user_id)
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            return row is not None
+        if node.entity_type == "bank_statement":
+            return await self._get_owned_statement(db, user_id=node.user_id, statement_id=node.entity_id) is not None
+        if node.entity_type == "uploaded_document":
+            row = (
+                await db.execute(
+                    select(UploadedDocument.id)
+                    .where(UploadedDocument.id == node.entity_id)
+                    .where(UploadedDocument.user_id == node.user_id)
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            return row is not None
+        if node.entity_type == "atomic_transaction":
+            return (
+                await self._get_owned_atomic_transaction(db, user_id=node.user_id, atomic_id=node.entity_id) is not None
+            )
+        return True
+
+    @staticmethod
+    def _add_blocker(result: EvidenceMaterializationResult, code: str, message: str) -> None:
+        blocker = EvidenceMaterializationBlocker(code=code, message=message)
+        if blocker not in result.blockers:
+            result.blockers.append(blocker)

--- a/apps/backend/src/services/evidence_graph_materialization.py
+++ b/apps/backend/src/services/evidence_graph_materialization.py
@@ -90,13 +90,13 @@ class EvidenceGraphMaterializationService:
             )
             return result
 
-        if entity_type == "journal_line" or node_kind == "ledger_line":
+        if entity_type == "journal_line":
             await self._materialize_journal_line(db, user_id=user_id, line_id=entity_id, result=result, cap=max_writes)
-        elif entity_type == "journal_entry" or node_kind == "ledger_entry":
+        elif entity_type == "journal_entry":
             await self._materialize_journal_entry(
                 db, user_id=user_id, entry_id=entity_id, result=result, cap=max_writes
             )
-        elif entity_type == "bank_statement_transaction" or node_kind == "extracted_record":
+        elif entity_type == "bank_statement_transaction":
             await self._materialize_statement_transaction(
                 db, user_id=user_id, transaction_id=entity_id, result=result, cap=max_writes
             )
@@ -108,7 +108,7 @@ class EvidenceGraphMaterializationService:
             await self._materialize_uploaded_document(
                 db, user_id=user_id, document_id=entity_id, result=result, cap=max_writes
             )
-        elif entity_type == "atomic_transaction" or node_kind == "atomic_fact":
+        elif entity_type == "atomic_transaction":
             await self._materialize_atomic_transaction(
                 db, user_id=user_id, atomic_id=entity_id, result=result, cap=max_writes
             )
@@ -877,7 +877,7 @@ class EvidenceGraphMaterializationService:
                 continue
             findings.append(
                 EvidenceConsistencyFinding(
-                    code="dangling_graph_edge",
+                    code="dangling_edge",
                     severity="high",
                     entity_type="evidence_edge",
                     entity_id=edge.id,

--- a/apps/backend/tests/api/test_evidence_lineage_router.py
+++ b/apps/backend/tests/api/test_evidence_lineage_router.py
@@ -15,6 +15,7 @@ from src.models.evidence import EvidenceEdge, EvidenceNode
 from src.models.journal import Direction, JournalEntry, JournalEntrySourceType, JournalEntryStatus, JournalLine
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.statement import BankStatement, BankStatementStatus, BankStatementTransaction
+from src.routers.evidence import _should_attempt_lazy_materialization
 from src.services.deduplication import DeduplicationService
 from src.services.evidence_lineage import EvidenceLineageService
 
@@ -322,3 +323,18 @@ async def test_AC18_10_3_AC18_10_4_lineage_api_lazily_materializes_historical_jo
 
     assert second.status_code == 200
     assert counts_after_second == counts_after_first
+
+
+def test_AC18_10_7_lazy_materialization_requires_supported_entity_type_and_matching_node_kind() -> None:
+    """AC18.10.7: Lazy materialization is keyed by entity identity, not a free-form node_kind fallback."""
+    assert (
+        _should_attempt_lazy_materialization(entity_type="journal_line", node_kind="ledger_line", anchor=None) is True
+    )
+    assert _should_attempt_lazy_materialization(entity_type="journal_line", node_kind=None, anchor=None) is True
+    assert (
+        _should_attempt_lazy_materialization(entity_type="future_table", node_kind="ledger_line", anchor=None) is False
+    )
+    assert (
+        _should_attempt_lazy_materialization(entity_type="journal_line", node_kind="source_document", anchor=None)
+        is False
+    )

--- a/apps/backend/tests/api/test_evidence_lineage_router.py
+++ b/apps/backend/tests/api/test_evidence_lineage_router.py
@@ -1,12 +1,21 @@
 """Evidence Graph navigation API tests."""
 
+from datetime import date
+from decimal import Decimal
 from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import User
+from src.models.account import Account, AccountType
+from src.models.evidence import EvidenceEdge, EvidenceNode
+from src.models.journal import Direction, JournalEntry, JournalEntrySourceType, JournalEntryStatus, JournalLine
+from src.models.layer2 import AtomicTransaction, TransactionDirection
+from src.models.statement import BankStatement, BankStatementStatus, BankStatementTransaction
+from src.services.deduplication import DeduplicationService
 from src.services.evidence_lineage import EvidenceLineageService
 
 
@@ -178,3 +187,138 @@ async def test_AC18_9_3_lineage_api_returns_blocker_for_missing_or_cross_user_an
             "message": "No owned Evidence Graph node exists for this entity identity.",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_AC18_10_3_AC18_10_4_lineage_api_lazily_materializes_historical_journal_line(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC18.10.3 AC18.10.4: Lineage reads repair a missing historical graph path once and idempotently."""
+    bank = Account(user_id=test_user.id, name="Lazy API Bank", type=AccountType.ASSET, currency="SGD")
+    income = Account(user_id=test_user.id, name="Lazy API Income", type=AccountType.INCOME, currency="SGD")
+    db.add_all([bank, income])
+    await db.flush()
+
+    statement = BankStatement(
+        user_id=test_user.id,
+        account_id=bank.id,
+        file_path="s3://lazy/api.csv",
+        file_hash=f"lazy-api-{uuid4().hex}",
+        original_filename="lazy-api.csv",
+        institution="Lazy API Bank",
+        currency="SGD",
+        status=BankStatementStatus.APPROVED,
+    )
+    txn = BankStatementTransaction(
+        statement=statement,
+        txn_date=date(2026, 5, 2),
+        description="Lazy API income",
+        amount=Decimal("77.00"),
+        direction="IN",
+        currency="SGD",
+        reference="API-1",
+    )
+    db.add_all([statement, txn])
+    await db.flush()
+
+    atomic = AtomicTransaction(
+        user_id=test_user.id,
+        txn_date=txn.txn_date,
+        amount=txn.amount,
+        direction=TransactionDirection.IN,
+        description=txn.description,
+        reference=txn.reference,
+        currency="SGD",
+        dedup_hash=DeduplicationService.calculate_transaction_hash(
+            test_user.id,
+            txn.txn_date,
+            txn.amount,
+            TransactionDirection.IN,
+            txn.description,
+            txn.reference,
+        ),
+        source_documents=[],
+    )
+    entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=txn.txn_date,
+        memo="Lazy API posted income",
+        source_type=JournalEntrySourceType.USER_CONFIRMED,
+        source_id=txn.id,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add_all([atomic, entry])
+    await db.flush()
+    line = JournalLine(
+        journal_entry_id=entry.id,
+        account_id=income.id,
+        direction=Direction.CREDIT,
+        amount=txn.amount,
+        currency="SGD",
+    )
+    db.add(line)
+    await db.commit()
+
+    first = await client.get(
+        "/evidence/lineage",
+        params={
+            "entity_type": "journal_line",
+            "entity_id": str(line.id),
+            "node_kind": "ledger_line",
+            "direction": "upstream",
+            "max_depth": "5",
+        },
+    )
+
+    assert first.status_code == 200
+    payload = first.json()
+    assert payload["blockers"] == []
+    node_keys = {(node["node_kind"], node["entity_type"], node["entity_id"]) for node in payload["nodes"]}
+    assert ("source_document", "bank_statement", str(statement.id)) in node_keys
+    assert ("extracted_record", "bank_statement_transaction", str(txn.id)) in node_keys
+    assert ("atomic_fact", "atomic_transaction", str(atomic.id)) in node_keys
+    assert ("ledger_entry", "journal_entry", str(entry.id)) in node_keys
+    assert ("ledger_line", "journal_line", str(line.id)) in node_keys
+    assert {edge["relation"] for edge in payload["edges"]} >= {"parsed_into", "posted_as", "contains"}
+    db_edges = {
+        (edge.from_node_id, edge.to_node_id, edge.relation)
+        for edge in (await db.execute(select(EvidenceEdge).where(EvidenceEdge.user_id == test_user.id))).scalars()
+    }
+    nodes_by_key = {
+        (node.node_kind, node.entity_type, node.entity_id): node
+        for node in (await db.execute(select(EvidenceNode).where(EvidenceNode.user_id == test_user.id))).scalars()
+    }
+    source_node = nodes_by_key[("source_document", "bank_statement", statement.id)]
+    extracted_node = nodes_by_key[("extracted_record", "bank_statement_transaction", txn.id)]
+    atomic_node = nodes_by_key[("atomic_fact", "atomic_transaction", atomic.id)]
+    ledger_entry_node = nodes_by_key[("ledger_entry", "journal_entry", entry.id)]
+    ledger_line_node = nodes_by_key[("ledger_line", "journal_line", line.id)]
+    assert (source_node.id, extracted_node.id, "parsed_into") in db_edges
+    assert (extracted_node.id, atomic_node.id, "deduped_into") in db_edges
+    assert (extracted_node.id, ledger_entry_node.id, "posted_as") in db_edges
+    assert (atomic_node.id, ledger_entry_node.id, "posted_as") in db_edges
+    assert (ledger_entry_node.id, ledger_line_node.id, "contains") in db_edges
+
+    counts_after_first = (
+        (await db.execute(select(func.count(EvidenceNode.id)))).scalar_one(),
+        (await db.execute(select(func.count(EvidenceEdge.id)))).scalar_one(),
+    )
+    second = await client.get(
+        "/evidence/lineage",
+        params={
+            "entity_type": "journal_line",
+            "entity_id": str(line.id),
+            "node_kind": "ledger_line",
+            "direction": "upstream",
+            "max_depth": "5",
+        },
+    )
+    counts_after_second = (
+        (await db.execute(select(func.count(EvidenceNode.id)))).scalar_one(),
+        (await db.execute(select(func.count(EvidenceEdge.id)))).scalar_one(),
+    )
+
+    assert second.status_code == 200
+    assert counts_after_second == counts_after_first

--- a/apps/backend/tests/services/test_evidence_graph_materialization.py
+++ b/apps/backend/tests/services/test_evidence_graph_materialization.py
@@ -275,7 +275,7 @@ async def test_AC18_10_4_direct_entity_materialization_branches_are_idempotent(
     test_user: User,
 ):
     """AC18.10.4: Direct entity requests use deterministic relationships and remain idempotent."""
-    statement, txn, atomic, entry, _ = await _create_historical_statement_entry(db, user_id=test_user.id)
+    statement, txn, atomic, entry, line = await _create_historical_statement_entry(db, user_id=test_user.id)
     document = UploadedDocument(
         user_id=test_user.id,
         file_path="s3://lazy/history-upload.csv",
@@ -285,6 +285,25 @@ async def test_AC18_10_4_direct_entity_materialization_branches_are_idempotent(
         status=DocumentStatus.COMPLETED,
     )
     db.add(document)
+    await db.flush()
+    atomic_entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=atomic.txn_date,
+        memo="Atomic sourced entry",
+        source_type=JournalEntrySourceType.MANUAL,
+        source_id=atomic.id,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(atomic_entry)
+    await db.flush()
+    atomic_line = JournalLine(
+        journal_entry_id=atomic_entry.id,
+        account_id=line.account_id,
+        direction=Direction.CREDIT,
+        amount=atomic.amount,
+        currency=atomic.currency,
+    )
+    db.add(atomic_line)
     await db.flush()
     service = EvidenceGraphMaterializationService()
 
@@ -321,6 +340,13 @@ async def test_AC18_10_4_direct_entity_materialization_branches_are_idempotent(
         entity_id=atomic.id,
         node_kind="atomic_fact",
     )
+    atomic_entry_result = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="journal_entry",
+        entity_id=atomic_entry.id,
+        node_kind="ledger_entry",
+    )
     unsupported = await service.materialize_for_entity(
         db,
         user_id=test_user.id,
@@ -333,6 +359,8 @@ async def test_AC18_10_4_direct_entity_materialization_branches_are_idempotent(
     assert journal_entry_result.blockers == []
     assert document_result.blockers == []
     assert atomic_result.blockers == []
+    assert atomic_entry_result.blockers == []
+    assert statement_result.has_writes
     assert [blocker.code for blocker in unsupported.blockers] == ["unsupported_provenance"]
     nodes = {
         (node.node_kind, node.entity_type, node.entity_id): node
@@ -347,6 +375,7 @@ async def test_AC18_10_4_direct_entity_materialization_branches_are_idempotent(
     assert ("extracted_record", "bank_statement_transaction", txn.id) in nodes
     assert ("atomic_fact", "atomic_transaction", atomic.id) in nodes
     assert ("ledger_entry", "journal_entry", entry.id) in nodes
+    assert ("ledger_entry", "journal_entry", atomic_entry.id) in nodes
     assert (
         nodes[("source_document", "uploaded_document", document.id)].id,
         nodes[("extracted_record", "bank_statement_transaction", txn.id)].id,
@@ -356,6 +385,11 @@ async def test_AC18_10_4_direct_entity_materialization_branches_are_idempotent(
         nodes[("extracted_record", "bank_statement_transaction", txn.id)].id,
         nodes[("atomic_fact", "atomic_transaction", atomic.id)].id,
         "deduped_into",
+    ) in edges
+    assert (
+        nodes[("atomic_fact", "atomic_transaction", atomic.id)].id,
+        nodes[("ledger_entry", "journal_entry", atomic_entry.id)].id,
+        "posted_as",
     ) in edges
 
 

--- a/apps/backend/tests/services/test_evidence_graph_materialization.py
+++ b/apps/backend/tests/services/test_evidence_graph_materialization.py
@@ -353,6 +353,13 @@ async def test_AC18_10_4_direct_entity_materialization_branches_are_idempotent(
         entity_type="future_table",
         entity_id=uuid4(),
     )
+    unsupported_with_supported_node_kind = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="future_table",
+        entity_id=uuid4(),
+        node_kind="ledger_line",
+    )
 
     assert statement_result.blockers == []
     assert transaction_result.blockers == []
@@ -362,6 +369,7 @@ async def test_AC18_10_4_direct_entity_materialization_branches_are_idempotent(
     assert atomic_entry_result.blockers == []
     assert statement_result.has_writes
     assert [blocker.code for blocker in unsupported.blockers] == ["unsupported_provenance"]
+    assert [blocker.code for blocker in unsupported_with_supported_node_kind.blockers] == ["unsupported_provenance"]
     nodes = {
         (node.node_kind, node.entity_type, node.entity_id): node
         for node in (await db.execute(select(EvidenceNode).where(EvidenceNode.user_id == test_user.id))).scalars()

--- a/apps/backend/tests/services/test_evidence_graph_materialization.py
+++ b/apps/backend/tests/services/test_evidence_graph_materialization.py
@@ -14,6 +14,7 @@ from src.models import User
 from src.models.account import Account, AccountType
 from src.models.evidence import EvidenceEdge, EvidenceNode
 from src.models.journal import Direction, JournalEntry, JournalEntrySourceType, JournalEntryStatus, JournalLine
+from src.models.layer1 import DocumentStatus, DocumentType, UploadedDocument
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.statement import BankStatement, BankStatementStatus, BankStatementTransaction
 from src.services.deduplication import DeduplicationService
@@ -266,3 +267,191 @@ async def test_AC18_10_7_materialization_caps_and_unknown_sources_return_blocker
     )
 
     assert "entity_missing" in {blocker.code for blocker in unknown.blockers}
+
+
+@pytest.mark.asyncio
+async def test_AC18_10_4_direct_entity_materialization_branches_are_idempotent(
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC18.10.4: Direct entity requests use deterministic relationships and remain idempotent."""
+    statement, txn, atomic, entry, _ = await _create_historical_statement_entry(db, user_id=test_user.id)
+    document = UploadedDocument(
+        user_id=test_user.id,
+        file_path="s3://lazy/history-upload.csv",
+        file_hash=statement.file_hash,
+        original_filename="history-upload.csv",
+        document_type=DocumentType.BANK_STATEMENT,
+        status=DocumentStatus.COMPLETED,
+    )
+    db.add(document)
+    await db.flush()
+    service = EvidenceGraphMaterializationService()
+
+    statement_result = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="bank_statement",
+        entity_id=statement.id,
+    )
+    transaction_result = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="bank_statement_transaction",
+        entity_id=txn.id,
+        node_kind="extracted_record",
+    )
+    journal_entry_result = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="journal_entry",
+        entity_id=entry.id,
+        node_kind="ledger_entry",
+    )
+    document_result = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="uploaded_document",
+        entity_id=document.id,
+    )
+    atomic_result = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="atomic_transaction",
+        entity_id=atomic.id,
+        node_kind="atomic_fact",
+    )
+    unsupported = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="future_table",
+        entity_id=uuid4(),
+    )
+
+    assert statement_result.blockers == []
+    assert transaction_result.blockers == []
+    assert journal_entry_result.blockers == []
+    assert document_result.blockers == []
+    assert atomic_result.blockers == []
+    assert [blocker.code for blocker in unsupported.blockers] == ["unsupported_provenance"]
+    nodes = {
+        (node.node_kind, node.entity_type, node.entity_id): node
+        for node in (await db.execute(select(EvidenceNode).where(EvidenceNode.user_id == test_user.id))).scalars()
+    }
+    edges = {
+        (edge.from_node_id, edge.to_node_id, edge.relation)
+        for edge in (await db.execute(select(EvidenceEdge).where(EvidenceEdge.user_id == test_user.id))).scalars()
+    }
+    assert ("source_document", "bank_statement", statement.id) in nodes
+    assert ("source_document", "uploaded_document", document.id) in nodes
+    assert ("extracted_record", "bank_statement_transaction", txn.id) in nodes
+    assert ("atomic_fact", "atomic_transaction", atomic.id) in nodes
+    assert ("ledger_entry", "journal_entry", entry.id) in nodes
+    assert (
+        nodes[("source_document", "uploaded_document", document.id)].id,
+        nodes[("extracted_record", "bank_statement_transaction", txn.id)].id,
+        "parsed_into",
+    ) in edges
+    assert (
+        nodes[("extracted_record", "bank_statement_transaction", txn.id)].id,
+        nodes[("atomic_fact", "atomic_transaction", atomic.id)].id,
+        "deduped_into",
+    ) in edges
+
+
+@pytest.mark.asyncio
+async def test_AC18_10_5_detector_recognizes_supported_business_entities(
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC18.10.5: Detector does not mark valid supported graph nodes as orphans."""
+    statement, txn, atomic, entry, line = await _create_historical_statement_entry(db, user_id=test_user.id)
+    document = UploadedDocument(
+        user_id=test_user.id,
+        file_path="s3://lazy/detector-upload.csv",
+        file_hash=f"detector-{uuid4().hex}",
+        original_filename="detector-upload.csv",
+        document_type=DocumentType.BANK_STATEMENT,
+        status=DocumentStatus.COMPLETED,
+    )
+    db.add(document)
+    await db.flush()
+    service = EvidenceGraphMaterializationService()
+    for node_kind, entity_type, entity_id in [
+        ("ledger_line", "journal_line", line.id),
+        ("ledger_entry", "journal_entry", entry.id),
+        ("extracted_record", "bank_statement_transaction", txn.id),
+        ("source_document", "bank_statement", statement.id),
+        ("source_document", "uploaded_document", document.id),
+        ("atomic_fact", "atomic_transaction", atomic.id),
+        ("future_node", "future_table", uuid4()),
+    ]:
+        await service.lineage.upsert_node(
+            db,
+            user_id=test_user.id,
+            node_kind=node_kind,
+            entity_type=entity_type,
+            entity_id=entity_id,
+        )
+
+    report = await service.detect_consistency_drift(db, user_id=test_user.id)
+
+    assert not any(finding.code == "orphan_graph_node" for finding in report.findings)
+
+
+@pytest.mark.asyncio
+async def test_AC18_10_7_missing_and_cross_user_requests_return_explicit_blockers(
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC18.10.7: Missing and cross-user materialization requests return explicit blockers."""
+    other_user = User(email=f"other-{uuid4()}@example.com", hashed_password="x")
+    db.add(other_user)
+    await db.flush()
+    statement, txn, atomic, entry, line = await _create_historical_statement_entry(db, user_id=other_user.id)
+    service = EvidenceGraphMaterializationService()
+
+    missing_results = [
+        await service.materialize_for_entity(
+            db, user_id=test_user.id, entity_type="journal_line", entity_id=uuid4(), node_kind="ledger_line"
+        ),
+        await service.materialize_for_entity(
+            db, user_id=test_user.id, entity_type="journal_entry", entity_id=uuid4(), node_kind="ledger_entry"
+        ),
+        await service.materialize_for_entity(
+            db,
+            user_id=test_user.id,
+            entity_type="bank_statement_transaction",
+            entity_id=uuid4(),
+            node_kind="extracted_record",
+        ),
+        await service.materialize_for_entity(db, user_id=test_user.id, entity_type="bank_statement", entity_id=uuid4()),
+        await service.materialize_for_entity(
+            db, user_id=test_user.id, entity_type="uploaded_document", entity_id=uuid4()
+        ),
+        await service.materialize_for_entity(
+            db, user_id=test_user.id, entity_type="atomic_transaction", entity_id=uuid4(), node_kind="atomic_fact"
+        ),
+    ]
+    line_cross_user = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="journal_line",
+        entity_id=line.id,
+        node_kind="ledger_line",
+    )
+    entry_cross_user = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="journal_entry",
+        entity_id=entry.id,
+        node_kind="ledger_entry",
+    )
+
+    assert all(result.blockers[0].code == "entity_missing" for result in missing_results)
+    assert [blocker.code for blocker in line_cross_user.blockers] == ["cross_user_lineage_blocked"]
+    assert [blocker.code for blocker in entry_cross_user.blockers] == ["cross_user_lineage_blocked"]
+    assert await _graph_counts(db) == (0, 0)
+    assert statement.user_id == other_user.id
+    assert txn.statement_id == statement.id
+    assert atomic.user_id == other_user.id

--- a/apps/backend/tests/services/test_evidence_graph_materialization.py
+++ b/apps/backend/tests/services/test_evidence_graph_materialization.py
@@ -1,0 +1,268 @@
+"""Evidence Graph lazy materialization and consistency detector tests."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import User
+from src.models.account import Account, AccountType
+from src.models.evidence import EvidenceEdge, EvidenceNode
+from src.models.journal import Direction, JournalEntry, JournalEntrySourceType, JournalEntryStatus, JournalLine
+from src.models.layer2 import AtomicTransaction, TransactionDirection
+from src.models.statement import BankStatement, BankStatementStatus, BankStatementTransaction
+from src.services.deduplication import DeduplicationService
+from src.services.evidence_graph_integration import EvidenceGraphIntegrationService
+from src.services.evidence_graph_materialization import EvidenceGraphMaterializationService
+
+
+async def _create_historical_statement_entry(
+    db: AsyncSession,
+    *,
+    user_id,
+) -> tuple[BankStatement, BankStatementTransaction, AtomicTransaction, JournalEntry, JournalLine]:
+    bank = Account(user_id=user_id, name=f"Lazy Bank {uuid4()}", type=AccountType.ASSET, currency="SGD")
+    income = Account(user_id=user_id, name=f"Lazy Income {uuid4()}", type=AccountType.INCOME, currency="SGD")
+    db.add_all([bank, income])
+    await db.flush()
+
+    statement = BankStatement(
+        user_id=user_id,
+        account_id=bank.id,
+        file_path="s3://lazy/history.csv",
+        file_hash=f"lazy-{uuid4().hex}",
+        original_filename="history.csv",
+        institution="Lazy Bank",
+        currency="SGD",
+        status=BankStatementStatus.APPROVED,
+    )
+    txn = BankStatementTransaction(
+        statement=statement,
+        txn_date=date(2026, 5, 1),
+        description="Historical income",
+        amount=Decimal("42.00"),
+        direction="IN",
+        currency="SGD",
+        reference="LZ-1",
+    )
+    db.add_all([statement, txn])
+    await db.flush()
+
+    dedup_hash = DeduplicationService.calculate_transaction_hash(
+        user_id,
+        txn.txn_date,
+        txn.amount,
+        TransactionDirection.IN,
+        txn.description,
+        txn.reference,
+    )
+    atomic = AtomicTransaction(
+        user_id=user_id,
+        txn_date=txn.txn_date,
+        amount=txn.amount,
+        direction=TransactionDirection.IN,
+        description=txn.description,
+        reference=txn.reference,
+        currency="SGD",
+        dedup_hash=dedup_hash,
+        source_documents=[],
+    )
+    entry = JournalEntry(
+        user_id=user_id,
+        entry_date=txn.txn_date,
+        memo="Historical posted income",
+        source_type=JournalEntrySourceType.USER_CONFIRMED,
+        source_id=txn.id,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add_all([atomic, entry])
+    await db.flush()
+    debit = JournalLine(
+        journal_entry_id=entry.id,
+        account_id=bank.id,
+        direction=Direction.DEBIT,
+        amount=txn.amount,
+        currency="SGD",
+    )
+    credit = JournalLine(
+        journal_entry_id=entry.id,
+        account_id=income.id,
+        direction=Direction.CREDIT,
+        amount=txn.amount,
+        currency="SGD",
+    )
+    db.add_all([debit, credit])
+    await db.flush()
+    await db.refresh(entry, ["lines"])
+    return statement, txn, atomic, entry, credit
+
+
+async def _graph_counts(db: AsyncSession) -> tuple[int, int]:
+    node_count = (await db.execute(select(func.count(EvidenceNode.id)))).scalar_one()
+    edge_count = (await db.execute(select(func.count(EvidenceEdge.id)))).scalar_one()
+    return node_count, edge_count
+
+
+@pytest.mark.asyncio
+async def test_AC18_10_2_graph_writes_share_the_business_transaction(
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC18.10.2: Graph materialization participates in the same DB transaction as business facts."""
+    _, txn, _, entry, _ = await _create_historical_statement_entry(db, user_id=test_user.id)
+
+    await EvidenceGraphIntegrationService().record_journal_posting(
+        db,
+        user_id=test_user.id,
+        source_transaction=txn,
+        journal_entry=entry,
+    )
+    assert (await db.execute(select(func.count(EvidenceNode.id)))).scalar_one() > 0
+
+    await db.rollback()
+
+    assert (await db.execute(select(func.count(EvidenceNode.id)))).scalar_one() == 0
+    assert (await db.execute(select(func.count(EvidenceEdge.id)))).scalar_one() == 0
+
+
+@pytest.mark.asyncio
+async def test_AC18_10_4_AC18_10_6_lazy_materialization_is_idempotent_and_preserves_accounting_facts(
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC18.10.4 AC18.10.6: Lazy repair is deterministic, idempotent, and does not mutate ledger facts."""
+    statement, txn, atomic, entry, line = await _create_historical_statement_entry(db, user_id=test_user.id)
+    original_source_type = entry.source_type
+    original_source_id = entry.source_id
+    original_amount = line.amount
+    service = EvidenceGraphMaterializationService()
+
+    first = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="journal_line",
+        entity_id=line.id,
+        node_kind="ledger_line",
+    )
+    first_counts = await _graph_counts(db)
+    second = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="journal_line",
+        entity_id=line.id,
+        node_kind="ledger_line",
+    )
+    second_counts = await _graph_counts(db)
+
+    assert first.blockers == []
+    assert second.blockers == []
+    assert first.created_nodes > 0
+    assert first.created_edges > 0
+    assert second.created_nodes == 0
+    assert second.created_edges == 0
+    assert second_counts == first_counts
+    assert entry.source_type == original_source_type
+    assert entry.source_id == original_source_id
+    assert line.amount == original_amount
+
+    node_keys = {
+        (node.node_kind, node.entity_type, node.entity_id)
+        for node in (await db.execute(select(EvidenceNode))).scalars().all()
+    }
+    assert ("source_document", "bank_statement", statement.id) in node_keys
+    assert ("extracted_record", "bank_statement_transaction", txn.id) in node_keys
+    assert ("atomic_fact", "atomic_transaction", atomic.id) in node_keys
+    assert ("ledger_entry", "journal_entry", entry.id) in node_keys
+    assert ("ledger_line", "journal_line", line.id) in node_keys
+
+
+@pytest.mark.asyncio
+async def test_AC18_10_5_detector_reports_missing_orphan_and_cross_user_drift(
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC18.10.1 AC18.10.5: Detector uses explicit blocker taxonomy for graph drift without writes."""
+    _, _, _, _, line = await _create_historical_statement_entry(db, user_id=test_user.id)
+    service = EvidenceGraphMaterializationService()
+    orphan = EvidenceNode(
+        user_id=test_user.id,
+        node_kind="ledger_line",
+        entity_type="journal_line",
+        entity_id=uuid4(),
+        properties={},
+    )
+    other_user_id = uuid4()
+    source = EvidenceNode(
+        user_id=test_user.id,
+        node_kind="source_document",
+        entity_type="bank_statement",
+        entity_id=uuid4(),
+        properties={},
+    )
+    target = EvidenceNode(
+        user_id=other_user_id,
+        node_kind="extracted_record",
+        entity_type="bank_statement_transaction",
+        entity_id=uuid4(),
+        properties={},
+    )
+    db.add_all([orphan, source, target])
+    await db.flush()
+    db.add(
+        EvidenceEdge(
+            user_id=test_user.id,
+            from_node_id=source.id,
+            to_node_id=target.id,
+            relation="parsed_into",
+            properties={},
+        )
+    )
+    await db.flush()
+    before = await _graph_counts(db)
+
+    report = await service.detect_consistency_drift(db, user_id=test_user.id)
+
+    assert await _graph_counts(db) == before
+    finding_keys = {(finding.code, finding.entity_type, finding.entity_id) for finding in report.findings}
+    assert ("graph_node_missing", "journal_line", line.id) in finding_keys
+    assert ("orphan_graph_node", "journal_line", orphan.entity_id) in finding_keys
+    assert any(finding.code == "cross_user_lineage_blocked" for finding in report.findings)
+
+
+@pytest.mark.asyncio
+async def test_AC18_10_7_materialization_caps_and_unknown_sources_return_blockers(
+    db: AsyncSession,
+    test_user: User,
+):
+    """AC18.10.7: Tests cover write caps and unknown provenance blockers."""
+    _, _, _, entry, line = await _create_historical_statement_entry(db, user_id=test_user.id)
+    service = EvidenceGraphMaterializationService()
+
+    capped = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="journal_line",
+        entity_id=line.id,
+        node_kind="ledger_line",
+        max_writes=0,
+    )
+
+    assert [blocker.code for blocker in capped.blockers] == ["materialization_write_cap_reached"]
+    assert await _graph_counts(db) == (0, 0)
+
+    entry.source_id = uuid4()
+    await db.flush()
+    unknown = await service.materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="journal_line",
+        entity_id=line.id,
+        node_kind="ledger_line",
+    )
+
+    assert "entity_missing" in {blocker.code for blocker in unknown.blockers}

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -1196,7 +1196,7 @@ describe("PersonalReportPackagePage", () => {
     expect(mockedApiFetch).toHaveBeenCalledWith(
       `/api/evidence/lineage?entity_type=journal_line&entity_id=${journalLineId}&node_kind=ledger_line&direction=both&max_depth=6`,
     );
-    expect(screen.getByText("source_document")).toBeInTheDocument();
+    expect(await screen.findByText("source_document")).toBeInTheDocument();
     expect(screen.getByText("extracted_record")).toBeInTheDocument();
     expect(screen.getByText("atomic_fact")).toBeInTheDocument();
     expect(screen.getByText("ledger_entry")).toBeInTheDocument();

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -325,7 +325,7 @@ Dependencies: AC18.7 Evidence Graph foundation and AC18.8 first production sourc
 | AC18.9.5 | Evidence navigation UI | The lineage panel renders source document, extracted record, atomic fact, ledger entry, ledger line, and report-line anchors when present |
 | AC18.9.6 | Evidence navigation proof | Tests cover report line to source document navigation and source document to impacted ledger/report navigation |
 
-### Planned #733: Evidence Graph Lazy Materialization and Consistency Guardrails
+### AC18.10: Evidence Graph Lazy Materialization and Consistency Guardrails
 
 MECE task frame:
 
@@ -337,16 +337,15 @@ MECE task frame:
 
 Dependencies: AC18.7 Evidence Graph foundation, AC18.8 source-to-report integration, and AC18.9 navigation API/UI. Out of scope: scheduled production auto-repair, probabilistic amount/date/description matching, graph database adoption, and mutating ledger balances or `JournalEntry.source_type/source_id`.
 
-Implementation must register formal AC IDs with tests in the same PR that lands
-code. The intended acceptance shape is:
-
-- Evidence Graph SSOT defines graph as an audit projection, business tables as source of truth, and blocker taxonomy for drift states.
-- New source-to-ledger workflows materialize graph nodes and edges in the same database transaction as their owning business facts.
-- The lineage API attempts one bounded deterministic materialization pass when an owned anchor or required local path is missing for historical data.
-- Lazy materialization is idempotent and only uses strong relationships such as owned source IDs, transaction lineage, and `journal_line.journal_entry_id`; it never infers links from fuzzy amount, date, or description similarity.
-- An operator-safe dry-run detector reports missing graph nodes, graph nodes pointing to missing business entities, dangling edges, cross-user edges, incomplete lineage, and ambiguous or unsupported provenance.
-- Detector and lazy repair never mutate accounting facts, report amounts, ledger balances, or legacy `JournalEntry.source_type/source_id` values.
-- Tests cover request-time lazy repair, repeated-read idempotency, dry-run no-write behavior, cross-user blocking, unknown provenance blockers, dangling/orphan detection, and request-level write caps.
+| AC ID | Phase | Description |
+|-------|-------|-------------|
+| AC18.10.1 | Evidence consistency | Evidence Graph SSOT defines graph as an audit projection, business tables as source of truth, and blocker taxonomy for drift states |
+| AC18.10.2 | Evidence consistency | New source-to-ledger workflows materialize graph nodes and edges in the same database transaction as their owning business facts |
+| AC18.10.3 | Evidence lazy materialization | The lineage API attempts one bounded deterministic materialization pass when an owned anchor or required local path is missing for historical data |
+| AC18.10.4 | Evidence lazy materialization | Lazy materialization is idempotent and only uses strong relationships such as owned source IDs, transaction lineage, and `journal_line.journal_entry_id`; it never infers links from fuzzy amount, date, or description similarity |
+| AC18.10.5 | Evidence consistency detector | An operator-safe dry-run detector reports missing graph nodes, graph nodes pointing to missing business entities, dangling edges, cross-user edges, incomplete lineage, and ambiguous or unsupported provenance |
+| AC18.10.6 | Evidence consistency safety | Detector and lazy repair never mutate accounting facts, report amounts, ledger balances, or legacy `JournalEntry.source_type/source_id` values |
+| AC18.10.7 | Evidence consistency proof | Tests cover request-time lazy repair, repeated-read idempotency, dry-run no-write behavior, cross-user blocking, unknown provenance blockers, dangling/orphan detection, and request-level write caps |
 
 ### AC18.6: Framework Measurement and Disclosure Suggestions
 

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -325,6 +325,29 @@ Dependencies: AC18.7 Evidence Graph foundation and AC18.8 first production sourc
 | AC18.9.5 | Evidence navigation UI | The lineage panel renders source document, extracted record, atomic fact, ledger entry, ledger line, and report-line anchors when present |
 | AC18.9.6 | Evidence navigation proof | Tests cover report line to source document navigation and source document to impacted ledger/report navigation |
 
+### Planned #733: Evidence Graph Lazy Materialization and Consistency Guardrails
+
+MECE task frame:
+
+- Write-through path: new business workflows continue to materialize Evidence Graph nodes and edges inside the same database transaction as the owning business facts.
+- Lazy materialization path: lineage reads may repair missing historical graph anchors on demand, but only from deterministic relationships already present in source-of-truth tables.
+- Consistency detection path: operator checks report graph drift without mutating accounting facts or deleting audit evidence.
+- Blocker handling: incomplete, ambiguous, unsupported, or cross-user provenance remains explicit and user-scoped instead of guessed.
+- Safety limits: request-time materialization is bounded by depth, write count, batch size, and user scope.
+
+Dependencies: AC18.7 Evidence Graph foundation, AC18.8 source-to-report integration, and AC18.9 navigation API/UI. Out of scope: scheduled production auto-repair, probabilistic amount/date/description matching, graph database adoption, and mutating ledger balances or `JournalEntry.source_type/source_id`.
+
+Implementation must register formal AC IDs with tests in the same PR that lands
+code. The intended acceptance shape is:
+
+- Evidence Graph SSOT defines graph as an audit projection, business tables as source of truth, and blocker taxonomy for drift states.
+- New source-to-ledger workflows materialize graph nodes and edges in the same database transaction as their owning business facts.
+- The lineage API attempts one bounded deterministic materialization pass when an owned anchor or required local path is missing for historical data.
+- Lazy materialization is idempotent and only uses strong relationships such as owned source IDs, transaction lineage, and `journal_line.journal_entry_id`; it never infers links from fuzzy amount, date, or description similarity.
+- An operator-safe dry-run detector reports missing graph nodes, graph nodes pointing to missing business entities, dangling edges, cross-user edges, incomplete lineage, and ambiguous or unsupported provenance.
+- Detector and lazy repair never mutate accounting facts, report amounts, ledger balances, or legacy `JournalEntry.source_type/source_id` values.
+- Tests cover request-time lazy repair, repeated-read idempotency, dry-run no-write behavior, cross-user blocking, unknown provenance blockers, dangling/orphan detection, and request-level write caps.
+
 ### AC18.6: Framework Measurement and Disclosure Suggestions
 
 | AC ID | Phase | Description |

--- a/docs/ssot/evidence-lineage.md
+++ b/docs/ssot/evidence-lineage.md
@@ -198,8 +198,8 @@ not return graph evidence.
 
 ## Materialization and Consistency
 
-Consistency proof for lazy materialization is planned by issue #733. Evidence
-Graph consistency is maintained through three mechanisms:
+Consistency proof for lazy materialization is owned by AC18.10. Evidence Graph
+consistency is maintained through three mechanisms:
 
 1. Transactional write-through for new facts.
 2. Bounded lazy materialization for historical facts reached by lineage reads.

--- a/docs/ssot/evidence-lineage.md
+++ b/docs/ssot/evidence-lineage.md
@@ -18,6 +18,11 @@ This layer does not replace double-entry bookkeeping. Journal entries and
 journal lines remain the accounting source of truth. Evidence lineage records
 how source, extracted, atomic, ledger, and report entities are connected.
 
+Evidence Graph is an audit projection. When graph rows disagree with business
+tables, the owning business table wins. Graph repair must not mutate accounting
+facts, report amounts, ledger balances, or legacy `JournalEntry.source_type` and
+`JournalEntry.source_id` values.
+
 ## Tables
 
 The foundation owns two generic tables:
@@ -190,3 +195,60 @@ ledger-line or source-document identifiers already returned by package
 traceability. The UI must show missing lineage as an explicit empty state and
 must not infer or fabricate source, ledger, or report anchors when the API does
 not return graph evidence.
+
+## Materialization and Consistency
+
+Consistency proof for lazy materialization is planned by issue #733. Evidence
+Graph consistency is maintained through three mechanisms:
+
+1. Transactional write-through for new facts.
+2. Bounded lazy materialization for historical facts reached by lineage reads.
+3. Operator dry-run detection for global drift reporting.
+
+New source-to-ledger workflows must write graph nodes and edges inside the same
+database transaction as the owning business facts. If the graph write cannot be
+completed, the workflow must either fail the transaction or return an explicit
+blocker. Silent graph omissions are not acceptable for new write paths.
+
+Historical data may be materialized on demand by the lineage API. When a caller
+requests an owned anchor and the expected graph anchor or local path is missing,
+the API may invoke one deterministic materialization pass, then retry graph
+traversal. This pass must be bounded by user scope, maximum traversal depth,
+maximum graph writes, and batch size.
+
+Lazy materialization may only use strong relationships that already exist in
+source-of-truth tables, such as:
+
+- owned uploaded document or bank statement identifiers;
+- bank statement transaction to atomic transaction lineage;
+- journal entry source identifiers when the source entity is owned and resolvable;
+- `journal_line.journal_entry_id`;
+- report traceability anchors that already reference owned ledger lines.
+
+Lazy materialization must not infer links from fuzzy amount, date, description,
+category, or account-name similarity. If provenance is ambiguous, unsupported,
+missing, or cross-user, the caller must return a blocker instead of writing a
+guessed edge.
+
+Operator consistency checks are read-only by default. They report drift across
+the whole graph or a user scope without modifying business tables or graph rows.
+Execution-mode repair, when added, must remain deterministic, idempotent, and
+limited to the same strong relationships allowed for lazy materialization.
+
+## Blocker Taxonomy
+
+Lineage APIs and consistency tooling must use explicit blocker codes for graph
+drift and unsupported provenance:
+
+- `graph_node_missing`: no owned graph node exists for the requested entity identity.
+- `lineage_incomplete`: a graph anchor exists but the requested upstream or downstream path is incomplete.
+- `orphan_graph_node`: a graph node points to a missing business entity.
+- `dangling_edge`: an edge references a missing endpoint node.
+- `entity_missing`: the business entity referenced by an identity cannot be resolved.
+- `ambiguous_provenance`: existing facts do not identify exactly one defensible source or target.
+- `unsupported_provenance`: the source type or entity type is outside the current graph contract.
+- `cross_user_lineage_blocked`: a candidate link would cross user ownership boundaries.
+- `materialization_write_cap_reached`: request-time repair stopped before completion because the write cap was reached.
+
+Blockers are audit facts about missing proof. They must be surfaced instead of
+fabricating source, ledger, or report anchors.


### PR DESCRIPTION
## Summary

Refs #733.

This PR implements the Evidence Graph consistency model planned for #733:

- registers AC18.10 as formal project acceptance criteria
- adds bounded lazy Evidence Graph materialization for historical lineage reads
- keeps new source-to-ledger graph writes in the same DB transaction as business facts
- adds a read-only consistency detector for missing nodes, orphan nodes, dangling edges, and cross-user edges
- documents Evidence Graph as an audit projection where business tables remain the source of truth

## Why

The graph is for audit navigation and should not become a second accounting database. This implementation repairs only deterministic graph projection rows from strong relationships such as `JournalEntry.source_id`, owned statement transactions, dedup hashes, and `journal_line.journal_entry_id`. It does not mutate accounting facts, report amounts, ledger balances, or legacy journal source fields.

## Review notes

- Addressed Copilot review: drift code now uses the SSOT taxonomy value `dangling_edge`.
- Addressed Copilot review: lazy materialization is gated by supported `entity_type`; `node_kind` may only narrow to the matching node kind and no longer triggers writes by itself.
- Addressed Copilot review: Dokploy/PR-preview lifecycle changes were split out of this PR. This PR now contains only Evidence Graph lazy materialization plus the related frontend test stabilization.

## Scope

- `apps/backend/src/services/evidence_graph_materialization.py`
  - lazy materializer with request write caps, idempotent upserts, and explicit blockers
  - dry-run consistency detector
- `apps/backend/src/routers/evidence.py`
  - lineage API attempts one bounded repair when the requested anchor is missing, then re-runs normal lineage traversal
- `apps/backend/tests/services/test_evidence_graph_materialization.py`
  - transactional rollback proof, idempotency, safety, detector findings, caps, and unresolved source blockers
- `apps/backend/tests/api/test_evidence_lineage_router.py`
  - API-level historical journal-line lazy materialization, repeated-read no-write proof, and entity_type-first gate coverage
- `docs/project/EPIC-018.ai-driven-pipeline.md`
  - formal AC18.10.1-AC18.10.7
- `docs/ssot/evidence-lineage.md`
  - materialization ownership updated to AC18.10

## Validation

Passed:

- `uv run pytest --no-cov -q apps/backend/tests/api/test_evidence_lineage_router.py apps/backend/tests/services/test_evidence_graph_materialization.py` (11 passed)
- `uv run ruff check apps/backend/src/routers/evidence.py apps/backend/src/services/evidence_graph_materialization.py apps/backend/tests/api/test_evidence_lineage_router.py apps/backend/tests/services/test_evidence_graph_materialization.py`
- `moon run :lint`
- `python tools/generate_ac_registry.py --check`
- `python tools/check_ac_traceability.py`
- `python tools/check_e2e_epic_traceability.py`
- `git diff --check`

Attempted:

- `moon run :test` failed before tests because local Podman cannot connect to the socket: `dial tcp 127.0.0.1:61270: connect: connection refused`.
