### PR TITLE
[finance_report_vision] Stabilize stale model cleanup E2E wait

### DIFF
--- a/tests/e2e/test_statement_upload_e2e.py
+++ b/tests/e2e/test_statement_upload_e2e.py
@@ -196,15 +196,20 @@ async def test_stale_model_id_auto_cleanup(authenticated_page: Page) -> None:
     """
     _skip_if_no_url()
     page = authenticated_page
-    await page.goto(_get_url("/statements"))
-    await page.wait_for_load_state("networkidle")
+    await page.goto(_get_url("/statements"), wait_until="domcontentloaded")
+    await expect(page.locator("select#ai-model")).to_be_visible(timeout=15_000)
 
     # Use a guaranteed-nonexistent model ID so the test is catalog-independent.
     # Real model IDs are provider-configured and may change over time; using
     # a clearly fake ID ensures the stale-cleanup logic is always exercised.
     stale_id = "test/nonexistent-model-for-stale-cleanup-test"
     await page.evaluate(f'localStorage.setItem("statement_model_v1", "{stale_id}")')
-    await page.reload()
-    await page.wait_for_load_state("networkidle")
+    await page.reload(wait_until="domcontentloaded")
+    await expect(page.locator("select#ai-model")).to_be_visible(timeout=15_000)
+    await page.wait_for_function(
+        "(staleId) => localStorage.getItem('statement_model_v1') !== staleId",
+        arg=stale_id,
+        timeout=15_000,
+    )
     stored_model: str | None = await page.evaluate('localStorage.getItem("statement_model_v1")')
     assert stored_model != stale_id, f"Stale model ID '{stale_id}' was not cleared from localStorage after reload"


### PR DESCRIPTION
## Summary

- Replace `networkidle` waits in the stale model cleanup E2E with explicit page-readiness checks.
- Wait for the stale localStorage value to be removed directly instead of requiring the whole staging page to become network-idle.

## Why

The post-merge staging deploy for `232a35b` successfully deployed and the smoke checks passed, but the E2E gate failed on `test_stale_model_id_auto_cleanup` because Playwright waited 30s for `networkidle` on `/statements`. The application was usable and the target SHA was live, so this was a brittle test wait rather than a staging availability failure.

## Verification

- `PYTHONPATH=$PWD APP_URL=https://report-staging.zitian.party TEST_ENV=staging SKIP_UI_TESTS=false STRICT_E2E_GATES=true uv run pytest tests/e2e/test_statement_upload_e2e.py::test_stale_model_id_auto_cleanup -q`
- `moon run :lint`
- `git diff --check`

## Notes

`moon run :test` could not complete locally because Podman is not running on this machine: `unable to connect to Podman socket`. The targeted E2E was verified against the real staging endpoint.
