### PR TITLE
[finance_report_vision] docs: vision axioms + four-axis doc-model calibration

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,7 +1,7 @@
 # Multi-runtime agent bridge
 
 This repo is open-and-develop for **Claude Code**, **Codex**, **OpenCode**, and
-the **Gemini / Antigravity CLI**. The single source of truth is `AGENTS.md`. The
+the **Gemini / Antigravity CLI**. The authoritative entry point is `AGENTS.md`. The
 instruction docs and skill libraries are symlinks (nothing to sync by hand); a
 few small committed config files (`.claude/settings.json`, `.mcp.json`,
 `.gemini/settings.json`, `opencode.json`) declare per-runtime MCP/approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,26 @@ Quick reference:
 
 ---
 
+## 🧱 Four Orthogonal Concerns
+
+These four are **orthogonal axes, not a hierarchy** — each answers a different
+question, so they never compete for ownership:
+
+| Concern | Question it answers | Axis |
+|---------|--------------------|------|
+| **vision.md** | *Why* — the overall product goal and culture | north star |
+| **SSOT** (`docs/ssot/`) | *In what shared language* — the canonical base elements, vocabulary, and contracts that everything else reuses | common dictionary |
+| **EPIC** (`docs/project/`) | *What, horizontally* — a cross-module goal, verified via `EPIC → AC → test` | feature slice |
+| **README** (root, `apps/*`) | *What, per module* — one module's goal and how it is built | module slice |
+
+Because they slice the project on different axes, the **same fact appearing in
+more than one is not drift** — each states it in its own register: vision as
+direction, SSOT as a defined term, EPIC as a horizontal goal, README as a module
+goal. Drift is only when a doc adopts another axis's *job* (e.g. vision dictating
+implementation, or an EPIC redefining a base element that SSOT already owns).
+
+---
+
 ## 🧭 Navigation Map
 
 | Goal | Go to |
@@ -32,7 +52,7 @@ Quick reference:
 | Copilot-specific settings | [.github/copilot-instructions.md](.github/copilot-instructions.md) |
 
 **Routing Rules**:
-- Business logic → [vision.md](vision.md)
+- Product goal, direction & culture → [vision.md](vision.md)
 - Moon commands / environment setup → [docs/ssot/development.md](docs/ssot/development.md)
 - Six environments (naming, isolation) → [docs/ssot/environments.md](docs/ssot/environments.md)
 - CI job structure / test strategy → [docs/ssot/ci-cd.md](docs/ssot/ci-cd.md)
@@ -44,10 +64,13 @@ Quick reference:
 
 ## 📐 SSOT-First Principle
 
-The **sole authoritative source** is `docs/ssot/`.  
+`docs/ssot/` is the **authoritative source for the shared base elements and
+contracts** — the common language the rest of the repo reuses. It does not own
+goals (vision / EPICs) or module design (READMEs); it owns the *terms* they
+speak in.  
 The SSOT ownership map is: **[docs/ssot/MANIFEST.yaml](docs/ssot/MANIFEST.yaml)**
 
-1. **No SSOT, no work**: Define truth in `docs/ssot/` before writing code.
+1. **No SSOT, no work**: Define the shared terms in `docs/ssot/` before writing code.
 2. **No hidden drift**: When code differs from SSOT, sync immediately.
 3. **Single owner**: Each concept has exactly one SSOT file; see MANIFEST.
 
@@ -126,6 +149,6 @@ tracking. Do not duplicate phase status in this quick-reference file.
 |----------|------|---------|
 | **Agent governance** | `docs/agents/` | Red lines, orchestration |
 | **Contributor guide** | `docs/contributing/` | Branch policy, pre-commit |
-| **SSOT** | `docs/ssot/` | Technical truth |
-| **Project EPICs** | `docs/project/` | Task tracking |
-| **Module READMEs** | `apps/*/README.md` | Per-app design guide |
+| **SSOT** | `docs/ssot/` | Shared base-element language & contracts |
+| **Project EPICs** | `docs/project/` | Horizontal (cross-module) goals & tracking |
+| **Module READMEs** | `apps/*/README.md` | Per-module goal & design guide |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ README -> EPIC -> AC -> test
 - **Tests** are the proof. A referenced AC is not enough; behavior must be
   asserted by real tests.
 
-`vision.md` is intentionally different. It is a decision filter for ambiguous
+`vision.md` is intentionally different. It owns the product's north-star goal
+and culture — the axioms, trade-off rules, and decision filter for ambiguous
 product and architecture choices. It guides endless iteration, but it does not
 own implementation status.
 
@@ -39,7 +40,7 @@ from project intent to executable proof without reading archive fragments.
 | Layer | Owner | What It Shows | Proof / Guard |
 |---|---|---|---|
 | Project entry | `README.md` | EPIC map, tracker entry points, and proof commands | `tools/check_ac_traceability.py` |
-| Decision filter | `vision.md` | Direction for ambiguous product and architecture choices | Referenced by EPIC vision anchors |
+| Goal & culture | `vision.md` | North-star goal, axioms, trade-off rules, and direction for ambiguous choices | Referenced by EPIC vision anchors |
 | Project tracking | `docs/project/README.md` | EPIC directory and non-EPIC documentation ownership | Active markdown ownership sweep |
 | EPIC scope | `docs/project/EPIC-*.md` | Scope, ACs, owned docs, known gaps | AC registries |
 | AC registry | `docs/ac_registry.yaml`, `docs/infra_registry.yaml`, `docs/ac_registry_overrides.yaml` | Generated acceptance criteria inventory and explicit non-derived overrides | `tools/generate_ac_registry.py --check` |

--- a/docs/project/DECISIONS.md
+++ b/docs/project/DECISIONS.md
@@ -283,8 +283,8 @@ Adjusted based on decision complexity:
 **Rationale**:
 - `README.md` is the project fact entry point for EPIC status, proof metrics,
   blocker links, and generated-report links.
-- `vision.md` is a decision filter for ambiguous direction and should not own
-  implementation status.
+- `vision.md` owns the product's north-star goal, culture, and decision filters
+  for ambiguous direction; it does not own implementation status.
 - EPIC documents own scope and AC definitions.
 - AC registries are generated from EPIC documents.
 - Tests and generated reports are the proof layer.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -88,7 +88,7 @@ sync with ACs and tests.
 | Documentation surface | Owner EPIC | Role |
 |---|---|---|
 | [Root README](https://github.com/wangzitian0/finance_report/blob/main/README.md) | Root project entry point | Status/proof summary generated or validated from registries and reports |
-| [Project vision](../target.md) | Vision layer | Decision filter, not implementation status |
+| [Project vision](../target.md) | Vision layer | North-star goal & culture (axioms, trade-off rules); not implementation status |
 | [../index.md](../index.md) | EPIC-001 | Documentation site navigation |
 | [../user-guide/getting-started.md](../user-guide/getting-started.md) | EPIC-001 | First-use guide and onboarding route |
 | [Backend README](https://github.com/wangzitian0/finance_report/blob/main/apps/backend/README.md) | EPIC-001 | Backend module entry point |

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -97,5 +97,5 @@ contracts is tracked in
 ## Related
 
 - [Root README](https://github.com/wangzitian0/finance_report/blob/main/README.md) — project fact entry point
-- [Project vision](../target.md) — decision filter and long-term direction
+- [Project vision](../target.md) — north-star goal, culture, and long-term direction
 - [Project EPIC index](../project/README.md)

--- a/docs/ssot/framework-reporting.md
+++ b/docs/ssot/framework-reporting.md
@@ -6,9 +6,9 @@
 
 ---
 
-## 1. Objective
+## 1. Policy Scope
 
-The product goal is:
+This framework policy governs the path:
 
 ```text
 Upload all settlement evidence -> choose US-like or HK-like framework ->

--- a/docs/ssot/tdd.md
+++ b/docs/ssot/tdd.md
@@ -18,7 +18,8 @@ README.md -> docs/project/EPIC-*.md -> docs/*_registry.yaml -> tests
 3. **AC registries** are generated from EPIC documents.
 4. **Tests** prove behavior.
 
-`vision.md` is a decision filter, not a status or acceptance document.
+`vision.md` owns the product's north-star goal, culture, and decision filters —
+not a status or acceptance document.
 
 ## Acceptance Criteria
 

--- a/vision.md
+++ b/vision.md
@@ -1,30 +1,30 @@
 # Finance Report Vision
 
+This file is culture, not specification. It carries the few irreducible bets
+and the rules for choosing when those bets conflict. It does not own status,
+scope, or contracts — see [Where Detail Lives](#where-detail-lives).
+
 ## Terminal Goal
 
 **A generated personal financial-report package backed by an accurate asset
 dashboard and an explainable financial assistant.**
 
-The final product should generate a self-hosted personal financial report
-package whose structure is inspired by US GAAP and Hong Kong listed-company
-reporting: statements, schedules, notes, and source traceability. It is a
-personal management report, not a regulated filing, audit opinion, legal
-advice, tax advice, or regulated investment advice.
+The output is a self-hosted personal report package — statements, schedules,
+notes, and source traceability — whose structure is inspired by US GAAP and
+Hong Kong listed-company reporting. The US public-company framing is not
+decoration: it is our schema discipline (see Axiom C). It is a personal
+management report, not a regulated filing, audit opinion, legal advice, tax
+advice, or regulated investment advice.
 
-## Product Promise
+## Why This Exists
 
-The user should only need to upload financial source documents, such as bank
-statements, brokerage statements, settlement notes, ESOP/RSU plan documents,
-property or liability statements, CSV exports, and other supported records.
+Financial data is scattered across banks, brokers, statements, PDFs, CSVs, and
+manual records. Manual entry can omit data; automated extraction can be wrong.
 
-After upload, the system should automate the rest where the behavior can be
-made trustworthy: extraction, validation, deduplication, reconciliation, FX and
-stock-price refresh, ESOP and long-term compensation schedules, recurring fixed
-expense accruals or pre-deductions, dashboard updates, and report-package
-preparation.
-
-Human review remains part of the product when source data is missing,
-ambiguous, material, or inconsistent.
+The product exists to make asset data trustworthy, auditable, explainable, and
+useful for personal financial decisions. The user uploads source documents; the
+system automates the rest wherever the behavior can be made trustworthy, and
+asks for human attention only where it cannot.
 
 At any time, the system should help answer:
 
@@ -35,55 +35,93 @@ At any time, the system should help answer:
 - How are my investments performing?
 - What is my annualized income across salary, ESOP, dividends, and other
   long-term components?
-- What financial suggestions should my assistant surface from trusted data,
-  known limitations, and pending actions?
+- What should my assistant surface from trusted data, known limitations, and
+  pending actions?
 
-## Core Challenge
+## The Three Axioms
 
-Financial data is scattered across banks, brokers, statements, PDFs, CSVs, and
-manual records. Manual entry can omit data; automated extraction can be wrong.
+These are the irreducible bets. When a product or architecture choice is
+ambiguous, derive the answer from these axioms first, then from the
+[Trade-off Rules](#trade-off-rules), then from the
+[Decision Filter](#decision-filter).
 
-The product exists to make asset data trustworthy, auditable, explainable, and
-useful for personal financial decisions.
+### Axiom A — Data is append-only; truth is recomputed, not edited
 
-## Product Principles
+Stored facts only accumulate; a recorded fact is never changed in place. Truth
+itself may change — a later statement corrects an earlier one, a price refreshes
+— but it changes by **recomputing from the accumulated record**, never by
+editing history.
 
-- Accounting integrity is non-negotiable.
-- Confirmed data is more valuable than merely imported data.
-- AI may parse, classify, explain, and suggest; it must not become the source of
-  record.
-- Deterministic logic owns core bookkeeping and report calculations.
-- Automation should reduce user effort without hiding uncertainty.
-- Human review should focus on uncertainty, exceptions, and material judgments.
-- Self-hosting and data ownership are first-class constraints.
-- Every workflow should preserve traceability from source document to ledger to
-  report.
+Every value carries a version, and one version maps to exactly one value as it
+propagates downstream. That is what lets the same number be both auditable and
+current: pin a version and it stays reproducible; recompute and it stays fresh.
+Append-only history plus versioned recomputation is what gives us retrospective
+analysis. (How the layers and versions are actually structured is implementation,
+owned downstream — not here.)
 
-## Confidence Accumulation
+### Axiom B — Automation by default; attention only on the low-confidence tail
 
-The guiding model is staged confidence:
+The default is fully automatic. The user is asked to look only at the nodes the
+system flags — the issues automated review could not resolve with confidence.
 
-```text
-raw source
-  -> extracted record
-  -> machine validation
-  -> human confirmation
-  -> reconciliation and deduplication
-  -> trusted ledger knowledge
-  -> dashboard, assistant, and reports
-```
+Confidence is a first-class, measured property, co-equal with traceability.
+What we ask a human to review, or an engineer to redesign, is exactly the
+computation that — in hindsight — looks low-confidence. The same problem has a
+macro face (which nodes the user reviews) and a micro face (which computations
+the team improves). The mission over time is to **drive the proportion of
+low-confidence data down**.
 
-Only trusted or explicitly reviewed data should drive conclusions that claim to
-be accurate.
+### Axiom C — Boundaries are risk-managed, not absolute
+
+Our hard constraints are managed as risk, not absolutes.
+
+- **Privacy / self-hosting**: the rule is *no catastrophically short stave*, not
+  *no data ever leaves the box*. A trusted vendor leaking is a low-probability
+  event; sending a statement image to a trusted extraction provider is
+  acceptable. What is not acceptable is a single weak link far worse than the
+  rest.
+- **Schema**: the messy variety of real-world instruments is absorbed by
+  adopting the discipline of US public-company reporting. Public companies have
+  already generalized the fancy operations; we align to that standard rather
+  than invent our own. Minor representational gaps are tolerable.
+
+## North-Star Metric
+
+**The proportion of low-confidence data trends down over time.** This is the
+single measurable expression of the axioms: more data crossing from
+machine-uncertain to trusted, with traceability intact, and less human attention
+required per unit of trust.
+
+## Trade-off Rules
+
+When two goods conflict, the higher rule wins.
+
+1. **Append-only over in-place truth.** The live number is a recompute; history
+   is never edited to make it look right. (Axiom A)
+2. **Accuracy over coverage.** Support fewer sources well before supporting many
+   unreliably.
+3. **Auditability over convenience — but automation stays the default.** We do
+   not collapse source→ledger→report traceability for a cleaner surface. The
+   cost of trust is paid as confidence-flagged review, not blanket manual entry.
+   (Axiom B)
+4. **No short stave over absolute isolation.** We drop a feature before we accept
+   a weakest link far worse than the rest — but not before we accept a
+   low-probability, well-bounded one. (Axiom C)
+5. **Deterministic logic owns the number.** Anything that lands a value in the
+   ledger or a report line is deterministic. AI may parse, classify, explain, and
+   suggest; it is measured by confidence and never becomes the source of record.
+
+If a choice still feels balanced after these rules, run the Decision Filter and
+take the smaller step that improves proof quality.
 
 <a id="decision-filter-accuracy-auditability"></a>
 
 ## Decision Filter
 
-Use this when product or architecture choices are ambiguous:
+Use this when the axioms and trade-off rules still leave a choice ambiguous:
 
 1. Does it improve accuracy, auditability, or reconciliation confidence?
-2. Does it keep the system self-hostable and data-private?
+2. Does it keep the system self-hostable and data-private (no short stave)?
 3. Does it reduce user cognitive load without hiding critical details?
 4. Does it preserve double-entry integrity and traceability?
 5. Can the behavior be expressed as EPIC -> AC -> test?
@@ -92,67 +130,40 @@ If the answer is unclear, choose the smaller step that improves proof quality.
 
 ## Directional Commitments
 
-These commitments describe product direction. Implementation contracts belong
-in `docs/ssot/`; delivery scope belongs in `docs/project/`.
-
-### Personal Report Package Is The North-Star Output
-
-Dashboards are working surfaces; the durable product output is a generated
-personal financial-report package with report sections, schedules, notes, and
-source-to-ledger-to-report traceability. Reporting contracts are owned by
-`docs/ssot/reporting.md` and `docs/ssot/framework-reporting.md`.
+Settled directions that the rest of the repo anchors to. Each one carries a
+cost; if it did not, it would not be a commitment. Implementation contracts are
+owned under [Where Detail Lives](#where-detail-lives).
 
 <a id="decision-1-portfolio-self-developed"></a>
-
-### Portfolio Is Native
-
-Portfolio management is part of the system, not an outsourced portfolio SaaS.
-Holdings, cost basis, dividends, allocation, performance, and restricted
-compensation must remain tied to the accounting and reporting model. Detailed
-contracts are owned by `docs/ssot/assets.md` and `docs/ssot/reporting.md`.
+**Portfolio is native.** Holdings, cost basis, dividends, allocation,
+performance, and restricted compensation stay tied to the accounting and
+reporting model — even at the cost of not outsourcing to a portfolio SaaS that
+would be faster to ship.
 
 <a id="decision-2-event-middle-layer"></a>
 <a id="decision-3-record-layer"></a>
-
-### Uploaded Sources Become Reviewed Records Before Ledger Knowledge
-
-Uploaded documents should become traceable records before they become trusted
-ledger facts. The upload, extraction, record, workflow-event, and review
-contracts are owned by `docs/ssot/extraction.md`,
-`docs/ssot/workflow-events.md`, and `docs/ssot/confirmation-workflow.md`.
+**Uploaded sources become reviewed records before ledger knowledge.** An upload
+becomes a traceable record, then a trusted ledger fact — even at the cost of an
+extra event/record layer between import and conclusion.
 
 <a id="decision-4-two-stage-review"></a>
-
-### Review Separates Source Accuracy From Batch Consistency
-
-Review should separate whether a source parsed correctly from whether the full
-batch reconciles consistently. Detailed review-state rules are owned by
-`docs/ssot/confirmation-workflow.md` and `docs/ssot/reconciliation.md`.
+**Review separates source accuracy from batch consistency.** Whether a source
+parsed correctly is judged apart from whether the full batch reconciles — even at
+the cost of two review concerns instead of one.
 
 <a id="decision-5-processing-account"></a>
+**In-transit funds stay visible.** Value that has left one account but not
+arrived in another remains visible and reconcilable in a Processing account —
+even at the cost of carrying balances that are not yet settled anywhere.
 
-### In-Transit Funds Must Stay Visible
-
-Transfers can leave one account before arriving in another. In-transit value
-must remain visible and reconcilable instead of disappearing from net worth.
-The detailed Processing account contract is owned by
-`docs/ssot/processing_account.md`.
-
-### Manual Data Is Explicitly Trusted
-
-Some assets and liabilities cannot be verified by imported statements. Manual
-records are trusted because the user explicitly supplied them, but they must
-remain clearly labeled as manual data. Source-type priority is owned by
-`docs/ssot/source-type-priority.md`.
+**Manual data is explicitly trusted.** Assets that no statement can verify are
+trusted because the user supplied them — at the cost of labeling them clearly as
+manual so they never masquerade as imported proof.
 
 <a id="decision-7-tech-stack"></a>
-
-### The Stack Must Stay Self-Hostable
-
-The stack should support transactional control, Decimal-safe accounting,
-explicit schemas, private deployment, and reproducible CI. Runtime and
-environment contracts are owned by `docs/ssot/development.md`,
-`docs/ssot/schema.md`, and `docs/ssot/deployment.md`.
+**The stack stays self-hostable.** Transactional control, Decimal-safe
+accounting, explicit schemas, private deployment, reproducible CI — even at the
+cost of declining managed services that would break private hosting.
 
 ## Non-Goals
 
@@ -164,12 +175,18 @@ environment contracts are owned by `docs/ssot/development.md`,
 - <a id="non-goals-not-robo-advisor"></a>Automated trading, portfolio
   optimization, or robo-advisory execution.
 
-## Relationship To Project Documents
+## Where Detail Lives
 
-This file does not own project status. Current implementation status lives in
-`README.md`, EPIC scope lives in `docs/project/`, and proof lives in AC
-registries plus tests.
+This file holds no contracts, status, or enumerations. They live with their
+owners:
 
-Vision changes should be rare and directional. Implementation details should be
-captured as EPIC -> AC -> test, or as code-owned contracts referenced by
-`docs/ssot/`.
+- **Implementation contracts** → `docs/ssot/`, routed by
+  `docs/ssot/MANIFEST.yaml` (one owner per concept). The staged
+  confidence pipeline (raw -> extracted -> validated -> confirmed -> reconciled
+  -> trusted -> reports) is owned by `docs/ssot/confirmation-workflow.md`;
+  supported source classes by `docs/ssot/source-coverage-matrix.yaml`.
+- **Delivery scope & status** → `docs/project/` (EPICs) and `README.md`.
+- **Agent process & governance** → `AGENTS.md` and `docs/agents/`.
+
+Vision changes should be rare and directional. Implementation belongs in
+EPIC -> AC -> test, or in code-owned contracts referenced by `docs/ssot/`.


### PR DESCRIPTION
## Why

Two requests, one branch:
1. **Slim `vision.md` to culture, not spec.** It had read like a table of contents — truism principles, enumerated lists, and a `owned by docs/ssot/...` tail on every commitment — with no actual spine for resolving trade-offs.
2. **Calibrate the doc model to four *orthogonal* concerns.** The repo's guide implied a linear `vision→README→EPIC→AC→test` stack. The real model is four axes that never compete:

| Concern | Question | Axis |
|---|---|---|
| `vision.md` | *why* — north-star goal & culture | north star |
| SSOT (`docs/ssot/`) | *in what shared language* — base-element terms & contracts | dictionary |
| EPIC (`docs/project/`) | *what, horizontally* — cross-module goals (EPIC→AC→test) | feature slice |
| README (root, `apps/*`) | *what, per module* — module goal & build | module slice |

## What changed

- **`vision.md`** — Three Axioms (append-only/recompute · automation-by-default + confidence · risk-managed boundaries), Trade-off Rules, a North-Star Metric (low-confidence proportion ↓), and `even at the cost of …` clauses on the Directional Commitments. **All 9 anchor ids preserved**, so every EPIC `Vision Anchor:` reference still resolves.
- **`AGENTS.md`** (entry point; `CLAUDE.md` symlinks it) — new **Four Orthogonal Concerns** section; scoped the SSOT-First claim to *shared terms* (not goals/module design); fixed `Business logic → vision` routing; aligned the Documentation Map wording. Key line agents now inherit: *the same fact appearing on more than one axis is not drift — drift is a doc doing another axis's job.*
- **Role-label consistency sweep** (rigor pass over all docs): stop calling `vision.md` only a "decision filter" (`README`, `docs/ssot/tdd.md`, `docs/ssot/README.md`, `docs/project/README.md`, `docs/project/DECISIONS.md`); `.claude/README.md` "single source of truth" → "authoritative entry point" (it's the entry point, SSOT is `docs/ssot/`); `docs/ssot/framework-reporting.md` no longer asserts a "product goal" (that's vision/EPIC's axis) — reframed as policy scope.

## Out of scope (intentional)

- **EPIC↔AC content drift** (embedded AC tables, missing test refs) — owned by a dedicated maintainer.
- **Dated audit snapshots** (`DECISIONS.md` / `AC-AUDIT-*` line refs like `vision.md L232`) — preserved as historical records, not rewritten.
- Did **not** propagate the four-axis blurb into every doc (`index.md`, `copilot-instructions.md`, …) — the model lives in the entry point on purpose; copying it everywhere would itself be drift.

## Safety

Docs-only. No markdown linter in CI; `check_manifest.py` validates file existence (unaffected); source-coverage test reads the matrix yaml, not vision prose. Anchors, cross-refs, and the `CLAUDE.md → AGENTS.md` symlink all verified intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)