### PR TITLE
[finance_report_vision] ci(pr-test): classify changed paths by merge-base (three-dot) diff

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -112,7 +112,12 @@ jobs:
             base_sha="$(git rev-parse "${head_sha}^" 2>/dev/null || git rev-parse HEAD^)"
           fi
 
-          if ! git diff --name-only "$base_sha" "$head_sha" > changed-files.txt; then
+          # Three-dot (merge-base) diff: classify only what THIS PR introduced,
+          # not files that diverged on the base branch since the PR forked.
+          # Two-dot ("$base_sha" "$head_sha") attributes the base branch's own
+          # post-fork commits to the PR, so a docs-only PR lagging a runtime
+          # change on main spuriously trips the pr-preview deploy gate.
+          if ! git diff --name-only "$base_sha...$head_sha" > changed-files.txt; then
             git diff --name-only HEAD^ HEAD > changed-files.txt
           fi
 


### PR DESCRIPTION
## Symptom

`PR Test Environment / Deploy Test Environment` runs (and is slow) on PRs that change **no runtime code at all** — e.g. a docs-only PR. The deploy job is the only one in the pipeline that provisions a live Dokploy preview env, so it dominates wall-clock.

## Evidence (across multiple real runs)

The deploy job, when it runs, is consistently ~7 min and the time is structural, not flaky retries:

| run | branch | total | **Deploy preview lifecycle** | api_wait | e2e |
|---|---|---|---|---|---|
| 27333312630 | docs-only | 449s | **292s (65%)** | 70s | 46s |
| 27329288573 | epic019 runtime | 410s | **275s (67%)** | 32s | 42s |
| 27325526381 | qa-schema | 395s | **258s (65%)** | 45s | 50s |

`Deploy preview lifecycle` = Dokploy provision + image + Traefik route + **SSL cert** (the workflow itself notes "first deployment may take 3-5 minutes"). That part is external infra — CI logic can't shorten it. Most PRs correctly **skip** this job; the lever is to stop the ones that should skip from running it.

## Root cause

The preview gate computes changed files with a **two-dot** diff:

```sh
git diff --name-only "$base_sha" "$head_sha"
```

`base_sha` is the base branch tip. When a PR lags `main` and `main` has since gained runtime commits, two-dot attributes **main's own files** to the PR. Reproduced on the docs-only branch (merge-base 3 commits behind main):

- two-dot → **41** changed files incl. `apps/backend/src/{config,routers/statements,services/statement_flow,statement_pipeline}.py` → `pr_preview_required=true` → deploy fires.
- three-dot `base...head` (merge-base) → **9** files, all docs → `pr_preview_required=false` → deploy skips. ✅

## Fix

One line in `pr-test.yml`: two-dot → three-dot `"$base_sha...$head_sha"`, classifying only what the PR introduced. `actions/checkout` already uses `fetch-depth: 0`, so the merge-base is present; the empty/zero-base fallback is unaffected (base resolves to `head^`, where the two forms agree).

## Scope / follow-up

`pr-test.yml` only — the preview deploy is pure waste when mis-triggered, and skipping is unambiguously correct. The same two-dot pattern exists in `ci.yml:53` (heavy-CI gate — changing it has **test-coverage** implications, where over-inclusion is fail-safe) and `staging-deploy.yml:169` (different trigger semantics). Both are left for a separate, deliberately-reviewed change rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)