### PR TITLE
[finance_report_ui] EPIC-022 PR9: everyday/Advanced boundary + naming unification

### DIFF
--- a/apps/frontend/playwright/reports-cockpit.spec.ts
+++ b/apps/frontend/playwright/reports-cockpit.spec.ts
@@ -94,7 +94,7 @@ test.describe("AC22.3.6 report cockpit + drill-down smoke", () => {
       await page.setViewportSize({ width, height });
 
       await page.goto("/reports", { waitUntil: "networkidle" });
-      for (const title of ["Balance Sheet", "Income Statement", "Annualized Income", "Statistics Accuracy"]) {
+      for (const title of ["Balance Sheet", "Income Statement", "Annualized Income", "Reconciliation coverage"]) {
         await expect(page.getByText(title, { exact: true })).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
       }
       await expect(page.getByRole("button", { name: /More reports/i })).toBeVisible();

--- a/apps/frontend/src/__tests__/dashboardPage.test.tsx
+++ b/apps/frontend/src/__tests__/dashboardPage.test.tsx
@@ -588,7 +588,7 @@ describe("HomePage", () => {
 
     render(<HomePage />)
 
-    await waitFor(() => expect(screen.getByText("Data health")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Reconciliation coverage")).toBeInTheDocument())
     expect(screen.getByText("80%")).toBeInTheDocument()
     expect(screen.queryByText("20%")).not.toBeInTheDocument()
     expect(screen.getByText("16 matched")).toBeInTheDocument()

--- a/apps/frontend/src/__tests__/infoHint.test.tsx
+++ b/apps/frontend/src/__tests__/infoHint.test.tsx
@@ -24,4 +24,13 @@ describe("InfoHint (EPIC-022 AC22.5.5)", () => {
             expect(GLOSSARY[term]).toBeTruthy();
         }
     });
+
+    it("AC22.9.2 exposes a single reconciliation-coverage term for the unified label", () => {
+        // Home and Reports both render "Reconciliation coverage" backed by this
+        // one glossary entry, replacing the old divergent "Data health" /
+        // "Statistics Accuracy" wording.
+        expect(GLOSSARY.reconciliation_coverage).toBeTruthy();
+        render(<InfoHint term="reconciliation_coverage" label="Reconciliation coverage" />);
+        expect(screen.getByRole("tooltip")).toHaveTextContent(GLOSSARY.reconciliation_coverage);
+    });
 });

--- a/apps/frontend/src/__tests__/reportsCockpit.test.tsx
+++ b/apps/frontend/src/__tests__/reportsCockpit.test.tsx
@@ -32,14 +32,36 @@ describe("Reports cockpit (EPIC-022 AC22.3)", () => {
   it("AC22.3.1 leads with exactly the four everyday report blocks and their live figures", async () => {
     render(<ReportsPage />)
 
-    for (const title of ["Balance Sheet", "Income Statement", "Annualized Income", "Statistics Accuracy"]) {
+    for (const title of ["Balance Sheet", "Income Statement", "Annualized Income", "Reconciliation coverage"]) {
       expect(screen.getByText(title)).toBeInTheDocument()
     }
 
-    // Annualized Income and Statistics Accuracy surface live numbers.
+    // Annualized Income and Reconciliation coverage surface live numbers.
     await waitFor(() => expect(screen.getByText("92% matched")).toBeInTheDocument())
     expect(screen.getByText("3 unmatched")).toBeInTheDocument()
     expect(screen.getByText(/120,000/)).toBeInTheDocument()
+  })
+
+  it("AC22.9.1 keeps the reconciliation-coverage block in the reports context, not linked into Advanced", async () => {
+    render(<ReportsPage />)
+
+    await waitFor(() => expect(screen.getByText("Reconciliation coverage")).toBeInTheDocument())
+    // The 4th cockpit block must not pull an everyday user into the Advanced
+    // reconciliation surface.
+    expect(screen.queryByRole("link", { name: /Reconciliation coverage/i })).toBeNull()
+    for (const link of screen.queryAllByRole("link")) {
+      expect(link.getAttribute("href")).not.toBe("/reconciliation")
+    }
+  })
+
+  it("AC22.9.3 makes the Annualized Income card's destination match its label", async () => {
+    render(<ReportsPage />)
+
+    const card = screen.getByText("Annualized Income").closest("a")
+    expect(card).not.toBeNull()
+    // It opens the report package, and the caption says so — no silent mismatch.
+    expect(card).toHaveAttribute("href", "/reports/package")
+    expect(screen.getByText(/report package/i)).toBeInTheDocument()
   })
 
   it("AC22.3.2 keeps Cash Flow and the Personal Report Package behind the More control", async () => {

--- a/apps/frontend/src/__tests__/reportsPage.test.tsx
+++ b/apps/frontend/src/__tests__/reportsPage.test.tsx
@@ -61,7 +61,7 @@ describe("ReportsPage", () => {
 
     // The cockpit still renders all four blocks; stat values degrade to "—".
     await waitFor(() => expect(screen.getByText("Annualized Income")).toBeInTheDocument())
-    expect(screen.getByText("Statistics Accuracy")).toBeInTheDocument()
+    expect(screen.getByText("Reconciliation coverage")).toBeInTheDocument()
     expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1)
   })
 

--- a/apps/frontend/src/app/(main)/page.tsx
+++ b/apps/frontend/src/app/(main)/page.tsx
@@ -369,7 +369,7 @@ export default function HomePage() {
               return (
                 <div className="min-w-[180px]">
                   <div className="flex justify-between text-xs text-muted mb-1">
-                    <span>Data health</span>
+                    <span className="inline-flex items-center">Reconciliation coverage<InfoHint term="reconciliation_coverage" label="Reconciliation coverage" /></span>
                     <span className="font-medium" style={{ color: barColor }}>{pct}%</span>
                   </div>
                   <div className="h-2 rounded-full bg-[var(--background-muted)] overflow-hidden">

--- a/apps/frontend/src/app/(main)/reports/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/page.tsx
@@ -140,10 +140,10 @@ function StatCard({ title, icon: Icon, href, value, caption, infoTerm }: StatCar
             <div className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-[var(--background-muted)] mb-3">
                 <Icon className="w-5 h-5 text-[var(--accent)]" aria-hidden="true" />
             </div>
-            <h3 className="font-semibold text-[var(--accent)] mb-1 inline-flex items-center">
-                {title}
+            <div className="mb-1 flex items-center">
+                <h3 className="font-semibold text-[var(--accent)]">{title}</h3>
                 {infoTerm && <InfoHint term={infoTerm} label={title} />}
-            </h3>
+            </div>
             <p className="text-xl font-semibold">{value}</p>
             <p className="text-xs text-muted mt-1">{caption}</p>
         </div>

--- a/apps/frontend/src/app/(main)/reports/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/page.tsx
@@ -6,6 +6,7 @@ import { BarChart2, TrendingUp, DollarSign, FileText, CalendarClock, ShieldCheck
 
 import { apiFetch } from "@/lib/api";
 import { formatCurrencyLocale } from "@/lib/currency";
+import { InfoHint, type GlossaryTerm } from "@/components/ui/InfoHint";
 import type { AnnualizedIncomeResponse, ReconciliationStatsResponse } from "@/lib/types";
 
 // The four reports an everyday user reads (EPIC-022 AC22.3.1). Everything else
@@ -51,14 +52,14 @@ export default function ReportsPage() {
                     icon={CalendarClock}
                     href="/reports/package"
                     value={annualized ? formatCurrencyLocale(annualized.annualized_total, annualized.currency) : "—"}
-                    caption="Projected annual total — opens the full report package"
+                    caption="Projected annual total — see the full breakdown in the report package →"
                 />
                 <StatCard
-                    title="Statistics Accuracy"
+                    title="Reconciliation coverage"
                     icon={ShieldCheck}
-                    href="/reconciliation"
+                    infoTerm="reconciliation_coverage"
                     value={matchRate === null ? "—" : `${matchRate}% matched`}
-                    caption={stats ? `${stats.unmatched_transactions} unmatched` : "Reconciliation coverage"}
+                    caption={stats ? `${stats.unmatched_transactions} unmatched` : "Share of transactions reconciled"}
                 />
             </div>
 
@@ -124,22 +125,28 @@ function ReportNavCard({ title, description, icon: Icon, href }: ReportNavCardPr
 interface StatCardProps {
     title: string;
     icon: React.ComponentType<{ className?: string }>;
-    href: string;
+    /** Optional destination. Omit for a display-only stat that must not pull an
+        everyday user into an Advanced surface (EPIC-022 AC22.9.1). */
+    href?: string;
     value: string;
     caption: string;
+    /** Optional glossary term rendered as an InfoHint next to the title. */
+    infoTerm?: GlossaryTerm;
 }
 
-function StatCard({ title, icon: Icon, href, value, caption }: StatCardProps) {
-    return (
-        <Link href={href}>
-            <div className="card p-5 transition-colors hover:border-[var(--accent)] cursor-pointer h-full">
-                <div className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-[var(--background-muted)] mb-3">
-                    <Icon className="w-5 h-5 text-[var(--accent)]" aria-hidden="true" />
-                </div>
-                <h3 className="font-semibold text-[var(--accent)] mb-1">{title}</h3>
-                <p className="text-xl font-semibold">{value}</p>
-                <p className="text-xs text-muted mt-1">{caption}</p>
+function StatCard({ title, icon: Icon, href, value, caption, infoTerm }: StatCardProps) {
+    const body = (
+        <div className={`card p-5 transition-colors h-full ${href ? "hover:border-[var(--accent)] cursor-pointer" : ""}`}>
+            <div className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-[var(--background-muted)] mb-3">
+                <Icon className="w-5 h-5 text-[var(--accent)]" aria-hidden="true" />
             </div>
-        </Link>
+            <h3 className="font-semibold text-[var(--accent)] mb-1 inline-flex items-center">
+                {title}
+                {infoTerm && <InfoHint term={infoTerm} label={title} />}
+            </h3>
+            <p className="text-xl font-semibold">{value}</p>
+            <p className="text-xs text-muted mt-1">{caption}</p>
+        </div>
     );
+    return href ? <Link href={href}>{body}</Link> : body;
 }

--- a/apps/frontend/src/components/ui/InfoHint.tsx
+++ b/apps/frontend/src/components/ui/InfoHint.tsx
@@ -18,6 +18,8 @@ export const GLOSSARY = {
     consistency_check:
         "An automatic check for duplicates, transfers, and anomalies before matches are approved.",
     match_score: "How confident we are that a bank transaction and a ledger entry are the same thing (0–100).",
+    reconciliation_coverage:
+        "The share of your bank transactions we've matched to a ledger entry. Higher means more of your data is reconciled and trustworthy.",
 } as const;
 
 export type GlossaryTerm = keyof typeof GLOSSARY;

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -151,7 +151,7 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
-| AC22.3.1 | The `/reports` front section renders exactly four report blocks: Balance Sheet, Income Statement, Annualized Income, and Statistics Accuracy (reconciliation coverage / unmatched count) | `reportsCockpit.test.tsx` | P1 |
+| AC22.3.1 | The `/reports` front section renders exactly four report blocks: Balance Sheet, Income Statement, Annualized Income, and Reconciliation coverage (reconciliation match rate / unmatched count) | `reportsCockpit.test.tsx` | P1 |
 | AC22.3.2 | All other reports (Cash Flow, Personal Report Package, and any future reports) live behind a single "More" control, not the front section | `reportsCockpit.test.tsx` | P1 |
 | AC22.3.3 | `GET /api/reports/account-lineage` returns the user-scoped posted/reconciled journal lines that contribute to an account's balance for the period, each carrying a `journal_line` evidence anchor, with Decimal-safe signed amounts | `test_account_lineage.py` | P1 |
 | AC22.3.4 | A reusable lineage drill-down component lets a user click any amount on the Balance Sheet or Income Statement, list the contributing journal lines, and open the full evidence chain (journal line → bank statement transaction → atomic transaction → source document) | `lineagePanel.test.tsx`, `balanceSheetDrilldown.test.tsx` | P1 |
@@ -187,3 +187,19 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 | AC22.5.4 | User-facing review-surface headings use plain language and do not expose internal "Stage 2" or raw score-band wording in their titles | `reviewBackLinks.test.tsx` | P1 |
 | AC22.5.5 | Core jargon terms (balance "drift"/"balanced", "needs review", transfer pair, anomaly, duplicate, consistency check, match score) expose a plain-language explanation through an accessible `InfoHint` affordance | `infoHint.test.tsx` | P1 |
 | AC22.5.6 | The Home surfaces a single primary next-action with overlapping reconciliation links de-duplicated, and the Chat page heading reads "AI Advisor" | `dashboardPage.test.tsx`, `ChatPageClient.test.tsx` | P1 |
+
+### AC22.9 — Everyday/Advanced Boundary And Naming Unification
+
+> PR9 slice (#865). The IA folds accounting modules into Advanced, but the
+> Reports cockpit still linked an everyday user into the Advanced reconciliation
+> page, and the same reconciliation match-rate was shown under three different
+> names ("Data health" on Home, "Statistics Accuracy" on Reports). This slice
+> keeps the cockpit in the reports context and unifies the term. (The `/assets`
+> and `/events` mislabels noted in review are already handled by permanent
+> redirects, so they are out of scope here.)
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC22.9.1 | The Reports cockpit's reconciliation-coverage block stays in the reports context and does not link into the Advanced `/reconciliation` surface | `reportsCockpit.test.tsx` | P1 |
+| AC22.9.2 | The reconciliation match-rate is shown under a single term ("Reconciliation coverage") on both Home and Reports, backed by one shared `InfoHint` glossary entry | `dashboardPage.test.tsx`, `reportsCockpit.test.tsx`, `infoHint.test.tsx` | P1 |
+| AC22.9.3 | The "Annualized Income" cockpit card's destination matches its label (it opens the report package and the caption says so), with no silent label/destination mismatch | `reportsCockpit.test.tsx` | P1 |

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -1,8 +1,8 @@
 # EPIC-022: Everyday-User Information Architecture
 
 > **Status**: In Progress — PR1–PR5 landed (IA skeleton, unified inbox, report
-> cockpit + Balance-Sheet/Income-Statement drill-down, hardening, flow guidance),
-> plus the lean-Home & review-mainline fix (#860). Remaining everyday-user slices
+> cockpit + Balance Sheet / Income Statement drill-down, hardening, flow
+> guidance), plus the lean Home and review-flow fix (#860). Remaining everyday-user slices
 > PR6–PR10 (confidence surface, cash-flow drill-down, readable report package,
 > boundary/naming cleanup, manual provenance) are tracked as sub-issues of the
 > root (#836).

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -1,7 +1,11 @@
 # EPIC-022: Everyday-User Information Architecture
 
-> **Status**: In Progress — PR1 (IA skeleton) slice landing; unified inbox and
-> report drill-down slices tracked separately.
+> **Status**: In Progress — PR1–PR5 landed (IA skeleton, unified inbox, report
+> cockpit + Balance-Sheet/Income-Statement drill-down, hardening, flow guidance),
+> plus the lean-Home & review-mainline fix (#860). Remaining everyday-user slices
+> PR6–PR10 (confidence surface, cash-flow drill-down, readable report package,
+> boundary/naming cleanup, manual provenance) are tracked as sub-issues of the
+> root (#836).
 > **Vision Anchor**: `decision-2-event-middle-layer`, `decision-4-two-stage-review`.
 > Builds on EPIC-019: it introduced workflow events but kept internal accounting
 > modules as first-class navigation; EPIC-022 restructures the shell so an
@@ -68,10 +72,44 @@ EPIC-022 finishes EPIC-019's intent at the navigation and report layers.
 | PR1 — IA skeleton | #834 | 3-peer nav, smart Home, route/name/icon alignment, Upload consolidation |
 | PR2 — unified inbox | #835 | merge Stage 1/2 Review Queue into the notification center |
 | PR3 — report cockpit | #836 (root) | 4-block Reports hub + `/api/evidence/lineage` drill-down |
+| PR4 — hardening | #853 | Stage 2 inbox event, orphan-route fixes, lean Home, E2E journeys |
 | PR5 — flow guidance & plain language | — | core-flow step banner, in-place unblock on review, deep-page back-links, jargon hints, single primary next-action |
+| PR6 — confidence & attention surface | #864 | confidence-ranked `/attention` queue + Home trust meter (Axiom B / north-star) |
+| PR7 — close traceability loop | #866 | cash-flow drill-down + linear evidence-chain view + beginning→ending cash reconciliation |
+| PR8 — readable report package + export | #867 | human-readable package view + pinned-version export MVP (terminal goal); pairs with #705 |
+| PR9 — boundary & naming cleanup | #865 | stop the Reports cockpit leaking into Advanced; unify the reconciliation-coverage term; fix mislabels |
+| PR10 — manual provenance labeling | #868 | Imported/Manual/Derived provenance badges + controlled asset source; pairs with #706 |
 
-Acceptance criteria for PR2/PR3 slices are added to this document when those
-slices land, so every registered AC has a behavioral test in the same change.
+Acceptance criteria for a slice are added to this document when that slice
+lands, so every registered AC has a behavioral test in the same change. PR1–PR5
+ACs are registered below; the planned PR6–PR10 ACs live in their sub-issues
+(#864–#868) until each lands.
+
+### Planned slices (PR6–PR10)
+
+The first five slices delivered the everyday-user *information architecture and
+core flow*. The remaining slices close the gap between that flow and the two
+vision pillars it must serve — **Axiom B** (automation by default, attention only
+on the low-confidence tail) and **source→ledger→report traceability** — plus the
+**terminal goal** (a readable, exportable report package).
+
+- **PR6 — confidence & attention surface** (#864): make confidence a first-class,
+  navigable concept — one confidence-ranked attention queue plus a Home trust
+  meter — instead of the same signal scattered across statement score, txn
+  high/medium/low, match score, and balance validation. Registers AC22.6.x on
+  landing.
+- **PR7 — close the traceability loop** (#866): wire cash-flow amounts to the
+  lineage drawer (only Balance Sheet / Income Statement have it today) and turn
+  the evidence chain into a readable ordered path. Registers AC22.7.x on landing.
+- **PR8 — readable report package + export** (#867): turn `reports/package` from a
+  developer-facing dump into a readable, exportable package — the product's
+  terminal deliverable. Pairs with #705. Registers AC22.8.x on landing.
+- **PR9 — boundary & naming cleanup** (#865): stop the Reports cockpit from
+  linking everyday users back into Advanced, and unify the reconciliation-coverage
+  term and other mislabels. Registers AC22.9.x on landing.
+- **PR10 — manual provenance labeling** (#868): give every value an honest
+  Imported/Manual/Derived badge so manual data never masquerades as imported
+  proof. Pairs with #706. Registers AC22.10.x on landing.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
Implements **#865** (EPIC-022 PR9), a P0 sub-issue of root **#836**.

> **Stacked on #869** (the EPIC-022 PR6–PR10 doc/tracking PR). Merge #869 first, or merge this — it contains #869's doc commit plus the AC22.9 implementation.

## Why

From the everyday-user review: the IA folds accounting modules into Advanced, but the **Reports cockpit still linked an everyday user into the Advanced `/reconciliation` page**, and the **same reconciliation match-rate was shown under three names** ("Data health" on Home, "Statistics Accuracy" on Reports). Decision Filter #3: reduce cognitive load without hiding detail.

## Changes (AC22.9)

- **AC22.9.1** — The Reports cockpit's reconciliation block is now a display-only stat in the reports context; it no longer links into `/reconciliation`. `StatCard` gained an optional `href` (omit → non-link).
- **AC22.9.2** — The reconciliation match-rate uses one term **"Reconciliation coverage"** on both Home (was "Data health") and Reports (was "Statistics Accuracy"), backed by one shared `InfoHint` glossary entry `reconciliation_coverage`.
- **AC22.9.3** — The "Annualized Income" card caption now states it opens the report package, so its destination matches its label.

The `/assets` ("Portfolio Performance" title) and `/events` mislabels noted in review are **already handled by permanent redirects**, so they're out of scope here (documented in the AC22.9 note).

## Verification

- New/updated tests reference AC22.9.1/.2/.3; AC22.3.1's label reference updated to match.
- Full frontend suite **687 passing**; `tsc --noEmit` clean; ESLint clean.
- AC traceability analyzer: `registered=1409, untested=0, invalid_real=0`.
- Frontend coverage **99.48%** (≥ baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)