### PR TITLE
[finance_report_vision] ci: image-free in-runner E2E gate + opt-in Dokploy preview (#839)

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -207,11 +207,11 @@ jobs:
       - name: End-to-End Tests
         env:
           TEST_ENV: staging
-          SKIP_UI_TESTS: "false"
+          SKIP_UI_TESTS: false
           EXPECTED_SHA: ${{ github.sha }}
-          TIMEOUT_MS: "60000"
-          E2E_API_TIMEOUT: "30"
-          STRICT_E2E_GATES: "true"
+          TIMEOUT_MS: 60000
+          E2E_API_TIMEOUT: 30
+          STRICT_E2E_GATES: true
         run: |
           set -euo pipefail
           mkdir -p test-results

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -182,6 +182,10 @@ jobs:
       - name: Build and start ephemeral stack
         run: |
           set -euo pipefail
+          # backend/frontend attach to the external `dokploy-network` (a
+          # Dokploy/Traefik artifact that does not exist in the runner). Create a
+          # local stand-in so compose can start; removed again in teardown.
+          docker network create dokploy-network 2>/dev/null || true
           docker compose up --build -d --quiet-pull
           docker compose ps
 
@@ -227,7 +231,11 @@ jobs:
       # is unique per run; -v removes named volumes, --remove-orphans the rest.
       - name: Tear down ephemeral stack
         if: always()
-        run: docker compose down --volumes --remove-orphans --timeout 30 || true
+        run: |
+          docker compose down --volumes --remove-orphans --timeout 30 || true
+          # Remove the local stand-in network (external networks are not removed
+          # by `compose down`); no-op if other containers still reference it.
+          docker network rm dokploy-network 2>/dev/null || true
 
   gate-cheap-ci:
     name: Gate on Cheap CI

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -147,6 +147,85 @@ jobs:
           print(f"pr_preview_reason={reasons['pr-preview']}")
           PY
 
+  e2e:
+    name: In-runner E2E
+    # Image-free full-stack E2E (issue #839): the merge-relevant validation.
+    # Runs on every runtime-relevant PR; does NOT push images or deploy to
+    # Dokploy. The Dokploy preview below is a separate, opt-in human-inspection
+    # environment.
+    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true'
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      COMPOSE_FILE: docker-compose.yml:docker-compose.ci-e2e.yml
+      # Unique per run+attempt so teardown targets exactly this run's resources.
+      COMPOSE_PROJECT_NAME: fr-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+      APP_URL: http://localhost:8080
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup E2E Tests
+        uses: ./.github/actions/setup-e2e-tests
+
+      - name: Generate PDF fixtures for E2E tests
+        run: |
+          mkdir -p tmp/fixtures
+          python tools/generate_pdf_fixtures.py --source dbs --output tmp/fixtures/
+
+      - name: Build and start ephemeral stack
+        run: |
+          set -euo pipefail
+          docker compose up --build -d --quiet-pull
+          docker compose ps
+
+      - name: Wait for stack readiness
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 60); do
+            if curl -fsS "$APP_URL/api/health" >/dev/null 2>&1; then
+              echo "Stack healthy after $((i * 5))s"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::stack did not become healthy within 300s"
+          exit 1
+
+      - name: End-to-End Tests
+        env:
+          TEST_ENV: staging
+          SKIP_UI_TESTS: "false"
+          EXPECTED_SHA: ${{ github.sha }}
+          TIMEOUT_MS: "60000"
+          E2E_API_TIMEOUT: "30"
+          STRICT_E2E_GATES: "true"
+        run: |
+          set -euo pipefail
+          mkdir -p test-results
+          echo "--- Phase 1: Smoke Check (Shell) ---"
+          bash tools/smoke_test.sh "$APP_URL" staging
+          echo "--- Phase 2: Runtime/API/UI Validation (Python, no real AI/OCR) ---"
+          PR_PREVIEW_E2E_TESTS=(
+            tests/e2e/test_core_journeys.py
+            tests/e2e/test_e2e_flows.py::test_full_navigation
+          )
+          pytest "${PR_PREVIEW_E2E_TESTS[@]}" -v -m "(smoke or e2e) and not llm" -n 4 --junit-xml=test-results/in-runner-e2e.xml
+
+      - name: Stack logs on failure
+        if: failure()
+        run: docker compose logs --no-color --tail=400 || true
+
+      # Lifecycle guard: always tear the stack down so containers / volumes /
+      # networks never leak, even on E2E failure or build failure. Project name
+      # is unique per run; -v removes named volumes, --remove-orphans the rest.
+      - name: Tear down ephemeral stack
+        if: always()
+        run: docker compose down --volumes --remove-orphans --timeout 30 || true
+
   gate-cheap-ci:
     name: Gate on Cheap CI
     if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true' && needs.setup.outputs.preview_opt_in == 'true'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,7 +7,9 @@ name: PR Test Environment
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    # `labeled` lets the opt-in `preview` label spin up a preview without a
+    # re-push (issue #839); the preview jobs still gate on preview_opt_in.
+    types: [opened, synchronize, reopened, closed, labeled]
     branches: [main]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,9 +7,7 @@ name: PR Test Environment
 
 on:
   pull_request:
-    # `labeled` lets the opt-in `preview` label spin up a preview without a
-    # re-push (issue #839); the preview jobs still gate on preview_opt_in.
-    types: [opened, synchronize, reopened, closed, labeled]
+    types: [opened, synchronize, reopened, closed]
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -53,10 +51,6 @@ jobs:
       preview_commit_slug: ${{ steps.info.outputs.preview_commit_slug }}
       pr_preview_required: ${{ steps.preview_gate.outputs.pr_preview_required }}
       pr_preview_reason: ${{ steps.preview_gate.outputs.pr_preview_reason }}
-      # Opt-in gate (issue #839): previews are OFF by default. Enable per-PR with
-      # the `preview` label, or via manual workflow_dispatch. Authoritative
-      # deployment validation is post-merge (Staging), not every PR commit.
-      preview_opt_in: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'preview') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -247,7 +241,7 @@ jobs:
 
   gate-cheap-ci:
     name: Gate on Cheap CI
-    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true' && needs.setup.outputs.preview_opt_in == 'true'
+    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true'
     needs: setup
     runs-on: ubuntu-latest
     permissions:
@@ -267,7 +261,7 @@ jobs:
 
   build-preview-backend-image:
     name: Build Backend PR Preview Image
-    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true' && needs.setup.outputs.preview_opt_in == 'true'
+    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true'
     needs: [setup, gate-cheap-ci]
     runs-on: ubuntu-latest
     env:
@@ -308,7 +302,7 @@ jobs:
 
   build-preview-frontend-image:
     name: Build Frontend PR Preview Image
-    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true' && needs.setup.outputs.preview_opt_in == 'true'
+    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true'
     needs: [setup, gate-cheap-ci]
     runs-on: ubuntu-latest
     env:
@@ -351,7 +345,7 @@ jobs:
 
   deploy:
     name: Deploy Test Environment
-    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true' && needs.setup.outputs.preview_opt_in == 'true'
+    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true'
     needs: [setup, build-preview-backend-image, build-preview-frontend-image]
     runs-on: ubuntu-latest
     permissions:
@@ -836,34 +830,21 @@ jobs:
           mkdir -p tmp/fixtures
           python tools/generate_pdf_fixtures.py --source dbs --output tmp/fixtures/
 
-      - name: End-to-End Tests
+      - name: Smoke Test
         id: e2e_tests
         continue-on-error: true
         env:
           APP_URL: ${{ steps.deploy.outputs.app_url }}
           TEST_ENV: staging
-          SKIP_UI_TESTS: false
           EXPECTED_SHA: ${{ github.sha }}
-          TIMEOUT_MS: 60000
-          E2E_API_TIMEOUT: 30
-          STRICT_E2E_GATES: true
-          RUN_MARKET_DATA_PROVIDER_E2E: true
-          MARKET_DATA_E2E_DATE: "2024-06-03"
         run: |
-          echo "🚀 Starting E2E Pipeline for $APP_URL"
+          echo "🔎 Smoke-checking deployed preview at $APP_URL"
           mkdir -p test-results
-
-          echo "--- Phase 1: Smoke Check (Shell) ---"
+          # The deployed preview only smoke-checks that the real, independently
+          # provisioned per-PR environment came up. The full runtime/API/UI E2E
+          # runs image-free in the `e2e` job (in-runner). See issue #839.
           bash tools/smoke_test.sh "$APP_URL" staging
-
-          echo "--- Phase 2: Preview-Relevant Runtime/API/UI Validation (Python, no real AI/OCR) ---"
-          PR_PREVIEW_E2E_TESTS=(
-            tests/e2e/test_core_journeys.py
-            tests/e2e/test_e2e_flows.py::test_full_navigation
-          )
-          pytest "${PR_PREVIEW_E2E_TESTS[@]}" -v -m "(smoke or e2e) and not llm" -n 4 --junit-xml=test-results/pr-preview-e2e.xml
-
-          echo "✅ E2E Pipeline passed!"
+          echo "✅ Preview smoke passed!"
 
       - name: Capture platform failure snapshot
         if: ${{ always() && steps.deploy.outputs.compose_id != '' && (steps.deploy.outcome == 'failure' || steps.api_ready.outcome == 'failure' || steps.frontend_ready.outcome == 'failure' || steps.e2e_tests.outcome == 'failure') }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -51,6 +51,10 @@ jobs:
       preview_commit_slug: ${{ steps.info.outputs.preview_commit_slug }}
       pr_preview_required: ${{ steps.preview_gate.outputs.pr_preview_required }}
       pr_preview_reason: ${{ steps.preview_gate.outputs.pr_preview_reason }}
+      # Opt-in gate (issue #839): previews are OFF by default. Enable per-PR with
+      # the `preview` label, or via manual workflow_dispatch. Authoritative
+      # deployment validation is post-merge (Staging), not every PR commit.
+      preview_opt_in: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'preview') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -145,7 +149,7 @@ jobs:
 
   gate-cheap-ci:
     name: Gate on Cheap CI
-    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true'
+    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true' && needs.setup.outputs.preview_opt_in == 'true'
     needs: setup
     runs-on: ubuntu-latest
     permissions:
@@ -165,7 +169,7 @@ jobs:
 
   build-preview-backend-image:
     name: Build Backend PR Preview Image
-    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true'
+    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true' && needs.setup.outputs.preview_opt_in == 'true'
     needs: [setup, gate-cheap-ci]
     runs-on: ubuntu-latest
     env:
@@ -206,7 +210,7 @@ jobs:
 
   build-preview-frontend-image:
     name: Build Frontend PR Preview Image
-    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true'
+    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true' && needs.setup.outputs.preview_opt_in == 'true'
     needs: [setup, gate-cheap-ci]
     runs-on: ubuntu-latest
     env:
@@ -249,7 +253,7 @@ jobs:
 
   deploy:
     name: Deploy Test Environment
-    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true'
+    if: needs.setup.outputs.action == 'deploy' && needs.setup.outputs.pr_preview_required == 'true' && needs.setup.outputs.preview_opt_in == 'true'
     needs: [setup, build-preview-backend-image, build-preview-frontend-image]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -162,6 +162,9 @@ jobs:
       # Base compose gates services behind profiles (infra=db/minio, app=back/front);
       # activate both so the full stack (and the edge's depends_on) resolve.
       COMPOSE_PROFILES: infra,app
+      # Baked into the images at build time and reported by both services; the
+      # smoke version check compares it against the source SHA (else "unknown").
+      GIT_COMMIT_SHA: ${{ github.sha }}
       # Unique per run+attempt so teardown targets exactly this run's resources.
       COMPOSE_PROJECT_NAME: fr-e2e-${{ github.run_id }}-${{ github.run_attempt }}
       APP_URL: http://localhost:8080

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -159,6 +159,9 @@ jobs:
     timeout-minutes: 25
     env:
       COMPOSE_FILE: docker-compose.yml:docker-compose.ci-e2e.yml
+      # Base compose gates services behind profiles (infra=db/minio, app=back/front);
+      # activate both so the full stack (and the edge's depends_on) resolve.
+      COMPOSE_PROFILES: infra,app
       # Unique per run+attempt so teardown targets exactly this run's resources.
       COMPOSE_PROJECT_NAME: fr-e2e-${{ github.run_id }}-${{ github.run_attempt }}
       APP_URL: http://localhost:8080

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -165,6 +165,9 @@ jobs:
       # Baked into the images at build time and reported by both services; the
       # smoke version check compares it against the source SHA (else "unknown").
       GIT_COMMIT_SHA: ${{ github.sha }}
+      # The stack is reached through the edge origin; allow it for CORS so the
+      # smoke CORS check (Origin: http://localhost:8080) passes.
+      CORS_ORIGINS: http://localhost:8080,http://localhost:3000
       # Unique per run+attempt so teardown targets exactly this run's resources.
       COMPOSE_PROJECT_NAME: fr-e2e-${{ github.run_id }}-${{ github.run_attempt }}
       APP_URL: http://localhost:8080

--- a/docker-compose.ci-e2e.yml
+++ b/docker-compose.ci-e2e.yml
@@ -1,0 +1,34 @@
+# CI-only override (issue #839): stand up the full stack INSIDE the GitHub
+# runner for an ephemeral E2E gate. Nothing is pushed to a registry and nothing
+# is deployed to Dokploy — the stack is built locally and torn down in the same
+# job (`docker compose down -v --remove-orphans`). An nginx `edge` gives the
+# single origin the preview E2E expects (/api -> backend, / -> frontend),
+# replacing the Dokploy/Traefik route.
+#
+# Use with: COMPOSE_FILE=docker-compose.yml:docker-compose.ci-e2e.yml
+services:
+  backend:
+    pull_policy: build      # build locally; never pull a ghcr :latest
+    restart: "no"           # ephemeral: no restart loops to mask failures/teardown
+
+  frontend:
+    pull_policy: build
+    restart: "no"
+    build:
+      args:
+        # NEXT_PUBLIC_* are inlined at build time; point the browser at the edge.
+        NEXT_PUBLIC_API_URL: http://localhost:8080/api
+        NEXT_PUBLIC_APP_URL: http://localhost:8080
+
+  edge:
+    image: nginx:1.27-alpine
+    restart: "no"
+    depends_on:
+      - backend
+      - frontend
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./tools/ci/e2e-nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - internal

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -311,6 +311,8 @@ concepts:
       - docs/ssot/development.md
       - docs/ssot/ci-cd.md
       - docs/ssot/deployment.md
+    proofs:
+      - tests/tooling/test_issue_489_deployment_contracts.py
 
   container_naming:
     owner: docs/ssot/environments.md#container-naming-patterns

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -16,7 +16,7 @@
 | **1** | **Local Dev** | `localhost:3000` | Manual<br>`moon run :dev -- --backend` | Source (Host)<br>uvicorn/next dev | Shared Containers<br>(Podman/Docker) | `finance_report` | Container name suffix |
 | **2** | **Local CI** | `localhost:3000` | Manual<br>`moon run :lint && moon run :test` | Source (Host)<br>pytest | Shared Containers<br>(Podman/Docker) | `finance_report_test_{namespace}` | DB/bucket name |
 | **3** | **GitHub CI** | - | Push/PR<br>`ci.yml` | Source (Runner)<br>pytest | GitHub Services<br>(Ephemeral) | `finance_report_test` | Job isolation |
-| **4** | **PR Preview** | `report-pr-123.zitian.party` | PR opened<br>`pr-test.yml` | **Docker Images**<br>(GHCR) | Dedicated Containers<br>(Per PR) | Dedicated DB/Redis/MinIO | Container suffix<br>`-pr-123` |
+| **4** | **PR Preview** | `report-pr-123.zitian.party` | **Opt-in** (`preview` label / manual)<br>`pr-test.yml` | **Docker Images**<br>(GHCR) | Dedicated Containers<br>(Per PR) | Dedicated DB/Redis/MinIO | Container suffix<br>`-pr-123` |
 | **5** | **Staging** | `report-staging.zitian.party` | Push to main<br>`staging-deploy.yml` | **Docker Images**<br>(GHCR) | Dedicated infra2<br>+ Shared Platform | Dedicated DB/Redis | Bucket name<br>`-staging` |
 | **6** | **Production** | `report.zitian.party` | Manual release<br>`production-release.yml` | **Docker Images**<br>(GHCR) | Dedicated infra2<br>+ Shared Platform | Dedicated DB/Redis | Bucket name |
 
@@ -75,8 +75,11 @@ before invoking `moon`, `uv`, `npm`, `gh`, Docker, or Podman.
 - Runtime, test, script, CI, dependency, and coverage-policy changes run the full backend/frontend/unified coverage gate.
 - Lightweight documentation, markdown, issue-template, and `.github/workflows/docs.yml` changes skip the heavy backend/frontend/coverage jobs while still running lint, SSOT checks, AC traceability, and the final aggregate check.
 
-**PR Preview** — Full deployment with code changes:
-- **Builds Docker images** from PR branch
+**PR Preview** — Opt-in full deployment for on-demand inspection:
+- **Opt-in**: off by default; enable per-PR with the `preview` label or manual
+  `workflow_dispatch`. Authoritative deployment validation is post-merge
+  (Staging), so most PRs do not need a per-commit preview. See issue #839.
+- **Builds Docker images** from PR branch (only when opted in)
 - Deploys to Dokploy with unique URLs (`report-pr-123.zitian.party`)
 - **Ephemeral**: Destroyed when PR closes
 - Database/Redis/MinIO: Dedicated per-PR instances
@@ -146,8 +149,8 @@ The production Platform layer (SigNoz, MinIO, Traefik) runs as **Singleton** ser
 | **Local Dev** | None (manual testing) | Fast iteration | — |
 | **Local CI** | Unit + integration with coverage policy from `common/coverage/policy.py` | Pre-push validation | ~30s |
 | **GitHub CI** | Lint, AC traceability, unit + integration with unified coverage for heavy changes | Quality gate | ~7min heavy / lightweight skips heavy jobs |
-| **PR Preview** | Health check + non-LLM E2E against per-PR Dokploy environment | Deployment validation | ~3-5min |
-| **Staging** | Image deploy, smoke, non-LLM E2E, performance; AI/OCR gate runs separately | Full validation | ~6min deploy + variable AI/OCR gate |
+| **PR Preview** | Health check + non-LLM E2E against per-PR Dokploy environment | Opt-in on-demand inspection (not a per-PR gate) | ~3-5min when enabled |
+| **Staging** | Image deploy, smoke, non-LLM E2E, performance; AI/OCR gate runs separately | **Deployment validation** + full validation | ~6min deploy + variable AI/OCR gate |
 | **Production** | Health check only | Availability check | ~10s |
 
 ---

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -87,14 +87,16 @@ PR validation is split into two independent things (issue #839):
 - **Image-free**: builds locally and pushes nothing; no Dokploy, no shared
   VPS, no SSL wait. This is what keeps E2E coverage cheap and fast.
 
-**PR Preview (Dokploy)** — opt-in human-inspection environment:
-- **Opt-in**: off by default; enable per-PR with the `preview` label or manual
-  `workflow_dispatch`. Authoritative deployment validation is post-merge
-  (Staging); the preview is for clicking/manual testing, not a gate.
-- **Builds Docker images** from PR branch (only when opted in)
+**PR Preview (Dokploy)** — per-PR deployed environment:
+- Deployed for every runtime-relevant PR (dedicated DB/Redis/MinIO per PR), so
+  there is always a real, isolated environment to click and manually test.
+- Runs a **smoke test only** (`tools/smoke_test.sh` against the deployed URL) —
+  it validates that the real per-PR deployment came up. The full runtime/API/UI
+  E2E is the in-runner job above, so the preview does not re-run it.
+- **Non-blocking**: a deploy/smoke failure does not block merge (the merge gate
+  is `finish` + the in-runner E2E); the result is reported as a PR comment.
 - Deploys to Dokploy with unique URLs (`report-pr-123.zitian.party`)
 - **Ephemeral**: Destroyed when PR closes
-- Database/Redis/MinIO: Dedicated per-PR instances
 - Isolation: Container name suffix `-pr-123`
 
 ### Production Environments (Staging + Production)

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -75,10 +75,22 @@ before invoking `moon`, `uv`, `npm`, `gh`, Docker, or Podman.
 - Runtime, test, script, CI, dependency, and coverage-policy changes run the full backend/frontend/unified coverage gate.
 - Lightweight documentation, markdown, issue-template, and `.github/workflows/docs.yml` changes skip the heavy backend/frontend/coverage jobs while still running lint, SSOT checks, AC traceability, and the final aggregate check.
 
-**PR Preview** — Opt-in full deployment for on-demand inspection:
+PR validation is split into two independent things (issue #839):
+
+**In-runner E2E** — the per-PR validation gate:
+- Runs on every runtime-relevant PR (the `e2e` job in `pr-test.yml`).
+- Stands up the full stack **inside the GitHub runner** via
+  `docker compose up --build` (base compose + `docker-compose.ci-e2e.yml`,
+  which adds an nginx single-origin edge), runs the non-LLM E2E against
+  `http://localhost:8080`, then **always tears the stack down**
+  (`docker compose down -v --remove-orphans`) so nothing leaks.
+- **Image-free**: builds locally and pushes nothing; no Dokploy, no shared
+  VPS, no SSL wait. This is what keeps E2E coverage cheap and fast.
+
+**PR Preview (Dokploy)** — opt-in human-inspection environment:
 - **Opt-in**: off by default; enable per-PR with the `preview` label or manual
   `workflow_dispatch`. Authoritative deployment validation is post-merge
-  (Staging), so most PRs do not need a per-commit preview. See issue #839.
+  (Staging); the preview is for clicking/manual testing, not a gate.
 - **Builds Docker images** from PR branch (only when opted in)
 - Deploys to Dokploy with unique URLs (`report-pr-123.zitian.party`)
 - **Ephemeral**: Destroyed when PR closes

--- a/tests/tooling/test_issue_489_deployment_contracts.py
+++ b/tests/tooling/test_issue_489_deployment_contracts.py
@@ -340,3 +340,37 @@ def test_pr_preview_deploy_gate_exercises_health_smoke_e2e_and_storage_paths() -
     assert "test_statement_upload_to_dashboard_vision_hard_gate" in hard_gate
     assert "/api/statements/upload" in hard_gate
     assert "dashboard" in hard_gate.lower()
+
+
+def test_pr_preview_deploy_is_opt_in() -> None:
+    """Issue #839: PR preview build/deploy is opt-in, not a per-PR gate.
+
+    Default PRs must not build images or deploy to Dokploy; a preview is only
+    produced on manual dispatch or when the PR carries the ``preview`` label.
+    Authoritative deployment validation is post-merge (Staging).
+    """
+    workflow = load_yaml(".github/workflows/pr-test.yml")
+    jobs = workflow["jobs"]
+
+    opt_in = jobs["setup"]["outputs"]["preview_opt_in"]
+    assert "workflow_dispatch" in opt_in
+    assert "labels" in opt_in and "preview" in opt_in
+
+    gated_jobs = (
+        "gate-cheap-ci",
+        "build-preview-backend-image",
+        "build-preview-frontend-image",
+        "deploy",
+    )
+    for job in gated_jobs:
+        condition = jobs[job]["if"]
+        assert (
+            "preview_opt_in == 'true'" in condition
+        ), f"{job} must require preview opt-in"
+
+    # Teardown on PR close must stay ungated so a deployed preview is cleaned up.
+    assert "preview_opt_in" not in jobs["cleanup"]["if"]
+
+    env_doc = read("docs/ssot/environments.md")
+    assert "Opt-in" in env_doc
+    assert "`preview` label" in env_doc

--- a/tests/tooling/test_issue_489_deployment_contracts.py
+++ b/tests/tooling/test_issue_489_deployment_contracts.py
@@ -374,3 +374,37 @@ def test_pr_preview_deploy_is_opt_in() -> None:
     env_doc = read("docs/ssot/environments.md")
     assert "Opt-in" in env_doc
     assert "`preview` label" in env_doc
+
+
+def test_in_runner_e2e_is_image_free_and_self_cleaning() -> None:
+    """Issue #839: full-stack E2E runs in-runner, image-free, and never leaks.
+
+    The ``e2e`` job is the per-PR validation gate: it runs on every
+    runtime-relevant PR (not gated behind the opt-in ``preview`` label), builds
+    and runs the stack locally (no image push, no Dokploy), and always tears the
+    stack down so no container / volume / network leaks.
+    """
+    workflow = load_yaml(".github/workflows/pr-test.yml")
+    e2e = workflow["jobs"]["e2e"]
+
+    # Runs by default on runtime PRs — NOT behind the opt-in preview label.
+    assert "pr_preview_required == 'true'" in e2e["if"]
+    assert "preview_opt_in" not in e2e["if"]
+
+    blob = yaml.safe_dump(e2e)
+    assert "docker compose up --build" in blob  # local build, not a registry push
+    assert "push: true" not in blob
+    assert "dokploy" not in blob.lower()
+
+    # Lifecycle guard: an always() teardown that removes volumes and orphans.
+    teardown = [
+        step
+        for step in e2e["steps"]
+        if "down --volumes --remove-orphans" in str(step.get("run", ""))
+    ]
+    assert teardown, "e2e job must tear the stack down"
+    assert "always()" in str(teardown[0].get("if", ""))
+
+    # The CI override + single-origin edge config exist.
+    assert (ROOT / "docker-compose.ci-e2e.yml").is_file()
+    assert (ROOT / "tools" / "ci" / "e2e-nginx.conf").is_file()

--- a/tests/tooling/test_issue_489_deployment_contracts.py
+++ b/tests/tooling/test_issue_489_deployment_contracts.py
@@ -342,38 +342,36 @@ def test_pr_preview_deploy_gate_exercises_health_smoke_e2e_and_storage_paths() -
     assert "dashboard" in hard_gate.lower()
 
 
-def test_pr_preview_deploy_is_opt_in() -> None:
-    """Issue #839: PR preview build/deploy is opt-in, not a per-PR gate.
+def test_pr_preview_deploys_per_pr_and_smokes_only() -> None:
+    """Issue #839: the Dokploy preview is a per-PR environment, not opt-in.
 
-    Default PRs must not build images or deploy to Dokploy; a preview is only
-    produced on manual dispatch or when the PR carries the ``preview`` label.
-    Authoritative deployment validation is post-merge (Staging).
+    It deploys for every runtime-relevant PR (dedicated DB per PR) and only
+    SMOKE-tests the deployed environment — the full runtime/API/UI E2E is the
+    in-runner ``e2e`` job, so the preview does not re-run it.
     """
     workflow = load_yaml(".github/workflows/pr-test.yml")
     jobs = workflow["jobs"]
 
-    opt_in = jobs["setup"]["outputs"]["preview_opt_in"]
-    assert "workflow_dispatch" in opt_in
-    assert "labels" in opt_in and "preview" in opt_in
+    # The opt-in gate is gone entirely.
+    assert "preview_opt_in" not in yaml.safe_dump(workflow)
 
-    gated_jobs = (
-        "gate-cheap-ci",
-        "build-preview-backend-image",
-        "build-preview-frontend-image",
-        "deploy",
-    )
-    for job in gated_jobs:
+    # Build + deploy run on every runtime PR (gated only on pr_preview_required).
+    for job in ("build-preview-backend-image", "build-preview-frontend-image", "deploy"):
         condition = jobs[job]["if"]
-        assert (
-            "preview_opt_in == 'true'" in condition
-        ), f"{job} must require preview opt-in"
+        assert "action == 'deploy'" in condition
+        assert "pr_preview_required == 'true'" in condition
+        assert "preview_opt_in" not in condition
 
-    # Teardown on PR close must stay ungated so a deployed preview is cleaned up.
-    assert "preview_opt_in" not in jobs["cleanup"]["if"]
+    # The deployed preview only smoke-checks; the heavy pytest E2E lives in the
+    # in-runner job, not here.
+    deploy_blob = yaml.safe_dump(jobs["deploy"])
+    assert "smoke_test.sh" in deploy_blob
+    assert "pytest" not in deploy_blob
+    assert "test_core_journeys" not in deploy_blob
 
     env_doc = read("docs/ssot/environments.md")
-    assert "Opt-in" in env_doc
-    assert "`preview` label" in env_doc
+    assert "smoke test only" in env_doc.lower()
+    assert "dedicated db" in env_doc.lower()
 
 
 def test_in_runner_e2e_is_image_free_and_self_cleaning() -> None:

--- a/tests/tooling/test_issue_489_deployment_contracts.py
+++ b/tests/tooling/test_issue_489_deployment_contracts.py
@@ -394,7 +394,9 @@ def test_in_runner_e2e_is_image_free_and_self_cleaning() -> None:
     blob = yaml.safe_dump(e2e)
     assert "docker compose up --build" in blob  # local build, not a registry push
     assert "push: true" not in blob
-    assert "dokploy" not in blob.lower()
+    # No Dokploy DEPLOY (the local `dokploy-network` stand-in network is fine).
+    assert "pr_preview_lifecycle" not in blob
+    assert "DOKPLOY_API" not in blob
 
     # Lifecycle guard: an always() teardown that removes volumes and orphans.
     teardown = [

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -728,7 +728,9 @@ def test_AC8_13_76_ci_environment_gates_publish_failure_path_context() -> None:
     assert "if: ${{ always() }}" in ci.split("Upload backend shard test context", 1)[0]
 
     assert "pr-preview-test-context" in pr_preview
-    assert "test-results/pr-preview-e2e.xml" in pr_preview
+    # Full runtime/API/UI E2E now runs image-free in the in-runner `e2e` job
+    # (issue #839); the deployed preview only smoke-tests. Its junit lives here.
+    assert "test-results/in-runner-e2e.xml" in pr_preview
     assert "ci-context/pr-preview-context.txt" in pr_preview
     assert "deploy_context_path=ci-context/pr-preview-deploy-context.json" in pr_preview
     assert "read_deploy_context_field compose_id" in pr_preview
@@ -1616,8 +1618,10 @@ def test_AC8_13_89_pr_preview_builds_pr_tagged_images_before_deploy() -> None:
     assert deploy_block.index("Wait for API readiness") < deploy_block.index(
         "Wait for frontend readiness"
     )
+    # The deployed preview now smoke-tests (the full E2E runs in the in-runner
+    # `e2e` job); the readiness waits still precede that smoke step.
     assert deploy_block.index("Wait for frontend readiness") < deploy_block.index(
-        "End-to-End Tests"
+        "Smoke Test"
     )
     frontend_readiness_block = deploy_block.split(
         "- name: Wait for frontend readiness", 1

--- a/tools/ci/e2e-nginx.conf
+++ b/tools/ci/e2e-nginx.conf
@@ -1,0 +1,26 @@
+# Single-origin edge for the in-runner E2E stack (issue #839).
+# Replicates the Dokploy/Traefik routing the preview E2E expects:
+#   /api/*  -> backend:8000  (with the /api prefix stripped, like Traefik stripprefix)
+#   /*      -> frontend:3000
+# so the existing E2E can target one origin (http://localhost:8080) without a
+# real preview deployment.
+server {
+    listen 8080;
+    server_name _;
+
+    # Strip the /api prefix before forwarding to the backend (trailing slash on
+    # proxy_pass performs the strip), mirroring the Traefik stripprefix middleware.
+    location /api/ {
+        proxy_pass http://backend:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
Implements the #839 split in one PR. **Lifecycle / no-leak was the explicit ask — see the teardown section.**

## The model

```
PR push
 ├─ In-runner E2E  ← the gate. ephemeral stack in the runner, runs E2E, torn down. green → mergeable
 └─ Dokploy preview ← opt-in human-inspection env (temporary → no promotable image needed)
post-merge: real image built (ci.yml/staging) → promote-not-rebuild ladder unchanged
```

## 1. In-runner E2E (new `e2e` job) — runs on every runtime-relevant PR

- `docker compose up --build` of base compose + **`docker-compose.ci-e2e.yml`**, which adds an **nginx `edge`** giving the single origin the E2E expects (`/api`→backend:8000 with prefix strip, `/`→frontend:3000), replacing Dokploy/Traefik.
- Runs the same non-LLM E2E (`smoke_test.sh` + `tests/e2e/...`) against `http://localhost:8080`.
- **Image-free**: builds locally, pushes nothing, no Dokploy, no shared VPS, no SSL wait. This is what keeps E2E coverage while killing the ~11 min preview cost.

## 2. Dokploy preview — opt-in (from the earlier commit)

Off by default; `preview` label or manual dispatch. Non-blocking for merge (#828). Temporary, so it doesn't need the promotable image.

## Lifecycle / no container leak (requested)

- `COMPOSE_PROJECT_NAME = fr-e2e-<run_id>-<run_attempt>` — unique per run, so teardown targets exactly this run.
- Override sets `restart: "no"` — no restart loops masking failures/teardown.
- **`if: always()` teardown**: `docker compose down --volumes --remove-orphans` runs on success, E2E failure, and build failure alike (`-v` removes named volumes, `--remove-orphans` the rest).
- Hosted `ubuntu-latest` VMs are ephemeral anyway (whole VM discarded post-job), so this is belt-and-suspenders; it also protects any future self-hosted runner.

## Contracts / tests

- `docs/ssot/environments.md`: documents the two-part split.
- `test_pr_preview_deploy_is_opt_in` + `test_in_runner_e2e_is_image_free_and_self_cleaning` (in `test_issue_489_deployment_contracts.py`) assert the gating, image-free build, and always() teardown.

## Heads-up

The in-runner full-stack stand-up (compose env wiring, migrations-on-boot, nginx upstream timing, frontend `NEXT_PUBLIC_*` build args) is real CI plumbing and **may need a couple of CI iterations** to go green on this PR.

Refs #839