### PR TITLE
[finance_report_vision] chore: verify PR preview env (throwaway, do not merge)

### DIFF
--- a/apps/backend/src/__init__.py
+++ b/apps/backend/src/__init__.py
@@ -1,1 +1,6 @@
 """Backend source package."""
+
+# Preview-environment verification probe (issue #839): this throwaway runtime
+# touch triggers the per-PR Dokploy preview deploy + smoke so the corrected
+# preview flow can be validated end-to-end without blocking other PRs.
+# Safe to close this PR once the preview deploy + smoke have gone green.


### PR DESCRIPTION
**Throwaway PR — do not merge; close once the preview is verified.**

Purpose: exercise the corrected per-PR Dokploy preview flow from #841 (issue #839) end-to-end, on its own PR, so verifying the slow (~11 min) preview deploy doesn't block real work.

A one-line comment in `apps/backend/src/__init__.py` is a runtime touch that makes the change classifier mark the PR as runtime-relevant, so `pr-test.yml` deploys a per-PR preview and runs the smoke test.

What this confirms:
- The preview **still deploys per PR** (with its own DB) — not opt-in.
- It runs **smoke only** (the full E2E is the in-runner `e2e` job).
- The deploy is **non-blocking** and reports via PR comment.

I will not push again to this branch so the deploy can run to completion uninterrupted.

Refs #839