### PR TITLE
[finance_report_audit] Harden audit anchor referential integrity

### DIFF
--- a/apps/backend/migrations/versions/0034_audit_anchor_referential_integrity.py
+++ b/apps/backend/migrations/versions/0034_audit_anchor_referential_integrity.py
@@ -1,0 +1,601 @@
+"""audit anchor referential integrity"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0034_audit_anchor_ri"
+down_revision = "0033_financial_fact_constraints"
+branch_labels = None
+depends_on = None
+
+
+UUID_RE = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+
+
+AUDIT_ANCHOR_PRECHECK_DDL = """
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM evidence_edges edge
+        JOIN evidence_nodes source_node ON source_node.id = edge.from_node_id
+        JOIN evidence_nodes target_node ON target_node.id = edge.to_node_id
+        WHERE edge.user_id <> source_node.user_id
+           OR edge.user_id <> target_node.user_id
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: evidence_edges contain cross-user endpoints';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM journal_lines line
+        JOIN journal_entries entry ON entry.id = line.journal_entry_id
+        JOIN accounts account ON account.id = line.account_id
+        WHERE account.user_id <> entry.user_id
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: journal_lines contain cross-user account references';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM statement_summaries summary
+        JOIN accounts account ON account.id = summary.account_id
+        WHERE summary.account_id IS NOT NULL
+          AND account.user_id <> summary.user_id
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: statement_summaries contain cross-user account references';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM classification_rules rule
+        JOIN accounts account ON account.id = rule.default_account_id
+        WHERE rule.default_account_id IS NOT NULL
+          AND account.user_id <> rule.user_id
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: classification_rules contain cross-user default accounts';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM transaction_classification classification
+        JOIN atomic_transactions atomic ON atomic.id = classification.atomic_txn_id
+        JOIN classification_rules rule ON rule.id = classification.rule_version_id
+        LEFT JOIN accounts account ON account.id = classification.account_id
+        WHERE rule.user_id <> atomic.user_id
+           OR (classification.account_id IS NOT NULL AND account.user_id <> atomic.user_id)
+    ) THEN
+        RAISE EXCEPTION 'preflight failed: transaction_classification contains cross-user rule or account references';
+    END IF;
+END
+$$;
+
+-- Existing JSONB/naked UUID fields are compatibility hints. This migration will
+-- backfill resolvable legacy audit anchors into normalized link tables.
+-- unresolved legacy audit anchors remain preserved for explicit blocker reporting.
+"""
+
+
+AUDIT_ANCHOR_FUNCTION_DDL = """
+CREATE OR REPLACE FUNCTION fr_validate_reconciliation_match_journal_entry_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_match_user_id uuid;
+    v_entry_user_id uuid;
+BEGIN
+    SELECT atomic.user_id
+    INTO v_match_user_id
+    FROM reconciliation_matches match
+    JOIN atomic_transactions atomic ON atomic.id = match.atomic_txn_id
+    WHERE match.id = NEW.match_id;
+
+    SELECT entry.user_id
+    INTO v_entry_user_id
+    FROM journal_entries entry
+    WHERE entry.id = NEW.journal_entry_id;
+
+    IF v_match_user_id IS NULL OR v_entry_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_match_user_id <> v_entry_user_id THEN
+        RAISE EXCEPTION 'reconciliation match % cannot link cross-user journal entry %',
+            NEW.match_id, NEW.journal_entry_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_reconciliation_match_journal_entries_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_atomic_transaction_source_document_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_atomic_user_id uuid;
+    v_document_user_id uuid;
+BEGIN
+    SELECT user_id INTO v_atomic_user_id
+    FROM atomic_transactions
+    WHERE id = NEW.atomic_txn_id;
+
+    SELECT user_id INTO v_document_user_id
+    FROM uploaded_documents
+    WHERE id = NEW.uploaded_document_id;
+
+    IF v_atomic_user_id IS NULL OR v_document_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_atomic_user_id <> v_document_user_id THEN
+        RAISE EXCEPTION 'atomic transaction % cannot link cross-user uploaded document %',
+            NEW.atomic_txn_id, NEW.uploaded_document_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_atomic_transaction_source_documents_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_atomic_position_source_document_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_atomic_user_id uuid;
+    v_document_user_id uuid;
+BEGIN
+    SELECT user_id INTO v_atomic_user_id
+    FROM atomic_positions
+    WHERE id = NEW.atomic_position_id;
+
+    SELECT user_id INTO v_document_user_id
+    FROM uploaded_documents
+    WHERE id = NEW.uploaded_document_id;
+
+    IF v_atomic_user_id IS NULL OR v_document_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_atomic_user_id <> v_document_user_id THEN
+        RAISE EXCEPTION 'atomic position % cannot link cross-user uploaded document %',
+            NEW.atomic_position_id, NEW.uploaded_document_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_atomic_position_source_documents_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_journal_line_account_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_entry_user_id uuid;
+    v_account_user_id uuid;
+BEGIN
+    SELECT user_id INTO v_entry_user_id
+    FROM journal_entries
+    WHERE id = NEW.journal_entry_id;
+
+    SELECT user_id INTO v_account_user_id
+    FROM accounts
+    WHERE id = NEW.account_id;
+
+    IF v_entry_user_id IS NULL OR v_account_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_entry_user_id <> v_account_user_id THEN
+        RAISE EXCEPTION 'journal line % cannot reference cross-user account %',
+            NEW.id, NEW.account_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_journal_lines_account_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_statement_summary_account_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_account_user_id uuid;
+BEGIN
+    IF NEW.account_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT user_id INTO v_account_user_id
+    FROM accounts
+    WHERE id = NEW.account_id;
+
+    IF v_account_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.user_id <> v_account_user_id THEN
+        RAISE EXCEPTION 'statement summary % cannot reference cross-user account %',
+            NEW.id, NEW.account_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_statement_summaries_account_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_classification_rule_account_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_account_user_id uuid;
+BEGIN
+    IF NEW.default_account_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT user_id INTO v_account_user_id
+    FROM accounts
+    WHERE id = NEW.default_account_id;
+
+    IF v_account_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.user_id <> v_account_user_id THEN
+        RAISE EXCEPTION 'classification rule % cannot reference cross-user default account %',
+            NEW.id, NEW.default_account_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_classification_rules_default_account_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_transaction_classification_user_scope()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_atomic_user_id uuid;
+    v_rule_user_id uuid;
+    v_account_user_id uuid;
+BEGIN
+    SELECT user_id INTO v_atomic_user_id
+    FROM atomic_transactions
+    WHERE id = NEW.atomic_txn_id;
+
+    SELECT user_id INTO v_rule_user_id
+    FROM classification_rules
+    WHERE id = NEW.rule_version_id;
+
+    IF v_atomic_user_id IS NOT NULL
+       AND v_rule_user_id IS NOT NULL
+       AND v_atomic_user_id <> v_rule_user_id THEN
+        RAISE EXCEPTION 'transaction classification % cannot link cross-user rule %',
+            NEW.id, NEW.rule_version_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_transaction_classification_rule_same_user';
+    END IF;
+
+    IF NEW.account_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT user_id INTO v_account_user_id
+    FROM accounts
+    WHERE id = NEW.account_id;
+
+    IF v_atomic_user_id IS NOT NULL
+       AND v_account_user_id IS NOT NULL
+       AND v_atomic_user_id <> v_account_user_id THEN
+        RAISE EXCEPTION 'transaction classification % cannot reference cross-user account %',
+            NEW.id, NEW.account_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_transaction_classification_account_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_evidence_edge_tenant_scope()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_from_user_id uuid;
+    v_to_user_id uuid;
+BEGIN
+    SELECT user_id INTO v_from_user_id
+    FROM evidence_nodes
+    WHERE id = NEW.from_node_id;
+
+    SELECT user_id INTO v_to_user_id
+    FROM evidence_nodes
+    WHERE id = NEW.to_node_id;
+
+    IF v_from_user_id IS NULL OR v_to_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.user_id <> v_from_user_id OR NEW.user_id <> v_to_user_id THEN
+        RAISE EXCEPTION 'evidence edge % cannot connect cross-user endpoints',
+            NEW.id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_evidence_edges_same_user_endpoints';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+"""
+
+
+def upgrade() -> None:
+    op.execute(AUDIT_ANCHOR_PRECHECK_DDL)
+
+    op.create_table(
+        "reconciliation_match_journal_entries",
+        sa.Column("match_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("journal_entry_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["match_id"], ["reconciliation_matches.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["journal_entry_id"], ["journal_entries.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("match_id", "journal_entry_id"),
+    )
+    op.create_index(
+        "idx_reconciliation_match_journal_entries_entry",
+        "reconciliation_match_journal_entries",
+        ["journal_entry_id"],
+    )
+
+    op.create_table(
+        "atomic_transaction_source_documents",
+        sa.Column("atomic_txn_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("uploaded_document_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("doc_type", sa.String(length=50), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["atomic_txn_id"], ["atomic_transactions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["uploaded_document_id"], ["uploaded_documents.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("atomic_txn_id", "uploaded_document_id"),
+    )
+    op.create_index(
+        "idx_atomic_txn_source_docs_document",
+        "atomic_transaction_source_documents",
+        ["uploaded_document_id"],
+    )
+
+    op.create_table(
+        "atomic_position_source_documents",
+        sa.Column("atomic_position_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("uploaded_document_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("doc_type", sa.String(length=50), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["atomic_position_id"], ["atomic_positions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["uploaded_document_id"], ["uploaded_documents.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("atomic_position_id", "uploaded_document_id"),
+    )
+    op.create_index(
+        "idx_atomic_position_source_docs_document",
+        "atomic_position_source_documents",
+        ["uploaded_document_id"],
+    )
+
+    op.execute(
+        f"""
+        INSERT INTO reconciliation_match_journal_entries (
+            match_id, journal_entry_id, created_at, updated_at
+        )
+        SELECT DISTINCT match.id, entry.id, now(), now()
+        FROM reconciliation_matches match
+        JOIN atomic_transactions atomic ON atomic.id = match.atomic_txn_id
+        CROSS JOIN LATERAL jsonb_array_elements_text(
+            CASE
+                WHEN jsonb_typeof(match.journal_entry_ids) = 'array' THEN match.journal_entry_ids
+                ELSE '[]'::jsonb
+            END
+        ) AS raw_entry(entry_id_text)
+        JOIN journal_entries entry
+          ON raw_entry.entry_id_text ~* '^{UUID_RE}$'
+         AND entry.id = raw_entry.entry_id_text::uuid
+         AND entry.user_id = atomic.user_id
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+    op.execute(
+        f"""
+        INSERT INTO atomic_transaction_source_documents (
+            atomic_txn_id, uploaded_document_id, doc_type, ordinal, created_at, updated_at
+        )
+        SELECT DISTINCT ON (atomic.id, document.id)
+            atomic.id,
+            document.id,
+            COALESCE(NULLIF(source_item.value ->> 'doc_type', ''), 'legacy'),
+            source_item.ordinality::integer - 1,
+            now(),
+            now()
+        FROM atomic_transactions atomic
+        CROSS JOIN LATERAL jsonb_array_elements(
+            CASE
+                WHEN jsonb_typeof(atomic.source_documents) = 'array' THEN atomic.source_documents
+                WHEN jsonb_typeof(atomic.source_documents) = 'object'
+                 AND jsonb_typeof(atomic.source_documents -> 'documents') = 'array'
+                    THEN atomic.source_documents -> 'documents'
+                ELSE '[]'::jsonb
+            END
+        ) WITH ORDINALITY AS source_item(value, ordinality)
+        JOIN uploaded_documents document
+          ON (source_item.value ->> 'doc_id') ~* '^{UUID_RE}$'
+         AND document.id = (source_item.value ->> 'doc_id')::uuid
+         AND document.user_id = atomic.user_id
+        ORDER BY atomic.id, document.id, source_item.ordinality
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+    op.execute(
+        f"""
+        INSERT INTO atomic_position_source_documents (
+            atomic_position_id, uploaded_document_id, doc_type, ordinal, created_at, updated_at
+        )
+        SELECT DISTINCT ON (position.id, document.id)
+            position.id,
+            document.id,
+            COALESCE(NULLIF(source_item.value ->> 'doc_type', ''), 'legacy'),
+            source_item.ordinality::integer - 1,
+            now(),
+            now()
+        FROM atomic_positions position
+        CROSS JOIN LATERAL jsonb_array_elements(
+            CASE
+                WHEN jsonb_typeof(position.source_documents) = 'array' THEN position.source_documents
+                WHEN jsonb_typeof(position.source_documents) = 'object'
+                 AND jsonb_typeof(position.source_documents -> 'documents') = 'array'
+                    THEN position.source_documents -> 'documents'
+                ELSE '[]'::jsonb
+            END
+        ) WITH ORDINALITY AS source_item(value, ordinality)
+        JOIN uploaded_documents document
+          ON (source_item.value ->> 'doc_id') ~* '^{UUID_RE}$'
+         AND document.id = (source_item.value ->> 'doc_id')::uuid
+         AND document.user_id = position.user_id
+        ORDER BY position.id, document.id, source_item.ordinality
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+    op.create_unique_constraint("uq_evidence_nodes_user_id", "evidence_nodes", ["user_id", "id"])
+    op.drop_constraint("evidence_edges_from_node_id_fkey", "evidence_edges", type_="foreignkey")
+    op.drop_constraint("evidence_edges_to_node_id_fkey", "evidence_edges", type_="foreignkey")
+    op.create_foreign_key(
+        "fk_evidence_edges_user_from_node",
+        "evidence_edges",
+        "evidence_nodes",
+        ["user_id", "from_node_id"],
+        ["user_id", "id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_evidence_edges_user_to_node",
+        "evidence_edges",
+        "evidence_nodes",
+        ["user_id", "to_node_id"],
+        ["user_id", "id"],
+        ondelete="CASCADE",
+    )
+
+    op.execute(AUDIT_ANCHOR_FUNCTION_DDL)
+    for table_name, trigger_name, function_name in [
+        (
+            "reconciliation_match_journal_entries",
+            "trg_reconciliation_match_journal_entries_same_user",
+            "fr_validate_reconciliation_match_journal_entry_user",
+        ),
+        (
+            "atomic_transaction_source_documents",
+            "trg_atomic_transaction_source_documents_same_user",
+            "fr_validate_atomic_transaction_source_document_user",
+        ),
+        (
+            "atomic_position_source_documents",
+            "trg_atomic_position_source_documents_same_user",
+            "fr_validate_atomic_position_source_document_user",
+        ),
+        ("journal_lines", "trg_journal_lines_account_same_user", "fr_validate_journal_line_account_user"),
+        (
+            "statement_summaries",
+            "trg_statement_summaries_account_same_user",
+            "fr_validate_statement_summary_account_user",
+        ),
+        (
+            "classification_rules",
+            "trg_classification_rules_default_account_same_user",
+            "fr_validate_classification_rule_account_user",
+        ),
+        (
+            "transaction_classification",
+            "trg_transaction_classification_user_scope",
+            "fr_validate_transaction_classification_user_scope",
+        ),
+        ("evidence_edges", "trg_evidence_edges_same_user_endpoints", "fr_validate_evidence_edge_tenant_scope"),
+    ]:
+        op.execute(
+            f"""
+            CREATE TRIGGER {trigger_name}
+            BEFORE INSERT OR UPDATE ON {table_name}
+            FOR EACH ROW EXECUTE FUNCTION {function_name}()
+            """
+        )
+
+
+def downgrade() -> None:
+    for table_name, trigger_name in [
+        ("evidence_edges", "trg_evidence_edges_same_user_endpoints"),
+        ("transaction_classification", "trg_transaction_classification_user_scope"),
+        ("classification_rules", "trg_classification_rules_default_account_same_user"),
+        ("statement_summaries", "trg_statement_summaries_account_same_user"),
+        ("journal_lines", "trg_journal_lines_account_same_user"),
+        ("atomic_position_source_documents", "trg_atomic_position_source_documents_same_user"),
+        ("atomic_transaction_source_documents", "trg_atomic_transaction_source_documents_same_user"),
+        ("reconciliation_match_journal_entries", "trg_reconciliation_match_journal_entries_same_user"),
+    ]:
+        op.execute(f"DROP TRIGGER IF EXISTS {trigger_name} ON {table_name}")
+
+    for function_name in [
+        "fr_validate_evidence_edge_tenant_scope",
+        "fr_validate_transaction_classification_user_scope",
+        "fr_validate_classification_rule_account_user",
+        "fr_validate_statement_summary_account_user",
+        "fr_validate_journal_line_account_user",
+        "fr_validate_atomic_position_source_document_user",
+        "fr_validate_atomic_transaction_source_document_user",
+        "fr_validate_reconciliation_match_journal_entry_user",
+    ]:
+        op.execute(f"DROP FUNCTION IF EXISTS {function_name}()")
+
+    op.drop_constraint("fk_evidence_edges_user_to_node", "evidence_edges", type_="foreignkey")
+    op.drop_constraint("fk_evidence_edges_user_from_node", "evidence_edges", type_="foreignkey")
+    op.create_foreign_key(
+        "evidence_edges_to_node_id_fkey",
+        "evidence_edges",
+        "evidence_nodes",
+        ["to_node_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "evidence_edges_from_node_id_fkey",
+        "evidence_edges",
+        "evidence_nodes",
+        ["from_node_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.drop_constraint("uq_evidence_nodes_user_id", "evidence_nodes", type_="unique")
+
+    op.drop_index("idx_atomic_position_source_docs_document", table_name="atomic_position_source_documents")
+    op.drop_table("atomic_position_source_documents")
+    op.drop_index("idx_atomic_txn_source_docs_document", table_name="atomic_transaction_source_documents")
+    op.drop_table("atomic_transaction_source_documents")
+    op.drop_index("idx_reconciliation_match_journal_entries_entry", table_name="reconciliation_match_journal_entries")
+    op.drop_table("reconciliation_match_journal_entries")

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -14,7 +14,13 @@ from src.models.journal import (
     JournalLine,
 )
 from src.models.layer1 import DocumentStatus, DocumentType, UploadedDocument
-from src.models.layer2 import AtomicPosition, AtomicTransaction, TransactionDirection
+from src.models.layer2 import (
+    AtomicPosition,
+    AtomicPositionSourceDocument,
+    AtomicTransaction,
+    AtomicTransactionSourceDocument,
+    TransactionDirection,
+)
 from src.models.layer3 import (
     ClassificationRule,
     ClassificationStatus,
@@ -38,7 +44,7 @@ from src.models.portfolio import (
     MarketDataOverride,
     PriceSource,
 )
-from src.models.reconciliation import ReconciliationMatch, ReconciliationStatus
+from src.models.reconciliation import ReconciliationMatch, ReconciliationMatchJournalEntry, ReconciliationStatus
 from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
 from src.models.user import AiFeedback, User
@@ -57,7 +63,9 @@ __all__ = [
     "AccountType",
     "AiFeedback",
     "AtomicPosition",
+    "AtomicPositionSourceDocument",
     "AtomicTransaction",
+    "AtomicTransactionSourceDocument",
     "BankStatementStatus",
     "ChatMessage",
     "ChatMessageRole",
@@ -94,6 +102,7 @@ __all__ = [
     "ManualValuationLiquidityClass",
     "ManualValuationSnapshot",
     "ReconciliationMatch",
+    "ReconciliationMatchJournalEntry",
     "ReconciliationStatus",
     "ReportSnapshot",
     "ReportType",

--- a/apps/backend/src/models/evidence.py
+++ b/apps/backend/src/models/evidence.py
@@ -3,9 +3,9 @@
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, ForeignKeyConstraint, Index, String, UniqueConstraint, event
+from sqlalchemy import ForeignKey, ForeignKeyConstraint, Index, String, UniqueConstraint, and_, event
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
 
 from src.database import Base
 from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
@@ -34,13 +34,22 @@ class EvidenceNode(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
 
     outgoing_edges: Mapped[list["EvidenceEdge"]] = relationship(
         back_populates="from_node",
-        foreign_keys="EvidenceEdge.from_node_id",
+        primaryjoin=lambda: and_(
+            EvidenceNode.user_id == foreign(EvidenceEdge.user_id),
+            EvidenceNode.id == foreign(EvidenceEdge.from_node_id),
+        ),
+        foreign_keys=lambda: [EvidenceEdge.user_id, EvidenceEdge.from_node_id],
         cascade="all, delete-orphan",
     )
     incoming_edges: Mapped[list["EvidenceEdge"]] = relationship(
         back_populates="to_node",
-        foreign_keys="EvidenceEdge.to_node_id",
+        primaryjoin=lambda: and_(
+            EvidenceNode.user_id == foreign(EvidenceEdge.user_id),
+            EvidenceNode.id == foreign(EvidenceEdge.to_node_id),
+        ),
+        foreign_keys=lambda: [EvidenceEdge.user_id, EvidenceEdge.to_node_id],
         cascade="all, delete-orphan",
+        overlaps="from_node,outgoing_edges",
     )
 
 
@@ -86,11 +95,20 @@ class EvidenceEdge(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
 
     from_node: Mapped[EvidenceNode] = relationship(
         back_populates="outgoing_edges",
-        foreign_keys=[from_node_id],
+        primaryjoin=lambda: and_(
+            EvidenceNode.user_id == foreign(EvidenceEdge.user_id),
+            EvidenceNode.id == foreign(EvidenceEdge.from_node_id),
+        ),
+        foreign_keys=lambda: [EvidenceEdge.user_id, EvidenceEdge.from_node_id],
     )
     to_node: Mapped[EvidenceNode] = relationship(
         back_populates="incoming_edges",
-        foreign_keys=[to_node_id],
+        primaryjoin=lambda: and_(
+            EvidenceNode.user_id == foreign(EvidenceEdge.user_id),
+            EvidenceNode.id == foreign(EvidenceEdge.to_node_id),
+        ),
+        foreign_keys=lambda: [EvidenceEdge.user_id, EvidenceEdge.to_node_id],
+        overlaps="from_node,outgoing_edges",
     )
 
 

--- a/apps/backend/src/models/evidence.py
+++ b/apps/backend/src/models/evidence.py
@@ -1,8 +1,9 @@
 """Evidence graph models for audit lineage."""
 
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy import ForeignKey, ForeignKeyConstraint, Index, String, UniqueConstraint, event
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -16,6 +17,7 @@ class EvidenceNode(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     __tablename__ = "evidence_nodes"
     __table_args__ = (
         UniqueConstraint("user_id", "node_kind", "entity_type", "entity_id", name="uq_evidence_nodes_user_entity"),
+        UniqueConstraint("user_id", "id", name="uq_evidence_nodes_user_id"),
         Index("idx_evidence_nodes_user_entity", "user_id", "entity_type", "entity_id"),
         Index("idx_evidence_nodes_user_kind", "user_id", "node_kind"),
     )
@@ -48,6 +50,18 @@ class EvidenceEdge(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     __tablename__ = "evidence_edges"
     __table_args__ = (
         UniqueConstraint("user_id", "from_node_id", "to_node_id", "relation", name="uq_evidence_edges_user_relation"),
+        ForeignKeyConstraint(
+            ["user_id", "from_node_id"],
+            ["evidence_nodes.user_id", "evidence_nodes.id"],
+            name="fk_evidence_edges_user_from_node",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["user_id", "to_node_id"],
+            ["evidence_nodes.user_id", "evidence_nodes.id"],
+            name="fk_evidence_edges_user_to_node",
+            ondelete="CASCADE",
+        ),
         Index("idx_evidence_edges_user_from", "user_id", "from_node_id"),
         Index("idx_evidence_edges_user_to", "user_id", "to_node_id"),
         Index("idx_evidence_edges_user_relation_from", "user_id", "relation", "from_node_id"),
@@ -61,12 +75,10 @@ class EvidenceEdge(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     )
     from_node_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey("evidence_nodes.id", ondelete="CASCADE"),
         nullable=False,
     )
     to_node_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey("evidence_nodes.id", ondelete="CASCADE"),
         nullable=False,
     )
     relation: Mapped[str] = mapped_column(String(100), nullable=False)
@@ -80,3 +92,312 @@ class EvidenceEdge(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
         back_populates="incoming_edges",
         foreign_keys=[to_node_id],
     )
+
+
+_AUDIT_ANCHOR_SCOPE_SQL = """
+CREATE OR REPLACE FUNCTION fr_validate_reconciliation_match_journal_entry_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_match_user_id uuid;
+    v_entry_user_id uuid;
+BEGIN
+    SELECT atomic.user_id
+    INTO v_match_user_id
+    FROM reconciliation_matches match
+    JOIN atomic_transactions atomic ON atomic.id = match.atomic_txn_id
+    WHERE match.id = NEW.match_id;
+
+    SELECT entry.user_id
+    INTO v_entry_user_id
+    FROM journal_entries entry
+    WHERE entry.id = NEW.journal_entry_id;
+
+    IF v_match_user_id IS NULL OR v_entry_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_match_user_id <> v_entry_user_id THEN
+        RAISE EXCEPTION 'reconciliation match % cannot link cross-user journal entry %',
+            NEW.match_id, NEW.journal_entry_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_reconciliation_match_journal_entries_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_atomic_transaction_source_document_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_atomic_user_id uuid;
+    v_document_user_id uuid;
+BEGIN
+    SELECT user_id INTO v_atomic_user_id
+    FROM atomic_transactions
+    WHERE id = NEW.atomic_txn_id;
+
+    SELECT user_id INTO v_document_user_id
+    FROM uploaded_documents
+    WHERE id = NEW.uploaded_document_id;
+
+    IF v_atomic_user_id IS NULL OR v_document_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_atomic_user_id <> v_document_user_id THEN
+        RAISE EXCEPTION 'atomic transaction % cannot link cross-user uploaded document %',
+            NEW.atomic_txn_id, NEW.uploaded_document_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_atomic_transaction_source_documents_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_atomic_position_source_document_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_atomic_user_id uuid;
+    v_document_user_id uuid;
+BEGIN
+    SELECT user_id INTO v_atomic_user_id
+    FROM atomic_positions
+    WHERE id = NEW.atomic_position_id;
+
+    SELECT user_id INTO v_document_user_id
+    FROM uploaded_documents
+    WHERE id = NEW.uploaded_document_id;
+
+    IF v_atomic_user_id IS NULL OR v_document_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_atomic_user_id <> v_document_user_id THEN
+        RAISE EXCEPTION 'atomic position % cannot link cross-user uploaded document %',
+            NEW.atomic_position_id, NEW.uploaded_document_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_atomic_position_source_documents_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_journal_line_account_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_entry_user_id uuid;
+    v_account_user_id uuid;
+BEGIN
+    SELECT user_id INTO v_entry_user_id
+    FROM journal_entries
+    WHERE id = NEW.journal_entry_id;
+
+    SELECT user_id INTO v_account_user_id
+    FROM accounts
+    WHERE id = NEW.account_id;
+
+    IF v_entry_user_id IS NULL OR v_account_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_entry_user_id <> v_account_user_id THEN
+        RAISE EXCEPTION 'journal line % cannot reference cross-user account %',
+            NEW.id, NEW.account_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_journal_lines_account_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_statement_summary_account_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_account_user_id uuid;
+BEGIN
+    IF NEW.account_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT user_id INTO v_account_user_id
+    FROM accounts
+    WHERE id = NEW.account_id;
+
+    IF v_account_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.user_id <> v_account_user_id THEN
+        RAISE EXCEPTION 'statement summary % cannot reference cross-user account %',
+            NEW.id, NEW.account_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_statement_summaries_account_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_classification_rule_account_user()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_account_user_id uuid;
+BEGIN
+    IF NEW.default_account_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT user_id INTO v_account_user_id
+    FROM accounts
+    WHERE id = NEW.default_account_id;
+
+    IF v_account_user_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.user_id <> v_account_user_id THEN
+        RAISE EXCEPTION 'classification rule % cannot reference cross-user default account %',
+            NEW.id, NEW.default_account_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_classification_rules_default_account_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION fr_validate_transaction_classification_user_scope()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_atomic_user_id uuid;
+    v_rule_user_id uuid;
+    v_account_user_id uuid;
+BEGIN
+    SELECT user_id INTO v_atomic_user_id
+    FROM atomic_transactions
+    WHERE id = NEW.atomic_txn_id;
+
+    SELECT user_id INTO v_rule_user_id
+    FROM classification_rules
+    WHERE id = NEW.rule_version_id;
+
+    IF v_atomic_user_id IS NOT NULL
+       AND v_rule_user_id IS NOT NULL
+       AND v_atomic_user_id <> v_rule_user_id THEN
+        RAISE EXCEPTION 'transaction classification % cannot link cross-user rule %',
+            NEW.id, NEW.rule_version_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_transaction_classification_rule_same_user';
+    END IF;
+
+    IF NEW.account_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT user_id INTO v_account_user_id
+    FROM accounts
+    WHERE id = NEW.account_id;
+
+    IF v_atomic_user_id IS NOT NULL
+       AND v_account_user_id IS NOT NULL
+       AND v_atomic_user_id <> v_account_user_id THEN
+        RAISE EXCEPTION 'transaction classification % cannot reference cross-user account %',
+            NEW.id, NEW.account_id
+            USING ERRCODE = '23514',
+                  CONSTRAINT = 'ck_transaction_classification_account_same_user';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_reconciliation_match_journal_entries_same_user ON reconciliation_match_journal_entries;
+CREATE TRIGGER trg_reconciliation_match_journal_entries_same_user
+BEFORE INSERT OR UPDATE ON reconciliation_match_journal_entries
+FOR EACH ROW EXECUTE FUNCTION fr_validate_reconciliation_match_journal_entry_user();
+
+DROP TRIGGER IF EXISTS trg_atomic_transaction_source_documents_same_user ON atomic_transaction_source_documents;
+CREATE TRIGGER trg_atomic_transaction_source_documents_same_user
+BEFORE INSERT OR UPDATE ON atomic_transaction_source_documents
+FOR EACH ROW EXECUTE FUNCTION fr_validate_atomic_transaction_source_document_user();
+
+DROP TRIGGER IF EXISTS trg_atomic_position_source_documents_same_user ON atomic_position_source_documents;
+CREATE TRIGGER trg_atomic_position_source_documents_same_user
+BEFORE INSERT OR UPDATE ON atomic_position_source_documents
+FOR EACH ROW EXECUTE FUNCTION fr_validate_atomic_position_source_document_user();
+
+DROP TRIGGER IF EXISTS trg_journal_lines_account_same_user ON journal_lines;
+CREATE TRIGGER trg_journal_lines_account_same_user
+BEFORE INSERT OR UPDATE ON journal_lines
+FOR EACH ROW EXECUTE FUNCTION fr_validate_journal_line_account_user();
+
+DROP TRIGGER IF EXISTS trg_statement_summaries_account_same_user ON statement_summaries;
+CREATE TRIGGER trg_statement_summaries_account_same_user
+BEFORE INSERT OR UPDATE ON statement_summaries
+FOR EACH ROW EXECUTE FUNCTION fr_validate_statement_summary_account_user();
+
+DROP TRIGGER IF EXISTS trg_classification_rules_default_account_same_user ON classification_rules;
+CREATE TRIGGER trg_classification_rules_default_account_same_user
+BEFORE INSERT OR UPDATE ON classification_rules
+FOR EACH ROW EXECUTE FUNCTION fr_validate_classification_rule_account_user();
+
+DROP TRIGGER IF EXISTS trg_transaction_classification_user_scope ON transaction_classification;
+CREATE TRIGGER trg_transaction_classification_user_scope
+BEFORE INSERT OR UPDATE ON transaction_classification
+FOR EACH ROW EXECUTE FUNCTION fr_validate_transaction_classification_user_scope();
+"""
+
+
+def _split_postgresql_ddl(sql: str) -> tuple[str, ...]:
+    statements: list[str] = []
+    start = 0
+    in_dollar_quote = False
+    index = 0
+
+    while index < len(sql):
+        if sql.startswith("$$", index):
+            in_dollar_quote = not in_dollar_quote
+            index += 2
+            continue
+
+        if sql[index] == ";" and not in_dollar_quote:
+            statement = sql[start : index + 1].strip()
+            if statement:
+                statements.append(statement)
+            start = index + 1
+
+        index += 1
+
+    trailing = sql[start:].strip()
+    if trailing:
+        statements.append(trailing)
+    return tuple(statements)
+
+
+def _install_audit_anchor_scope_ddl(target: Any, connection: Any, **_: Any) -> None:
+    if connection.dialect.name != "postgresql":
+        return
+
+    for statement in _split_postgresql_ddl(_AUDIT_ANCHOR_SCOPE_SQL):
+        connection.exec_driver_sql(statement)
+
+
+event.listen(Base.metadata, "after_create", _install_audit_anchor_scope_ddl)

--- a/apps/backend/src/models/layer2.py
+++ b/apps/backend/src/models/layer2.py
@@ -3,10 +3,22 @@
 from datetime import date
 from decimal import Decimal
 from enum import Enum
+from uuid import UUID
 
-from sqlalchemy import CheckConstraint, Date, Enum as SQLEnum, Numeric, String, Text, UniqueConstraint
-from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    Enum as SQLEnum,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
 from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
@@ -81,6 +93,29 @@ class AtomicTransaction(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
         return f"<AtomicTransaction {self.txn_date} {self.direction.value} {self.amount} {self.currency}>"
 
 
+class AtomicTransactionSourceDocument(Base, TimestampMixin):
+    """Trusted normalized source-document anchor for an atomic transaction."""
+
+    __tablename__ = "atomic_transaction_source_documents"
+    __table_args__ = (Index("idx_atomic_txn_source_docs_document", "uploaded_document_id"),)
+
+    atomic_txn_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("atomic_transactions.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    uploaded_document_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("uploaded_documents.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    doc_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    atomic_transaction: Mapped[AtomicTransaction] = relationship("AtomicTransaction")
+    uploaded_document = relationship("UploadedDocument")
+
+
 class AtomicPosition(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """
     Layer 2: Deduplicated position snapshots.
@@ -138,3 +173,26 @@ class AtomicPosition(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
             f"<AtomicPosition {self.snapshot_date} {self.asset_identifier} "
             f"{self.quantity} @ {self.market_value} {self.currency}>"
         )
+
+
+class AtomicPositionSourceDocument(Base, TimestampMixin):
+    """Trusted normalized source-document anchor for an atomic position snapshot."""
+
+    __tablename__ = "atomic_position_source_documents"
+    __table_args__ = (Index("idx_atomic_position_source_docs_document", "uploaded_document_id"),)
+
+    atomic_position_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("atomic_positions.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    uploaded_document_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("uploaded_documents.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    doc_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    atomic_position: Mapped[AtomicPosition] = relationship("AtomicPosition")
+    uploaded_document = relationship("UploadedDocument")

--- a/apps/backend/src/models/reconciliation.py
+++ b/apps/backend/src/models/reconciliation.py
@@ -59,3 +59,24 @@ class ReconciliationMatch(Base, UUIDMixin, TimestampMixin):
         "AtomicTransaction",
         foreign_keys=[atomic_txn_id],
     )
+
+
+class ReconciliationMatchJournalEntry(Base, TimestampMixin):
+    """Trusted normalized journal-entry anchor for a reconciliation match."""
+
+    __tablename__ = "reconciliation_match_journal_entries"
+    __table_args__ = (Index("idx_reconciliation_match_journal_entries_entry", "journal_entry_id"),)
+
+    match_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("reconciliation_matches.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    journal_entry_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("journal_entries.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+
+    reconciliation_match: Mapped[ReconciliationMatch] = relationship("ReconciliationMatch")
+    journal_entry = relationship("JournalEntry")

--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -10,7 +10,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.logger import get_logger
 from src.models.layer1 import DocumentType, UploadedDocument
-from src.models.layer2 import AtomicPosition, AtomicTransaction, TransactionDirection
+from src.models.layer2 import (
+    AtomicPosition,
+    AtomicPositionSourceDocument,
+    AtomicTransaction,
+    AtomicTransactionSourceDocument,
+    TransactionDirection,
+)
 from src.models.statement_summary import StatementSummary
 
 logger = get_logger(__name__)
@@ -139,6 +145,14 @@ class DeduplicationService:
                 source_docs.append(source_doc)
                 existing.source_documents = source_docs
                 await db.flush()
+            await self._upsert_transaction_source_link(
+                db,
+                user_id=user_id,
+                atomic_txn_id=existing.id,
+                source_doc_id=source_doc_id,
+                source_doc_type=source_doc_type,
+                ordinal=source_docs.index(source_doc) if source_doc in source_docs else 0,
+            )
 
             logger.info(
                 f"Appended source document to existing atomic transaction {existing.id}",
@@ -163,6 +177,14 @@ class DeduplicationService:
         )
         db.add(new_txn)
         await db.flush()
+        await self._upsert_transaction_source_link(
+            db,
+            user_id=user_id,
+            atomic_txn_id=new_txn.id,
+            source_doc_id=source_doc_id,
+            source_doc_type=source_doc_type,
+            ordinal=0,
+        )
 
         logger.info(
             f"Created new atomic transaction {new_txn.id}",
@@ -216,6 +238,14 @@ class DeduplicationService:
                 source_docs.append(source_doc)
                 existing.source_documents = source_docs
                 await db.flush()
+            await self._upsert_position_source_link(
+                db,
+                user_id=user_id,
+                atomic_position_id=existing.id,
+                source_doc_id=source_doc_id,
+                source_doc_type=source_doc_type,
+                ordinal=source_docs.index(source_doc) if source_doc in source_docs else 0,
+            )
 
             logger.info(
                 f"Appended source document to existing atomic position {existing.id}",
@@ -240,6 +270,14 @@ class DeduplicationService:
         )
         db.add(new_pos)
         await db.flush()
+        await self._upsert_position_source_link(
+            db,
+            user_id=user_id,
+            atomic_position_id=new_pos.id,
+            source_doc_id=source_doc_id,
+            source_doc_type=source_doc_type,
+            ordinal=0,
+        )
 
         logger.info(
             f"Created new atomic position {new_pos.id}",
@@ -251,6 +289,64 @@ class DeduplicationService:
             },
         )
         return new_pos
+
+    async def _upsert_transaction_source_link(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        atomic_txn_id: UUID,
+        source_doc_id: UUID,
+        source_doc_type: DocumentType,
+        ordinal: int,
+    ) -> None:
+        document = await db.get(UploadedDocument, source_doc_id)
+        if document is None or document.user_id != user_id:
+            return
+
+        existing = await db.get(AtomicTransactionSourceDocument, (atomic_txn_id, source_doc_id))
+        if existing is None:
+            db.add(
+                AtomicTransactionSourceDocument(
+                    atomic_txn_id=atomic_txn_id,
+                    uploaded_document_id=source_doc_id,
+                    doc_type=source_doc_type.value,
+                    ordinal=ordinal,
+                )
+            )
+        else:
+            existing.doc_type = source_doc_type.value
+            existing.ordinal = ordinal
+        await db.flush()
+
+    async def _upsert_position_source_link(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        atomic_position_id: UUID,
+        source_doc_id: UUID,
+        source_doc_type: DocumentType,
+        ordinal: int,
+    ) -> None:
+        document = await db.get(UploadedDocument, source_doc_id)
+        if document is None or document.user_id != user_id:
+            return
+
+        existing = await db.get(AtomicPositionSourceDocument, (atomic_position_id, source_doc_id))
+        if existing is None:
+            db.add(
+                AtomicPositionSourceDocument(
+                    atomic_position_id=atomic_position_id,
+                    uploaded_document_id=source_doc_id,
+                    doc_type=source_doc_type.value,
+                    ordinal=ordinal,
+                )
+            )
+        else:
+            existing.doc_type = source_doc_type.value
+            existing.ordinal = ordinal
+        await db.flush()
 
     async def create_uploaded_document(
         self,
@@ -315,6 +411,12 @@ async def _detach_document_from_atomic_transactions(db: Any, user_id: UUID, doc_
             db.add(txn)
         else:
             await db.delete(txn)
+        await db.execute(
+            AtomicTransactionSourceDocument.__table__.delete().where(
+                AtomicTransactionSourceDocument.atomic_txn_id == txn.id,
+                AtomicTransactionSourceDocument.uploaded_document_id == doc_id,
+            )
+        )
     if rows:
         await db.flush()
 

--- a/apps/backend/src/services/evidence_graph_integration.py
+++ b/apps/backend/src/services/evidence_graph_integration.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models.evidence import EvidenceNode
 from src.models.journal import JournalEntry, JournalLine
 from src.models.layer1 import DocumentType, UploadedDocument
-from src.models.layer2 import AtomicTransaction
+from src.models.layer2 import AtomicTransaction, AtomicTransactionSourceDocument
 from src.models.statement_summary import StatementSummary
 from src.services.evidence_lineage import EvidenceLineageService
 
@@ -71,6 +71,17 @@ class EvidenceGraphIntegrationService:
         if uploaded_document.id is None or atomic_transaction.id is None:
             return
         doc_type = document_type or uploaded_document.document_type
+        existing_link = await db.get(AtomicTransactionSourceDocument, (atomic_transaction.id, uploaded_document.id))
+        if existing_link is None:
+            db.add(
+                AtomicTransactionSourceDocument(
+                    atomic_txn_id=atomic_transaction.id,
+                    uploaded_document_id=uploaded_document.id,
+                    doc_type=doc_type.value if doc_type is not None else uploaded_document.document_type.value,
+                    ordinal=0,
+                )
+            )
+            await db.flush()
         source_node = await self.lineage.upsert_node(
             db,
             user_id=user_id,

--- a/apps/backend/src/services/evidence_graph_materialization.py
+++ b/apps/backend/src/services/evidence_graph_materialization.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import aliased, selectinload
 from src.models.evidence import EvidenceEdge, EvidenceNode
 from src.models.journal import JournalEntry, JournalEntrySourceType, JournalLine
 from src.models.layer1 import UploadedDocument
-from src.models.layer2 import AtomicTransaction
+from src.models.layer2 import AtomicTransaction, AtomicTransactionSourceDocument
 from src.models.statement_summary import StatementSummary
 from src.services.evidence_graph_integration import _ordered_source_doc_ids
 from src.services.evidence_lineage import EvidenceLineageService
@@ -376,6 +376,46 @@ class EvidenceGraphMaterializationService:
         (``source_documents``) and links each one straight to the atomic fact. The
         legacy extracted-record middle node is dropped.
         """
+        linked_documents = (
+            (
+                await db.execute(
+                    select(UploadedDocument)
+                    .join(
+                        AtomicTransactionSourceDocument,
+                        AtomicTransactionSourceDocument.uploaded_document_id == UploadedDocument.id,
+                    )
+                    .where(AtomicTransactionSourceDocument.atomic_txn_id == atomic.id)
+                    .where(UploadedDocument.user_id == user_id)
+                    .order_by(
+                        AtomicTransactionSourceDocument.ordinal.asc(),
+                        AtomicTransactionSourceDocument.uploaded_document_id.asc(),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if linked_documents:
+            for document in linked_documents:
+                source = await self._materialize_uploaded_document(
+                    db, user_id=user_id, document=document, result=result, cap=cap
+                )
+                if source is None:
+                    return
+                edge = await self._upsert_edge(
+                    db,
+                    user_id=user_id,
+                    from_node_id=source.id,
+                    to_node_id=atomic_node.id,
+                    relation="deduped_into",
+                    properties={"dedup_hash": atomic.dedup_hash, "adapter": "lazy_materialization"},
+                    result=result,
+                    cap=cap,
+                )
+                if edge is None:
+                    return
+            return
+
         doc_ids = _ordered_source_doc_ids(atomic.source_documents)
         if not doc_ids:
             return
@@ -394,6 +434,11 @@ class EvidenceGraphMaterializationService:
         for doc_id in doc_ids:
             document = by_id.get(doc_id)
             if document is None:
+                self._add_blocker(
+                    result,
+                    "entity_missing",
+                    "Legacy atomic source document does not resolve to an owned uploaded document.",
+                )
                 continue
             source = await self._materialize_uploaded_document(
                 db, user_id=user_id, document=document, result=result, cap=cap

--- a/apps/backend/src/services/reconciliation.py
+++ b/apps/backend/src/services/reconciliation.py
@@ -754,6 +754,13 @@ async def _get_existing_active_match(
     return result.scalar_one_or_none()
 
 
+def _mark_auto_accepted_entry_reconciled(entry: JournalEntry) -> None:
+    was_immutable = entry.status in (JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED)
+    entry.status = JournalEntryStatus.RECONCILED
+    if not was_immutable:
+        promote_entry_source_type(entry, JournalEntrySourceType.AUTO_MATCHED)
+
+
 def _find_transfer_candidates(
     pending_txns: list[AtomicTransaction],
     atomic_txns: list[JournalEntry],
@@ -1210,8 +1217,7 @@ async def execute_matching(
                 matched_txn_ids.add(txn.id)
                 if status == ReconciliationStatus.AUTO_ACCEPTED:
                     if best_entry.status != JournalEntryStatus.VOID:
-                        best_entry.status = JournalEntryStatus.RECONCILED
-                        promote_entry_source_type(best_entry, JournalEntrySourceType.AUTO_MATCHED)
+                        _mark_auto_accepted_entry_reconciled(best_entry)
 
     # Phase 2: Normal Matching (existing logic)
     # Skip transactions already matched in Phase 1 (transfer detection)
@@ -1325,8 +1331,7 @@ async def execute_matching(
             )
             for entry in result.scalars():
                 if entry.status != JournalEntryStatus.VOID:
-                    entry.status = JournalEntryStatus.RECONCILED
-                    promote_entry_source_type(entry, JournalEntrySourceType.AUTO_MATCHED)
+                    _mark_auto_accepted_entry_reconciled(entry)
 
     # Phase 3: Auto-Pair Transfers (AFTER all matching complete)
     # Find and pair transfers automatically per processing_account.md

--- a/apps/backend/src/services/reconciliation.py
+++ b/apps/backend/src/services/reconciliation.py
@@ -13,7 +13,7 @@ from itertools import combinations
 from pathlib import Path
 from uuid import UUID
 
-from sqlalchemy import distinct, func, select
+from sqlalchemy import delete, distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -28,6 +28,7 @@ from src.models import (
     JournalEntryStatus,
     JournalLine,
     ReconciliationMatch,
+    ReconciliationMatchJournalEntry,
     ReconciliationStatus,
 )
 from src.services.accounting import ValidationError, validate_journal_balance
@@ -1347,6 +1348,8 @@ async def execute_matching(
 
     try:
         await db.flush()
+        for match in matches:
+            await sync_reconciliation_match_journal_entry_links(db, match)
     except Exception as e:
         logger.error(
             "Reconciliation flush failed",
@@ -1359,6 +1362,72 @@ async def execute_matching(
         raise
 
     return matches
+
+
+async def sync_reconciliation_match_journal_entry_links(db: AsyncSession, match: ReconciliationMatch) -> None:
+    """Synchronize trusted reconciliation anchor links from the compatibility JSONB list."""
+    if match.id is None:
+        await db.flush()
+
+    target_ids: list[UUID] = []
+    seen: set[UUID] = set()
+    for raw_entry_id in match.journal_entry_ids or []:
+        try:
+            entry_id = UUID(str(raw_entry_id))
+        except (TypeError, ValueError):
+            continue
+        if entry_id not in seen:
+            seen.add(entry_id)
+            target_ids.append(entry_id)
+
+    if target_ids:
+        match_user_id = (
+            await db.execute(select(AtomicTransaction.user_id).where(AtomicTransaction.id == match.atomic_txn_id))
+        ).scalar_one_or_none()
+        if match_user_id is None:
+            target_ids = []
+        else:
+            valid_entry_ids = set(
+                (
+                    await db.execute(
+                        select(JournalEntry.id)
+                        .where(JournalEntry.id.in_(target_ids))
+                        .where(JournalEntry.user_id == match_user_id)
+                    )
+                ).scalars()
+            )
+            target_ids = [entry_id for entry_id in target_ids if entry_id in valid_entry_ids]
+
+    existing_ids = set(
+        (
+            await db.execute(
+                select(ReconciliationMatchJournalEntry.journal_entry_id).where(
+                    ReconciliationMatchJournalEntry.match_id == match.id
+                )
+            )
+        ).scalars()
+    )
+    target_set = set(target_ids)
+
+    stale_ids = existing_ids - target_set
+    if stale_ids:
+        await db.execute(
+            delete(ReconciliationMatchJournalEntry).where(
+                ReconciliationMatchJournalEntry.match_id == match.id,
+                ReconciliationMatchJournalEntry.journal_entry_id.in_(stale_ids),
+            )
+        )
+
+    for ordinal_entry_id in target_ids:
+        if ordinal_entry_id in existing_ids:
+            continue
+        db.add(
+            ReconciliationMatchJournalEntry(
+                match_id=match.id,
+                journal_entry_id=ordinal_entry_id,
+            )
+        )
+    await db.flush()
 
 
 def auto_accept(match_score: int, config: ReconciliationConfig) -> bool:

--- a/apps/backend/src/services/review_queue.py
+++ b/apps/backend/src/services/review_queue.py
@@ -27,7 +27,7 @@ from src.models.layer3 import ClassificationStatus, TransactionClassification
 from src.models.statement_summary import StatementSummary
 from src.services.accounting import ValidationError, validate_journal_balance, validate_journal_posting_invariants
 from src.services.fx import FxRateError, get_exchange_rate
-from src.services.reconciliation import entry_total_amount
+from src.services.reconciliation import entry_total_amount, sync_reconciliation_match_journal_entry_links
 from src.services.source_type_priority import (
     STATEMENT_SOURCE_TYPES,
     normalize_source_type,
@@ -210,6 +210,7 @@ async def accept_match(
                 promote_entry_source_type(entry, JournalEntrySourceType.USER_CONFIRMED)
 
     await db.flush()
+    await sync_reconciliation_match_journal_entry_links(db, match)
     return match
 
 

--- a/apps/backend/tests/accounting/test_accounting_integration.py
+++ b/apps/backend/tests/accounting/test_accounting_integration.py
@@ -12,6 +12,8 @@ from decimal import Decimal
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
@@ -257,13 +259,13 @@ async def test_AC2_13_1_line_account_ownership_rejects_missing_account(
 
 
 @pytest.mark.asyncio
-async def test_AC2_13_2_post_journal_entry_rejects_cross_user_account(
+async def test_AC2_13_2_journal_lines_reject_cross_user_account_at_db_boundary(
     db: AsyncSession,
     bank_account,
     salary_account,
     test_user_id,
 ):
-    """AC2.13.2: Posting validates that every line account belongs to the entry owner."""
+    """AC2.13.2: Database invariants reject line accounts outside the entry owner."""
     other_user_id = uuid4()
     other_account = Account(
         user_id=other_user_id,
@@ -301,10 +303,10 @@ async def test_AC2_13_2_post_journal_entry_rejects_cross_user_account(
             ),
         ]
     )
-    await db.commit()
 
-    with pytest.raises(ValidationError, match="Account does not belong to user"):
-        await post_journal_entry(db, entry.id, test_user_id)
+    with pytest.raises(IntegrityError, match="cannot reference cross-user account"):
+        await db.flush()
+    await db.rollback()
 
 
 @pytest.mark.asyncio
@@ -368,24 +370,29 @@ async def test_AC2_13_3_balance_queries_ignore_cross_user_entry_headers(
     )
     db.add(polluted_entry)
     await db.flush()
-    db.add_all(
-        [
-            JournalLine(
-                journal_entry_id=polluted_entry.id,
-                account_id=other_account.id,
-                direction=Direction.DEBIT,
-                amount=Decimal("99.00"),
-                currency="SGD",
-            ),
-            JournalLine(
-                journal_entry_id=polluted_entry.id,
-                account_id=salary_account.id,
-                direction=Direction.CREDIT,
-                amount=Decimal("99.00"),
-                currency="SGD",
-            ),
-        ]
-    )
+    try:
+        await db.execute(text("SET LOCAL session_replication_role = replica"))
+        db.add_all(
+            [
+                JournalLine(
+                    journal_entry_id=polluted_entry.id,
+                    account_id=other_account.id,
+                    direction=Direction.DEBIT,
+                    amount=Decimal("99.00"),
+                    currency="SGD",
+                ),
+                JournalLine(
+                    journal_entry_id=polluted_entry.id,
+                    account_id=salary_account.id,
+                    direction=Direction.CREDIT,
+                    amount=Decimal("99.00"),
+                    currency="SGD",
+                ),
+            ]
+        )
+        await db.flush()
+    finally:
+        await db.execute(text("SET LOCAL session_replication_role = DEFAULT"))
     await db.commit()
 
     balances = await calculate_account_balances(db, [other_account], other_user_id)

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -23,7 +23,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException, UploadFile, status
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
@@ -2175,34 +2175,27 @@ async def test_approve_statement_stage1_blocks_missing_account_metadata(db, test
 
 async def test_approve_statement_stage1_blocks_invalid_explicit_account_mapping(db, test_user):
     """AC3.6.2: Stage 1 posting blocks stale statement account references."""
-    from uuid import uuid4
-
     user_id = test_user.id
-    other_user_account = Account(
-        user_id=uuid4(),
-        name="Other User Bank",
-        type=AccountType.ASSET,
-        currency="SGD",
-    )
-    db.add(other_user_account)
-    await db.flush()
 
     statement = build_statement(user_id, "hash_s1_invalid_account_mapping", 90)
     statement.status = BankStatementStatus.PARSED
-    statement.account_id = other_user_account.id
+    statement.account_id = uuid4()
     statement.closing_balance = Decimal("120.00")
     db.add(statement)
-    await db.flush()
-    statement_id = statement.id
-
-    await add_txn(
-        db,
-        statement_id,
-        txn_date=date(2025, 1, 6),
-        description="Salary",
-        amount=Decimal("20.00"),
-        direction="IN",
-    )
+    try:
+        await db.execute(text("SET LOCAL session_replication_role = replica"))
+        await db.flush()
+        statement_id = statement.id
+        await add_txn(
+            db,
+            statement_id,
+            txn_date=date(2025, 1, 6),
+            description="Salary",
+            amount=Decimal("20.00"),
+            direction="IN",
+        )
+    finally:
+        await db.execute(text("SET LOCAL session_replication_role = DEFAULT"))
     await db.commit()
 
     with pytest.raises(HTTPException) as exc:

--- a/apps/backend/tests/infra/test_audit_anchor_schema_invariants.py
+++ b/apps/backend/tests/infra/test_audit_anchor_schema_invariants.py
@@ -8,9 +8,10 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from src.models.account import Account, AccountType
 from src.models.evidence import EvidenceEdge, EvidenceNode
@@ -309,6 +310,61 @@ async def test_AC18_11_3_evidence_edges_reject_cross_user_endpoints(
             properties={},
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_AC18_11_3_evidence_edge_relationships_preserve_tenant_scope(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC18.11.3: ORM evidence edge relationships honor tenant-scoped composite FKs."""
+    other_user = await _make_user(db, email_prefix="anchor-edge-relationship-other")
+    source = EvidenceNode(
+        user_id=test_user.id,
+        node_kind="source_document",
+        entity_type="uploaded_document",
+        entity_id=uuid4(),
+        properties={},
+    )
+    other_target = EvidenceNode(
+        user_id=other_user.id,
+        node_kind="atomic_fact",
+        entity_type="atomic_transaction",
+        entity_id=uuid4(),
+        properties={},
+    )
+    db.add_all([source, other_target])
+    await db.flush()
+
+    edge = EvidenceEdge(
+        user_id=test_user.id,
+        from_node_id=source.id,
+        to_node_id=other_target.id,
+        relation="deduped_into",
+        properties={},
+    )
+    await db.execute(text("SET LOCAL session_replication_role = replica"))
+    try:
+        db.add(edge)
+        await db.flush()
+    finally:
+        await db.execute(text("SET LOCAL session_replication_role = DEFAULT"))
+
+    edge_id = edge.id
+    source_id = source.id
+    db.expunge_all()
+
+    reloaded = (
+        await db.execute(
+            select(EvidenceEdge)
+            .options(selectinload(EvidenceEdge.from_node), selectinload(EvidenceEdge.to_node))
+            .where(EvidenceEdge.id == edge_id)
+        )
+    ).scalar_one()
+
+    assert reloaded.from_node is not None
+    assert reloaded.from_node.id == source_id
+    assert reloaded.to_node is None
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/infra/test_audit_anchor_schema_invariants.py
+++ b/apps/backend/tests/infra/test_audit_anchor_schema_invariants.py
@@ -1,0 +1,441 @@
+"""Database-level audit anchor invariant tests for issue #846."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.account import Account, AccountType
+from src.models.evidence import EvidenceEdge, EvidenceNode
+from src.models.journal import Direction, JournalEntry, JournalEntrySourceType, JournalEntryStatus, JournalLine
+from src.models.layer1 import DocumentStatus, DocumentType, UploadedDocument
+from src.models.layer2 import (
+    AtomicPosition,
+    AtomicPositionSourceDocument,
+    AtomicTransaction,
+    AtomicTransactionSourceDocument,
+    TransactionDirection,
+)
+from src.models.layer3 import ClassificationRule, ClassificationStatus, RuleType, TransactionClassification
+from src.models.reconciliation import ReconciliationMatch, ReconciliationMatchJournalEntry, ReconciliationStatus
+from src.models.statement_enums import BankStatementStatus
+from src.models.statement_summary import StatementSummary
+from src.models.user import User
+from src.services.evidence_graph_materialization import EvidenceGraphMaterializationService
+from src.services.reconciliation import sync_reconciliation_match_journal_entry_links
+
+BACKEND_DIR = Path(__file__).parent.parent.parent
+MIGRATION_PATH = BACKEND_DIR / "migrations" / "versions" / "0034_audit_anchor_referential_integrity.py"
+RISK_PATH = BACKEND_DIR.parent.parent / "docs" / "ssot" / "migration-risk.yaml"
+
+
+async def _expect_integrity_error(db: AsyncSession, *objects: object) -> None:
+    db.add_all(objects)
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+
+
+async def _make_user(db: AsyncSession, *, email_prefix: str = "anchor") -> User:
+    user = User(
+        email=f"{email_prefix}-{uuid4().hex}@example.com",
+        hashed_password="test",
+        ai_settings={},
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_account(
+    db: AsyncSession,
+    user_id,
+    *,
+    name: str | None = None,
+    account_type: AccountType = AccountType.ASSET,
+) -> Account:
+    account = Account(
+        user_id=user_id,
+        name=name or f"Anchor Account {uuid4()}",
+        type=account_type,
+        currency="SGD",
+    )
+    db.add(account)
+    await db.flush()
+    return account
+
+
+async def _make_document(db: AsyncSession, user_id, *, document_type: DocumentType) -> UploadedDocument:
+    document = UploadedDocument(
+        user_id=user_id,
+        file_path=f"s3://anchor/{uuid4().hex}.csv",
+        file_hash=uuid4().hex + uuid4().hex,
+        original_filename="anchor.csv",
+        document_type=document_type,
+        status=DocumentStatus.COMPLETED,
+    )
+    db.add(document)
+    await db.flush()
+    return document
+
+
+async def _make_atomic_transaction(
+    db: AsyncSession,
+    user_id,
+    *,
+    source_documents: object | None = None,
+) -> AtomicTransaction:
+    atomic = AtomicTransaction(
+        user_id=user_id,
+        txn_date=date(2026, 3, 1),
+        amount=Decimal("42.00"),
+        direction=TransactionDirection.IN,
+        description=f"Anchor txn {uuid4()}",
+        currency="SGD",
+        dedup_hash=uuid4().hex + uuid4().hex,
+        source_documents=source_documents if source_documents is not None else [],
+    )
+    db.add(atomic)
+    await db.flush()
+    return atomic
+
+
+async def _make_atomic_position(
+    db: AsyncSession,
+    user_id,
+    *,
+    source_documents: object | None = None,
+) -> AtomicPosition:
+    position = AtomicPosition(
+        user_id=user_id,
+        snapshot_date=date(2026, 3, 1),
+        asset_identifier=f"ANCHOR-{uuid4().hex[:8]}",
+        broker="Anchor Broker",
+        quantity=Decimal("1.000000"),
+        market_value=Decimal("100.00"),
+        currency="SGD",
+        dedup_hash=uuid4().hex + uuid4().hex,
+        source_documents=source_documents if source_documents is not None else [],
+    )
+    db.add(position)
+    await db.flush()
+    return position
+
+
+async def _make_journal_entry(db: AsyncSession, user_id) -> JournalEntry:
+    entry = JournalEntry(
+        user_id=user_id,
+        entry_date=date(2026, 3, 1),
+        memo=f"Anchor entry {uuid4()}",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.DRAFT,
+    )
+    db.add(entry)
+    await db.flush()
+    return entry
+
+
+async def _make_rule(db: AsyncSession, user_id, *, default_account_id=None) -> ClassificationRule:
+    rule = ClassificationRule(
+        user_id=user_id,
+        version_number=1,
+        effective_date=date(2026, 3, 1),
+        is_active=True,
+        rule_name=f"anchor-rule-{uuid4()}",
+        rule_type=RuleType.KEYWORD_MATCH,
+        rule_config={"keywords": ["anchor"]},
+        default_account_id=default_account_id,
+        created_by=user_id,
+    )
+    db.add(rule)
+    await db.flush()
+    return rule
+
+
+@pytest.mark.asyncio
+async def test_AC18_11_1_reconciliation_links_reject_missing_and_cross_user_entries(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC18.11.1: Trusted reconciliation anchors are normalized and tenant-scoped."""
+    other_user = await _make_user(db, email_prefix="anchor-recon-other")
+    atomic = await _make_atomic_transaction(db, test_user.id)
+    entry = await _make_journal_entry(db, test_user.id)
+    other_entry = await _make_journal_entry(db, other_user.id)
+    missing_entry_id = uuid4()
+    match = ReconciliationMatch(
+        atomic_txn_id=atomic.id,
+        journal_entry_ids=[str(entry.id), str(other_entry.id), str(missing_entry_id), "not-a-uuid"],
+        match_score=100,
+        score_breakdown={"anchor": 100.0},
+        status=ReconciliationStatus.ACCEPTED,
+    )
+    db.add(match)
+    await db.flush()
+    match_id = match.id
+    entry_id = entry.id
+    other_entry_id = other_entry.id
+
+    await sync_reconciliation_match_journal_entry_links(db, match)
+    await db.commit()
+
+    link = await db.get(ReconciliationMatchJournalEntry, (match_id, entry_id))
+    assert link is not None
+    assert await db.get(ReconciliationMatchJournalEntry, (match_id, other_entry_id)) is None
+    assert await db.get(ReconciliationMatchJournalEntry, (match_id, missing_entry_id)) is None
+
+    await _expect_integrity_error(
+        db,
+        ReconciliationMatchJournalEntry(match_id=match_id, journal_entry_id=uuid4()),
+    )
+    await _expect_integrity_error(
+        db,
+        ReconciliationMatchJournalEntry(match_id=match_id, journal_entry_id=other_entry_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_AC18_11_2_atomic_source_links_reject_missing_and_cross_user_documents(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC18.11.2: Trusted atomic source-document anchors are normalized and tenant-scoped."""
+    other_user = await _make_user(db, email_prefix="anchor-doc-other")
+    transaction = await _make_atomic_transaction(db, test_user.id)
+    position = await _make_atomic_position(db, test_user.id)
+    txn_document = await _make_document(db, test_user.id, document_type=DocumentType.BANK_STATEMENT)
+    pos_document = await _make_document(db, test_user.id, document_type=DocumentType.BROKERAGE_STATEMENT)
+    other_document = await _make_document(db, other_user.id, document_type=DocumentType.BANK_STATEMENT)
+    transaction_id = transaction.id
+    position_id = position.id
+    txn_document_id = txn_document.id
+    pos_document_id = pos_document.id
+    other_document_id = other_document.id
+
+    db.add_all(
+        [
+            AtomicTransactionSourceDocument(
+                atomic_txn_id=transaction_id,
+                uploaded_document_id=txn_document_id,
+                doc_type=DocumentType.BANK_STATEMENT.value,
+                ordinal=0,
+            ),
+            AtomicPositionSourceDocument(
+                atomic_position_id=position_id,
+                uploaded_document_id=pos_document_id,
+                doc_type=DocumentType.BROKERAGE_STATEMENT.value,
+                ordinal=0,
+            ),
+        ]
+    )
+    await db.commit()
+
+    await _expect_integrity_error(
+        db,
+        AtomicTransactionSourceDocument(
+            atomic_txn_id=transaction_id,
+            uploaded_document_id=uuid4(),
+            doc_type=DocumentType.BANK_STATEMENT.value,
+            ordinal=1,
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        AtomicPositionSourceDocument(
+            atomic_position_id=position_id,
+            uploaded_document_id=other_document_id,
+            doc_type=DocumentType.BANK_STATEMENT.value,
+            ordinal=1,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_AC18_11_3_evidence_edges_reject_cross_user_endpoints(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC18.11.3: Evidence Graph edges cannot connect nodes across tenants."""
+    other_user = await _make_user(db, email_prefix="anchor-edge-other")
+    source = EvidenceNode(
+        user_id=test_user.id,
+        node_kind="source_document",
+        entity_type="uploaded_document",
+        entity_id=uuid4(),
+        properties={},
+    )
+    target = EvidenceNode(
+        user_id=test_user.id,
+        node_kind="atomic_fact",
+        entity_type="atomic_transaction",
+        entity_id=uuid4(),
+        properties={},
+    )
+    other_target = EvidenceNode(
+        user_id=other_user.id,
+        node_kind="atomic_fact",
+        entity_type="atomic_transaction",
+        entity_id=uuid4(),
+        properties={},
+    )
+    db.add_all([source, target, other_target])
+    await db.flush()
+
+    db.add(
+        EvidenceEdge(
+            user_id=test_user.id,
+            from_node_id=source.id,
+            to_node_id=target.id,
+            relation="deduped_into",
+            properties={},
+        )
+    )
+    await db.commit()
+
+    await _expect_integrity_error(
+        db,
+        EvidenceEdge(
+            user_id=test_user.id,
+            from_node_id=source.id,
+            to_node_id=other_target.id,
+            relation="deduped_into",
+            properties={},
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_AC18_11_4_account_references_reject_cross_user_accounts(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC18.11.4: Account-bearing facts reject cross-user account references."""
+    test_user_id = test_user.id
+    other_user = await _make_user(db, email_prefix="anchor-account-other")
+    own_account = await _make_account(db, test_user_id)
+    other_account = await _make_account(db, other_user.id)
+    entry = await _make_journal_entry(db, test_user_id)
+    atomic = await _make_atomic_transaction(db, test_user_id)
+    rule = await _make_rule(db, test_user_id)
+    own_account_id = own_account.id
+    other_account_id = other_account.id
+    entry_id = entry.id
+    atomic_id = atomic.id
+    rule_id = rule.id
+    await db.commit()
+
+    await _expect_integrity_error(
+        db,
+        JournalLine(
+            journal_entry_id=entry_id,
+            account_id=other_account_id,
+            direction=Direction.DEBIT,
+            amount=Decimal("10.00"),
+            currency="SGD",
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        StatementSummary(
+            user_id=test_user_id,
+            file_hash=uuid4().hex + uuid4().hex,
+            institution="Anchor Bank",
+            account_id=other_account_id,
+            currency="SGD",
+            period_start=date(2026, 3, 1),
+            period_end=date(2026, 3, 31),
+            opening_balance=Decimal("100.00"),
+            closing_balance=Decimal("110.00"),
+            status=BankStatementStatus.APPROVED,
+        ),
+    )
+    await _expect_integrity_error(
+        db,
+        TransactionClassification(
+            atomic_txn_id=atomic_id,
+            rule_version_id=rule_id,
+            account_id=other_account_id,
+            status=ClassificationStatus.APPLIED,
+        ),
+    )
+
+    db.add(
+        TransactionClassification(
+            atomic_txn_id=atomic_id,
+            rule_version_id=rule_id,
+            account_id=own_account_id,
+            status=ClassificationStatus.APPLIED,
+        )
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_AC18_11_5_unresolved_legacy_source_ids_remain_blockers(
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """AC18.11.5: Unresolved legacy source UUIDs remain blockers, not trusted anchors."""
+    entry = JournalEntry(
+        user_id=test_user.id,
+        entry_date=date(2026, 3, 1),
+        memo="Unresolved source",
+        source_type=JournalEntrySourceType.USER_CONFIRMED,
+        source_id=uuid4(),
+        status=JournalEntryStatus.DRAFT,
+    )
+    db.add(entry)
+    await db.flush()
+    account = await _make_account(db, test_user.id)
+    line = JournalLine(
+        journal_entry_id=entry.id,
+        account_id=account.id,
+        direction=Direction.DEBIT,
+        amount=Decimal("10.00"),
+        currency="SGD",
+    )
+    db.add(line)
+    await db.flush()
+
+    result = await EvidenceGraphMaterializationService().materialize_for_entity(
+        db,
+        user_id=test_user.id,
+        entity_type="journal_line",
+        entity_id=line.id,
+        node_kind="ledger_line",
+    )
+
+    assert "entity_missing" in {blocker.code for blocker in result.blockers}
+    trusted_sources = (
+        await db.execute(
+            select(EvidenceNode)
+            .where(EvidenceNode.user_id == test_user.id)
+            .where(EvidenceNode.node_kind == "source_document")
+        )
+    ).scalars()
+    assert list(trusted_sources) == []
+
+
+def test_AC18_11_6_migration_preflights_and_risk_contract_are_declared() -> None:
+    """AC18.11.6: Migration declares compatibility preflights, backfills, and risk metadata."""
+    migration_source = MIGRATION_PATH.read_text()
+    risk_source = RISK_PATH.read_text()
+
+    assert "reconciliation_match_journal_entries" in migration_source
+    assert "atomic_transaction_source_documents" in migration_source
+    assert "atomic_position_source_documents" in migration_source
+    assert "fr_validate_evidence_edge_tenant_scope" in migration_source
+    assert "fr_validate_journal_line_account_user" in migration_source
+    assert "backfill resolvable legacy audit anchors" in migration_source
+    assert "unresolved legacy audit anchors remain preserved" in migration_source
+    assert "raw_entry.entry_id_text ~*" in migration_source
+    assert "(source_item.value ->> 'doc_id') ~*" in migration_source
+    assert "0034_audit_anchor_ri" in risk_source
+    assert "Issue #846" in risk_source or 'issue: "#846"' in risk_source

--- a/apps/backend/tests/reconciliation/test_review_queue.py
+++ b/apps/backend/tests/reconciliation/test_review_queue.py
@@ -20,6 +20,7 @@ from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import (
@@ -615,7 +616,7 @@ async def test_create_entry_from_txn_uses_statement_linked_account(db, test_user
 
 
 @pytest.mark.asyncio
-async def test_create_entry_from_txn_falls_back_when_linked_account_not_owned(db, test_user):
+async def test_statement_summary_rejects_linked_account_not_owned(db, test_user):
     other_user_id = uuid4()
     other_users_account = await AccountFactory.create_async(
         db,
@@ -624,31 +625,9 @@ async def test_create_entry_from_txn_falls_back_when_linked_account_not_owned(db
         type=AccountType.ASSET,
         currency="SGD",
     )
-    stmt = await _make_statement(db, test_user.id, account_id=other_users_account.id)
-    txn = await _make_txn(
-        db,
-        test_user.id,
-        stmt,
-        direction=TransactionDirection.IN,
-        amount=Decimal("120.00"),
-        txn_date=date(2025, 2, 5),
-        description="Unowned linked account fallback",
-    )
-    await db.commit()
-
-    entry = await create_entry_from_txn(db, txn, user_id=test_user.id)
-
-    bank_account_ids = {line.account_id for line in entry.lines}
-    assert other_users_account.id not in bank_account_ids
-
-    default_bank = await get_or_create_account(
-        db,
-        name="Bank - Main",
-        account_type=AccountType.ASSET,
-        currency="SGD",
-        user_id=test_user.id,
-    )
-    assert default_bank.id in bank_account_ids
+    with pytest.raises(IntegrityError):
+        await _make_statement(db, test_user.id, account_id=other_users_account.id)
+    await db.rollback()
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/reconciliation/test_source_type.py
+++ b/apps/backend/tests/reconciliation/test_source_type.py
@@ -19,6 +19,7 @@ from src.models import (
     JournalEntrySourceType,
     JournalEntryStatus,
     JournalLine,
+    ReconciliationMatchJournalEntry,
     StatementSummary,
     TransactionDirection,
     UploadedDocument,
@@ -211,8 +212,8 @@ async def test_all_four_source_type_values_accepted_by_api(
     assert response.json()["source_type"] == source_type
 
 
-async def test_auto_match_sets_source_type(db: AsyncSession) -> None:
-    """AC13.10.2: Auto-accepted reconciliation promotes source_type=auto_matched."""
+async def test_auto_match_records_anchor_without_mutating_posted_source_type(db: AsyncSession) -> None:
+    """AC13.10.2 AC18.11.1: Auto-accepted reconciliation records a trusted match anchor."""
     user = User(email=f"auto-match-{uuid4()}@example.com", hashed_password="hashed")
     db.add(user)
     await db.flush()
@@ -238,7 +239,9 @@ async def test_auto_match_sets_source_type(db: AsyncSession) -> None:
 
     assert len(matches) == 1
     assert entry.status == JournalEntryStatus.RECONCILED
-    assert entry.source_type == JournalEntrySourceType.AUTO_MATCHED
+    assert entry.source_type == JournalEntrySourceType.AUTO_PARSED
+    link = await db.get(ReconciliationMatchJournalEntry, (matches[0].id, entry.id))
+    assert link is not None
 
 
 async def test_manual_wins_conflict_resolution(db: AsyncSession) -> None:

--- a/apps/backend/tests/services/test_evidence_graph_materialization.py
+++ b/apps/backend/tests/services/test_evidence_graph_materialization.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import User
@@ -210,6 +210,7 @@ async def test_AC18_10_5_detector_reports_missing_orphan_and_cross_user_drift(
     )
     db.add_all([orphan, source, target])
     await db.flush()
+    await db.execute(text("SET LOCAL session_replication_role = replica"))
     db.add(
         EvidenceEdge(
             user_id=test_user.id,
@@ -220,6 +221,7 @@ async def test_AC18_10_5_detector_reports_missing_orphan_and_cross_user_drift(
         )
     )
     await db.flush()
+    await db.execute(text("SET LOCAL session_replication_role = DEFAULT"))
     before = await _graph_counts(db)
 
     report = await service.detect_consistency_drift(db, user_id=test_user.id)

--- a/apps/backend/tests/services/test_evidence_graph_materialization.py
+++ b/apps/backend/tests/services/test_evidence_graph_materialization.py
@@ -211,17 +211,19 @@ async def test_AC18_10_5_detector_reports_missing_orphan_and_cross_user_drift(
     db.add_all([orphan, source, target])
     await db.flush()
     await db.execute(text("SET LOCAL session_replication_role = replica"))
-    db.add(
-        EvidenceEdge(
-            user_id=test_user.id,
-            from_node_id=source.id,
-            to_node_id=target.id,
-            relation="deduped_into",
-            properties={},
+    try:
+        db.add(
+            EvidenceEdge(
+                user_id=test_user.id,
+                from_node_id=source.id,
+                to_node_id=target.id,
+                relation="deduped_into",
+                properties={},
+            )
         )
-    )
-    await db.flush()
-    await db.execute(text("SET LOCAL session_replication_role = DEFAULT"))
+        await db.flush()
+    finally:
+        await db.execute(text("SET LOCAL session_replication_role = DEFAULT"))
     before = await _graph_counts(db)
 
     report = await service.detect_consistency_drift(db, user_id=test_user.id)

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -198,7 +198,7 @@ Expected routing behavior remains threshold-based (See: `docs/ssot/reconciliatio
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC13.10.1 | Source type stamped on manual entry creation | `test_source_type_stamped_on_create` | `apps/backend/tests/reconciliation/test_source_type.py` | P0 |
-| AC13.10.2 | Auto-match sets source_type=auto_matched | `test_auto_match_sets_source_type` | `apps/backend/tests/reconciliation/test_source_type.py` | P0 |
+| AC13.10.2 | Auto-match records trusted anchor without mutating posted source_type | `test_auto_match_records_anchor_without_mutating_posted_source_type` | `apps/backend/tests/reconciliation/test_source_type.py` | P0 |
 | AC13.10.3 | Stage-1 approve promotes to user_confirmed | `test_stage1_approve_promotes_source_type` | `apps/backend/tests/extraction/test_source_type_promotion.py` | P0 |
 | AC13.10.4 | Manual entry wins over auto_parsed in conflict | `test_manual_wins_conflict_resolution` | `apps/backend/tests/reconciliation/test_source_type.py` | P0 |
 | AC13.10.5 | source_type cannot be downgraded | `test_source_type_no_downgrade` | `apps/backend/tests/reconciliation/test_source_type.py` | P1 |

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -347,6 +347,27 @@ Dependencies: AC18.7 Evidence Graph foundation, AC18.8 source-to-report integrat
 | AC18.10.6 | Evidence consistency safety | Detector and lazy repair never mutate accounting facts, report amounts, ledger balances, or legacy `JournalEntry.source_type/source_id` values |
 | AC18.10.7 | Evidence consistency proof | Tests cover request-time lazy repair, repeated-read idempotency, dry-run no-write behavior, cross-user blocking, unknown provenance blockers, dangling/orphan detection, and request-level write caps |
 
+### AC18.11: Audit Anchor Referential Integrity
+
+MECE task frame:
+
+- Normalized trusted anchors: reconciliation-to-ledger and atomic-to-source-document proof uses relational link tables with database-enforced existence checks.
+- Tenant-scoped graph edges: Evidence Graph edges cannot cross user ownership boundaries even through direct database writes.
+- Tenant-scoped account references: account-bearing DWD/ledger facts cannot point at accounts owned by another user at the database boundary.
+- Legacy compatibility: existing JSONB/naked UUID anchor fields remain preserved as compatibility hints, but unresolved values are explicit blockers and are not trusted source anchors.
+- Migration safety: existing resolvable JSONB anchors are backfilled into normalized link tables, while unresolved legacy hints remain preserved for blocker reporting.
+
+Dependencies: AC18.7 Evidence Graph foundation, AC18.8 source-to-report integration, AC18.10 consistency/blocker semantics, and the ledger invariants from AC2.14. Out of scope: deleting legacy JSONB/naked UUID fields, graph database adoption, fuzzy/probabilistic anchor inference, and mutating ledger/report facts.
+
+| AC ID | Phase | Description | Test | File | Priority |
+|-------|-------|-------------|------|------|----------|
+| AC18.11.1 | Audit anchors | Reconciliation match journal-entry anchors are represented by a normalized link table that rejects missing or cross-user journal entries | `test_AC18_11_1_reconciliation_links_reject_missing_and_cross_user_entries()` | `infra/test_audit_anchor_schema_invariants.py` | P0 |
+| AC18.11.2 | Audit anchors | Atomic transaction and position source-document anchors are represented by normalized link tables that reject missing or cross-user uploaded documents | `test_AC18_11_2_atomic_source_links_reject_missing_and_cross_user_documents()` | `infra/test_audit_anchor_schema_invariants.py` | P0 |
+| AC18.11.3 | Evidence lineage | Evidence Graph edges are tenant-scoped at the database boundary and cannot connect nodes owned by different users | `test_AC18_11_3_evidence_edges_reject_cross_user_endpoints()` | `infra/test_audit_anchor_schema_invariants.py` | P0 |
+| AC18.11.4 | Tenant scope | Journal lines, approved statement summaries, and transaction classifications reject cross-user account references at the database boundary | `test_AC18_11_4_account_references_reject_cross_user_accounts()` | `infra/test_audit_anchor_schema_invariants.py` | P0 |
+| AC18.11.5 | Blocker semantics | Unresolved legacy source UUIDs remain explicit blockers and are never promoted to trusted source anchors | `test_AC18_11_5_unresolved_legacy_source_ids_remain_blockers()` | `infra/test_audit_anchor_schema_invariants.py` | P0 |
+| AC18.11.6 | Migration safety | The audit-anchor migration declares preflights, backfills resolvable legacy anchors, preserves unresolved hints, and is registered in migration-risk metadata | `test_AC18_11_6_migration_preflights_and_risk_contract_are_declared()` | `infra/test_audit_anchor_schema_invariants.py` | P0 |
+
 ### AC18.6: Framework Measurement and Disclosure Suggestions
 
 | AC ID | Phase | Description |

--- a/docs/ssot/evidence-lineage.md
+++ b/docs/ssot/evidence-lineage.md
@@ -104,6 +104,11 @@ An edge is idempotent by:
 user_id + from_node_id + to_node_id + relation
 ```
 
+At the database boundary, `evidence_edges.user_id` must match both endpoint
+nodes. The composite edge FKs are tenant-scoped so direct writes cannot connect
+nodes owned by different users. Service-level checks remain the first line of
+defense, but the database is the final proof boundary.
+
 Business tables keep their own primary keys. Evidence lineage references them
 through `entity_type` and `entity_id` so future tables can join the graph
 without schema changes to the graph foundation.
@@ -167,6 +172,18 @@ Report traceability may still use legacy `JournalEntry.source_type/source_id`
 as a compatibility fallback. When a legacy source ID cannot be resolved to an
 owned source, extracted, atomic, or graph node, the caller must return an
 explicit blocker state rather than fabricating a source anchor.
+
+Trusted source-document and reconciliation anchors use normalized relational
+link tables:
+
+- `atomic_transaction_source_documents`
+- `atomic_position_source_documents`
+- `reconciliation_match_journal_entries`
+
+Legacy JSONB arrays and naked UUID fields are compatibility hints only. They
+may be preserved for historical context, but unresolved or cross-user values
+must surface as blocker states such as `entity_missing`,
+`unknown_source_anchor`, or `cross_user_lineage_blocked`.
 
 ## Navigation API and UI
 

--- a/docs/ssot/migration-risk.yaml
+++ b/docs/ssot/migration-risk.yaml
@@ -175,6 +175,14 @@ migrations:
     risk: medium
     issue: "#845"
     proof: Adds preflight checks plus database CHECK/UNIQUE/partial-index guards for financial facts, statement envelopes, market prices, managed positions, and latest report snapshots; covered by AC11.18 direct DB invariant tests and the PR Alembic contract.
+  0034_audit_anchor_ri:
+    file: 0034_audit_anchor_referential_integrity.py
+    risk: high
+    issue: "#846"
+    proof: Adds normalized audit-anchor link tables, backfills resolvable legacy JSONB anchors, preserves unresolved legacy hints for blocker reporting, and enforces tenant-scoped anchor/account references; covered by AC18.11 direct DB invariant tests and the PR Alembic contract.
+    staging_validation: Deploy to staging and exercise upload -> parse -> evidence materialization -> reconciliation accept against normalized anchor links; confirm unresolved legacy anchors produce blockers instead of trusted source nodes.
+    production_preflight: Count legacy JSONB audit anchors and cross-tenant/account references before upgrade; abort if any preflight query in revision 0034_audit_anchor_ri returns rows.
+    rollback_strategy: Restore from pre-migration snapshot if the tenant-scope constraints reject existing data unexpectedly; normalized links are derived from legacy anchors and can be rebuilt after correcting source data.
   51aa128d8189:
     file: 51aa128d8189_remove_report_snapshot_constraint.py
     risk: medium

--- a/docs/ssot/reconciliation.md
+++ b/docs/ssot/reconciliation.md
@@ -320,6 +320,21 @@ The `/review/run/[runId]` frontend page currently uses the shared global
 Until a backend run-scoped queue contract is introduced, the UI must not imply
 that the queue payload is isolated to a persisted batch/run.
 
+## Audit Anchors
+
+`reconciliation_matches.journal_entry_ids` remains a compatibility JSONB field
+for existing API responses and historical payloads. The trusted audit anchor is
+the normalized `reconciliation_match_journal_entries` table.
+
+Rules:
+
+- A normalized reconciliation link must reference an existing
+  `journal_entries.id`.
+- The referenced journal entry must belong to the same user as the match's
+  `atomic_txn_id`.
+- Invalid, missing, or cross-user legacy UUIDs in `journal_entry_ids` must not
+  be treated as trusted report/source anchors.
+
 **State Machine**:
 ```
 [*] --> pending: Check detected

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -470,6 +470,11 @@ Reconciliation match table.
 | created_at | TIMESTAMP | NOT NULL | Creation time |
 | updated_at | TIMESTAMP | NOT NULL | Update time |
 
+`journal_entry_ids` is preserved as a compatibility field. Trusted
+reconciliation anchors are normalized in
+`reconciliation_match_journal_entries`; unresolved or malformed legacy UUIDs
+must not be promoted to trusted report/source anchors.
+
 ### ConsistencyChecks
 
 Stage 2 blocker table.
@@ -535,7 +540,9 @@ fact; account is **not** stored here (conformed downstream via
 **Constraints**:
 - `(user_id, dedup_hash)` unique
 - `amount > 0`
-- Append-only `source_documents` array
+- Append-only `source_documents` array is a legacy compatibility hint.
+- Trusted source-document anchors live in `atomic_transaction_source_documents`
+  and must reference existing uploaded documents owned by the same user.
 
 ### DWD: AtomicPositions (EPIC-011)
 Deduplicated, immutable asset snapshots (source-pure detail fact).
@@ -558,6 +565,22 @@ Deduplicated, immutable asset snapshots (source-pure detail fact).
 **Constraints**:
 - `(user_id, dedup_hash)` unique
 - `market_value >= 0`; `quantity` may be negative for short positions
+- Append-only `source_documents` array is a legacy compatibility hint.
+- Trusted source-document anchors live in `atomic_position_source_documents`
+  and must reference existing uploaded documents owned by the same user.
+
+### Audit Anchor Link Tables
+
+Normalized audit-anchor link tables are the trusted database representation for
+source-to-fact and reconciliation-to-ledger proof. Legacy JSONB/naked UUID
+fields remain preserved for backward compatibility and blocker reporting, but
+report traceability must not treat unresolved legacy values as trusted anchors.
+
+| Table | Purpose | Constraints |
+|-------|---------|-------------|
+| `atomic_transaction_source_documents` | Atomic transaction to uploaded document anchors | `(atomic_txn_id, uploaded_document_id)` PK; uploaded document must exist and share the atomic transaction user |
+| `atomic_position_source_documents` | Atomic position snapshot to uploaded document anchors | `(atomic_position_id, uploaded_document_id)` PK; uploaded document must exist and share the atomic position user |
+| `reconciliation_match_journal_entries` | Reconciliation match to journal entry anchors | `(match_id, journal_entry_id)` PK; journal entry must exist and share the reconciliation match atomic transaction user |
 
 ### DIM + DWD: ClassificationRules (DIM) and TransactionClassification (DWD) (EPIC-011)
 `classification_rules` are **DIM** reference data (versioned mapping rules,

--- a/docs/ssot/source-type-priority.md
+++ b/docs/ssot/source-type-priority.md
@@ -28,7 +28,7 @@ Defined in [Project Vision](../target.md), under "Manual Data Is Explicitly Trus
 |----------|-------------|-------------|-------------|
 | 1 (Highest) | `manual` | TRUSTED | User typed the entry directly — highest confidence |
 | 2 | `user_confirmed` | HIGH | Auto-extracted, but user explicitly confirmed it |
-| 3 | `auto_matched` | MEDIUM | Reconciliation engine matched at score ≥ 85 |
+| 3 | `auto_matched` | MEDIUM | Reconciliation engine matched at score ≥ 85 before the entry became immutable |
 | 4 (Lowest) | `auto_parsed` | LOW | AI extracted from document, unconfirmed |
 
 ### Conflict Resolution Rule
@@ -52,7 +52,7 @@ stateDiagram-v2
     [*] --> auto_parsed: AI extraction
     auto_parsed --> user_confirmed: User confirms in Stage-1 review
     auto_parsed --> manual: User edits and saves
-    auto_parsed --> auto_matched: Reconciliation score ≥ 85
+    auto_parsed --> auto_matched: Reconciliation score ≥ 85 before posting
     auto_matched --> user_confirmed: User confirms in review queue
     user_confirmed --> manual: User re-edits
     manual --> [*]: Highest trust, no further promotion
@@ -65,7 +65,7 @@ stateDiagram-v2
 ### Recommended Patterns
 
 - **Pattern A**: Always stamp `source_type` at entry creation time — never leave it null.
-- **Pattern B**: Reconciliation engine sets `auto_matched` on the journal entry when it auto-accepts; keeps `auto_parsed` if deferred to review queue.
+- **Pattern B**: Reconciliation auto-accept records trusted match provenance on `ReconciliationMatch` and its normalized journal-entry anchor. It may set `source_type=auto_matched` only before the journal entry becomes posted/reconciled; immutable posted entries keep their original `source_type`.
 - **Pattern C**: When resolving a conflict, log both the winning and losing source_type in the audit trail (`ReconciliationMatch.score_breakdown`).
 - **Pattern D**: UI must surface `source_type` with a trust badge (TRUSTED / HIGH / MEDIUM / LOW) so users know data confidence at a glance.
 
@@ -88,7 +88,7 @@ stateDiagram-v2
 ```
 
 Allowed user-data values: `manual`, `user_confirmed`, `auto_matched`, `auto_parsed`.
-The field is immutable after creation except via explicit promotion endpoints (Stage-1 approve, review queue confirm).
+The field is immutable after creation except via explicit promotion endpoints (Stage-1 approve, review queue confirm). Auto-match provenance for already posted entries is represented by `ReconciliationMatch` and normalized anchor links, not by mutating the immutable journal row.
 
 ---
 
@@ -97,7 +97,7 @@ The field is immutable after creation except via explicit promotion endpoints (S
 | Behavior | Test Function | File | Status |
 |----------|---------------|------|--------|
 | Source type stamped on manual entry creation | `test_source_type_stamped_on_create` | `reconciliation/test_source_type.py` | ✅ Implemented |
-| Auto-matched sets source_type=auto_matched | `test_auto_match_sets_source_type` | `reconciliation/test_source_type.py` | ✅ Implemented |
+| Auto-matched records a trusted anchor without mutating posted source_type | `test_auto_match_records_anchor_without_mutating_posted_source_type` | `reconciliation/test_source_type.py` | ✅ Implemented |
 | Stage-1 approve promotes to user_confirmed | `test_stage1_approve_promotes_source_type` | `extraction/test_source_type_promotion.py` | ✅ Implemented |
 | Manual entry wins over auto_parsed in conflict | `test_manual_wins_conflict_resolution` | `reconciliation/test_source_type.py` | ✅ Implemented |
 | source_type cannot be downgraded | `test_source_type_no_downgrade` | `reconciliation/test_source_type.py` | ✅ Implemented |

--- a/tests/tooling/test_reconciliation_thresholds_unit.py
+++ b/tests/tooling/test_reconciliation_thresholds_unit.py
@@ -87,7 +87,9 @@ def _load_reconciliation_module():
         if previous_source_type_priority is None:
             sys.modules.pop("src.services.source_type_priority", None)
         else:
-            sys.modules["src.services.source_type_priority"] = previous_source_type_priority
+            sys.modules["src.services.source_type_priority"] = (
+                previous_source_type_priority
+            )
         if previous_statement_summary is None:
             sys.modules.pop("src.services.statement_summary", None)
         else:
@@ -106,8 +108,16 @@ class _ScalarResult:
     def scalars(self) -> _ScalarResult:
         return self
 
+    def __iter__(self):
+        return iter(self._items)
+
     def all(self) -> list[object]:
         return self._items
+
+    def scalar_one_or_none(self) -> object | None:
+        if not self._items:
+            return None
+        return self._items[0]
 
 
 def _make_pending_txn() -> SimpleNamespace:
@@ -136,6 +146,7 @@ def _make_db(*, txn: object, entry: object) -> AsyncMock:
         side_effect=[
             _ScalarResult([txn]),
             _ScalarResult([entry]),
+            _ScalarResult([]),
         ]
     )
     db.flush = AsyncMock()


### PR DESCRIPTION
## Summary

Normalize audit anchors into trusted relational link tables and enforce tenant-scoped referential integrity for evidence, reconciliation, source-document, and account-bearing facts.

Closes #846

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-018 — AI-Driven Pipeline |
| **AC IDs** | AC18.11.1, AC18.11.2, AC18.11.3, AC18.11.4, AC18.11.5, AC18.11.6 |
| **AC source updated** | Owning EPIC and generated AC registry |

---

## SSOT Changes

- [x] `docs/ssot/schema.md` — documents normalized audit-anchor link tables and legacy hint semantics
- [x] `docs/ssot/evidence-lineage.md` — documents tenant-scoped evidence edges and trusted anchor tables
- [x] `docs/ssot/reconciliation.md` — documents normalized reconciliation match journal-entry anchors
- [x] `docs/ssot/migration-risk.yaml` — registers 0034 as high-risk with staging/preflight/rollback proof

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | Local pre-commit run | `tests/infra/test_audit_anchor_schema_invariants.py` first failed on missing normalized link models/constraints |
| Green (passing test) | `8624b956` | Implements migration, models, service sync paths, SSOT updates, and passing focused checks |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (N/A: no frontend/env changes)
- [x] `repo/` submodule updated for production config changes (N/A: no production config changes)
- [x] `tools/check_env_keys.py` passes (N/A: no env vars changed)
- [x] `tools/check_manifest.py` passes (if SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

N/A: this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
uv run ruff check src/models/evidence.py src/models/layer2.py src/models/reconciliation.py src/services/deduplication.py src/services/evidence_graph_integration.py src/services/evidence_graph_materialization.py src/services/reconciliation.py src/services/review_queue.py tests/infra/test_audit_anchor_schema_invariants.py tests/services/test_evidence_graph_materialization.py tests/reconciliation/test_review_queue.py migrations/versions/0034_audit_anchor_referential_integrity.py
uv run ruff format --check src/models/evidence.py src/models/layer2.py src/models/reconciliation.py src/services/deduplication.py src/services/evidence_graph_integration.py src/services/evidence_graph_materialization.py src/services/reconciliation.py src/services/review_queue.py tests/infra/test_audit_anchor_schema_invariants.py tests/services/test_evidence_graph_materialization.py tests/reconciliation/test_review_queue.py migrations/versions/0034_audit_anchor_referential_integrity.py
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_migration_risk.py
uv run --with pyyaml python tools/lint_doc_consistency.py
uv run --with pyyaml python tools/check_manifest.py
git diff --check
uv run pytest tests/infra/test_audit_anchor_schema_invariants.py -q --no-cov -n 0 -s -p no:cacheprovider --tb=short
uv run pytest tests/infra/test_migrations.py tests/infra/test_schema_guardrails.py tests/infra/test_schema_drift.py -q --no-cov -n 0 -s -p no:cacheprovider --tb=short
uv run pytest tests/extraction/test_deduplication.py tests/services/test_evidence_graph_materialization.py::test_AC18_10_5_detector_reports_missing_orphan_and_cross_user_drift tests/reconciliation/test_review_queue.py::test_statement_summary_rejects_linked_account_not_owned -q --no-cov -n 0 -s -p no:cacheprovider --tb=short
DATABASE_URL=<temp-db> uv run python -m alembic upgrade head
DATABASE_URL=<temp-db> uv run python -m alembic check
DATABASE_URL=<temp-db> uv run python -m alembic downgrade 0033_financial_fact_constraints
```

Additional local migration data proof: upgraded a temporary database from `0033_financial_fact_constraints` to `0034_audit_anchor_ri` with mixed valid, missing, cross-user/invalid legacy anchor UUIDs; only resolvable same-tenant anchors backfilled into the three normalized link tables.

Local limitation: after extended DB test reruns, the local `fr_pg_test` container was OOM-killed and stayed in recovery/no-response state, so final DB pytest reruns after the last helper adjustment are left to PR CI.

---

## Screenshots / Evidence

N/A — backend schema and service change.