### PR TITLE
feat(EPIC-019): config-gated Prefect dispatch for upload→report (P0 seam, default OFF)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,10 @@ AI_MODEL_CATALOG_SOURCE=configured
 PRIMARY_MODEL=glm-5.1
 OCR_MODEL=glm-4.6v
 VISION_MODEL=glm-4.6v
+# EPIC-019: set to the Prefect API URL to run upload→report parsing as durable
+# Prefect flow runs (staging/prod, and the per-PR ephemeral Prefect). Leave unset
+# for CI/local/preview → in-process asyncio fallback (no Prefect needed).
+# PREFECT_API_URL=http://platform-prefect-server:4200/api
 FALLBACK_MODELS=glm-5-turbo,glm-5
 AI_JSON_TIMEOUT_SECONDS=360
 AI_JSON_MAX_TOKENS=8192

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -32,8 +32,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# EPIC-019: only the Prefect worker image installs this (`pip install .[prefect]`).
-# The API process and CI/local run the in-process fallback without Prefect.
+# EPIC-019: installed (`pip install .[prefect]`) by any process that runs with
+# PREFECT_API_URL set — the API (to submit flow runs) AND the worker (to execute
+# them). The base image / CI / local fallback run in-process without Prefect.
 prefect = [
     "prefect>=3.7.0",
 ]

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -31,6 +31,13 @@ dependencies = [
     "pymupdf>=1.24.0",
 ]
 
+[project.optional-dependencies]
+# EPIC-019: only the Prefect worker image installs this (`pip install .[prefect]`).
+# The API process and CI/local run the in-process fallback without Prefect.
+prefect = [
+    "prefect>=3.7.0",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=8.0.0",

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -145,6 +145,10 @@ class Settings(BaseSettings):
     vision_model: str = Field(default="glm-4.6v", validation_alias="VISION_MODEL")
     ocr_model: str = Field(default="glm-4.6v", validation_alias="OCR_MODEL")
     fallback_models_str: str | None = Field(default=None, validation_alias="FALLBACK_MODELS")
+    # EPIC-019: when set, upload→report parsing is submitted as a durable Prefect
+    # flow run instead of an in-process asyncio task. Unset (CI/local/preview) →
+    # in-process fallback, no Prefect dependency. See services/statement_pipeline.py.
+    prefect_api_url: str | None = Field(default=None, validation_alias="PREFECT_API_URL")
     ai_json_timeout_seconds: float = Field(
         default=360.0,
         validation_alias="AI_JSON_TIMEOUT_SECONDS",

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -97,10 +97,10 @@ async def _queue_statement_reparse(
     *,
     model: str | None = None,
 ) -> None:
-    storage = StorageService()
-    content = await run_in_threadpool(storage.get_object, statement.file_path)
     request_id = _current_request_id()
     model_to_use = None if model == settings.ocr_model else model
+    # No content pre-fetch here: in Prefect mode the worker re-fetches it, and in
+    # fallback mode submit_parse_pipeline fetches it from storage_key on demand.
     task = await submit_parse_pipeline(
         statement_id=statement.id,
         filename=statement.original_filename,
@@ -109,7 +109,6 @@ async def _queue_statement_reparse(
         account_id=statement.account_id,
         file_hash=statement.file_hash,
         storage_key=statement.file_path,
-        content=content,
         model=model_to_use,
         db=db,
         request_id=request_id,

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -97,10 +97,10 @@ async def _queue_statement_reparse(
     *,
     model: str | None = None,
 ) -> None:
+    storage = StorageService()
+    content = await run_in_threadpool(storage.get_object, statement.file_path)
     request_id = _current_request_id()
     model_to_use = None if model == settings.ocr_model else model
-    # No content pre-fetch here: in Prefect mode the worker re-fetches it, and in
-    # fallback mode submit_parse_pipeline fetches it from storage_key on demand.
     task = await submit_parse_pipeline(
         statement_id=statement.id,
         filename=statement.original_filename,
@@ -109,6 +109,7 @@ async def _queue_statement_reparse(
         account_id=statement.account_id,
         file_hash=statement.file_hash,
         storage_key=statement.file_path,
+        content=content,
         model=model_to_use,
         db=db,
         request_id=request_id,

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import selectinload
 
 from src.config import settings
 from src.constants.error_ids import ErrorIds
-from src.database import create_session_maker_from_db
 from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
 from src.models import (
@@ -45,7 +44,7 @@ from src.schemas.review import (
 from src.services import StorageError, StorageService
 from src.services.brokerage_positions import BrokeragePositionImportService
 from src.services.openrouter_models import ModelCatalogError, get_model_info, model_matches_modality
-from src.services.statement_parsing import parse_statement_background
+from src.services.statement_pipeline import submit_parse_pipeline
 from src.services.statement_posting import auto_create_posted_entries_for_statement
 from src.services.statement_validation import (
     approve_statement as approve_statement_svc,
@@ -102,22 +101,21 @@ async def _queue_statement_reparse(
     content = await run_in_threadpool(storage.get_object, statement.file_path)
     request_id = _current_request_id()
     model_to_use = None if model == settings.ocr_model else model
-    task = asyncio.create_task(
-        parse_statement_background(
-            statement_id=statement.id,
-            filename=statement.original_filename,
-            institution=statement.institution,
-            user_id=user_id,
-            account_id=statement.account_id,
-            file_hash=statement.file_hash,
-            storage_key=statement.file_path,
-            content=content,
-            model=model_to_use,
-            session_maker=create_session_maker_from_db(db),
-            request_id=request_id,
-        )
+    task = await submit_parse_pipeline(
+        statement_id=statement.id,
+        filename=statement.original_filename,
+        institution=statement.institution,
+        user_id=user_id,
+        account_id=statement.account_id,
+        file_hash=statement.file_hash,
+        storage_key=statement.file_path,
+        content=content,
+        model=model_to_use,
+        db=db,
+        request_id=request_id,
     )
-    _track_task(task)
+    if task is not None:
+        _track_task(task)
     logger.info(
         "statement.parse.enqueued",
         audit_event="statement.parse.enqueued",
@@ -337,22 +335,21 @@ async def upload_statement(
             )
         raise_internal_error("Failed to persist statement metadata", cause=exc)
 
-    task = asyncio.create_task(
-        parse_statement_background(
-            statement_id=statement_id,
-            filename=filename,
-            institution=institution,
-            user_id=user_id,
-            account_id=account_id,
-            file_hash=file_hash,
-            storage_key=storage_key,
-            content=content,
-            model=model_to_use,
-            session_maker=create_session_maker_from_db(db),
-            request_id=request_id,
-        )
+    task = await submit_parse_pipeline(
+        statement_id=statement_id,
+        filename=filename,
+        institution=institution,
+        user_id=user_id,
+        account_id=account_id,
+        file_hash=file_hash,
+        storage_key=storage_key,
+        content=content,
+        model=model_to_use,
+        db=db,
+        request_id=request_id,
     )
-    _track_task(task)
+    if task is not None:
+        _track_task(task)
     logger.info(
         "statement.parse.enqueued",
         audit_event="statement.parse.enqueued",

--- a/apps/backend/src/services/statement_flow.py
+++ b/apps/backend/src/services/statement_flow.py
@@ -1,0 +1,62 @@
+"""Prefect flow for durable statement parsing (EPIC-019).
+
+This module imports ``prefect`` at load time, so it is imported ONLY by the
+Prefect worker (which runs this backend image with the ``prefect`` extra) and by
+the deployment-registration step — never by the API process in fallback mode.
+The config-gated dispatch lives in ``statement_pipeline.py``.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi.concurrency import run_in_threadpool
+from prefect import flow
+
+from src.database import async_session_maker
+from src.logger import get_logger
+from src.services import StorageService
+from src.services.statement_parsing import parse_statement_background
+
+logger = get_logger(__name__)
+
+
+@flow(name="parse-statement", retries=2, retry_delay_seconds=30)
+async def parse_statement_flow(
+    *,
+    statement_id: str,
+    filename: str,
+    institution: str | None,
+    user_id: str,
+    account_id: str | None,
+    file_hash: str,
+    storage_key: str,
+    model: str | None,
+    request_id: str | None = None,
+) -> None:
+    """Durable, retriable statement parse.
+
+    Re-fetches content from storage and uses the worker's own session maker,
+    then runs the existing parse logic. Idempotency is keyed on ``statement_id``
+    (the underlying parse persists by statement id), so retries/re-runs are safe.
+    """
+    logger.info(
+        "statement.parse.flow_started",
+        statement_id=statement_id,
+        request_id=request_id,
+    )
+    storage = StorageService()
+    content = await run_in_threadpool(storage.get_object, storage_key)
+    await parse_statement_background(
+        statement_id=UUID(statement_id),
+        filename=filename,
+        institution=institution,
+        user_id=UUID(user_id),
+        account_id=UUID(account_id) if account_id else None,
+        file_hash=file_hash,
+        storage_key=storage_key,
+        content=content,
+        model=model,
+        session_maker=async_session_maker,
+        request_id=request_id,
+    )

--- a/apps/backend/src/services/statement_pipeline.py
+++ b/apps/backend/src/services/statement_pipeline.py
@@ -22,13 +22,11 @@ from __future__ import annotations
 import asyncio
 from uuid import UUID
 
-from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
 from src.database import create_session_maker_from_db
 from src.logger import get_logger
-from src.services import StorageService
 from src.services.statement_parsing import parse_statement_background
 
 logger = get_logger(__name__)
@@ -46,20 +44,20 @@ async def submit_parse_pipeline(
     account_id: UUID | None,
     file_hash: str,
     storage_key: str,
-    content: bytes | None = None,
+    content: bytes,
     model: str | None,
     db: AsyncSession,
     request_id: str | None,
 ) -> asyncio.Task[None] | None:
     """Dispatch statement parsing.
 
-    ``content`` is optional: pass it when the bytes are already in hand (e.g. a
-    fresh upload). In Prefect mode it is never used (the worker re-fetches from
-    ``storage_key``), so callers should NOT pre-download it just to dispatch. In
-    fallback mode, if ``content`` is None it is fetched from ``storage_key``.
-
     Returns the in-process ``asyncio.Task`` for the caller to track in fallback
     mode, or ``None`` when the work was submitted to Prefect.
+
+    Note: in Prefect mode ``content`` is not sent to the worker (it re-fetches
+    from ``storage_key``). Avoiding the caller's pre-download in that mode is a
+    P1 optimization deferred until the worker lands; in P0 (fallback only) the
+    content is needed in-process anyway.
     """
     if settings.prefect_api_url:
         # Remote durable execution. Only serializable params cross the boundary
@@ -89,9 +87,6 @@ async def submit_parse_pipeline(
             request_id=request_id,
         )
         return None
-
-    if content is None:
-        content = await run_in_threadpool(StorageService().get_object, storage_key)
 
     return asyncio.create_task(
         parse_statement_background(

--- a/apps/backend/src/services/statement_pipeline.py
+++ b/apps/backend/src/services/statement_pipeline.py
@@ -1,0 +1,97 @@
+"""Config-gated dispatch for the upload→report async pipeline (EPIC-019).
+
+The upload→report background work is migrating from an in-process
+``asyncio.create_task`` (fire-and-forget, lost on restart, competes with the API
+process) to durable Prefect flow runs. This module is the seam:
+
+- ``PREFECT_API_URL`` unset (CI / local / preview-without-Prefect) → fall back to
+  the existing in-process ``asyncio.create_task``. Zero Prefect dependency: the
+  app boots and tests run without any Prefect server (delivery speed unaffected).
+- ``PREFECT_API_URL`` set (staging / prod, and the per-PR ephemeral Prefect) →
+  submit a flow run to the Prefect server; an isolated worker (running this same
+  backend image) executes ``parse_statement_flow``.
+
+Prefect is imported lazily, so the fallback path never needs it installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.database import create_session_maker_from_db
+from src.logger import get_logger
+from src.services.statement_parsing import parse_statement_background
+
+logger = get_logger(__name__)
+
+# Prefect deployment name "<flow-name>/<deployment-name>".
+PARSE_DEPLOYMENT = "parse-statement/parse-statement"
+
+
+async def submit_parse_pipeline(
+    *,
+    statement_id: UUID,
+    filename: str,
+    institution: str | None,
+    user_id: UUID,
+    account_id: UUID | None,
+    file_hash: str,
+    storage_key: str,
+    content: bytes,
+    model: str | None,
+    db: AsyncSession,
+    request_id: str | None,
+) -> asyncio.Task[None] | None:
+    """Dispatch statement parsing.
+
+    Returns the in-process ``asyncio.Task`` for the caller to track in fallback
+    mode, or ``None`` when the work was submitted to Prefect.
+    """
+    if settings.prefect_api_url:
+        # Remote durable execution. Only serializable params cross the boundary
+        # (no raw bytes, no session maker): the worker re-fetches ``content``
+        # from storage and builds its own DB session.
+        from prefect.deployments import run_deployment  # lazy: fallback never imports prefect
+
+        await run_deployment(
+            name=PARSE_DEPLOYMENT,
+            parameters={
+                "statement_id": str(statement_id),
+                "filename": filename,
+                "institution": institution,
+                "user_id": str(user_id),
+                "account_id": str(account_id) if account_id is not None else None,
+                "file_hash": file_hash,
+                "storage_key": storage_key,
+                "model": model,
+                "request_id": request_id,
+            },
+            timeout=0,  # fire-and-submit: do not block the upload request on completion
+        )
+        logger.info(
+            "statement.parse.submitted_to_prefect",
+            statement_id=str(statement_id),
+            deployment=PARSE_DEPLOYMENT,
+            request_id=request_id,
+        )
+        return None
+
+    return asyncio.create_task(
+        parse_statement_background(
+            statement_id=statement_id,
+            filename=filename,
+            institution=institution,
+            user_id=user_id,
+            account_id=account_id,
+            file_hash=file_hash,
+            storage_key=storage_key,
+            content=content,
+            model=model,
+            session_maker=create_session_maker_from_db(db),
+            request_id=request_id,
+        )
+    )

--- a/apps/backend/src/services/statement_pipeline.py
+++ b/apps/backend/src/services/statement_pipeline.py
@@ -11,7 +11,10 @@ process) to durable Prefect flow runs. This module is the seam:
   submit a flow run to the Prefect server; an isolated worker (running this same
   backend image) executes ``parse_statement_flow``.
 
-Prefect is imported lazily, so the fallback path never needs it installed.
+``prefect`` is imported lazily here, so the fallback path never needs it. Any
+process that runs with ``PREFECT_API_URL`` set must install the ``prefect`` extra
+— both the API (to *submit* the run) and the worker (to *execute* it). The base
+image / CI / fallback do not.
 """
 
 from __future__ import annotations
@@ -19,11 +22,13 @@ from __future__ import annotations
 import asyncio
 from uuid import UUID
 
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
 from src.database import create_session_maker_from_db
 from src.logger import get_logger
+from src.services import StorageService
 from src.services.statement_parsing import parse_statement_background
 
 logger = get_logger(__name__)
@@ -41,12 +46,17 @@ async def submit_parse_pipeline(
     account_id: UUID | None,
     file_hash: str,
     storage_key: str,
-    content: bytes,
+    content: bytes | None = None,
     model: str | None,
     db: AsyncSession,
     request_id: str | None,
 ) -> asyncio.Task[None] | None:
     """Dispatch statement parsing.
+
+    ``content`` is optional: pass it when the bytes are already in hand (e.g. a
+    fresh upload). In Prefect mode it is never used (the worker re-fetches from
+    ``storage_key``), so callers should NOT pre-download it just to dispatch. In
+    fallback mode, if ``content`` is None it is fetched from ``storage_key``.
 
     Returns the in-process ``asyncio.Task`` for the caller to track in fallback
     mode, or ``None`` when the work was submitted to Prefect.
@@ -79,6 +89,9 @@ async def submit_parse_pipeline(
             request_id=request_id,
         )
         return None
+
+    if content is None:
+        content = await run_in_threadpool(StorageService().get_object, storage_key)
 
     return asyncio.create_task(
         parse_statement_background(

--- a/apps/backend/tests/api/test_statement_pipeline.py
+++ b/apps/backend/tests/api/test_statement_pipeline.py
@@ -46,9 +46,7 @@ async def test_AC19_13_1_dispatch_falls_back_to_asyncio_when_prefect_unset(monke
         seen.update(kwargs)
 
     monkeypatch.setattr(statement_pipeline, "parse_statement_background", fake_background)
-    monkeypatch.setattr(
-        statement_pipeline, "create_session_maker_from_db", lambda db: "session-maker"
-    )
+    monkeypatch.setattr(statement_pipeline, "create_session_maker_from_db", lambda db: "session-maker")
 
     task = await statement_pipeline.submit_parse_pipeline(**_dispatch_kwargs())
 

--- a/apps/backend/tests/api/test_statement_pipeline.py
+++ b/apps/backend/tests/api/test_statement_pipeline.py
@@ -1,0 +1,85 @@
+"""AC19.13: config-gated dispatch for the upload→report pipeline (EPIC-019).
+
+These are the safety-critical seam tests: with Prefect unconfigured the dispatch
+MUST fall back to the in-process task (so CI/local/preview run with no Prefect),
+and with Prefect configured it MUST submit only serializable params.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.services import statement_pipeline
+
+pytestmark = pytest.mark.no_db
+
+
+def _dispatch_kwargs() -> dict:
+    return {
+        "statement_id": uuid4(),
+        "filename": "stmt.pdf",
+        "institution": None,
+        "user_id": uuid4(),
+        "account_id": None,
+        "file_hash": "hash",
+        "storage_key": "uploads/stmt.pdf",
+        "content": b"file-bytes",
+        "model": None,
+        "db": object(),
+        "request_id": "req-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_AC19_13_1_dispatch_falls_back_to_asyncio_when_prefect_unset(monkeypatch):
+    """AC19.13.1: PREFECT_API_URL unset → in-process asyncio fallback, no Prefect."""
+    monkeypatch.setattr(statement_pipeline.settings, "prefect_api_url", None)
+    seen: dict = {}
+
+    async def fake_background(**kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr(statement_pipeline, "parse_statement_background", fake_background)
+    monkeypatch.setattr(
+        statement_pipeline, "create_session_maker_from_db", lambda db: "session-maker"
+    )
+
+    task = await statement_pipeline.submit_parse_pipeline(**_dispatch_kwargs())
+
+    assert isinstance(task, asyncio.Task)
+    await task
+    # In-process path keeps the raw content + a session maker.
+    assert seen["filename"] == "stmt.pdf"
+    assert seen["content"] == b"file-bytes"
+    assert seen["session_maker"] == "session-maker"
+
+
+@pytest.mark.asyncio
+async def test_AC19_13_2_dispatch_submits_serializable_params_to_prefect(monkeypatch):
+    """AC19.13.2: PREFECT_API_URL set → submit flow run with serializable params only."""
+    monkeypatch.setattr(statement_pipeline.settings, "prefect_api_url", "http://prefect:4200/api")
+
+    run_deployment = AsyncMock(return_value=None)
+    fake_deployments = types.ModuleType("prefect.deployments")
+    fake_deployments.run_deployment = run_deployment
+    monkeypatch.setitem(sys.modules, "prefect", types.ModuleType("prefect"))
+    monkeypatch.setitem(sys.modules, "prefect.deployments", fake_deployments)
+
+    kwargs = _dispatch_kwargs()
+    task = await statement_pipeline.submit_parse_pipeline(**kwargs)
+
+    assert task is None  # submitted to Prefect, nothing to track in-process
+    run_deployment.assert_awaited_once()
+    params = run_deployment.await_args.kwargs["parameters"]
+    # Serializable only — never the raw bytes or the DB session.
+    assert "content" not in params
+    assert "db" not in params
+    assert "session_maker" not in params
+    assert params["statement_id"] == str(kwargs["statement_id"])
+    assert params["storage_key"] == "uploads/stmt.pdf"

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -44,6 +44,7 @@ from src.services import (
     ExtractionError,
     StorageError,
     statement_parsing as statement_parsing_mod,
+    statement_pipeline,
     statement_validation as statement_validation_mod,
 )
 from src.services.review_queue import accept_match as accept_match_service, create_entry_from_txn
@@ -319,7 +320,7 @@ async def test_AC3_5_upload_rejects_cross_user_account_id(db, monkeypatch, test_
 async def test_upload_uses_default_ocr_pipeline_for_pdf(db, monkeypatch, storage_stub, test_user):
     """AC3.5.7: PDF/image uploads may omit model and use the default OCR pipeline."""
     mock_parse = AsyncMock(return_value=None)
-    monkeypatch.setattr(statements_router, "parse_statement_background", mock_parse)
+    monkeypatch.setattr(statement_pipeline, "parse_statement_background", mock_parse)
 
     upload_file = make_upload_file("statement.pdf", b"content")
 
@@ -350,7 +351,7 @@ async def test_AC10_8_1_upload_audit_logs_include_statement_input_provenance(
     content = b"audit-log-input"
     mock_parse = AsyncMock(return_value=None)
     mock_info = MagicMock()
-    monkeypatch.setattr(statements_router, "parse_statement_background", mock_parse)
+    monkeypatch.setattr(statement_pipeline, "parse_statement_background", mock_parse)
     monkeypatch.setattr(statements_router.logger, "info", mock_info)
 
     upload_file = make_upload_file("staging-audit.pdf", content)
@@ -673,7 +674,7 @@ async def test_stage1_reject_triggers_reparse(db, monkeypatch, storage_stub, tes
     async def fake_parse_statement_background(**kwargs):
         queued.update(kwargs)
 
-    monkeypatch.setattr(statements_router, "parse_statement_background", fake_parse_statement_background)
+    monkeypatch.setattr(statement_pipeline, "parse_statement_background", fake_parse_statement_background)
 
     response = await statements_router.reject_statement_stage1(
         statement_id=statement.id,

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -426,6 +426,18 @@ workflow state exists.
 | AC19.12.5 | Dashboard status feed and event inbox render lightweight derived events as user actions while routine/internal details remain collapsed or absent | `workflowSurfaces.test.tsx` | P0 |
 | AC19.12.6 | Lightweight derivation tests cover multi-user isolation, repeated sync idempotency, lifecycle preservation, and resolved-blocker archival | `test_AC19_12_2_review_events_are_current_user_actions_with_lifecycle_preserved`, `test_AC19_12_3_report_readiness_events_follow_package_readiness_without_stale_blockers`, `test_AC19_12_4_readiness_blocker_events_are_user_action_scoped` | P0 |
 
+### AC19.13 — Durable Orchestration via Prefect
+
+Realizes the deferred "full event bus or message queue" non-goal: upload→report
+parsing migrates from in-process `asyncio.create_task` to durable Prefect flow
+runs, behind a config gate so CI/local/preview keep running without any Prefect
+dependency (delivery speed unaffected).
+
+| AC | Description | Test Anchor | Priority |
+|----|-------------|-------------|----------|
+| AC19.13.1 | Statement parse dispatch is config-gated: with `PREFECT_API_URL` unset, `submit_parse_pipeline` runs the existing in-process `asyncio.create_task` fallback (no Prefect import) and returns the task to track | `test_AC19_13_1_dispatch_falls_back_to_asyncio_when_prefect_unset` | P0 |
+| AC19.13.2 | With `PREFECT_API_URL` set, `submit_parse_pipeline` submits a Prefect flow run with serializable params only (no raw bytes, no session maker — the worker re-fetches content and builds its own session) and returns None | `test_AC19_13_2_dispatch_submits_serializable_params_to_prefect` | P0 |
+
 ## How To Build It
 
 ### Backend


### PR DESCRIPTION
Realizes EPIC-019's deferred *"full event bus or message queue"* non-goal. Refs #813.

## What (P0 — application-layer seam, default OFF)
Migrates upload→report parsing off the fragile in-process `asyncio.create_task` (fire-and-forget, lost on restart, competes with the API process) toward **durable Prefect flow runs**, behind a **config gate** so nothing changes until enabled.

- `services/statement_pipeline.py` — `submit_parse_pipeline()` dispatches on `PREFECT_API_URL`:
  - **unset** (CI / local / preview) → existing **in-process asyncio fallback**, `prefect` never imported. **AC19.13.1**
  - **set** (staging/prod, per-PR ephemeral Prefect) → submit a flow run with **serializable params only** (no raw bytes, no DB session; `prefect` imported lazily). **AC19.13.2**
- `services/statement_flow.py` — `parse_statement_flow` (worker-only): re-fetches content from storage + builds its own session, then runs the existing parse. Imports `prefect` at load, so the API never imports it in fallback mode.
- Both upload call sites route through `submit_parse_pipeline`.
- `prefect` is an **optional extra** (`.[prefect]`) — only the worker image installs it; base image + CI stay lean.
- Existing `test_statements_router.py` mocks repointed to the new dispatch module.

## Safety
`PREFECT_API_URL` unset everywhere by default → **behavior identical to today, zero prod risk**. The gate only flips on once the worker + deployment exist.

## Tests
- `test_AC19_13_1_dispatch_falls_back_to_asyncio_when_prefect_unset`
- `test_AC19_13_2_dispatch_submits_serializable_params_to_prefect`
- doc-consistency + AC-traceability pass; ruff clean. (Note: I validated syntax/lint locally; the full backend pytest runs in CI.)

## Next (separate PRs)
1. Prefect **worker** (FR image + `.[prefect]`, `prefect worker start`).
2. Per-PR **ephemeral Prefect** in preview compose; CI uses `prefect_test_harness`/`.fn()`.
3. **Deployment registration** (`parse-statement/parse-statement`).
4. Enable `PREFECT_API_URL` in staging → prod.
5. Then P1+: extraction/reconcile/report as flow tasks, two-stage review via pause/resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)