### PR TITLE
[finance_report_test_and_doc] Fix chat enum persistence for staging provider gate

### DIFF
--- a/apps/backend/src/models/chat.py
+++ b/apps/backend/src/models/chat.py
@@ -29,6 +29,10 @@ class ChatMessageRole(str, enum.Enum):
     SYSTEM = "system"
 
 
+def _enum_values(enum_cls: type[enum.Enum]) -> list[str]:
+    return [str(member.value) for member in enum_cls]
+
+
 class ChatSession(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """Chat session header for AI advisor conversations."""
 
@@ -36,7 +40,7 @@ class ChatSession(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
 
     title: Mapped[str | None] = mapped_column(String(200), nullable=True)
     status: Mapped[ChatSessionStatus] = mapped_column(
-        Enum(ChatSessionStatus, name="chat_session_status_enum"),
+        Enum(ChatSessionStatus, name="chat_session_status_enum", values_callable=_enum_values),
         nullable=False,
         default=ChatSessionStatus.ACTIVE,
         index=True,
@@ -62,7 +66,10 @@ class ChatMessage(Base, UUIDMixin):
         nullable=False,
         index=True,
     )
-    role: Mapped[ChatMessageRole] = mapped_column(Enum(ChatMessageRole, name="chat_message_role_enum"), nullable=False)
+    role: Mapped[ChatMessageRole] = mapped_column(
+        Enum(ChatMessageRole, name="chat_message_role_enum", values_callable=_enum_values),
+        nullable=False,
+    )
     content: Mapped[str] = mapped_column(Text, nullable=False)
     tokens_in: Mapped[int | None] = mapped_column(Integer, nullable=True)
     tokens_out: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/apps/backend/tests/ai/test_models_repr.py
+++ b/apps/backend/tests/ai/test_models_repr.py
@@ -34,6 +34,12 @@ def test_chat_message_repr():
     assert str(session_id) in repr_str
 
 
+def test_chat_model_enums_match_migration_values():
+    """AC6.4.1: Chat ORM enums persist the lowercase PostgreSQL enum values."""
+    assert ChatSession.__table__.c.status.type.enums == ["active", "deleted"]
+    assert ChatMessage.__table__.c.role.type.enums == ["user", "assistant", "system"]
+
+
 def test_fx_rate_repr():
     fx_rate = FxRate(
         base_currency="USD",


### PR DESCRIPTION
## Summary
- Persist chat session status and message role enums using their PostgreSQL lowercase values.
- Add regression coverage that keeps ORM enum values aligned with the existing chat migrations.

## Root Cause
The latest staging provider connectivity gate failed before reaching the provider. `/api/chat` attempted to insert `ACTIVE` into `chat_session_status_enum`, while the deployed PostgreSQL enum accepts lowercase `active`/`deleted`. The same mismatch existed for chat message roles.

## Verification
- `uv run ruff check apps/backend/src/models/chat.py apps/backend/tests/ai/test_models_repr.py`
- `uv run pytest apps/backend/tests/ai/test_models_repr.py -q --no-cov`
- pre-push hook: backend lint, frontend lint, backend test suite (`2188 passed`)

## Deployment Note
Production deployment remains blocked until this PR merges, main CI passes, and staging provider connectivity passes on the merged SHA.
