### PR TITLE
[finance_report_ui] EPIC-022: lean Home, plain-language status, unbroken review mainline

### DIFF
--- a/apps/frontend/src/__tests__/dashboardPage.test.tsx
+++ b/apps/frontend/src/__tests__/dashboardPage.test.tsx
@@ -289,7 +289,8 @@ describe("HomePage", () => {
     expect(mockedApiFetch).toHaveBeenCalledWith("/api/chat/suggestions?language=en&include_structured=true")
     expect(screen.getByText("Total Assets")).toBeInTheDocument()
     expect(screen.getByText("Total Liabilities")).toBeInTheDocument()
-    expect(screen.getByText("Net Assets")).toBeInTheDocument()
+    // Net worth is shown once, in the hero banner — not duplicated as a KPI card.
+    expect(screen.getByText("Net Worth")).toBeInTheDocument()
     expect(screen.getByText("PieChartMock")).toBeInTheDocument()
     expect(screen.getByText("BarChartMock")).toBeInTheDocument()
     expect(screen.getByText("Recent Entries")).toBeInTheDocument()
@@ -654,7 +655,7 @@ describe("HomePage", () => {
     expect(screen.getByText("Build your first accurate financial view")).toBeInTheDocument()
     expect(screen.getByRole("link", { name: /Add your first account/i })).toHaveAttribute("href", "/accounts")
     expect(screen.getByRole("link", { name: /Upload a bank statement/i })).toHaveAttribute("href", "/upload")
-    expect(screen.getByRole("link", { name: /Review and approve/i })).toHaveAttribute("href", "/review")
+    expect(screen.getByRole("link", { name: /Review and approve/i })).toHaveAttribute("href", "/notifications")
   })
 
   it("AC16.12.17 keeps onboarding visible with partial progress markers", async () => {
@@ -675,7 +676,7 @@ describe("HomePage", () => {
     await waitFor(() => expect(screen.getByLabelText("Getting started")).toBeInTheDocument())
     expect(screen.getAllByText("Done")).toHaveLength(2)
     expect(screen.getByText("Next")).toBeInTheDocument()
-    expect(screen.getByRole("link", { name: /Review and approve/i })).toHaveAttribute("href", "/review")
+    expect(screen.getByRole("link", { name: /Review and approve/i })).toHaveAttribute("href", "/notifications")
   })
 
   it("AC16.12.19 hides first-time onboarding after approved statement and posted journal entry exist", async () => {

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import StatementsPage from "@/app/(main)/upload/page"
 import { apiFetch } from "@/lib/api"
+import type { BankStatement } from "@/lib/types"
 
 const showToastMock = vi.fn()
 
@@ -150,6 +151,51 @@ describe("StatementsPage", () => {
     await waitFor(() => expect(screen.getByText("fresh.pdf")).toBeInTheDocument())
     expect(screen.getByText("Uploaded")).toBeInTheDocument()
     expect(screen.queryByText("uploaded")).toBeNull()
+  })
+
+  it("AC22.5.x labels rejected statements and falls back gracefully for unknown statuses", async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      items: [
+        {
+          id: "s11",
+          original_filename: "rejected.pdf",
+          institution: "DBS",
+          status: "rejected",
+          period_start: "2026-01-01",
+          period_end: "2026-01-31",
+          currency: "SGD",
+          confidence_score: 40,
+          transactions: [],
+          opening_balance: 0,
+          closing_balance: 0,
+          balance_validated: false,
+          validation_error: "Could not read totals",
+        },
+        {
+          id: "s12",
+          original_filename: "weird.pdf",
+          institution: "DBS",
+          // Defensive: a status outside the known union still renders, unstyled.
+          status: "frobnicating" as unknown as BankStatement["status"],
+          period_start: "2026-01-01",
+          period_end: "2026-01-31",
+          currency: "SGD",
+          confidence_score: 50,
+          transactions: [],
+          opening_balance: 0,
+          closing_balance: 0,
+          balance_validated: null,
+          validation_error: null,
+        },
+      ],
+    })
+
+    render(<StatementsPage />)
+
+    await waitFor(() => expect(screen.getByText("rejected.pdf")).toBeInTheDocument())
+    expect(screen.getByText("Rejected")).toBeInTheDocument()
+    // Unknown status degrades to its raw value rather than crashing.
+    expect(screen.getByText("frobnicating")).toBeInTheDocument()
   })
 
   it("AC16.14.11 enables polling when parsing statements exist", async () => {

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -124,6 +124,34 @@ describe("StatementsPage", () => {
     expect(routerPushMock).toHaveBeenCalledWith("/statements/s9/review")
   })
 
+  it("AC22.5.x maps every status to a plain-language label (no raw 'uploaded')", async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      items: [
+        {
+          id: "s10",
+          original_filename: "fresh.pdf",
+          institution: "DBS",
+          status: "uploaded",
+          period_start: null,
+          period_end: null,
+          currency: "SGD",
+          confidence_score: null,
+          transactions: [],
+          opening_balance: null,
+          closing_balance: null,
+          balance_validated: null,
+          validation_error: null,
+        },
+      ],
+    })
+
+    render(<StatementsPage />)
+
+    await waitFor(() => expect(screen.getByText("fresh.pdf")).toBeInTheDocument())
+    expect(screen.getByText("Uploaded")).toBeInTheDocument()
+    expect(screen.queryByText("uploaded")).toBeNull()
+  })
+
   it("AC16.14.11 enables polling when parsing statements exist", async () => {
     mockedApiFetch.mockResolvedValueOnce({
       items: [

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -15,6 +15,12 @@ vi.mock("next/link", () => ({
   ),
 }))
 
+const routerPushMock = vi.fn()
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPushMock }),
+}))
+
 vi.mock("@/components/statements/StatementUploader", () => ({
   default: ({ onUploadComplete }: { onUploadComplete: () => void }) => (
     <button onClick={onUploadComplete}>UploadMock</button>
@@ -82,6 +88,40 @@ describe("StatementsPage", () => {
     await waitFor(() => expect(screen.getByText("No statements uploaded yet")).toBeInTheDocument())
     fireEvent.click(screen.getByText("UploadMock"))
     await waitFor(() => expect(screen.getByText("stmt.pdf")).toBeInTheDocument())
+  })
+
+  it("AC22.5.x surfaces a parsed statement as ready-to-review with a direct review deep-link", async () => {
+    routerPushMock.mockClear()
+    mockedApiFetch.mockResolvedValueOnce({
+      items: [
+        {
+          id: "s9",
+          original_filename: "ready.pdf",
+          institution: "DBS",
+          status: "parsed",
+          period_start: "2026-01-01",
+          period_end: "2026-01-31",
+          currency: "SGD",
+          confidence_score: 90,
+          transactions: [],
+          opening_balance: 100,
+          closing_balance: 200,
+          balance_validated: true,
+          validation_error: null,
+        },
+      ],
+    })
+
+    render(<StatementsPage />)
+
+    await waitFor(() => expect(screen.getByText("ready.pdf")).toBeInTheDocument())
+    // Plain-language status, not the raw "parsed" word.
+    expect(screen.getByText("Ready to review")).toBeInTheDocument()
+    expect(screen.queryByText("parsed")).toBeNull()
+
+    // Direct deep-link into the review page, skipping the detail-page hop.
+    fireEvent.click(screen.getByRole("button", { name: /Review/i }))
+    expect(routerPushMock).toHaveBeenCalledWith("/statements/s9/review")
   })
 
   it("AC16.14.11 enables polling when parsing statements exist", async () => {

--- a/apps/frontend/src/app/(main)/page.tsx
+++ b/apps/frontend/src/app/(main)/page.tsx
@@ -238,7 +238,7 @@ export default function HomePage() {
     return [
       { label: "Add your first account", href: "/accounts", done: hasAccount, Icon: Landmark },
       { label: "Upload a bank statement", href: "/upload", done: hasStatement, Icon: FileText },
-      { label: "Review and approve", href: "/review", done: hasApprovedOutput, Icon: BookOpen },
+      { label: "Review and approve", href: "/notifications", done: hasApprovedOutput, Icon: BookOpen },
     ];
   }, [isCoreFlowComplete, onboardingStatus]);
 
@@ -322,8 +322,9 @@ export default function HomePage() {
         </section>
       )}
 
-      {/* KPI Cards */}
-      <div className="grid gap-4 md:grid-cols-4 mb-6">
+      {/* KPI Cards — Net Worth lives in the hero banner below, so it is not
+          duplicated here as a "Net Assets" card. */}
+      <div className="grid gap-4 md:grid-cols-3 mb-6">
         <ProcessingSummaryCard />
         <div className="card p-5">
           <p className="text-xs text-muted uppercase tracking-wide">Total Assets</p>
@@ -338,13 +339,6 @@ export default function HomePage() {
             {balanceSheet ? formatCurrencyLocale(balanceSheet.total_liabilities, balanceSheet.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}
           </p>
           <p className="text-xs text-muted mt-1">Obligations</p>
-        </div>
-        <div className="card p-5">
-          <p className="text-xs text-muted uppercase tracking-wide">Net Assets</p>
-          <p className="text-2xl font-semibold mt-1">
-            {balanceSheet ? formatCurrencyLocale(netAssets, balanceSheet.currency, "en-US", { maximumFractionDigits: 0 }) : "—"}
-          </p>
-          <p className="text-xs text-muted mt-1">{balanceSheet?.is_balanced ? "✓ Balanced" : "⚠ Drift"}</p>
         </div>
       </div>
       {/* Hero: Net Worth Banner (C2 + C3) */}

--- a/apps/frontend/src/app/(main)/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/upload/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 
 import StatementUploader from "@/components/statements/StatementUploader";
@@ -10,12 +11,31 @@ import { InfoHint } from "@/components/ui/InfoHint";
 import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import { useToast } from "@/components/ui/Toast";
 import { Alert, Badge, Button, EmptyState, IconButton, LoadingState, PageHeader } from "@/components/ui";
+import type { BadgeVariant } from "@/components/ui";
 import { apiFetch } from "@/lib/api";
 import { BankStatement, BankStatementListResponse } from "@/lib/types";
 import { formatCurrencyLocale } from "@/lib/currency";
 
+// Plain-language status for everyday users. "parsed" means the AI finished and
+// it is the user's turn to review — surface that as an action, not a warning.
+function statusDisplay(status: string): { label: string; variant: BadgeVariant } {
+    switch (status) {
+        case "approved":
+            return { label: "Approved", variant: "success" };
+        case "rejected":
+            return { label: "Rejected", variant: "error" };
+        case "parsed":
+            return { label: "Ready to review", variant: "info" };
+        case "parsing":
+            return { label: "Parsing", variant: "muted" };
+        default:
+            return { label: status, variant: "muted" };
+    }
+}
+
 export default function UploadPage() {
     const { showToast } = useToast();
+    const router = useRouter();
     const [statements, setStatements] = useState<BankStatement[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -167,15 +187,11 @@ export default function UploadPage() {
                                     <div className="flex-1 min-w-0">
                                         <div className="flex items-center gap-2 mb-1">
                                             <span className="font-medium truncate">{statement.original_filename}</span>
-                                            <Badge variant={statement.status === "approved" ? "success" :
-                                                statement.status === "rejected" ? "error" :
-                                                    statement.status === "parsed" ? "warning" :
-                                                        "muted"
-                                            }>
+                                            <Badge variant={statusDisplay(statement.status).variant}>
                                                 {statement.status === "parsing" && (
                                                     <span className="inline-block w-3 h-3 mr-1 border-2 border-current border-t-transparent rounded-full animate-spin" />
                                                 )}
-                                                {statement.status}
+                                                {statusDisplay(statement.status).label}
                                             </Badge>
                                         </div>
                                         {statement.status === "rejected" && statement.validation_error && (
@@ -192,6 +208,19 @@ export default function UploadPage() {
                                         </div>
                                     </div>
                                     <div className="text-right flex-shrink-0 flex flex-col items-end gap-2">
+                                        {statement.status === "parsed" && (
+                                            <Button
+                                                variant="primary"
+                                                className="text-sm"
+                                                onClick={(e) => {
+                                                    e.preventDefault();
+                                                    e.stopPropagation();
+                                                    router.push(`/statements/${statement.id}/review`);
+                                                }}
+                                            >
+                                                Review →
+                                            </Button>
+                                        )}
                                         <IconButton
                                             icon={Trash2}
                                             label="Delete Statement"

--- a/apps/frontend/src/app/(main)/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/upload/page.tsx
@@ -28,6 +28,8 @@ function statusDisplay(status: string): { label: string; variant: BadgeVariant }
             return { label: "Ready to review", variant: "info" };
         case "parsing":
             return { label: "Parsing", variant: "muted" };
+        case "uploaded":
+            return { label: "Uploaded", variant: "muted" };
         default:
             return { label: status, variant: "muted" };
     }
@@ -178,15 +180,22 @@ export default function UploadPage() {
                 ) : (
                     <div className="divide-y divide-[var(--border)]">
                         {statements.map((statement) => (
-                            <Link
+                            <div
                                 key={statement.id}
-                                href={`/statements/${statement.id}`}
-                                className="block px-6 py-4 hover:bg-[var(--background-muted)]/50 transition-colors cursor-pointer"
+                                className="relative block px-6 py-4 hover:bg-[var(--background-muted)]/50 transition-colors"
                             >
                                 <div className="flex items-start justify-between gap-4">
                                     <div className="flex-1 min-w-0">
                                         <div className="flex items-center gap-2 mb-1">
-                                            <span className="font-medium truncate">{statement.original_filename}</span>
+                                            {/* Stretched link: makes the whole row open the detail page while
+                                                keeping the action buttons as non-nested, separately clickable
+                                                elements (valid HTML, no <button> inside <a>). */}
+                                            <Link
+                                                href={`/statements/${statement.id}`}
+                                                className="font-medium truncate hover:text-[var(--accent)] after:absolute after:inset-0"
+                                            >
+                                                {statement.original_filename}
+                                            </Link>
                                             <Badge variant={statusDisplay(statement.status).variant}>
                                                 {statement.status === "parsing" && (
                                                     <span className="inline-block w-3 h-3 mr-1 border-2 border-current border-t-transparent rounded-full animate-spin" />
@@ -207,16 +216,12 @@ export default function UploadPage() {
                                             <span>{formatCurrency(statement.currency)}</span>
                                         </div>
                                     </div>
-                                    <div className="text-right flex-shrink-0 flex flex-col items-end gap-2">
+                                    <div className="relative z-10 text-right flex-shrink-0 flex flex-col items-end gap-2">
                                         {statement.status === "parsed" && (
                                             <Button
                                                 variant="primary"
                                                 className="text-sm"
-                                                onClick={(e) => {
-                                                    e.preventDefault();
-                                                    e.stopPropagation();
-                                                    router.push(`/statements/${statement.id}/review`);
-                                                }}
+                                                onClick={() => router.push(`/statements/${statement.id}/review`)}
                                             >
                                                 Review →
                                             </Button>
@@ -254,13 +259,13 @@ export default function UploadPage() {
                                     ) : statement.balance_validated ? (
                                         <Badge variant="success">✓ Verified</Badge>
                                     ) : (
-                                        <span className="inline-flex items-center">
+                                        <span className="relative z-10 inline-flex items-center">
                                             <Badge variant="warning">Needs Review</Badge>
                                             <InfoHint term="needs_review" label="Needs review" />
                                         </span>
                                     )}
                                 </div>
-                            </Link>
+                            </div>
                         ))}
                     </div>
                 )}

--- a/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
+++ b/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
@@ -548,7 +548,7 @@ export function UploadToReportHome({ status, events }: WorkflowStatusFeedProps) 
     <section className="space-y-4" aria-label="Upload-to-report home">
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
         <div className="card p-5">
-          <p className="text-xs uppercase tracking-wide text-muted">Upload Pipeline</p>
+          <p className="text-xs uppercase tracking-wide text-muted">Your statements</p>
           <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div className="min-w-0">
               <h1 className="text-2xl font-semibold">{activeSession?.title ?? "Upload to report"}</h1>


### PR DESCRIPTION
## Why

From an everyday (non-accountant) user's perspective, three core-flow confusions remained after EPIC-022 PR1–PR5. This PR fixes them.

## Changes

### 1. Home overload / duplication
- Removed the redundant **"Net Assets"** KPI card — net worth was shown twice (KPI card + hero banner). It now appears once, in the richer hero banner (which keeps the data-health bar and the include-restricted toggle). KPI grid `md:grid-cols-4` → `md:grid-cols-3`.
- The other "needs attention" surfaces (reconciliation risk radar, unmatched alerts) already sit behind the opt-in **Show analytics** toggle, so the lean default surfaces todos in one place (the workflow panel + bell).

### 2. Residual "Upload Pipeline" jargon
- AC22.1.4 killed the "Upload Pipeline" label from the nav, but the Home workflow panel still rendered it as a card eyebrow. Renamed **"Upload Pipeline" → "Your statements"** (`WorkflowNotifications.tsx`).

### 3. Broken "what's next after upload" mainline
- `/upload` status badge mapped the raw lowercase **`parsed`** (rendered as a yellow *warning*) to a plain-language **"Ready to review"** info badge; all statuses now use friendly labels.
- Added a direct **"Review →"** button on parsed rows that deep-links straight to `/statements/{id}/review`, skipping the detail-page hop.
- Aligned the Home onboarding **"Review and approve"** step to `/notifications` so it matches the `FlowStepBanner` review step — a single, consistent review destination.

## Tests
- Updated `dashboardPage.test.tsx` (net worth shown once; onboarding review → `/notifications`).
- Added a `statementsPage.test.tsx` case asserting the "Ready to review" label and the `/statements/{id}/review` deep-link; mocked `next/navigation`.
- Full frontend suite **682 passing**, `tsc --noEmit` clean, ESLint clean.

## Out of scope (noted in review, not in this PR)
Inconsistent naming of the reconciliation match rate ("Data health" / "Statistics Accuracy" / "Books balanced"); Reports cards that link into Advanced pages; single-transaction edit (reject+reparse loop). Can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)