### PR TITLE
[finance_report_hacker] EPIC-011 Stage 2a: backfill Layer 0→2 from legacy statements

### DIFF
--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -6,12 +6,14 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from src.logger import get_logger
 from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AtomicPosition, AtomicTransaction, TransactionDirection
-from src.models.statement import BankStatementTransaction
+from src.models.statement import BankStatement, BankStatementTransaction
 
 logger = get_logger(__name__)
 
@@ -353,3 +355,115 @@ async def dual_write_layer2(
         )
         # Re-raise to ensure caller knows dual-write failed
         raise RuntimeError(f"Failed to write to Layer 2: {e}") from e
+
+
+async def backfill_atomic_transactions_from_statements(
+    db: AsyncSession,
+    user_id: UUID | None = None,
+) -> dict[str, int]:
+    """Idempotently populate Layer 1/2 from existing Layer 0 statements (EPIC-011 Stage 2).
+
+    For every ``BankStatement`` (optionally scoped to ``user_id``) this ensures a
+    Layer 1 ``UploadedDocument`` exists and every ``BankStatementTransaction`` has a
+    Layer 2 ``AtomicTransaction``. This backfills historical data that predates the
+    Stage 1 dual-write activation, so the Layer-2 read path has full coverage before
+    ``ENABLE_4_LAYER_READ`` is turned on.
+
+    Safe to re-run: ``UploadedDocument`` is keyed by ``(user_id, file_hash)`` and
+    ``AtomicTransaction`` by ``(user_id, dedup_hash)``, so re-execution upserts
+    rather than duplicates.
+
+    Returns counts: ``statements_scanned``, ``documents_created``,
+    ``atomic_transactions_upserted``.
+    """
+    dedup_service = DeduplicationService()
+
+    query = select(BankStatement).options(selectinload(BankStatement.transactions))
+    if user_id is not None:
+        query = query.where(BankStatement.user_id == user_id)
+    query = query.order_by(BankStatement.created_at)
+
+    statements = (await db.execute(query)).scalars().all()
+
+    statements_scanned = 0
+    documents_created = 0
+    atomic_upserted = 0
+
+    for stmt in statements:
+        statements_scanned += 1
+        owner_id = stmt.user_id
+        if owner_id is None:
+            logger.warning("Skipping statement without owner during backfill", extra={"statement_id": str(stmt.id)})
+            continue
+
+        doc_type = (
+            DocumentType.BROKERAGE_STATEMENT
+            if (stmt.extraction_metadata or {}).get("extraction_payload")
+            else DocumentType.BANK_STATEMENT
+        )
+
+        existing_doc = (
+            await db.execute(
+                select(UploadedDocument).where(
+                    UploadedDocument.user_id == owner_id,
+                    UploadedDocument.file_hash == stmt.file_hash,
+                )
+            )
+        ).scalar_one_or_none()
+
+        if existing_doc is None:
+            try:
+                existing_doc = await dedup_service.create_uploaded_document(
+                    db=db,
+                    user_id=owner_id,
+                    file_path=stmt.file_path or stmt.file_hash,
+                    file_hash=stmt.file_hash,
+                    original_filename=stmt.original_filename or "unknown",
+                    document_type=doc_type,
+                    extraction_metadata=stmt.extraction_metadata,
+                )
+                documents_created += 1
+            except IntegrityError:
+                # Concurrent/duplicate creation; reload the existing row.
+                await db.rollback()
+                existing_doc = (
+                    await db.execute(
+                        select(UploadedDocument).where(
+                            UploadedDocument.user_id == owner_id,
+                            UploadedDocument.file_hash == stmt.file_hash,
+                        )
+                    )
+                ).scalar_one()
+
+        for txn in stmt.transactions:
+            direction_map = {"IN": TransactionDirection.IN, "OUT": TransactionDirection.OUT}
+            l2_direction = direction_map.get(txn.direction, TransactionDirection.IN)
+            await dedup_service.upsert_atomic_transaction(
+                db=db,
+                user_id=owner_id,
+                txn_date=txn.txn_date,
+                amount=txn.amount,
+                direction=l2_direction,
+                description=txn.description,
+                currency=txn.currency or stmt.currency or "SGD",
+                source_doc_id=existing_doc.id,
+                source_doc_type=doc_type,
+                reference=txn.reference,
+            )
+            atomic_upserted += 1
+
+    logger.info(
+        "Layer 2 backfill completed",
+        extra={
+            "statements_scanned": statements_scanned,
+            "documents_created": documents_created,
+            "atomic_transactions_upserted": atomic_upserted,
+            "user_scope": str(user_id) if user_id else "all",
+        },
+    )
+
+    return {
+        "statements_scanned": statements_scanned,
+        "documents_created": documents_created,
+        "atomic_transactions_upserted": atomic_upserted,
+    }

--- a/apps/backend/tests/extraction/test_backfill_layer2.py
+++ b/apps/backend/tests/extraction/test_backfill_layer2.py
@@ -1,0 +1,119 @@
+"""Tests for EPIC-011 Stage 2 Layer 0 -> Layer 1/2 backfill."""
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.layer1 import UploadedDocument
+from src.models.layer2 import AtomicTransaction
+from src.models.statement import BankStatement, BankStatementTransaction
+from src.models.user import User
+from src.services.deduplication import backfill_atomic_transactions_from_statements
+
+
+async def _seed_statement(db: AsyncSession, user_id, *, file_hash: str) -> BankStatement:
+    statement = BankStatement(
+        user_id=user_id,
+        file_path=f"statements/{file_hash}.pdf",
+        file_hash=file_hash,
+        original_filename="legacy.pdf",
+        institution="DBS",
+        account_last4="1234",
+        currency="SGD",
+        period_start=date(2024, 1, 1),
+        period_end=date(2024, 1, 31),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("0.00"),
+    )
+    db.add(statement)
+    await db.flush()
+    db.add_all(
+        [
+            BankStatementTransaction(
+                statement_id=statement.id,
+                txn_date=date(2024, 1, 15),
+                description="Salary Deposit",
+                amount=Decimal("3000.00"),
+                direction="IN",
+                reference="SAL001",
+            ),
+            BankStatementTransaction(
+                statement_id=statement.id,
+                txn_date=date(2024, 1, 20),
+                description="Rent Payment",
+                amount=Decimal("2500.00"),
+                direction="OUT",
+                reference="RENT001",
+            ),
+        ]
+    )
+    await db.commit()
+    return statement
+
+
+@pytest.mark.asyncio
+class TestBackfillLayer2:
+    async def test_backfill_creates_layer1_and_layer2_from_legacy_statement(self, db, test_user):
+        """AC11.12.1: Historical Layer 0 statements are projected into Layer 1/2."""
+        await _seed_statement(db, test_user.id, file_hash="hash-backfill-1")
+
+        result = await backfill_atomic_transactions_from_statements(db, user_id=test_user.id)
+        await db.commit()
+
+        assert result["statements_scanned"] == 1
+        assert result["documents_created"] == 1
+        assert result["atomic_transactions_upserted"] == 2
+
+        docs = (
+            await db.execute(select(UploadedDocument).where(UploadedDocument.user_id == test_user.id))
+        ).scalars().all()
+        assert len(docs) == 1
+        assert docs[0].file_hash == "hash-backfill-1"
+
+        atomic = (
+            await db.execute(select(AtomicTransaction).where(AtomicTransaction.user_id == test_user.id))
+        ).scalars().all()
+        assert {t.amount for t in atomic} == {Decimal("3000.00"), Decimal("2500.00")}
+
+    async def test_backfill_is_idempotent(self, db, test_user):
+        """AC11.12.2: Re-running the backfill upserts instead of duplicating."""
+        await _seed_statement(db, test_user.id, file_hash="hash-backfill-2")
+
+        await backfill_atomic_transactions_from_statements(db, user_id=test_user.id)
+        await db.commit()
+        second = await backfill_atomic_transactions_from_statements(db, user_id=test_user.id)
+        await db.commit()
+
+        # Second pass creates no new Layer 1 doc and inserts no new Layer 2 rows.
+        assert second["documents_created"] == 0
+
+        docs = (
+            await db.execute(select(UploadedDocument).where(UploadedDocument.user_id == test_user.id))
+        ).scalars().all()
+        assert len(docs) == 1
+
+        atomic = (
+            await db.execute(select(AtomicTransaction).where(AtomicTransaction.user_id == test_user.id))
+        ).scalars().all()
+        assert len(atomic) == 2
+
+    async def test_backfill_scopes_to_requested_user(self, db, test_user):
+        """AC11.12.3: User-scoped backfill ignores other users' statements."""
+        other_user = User(email=f"other-{uuid4()}@example.com", hashed_password="hashed")
+        db.add(other_user)
+        await db.flush()
+        await _seed_statement(db, other_user.id, file_hash="hash-other-user")
+        await _seed_statement(db, test_user.id, file_hash="hash-this-user")
+
+        result = await backfill_atomic_transactions_from_statements(db, user_id=test_user.id)
+        await db.commit()
+
+        assert result["statements_scanned"] == 1
+        atomic = (
+            await db.execute(select(AtomicTransaction).where(AtomicTransaction.user_id == other_user.id))
+        ).scalars().all()
+        assert len(atomic) == 0

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -168,6 +168,19 @@ alongside legacy Layer 0, with an env opt-out preserved for rollback.
 | AC11.11.1 | Parsing populates Layer 1/2 by default, without any feature-flag override | `test_dual_write_enabled_by_default()` | `extraction/test_dual_write_layer2.py` | P0 |
 | AC11.11.2 | `ENABLE_4_LAYER_WRITE=false` preserves the legacy Layer-0-only opt-out for rollback | `test_dual_write_can_be_disabled_via_flag()` | `extraction/test_dual_write_layer2.py` | P0 |
 
+### AC11.12: 4-Layer Migration — Stage 2a Layer 0→2 Backfill
+
+Stage 2a backfills historical Layer 0 statements (those uploaded before Stage 1
+dual-write) into Layer 1/2, so the Layer-2 read path has complete coverage
+before `ENABLE_4_LAYER_READ` is activated. Idempotent and re-runnable via
+`tools/backfill_layer2.py`.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.12.1 | Historical Layer 0 statements are projected into Layer 1 documents and Layer 2 atomic transactions | `test_backfill_creates_layer1_and_layer2_from_legacy_statement()` | `extraction/test_backfill_layer2.py` | P0 |
+| AC11.12.2 | Re-running the backfill upserts by dedup hash instead of duplicating rows | `test_backfill_is_idempotent()` | `extraction/test_backfill_layer2.py` | P0 |
+| AC11.12.3 | A user-scoped backfill ignores other users' statements | `test_backfill_scopes_to_requested_user()` | `extraction/test_backfill_layer2.py` | P0 |
+
 ## Implementation Pattern Ownership
 
 Do not copy reusable code patterns, router examples, migration guardrails, or

--- a/tools/_lib/migrations/backfill_layer2.py
+++ b/tools/_lib/migrations/backfill_layer2.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Backfill Layer 1/2 (uploaded_documents + atomic_transactions) from legacy Layer 0.
+
+EPIC-011 Stage 2: project historical ``BankStatement`` data into the 4-layer
+tables so the Layer-2 read path has full coverage before ``ENABLE_4_LAYER_READ``
+is turned on. Idempotent — safe to re-run.
+
+Usage:
+    # Local development
+    python tools/backfill_layer2.py --env local
+
+    # Staging / production (requires DATABASE_URL)
+    DATABASE_URL=... python tools/backfill_layer2.py --env production
+
+    # Scope to a single user
+    python tools/backfill_layer2.py --env local --user-id <uuid>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "apps" / "backend"))
+
+from src.config import settings  # noqa: E402
+from src.services.deduplication import backfill_atomic_transactions_from_statements  # noqa: E402
+
+
+def get_database_url(env: str) -> str:
+    if env in ("staging", "production"):
+        database_url = os.getenv("DATABASE_URL")
+        if not database_url:
+            raise SystemExit(f"DATABASE_URL must be set for env={env}")
+        return database_url
+    return os.getenv("DATABASE_URL", settings.database_url)
+
+
+async def run(env: str, user_id: UUID | None) -> int:
+    engine = create_async_engine(get_database_url(env))
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with maker() as session:
+            result = await backfill_atomic_transactions_from_statements(session, user_id=user_id)
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+    print(
+        "Layer 2 backfill complete: "
+        f"statements_scanned={result['statements_scanned']} "
+        f"documents_created={result['documents_created']} "
+        f"atomic_transactions_upserted={result['atomic_transactions_upserted']}"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill Layer 1/2 from legacy Layer 0 statements.")
+    parser.add_argument("--env", default="local", choices=["local", "staging", "production"])
+    parser.add_argument("--user-id", default=None, help="Optional UUID to scope the backfill to one user.")
+    args = parser.parse_args()
+
+    user_id = UUID(args.user_id) if args.user_id else None
+    return asyncio.run(run(args.env, user_id))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/backfill_layer2.py
+++ b/tools/backfill_layer2.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from tools._lib.migrations.backfill_layer2 import main  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
**Stacked on #796 (Stage 1).** Base = `epic011-stage1-activate-dual-write`; will retarget to `main` once Stage 1 merges.

## Why

Stage 1 (#796) turns dual-write on, so *new* uploads populate Layer 1/2. But statements uploaded **before** Stage 1 have no Layer 2 counterpart. Before we can flip the read path to Layer 2 (Stage 2b), historical data must be backfilled — otherwise reconciliation would silently see fewer transactions.

## What

`backfill_atomic_transactions_from_statements(db, user_id=None)` — for every `BankStatement`, ensure a Layer 1 `UploadedDocument` and upsert a Layer 2 `AtomicTransaction` per legacy `BankStatementTransaction`.

- **Idempotent**: keyed by `(user_id, file_hash)` and `(user_id, dedup_hash)`, so re-runs upsert instead of duplicating. Reuses the same `DeduplicationService` upsert path as live dual-write, so backfilled rows are byte-identical to organically-written ones.
- `tools/backfill_layer2.py`: ops CLI (`--env local|staging|production`, `--user-id`).
- Tests: AC11.12.1/.2/.3 cover projection, idempotency, user scoping.

**Additive** — no flags flipped, no rows deleted.

## Verification

`test_backfill_layer2.py` 3/3 pass; ruff, doc-consistency, ssot-ownership, AC-registry `--check` green.

## Next

- **Stage 2b**: flip `ENABLE_4_LAYER_READ` default → reconciliation reads `atomic_transactions`. Measured fallout: 36 recon tests (43 `execute_matching` sites; ~9 assert legacy `bank txn.status`) migrate to Layer 2 fixtures via a shared bridge helper.
- **Stage 3**: delete old-path branches + deprecate `bank_statement*` tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)