### PR TITLE
[finance_report_audit] Harden financial fact schema constraints

### DIFF
--- a/apps/backend/migrations/versions/0033_financial_fact_constraints.py
+++ b/apps/backend/migrations/versions/0033_financial_fact_constraints.py
@@ -55,7 +55,7 @@ BEGIN
         WHERE status::text = 'approved'
           AND (
             account_id IS NULL
-            OR currency IS NULL
+            OR NULLIF(BTRIM(currency), '') IS NULL
             OR period_start IS NULL
             OR period_end IS NULL
             OR opening_balance IS NULL
@@ -217,7 +217,7 @@ $$
         "statement_summaries",
         "status::text != 'approved' OR ("
         "account_id IS NOT NULL AND "
-        "currency IS NOT NULL AND "
+        "NULLIF(BTRIM(currency), '') IS NOT NULL AND "
         "period_start IS NOT NULL AND "
         "period_end IS NOT NULL AND "
         "opening_balance IS NOT NULL AND "

--- a/apps/backend/migrations/versions/0033_financial_fact_constraints.py
+++ b/apps/backend/migrations/versions/0033_financial_fact_constraints.py
@@ -1,0 +1,347 @@
+"""add financial fact constraints"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0033_financial_fact_constraints"
+down_revision = "0032_ledger_invariants"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM atomic_transactions
+        WHERE amount <= 0
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: atomic_transactions contains non-positive amounts';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM atomic_positions
+        WHERE market_value < 0
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: atomic_positions contains negative market values';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM manual_valuation_snapshots
+        WHERE value <= 0
+           OR recurrence_days <= 0
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: manual_valuation_snapshots contains non-positive values';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM statement_summaries
+        WHERE period_start IS NOT NULL
+          AND period_end IS NOT NULL
+          AND period_start > period_end
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: statement_summaries contains inverted periods';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM statement_summaries
+        WHERE status::text = 'approved'
+          AND (
+            account_id IS NULL
+            OR currency IS NULL
+            OR period_start IS NULL
+            OR period_end IS NULL
+            OR opening_balance IS NULL
+            OR closing_balance IS NULL
+          )
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: approved statement_summaries are missing required envelope fields';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM managed_positions
+        GROUP BY user_id, account_id, asset_identifier
+        HAVING count(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: duplicate managed_positions exist for deterministic scope';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM managed_positions
+        WHERE cost_basis < 0
+           OR (disposal_date IS NOT NULL AND disposal_date < acquisition_date)
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: managed_positions contains invalid cost or date facts';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM report_snapshots
+        WHERE start_date IS NOT NULL
+          AND start_date > as_of_date
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: report_snapshots contains inverted date ranges';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM report_snapshots
+        WHERE is_latest = true
+          AND start_date IS NULL
+        GROUP BY user_id, report_type, as_of_date
+        HAVING count(*) > 1
+    ) OR EXISTS (
+        SELECT 1
+        FROM report_snapshots
+        WHERE is_latest = true
+          AND start_date IS NOT NULL
+        GROUP BY user_id, report_type, start_date, as_of_date
+        HAVING count(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: duplicate latest report_snapshots exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM fx_rates
+        WHERE rate <= 0
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: fx_rates contains non-positive rates';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM stock_prices
+        WHERE price <= 0
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: stock_prices contains non-positive prices';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM stock_prices
+        GROUP BY symbol, currency, source, price_date
+        HAVING count(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: stock_prices contain duplicate provider-scoped facts';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM investment_transactions
+        WHERE gross_amount <= 0
+           OR fees < 0
+           OR (
+                transaction_type::text IN ('buy', 'sell')
+                AND (
+                    quantity IS NULL
+                    OR quantity <= 0
+                    OR unit_price IS NULL
+                    OR unit_price < 0
+                    OR cost_basis IS NULL
+                    OR cost_basis < 0
+                )
+           )
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: investment_transactions contains invalid amount or trade facts';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM investment_lots
+        WHERE original_quantity <= 0
+           OR remaining_quantity < 0
+           OR remaining_quantity > original_quantity
+           OR unit_cost < 0
+           OR (disposed_date IS NOT NULL AND disposed_date < acquisition_date)
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: investment_lots contains invalid quantity, cost, or date facts';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM dividend_income
+        WHERE amount <= 0
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: dividend_income contains non-positive amounts';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM market_data_override
+        WHERE price <= 0
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: market_data_override contains non-positive prices';
+    END IF;
+END
+$$
+"""
+    )
+
+    op.create_check_constraint(
+        "ck_atomic_transactions_amount_positive",
+        "atomic_transactions",
+        "amount > 0",
+    )
+    op.create_check_constraint(
+        "ck_atomic_positions_market_value_non_negative",
+        "atomic_positions",
+        "market_value >= 0",
+    )
+    op.create_check_constraint(
+        "ck_manual_valuation_snapshots_value_positive",
+        "manual_valuation_snapshots",
+        "value > 0",
+    )
+    op.create_check_constraint(
+        "ck_manual_valuation_snapshots_recurrence_days_positive",
+        "manual_valuation_snapshots",
+        "recurrence_days IS NULL OR recurrence_days > 0",
+    )
+    op.create_check_constraint(
+        "ck_statement_summaries_period_order",
+        "statement_summaries",
+        "period_start IS NULL OR period_end IS NULL OR period_start <= period_end",
+    )
+    op.create_check_constraint(
+        "ck_statement_summaries_approved_complete",
+        "statement_summaries",
+        "status::text != 'approved' OR ("
+        "account_id IS NOT NULL AND "
+        "currency IS NOT NULL AND "
+        "period_start IS NOT NULL AND "
+        "period_end IS NOT NULL AND "
+        "opening_balance IS NOT NULL AND "
+        "closing_balance IS NOT NULL"
+        ")",
+    )
+    op.create_unique_constraint(
+        "uq_managed_positions_user_account_asset",
+        "managed_positions",
+        ["user_id", "account_id", "asset_identifier"],
+    )
+    op.create_check_constraint(
+        "ck_managed_positions_cost_basis_non_negative",
+        "managed_positions",
+        "cost_basis >= 0",
+    )
+    op.create_check_constraint(
+        "ck_managed_positions_disposal_after_acquisition",
+        "managed_positions",
+        "disposal_date IS NULL OR disposal_date >= acquisition_date",
+    )
+    op.create_check_constraint(
+        "ck_report_snapshots_date_order",
+        "report_snapshots",
+        "start_date IS NULL OR start_date <= as_of_date",
+    )
+    op.create_index(
+        "uq_report_snapshots_latest_point_scope",
+        "report_snapshots",
+        ["user_id", "report_type", "as_of_date"],
+        unique=True,
+        postgresql_where=sa.text("is_latest = true AND start_date IS NULL"),
+    )
+    op.create_index(
+        "uq_report_snapshots_latest_range_scope",
+        "report_snapshots",
+        ["user_id", "report_type", "start_date", "as_of_date"],
+        unique=True,
+        postgresql_where=sa.text("is_latest = true AND start_date IS NOT NULL"),
+    )
+    op.create_check_constraint("ck_fx_rates_rate_positive", "fx_rates", "rate > 0")
+    op.create_check_constraint("ck_stock_prices_price_positive", "stock_prices", "price > 0")
+    op.drop_constraint("uq_stock_prices_symbol_date", "stock_prices", type_="unique")
+    op.create_unique_constraint(
+        "uq_stock_prices_symbol_currency_source_date",
+        "stock_prices",
+        ["symbol", "currency", "source", "price_date"],
+    )
+    op.create_check_constraint(
+        "ck_investment_transactions_gross_amount_positive",
+        "investment_transactions",
+        "gross_amount > 0",
+    )
+    op.create_check_constraint(
+        "ck_investment_transactions_fees_non_negative",
+        "investment_transactions",
+        "fees >= 0",
+    )
+    op.create_check_constraint(
+        "ck_investment_transactions_trade_values_valid",
+        "investment_transactions",
+        "transaction_type::text NOT IN ('buy', 'sell') OR ("
+        "quantity IS NOT NULL AND quantity > 0 AND "
+        "unit_price IS NOT NULL AND unit_price >= 0 AND "
+        "cost_basis IS NOT NULL AND cost_basis >= 0"
+        ")",
+    )
+    op.create_check_constraint(
+        "ck_investment_lots_original_quantity_positive",
+        "investment_lots",
+        "original_quantity > 0",
+    )
+    op.create_check_constraint(
+        "ck_investment_lots_remaining_quantity_non_negative",
+        "investment_lots",
+        "remaining_quantity >= 0",
+    )
+    op.create_check_constraint(
+        "ck_investment_lots_remaining_not_above_original",
+        "investment_lots",
+        "remaining_quantity <= original_quantity",
+    )
+    op.create_check_constraint(
+        "ck_investment_lots_unit_cost_non_negative",
+        "investment_lots",
+        "unit_cost >= 0",
+    )
+    op.create_check_constraint(
+        "ck_investment_lots_disposed_after_acquisition",
+        "investment_lots",
+        "disposed_date IS NULL OR disposed_date >= acquisition_date",
+    )
+    op.create_check_constraint("ck_dividend_income_amount_positive", "dividend_income", "amount > 0")
+    op.create_check_constraint("ck_market_data_override_price_positive", "market_data_override", "price > 0")
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_market_data_override_price_positive", "market_data_override", type_="check")
+    op.drop_constraint("ck_dividend_income_amount_positive", "dividend_income", type_="check")
+    op.drop_constraint("ck_investment_lots_disposed_after_acquisition", "investment_lots", type_="check")
+    op.drop_constraint("ck_investment_lots_unit_cost_non_negative", "investment_lots", type_="check")
+    op.drop_constraint("ck_investment_lots_remaining_not_above_original", "investment_lots", type_="check")
+    op.drop_constraint("ck_investment_lots_remaining_quantity_non_negative", "investment_lots", type_="check")
+    op.drop_constraint("ck_investment_lots_original_quantity_positive", "investment_lots", type_="check")
+    op.drop_constraint("ck_investment_transactions_trade_values_valid", "investment_transactions", type_="check")
+    op.drop_constraint("ck_investment_transactions_fees_non_negative", "investment_transactions", type_="check")
+    op.drop_constraint("ck_investment_transactions_gross_amount_positive", "investment_transactions", type_="check")
+    op.drop_constraint("uq_stock_prices_symbol_currency_source_date", "stock_prices", type_="unique")
+    op.create_unique_constraint("uq_stock_prices_symbol_date", "stock_prices", ["symbol", "price_date"])
+    op.drop_constraint("ck_stock_prices_price_positive", "stock_prices", type_="check")
+    op.drop_constraint("ck_fx_rates_rate_positive", "fx_rates", type_="check")
+    op.drop_index("uq_report_snapshots_latest_range_scope", table_name="report_snapshots")
+    op.drop_index("uq_report_snapshots_latest_point_scope", table_name="report_snapshots")
+    op.drop_constraint("ck_report_snapshots_date_order", "report_snapshots", type_="check")
+    op.drop_constraint("ck_managed_positions_disposal_after_acquisition", "managed_positions", type_="check")
+    op.drop_constraint("ck_managed_positions_cost_basis_non_negative", "managed_positions", type_="check")
+    op.drop_constraint("uq_managed_positions_user_account_asset", "managed_positions", type_="unique")
+    op.drop_constraint("ck_statement_summaries_approved_complete", "statement_summaries", type_="check")
+    op.drop_constraint("ck_statement_summaries_period_order", "statement_summaries", type_="check")
+    op.drop_constraint(
+        "ck_manual_valuation_snapshots_recurrence_days_positive",
+        "manual_valuation_snapshots",
+        type_="check",
+    )
+    op.drop_constraint("ck_manual_valuation_snapshots_value_positive", "manual_valuation_snapshots", type_="check")
+    op.drop_constraint("ck_atomic_positions_market_value_non_negative", "atomic_positions", type_="check")
+    op.drop_constraint("ck_atomic_transactions_amount_positive", "atomic_transactions", type_="check")

--- a/apps/backend/src/models/layer2.py
+++ b/apps/backend/src/models/layer2.py
@@ -4,7 +4,7 @@ from datetime import date
 from decimal import Decimal
 from enum import Enum
 
-from sqlalchemy import Date, Enum as SQLEnum, Numeric, String, Text, UniqueConstraint
+from sqlalchemy import CheckConstraint, Date, Enum as SQLEnum, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -46,7 +46,10 @@ class AtomicTransaction(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """
 
     __tablename__ = "atomic_transactions"
-    __table_args__ = (UniqueConstraint("user_id", "dedup_hash", name="uq_atomic_transactions_user_dedup_hash"),)
+    __table_args__ = (
+        UniqueConstraint("user_id", "dedup_hash", name="uq_atomic_transactions_user_dedup_hash"),
+        CheckConstraint("amount > 0", name="ck_atomic_transactions_amount_positive"),
+    )
 
     txn_date: Mapped[date] = mapped_column(Date, nullable=False)
     amount: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False, comment="Absolute value")
@@ -89,7 +92,10 @@ class AtomicPosition(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """
 
     __tablename__ = "atomic_positions"
-    __table_args__ = (UniqueConstraint("user_id", "dedup_hash", name="uq_atomic_positions_user_dedup_hash"),)
+    __table_args__ = (
+        UniqueConstraint("user_id", "dedup_hash", name="uq_atomic_positions_user_dedup_hash"),
+        CheckConstraint("market_value >= 0", name="ck_atomic_positions_market_value_non_negative"),
+    )
 
     snapshot_date: Mapped[date] = mapped_column(Date, nullable=False)
     asset_identifier: Mapped[str] = mapped_column(

--- a/apps/backend/src/models/layer3.py
+++ b/apps/backend/src/models/layer3.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from sqlalchemy import (
     Boolean,
+    CheckConstraint,
     Date,
     Enum as SQLEnum,
     ForeignKey,
@@ -168,6 +169,14 @@ class ManagedPosition(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """
 
     __tablename__ = "managed_positions"
+    __table_args__ = (
+        UniqueConstraint("user_id", "account_id", "asset_identifier", name="uq_managed_positions_user_account_asset"),
+        CheckConstraint("cost_basis >= 0", name="ck_managed_positions_cost_basis_non_negative"),
+        CheckConstraint(
+            "disposal_date IS NULL OR disposal_date >= acquisition_date",
+            name="ck_managed_positions_disposal_after_acquisition",
+        ),
+    )
 
     account_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
@@ -253,6 +262,11 @@ class ManualValuationSnapshot(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
 
     __tablename__ = "manual_valuation_snapshots"
     __table_args__ = (
+        CheckConstraint("value > 0", name="ck_manual_valuation_snapshots_value_positive"),
+        CheckConstraint(
+            "recurrence_days IS NULL OR recurrence_days > 0",
+            name="ck_manual_valuation_snapshots_recurrence_days_positive",
+        ),
         UniqueConstraint(
             "user_id",
             "component_type",

--- a/apps/backend/src/models/layer4.py
+++ b/apps/backend/src/models/layer4.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import Boolean, Date, DateTime, Enum as SQLEnum, ForeignKey
+from sqlalchemy import Boolean, CheckConstraint, Date, DateTime, Enum as SQLEnum, ForeignKey, Index, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -33,7 +33,29 @@ class ReportSnapshot(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """
 
     __tablename__ = "report_snapshots"
-    __table_args__ = ()
+    __table_args__ = (
+        CheckConstraint(
+            "start_date IS NULL OR start_date <= as_of_date",
+            name="ck_report_snapshots_date_order",
+        ),
+        Index(
+            "uq_report_snapshots_latest_point_scope",
+            "user_id",
+            "report_type",
+            "as_of_date",
+            unique=True,
+            postgresql_where=text("is_latest = true AND start_date IS NULL"),
+        ),
+        Index(
+            "uq_report_snapshots_latest_range_scope",
+            "user_id",
+            "report_type",
+            "start_date",
+            "as_of_date",
+            unique=True,
+            postgresql_where=text("is_latest = true AND start_date IS NOT NULL"),
+        ),
+    )
 
     report_type: Mapped[ReportType] = mapped_column(
         SQLEnum(

--- a/apps/backend/src/models/market_data.py
+++ b/apps/backend/src/models/market_data.py
@@ -6,7 +6,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from uuid import uuid4
 
-from sqlalchemy import DECIMAL, Date, DateTime, Index, String, UniqueConstraint
+from sqlalchemy import DECIMAL, CheckConstraint, Date, DateTime, Index, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -24,6 +24,7 @@ class FxRate(Base):
             "rate_date",
             name="uq_fx_rates_pair_date",
         ),
+        CheckConstraint("rate > 0", name="ck_fx_rates_rate_positive"),
         Index("idx_fx_rates_lookup", "base_currency", "quote_currency", "rate_date"),
     )
 
@@ -46,7 +47,14 @@ class StockPrice(Base):
 
     __tablename__ = "stock_prices"
     __table_args__ = (
-        UniqueConstraint("symbol", "price_date", name="uq_stock_prices_symbol_date"),
+        UniqueConstraint(
+            "symbol",
+            "currency",
+            "source",
+            "price_date",
+            name="uq_stock_prices_symbol_currency_source_date",
+        ),
+        CheckConstraint("price > 0", name="ck_stock_prices_price_positive"),
         Index("idx_stock_prices_lookup", "symbol", "price_date"),
     )
 

--- a/apps/backend/src/models/portfolio.py
+++ b/apps/backend/src/models/portfolio.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import Date, Enum as SQLEnum, ForeignKey, Numeric, String
+from sqlalchemy import CheckConstraint, Date, Enum as SQLEnum, ForeignKey, Numeric, String
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -31,6 +31,18 @@ class InvestmentTransaction(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """Auditable brokerage transaction that drives portfolio accounting."""
 
     __tablename__ = "investment_transactions"
+    __table_args__ = (
+        CheckConstraint("gross_amount > 0", name="ck_investment_transactions_gross_amount_positive"),
+        CheckConstraint("fees >= 0", name="ck_investment_transactions_fees_non_negative"),
+        CheckConstraint(
+            "transaction_type::text NOT IN ('buy', 'sell') OR ("
+            "quantity IS NOT NULL AND quantity > 0 AND "
+            "unit_price IS NOT NULL AND unit_price >= 0 AND "
+            "cost_basis IS NOT NULL AND cost_basis >= 0"
+            ")",
+            name="ck_investment_transactions_trade_values_valid",
+        ),
+    )
 
     position_id: Mapped[UUID | None] = mapped_column(
         PGUUID(as_uuid=True),
@@ -80,6 +92,19 @@ class InvestmentLot(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """Open tax/accounting lot for cost-basis calculations."""
 
     __tablename__ = "investment_lots"
+    __table_args__ = (
+        CheckConstraint("original_quantity > 0", name="ck_investment_lots_original_quantity_positive"),
+        CheckConstraint("remaining_quantity >= 0", name="ck_investment_lots_remaining_quantity_non_negative"),
+        CheckConstraint(
+            "remaining_quantity <= original_quantity",
+            name="ck_investment_lots_remaining_not_above_original",
+        ),
+        CheckConstraint("unit_cost >= 0", name="ck_investment_lots_unit_cost_non_negative"),
+        CheckConstraint(
+            "disposed_date IS NULL OR disposed_date >= acquisition_date",
+            name="ck_investment_lots_disposed_after_acquisition",
+        ),
+    )
 
     position_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
@@ -121,6 +146,7 @@ class DividendIncome(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """
 
     __tablename__ = "dividend_income"
+    __table_args__ = (CheckConstraint("amount > 0", name="ck_dividend_income_amount_positive"),)
 
     position_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
@@ -164,6 +190,7 @@ class MarketDataOverride(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """
 
     __tablename__ = "market_data_override"
+    __table_args__ = (CheckConstraint("price > 0", name="ck_market_data_override_price_positive"),)
 
     asset_identifier: Mapped[str] = mapped_column(String(100), nullable=False)
     price_date: Mapped[date] = mapped_column(Date, nullable=False)

--- a/apps/backend/src/models/statement_summary.py
+++ b/apps/backend/src/models/statement_summary.py
@@ -20,6 +20,7 @@ from decimal import Decimal
 from uuid import UUID
 
 from sqlalchemy import (
+    CheckConstraint,
     Date,
     DateTime,
     Enum as SQLEnum,
@@ -45,6 +46,21 @@ class StatementSummary(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     __tablename__ = "statement_summaries"
     __table_args__ = (
         UniqueConstraint("user_id", "file_hash", name="uq_statement_summaries_user_file_hash"),
+        CheckConstraint(
+            "period_start IS NULL OR period_end IS NULL OR period_start <= period_end",
+            name="ck_statement_summaries_period_order",
+        ),
+        CheckConstraint(
+            "status::text != 'approved' OR ("
+            "account_id IS NOT NULL AND "
+            "currency IS NOT NULL AND "
+            "period_start IS NOT NULL AND "
+            "period_end IS NOT NULL AND "
+            "opening_balance IS NOT NULL AND "
+            "closing_balance IS NOT NULL"
+            ")",
+            name="ck_statement_summaries_approved_complete",
+        ),
         Index("idx_statement_summaries_user_account", "user_id", "account_id"),
     )
 

--- a/apps/backend/src/models/statement_summary.py
+++ b/apps/backend/src/models/statement_summary.py
@@ -53,7 +53,7 @@ class StatementSummary(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
         CheckConstraint(
             "status::text != 'approved' OR ("
             "account_id IS NOT NULL AND "
-            "currency IS NOT NULL AND "
+            "NULLIF(BTRIM(currency), '') IS NOT NULL AND "
             "period_start IS NOT NULL AND "
             "period_end IS NOT NULL AND "
             "opening_balance IS NOT NULL AND "

--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -717,7 +717,7 @@ async def get_investment_performance_report_schedule(
             select(StockPrice)
             .where(StockPrice.symbol.in_(asset_identifiers))
             .where(StockPrice.price_date <= as_of_date)
-            .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc())
+            .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc(), StockPrice.source.asc())
         )
         stock_prices = list(stock_price_result.scalars().all())
     latest_stock_price_by_asset: dict[str, StockPrice] = {}

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -47,7 +47,7 @@ from src.services import StorageError, StorageService
 from src.services.brokerage_positions import BrokeragePositionImportService
 from src.services.openrouter_models import ModelCatalogError, get_model_info, model_matches_modality
 from src.services.statement_pipeline import submit_parse_pipeline
-from src.services.statement_posting import auto_create_posted_entries_for_statement
+from src.services.statement_posting import auto_create_posted_entries_for_statement, resolve_statement_posting_account
 from src.services.statement_validation import (
     approve_statement as approve_statement_svc,
     edit_and_approve,
@@ -856,9 +856,13 @@ async def approve_statement_stage1(
 ) -> Stage1ApprovalResponse:
     """Stage 1: Approve statement with balance validation."""
     try:
-        statement = await approve_statement_svc(db, statement_id, user_id)
+        statement = await _get_statement_or_404(db, statement_id, user_id)
         if request and request.create_account_if_missing and not statement.account_id:
             await _create_statement_account_from_confirmation(db, statement, user_id)
+        elif not statement.account_id:
+            await resolve_statement_posting_account(db, statement, user_id)
+
+        statement = await approve_statement_svc(db, statement_id, user_id)
         created_count = await auto_create_posted_entries_for_statement(db, statement, user_id)
         await db.commit()
     except ValueError as e:

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -514,6 +514,8 @@ class ExtractionService:
                 status = (
                     BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(confidence, is_valid)
                 )
+                if status == BankStatementStatus.APPROVED and account_id is None:
+                    status = BankStatementStatus.PARSED
 
             statement.balance_validated = is_valid
             if has_inferred_csv_balances:

--- a/apps/backend/src/services/market_data.py
+++ b/apps/backend/src/services/market_data.py
@@ -514,7 +514,7 @@ async def _load_stored_stock_price(
         select(StockPrice.price, StockPrice.currency, StockPrice.price_date, StockPrice.source)
         .where(StockPrice.symbol == normalized)
         .where(StockPrice.price_date <= requested_date)
-        .order_by(StockPrice.price_date.desc())
+        .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc(), StockPrice.source.asc())
         .limit(1)
     )
     result = await db.execute(stmt)

--- a/apps/backend/src/services/market_data.py
+++ b/apps/backend/src/services/market_data.py
@@ -514,7 +514,13 @@ async def _load_stored_stock_price(
         select(StockPrice.price, StockPrice.currency, StockPrice.price_date, StockPrice.source)
         .where(StockPrice.symbol == normalized)
         .where(StockPrice.price_date <= requested_date)
-        .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc(), StockPrice.source.asc())
+        .order_by(
+            StockPrice.price_date.desc(),
+            StockPrice.created_at.desc(),
+            StockPrice.source.asc(),
+            StockPrice.currency.asc(),
+            StockPrice.id.asc(),
+        )
         .limit(1)
     )
     result = await db.execute(stmt)

--- a/apps/backend/src/services/portfolio.py
+++ b/apps/backend/src/services/portfolio.py
@@ -796,7 +796,13 @@ class PortfolioService:
             select(StockPrice)
             .where(StockPrice.symbol == asset_identifier.strip().upper())
             .where(StockPrice.price_date <= eval_date)
-            .order_by(StockPrice.price_date.desc())
+            .order_by(
+                StockPrice.price_date.desc(),
+                StockPrice.created_at.desc(),
+                StockPrice.source.asc(),
+                StockPrice.currency.asc(),
+                StockPrice.id.asc(),
+            )
             .limit(1)
         )
 

--- a/apps/backend/src/services/statement_validation.py
+++ b/apps/backend/src/services/statement_validation.py
@@ -182,12 +182,28 @@ def _raise_if_statement_conflicts_unresolved(transactions: list[AtomicTransactio
         raise ValueError("Cannot approve statement while unresolved duplicate or transfer-pair candidates remain")
 
 
+def _raise_if_approved_envelope_incomplete(statement: StatementSummary) -> None:
+    if statement.account_id is None:
+        raise ValueError("Account mapping required before posting. Confirm the statement account before posting.")
+    if not (statement.currency or "").strip():
+        raise ValueError("Statement currency required before posting. Confirm the source currency before posting.")
+    if statement.period_start is None or statement.period_end is None:
+        raise ValueError("Statement period required before posting. Confirm the source date range before posting.")
+    if statement.period_start > statement.period_end:
+        raise ValueError("Statement period is invalid. Confirm the source date range before posting.")
+    if statement.opening_balance is None or statement.closing_balance is None:
+        raise ValueError(
+            "Statement opening and closing balances required before approval. Confirm the source balances first."
+        )
+
+
 async def approve_statement(
     db: AsyncSession,
     statement_id: UUID,
     user_id: UUID,
 ) -> StatementSummary:
     statement = await _get_statement_for_update(db, statement_id, user_id)
+    _raise_if_approved_envelope_incomplete(statement)
     validation_result = await validate_balance_chain(db, statement_id)
     transactions = await resolve_statement_transactions(db, statement)
 

--- a/apps/backend/tests/accounting/test_account_statement_coverage.py
+++ b/apps/backend/tests/accounting/test_account_statement_coverage.py
@@ -35,6 +35,7 @@ async def _create_statement(
     period_end: date,
     opening_balance: Decimal | None,
     closing_balance: Decimal | None,
+    status: BankStatementStatus = BankStatementStatus.APPROVED,
     institution: str = "DBS",
     currency: str = "SGD",
 ) -> StatementSummary:
@@ -48,8 +49,8 @@ async def _create_statement(
         period_end=period_end,
         opening_balance=opening_balance,
         closing_balance=closing_balance,
-        status=BankStatementStatus.APPROVED,
-        balance_validated=True,
+        status=status,
+        balance_validated=status == BankStatementStatus.APPROVED,
     )
     db.add(statement)
     await db.flush()
@@ -166,10 +167,10 @@ async def test_account_coverage_detects_adjacent_opening_balance_mismatch(
     assert _decimal(issue["delta"]) == Decimal("0.01")
 
 
-async def test_account_coverage_skips_opening_mismatch_when_boundary_balances_are_missing(
+async def test_account_coverage_ignores_incomplete_unapproved_boundary_statement(
     client: AsyncClient, db: AsyncSession, test_user
 ) -> None:
-    """AC3.7.2: Balance continuity is skipped when either boundary balance is absent."""
+    """AC3.7.2: Incomplete unapproved boundary statements do not create continuity issues."""
     account = await _create_account(db, test_user.id, name="Pending Balance Boundary")
     await _create_statement(
         db,
@@ -180,6 +181,7 @@ async def test_account_coverage_skips_opening_mismatch_when_boundary_balances_ar
         period_end=date(2025, 1, 31),
         opening_balance=Decimal("1000.00"),
         closing_balance=None,
+        status=BankStatementStatus.PARSED,
     )
     await _create_statement(
         db,

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -266,8 +266,11 @@ def _statement(
         account_id=account_id,
         file_hash=uuid4().hex,
         institution="Readiness Bank",
+        currency="SGD",
         period_start=date(2026, 5, 1),
         period_end=date(2026, 5, 31),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("0.00"),
         status=status,
         balance_validated=balance_validated,
         validation_error=validation_error,
@@ -682,6 +685,15 @@ async def test_AC19_5_3_package_readiness_state_priority_and_snapshot_freshness(
     # report input / statement source.
     assert response.model_dump(mode="json")["source_summary"]["statements"] == 0
 
+    processing_account = Account(
+        user_id=test_user.id,
+        name=f"Processing Cash {uuid4()}",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add(processing_account)
+    await db.flush()
+    processing.account_id = processing_account.id
     processing.status = BankStatementStatus.APPROVED
     processing.stage1_status = Stage1Status.APPROVED
     processing.balance_validated = True
@@ -908,8 +920,11 @@ async def test_AC5_13_5_package_traceability_returns_dynamic_current_user_identi
         uploaded_document_id=document.id,
         file_hash=document.file_hash,
         institution="Trace Bank",
+        currency="SGD",
         period_start=date(2026, 5, 1),
         period_end=report_date,
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("100.00"),
         status=BankStatementStatus.APPROVED,
         balance_validated=True,
         stage1_status=Stage1Status.APPROVED,
@@ -1293,6 +1308,8 @@ async def test_AC18_8_4_AC18_8_7_package_traceability_resolves_report_line_to_so
         currency="SGD",
         period_start=date(2026, 5, 1),
         period_end=report_date,
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("120.00"),
         status=BankStatementStatus.APPROVED,
         balance_validated=True,
         stage1_status=Stage1Status.APPROVED,

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException, UploadFile, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
 from src.models import Account, AccountType, User
@@ -690,6 +691,7 @@ async def test_pending_review_and_decisions(db, monkeypatch, storage_stub, model
     ):
         score = score_by_hash[file_hash or ""]
         statement = build_statement(test_user.id, file_hash or "", confidence_score=score)
+        statement.account_id = account_id
         statement.closing_balance = Decimal("100.00")
         await dual_write_layer2(db, test_user.id, statement, [], original_filename=original_filename)
         return statement, []
@@ -700,13 +702,14 @@ async def test_pending_review_and_decisions(db, monkeypatch, storage_stub, model
         fake_parse_document,
     )
 
+    account = await create_statement_account(db, test_user.id, "Review Queue Account")
     created_ids = []
     for index, content in enumerate(contents):
         upload_file = make_upload_file(f"statement-{index}.pdf", content)
         created = await statements_router.upload_statement(
             file=upload_file,
             institution="DBS",
-            account_id=None,
+            account_id=account.id,
             model="google/gemini-3-flash-preview",
             db=db,
             user_id=test_user.id,
@@ -1640,8 +1643,10 @@ async def test_approve_statement_stage1_success(db, test_user, monkeypatch):
     When approve_statement_stage1 is called,
     Then it approves the statement (lines 761-771).
     """
+    account = await create_statement_account(db, test_user.id, "Stage 1 Approve Account")
     statement = build_statement(test_user.id, "hash_s1_approve", 80)
     statement.status = BankStatementStatus.PARSED
+    statement.account_id = account.id
     # With no transactions, calculated_closing = opening_balance = 100.
     # Set closing_balance to match so validation passes.
     statement.closing_balance = Decimal("100.00")
@@ -1732,7 +1737,8 @@ async def test_approve_statement_stage1_auto_maps_unique_prior_confirmed_account
     statement.account_id = None
     statement.period_start = date(2025, 2, 1)
     statement.period_end = date(2025, 2, 28)
-    statement.closing_balance = Decimal("120.00")
+    statement.opening_balance = Decimal("110.00")
+    statement.closing_balance = Decimal("130.00")
     db.add(statement)
     await db.flush()
     statement_id = statement.id
@@ -1820,9 +1826,18 @@ async def test_auto_approve_high_confidence_statement_returns_zero_for_non_candi
 
 async def test_auto_approve_high_confidence_statement_falls_back_to_pending_review_on_guard_failure(db, test_user):
     """AC3.3.1: Unsafe high-confidence statements remain reviewable instead of failing parsing."""
+    unsafe_account = Account(
+        user_id=test_user.id,
+        name="High Confidence Liability",
+        type=AccountType.LIABILITY,
+        currency="SGD",
+    )
+    db.add(unsafe_account)
+    await db.flush()
+
     statement = build_statement(test_user.id, "hash_s1_high_confidence_guard_failure", 90)
     statement.status = BankStatementStatus.APPROVED
-    statement.account_id = None
+    statement.account_id = unsafe_account.id
     statement.closing_balance = Decimal("120.00")
     db.add(statement)
     await db.flush()
@@ -1843,14 +1858,23 @@ async def test_auto_approve_high_confidence_statement_falls_back_to_pending_revi
     await db.refresh(statement)
     assert statement.status == BankStatementStatus.PARSED
     assert statement.stage1_status == Stage1Status.PENDING_REVIEW
-    assert "Account mapping required" in (statement.validation_error or "")
+    assert "active asset account" in (statement.validation_error or "")
 
 
 async def test_auto_approve_guard_failure_preserves_uncommitted_parse_data(db, test_user):
     """AC3.3.1: Auto-approval guard fallback must not roll back parsed statement data."""
+    unsafe_account = Account(
+        user_id=test_user.id,
+        name="Uncommitted Liability",
+        type=AccountType.LIABILITY,
+        currency="SGD",
+    )
+    db.add(unsafe_account)
+    await db.flush()
+
     statement = build_statement(test_user.id, "hash_s1_guard_failure_preserves_parse", 90)
     statement.status = BankStatementStatus.APPROVED
-    statement.account_id = None
+    statement.account_id = unsafe_account.id
     statement.closing_balance = Decimal("120.00")
     db.add(statement)
     await db.flush()
@@ -1874,7 +1898,7 @@ async def test_auto_approve_guard_failure_preserves_uncommitted_parse_data(db, t
     assert persisted_statement is not None
     assert persisted_statement.status == BankStatementStatus.PARSED
     assert persisted_statement.stage1_status == Stage1Status.PENDING_REVIEW
-    assert "Account mapping required" in (persisted_statement.validation_error or "")
+    assert "active asset account" in (persisted_statement.validation_error or "")
 
     persisted_txns = await statement_validation_mod.resolve_statement_transactions(db, persisted_statement)
     assert len(persisted_txns) == 1
@@ -2046,24 +2070,9 @@ async def test_approve_statement_stage1_blocks_invalid_statement_period_before_p
     statement.period_start = date(2025, 2, 1)
     statement.period_end = date(2025, 1, 31)
     statement.closing_balance = Decimal("120.00")
-    db.add(statement)
-    await db.flush()
-
-    await add_txn(
-        db,
-        statement,
-        txn_date=date(2025, 1, 20),
-        description="Salary",
-        amount=Decimal("20.00"),
-        direction="IN",
-    )
-    await db.commit()
-
-    with pytest.raises(HTTPException) as exc:
-        await statements_router.approve_statement_stage1(statement_id=statement.id, db=db, user_id=user_id)
-
-    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert "Statement period is invalid" in str(exc.value.detail)
+    with pytest.raises(IntegrityError, match="ck_statement_summaries_period_order"):
+        db.add(statement)
+        await db.flush()
 
 
 async def test_approve_statement_stage1_blocks_missing_statement_currency_before_posting(db, test_user):
@@ -2368,8 +2377,10 @@ async def test_approve_statement_stage1_blocks_ambiguous_account_mapping(db, tes
 
 
 async def test_approve_statement_stage1_keeps_transfer_detection_priority(db, test_user):
+    bank_account = await create_statement_account(db, test_user.id, "Transfer Priority Account")
     statement = build_statement(test_user.id, "hash_s1_transfer_priority", 90)
     statement.status = BankStatementStatus.PARSED
+    statement.account_id = bank_account.id
     statement.closing_balance = Decimal("90.00")
     db.add(statement)
     await db.flush()
@@ -2471,7 +2482,9 @@ async def test_approve_statement_stage1_balance_mismatch(db, test_user):
     When approve_statement_stage1 is called,
     Then it raises 400 (lines 764-765).
     """
+    account = await create_statement_account(db, test_user.id, "Balance Mismatch Account")
     statement = build_statement(test_user.id, "hash_s1_mismatch", 80)
+    statement.account_id = account.id
     statement.closing_balance = Decimal("999.99")  # Wrong closing balance
     db.add(statement)
     await db.commit()
@@ -2501,8 +2514,8 @@ async def test_approve_statement_stage1_authorizes_before_balance_validation(db,
     with pytest.raises(HTTPException) as exc:
         await statements_router.approve_statement_stage1(statement_id=statement_id, db=db, user_id=test_user.id)
 
-    assert exc.value.status_code == 400
-    assert "access denied" in exc.value.detail
+    assert exc.value.status_code == 404
+    assert "Statement not found" in exc.value.detail
     validation.assert_not_awaited()
 
 
@@ -2687,8 +2700,10 @@ async def test_get_stage2_review_queue_with_pending_match(db, test_user):
     """
     from src.models.reconciliation import ReconciliationMatch, ReconciliationStatus
 
+    account = await create_statement_account(db, test_user.id, "Stage 2 Queue Account")
     statement = build_statement(test_user.id, "hash_s2_queue", 90)
     statement.status = BankStatementStatus.APPROVED
+    statement.account_id = account.id
     db.add(statement)
     await db.commit()
 
@@ -2726,8 +2741,10 @@ async def test_run_stage2_checks_success(db, test_user):
     When run_stage2_checks is called,
     Then it runs consistency checks and returns results (lines 881-891).
     """
+    account = await create_statement_account(db, test_user.id, "Stage 2 Checks Account")
     statement = build_statement(test_user.id, "hash_s2_checks", 90)
     statement.status = BankStatementStatus.APPROVED
+    statement.account_id = account.id
     db.add(statement)
     await db.commit()
     statement_id = statement.id
@@ -2944,8 +2961,10 @@ async def test_AC16_32_1_stage1_approval_blocks_unresolved_conflicts(db, test_us
 
 async def test_AC16_32_1_stage1_approval_blocks_unresolved_transfer_pairs(db, test_user):
     """AC16.32.1: Stage 1 approval cannot bypass unresolved transfer-pair candidates."""
+    account = await create_statement_account(db, test_user.id, "Transfer Conflict Account")
     statement = build_statement(test_user.id, "hash_stage1_transfer_conflict", 90)
     statement.status = BankStatementStatus.PARSED
+    statement.account_id = account.id
     statement.closing_balance = Decimal("100.00")
     db.add(statement)
     await db.commit()
@@ -3569,8 +3588,10 @@ async def test_batch_reject_matches_success(db, test_user):
     """
     from src.models.reconciliation import ReconciliationMatch, ReconciliationStatus
 
+    account = await create_statement_account(db, test_user.id, "DBS Batch Reject")
     statement = build_statement(test_user.id, "hash_batch_rej", 90)
     statement.status = BankStatementStatus.APPROVED
+    statement.account_id = account.id
     db.add(statement)
     await db.commit()
 

--- a/apps/backend/tests/api/test_workflow_router.py
+++ b/apps/backend/tests/api/test_workflow_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
 from pathlib import Path
 from uuid import UUID, uuid4
 
@@ -152,6 +153,11 @@ def _approved_statement(user_id: UUID, *, account_id: UUID | None = None, update
         account_id=account_id,
         file_hash=uuid4().hex,
         institution="Workflow Readiness Bank",
+        currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 31),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("0.00"),
         status=BankStatementStatus.APPROVED,
         stage1_status=Stage1Status.APPROVED,
         balance_validated=True,

--- a/apps/backend/tests/extraction/test_account_last4_defense.py
+++ b/apps/backend/tests/extraction/test_account_last4_defense.py
@@ -16,6 +16,7 @@ Each test class below closes one specific gap.
 """
 
 import string
+from datetime import date
 from decimal import Decimal
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -25,10 +26,24 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.models.account import Account, AccountType
 from src.models.statement_enums import BankStatementStatus
 from src.models.statement_summary import StatementSummary
 from src.services.extraction import ExtractionService
 from tests.factories import StatementSummaryFactory
+
+
+async def _make_statement_account(db: AsyncSession, user_id) -> Account:
+    account = Account(
+        user_id=user_id,
+        name=f"DBS Statement {uuid4().hex[:8]}",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add(account)
+    await db.flush()
+    return account
+
 
 # ---------------------------------------------------------------------------
 # Gap 1: AI returns dirty account_last4 → parse_document sanitizes → DB stores ≤ 4 chars
@@ -96,6 +111,7 @@ class TestDirtyAccountLast4Integration:
     async def test_dirty_account_last4_persists_to_db(self, db, test_user):
         """End-to-end: AI returns "553-3" → sanitized → saved to real DB → read back OK."""
         service = ExtractionService()
+        account = await _make_statement_account(db, test_user.id)
 
         mock_data = {
             "institution": "DBS",
@@ -123,6 +139,7 @@ class TestDirtyAccountLast4Integration:
                 user_id=uid,
                 file_content=b"dummy",
                 file_hash=f"persist_test_{uuid4().hex[:8]}",
+                account_id=account.id,
             )
 
         db.add(stmt)
@@ -132,6 +149,42 @@ class TestDirtyAccountLast4Integration:
         assert saved is not None
         assert saved.account_last4 == "5533"
         assert len(saved.account_last4) <= 4
+
+    @pytest.mark.no_db
+    @pytest.mark.asyncio
+    async def test_parse_document_without_account_stays_parsed_before_approval(self):
+        """High-confidence extraction without a custody account cannot become APPROVED."""
+        service = ExtractionService()
+
+        mock_data = {
+            "institution": "DBS",
+            "account_last4": "553-3",
+            "currency": "SGD",
+            "period_start": "2025-01-01",
+            "period_end": "2025-01-31",
+            "opening_balance": "1000.00",
+            "closing_balance": "1100.00",
+            "transactions": [
+                {
+                    "date": "2025-01-15",
+                    "description": "Test",
+                    "amount": "100.00",
+                    "direction": "IN",
+                },
+            ],
+        }
+
+        with patch.object(service, "extract_financial_data", new=AsyncMock(return_value=mock_data)):
+            stmt, _ = await service.parse_document(
+                file_path=Path("/tmp/test_requires_account.pdf"),
+                institution="DBS",
+                user_id=uuid4(),
+                file_content=b"dummy",
+                file_hash=f"requires_account_{uuid4().hex[:8]}",
+            )
+
+        assert stmt.balance_validated is True
+        assert stmt.status == BankStatementStatus.PARSED
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +270,7 @@ class TestBackgroundTaskDirtyData:
 
         sid = uuid4()
         uid = test_user.id
+        account = await _make_statement_account(db, uid)
         stmt = StatementSummaryFactory.build(
             id=sid,
             user_id=uid,
@@ -234,7 +288,10 @@ class TestBackgroundTaskDirtyData:
             session = kwargs["db"]
             summary = await session.get(StatementSummary, sid)
             summary.account_last4 = "5533"  # Already sanitized by _sanitize_account_last4
+            summary.account_id = account.id
             summary.currency = "SGD"
+            summary.period_start = date(2025, 1, 1)
+            summary.period_end = date(2025, 1, 31)
             summary.opening_balance = Decimal("1000.00")
             summary.closing_balance = Decimal("1000.00")
             summary.confidence_score = 90
@@ -257,7 +314,7 @@ class TestBackgroundTaskDirtyData:
             filename="test.pdf",
             institution="DBS",
             user_id=uid,
-            account_id=None,
+            account_id=account.id,
             file_hash=f"bg_dirty_{uuid4().hex[:8]}",
             storage_key="test_path",
             content=b"dummy content",
@@ -342,7 +399,7 @@ class TestCascadingFailureRecovery:
         stmt1 = StatementSummaryFactory.build(
             id=uuid4(),
             user_id=uid,
-            status=BankStatementStatus.APPROVED,
+            status=BankStatementStatus.PARSED,
             file_hash=shared_hash,
             institution="DBS",
         )
@@ -390,6 +447,7 @@ class TestCascadingFailureRecovery:
 
         sid = uuid4()
         uid = test_user.id
+        account = await _make_statement_account(db, uid)
         stmt = StatementSummaryFactory.build(
             id=sid,
             user_id=uid,
@@ -424,10 +482,11 @@ class TestCascadingFailureRecovery:
         parsed_stmt = StatementSummaryFactory.build(
             user_id=uid,
             institution="DBS",
+            account_id=account.id,
             account_last4="1234",
             currency="SGD",
-            period_start=None,
-            period_end=None,
+            period_start=date(2025, 1, 1),
+            period_end=date(2025, 1, 31),
             opening_balance=Decimal("1000.00"),
             closing_balance=Decimal("1100.00"),
             confidence_score=90,
@@ -461,7 +520,7 @@ class TestCascadingFailureRecovery:
                 filename="test.pdf",
                 institution="DBS",
                 user_id=uid,
-                account_id=None,
+                account_id=account.id,
                 file_hash=f"commit_fail_{uuid4().hex[:8]}",
                 storage_key="test_path",
                 content=b"dummy content",

--- a/apps/backend/tests/extraction/test_statement_summary_conform.py
+++ b/apps/backend/tests/extraction/test_statement_summary_conform.py
@@ -23,6 +23,8 @@ async def _make_account(db: AsyncSession, user_id) -> Account:
 
 
 async def _make_summary(db: AsyncSession, user_id, *, file_hash: str, account_id=None, uploaded_document_id=None):
+    status = BankStatementStatus.APPROVED if account_id is not None else BankStatementStatus.PARSED
+    stage1_status = Stage1Status.APPROVED if account_id is not None else Stage1Status.PENDING_REVIEW
     return await StatementSummaryFactory.create_async(
         db,
         user_id,
@@ -36,9 +38,9 @@ async def _make_summary(db: AsyncSession, user_id, *, file_hash: str, account_id
         period_end=date(2024, 1, 31),
         opening_balance=Decimal("1000.00"),
         closing_balance=Decimal("1500.00"),
-        status=BankStatementStatus.APPROVED,
-        stage1_status=Stage1Status.APPROVED,
-        balance_validated=True,
+        status=status,
+        stage1_status=stage1_status,
+        balance_validated=account_id is not None,
     )
 
 

--- a/apps/backend/tests/infra/test_financial_fact_schema_invariants.py
+++ b/apps/backend/tests/infra/test_financial_fact_schema_invariants.py
@@ -1,0 +1,532 @@
+"""Database-level financial fact invariant tests for issue #845."""
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.account import Account, AccountType
+from src.models.layer2 import AssetType, AtomicPosition, AtomicTransaction, TransactionDirection
+from src.models.layer3 import (
+    ClassificationRule,
+    CostBasisMethod,
+    ManagedPosition,
+    ManualValuationComponentType,
+    ManualValuationLiquidityClass,
+    ManualValuationSnapshot,
+    PositionStatus,
+    RuleType,
+)
+from src.models.layer4 import ReportSnapshot, ReportType
+from src.models.market_data import FxRate, StockPrice
+from src.models.portfolio import (
+    DividendIncome,
+    DividendType,
+    InvestmentLot,
+    InvestmentTransaction,
+    InvestmentTransactionType,
+    MarketDataOverride,
+    PriceSource,
+)
+from src.models.statement_enums import BankStatementStatus
+from src.models.statement_summary import StatementSummary
+from src.services.market_data import _load_stored_stock_price
+
+BACKEND_DIR = Path(__file__).parent.parent.parent
+MIGRATION_PATH = BACKEND_DIR / "migrations" / "versions" / "0033_financial_fact_constraints.py"
+RISK_PATH = BACKEND_DIR.parent.parent / "docs" / "ssot" / "migration-risk.yaml"
+
+
+async def _expect_integrity_error(db: AsyncSession, *objects: object) -> None:
+    db.add_all(objects)
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+
+
+async def _make_account(db: AsyncSession, user_id, *, name: str | None = None) -> Account:
+    account = Account(
+        user_id=user_id,
+        name=name or f"Account {uuid4()}",
+        type=AccountType.ASSET,
+        currency="USD",
+    )
+    db.add(account)
+    await db.flush()
+    return account
+
+
+async def _make_rule(db: AsyncSession, user_id, *, version: int = 1) -> ClassificationRule:
+    rule = ClassificationRule(
+        user_id=user_id,
+        version_number=version,
+        effective_date=date(2026, 1, 1),
+        rule_name=f"schema-invariant-rule-{uuid4()}",
+        rule_type=RuleType.KEYWORD_MATCH,
+        rule_config={"keywords": ["schema"]},
+        created_by=user_id,
+    )
+    db.add(rule)
+    await db.flush()
+    return rule
+
+
+def _source_documents() -> dict[str, list[dict[str, str]]]:
+    return {"documents": [{"doc_id": str(uuid4()), "doc_type": "test"}]}
+
+
+@pytest.mark.asyncio
+async def test_AC11_18_1_positive_source_fact_constraints(db: AsyncSession, test_user) -> None:
+    """AC11.18.1: Source financial facts reject non-positive values where positive is required."""
+    user_id = test_user.id
+    await _expect_integrity_error(
+        db,
+        AtomicTransaction(
+            user_id=user_id,
+            txn_date=date(2026, 1, 2),
+            amount=Decimal("0.00"),
+            direction=TransactionDirection.IN,
+            description="zero amount should fail",
+            currency="USD",
+            dedup_hash=uuid4().hex + uuid4().hex,
+            source_documents=_source_documents(),
+        ),
+    )
+
+    await _expect_integrity_error(
+        db,
+        AtomicPosition(
+            user_id=user_id,
+            snapshot_date=date(2026, 1, 2),
+            asset_identifier="AAPL",
+            broker="Moomoo",
+            quantity=Decimal("1.000000"),
+            market_value=Decimal("-1.00"),
+            currency="USD",
+            asset_type=AssetType.STOCK,
+            dedup_hash=uuid4().hex + uuid4().hex,
+            source_documents=_source_documents(),
+        ),
+    )
+
+    short_position = AtomicPosition(
+        user_id=user_id,
+        snapshot_date=date(2026, 1, 3),
+        asset_identifier="AAPL",
+        broker="Moomoo",
+        quantity=Decimal("-5.000000"),
+        market_value=Decimal("500.00"),
+        currency="USD",
+        asset_type=AssetType.STOCK,
+        dedup_hash=uuid4().hex + uuid4().hex,
+        source_documents=_source_documents(),
+    )
+    db.add(short_position)
+    await db.commit()
+
+    await _expect_integrity_error(
+        db,
+        ManualValuationSnapshot(
+            user_id=user_id,
+            component_type=ManualValuationComponentType.PROPERTY_VALUE,
+            liquidity_class=ManualValuationLiquidityClass.ILLIQUID,
+            as_of_date=date(2026, 1, 31),
+            value=Decimal("0.00"),
+            currency="USD",
+            source="manual appraisal",
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        ManualValuationSnapshot(
+            user_id=user_id,
+            component_type=ManualValuationComponentType.CPF_BALANCE,
+            liquidity_class=ManualValuationLiquidityClass.RESTRICTED,
+            as_of_date=date(2026, 1, 31),
+            value=Decimal("1000.00"),
+            currency="SGD",
+            source="manual CPF",
+            recurrence_days=0,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_AC11_18_2_statement_summary_approved_completeness_and_period_order(
+    db: AsyncSession,
+    test_user,
+) -> None:
+    """AC11.18.2: Approved statement summaries require complete envelopes and ordered periods."""
+    user_id = test_user.id
+    account = await _make_account(db, user_id)
+    account_id = account.id
+    await db.commit()
+
+    await _expect_integrity_error(
+        db,
+        StatementSummary(
+            user_id=user_id,
+            file_hash=uuid4().hex,
+            institution="Schema Bank",
+            currency="USD",
+            period_start=date(2026, 2, 1),
+            period_end=date(2026, 1, 31),
+            opening_balance=Decimal("100.00"),
+            closing_balance=Decimal("110.00"),
+            status=BankStatementStatus.PARSED,
+        ),
+    )
+
+    await _expect_integrity_error(
+        db,
+        StatementSummary(
+            user_id=user_id,
+            file_hash=uuid4().hex,
+            institution="Schema Bank",
+            account_id=account_id,
+            currency="USD",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            opening_balance=Decimal("100.00"),
+            closing_balance=None,
+            status=BankStatementStatus.APPROVED,
+        ),
+    )
+
+    await _expect_integrity_error(
+        db,
+        StatementSummary(
+            user_id=user_id,
+            file_hash=uuid4().hex,
+            institution="Schema Bank",
+            currency="USD",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            opening_balance=Decimal("100.00"),
+            closing_balance=Decimal("110.00"),
+            status=BankStatementStatus.APPROVED,
+        ),
+    )
+
+    approved = StatementSummary(
+        user_id=user_id,
+        file_hash=uuid4().hex,
+        institution="Schema Bank",
+        account_id=account_id,
+        currency="USD",
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 1, 31),
+        opening_balance=Decimal("100.00"),
+        closing_balance=Decimal("110.00"),
+        status=BankStatementStatus.APPROVED,
+    )
+    db.add(approved)
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_AC11_18_3_portfolio_fact_constraints_and_managed_position_uniqueness(
+    db: AsyncSession,
+    test_user,
+) -> None:
+    """AC11.18.3: Portfolio facts enforce deterministic uniqueness and cost/quantity relationships."""
+    user_id = test_user.id
+    account = await _make_account(db, user_id)
+    account_id = account.id
+    position = ManagedPosition(
+        user_id=user_id,
+        account_id=account_id,
+        asset_identifier="AAPL",
+        quantity=Decimal("-5.000000"),
+        cost_basis=Decimal("500.00"),
+        cost_basis_method=CostBasisMethod.FIFO,
+        acquisition_date=date(2026, 1, 2),
+        status=PositionStatus.ACTIVE,
+        currency="USD",
+    )
+    db.add(position)
+    await db.commit()
+    position_id = position.id
+
+    await _expect_integrity_error(
+        db,
+        ManagedPosition(
+            user_id=user_id,
+            account_id=account_id,
+            asset_identifier="AAPL",
+            quantity=Decimal("1.000000"),
+            cost_basis=Decimal("100.00"),
+            acquisition_date=date(2026, 1, 3),
+            status=PositionStatus.ACTIVE,
+            currency="USD",
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        ManagedPosition(
+            user_id=user_id,
+            account_id=account_id,
+            asset_identifier="MSFT",
+            quantity=Decimal("1.000000"),
+            cost_basis=Decimal("-1.00"),
+            acquisition_date=date(2026, 1, 3),
+            status=PositionStatus.ACTIVE,
+            currency="USD",
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        ManagedPosition(
+            user_id=user_id,
+            account_id=account_id,
+            asset_identifier="NVDA",
+            quantity=Decimal("1.000000"),
+            cost_basis=Decimal("1.00"),
+            acquisition_date=date(2026, 1, 5),
+            disposal_date=date(2026, 1, 4),
+            status=PositionStatus.DISPOSED,
+            currency="USD",
+        ),
+    )
+
+    transaction = InvestmentTransaction(
+        user_id=user_id,
+        position_id=position_id,
+        transaction_date=date(2026, 1, 4),
+        transaction_type=InvestmentTransactionType.BUY,
+        asset_identifier="AAPL",
+        quantity=Decimal("10.000000"),
+        unit_price=Decimal("10.000000"),
+        gross_amount=Decimal("100.00"),
+        fees=Decimal("0.00"),
+        currency="USD",
+        cost_basis=Decimal("100.00"),
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    db.add(transaction)
+    await db.commit()
+    transaction_id = transaction.id
+
+    await _expect_integrity_error(
+        db,
+        InvestmentTransaction(
+            user_id=user_id,
+            position_id=position_id,
+            transaction_date=date(2026, 1, 5),
+            transaction_type=InvestmentTransactionType.BUY,
+            asset_identifier="AAPL",
+            quantity=Decimal("-1.000000"),
+            unit_price=Decimal("10.000000"),
+            gross_amount=Decimal("10.00"),
+            fees=Decimal("0.00"),
+            currency="USD",
+            cost_basis=Decimal("10.00"),
+            cost_basis_method=CostBasisMethod.FIFO,
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        InvestmentTransaction(
+            user_id=user_id,
+            position_id=position_id,
+            transaction_date=date(2026, 1, 5),
+            transaction_type=InvestmentTransactionType.DIVIDEND,
+            asset_identifier="AAPL",
+            gross_amount=Decimal("0.00"),
+            fees=Decimal("0.00"),
+            currency="USD",
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        InvestmentLot(
+            user_id=user_id,
+            position_id=position_id,
+            opening_transaction_id=transaction_id,
+            asset_identifier="AAPL",
+            acquisition_date=date(2026, 1, 4),
+            original_quantity=Decimal("10.000000"),
+            remaining_quantity=Decimal("11.000000"),
+            unit_cost=Decimal("10.000000"),
+            currency="USD",
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        DividendIncome(
+            user_id=user_id,
+            position_id=position_id,
+            payment_date=date(2026, 2, 1),
+            amount=Decimal("0.00"),
+            currency="USD",
+            dividend_type=DividendType.ORDINARY,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_AC11_18_4_report_snapshot_latest_scope_and_date_constraints(
+    db: AsyncSession,
+    test_user,
+) -> None:
+    """AC11.18.4: Latest report snapshots are unique per logical report scope."""
+    user_id = test_user.id
+    rule = await _make_rule(db, user_id, version=1)
+    second_rule = await _make_rule(db, user_id, version=2)
+    rule_id = rule.id
+    second_rule_id = second_rule.id
+    await db.commit()
+
+    await _expect_integrity_error(
+        db,
+        ReportSnapshot(
+            user_id=user_id,
+            report_type=ReportType.INCOME_STATEMENT,
+            start_date=date(2026, 2, 1),
+            as_of_date=date(2026, 1, 31),
+            rule_version_id=rule_id,
+            report_data={"total_income": "1.00"},
+            is_latest=True,
+        ),
+    )
+
+    history_one = ReportSnapshot(
+        user_id=user_id,
+        report_type=ReportType.BALANCE_SHEET,
+        as_of_date=date(2026, 1, 31),
+        rule_version_id=rule_id,
+        report_data={"version": 1},
+        is_latest=False,
+    )
+    history_two = ReportSnapshot(
+        user_id=user_id,
+        report_type=ReportType.BALANCE_SHEET,
+        as_of_date=date(2026, 1, 31),
+        rule_version_id=rule_id,
+        report_data={"version": 2},
+        is_latest=False,
+    )
+    db.add_all([history_one, history_two])
+    await db.commit()
+
+    latest = ReportSnapshot(
+        user_id=user_id,
+        report_type=ReportType.BALANCE_SHEET,
+        as_of_date=date(2026, 1, 31),
+        rule_version_id=rule_id,
+        report_data={"version": 3},
+        is_latest=True,
+    )
+    db.add(latest)
+    await db.commit()
+
+    await _expect_integrity_error(
+        db,
+        ReportSnapshot(
+            user_id=user_id,
+            report_type=ReportType.BALANCE_SHEET,
+            as_of_date=date(2026, 1, 31),
+            rule_version_id=second_rule_id,
+            report_data={"version": 4},
+            is_latest=True,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_AC11_18_5_market_data_constraints_and_stock_price_uniqueness(
+    db: AsyncSession,
+    test_user,
+) -> None:
+    """AC11.18.5: Market facts are positive and stock-price uniqueness includes provider dimensions."""
+    user_id = test_user.id
+    await _expect_integrity_error(
+        db,
+        FxRate(
+            base_currency="USD",
+            quote_currency="SGD",
+            rate=Decimal("0.000000"),
+            rate_date=date(2026, 1, 5),
+            source="test",
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        StockPrice(
+            symbol="AAPL",
+            price=Decimal("0.000000"),
+            currency="USD",
+            price_date=date(2026, 1, 5),
+            source="test",
+        ),
+    )
+
+    first_price = StockPrice(
+        symbol="AAPL",
+        price=Decimal("100.000000"),
+        currency="USD",
+        price_date=date(2026, 1, 5),
+        source="alpha",
+        created_at=datetime(2026, 1, 5, 12, 0, tzinfo=UTC),
+    )
+    second_price = StockPrice(
+        symbol="AAPL",
+        price=Decimal("101.000000"),
+        currency="USD",
+        price_date=date(2026, 1, 5),
+        source="beta",
+        created_at=datetime(2026, 1, 5, 13, 0, tzinfo=UTC),
+    )
+    db.add_all([first_price, second_price])
+    await db.commit()
+
+    stored = await _load_stored_stock_price(db, "aapl", date(2026, 1, 5))
+    assert stored is not None
+    assert stored.price == Decimal("101.000000")
+    assert stored.source == "beta"
+
+    await _expect_integrity_error(
+        db,
+        StockPrice(
+            symbol="AAPL",
+            price=Decimal("102.000000"),
+            currency="USD",
+            price_date=date(2026, 1, 5),
+            source="beta",
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        MarketDataOverride(
+            user_id=user_id,
+            asset_identifier="AAPL",
+            price_date=date(2026, 1, 5),
+            price=Decimal("0.00"),
+            currency="USD",
+            source=PriceSource.MANUAL,
+        ),
+    )
+
+
+@pytest.mark.no_db
+def test_AC11_18_6_migration_preflights_and_risk_contract_are_declared() -> None:
+    """AC11.18.6: The migration declares preflight checks and risk classification."""
+    migration_source = MIGRATION_PATH.read_text()
+    risk_source = RISK_PATH.read_text()
+
+    for expected in (
+        "preflight failed: atomic_transactions contains non-positive amounts",
+        "preflight failed: approved statement_summaries are missing required envelope fields",
+        "preflight failed: duplicate latest report_snapshots exist",
+        "preflight failed: duplicate managed_positions exist for deterministic scope",
+        "preflight failed: stock_prices contain duplicate provider-scoped facts",
+    ):
+        assert expected in migration_source
+
+    assert "0033_financial_fact_constraints" in risk_source
+    assert 'issue: "#845"' in risk_source
+    assert "preflight" in risk_source

--- a/apps/backend/tests/infra/test_financial_fact_schema_invariants.py
+++ b/apps/backend/tests/infra/test_financial_fact_schema_invariants.py
@@ -212,6 +212,22 @@ async def test_AC11_18_2_statement_summary_approved_completeness_and_period_orde
         ),
     )
 
+    await _expect_integrity_error(
+        db,
+        StatementSummary(
+            user_id=user_id,
+            file_hash=uuid4().hex,
+            institution="Schema Bank",
+            account_id=account_id,
+            currency="   ",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            opening_balance=Decimal("100.00"),
+            closing_balance=Decimal("110.00"),
+            status=BankStatementStatus.APPROVED,
+        ),
+    )
+
     approved = StatementSummary(
         user_id=user_id,
         file_hash=uuid4().hex,
@@ -527,6 +543,7 @@ def test_AC11_18_6_migration_preflights_and_risk_contract_are_declared() -> None
     ):
         assert expected in migration_source
 
+    assert "NULLIF(BTRIM(currency), '') IS NULL" in migration_source
     assert "0033_financial_fact_constraints" in risk_source
     assert 'issue: "#845"' in risk_source
     assert "preflight" in risk_source

--- a/apps/backend/tests/portfolio/test_portfolio_service.py
+++ b/apps/backend/tests/portfolio/test_portfolio_service.py
@@ -884,7 +884,21 @@ async def test_portfolio_summary_with_disposed(db, test_user, svc, account, atom
         status=PositionStatus.DISPOSED,
         cost_basis_method=CostBasisMethod.FIFO,
     )
-    db.add(disposed)
+    msft_snapshot = AtomicPosition(
+        user_id=test_user.id,
+        snapshot_date=date.today(),
+        asset_identifier="MSFT",
+        broker="Test Broker",
+        quantity=Decimal("50"),
+        market_value=Decimal("5500.00"),
+        currency="SGD",
+        sector="Technology",
+        geography="US",
+        asset_type="stock",
+        dedup_hash="msft_disposed_summary_test",
+        source_documents={},
+    )
+    db.add_all([disposed, msft_snapshot])
     await db.flush()
     summary = await svc.get_portfolio_summary(db, test_user.id)
     assert summary.active_positions_count == 1

--- a/apps/backend/tests/portfolio/test_portfolio_service.py
+++ b/apps/backend/tests/portfolio/test_portfolio_service.py
@@ -875,7 +875,7 @@ async def test_portfolio_summary_with_disposed(db, test_user, svc, account, atom
     disposed = ManagedPosition(
         user_id=test_user.id,
         account_id=account.id,
-        asset_identifier="AAPL",
+        asset_identifier="MSFT",
         quantity=Decimal("50"),
         cost_basis=Decimal("5000.00"),
         currency="SGD",

--- a/apps/backend/tests/reporting/test_framework_package_integration.py
+++ b/apps/backend/tests/reporting/test_framework_package_integration.py
@@ -418,12 +418,24 @@ async def test_AC19_7_1_statement_only_inputs_do_not_require_framework_policy_re
 ) -> None:
     """AC19.7.1: Statement-only package inputs do not require an empty framework policy result."""
     report_date = date(2026, 5, 31)
+    account = Account(
+        user_id=test_user.id,
+        name="Framework Bank Checking",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add(account)
+    await db.flush()
     statement = StatementSummary(
         user_id=test_user.id,
         file_hash=uuid4().hex,
+        account_id=account.id,
         institution="Framework Bank",
+        currency="SGD",
         period_start=date(2026, 5, 1),
         period_end=report_date,
+        opening_balance=Decimal("1000.00"),
+        closing_balance=Decimal("1200.00"),
         status=BankStatementStatus.APPROVED,
         balance_validated=True,
         validation_error=None,

--- a/apps/backend/tests/review/test_consistency_checks.py
+++ b/apps/backend/tests/review/test_consistency_checks.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 
+from src.models import Account, AccountType
 from src.models.consistency_check import CheckStatus, CheckType, ConsistencyCheck
 from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AtomicTransaction, TransactionDirection
@@ -29,6 +30,12 @@ def user_id(test_user):
 
 async def _make_statement(db, user_id, *, file_hash: str) -> StatementSummary:
     """Create an ODS document + linked StatementSummary conform envelope."""
+    account = Account(
+        user_id=user_id,
+        name=f"Consistency Account {uuid4()}",
+        type=AccountType.ASSET,
+        currency="USD",
+    )
     doc = UploadedDocument(
         id=uuid4(),
         user_id=user_id,
@@ -37,7 +44,7 @@ async def _make_statement(db, user_id, *, file_hash: str) -> StatementSummary:
         original_filename="test.pdf",
         document_type=DocumentType.BANK_STATEMENT,
     )
-    db.add(doc)
+    db.add_all([account, doc])
     await db.flush()
 
     statement = StatementSummary(
@@ -45,8 +52,13 @@ async def _make_statement(db, user_id, *, file_hash: str) -> StatementSummary:
         user_id=user_id,
         uploaded_document_id=doc.id,
         file_hash=file_hash,
+        account_id=account.id,
         institution="Test Bank",
         currency="USD",
+        period_start=date(2024, 1, 1),
+        period_end=date(2024, 1, 31),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("0.00"),
         status=BankStatementStatus.APPROVED,
     )
     db.add(statement)

--- a/apps/backend/tests/review/test_review_conflicts_router.py
+++ b/apps/backend/tests/review/test_review_conflicts_router.py
@@ -8,6 +8,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.models import Account, AccountType
 from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.statement_enums import BankStatementStatus
@@ -21,6 +22,12 @@ async def test_review_conflicts_returns_duplicate_and_transfer_candidates(
     test_user,
 ):
     """AC16.13.13: GET /review/conflicts/{statement_id} returns duplicates and transfer_pairs."""
+    account = Account(
+        user_id=test_user.id,
+        name=f"Conflict Account {uuid4()}",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
     doc = UploadedDocument(
         id=uuid4(),
         user_id=test_user.id,
@@ -29,7 +36,7 @@ async def test_review_conflicts_returns_duplicate_and_transfer_candidates(
         original_filename="test.pdf",
         document_type=DocumentType.BANK_STATEMENT,
     )
-    db.add(doc)
+    db.add_all([account, doc])
     await db.flush()
 
     statement = StatementSummary(
@@ -37,8 +44,13 @@ async def test_review_conflicts_returns_duplicate_and_transfer_candidates(
         user_id=test_user.id,
         uploaded_document_id=doc.id,
         file_hash="conflict-hash",
+        account_id=account.id,
         institution="DBS",
         currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 31),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("0.00"),
         status=BankStatementStatus.APPROVED,
     )
     db.add(statement)

--- a/apps/backend/tests/review/test_statement_validation.py
+++ b/apps/backend/tests/review/test_statement_validation.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 
 from src.models import Account, AccountType
 from src.models.layer1 import DocumentType, UploadedDocument
@@ -21,10 +22,32 @@ from src.services.statement_validation import (
     validate_balance_chain,
 )
 
+DEFAULT_ACCOUNT_NAME = "Statement Validation Default Account"
+
 
 @pytest.fixture
 def user_id(test_user):
     return test_user.id
+
+
+async def _default_account_id(db, user_id):
+    result = await db.execute(
+        select(Account.id).where(Account.user_id == user_id, Account.name == DEFAULT_ACCOUNT_NAME).limit(1)
+    )
+    account_id = result.scalar_one_or_none()
+    if account_id is not None:
+        return account_id
+
+    account = Account(
+        id=uuid4(),
+        user_id=user_id,
+        name=DEFAULT_ACCOUNT_NAME,
+        type=AccountType.ASSET,
+        currency="USD",
+    )
+    db.add(account)
+    await db.flush()
+    return account.id
 
 
 async def _make_statement(
@@ -53,6 +76,9 @@ async def _make_statement(
     )
     db.add(doc)
     await db.flush()
+
+    if account_id is None:
+        account_id = await _default_account_id(db, user_id)
 
     statement = StatementSummary(
         id=uuid4(),
@@ -335,8 +361,8 @@ class TestGetPendingStage1Review:
             db,
             user_id,
             file_hash="hash_approved",
-            period_start=None,
-            period_end=None,
+            opening_balance=Decimal("0.00"),
+            closing_balance=Decimal("0.00"),
             status=BankStatementStatus.APPROVED,
             stage1_status=Stage1Status.APPROVED,
         )

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -220,6 +220,24 @@ the `StatementSummary` conform (DWD) instead of `bank_statements.account_id`
 | AC11.17.1 | Transfer OUT/IN detection resolves custody account from DWD and creates the Processing entry under the Layer-2 read path | `test_transfer_out_creates_match()`, `test_transfer_in_creates_match()` | `reconciliation/test_reconciliation_matching_unit.py` | P0 |
 | AC11.17.2 | Mixed transfer + normal transactions both reconcile under the Layer-2 read path | `test_mixed_transactions_both_phases_execute()` | `reconciliation/test_transfer_integration.py` | P0 |
 
+### AC11.18: 4-Layer Migration — Financial Fact Schema Invariants
+
+Financial source facts and derived snapshots reject invalid financial states at
+the database layer before reporting, readiness checks, or export paths need to
+guess around them. The invariant set covers positive financial facts, statement
+envelope completeness, deterministic asset and market-data uniqueness, and
+latest-report snapshot guards. Short positions remain valid: negative position
+quantity is allowed, while market value and cost facts stay non-negative.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.18.1 | Positive source fact constraints reject zero or negative atomic and manual valuation amounts while allowing valid short-position quantities | `test_AC11_18_1_positive_source_fact_constraints()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
+| AC11.18.2 | Approved statement summaries require account, currency, period, and balance fields, and statement periods cannot be inverted | `test_AC11_18_2_statement_summary_approved_completeness_and_period_order()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
+| AC11.18.3 | Managed positions, investment lots, and investment facts enforce deterministic uniqueness and non-negative quantity/cost relationships | `test_AC11_18_3_portfolio_fact_constraints_and_managed_position_uniqueness()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
+| AC11.18.4 | Latest report snapshots cannot conflict for the same logical report scope and report date ranges cannot be inverted | `test_AC11_18_4_report_snapshot_latest_scope_and_date_constraints()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
+| AC11.18.5 | Market-data facts enforce positive rates/prices and stock prices are unique by symbol, currency, provider source, and date | `test_AC11_18_5_market_data_constraints_and_stock_price_uniqueness()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
+| AC11.18.6 | The constraint migration declares preflight checks and migration-risk classification for existing data compatibility | `test_AC11_18_6_migration_preflights_and_risk_contract_are_declared()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
+
 ## Implementation Pattern Ownership
 
 Do not copy reusable code patterns, router examples, migration guardrails, or

--- a/docs/ssot/assets.md
+++ b/docs/ssot/assets.md
@@ -45,7 +45,7 @@ ROW_NUMBER() OVER (
 For each latest atomic position:
 
 1. **Skip** if `quantity` or `market_value` is NULL → recorded in `skipped_assets`
-2. **Lookup** existing `ManagedPosition` by `(account_id, asset_identifier)`
+2. **Lookup** existing `ManagedPosition` by `(user_id, account_id, asset_identifier)`
 3. **Update** if found — refresh quantity, cost_basis, currency, metadata, clear disposal
 4. **Create** if not found — new ACTIVE position with auto-created broker account
 5. **Dispose** any existing managed positions not seen in the latest snapshot → set `status=DISPOSED`, `disposal_date=today`
@@ -172,6 +172,7 @@ class DepreciationResult:
 ```sql
 CREATE TABLE managed_positions (
     id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     account_id UUID NOT NULL REFERENCES accounts(id),
     asset_identifier VARCHAR(100) NOT NULL,
     quantity NUMERIC(18,6) NOT NULL,
@@ -185,6 +186,11 @@ CREATE TABLE managed_positions (
     updated_at TIMESTAMP NOT NULL
 );
 ```
+
+Constraints: `(user_id, account_id, asset_identifier)` is unique,
+`cost_basis >= 0`, and `disposal_date` cannot precede `acquisition_date`.
+`quantity` may be negative for short positions; short positions still require
+non-negative market value and cost facts.
 
 ### InvestmentTransaction
 
@@ -211,6 +217,9 @@ CREATE TABLE investment_transactions (
 );
 ```
 
+Constraints: `gross_amount > 0`, `fees >= 0`, and buy/sell rows require
+positive quantity plus non-negative unit price and cost basis.
+
 ### InvestmentLot
 
 ```sql
@@ -230,6 +239,10 @@ CREATE TABLE investment_lots (
     updated_at TIMESTAMP NOT NULL
 );
 ```
+
+Constraints: original quantity is positive, remaining quantity is non-negative
+and cannot exceed original quantity, unit cost is non-negative, and disposed
+date cannot precede acquisition date.
 
 ### PositionStatus Enum
 
@@ -262,6 +275,7 @@ CREATE TABLE manual_valuation_snapshots (
 ```
 
 Manual snapshots cover property value, mortgage or loan balance, CPF or long-term savings, tax payable/refund, insurance cash value, ESOP, RSU, stock options, and generic assets/liabilities. The value is always stored as a positive `Decimal`; the liquidity class determines whether it contributes to assets, liabilities, restricted, or illiquid net worth presentation.
+Reminder cadence is optional; when present, `recurrence_days` is positive.
 
 ---
 

--- a/docs/ssot/market_data.md
+++ b/docs/ssot/market_data.md
@@ -92,6 +92,7 @@ CREATE TABLE fx_rates (
     rate_date DATE NOT NULL,
     source VARCHAR(50) NOT NULL,
     created_at TIMESTAMP NOT NULL,
+    CHECK (rate > 0),
     UNIQUE(base_currency, quote_currency, rate_date)
 );
 
@@ -109,12 +110,19 @@ CREATE TABLE stock_prices (
     price_date DATE NOT NULL,
     source VARCHAR(50) NOT NULL,
     created_at TIMESTAMP NOT NULL,
-    UNIQUE(symbol, price_date)
+    CHECK (price > 0),
+    UNIQUE(symbol, currency, source, price_date)
 );
 
 CREATE INDEX idx_stock_prices_lookup 
     ON stock_prices(symbol, price_date);
 ```
+
+`stock_prices` uses provider-scoped uniqueness because the same symbol/date can
+arrive from different sources or currencies. Report and portfolio read paths
+still query by `symbol` and `price_date`; when more than one provider-scoped row
+exists on the same date, they select deterministically by latest `created_at`
+and then `source`.
 
 ### market_data_sync_state
 ```sql
@@ -194,6 +202,8 @@ async def get_fx_rate_cached(base: str, quote: str, date: date) -> Decimal:
 - **Pattern B**: Use Decimal(6) for rates, Decimal(2) for converted amounts
 - **Pattern C**: Prefer historical rates over real-time for reporting
 - **Pattern D**: Persist derived report-side rates with `source` values such as `derived:inverse:SGD/HKD`, `derived:bridge:USD`, or `yahoo_finance`.
+- **Pattern E**: Persist only positive FX rates and stock prices; invalid
+  zero/negative provider outputs are rejected at the database boundary.
 
 ### ⛔ Prohibited Patterns
 - **Anti-pattern A**: **NEVER** hardcode exchange rates

--- a/docs/ssot/migration-risk.yaml
+++ b/docs/ssot/migration-risk.yaml
@@ -170,6 +170,11 @@ migrations:
     risk: medium
     issue: "#844"
     proof: Adds preflight checks, PostgreSQL ledger invariant triggers, an FX-rate check, and void reversal FK; covered by AC2.14 direct DB-bypass tests and the PR Alembic contract.
+  0033_financial_fact_constraints:
+    file: 0033_financial_fact_constraints.py
+    risk: medium
+    issue: "#845"
+    proof: Adds preflight checks plus database CHECK/UNIQUE/partial-index guards for financial facts, statement envelopes, market prices, managed positions, and latest report snapshots; covered by AC11.18 direct DB invariant tests and the PR Alembic contract.
   51aa128d8189:
     file: 51aa128d8189_remove_report_snapshot_constraint.py
     risk: medium

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -30,6 +30,18 @@ blockers, notes, and source links. If an input is missing, stale, ambiguous, or
 outside the implemented contract, the report must disclose the limitation or
 block readiness instead of silently filling the gap.
 
+### 1.2 Report Snapshot Determinism
+
+`report_snapshots` stores generated ADS report payloads. Regeneration may keep
+historical non-latest rows for the same report date, but the database prevents
+conflicting published state:
+
+- point-in-time reports have at most one `is_latest=true` row per
+  `(user_id, report_type, as_of_date)`;
+- range reports have at most one `is_latest=true` row per
+  `(user_id, report_type, start_date, as_of_date)`;
+- range snapshots require `start_date <= as_of_date`.
+
 ---
 
 ## 2. Report Types

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -347,6 +347,13 @@ Auditable brokerage transaction table for buy, sell, and dividend accounting.
 | created_at | TIMESTAMP | NOT NULL | Creation time |
 | updated_at | TIMESTAMP | NOT NULL | Update time |
 
+**Constraints**:
+- `gross_amount > 0`
+- `fees >= 0`
+- Buy and sell rows require `quantity > 0`, `unit_price >= 0`, and
+  `cost_basis >= 0`; dividend rows carry positive `gross_amount` without trade
+  quantity requirements.
+
 ### InvestmentLots
 Open lot table used for FIFO, LIFO, and average-cost realized P&L.
 
@@ -365,6 +372,13 @@ Open lot table used for FIFO, LIFO, and average-cost realized P&L.
 | disposed_date | DATE | | Date the lot was fully consumed |
 | created_at | TIMESTAMP | NOT NULL | Creation time |
 | updated_at | TIMESTAMP | NOT NULL | Update time |
+
+**Constraints**:
+- `original_quantity > 0`
+- `remaining_quantity >= 0`
+- `remaining_quantity <= original_quantity`
+- `unit_cost >= 0`
+- `disposed_date` cannot precede `acquisition_date`
 
 ### ChatSessions
 Chat session header table.
@@ -424,6 +438,9 @@ Stage 1 review/workflow state; per-transaction detail lives in
 
 **Constraints**:
 - `(user_id, file_hash)` unique to prevent duplicate imports
+- `period_start <= period_end` when both dates are present
+- `status=approved` requires `account_id`, `currency`, `period_start`,
+  `period_end`, `opening_balance`, and `closing_balance`
 
 **Derived API Surface**:
 - `GET /api/accounts/coverage` derives account-level statement coverage from
@@ -517,6 +534,7 @@ fact; account is **not** stored here (conformed downstream via
 
 **Constraints**:
 - `(user_id, dedup_hash)` unique
+- `amount > 0`
 - Append-only `source_documents` array
 
 ### DWD: AtomicPositions (EPIC-011)
@@ -539,6 +557,7 @@ Deduplicated, immutable asset snapshots (source-pure detail fact).
 
 **Constraints**:
 - `(user_id, dedup_hash)` unique
+- `market_value >= 0`; `quantity` may be negative for short positions
 
 ### DIM + DWD: ClassificationRules (DIM) and TransactionClassification (DWD) (EPIC-011)
 `classification_rules` are **DIM** reference data (versioned mapping rules,
@@ -580,6 +599,28 @@ drives presentation downstream).
 **Constraints**:
 - `(user_id, component_type, source, as_of_date)` unique
 - Values remain positive; `liquidity_class=liability` controls liability presentation.
+- `recurrence_days` is either null or positive.
+
+### ADS: ReportSnapshots (EPIC-011/EPIC-005)
+Report snapshot rows are immutable generated report payloads. Historical
+non-latest rows may repeat the same report date when a report is regenerated,
+but published latest rows must be deterministic.
+
+**Constraints**:
+- `start_date <= as_of_date` when `start_date` is present.
+- Only one latest point-in-time snapshot can exist per
+  `(user_id, report_type, as_of_date)`.
+- Only one latest range snapshot can exist per
+  `(user_id, report_type, start_date, as_of_date)`.
+
+### Market Data Fact Constraints
+Market data facts are source-bearing valuation inputs.
+
+**Constraints**:
+- `fx_rates.rate > 0`
+- `stock_prices.price > 0`
+- `stock_prices` are unique by `(symbol, currency, source, price_date)`, while
+  `idx_stock_prices_lookup(symbol, price_date)` remains the report lookup index.
 
 ---
 

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -439,7 +439,7 @@ Stage 1 review/workflow state; per-transaction detail lives in
 **Constraints**:
 - `(user_id, file_hash)` unique to prevent duplicate imports
 - `period_start <= period_end` when both dates are present
-- `status=approved` requires `account_id`, `currency`, `period_start`,
+- `status=approved` requires `account_id`, non-blank `currency`, `period_start`,
   `period_end`, `opening_balance`, and `closing_balance`
 
 **Derived API Surface**:


### PR DESCRIPTION
## Summary

Adds database-level financial fact constraints, deterministic uniqueness for financial snapshots/provider facts, and approval-time guards so incomplete facts cannot be posted as approved.

Closes #845

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-011 — Asset Lifecycle |
| **AC IDs** | AC11.18.1, AC11.18.2, AC11.18.3, AC11.18.4, AC11.18.5, AC11.18.6 |
| **AC source updated** | Owning EPIC (`docs/project/EPIC-011.asset-lifecycle.md`) |

---

## SSOT Changes

- [x] `docs/ssot/schema.md` — documented financial fact CHECK constraints and deterministic keys
- [x] `docs/ssot/assets.md` — documented managed-position and manual-valuation invariants
- [x] `docs/ssot/market_data.md` — documented positive market facts and provider-scoped stock-price uniqueness
- [x] `docs/ssot/reporting.md` — documented latest report snapshot scope uniqueness
- [x] `docs/ssot/migration-risk.yaml` — registered migration `0033_financial_fact_constraints`

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `local pre-commit` | `test_financial_fact_schema_invariants.py` initially failed before constraints were added |
| 🟢 Green (passing test) | `1ecde93f` | Implemented constraints, migration preflights, service guards, and fixture updates |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Not applicable. This PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
moon run :lint
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_migration_risk.py
uv run --with pyyaml python tools/check_manifest.py
uv run --with pyyaml python tools/lint_doc_consistency.py
cd apps/backend && PYTHONPATH=. CONTAINER_RUNTIME=podman BRANCH_NAME=issue-845-financial-fact-constraints uv run alembic upgrade head
cd apps/backend && PYTHONPATH=. CONTAINER_RUNTIME=podman BRANCH_NAME=issue-845-financial-fact-constraints uv run alembic check
CONTAINER_RUNTIME=podman BRANCH_NAME=issue-845-financial-fact-constraints uv run pytest apps/backend/tests/infra/test_financial_fact_schema_invariants.py -q --no-cov
CONTAINER_RUNTIME=podman BRANCH_NAME=issue-845-financial-fact-constraints uv run pytest apps/backend/tests/review/test_review_conflicts_router.py apps/backend/tests/review/test_consistency_checks.py apps/backend/tests/review/test_statement_validation.py -q --no-cov -x
CONTAINER_RUNTIME=podman BRANCH_NAME=issue-845-financial-fact-constraints uv run pytest apps/backend/tests/api/test_workflow_router.py apps/backend/tests/api/test_personal_report_package_contract.py apps/backend/tests/api/test_statements_router.py apps/backend/tests/accounting/test_account_statement_coverage.py -q --no-cov -x
CONTAINER_RUNTIME=podman BRANCH_NAME=issue-845-financial-fact-constraints uv run pytest apps/backend/tests/infra/test_financial_fact_schema_invariants.py apps/backend/tests/review/test_review_conflicts_router.py apps/backend/tests/review/test_consistency_checks.py apps/backend/tests/review/test_statement_validation.py apps/backend/tests/assets/test_asset_service.py apps/backend/tests/reporting/test_reporting_snapshot.py apps/backend/tests/market_data/test_sync.py apps/backend/tests/market_data/test_sync_router.py apps/backend/tests/market_data/test_fx.py -q --no-cov
uv run --python 3.12.12 python - <<PY
# Direct parse_document smoke checks for account-gated approval were run locally.
PY
```

`moon run :test` was started locally and exposed additional fixture updates that are included here, but the local Podman runtime then became unresponsive (`podman ps` timed out), so the final full-suite verification must come from GitHub CI.

---

## Screenshots / Evidence

N/A
