### PR TITLE
ci(pr-preview): reap orphan previews on post-merge CI (visible), not a cron

### DIFF
--- a/.github/workflows/pr-preview-host-hygiene.yml
+++ b/.github/workflows/pr-preview-host-hygiene.yml
@@ -1,0 +1,67 @@
+name: PR Preview Host Hygiene
+
+# Reaps orphaned closed-PR preview containers (and prunes host garbage) by
+# running the existing host-hygiene script ON the VPS over SSH. Runs on every
+# merge to main (post-merge CI), not an invisible cron: a failed reap shows up
+# red in CI where it gets seen. The script is open-PR aware, so only closed-PR
+# previews are removed. AC8.13.73.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Emit and run the hygiene script in dry-run (no deletions)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+concurrency:
+  group: pr-preview-host-hygiene
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+jobs:
+  host-hygiene:
+    name: Reap orphan previews on the VPS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Configure SSH for host hygiene
+        if: ${{ secrets.INFRA2_WATCHDOG_SSH_PRIVATE_KEY != '' }}
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.INFRA2_WATCHDOG_SSH_PRIVATE_KEY }}
+          SSH_HOST: ${{ secrets.INFRA2_WATCHDOG_SSH_HOST }}
+          SSH_USER: ${{ secrets.INFRA2_WATCHDOG_SSH_USER }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/host_hygiene
+          chmod 600 ~/.ssh/host_hygiene
+          printf 'Host host-hygiene\n  HostName %s\n  User %s\n  IdentityFile ~/.ssh/host_hygiene\n  IdentitiesOnly yes\n  StrictHostKeyChecking accept-new\n' \
+            "$SSH_HOST" "$SSH_USER" >> ~/.ssh/config
+          echo "HYGIENE_SSH_TARGET=host-hygiene" >> "$GITHUB_ENV"
+
+      - name: Run host hygiene on the VPS
+        if: ${{ env.HYGIENE_SSH_TARGET != '' }}
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true' && '--dry-run' || '' }}
+        run: |
+          set -euo pipefail
+          # Generate the hygiene script locally and run it on the VPS; the SSH
+          # exit code is the visible result in this CI step.
+          python tools/vps_host_hygiene.py --emit-script ${DRY_RUN:+$DRY_RUN} > /tmp/host_hygiene.sh
+          ssh -o BatchMode=yes "$HYGIENE_SSH_TARGET" 'bash -s' < /tmp/host_hygiene.sh

--- a/tests/tooling/test_vps_host_hygiene.py
+++ b/tests/tooling/test_vps_host_hygiene.py
@@ -327,6 +327,40 @@ def test_AC8_13_73_hygiene_main_streams_output_and_returns_command_status(
     assert captured_scripts and "DISK_ERROR_PERCENT='99'" in captured_scripts[0]
 
 
+def test_AC8_13_73_emit_script_prints_without_running_locally(monkeypatch, capsys) -> None:
+    """AC8.13.73: --emit-script prints the hygiene script (for post-merge CI to
+    run on the VPS over SSH) and does NOT execute it locally."""
+    hygiene = hygiene_module()
+    ran = []
+    monkeypatch.setattr(hygiene, "run_command", lambda *a, **k: ran.append(a) or None)
+
+    assert hygiene.main(["--emit-script"]) == 0
+
+    out = capsys.readouterr().out
+    assert "PR_PREVIEW_CONTAINER_PATTERN" in out
+    assert "should_delete_pr_container" in out
+    assert ran == []  # emit must not run the script locally
+
+
+def test_AC8_13_73_post_merge_workflow_runs_hygiene_on_vps_over_ssh() -> None:
+    """AC8.13.73: host hygiene runs from post-merge CI (visible), over SSH,
+    reusing the emit-script path — not bolted onto the reconciliation-only PR
+    preview cleanup workflow."""
+    workflow = (
+        ROOT / ".github/workflows/pr-preview-host-hygiene.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "push:" in workflow and "branches: [main]" in workflow
+    assert "--emit-script" in workflow
+    assert "ssh -o BatchMode=yes" in workflow
+    assert "tools/vps_host_hygiene.py" in workflow
+    # Stays out of the reconciliation-only cleanup workflow (AC8.13.74).
+    cleanup = (
+        ROOT / ".github/workflows/pr-preview-cleanup.yml"
+    ).read_text(encoding="utf-8")
+    assert "vps_host_hygiene" not in cleanup
+
+
 def test_AC8_13_73_dokploy_schedule_payload_is_server_job_with_retention() -> None:
     hygiene = hygiene_module()
 

--- a/tools/_lib/dev/vps_host_hygiene.py
+++ b/tools/_lib/dev/vps_host_hygiene.py
@@ -482,6 +482,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--cron-expression", default=DEFAULT_CRON_EXPRESSION)
     parser.add_argument("--timezone", default=DEFAULT_TIMEZONE)
     parser.add_argument("--disabled", action="store_true")
+    parser.add_argument(
+        "--emit-script",
+        action="store_true",
+        help=(
+            "Print the hygiene script to stdout instead of running it locally, "
+            "so post-merge CI can run it on the VPS over SSH and see the result."
+        ),
+    )
     args = parser.parse_args(argv)
 
     script = build_hygiene_script(
@@ -499,6 +507,9 @@ def main(argv: list[str] | None = None) -> int:
         pr_preview_keep_recent=args.pr_preview_keep_recent,
         github_repository=args.github_repository,
     )
+    if args.emit_script:
+        print(script)
+        return 0
     if args.print_dokploy_schedule_payload:
         if not args.server_id:
             parser.error("--server-id is required for Dokploy schedule payloads")


### PR DESCRIPTION
## What & why
Orphan closed-PR preview containers leaked because the reaper (`vps_host_hygiene.py`, AC8.13.73) ran only as an **invisible cron** (a Dokploy server schedule that was, in fact, never deployed). A failed cron run is easy to miss.

Run it from **post-merge CI** instead — failures show up **red on every merge** — but in a **dedicated workflow**, because AC8.13.74 keeps `pr-preview-cleanup.yml` reconciliation-only (no host hygiene / SSH; an earlier attempt to bolt it on there failed that AC test).

- **New** `.github/workflows/pr-preview-host-hygiene.yml`: triggers on **push to main**, SSHes to the VPS, runs the existing open-PR-aware host-hygiene script; the SSH step's exit code is the visible result.
- `vps_host_hygiene.py` gains `--emit-script`: prints the generated script so CI can pipe it over SSH (`--emit-script | ssh vps bash`). **No reaping logic reinvented.**
- `pr-preview-cleanup.yml` unchanged; no Dokploy cron (the one I temporarily created has been deleted).
- `cleanup_action`'s ignore-only-Dokploy-errors behavior left intact (AC8.13.102).

## Tests (green)
- `test_AC8_13_73_emit_script_prints_without_running_locally`
- `test_AC8_13_73_post_merge_workflow_runs_hygiene_on_vps_over_ssh`
- The previously-failing `test_AC8_13_74_workflow_runs_lifecycle_reconciliation_only` passes again (cleanup workflow untouched). 20 tooling tests pass; doc-consistency/ruff/YAML green.

## Setup
Add repo secrets `INFRA2_WATCHDOG_SSH_{HOST,USER,PRIVATE_KEY}` (reuse the watchdog's). Steps guarded; no-op without them.

> Note: the separate **Deploy Test Environment** failure on this PR is a Dokploy 502 from VPS overload, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)