### PR TITLE
[finance_report_test_and_doc] Centralize runtime incident response SSOT

### DIFF
--- a/docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md
+++ b/docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md
@@ -67,6 +67,10 @@ are confirmed to rely only on the structured consumers.
 June 9, 2026 evidence sample: the review checked the three newest successful
 and three newest failed available logs for each active delivery lane. Cancelled
 runs were ignored because they prove supersession behavior, not a gate result.
+Runtime incident categories such as stale-version, route, dependency,
+observability, secrets, and flapping are owned by
+[runtime-incident-response.md](../ssot/runtime-incident-response.md). This note
+records delivery-engine evidence and recommendations only.
 
 | Lane | Three newest successful samples | Three newest failed samples | Observed signal |
 |---|---|---|---|
@@ -98,7 +102,8 @@ resource leak candidates:
 - Docker build cache and stopped containers on the Dokploy host after repeated
   image build, redeploy, or failed rollout loops.
 - stale staging or production routes/images where health reports an older SHA or
-  version, as seen in release failure logs.
+  version, as seen in release failure logs. Classification and closure proof
+  stay in [runtime-incident-response.md](../ssot/runtime-incident-response.md).
 - Provider-backed runs that retry externally visible OCR/LLM work without tight
   path gating or isolated users.
 
@@ -124,7 +129,8 @@ coupled but do not require a topology rewrite:
   deploy context now records `production_before_version`, deploy-health
   outcome, smoke outcomes, and a production failure domain so stale version
   mismatches are diagnosable without turning production into the first
-  correctness proof.
+  correctness proof. Incident classification and stability proof stay in
+  [runtime-incident-response.md](../ssot/runtime-incident-response.md).
 - provider-backed external-state residue: staging AI/OCR remains gated by the
   structured provider relevance output and records
   `isolated-users-provider-gate-only`; the contract test rejects shared mutable

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -396,6 +396,7 @@ job inventories or scenario counts into this EPIC.
 | AC8.13.123 | Schema guardrails scan the real `apps/backend/migrations/versions` directory instead of a test-local path | `test_AC8_13_123_schema_guardrails_scan_real_migration_directory` | `tests/tooling/test_schema_quality_contract.py` | P0 |
 | AC8.13.124 | AC traceability gate and uploaded audit builder consume the same SSOT test-surface definition, including frontend Playwright tests | `test_AC8_13_124_traceability_gate_and_audit_builder_share_test_surface` | `tests/tooling/test_schema_quality_contract.py` | P1 |
 | AC8.13.125 | PR preview waits stay bounded: current runner preview has a hard workflow timeout and legacy Dokploy busy-queue extensions cannot exceed the compatibility rollout deadline | `test_AC8_13_125_busy_dokploy_queue_cannot_extend_past_rollout_deadline`; `test_AC8_13_125_pr_preview_runner_lifecycle_has_hard_timeout` | `tests/tooling/test_pr_preview_lifecycle.py` | P1 |
+| AC8.13.126 | Runtime incident response SSOT centralizes service-failure triage and stability proof ownership, while deployment, observability, CI/CD, and environment smoke docs link to it instead of duplicating playbooks | `test_AC8_13_126_runtime_incident_response_ssot_centralizes_triage` | `tests/tooling/test_runtime_incident_response_ssot.py` | P0 |
 
 ### AC8.14: Product Trust Proof Mirrors
 

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -258,6 +258,23 @@ concepts:
       - .github/workflows/staging-deploy.yml
       - .github/workflows/staging-ai-ocr-gate.yml
 
+  runtime_incident_response:
+    owner: docs/ssot/runtime-incident-response.md
+    description: App-side runtime incident triage and stability-proof routing.
+    family: runtime
+    kind: playbook
+    cross_refs:
+      - docs/ssot/deployment.md
+      - docs/ssot/observability.md
+      - docs/ssot/ci-cd.md
+      - docs/ssot/env_smoke_test.md
+      - docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md
+      - repo/docs/ssot/ops.alerting.md
+      - repo/docs/ssot/ops.availability-ledger.md
+      - repo/docs/ssot/ops.recovery.md
+    proofs:
+      - tests/tooling/test_runtime_incident_response_ssot.py
+
   # ── Development environment ────────────────────────────────────────────
   moon_commands:
     owner: docs/ssot/development.md#moon-commands
@@ -477,3 +494,5 @@ concepts:
     description: Environment smoke testing via real boot operations.
     cross_refs:
       - docs/ssot/development.md
+    proofs:
+      - tests/tooling/test_runtime_incident_response_ssot.py

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -49,6 +49,7 @@ contracts is tracked in
 | [ci-cd.md](./ci-cd.md) | `ci-cd` | CI gate semantics and workflow references |
 | [deployment.md](./deployment.md) | `deployment` | Deployment model and release rationale |
 | [observability.md](./observability.md) | `observability` | Structured logging and SigNoz OTLP rationale |
+| [runtime-incident-response.md](./runtime-incident-response.md) | `runtime_incident_response` | Runtime incident triage and stability-proof routing |
 | [tdd.md](./tdd.md) | `tdd-transformation` | EPIC -> AC -> test workflow |
 | [coverage.md](./coverage.md) | `coverage` | Coverage metric semantics; code owner is `common/coverage/policy.py` |
 | [auth.md](./auth.md) | `auth` | Auth architecture rationale and code references |

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -113,13 +113,16 @@ integrity and availability, not first-time deterministic business behavior.
 ### Path Risk to Local Gate Matrix
 
 Default local verification starts with affected fast tests such as
-`moon run :test -- --smart`, focused Vitest/spec runs, or the smallest relevant
-tooling contract. Risk-triggered local escalation applies when the changed path
-can affect behavior outside the touched file.
+`moon run :test -- --smart`, focused backend paths through
+`moon run :test -- --fast tests/...`, focused Vitest/spec runs, or the smallest
+relevant tooling contract. Direct backend `pytest tests/...` uses the backend
+default coverage policy and is not the focused TDD path. Risk-triggered local
+escalation applies when the changed path can affect behavior outside the touched
+file.
 
 | Changed path or concern | Default local gate | Escalation trigger |
 |---|---|---|
-| Ordinary backend source | `moon run :test -- --smart` or focused pytest file | Escalate when the change crosses service boundaries or touches shared helpers |
+| Ordinary backend source | `moon run :test -- --smart` or `moon run :test -- --fast tests/...` for a focused backend path | Escalate when the change crosses service boundaries or touches shared helpers |
 | accounting, posting, reconciliation, money, balance | Focused domain pytest suite plus changed-file tests | Always include invariant tests beyond the touched file |
 | schema, migrations | `cd apps/backend && uv run alembic upgrade head && uv run alembic check`, plus focused DB-backed tests | Required for any Alembic, SQLAlchemy model, enum, or persistence contract change |
 | API contract, OpenAPI | Backend API tests plus affected frontend API consumer tests | Required for route, schema, generated API reference, or response-shape changes |
@@ -323,6 +326,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Staging deploy context artifacts record triggering CI metadata: CI run id, run attempt, trigger event, head SHA, creation timestamp, conclusion, and run URL. They also record the structured build/deploy failure domain, failed step, and failure summary so early failures can be split between checkout/SHA resolution, post-merge train wait, change classification, toolchain setup, registry login, runner/Buildx bootstrap, GHCR image lookup/build/promotion, Dokploy rollout/health, E2E setup, and application smoke/E2E without manually scraping the raw job log first. The classifier fails closed: a failed classification step is never reported as `not-required`, and an unexpected failed step is reported as `unclassified-build-deploy-failure` rather than `none`.
 - After successful main CI, post-merge staging first looks up the backend and frontend SHA-tagged staging images from GHCR. If a SHA image is missing, the workflow falls back to building only the missing image. Once both SHA images are present, staging retags those immutable images as `staging` before deploy. This keeps deploy detection strict while moving normal image build time out of the serialized post-merge lane.
 - Deploy health covers image build/push, Dokploy rollout, `/api/health`, shell smoke checks, and core non-LLM E2E.
+- Runtime incident classification for route, dependency, observability, secrets, stale-version, and flapping failures is owned by [runtime-incident-response.md](./runtime-incident-response.md). This CI/CD SSOT owns where the gates run and what they block, not the shared incident playbooks.
 - Staging Dokploy rollout logs include a redacted rollout summary on the first, periodic, non-idle, error, and timeout probes. The summary may include compose identity, source path, command, compose status, deployment count, latest deployment status/timestamps, and deployment `logPath`; it must keep raw compose, raw deployment, and raw environment payloads out of GitHub Actions logs.
 - Staging deploy proof is not satisfied by a Dokploy trigger alone. After `compose.deploy`, `tools/dokploy_deploy.sh` waits for Dokploy to expose a new deployment record and for that record to reach `done` before application readiness starts. A `running` deployment record only proves the worker started; it does not prove Docker containers and Traefik routes have materialized the target SHA. If `compose.deploy` does not expose a new deployment record within the short new-record window, staging retries once with `compose.redeploy`. It also retries once when `compose.deploy` leaves the compose in `error` before a new deployment record exists, because Dokploy can hold a stale compose error state while accepting a fresh environment update. If the redeploy still leaves the compose in `error`, staging fails as a Dokploy rollout failure with redacted rollout diagnostics. If the redeploy still does not expose a new record, staging fails before application readiness when no deployment record materializes instead of treating an accepted no-op request as deploy proof. `tools/health_check.sh` remains the final target-SHA proof after a completed rollout record; it must read `/api/health.git_sha` or `/api/health.version` and fail unless it matches the target image tag/SHA. If a new deployment record appears but does not reach `done`, staging fails as a platform rollout failure before application readiness.
 - Automatic provider-backed AI/OCR validation runs as a conditional downstream job in the same serialized post-merge workflow unit when the normalized staging provider gate is required. This keeps staging stable for the SHA under validation: a newer deploy cannot overwrite staging while an older automatic AI/OCR gate is running. When the provider gate is not required, a successful deploy-health job is enough to close the staging gate for that merge commit.

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -253,14 +253,14 @@ post-deploy detectors.
 
 ---
 
-## Deployment Failures
+## Runtime Incident Response
 
-| Symptom | Cause | Resolution |
-|---------|-------|------------|
-| Stuck "Waiting for secrets" | Vault token expired | `DEPLOY_ENV=staging invoke vault.setup-tokens --project=finance_report --service=app` from infra2 |
-| 6 min timeout | Migration failed | Check SigNoz for CHECKPOINT-2 errors |
-| "Image not found" | Tag not built | `git push origin v1.2.3` to trigger build |
-| 502 Bad Gateway | Backend crashed | Check CHECKPOINT-3 in SigNoz logs |
+Runtime failure triage is owned by
+[runtime-incident-response.md](./runtime-incident-response.md). This deployment
+SSOT owns deploy architecture, release flow, Vault token boundaries, and
+Dokploy safety rules. Use the runtime incident SSOT for 502/503 responses,
+route failures, stale deployed versions, missing logs/alerts, expired-secret
+symptoms, and flapping recovery proof.
 
 ---
 
@@ -312,4 +312,5 @@ If a change requires new environment variables or changes to `docker-compose.yml
 - [environments.md](./environments.md) — Six environment overview and naming
 - [development.md](./development.md) — Local development and Moon commands
 - [ci-cd.md](./ci-cd.md) — CI job structure and test strategy
-- [observability.md](./observability.md) — SigNoz logs for debugging deployments
+- [observability.md](./observability.md) — App observability runtime contract and SigNoz OTLP setup
+- [runtime-incident-response.md](./runtime-incident-response.md) — Runtime failure triage and stability proof routing

--- a/docs/ssot/env_smoke_test.md
+++ b/docs/ssot/env_smoke_test.md
@@ -82,6 +82,12 @@ Bootloader: Running validation cycle (mode=full)
 
 ## 4. Debugging Guide
 
+For deployed-service incidents, use
+[runtime-incident-response.md](./runtime-incident-response.md) to route 502/503,
+route, dependency, observability, stale-version, secrets, and flapping symptoms.
+This document only owns the Bootloader gates and environment smoke-test
+rationale.
+
 ### "Gate 2 Failed: Startup Crash"
 - **Symptom**: App exits immediately with exit code 1.
 - **Cause**: Database unreachable or `DATABASE_URL` invalid.

--- a/docs/ssot/observability.md
+++ b/docs/ssot/observability.md
@@ -233,33 +233,18 @@ the shared rule can query.
 
 ---
 
-## 8. Troubleshooting
+## 8. Runtime Incident Routing
 
-### Logs not appearing in SigNoz
+Runtime failure triage is owned by
+[runtime-incident-response.md](./runtime-incident-response.md). This document
+owns the observability contract only: structured log shape, OTEL/SigNoz
+configuration, the redacted `/health.observability` fields, and app service
+metadata used by the shared alert rule.
 
-1. **Check OTEL endpoint is reachable** (from backend container):
-   ```bash
-   # Enter the backend container (which is in dokploy-network)
-   docker exec -it finance-report-backend sh
-   
-   # Test connectivity to OTEL collector
-   curl -v http://platform-signoz-otel-collector:4318/v1/logs
-   ```
-
-2. **Verify environment variables are set**:
-   ```bash
-   # Check container env
-   docker exec finance-report-backend env | grep OTEL
-   ```
-
-3. **Check backend logs for OTLP errors**:
-   ```bash
-   docker logs finance-report-backend 2>&1 | grep -i otel
-   ```
-
-### Wrong environment showing
-
-Ensure `OTEL_RESOURCE_ATTRIBUTES` includes correct `deployment.environment` value.
+Use the runtime incident SSOT for missing logs, wrong environment labels,
+502/503 responses, route failures, stale deployed versions, and flapping
+recovery proof. Use `repo/docs/ssot/ops.alerting.md` for shared SigNoz alert
+automation, bridge delivery, and Lark channel behavior.
 
 ---
 
@@ -365,19 +350,12 @@ infra2/platform (repo submodule)
 
 ### 10.4 Post-Deployment Verification
 
-After deploying to staging/production, verify observability:
+After staging or production deploys, keep observability verification narrow:
 
-```bash
-# 1. Check logs are arriving in SigNoz (within 2 minutes)
-open https://signoz.zitian.party
-# Filter: deployment.environment = staging
-# Look for recent logs from finance-report-backend
-
-# 2. Verify OTEL endpoint is reachable from container
-ssh root@$VPS_HOST
-# For production:
-docker exec finance_report-backend curl -sf http://platform-signoz-otel-collector:4318/v1/logs
-# For staging:
-docker exec finance_report-backend-staging curl -sf http://platform-signoz-otel-collector:4318/v1/logs
-# Should return HTTP 405 (Method Not Allowed) - means endpoint is reachable
-```
+1. Confirm `/health.observability` exposes the expected service name, deployment
+   environment, alert rule, and alerting pipeline without secret URLs or keys.
+2. Confirm SigNoz has recent `finance-report-backend` logs for the target
+   `deployment.environment`.
+3. If logs or alerts are missing during an incident, route through
+   [runtime-incident-response.md](./runtime-incident-response.md) instead of
+   adding environment-specific debugging steps here.

--- a/docs/ssot/runtime-incident-response.md
+++ b/docs/ssot/runtime-incident-response.md
@@ -1,0 +1,174 @@
+# Runtime Incident Response SSOT
+
+> **SSOT Key**: `runtime_incident_response`
+> **Core Definition**: App-side entry point for diagnosing Finance Report
+> runtime incidents and proving service stability after deploy or recovery.
+
+This SSOT owns the shared language for "the service is down again" triage.
+It does not replace the deployment, CI/CD, environment, or infra2 documents;
+it routes an incident to the right owner without copying the same playbook into
+every document.
+
+---
+
+## Source of Truth
+
+| Area | Owner |
+|---|---|
+| App deployment model and release flow | `docs/ssot/deployment.md` |
+| CI, preview, staging, and production gate semantics | `docs/ssot/ci-cd.md` |
+| Boot/runtime health validation | `docs/ssot/env_smoke_test.md`, `apps/backend/src/boot.py`, `apps/backend/src/main.py` |
+| App observability runtime contract | `docs/ssot/observability.md`, `apps/backend/src/observability.py` |
+| Staging/production health and version smoke | `tools/health_check.sh`, `tools/production_infra_smoke.py`, `common/ci/production_infra_smoke.py` |
+| Delivery-engine evidence and optimization recommendations | `docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md` |
+| Infra alerting, Lark delivery, watchdogs | `repo/docs/ssot/ops.alerting.md` |
+| Availability history and stability windows | `repo/docs/ssot/ops.availability-ledger.md` |
+| Infra recovery and backup restoration | `repo/docs/ssot/ops.recovery.md` |
+
+## Ownership Boundary
+
+Finance Report owns:
+- App health response semantics, including status, dependency checks, version,
+  and redacted observability fields.
+- Release-gate interpretation for `/api/health`, `/api/ping`, frontend
+  reachability, deployed SHA/version, and production smoke output.
+- App-side triage labels: `route`, `dependency`, `observability`, `secrets`,
+  `stale-version`, and `flapping`.
+- The proof that a recovered app version is the intended version and passes
+  the expected smoke gates.
+
+Infra2 owns:
+- Vault, Traefik, Dokploy host scheduling, SigNoz platform health, Lark bridge
+  delivery, watchdog implementation, availability-ledger storage, and backup
+  recovery.
+- Platform evidence such as restart counts, watchdog samples, route materialized
+  state, and cross-service availability windows.
+
+## Triage Entry Points
+
+Start from the user-visible symptom, then move left to right. Do not start by
+rewriting docs or rerunning broad test suites.
+
+| Symptom | First proof | Failure domain | Owner |
+|---|---|---|---|
+| HTTP `000`, timeout, or DNS/TLS failure | `tools/health_check.sh` route probes and infra alert samples | `route` | Deployment + infra alerting |
+| Repeated `/api/health` `404` | Health script `route_probe` output for `/api/health`, `/api/ping`, and `/` | `route` | Deployment routing |
+| `502 Bad Gateway` | Backend container state, startup checkpoint logs, and `/api/ping` reachability | `crash` | App startup/deploy |
+| `/api/health` returns `503` | Health payload `checks` object and Bootloader mode | `dependency` | App dependency config, then infra service |
+| App is healthy but `git_sha` or `version` is old | `/api/health.git_sha`, release image tag, Dokploy effective env diff | `stale-version` | Deploy workflow/Dokploy/image routing |
+| Logs or alerts missing while app serves traffic | `/health.observability`, service name, alert rule, SigNoz health | `observability` | App observability contract + infra alerting |
+| Startup waits for secrets or exits before CHECKPOINT-2 | Vault sidecar output, rendered secret freshness, Bootloader protected-runtime checks | `secrets` | Infra2 Vault + app boot validation |
+| Alternating healthy/unhealthy samples, repeat restarts, or repeated alerts | Watchdog samples, restart counts, availability ledger | `flapping` | Infra watchdog + app incident owner |
+
+## Failure Domain Routing
+
+Use one domain for the first response. Split only after the first domain has a
+specific proof gap.
+
+| Domain | Definition | Primary evidence | Escalate when |
+|---|---|---|---|
+| `route` | Public route cannot reach the intended app endpoint | Health script route probes, Traefik/Dokploy route state | The backend is healthy internally but public routes fail |
+| `dependency` | App is reachable but a required dependency is unhealthy | `/api/health.checks`, Bootloader logs, smoke output | The dependency container/service itself is unavailable |
+| `observability` | App serves but logs, traces, alert rule, or SigNoz/Lark delivery is broken | `/health.observability`, SigNoz health/version, alert rule metadata | SigNoz or Lark platform health is degraded |
+| `secrets` | Protected runtime lacks usable runtime secrets | Vault sidecar render, secret file freshness, Bootloader config failure | Vault token or template state must be repaired in infra2 |
+| `stale-version` | Public app answers but not with the requested SHA/version | `/api/health.git_sha`, `IMAGE_TAG`, `GIT_COMMIT_SHA`, Dokploy env diff | Dokploy materialized a previous image/env after a successful trigger |
+| `flapping` | Recovered service does not stay recovered | Availability ledger, watchdog samples, restart counts | The app passes one smoke check but fails the stability window |
+
+## Stability Proof
+
+An incident is closed only after the recovered runtime has both point-in-time
+health and short-window stability.
+
+Required app-side proof:
+- `/api/health` is healthy for the target environment.
+- `/api/health.git_sha` or `/api/health.version` matches the intended
+  deployment target.
+- Required dependency checks in `/api/health.checks` are green.
+- Production release recovery runs `production_infra_smoke.py` or records why
+  the production smoke result is not applicable.
+- App observability fields match `docs/ssot/observability.md`: service
+  `finance-report-backend`, alert rule `FinanceReportBackendErrorLogs`, and
+  no secret collector or webhook fields in health output.
+
+Required stability-window proof:
+- No repeated stale SHA/version after the deploy-health window.
+- No recent public route failure for `/api/health` or `/api/ping`.
+- No unhealthy required dependency sample.
+- No watchdog or availability-ledger evidence of `flapping`.
+
+The hard production release gate is still the production release workflow and
+`production_infra_smoke.py`. The infra2 availability ledger and watchdog are
+the positive stability proof for repeated incidents. If that proof is not yet
+automated in a release lane, capture it as manual incident-closure evidence
+instead of duplicating the procedure in app docs.
+
+## Playbooks
+
+### Stale Version
+
+1. Compare requested tag/SHA with `/api/health.git_sha` or `/api/health.version`.
+2. Check the allowlisted Dokploy env diff for `IMAGE_TAG`, `GIT_COMMIT_SHA`,
+   `IAC_CONFIG_HASH`, `ENV_SUFFIX`, and `COMPOSE_PROFILES`.
+3. If Dokploy reports success but the public route remains old, classify as
+   `stale-version` and inspect route/materialized deployment state before
+   rerunning business E2E.
+
+### Crash or 502
+
+1. Confirm whether `/api/ping` and `/api/health` fail the same way.
+2. Inspect backend startup checkpoints and container state.
+3. If startup fails before app readiness, route to deployment/boot validation.
+   If the app starts and then crashes repeatedly, add `flapping` evidence.
+
+### Dependency 503
+
+1. Read `/api/health.checks`; do not infer from the HTTP code alone.
+2. For database failures, compare Bootloader startup logs with migration proof.
+3. For S3/Redis failures, route to the owning dependency after proving the app
+   config points at the intended endpoint.
+
+### Observability Missing
+
+1. Check `/health.observability` or `/api/health.observability` for the redacted
+   app contract.
+2. Confirm SigNoz health/version through production smoke or the SigNoz UI.
+3. Use `repo/docs/ssot/ops.alerting.md` for shared alert rule, bridge, and Lark
+   delivery automation. The app doc owns only service metadata and log shape.
+
+### Secret Startup Failure
+
+1. Confirm the failure is in protected runtime boot validation or secret render.
+2. Use `docs/ssot/deployment.md` for Finance Report's Vault token boundary.
+3. Use `repo/docs/ssot/ops.recovery.md` for infra recovery if Vault or backup
+   state is degraded.
+
+### Flapping
+
+1. Require more than one sample; one green smoke is not recovery proof.
+2. Check availability-ledger and watchdog samples for repeated failures or
+   restarts.
+3. Close the incident only when the stability window is clean for the target
+   runtime.
+
+## Caller Document Rules
+
+Other docs should link here instead of copying these playbooks:
+- `docs/ssot/deployment.md` owns deployment architecture, release flow, Vault
+  token boundaries, and Dokploy safety rules.
+- `docs/ssot/observability.md` owns structured logging, OTEL/SigNoz config, and
+  redacted app observability fields.
+- `docs/ssot/ci-cd.md` owns gate placement, workflow semantics, and required
+  checks.
+- `docs/ssot/env_smoke_test.md` owns Bootloader gate definitions and smoke-test
+  rationale.
+- `docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md` may record historical
+  delivery evidence, but runtime incident categories and closure proof still
+  link back here.
+- `repo/docs/ssot/ops.alerting.md`, `repo/docs/ssot/ops.availability-ledger.md`,
+  and `repo/docs/ssot/ops.recovery.md` own platform-side alerting, availability,
+  and recovery facts.
+
+## Proof
+
+The documentation contract is enforced by
+`tests/tooling/test_runtime_incident_response_ssot.py`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - CI/CD: ssot/ci-cd.md
       - Coverage: ssot/coverage.md
       - Deployment: ssot/deployment.md
+      - Runtime Incident Response: ssot/runtime-incident-response.md
       - TDD Workflow: ssot/tdd.md
       - Accounting Model: ssot/accounting.md
       - Auth: ssot/auth.md

--- a/tests/tooling/test_cli_and_dev_servers.py
+++ b/tests/tooling/test_cli_and_dev_servers.py
@@ -189,6 +189,34 @@ def test_AC16_11_17_cmd_test_backend_path_route(monkeypatch):
     ]
 
 
+def test_AC16_11_17_cmd_test_backend_path_route_honors_fast_mode(monkeypatch):
+    """AC16.11.17: focused backend test paths keep lifecycle flags."""
+    calls = []
+    monkeypatch.setattr(
+        cli,
+        "run",
+        lambda cmd, cwd=cli.REPO_ROOT, env=None, check=True: calls.append((cmd, cwd)),
+    )
+    cli.cmd_test(
+        SimpleNamespace(
+            frontend=False,
+            e2e=False,
+            backend_e2e=False,
+            perf=False,
+            fast=True,
+            smart=False,
+            ephemeral=False,
+        ),
+        ["tests/infra/test_boot.py"],
+    )
+
+    cmd = calls[0][0]
+    assert cmd[:2] == [sys.executable, str(cli.REPO_ROOT / "tools" / "test_lifecycle.py")]
+    assert "--fast" in cmd
+    assert "tests/infra/test_boot.py" in cmd
+    assert calls[0][1] == cli.BACKEND_DIR
+
+
 def test_AC16_11_17_cmd_test_lifecycle_route(monkeypatch):
     calls = []
     monkeypatch.setattr(

--- a/tests/tooling/test_runtime_incident_response_ssot.py
+++ b/tests/tooling/test_runtime_incident_response_ssot.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_AC8_13_126_runtime_incident_response_ssot_centralizes_triage() -> None:
+    """AC8.13.126: Runtime incident triage has one SSOT and link-only callers."""
+
+    runtime_path = ROOT / "docs/ssot/runtime-incident-response.md"
+    assert runtime_path.exists()
+
+    runtime = runtime_path.read_text(encoding="utf-8")
+    required_runtime_tokens = [
+        "# Runtime Incident Response SSOT",
+        "`runtime_incident_response`",
+        "## Triage Entry Points",
+        "## Failure Domain Routing",
+        "## Stability Proof",
+        "docs/ssot/deployment.md",
+        "docs/ssot/observability.md",
+        "docs/ssot/ci-cd.md",
+        "docs/ssot/env_smoke_test.md",
+        "docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md",
+        "repo/docs/ssot/ops.alerting.md",
+        "repo/docs/ssot/ops.availability-ledger.md",
+        "repo/docs/ssot/ops.recovery.md",
+        "`route`",
+        "`dependency`",
+        "`observability`",
+        "`secrets`",
+        "`stale-version`",
+        "`flapping`",
+        "production_infra_smoke.py",
+        "tools/health_check.sh",
+    ]
+    for token in required_runtime_tokens:
+        assert token in runtime
+
+    manifest = yaml.safe_load(read("docs/ssot/MANIFEST.yaml"))
+    concept = manifest["concepts"]["runtime_incident_response"]
+    assert concept["owner"] == "docs/ssot/runtime-incident-response.md"
+    assert concept["family"] == "runtime"
+    assert concept["kind"] == "playbook"
+    assert "tests/tooling/test_runtime_incident_response_ssot.py" in concept["proofs"]
+    assert set(concept["cross_refs"]) >= {
+        "docs/ssot/deployment.md",
+        "docs/ssot/observability.md",
+        "docs/ssot/ci-cd.md",
+        "docs/ssot/env_smoke_test.md",
+        "docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md",
+        "repo/docs/ssot/ops.alerting.md",
+        "repo/docs/ssot/ops.availability-ledger.md",
+        "repo/docs/ssot/ops.recovery.md",
+    }
+    assert (
+        "tests/tooling/test_runtime_incident_response_ssot.py"
+        in manifest["concepts"]["env_smoke_test"]["proofs"]
+    )
+
+    index = read("docs/ssot/README.md")
+    assert "[runtime-incident-response.md](./runtime-incident-response.md)" in index
+    assert "`runtime_incident_response`" in index
+
+    deployment = read("docs/ssot/deployment.md")
+    assert "(./runtime-incident-response.md)" in deployment
+    assert "| 502 Bad Gateway | Backend crashed | Check CHECKPOINT-3 in SigNoz logs |" not in deployment
+
+    observability = read("docs/ssot/observability.md")
+    assert "(./runtime-incident-response.md)" in observability
+    assert "docker exec finance-report-backend env | grep OTEL" not in observability
+
+    ci_cd = read("docs/ssot/ci-cd.md")
+    assert "(./runtime-incident-response.md)" in ci_cd
+
+    env_smoke = read("docs/ssot/env_smoke_test.md")
+    assert "(./runtime-incident-response.md)" in env_smoke
+
+    recommendation = read("docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md")
+    assert "(../ssot/runtime-incident-response.md)" in recommendation

--- a/tools/_lib/dev/cli.py
+++ b/tools/_lib/dev/cli.py
@@ -161,7 +161,8 @@ def cmd_test(args, extra_args: list[str]):
         )
         return
 
-    if extra_args and extra_args[0].startswith("tests/"):
+    lifecycle_requested = args.fast or args.smart or args.ephemeral
+    if extra_args and extra_args[0].startswith("tests/") and not lifecycle_requested:
         run(uv_run("python", "-m", "pytest") + extra_args, cwd=BACKEND_DIR)
         return
     lifecycle_args = []


### PR DESCRIPTION
## Summary

Centralize runtime incident triage into a new SSOT, shorten duplicate caller docs into links, and preserve focused backend fast-mode test routing.

Closes N/A

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Comprehensive Testing Strategy |
| **AC IDs** | AC8.13.126, AC16.11.17 |
| **AC source updated** | `docs/project/EPIC-008.testing-strategy.md` |

---

## SSOT Changes

- [x] `docs/ssot/MANIFEST.yaml` — added `runtime_incident_response` owner and cross-references.
- [x] `docs/ssot/runtime-incident-response.md` — new runtime incident triage, failure-domain routing, and stability-proof SSOT.
- [x] `docs/ssot/README.md` — added the new SSOT to the index.
- [x] `docs/ssot/deployment.md` — replaced duplicate deployment-failure playbook with a runtime incident SSOT link.
- [x] `docs/ssot/observability.md` — replaced generic troubleshooting with observability ownership boundaries and a runtime incident SSOT link.
- [x] `docs/ssot/ci-cd.md` — linked runtime failure classification to the new SSOT while keeping gate semantics here.
- [x] `docs/ssot/env_smoke_test.md` — linked deployed-service incident routing to the new SSOT.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | Local pre-commit red phase | `test_AC8_13_126_runtime_incident_response_ssot_centralizes_triage` failed because `docs/ssot/runtime-incident-response.md` did not exist. |
| 🟢 Green (passing test) | `21c32bdc` | Added the SSOT, caller links, manifest/index entries, and regression tests. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no schema changes.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A, no frontend env vars.
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A, no production config changes; pre-existing local `repo` dirty state was not committed.
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env vars changed.
- [x] `tools/check_manifest.py` passes (if SSOT files changed).
- [x] `tools/lint_doc_consistency.py` passes.

### CI/CD, Runtime, and VPS Infra Audit

N/A: this PR changes documentation, tooling tests, and the local test command router only. It does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or runtime logs.

---

## Testing

```bash
moon run :lint
uv run pytest tests/tooling/test_runtime_incident_response_ssot.py tests/tooling/test_post_merge_e2e_gates.py::test_AC8_13_113_sparse_matrix_evidence_and_resource_leak_audit_are_recorded tests/tooling/test_post_merge_e2e_gates.py::test_AC8_13_119_delivery_resource_leak_hardening_is_contracted -q
uv run --with pyyaml python tools/check_manifest.py
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_ac_traceability.py
uv run --with pyyaml python tools/lint_doc_consistency.py
# pre-push hook also ran backend lint, frontend lint, and backend full tests:
# 2192 passed, coverage 96.91%
```

---

## Screenshots / Evidence

N/A — documentation/tooling change.
