### PR TITLE
[finance_report_test_and_doc] Add coverage tests for risk hotspots

### DIFF
--- a/apps/backend/tests/services/test_reconciliation_audit.py
+++ b/apps/backend/tests/services/test_reconciliation_audit.py
@@ -1,0 +1,269 @@
+"""Backend-shard coverage for the reconciliation audit harness."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.models import AccountType
+from src.services import reconciliation_audit as audit
+
+
+def test_AC4_10_1_backend_reconciliation_audit_writes_reports(tmp_path) -> None:
+    """AC4.10.1: Backend coverage owns the reconciliation audit implementation."""
+    report = audit.build_report(benchmark_size=3)
+
+    json_path, markdown_path = audit.write_report(report, tmp_path)
+
+    assert json_path.exists()
+    assert markdown_path.exists()
+    assert report["metadata"]["epic"] == "EPIC-004"
+    assert report["targets"]["passed"] is True
+    assert report["summary"]["failed"] == 0
+    assert "Target gate passed" in markdown_path.read_text(encoding="utf-8")
+
+
+def test_AC4_10_2_backend_reconciliation_audit_classifies_failure_modes() -> None:
+    """AC4.10.2: Audit diagnostics classify false negatives and wrong entries."""
+    user_id = audit._stable_uuid("user:backend-failure-modes")
+    bank = audit._account(user_id, "Backend Audit Bank", AccountType.ASSET)
+    expense = audit._account(user_id, "Backend Audit Expense", AccountType.EXPENSE)
+    expected_entry = audit._entry(
+        user_id,
+        "expected-entry",
+        date(2024, 7, 1),
+        "Expected vendor payment",
+        "25.00",
+        bank_account=bank,
+        other_account=expense,
+        direction="OUT",
+    )
+    actual_entry = audit._entry(
+        user_id,
+        "actual-entry",
+        date(2024, 7, 1),
+        "Expected vendor payment",
+        "25.00",
+        bank_account=bank,
+        other_account=expense,
+        direction="OUT",
+    )
+    matching_txn = audit._txn(
+        "wrong_entry_txn",
+        date(2024, 7, 1),
+        "Expected vendor payment",
+        "25.00",
+        "OUT",
+    )
+    missing_txn = audit._txn(
+        "missing_txn",
+        date(2024, 7, 2),
+        "Missing journal entry",
+        "35.00",
+        "OUT",
+    )
+
+    report = audit.build_report(
+        scenarios=[
+            audit.AuditScenario(
+                scenario_id="backend-wrong-entry",
+                title="Matching route with unexpected entry id",
+                transactions=(matching_txn,),
+                entries=(actual_entry,),
+                expectations=(
+                    audit.AuditExpectation(
+                        "wrong_entry_txn",
+                        audit.AUTO_ACCEPT,
+                        (str(expected_entry.id),),
+                    ),
+                ),
+            ),
+            audit.AuditScenario(
+                scenario_id="backend-false-negative",
+                title="Expected match is absent from journal candidates",
+                transactions=(missing_txn,),
+                entries=(),
+                expectations=(
+                    audit.AuditExpectation(
+                        "missing_txn",
+                        audit.AUTO_ACCEPT,
+                        (str(expected_entry.id),),
+                    ),
+                ),
+            ),
+        ],
+        benchmark_size=1,
+    )
+
+    failure_types = {row["failure_type"] for row in report["failures"]}
+    assert failure_types == {"wrong_entry", "false_negative"}
+    assert report["summary"]["failed"] == 2
+    assert report["targets"]["passed"] is False
+
+
+def test_AC4_10_2_backend_reconciliation_audit_covers_false_positive_and_routing_miss() -> None:
+    """AC4.10.2: Audit failures include false-positive and routing-miss diagnostics."""
+    user_id = audit._stable_uuid("user:backend-diagnostic-modes")
+    bank = audit._account(user_id, "Backend Diagnostic Bank", AccountType.ASSET)
+    expense = audit._account(
+        user_id,
+        "Backend Diagnostic Expense",
+        AccountType.EXPENSE,
+    )
+    entry = audit._entry(
+        user_id,
+        "diagnostic-entry",
+        date(2024, 8, 1),
+        "Diagnostic vendor",
+        "42.00",
+        bank_account=bank,
+        other_account=expense,
+        direction="OUT",
+    )
+    txn = audit._txn(
+        "diagnostic_txn",
+        date(2024, 8, 1),
+        "Diagnostic vendor",
+        "42.00",
+        "OUT",
+    )
+
+    report = audit.build_report(
+        scenarios=[
+            audit.AuditScenario(
+                scenario_id="backend-false-positive",
+                title="Unexpected auto-accept",
+                transactions=(txn,),
+                entries=(entry,),
+                expectations=(audit.AuditExpectation("diagnostic_txn", audit.UNMATCHED),),
+            ),
+            audit.AuditScenario(
+                scenario_id="backend-routing-miss",
+                title="Auto-accept when review was expected",
+                transactions=(txn,),
+                entries=(entry,),
+                expectations=(audit.AuditExpectation("diagnostic_txn", audit.REVIEW),),
+            ),
+        ],
+        benchmark_size=1,
+    )
+
+    markdown = audit.render_markdown(report)
+    failure_types = {row["failure_type"] for row in report["failures"]}
+    assert failure_types == {"false_positive", "routing_miss"}
+    assert "## Failures" in markdown
+    assert "backend-false-positive" in markdown
+
+
+def test_AC4_10_3_backend_reconciliation_audit_runtime_target_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC4.10.3: Runtime target failures are reported as hard-gate failures."""
+    monkeypatch.setattr(
+        audit,
+        "_run_benchmark",
+        lambda config, benchmark_size: {
+            "benchmark_size": benchmark_size,
+            "runtime_seconds": 11.0,
+            "transactions_per_second": 1.0,
+            "target_runtime_seconds": 10.0,
+            "target_met": False,
+            "mode": "deterministic_pair_scoring",
+        },
+    )
+
+    report = audit.build_report(benchmark_size=1)
+
+    assert report["targets"]["passed"] is False
+    assert "runtime" in report["targets"]["failures"]
+
+
+@pytest.mark.parametrize(
+    ("score", "expected_route"),
+    [
+        (audit.DEFAULT_CONFIG.auto_accept, audit.AUTO_ACCEPT),
+        (audit.DEFAULT_CONFIG.pending_review, audit.REVIEW),
+        (audit.DEFAULT_CONFIG.pending_review - 1, audit.UNMATCHED),
+    ],
+)
+def test_AC4_10_3_backend_reconciliation_audit_score_route_boundaries(
+    score: int,
+    expected_route: str,
+) -> None:
+    """AC4.10.3: Audit scoring boundaries match reconciliation config gates."""
+    assert audit._route_for_score(score, audit.DEFAULT_CONFIG) == expected_route
+
+
+def test_AC4_10_1_backend_reconciliation_audit_cli_stdout_and_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AC4.10.1: CLI writes artifacts, prints markdown, and exits from targets."""
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = audit.main(
+        [
+            "--output-dir",
+            str(tmp_path / "audit"),
+            "--benchmark-size",
+            "2",
+            "--stdout",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "# Reconciliation Accuracy Audit" in out
+    assert (tmp_path / "audit" / "reconciliation-audit.json").exists()
+
+
+def test_AC4_10_1_backend_reconciliation_audit_cli_returns_nonzero_when_gate_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """AC4.10.1: CLI exit code follows the audit target gate."""
+    monkeypatch.setattr(
+        audit,
+        "_run_benchmark",
+        lambda config, benchmark_size: {
+            "benchmark_size": benchmark_size,
+            "runtime_seconds": 11.0,
+            "transactions_per_second": 1.0,
+            "target_runtime_seconds": 10.0,
+            "target_met": False,
+            "mode": "deterministic_pair_scoring",
+        },
+    )
+
+    assert (
+        audit.main(
+            [
+                "--output-dir",
+                str(tmp_path / "audit"),
+                "--benchmark-size",
+                "1",
+            ]
+        )
+        == 1
+    )
+
+
+def test_AC4_10_1_backend_reconciliation_audit_entry_refs_are_stable() -> None:
+    """AC4.10.1: Audit entry refs stay deterministic for stable report diffs."""
+    user_id = audit._stable_uuid("user:entry-refs")
+    bank = audit._account(user_id, "Entry Ref Bank", AccountType.ASSET)
+    expense = audit._account(user_id, "Entry Ref Expense", AccountType.EXPENSE)
+    entry = audit._entry(
+        user_id,
+        "entry-ref",
+        date(2024, 9, 1),
+        "Entry ref memo",
+        "9.00",
+        bank_account=bank,
+        other_account=expense,
+        direction="OUT",
+    )
+
+    assert audit._entry_refs((entry,)) == {str(entry.id): str(entry.id)}

--- a/apps/frontend/src/__tests__/journalPage.test.tsx
+++ b/apps/frontend/src/__tests__/journalPage.test.tsx
@@ -181,7 +181,7 @@ describe("JournalPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Mock Submit Entry" }))
     await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledTimes(2))
 
-    fireEvent.click(screen.getByRole("button", { name: "Create First Entry" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Create First Entry" }))
     expect(screen.getByRole("button", { name: "Mock Submit Entry" })).toBeInTheDocument()
   })
 

--- a/tests/tooling/test_cleanup_orphaned_dbs.py
+++ b/tests/tooling/test_cleanup_orphaned_dbs.py
@@ -90,6 +90,20 @@ def test_AC16_11_13_cleanup_orphaned_no_databases(monkeypatch):
     assert cod.cleanup_orphaned() == 0
 
 
+def test_AC16_11_13_cleanup_orphaned_returns_error_when_container_is_missing(
+    monkeypatch,
+):
+    monkeypatch.setattr(cod, "get_container_runtime", lambda: "docker")
+
+    def fake_run(cmd, capture_output=True):
+        if cmd[:3] == ["docker", "ps", "-q"]:
+            return SimpleNamespace(stdout="")
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr(cod.subprocess, "run", fake_run)
+    assert cod.cleanup_orphaned() == 1
+
+
 def test_AC16_11_14_cleanup_orphaned_skips_active(monkeypatch):
     monkeypatch.setattr(cod, "get_container_runtime", lambda: "docker")
     monkeypatch.setattr(
@@ -145,6 +159,41 @@ def test_AC16_11_15_cleanup_orphaned_clean_all(monkeypatch):
 
 def test_AC16_11_30_drop_database_dry_run_returns_true():
     assert cod.drop_database("docker", "finance_report_test_x", dry_run=True) is True
+
+
+def test_AC16_11_30_drop_database_returns_false_on_subprocess_error(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise cod.subprocess.CalledProcessError(1, "psql")
+
+    monkeypatch.setattr(cod.subprocess, "run", fake_run)
+    assert cod.drop_database("docker", "finance_report_test_x") is False
+
+
+def test_AC16_11_14_cleanup_orphaned_attempts_all_drops_when_one_fails(monkeypatch):
+    monkeypatch.setattr(cod, "get_container_runtime", lambda: "docker")
+    monkeypatch.setattr(
+        cod,
+        "list_test_databases",
+        lambda runtime: ["finance_report_test_a", "finance_report_test_b"],
+    )
+    monkeypatch.setattr(cod, "load_active_namespaces", lambda: [])
+
+    attempted = []
+
+    def fake_drop(runtime, db_name, dry_run=False):
+        attempted.append(db_name)
+        return db_name.endswith("_a")
+
+    def fake_run(cmd, capture_output=True):
+        if cmd[:3] == ["docker", "ps", "-q"]:
+            return SimpleNamespace(stdout="container-id\n")
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr(cod, "drop_database", fake_drop)
+    monkeypatch.setattr(cod.subprocess, "run", fake_run)
+
+    assert cod.cleanup_orphaned() == 0
+    assert attempted == ["finance_report_test_a", "finance_report_test_b"]
 
 
 def test_AC16_11_31_main_calls_cleanup_orphaned(monkeypatch):

--- a/tests/tooling/test_merge_lcov.py
+++ b/tests/tooling/test_merge_lcov.py
@@ -71,6 +71,13 @@ end_of_record
         records = ml.parse_lcov_to_records(f)
         assert records["/repo/x.py"]["lines"].get(1) == 1
 
+    def test_ignores_short_da_line(self, tmp_path):
+        content = "SF:/repo/x.py\nDA:1\nDA:2,3\nend_of_record\n"
+        f = tmp_path / "short.lcov"
+        f.write_text(content)
+        records = ml.parse_lcov_to_records(f)
+        assert records["/repo/x.py"]["lines"] == {2: 3}
+
     def test_handles_last_record_without_end_of_record(self, tmp_path):
         content = "SF:/repo/z.py\nDA:1,1\n"
         f = tmp_path / "partial.lcov"
@@ -78,6 +85,19 @@ end_of_record
         records = ml.parse_lcov_to_records(f)
         assert "/repo/z.py" in records
         assert records["/repo/z.py"]["lines"][1] == 1
+
+    def test_merges_duplicate_records_without_end_of_record(self, tmp_path):
+        content = """\
+SF:/repo/dup.py
+DA:1,0
+end_of_record
+SF:/repo/dup.py
+DA:1,4
+"""
+        f = tmp_path / "duplicate-partial.lcov"
+        f.write_text(content)
+        records = ml.parse_lcov_to_records(f)
+        assert records["/repo/dup.py"]["lines"] == {1: 4}
 
     def test_empty_lcov(self, tmp_path):
         f = tmp_path / "empty.lcov"
@@ -204,6 +224,8 @@ class TestMain:
         ml.main()
         captured = capsys.readouterr()
         assert "not found" in captured.out or "Warning" in captured.out
+        assert out.exists()
+        assert ml.parse_lcov_to_records(out) == {}
 
     def test_main_exits_on_no_args(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["merge_lcov.py"])

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -2111,6 +2111,40 @@ def test_AC8_13_107_deploy_action_fails_fast_on_missing_required_inputs(
     assert calls == 0
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    [
+        ("pr_number", -1, "positive pr_number"),
+        ("image_prefix", "finance_report", "include the registry namespace"),
+        ("internal_domain", "localhost", "must be a DNS name"),
+    ],
+)
+def test_AC8_13_107_deploy_input_validation_rejects_invalid_values(
+    field: str,
+    value: object,
+    expected_error: str,
+) -> None:
+    """AC8.13.107: Invalid deploy input values fail before rollout mutation."""
+    lifecycle = lifecycle_module()
+    args = SimpleNamespace(
+        pr_number=591,
+        compose_name="pr-591",
+        environment_id="env-test",
+        api_url="https://cloud.example/api",
+        api_key="secret-key",
+        github_integration_id="ghid",
+        branch="feature",
+        commit_sha="abc123",
+        registry="ghcr.io",
+        image_prefix="owner/finance_report",
+        internal_domain="zitian.party",
+    )
+    setattr(args, field, value)
+
+    with pytest.raises(ValueError, match=expected_error):
+        lifecycle.validate_deploy_inputs(args)
+
+
 def test_AC8_13_107_preview_deploy_context_is_written_without_secrets(
     tmp_path: Path,
 ) -> None:
@@ -2168,6 +2202,19 @@ def test_AC8_13_107_preview_deploy_context_is_written_without_secrets(
     assert "secret-token" not in rendered
     assert "hvs.secret" not in rendered
     assert "do-not-preserve" not in rendered
+
+
+def test_AC8_13_107_empty_preview_context_path_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC8.13.107: Missing context path does not create stray local artifacts."""
+    lifecycle = lifecycle_module()
+    monkeypatch.chdir(tmp_path)
+
+    lifecycle.write_preview_context("", {"phase": "preflight"})
+
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_AC8_13_107_pr_preview_workflow_fast_fails_missing_images_and_uploads_context() -> (


### PR DESCRIPTION
## Summary
- Add backend-shard tests for `src.services.reconciliation_audit`, moving the audit implementation from backend LCOV 0% to 99% in targeted coverage.
- Add focused tooling coverage for PR preview input/context safety, orphan DB cleanup failure paths, and LCOV merge malformed/partial records.
- Update the `repo` submodule pointer to infra2 main commit `bb1cb77` from wangzitian0/infra2#242. infra2#239 landed the non-blocking coverage artifact; infra2#242 adds the Coveralls badge/upload wiring.

## Why
The latest coverage review showed the highest-risk blind spot was `reconciliation_audit.py` being tested through root tooling but absent from backend LCOV. The tooling additions cover delivery and resource-cleanup paths tied to deploy consistency and leak prevention. infra2 now publishes module-level coverage context, and the badge PR makes that visibility obvious from the infra2 README.

## Dependency
- infra2 coverage artifact PR is merged: https://github.com/wangzitian0/infra2/pull/239
- infra2 Coveralls badge PR is merged: https://github.com/wangzitian0/infra2/pull/242

## Validation
- `uv run pytest tests/services/test_reconciliation_audit.py -q -o addopts='' --cov=src.services.reconciliation_audit --cov-report=term-missing --cov-fail-under=0`
  - Result: 10 passed, `src/services/reconciliation_audit.py` 99% line coverage.
- `uv run pytest tests/tooling/test_cleanup_orphaned_dbs.py tests/tooling/test_merge_lcov.py tests/tooling/test_pr_preview_lifecycle.py -q`
  - Result: 103 passed.
- `uv run ruff check apps/backend/tests/services/test_reconciliation_audit.py tests/tooling/test_cleanup_orphaned_dbs.py tests/tooling/test_merge_lcov.py tests/tooling/test_pr_preview_lifecycle.py`
- `uv run --with pyyaml python tools/check_ac_traceability.py --report-only`
  - Result: mandatory ACs 100% covered.
- `npm test -- journalPage.test.tsx`
  - Result: 8 passed.
- Pre-push hook:
  - backend lint passed
  - frontend lint passed
  - backend tests: 2198 passed, coverage 97.46%

## Checklist
- [x] Anchored to existing ACs: AC4.10.x, AC8.13.107, AC16.11.x, Infra-012.13 in submodule.
- [x] No secrets or generated coverage artifacts committed.
- [x] Submodule points at an infra2 main commit.