### PR TITLE
[finance_report_hacker] EPIC-011 PR-B: activate DWD read cutover (ENABLE_4_LAYER_READ)

### DIFF
--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -185,8 +185,12 @@ class Settings(BaseSettings):
         default=True,
         validation_alias="ENABLE_4_LAYER_WRITE",
     )
+    # Stage 2b / PR-B cutover: reconciliation now reads Layer 2 (atomic_transactions)
+    # by default. Requires the Stage 2a backfill (historical Layer-0 -> Layer-2) and
+    # the PR-A StatementSummary conform (custody account) to be populated. Set
+    # ENABLE_4_LAYER_READ=false to fall back to reading legacy Layer 0.
     enable_4_layer_read: bool = Field(
-        default=False,
+        default=True,
         validation_alias="ENABLE_4_LAYER_READ",
     )
     enable_layer_0_write: bool = Field(

--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -30,10 +30,17 @@ class DeduplicationService:
         direction: TransactionDirection,
         description: str,
         reference: str | None = None,
+        balance_after: Decimal | None = None,
     ) -> str:
         """Calculate deduplication hash for atomic transaction.
 
-        Hash = SHA256(user_id|date|amount|direction|description|reference)
+        Hash = SHA256(user_id|date|amount|direction|description|reference|balance_after)
+
+        ``balance_after`` (the statement running balance) is included so two real,
+        otherwise-identical transactions (same date/amount/direction/description, no
+        reference) stay distinct — their running balances differ. Genuine duplicate
+        extractions share the same running balance and still collapse. When the
+        source has no running balance the field is empty and behaviour is unchanged.
         """
         components = [
             str(user_id),
@@ -42,6 +49,7 @@ class DeduplicationService:
             direction.value,
             description.strip().lower(),
             reference or "",
+            str(balance_after) if balance_after is not None else "",
         ]
         hash_input = "|".join(components).encode("utf-8")
         return hashlib.sha256(hash_input).hexdigest()
@@ -78,13 +86,16 @@ class DeduplicationService:
         source_doc_id: UUID,
         source_doc_type: DocumentType,
         reference: str | None = None,
+        balance_after: Decimal | None = None,
     ) -> AtomicTransaction:
         """Upsert atomic transaction with deduplication.
 
         If dedup_hash exists -> Append to source_documents array
         If dedup_hash new -> Insert new record
         """
-        dedup_hash = self.calculate_transaction_hash(user_id, txn_date, amount, direction, description, reference)
+        dedup_hash = self.calculate_transaction_hash(
+            user_id, txn_date, amount, direction, description, reference, balance_after
+        )
 
         stmt = select(AtomicTransaction).where(
             AtomicTransaction.user_id == user_id,
@@ -319,6 +330,7 @@ async def dual_write_layer2(
                 source_doc_id=uploaded_doc.id,
                 source_doc_type=doc_type,
                 reference=txn.reference,
+                balance_after=txn.balance_after,
             )
             await evidence_graph.record_layer2_dual_write(
                 db,
@@ -479,6 +491,7 @@ async def backfill_atomic_transactions_from_statements(
                     source_doc_id=existing_doc.id,
                     source_doc_type=doc_type,
                     reference=txn.reference,
+                    balance_after=txn.balance_after,
                 )
                 atomic_upserted += 1
 

--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -19,6 +19,15 @@ from src.services.statement_summary import sync_statement_summary
 logger = get_logger(__name__)
 
 
+def _decimal_key(value: Decimal) -> str:
+    """Canonical, scale-independent string for a Decimal used in dedup hashing.
+
+    ``Decimal('50')``, ``Decimal('50.00')`` and ``Decimal('50.000')`` all map to
+    ``'50'`` so values differing only in scale hash identically.
+    """
+    return format(value.normalize(), "f")
+
+
 class DeduplicationService:
     """Service for managing Layer 2 deduplicated records with hash-based upsert logic."""
 
@@ -41,15 +50,18 @@ class DeduplicationService:
         reference) stay distinct — their running balances differ. Genuine duplicate
         extractions share the same running balance and still collapse. When the
         source has no running balance the field is empty and behaviour is unchanged.
+
+        Decimal amounts are canonicalized (``Decimal('50')`` and ``Decimal('50.00')``
+        hash identically) so values that differ only in scale do not break dedup.
         """
         components = [
             str(user_id),
             txn_date.isoformat(),
-            str(amount),
+            _decimal_key(amount),
             direction.value,
             description.strip().lower(),
             reference or "",
-            str(balance_after) if balance_after is not None else "",
+            _decimal_key(balance_after) if balance_after is not None else "",
         ]
         hash_input = "|".join(components).encode("utf-8")
         return hashlib.sha256(hash_input).hexdigest()

--- a/apps/backend/src/services/reconciliation.py
+++ b/apps/backend/src/services/reconciliation.py
@@ -42,6 +42,7 @@ from src.services.processing_account import (
     find_transfer_pairs,
 )
 from src.services.source_type_priority import promote_entry_source_type, source_type_rank
+from src.services.statement_summary import resolve_custody_account_id
 
 logger = get_logger(__name__)
 
@@ -1158,16 +1159,23 @@ async def execute_matching(
                     matched_txn_ids.add(txn.id)
                     continue
 
-                # Fetch statement to get account_id
-                stmt_result = await db.execute(select(BankStatement).where(BankStatement.id == txn.statement_id))
-                stmt = stmt_result.scalar_one()
+                # Resolve the custody (source) account. Under the Layer-2/DWD read
+                # path the txn is an AtomicTransaction with no statement_id, so the
+                # custody account comes from the StatementSummary conform; the legacy
+                # path reads it from the originating BankStatement (ODS).
+                if settings.enable_4_layer_read:
+                    source_account_id = await resolve_custody_account_id(db, txn)
+                else:
+                    stmt = (
+                        await db.execute(select(BankStatement).where(BankStatement.id == txn.statement_id))
+                    ).scalar_one()
+                    source_account_id = stmt.account_id
 
-                # Skip transfer detection if statement has no linked account
-                if stmt.account_id is None:
+                # Skip transfer detection if the source statement has no linked account
+                if source_account_id is None:
                     logger.warning(
-                        "Transfer detected but statement has no linked account - skipping Processing entry",
+                        "Transfer detected but source statement has no linked account - skipping Processing entry",
                         txn_id=str(txn.id),
-                        statement_id=str(txn.statement_id),
                     )
                     continue
                 # Create Processing account entry based on direction
@@ -1175,7 +1183,7 @@ async def execute_matching(
                     transfer_entry = await create_transfer_out_entry(
                         db=db,
                         user_id=user_id,
-                        source_account_id=stmt.account_id,
+                        source_account_id=source_account_id,
                         amount=txn.amount,
                         txn_date=txn.txn_date,
                         description=txn.description,
@@ -1209,7 +1217,7 @@ async def execute_matching(
                     transfer_entry = await create_transfer_in_entry(
                         db=db,
                         user_id=user_id,
-                        dest_account_id=stmt.account_id,
+                        dest_account_id=source_account_id,
                         amount=txn.amount,
                         txn_date=txn.txn_date,
                         description=txn.description,

--- a/apps/backend/src/services/statement_summary.py
+++ b/apps/backend/src/services/statement_summary.py
@@ -20,13 +20,10 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.logger import get_logger
-from src.models.layer1 import UploadedDocument
+from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AtomicTransaction
 from src.models.statement import BankStatement
 from src.models.statement_summary import StatementSummary
-
-logger = get_logger(__name__)
 
 # Envelope fields copied verbatim from BankStatement -> StatementSummary.
 _ENVELOPE_FIELDS = (
@@ -94,41 +91,81 @@ async def sync_statement_summary(db: AsyncSession, statement: BankStatement) -> 
     return summary
 
 
+def _ordered_bank_statement_doc_ids(source_documents: object) -> list[UUID]:
+    """Extract source ``UploadedDocument`` ids, in order, for bank-statement sources.
+
+    Accepts the canonical list form (``[{"doc_id": ..., "doc_type": ...}]``) and a
+    ``{"documents": [...]}`` wrapper. Non-bank-statement sources are ignored (custody
+    is a cash/bank-account concept), entries with a missing ``doc_type`` are kept,
+    and invalid UUID strings are skipped so they never raise during query binding.
+    """
+    if isinstance(source_documents, dict):
+        source_documents = source_documents.get("documents", [])
+    if not isinstance(source_documents, list):
+        return []
+
+    bank_statement = DocumentType.BANK_STATEMENT.value
+    ordered: list[UUID] = []
+    seen: set[UUID] = set()
+    for entry in source_documents:
+        if not isinstance(entry, dict):
+            continue
+        doc_type = entry.get("doc_type")
+        if doc_type is not None and doc_type != bank_statement:
+            continue
+        raw = entry.get("doc_id")
+        if not raw:
+            continue
+        try:
+            doc_id = UUID(str(raw))
+        except (ValueError, TypeError):
+            continue
+        if doc_id not in seen:
+            seen.add(doc_id)
+            ordered.append(doc_id)
+    return ordered
+
+
 async def resolve_custody_account_id(db: AsyncSession, atomic_txn: AtomicTransaction) -> UUID | None:
     """Resolve the custody account for a Layer-2 atomic transaction via the conform.
 
-    Walks ``atomic_txn.source_documents -> UploadedDocument -> StatementSummary``
-    and returns the first confirmed custody ``account_id``. Returns ``None`` when
-    the source statement has no linked account yet.
+    Walks ``atomic_txn.source_documents -> UploadedDocument -> StatementSummary`` and
+    returns the confirmed custody ``account_id`` of the **first** source document (in
+    source-document order) that has one. Returns ``None`` when no source statement has
+    a confirmed custody account.
     """
-    source_docs = atomic_txn.source_documents if isinstance(atomic_txn.source_documents, list) else []
-    doc_ids = [d["doc_id"] for d in source_docs if isinstance(d, dict) and d.get("doc_id")]
+    doc_ids = _ordered_bank_statement_doc_ids(atomic_txn.source_documents)
     if not doc_ids:
         return None
 
-    file_hashes = (
-        (
-            await db.execute(
-                select(UploadedDocument.file_hash).where(
-                    UploadedDocument.user_id == atomic_txn.user_id,
-                    UploadedDocument.id.in_(doc_ids),
-                )
+    # doc_id -> file_hash for the source documents.
+    doc_hash_rows = (
+        await db.execute(
+            select(UploadedDocument.id, UploadedDocument.file_hash).where(
+                UploadedDocument.user_id == atomic_txn.user_id,
+                UploadedDocument.id.in_(doc_ids),
             )
         )
-        .scalars()
-        .all()
-    )
-    if not file_hashes:
+    ).all()
+    hash_by_doc_id = {doc_id: file_hash for doc_id, file_hash in doc_hash_rows}
+    if not hash_by_doc_id:
         return None
 
-    return (
+    # file_hash -> confirmed custody account.
+    account_rows = (
         await db.execute(
-            select(StatementSummary.account_id)
-            .where(
+            select(StatementSummary.file_hash, StatementSummary.account_id).where(
                 StatementSummary.user_id == atomic_txn.user_id,
-                StatementSummary.file_hash.in_(file_hashes),
+                StatementSummary.file_hash.in_(hash_by_doc_id.values()),
                 StatementSummary.account_id.isnot(None),
             )
-            .limit(1)
         )
-    ).scalar_one_or_none()
+    ).all()
+    account_by_hash = {file_hash: account_id for file_hash, account_id in account_rows}
+
+    # Preserve source-document order: first source with a confirmed account wins.
+    for doc_id in doc_ids:
+        account_id = account_by_hash.get(hash_by_doc_id.get(doc_id))
+        if account_id is not None:
+            return account_id
+    return None

--- a/apps/backend/tests/extraction/test_deduplication.py
+++ b/apps/backend/tests/extraction/test_deduplication.py
@@ -95,6 +95,11 @@ class TestDeduplicationService:
         assert _hash(None) == service.calculate_transaction_hash(
             user_id, txn_date, amount, direction, description, reference=None
         )
+        # Scale differences are canonicalized: amount/balance differing only in scale hash identically.
+        assert _hash(Decimal("950")) == _hash(Decimal("950.00")) == _hash(Decimal("950.000"))
+        assert service.calculate_transaction_hash(
+            user_id, txn_date, Decimal("50"), direction, description
+        ) == service.calculate_transaction_hash(user_id, txn_date, Decimal("50.00"), direction, description)
 
     def test_calculate_position_hash(self):
         """GIVEN: Position details with broker

--- a/apps/backend/tests/extraction/test_deduplication.py
+++ b/apps/backend/tests/extraction/test_deduplication.py
@@ -72,6 +72,30 @@ class TestDeduplicationService:
         )
         assert hash_result == hash_empty_ref
 
+    def test_running_balance_distinguishes_identical_transactions(self):
+        """AC11.16.1: two otherwise-identical txns with different running balances hash differently;
+        identical running balances (or none) collapse."""
+        service = DeduplicationService()
+        user_id = uuid4()
+        txn_date = date(2024, 1, 1)
+        amount = Decimal("50.00")
+        direction = TransactionDirection.OUT
+        description = "Batch Payment"
+
+        def _hash(balance_after):
+            return service.calculate_transaction_hash(
+                user_id, txn_date, amount, direction, description, reference=None, balance_after=balance_after
+            )
+
+        # Different running balances -> distinct hashes (two real, separate payments).
+        assert _hash(Decimal("950.00")) != _hash(Decimal("900.00"))
+        # Same running balance -> same hash (a genuine duplicate extraction collapses).
+        assert _hash(Decimal("950.00")) == _hash(Decimal("950.00"))
+        # No running balance -> unchanged from the no-balance hash.
+        assert _hash(None) == service.calculate_transaction_hash(
+            user_id, txn_date, amount, direction, description, reference=None
+        )
+
     def test_calculate_position_hash(self):
         """GIVEN: Position details with broker
         WHEN: Calculating position hash

--- a/apps/backend/tests/extraction/test_statement_summary_conform.py
+++ b/apps/backend/tests/extraction/test_statement_summary_conform.py
@@ -129,6 +129,100 @@ class TestStatementSummaryConform:
         resolved = await resolve_custody_account_id(db, atomic)
         assert resolved == account.id
 
+    async def _confirmed_doc(self, db, user_id, *, file_hash, account_id):
+        statement = await _make_statement(db, user_id, file_hash=file_hash, account_id=account_id)
+        doc = UploadedDocument(
+            user_id=user_id,
+            file_path=f"statements/{file_hash}.pdf",
+            file_hash=file_hash,
+            original_filename="dbs.pdf",
+            document_type=DocumentType.BANK_STATEMENT,
+        )
+        db.add(doc)
+        await db.flush()
+        await sync_statement_summary(db, statement)
+        return doc
+
+    def _atomic(self, user_id, *, source_documents, dedup_hash):
+        return AtomicTransaction(
+            user_id=user_id,
+            txn_date=date(2024, 1, 15),
+            amount=Decimal("500.00"),
+            direction=TransactionDirection.OUT,
+            description="TRANSFER",
+            currency="SGD",
+            dedup_hash=dedup_hash,
+            source_documents=source_documents,
+        )
+
+    async def test_resolve_handles_dict_wrapper_source_documents(self, db, test_user):
+        """AC11.15.5: a {"documents": [...]} wrapper is normalized before resolution."""
+        account = await _make_account(db, test_user.id)
+        doc = await self._confirmed_doc(db, test_user.id, file_hash="hash-wrap", account_id=account.id)
+        atomic = self._atomic(
+            test_user.id,
+            source_documents={"documents": [{"doc_id": str(doc.id), "doc_type": "bank_statement"}]},
+            dedup_hash="dedup-wrap",
+        )
+        db.add(atomic)
+        await db.commit()
+        assert await resolve_custody_account_id(db, atomic) == account.id
+
+    async def test_resolve_ignores_invalid_and_non_bank_sources(self, db, test_user):
+        """AC11.15.6: junk entries, non-bank doc types, and invalid UUIDs are skipped."""
+        atomic = self._atomic(
+            test_user.id,
+            source_documents=[
+                "junk",
+                {"doc_type": "bank_statement"},  # missing doc_id
+                {"doc_id": "not-a-uuid", "doc_type": "bank_statement"},
+                {"doc_id": str(uuid4()), "doc_type": "brokerage_statement"},
+            ],
+            dedup_hash="dedup-junk",
+        )
+        db.add(atomic)
+        await db.commit()
+        assert await resolve_custody_account_id(db, atomic) is None
+
+    async def test_resolve_returns_none_when_no_source_has_account(self, db, test_user):
+        """AC11.15.9: a known source document with no confirmed custody account resolves to None."""
+        doc = await self._confirmed_doc(db, test_user.id, file_hash="hash-noacct", account_id=None)
+        atomic = self._atomic(
+            test_user.id,
+            source_documents=[{"doc_id": str(doc.id), "doc_type": "bank_statement"}],
+            dedup_hash="dedup-noacct",
+        )
+        db.add(atomic)
+        await db.commit()
+        assert await resolve_custody_account_id(db, atomic) is None
+
+    async def test_resolve_returns_none_for_non_list_source_documents(self, db, test_user):
+        """AC11.15.7: a non-list/non-dict source_documents value resolves to None."""
+        atomic = self._atomic(test_user.id, source_documents="weird", dedup_hash="dedup-weird")
+        db.add(atomic)
+        await db.commit()
+        assert await resolve_custody_account_id(db, atomic) is None
+
+    async def test_resolve_preserves_source_document_order(self, db, test_user):
+        """AC11.15.8: the first source document (in order) with a confirmed account wins."""
+        second = Account(user_id=test_user.id, name="OCBC", type=AccountType.ASSET, currency="SGD")
+        db.add(second)
+        await db.flush()
+        # First source has NO confirmed account; second does -> resolver returns the second.
+        doc_unconfirmed = await self._confirmed_doc(db, test_user.id, file_hash="hash-ord-1", account_id=None)
+        doc_confirmed = await self._confirmed_doc(db, test_user.id, file_hash="hash-ord-2", account_id=second.id)
+        atomic = self._atomic(
+            test_user.id,
+            source_documents=[
+                {"doc_id": str(doc_unconfirmed.id), "doc_type": "bank_statement"},
+                {"doc_id": str(doc_confirmed.id), "doc_type": "bank_statement"},
+            ],
+            dedup_hash="dedup-order",
+        )
+        db.add(atomic)
+        await db.commit()
+        assert await resolve_custody_account_id(db, atomic) == second.id
+
     async def test_resolve_returns_none_without_source_documents(self, db, test_user):
         """AC11.15.4: resolver returns None when the atomic txn has no source documents."""
         atomic = AtomicTransaction(

--- a/apps/backend/tests/reconciliation/conftest.py
+++ b/apps/backend/tests/reconciliation/conftest.py
@@ -1,0 +1,34 @@
+"""Reconciliation test fixtures for the EPIC-011 PR-B read cutover.
+
+`ENABLE_4_LAYER_READ` now defaults to True, so `execute_matching` reads Layer 2
+(`atomic_transactions`) and resolves the transfer custody account from the
+`StatementSummary` conform. Most reconciliation tests still seed Layer 0 fixtures
+(BankStatement + BankStatementTransaction) directly.
+
+This autouse fixture projects those Layer 0 fixtures into Layer 2 + the conform
+(the exact projection production gets from Stage 1 dual-write + Stage 2a backfill
++ the PR-A StatementSummary sync) immediately before the engine reads them, so
+existing fixtures exercise the real activated read path without rewriting every
+test body.
+
+Removed in Stage 3, when reconciliation fixtures are rebuilt natively on Layer 2
+and the legacy `bank_statement*` tables are deprecated.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def bridge_layer0_recon_fixtures_into_layer2(monkeypatch):
+    from src.services import reconciliation as recon
+    from src.services.deduplication import backfill_atomic_transactions_from_statements
+
+    original = recon._get_pending_layer2_transactions
+
+    async def _backfilled_pending(db, user_id, limit=None):
+        # Projects Layer 0 -> atomic_transactions AND StatementSummary (custody account).
+        await backfill_atomic_transactions_from_statements(db, user_id=user_id)
+        return await original(db, user_id, limit=limit)
+
+    monkeypatch.setattr(recon, "_get_pending_layer2_transactions", _backfilled_pending)
+    yield

--- a/apps/backend/tests/reconciliation/test_reconciliation_dual_read.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_dual_read.py
@@ -57,6 +57,9 @@ class TestReconciliationDualRead:
     async def test_dual_read_validation_logs_consistency(self, db, test_user, mock_ai_response, monkeypatch):
         """Test that consistent Layer 0/2 data is validated."""
         monkeypatch.setattr(settings, "enable_4_layer_write", True)
+        # Layer 0/2 consistency validation only runs on the legacy dual-read path
+        # (removed in Stage 3 with the Layer-0 read path).
+        monkeypatch.setattr(settings, "enable_4_layer_read", False)
 
         service = ExtractionService()
         content = b"PDF-CONTENT"
@@ -87,6 +90,9 @@ class TestReconciliationDualRead:
     async def test_dual_read_validation_detects_mismatch(self, db, test_user, mock_ai_response, monkeypatch):
         """Test that missing Layer 2 data triggers mismatch warning."""
         monkeypatch.setattr(settings, "enable_4_layer_write", True)
+        # Layer 0/2 consistency validation only runs on the legacy dual-read path
+        # (removed in Stage 3 with the Layer-0 read path).
+        monkeypatch.setattr(settings, "enable_4_layer_read", False)
 
         service = ExtractionService()
         content = b"PDF-CONTENT-MISMATCH"

--- a/apps/backend/tests/reconciliation/test_reconciliation_engine.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_engine.py
@@ -184,7 +184,6 @@ async def test_execute_matching_no_candidates(db: AsyncSession):
     matches = await execute_matching(db, user_id=user_id)
     assert len(matches) == 0
     await db.refresh(txn)
-    assert txn.status == BankTransactionStatus.UNMATCHED
 
 
 async def test_transfer_pair_not_double_counted(db: AsyncSession) -> None:
@@ -246,8 +245,6 @@ async def test_transfer_pair_not_double_counted(db: AsyncSession) -> None:
 
     await db.refresh(out_txn)
     await db.refresh(in_txn)
-    assert out_txn.status == BankTransactionStatus.MATCHED
-    assert in_txn.status == BankTransactionStatus.MATCHED
 
     transfer_entries_result = await db.execute(
         select(JournalEntry)
@@ -330,7 +327,6 @@ async def test_execute_matching_pending_review_and_unmatched(db: AsyncSession) -
     await db.refresh(txn_pending)
     await db.refresh(txn_unmatched)
     assert txn_pending.status == BankTransactionStatus.PENDING
-    assert txn_unmatched.status == BankTransactionStatus.UNMATCHED
 
 
 async def test_execute_matching_many_to_one_group(db: AsyncSession) -> None:
@@ -557,7 +553,6 @@ async def test_execute_matching_multi_entry_combinations(db: AsyncSession) -> No
     assert match.score_breakdown.get("multi_entry") == 2
 
     await db.refresh(txn)
-    assert txn.status == BankTransactionStatus.MATCHED
 
 
 async def test_review_queue_error_paths(db: AsyncSession) -> None:

--- a/apps/backend/tests/reconciliation/test_reconciliation_matching_unit.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_matching_unit.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from src.config import settings
 from src.models import (
     Account,
     AccountType,
@@ -456,11 +457,6 @@ async def test_execute_matching_no_candidates_marked_unmatched(db: AsyncSession)
     matches = await execute_matching(db, user_id=user_id)
     assert len(matches) == 0
 
-    # Reload txn to check status
-    result = await db.execute(select(BankStatementTransaction).where(BankStatementTransaction.id == txn.id))
-    txn_reloaded = result.scalar_one()
-    assert txn_reloaded.status == BankStatementTransactionStatus.UNMATCHED
-
 
 async def test_execute_matching_complex_multi_entry(db: AsyncSession):
     user_id = uuid4()
@@ -605,18 +601,22 @@ async def test_execute_matching_triple_entry(db: AsyncSession):
 
 
 async def test_execute_matching_many_to_one_batch(db: AsyncSession):
+    """AC11.16.2: many-to-one matches on Layer 2 when running balances keep batch txns distinct."""
     user_id = uuid4()
     user = User(id=user_id, email=f"batch-{uuid4()}@example.com", hashed_password="hashed")
     statement = _make_statement(owner_id=user_id, base_date=date(2024, 1, 1))
     db.add_all([user, statement])
     await db.flush()
 
+    # Distinct running balances keep these two otherwise-identical txns separate in
+    # Layer 2 (real statements progress the running balance); see dedup_hash.
     t1 = BankStatementTransaction(
         statement_id=statement.id,
         txn_date=date(2024, 1, 1),
         description="Batch Payment #1",
         amount=Decimal("50.00"),
         direction="OUT",
+        balance_after=Decimal("950.00"),
         status=BankStatementTransactionStatus.PENDING,
     )
     t2 = BankStatementTransaction(
@@ -625,6 +625,7 @@ async def test_execute_matching_many_to_one_batch(db: AsyncSession):
         description="Batch Payment #1",
         amount=Decimal("50.00"),
         direction="OUT",
+        balance_after=Decimal("900.00"),
         status=BankStatementTransactionStatus.PENDING,
     )
     db.add_all([t1, t2])
@@ -802,9 +803,6 @@ async def test_execute_matching_low_score_unmatched(db: AsyncSession):
 
     matches = await execute_matching(db, user_id=user_id)
     assert len(matches) == 0
-
-    result = await db.execute(select(BankStatementTransaction).where(BankStatementTransaction.id == txn.id))
-    assert result.scalar_one().status == BankStatementTransactionStatus.UNMATCHED
 
 
 def test_load_reconciliation_config_yaml_import_error():
@@ -1064,7 +1062,7 @@ async def test_transfer_detection_no_account_id(db: AsyncSession):
 
 
 async def test_transfer_out_creates_match(db: AsyncSession):
-    """Cover lines 703-736: Transfer OUT creates Processing entry + match."""
+    """AC11.17.1 · Cover lines 703-736: Transfer OUT creates Processing entry + match."""
     user_id = uuid4()
     user = User(id=user_id, email=f"xfer-out-{uuid4()}@example.com", hashed_password="hashed")
     db.add(user)
@@ -1104,6 +1102,40 @@ async def test_transfer_out_creates_match(db: AsyncSession):
     assert len(transfer_matches) == 1
     assert transfer_matches[0].match_score == 100
     assert transfer_matches[0].status == ReconciliationStatus.AUTO_ACCEPTED
+
+
+async def test_transfer_out_creates_match_legacy_read(db: AsyncSession, monkeypatch):
+    """AC11.17.1 · Legacy Layer-0 read path: transfer custody comes from BankStatement.account_id."""
+    monkeypatch.setattr(settings, "enable_4_layer_read", False)
+    user_id = uuid4()
+    user = User(id=user_id, email=f"xfer-legacy-{uuid4()}@example.com", hashed_password="hashed")
+    db.add(user)
+    await db.flush()
+
+    source_account = Account(id=uuid4(), name="Checking", type=AccountType.ASSET, user_id=user_id, currency="SGD")
+    db.add(source_account)
+    await db.flush()
+
+    statement = _make_statement(owner_id=user_id, base_date=date(2024, 1, 1))
+    statement.account_id = source_account.id
+    db.add(statement)
+    await db.flush()
+
+    txn = BankStatementTransaction(
+        statement_id=statement.id,
+        txn_date=date(2024, 1, 1),
+        description="TRANSFER TO SAVINGS",
+        amount=Decimal("500.00"),
+        direction="OUT",
+        status=BankStatementTransactionStatus.PENDING,
+    )
+    db.add(txn)
+    await db.commit()
+
+    matches = await execute_matching(db, user_id=user_id)
+    transfer_matches = [m for m in matches if m.score_breakdown.get("transfer_out")]
+    assert len(transfer_matches) == 1
+    assert transfer_matches[0].bank_txn_id == txn.id
 
 
 async def test_transfer_in_creates_match(db: AsyncSession):
@@ -1213,13 +1245,15 @@ async def test_many_to_one_all_already_matched(db: AsyncSession):
     db.add(statement)
     await db.flush()
 
-    # Batch-looking transactions that are also transfers → all get matched in Phase 1
+    # Batch-looking transactions that are also transfers → all get matched in Phase 1.
+    # Distinct running balances keep them separate in Layer 2.
     t1 = BankStatementTransaction(
         statement_id=statement.id,
         txn_date=date(2024, 1, 1),
         description="Batch Transfer TO savings",
         amount=Decimal("50.00"),
         direction="OUT",
+        balance_after=Decimal("950.00"),
         status=BankStatementTransactionStatus.PENDING,
     )
     t2 = BankStatementTransaction(
@@ -1228,6 +1262,7 @@ async def test_many_to_one_all_already_matched(db: AsyncSession):
         description="Batch Transfer TO savings",
         amount=Decimal("50.00"),
         direction="OUT",
+        balance_after=Decimal("900.00"),
         status=BankStatementTransactionStatus.PENDING,
     )
     db.add_all([t1, t2])
@@ -1346,8 +1381,11 @@ async def test_normal_matching_supersession_same_entries(db: AsyncSession):
     assert len(matches2) == 0
 
 
-async def test_normal_matching_supersession_different_entries(db: AsyncSession):
+async def test_normal_matching_supersession_different_entries(db: AsyncSession, monkeypatch):
     """Cover lines 953, 974-976: re-match different entries → supersede old match."""
+    # Re-run supersession is a legacy Layer-0 read mechanism (matched Layer-2
+    # atomic txns are not re-processed); removed in Stage 3.
+    monkeypatch.setattr(settings, "enable_4_layer_read", False)
     user_id = uuid4()
     user = User(id=user_id, email=f"supersede-diff-{uuid4()}@example.com", hashed_password="hashed")
     statement = _make_statement(owner_id=user_id, base_date=date(2024, 1, 1))
@@ -1588,8 +1626,11 @@ async def test_find_transfer_pairs_exception_non_fatal(db: AsyncSession):
         assert isinstance(matches, list)
 
 
-async def test_many_to_one_supersession(db: AsyncSession):
+async def test_many_to_one_supersession(db: AsyncSession, monkeypatch):
     """Cover lines 833-860: many-to-one with existing match → supersession."""
+    # Re-run supersession is a legacy Layer-0 read mechanism (matched Layer-2
+    # atomic txns are not re-processed); removed in Stage 3.
+    monkeypatch.setattr(settings, "enable_4_layer_read", False)
     user_id = uuid4()
     user = User(id=user_id, email=f"m2o-supersede-{uuid4()}@example.com", hashed_password="hashed")
     db.add(user)
@@ -1609,13 +1650,14 @@ async def test_many_to_one_supersession(db: AsyncSession):
     db.add(statement)
     await db.flush()
 
-    # Create batch transactions
+    # Create batch transactions (distinct running balances keep them separate in Layer 2)
     t1 = BankStatementTransaction(
         statement_id=statement.id,
         txn_date=date(2024, 1, 1),
         description="Batch Settlement payment",
         amount=Decimal("50.00"),
         direction="OUT",
+        balance_after=Decimal("950.00"),
         status=BankStatementTransactionStatus.PENDING,
     )
     t2 = BankStatementTransaction(
@@ -1624,6 +1666,7 @@ async def test_many_to_one_supersession(db: AsyncSession):
         description="Batch Settlement payment",
         amount=Decimal("50.00"),
         direction="OUT",
+        balance_after=Decimal("900.00"),
         status=BankStatementTransactionStatus.PENDING,
     )
     db.add_all([t1, t2])
@@ -1885,11 +1928,6 @@ async def test_normal_matching_auto_accept_reconciles_entries(db: AsyncSession):
     result = await db.execute(select(JournalEntry).where(JournalEntry.id == entry.id))
     reconciled_entry = result.scalar_one()
     assert reconciled_entry.status == JournalEntryStatus.RECONCILED
-
-    # Verify txn is MATCHED
-    result = await db.execute(select(BankStatementTransaction).where(BankStatementTransaction.id == txn.id))
-    matched_txn = result.scalar_one()
-    assert matched_txn.status == BankStatementTransactionStatus.MATCHED
 
 
 async def test_normal_matching_pending_review(db: AsyncSession):

--- a/apps/backend/tests/reconciliation/test_transfer_idempotency.py
+++ b/apps/backend/tests/reconciliation/test_transfer_idempotency.py
@@ -87,7 +87,6 @@ class TestTransferDetectionIdempotency:
         # Verify: still only one active (non-superseded) match in DB for this txn
         all_matches_result = await db.execute(
             select(ReconciliationMatch).where(
-                ReconciliationMatch.bank_txn_id == txn.id,
                 ReconciliationMatch.status != ReconciliationStatus.SUPERSEDED,
             )
         )
@@ -119,7 +118,6 @@ class TestTransferDetectionIdempotency:
         # Verify: only one non-superseded match for this txn
         all_matches_result = await db.execute(
             select(ReconciliationMatch).where(
-                ReconciliationMatch.bank_txn_id == txn.id,
                 ReconciliationMatch.status != ReconciliationStatus.SUPERSEDED,
             )
         )

--- a/apps/backend/tests/reconciliation/test_transfer_idempotency.py
+++ b/apps/backend/tests/reconciliation/test_transfer_idempotency.py
@@ -85,8 +85,17 @@ class TestTransferDetectionIdempotency:
         )
 
         # Verify: still only one active (non-superseded) match in DB for this txn
+        # Scope to the txn under test (matches are keyed by atomic_txn_id on the
+        # Layer-2 read path, bank_txn_id on the legacy path).
+        first_match = matches_first[0]
+        id_filter = (
+            ReconciliationMatch.atomic_txn_id == first_match.atomic_txn_id
+            if first_match.atomic_txn_id is not None
+            else ReconciliationMatch.bank_txn_id == first_match.bank_txn_id
+        )
         all_matches_result = await db.execute(
             select(ReconciliationMatch).where(
+                id_filter,
                 ReconciliationMatch.status != ReconciliationStatus.SUPERSEDED,
             )
         )
@@ -116,8 +125,17 @@ class TestTransferDetectionIdempotency:
         )
 
         # Verify: only one non-superseded match for this txn
+        # Scope to the txn under test (matches are keyed by atomic_txn_id on the
+        # Layer-2 read path, bank_txn_id on the legacy path).
+        first_match = matches_first[0]
+        id_filter = (
+            ReconciliationMatch.atomic_txn_id == first_match.atomic_txn_id
+            if first_match.atomic_txn_id is not None
+            else ReconciliationMatch.bank_txn_id == first_match.bank_txn_id
+        )
         all_matches_result = await db.execute(
             select(ReconciliationMatch).where(
+                id_filter,
                 ReconciliationMatch.status != ReconciliationStatus.SUPERSEDED,
             )
         )

--- a/apps/backend/tests/reconciliation/test_transfer_integration.py
+++ b/apps/backend/tests/reconciliation/test_transfer_integration.py
@@ -115,7 +115,6 @@ class TestTransferDetectionDuringReconciliation:
 
         # Verify: Transaction status updated to MATCHED
         await db.refresh(txn)
-        assert txn.status == BankTransactionStatus.MATCHED
 
     @pytest.mark.asyncio
     async def test_transfer_detection_skips_when_no_account_linked(self, db: AsyncSession, test_user):
@@ -154,7 +153,6 @@ class TestTransferDetectionDuringReconciliation:
 
         # Verify: Transaction remains PENDING (not matched)
         await db.refresh(txn)
-        assert txn.status == BankTransactionStatus.UNMATCHED  # Transaction marked UNMATCHED when no match found
 
         # Verify: No Processing account entry created
         processing = await get_or_create_processing_account(db, user_id)
@@ -463,7 +461,7 @@ class TestNormalMatchingPhaseIntegration:
 
     @pytest.mark.asyncio
     async def test_mixed_transactions_both_phases_execute(self, db: AsyncSession, test_user):
-        """AC15.6.6 · Mix of transfer and non-transfer transactions: Phase 1 and Phase 2 both execute."""
+        """AC15.6.6 · AC11.17.2 · Mix of transfer and non-transfer transactions: Phase 1 and Phase 2 both execute."""
         user_id = test_user.id
 
         # Setup accounts
@@ -551,12 +549,20 @@ class TestNormalMatchingPhaseIntegration:
         assert len(matches) == 2
 
         # Verify: Transfer matched via Phase 1 (new Processing entry)
-        transfer_match = next((m for m in matches if m.bank_txn_id == txn_transfer.id), None)
+        transfer_match = next(
+            (m for m in matches if m.score_breakdown.get("transfer_out") or m.score_breakdown.get("transfer_in")),
+            None,
+        )
         assert transfer_match is not None
         assert transfer_match.match_score == 100  # Transfer detection score
 
-        # Verify: Grocery matched via Phase 2 (existing manual entry)
-        grocery_match = next((m for m in matches if m.bank_txn_id == txn_grocery.id), None)
+        # Verify: Grocery matched via Phase 2 (existing manual entry).
+        # Match it by its linked journal entry (path-agnostic: matches are keyed by
+        # atomic_txn_id under the Layer-2 read path, not bank_txn_id).
+        grocery_match = next(
+            (m for m in matches if str(grocery_entry.id) in (m.journal_entry_ids or [])),
+            None,
+        )
         assert grocery_match is not None
         assert UUID(grocery_match.journal_entry_ids[0]) == grocery_entry.id
 

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -24,6 +24,7 @@ These files are test infrastructure, not behavior proof.
 | `apps/backend/tests/assets/__init__.py` | Package marker |
 | `apps/backend/tests/auth/__init__.py` | Package marker |
 | `apps/backend/tests/conftest.py` | Shared backend pytest fixtures |
+| `apps/backend/tests/reconciliation/conftest.py` | EPIC-011 PR-B Layer-2 read bridge fixture |
 | `apps/backend/tests/e2e/conftest.py` | Shared E2E fixtures |
 | `apps/backend/tests/extraction/__init__.py` | Package marker |
 | `apps/backend/tests/factories.py` | Shared backend test factories |

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -201,6 +201,31 @@ ODS `bank_statements.account_id` reach-back. Additive — no flags flipped.
 | AC11.15.8 | The first source document (in order) with a confirmed account wins | `test_resolve_preserves_source_document_order()` | `extraction/test_statement_summary_conform.py` | P0 |
 | AC11.15.9 | A known source document with no confirmed custody account resolves to None | `test_resolve_returns_none_when_no_source_has_account()` | `extraction/test_statement_summary_conform.py` | P0 |
 
+### AC11.16: 4-Layer Migration — Balance-aware Layer 2 dedup
+
+The Layer 2 `dedup_hash` includes the statement running balance (`balance_after`)
+so two real, otherwise-identical transactions (same date/amount/direction/
+description, no reference) stay distinct — their running balances differ — while
+genuine duplicate extractions (same running balance) still collapse. This keeps
+many-to-one reconciliation correct on the Layer-2 read path.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.16.1 | Distinct running balances hash differently; identical/absent balances collapse | `test_running_balance_distinguishes_identical_transactions()` | `extraction/test_deduplication.py` | P0 |
+| AC11.16.2 | Many-to-one matching works on Layer 2 when running balances keep batch txns distinct | `test_execute_matching_many_to_one_batch()` | `reconciliation/test_reconciliation_matching_unit.py` | P0 |
+
+### AC11.17: 4-Layer Migration — PR-B DWD read cutover
+
+PR-B activates `ENABLE_4_LAYER_READ` by default: reconciliation reads Layer 2
+(`atomic_transactions`) and transfer detection resolves the custody account from
+the `StatementSummary` conform (DWD) instead of `bank_statements.account_id`
+(ODS). The legacy Layer-0 read path remains available via the flag until Stage 3.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.17.1 | Transfer OUT/IN detection resolves custody account from DWD and creates the Processing entry under the Layer-2 read path | `test_transfer_out_creates_match()`, `test_transfer_in_creates_match()` | `reconciliation/test_reconciliation_matching_unit.py` | P0 |
+| AC11.17.2 | Mixed transfer + normal transactions both reconcile under the Layer-2 read path | `test_mixed_transactions_both_phases_execute()` | `reconciliation/test_transfer_integration.py` | P0 |
+
 ## Implementation Pattern Ownership
 
 Do not copy reusable code patterns, router examples, migration guardrails, or

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -195,6 +195,11 @@ ODS `bank_statements.account_id` reach-back. Additive — no flags flipped.
 | AC11.15.2 | Re-sync updates the conform in place and links the source UploadedDocument | `test_sync_is_idempotent_and_links_uploaded_document()` | `extraction/test_statement_summary_conform.py` | P0 |
 | AC11.15.3 | Custody account resolves from a Layer-2 atomic transaction via the conform (DWD-native) | `test_resolve_custody_account_from_atomic_txn()` | `extraction/test_statement_summary_conform.py` | P0 |
 | AC11.15.4 | The resolver returns None when the source statement has no confirmed custody account | `test_resolve_returns_none_without_account()` | `extraction/test_statement_summary_conform.py` | P0 |
+| AC11.15.5 | The resolver normalizes a `{"documents": [...]}` source-documents wrapper | `test_resolve_handles_dict_wrapper_source_documents()` | `extraction/test_statement_summary_conform.py` | P0 |
+| AC11.15.6 | The resolver skips junk entries, non-bank-statement sources, and invalid UUIDs | `test_resolve_ignores_invalid_and_non_bank_sources()` | `extraction/test_statement_summary_conform.py` | P0 |
+| AC11.15.7 | A non-list/non-dict source_documents value resolves to None | `test_resolve_returns_none_for_non_list_source_documents()` | `extraction/test_statement_summary_conform.py` | P0 |
+| AC11.15.8 | The first source document (in order) with a confirmed account wins | `test_resolve_preserves_source_document_order()` | `extraction/test_statement_summary_conform.py` | P0 |
+| AC11.15.9 | A known source document with no confirmed custody account resolves to None | `test_resolve_returns_none_when_no_source_has_account()` | `extraction/test_statement_summary_conform.py` | P0 |
 
 ## Implementation Pattern Ownership
 

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -59,7 +59,9 @@ The system is migrating to a 4-layer architecture. As of Stage 1 cutover, dual-w
 - Status tracking: `uploaded` → `processing` → `completed`
 
 **Layer 2: Atomic Data (`AtomicTransaction`, `AtomicPosition`)**
-- Deduplicated via SHA256 hash of core fields
+- Deduplicated via SHA256 hash of core fields. For transactions the hash includes
+  the statement running balance (`balance_after`), so two real but otherwise
+  identical transactions stay distinct while genuine duplicate extractions collapse.
 - `source_documents` (JSONB) tracks lineage (which files contributed this record)
 - Immutable once written (except for appending sources)
 

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -65,12 +65,12 @@ sits in the wrong layer, that is drift to be fixed, not worked around.
 4. **DWM stays thin.** Add a DWM table only for a genuinely complex cross-fact
    domain (today: reconciliation/transfer matching). Default new work to DWD or DWS.
 
-> **Known drift (being closed):** reconciliation transfer detection (a DWM
-> concern) still resolves the source account from ODS
-> (`bank_statements.account_id`). PR-A adds the DWD-native custody conform —
-> `statement_summaries` (with `resolve_custody_account_id`) — so PR-B can switch
-> transfer detection to read the custody account from DWD and flip the read
-> cutover. See `docs/project/EPIC-011.asset-lifecycle.md`.
+> **Drift closed (PR-B):** under the default Layer-2 read path
+> (`ENABLE_4_LAYER_READ=true`), reconciliation transfer detection now resolves
+> the custody account from DWD (`statement_summaries` via
+> `resolve_custody_account_id`), not from ODS (`bank_statements.account_id`).
+> The legacy Layer-0 read path remains behind the flag until Stage 3 removes
+> the `bank_statement*` tables. See `docs/project/EPIC-011.asset-lifecycle.md`.
 
 ---
 

--- a/tests/tooling/test_reconciliation_thresholds_unit.py
+++ b/tests/tooling/test_reconciliation_thresholds_unit.py
@@ -192,7 +192,7 @@ async def test_execute_matching_score_thresholds(
         )
 
     assert len(matches) == expected_match_count
-    assert txn.status == expected_txn_status
+    # bank-txn.status is no longer mutated under the Layer-2 read path (Stage 3 removes it)
 
     if expected_status is None:
         db.add.assert_not_called()


### PR DESCRIPTION
**PR-B of the DWD read cutover (PR-A #807 → PR-B).** Builds on PR-A's `StatementSummary` conform. Also resolves PR-A's Copilot review (custody resolver hardening).

## What

Reconciliation now reads **Layer 2** (`atomic_transactions`) by default, and transfer detection resolves the **custody account** from the DWD `StatementSummary` conform — not from ODS `bank_statements.account_id`.

- **config**: `ENABLE_4_LAYER_READ` default `False → True`.
- **transfer detection**: under the read path, custody comes from `resolve_custody_account_id` (DWD); the legacy `BankStatement.account_id` lookup stays behind the flag.
- **balance-aware dedup** (the key correctness fix): the Layer 2 transaction `dedup_hash` now includes the statement **running balance** (`balance_after`). Two real but otherwise-identical transactions (same date/amount/direction/description, no reference) stay distinct because their running balances differ; genuine duplicate extractions (same running balance) still collapse. This fixes many-to-one matching on Layer 2 — previously two identical $50 payments collapsed into one atomic row and never reconciled against a $100 entry.

## Test migration

- `tests/reconciliation/conftest.py` bridges Layer 0 fixtures → Layer 2 + the conform before the engine reads them (the projection production gets from dual-write + backfill + the PR-A sync).
- Dropped legacy `bank_txn.status` assertions (the engine no longer mutates Layer 0 under the read path); matched path-agnostically by `atomic_txn_id`/`journal_entry_ids`; batch txns given distinct running balances.
- Legacy **re-run-supersession** and **dual-read-validation** tests pinned `read=False` (they cover Layer-0-only mechanisms removed in Stage 3).

## The dedup finding (worth a read)

The "second gap" (many-to-one returning 0 on Layer 2) was a real money-correctness issue: Layer 2 dedup collapsed identical transactions. The running-balance distinguisher is the clean fix — real statements progress the running balance, so identical-balance rows are true duplicates and *should* collapse.

## Verification

Full backend suite green under `read=True`: 228 reconciliation + ~1740 other tests. ruff, format, enum guardrails, doc-consistency, ac-registry, ssot-ownership all pass locally. AC11.16 (balance dedup) + AC11.17 (read cutover) registered.

## Next: Stage 3 (separate, irreversible)

Remove the `enable_4_layer_read` branches + Layer-0-only code, delete the read=False-pinned legacy tests, and drop the `bank_statement*` tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)