### PR TITLE
fix(pr-preview): stop orphans leaking; runtime sweep on post-merge

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,8 +1,13 @@
 name: PR Preview Cleanup
 
+# Runs the orphan sweep on every merge to main (post-merge), not on a cron.
+# A per-merge sweep is at most a few deletes, runs visibly (a failure shows red
+# in CI, unlike a silently-failing daily cron), and is global so it heals
+# orphans from any close type. Closed-unmerged PRs are still caught by the next
+# merge's sweep.
 on:
-  schedule:
-    - cron: "37 */6 * * *"
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -35,6 +40,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure SSH key for runtime orphan sweep
+        if: ${{ secrets.INFRA2_WATCHDOG_SSH_PRIVATE_KEY != '' }}
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.INFRA2_WATCHDOG_SSH_PRIVATE_KEY }}
+          SSH_HOST: ${{ secrets.INFRA2_WATCHDOG_SSH_HOST }}
+          SSH_USER: ${{ secrets.INFRA2_WATCHDOG_SSH_USER }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/preview_sweep
+          chmod 600 ~/.ssh/preview_sweep
+          printf 'Host preview-sweep-host\n  HostName %s\n  User %s\n  IdentityFile ~/.ssh/preview_sweep\n  IdentitiesOnly yes\n  StrictHostKeyChecking accept-new\n' \
+            "$SSH_HOST" "$SSH_USER" >> ~/.ssh/config
+          echo "RECONCILE_SSH_TARGET=preview-sweep-host" >> "$GITHUB_ENV"
+
       - name: Remove stale preview resources
         env:
           GH_TOKEN: ${{ github.token }}
@@ -48,6 +68,7 @@ jobs:
             --environment-id="${{ env.TEST_ENV_ID }}" \
             --api-url "${{ env.DOKPLOY_API_URL }}" \
             --api-key "$DOKPLOY_API_KEY" \
+            ${RECONCILE_SSH_TARGET:+--ssh-target "$RECONCILE_SSH_TARGET"} \
             ${DRY_RUN:+"$DRY_RUN"}
 
       - name: Prune stale PR preview GHCR tags

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -2402,10 +2402,13 @@ def test_AC8_13_102_api_call_retries_transient_failures_on_get(
     assert calls == 1
 
 
-def test_AC8_13_102_cleanup_and_delete_actions_ignore_api_exceptions(
+def test_AC8_13_102_cleanup_surfaces_but_delete_ignores_api_exceptions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC8.13.102: cleanup_action and delete_action ignore Dokploy API exceptions."""
+    """cleanup_action MUST surface a failed delete (non-zero) so a timed-out
+    teardown cannot silently leak a preview into an untracked orphan. The
+    redeploy-path delete_action stays tolerant so a stale-cleanup failure does
+    not block a new deploy."""
     lifecycle = lifecycle_module()
 
     def fake_find_compose_id(*args: object, **kwargs: object) -> str:
@@ -2413,7 +2416,7 @@ def test_AC8_13_102_cleanup_and_delete_actions_ignore_api_exceptions(
 
     monkeypatch.setattr(lifecycle, "find_compose_id_by_name", fake_find_compose_id)
 
-    # Both actions should catch the exception and return 0
+    # cleanup: a real API failure must NOT masquerade as a clean teardown.
     cleanup_res = lifecycle.cleanup_action(
         SimpleNamespace(
             api_url="https://cloud.example/api",
@@ -2423,8 +2426,9 @@ def test_AC8_13_102_cleanup_and_delete_actions_ignore_api_exceptions(
             compose_name="pr-123",
         )
     )
-    assert cleanup_res == 0
+    assert cleanup_res == 1
 
+    # delete (redeploy path): stays tolerant.
     delete_res = lifecycle.delete_action(
         SimpleNamespace(
             api_url="https://cloud.example/api",

--- a/tests/tooling/test_pr_preview_orphan_sweep.py
+++ b/tests/tooling/test_pr_preview_orphan_sweep.py
@@ -1,0 +1,133 @@
+"""Safety tests for the runtime orphan sweep.
+
+This logic decides which containers get `docker rm -f` on prod, so it gets
+paired positive (正例) and negative (反例) cases. The negatives are the point:
+prod/platform/open-PR containers must NEVER be selected for removal.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+
+def lifecycle():
+    return importlib.import_module("tools._lib.dev.pr_preview_lifecycle")
+
+
+# ---- parse_preview_pr_from_container ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("finance-report-backend-pr-780-f17d4bd5ece1", 780),
+        ("finance-report-frontend-pr-795-385c34621b0a", 795),
+        ("finance-report-minio-init-pr-784-3b5097eb01f8", 784),
+        ("finance-report-db-pr-1-abcdef123456", 1),
+    ],
+)
+def test_positive_parses_preview_containers(name, expected) -> None:
+    assert lifecycle().parse_preview_pr_from_container(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "finance_report-backend",  # prod app (underscore, no -pr-)
+        "finance_report-frontend-staging",  # staging app
+        "platform-prefect-server",  # platform service
+        "dokploy-postgres.1.p7sk11xamk4i35ggidcoxknug",  # dokploy infra
+        "finance-report-backend-pr-780",  # no commit-hash suffix
+        "finance-report-backend-pr-0-abcdef123456",  # PR 0 is not valid
+        "finance-report-backend-pr-abc-abcdef123456",  # non-numeric PR
+        "",
+    ],
+)
+def test_negative_never_parses_non_preview_or_malformed(name) -> None:
+    """Anything not unmistakably a preview container must return None."""
+    assert lifecycle().parse_preview_pr_from_container(name) is None
+
+
+# ---- compute_orphan_containers ----------------------------------------------
+
+
+def test_positive_closed_pr_containers_are_orphans() -> None:
+    running = [
+        "finance-report-backend-pr-780-f17d4bd5ece1",
+        "finance-report-db-pr-780-f17d4bd5ece1",
+    ]
+    orphans = lifecycle().compute_orphan_containers(running, open_prs={795, 796})
+    assert orphans == running
+
+
+def test_negative_open_pr_and_prod_containers_are_never_orphans() -> None:
+    """The core safety guarantee: open-PR and non-preview never get removed."""
+    running = [
+        "finance-report-backend-pr-795-385c34621b0a",  # open PR -> keep
+        "finance-report-db-pr-796-aaaaaaaaaaaa",  # open PR -> keep
+        "finance_report-backend",  # prod -> never matches
+        "platform-prefect-server",  # platform -> never matches
+        "dokploy-traefik",  # infra -> never matches
+        "finance-report-backend-pr-780-f17d4bd5ece1",  # closed PR -> the only orphan
+    ]
+    orphans = lifecycle().compute_orphan_containers(running, open_prs={795, 796})
+
+    assert orphans == ["finance-report-backend-pr-780-f17d4bd5ece1"]
+    assert "finance_report-backend" not in orphans
+    assert "platform-prefect-server" not in orphans
+    assert all("pr-795" not in o and "pr-796" not in o for o in orphans)
+
+
+def test_negative_empty_open_prs_still_skips_non_preview() -> None:
+    """Even with zero open PRs, non-preview containers are untouched."""
+    running = ["platform-prefect-server", "finance_report-backend", "dokploy-redis"]
+    assert lifecycle().compute_orphan_containers(running, open_prs=set()) == []
+
+
+# ---- remove_orphan_containers: dry-run / empty ------------------------------
+
+
+def test_negative_remove_is_noop_when_no_orphans(capsys) -> None:
+    lifecycle().remove_orphan_containers("user@host", [], dry_run=False)
+    assert capsys.readouterr().out == ""  # no SSH, nothing printed
+
+
+def test_positive_dry_run_does_not_execute_removal(capsys) -> None:
+    lifecycle().remove_orphan_containers(
+        "user@host", ["finance-report-db-pr-780-f17d4bd5ece1"], dry_run=True
+    )
+    assert "[dry-run] Would remove 1 orphan" in capsys.readouterr().out
+
+
+# ---- cleanup_action must NOT swallow failures (#2) --------------------------
+
+
+def test_negative_cleanup_surfaces_dokploy_error(monkeypatch) -> None:
+    """A failed delete must return non-zero, not a silent clean exit."""
+    mod = lifecycle()
+
+    def boom(*_args, **_kwargs):
+        raise mod.DokployRequestError("read timed out")
+
+    monkeypatch.setattr(mod, "find_compose_id_by_name", boom)
+    args = SimpleNamespace(
+        api_url="x", api_key="y", compose_id="", environment_id="e", compose_name="pr-780"
+    )
+    assert mod.cleanup_action(args) == 1
+
+
+def test_positive_cleanup_clean_when_already_gone(monkeypatch) -> None:
+    mod = lifecycle()
+    monkeypatch.setattr(mod, "find_compose_id_by_name", lambda *a, **k: "")
+    args = SimpleNamespace(
+        api_url="x", api_key="y", compose_id="", environment_id="e", compose_name="pr-780"
+    )
+    assert mod.cleanup_action(args) == 0

--- a/tools/_lib/dev/pr_preview_lifecycle.py
+++ b/tools/_lib/dev/pr_preview_lifecycle.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -1029,11 +1030,15 @@ def wait_for_dokploy_deployment_rollout(
 
 
 def delete_compose(config: DokployConfig, *, compose_id: str) -> None:
+    # deleteVolumes so preview data (per-PR Postgres/MinIO) is reclaimed, not
+    # just the Dokploy record. Dokploy's delete is still not guaranteed to tear
+    # down already-running containers, so the runtime sweep in reconcile_action
+    # is the safety net for orphans.
     dokploy_api_call(
         config,
         "POST",
         "compose.delete",
-        payload={"composeId": compose_id},
+        payload={"composeId": compose_id, "deleteVolumes": True},
     )
     print(f"Compose deleted: {compose_id}")
 
@@ -1176,7 +1181,7 @@ def deploy_action(args: argparse.Namespace) -> int:
                 )
                 try:
                     trigger_and_wait(force_redeploy=True)
-                except DokployDeploymentDidNotStart as retry_error:
+                except DokployDeploymentDidNotStart:
                     print(
                         "New PR preview compose still did not create a Dokploy "
                         "deployment record after redeploy; recreating compose "
@@ -1226,22 +1231,35 @@ def deploy_action(args: argparse.Namespace) -> int:
 
 
 def cleanup_action(args: argparse.Namespace) -> int:
+    config = DokployConfig(api_url=args.api_url, api_key=args.api_key)
     try:
-        config = DokployConfig(api_url=args.api_url, api_key=args.api_key)
         compose_id = args.compose_id or find_compose_id_by_name(
             config,
             args.environment_id,
             args.compose_name,
         )
-        if compose_id:
-            delete_compose(config, compose_id=compose_id)
-        else:
-            print(f"Compose not found: {args.compose_name}")
     except DokployRequestError as exc:
+        # A failed lookup must not masquerade as a clean teardown. Surfacing it
+        # (non-zero) is what keeps a timed-out delete from silently leaking a
+        # preview into an untracked orphan. The post-merge runtime sweep still
+        # backstops it, but the failure must be visible.
         print(
-            f"WARNING: Cleanup action failed for {args.compose_name} (ignoring): {exc}",
+            f"ERROR: cleanup could not resolve compose {args.compose_name}: {exc}",
             file=sys.stderr,
         )
+        return 1
+    if not compose_id:
+        # Already gone is a legitimately clean outcome, not a failure.
+        print(f"Compose not found: {args.compose_name}")
+        return 0
+    try:
+        delete_compose(config, compose_id=compose_id)
+    except DokployRequestError as exc:
+        print(
+            f"ERROR: cleanup delete failed for {args.compose_name}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 
@@ -1310,6 +1328,71 @@ def list_preview_composes(config: DokployConfig, environment_id: str) -> dict[in
     return previews
 
 
+# Strict: only a preview container has the `finance-report-<svc>-pr-<N>-<hex>`
+# shape. The trailing hex commit slug is required so this can NEVER match a
+# platform/prod container (e.g. `finance_report-backend`, `platform-prefect-server`).
+_PREVIEW_CONTAINER_RE = re.compile(
+    r"^finance-report-[a-z0-9-]+-pr-([1-9][0-9]*)-[0-9a-f]{6,}$"
+)
+
+
+def parse_preview_pr_from_container(name: str) -> int | None:
+    """Return the PR number for a preview container name, else None.
+
+    Safety-critical: anything that is not unmistakably a PR-preview container
+    (including prod/staging/platform containers) returns None and is never
+    touched.
+    """
+    match = _PREVIEW_CONTAINER_RE.match(name.strip())
+    return int(match.group(1)) if match else None
+
+
+def compute_orphan_containers(
+    running_containers: list[str], open_prs: set[int]
+) -> list[str]:
+    """Preview containers whose PR is no longer open. Pure + tested.
+
+    A container is only ever an orphan candidate if it parses as a preview
+    container AND its PR is not in the open set. Non-preview names are skipped.
+    """
+    orphans = []
+    for name in running_containers:
+        pr_number = parse_preview_pr_from_container(name)
+        if pr_number is not None and pr_number not in open_prs:
+            orphans.append(name)
+    return orphans
+
+
+def list_running_preview_containers(ssh_target: str) -> list[str]:
+    """List running container names on the VPS via SSH (runtime truth)."""
+    result = run_command(
+        [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            ssh_target,
+            "docker ps --format '{{.Names}}'",
+        ]
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def remove_orphan_containers(
+    ssh_target: str, names: list[str], *, dry_run: bool
+) -> None:
+    """Force-remove orphan containers (and their anonymous volumes) over SSH."""
+    if not names:
+        return
+    if dry_run:
+        print(f"[dry-run] Would remove {len(names)} orphan container(s): {names}")
+        return
+    quoted = " ".join(shlex.quote(name) for name in names)
+    run_command(["ssh", "-o", "BatchMode=yes", ssh_target, f"docker rm -f -v {quoted}"])
+    print(f"Removed {len(names)} orphan container(s): {names}")
+
+
 def reconcile_action(args: argparse.Namespace) -> int:
     open_prs = list_open_pr_numbers()
     config = DokployConfig(api_url=args.api_url, api_key=args.api_key)
@@ -1325,6 +1408,21 @@ def reconcile_action(args: argparse.Namespace) -> int:
             print(f"[dry-run] Would delete compose for PR #{pr_number}: {compose_id}")
         else:
             delete_compose(config, compose_id=compose_id)
+
+    # Runtime sweep: Dokploy-record reconcile above is blind to ORPHANS (records
+    # already deleted but containers still running). Compare actual running
+    # containers against open PRs and force-remove the leftovers. This is the
+    # self-healing net that runs on every post-merge CI.
+    ssh_target = getattr(args, "ssh_target", "") or os.environ.get(
+        "RECONCILE_SSH_TARGET", ""
+    )
+    if ssh_target:
+        running = list_running_preview_containers(ssh_target)
+        orphans = compute_orphan_containers(running, open_prs)
+        print(f"Runtime orphan containers: {orphans}")
+        remove_orphan_containers(ssh_target, orphans, dry_run=args.dry_run)
+    else:
+        print("No RECONCILE_SSH_TARGET configured; skipping runtime orphan sweep.")
     return 0
 
 
@@ -1375,6 +1473,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--registry", default="ghcr.io")
     parser.add_argument("--image-prefix", default="")
     parser.add_argument("--internal-domain", default="zitian.party")
+    parser.add_argument(
+        "--ssh-target",
+        default="",
+        help="user@host for the runtime orphan sweep; falls back to RECONCILE_SSH_TARGET.",
+    )
     parser.add_argument("--dry-run", action="store_true")
     return main_from_args(parser.parse_args(argv))
 


### PR DESCRIPTION
## Why previews leaked (root cause)
Previews are PR-lifecycle-bound and cleanup *does* fire on close — yet merged-PR stacks (780–788) kept running on the VPS. Three compounding holes in `tools/_lib/dev/pr_preview_lifecycle.py`:

1. **delete record ≠ teardown** — `delete_compose` only called Dokploy `compose.delete` (no `deleteVolumes`, no verification). Dokploy drops its record without reliably stopping the containers (worse under host overload).
2. **errors swallowed** — `cleanup_action` caught `DokployRequestError` and `return 0`. A timed-out delete reported **success**, so the lifecycle "thought" it cleaned up.
3. **reconcile blind to orphans** — it compared open PRs against Dokploy-**tracked** previews only. Once the record was gone, the orphan was invisible to it forever.

Evidence: reconcile saw `Preview PRs in Dokploy: [795,796]` while 780-788 containers were still running — records gone, containers orphaned.

## Fixes
- **#1** `delete_compose`: pass `deleteVolumes: true` (reclaim per-PR Postgres/MinIO).
- **#2** `cleanup_action`: surface failures (non-zero); "already gone" stays a clean `0`. `delete_action` (redeploy path) stays tolerant on purpose.
- **#3** `reconcile`: add a **runtime orphan sweep** — list actual running containers over SSH, select only PR-preview names via a strict regex, and force-remove leftovers whose PR is closed.
- **Workflow**: `pr-preview-cleanup.yml` now runs on **every push to main** (post-merge), drops the 6h cron. A per-merge global sweep self-heals all orphans and **fails visibly in CI**, unlike a silently-failing daily cron. Closed-unmerged PRs are caught by the next merge's sweep.

## Safety (this does `docker rm -f` on prod)
The selection logic is a strict pure function with paired **positive/negative** tests — prod (`finance_report-backend`), platform (`platform-prefect-server`), and **open-PR** containers are *never* selected. Regex requires the full `finance-report-<svc>-pr-<N>-<hex>` shape (trailing commit hash), so it cannot match non-preview names. Dry-run supported.

## Tests
83 passed. Key negatives:
- `test_negative_open_pr_and_prod_containers_are_never_orphans`
- `test_negative_never_parses_non_preview_or_malformed[...]`
- `test_AC8_13_102_cleanup_surfaces_but_delete_ignores_api_exceptions` (the old test encoded the swallow-bug; updated to the correct contract)

## Setup needed
Add repo secrets `INFRA2_WATCHDOG_SSH_{HOST,USER,PRIVATE_KEY}` (reuse the watchdog's). Without them the runtime sweep is skipped and only the Dokploy reconcile runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)