### PR TITLE
[finance_report_hacker] Fix migration head and account ownership gaps

### DIFF
--- a/apps/backend/migrations/versions/0027_merge_review_email_heads.py
+++ b/apps/backend/migrations/versions/0027_merge_review_email_heads.py
@@ -1,0 +1,22 @@
+"""merge review scope and normalized email heads
+
+Revision ID: 0027_merge_review_email_heads
+Revises: 0026_add_review_run_scope, 0026_user_email_norm_idx
+Create Date: 2026-06-06 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+revision = "0027_merge_review_email_heads"
+down_revision = ("0026_add_review_run_scope", "0026_user_email_norm_idx")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -207,6 +207,13 @@ async def upload_statement(
     if extension not in ("pdf", "csv", "png", "jpg", "jpeg"):
         raise_bad_request(f"Unsupported file type: {extension}")
 
+    if account_id is not None:
+        account_result = await db.execute(
+            select(Account.id).where(Account.id == account_id).where(Account.user_id == user_id)
+        )
+        if account_result.scalar_one_or_none() is None:
+            raise_not_found("Account")
+
     content = await file.read()
     if len(content) > MAX_UPLOAD_BYTES:
         raise_too_large("File exceeds 10MB limit")

--- a/apps/backend/src/services/correction_service.py
+++ b/apps/backend/src/services/correction_service.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.logger import get_logger
+from src.models.account import Account
 from src.models.correction import CorrectionLog
 from src.models.statement import BankStatement, BankStatementTransaction
 
@@ -54,6 +55,13 @@ async def record_correction(
     txn = result.scalar_one_or_none()
     if not txn:
         raise ValueError(f"Transaction {transaction_id} not found")
+
+    if corrected_account_id is not None:
+        account_result = await db.execute(
+            select(Account.id).where(Account.id == corrected_account_id).where(Account.user_id == user_id)
+        )
+        if account_result.scalar_one_or_none() is None:
+            raise ValueError(f"Account {corrected_account_id} not found")
 
     correction = CorrectionLog(
         user_id=user_id,

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -53,6 +53,7 @@ from src.services.statement_posting import (
     is_high_confidence_auto_approve_candidate,
     try_auto_approve_high_confidence_statement,
 )
+from tests.factories import AccountFactory, UserFactory
 
 pytestmark = pytest.mark.asyncio
 
@@ -287,6 +288,32 @@ async def test_upload_invalid_extension(db, test_user):
 
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
     assert "Unsupported file type" in exc.value.detail
+
+
+async def test_AC3_5_upload_rejects_cross_user_account_id(db, monkeypatch, test_user):
+    """AC3.5: Statement upload must not bind another user's account."""
+    other_user = await UserFactory.create_async(db)
+    other_account = await AccountFactory.create_async(db, user_id=other_user.id, name="Other User Cash")
+    await db.commit()
+
+    mock_storage = MagicMock()
+    monkeypatch.setattr(statements_router, "StorageService", MagicMock(return_value=mock_storage))
+
+    upload_file = make_upload_file("statement.pdf", b"content")
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.upload_statement(
+            file=upload_file,
+            institution="DBS",
+            account_id=other_account.id,
+            model=None,
+            db=db,
+            user_id=test_user.id,
+        )
+    await upload_file.close()
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc.value.detail == "Account not found"
+    assert mock_storage.upload_bytes.call_count == 0
 
 
 async def test_upload_uses_default_ocr_pipeline_for_pdf(db, monkeypatch, storage_stub, test_user):

--- a/apps/backend/tests/extraction/test_correction_service.py
+++ b/apps/backend/tests/extraction/test_correction_service.py
@@ -12,8 +12,10 @@ from src.services.correction_service import (
     record_correction,
 )
 from tests.factories import (
+    AccountFactory,
     BankStatementFactory,
     BankStatementTransactionFactory,
+    UserFactory,
 )
 
 
@@ -84,6 +86,30 @@ async def test_record_correction_not_found_raises(db, test_user):
             user_id=test_user.id,
             transaction_id=uuid4(),
             corrected_category="Transport",
+        )
+
+
+@pytest.mark.asyncio
+async def test_AC18_2_2_record_correction_rejects_cross_user_corrected_account(db, test_user):
+    """AC18.2.2: Correction feedback must not bind another user's account."""
+    stmt = await BankStatementFactory.create_async(db, user_id=test_user.id)
+    txn = await BankStatementTransactionFactory.create_async(
+        db,
+        statement_id=stmt.id,
+        description="Grab taxi",
+        suggested_category="Shopping",
+    )
+    other_user = await UserFactory.create_async(db)
+    other_account = await AccountFactory.create_async(db, user_id=other_user.id, name="Other User Account")
+    await db.commit()
+
+    with pytest.raises(ValueError, match="Account .* not found"):
+        await record_correction(
+            db,
+            user_id=test_user.id,
+            transaction_id=txn.id,
+            corrected_category="Transport",
+            corrected_account_id=other_account.id,
         )
 
 


### PR DESCRIPTION
## Summary

Fix the merged migration graph and close two account ownership gaps found in the priority 1-3 audit.

Closes #N/A - user-requested audit fix without a tracking issue.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-003 - Statement parsing; EPIC-018 - AI-driven pipeline; EPIC-001 - Infrastructure & authentication |
| **AC IDs** | AC3.5, AC18.2.2, AC1.2.3 |
| **AC source updated** | N/A - existing AC coverage used |

---

## SSOT Changes

- [x] None - existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | N/A | User requested a direct PR fix; tests and implementation were committed together. Existing `test_single_head` already failed before the merge revision. |
| Green (passing test) | `85daaab` | Added ownership regression tests and implemented migration/account validation fixes. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter - no enum changes
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) - N/A
- [x] `repo/` submodule updated for production config changes (if applicable) - N/A, no production config changes
- [x] `tools/check_env_keys.py` passes (if env vars changed) - N/A
- [x] `tools/check_manifest.py` passes (if SSOT files changed) - N/A
- [x] `tools/lint_doc_consistency.py` passes - covered by `moon run :lint`

### CI/CD, Runtime, and VPS Infra Audit

N/A - this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
PYTHONPATH=apps/backend uv run pytest -n0 --no-cov apps/backend/tests/infra/test_migrations.py apps/backend/tests/api/test_statements_router.py::test_AC3_5_upload_rejects_cross_user_account_id apps/backend/tests/extraction/test_correction_service.py::test_AC18_2_2_record_correction_rejects_cross_user_corrected_account -q
# 6 passed

cd apps/backend && PYTHONPATH=. uv run alembic heads
# 0027_merge_review_email_heads (head)

uv run ruff check apps/backend/src/routers/statements.py apps/backend/src/services/correction_service.py apps/backend/tests/api/test_statements_router.py apps/backend/tests/extraction/test_correction_service.py
# All checks passed

moon run :lint
# Passed

moon run :test
# Blocked locally before tests: Podman socket refused connection while starting the test database.
```

---

## Screenshots / Evidence

N/A - backend/infrastructure fix.
