### PR TITLE
[finance_report_audit] Harden ledger schema invariants

### DIFF
--- a/apps/backend/migrations/versions/0032_ledger_invariants.py
+++ b/apps/backend/migrations/versions/0032_ledger_invariants.py
@@ -1,170 +1,14 @@
-"""Journal entry models for double-entry bookkeeping."""
+"""harden ledger invariants"""
 
-from __future__ import annotations
+from alembic import op
 
-import enum
-from datetime import UTC, date, datetime
-from decimal import Decimal
-from typing import TYPE_CHECKING, Any
-from uuid import UUID
-
-from sqlalchemy import DECIMAL, CheckConstraint, Date, DateTime, Enum, ForeignKey, String, Text, event
-from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
-
-from src.database import Base
-from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
-
-if TYPE_CHECKING:
-    from src.models.account import Account
+revision = "0032_ledger_invariants"
+down_revision = "0031_drop_orphan_stage1_enum"
+branch_labels = None
+depends_on = None
 
 
-class JournalEntryStatus(str, enum.Enum):
-    """Status of a journal entry."""
-
-    DRAFT = "draft"
-    POSTED = "posted"
-    RECONCILED = "reconciled"
-    VOID = "void"
-
-
-class JournalEntrySourceType(str, enum.Enum):
-    """Source type of a journal entry."""
-
-    MANUAL = "manual"
-    USER_CONFIRMED = "user_confirmed"
-    AUTO_MATCHED = "auto_matched"
-    AUTO_PARSED = "auto_parsed"
-    # Deprecated legacy value. New statement-derived entries should use
-    # AUTO_PARSED, USER_CONFIRMED, or AUTO_MATCHED.
-    BANK_STATEMENT = "bank_statement"
-    SYSTEM = "system"
-    FX_REVALUATION = "fx_revaluation"
-
-
-class Direction(str, enum.Enum):
-    """Debit or credit direction."""
-
-    DEBIT = "DEBIT"
-    CREDIT = "CREDIT"
-
-
-class JournalEntry(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
-    """
-    Journal entry header containing metadata for a bookkeeping transaction.
-
-    Each entry must have at least 2 journal lines with balanced debits and credits.
-    """
-
-    __tablename__ = "journal_entries"
-
-    entry_date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
-    memo: Mapped[str] = mapped_column(String(500), nullable=False)
-    source_type: Mapped[JournalEntrySourceType] = mapped_column(
-        Enum(
-            JournalEntrySourceType,
-            name="journal_source_type_enum",
-            values_callable=lambda obj: [e.value for e in obj],
-        ),
-        nullable=False,
-        default=JournalEntrySourceType.MANUAL,
-    )
-    source_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
-    status: Mapped[JournalEntryStatus] = mapped_column(
-        Enum(
-            JournalEntryStatus,
-            name="journal_entry_status_enum",
-            values_callable=lambda obj: [e.value for e in obj],
-        ),
-        nullable=False,
-        default=JournalEntryStatus.DRAFT,
-        index=True,
-    )
-    void_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
-    void_reversal_entry_id: Mapped[UUID | None] = mapped_column(
-        PGUUID(as_uuid=True),
-        ForeignKey(
-            "journal_entries.id",
-            name="fk_journal_entries_void_reversal_entry_id",
-            ondelete="RESTRICT",
-        ),
-        nullable=True,
-    )
-
-    lines: Mapped[list[JournalLine]] = relationship(
-        "JournalLine", back_populates="journal_entry", cascade="all, delete-orphan"
-    )
-
-    def __repr__(self) -> str:
-        return f"<JournalEntry {self.entry_date} - {self.memo[:30]}>"
-
-    @property
-    def confidence_tier(self) -> str:
-        """Derived UI confidence tier based on source type."""
-        from src.services.confidence_tier import derive_confidence_tier
-
-        return derive_confidence_tier(self.source_type)
-
-
-class JournalLine(Base, UUIDMixin, TimestampMixin):
-    """
-    Individual debit or credit line in a journal entry.
-
-    Amount must always be positive. Direction (DEBIT/CREDIT) determines
-    the effect on the account based on account type.
-    """
-
-    __tablename__ = "journal_lines"
-    __table_args__ = (
-        CheckConstraint("amount > 0", name="positive_amount"),
-        CheckConstraint("fx_rate IS NULL OR fx_rate > 0", name="ck_journal_lines_fx_rate_positive"),
-    )
-
-    journal_entry_id: Mapped[UUID] = mapped_column(
-        PGUUID(as_uuid=True), ForeignKey("journal_entries.id", ondelete="CASCADE"), nullable=False, index=True
-    )
-    account_id: Mapped[UUID] = mapped_column(
-        PGUUID(as_uuid=True), ForeignKey("accounts.id"), nullable=False, index=True
-    )
-    direction: Mapped[Direction] = mapped_column(
-        Enum(
-            Direction,
-            name="journal_line_direction_enum",
-            values_callable=lambda obj: [e.value for e in obj],
-        ),
-        nullable=False,
-    )
-    amount: Mapped[Decimal] = mapped_column(DECIMAL(18, 2), nullable=False)
-    currency: Mapped[str] = mapped_column(String(3), nullable=False, default="SGD")
-    fx_rate: Mapped[Decimal | None] = mapped_column(DECIMAL(18, 6), nullable=True)
-    event_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    tags: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-
-    journal_entry: Mapped[JournalEntry] = relationship("JournalEntry", back_populates="lines")
-    account: Mapped[Account] = relationship("Account", back_populates="journal_lines")
-
-    def __repr__(self) -> str:
-        return f"<JournalLine {self.direction.value} {self.amount} {self.currency}>"
-
-
-class JournalAuditLog(Base, UUIDMixin):
-    """Audit trail entry for journal transaction changes."""
-
-    __tablename__ = "journal_audit_log"
-
-    entry_id: Mapped[UUID] = mapped_column(
-        PGUUID(as_uuid=True), ForeignKey("journal_entries.id", ondelete="CASCADE"), nullable=False, index=True
-    )
-    actor: Mapped[str] = mapped_column(Text, nullable=False)
-    action: Mapped[str] = mapped_column(Text, nullable=False)
-    old_value: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
-    new_value: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
-    )
-
-
-_LEDGER_INVARIANT_SQL = """
+LEDGER_INVARIANT_DDL = """
 CREATE OR REPLACE FUNCTION fr_ledger_base_currency()
 RETURNS text
 LANGUAGE sql
@@ -475,39 +319,141 @@ FOR EACH ROW EXECUTE FUNCTION fr_guard_journal_line_immutability();
 """
 
 
-def _split_postgresql_ddl(sql: str) -> tuple[str, ...]:
-    statements: list[str] = []
-    start = 0
-    in_dollar_quote = False
-    index = 0
-
-    while index < len(sql):
-        if sql.startswith("$$", index):
-            in_dollar_quote = not in_dollar_quote
-            index += 2
-            continue
-
-        if sql[index] == ";" and not in_dollar_quote:
-            statement = sql[start : index + 1].strip()
-            if statement:
-                statements.append(statement)
-            start = index + 1
-
-        index += 1
-
-    trailing = sql[start:].strip()
-    if trailing:
-        statements.append(trailing)
-    return tuple(statements)
+DROP_LEDGER_INVARIANT_DDL = """
+DROP TRIGGER IF EXISTS ck_journal_lines_immutable ON journal_lines;
+DROP TRIGGER IF EXISTS ck_journal_entries_immutable ON journal_entries;
+DROP TRIGGER IF EXISTS ck_journal_lines_ledger_invariants ON journal_lines;
+DROP TRIGGER IF EXISTS ck_journal_entries_ledger_invariants ON journal_entries;
+DROP FUNCTION IF EXISTS fr_guard_journal_line_immutability();
+DROP FUNCTION IF EXISTS fr_guard_journal_entry_immutability();
+DROP FUNCTION IF EXISTS fr_check_journal_line_deferred();
+DROP FUNCTION IF EXISTS fr_check_journal_entry_deferred();
+DROP FUNCTION IF EXISTS fr_validate_journal_void_reversal(uuid);
+DROP FUNCTION IF EXISTS fr_validate_journal_entry_invariants(uuid);
+DROP FUNCTION IF EXISTS fr_ledger_base_currency();
+"""
 
 
-def _install_ledger_invariant_ddl(target: Any, connection: Any, **_: Any) -> None:
-    if connection.dialect.name != "postgresql":
-        return
+def upgrade() -> None:
+    op.execute(
+        """
+CREATE OR REPLACE FUNCTION fr_ledger_base_currency()
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT COALESCE(NULLIF(current_setting('finance_report.base_currency', true), ''), 'SGD')
+$$
+"""
+    )
+    op.execute(
+        """
+DO $$
+DECLARE
+    v_base_currency text := upper(fr_ledger_base_currency());
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM journal_lines
+        WHERE fx_rate <= 0
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: journal_lines contains non-positive fx_rate values';
+    END IF;
 
-    # asyncpg rejects multi-command prepared statements during metadata create_all().
-    for statement in _split_postgresql_ddl(_LEDGER_INVARIANT_SQL):
-        connection.exec_driver_sql(statement)
+    IF EXISTS (
+        SELECT 1
+        FROM journal_entries entry
+        LEFT JOIN journal_lines line ON line.journal_entry_id = entry.id
+        WHERE entry.status::text IN ('posted', 'reconciled')
+        GROUP BY entry.id
+        HAVING count(line.id) < 2
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: posted/reconciled journal_entries with fewer than two lines exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM journal_entries entry
+        JOIN journal_lines line ON line.journal_entry_id = entry.id
+        WHERE entry.status::text IN ('posted', 'reconciled')
+          AND COALESCE(upper(line.currency), v_base_currency) <> v_base_currency
+          AND (line.fx_rate IS NULL OR line.fx_rate <= 0)
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: posted/reconciled non-base journal lines lack positive fx_rate';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM (
+            SELECT
+                entry.id,
+                COALESCE(
+                    sum(
+                        CASE WHEN line.direction::text = 'DEBIT'
+                        THEN line.amount * CASE
+                            WHEN COALESCE(upper(line.currency), v_base_currency) = v_base_currency THEN 1
+                            ELSE line.fx_rate
+                        END
+                        ELSE 0 END
+                    ),
+                    0
+                ) AS total_debit,
+                COALESCE(
+                    sum(
+                        CASE WHEN line.direction::text = 'CREDIT'
+                        THEN line.amount * CASE
+                            WHEN COALESCE(upper(line.currency), v_base_currency) = v_base_currency THEN 1
+                            ELSE line.fx_rate
+                        END
+                        ELSE 0 END
+                    ),
+                    0
+                ) AS total_credit
+            FROM journal_entries entry
+            JOIN journal_lines line ON line.journal_entry_id = entry.id
+            WHERE entry.status::text IN ('posted', 'reconciled')
+            GROUP BY entry.id
+        ) totals
+        WHERE abs(total_debit - total_credit) > 0.01
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: unbalanced posted/reconciled journal_entries exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM journal_entries voided
+        LEFT JOIN journal_entries reversal ON reversal.id = voided.void_reversal_entry_id
+        WHERE voided.status::text = 'void'
+          AND (
+            voided.void_reversal_entry_id IS NULL
+            OR reversal.id IS NULL
+            OR reversal.user_id <> voided.user_id
+            OR reversal.status::text NOT IN ('posted', 'reconciled')
+          )
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: void journal_entries have invalid reversal relationships';
+    END IF;
+END
+$$
+"""
+    )
+    op.create_check_constraint(
+        "ck_journal_lines_fx_rate_positive",
+        "journal_lines",
+        "fx_rate IS NULL OR fx_rate > 0",
+    )
+    op.create_foreign_key(
+        "fk_journal_entries_void_reversal_entry_id",
+        "journal_entries",
+        "journal_entries",
+        ["void_reversal_entry_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.execute(LEDGER_INVARIANT_DDL)
 
 
-event.listen(JournalLine.__table__, "after_create", _install_ledger_invariant_ddl)
+def downgrade() -> None:
+    op.execute(DROP_LEDGER_INVARIANT_DDL)
+    op.drop_constraint("fk_journal_entries_void_reversal_entry_id", "journal_entries", type_="foreignkey")
+    op.drop_constraint("ck_journal_lines_fx_rate_positive", "journal_lines", type_="check")

--- a/apps/backend/src/services/review_queue.py
+++ b/apps/backend/src/services/review_queue.py
@@ -330,8 +330,8 @@ async def create_entry_from_txn(
 
     Uses the owning statement summary's linked account if available. Draft entries
     may still use the legacy default account, but posted entries require an explicit
-    mapping. When auto_post is True, the generated entry is created with POSTED
-    status; otherwise it is created as DRAFT.
+    mapping. When auto_post is True, the generated entry is first persisted as
+    DRAFT with its lines and then promoted to POSTED; otherwise it remains DRAFT.
     preloaded_statement/preloaded_bank_account may be passed by trusted callers
     that already loaded them for the same authenticated user context.
 
@@ -432,7 +432,7 @@ async def create_entry_from_txn(
         memo=txn.description,
         source_type=normalize_source_type(source_type),
         source_id=txn.id,
-        status=JournalEntryStatus.POSTED if auto_post else JournalEntryStatus.DRAFT,
+        status=JournalEntryStatus.DRAFT,
     )
 
     entry.lines.append(
@@ -468,6 +468,9 @@ async def create_entry_from_txn(
 
     db.add(entry)
     await db.flush()
+    if auto_post:
+        entry.status = JournalEntryStatus.POSTED
+        await db.flush()
     await db.refresh(entry, ["lines"])
 
     # Eager evidence-graph lineage (AtomicTransaction --posted_as--> JournalEntry

--- a/apps/backend/tests/accounting/_ledger_helpers.py
+++ b/apps/backend/tests/accounting/_ledger_helpers.py
@@ -1,0 +1,101 @@
+"""Ledger test fixtures that satisfy database-level posting invariants."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import (
+    Account,
+    AccountType,
+    Direction,
+    JournalEntry,
+    JournalEntrySourceType,
+    JournalEntryStatus,
+    JournalLine,
+)
+
+
+async def create_valid_posted_entry(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    entry_date: date | None = None,
+    memo: str = "Posted entry",
+    amount: Decimal = Decimal("100.00"),
+    source_type: JournalEntrySourceType = JournalEntrySourceType.MANUAL,
+    source_id: UUID | None = None,
+    debit_account_type: AccountType = AccountType.ASSET,
+    credit_account_type: AccountType = AccountType.INCOME,
+) -> JournalEntry:
+    debit_account = Account(
+        user_id=user_id,
+        name=f"{memo} cash",
+        type=debit_account_type,
+        currency="SGD",
+    )
+    credit_account = Account(
+        user_id=user_id,
+        name=f"{memo} income",
+        type=credit_account_type,
+        currency="SGD",
+    )
+    db.add_all([debit_account, credit_account])
+    await db.flush()
+
+    entry = JournalEntry(
+        user_id=user_id,
+        entry_date=entry_date or date.today(),
+        memo=memo,
+        source_type=source_type,
+        source_id=source_id,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(entry)
+    await db.flush()
+
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=debit_account.id,
+                direction=Direction.DEBIT,
+                amount=amount,
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=credit_account.id,
+                direction=Direction.CREDIT,
+                amount=amount,
+                currency="SGD",
+            ),
+        ]
+    )
+    await db.commit()
+    await db.refresh(entry)
+    return entry
+
+
+async def create_valid_void_entry(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    entry_date: date | None = None,
+    memo: str = "Voided entry",
+) -> JournalEntry:
+    entry = await create_valid_posted_entry(db, user_id, entry_date=entry_date, memo=memo)
+    entry_id = entry.id
+    reversal = await create_valid_posted_entry(db, user_id, entry_date=entry_date, memo=f"{memo} reversal")
+
+    entry = await db.get(JournalEntry, entry_id)
+    assert entry is not None
+    entry.status = JournalEntryStatus.VOID
+    entry.void_reason = "test void"
+    entry.void_reversal_entry_id = reversal.id
+    await db.commit()
+    await db.refresh(entry)
+    return entry

--- a/apps/backend/tests/accounting/test_accounting_equation.py
+++ b/apps/backend/tests/accounting/test_accounting_equation.py
@@ -16,6 +16,7 @@ from decimal import Decimal
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import (
@@ -135,9 +136,9 @@ async def test_accounting_equation_violation_detected(
     """
     CRITICAL #1: Verify that accounting equation violations are detected.
 
-    This test intentionally creates an imbalanced state by directly
-    manipulating the database (bypassing validation) to verify that
-    verify_accounting_equation() correctly returns False.
+    This test intentionally attempts an imbalanced direct database write.
+    The database now rejects the dirty posted state before it can affect
+    verify_accounting_equation().
     """
     # Create a valid balanced entry first: Salary income
     entry = JournalEntry(
@@ -174,7 +175,7 @@ async def test_accounting_equation_violation_detected(
     # First verify equation holds with balanced data
     assert await verify_accounting_equation(db, test_user_id) is True
 
-    # Now create an UNBALANCED entry by directly inserting (bypass validation)
+    # Now attempt an UNBALANCED entry by directly inserting (bypass validation).
     bad_entry = JournalEntry(
         user_id=test_user_id,
         entry_date=date.today(),
@@ -185,22 +186,30 @@ async def test_accounting_equation_violation_detected(
     db.add(bad_entry)
     await db.flush()
 
-    # Only add DEBIT line without matching CREDIT - this creates imbalance
-    db.add(
-        JournalLine(
-            journal_entry_id=bad_entry.id,
-            account_id=asset_account.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("1000.00"),
-            currency="SGD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=bad_entry.id,
+                account_id=asset_account.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("1000.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=bad_entry.id,
+                account_id=income_account.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("999.00"),
+                currency="SGD",
+            ),
+        ]
     )
-    await db.commit()
 
-    # Now the equation should NOT hold
-    result = await verify_accounting_equation(db, test_user_id)
-    # Assets increased by 1000 without corresponding increase on right side
-    assert result is False, "Accounting equation should detect imbalance"
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+
+    assert await verify_accounting_equation(db, test_user_id) is True
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/accounting/test_accounting_service_errors.py
+++ b/apps/backend/tests/accounting/test_accounting_service_errors.py
@@ -34,6 +34,7 @@ from src.services.accounting import (
     verify_accounting_equation,
     void_journal_entry,
 )
+from tests.accounting._ledger_helpers import create_valid_posted_entry
 
 
 @pytest.fixture
@@ -135,17 +136,7 @@ async def test_void_journal_entry_errors(db: AsyncSession, test_user_id):
         await void_journal_entry(db, uuid4(), "reason", test_user_id)
 
     other_user_id = uuid4()
-    entry = JournalEntry(
-        user_id=other_user_id,
-        entry_date=date.today(),
-        memo="Other user entry",
-        status=JournalEntryStatus.POSTED,
-    )
-    db.add(entry)
-    await db.commit()
-    # Use select instead of refresh to avoid greenlet issues in some environments
-    result = await db.execute(select(JournalEntry).where(JournalEntry.id == entry.id))
-    entry = result.scalar_one()
+    entry = await create_valid_posted_entry(db, other_user_id, memo="Other user entry")
 
     with pytest.raises(ValidationError, match="does not belong to user"):
         await void_journal_entry(db, entry.id, "reason", test_user_id)
@@ -418,14 +409,7 @@ async def test_accounting_more_errors(db: AsyncSession, test_user_id):
             ]
         )
 
-    entry = JournalEntry(
-        user_id=test_user_id,
-        status=JournalEntryStatus.POSTED,
-        entry_date=date.today(),
-        memo="Posted Entry",
-    )
-    db.add(entry)
-    await db.commit()
+    entry = await create_valid_posted_entry(db, test_user_id, memo="Posted Entry")
     with pytest.raises(ValidationError, match="Can only post draft entries"):
         await post_journal_entry(db, entry.id, test_user_id)
 

--- a/apps/backend/tests/accounting/test_delete_endpoints.py
+++ b/apps/backend/tests/accounting/test_delete_endpoints.py
@@ -25,6 +25,7 @@ from src.models import (
     JournalLine,
 )
 from src.models.statement_summary import StatementSummary
+from tests.accounting._ledger_helpers import create_valid_posted_entry
 
 
 @pytest.mark.asyncio
@@ -104,16 +105,7 @@ async def test_delete_draft_journal_entry(client: AsyncClient, db: AsyncSession,
 @pytest.mark.asyncio
 async def test_delete_posted_journal_entry_fails(client: AsyncClient, db: AsyncSession, test_user):
     # 1. Create posted
-    entry = JournalEntry(
-        user_id=test_user.id,
-        entry_date=date.today(),
-        memo="Posted",
-        source_type="manual",
-        status=JournalEntryStatus.POSTED,
-    )
-    db.add(entry)
-    await db.commit()
-    await db.refresh(entry)
+    entry = await create_valid_posted_entry(db, test_user.id, memo="Posted")
 
     # 2. Delete
     resp = await client.delete(f"/journal-entries/{entry.id}")

--- a/apps/backend/tests/accounting/test_journal_delete_and_validation.py
+++ b/apps/backend/tests/accounting/test_journal_delete_and_validation.py
@@ -16,6 +16,7 @@ from src.models.journal import (
     JournalEntrySourceType,
     JournalEntryStatus,
 )
+from tests.accounting._ledger_helpers import create_valid_posted_entry, create_valid_void_entry
 
 
 @pytest.mark.asyncio
@@ -66,16 +67,7 @@ class TestJournalDeleteEndpoint:
         WHEN DELETE /journal-entries/{entry_id}
         THEN it should return 400 because only draft entries can be deleted.
         """
-        entry = JournalEntry(
-            user_id=test_user.id,
-            entry_date=date.today(),
-            memo="Posted - cannot delete",
-            status=JournalEntryStatus.POSTED,
-            source_type=JournalEntrySourceType.MANUAL,
-        )
-        db.add(entry)
-        await db.commit()
-        await db.refresh(entry)
+        entry = await create_valid_posted_entry(db, test_user.id, memo="Posted - cannot delete")
 
         response = await client.delete(f"/journal-entries/{entry.id}")
         assert response.status_code == 400
@@ -87,16 +79,7 @@ class TestJournalDeleteEndpoint:
         WHEN DELETE /journal-entries/{entry_id}
         THEN it should return 400 because only draft entries can be deleted.
         """
-        entry = JournalEntry(
-            user_id=test_user.id,
-            entry_date=date.today(),
-            memo="Voided - cannot delete",
-            status=JournalEntryStatus.VOID,
-            source_type=JournalEntrySourceType.MANUAL,
-        )
-        db.add(entry)
-        await db.commit()
-        await db.refresh(entry)
+        entry = await create_valid_void_entry(db, test_user.id, memo="Voided - cannot delete")
 
         response = await client.delete(f"/journal-entries/{entry.id}")
         assert response.status_code == 400

--- a/apps/backend/tests/accounting/test_journal_router_errors.py
+++ b/apps/backend/tests/accounting/test_journal_router_errors.py
@@ -13,6 +13,7 @@ import pytest
 from src.models.account import Account, AccountType
 from src.models.journal import JournalEntry, JournalEntryStatus
 from src.services.accounting import ValidationError
+from tests.accounting._ledger_helpers import create_valid_posted_entry
 
 
 @pytest.mark.asyncio
@@ -117,22 +118,7 @@ class TestJournalRouterErrors:
         WHEN attempting to delete it
         THEN it should return 400 error
         """
-        # Create accounts
-        cash = Account(user_id=test_user.id, name="Cash", type=AccountType.ASSET, currency="USD")
-        revenue = Account(user_id=test_user.id, name="Revenue", type=AccountType.INCOME, currency="USD")
-        db.add_all([cash, revenue])
-        await db.flush()
-
-        # Create a posted entry
-        entry = JournalEntry(
-            user_id=test_user.id,
-            entry_date=date.today(),
-            memo="Posted entry",
-            status=JournalEntryStatus.POSTED,
-        )
-        db.add(entry)
-        await db.commit()
-        await db.refresh(entry)
+        entry = await create_valid_posted_entry(db, test_user.id, memo="Posted entry")
 
         response = await client.delete(f"/journal-entries/{entry.id}")
         assert response.status_code == 400

--- a/apps/backend/tests/accounting/test_ledger_schema_invariants.py
+++ b/apps/backend/tests/accounting/test_ledger_schema_invariants.py
@@ -1,0 +1,285 @@
+"""Database-level ledger invariant tests for direct write bypass attempts."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import (
+    Account,
+    AccountType,
+    Direction,
+    JournalEntry,
+    JournalEntrySourceType,
+    JournalEntryStatus,
+    JournalLine,
+)
+
+
+async def _account(db: AsyncSession, user_id, name: str, account_type: AccountType) -> Account:
+    account = Account(user_id=user_id, name=name, type=account_type, is_active=True)
+    db.add(account)
+    await db.flush()
+    return account
+
+
+async def _valid_posted_entry(
+    db: AsyncSession, user_id, *, memo: str = "posted"
+) -> tuple[JournalEntry, JournalLine, JournalLine]:
+    debit_account = await _account(db, user_id, f"{memo} cash", AccountType.ASSET)
+    credit_account = await _account(db, user_id, f"{memo} income", AccountType.INCOME)
+    entry = JournalEntry(
+        user_id=user_id,
+        entry_date=date.today(),
+        memo=memo,
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(entry)
+    await db.flush()
+
+    debit = JournalLine(
+        journal_entry_id=entry.id,
+        account_id=debit_account.id,
+        direction=Direction.DEBIT,
+        amount=Decimal("100.00"),
+        currency="SGD",
+    )
+    credit = JournalLine(
+        journal_entry_id=entry.id,
+        account_id=credit_account.id,
+        direction=Direction.CREDIT,
+        amount=Decimal("100.00"),
+        currency="SGD",
+    )
+    db.add_all([debit, credit])
+    await db.commit()
+    await db.refresh(entry)
+    await db.refresh(debit)
+    await db.refresh(credit)
+    return entry, debit, credit
+
+
+@pytest.mark.asyncio
+async def test_AC2_14_1_posted_entry_requires_two_lines_at_database_boundary(db: AsyncSession, test_user):
+    """AC2.14.1: Posted/reconciled entries need at least two lines at the database boundary."""
+    cash = await _account(db, test_user.id, "cash", AccountType.ASSET)
+    entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=date.today(),
+        memo="single line posted bypass",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(entry)
+    await db.flush()
+    db.add(
+        JournalLine(
+            journal_entry_id=entry.id,
+            account_id=cash.id,
+            direction=Direction.DEBIT,
+            amount=Decimal("10.00"),
+            currency="SGD",
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_AC2_14_2_posted_entry_must_balance_in_base_currency(db: AsyncSession, test_user):
+    """AC2.14.2: Posted/reconciled entries balance debit and credit totals in base currency."""
+    cash = await _account(db, test_user.id, "cash", AccountType.ASSET)
+    income = await _account(db, test_user.id, "income", AccountType.INCOME)
+    entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=date.today(),
+        memo="unbalanced posted bypass",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=income.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("99.98"),
+                currency="SGD",
+            ),
+        ]
+    )
+
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_AC2_14_3_non_base_posted_lines_require_positive_fx_rate(db: AsyncSession, test_user):
+    """AC2.14.3: Non-base posted/reconciled lines require positive FX rates."""
+    cash = await _account(db, test_user.id, "hkd cash", AccountType.ASSET)
+    income = await _account(db, test_user.id, "sgd income", AccountType.INCOME)
+    entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=date.today(),
+        memo="missing fx bypass",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100.00"),
+                currency="HKD",
+                fx_rate=Decimal("0.000000"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=income.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100.00"),
+                currency="SGD",
+            ),
+        ]
+    )
+
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_AC2_14_4_posted_entries_and_lines_are_immutable_but_drafts_are_editable(db: AsyncSession, test_user):
+    """AC2.14.4: Posted/reconciled ledger facts block direct mutation; drafts remain editable."""
+    user_id = test_user.id
+    entry, debit, _credit = await _valid_posted_entry(db, user_id)
+    entry_id = entry.id
+
+    entry.memo = "mutated posted memo"
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+    await db.refresh(entry)
+    await db.refresh(debit)
+
+    debit.amount = Decimal("101.00")
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+    await db.refresh(debit)
+
+    await db.delete(debit)
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+
+    extra_cash = await _account(db, user_id, "extra cash", AccountType.ASSET)
+    extra_income = await _account(db, user_id, "extra income", AccountType.INCOME)
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry_id,
+                account_id=extra_cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("1.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=entry_id,
+                account_id=extra_income.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("1.00"),
+                currency="SGD",
+            ),
+        ]
+    )
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+
+    reconcile_entry, _reconcile_debit, _reconcile_credit = await _valid_posted_entry(
+        db, user_id, memo="reconcile source guard"
+    )
+    reconcile_entry.status = JournalEntryStatus.RECONCILED
+    reconcile_entry.source_type = JournalEntrySourceType.AUTO_PARSED
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+
+    draft_account = await _account(db, user_id, "draft cash", AccountType.ASSET)
+    draft = JournalEntry(
+        user_id=user_id,
+        entry_date=date.today(),
+        memo="editable draft",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.DRAFT,
+    )
+    db.add(draft)
+    await db.flush()
+    draft_line = JournalLine(
+        journal_entry_id=draft.id,
+        account_id=draft_account.id,
+        direction=Direction.DEBIT,
+        amount=Decimal("1.00"),
+        currency="SGD",
+    )
+    db.add(draft_line)
+    await db.commit()
+
+    draft.memo = "edited draft"
+    draft_line.amount = Decimal("2.00")
+    await db.commit()
+    await db.delete(draft_line)
+    await db.delete(draft)
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_AC2_14_5_void_transition_requires_reversal_relationship(db: AsyncSession, test_user):
+    """AC2.14.5: Voiding preserves a non-null immutable reversal relationship."""
+    user_id = test_user.id
+    entry, _debit, _credit = await _valid_posted_entry(db, user_id, memo="original")
+    entry_id = entry.id
+
+    entry.status = JournalEntryStatus.VOID
+    entry.void_reason = "missing reversal"
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+    entry = await db.get(JournalEntry, entry_id)
+    assert entry is not None
+
+    reversal, _reversal_debit, _reversal_credit = await _valid_posted_entry(db, user_id, memo="reversal")
+    entry.status = JournalEntryStatus.VOID
+    entry.void_reason = "valid reversal"
+    entry.void_reversal_entry_id = reversal.id
+    await db.commit()
+
+    entry.void_reversal_entry_id = None
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+    entry = await db.get(JournalEntry, entry_id)
+    assert entry is not None
+
+    await db.delete(entry)
+    with pytest.raises(IntegrityError):
+        await db.commit()

--- a/apps/backend/tests/api/test_evidence_lineage_router.py
+++ b/apps/backend/tests/api/test_evidence_lineage_router.py
@@ -204,7 +204,9 @@ async def test_AC18_10_3_AC18_10_4_lineage_api_lazily_materializes_historical_jo
     amount = Decimal("77.00")
     description = "Lazy API income"
     reference = "API-1"
+    atomic_id = uuid4()
     atomic = AtomicTransaction(
+        id=atomic_id,
         user_id=test_user.id,
         txn_date=txn_date,
         amount=amount,
@@ -227,12 +229,18 @@ async def test_AC18_10_3_AC18_10_4_lineage_api_lazily_materializes_historical_jo
         entry_date=txn_date,
         memo="Lazy API posted income",
         source_type=JournalEntrySourceType.USER_CONFIRMED,
-        source_id=None,
+        source_id=atomic_id,
         status=JournalEntryStatus.POSTED,
     )
     db.add_all([atomic, entry])
     await db.flush()
-    entry.source_id = atomic.id
+    debit_line = JournalLine(
+        journal_entry_id=entry.id,
+        account_id=bank.id,
+        direction=Direction.DEBIT,
+        amount=amount,
+        currency="SGD",
+    )
     line = JournalLine(
         journal_entry_id=entry.id,
         account_id=income.id,
@@ -240,7 +248,7 @@ async def test_AC18_10_3_AC18_10_4_lineage_api_lazily_materializes_historical_jo
         amount=amount,
         currency="SGD",
     )
-    db.add(line)
+    db.add_all([debit_line, line])
     await db.commit()
 
     first = await client.get(

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -569,6 +569,7 @@ async def test_AC19_5_7_package_readiness_converts_processing_balance_before_zer
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.000000"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -606,6 +607,12 @@ async def test_AC19_8_8_package_readiness_blocks_when_processing_fx_conversion_f
         currency="SGD",
         is_system=True,
     )
+    offset_account = Account(
+        user_id=test_user.id,
+        name="Processing Offset",
+        type=AccountType.EQUITY,
+        currency="USD",
+    )
     entry = JournalEntry(
         user_id=test_user.id,
         entry_date=date(2026, 5, 3),
@@ -613,16 +620,27 @@ async def test_AC19_8_8_package_readiness_blocks_when_processing_fx_conversion_f
         source_type=JournalEntrySourceType.SYSTEM,
         status=JournalEntryStatus.POSTED,
     )
-    db.add_all([processing_account, entry])
+    db.add_all([processing_account, offset_account, entry])
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=processing_account.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("25.00"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=processing_account.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("25.00"),
+                currency="USD",
+                fx_rate=Decimal("1.000000"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=offset_account.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("25.00"),
+                currency="USD",
+                fx_rate=Decimal("1.000000"),
+            ),
+        ]
     )
     await db.flush()
 
@@ -870,8 +888,9 @@ async def test_AC5_13_5_package_traceability_returns_dynamic_current_user_identi
     bank = Account(user_id=test_user.id, name="Trace Bank", type=AccountType.ASSET, currency="SGD")
     income = Account(user_id=test_user.id, name="Trace Salary", type=AccountType.INCOME, currency="SGD")
     investment = Account(user_id=test_user.id, name="Trace Brokerage", type=AccountType.ASSET, currency="SGD")
+    other_bank = Account(user_id=other_user.id, name="Other Bank", type=AccountType.ASSET, currency="SGD")
     other_income = Account(user_id=other_user.id, name="Other Income", type=AccountType.INCOME, currency="SGD")
-    db.add_all([bank, income, investment, other_income])
+    db.add_all([bank, income, investment, other_bank, other_income])
     await db.flush()
 
     document = UploadedDocument(
@@ -943,6 +962,13 @@ async def test_AC5_13_5_package_traceability_returns_dynamic_current_user_identi
                 journal_entry_id=entry.id,
                 account_id=income.id,
                 direction=Direction.CREDIT,
+                amount=Decimal("100.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=other_entry.id,
+                account_id=other_bank.id,
+                direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="SGD",
             ),

--- a/apps/backend/tests/api/test_reconciliation_router.py
+++ b/apps/backend/tests/api/test_reconciliation_router.py
@@ -610,7 +610,7 @@ class TestReconciliationEndpoints:
             status=JournalEntryStatus.POSTED,
         )
         db.add(entry)
-        await db.commit()
+        await db.flush()
 
         # GIVEN journal lines
         from src.models import Direction

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -52,6 +52,7 @@ from src.services.statement_posting import (
     is_high_confidence_auto_approve_candidate,
     try_auto_approve_high_confidence_statement,
 )
+from tests.accounting._ledger_helpers import create_valid_posted_entry
 from tests.factories import AccountFactory, UserFactory
 
 pytestmark = pytest.mark.asyncio
@@ -1900,16 +1901,14 @@ async def test_approve_statement_stage1_promotes_existing_statement_entries_with
     db.add(txn)
     await db.flush()
 
-    existing_entry = JournalEntry(
-        user_id=test_user.id,
+    existing_entry = await create_valid_posted_entry(
+        db,
+        test_user.id,
         entry_date=txn.txn_date,
         memo="Existing parsed entry",
         source_type=JournalEntrySourceType.AUTO_PARSED,
         source_id=txn.id,
-        status=JournalEntryStatus.POSTED,
     )
-    db.add(existing_entry)
-    await db.commit()
 
     result = await statements_router.approve_statement_stage1(statement_id=statement.id, db=db, user_id=test_user.id)
 
@@ -2386,15 +2385,13 @@ async def test_approve_statement_stage1_keeps_transfer_detection_priority(db, te
     db.add(txn)
     await db.flush()
 
-    transfer_entry = JournalEntry(
-        user_id=test_user.id,
+    transfer_entry = await create_valid_posted_entry(
+        db,
+        test_user.id,
         entry_date=date(2025, 1, 4),
         memo="Transfer OUT via processing account",
         source_type=JournalEntrySourceType.SYSTEM,
-        status=JournalEntryStatus.POSTED,
     )
-    db.add(transfer_entry)
-    await db.flush()
 
     db.add(
         ReconciliationMatch(
@@ -2438,15 +2435,13 @@ async def test_approve_statement_stage1_ignores_rejected_matches_for_skip_logic(
     db.add(txn)
     await db.flush()
 
-    stale_entry = JournalEntry(
-        user_id=test_user.id,
+    stale_entry = await create_valid_posted_entry(
+        db,
+        test_user.id,
         entry_date=date(2025, 1, 4),
         memo="Stale candidate",
         source_type=JournalEntrySourceType.SYSTEM,
-        status=JournalEntryStatus.POSTED,
     )
-    db.add(stale_entry)
-    await db.flush()
 
     db.add(
         ReconciliationMatch(

--- a/apps/backend/tests/api/test_workflow_router.py
+++ b/apps/backend/tests/api/test_workflow_router.py
@@ -18,8 +18,6 @@ from src.models import (
     AccountType,
     BankStatementStatus,
     ClassificationRule,
-    JournalEntry,
-    JournalEntryStatus,
     ReportSnapshot,
     ReportType,
     RuleType,
@@ -45,6 +43,7 @@ from src.schemas.workflow import (
     WorkflowStatusResponse,
 )
 from src.services.workflow_events import upsert_workflow_event
+from tests.accounting._ledger_helpers import create_valid_posted_entry
 
 pytestmark = pytest.mark.asyncio
 
@@ -327,15 +326,13 @@ async def test_AC19_2_2_workflow_status_endpoint_returns_priority_summaries(
         action_href="/reports",
         title="Report ready",
     )
-    db.add(
-        JournalEntry(
-            user_id=ready_user.id,
-            entry_date=date(2026, 5, 31),
-            memo="Ready report input",
-            status=JournalEntryStatus.POSTED,
-        )
+    await create_valid_posted_entry(
+        db,
+        ready_user.id,
+        entry_date=date(2026, 5, 31),
+        memo="Ready report input",
+        debit_account_type=AccountType.EXPENSE,
     )
-    await db.commit()
 
     ready = await _get_as_user(public_client, ready_user.id, "/workflow/status")
     assert ready["primary_state"] == "ready"

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -11,13 +11,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import FxRate
 from src.models.account import Account, AccountType
-from src.models.journal import JournalEntry, JournalEntrySourceType, JournalEntryStatus
+from src.models.journal import JournalEntrySourceType
 from src.models.layer2 import AtomicPosition, AtomicTransaction, TransactionDirection
 from src.models.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
 from src.models.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType
 from src.routers import portfolio as portfolio_router
 from src.schemas.portfolio import HoldingResponse
 from src.services.portfolio import AssetNotFoundError
+from tests.accounting._ledger_helpers import create_valid_posted_entry
 
 
 @pytest.fixture
@@ -446,15 +447,13 @@ async def test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule(
     """AC17.10.1 AC17.10.2 AC17.10.3: schedule exposes metrics, rows, freshness, sources, and notes."""
     position = portfolio_with_data["position"]
     source_id = uuid4()
-    journal_entry = JournalEntry(
-        user_id=test_user.id,
+    journal_entry = await create_valid_posted_entry(
+        db,
+        test_user.id,
         entry_date=date.today() - timedelta(days=5),
         memo="Realized investment sale",
         source_type=JournalEntrySourceType.AUTO_PARSED,
-        status=JournalEntryStatus.POSTED,
     )
-    db.add(journal_entry)
-    await db.flush()
     dividend = DividendIncome(
         user_id=test_user.id,
         position_id=position.id,

--- a/apps/backend/tests/reconciliation/test_reconciliation_engine.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_engine.py
@@ -45,6 +45,7 @@ from src.services.review_queue import (
     get_or_create_account,
     reject_match,
 )
+from tests.accounting._ledger_helpers import create_valid_posted_entry
 
 
 async def _seed_summary(
@@ -452,14 +453,7 @@ async def test_find_candidates(db: AsyncSession):
     user_id = uuid4()
     config = load_reconciliation_config()
 
-    entry = JournalEntry(
-        user_id=user_id,
-        entry_date=date(2024, 1, 1),
-        memo="Test Entry",
-        status=JournalEntryStatus.POSTED,
-    )
-    db.add(entry)
-    await db.commit()
+    await create_valid_posted_entry(db, user_id, entry_date=date(2024, 1, 1), memo="Test Entry")
 
     # Within range
     results = await find_candidates(db, date(2024, 1, 1), config, user_id)
@@ -924,34 +918,16 @@ async def test_execute_matching_reuses_pattern_score_cache(db: AsyncSession) -> 
 async def test_execute_matching_many_to_one_skips_unbalanced_entry(db: AsyncSession) -> None:
     """AC4.6.7: Many-to-one skips unbalanced candidates and leaves transactions unmatched."""
     user_id = uuid4()
-    bank = Account(user_id=user_id, name="Bank - M2O", type=AccountType.ASSET, currency="SGD")
-    expense = Account(user_id=user_id, name="Expense - M2O", type=AccountType.EXPENSE, currency="SGD")
-    bad_entry = JournalEntry(
-        user_id=user_id,
+    await create_valid_posted_entry(
+        db,
+        user_id,
         entry_date=date(2024, 7, 1),
         memo="Batch settlement",
-        source_type=JournalEntrySourceType.MANUAL,
-        status=JournalEntryStatus.POSTED,
+        amount=Decimal("100.00"),
     )
-    db.add_all([bank, expense, bad_entry])
-    await db.flush()
     summary = await _seed_summary(db, owner_id=user_id, base_date=date(2024, 7, 1))
     db.add_all(
         [
-            JournalLine(
-                journal_entry_id=bad_entry.id,
-                account_id=expense.id,
-                direction=Direction.DEBIT,
-                amount=Decimal("100.00"),
-                currency="SGD",
-            ),
-            JournalLine(
-                journal_entry_id=bad_entry.id,
-                account_id=bank.id,
-                direction=Direction.CREDIT,
-                amount=Decimal("90.00"),
-                currency="SGD",
-            ),
             _atomic(
                 owner_id=user_id,
                 summary=summary,
@@ -972,7 +948,10 @@ async def test_execute_matching_many_to_one_skips_unbalanced_entry(db: AsyncSess
     )
     await db.commit()
 
-    with patch("src.services.reconciliation.find_transfer_pairs", new_callable=AsyncMock, return_value=[]):
+    with (
+        patch("src.services.reconciliation.find_transfer_pairs", new_callable=AsyncMock, return_value=[]),
+        patch("src.services.reconciliation.is_entry_balanced", return_value=False),
+    ):
         matches = await execute_matching(db, user_id=user_id)
 
     assert matches == []
@@ -1039,16 +1018,15 @@ async def test_execute_matching_many_to_one_layer2_sets_atomic_txn_id(db: AsyncS
         source_documents=[{"doc_id": str(uuid4())}],
     )
     db.add(txn)
+    await db.flush()
 
-    entry = JournalEntry(
-        user_id=user_id,
+    entry = await create_valid_posted_entry(
+        db,
+        user_id,
         entry_date=date(2024, 8, 10),
         memo="candidate",
-        source_type=JournalEntrySourceType.MANUAL,
-        status=JournalEntryStatus.POSTED,
+        amount=Decimal("30.00"),
     )
-    db.add(entry)
-    await db.commit()
 
     candidate = MatchCandidate(journal_entry_ids=[str(entry.id)], score=95, breakdown={"amount": 100.0})
 
@@ -1081,29 +1059,30 @@ async def test_execute_matching_three_entry_combination_skips_unbalanced_member(
         amount=Decimal("3.00"),
         direction="OUT",
     )
-    entry_a = JournalEntry(
-        user_id=user_id,
+    db.add(txn)
+    await db.flush()
+
+    entry_a = await create_valid_posted_entry(
+        db,
+        user_id,
         entry_date=date(2024, 9, 12),
         memo="a",
-        source_type=JournalEntrySourceType.MANUAL,
-        status=JournalEntryStatus.POSTED,
+        amount=Decimal("1.00"),
     )
-    entry_b = JournalEntry(
-        user_id=user_id,
+    entry_b = await create_valid_posted_entry(
+        db,
+        user_id,
         entry_date=date(2024, 9, 12),
         memo="b",
-        source_type=JournalEntrySourceType.MANUAL,
-        status=JournalEntryStatus.POSTED,
+        amount=Decimal("1.00"),
     )
-    entry_c = JournalEntry(
-        user_id=user_id,
+    entry_c = await create_valid_posted_entry(
+        db,
+        user_id,
         entry_date=date(2024, 9, 12),
         memo="c",
-        source_type=JournalEntrySourceType.MANUAL,
-        status=JournalEntryStatus.POSTED,
+        amount=Decimal("1.00"),
     )
-    db.add_all([txn, entry_a, entry_b, entry_c])
-    await db.commit()
 
     low_score = MatchCandidate(journal_entry_ids=[str(entry_a.id)], score=0, breakdown={"amount": 0.0})
 

--- a/apps/backend/tests/reconciliation/test_reconciliation_matching_unit.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_matching_unit.py
@@ -49,6 +49,7 @@ from src.services.reconciliation import (
     score_pattern,
     weighted_total,
 )
+from tests.accounting._ledger_helpers import create_valid_posted_entry
 
 
 def _make_statement(*, owner_id: UUID | None = None, base_date: date) -> StatementSummary:
@@ -752,35 +753,16 @@ async def test_execute_matching_skip_unbalanced(db: AsyncSession):
     )
     db.add(txn)
 
-    account = Account(
-        id=uuid4(),
-        name="Test Account",
-        type=AccountType.ASSET,
-        user_id=user_id,
-        currency="SGD",
-    )
-    db.add(account)
-    await db.flush()
-
-    entry = JournalEntry(
-        user_id=user_id,
+    await create_valid_posted_entry(
+        db,
+        user_id,
         entry_date=date(2024, 1, 1),
         memo="Unbalanced",
-        status=JournalEntryStatus.POSTED,
+        amount=Decimal("100.00"),
     )
-    db.add(entry)
-    await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=account.id,
-            amount=Decimal("100.00"),
-            direction=Direction.DEBIT,
-        )
-    )
-    await db.commit()
 
-    matches = await execute_matching(db, user_id=user_id)
+    with patch("src.services.reconciliation.is_entry_balanced", return_value=False):
+        matches = await execute_matching(db, user_id=user_id)
     assert len(matches) == 0
 
 
@@ -2074,7 +2056,8 @@ async def test_execute_matching_multi_entry_unbalanced_skip(db: AsyncSession):
         ]
     )
 
-    # Entry B: UNBALANCED (debit=60, credit=50)
+    # Entry B is persisted balanced; the test mocks the reconciliation balance
+    # predicate to exercise the skip-unbalanced branch without dirty DB state.
     entry_b = JournalEntry(
         user_id=user_id,
         entry_date=date(2024, 1, 1),
@@ -2089,7 +2072,7 @@ async def test_execute_matching_multi_entry_unbalanced_skip(db: AsyncSession):
                 journal_entry_id=entry_b.id, account_id=account.id, amount=Decimal("60.00"), direction=Direction.DEBIT
             ),
             JournalLine(
-                journal_entry_id=entry_b.id, account_id=account.id, amount=Decimal("50.00"), direction=Direction.CREDIT
+                journal_entry_id=entry_b.id, account_id=account.id, amount=Decimal("60.00"), direction=Direction.CREDIT
             ),
         ]
     )
@@ -2108,8 +2091,9 @@ async def test_execute_matching_multi_entry_unbalanced_skip(db: AsyncSession):
     db.add(txn)
     await db.commit()
 
-    # The combinations(candidates, 2) check should skip (entry_a, entry_b) because entry_b is unbalanced
-    matches = await execute_matching(db, user_id=user_id)
+    # The combinations(candidates, 2) check should skip (entry_a, entry_b) because entry_b is marked unbalanced
+    with patch("src.services.reconciliation.is_entry_balanced", side_effect=lambda entry: entry.id != entry_b.id):
+        matches = await execute_matching(db, user_id=user_id)
     # entry_a alone (50) doesn't match txn (100) well; unbalanced pair is skipped
     # Result depends on scoring but the key is the code path is exercised
     assert isinstance(matches, list)

--- a/apps/backend/tests/reconciliation/test_review_queue.py
+++ b/apps/backend/tests/reconciliation/test_review_queue.py
@@ -45,6 +45,7 @@ from src.services.review_queue import (
     get_pending_items,
     reject_match,
 )
+from tests.accounting._ledger_helpers import create_valid_void_entry
 from tests.factories import (
     AccountFactory,
     AtomicTransactionFactory,
@@ -261,9 +262,7 @@ async def test_accept_match_creates_missing_journal_entry(db, test_user):
 async def test_accept_match_does_not_reconcile_void_entries(db, test_user):
     stmt = await _make_statement(db, test_user.id)
     txn = await _make_txn(db, test_user.id, stmt, amount=Decimal("100.00"))
-    entry, _, _ = await JournalEntryFactory.create_balanced_async(
-        db, user_id=test_user.id, amount=Decimal("100.00"), status=JournalEntryStatus.VOID
-    )
+    entry = await create_valid_void_entry(db, test_user.id, memo="Void match candidate")
     match = await ReconciliationMatchFactory.create_async(
         db,
         atomic_txn_id=txn.id,

--- a/apps/backend/tests/reporting/test_annualized_income_schedule.py
+++ b/apps/backend/tests/reporting/test_annualized_income_schedule.py
@@ -39,7 +39,8 @@ async def test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restr
     salary = Account(user_id=test_user.id, name="Salary Income", type=AccountType.INCOME, currency="SGD")
     bonus = Account(user_id=test_user.id, name="Annual Bonus", type=AccountType.INCOME, currency="SGD")
     dividend = Account(user_id=test_user.id, name="Dividend Income", type=AccountType.INCOME, currency="SGD")
-    db.add_all([salary, bonus, dividend])
+    cash = Account(user_id=test_user.id, name="Cash", type=AccountType.ASSET, currency="SGD")
+    db.add_all([salary, bonus, dividend, cash])
     await db.flush()
 
     income_entry = JournalEntry(
@@ -52,6 +53,13 @@ async def test_AC11_11_1_AC11_11_2_annualized_schedule_includes_income_and_restr
     await db.flush()
     db.add_all(
         [
+            JournalLine(
+                journal_entry_id=income_entry.id,
+                account_id=cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("137400.00"),
+                currency="SGD",
+            ),
             JournalLine(
                 journal_entry_id=income_entry.id,
                 account_id=salary.id,
@@ -151,7 +159,9 @@ async def test_AC5_11_3_AC11_11_3_annualized_schedule_converts_mixed_currency_to
     """AC5.11.3/AC11.11.3: Annualized package totals use one reporting currency."""
     salary = Account(user_id=test_user.id, name="Salary Income", type=AccountType.INCOME, currency="SGD")
     dividend = Account(user_id=test_user.id, name="Dividend Income", type=AccountType.INCOME, currency="USD")
-    db.add_all([salary, dividend])
+    sgd_cash = Account(user_id=test_user.id, name="SGD Cash", type=AccountType.ASSET, currency="SGD")
+    usd_cash = Account(user_id=test_user.id, name="USD Cash", type=AccountType.ASSET, currency="USD")
+    db.add_all([salary, dividend, sgd_cash, usd_cash])
     await db.flush()
 
     income_entry = JournalEntry(
@@ -166,6 +176,13 @@ async def test_AC5_11_3_AC11_11_3_annualized_schedule_converts_mixed_currency_to
         [
             JournalLine(
                 journal_entry_id=income_entry.id,
+                account_id=sgd_cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=income_entry.id,
                 account_id=salary.id,
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
@@ -173,10 +190,19 @@ async def test_AC5_11_3_AC11_11_3_annualized_schedule_converts_mixed_currency_to
             ),
             JournalLine(
                 journal_entry_id=income_entry.id,
+                account_id=usd_cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("10.00"),
+                currency="USD",
+                fx_rate=Decimal("1.500000"),
+            ),
+            JournalLine(
+                journal_entry_id=income_entry.id,
                 account_id=dividend.id,
                 direction=Direction.CREDIT,
                 amount=Decimal("10.00"),
                 currency="USD",
+                fx_rate=Decimal("1.500000"),
             ),
             FxRate(
                 base_currency="USD",

--- a/apps/backend/tests/reporting/test_fx_revaluation.py
+++ b/apps/backend/tests/reporting/test_fx_revaluation.py
@@ -720,7 +720,7 @@ class TestGetRevaluationEntriesFilter:
             entry_date=date(2025, 1, 15),
             memo="Manual entry",
             source_type=JournalEntrySourceType.MANUAL,
-            status=JournalEntryStatus.POSTED,
+            status=JournalEntryStatus.DRAFT,
         )
         db.add(manual_entry)
 
@@ -813,7 +813,15 @@ class TestCalculateAccountBalanceInCurrencyLiability:
             currency="USD",
             is_active=True,
         )
-        db.add(liability_account)
+        offset_account = Account(
+            user_id=test_user_id,
+            name="Liability Offset USD",
+            code="ASSET-USD-OFFSET",
+            type=AccountType.ASSET,
+            currency="USD",
+            is_active=True,
+        )
+        db.add_all([liability_account, offset_account])
         await db.flush()
 
         entry = JournalEntry(
@@ -842,7 +850,15 @@ class TestCalculateAccountBalanceInCurrencyLiability:
             currency="USD",
             fx_rate=Decimal("1"),
         )
-        db.add_all([debit_line, credit_line])
+        offset_line = JournalLine(
+            journal_entry_id=entry.id,
+            account_id=offset_account.id,
+            direction=Direction.DEBIT,
+            amount=Decimal("300"),
+            currency="USD",
+            fx_rate=Decimal("1"),
+        )
+        db.add_all([debit_line, credit_line, offset_line])
         await db.commit()
 
         balance = await calculate_account_balance_in_currency(db, liability_account)

--- a/apps/backend/tests/reporting/test_income_annualized_router.py
+++ b/apps/backend/tests/reporting/test_income_annualized_router.py
@@ -23,7 +23,8 @@ async def test_annualized_income_endpoint_groups_last_12_month_income(
     dividend = Account(user_id=test_user.id, name="Dividend Income", type=AccountType.INCOME, currency="SGD")
     other_income = Account(user_id=test_user.id, name="Interest Income", type=AccountType.INCOME, currency="SGD")
     old_salary = Account(user_id=test_user.id, name="Salary Prior Year", type=AccountType.INCOME, currency="SGD")
-    db.add_all([salary, bonus, dividend, other_income, old_salary])
+    cash = Account(user_id=test_user.id, name="Cash", type=AccountType.ASSET, currency="SGD")
+    db.add_all([salary, bonus, dividend, other_income, old_salary, cash])
     await db.flush()
 
     current_entry = JournalEntry(
@@ -42,6 +43,13 @@ async def test_annualized_income_endpoint_groups_last_12_month_income(
     await db.flush()
     db.add_all(
         [
+            JournalLine(
+                journal_entry_id=current_entry.id,
+                account_id=cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("137700.00"),
+                currency="SGD",
+            ),
             JournalLine(
                 journal_entry_id=current_entry.id,
                 account_id=salary.id,
@@ -68,6 +76,13 @@ async def test_annualized_income_endpoint_groups_last_12_month_income(
                 account_id=other_income.id,
                 direction=Direction.CREDIT,
                 amount=Decimal("300.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=old_entry.id,
+                account_id=cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("999.00"),
                 currency="SGD",
             ),
             JournalLine(
@@ -104,7 +119,9 @@ async def test_AC11_8_7_annualized_income_endpoint_converts_mixed_currency_total
     """AC11.8.7: Dashboard annualized income totals use one reporting currency."""
     salary = Account(user_id=test_user.id, name="Salary Income", type=AccountType.INCOME, currency="SGD")
     dividend = Account(user_id=test_user.id, name="Dividend Income", type=AccountType.INCOME, currency="USD")
-    db.add_all([salary, dividend])
+    sgd_cash = Account(user_id=test_user.id, name="SGD Cash", type=AccountType.ASSET, currency="SGD")
+    usd_cash = Account(user_id=test_user.id, name="USD Cash", type=AccountType.ASSET, currency="USD")
+    db.add_all([salary, dividend, sgd_cash, usd_cash])
     await db.flush()
 
     income_entry = JournalEntry(
@@ -119,6 +136,13 @@ async def test_AC11_8_7_annualized_income_endpoint_converts_mixed_currency_total
         [
             JournalLine(
                 journal_entry_id=income_entry.id,
+                account_id=sgd_cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=income_entry.id,
                 account_id=salary.id,
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
@@ -126,10 +150,19 @@ async def test_AC11_8_7_annualized_income_endpoint_converts_mixed_currency_total
             ),
             JournalLine(
                 journal_entry_id=income_entry.id,
+                account_id=usd_cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("10.00"),
+                currency="USD",
+                fx_rate=Decimal("1.500000"),
+            ),
+            JournalLine(
+                journal_entry_id=income_entry.id,
                 account_id=dividend.id,
                 direction=Direction.CREDIT,
                 amount=Decimal("10.00"),
                 currency="USD",
+                fx_rate=Decimal("1.500000"),
             ),
             FxRate(
                 base_currency="USD",

--- a/apps/backend/tests/reporting/test_net_income_average_rates.py
+++ b/apps/backend/tests/reporting/test_net_income_average_rates.py
@@ -102,6 +102,7 @@ async def test_aggregate_net_income_uses_average_rate(
                 direction=Direction.DEBIT,
                 amount=Decimal("1000"),
                 currency="USD",
+                fx_rate=Decimal("1.20"),
             ),
             JournalLine(
                 journal_entry_id=entry_early.id,
@@ -109,6 +110,7 @@ async def test_aggregate_net_income_uses_average_rate(
                 direction=Direction.CREDIT,
                 amount=Decimal("1000"),
                 currency="USD",
+                fx_rate=Decimal("1.20"),
             ),
             JournalLine(
                 journal_entry_id=entry_late.id,
@@ -116,6 +118,7 @@ async def test_aggregate_net_income_uses_average_rate(
                 direction=Direction.DEBIT,
                 amount=Decimal("200"),
                 currency="USD",
+                fx_rate=Decimal("1.40"),
             ),
             JournalLine(
                 journal_entry_id=entry_late.id,
@@ -123,6 +126,7 @@ async def test_aggregate_net_income_uses_average_rate(
                 direction=Direction.CREDIT,
                 amount=Decimal("200"),
                 currency="USD",
+                fx_rate=Decimal("1.40"),
             ),
         ]
     )
@@ -162,6 +166,7 @@ async def test_aggregate_net_income_no_start_date_uses_all_time_average(
                 direction=Direction.DEBIT,
                 amount=Decimal("500"),
                 currency="USD",
+                fx_rate=Decimal("1.30"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -169,6 +174,7 @@ async def test_aggregate_net_income_no_start_date_uses_all_time_average(
                 direction=Direction.CREDIT,
                 amount=Decimal("500"),
                 currency="USD",
+                fx_rate=Decimal("1.30"),
             ),
         ]
     )
@@ -268,6 +274,7 @@ async def test_aggregate_net_income_raises_on_missing_fx_rate(
                 direction=Direction.DEBIT,
                 amount=Decimal("100"),
                 currency="EUR",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -275,6 +282,7 @@ async def test_aggregate_net_income_raises_on_missing_fx_rate(
                 direction=Direction.CREDIT,
                 amount=Decimal("100"),
                 currency="EUR",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )

--- a/apps/backend/tests/reporting/test_net_worth_timeseries.py
+++ b/apps/backend/tests/reporting/test_net_worth_timeseries.py
@@ -44,6 +44,7 @@ async def _entry(db, user_id, entry_date: date, lines: list[tuple[Account, Direc
                 direction=direction,
                 amount=amount,
                 currency=currency,
+                fx_rate=Decimal("1.00") if currency.upper() != "SGD" else None,
             )
         )
     await db.flush()

--- a/apps/backend/tests/reporting/test_reporting.py
+++ b/apps/backend/tests/reporting/test_reporting.py
@@ -423,6 +423,7 @@ async def test_balance_sheet_fx_error(db: AsyncSession, chart_of_accounts, test_
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -430,6 +431,7 @@ async def test_balance_sheet_fx_error(db: AsyncSession, chart_of_accounts, test_
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )
@@ -474,6 +476,7 @@ async def test_income_statement_fx_error(db: AsyncSession, chart_of_accounts, te
                 direction=Direction.DEBIT,
                 amount=Decimal("50.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -481,6 +484,7 @@ async def test_income_statement_fx_error(db: AsyncSession, chart_of_accounts, te
                 direction=Direction.CREDIT,
                 amount=Decimal("50.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )
@@ -524,6 +528,7 @@ async def test_account_trend_invalid_period(db: AsyncSession, chart_of_accounts,
 @pytest.mark.asyncio
 async def test_account_trend_fx_error(db: AsyncSession, chart_of_accounts, test_user_id):
     account = chart_of_accounts[0]
+    equity = chart_of_accounts[2]
     entry = JournalEntry(
         user_id=test_user_id,
         entry_date=date.today(),
@@ -533,14 +538,25 @@ async def test_account_trend_fx_error(db: AsyncSession, chart_of_accounts, test_
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=account.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("10.00"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=account.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("10.00"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=equity.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("10.00"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -580,6 +596,7 @@ async def test_category_breakdown_invalid_period(db: AsyncSession, test_user_id)
 
 @pytest.mark.asyncio
 async def test_category_breakdown_fx_error(db: AsyncSession, chart_of_accounts, test_user_id):
+    cash = chart_of_accounts[0]
     expense = chart_of_accounts[-1]
     entry = JournalEntry(
         user_id=test_user_id,
@@ -590,14 +607,25 @@ async def test_category_breakdown_fx_error(db: AsyncSession, chart_of_accounts, 
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=expense.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("15.00"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=expense.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("15.00"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=cash.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("15.00"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -626,6 +654,7 @@ async def test_cash_flow_invalid_range(db: AsyncSession, test_user_id):
 @pytest.mark.asyncio
 async def test_cash_flow_fx_error_before(db: AsyncSession, chart_of_accounts, test_user_id):
     account = chart_of_accounts[0]
+    equity = chart_of_accounts[2]
     entry = JournalEntry(
         user_id=test_user_id,
         entry_date=date(2025, 1, 1),
@@ -635,14 +664,25 @@ async def test_cash_flow_fx_error_before(db: AsyncSession, chart_of_accounts, te
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=account.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("5.00"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=account.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("5.00"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=equity.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("5.00"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -659,6 +699,7 @@ async def test_cash_flow_fx_error_before(db: AsyncSession, chart_of_accounts, te
 @pytest.mark.asyncio
 async def test_cash_flow_fx_error_during(db: AsyncSession, chart_of_accounts, test_user_id):
     account = chart_of_accounts[0]
+    equity = chart_of_accounts[2]
     entry = JournalEntry(
         user_id=test_user_id,
         entry_date=date(2025, 2, 10),
@@ -668,14 +709,25 @@ async def test_cash_flow_fx_error_during(db: AsyncSession, chart_of_accounts, te
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=account.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("7.00"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=account.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("7.00"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=equity.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("7.00"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -731,6 +783,7 @@ async def test_category_breakdown_annual(db: AsyncSession, test_user_id):
 @pytest.mark.asyncio
 async def test_cash_flow_balances_before_period(db: AsyncSession, chart_of_accounts, test_user_id) -> None:
     account = chart_of_accounts[0]
+    equity = chart_of_accounts[2]
     entry = JournalEntry(
         user_id=test_user_id,
         entry_date=date(2025, 1, 1),
@@ -740,14 +793,23 @@ async def test_cash_flow_balances_before_period(db: AsyncSession, chart_of_accou
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=account.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("20.00"),
-            currency="SGD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=account.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("20.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=equity.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("20.00"),
+                currency="SGD",
+            ),
+        ]
     )
     await db.commit()
 
@@ -1161,29 +1223,58 @@ async def test_income_statement_with_account_type_filter(db: AsyncSession, chart
     """Income statement should filter by account type when specified."""
     cash, _liability, _equity, income, expense = chart_of_accounts
 
-    entry = JournalEntry(
+    income_entry = JournalEntry(
         user_id=test_user_id,
         entry_date=date(2025, 1, 15),
-        memo="Mixed entry",
+        memo="Income entry",
         source_type=JournalEntrySourceType.MANUAL,
         status=JournalEntryStatus.POSTED,
     )
-    db.add(entry)
+    db.add(income_entry)
     await db.flush()
 
     db.add_all(
         [
             JournalLine(
-                journal_entry_id=entry.id,
+                journal_entry_id=income_entry.id,
+                account_id=cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("5000.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=income_entry.id,
                 account_id=income.id,
                 direction=Direction.CREDIT,
                 amount=Decimal("5000.00"),
                 currency="SGD",
             ),
+        ]
+    )
+
+    expense_entry = JournalEntry(
+        user_id=test_user_id,
+        entry_date=date(2025, 1, 16),
+        memo="Expense entry",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(expense_entry)
+    await db.flush()
+
+    db.add_all(
+        [
             JournalLine(
-                journal_entry_id=entry.id,
+                journal_entry_id=expense_entry.id,
                 account_id=expense.id,
                 direction=Direction.DEBIT,
+                amount=Decimal("2000.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=expense_entry.id,
+                account_id=cash.id,
+                direction=Direction.CREDIT,
                 amount=Decimal("2000.00"),
                 currency="SGD",
             ),
@@ -1336,6 +1427,7 @@ async def test_income_statement_fallback_rate(db: AsyncSession, chart_of_account
             direction=Direction.DEBIT,
             amount=Decimal("100.00"),
             currency="USD",
+            fx_rate=Decimal("1.35"),
         )
     )
     db.add(
@@ -1345,6 +1437,7 @@ async def test_income_statement_fallback_rate(db: AsyncSession, chart_of_account
             direction=Direction.CREDIT,
             amount=Decimal("100.00"),
             currency="USD",
+            fx_rate=Decimal("1.35"),
         )
     )
     await db.commit()

--- a/apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py
+++ b/apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py
@@ -58,6 +58,7 @@ async def test_reporting_extreme_fallbacks_failure_reporting(db: AsyncSession, t
                 direction=Direction.DEBIT,
                 amount=Decimal("100"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -65,6 +66,7 @@ async def test_reporting_extreme_fallbacks_failure_reporting(db: AsyncSession, t
                 direction=Direction.CREDIT,
                 amount=Decimal("100"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )
@@ -131,6 +133,7 @@ async def test_reporting_monthly_avg_fallback_coverage(db: AsyncSession, test_us
                 direction=Direction.DEBIT,
                 amount=Decimal("100"),
                 currency="USD",
+                fx_rate=Decimal("1.30"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -138,6 +141,7 @@ async def test_reporting_monthly_avg_fallback_coverage(db: AsyncSession, test_us
                 direction=Direction.CREDIT,
                 amount=Decimal("100"),
                 currency="USD",
+                fx_rate=Decimal("1.30"),
             ),
         ]
     )
@@ -154,9 +158,11 @@ async def test_reporting_cash_flow_account_lookup_coverage(db: AsyncSession, tes
     from src.services.reporting import generate_cash_flow
 
     acc = Account(user_id=test_user_id, name="Bank Cash", type=AccountType.ASSET, currency="SGD")
-    db.add(acc)
+    offset = Account(user_id=test_user_id, name="Owner Equity", type=AccountType.EQUITY, currency="SGD")
+    db.add_all([acc, offset])
     await db.commit()
     await db.refresh(acc)
+    await db.refresh(offset)
 
     entry = JournalEntry(
         user_id=test_user_id,
@@ -166,14 +172,23 @@ async def test_reporting_cash_flow_account_lookup_coverage(db: AsyncSession, tes
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=acc.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("100"),
-            currency="SGD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=acc.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=offset.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100"),
+                currency="SGD",
+            ),
+        ]
     )
     await db.commit()
 
@@ -184,21 +199,33 @@ async def test_reporting_cash_flow_account_lookup_coverage(db: AsyncSession, tes
 async def test_net_income_sql_raises_when_fx_rate_missing(db: AsyncSession, test_user_id):
     """AC5.6.7: Net income FX aggregation raises when source FX rates are unavailable."""
     account = Account(user_id=test_user_id, name="USD Income", type=AccountType.INCOME, currency="USD")
-    db.add(account)
+    asset = Account(user_id=test_user_id, name="USD Cash", type=AccountType.ASSET, currency="USD")
+    db.add_all([account, asset])
     await db.flush()
     entry = JournalEntry(
         user_id=test_user_id, entry_date=date(2025, 2, 1), memo="income", status=JournalEntryStatus.POSTED
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=account.id,
-            direction=Direction.CREDIT,
-            amount=Decimal("20"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=asset.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("20"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=account.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("20"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -255,6 +282,7 @@ async def test_net_income_sql_uses_period_average_rate(db: AsyncSession, test_us
                 direction=Direction.DEBIT,
                 amount=Decimal("100"),
                 currency="USD",
+                fx_rate=Decimal("1.40"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -262,6 +290,7 @@ async def test_net_income_sql_uses_period_average_rate(db: AsyncSession, test_us
                 direction=Direction.CREDIT,
                 amount=Decimal("100"),
                 currency="USD",
+                fx_rate=Decimal("1.40"),
             ),
         ]
     )
@@ -316,19 +345,31 @@ async def test_net_income_sql_detects_missing_fx_map_row() -> None:
 async def test_account_trend_raises_when_prefetched_rate_missing(db: AsyncSession, test_user_id):
     """AC5.6.8: Account trend raises when prefetched non-base FX rate is missing."""
     account = Account(user_id=test_user_id, name="USD Trend", type=AccountType.ASSET, currency="USD")
-    db.add(account)
+    offset = Account(user_id=test_user_id, name="USD Equity", type=AccountType.EQUITY, currency="USD")
+    db.add_all([account, offset])
     await db.flush()
     entry = JournalEntry(user_id=test_user_id, entry_date=date.today(), memo="trend", status=JournalEntryStatus.POSTED)
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=account.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("5"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=account.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("5"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=offset.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("5"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -360,6 +401,7 @@ async def test_category_breakdown_raises_when_prefetched_rate_missing(db: AsyncS
                 direction=Direction.DEBIT,
                 amount=Decimal("7"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -367,6 +409,7 @@ async def test_category_breakdown_raises_when_prefetched_rate_missing(db: AsyncS
                 direction=Direction.CREDIT,
                 amount=Decimal("7"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )
@@ -406,6 +449,7 @@ async def test_cash_flow_raises_when_start_date_rate_missing(db: AsyncSession, t
                 direction=Direction.DEBIT,
                 amount=Decimal("10"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -413,6 +457,7 @@ async def test_cash_flow_raises_when_start_date_rate_missing(db: AsyncSession, t
                 direction=Direction.CREDIT,
                 amount=Decimal("10"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )
@@ -448,6 +493,7 @@ async def test_cash_flow_raises_when_end_date_rate_missing(db: AsyncSession, tes
                 direction=Direction.DEBIT,
                 amount=Decimal("12"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -455,6 +501,7 @@ async def test_cash_flow_raises_when_end_date_rate_missing(db: AsyncSession, tes
                 direction=Direction.CREDIT,
                 amount=Decimal("12"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )

--- a/apps/backend/tests/reporting/test_reporting_fx.py
+++ b/apps/backend/tests/reporting/test_reporting_fx.py
@@ -97,6 +97,7 @@ async def test_fx_unrealized_gain_calculation(db: AsyncSession, multi_currency_a
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.30"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -143,6 +144,7 @@ async def test_income_statement_comprehensive_income(db: AsyncSession, multi_cur
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.30"),
             ),
             JournalLine(
                 journal_entry_id=entry1.id,
@@ -231,6 +233,7 @@ async def test_fx_liability_inversion(db: AsyncSession, multi_currency_accounts,
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.30"),
             ),
         ]
     )
@@ -294,6 +297,7 @@ async def test_multi_currency_aggregation(db: AsyncSession, multi_currency_accou
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.30"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -301,6 +305,7 @@ async def test_multi_currency_aggregation(db: AsyncSession, multi_currency_accou
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="EUR",
+                fx_rate=Decimal("1.50"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -383,6 +388,7 @@ async def test_historical_vs_average_discrepancy_bridge(db: AsyncSession, multi_
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.40"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -390,6 +396,7 @@ async def test_historical_vs_average_discrepancy_bridge(db: AsyncSession, multi_
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.40"),
             ),
         ]
     )
@@ -452,6 +459,7 @@ async def test_reporting_fx_fallbacks(db: AsyncSession, multi_currency_accounts,
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.50"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -459,6 +467,7 @@ async def test_reporting_fx_fallbacks(db: AsyncSession, multi_currency_accounts,
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.50"),
             ),
         ]
     )
@@ -676,6 +685,7 @@ async def test_reporting_fx_extreme_fallbacks(db: AsyncSession, multi_currency_a
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -683,6 +693,7 @@ async def test_reporting_fx_extreme_fallbacks(db: AsyncSession, multi_currency_a
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )
@@ -837,7 +848,7 @@ async def test_reporting_remaining_branches(db: AsyncSession, multi_currency_acc
 @pytest.mark.asyncio
 async def test_reporting_cash_flow_before_fx_error(db: AsyncSession, multi_currency_accounts, test_user_id):
     """Test cash flow error when FX fails for 'before' period balances."""
-    _, usd_savings, *_ = multi_currency_accounts
+    _, usd_savings, capital, *_ = multi_currency_accounts
 
     # Entry BEFORE start_date
     entry = JournalEntry(
@@ -848,14 +859,25 @@ async def test_reporting_cash_flow_before_fx_error(db: AsyncSession, multi_curre
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=usd_savings.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("100"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=usd_savings.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=capital.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -867,7 +889,7 @@ async def test_reporting_cash_flow_before_fx_error(db: AsyncSession, multi_curre
 @pytest.mark.asyncio
 async def test_reporting_cash_flow_fx_error_handling(db: AsyncSession, multi_currency_accounts, test_user_id):
     """Test cash flow error handling for FX conversion."""
-    sgd_bank, usd_savings, *_ = multi_currency_accounts
+    sgd_bank, usd_savings, capital, *_ = multi_currency_accounts
     sgd_bank.name = "Bank account"
 
     # No rates in DB
@@ -879,14 +901,25 @@ async def test_reporting_cash_flow_fx_error_handling(db: AsyncSession, multi_cur
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=usd_savings.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("100"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=usd_savings.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=capital.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -897,7 +930,7 @@ async def test_reporting_cash_flow_fx_error_handling(db: AsyncSession, multi_cur
 @pytest.mark.asyncio
 async def test_reporting_breakdown_fx_error_handling(db: AsyncSession, multi_currency_accounts, test_user_id):
     """Test breakdown error handling for FX conversion."""
-    _, _, _, salary, _ = multi_currency_accounts
+    sgd_cash, _, _, salary, _ = multi_currency_accounts
 
     # No rates in DB
     entry = JournalEntry(
@@ -908,14 +941,25 @@ async def test_reporting_breakdown_fx_error_handling(db: AsyncSession, multi_cur
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=salary.id,
-            direction=Direction.CREDIT,
-            amount=Decimal("100"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=sgd_cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=salary.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -926,7 +970,7 @@ async def test_reporting_breakdown_fx_error_handling(db: AsyncSession, multi_cur
 @pytest.mark.asyncio
 async def test_reporting_trend_fx_error_handling(db: AsyncSession, multi_currency_accounts, test_user_id):
     """Test trend error handling for FX conversion."""
-    _, usd_savings, *_ = multi_currency_accounts
+    _, usd_savings, capital, *_ = multi_currency_accounts
 
     # No rates in DB
     entry = JournalEntry(
@@ -937,14 +981,25 @@ async def test_reporting_trend_fx_error_handling(db: AsyncSession, multi_currenc
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=usd_savings.id,
-            direction=Direction.DEBIT,
-            amount=Decimal("100"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=usd_savings.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=capital.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.00"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -957,7 +1012,7 @@ async def test_reporting_income_statement_period_fx_fallback_to_spot(
     db: AsyncSession, multi_currency_accounts, test_user_id
 ):
     """Test IS fallback from average rate to spot rate when average rate is missing."""
-    _, _, _, salary, _ = multi_currency_accounts
+    sgd_cash, _, _, salary, _ = multi_currency_accounts
 
     # Rate only at end_date
     db.add(
@@ -979,14 +1034,25 @@ async def test_reporting_income_statement_period_fx_fallback_to_spot(
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=salary.id,
-            direction=Direction.CREDIT,
-            amount=Decimal("100"),
-            currency="USD",
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=sgd_cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.50"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=salary.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100"),
+                currency="USD",
+                fx_rate=Decimal("1.50"),
+            ),
+        ]
     )
     await db.commit()
 
@@ -1034,6 +1100,7 @@ async def test_balance_sheet_net_income_fx_fallback(db: AsyncSession, multi_curr
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.35"),
             ),
             JournalLine(
                 journal_entry_id=income_entry.id,
@@ -1041,6 +1108,7 @@ async def test_balance_sheet_net_income_fx_fallback(db: AsyncSession, multi_curr
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.35"),
             ),
         ]
     )
@@ -1097,6 +1165,7 @@ async def test_reports_lazy_resolve_missing_hkd_sgd_from_bridge_rates(db: AsyncS
                 direction=Direction.DEBIT,
                 amount=Decimal("780.00"),
                 currency="HKD",
+                fx_rate=Decimal("0.173077"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -1104,6 +1173,7 @@ async def test_reports_lazy_resolve_missing_hkd_sgd_from_bridge_rates(db: AsyncS
                 direction=Direction.CREDIT,
                 amount=Decimal("780.00"),
                 currency="HKD",
+                fx_rate=Decimal("0.173077"),
             ),
         ]
     )
@@ -1160,6 +1230,7 @@ async def test_balance_sheet_net_income_no_fx_rate_error(db: AsyncSession, multi
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=income_entry.id,
@@ -1167,6 +1238,7 @@ async def test_balance_sheet_net_income_no_fx_rate_error(db: AsyncSession, multi
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )

--- a/apps/backend/tests/reporting/test_reporting_fx_fallbacks.py
+++ b/apps/backend/tests/reporting/test_reporting_fx_fallbacks.py
@@ -149,6 +149,7 @@ async def test_aggregate_balances_missing_fx_skips_unconvertible_currency_with_w
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -156,6 +157,7 @@ async def test_aggregate_balances_missing_fx_skips_unconvertible_currency_with_w
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.00"),
             ),
         ]
     )
@@ -278,6 +280,7 @@ async def test_net_income_fx_data_consistency_error(db: AsyncSession, accounts, 
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.35"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -285,6 +288,7 @@ async def test_net_income_fx_data_consistency_error(db: AsyncSession, accounts, 
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.35"),
             ),
         ]
     )
@@ -365,6 +369,7 @@ async def test_income_statement_fx_average_to_spot_fallback(db: AsyncSession, ac
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.35"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -372,6 +377,7 @@ async def test_income_statement_fx_average_to_spot_fallback(db: AsyncSession, ac
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.35"),
             ),
         ]
     )
@@ -436,6 +442,7 @@ async def test_income_statement_fx_all_fallbacks_fail(db: AsyncSession, accounts
                 direction=Direction.DEBIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.35"),
             ),
             JournalLine(
                 journal_entry_id=entry.id,
@@ -443,6 +450,7 @@ async def test_income_statement_fx_all_fallbacks_fail(db: AsyncSession, accounts
                 direction=Direction.CREDIT,
                 amount=Decimal("100.00"),
                 currency="USD",
+                fx_rate=Decimal("1.35"),
             ),
         ]
     )
@@ -529,7 +537,7 @@ async def test_breakdown_same_currency_rate_none_fallback(db: AsyncSession, acco
     WHEN PrefetchedFxRates.get_rate returns None
     THEN fallback to Decimal("1") rate succeeds
     """
-    _, _, _, salary, _ = accounts
+    sgd_cash, _, _, salary, _ = accounts
 
     entry = JournalEntry(
         user_id=user_id,
@@ -541,6 +549,13 @@ async def test_breakdown_same_currency_rate_none_fallback(db: AsyncSession, acco
     await db.flush()
     db.add_all(
         [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=sgd_cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("300.00"),
+                currency="SGD",
+            ),
             JournalLine(
                 journal_entry_id=entry.id,
                 account_id=salary.id,

--- a/apps/backend/tests/reporting/test_reporting_fx_revaluation_integration.py
+++ b/apps/backend/tests/reporting/test_reporting_fx_revaluation_integration.py
@@ -95,6 +95,7 @@ async def test_income_statement_includes_average_rate_fallback_warning(db: Async
     """AC5.6.7: Report output lists currencies that used average-rate spot fallback."""
     start_date = date(2025, 1, 1)
     end_date = date(2025, 1, 31)
+    cash = await _account(db, test_user.id, "USD Cash", AccountType.ASSET, "USD")
     income = await _account(db, test_user.id, "USD Salary", AccountType.INCOME, "USD")
     db.add(
         FxRate(
@@ -111,15 +112,25 @@ async def test_income_statement_includes_average_rate_fallback_warning(db: Async
     )
     db.add(entry)
     await db.flush()
-    db.add(
-        JournalLine(
-            journal_entry_id=entry.id,
-            account_id=income.id,
-            direction=Direction.CREDIT,
-            amount=Decimal("100.00"),
-            currency="USD",
-            fx_rate=Decimal("1.50"),
-        )
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("100.00"),
+                currency="USD",
+                fx_rate=Decimal("1.50"),
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=income.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("100.00"),
+                currency="USD",
+                fx_rate=Decimal("1.50"),
+            ),
+        ]
     )
     await db.commit()
 

--- a/apps/backend/tests/reporting/test_reports_errors.py
+++ b/apps/backend/tests/reporting/test_reports_errors.py
@@ -9,11 +9,8 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models import (
-    JournalEntry,
-    JournalEntryStatus,
-)
 from src.services.reporting import ReportError
+from tests.accounting._ledger_helpers import create_valid_posted_entry
 
 
 @pytest.mark.asyncio
@@ -130,16 +127,7 @@ async def test_journal_router_coverage_errors(client: AsyncClient, db: AsyncSess
     assert resp.status_code == 404
 
     # 5. Delete non-draft
-    entry = JournalEntry(
-        user_id=test_user.id,
-        entry_date=date.today(),
-        memo="Posted",
-        source_type="manual",
-        status=JournalEntryStatus.POSTED,
-    )
-    db.add(entry)
-    await db.commit()
-    await db.refresh(entry)
+    entry = await create_valid_posted_entry(db, test_user.id, entry_date=date.today(), memo="Posted")
 
     resp = await client.delete(f"/journal-entries/{entry.id}")
     assert resp.status_code == 400

--- a/apps/backend/tests/services/test_evidence_graph_materialization.py
+++ b/apps/backend/tests/services/test_evidence_graph_materialization.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import func, select
@@ -25,6 +25,7 @@ async def _create_historical_statement_entry(
     db: AsyncSession,
     *,
     user_id,
+    entry_source_id: UUID | None = None,
 ) -> tuple[UploadedDocument, AtomicTransaction, JournalEntry, JournalLine]:
     """Build a deduped lineage: UploadedDocument -> AtomicTransaction -> JournalEntry/lines."""
     bank = Account(user_id=user_id, name=f"Lazy Bank {uuid4()}", type=AccountType.ASSET, currency="SGD")
@@ -46,7 +47,7 @@ async def _create_historical_statement_entry(
     txn_date = date(2026, 5, 1)
     amount = Decimal("42.00")
     description = "Historical income"
-    reference = "LZ-1"
+    reference = f"LZ-{uuid4().hex[:8]}"
     dedup_hash = DeduplicationService.calculate_transaction_hash(
         user_id,
         txn_date,
@@ -55,7 +56,10 @@ async def _create_historical_statement_entry(
         description,
         reference,
     )
+    atomic_id = uuid4()
+    source_id = entry_source_id or atomic_id
     atomic = AtomicTransaction(
+        id=atomic_id,
         user_id=user_id,
         txn_date=txn_date,
         amount=amount,
@@ -71,12 +75,10 @@ async def _create_historical_statement_entry(
         entry_date=txn_date,
         memo="Historical posted income",
         source_type=JournalEntrySourceType.USER_CONFIRMED,
-        source_id=None,
+        source_id=source_id,
         status=JournalEntryStatus.POSTED,
     )
     db.add_all([atomic, entry])
-    await db.flush()
-    entry.source_id = atomic.id
     await db.flush()
     debit = JournalLine(
         journal_entry_id=entry.id,
@@ -250,13 +252,16 @@ async def test_AC18_10_7_materialization_caps_and_unknown_sources_return_blocker
     assert [blocker.code for blocker in capped.blockers] == ["materialization_write_cap_reached"]
     assert await _graph_counts(db) == (0, 0)
 
-    entry.source_id = uuid4()
-    await db.flush()
+    _, _, _, unknown_line = await _create_historical_statement_entry(
+        db,
+        user_id=test_user.id,
+        entry_source_id=uuid4(),
+    )
     unknown = await service.materialize_for_entity(
         db,
         user_id=test_user.id,
         entity_type="journal_line",
-        entity_id=line.id,
+        entity_id=unknown_line.id,
         node_kind="ledger_line",
     )
 

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -20,6 +20,7 @@ These files are test infrastructure, not behavior proof.
 |---|---|
 | `apps/backend/tests/__init__.py` | Package marker |
 | `apps/backend/tests/accounting/__init__.py` | Package marker |
+| `apps/backend/tests/accounting/_ledger_helpers.py` | Shared accounting ledger invariant test helper |
 | `apps/backend/tests/ai/__init__.py` | Package marker |
 | `apps/backend/tests/assets/__init__.py` | Package marker |
 | `apps/backend/tests/auth/__init__.py` | Package marker |

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -213,6 +213,16 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 | AC2.13.2 | Posting validates that every line account belongs to the entry owner | `test_AC2_13_2_post_journal_entry_rejects_cross_user_account()` | `accounting/test_accounting_integration.py` | P0 |
 | AC2.13.3 | Balance aggregation requires account and entry ownership to match | `test_AC2_13_3_balance_queries_ignore_cross_user_entry_headers()` | `accounting/test_accounting_integration.py` | P0 |
 
+### AC2.14: Database Ledger Invariant Floor
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC2.14.1 | PostgreSQL rejects posted/reconciled entries with fewer than two lines even when service validation is bypassed | `test_AC2_14_1_posted_entry_requires_two_lines_at_database_boundary()` | `accounting/test_ledger_schema_invariants.py` | P0 |
+| AC2.14.2 | PostgreSQL rejects posted/reconciled entries whose debits and credits do not balance after base-currency conversion | `test_AC2_14_2_posted_entry_must_balance_in_base_currency()` | `accounting/test_ledger_schema_invariants.py` | P0 |
+| AC2.14.3 | PostgreSQL rejects posted/reconciled non-base-currency lines without a positive FX rate | `test_AC2_14_3_non_base_posted_lines_require_positive_fx_rate()` | `accounting/test_ledger_schema_invariants.py` | P0 |
+| AC2.14.4 | PostgreSQL blocks direct update/delete of posted/reconciled entries and lines while draft entries remain editable | `test_AC2_14_4_posted_entries_and_lines_are_immutable_but_drafts_are_editable()` | `accounting/test_ledger_schema_invariants.py` | P0 |
+| AC2.14.5 | Voiding a posted entry preserves a non-null immutable reversal relationship instead of deleting or editing posted lines | `test_AC2_14_5_void_transition_requires_reversal_relationship()` | `accounting/test_ledger_schema_invariants.py` | P0 |
+
 ## 📏 Acceptance Criteria
 
 > ℹ️ **Non-contiguous AC numbering**: Gaps in `AC2.x.y` numbers reflect deprecated or merged ACs preserved through generated registry indexes plus explicit overrides. Do **not** renumber. New ACs append to the next available index in this EPIC.

--- a/docs/ssot/accounting.md
+++ b/docs/ssot/accounting.md
@@ -53,6 +53,27 @@ base_amount = line.amount * line.fx_rate
 
 Debit and credit totals are valid only when their converted base amounts differ by no more than `0.01`.
 
+### Posted Ledger Database Floor
+
+Application services validate drafts before posting, but the database is the
+final boundary for posted/reconciled ledger facts. Direct writes that bypass
+services must still be rejected when they would create a posted or reconciled
+entry with fewer than two lines, unbalanced base-currency debit/credit totals,
+or non-base lines without a positive `fx_rate`.
+
+Posted and reconciled entries are immutable ledger facts. They must not be
+updated or deleted directly; the only supported correction is a void transition
+that preserves an immutable reversal relationship. Draft entries remain editable
+and deletable until posting.
+
+Ledger immutability protects accounting facts: entry ownership/date/memo/source
+identity, status correction path, and all journal-line amounts, directions,
+accounts, currencies, and FX rates. The only non-fact metadata update allowed on
+a posted/reconciled entry is the source-type-priority promotion from
+`auto_parsed`, `bank_statement`, or `auto_matched` to `user_confirmed`, with
+`source_id` and every accounting fact unchanged. The same promotion is allowed
+when the entry moves from `posted` to `reconciled`.
+
 ---
 
 ## 3. Design Constraints (Dos & Don'ts)
@@ -68,6 +89,8 @@ Debit and credit totals are valid only when their converted base amounts differ 
 - **Pattern C**: Posted entries can only be voided, not directly modified
 - **Pattern D**: Multi-currency entries validate debit/credit balance after base-currency conversion.
 - **Pattern E**: Journal line account authorization is a domain invariant. Accounting services must validate that every `JournalLine.account_id` belongs to the same `user_id` as the `JournalEntry`; HTTP middleware is not sufficient because service calls and background tasks can write ledger records without a request object.
+- **Pattern F**: Posted/reconciled ledger invariants are enforced at both service and database boundaries.
+- **Pattern G**: Posted/reconciled source-type promotion may only increase trust from auto/statement-derived provenance to `user_confirmed`; it must not change source identity or accounting facts.
 
 ### ⛔ Prohibited Patterns
 
@@ -84,6 +107,8 @@ Debit and credit totals are valid only when their converted base amounts differ 
 - **Anti-pattern C**: **NEVER** skip validation when writing posted status. See: `apps/backend/tests/accounting/test_accounting_integration.py::test_post_journal_entry_already_posted_fails`
 - **Anti-pattern E**: **NEVER** validate a multi-currency journal entry by comparing raw original-currency nominal amounts.
 - **Anti-pattern F**: **NEVER** create, post, or aggregate journal lines across user boundaries. Balance queries must require both `Account.user_id == user_id` and `JournalEntry.user_id == user_id`.
+- **Anti-pattern G**: **NEVER** directly update or delete posted/reconciled/void ledger facts. Use the void/reversal workflow.
+- **Anti-pattern H**: **NEVER** downgrade `source_type` or change `source_id` after posting/reconciliation. Provenance corrections must use the explicit source-type promotion path only.
 
 <a id="async-tx-boundary"></a>
 
@@ -183,6 +208,7 @@ def void_entry(entry: JournalEntry, reason: str) -> JournalEntry:
 | Multi-currency base balance | Unit test `test_AC2_12_1_multicurrency_entry_balances_in_base_currency` | ✅ Implemented |
 | Accounting equation base conversion | Integration test `test_AC2_12_2_accounting_equation_uses_base_currency_balances` | ✅ Implemented |
 | User-scoped line ownership | Integration tests `test_AC2_13_1_*`, `test_AC2_13_2_*`, `test_AC2_13_3_*` | ✅ Implemented |
+| Database ledger invariant floor | Direct DB-bypass tests `test_AC2_14_*` | ✅ Implemented |
 | Void logic | Unit test `test_void_entry` | ⏳ Pending |
 
 ---

--- a/docs/ssot/migration-risk.yaml
+++ b/docs/ssot/migration-risk.yaml
@@ -165,6 +165,11 @@ migrations:
     file: 0031_drop_orphan_stage1_status_enum.py
     risk: low
     proof: "Drops the orphaned stage1_status_enum left after EPIC-011 Stage 3 dropped bank_statements; no column references it."
+  0032_ledger_invariants:
+    file: 0032_ledger_invariants.py
+    risk: medium
+    issue: "#844"
+    proof: Adds preflight checks, PostgreSQL ledger invariant triggers, an FX-rate check, and void reversal FK; covered by AC2.14 direct DB-bypass tests and the PR Alembic contract.
   51aa128d8189:
     file: 51aa128d8189_remove_report_snapshot_constraint.py
     risk: medium

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -296,6 +296,12 @@ Journal entry header table.
 | created_at | TIMESTAMP | NOT NULL | Creation time |
 | updated_at | TIMESTAMP | NOT NULL | Update time |
 
+**Constraints**:
+- `void_reversal_entry_id` is a self-FK to `journal_entries.id` with restricted delete semantics.
+- Posted/reconciled rows are validated by database triggers so direct DB writes cannot persist fewer than two lines or unbalanced base-currency debit/credit totals.
+- Posted/reconciled/void rows are protected by database triggers from direct update/delete. The supported correction path is a void transition with `void_reason` and `void_reversal_entry_id`.
+- The only posted/reconciled metadata update outside the void path is source-type-priority promotion from `auto_parsed`, `bank_statement`, or `auto_matched` to `user_confirmed`; `source_id` and all accounting facts remain unchanged, and the same promotion may accompany the `posted` to `reconciled` status transition.
+
 ### JournalLines
 Journal entry line table.
 
@@ -310,6 +316,12 @@ Journal entry line table.
 | fx_rate | DECIMAL(12,6) | | Exchange rate |
 | event_type | VARCHAR(100) | | Event type |
 | tags | JSONB | | Tags |
+
+**Constraints**:
+- `amount > 0`
+- `fx_rate IS NULL OR fx_rate > 0`
+- Non-base posted/reconciled lines require a positive `fx_rate` at the database boundary.
+- Posted/reconciled/void parent entries protect their lines from direct mutation; draft entry lines remain editable.
 
 ### InvestmentTransactions
 Auditable brokerage transaction table for buy, sell, and dividend accounting.
@@ -460,10 +472,9 @@ Stage 2 blocker table.
 | created_at | TIMESTAMP | NOT NULL | Creation time |
 | updated_at | TIMESTAMP | NOT NULL | Update time |
 
-**Constraints**:
-- Each JournalEntry must have at least 2 JournalLines
-    - `SUM(DEBIT) = SUM(CREDIT)` (debit/credit balance)
-    - `JournalLine.amount > 0` (positive_amount check)
+Journal ledger constraints are specified above under `JournalEntries` and
+`JournalLines`; accounting rationale is owned by
+[`accounting.md`](./accounting.md).
 
 ### ODS: UploadedDocuments (EPIC-011)
 Immutable registry of all raw uploaded files (user-side source landing).


### PR DESCRIPTION
## Summary

Harden the ledger database boundary so posted/reconciled entries cannot persist invalid facts or be directly mutated after posting.

Closes #844

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-002 — Double-entry core |
| **AC IDs** | AC2.14.1, AC2.14.2, AC2.14.3, AC2.14.4, AC2.14.5 |
| **AC source updated** | Owning EPIC |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — no ownership change
- [x] `docs/ssot/accounting.md` — documented posted/reconciled database invariant floor and source-type promotion exception
- [x] `docs/ssot/schema.md` — documented journal entry/line trigger constraints and void reversal FK
- [x] `docs/ssot/migration-risk.yaml` — registered migration `0032_ledger_invariants`
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | local worktree before final commit | AC2.14 direct DB-bypass tests failed before trigger/migration implementation |
| 🟢 Green (passing test) | `c91c9dda` | Implement ledger invariant triggers, migration, docs, and fixture updates |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes / no manifest ownership change
- [x] `tools/lint_doc_consistency.py` passes (not applicable to touched SSOT scope)

### CI/CD, Runtime, and VPS Infra Audit

Not applicable: this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
moon run :lint
apps/backend/.venv/bin/python tools/generate_ac_registry.py --check
apps/backend/.venv/bin/python tools/analyze_test_ac_coverage.py --no-write --stdout
apps/backend/.venv/bin/python tools/check_ssot_ownership.py
apps/backend/.venv/bin/python tools/check_migration_risk.py
CONTAINER_RUNTIME=podman BRANCH_NAME=issue-844-ledger-schema-invariants moon run :test -- tests/accounting/test_ledger_schema_invariants.py tests/reconciliation/test_review_queue.py::test_accept_match_creates_missing_journal_entry -ra --no-cov -n 0
```

Earlier broad local backend runs were limited by local Podman/Postgres recovery on this 2 GiB VM; CI is the source of truth for the full matrix.

---

## Screenshots / Evidence

N/A — backend schema and test changes only.
