### PR TITLE
[finance_report_test_and_doc] Release Promote-Not-Rebuild Integrity (#532)

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -97,6 +97,26 @@ jobs:
           fi
           echo "Using successful main CI run: $run_id"
 
+      - name: Verify staging passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          staging_run_id="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow staging-deploy.yml \
+              --commit "$GITHUB_SHA" \
+              --limit 20 \
+              --json databaseId,status,conclusion \
+              --jq '[.[] | select(.status == "completed" and .conclusion == "success")][0].databaseId // ""'
+          )"
+          if [ -z "$staging_run_id" ]; then
+            echo "::error::No successful Deploy Staging run found for $GITHUB_SHA"
+            exit 1
+          fi
+          echo "Using successful Deploy Staging run: $staging_run_id"
+          echo "staging_run_id=$staging_run_id" >> "$GITHUB_ENV"
+
       - name: Verify Release Codebase
         env:
           GITHUB_SHA: ${{ github.sha }}
@@ -116,30 +136,63 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Backend
-        uses: docker/build-push-action@v5
-        with:
-          context: ./apps/backend
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.version.outputs.tag }}
-          build-args: |
-            GIT_COMMIT_SHA=${{ steps.version.outputs.tag }}
-
-      - name: Build Frontend
-        uses: docker/build-push-action@v5
-        with:
-          context: ./apps/frontend
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.version.outputs.tag }}
-          build-args: |
-            GIT_COMMIT_SHA=${{ steps.version.outputs.tag }}
-            NEXT_PUBLIC_API_URL=https://report.zitian.party
-            NEXT_PUBLIC_APP_URL=https://report.zitian.party
+      - name: Promote Images
+        id: promote
+        run: |
+          short_sha=$(git rev-parse --short "$GITHUB_SHA")
+          tag="${{ steps.version.outputs.tag }}"
+          
+          backend_sha_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${short_sha}"
+          frontend_sha_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${short_sha}"
+          
+          backend_version_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${tag}"
+          frontend_version_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${tag}"
+          
+          # Inspect and check SHA images exist
+          backend_sha_digest="$(docker buildx imagetools inspect "$backend_sha_image" | grep -i '^Digest:' | awk '{print $2}')"
+          frontend_sha_digest="$(docker buildx imagetools inspect "$frontend_sha_image" | grep -i '^Digest:' | awk '{print $2}')"
+          
+          if [ -z "$backend_sha_digest" ] || [ -z "$frontend_sha_digest" ]; then
+            echo "::error::Staging-validated SHA images not found for SHA $short_sha"
+            exit 1
+          fi
+          
+          echo "Found backend SHA image digest: $backend_sha_digest"
+          echo "Found frontend SHA image digest: $frontend_sha_digest"
+          
+          # Promote images
+          docker buildx imagetools create --tag "$backend_version_image" "$backend_sha_image"
+          docker buildx imagetools create --tag "$frontend_version_image" "$frontend_sha_image"
+          
+          # Verify digests
+          backend_promoted_digest="$(docker buildx imagetools inspect "$backend_version_image" | grep -i '^Digest:' | awk '{print $2}')"
+          frontend_promoted_digest="$(docker buildx imagetools inspect "$frontend_version_image" | grep -i '^Digest:' | awk '{print $2}')"
+          
+          if [ "$backend_sha_digest" != "$backend_promoted_digest" ]; then
+            echo "::error::Backend digests differ! Expected $backend_sha_digest, got $backend_promoted_digest"
+            exit 1
+          fi
+          
+          if [ "$frontend_sha_digest" != "$frontend_promoted_digest" ]; then
+            echo "::error::Frontend digests differ! Expected $frontend_sha_digest, got $frontend_promoted_digest"
+            exit 1
+          fi
+          
+          echo "backend_digest=$backend_sha_digest" >> "$GITHUB_OUTPUT"
+          echo "frontend_digest=$frontend_sha_digest" >> "$GITHUB_OUTPUT"
+          echo "✅ Release $tag promoted successfully"
 
       - name: Summary
         run: |
-          echo "✅ Release ${{ steps.version.outputs.tag }} built"
-          echo "Deploy: Actions → Production Release → Run workflow"
+          {
+            echo "## Production Release Promoted"
+            echo ""
+            echo "- Released commit: ${{ github.sha }}"
+            echo "- Source CI run: ${{ env.staging_run_id }}"
+            echo "- Promoted backend image digest: ${{ steps.promote.outputs.backend_digest }}"
+            echo "- Promoted frontend image digest: ${{ steps.promote.outputs.frontend_digest }}"
+            echo "- No rebuild occurred: true"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Write production release build context
         if: ${{ always() }}
@@ -157,6 +210,9 @@ jobs:
             echo "tag=${{ steps.version.outputs.tag }}"
             echo "backend_image=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.version.outputs.tag }}"
             echo "frontend_image=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.version.outputs.tag }}"
+            echo "backend_digest=${{ steps.promote.outputs.backend_digest }}"
+            echo "frontend_digest=${{ steps.promote.outputs.frontend_digest }}"
+            echo "no_rebuild=true"
           } > ci-context/production-release-build-context.txt
 
       - name: Upload production release build context
@@ -232,6 +288,26 @@ jobs:
           fi
           echo "Using successful main CI run: $run_id"
 
+      - name: Verify staging passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          staging_run_id="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow staging-deploy.yml \
+              --commit "$GITHUB_SHA" \
+              --limit 20 \
+              --json databaseId,status,conclusion \
+              --jq '[.[] | select(.status == "completed" and .conclusion == "success")][0].databaseId // ""'
+          )"
+          if [ -z "$staging_run_id" ]; then
+            echo "::error::No successful Deploy Staging run found for $GITHUB_SHA"
+            exit 1
+          fi
+          echo "Using successful Deploy Staging run: $staging_run_id"
+          echo "staging_run_id=$staging_run_id" >> "$GITHUB_ENV"
+
       - name: Verify Release Codebase
         env:
           GITHUB_SHA: ${{ github.sha }}
@@ -241,35 +317,39 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Backend Image Without Push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./apps/backend
-          push: false
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.version.outputs.tag }}
-          build-args: |
-            GIT_COMMIT_SHA=${{ steps.version.outputs.tag }}
-
-      - name: Build Frontend Image Without Push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./apps/frontend
-          push: false
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.version.outputs.tag }}
-          build-args: |
-            GIT_COMMIT_SHA=${{ steps.version.outputs.tag }}
-            NEXT_PUBLIC_API_URL=https://report.zitian.party
-            NEXT_PUBLIC_APP_URL=https://report.zitian.party
+      - name: Verify SHA Images Dry Run
+        id: promote_dry
+        run: |
+          short_sha=$(git rev-parse --short "$GITHUB_SHA")
+          backend_sha_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${short_sha}"
+          frontend_sha_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${short_sha}"
+          
+          # Inspect and check SHA images exist
+          backend_sha_digest="$(docker buildx imagetools inspect "$backend_sha_image" | grep -i '^Digest:' | awk '{print $2}')"
+          frontend_sha_digest="$(docker buildx imagetools inspect "$frontend_sha_image" | grep -i '^Digest:' | awk '{print $2}')"
+          
+          if [ -z "$backend_sha_digest" ] || [ -z "$frontend_sha_digest" ]; then
+            echo "::error::Staging-validated SHA images not found for SHA $short_sha"
+            exit 1
+          fi
+          
+          echo "Found backend SHA image digest: $backend_sha_digest"
+          echo "Found frontend SHA image digest: $frontend_sha_digest"
+          
+          echo "backend_digest=$backend_sha_digest" >> "$GITHUB_OUTPUT"
+          echo "frontend_digest=$frontend_sha_digest" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         run: |
           {
             echo "## Production Release Dry Run"
             echo ""
-            echo "- Ref: ${{ github.ref_name }}"
-            echo "- Validation tag: ${{ steps.version.outputs.tag }}"
+            echo "- Released commit: ${{ github.sha }}"
+            echo "- Source CI run: ${{ env.staging_run_id }}"
+            echo "- Promoted backend image digest: ${{ steps.promote_dry.outputs.backend_digest }}"
+            echo "- Promoted frontend image digest: ${{ steps.promote_dry.outputs.frontend_digest }}"
+            echo "- No rebuild occurred: true"
             echo "- Production mutation skipped: true"
-            echo "- Production mutation skipped because dry_run=true"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "Production mutation skipped"
 
@@ -290,6 +370,9 @@ jobs:
             echo "production_mutation_skipped=true"
             echo "backend_image=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${{ steps.version.outputs.tag }}"
             echo "frontend_image=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.version.outputs.tag }}"
+            echo "backend_digest=${{ steps.promote_dry.outputs.backend_digest }}"
+            echo "frontend_digest=${{ steps.promote_dry.outputs.frontend_digest }}"
+            echo "no_rebuild=true"
           } > ci-context/production-dry-run-context.txt
 
       - name: Upload production dry-run context

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -208,6 +208,17 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 | AC7.9.7 | Backend health endpoint | `test_health_when_all_services_healthy()` | `infra/test_main.py` | P0 |
 | AC7.9.8 | Config contract validation | `TestConfigContract` class | `infra/test_config_contract.py` | P0 |
 
+### AC7.10: Promote and Release Pipeline Integrity
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC7.10.1 | `production-release.yml` promotes the staging-validated image to `vX.Y.Z` instead of rebuilding from source | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+| AC7.10.2 | Release fails closed if no staging-validated SHA image exists or if digests differ | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+| AC7.10.3 | Workflow summary records released commit, source CI run, promoted image digest, and no rebuild | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+| AC7.10.4 | Deployment and CI SSOTs document the promote-not-rebuild consistency ladder | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+| AC7.10.5 | Retain `workflow_dispatch` dry-run to prove the release/promote path without mutating production | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+
+
 ## 📏 Acceptance Criteria
 
 ### 🟢 Must Have

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -273,9 +273,11 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Frontend dependency installation uses `actions/setup-node@v4` with npm cache and deterministic `npm ci`. PR CI also runs `npm run audit:prod` after install so production frontend dependency advisories fail before merge; dev-only advisories remain outside this production gate.
 - GitHub JavaScript action runtime is explicitly validated on Node 24 by setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at the workflow level. This does not change the application toolchain `NODE_VERSION`; it only opts GitHub-hosted JavaScript actions into the runtime that GitHub will make the default.
 - Production release tag builds and dry-runs verify that the target SHA already
-  has a successful `main` CI `finish` result, then run release lint and image
-  build validation. They do not rerun the container-backed `moon run :test`
-  lifecycle in the release lane.
+  has a successful `main` CI `finish` result and a successful post-merge `staging`
+  deployment, then run release lint and image promotion/validation. They do not
+  rebuild images from source or rerun the container-backed `moon run :test`
+  lifecycle in the release lane, maintaining the promote-not-rebuild consistency ladder
+  where the exact same staging-validated image digest is promoted to production.
 - The `finish` job appends a GitHub Step Summary from `tools/github_workflow_timing_summary.py` with queue delay, execution window, run wall time, longest completed job, and per-job durations.
 - The `finish` job appends a coverage gate summary so reviewers can identify the authoritative local coverage gate.
 - The `tooling-coverage` job uploads `coverage-tooling`; the `unified-coverage` job downloads it and uploads the `unified-coverage-context` artifact so reviewers can inspect raw line-count inputs instead of inferring failures from rounded percentages.
@@ -350,10 +352,10 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - GLM/OCR CI traffic uses `AI_BASE_URL=https://api.z.ai/api/coding/paas/v4`; the URL remains an env override so the base provider can be replaced without code changes.
 
 **Production release dry-run** (`.github/workflows/production-release.yml`):
-- Manual `workflow_dispatch` with `dry_run=true` verifies the target SHA's successful `main` CI result, runs release lint, and builds production images with `push: false`.
-- The dry-run uses production frontend build arguments without changing Dokploy or production tags, and does not enter the `production` environment or push GHCR images. Its summary reports the validated ref/tag and states that production mutation was skipped.
-- Tag pushes remain the only automatic path that pushes versioned release images. Manual dispatch with `dry_run=false` remains the production deploy path for an existing version.
-- Production backend release images bake `GIT_COMMIT_SHA` from the release tag, and Dokploy deploys also inject the same runtime `GIT_COMMIT_SHA` so `/api/health` can prove the deployed version even after a same-tag redeploy.
+- Manual `workflow_dispatch` with `dry_run=true` verifies the target SHA's successful `main` CI result, a successful staging deployment, runs release lint, and dry-runs image promotion by verifying that staging-validated SHA-tagged images exist on GHCR and retrieving their digests without pushing any tags.
+- The dry-run reports the validated ref/tag, the staging run checked, the target image digests, and states that production mutation was skipped. No rebuild occurs.
+- Tag pushes remain the only automatic path that promotes versioned release images. Manual dispatch with `dry_run=false` remains the production deploy path for an existing version.
+- Production backend release images carry the original commit's `GIT_COMMIT_SHA`, and Dokploy deploys inject the release version tag as the runtime `IMAGE_TAG` / `GIT_COMMIT_SHA` so `/api/health` can prove the deployed version even after a same-tag redeploy.
 - Production deploys run `tools/production_infra_smoke.py` after health check. That gate verifies the deployed version, `/api/health` dependency checks for database and S3, read-only `/api/ping`, frontend reachability, and the shared SigNoz health/version endpoints before production smoke and read-only E2E run.
 
 The remaining higher-risk CI and post-merge optimization candidates are tracked

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -74,6 +74,8 @@ Non-`push`, failed, cancelled, timed-out, or non-main CI workflow runs write a
 skipped summary before FIFO wait, image promotion, Dokploy rollout, smoke tests,
 or AI/OCR validation can run.
 
+The production release workflow strictly promotes the staging-validated image digest to the release version tag (`vX.Y.Z`) instead of rebuilding from source. This creates a promote-not-rebuild consistency ladder: `pr (SHA image) → staging (promotes SHA to staging tag, validates digest) → prod (promotes staging-validated SHA to version tag)`. By keeping the exact same image digest across all three environments, we eliminate drift from base images, build-time dependencies, or workflow changes, ensuring that production only runs artifacts that have been fully tested and validated.
+
 The staging deploy gate separates platform rollout from application readiness.
 `tools/dokploy_deploy.sh` updates the allowlisted Dokploy environment, triggers
 `compose.deploy`, then waits up to 600 seconds for a new Dokploy deployment
@@ -88,12 +90,12 @@ health timeout.
 
 ```yaml
 Triggers:
-  - Tag push (v*.*.*): Build release images
+  - Tag push (v*.*.*): Promote staging-validated images
   - Manual dispatch:   Deploy to production
   - Manual dry-run:    Validate release prerequisites without deploy
 
-Build job:  Tag → Verify successful main CI for SHA → Release lint → Build backend + frontend → Push to GHCR
-Dry-run:    Manual → Verify successful main CI for SHA → Release lint → Build production images with push=false → Skip Dokploy
+Build job:  Tag → Verify successful main CI for SHA → Verify successful staging run → Release lint → Promote staging-validated SHA images to version tag → Skip rebuild
+Dry-run:    Manual → Verify successful main CI for SHA → Verify successful staging run → Release lint → Verify SHA images exist and fetch digests → Skip promotion and rebuild
 Deploy job: Verify images → Deploy → Health (4min) → Smoke test
 
 URL: https://report.zitian.party

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -994,14 +994,15 @@ def test_AC8_13_52_production_release_dry_run_does_not_mutate_production() -> No
     assert "--workflow ci.yml" in workflow
     assert '--commit "$GITHUB_SHA"' in workflow
     assert '.headBranch == "main"' in workflow
-    assert "push: false" in workflow
+    assert "Verify SHA Images Dry Run" in workflow
     assert "Production mutation skipped" in workflow
     dry_run_section = workflow.split("dry-run:", 1)[1].split("\n  deploy:", 1)[0]
     assert "environment:" not in dry_run_section
     assert "dokploy_deploy.sh" not in dry_run_section
     assert "inputs.dry_run" in workflow.split("deploy:", 1)[1].split("steps:", 1)[0]
     assert "Production release dry-run" in ci_cd
-    assert "without changing Dokploy or production tags" in ci_cd
+    assert "Verify SHA Images Dry Run" in workflow
+    assert "docker buildx imagetools create" not in dry_run_section
 
 
 def test_AC8_13_16_ci_change_classification_and_frontend_cache() -> None:
@@ -1235,27 +1236,16 @@ def test_AC8_13_67_production_release_preserves_version_metadata() -> None:
     deploy_script = read("tools/_lib/shell/dokploy_deploy.sh")
     app_compose = read("repo/finance_report/finance_report/10.app/compose.yaml")
 
-    backend_build_blocks = re.findall(
-        r"- name: Build Backend(?: Image Without Push)?\n(?:(?!\n      - name:).)*",
-        workflow,
-        flags=re.S,
+    # In the promote-not-rebuild pattern, we promote staging-validated images instead of rebuilding.
+    # We verify that promotion uses docker buildx imagetools create.
+    promote_blocks = re.findall(
+        r"docker buildx imagetools create --tag",
+        workflow
     )
-    assert len(backend_build_blocks) == 2
-    for block in backend_build_blocks:
-        assert "context: ./apps/backend" in block
-        assert "build-args:" in block
-        assert "GIT_COMMIT_SHA=${{ steps.version.outputs.tag }}" in block
+    assert len(promote_blocks) == 2
 
-    frontend_build_blocks = re.findall(
-        r"- name: Build Frontend(?: Image Without Push)?\n(?:(?!\n      - name:).)*",
-        workflow,
-        flags=re.S,
-    )
-    assert len(frontend_build_blocks) == 2
-    for block in frontend_build_blocks:
-        assert "context: ./apps/frontend" in block
-        assert "build-args:" in block
-        assert "GIT_COMMIT_SHA=${{ steps.version.outputs.tag }}" in block
+    assert "Verify staging passed" in workflow
+    assert "Verify SHA Images Dry Run" in workflow
 
     config_hash_update = 'new_env=$(update_env_var "$new_env" "IAC_CONFIG_HASH" "deploy-${IMAGE_TAG}-$(date +%s)")'
     assert config_hash_update in deploy_script
@@ -1269,6 +1259,37 @@ def test_AC8_13_67_production_release_preserves_version_metadata() -> None:
     assert app_compose.index("backend:") < app_compose.index(
         "GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-unknown}"
     )
+
+
+def test_AC7_10_production_release_promotes_not_rebuilds() -> None:
+    """AC7.10.1 - AC7.10.5: Production release promotes staging-validated SHA image and fails closed on drift."""
+    workflow = read(".github/workflows/production-release.yml")
+    ci_cd = read("docs/ssot/ci-cd.md")
+    deployment = read("docs/ssot/deployment.md")
+
+    # AC7.10.1: promotes staging-validated image instead of rebuilding
+    assert "docker buildx imagetools create --tag" in workflow
+    assert "docker/build-push-action" not in workflow
+
+    # AC7.10.2: fails closed if no staging-validated SHA image exists or digests differ
+    assert "Verify staging passed" in workflow
+    assert "docker buildx imagetools inspect" in workflow
+    assert 'backend_sha_digest" != "$backend_promoted_digest' in workflow
+    assert 'frontend_sha_digest" != "$frontend_promoted_digest' in workflow
+
+    # AC7.10.3: summary records released commit, source CI run, digest, and no rebuild
+    assert "Released commit: ${{ github.sha }}" in workflow
+    assert "Source CI run: ${{ env.staging_run_id }}" in workflow
+    assert "Promoted backend image digest" in workflow
+    assert "No rebuild occurred" in workflow
+
+    # AC7.10.4: SSOTs document promote-not-rebuild consistency ladder
+    assert "promote-not-rebuild consistency ladder" in deployment
+    assert "promote-not-rebuild consistency ladder" in ci_cd
+
+    # AC7.10.5: workflow_dispatch dry-run proves promote path without mutating
+    assert "Verify SHA Images Dry Run" in workflow
+    assert "dry_run:" in workflow
 
 
 def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:


### PR DESCRIPTION
This PR implements the promote-not-rebuild strategy for the production release pipeline as specified in #532.

## Acceptance Criteria (#532 / AC7.10)

* **AC7.10.1**: `production-release.yml` promotes the staging-validated image to `vX.Y.Z` instead of rebuilding from source.
* **AC7.10.2**: Release fails closed if no staging-validated SHA image exists or if digests differ.
* **AC7.10.3**: Workflow summary records released commit, source CI run, promoted image digest, and no rebuild.
* **AC7.10.4**: Deployment and CI SSOTs document the promote-not-rebuild consistency ladder.
* **AC7.10.5**: Retain `workflow_dispatch` dry-run to prove the release/promote path without mutating production.

## Implementation Details
* Updated `.github/workflows/production-release.yml` to remove rebuild logic and verify the staging-validated image SHA digest.
* Promoted SHA-based images using `docker buildx imagetools create` instead of rebuilding.
* Implemented workflow summary record logic.
* Updated `docs/ssot/deployment.md` and `docs/ssot/ci-cd.md` to document the promote-not-rebuild consistency ladder.
* Added tests in `tests/tooling/test_post_merge_e2e_gates.py` (`test_AC7_10_production_release_promotes_not_rebuilds`) to verify this behavior.
