### PR TITLE
[finance_report_audit] fix(#768): pipeline failure observability — OTEL request tracing + platform snapshot

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -624,6 +624,26 @@ jobs:
 
           echo "✅ E2E Pipeline passed!"
 
+      - name: Capture platform failure snapshot
+        if: ${{ failure() && steps.deploy.outputs.compose_id != '' }}
+        env:
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+        run: |
+          mkdir -p ci-context
+          # Diagnostic only: surface Dokploy platform state so triage can tell a
+          # platform failure (worker/route/rollout) from an app failure without
+          # SSH. Never fails the job (issue #768).
+          python tools/dokploy_failure_snapshot.py \
+            --compose-id "${{ steps.deploy.outputs.compose_id }}" \
+            --api-url "${{ env.DOKPLOY_API_URL }}" \
+            --markdown | tee ci-context/platform-failure-snapshot.txt
+          {
+            echo "## Platform failure snapshot"
+            echo '```'
+            cat ci-context/platform-failure-snapshot.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Rollback on E2E Failure
         if: failure() && steps.e2e_tests.outcome == 'failure'
         env:

--- a/apps/backend/src/logger.py
+++ b/apps/backend/src/logger.py
@@ -80,7 +80,13 @@ def _build_otel_resource() -> Any:
     """Build OTEL resource with service name and attributes."""
     from opentelemetry.sdk.resources import Resource
 
-    resource_attributes = {"service.name": settings.otel_service_name}
+    resource_attributes = {
+        "service.name": settings.otel_service_name,
+        # Version correlation: every span/log carries the deployed commit so a
+        # CI/CD run can pivot directly to this version's traces in SigNoz.
+        "service.version": settings.git_commit_sha,
+        "git.commit": settings.git_commit_sha,
+    }
     resource_attributes.update(parse_key_value_pairs(settings.otel_resource_attributes))
     return Resource.create(resource_attributes)
 

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -22,7 +22,11 @@ from src.config import settings
 from src.database import engine, get_db, init_db
 from src.logger import configure_logging, get_logger
 from src.models import PingState
-from src.observability import get_observability_status, log_observability_startup
+from src.observability import (
+    get_observability_status,
+    log_observability_startup,
+    mark_fastapi_instrumentation_active,
+)
 from src.rate_limit import api_rate_limiter
 from src.routers import (
     accounts,
@@ -58,23 +62,21 @@ logger = get_logger(__name__)
 
 
 def _init_otel_instrumentation() -> None:
-    """Initialize OpenTelemetry auto-instrumentation for FastAPI, SQLAlchemy, and HTTPX.
+    """Initialize OpenTelemetry auto-instrumentation for SQLAlchemy and HTTPX.
 
-    This enables distributed tracing across HTTP requests, database queries,
-    and outbound HTTP calls. Must be called after TracerProvider is configured.
+    These are global instrumentors that do not require the FastAPI app instance,
+    so they are wired here. FastAPI request instrumentation is bound to the app
+    instance in `_instrument_fastapi_app` after the app is created.
+    Must be called after the TracerProvider is configured.
     """
     if not settings.otel_exporter_otlp_endpoint:
         return
 
     try:
-        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # pyright: ignore[reportMissingImports]
         from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor  # pyright: ignore[reportMissingImports]
         from opentelemetry.instrumentation.sqlalchemy import (
             SQLAlchemyInstrumentor,  # pyright: ignore[reportMissingImports]
         )
-
-        # Instrument FastAPI - will be applied to app after creation
-        FastAPIInstrumentor.instrument()
 
         # Instrument SQLAlchemy with the async engine
         SQLAlchemyInstrumentor().instrument(engine=engine.sync_engine)
@@ -82,12 +84,34 @@ def _init_otel_instrumentation() -> None:
         # Instrument HTTPX for outbound HTTP calls
         HTTPXClientInstrumentor().instrument()
 
-        logger.info("OTEL instrumentation initialized", components=["fastapi", "sqlalchemy", "httpx"])
+        logger.info("OTEL instrumentation initialized", components=["sqlalchemy", "httpx"])
     except Exception:  # pragma: no cover - defensive import guard
         logger.warning("OTEL instrumentation not available", exc_info=True)
 
 
-# Initialize instrumentation after logging is configured
+def _instrument_fastapi_app(app: FastAPI) -> None:
+    """Apply OpenTelemetry request instrumentation to the FastAPI app instance.
+
+    Uses ``FastAPIInstrumentor.instrument_app(app)`` (the supported per-app API).
+    The previous code used the base instrumentor's no-arg classmethod with no
+    instance and before the app existed, which raised and silently disabled
+    request tracing in production (see issue #768/#576).
+    """
+    if not settings.otel_exporter_otlp_endpoint:
+        return
+
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # pyright: ignore[reportMissingImports]
+
+        FastAPIInstrumentor.instrument_app(app)
+        mark_fastapi_instrumentation_active(True)
+        logger.info("OTEL FastAPI request instrumentation applied")
+    except Exception:  # pragma: no cover - defensive import guard
+        mark_fastapi_instrumentation_active(False)
+        logger.warning("OTEL FastAPI instrumentation not available", exc_info=True)
+
+
+# Initialize global (app-independent) instrumentation after logging is configured
 _init_otel_instrumentation()
 
 
@@ -129,6 +153,9 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
+# Apply OTEL request instrumentation to the app instance (issue #768/#576).
+_instrument_fastapi_app(app)
 
 
 @app.middleware("http")

--- a/apps/backend/src/observability.py
+++ b/apps/backend/src/observability.py
@@ -10,6 +10,23 @@ ERROR_LOG_ALERT_RULE_NAME = "FinanceReportBackendErrorLogs"
 ERROR_LOG_ALERT_SERVICE_NAME = "finance-report-backend"
 ALERTING_PIPELINE = "component->otel->signoz->lark"
 
+# Runtime flag set by the app once FastAPI request instrumentation is actually
+# applied to the app instance. This is real init state, not configuration: a
+# misconfigured instrumentor leaves this False even when the exporter endpoint
+# is configured, so /health and startup logs can no longer look green while
+# request tracing is silently absent.
+_fastapi_instrumentation_active = False
+
+
+def mark_fastapi_instrumentation_active(active: bool = True) -> None:
+    """Record whether FastAPI request instrumentation was applied to the app."""
+    global _fastapi_instrumentation_active
+    _fastapi_instrumentation_active = active
+
+
+def is_fastapi_instrumentation_active() -> bool:
+    return _fastapi_instrumentation_active
+
 
 def _deployment_environment(resource_attributes: dict[str, str]) -> str:
     return resource_attributes.get("deployment.environment") or settings.environment
@@ -28,7 +45,11 @@ def get_observability_status() -> dict[str, Any]:
         "otel_exporter_configured": exporter_configured,
         "logs_export_enabled": exporter_configured,
         "traces_export_enabled": exporter_configured,
+        # Real init state: True only when FastAPI request instrumentation was
+        # actually applied to the app instance (not merely configured).
+        "request_instrumentation_active": _fastapi_instrumentation_active,
         "service_name": settings.otel_service_name,
+        "service_version": settings.git_commit_sha,
         "deployment_environment": _deployment_environment(resource_attributes),
         "resource_attributes": resource_attributes,
         "alert_rule_name": ERROR_LOG_ALERT_RULE_NAME,

--- a/apps/backend/tests/infra/test_observability_contract.py
+++ b/apps/backend/tests/infra/test_observability_contract.py
@@ -266,10 +266,7 @@ def test_AC10_4_3_instrumentation_state_reflected_in_status() -> None:
         assert "service_version" in status
 
         observability_module.mark_fastapi_instrumentation_active(True)
-        assert (
-            observability_module.get_observability_status()["request_instrumentation_active"]
-            is True
-        )
+        assert observability_module.get_observability_status()["request_instrumentation_active"] is True
     finally:
         observability_module.mark_fastapi_instrumentation_active(original)
 
@@ -297,9 +294,7 @@ def test_AC10_4_3_instrument_app_applies_to_instance(monkeypatch) -> None:
     fake_instrumentor = Mock()
     fake_module.FastAPIInstrumentor = fake_instrumentor
     monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation.fastapi", fake_module)
-    monkeypatch.setattr(
-        main_module.settings, "otel_exporter_otlp_endpoint", "http://collector:4318", raising=False
-    )
+    monkeypatch.setattr(main_module.settings, "otel_exporter_otlp_endpoint", "http://collector:4318", raising=False)
     observability_module.mark_fastapi_instrumentation_active(False)
 
     app = FastAPI()
@@ -315,9 +310,7 @@ def test_AC10_4_3_instrument_app_skips_without_endpoint(monkeypatch) -> None:
 
     from src import main as main_module
 
-    monkeypatch.setattr(
-        main_module.settings, "otel_exporter_otlp_endpoint", None, raising=False
-    )
+    monkeypatch.setattr(main_module.settings, "otel_exporter_otlp_endpoint", None, raising=False)
     observability_module.mark_fastapi_instrumentation_active(False)
 
     main_module._instrument_fastapi_app(FastAPI())

--- a/apps/backend/tests/infra/test_observability_contract.py
+++ b/apps/backend/tests/infra/test_observability_contract.py
@@ -239,3 +239,87 @@ def test_AC10_9_4_observability_docs_declare_shared_alerting_pipeline() -> None:
 
     assert "alerting.shared.ensure-log-error-rule" in infra_alerting
     assert "First live instance via shared rule automation" in infra_alerting
+
+
+def test_AC10_4_3_main_instruments_fastapi_app_instance() -> None:
+    """AC10.4.3: main wires FastAPI request instrumentation to the app instance.
+
+    Regression guard for #768/#576: the broken `FastAPIInstrumentor.instrument()`
+    (no instance, before the app existed) must not return, and the per-app
+    `instrument_app(app)` API must be used after app creation.
+    """
+    source = _read(REPO_ROOT / "apps" / "backend" / "src" / "main.py")
+
+    assert "FastAPIInstrumentor.instrument_app(app)" in source
+    assert "_instrument_fastapi_app(app)" in source
+    # The no-op base-class form must never be reintroduced.
+    assert "FastAPIInstrumentor.instrument()" not in source
+
+
+def test_AC10_4_3_instrumentation_state_reflected_in_status() -> None:
+    """AC10.4.3: observability status reports REAL instrumentation init, not config."""
+    original = observability_module.is_fastapi_instrumentation_active()
+    try:
+        observability_module.mark_fastapi_instrumentation_active(False)
+        status = observability_module.get_observability_status()
+        assert status["request_instrumentation_active"] is False
+        assert "service_version" in status
+
+        observability_module.mark_fastapi_instrumentation_active(True)
+        assert (
+            observability_module.get_observability_status()["request_instrumentation_active"]
+            is True
+        )
+    finally:
+        observability_module.mark_fastapi_instrumentation_active(original)
+
+
+def test_AC10_4_4_otel_resource_includes_commit_version(monkeypatch) -> None:
+    """AC10.4.4: trace/log resource carries the deploy commit for correlation."""
+    monkeypatch.setattr(logger_module.settings, "git_commit_sha", "abc1234", raising=False)
+    resource = logger_module._build_otel_resource()
+    attributes = dict(resource.attributes)
+    assert attributes.get("service.version") == "abc1234"
+    assert attributes.get("git.commit") == "abc1234"
+    assert attributes.get("service.name") == logger_module.settings.otel_service_name
+
+
+def test_AC10_4_3_instrument_app_applies_to_instance(monkeypatch) -> None:
+    """AC10.4.3: _instrument_fastapi_app applies instrumentation to the app instance."""
+    import sys
+    import types
+
+    from fastapi import FastAPI
+
+    from src import main as main_module
+
+    fake_module = types.ModuleType("opentelemetry.instrumentation.fastapi")
+    fake_instrumentor = Mock()
+    fake_module.FastAPIInstrumentor = fake_instrumentor
+    monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation.fastapi", fake_module)
+    monkeypatch.setattr(
+        main_module.settings, "otel_exporter_otlp_endpoint", "http://collector:4318", raising=False
+    )
+    observability_module.mark_fastapi_instrumentation_active(False)
+
+    app = FastAPI()
+    main_module._instrument_fastapi_app(app)
+
+    fake_instrumentor.instrument_app.assert_called_once_with(app)
+    assert observability_module.is_fastapi_instrumentation_active() is True
+
+
+def test_AC10_4_3_instrument_app_skips_without_endpoint(monkeypatch) -> None:
+    """AC10.4.3: instrumentation is a no-op (and stays inactive) without an endpoint."""
+    from fastapi import FastAPI
+
+    from src import main as main_module
+
+    monkeypatch.setattr(
+        main_module.settings, "otel_exporter_otlp_endpoint", None, raising=False
+    )
+    observability_module.mark_fastapi_instrumentation_active(False)
+
+    main_module._instrument_fastapi_app(FastAPI())
+
+    assert observability_module.is_fastapi_instrumentation_active() is False

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -111,6 +111,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_check_manifest.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_check_ssot_ownership.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_coverage_analyzer.py` | `docs/ssot/coverage.md` |
+| `tests/tooling/test_dokploy_failure_snapshot.py` | `docs/ssot/ci-cd.md` |
 | `tests/tooling/test_generate_fixtures.py` | `docs/ssot/extraction.md` |
 | `tests/tooling/test_github_workflow_timing_summary.py` | `docs/ssot/ci-cd.md` |
 | `tests/tooling/test_merge_lcov.py` | `docs/ssot/coverage.md` |

--- a/docs/project/EPIC-010.signoz-logging.md
+++ b/docs/project/EPIC-010.signoz-logging.md
@@ -119,6 +119,8 @@ Enable production-grade log observability via SigNoz (OTLP), while keeping local
 |----|-----------|---------------|------|----------|
 | AC10.4.1 | Configure OTEL logging warns on missing dependency | `test_configure_otel_logging_missing_dependency_warns()` | `infra/test_logger.py` | P0 |
 | AC10.4.2 | Configure OTEL logging with fake exporter | `test_configure_otel_logging_with_fake_exporter()` | `infra/test_logger.py` | P1 |
+| AC10.4.3 | FastAPI request instrumentation binds the app instance (not the no-op classmethod) | `test_AC10_4_3_main_instruments_fastapi_app_instance()` | `infra/test_observability_contract.py` | P0 |
+| AC10.4.4 | OTEL resource carries deploy commit for run-to-trace correlation | `test_AC10_4_4_otel_resource_includes_commit_version()` | `infra/test_observability_contract.py` | P0 |
 
 ### AC10.5: Documentation (SSOT)
 

--- a/tests/tooling/test_dokploy_failure_snapshot.py
+++ b/tests/tooling/test_dokploy_failure_snapshot.py
@@ -1,0 +1,50 @@
+"""Unit tests for the Dokploy platform-failure snapshot (issue #768)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = ROOT / "tools" / "dokploy_failure_snapshot.py"
+_spec = importlib.util.spec_from_file_location("dokploy_failure_snapshot", _MODULE_PATH)
+assert _spec and _spec.loader
+snapshot = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(snapshot)
+
+
+def test_classify_compose_error_is_deployment_error() -> None:
+    assert snapshot._classify("error", [{"status": "error", "startedAt": "1"}]) == (
+        "dokploy-deployment-error"
+    )
+
+
+def test_classify_no_deployments_is_worker_record_domain() -> None:
+    assert snapshot._classify("idle", []) == "dokploy-worker-or-deployment-record"
+
+
+def test_classify_done_is_platform_ok() -> None:
+    deployments = [{"status": "done", "startedAt": "2"}]
+    assert snapshot._classify("done", deployments) == "platform-ok-check-application-or-route"
+
+
+def test_classify_picks_latest_deployment_by_started_at() -> None:
+    deployments = [
+        {"status": "done", "startedAt": "2026-01-01T00:00:00Z"},
+        {"status": "error", "startedAt": "2026-01-02T00:00:00Z"},
+    ]
+    assert snapshot._classify("done", deployments) == "dokploy-deployment-error"
+
+
+def test_main_skips_cleanly_without_inputs(capsys) -> None:
+    rc = snapshot.main(["--compose-id", "", "--api-url", "", "--api-key", ""])
+    assert rc == 0
+    assert "snapshot-skipped-missing-inputs" in capsys.readouterr().out
+
+
+def test_render_markdown_includes_failure_domain() -> None:
+    md = snapshot.render_markdown(
+        {"compose_id": "abc", "platform_failure_domain": "dokploy-deployment-error"}
+    )
+    assert "platform_failure_domain" in md
+    assert "dokploy-deployment-error" in md

--- a/tests/tooling/test_dokploy_failure_snapshot.py
+++ b/tests/tooling/test_dokploy_failure_snapshot.py
@@ -25,7 +25,10 @@ def test_classify_no_deployments_is_worker_record_domain() -> None:
 
 def test_classify_done_is_platform_ok() -> None:
     deployments = [{"status": "done", "startedAt": "2"}]
-    assert snapshot._classify("done", deployments) == "platform-ok-check-application-or-route"
+    assert (
+        snapshot._classify("done", deployments)
+        == "platform-ok-check-application-or-route"
+    )
 
 
 def test_classify_picks_latest_deployment_by_started_at() -> None:
@@ -48,3 +51,99 @@ def test_render_markdown_includes_failure_domain() -> None:
     )
     assert "platform_failure_domain" in md
     assert "dokploy-deployment-error" in md
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+def test_api_get_parses_json(monkeypatch) -> None:
+    import json as _json
+
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=0):  # noqa: ANN001
+        captured["headers"] = req.headers
+        return _FakeResponse(_json.dumps({"composeStatus": "done"}).encode())
+
+    monkeypatch.setattr(snapshot.urllib.request, "urlopen", fake_urlopen)
+    data = snapshot._api_get("https://api/", "k", "compose.one?composeId=x")
+    assert data["composeStatus"] == "done"
+    # Non-default User-Agent must be set to avoid Cloudflare bot blocking.
+    assert any("User-agent" in h or "User-Agent" in h for h in captured["headers"])
+
+
+def test_build_snapshot_success(monkeypatch) -> None:
+    monkeypatch.setattr(
+        snapshot,
+        "_api_get",
+        lambda *a, **k: {
+            "composeStatus": "done",
+            "deployments": [
+                {"status": "done", "startedAt": "2026-01-02T00:00:00Z", "title": "t"},
+                {"status": "error", "startedAt": "2026-01-01T00:00:00Z"},
+            ],
+        },
+    )
+    snap = snapshot.build_snapshot("https://api", "k", "cid")
+    assert snap["compose_status"] == "done"
+    assert snap["deployment_count"] == 2
+    assert snap["latest_deployment_status"] == "done"
+    assert snap["platform_failure_domain"] == "platform-ok-check-application-or-route"
+
+
+def test_build_snapshot_api_unreachable(monkeypatch) -> None:
+    def boom(*a, **k):  # noqa: ANN002, ANN003
+        raise snapshot.urllib.error.URLError("down")
+
+    monkeypatch.setattr(snapshot, "_api_get", boom)
+    snap = snapshot.build_snapshot("https://api", "k", "cid")
+    assert snap["platform_failure_domain"] == "dokploy-api-unreachable"
+    assert "could not read" in snap["error"]
+
+
+def test_main_happy_path_prints_snapshot(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        snapshot,
+        "build_snapshot",
+        lambda *a, **k: {
+            "compose_id": "cid",
+            "platform_failure_domain": "dokploy-deployment-error",
+        },
+    )
+    rc = snapshot.main(
+        [
+            "--compose-id",
+            "cid",
+            "--api-url",
+            "https://api",
+            "--api-key",
+            "k",
+            "--markdown",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "dokploy-deployment-error" in out
+
+
+def test_build_snapshot_no_deployments(monkeypatch) -> None:
+    monkeypatch.setattr(
+        snapshot,
+        "_api_get",
+        lambda *a, **k: {"composeStatus": "idle", "deployments": []},
+    )
+    snap = snapshot.build_snapshot("https://api", "k", "cid")
+    assert snap["deployment_count"] == 0
+    assert snap["latest_deployment_status"] == "none"
+    assert snap["platform_failure_domain"] == "dokploy-worker-or-deployment-record"

--- a/tools/dokploy_failure_snapshot.py
+++ b/tools/dokploy_failure_snapshot.py
@@ -25,6 +25,11 @@ import os
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 # Compose/deployment states Dokploy reports once a rollout has actually started.
 _ACTIVE_STATES = {"running", "done", "success", "successful"}
@@ -49,7 +54,9 @@ def _classify(compose_status: str, deployments: list[dict]) -> str:
     """Classify the platform failure domain from Dokploy state."""
     latest_status = ""
     if deployments:
-        latest = sorted(deployments, key=lambda d: str(d.get("startedAt") or ""), reverse=True)[0]
+        latest = sorted(
+            deployments, key=lambda d: str(d.get("startedAt") or ""), reverse=True
+        )[0]
         latest_status = str(latest.get("status") or "").lower()
 
     if compose_status == "error" or latest_status == "error":
@@ -74,7 +81,9 @@ def build_snapshot(api_url: str, api_key: str, compose_id: str) -> dict:
     deployments = [d for d in (data.get("deployments") or []) if isinstance(d, dict)]
     compose_status = str(data.get("composeStatus") or "unknown")
     latest = (
-        sorted(deployments, key=lambda d: str(d.get("startedAt") or ""), reverse=True)[0]
+        sorted(deployments, key=lambda d: str(d.get("startedAt") or ""), reverse=True)[
+            0
+        ]
         if deployments
         else {}
     )
@@ -90,7 +99,12 @@ def build_snapshot(api_url: str, api_key: str, compose_id: str) -> dict:
 
 
 def render_markdown(snapshot: dict) -> str:
-    lines = ["### Platform failure snapshot (Dokploy)", "", "| field | value |", "|---|---|"]
+    lines = [
+        "### Platform failure snapshot (Dokploy)",
+        "",
+        "| field | value |",
+        "|---|---|",
+    ]
     for key in (
         "compose_id",
         "compose_status",
@@ -111,7 +125,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--compose-id", required=True)
     parser.add_argument("--api-url", default=os.getenv("DOKPLOY_API_URL", ""))
     parser.add_argument("--api-key", default=os.getenv("DOKPLOY_API_KEY", ""))
-    parser.add_argument("--markdown", action="store_true", help="Also print a Markdown table")
+    parser.add_argument(
+        "--markdown", action="store_true", help="Also print a Markdown table"
+    )
     args = parser.parse_args(argv)
 
     if not args.compose_id or not args.api_url or not args.api_key:

--- a/tools/dokploy_failure_snapshot.py
+++ b/tools/dokploy_failure_snapshot.py
@@ -149,5 +149,5 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main(sys.argv[1:]))

--- a/tools/dokploy_failure_snapshot.py
+++ b/tools/dokploy_failure_snapshot.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Emit a platform-failure snapshot for a Dokploy compose on deploy failure.
+
+Part of issue #768: when a PR-preview / staging deploy or readiness gate fails,
+the pipeline should surface the platform-layer state (Dokploy compose status,
+latest deployment status/error, whether a new deployment record was ever
+created) so triage can separate a platform failure from an application failure
+without SSHing to the host.
+
+Reads only the Dokploy API (no SSH), so it runs from any CI job that already
+holds DOKPLOY_API_KEY. Stdlib-only and never fails the calling job: diagnostic
+output goes to stdout; exit code is always 0.
+
+Usage:
+  python tools/dokploy_failure_snapshot.py \
+    --compose-id "$COMPOSE_ID" --api-url "$DOKPLOY_API_URL"
+  (DOKPLOY_API_KEY is read from the environment.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+# Compose/deployment states Dokploy reports once a rollout has actually started.
+_ACTIVE_STATES = {"running", "done", "success", "successful"}
+
+
+def _api_get(api_url: str, api_key: str, path: str) -> dict:
+    url = f"{api_url.rstrip('/')}/{path}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "x-api-key": api_key,
+            "Accept": "application/json",
+            # A non-default User-Agent avoids Cloudflare bot blocking (error 1010).
+            "User-Agent": "finance-report-pipeline-snapshot/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310 - fixed internal API host
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _classify(compose_status: str, deployments: list[dict]) -> str:
+    """Classify the platform failure domain from Dokploy state."""
+    latest_status = ""
+    if deployments:
+        latest = sorted(deployments, key=lambda d: str(d.get("startedAt") or ""), reverse=True)[0]
+        latest_status = str(latest.get("status") or "").lower()
+
+    if compose_status == "error" or latest_status == "error":
+        return "dokploy-deployment-error"
+    if not deployments or compose_status in {"idle", ""}:
+        return "dokploy-worker-or-deployment-record"
+    if compose_status in _ACTIVE_STATES and latest_status in _ACTIVE_STATES:
+        return "platform-ok-check-application-or-route"
+    return "dokploy-rollout-incomplete"
+
+
+def build_snapshot(api_url: str, api_key: str, compose_id: str) -> dict:
+    try:
+        data = _api_get(api_url, api_key, f"compose.one?composeId={compose_id}")
+    except (urllib.error.URLError, ValueError, TimeoutError) as exc:
+        return {
+            "compose_id": compose_id,
+            "error": f"could not read Dokploy compose: {type(exc).__name__}",
+            "platform_failure_domain": "dokploy-api-unreachable",
+        }
+
+    deployments = [d for d in (data.get("deployments") or []) if isinstance(d, dict)]
+    compose_status = str(data.get("composeStatus") or "unknown")
+    latest = (
+        sorted(deployments, key=lambda d: str(d.get("startedAt") or ""), reverse=True)[0]
+        if deployments
+        else {}
+    )
+    return {
+        "compose_id": compose_id,
+        "compose_status": compose_status,
+        "deployment_count": len(deployments),
+        "latest_deployment_status": str(latest.get("status") or "none"),
+        "latest_deployment_title": str(latest.get("title") or ""),
+        "latest_deployment_error": str(latest.get("errorMessage") or "")[:500],
+        "platform_failure_domain": _classify(compose_status, deployments),
+    }
+
+
+def render_markdown(snapshot: dict) -> str:
+    lines = ["### Platform failure snapshot (Dokploy)", "", "| field | value |", "|---|---|"]
+    for key in (
+        "compose_id",
+        "compose_status",
+        "deployment_count",
+        "latest_deployment_status",
+        "latest_deployment_title",
+        "latest_deployment_error",
+        "platform_failure_domain",
+        "error",
+    ):
+        if key in snapshot and snapshot[key] != "":
+            lines.append(f"| {key} | {snapshot[key]} |")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--compose-id", required=True)
+    parser.add_argument("--api-url", default=os.getenv("DOKPLOY_API_URL", ""))
+    parser.add_argument("--api-key", default=os.getenv("DOKPLOY_API_KEY", ""))
+    parser.add_argument("--markdown", action="store_true", help="Also print a Markdown table")
+    args = parser.parse_args(argv)
+
+    if not args.compose_id or not args.api_url or not args.api_key:
+        # Missing inputs must not fail the calling job; emit a clear marker.
+        print(
+            json.dumps(
+                {
+                    "platform_failure_domain": "snapshot-skipped-missing-inputs",
+                    "compose_id": args.compose_id or "",
+                }
+            )
+        )
+        return 0
+
+    snapshot = build_snapshot(args.api_url, args.api_key, args.compose_id)
+    print(json.dumps(snapshot, indent=2, sort_keys=True))
+    if args.markdown:
+        print(render_markdown(snapshot))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Fixes the observability half of #768.

## Problem
- Backend **OTEL request instrumentation was silently broken**: `apps/backend/src/main.py` called the base `FastAPIInstrumentor` no-arg classmethod **before the app existed**, so request tracing never attached in production, while `/api/health` still reported OTEL as configured (#768 / #576). On a deploy failure the backend traces that should explain it were absent.
- The pipeline was **blind to platform-layer root causes**: a deploy/readiness failure logged only the app-level symptom (e.g. route 404), so triage required SSH.

## Changes

### Observability (fix OTEL + real-state /health + run↔trace correlation)
- `main.py`: apply `FastAPIInstrumentor.instrument_app(app)` to the **app instance** after creation; SQLAlchemy/HTTPX global instrumentation stays in init.
- `observability.py`: track **real** instrumentation init state — `/api/health` now reports `request_instrumentation_active` (not just config) and `service_version`.
- `logger.py`: OTEL resource carries `service.version` + `git.commit`, so a CI/CD run links directly to that version's traces/logs in SigNoz.
- `EPIC-010` AC10.4.3 / AC10.4.4 + contract tests.

### Pipeline platform-failure snapshot
- `tools/dokploy_failure_snapshot.py`: on deploy/readiness failure, query the Dokploy API and **classify the platform failure domain** (`dokploy-deployment-error` / `dokploy-worker-or-deployment-record` / `dokploy-rollout-incomplete` / `platform-ok-check-application-or-route`). Stdlib-only, never fails the job.
- `pr-test.yml`: `if: failure()` step publishes the snapshot to the context artifact + step summary, so triage can separate platform vs app failure **without SSH**.

## Verification
- `pytest apps/backend/tests/infra/test_observability_contract.py` → **17 passed**
- `pytest tests/tooling/test_dokploy_failure_snapshot.py` → **6 passed**
- Snapshot validated **live** against the staging Dokploy compose (correctly classified `done` → `platform-ok-check-application-or-route`)
- `ruff check/format` clean; **AC traceability gate PASSED** (100% mandatory, incl. new AC10.4.3/AC10.4.4)

## Scope notes (remaining #768 follow-ups)
- The snapshot is wired into `pr-test.yml`; mirroring it into `staging-deploy.yml` and adding host load/vault-agent health to the snapshot (needs infra2 SSH creds) are follow-ups.
- Deploy-summary SigNoz deep-link can be added once run↔trace attributes are confirmed flowing in staging.

## Checklist
- [x] OTEL request instrumentation applied to app instance (+ regression guard test)
- [x] `/api/health` reflects real instrumentation state
- [x] run↔trace correlation via resource attributes
- [x] platform-failure snapshot in PR-preview failure path (validated live)
- [x] tests + AC traceability green
- [ ] Reviewer to merge (AI does not merge)