### PR TITLE
[finance_report_audit] chore: bump repo/ submodule to infra2 main (bf95e7e)

### DIFF
--- a/tests/tooling/test_issue_489_deployment_contracts.py
+++ b/tests/tooling/test_issue_489_deployment_contracts.py
@@ -209,8 +209,12 @@ def test_app_iac_wires_vault_secrets_health_and_traefik_routes() -> None:
     assert "loadbalancer.server.port=3000" in labels
     assert "finance-report-web${ENV_DOMAIN_SUFFIX}.priority=1" in labels
 
-    assert "VAULT_APP_TOKEN is required" in shell_text(vault_agent["entrypoint"])
-    assert "vault token lookup" in shell_text(vault_agent["healthcheck"]["test"])
+    # The app is the AppRole pilot (infra2 #257): its vault-agent authenticates
+    # via VAULT_ROLE_ID/VAULT_SECRET_ID, not a VAULT_APP_TOKEN (postgres/redis
+    # still use the token path — see test_infra2_submodule_and_finance_report_iac_tree).
+    vault_agent_entrypoint = shell_text(vault_agent["entrypoint"])
+    assert "VAULT_ROLE_ID and VAULT_SECRET_ID are required" in vault_agent_entrypoint
+    assert "auth/token/lookup-self" in shell_text(vault_agent["healthcheck"]["test"])
     assert "IAC_CONFIG_HASH" in vault_agent["environment"]
 
     app_template = read(app_dir / "secrets.ctmpl")


### PR DESCRIPTION
Advances the `repo/` submodule from `cebaf2b3` → `bf95e7e` (infra2 main), picking up today's deploy-reliability work:

- **#269 / #272 / #273** — deploy dependency-graph fan-out (kills the `libs/ → redeploy-everything` over-fan-out), its logging/monitoring/alerting, and the iac-runner libs/ import fix.
- **#275** — deployer verifies the *running* container, not just the recorded hash (intent-vs-reality).
- **#276** — API-based deploy-queue guard sidecar (observe + opt-in remediate via Dokploy's own API) + observe-only watchdog (no more raw Redis `LREM`/`DEL`).
- **#281** — iac-runner surfaces a *failed* deploy action instead of a silent green check (root-caused from a real silent non-deploy).
- **#282** — alerting image ships the guard's runtime deps (httpx).

All of the above are merged on infra2 `main` and verified live on staging (the guard is observing 40 composes; op/Dokploy auth fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)