### PR TITLE
[finance_report_test_and_doc] feat: enforce migration risk classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
       - name: SSOT Manifest Check
         run: |
           uv run --with pyyaml python tools/check_manifest.py
+      - name: Migration Risk Contract Check
+        run: |
+          uv run --with pyyaml python tools/check_migration_risk.py
       - name: CI Metrics Contract Check
         run: |
           uv run python tools/check_ci_metrics_contract.py

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -314,6 +314,12 @@ jobs:
         run: |
           moon run :lint
 
+      - name: Validate Migration Risk Contract
+        run: |
+          mkdir -p ci-context
+          uv run --with pyyaml python tools/check_migration_risk.py \
+            --summary ci-context/production-migration-risk-context.md
+
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -350,6 +356,8 @@ jobs:
             echo "- Promoted frontend image digest: ${{ steps.promote_dry.outputs.frontend_digest }}"
             echo "- No rebuild occurred: true"
             echo "- Production mutation skipped: true"
+            echo ""
+            cat ci-context/production-migration-risk-context.md
           } >> "$GITHUB_STEP_SUMMARY"
           echo "Production mutation skipped"
 
@@ -380,7 +388,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: production-dry-run-context
-          path: ci-context/production-dry-run-context.txt
+          path: |
+            ci-context/production-dry-run-context.txt
+            ci-context/production-migration-risk-context.md
           retention-days: 14
 
   deploy:

--- a/common/ci/migration_risk.py
+++ b/common/ci/migration_risk.py
@@ -1,0 +1,344 @@
+"""Validate Alembic migration risk classification.
+
+The contract is intentionally static. It does not try to prove production data
+safety; it checks that migration risk is declared and that higher-risk changes
+carry the release proof notes needed before a human approves deployment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+RISK_LEVELS = ("low", "medium", "high", "critical")
+RISK_RANK = {risk: index for index, risk in enumerate(RISK_LEVELS)}
+HIGH_RISK_FIELDS = (
+    "issue",
+    "staging_validation",
+    "production_preflight",
+    "rollback_strategy",
+)
+CRITICAL_RISK_FIELDS = HIGH_RISK_FIELDS + ("destructive_confirmation",)
+
+DESTRUCTIVE_UPGRADE_PATTERNS = (
+    r"\bop\.drop_table\s*\(",
+    r"\bop\.drop_column\s*\(",
+    r"\bDROP\s+TABLE\b",
+    r"\bDROP\s+COLUMN\b",
+    r"\bTRUNCATE\b",
+)
+DATA_MUTATION_UPGRADE_PATTERNS = (
+    r"\bUPDATE\s+",
+    r"\bINSERT\s+INTO\b",
+    r"\bDELETE\s+FROM\b",
+)
+
+
+@dataclass(frozen=True)
+class ParsedMigration:
+    revision: str
+    file_name: str
+    upgrade_source: str
+
+
+@dataclass(frozen=True)
+class MigrationRecord:
+    revision: str
+    file_name: str
+    risk: str
+    proof: str
+    issue: str | None = None
+    staging_validation: str | None = None
+    production_preflight: str | None = None
+    rollback_strategy: str | None = None
+    destructive_confirmation: str | None = None
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    manifest_path: Path
+    migrations_dir: Path
+    migrations: dict[str, MigrationRecord]
+    errors: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _literal_string(node: ast.AST) -> str | None:
+    try:
+        value = ast.literal_eval(node)
+    except (ValueError, TypeError):
+        return None
+    return value if isinstance(value, str) else None
+
+
+def _parse_revision(tree: ast.Module) -> str | None:
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "revision":
+                    return _literal_string(node.value)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "revision"
+        ):
+            return _literal_string(node.value) if node.value is not None else None
+    return None
+
+
+def _parse_upgrade_source(source: str, tree: ast.Module) -> str:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "upgrade":
+            return ast.get_source_segment(source, node) or ""
+    return ""
+
+
+def parse_migration_file(path: Path) -> ParsedMigration | str:
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return f"{path.name}: cannot parse migration Python: {exc}"
+
+    revision = _parse_revision(tree)
+    if not revision:
+        return f"{path.name}: missing string Alembic revision"
+
+    return ParsedMigration(
+        revision=revision,
+        file_name=path.name,
+        upgrade_source=_parse_upgrade_source(source, tree),
+    )
+
+
+def _load_manifest(path: Path) -> tuple[dict[str, Any], list[str]]:
+    if not path.exists():
+        return {}, [f"{path}: migration risk manifest does not exist"]
+
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return {}, [f"{path}: invalid YAML: {exc}"]
+
+    if not isinstance(payload, dict):
+        return {}, [f"{path}: manifest must be a YAML mapping"]
+    if not isinstance(payload.get("migrations"), dict):
+        return payload, [f"{path}: missing 'migrations' mapping"]
+    return payload, []
+
+
+def _matches_any(source: str, patterns: tuple[str, ...]) -> bool:
+    return any(re.search(pattern, source, flags=re.IGNORECASE) for pattern in patterns)
+
+
+def _entry_text(entry: dict[str, Any], field: str) -> str:
+    value = entry.get(field)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _validate_entry(
+    revision: str, parsed: ParsedMigration, entry: object
+) -> tuple[MigrationRecord | None, list[str]]:
+    errors: list[str] = []
+    if not isinstance(entry, dict):
+        return None, [f"{revision}: manifest entry must be a mapping"]
+
+    file_name = _entry_text(entry, "file")
+    risk = _entry_text(entry, "risk")
+    proof = _entry_text(entry, "proof")
+
+    if file_name != parsed.file_name:
+        errors.append(
+            f"{revision}: manifest file must be {parsed.file_name!r}, got {file_name!r}"
+        )
+    if risk not in RISK_LEVELS:
+        errors.append(f"{revision}: risk must be one of {', '.join(RISK_LEVELS)}")
+    if not proof:
+        errors.append(f"{revision}: proof is required")
+
+    if risk in {"high", "critical"}:
+        for field in CRITICAL_RISK_FIELDS if risk == "critical" else HIGH_RISK_FIELDS:
+            if not _entry_text(entry, field):
+                errors.append(
+                    f"{revision}: {field} is required for {risk} migration risk"
+                )
+
+    issue = _entry_text(entry, "issue") or None
+    if (
+        risk in {"high", "critical"}
+        and issue
+        and not (issue.startswith("#") or issue.startswith("https://github.com/"))
+    ):
+        errors.append(
+            f"{revision}: issue must be a GitHub issue reference like #815 or a GitHub URL"
+        )
+
+    if (
+        _matches_any(parsed.upgrade_source, DESTRUCTIVE_UPGRADE_PATTERNS)
+        and risk != "critical"
+    ):
+        errors.append(
+            f"{revision}: destructive upgrade operation must be classified as critical"
+        )
+
+    if (
+        _matches_any(parsed.upgrade_source, DATA_MUTATION_UPGRADE_PATTERNS)
+        and RISK_RANK.get(risk, -1) < RISK_RANK["high"]
+    ):
+        errors.append(
+            f"{revision}: data-mutating upgrade operation must be classified as high or critical"
+        )
+
+    if errors:
+        return None, errors
+
+    return (
+        MigrationRecord(
+            revision=revision,
+            file_name=file_name,
+            risk=risk,
+            proof=proof,
+            issue=issue,
+            staging_validation=_entry_text(entry, "staging_validation") or None,
+            production_preflight=_entry_text(entry, "production_preflight") or None,
+            rollback_strategy=_entry_text(entry, "rollback_strategy") or None,
+            destructive_confirmation=_entry_text(entry, "destructive_confirmation")
+            or None,
+        ),
+        [],
+    )
+
+
+def validate(*, manifest_path: Path, migrations_dir: Path) -> ValidationResult:
+    payload, errors = _load_manifest(manifest_path)
+    manifest_entries = (
+        payload.get("migrations", {})
+        if isinstance(payload.get("migrations"), dict)
+        else {}
+    )
+
+    parsed_by_revision: dict[str, ParsedMigration] = {}
+    for path in sorted(migrations_dir.glob("*.py")):
+        parsed = parse_migration_file(path)
+        if isinstance(parsed, str):
+            errors.append(parsed)
+            continue
+        if parsed.revision in parsed_by_revision:
+            errors.append(f"{parsed.revision}: duplicate Alembic revision")
+            continue
+        parsed_by_revision[parsed.revision] = parsed
+
+    records: dict[str, MigrationRecord] = {}
+    for revision, parsed in parsed_by_revision.items():
+        if revision not in manifest_entries:
+            errors.append(f"{revision}: missing migration risk manifest entry")
+            continue
+        record, entry_errors = _validate_entry(
+            revision, parsed, manifest_entries[revision]
+        )
+        errors.extend(entry_errors)
+        if record is not None:
+            records[revision] = record
+
+    for revision in sorted(set(manifest_entries) - set(parsed_by_revision)):
+        errors.append(f"{revision}: manifest entry has no matching migration file")
+
+    return ValidationResult(
+        manifest_path=manifest_path,
+        migrations_dir=migrations_dir,
+        migrations=records,
+        errors=errors,
+    )
+
+
+def validate_repository(repo_root: Path) -> ValidationResult:
+    return validate(
+        manifest_path=repo_root / "docs" / "ssot" / "migration-risk.yaml",
+        migrations_dir=repo_root / "apps" / "backend" / "migrations" / "versions",
+    )
+
+
+def render_summary(result: ValidationResult) -> str:
+    counts = Counter(record.risk for record in result.migrations.values())
+    high_risk = [
+        record
+        for record in result.migrations.values()
+        if record.risk in {"high", "critical"}
+    ]
+
+    lines = [
+        "## Migration Risk Contract",
+        "",
+        f"- Manifest: `{result.manifest_path.as_posix()}`",
+        f"- Migrations checked: {len(result.migrations)}",
+        f"- Status: {'pass' if result.ok else 'fail'}",
+        "",
+        "| Risk | Count |",
+        "|---|---:|",
+    ]
+    for risk in RISK_LEVELS:
+        lines.append(f"| {risk} | {counts[risk]} |")
+    if high_risk:
+        lines.extend(["", "### High/Critical Migrations", ""])
+        for record in sorted(high_risk, key=lambda item: item.revision):
+            issue = f" ({record.issue})" if record.issue else ""
+            lines.append(
+                f"- `{record.revision}`: {record.risk}{issue} - {record.proof}"
+            )
+    if result.errors:
+        lines.extend(["", "### Errors", ""])
+        lines.extend(f"- {error}" for error in result.errors)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Alembic migration risk classification."
+    )
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--manifest", type=Path, default=None)
+    parser.add_argument("--migrations-dir", type=Path, default=None)
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=None,
+        help="Optional Markdown summary output path.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    result = validate(
+        manifest_path=args.manifest
+        or repo_root / "docs" / "ssot" / "migration-risk.yaml",
+        migrations_dir=args.migrations_dir
+        or repo_root / "apps" / "backend" / "migrations" / "versions",
+    )
+
+    summary = render_summary(result)
+    if args.summary:
+        args.summary.parent.mkdir(parents=True, exist_ok=True)
+        args.summary.write_text(summary, encoding="utf-8")
+
+    if result.errors:
+        print(summary, file=sys.stderr)
+        return 1
+
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -218,6 +218,15 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 | AC7.10.4 | Deployment and CI SSOTs document the promote-not-rebuild consistency ladder | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC7.10.5 | Retain `workflow_dispatch` dry-run to prove the release/promote path without mutating production | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 
+### AC7.11: Database Migration Risk Governance
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC7.11.1 | Backend Alembic migrations are covered by a machine-readable migration risk manifest | `test_AC7_11_1_migration_risk_manifest_covers_backend_migrations` | `tests/tooling/test_migration_risk_contract.py` | P0 |
+| AC7.11.2 | High and critical migration risk entries require release proof notes for staging, production preflight, and rollback/expand-contract strategy | `test_AC7_11_2_high_and_critical_migrations_require_release_proof` | `tests/tooling/test_migration_risk_contract.py` | P0 |
+| AC7.11.3 | Destructive upgrade operations cannot be classified below critical risk | `test_AC7_11_3_destructive_migrations_must_be_classified_critical` | `tests/tooling/test_migration_risk_contract.py` | P0 |
+| AC7.11.4 | CI lint and production release dry-run execute the migration risk contract and publish release context | `test_AC7_11_4_ci_and_release_dry_run_execute_migration_risk_contract` | `tests/tooling/test_migration_risk_contract.py` | P0 |
+
 
 ## 📏 Acceptance Criteria
 

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -76,6 +76,17 @@ concepts:
       - docs/agents/red-lines.md
       - apps/backend/tests/infra/test_schema_guardrails.py
 
+  migration_risk_classification:
+    owner: docs/ssot/migration-risk.yaml
+    description: Machine-readable risk level and release proof contract for Alembic migrations.
+    cross_refs:
+      - docs/ssot/schema.md
+      - docs/ssot/ci-cd.md
+      - docs/ssot/deployment.md
+      - tools/check_migration_risk.py
+      - common/ci/migration_risk.py
+      - tests/tooling/test_migration_risk_contract.py
+
   # ── Reconciliation domain ──────────────────────────────────────────────
   reconciliation_thresholds:
     owner: docs/ssot/reconciliation.md#thresholds

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -54,6 +54,7 @@ contracts is tracked in
 | [auth.md](./auth.md) | `auth` | Auth architecture rationale and code references |
 | [frontend-patterns.md](./frontend-patterns.md) | `frontend-patterns` | Frontend integration rules and proof references |
 | [schema.md](./schema.md) | `schema` | Database model rationale; code owner is models/migrations |
+| [migration-risk.yaml](./migration-risk.yaml) | `migration_risk_classification` | Alembic migration risk levels and required release proof notes |
 | [accounting.md](./accounting.md) | `accounting` | Double-entry rationale and invariant references |
 | [MANIFEST.yaml](./MANIFEST.yaml) | `manifest` | Machine-readable concept owner registry |
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -176,6 +176,7 @@ The test system separates proof by where the failure can be acted on:
 |---|---|---|
 | Behavioral tests | PR CI before merge | Prove deterministic product behavior, accounting invariants, API contracts, frontend flows, and tooling contracts before code enters `main`. |
 | Schema migration contract | PR CI before merge | Prove Alembic can build the production schema from empty Postgres and that model definitions do not drift from generated migrations. |
+| Migration risk contract | PR CI lint and production dry-run | Prove each Alembic revision has a right-sized risk classification. High and critical migrations must carry staging, production preflight, and rollback/expand-contract notes; this does not guarantee production data safety. |
 | Environment gates | Post-merge deploy workflows | Prove the exact merged SHA can run in staging/production-like environments with real routing, Vault/Dokploy/GHCR/SigNoz wiring, deployed images, and provider-backed OCR/LLM credentials. |
 | Reference traceability | PR and `main` CI | Prove every mandatory AC has a real non-placeholder test reference in a CI-required execution stage from `docs/ssot/test-execution-matrix.yaml`; this is not line coverage. |
 | E2E EPIC traceability | PR and `main` CI | Prove every product E2E root `test_*` function has a function-level EPIC ID, every project EPIC has at least one product E2E owner test, the README EPIC map matches project EPIC files, and E2E-like assets are declared as product or non-product. |
@@ -189,6 +190,11 @@ must not be the first proof for deterministic business behavior.
 Schema DDL correctness is deterministic and belongs in PR CI through
 `schema-migrations`; preview and staging may catch environment-specific
 deployment wiring, but they are not substitutes for migration proof.
+Production data migration safety is not fully provable before production. The
+migration risk contract classifies the risk and required evidence so staging is
+used for the issues it can realistically catch, while production residual risk
+is handled through preflight, backup, feature-flag, idempotency, and
+post-deploy controls.
 
 ---
 

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -236,7 +236,18 @@ entrypoint:
 **Before deploying schema changes**:
 1. Test migration locally with `docker-compose.yml`
 2. Ensure migration is backward-compatible (for rollback)
-3. Consider: existing data, indexes, constraints
+3. Run `python tools/check_migration_risk.py` and review
+   `docs/ssot/migration-risk.yaml`
+4. Use the declared risk level to choose the release proof:
+   - **low**: PR Alembic contract is usually enough
+   - **medium**: require staging deploy proof for the compatibility-sensitive path
+   - **high**: require staging evidence plus production preflight and rollback/expand-contract notes
+   - **critical**: require all high-risk proof plus explicit destructive-change confirmation
+
+This process does not guarantee production data migration safety. Staging should
+catch most migration problems, while production-only residual risk is controlled
+with backups, idempotent backfills, feature flags, preflight queries, and
+post-deploy detectors.
 
 ---
 

--- a/docs/ssot/migration-risk.yaml
+++ b/docs/ssot/migration-risk.yaml
@@ -1,0 +1,185 @@
+# Machine-readable Alembic migration risk contract.
+#
+# Owner issue: #815
+# Validated by: tools/check_migration_risk.py
+#
+# This manifest does not guarantee production data migration safety. It records
+# the right-sized proof expected before release and prevents new migrations from
+# bypassing risk classification.
+
+version: 1
+
+risk_levels:
+  low: Additive or clean-schema-only change; PR Alembic contract is usually enough.
+  medium: Compatibility-sensitive schema, enum/type, index, or constraint change; staging should exercise the deployed path.
+  high: Data rewrite, backfill, read-path cutover, large-table concern, or production-volume concern.
+  critical: Destructive or irreversible production change, such as dropping legacy tables or columns.
+
+high_risk_defaults: &historical_high_risk
+  issue: "#815"
+  staging_validation: Historical baseline is covered by staging deploy proof; future high-risk revisions must provide revision-specific staging evidence.
+  production_preflight: Historical baseline only; future high-risk revisions must define production preflight or rollout controls.
+  rollback_strategy: Historical baseline only; future high-risk revisions must define backup, rollback, or expand/contract strategy.
+
+migrations:
+  0001_initial_schema:
+    file: 0001_initial_schema.py
+    risk: low
+    proof: Initial clean-schema baseline; covered by PR Alembic contract.
+  0002_add_chat_tables:
+    file: 0002_add_chat_tables.py
+    risk: low
+    proof: Additive chat tables and indexes; covered by PR Alembic contract.
+  0003_add_users_table:
+    file: 0003_add_users_table.py
+    risk: low
+    proof: Additive users table baseline; covered by PR Alembic contract.
+  0004_add_name_to_users:
+    file: 0004_add_name_to_users.py
+    risk: low
+    proof: Additive nullable user profile column; covered by PR Alembic contract.
+  0005_fix_txn_status_enum:
+    file: 0005_fix_txn_status_enum.py
+    risk: medium
+    proof: Enum type normalization; staging should exercise statement transaction status paths.
+  0006_parse_nullable_fields:
+    file: 0006_parse_nullable_fields.py
+    risk: medium
+    proof: Statement field nullability relaxation; staging should exercise statement parsing paths.
+  0007_normalize_all_enums:
+    file: 0007_normalize_all_enums.py
+    risk: medium
+    proof: Enum normalization across existing tables; staging should exercise core write/read paths.
+  0008_layer12:
+    file: 0008_add_layer1_layer2_tables.py
+    risk: low
+    proof: Additive Layer 1/2 tables; covered by PR Alembic contract.
+  0009_fx_reval:
+    file: 0009_add_fx_revaluation_source_type.py
+    risk: medium
+    proof: Journal source enum expansion; staging should exercise journal source serialization.
+  0010_add_parsing_progress:
+    file: 0010_add_parsing_progress.py
+    risk: low
+    proof: Additive parsing progress column; covered by PR Alembic contract.
+  0010_ai_category:
+    file: 0010_add_ai_category_fields.py
+    risk: low
+    proof: Additive AI category fields; covered by PR Alembic contract.
+  0011_add_txn_currency_balance:
+    file: 0011_add_txn_currency_balance.py
+    risk: low
+    proof: Additive transaction currency/balance fields; covered by PR Alembic contract.
+  0012_add_stage1_review:
+    file: 0012_add_stage1_review.py
+    risk: medium
+    proof: Stage-1 enum and statement review columns; staging should exercise statement review paths.
+  0013_add_consistency_checks:
+    file: 0013_add_consistency_checks.py
+    risk: low
+    proof: Additive consistency check table; covered by PR Alembic contract.
+  0014_add_correction_logs:
+    file: 0014_add_correction_logs.py
+    risk: low
+    proof: Additive correction log table; covered by PR Alembic contract.
+  0015_ai_ui_feedback_audit:
+    file: 0015_ai_ui_feedback_audit.py
+    risk: low
+    proof: Additive AI feedback/audit tables and user settings column; covered by PR Alembic contract.
+  0016_manual_valuation_snapshots:
+    file: 0016_manual_valuation_snapshots.py
+    risk: low
+    proof: Additive manual valuation snapshot table; covered by PR Alembic contract.
+  0017_investment_accounting:
+    file: 0017_investment_accounting.py
+    risk: low
+    proof: Additive investment accounting structures; covered by PR Alembic contract.
+  0018_source_type_priority:
+    <<: *historical_high_risk
+    file: 0018_source_type_priority.py
+    risk: high
+    proof: Forward upgrade rewrites journal_entries.source_type after enum expansion.
+  0019_add_stock_prices:
+    file: 0019_add_stock_prices.py
+    risk: low
+    proof: Additive stock price table and lookup index; covered by PR Alembic contract.
+  0020_add_market_data_sync_state:
+    file: 0020_add_market_data_sync_state.py
+    risk: low
+    proof: Additive market data sync state table; covered by PR Alembic contract.
+  0021_add_workflow_events:
+    file: 0021_add_workflow_events.py
+    risk: low
+    proof: Additive workflow event table; covered by PR Alembic contract.
+  0022_harden_workflow_contract:
+    file: 0022_harden_workflow_contract.py
+    risk: medium
+    proof: Workflow event contract hardening; staging should exercise upload-to-report event paths.
+  0023_stmt_extract_metadata:
+    file: 0023_stmt_extract_metadata.py
+    risk: low
+    proof: Additive statement extraction metadata field; covered by PR Alembic contract.
+  0024_add_workflow_sessions:
+    file: 0024_add_workflow_sessions.py
+    risk: low
+    proof: Additive workflow session table and nullable event link; covered by PR Alembic contract.
+  0025_add_evidence_lineage:
+    file: 0025_add_evidence_lineage.py
+    risk: low
+    proof: Additive evidence graph tables and indexes; covered by PR Alembic contract.
+  0026_user_email_norm_idx:
+    file: 0026_user_email_norm_idx.py
+    risk: medium
+    proof: Email normalization index; staging should exercise auth/user lookup paths.
+  0026_add_review_run_scope:
+    file: 0026_add_review_run_scope.py
+    risk: low
+    proof: Additive review run scope fields; covered by PR Alembic contract.
+  0027_merge_review_email_heads:
+    file: 0027_merge_review_email_heads.py
+    risk: low
+    proof: Alembic merge revision only; covered by PR Alembic contract.
+  0028_statement_summaries:
+    file: 0028_statement_summaries.py
+    risk: low
+    proof: Additive StatementSummary conform table; covered by PR Alembic contract.
+  51aa128d8189:
+    file: 51aa128d8189_remove_report_snapshot_constraint.py
+    risk: medium
+    proof: Constraint compatibility change on report snapshots; staging should exercise report snapshot paths.
+  5e7857c97b74:
+    file: 5e7857c97b74_epic17_add_portfolio_models_and_extend_.py
+    risk: medium
+    proof: Broad portfolio schema extension with index/FK compatibility repairs; staging should exercise portfolio and statement paths.
+  76c3ccfe844b:
+    file: 76c3ccfe844b_add_managed_positions.py
+    risk: low
+    proof: Additive managed positions table; covered by PR Alembic contract.
+  ba0777d5eb6c:
+    file: ba0777d5eb6c_fix_ensure_bank_statement_status_enum_.py
+    risk: medium
+    proof: Bank statement enum compatibility repair; staging should exercise statement status paths.
+  bb0888e6fc7d:
+    file: bb0888e6fc7d_add_updated_at_to_journal_lines.py
+    risk: low
+    proof: Additive journal line timestamp column; covered by PR Alembic contract.
+  bc9a8105e644:
+    file: bc9a8105e644_restore_cascading_fks.py
+    risk: medium
+    proof: Restores cascading foreign keys; staging should exercise user-owned data deletion and ownership paths.
+  bcd695dcaf71:
+    file: bcd695dcaf71_add_layer4_reporting.py
+    risk: low
+    proof: Additive Layer-4 reporting tables; covered by PR Alembic contract.
+  c955c65dcc1f:
+    file: c955c65dcc1f_add_is_system_to_accounts.py
+    risk: medium
+    proof: Adds non-null account flag with server default; staging should exercise account reads and writes.
+  cec0bf343b59:
+    file: cec0bf343b59_add_layer3_tables.py
+    risk: low
+    proof: Additive Layer-3 tables; covered by PR Alembic contract.
+  e40975f66f7f:
+    file: e40975f66f7f_add_atomic_txn_id_to_matches.py
+    risk: low
+    proof: Additive reconciliation match link; covered by PR Alembic contract.

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -643,6 +643,29 @@ Preview and staging validate deployed runtime health after merge or during PR
 preview deployment. They must not be the first environment that discovers a
 broken migration chain or model/migration drift.
 
+### Migration Risk Classification
+
+Clean-schema Alembic proof does not guarantee production data migration safety.
+Production data can contain historical rows, old enum values, production-only
+volume, and edge cases that CI and staging will never reproduce perfectly.
+
+The machine-readable owner for migration risk is
+[`migration-risk.yaml`](./migration-risk.yaml), validated by
+`tools/check_migration_risk.py`. Every Alembic revision must appear in that
+manifest with one of four risk levels:
+
+| Risk | Meaning | Default proof |
+|---|---|---|
+| low | Additive or clean-schema-only change | PR `schema-migrations` is usually enough |
+| medium | Compatibility-sensitive schema, enum/type, index, or constraint change | PR proof plus staging deploy proof |
+| high | Data rewrite, backfill, read-path cutover, large-table concern, or production-volume concern | PR proof plus staging evidence plus production preflight/rollback notes |
+| critical | Destructive or irreversible production change, such as dropping legacy tables or columns | High-risk proof plus explicit destructive-change confirmation |
+
+This contract is a risk-classification gate, not a production guarantee.
+Staging should catch most migration mistakes, but production residual risk is
+managed through backups, expand/contract sequencing, feature flags, idempotent
+backfills, preflight queries, and post-deploy detectors.
+
 ### Async Session Management
 
 To prevent connection leaks and data race conditions:

--- a/tests/tooling/test_common_tooling_modules.py
+++ b/tests/tooling/test_common_tooling_modules.py
@@ -210,6 +210,7 @@ def test_AC8_13_57_ssot_tools_delegate_to_common_implementations():
 def test_AC8_13_58_ci_tools_delegate_to_common_implementations():
     """AC8.13.58: CI commands keep common contracts separate from tool reports."""
     command_modules = {
+        "tools.check_migration_risk": "common.ci.migration_risk",
         "tools.check_toolchain_contract": "common.ci.check_toolchain_contract",
         "tools.ci_change_classifier": "common.ci.change_classifier",
         "tools.github_workflow_timing_summary": (

--- a/tests/tooling/test_migration_risk_contract.py
+++ b/tests/tooling/test_migration_risk_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from textwrap import dedent
 
 import yaml
 
@@ -14,11 +15,23 @@ def read(path: str) -> str:
     return (ROOT / path).read_text(encoding="utf-8")
 
 
+def write(path: Path, content: str) -> None:
+    path.write_text(dedent(content).lstrip(), encoding="utf-8")
+
+
+def write_manifest(path: Path, migrations: dict[str, object]) -> None:
+    path.write_text(
+        yaml.safe_dump({"version": 1, "migrations": migrations}),
+        encoding="utf-8",
+    )
+
+
 def test_AC7_11_1_migration_risk_manifest_covers_backend_migrations() -> None:
     """AC7.11.1: Backend Alembic migrations are covered by the risk manifest."""
 
     result = migration_risk.validate_repository(ROOT)
 
+    assert result.ok
     assert result.errors == []
     assert len(result.migrations) >= 40
     assert result.manifest_path == ROOT / "docs/ssot/migration-risk.yaml"
@@ -36,7 +49,8 @@ def test_AC7_11_2_high_and_critical_migrations_require_release_proof(
     migrations_dir = tmp_path / "migrations"
     migrations_dir.mkdir()
     (migrations_dir / "0001_high.py").write_text(
-        """
+        dedent(
+            """
 from alembic import op
 
 revision = "0001_high"
@@ -44,7 +58,8 @@ down_revision = None
 
 def upgrade():
     op.execute("UPDATE accounts SET name = name")
-""",
+"""
+        ).lstrip(),
         encoding="utf-8",
     )
     manifest = tmp_path / "migration-risk.yaml"
@@ -89,7 +104,8 @@ def test_AC7_11_3_destructive_migrations_must_be_classified_critical(
     migrations_dir = tmp_path / "migrations"
     migrations_dir.mkdir()
     (migrations_dir / "0002_drop_legacy.py").write_text(
-        """
+        dedent(
+            """
 from alembic import op
 
 revision = "0002_drop_legacy"
@@ -97,7 +113,8 @@ down_revision = None
 
 def upgrade():
     op.drop_table("legacy_rows")
-""",
+"""
+        ).lstrip(),
         encoding="utf-8",
     )
     manifest = tmp_path / "migration-risk.yaml"
@@ -128,6 +145,379 @@ def upgrade():
     assert any(
         "0002_drop_legacy" in error and "critical" in error for error in result.errors
     )
+
+
+def test_AC7_11_3_migration_parser_and_manifest_shape_errors_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC7.11.3: Parser and manifest-shape failures are surfaced as contract errors."""
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+
+    missing_manifest = migration_risk.validate(
+        manifest_path=tmp_path / "missing.yaml",
+        migrations_dir=migrations_dir,
+    )
+    assert not missing_manifest.ok
+    assert any("does not exist" in error for error in missing_manifest.errors)
+
+    invalid_yaml = tmp_path / "invalid.yaml"
+    invalid_yaml.write_text("migrations: [", encoding="utf-8")
+    invalid_yaml_result = migration_risk.validate(
+        manifest_path=invalid_yaml,
+        migrations_dir=migrations_dir,
+    )
+    assert any("invalid YAML" in error for error in invalid_yaml_result.errors)
+
+    scalar_manifest = tmp_path / "scalar.yaml"
+    scalar_manifest.write_text("[]", encoding="utf-8")
+    scalar_result = migration_risk.validate(
+        manifest_path=scalar_manifest,
+        migrations_dir=migrations_dir,
+    )
+    assert any("must be a YAML mapping" in error for error in scalar_result.errors)
+
+    missing_migrations_manifest = tmp_path / "missing-migrations.yaml"
+    missing_migrations_manifest.write_text("version: 1\n", encoding="utf-8")
+    missing_migrations_result = migration_risk.validate(
+        manifest_path=missing_migrations_manifest,
+        migrations_dir=migrations_dir,
+    )
+    assert any(
+        "missing 'migrations' mapping" in error
+        for error in missing_migrations_result.errors
+    )
+
+
+def test_AC7_11_3_migration_file_parse_errors_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC7.11.3: Alembic revision parsing handles syntax, missing, typed, and duplicate cases."""
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    write(migrations_dir / "bad_syntax.py", "def upgrade(:\n    pass\n")
+    write(
+        migrations_dir / "missing_revision.py",
+        """
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+    write(
+        migrations_dir / "dynamic_revision.py",
+        """
+        revision = make_revision()
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+    write(
+        migrations_dir / "typed_revision.py",
+        """
+        revision: str = "typed_revision"
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+    write(
+        migrations_dir / "no_upgrade.py",
+        """
+        revision = "no_upgrade"
+        down_revision = None
+        """,
+    )
+    write(
+        migrations_dir / "duplicate_a.py",
+        """
+        revision = "duplicate_revision"
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+    write(
+        migrations_dir / "duplicate_b.py",
+        """
+        revision = "duplicate_revision"
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+    write(
+        migrations_dir / "missing_manifest.py",
+        """
+        revision = "missing_manifest"
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+
+    manifest = tmp_path / "migration-risk.yaml"
+    write_manifest(
+        manifest,
+        {
+            "typed_revision": {
+                "file": "typed_revision.py",
+                "risk": "low",
+                "proof": "Typed revision assignment is accepted.",
+            },
+            "no_upgrade": {
+                "file": "no_upgrade.py",
+                "risk": "low",
+                "proof": "No upgrade function is accepted for merge-only style revisions.",
+            },
+            "duplicate_revision": {
+                "file": "duplicate_a.py",
+                "risk": "low",
+                "proof": "Only the first duplicate can be validated.",
+            },
+            "extra_revision": {
+                "file": "extra_revision.py",
+                "risk": "low",
+                "proof": "Extra manifest entries must be rejected.",
+            },
+        },
+    )
+
+    result = migration_risk.validate(
+        manifest_path=manifest, migrations_dir=migrations_dir
+    )
+
+    assert any("bad_syntax.py: cannot parse" in error for error in result.errors)
+    assert any(
+        "missing_revision.py: missing string Alembic revision" in error
+        for error in result.errors
+    )
+    assert any(
+        "dynamic_revision.py: missing string Alembic revision" in error
+        for error in result.errors
+    )
+    assert any("duplicate Alembic revision" in error for error in result.errors)
+    assert any(
+        "missing_manifest: missing migration risk manifest entry" in error
+        for error in result.errors
+    )
+    assert any(
+        "extra_revision: manifest entry has no matching migration file" in error
+        for error in result.errors
+    )
+    assert result.migrations["typed_revision"].file_name == "typed_revision.py"
+    assert result.migrations["no_upgrade"].proof.startswith("No upgrade")
+
+
+def test_AC7_11_3_manifest_entry_errors_are_reported(tmp_path: Path) -> None:
+    """AC7.11.3: Invalid manifest entries and under-classified data mutations fail."""
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    write(
+        migrations_dir / "not_mapping.py",
+        """
+        revision = "not_mapping"
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+    write(
+        migrations_dir / "bad_fields.py",
+        """
+        revision = "bad_fields"
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+    write(
+        migrations_dir / "bad_issue.py",
+        """
+        revision = "bad_issue"
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+    write(
+        migrations_dir / "low_update.py",
+        """
+        from alembic import op
+
+        revision = "low_update"
+        down_revision = None
+
+        def upgrade():
+            op.execute("UPDATE accounts SET name = name")
+        """,
+    )
+    write(
+        migrations_dir / "critical_drop.py",
+        """
+        from alembic import op
+
+        revision = "critical_drop"
+        down_revision = None
+
+        def upgrade():
+            op.drop_column("legacy_rows", "legacy_value")
+        """,
+    )
+
+    manifest = tmp_path / "migration-risk.yaml"
+    write_manifest(
+        manifest,
+        {
+            "not_mapping": "bad",
+            "bad_fields": {
+                "file": "wrong.py",
+                "risk": "extreme",
+                "proof": " ",
+            },
+            "bad_issue": {
+                "file": "bad_issue.py",
+                "risk": "high",
+                "proof": "High risk proof.",
+                "issue": "815",
+                "staging_validation": "Staging proof.",
+                "production_preflight": "Production preflight.",
+                "rollback_strategy": "Rollback proof.",
+            },
+            "low_update": {
+                "file": "low_update.py",
+                "risk": "low",
+                "proof": "This intentionally under-classifies a data rewrite.",
+            },
+            "critical_drop": {
+                "file": "critical_drop.py",
+                "risk": "critical",
+                "proof": "Critical destructive migration proof.",
+                "issue": "https://github.com/wangzitian0/finance_report/issues/815",
+                "staging_validation": "Staging destructive proof.",
+                "production_preflight": "Production dependency check.",
+                "rollback_strategy": "Backup and restore strategy.",
+                "destructive_confirmation": "Destructive operation explicitly confirmed.",
+            },
+        },
+    )
+
+    result = migration_risk.validate(
+        manifest_path=manifest, migrations_dir=migrations_dir
+    )
+
+    assert any(
+        "not_mapping: manifest entry must be a mapping" in error
+        for error in result.errors
+    )
+    assert any("bad_fields: manifest file must be" in error for error in result.errors)
+    assert any("bad_fields: risk must be one of" in error for error in result.errors)
+    assert any("bad_fields: proof is required" in error for error in result.errors)
+    assert any(
+        "bad_issue: issue must be a GitHub issue reference" in error
+        for error in result.errors
+    )
+    assert any(
+        "low_update: data-mutating upgrade operation must be classified as high or critical"
+        in error
+        for error in result.errors
+    )
+    assert result.migrations["critical_drop"].destructive_confirmation is not None
+
+
+def test_AC7_11_4_summary_and_cli_paths_are_reported(tmp_path: Path, capsys) -> None:
+    """AC7.11.4: CLI summary paths report pass/fail status and write release context."""
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    write(
+        migrations_dir / "0001_low.py",
+        """
+        revision = "0001_low"
+        down_revision = None
+
+        def upgrade():
+            pass
+        """,
+    )
+    manifest = tmp_path / "migration-risk.yaml"
+    write_manifest(
+        manifest,
+        {
+            "0001_low": {
+                "file": "0001_low.py",
+                "risk": "low",
+                "proof": "CLI success path proof.",
+            }
+        },
+    )
+    summary_path = tmp_path / "ci-context" / "migration-risk.md"
+
+    rc = migration_risk.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--manifest",
+            str(manifest),
+            "--migrations-dir",
+            str(migrations_dir),
+            "--summary",
+            str(summary_path),
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Status: pass" in stdout
+    assert "Status: pass" in summary_path.read_text(encoding="utf-8")
+
+    failed = migration_risk.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--manifest",
+            str(tmp_path / "missing.yaml"),
+            "--migrations-dir",
+            str(migrations_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert failed == 1
+    assert "Status: fail" in captured.err
+
+    summary = migration_risk.render_summary(
+        migration_risk.ValidationResult(
+            manifest_path=Path("manifest.yaml"),
+            migrations_dir=Path("migrations"),
+            migrations={
+                "critical_manual": migration_risk.MigrationRecord(
+                    revision="critical_manual",
+                    file_name="critical_manual.py",
+                    risk="critical",
+                    proof="Manual summary proof without issue.",
+                )
+            },
+            errors=["synthetic error"],
+        )
+    )
+    assert (
+        "`critical_manual`: critical - Manual summary proof without issue." in summary
+    )
+    assert "- synthetic error" in summary
 
 
 def test_AC7_11_4_ci_and_release_dry_run_execute_migration_risk_contract() -> None:

--- a/tests/tooling/test_migration_risk_contract.py
+++ b/tests/tooling/test_migration_risk_contract.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from common.ci import migration_risk
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_AC7_11_1_migration_risk_manifest_covers_backend_migrations() -> None:
+    """AC7.11.1: Backend Alembic migrations are covered by the risk manifest."""
+
+    result = migration_risk.validate_repository(ROOT)
+
+    assert result.errors == []
+    assert len(result.migrations) >= 40
+    assert result.manifest_path == ROOT / "docs/ssot/migration-risk.yaml"
+    assert all(
+        record.risk in migration_risk.RISK_LEVELS
+        for record in result.migrations.values()
+    )
+
+
+def test_AC7_11_2_high_and_critical_migrations_require_release_proof(
+    tmp_path: Path,
+) -> None:
+    """AC7.11.2: High and critical migrations carry right-sized release proof notes."""
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "0001_high.py").write_text(
+        """
+from alembic import op
+
+revision = "0001_high"
+down_revision = None
+
+def upgrade():
+    op.execute("UPDATE accounts SET name = name")
+""",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "migration-risk.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "migrations": {
+                    "0001_high": {
+                        "file": "0001_high.py",
+                        "risk": "high",
+                        "proof": "Data rewrite requires more than clean-schema proof.",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = migration_risk.validate(
+        manifest_path=manifest, migrations_dir=migrations_dir
+    )
+
+    assert any(
+        "0001_high" in error and "staging_validation" in error
+        for error in result.errors
+    )
+    assert any(
+        "0001_high" in error and "production_preflight" in error
+        for error in result.errors
+    )
+    assert any(
+        "0001_high" in error and "rollback_strategy" in error for error in result.errors
+    )
+
+
+def test_AC7_11_3_destructive_migrations_must_be_classified_critical(
+    tmp_path: Path,
+) -> None:
+    """AC7.11.3: Destructive upgrade operations cannot be under-classified."""
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "0002_drop_legacy.py").write_text(
+        """
+from alembic import op
+
+revision = "0002_drop_legacy"
+down_revision = None
+
+def upgrade():
+    op.drop_table("legacy_rows")
+""",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "migration-risk.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "migrations": {
+                    "0002_drop_legacy": {
+                        "file": "0002_drop_legacy.py",
+                        "risk": "high",
+                        "proof": "This intentionally under-classifies a destructive migration.",
+                        "issue": "#815",
+                        "staging_validation": "Staging drop rehearsal.",
+                        "production_preflight": "Production table dependency check.",
+                        "rollback_strategy": "Backup before destructive change.",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = migration_risk.validate(
+        manifest_path=manifest, migrations_dir=migrations_dir
+    )
+
+    assert any(
+        "0002_drop_legacy" in error and "critical" in error for error in result.errors
+    )
+
+
+def test_AC7_11_4_ci_and_release_dry_run_execute_migration_risk_contract() -> None:
+    """AC7.11.4: CI and production dry-run surface migration risk classification."""
+
+    ci = read(".github/workflows/ci.yml")
+    release = read(".github/workflows/production-release.yml")
+
+    assert "Migration Risk Contract Check" in ci
+    assert "python tools/check_migration_risk.py" in ci
+    assert "Validate Migration Risk Contract" in release
+    assert "production-migration-risk-context.md" in release

--- a/tools/check_migration_risk.py
+++ b/tools/check_migration_risk.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Command wrapper for Alembic migration risk validation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.ci.migration_risk import main  # noqa: E402
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds an SSOT-backed migration risk contract so every Alembic migration declares a risk level and high/critical migrations carry right-sized release proof notes.

Closes #815

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-007 — Deployment |
| **AC IDs** | AC7.11.1, AC7.11.2, AC7.11.3, AC7.11.4 |
| **AC source updated** | `docs/project/EPIC-007.deployment.md` |

---

## SSOT Changes

- [x] `docs/ssot/MANIFEST.yaml` — added `migration_risk_classification`
- [x] `docs/ssot/migration-risk.yaml` — new machine-readable Alembic migration risk manifest
- [x] `docs/ssot/schema.md` — documented migration risk classification and production residual-risk boundary
- [x] `docs/ssot/ci-cd.md` — documented PR/staging/production proof split for migration risk
- [x] `docs/ssot/deployment.md` — documented risk-based release proof before schema deployments
- [x] `docs/ssot/README.md` — added the migration risk SSOT entry

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `be9cde1f` | Added AC7.11 migration risk contract tests before `common.ci.migration_risk` existed |
| 🟢 Green (passing test) | `9823a8f3` | Implemented checker, manifest, SSOT docs, CI lint gate, and production dry-run summary |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no SQLAlchemy enum changes
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A, no Dokploy/runtime config changes
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env vars changed
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

- [x] Lifecycle ownership is unified or unchanged: this PR only adds read-only migration risk validation to CI/release dry-run.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys.
- [x] API/CLI diagnostics show only migration file/revision/risk/proof context; no secret fields are logged.
- [x] VPS host hygiene is unchanged; this PR does not add GitHub SSH or Vault dependencies.
- [x] Cleanup is unchanged; this PR does not alter PR-preview or Docker host cleanup behavior.
- [x] Proof commands include workflow lint, migration risk contract tests, and production dry-run contract coverage.

---

## Testing

```bash
uv run --with pytest --with pyyaml pytest tests/tooling/test_migration_risk_contract.py -q
uv run --with pyyaml python tools/check_migration_risk.py
actionlint -color
git diff --check HEAD~2..HEAD
uv run --with pyyaml python tools/check_manifest.py
uv run --with pyyaml python tools/check_ssot_ownership.py --verbose
uv run --with pyyaml python tools/check_ac_traceability.py
uv run --with ruff ruff check common/ci/migration_risk.py tools/check_migration_risk.py tests/tooling/test_migration_risk_contract.py tests/tooling/test_common_tooling_modules.py
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/lint_doc_consistency.py
uv run --with pytest --with pyyaml pytest tests/tooling/test_common_tooling_modules.py::test_AC8_13_58_ci_tools_delegate_to_common_implementations -q
moon run :lint
moon run :test
```

Pre-push hook also passed backend/frontend lint and backend tests (`2216 passed`, backend coverage `97.28%`).

---

## Screenshots / Evidence

`tools/check_migration_risk.py` currently checks 40 migrations: 27 low, 12 medium, 1 high, 0 critical. The one high-risk historical migration is `0018_source_type_priority` because it rewrites `journal_entries.source_type`.
