### PR TITLE
[finance_report_hacker] EPIC-011 PR-A: StatementSummary conform (custody account in DWD)

### DIFF
--- a/apps/backend/migrations/versions/0028_statement_summaries.py
+++ b/apps/backend/migrations/versions/0028_statement_summaries.py
@@ -1,0 +1,78 @@
+"""add statement_summaries conform table (EPIC-011 PR-A)"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0028_statement_summaries"
+down_revision = "0027_merge_review_email_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "statement_summaries",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("uploaded_document_id", sa.UUID(), nullable=True),
+        sa.Column("file_hash", sa.String(length=64), nullable=False, comment="SHA256, canonical document join key"),
+        sa.Column(
+            "account_id",
+            sa.UUID(),
+            nullable=True,
+            comment="Custody account (DIM conform); set at statement confirmation",
+        ),
+        sa.Column("institution", sa.String(length=100), nullable=False),
+        sa.Column("account_last4", sa.String(length=4), nullable=True),
+        sa.Column("currency", sa.String(length=3), nullable=True),
+        sa.Column("period_start", sa.Date(), nullable=True),
+        sa.Column("period_end", sa.Date(), nullable=True),
+        sa.Column("opening_balance", sa.Numeric(precision=18, scale=2), nullable=True),
+        sa.Column("closing_balance", sa.Numeric(precision=18, scale=2), nullable=True),
+        sa.Column("manual_opening_balance", sa.Numeric(precision=18, scale=2), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "uploaded",
+                "parsing",
+                "parsed",
+                "approved",
+                "rejected",
+                name="statement_summary_status_enum",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "stage1_status",
+            sa.Enum(
+                "pending_review",
+                "approved",
+                "rejected",
+                "edited",
+                name="statement_summary_stage1_status_enum",
+            ),
+            nullable=True,
+        ),
+        sa.Column("confidence_score", sa.Integer(), nullable=True),
+        sa.Column("balance_validated", sa.Boolean(), nullable=True),
+        sa.Column("validation_error", sa.Text(), nullable=True),
+        sa.Column("balance_validation_result", postgresql.JSONB(), nullable=True),
+        sa.Column("stage1_reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("extraction_metadata", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["uploaded_document_id"], ["uploaded_documents.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["account_id"], ["accounts.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "file_hash", name="uq_statement_summaries_user_file_hash"),
+    )
+    op.create_index("idx_statement_summaries_user_account", "statement_summaries", ["user_id", "account_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_statement_summaries_user_account", table_name="statement_summaries")
+    op.drop_table("statement_summaries")
+    op.execute("DROP TYPE IF EXISTS statement_summary_status_enum")
+    op.execute("DROP TYPE IF EXISTS statement_summary_stage1_status_enum")

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -47,6 +47,7 @@ from src.models.statement import (
     ConfidenceLevel,
     Stage1Status,
 )
+from src.models.statement_summary import StatementSummary
 from src.models.user import AiFeedback, User
 from src.models.workflow import (
     WorkflowEvent,
@@ -118,6 +119,7 @@ __all__ = [
     "ReportType",
     "RuleType",
     "Statement",  # Alias for BankStatement
+    "StatementSummary",
     "Stage1Status",
     "StockPrice",
     "PriceSource",

--- a/apps/backend/src/models/statement_summary.py
+++ b/apps/backend/src/models/statement_summary.py
@@ -1,0 +1,99 @@
+"""DWD conform: the confirmed statement envelope.
+
+A ``StatementSummary`` is the durable, mutable conform record that binds an
+uploaded statement document (ODS ``UploadedDocument``) to its custody account
+(DIM ``accounts``) and carries the confirmed statement envelope — period,
+opening/closing balances, institution, and review state.
+
+Together with ``UploadedDocument`` (the raw file) and ``AtomicTransaction`` (the
+per-transaction DWD facts), this completes the decomposition of the legacy
+``BankStatement`` into the layered model, so ``bank_statements`` can eventually
+be deprecated (EPIC-011 Stage 3).
+
+The Python ``BankStatementStatus`` / ``Stage1Status`` enums are reused, but with
+distinct PostgreSQL type names so this table does not collide with the legacy
+``bank_statements`` enum types.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    Enum as SQLEnum,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.database import Base
+from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
+from src.models.statement import BankStatementStatus, Stage1Status
+
+
+class StatementSummary(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
+    """Confirmed statement envelope (DWD conform) for an uploaded statement."""
+
+    __tablename__ = "statement_summaries"
+    __table_args__ = (UniqueConstraint("user_id", "file_hash", name="uq_statement_summaries_user_file_hash"),)
+
+    # Link to the ODS document (canonical join is (user_id, file_hash), mirrored
+    # by UploadedDocument and the legacy BankStatement).
+    uploaded_document_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("uploaded_documents.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    file_hash: Mapped[str] = mapped_column(String(64), nullable=False, comment="SHA256, canonical document join key")
+
+    # DIM conform: custody account the statement belongs to (set at confirm).
+    account_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("accounts.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="Custody account (DIM conform); set at statement confirmation",
+    )
+
+    # Statement envelope (source facts).
+    institution: Mapped[str] = mapped_column(String(100), nullable=False)
+    account_last4: Mapped[str | None] = mapped_column(String(4), nullable=True)
+    currency: Mapped[str | None] = mapped_column(String(3), nullable=True)
+    period_start: Mapped[date | None] = mapped_column(Date, nullable=True)
+    period_end: Mapped[date | None] = mapped_column(Date, nullable=True)
+    opening_balance: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+    closing_balance: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+    manual_opening_balance: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+
+    # Review / confirmation state.
+    status: Mapped[BankStatementStatus] = mapped_column(
+        SQLEnum(
+            BankStatementStatus,
+            name="statement_summary_status_enum",
+            values_callable=lambda obj: [e.value for e in obj],
+        ),
+        default=BankStatementStatus.UPLOADED,
+        nullable=False,
+    )
+    stage1_status: Mapped[Stage1Status | None] = mapped_column(
+        SQLEnum(
+            Stage1Status,
+            name="statement_summary_stage1_status_enum",
+            values_callable=lambda obj: [e.value for e in obj],
+            validate_strings=True,
+        ),
+        nullable=True,
+        default=None,
+    )
+    confidence_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    balance_validated: Mapped[bool | None] = mapped_column(default=None, nullable=True)
+    validation_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    balance_validation_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
+    stage1_reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    extraction_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -47,6 +47,7 @@ from src.services.brokerage_positions import BrokeragePositionImportService
 from src.services.openrouter_models import ModelCatalogError, get_model_info, model_matches_modality
 from src.services.statement_parsing import parse_statement_background
 from src.services.statement_posting import auto_create_posted_entries_for_statement
+from src.services.statement_summary import sync_statement_summary
 from src.services.statement_validation import (
     approve_statement as approve_statement_svc,
     edit_and_approve,
@@ -163,6 +164,7 @@ async def _create_statement_account_from_confirmation(
     await db.flush()
     statement.account_id = account.id
     await db.flush()
+    await sync_statement_summary(db, statement)
     return account
 
 

--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -14,6 +14,7 @@ from src.logger import get_logger
 from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AtomicPosition, AtomicTransaction, TransactionDirection
 from src.models.statement import BankStatement, BankStatementTransaction
+from src.services.statement_summary import sync_statement_summary
 
 logger = get_logger(__name__)
 
@@ -399,6 +400,7 @@ async def backfill_atomic_transactions_from_statements(
     statements_scanned = 0
     documents_created = 0
     atomic_upserted = 0
+    summaries_synced = 0
 
     for offset in range(0, len(statement_ids), batch_size):
         batch_ids = statement_ids[offset : offset + batch_size]
@@ -480,12 +482,18 @@ async def backfill_atomic_transactions_from_statements(
                 )
                 atomic_upserted += 1
 
+            # Project the confirmed statement envelope (custody account, period,
+            # balances, review state) into the StatementSummary conform.
+            await sync_statement_summary(db, stmt)
+            summaries_synced += 1
+
     logger.info(
         "Layer 2 backfill completed",
         extra={
             "statements_scanned": statements_scanned,
             "documents_created": documents_created,
             "atomic_transactions_upserted": atomic_upserted,
+            "statement_summaries_synced": summaries_synced,
             "user_scope": str(user_id) if user_id else "all",
         },
     )
@@ -494,4 +502,5 @@ async def backfill_atomic_transactions_from_statements(
         "statements_scanned": statements_scanned,
         "documents_created": documents_created,
         "atomic_transactions_upserted": atomic_upserted,
+        "statement_summaries_synced": summaries_synced,
     }

--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -17,6 +17,7 @@ from src.models import BankStatement, BankStatementStatus
 from src.services import ExtractionError, ExtractionService, StorageError, StorageService
 from src.services.brokerage_positions import BrokeragePositionImportService, looks_like_brokerage_payload
 from src.services.statement_posting import try_auto_approve_high_confidence_statement
+from src.services.statement_summary import sync_statement_summary
 
 if TYPE_CHECKING:
     pass
@@ -464,6 +465,8 @@ async def parse_statement_background(
             statement.balance_validated = parsed_statement.balance_validated
             statement.validation_error = parsed_statement.validation_error
             statement.status = parsed_statement.status
+
+            await sync_statement_summary(session, statement)
 
             await update_progress(100)
             auto_posted_count = await try_auto_approve_high_confidence_statement(session, statement.id, user_id)

--- a/apps/backend/src/services/statement_posting.py
+++ b/apps/backend/src/services/statement_posting.py
@@ -23,6 +23,7 @@ from src.models import (
 from src.models.statement import Stage1Status
 from src.services.review_queue import create_entry_from_txn
 from src.services.source_type_priority import STATEMENT_SOURCE_TYPES, promote_entry_source_type
+from src.services.statement_summary import sync_statement_summary
 from src.services.statement_validation import approve_statement
 
 HIGH_CONFIDENCE_AUTO_APPROVE_THRESHOLD = 85
@@ -153,6 +154,7 @@ async def resolve_statement_posting_account(
         account = next(iter(accounts_by_id.values()))
         statement.account_id = account.id
         await db.flush()
+        await sync_statement_summary(db, statement)
         return account
     if len(accounts_by_id) > 1:
         raise ValueError(

--- a/apps/backend/src/services/statement_summary.py
+++ b/apps/backend/src/services/statement_summary.py
@@ -1,0 +1,134 @@
+"""StatementSummary conform sync + custody-account resolution (EPIC-011 PR-A).
+
+``sync_statement_summary`` mirrors a ``BankStatement`` envelope into the durable
+``StatementSummary`` conform table (keyed by ``(user_id, file_hash)``), linking
+the ODS ``UploadedDocument`` when present. It is called at statement
+finalization points (parse completion, confirm/approve/reject/edit) so the
+conform stays current while the legacy ``bank_statements`` table is still the
+write path.
+
+``resolve_custody_account_id`` is the DWD-native lookup the reconciliation
+transfer-detection path will use (PR-B): given a Layer-2 ``AtomicTransaction``,
+resolve its custody account from the conform via the source document, instead of
+reaching back into the legacy ``bank_statements.account_id`` (ODS).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logger import get_logger
+from src.models.layer1 import UploadedDocument
+from src.models.layer2 import AtomicTransaction
+from src.models.statement import BankStatement
+from src.models.statement_summary import StatementSummary
+
+logger = get_logger(__name__)
+
+# Envelope fields copied verbatim from BankStatement -> StatementSummary.
+_ENVELOPE_FIELDS = (
+    "account_id",
+    "institution",
+    "account_last4",
+    "currency",
+    "period_start",
+    "period_end",
+    "opening_balance",
+    "closing_balance",
+    "manual_opening_balance",
+    "status",
+    "stage1_status",
+    "confidence_score",
+    "balance_validated",
+    "validation_error",
+    "balance_validation_result",
+    "stage1_reviewed_at",
+    "extraction_metadata",
+)
+
+
+async def sync_statement_summary(db: AsyncSession, statement: BankStatement) -> StatementSummary:
+    """Upsert the StatementSummary conform from a BankStatement's current envelope.
+
+    Idempotent: keyed by ``(user_id, file_hash)``; re-running refreshes the
+    envelope in place. Does not commit (caller owns the transaction).
+    """
+    summary = (
+        await db.execute(
+            select(StatementSummary).where(
+                StatementSummary.user_id == statement.user_id,
+                StatementSummary.file_hash == statement.file_hash,
+            )
+        )
+    ).scalar_one_or_none()
+
+    uploaded_document_id = (
+        await db.execute(
+            select(UploadedDocument.id).where(
+                UploadedDocument.user_id == statement.user_id,
+                UploadedDocument.file_hash == statement.file_hash,
+            )
+        )
+    ).scalar_one_or_none()
+
+    values = {field: getattr(statement, field) for field in _ENVELOPE_FIELDS}
+
+    if summary is None:
+        summary = StatementSummary(
+            user_id=statement.user_id,
+            file_hash=statement.file_hash,
+            uploaded_document_id=uploaded_document_id,
+            **values,
+        )
+        db.add(summary)
+    else:
+        if uploaded_document_id is not None:
+            summary.uploaded_document_id = uploaded_document_id
+        for field, value in values.items():
+            setattr(summary, field, value)
+
+    await db.flush()
+    return summary
+
+
+async def resolve_custody_account_id(db: AsyncSession, atomic_txn: AtomicTransaction) -> UUID | None:
+    """Resolve the custody account for a Layer-2 atomic transaction via the conform.
+
+    Walks ``atomic_txn.source_documents -> UploadedDocument -> StatementSummary``
+    and returns the first confirmed custody ``account_id``. Returns ``None`` when
+    the source statement has no linked account yet.
+    """
+    source_docs = atomic_txn.source_documents if isinstance(atomic_txn.source_documents, list) else []
+    doc_ids = [d["doc_id"] for d in source_docs if isinstance(d, dict) and d.get("doc_id")]
+    if not doc_ids:
+        return None
+
+    file_hashes = (
+        (
+            await db.execute(
+                select(UploadedDocument.file_hash).where(
+                    UploadedDocument.user_id == atomic_txn.user_id,
+                    UploadedDocument.id.in_(doc_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not file_hashes:
+        return None
+
+    return (
+        await db.execute(
+            select(StatementSummary.account_id)
+            .where(
+                StatementSummary.user_id == atomic_txn.user_id,
+                StatementSummary.file_hash.in_(file_hashes),
+                StatementSummary.account_id.isnot(None),
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()

--- a/apps/backend/src/services/statement_validation.py
+++ b/apps/backend/src/services/statement_validation.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from src.models import BankStatement, BankStatementStatus
 from src.models.statement import Stage1Status
+from src.services.statement_summary import sync_statement_summary
 
 BALANCE_TOLERANCE = Decimal("0.001")
 
@@ -160,6 +161,7 @@ async def approve_statement(
     statement.status = BankStatementStatus.APPROVED
 
     await db.flush()
+    await sync_statement_summary(db, statement)
     return statement
 
 
@@ -177,6 +179,7 @@ async def reject_statement(
         statement.validation_error = reason
 
     await db.flush()
+    await sync_statement_summary(db, statement)
     return statement
 
 
@@ -213,6 +216,7 @@ async def edit_and_approve(
     statement.status = BankStatementStatus.APPROVED
 
     await db.flush()
+    await sync_statement_summary(db, statement)
     return statement
 
 

--- a/apps/backend/tests/extraction/test_backfill_layer2.py
+++ b/apps/backend/tests/extraction/test_backfill_layer2.py
@@ -67,6 +67,7 @@ class TestBackfillLayer2:
         assert result["statements_scanned"] == 1
         assert result["documents_created"] == 1
         assert result["atomic_transactions_upserted"] == 2
+        assert result["statement_summaries_synced"] == 1
 
         docs = (
             (await db.execute(select(UploadedDocument).where(UploadedDocument.user_id == test_user.id))).scalars().all()

--- a/apps/backend/tests/extraction/test_statement_summary_conform.py
+++ b/apps/backend/tests/extraction/test_statement_summary_conform.py
@@ -129,6 +129,23 @@ class TestStatementSummaryConform:
         resolved = await resolve_custody_account_id(db, atomic)
         assert resolved == account.id
 
+    async def test_resolve_returns_none_without_source_documents(self, db, test_user):
+        """AC11.15.4: resolver returns None when the atomic txn has no source documents."""
+        atomic = AtomicTransaction(
+            user_id=test_user.id,
+            txn_date=date(2024, 1, 15),
+            amount=Decimal("500.00"),
+            direction=TransactionDirection.OUT,
+            description="NO SOURCE",
+            currency="SGD",
+            dedup_hash="dedup-no-source",
+            source_documents=[],
+        )
+        db.add(atomic)
+        await db.commit()
+
+        assert await resolve_custody_account_id(db, atomic) is None
+
     async def test_resolve_returns_none_without_account(self, db, test_user):
         """AC11.15.4: resolver returns None when the source statement has no custody account."""
         atomic = AtomicTransaction(

--- a/apps/backend/tests/extraction/test_statement_summary_conform.py
+++ b/apps/backend/tests/extraction/test_statement_summary_conform.py
@@ -1,0 +1,147 @@
+"""Tests for the StatementSummary conform sync + custody-account resolver (EPIC-011 PR-A)."""
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.account import Account, AccountType
+from src.models.layer1 import DocumentType, UploadedDocument
+from src.models.layer2 import AtomicTransaction, TransactionDirection
+from src.models.statement import BankStatement, BankStatementStatus, Stage1Status
+from src.models.statement_summary import StatementSummary
+from src.services.statement_summary import resolve_custody_account_id, sync_statement_summary
+
+
+async def _make_account(db: AsyncSession, user_id) -> Account:
+    account = Account(user_id=user_id, name="DBS Checking", type=AccountType.ASSET, currency="SGD")
+    db.add(account)
+    await db.flush()
+    return account
+
+
+async def _make_statement(db: AsyncSession, user_id, *, file_hash: str, account_id=None) -> BankStatement:
+    statement = BankStatement(
+        user_id=user_id,
+        account_id=account_id,
+        file_path=f"statements/{file_hash}.pdf",
+        file_hash=file_hash,
+        original_filename="dbs.pdf",
+        institution="DBS",
+        account_last4="1234",
+        currency="SGD",
+        period_start=date(2024, 1, 1),
+        period_end=date(2024, 1, 31),
+        opening_balance=Decimal("1000.00"),
+        closing_balance=Decimal("1500.00"),
+        status=BankStatementStatus.APPROVED,
+        stage1_status=Stage1Status.APPROVED,
+        balance_validated=True,
+    )
+    db.add(statement)
+    await db.flush()
+    return statement
+
+
+@pytest.mark.asyncio
+class TestStatementSummaryConform:
+    async def test_sync_mirrors_bank_statement_envelope(self, db, test_user):
+        """AC11.15.1: sync projects the BankStatement envelope into StatementSummary."""
+        account = await _make_account(db, test_user.id)
+        await _make_statement(db, test_user.id, file_hash="hash-sum-1", account_id=account.id)
+        statement = (
+            await db.execute(select(BankStatement).where(BankStatement.file_hash == "hash-sum-1"))
+        ).scalar_one()
+
+        summary = await sync_statement_summary(db, statement)
+        await db.commit()
+
+        assert summary.user_id == test_user.id
+        assert summary.file_hash == "hash-sum-1"
+        assert summary.account_id == account.id
+        assert summary.institution == "DBS"
+        assert summary.period_start == date(2024, 1, 1)
+        assert summary.closing_balance == Decimal("1500.00")
+        assert summary.status == BankStatementStatus.APPROVED
+        assert summary.balance_validated is True
+
+    async def test_sync_is_idempotent_and_links_uploaded_document(self, db, test_user):
+        """AC11.15.2: re-sync updates in place and links the UploadedDocument when present."""
+        account = await _make_account(db, test_user.id)
+        statement = await _make_statement(db, test_user.id, file_hash="hash-sum-2", account_id=None)
+        doc = UploadedDocument(
+            user_id=test_user.id,
+            file_path="statements/hash-sum-2.pdf",
+            file_hash="hash-sum-2",
+            original_filename="dbs.pdf",
+            document_type=DocumentType.BANK_STATEMENT,
+        )
+        db.add(doc)
+        await db.flush()
+
+        # First sync: no account yet.
+        await sync_statement_summary(db, statement)
+        await db.commit()
+
+        # Confirm sets the custody account; re-sync should update in place.
+        statement.account_id = account.id
+        await sync_statement_summary(db, statement)
+        await db.commit()
+
+        summaries = (
+            (await db.execute(select(StatementSummary).where(StatementSummary.user_id == test_user.id))).scalars().all()
+        )
+        assert len(summaries) == 1
+        assert summaries[0].account_id == account.id
+        assert summaries[0].uploaded_document_id == doc.id
+
+    async def test_resolve_custody_account_from_atomic_txn(self, db, test_user):
+        """AC11.15.3: custody account resolves from an atomic txn via the conform (DWD-native)."""
+        account = await _make_account(db, test_user.id)
+        statement = await _make_statement(db, test_user.id, file_hash="hash-sum-3", account_id=account.id)
+        doc = UploadedDocument(
+            user_id=test_user.id,
+            file_path="statements/hash-sum-3.pdf",
+            file_hash="hash-sum-3",
+            original_filename="dbs.pdf",
+            document_type=DocumentType.BANK_STATEMENT,
+        )
+        db.add(doc)
+        await db.flush()
+        await sync_statement_summary(db, statement)
+
+        atomic = AtomicTransaction(
+            user_id=test_user.id,
+            txn_date=date(2024, 1, 15),
+            amount=Decimal("500.00"),
+            direction=TransactionDirection.OUT,
+            description="TRANSFER TO SAVINGS",
+            currency="SGD",
+            dedup_hash="dedup-sum-3",
+            source_documents=[{"doc_id": str(doc.id), "doc_type": "bank_statement"}],
+        )
+        db.add(atomic)
+        await db.commit()
+
+        resolved = await resolve_custody_account_id(db, atomic)
+        assert resolved == account.id
+
+    async def test_resolve_returns_none_without_account(self, db, test_user):
+        """AC11.15.4: resolver returns None when the source statement has no custody account."""
+        atomic = AtomicTransaction(
+            user_id=test_user.id,
+            txn_date=date(2024, 1, 15),
+            amount=Decimal("500.00"),
+            direction=TransactionDirection.OUT,
+            description="UNKNOWN",
+            currency="SGD",
+            dedup_hash="dedup-none",
+            source_documents=[{"doc_id": str(uuid4()), "doc_type": "bank_statement"}],
+        )
+        db.add(atomic)
+        await db.commit()
+
+        assert await resolve_custody_account_id(db, atomic) is None

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -181,6 +181,21 @@ before `ENABLE_4_LAYER_READ` is activated. Idempotent and re-runnable via
 | AC11.14.2 | Re-running the backfill upserts by dedup hash instead of duplicating rows | `test_backfill_is_idempotent()` | `extraction/test_backfill_layer2.py` | P0 |
 | AC11.14.3 | A user-scoped backfill ignores other users' statements | `test_backfill_scopes_to_requested_user()` | `extraction/test_backfill_layer2.py` | P0 |
 
+### AC11.15: 4-Layer Migration — PR-A StatementSummary Conform (custody account)
+
+PR-A introduces the durable `StatementSummary` conform: it binds an uploaded
+statement document to its custody account (DIM) and carries the confirmed
+statement envelope (period, balances, review state). This is the DWD-native home
+for the account context reconciliation transfer detection needs, replacing the
+ODS `bank_statements.account_id` reach-back. Additive — no flags flipped.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.15.1 | Syncing projects the BankStatement envelope into the StatementSummary conform | `test_sync_mirrors_bank_statement_envelope()` | `extraction/test_statement_summary_conform.py` | P0 |
+| AC11.15.2 | Re-sync updates the conform in place and links the source UploadedDocument | `test_sync_is_idempotent_and_links_uploaded_document()` | `extraction/test_statement_summary_conform.py` | P0 |
+| AC11.15.3 | Custody account resolves from a Layer-2 atomic transaction via the conform (DWD-native) | `test_resolve_custody_account_from_atomic_txn()` | `extraction/test_statement_summary_conform.py` | P0 |
+| AC11.15.4 | The resolver returns None when the source statement has no confirmed custody account | `test_resolve_returns_none_without_account()` | `extraction/test_statement_summary_conform.py` | P0 |
+
 ## Implementation Pattern Ownership
 
 Do not copy reusable code patterns, router examples, migration guardrails, or

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -44,7 +44,7 @@ sits in the wrong layer, that is drift to be fixed, not worked around.
 |-------|--------|
 | **DIM** | `accounts` (chart of accounts, including the account-type enum column); `classification_rules`; `fx_rates`, `stock_prices`, `market_data_sync_state`, `market_data_overrides`; security / institution master data |
 | **ODS** | `uploaded_documents`; `manual_valuation_snapshots`; *(legacy, deprecating)* `bank_statements`, `bank_statement_transactions` |
-| **DWD** | `atomic_transactions`, `atomic_positions`; `transaction_classification` (account conform); `journal_entries`, `journal_lines` (double-entry ledger); `investment_transactions`; `dividend_income` |
+| **DWD** | `atomic_transactions`, `atomic_positions`; `transaction_classification` (posting-account conform); `statement_summaries` (statement envelope + custody-account conform); `journal_entries`, `journal_lines` (double-entry ledger); `investment_transactions`; `dividend_income` |
 | **DWM** | `reconciliation_matches`, `consistency_checks` (matching + transfer-pair / Processing-account resolution) |
 | **DWS** | `managed_positions`; `investment_lots`; derived account balances / period aggregates |
 | **ADS** | `report_snapshots` (balance sheet, income statement, cash flow) |
@@ -65,12 +65,12 @@ sits in the wrong layer, that is drift to be fixed, not worked around.
 4. **DWM stays thin.** Add a DWM table only for a genuinely complex cross-fact
    domain (today: reconciliation/transfer matching). Default new work to DWD or DWS.
 
-> **Known drift (tracked):** reconciliation transfer detection (a DWM concern)
-> currently resolves the source account from ODS (`bank_statements.account_id`)
-> instead of from the DWD account conform. The DWD conform step
-> (`transaction_classification` account assignment) is not yet wired into the
-> live flow, which is why the Layer-2/DWD read cutover is blocked. See
-> `docs/project/EPIC-011.asset-lifecycle.md`.
+> **Known drift (being closed):** reconciliation transfer detection (a DWM
+> concern) still resolves the source account from ODS
+> (`bank_statements.account_id`). PR-A adds the DWD-native custody conform —
+> `statement_summaries` (with `resolve_custody_account_id`) — so PR-B can switch
+> transfer detection to read the custody account from DWD and flip the read
+> cutover. See `docs/project/EPIC-011.asset-lifecycle.md`.
 
 ---
 


### PR DESCRIPTION
**PR-A of the DWD read-cutover (PR-A → PR-B).** Additive — no feature flags flipped, no reconciliation behavior change.

## Why

The DWD read cutover (`ENABLE_4_LAYER_READ`) is blocked because reconciliation **transfer detection** needs a transaction's **custody account** (which account the cash is in, e.g. "DBS Checking"), but resolves it by reaching into legacy ODS `bank_statements.account_id` — a cross-layer reach-back that breaks once `bank_statements` is dropped (Stage 3).

The custody account is decided at **confirm** time, but `UploadedDocument` (ODS) and `AtomicTransaction` (DWD) are immutable, and `transaction_classification` is for the *posting/category* account — none can hold it. So this PR adds the mutable DWD conform that can.

## What

A durable **`StatementSummary`** conform — the confirmed statement envelope. This completes the decomposition of the legacy `BankStatement`:

```
BankStatement  ==  UploadedDocument  (file, ODS)
                +  AtomicTransaction (per-txn facts, DWD)
                +  StatementSummary  (envelope + custody account, DWD conform)  ← new
```

- **model + migration `0028`**: `statement_summaries` — `account_id` (custody, DIM conform) + the full envelope (institution, account_last4, currency, period, opening/closing balance, status, stage1_status, balance_validated, validation, confidence, extraction_metadata), keyed by `(user_id, file_hash)`, linked to `uploaded_documents`. Distinct enum type names to avoid colliding with `bank_statements`.
- **`sync_statement_summary()`** — idempotently mirrors a BankStatement envelope into the conform. Hooked at parse completion, approve / reject / edit, and the two custody-account assignment points.
- **`resolve_custody_account_id()`** — `atomic txn → source doc → conform.account_id`. **This is the DWD-native lookup PR-B's transfer detection will use** instead of `bank_statements.account_id`.
- **backfill** also syncs `StatementSummary` for historical statements.

## Why this also matters for Stage 3

Many downstream consumers read the BankStatement envelope (coverage/continuity, balance validation, report-readiness, workflow events, posting). Capturing the envelope here now gives them a durable home, so `bank_statements` can actually be dropped later instead of leaving those features stranded.

## Verification

`AC11.15.1-4` cover sync (envelope projection), idempotency + document linkage, and custody-account resolution. ~1200 tests pass across extraction/review/api/services/workflow/reconciliation/accounting; ruff, format, enum guardrails, doc-consistency, ac-registry, ssot-ownership all green locally.

## Next: PR-B

Switch transfer detection to `resolve_custody_account_id` (read DWD), flip `ENABLE_4_LAYER_READ`, migrate ~36 reconciliation tests to Layer-2 fixtures, and root-cause the many-to-one gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)