### PR TITLE
[finance_report_vision] chore: route OpenCode models off ban-risk providers

### DIFF
--- a/.opencode/oh-my-openagent.json
+++ b/.opencode/oh-my-openagent.json
@@ -20,15 +20,15 @@
     },
     "prometheus": {
       "replace_plan": true,
-      "model": "openai/gpt-5.5",
+      "model": "github-copilot/claude-opus-4.7",
       "skills": ["agents-rules", "tools-index"]
     },
     "oracle": {
-      "model": "openai/gpt-5.5",
+      "model": "github-copilot/claude-opus-4.7",
       "skills": ["agents-rules", "tools-index"]
     },
     "momus": {
-      "model": "openai/gpt-5.5",
+      "model": "github-copilot/claude-sonnet-4.6",
       "skills": ["agents-rules"]
     },
     "metis": {
@@ -36,7 +36,7 @@
       "skills": ["agents-rules"]
     },
     "hephaestus": {
-      "model": "openai/gpt-5.5",
+      "model": "github-copilot/claude-sonnet-4.6",
       "skills": ["agents-rules", "tools-index"]
     },
     "atlas": {
@@ -61,11 +61,11 @@
       "skills": ["agents-rules", "tools-index", "headless-fast-internal-browser"]
     },
     "librarian": {
-      "model": "google/antigravity-gemini-3-flash",
+      "model": "zai-coding-plan/glm-5.1",
       "skills": ["agents-rules", "tools-index", "headless-fast-internal-browser", "headed-internal-browser"]
     },
     "multimodal-looker": {
-      "model": "google/antigravity-gemini-3-pro-high",
+      "model": "github-copilot/claude-opus-4.7",
       "skills": ["agents-rules", "tools-index"]
     }
   },
@@ -75,19 +75,19 @@
       "description": "Trivial tasks - single file changes, typo fixes"
     },
     "visual-engineering": {
-      "model": "google/antigravity-gemini-3-flash",
+      "model": "github-copilot/claude-sonnet-4.6",
       "description": "Frontend, UI/UX, design, styling"
     },
     "ultrabrain": {
-      "model": "openai/gpt-5.5",
+      "model": "github-copilot/claude-opus-4.7",
       "description": "Deep logical reasoning, complex architecture decisions"
     },
     "deep": {
-      "model": "openai/gpt-5.5",
+      "model": "github-copilot/claude-opus-4.7",
       "description": "Goal-oriented autonomous problem-solving. Thorough research before action. For hairy problems requiring deep understanding."
     },
     "artistry": {
-      "model": "google/antigravity-gemini-3-flash",
+      "model": "github-copilot/claude-sonnet-4.6",
       "description": "Complex problem-solving with unconventional, creative approaches - beyond standard patterns"
     },
     "writing": {
@@ -116,17 +116,12 @@
     "staleTimeoutMs": 180000,
     "providerConcurrency": {
       "github-copilot": 3,
-      "openai": 5,
-      "google": 10,
       "zai-coding-plan": 3
     },
     "modelConcurrency": {
       "github-copilot/claude-opus-4.7": 2,
       "github-copilot/claude-sonnet-4.6": 3,
-      "openai/gpt-5.5": 4,
-      "zai-coding-plan/glm-5.1": 3,
-      "google/antigravity-gemini-3-pro-high": 2,
-      "google/antigravity-gemini-3-flash": 8
+      "zai-coding-plan/glm-5.1": 3
     }
   },
   "git_master": {

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "openai/gpt-5.5",
+  "model": "github-copilot/claude-sonnet-4.6",
   "plugin": [
     "oh-my-opencode@3.17.6"
   ],
@@ -11,64 +11,6 @@
       "oauth": false,
       "headers": {
         "Authorization": "Bearer {env:GITHUB_PAT}"
-      }
-    }
-  },
-  "provider": {
-    "google": {
-      "name": "Google",
-      "models": {
-        "antigravity-gemini-3-flash": {
-          "name": "Gemini 3 Flash (Antigravity)",
-          "attachment": true,
-          "limit": { "context": 1048576, "output": 65536 },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
-        }
-      }
-    },
-    "openai": {
-      "name": "OpenAI",
-      "models": {
-        "gpt-5.5": {
-          "name": "GPT 5.5 (OAuth)",
-          "limit": { "context": 272000, "output": 128000 },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          },
-          "variants": {
-            "none": { "reasoningEffort": "none", "reasoningSummary": "auto", "textVerbosity": "medium" },
-            "low": { "reasoningEffort": "low", "reasoningSummary": "auto", "textVerbosity": "medium" },
-            "medium": { "reasoningEffort": "medium", "reasoningSummary": "auto", "textVerbosity": "medium" },
-            "high": { "reasoningEffort": "high", "reasoningSummary": "detailed", "textVerbosity": "medium" },
-            "xhigh": { "reasoningEffort": "xhigh", "reasoningSummary": "detailed", "textVerbosity": "medium" }
-          }
-        },
-        "gpt-5.4": {
-          "name": "GPT 5.4 (OAuth)",
-          "limit": { "context": 272000, "output": 128000 },
-          "modalities": {
-            "input": ["text", "image"],
-            "output": ["text"]
-          },
-          "variants": {
-            "none": { "reasoningEffort": "none", "reasoningSummary": "auto", "textVerbosity": "medium" },
-            "low": { "reasoningEffort": "low", "reasoningSummary": "auto", "textVerbosity": "medium" },
-            "medium": { "reasoningEffort": "medium", "reasoningSummary": "auto", "textVerbosity": "medium" },
-            "high": { "reasoningEffort": "high", "reasoningSummary": "detailed", "textVerbosity": "medium" },
-            "xhigh": { "reasoningEffort": "xhigh", "reasoningSummary": "detailed", "textVerbosity": "medium" }
-          }
-        }
-      },
-      "options": {
-        "reasoningEffort": "medium",
-        "reasoningSummary": "auto",
-        "textVerbosity": "medium",
-        "include": ["reasoning.encrypted_content"],
-        "store": false
       }
     }
   }

--- a/tests/tooling/test_agent_runtime_symlinks.py
+++ b/tests/tooling/test_agent_runtime_symlinks.py
@@ -32,6 +32,30 @@ BANNED_OPENCODE_PLUGINS = (
     "opencode-openai-codex-auth",
 )
 
+# Model providers that OpenCode can only reach through a borrowed subscription
+# OAuth seat (ChatGPT for `openai/*`, Antigravity for `google/*`). Routing any
+# agent/category/default model at them re-introduces the suspension risk, so
+# OpenCode is pinned to github-copilot (official OAuth) + api-key providers.
+BANNED_MODEL_PROVIDER_PREFIXES = ("openai/", "google/")
+
+
+def _all_opencode_model_refs() -> dict[str, str]:
+    """Collect every `model` string from opencode.json + oh-my-openagent.json."""
+    refs: dict[str, str] = {}
+
+    root_config = json.loads((ROOT / "opencode.json").read_text(encoding="utf-8"))
+    if "model" in root_config:
+        refs["opencode.json:model"] = root_config["model"]
+
+    agent_config = json.loads(
+        (ROOT / ".opencode" / "oh-my-openagent.json").read_text(encoding="utf-8")
+    )
+    for section in ("agents", "categories"):
+        for name, body in agent_config.get(section, {}).items():
+            if isinstance(body, dict) and "model" in body:
+                refs[f"{section}.{name}"] = body["model"]
+    return refs
+
 
 def _opencode_leaf_skill_dirs() -> dict[str, Path]:
     """Map skill name -> leaf directory for every SKILL.md under .opencode."""
@@ -99,4 +123,17 @@ def test_opencode_config_has_no_banrisk_auth_plugins() -> None:
             assert banned not in plugin, (
                 f"ban-risk auth plugin {banned!r} must not be re-added to "
                 f"opencode.json (found {plugin!r})"
+            )
+
+
+def test_no_opencode_agent_routes_to_banrisk_provider() -> None:
+    """Every OpenCode model must use github-copilot or an api-key provider."""
+    refs = _all_opencode_model_refs()
+    assert refs, "expected to find model references to validate"
+    for location, model in sorted(refs.items()):
+        for prefix in BANNED_MODEL_PROVIDER_PREFIXES:
+            assert not model.startswith(prefix), (
+                f"{location} routes to ban-risk provider {model!r}; OpenCode can "
+                f"only reach {prefix}* via borrowed subscription OAuth. Re-point "
+                f"it at github-copilot or an api-key provider."
             )


### PR DESCRIPTION
## Why

Follow-up to #787. Removing the two auth plugins took out the *login mechanism*, but OpenCode's stored OAuth **tokens** for `openai` (ChatGPT subscription) and `google` (Antigravity subscription) still sat in its auth store — so the suspension risk lived in the **routing**, not just the plugins. This pins OpenCode to `github-copilot` (officially OAuth-supported) plus api-key providers.

## Changes

- **`opencode.json`**: default model `openai/gpt-5.5` → `github-copilot/claude-sonnet-4.6`; drop the `openai` + `google` provider blocks.
- **`oh-my-openagent.json`**: re-point every `openai/*` and `google/*` agent + category:
  | was | now |
  |---|---|
  | `openai/gpt-5.5` (oracle, prometheus, ultrabrain, deep) | `github-copilot/claude-opus-4.7` |
  | `openai/gpt-5.5` (momus, hephaestus) | `github-copilot/claude-sonnet-4.6` |
  | `google/antigravity-*` (visual-engineering, artistry) | `github-copilot/claude-sonnet-4.6` |
  | `google/antigravity-gemini-3-pro-high` (multimodal-looker) | `github-copilot/claude-opus-4.7` |
  | `google/antigravity-gemini-3-flash` (librarian) | `zai-coding-plan/glm-5.1` |
  Pruned `openai`/`google` from `background_task` concurrency.
- **Test**: `test_no_opencode_agent_routes_to_banrisk_provider` — any future `openai/*` or `google/*` routing now fails CI.

## Out of scope / notes

- OpenCode's stored `openai`/`google` OAuth tokens were cleared **locally** (auth store, backed up) — not a repo change.
- Codex continues using ChatGPT (and Gemini) via their own **first-party CLIs**, which is sanctioned — the risk was only third-party (OpenCode) reuse.
- **Tradeoff**: `multimodal-looker` loses native Gemini PDF input; it now runs on Copilot's vision-capable Claude. Adjust if PDF extraction quality regresses.
- Pre-existing `M repo` submodule drift untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)