### PR TITLE
feat(frontend): non-blocking OpenPanel page-view tracking, per-environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,5 +153,8 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 OPENPANEL_CLIENT_ID=
 # OpenPanel API endpoint (defaults to the self-hosted instance when empty)
 OPENPANEL_API_URL=https://openpanel.zitian.party/api
+# OpenPanel SDK script URL — point at the self-hosted instance so the script loads
+# from our own origin (leave empty to use the SDK's built-in default)
+OPENPANEL_SCRIPT_URL=
 # Logical environment name tagged onto every event (e.g. staging, production, pr-47)
 OPENPANEL_ENVIRONMENT=

--- a/.env.example
+++ b/.env.example
@@ -137,3 +137,21 @@ NEXT_PUBLIC_API_URL=
 # Note: Also used by backend if it needs to generate links back to the frontend
 # [VAULT] Managed by Vault in production/staging
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# ------------------------------------------------------------------------------
+# OpenPanel web analytics (page-view tracking)
+# ------------------------------------------------------------------------------
+# These are intentionally NOT NEXT_PUBLIC_*: staging and production share the
+# same promoted Docker image, so a NEXT_PUBLIC_* value would be inlined at build
+# time and baked identically into both environments. Instead the root layout
+# (a server component) reads these at request time and passes them to the client
+# <Analytics> component. Supply per-environment values via the container
+# `environment:` block at runtime (same mechanism as GIT_COMMIT_SHA).
+#
+# Leave OPENPANEL_CLIENT_ID empty until OpenPanel onboarding issues a client id.
+# While empty, <Analytics> is a complete no-op (renders nothing).
+OPENPANEL_CLIENT_ID=
+# OpenPanel API endpoint (defaults to the self-hosted instance when empty)
+OPENPANEL_API_URL=https://openpanel.zitian.party/api
+# Logical environment name tagged onto every event (e.g. staging, production, pr-47)
+OPENPANEL_ENVIRONMENT=

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@openpanel/nextjs": "^1.5.1",
         "@tanstack/react-query": "^5.90.19",
         "decimal.js": "^10.6.0",
         "echarts": "^6.0.0",
@@ -1928,6 +1929,37 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@openpanel/nextjs": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@openpanel/nextjs/-/nextjs-1.5.1.tgz",
+      "integrity": "sha512-60vhKw29weFWmwntx/cSIYU1TcwNzRykeg8P70onr3jzeyMGsEd78d/wgF5Mp/NIxQDN0IT4LneS6hIDIyrTpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@openpanel/web": "1.4.1"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@openpanel/sdk": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@openpanel/sdk/-/sdk-1.3.1.tgz",
+      "integrity": "sha512-mQ5xaBUGXnyRg3qYxwnbVaUYyW7w8u+munrWk/ClnqxEeR2j+FYPiA6noHbHMCFC2aZutYD5OoRzEvw3FBNFxw==",
+      "license": "MIT"
+    },
+    "node_modules/@openpanel/web": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@openpanel/web/-/web-1.4.1.tgz",
+      "integrity": "sha512-DgUWeocZw+b57YiJjefZPg+6sceR7TdOF8x7Ut75lu3CwcwqGi5jZNPXjikNemGL37aNWXCB4buhcoNan2j7RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@openpanel/sdk": "1.3.1",
+        "@rrweb/types": "2.0.0-alpha.20",
+        "rrweb": "2.0.0-alpha.20"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
@@ -2301,6 +2333,18 @@
         "win32"
       ]
     },
+    "node_modules/@rrweb/types": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.1.tgz",
+      "integrity": "sha512-t+b+4rB23/e4EpoGMdPUr6cKtDsFuOb3LxA9IHE8e3A/Xo0nMUfH0bkwqdpUNa/VGDOdiGeG3bhHjuO9zWX54g==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2538,6 +2582,12 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -3349,6 +3399,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3755,6 +3811,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.14",
@@ -6603,6 +6668,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7668,6 +7739,40 @@
         "@rollup/rollup-win32-x64-gnu": "4.55.2",
         "@rollup/rollup-win32-x64-msvc": "4.55.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrdom": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.1.tgz",
+      "integrity": "sha512-z8GdQWFmVfa8GpcGkAqfBXseb89z0ciTPSBkID0qr0i6KHCye1MdQ4VoXFf0Ejp3ELe/c7AObu4zsbSbMT+hiw==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.0.1"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.0.0-alpha.20",
+        "@rrweb/utils": "^2.0.0-alpha.20",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.0.0-alpha.20",
+        "rrweb-snapshot": "^2.0.0-alpha.20"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.1.tgz",
+      "integrity": "sha512-H8TA29ct2tpYtr5oaB0N+ksRY9bhEErfAYcKbce4+w8lqEUQChpKZd41HpBJLkp04b5QUfWUg4v6r9Okf8r7vA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
       }
     },
     "node_modules/run-parallel": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@openpanel/nextjs": "^1.5.1",
     "@tanstack/react-query": "^5.90.19",
     "decimal.js": "^10.6.0",
     "echarts": "^6.0.0",

--- a/apps/frontend/src/__tests__/analytics.test.tsx
+++ b/apps/frontend/src/__tests__/analytics.test.tsx
@@ -1,0 +1,81 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { Analytics, DEFAULT_OPENPANEL_API_URL } from "@/components/Analytics"
+
+// Capture the props OpenPanelComponent is rendered with, without loading the
+// real SDK (which would attempt to inject a script tag).
+const openPanelProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
+
+vi.mock("@openpanel/nextjs", () => ({
+  OpenPanelComponent: vi.fn((props: Record<string, unknown>) => {
+    openPanelProps.current = props
+    return <div data-testid="openpanel" />
+  }),
+}))
+
+describe("Analytics", () => {
+  it("renders nothing (no-op) when clientId is unset — safety contract", () => {
+    openPanelProps.current = null
+    const { container } = render(<Analytics />)
+    expect(container).toBeEmptyDOMElement()
+    expect(openPanelProps.current).toBeNull()
+  })
+
+  it("renders nothing when clientId is an empty / whitespace string", () => {
+    openPanelProps.current = null
+    const { container, rerender } = render(<Analytics clientId="" />)
+    expect(container).toBeEmptyDOMElement()
+
+    rerender(<Analytics clientId="   " />)
+    expect(container).toBeEmptyDOMElement()
+    expect(openPanelProps.current).toBeNull()
+  })
+
+  it("renders OpenPanelComponent with env-tagged global properties when configured", () => {
+    render(
+      <Analytics
+        clientId="real-client-id"
+        apiUrl="https://op.example.com/api"
+        environment="staging"
+      />,
+    )
+
+    expect(openPanelProps.current).toMatchObject({
+      clientId: "real-client-id",
+      apiUrl: "https://op.example.com/api",
+      trackScreenViews: true,
+      globalProperties: { environment: "staging" },
+    })
+  })
+
+  it("defaults apiUrl and sends empty global properties when env not provided", () => {
+    render(<Analytics clientId="real-client-id" />)
+
+    expect(openPanelProps.current).toMatchObject({
+      clientId: "real-client-id",
+      apiUrl: DEFAULT_OPENPANEL_API_URL,
+      globalProperties: {},
+    })
+  })
+
+  it("error boundary swallows a render error from OpenPanelComponent (no rethrow)", async () => {
+    const { OpenPanelComponent } = await import("@openpanel/nextjs")
+    const mocked = vi.mocked(OpenPanelComponent)
+    const original = mocked.getMockImplementation()
+    mocked.mockImplementation(() => {
+      throw new Error("boom")
+    })
+    // React logs caught errors to console.error; silence it for a clean run.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    // Must not throw — the boundary catches and renders null.
+    const { container } = render(<Analytics clientId="real-client-id" />)
+    expect(container).toBeEmptyDOMElement()
+
+    errorSpy.mockRestore()
+    if (original) {
+      mocked.mockImplementation(original)
+    }
+  })
+})

--- a/apps/frontend/src/__tests__/rootLayout.test.tsx
+++ b/apps/frontend/src/__tests__/rootLayout.test.tsx
@@ -12,6 +12,10 @@ vi.mock("@/components/AuthGuard", () => ({
   AuthGuard: ({ children }: { children: ReactNode }) => <div data-testid="auth-guard">{children}</div>,
 }))
 
+vi.mock("@/components/Analytics", () => ({
+  Analytics: () => <div data-testid="analytics" />,
+}))
+
 vi.mock("@/app/providers", () => ({
   Providers: ({ children }: { children: ReactNode }) => <div data-testid="providers">{children}</div>,
 }))

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -37,29 +37,35 @@ export const viewport: Viewport = {
   themeColor: "#7c3aed",
 };
 
+// Read OpenPanel config at request time (server-side), not build time. These are
+// plain (non-NEXT_PUBLIC) vars so they are NOT inlined into the client bundle:
+// staging and production share the same promoted image, and each environment
+// supplies its own values via the container `environment:` block at runtime.
+// `force-dynamic` opts the root segment out of static pre-render so the env is
+// read per request rather than captured at build (the finance app is auth-gated
+// and already effectively dynamic).
+export const dynamic = "force-dynamic";
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // Read OpenPanel config from runtime (server-side) env. These are plain
-  // (non-NEXT_PUBLIC) vars so they are NOT inlined at build time: staging and
-  // production share the same promoted Docker image, and each environment
-  // supplies its own values via the container `environment:` block at runtime.
-  // The server component reads them per request and passes them to the client
-  // <Analytics> component, which is a complete no-op when the client id is unset.
-  const openpanelClientId = process.env.OPENPANEL_CLIENT_ID;
-  const openpanelApiUrl = process.env.OPENPANEL_API_URL;
-  const openpanelEnvironment = process.env.OPENPANEL_ENVIRONMENT;
+  // Gate entirely on the client id: when unset, no <Analytics> (and no extra
+  // client boundary / analytics bundle) is rendered at all — a complete no-op.
+  const openpanelClientId = process.env.OPENPANEL_CLIENT_ID?.trim();
 
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
-        <Analytics
-          clientId={openpanelClientId}
-          apiUrl={openpanelApiUrl}
-          environment={openpanelEnvironment}
-        />
+        {openpanelClientId ? (
+          <Analytics
+            clientId={openpanelClientId}
+            apiUrl={process.env.OPENPANEL_API_URL}
+            scriptUrl={process.env.OPENPANEL_SCRIPT_URL}
+            environment={process.env.OPENPANEL_ENVIRONMENT}
+          />
+        ) : null}
         <Providers>
           <AuthGuard>
             {children}

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { Viewport } from "next";
+import { Analytics } from "@/components/Analytics";
 import { AuthGuard } from "@/components/AuthGuard";
 import { Inter } from "next/font/google";
 import { Providers } from "./providers";
@@ -41,9 +42,24 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // Read OpenPanel config from runtime (server-side) env. These are plain
+  // (non-NEXT_PUBLIC) vars so they are NOT inlined at build time: staging and
+  // production share the same promoted Docker image, and each environment
+  // supplies its own values via the container `environment:` block at runtime.
+  // The server component reads them per request and passes them to the client
+  // <Analytics> component, which is a complete no-op when the client id is unset.
+  const openpanelClientId = process.env.OPENPANEL_CLIENT_ID;
+  const openpanelApiUrl = process.env.OPENPANEL_API_URL;
+  const openpanelEnvironment = process.env.OPENPANEL_ENVIRONMENT;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
+        <Analytics
+          clientId={openpanelClientId}
+          apiUrl={openpanelApiUrl}
+          environment={openpanelEnvironment}
+        />
         <Providers>
           <AuthGuard>
             {children}

--- a/apps/frontend/src/components/Analytics.tsx
+++ b/apps/frontend/src/components/Analytics.tsx
@@ -24,6 +24,12 @@ export interface AnalyticsProps {
    */
   apiUrl?: string;
   /**
+   * OpenPanel SDK script URL. Set to the self-hosted instance's script so the
+   * SDK loads from our own origin rather than the OpenPanel cloud default.
+   * Left unset → the SDK's built-in default is used.
+   */
+  scriptUrl?: string;
+  /**
    * Logical environment name (e.g. "staging", "production", "pr-47").
    * Tagged onto every tracked event via `globalProperties.environment` so PV
    * data can be split per environment even though staging/prod share the same
@@ -74,19 +80,27 @@ class AnalyticsErrorBoundary extends Component<
  * 3. Relies on the SDK's async script load + sendBeacon — render is never
  *    blocked and no tracking call is awaited on a critical path.
  */
-export function Analytics({ clientId, apiUrl, environment }: AnalyticsProps) {
-  // Config-gate: complete no-op when no client id is configured.
-  if (!clientId || clientId.trim() === "") {
+export function Analytics({ clientId, apiUrl, scriptUrl, environment }: AnalyticsProps) {
+  // Normalize once: treat whitespace-only values as unset.
+  const id = clientId?.trim();
+  const resolvedApiUrl = apiUrl?.trim() || DEFAULT_OPENPANEL_API_URL;
+  const resolvedScriptUrl = scriptUrl?.trim() || undefined;
+  const resolvedEnvironment = environment?.trim() || undefined;
+
+  // Config-gate (defense-in-depth; the layout already gates on this): complete
+  // no-op when no client id is configured.
+  if (!id) {
     return null;
   }
 
   return (
     <AnalyticsErrorBoundary>
       <OpenPanelComponent
-        clientId={clientId}
-        apiUrl={apiUrl && apiUrl.trim() !== "" ? apiUrl : DEFAULT_OPENPANEL_API_URL}
+        clientId={id}
+        apiUrl={resolvedApiUrl}
+        scriptUrl={resolvedScriptUrl}
         trackScreenViews
-        globalProperties={environment ? { environment } : {}}
+        globalProperties={resolvedEnvironment ? { environment: resolvedEnvironment } : {}}
       />
     </AnalyticsErrorBoundary>
   );

--- a/apps/frontend/src/components/Analytics.tsx
+++ b/apps/frontend/src/components/Analytics.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+import { OpenPanelComponent } from "@openpanel/nextjs";
+
+/**
+ * Default OpenPanel API endpoint for the self-hosted instance.
+ *
+ * Each environment can override this at runtime; this constant is only the
+ * fallback used when no explicit `apiUrl` is supplied.
+ */
+export const DEFAULT_OPENPANEL_API_URL = "https://openpanel.zitian.party/api";
+
+export interface AnalyticsProps {
+  /**
+   * OpenPanel client id. When empty/undefined the whole component is a
+   * complete no-op (renders nothing). This is the safety contract that keeps
+   * local/preview-without-config inert until OpenPanel onboarding provides a
+   * real client id.
+   */
+  clientId?: string;
+  /**
+   * OpenPanel API endpoint. Defaults to the self-hosted instance.
+   */
+  apiUrl?: string;
+  /**
+   * Logical environment name (e.g. "staging", "production", "pr-47").
+   * Tagged onto every tracked event via `globalProperties.environment` so PV
+   * data can be split per environment even though staging/prod share the same
+   * promoted Docker image.
+   */
+  environment?: string;
+}
+
+/**
+ * Error boundary that SWALLOWS any mount/render error from its children and
+ * renders nothing. Analytics must never affect the app: if OpenPanel's SDK
+ * throws on mount/render, the page stays completely unaffected.
+ */
+class AnalyticsErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    // Swallow the error: flip to a render-nothing state. No rethrow.
+    return { hasError: true };
+  }
+
+  componentDidCatch(): void {
+    // Intentionally empty: do not surface or rethrow analytics failures.
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return null;
+    }
+    return this.props.children;
+  }
+}
+
+/**
+ * Non-blocking, fail-safe analytics wrapper.
+ *
+ * Guarantees:
+ * 1. Config-gate — renders nothing when `clientId` is empty/unset, so the
+ *    feature is a complete no-op until a client id is configured.
+ * 2. Error boundary — any mount/render error from OpenPanel is caught and
+ *    swallowed (renders null, never rethrows, never user-visible).
+ * 3. Relies on the SDK's async script load + sendBeacon — render is never
+ *    blocked and no tracking call is awaited on a critical path.
+ */
+export function Analytics({ clientId, apiUrl, environment }: AnalyticsProps) {
+  // Config-gate: complete no-op when no client id is configured.
+  if (!clientId || clientId.trim() === "") {
+    return null;
+  }
+
+  return (
+    <AnalyticsErrorBoundary>
+      <OpenPanelComponent
+        clientId={clientId}
+        apiUrl={apiUrl && apiUrl.trim() !== "" ? apiUrl : DEFAULT_OPENPANEL_API_URL}
+        trackScreenViews
+        globalProperties={environment ? { environment } : {}}
+      />
+    </AnalyticsErrorBoundary>
+  );
+}
+
+export default Analytics;

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -86,6 +86,7 @@ explicit AC IDs for the behavior.
 | `apps/backend/tests/unit/services/test_source_type_priority.py` | `docs/ssot/source-type-priority.md` |
 | `apps/backend/tests/unit/utils/test_exceptions.py` | `docs/ssot/development.md` |
 | `apps/backend/tests/test_factories.py` | `apps/backend/tests/factories.py` |
+| `apps/frontend/src/__tests__/analytics.test.tsx` | Frontend analytics tracking (OpenPanel PV) — non-blocking infra, not product behavior |
 | `apps/frontend/src/__tests__/ConflictResolutionDialog.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/__tests__/ThemeToggle.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/__tests__/TransactionTable.test.tsx` | `docs/ssot/frontend-patterns.md` |


### PR DESCRIPTION
Instruments the frontend with OpenPanel auto page-view (PV) tracking so each environment's traffic is visible **split by `environment`** in OpenPanel — toward the "see basic PV per env" goal.

## Non-blocking / fail-safe (the hard requirement) — all three implemented
Analytics tracking must **never** affect the app's performance or behavior:
1. **Config-gate** — `<Analytics>` renders nothing when `OPENPANEL_CLIENT_ID` is unset → a **complete no-op** for local/preview-without-config and until onboarding provides a client id. **This PR is fully inert by default.**
2. **Error boundary** — swallows any mount/render error from the OpenPanel SDK (renders null, never rethrows, no user-visible effect) → a down/unreachable OpenPanel can't touch the page.
3. **No critical-path blocking** — relies on the SDK's async script + sendBeacon; render is never blocked, no tracking call is awaited.

## Per-env with promote-not-rebuild
staging/prod share ONE promoted image, so `NEXT_PUBLIC_*` (build-time-inlined) can't carry a per-env value. `layout.tsx` (server component) reads plain `OPENPANEL_*` env **at request time** and passes them to the client `<Analytics>` — each env sets its own values on the same image (same pattern as `GIT_COMMIT_SHA`).

## What's in / what's next
- In: `@openpanel/nextjs`, `Analytics.tsx`, layout wiring, `.env.example` (`OPENPANEL_{CLIENT_ID,API_URL,ENVIRONMENT}`, all empty/default), 5 tests (incl. no-op + error-swallow contract). Lint/typecheck/coverage green.
- **Next (separate, out of this app-code PR):** (1) OpenPanel onboarding → create a project → get a `client_id`; (2) wire `OPENPANEL_CLIENT_ID` / `OPENPANEL_ENVIRONMENT: <env>` into the frontend service `environment:` in the infra2 app compose per env. Until then this is a verified no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)