### PR TITLE
infra: bump repo submodule to infra2 main (a791e4f)

### DIFF
--- a/tests/tooling/test_issue_489_deployment_contracts.py
+++ b/tests/tooling/test_issue_489_deployment_contracts.py
@@ -138,12 +138,17 @@ def test_postgres_and_redis_iac_services_have_vault_gated_runtime_contracts() ->
         assert ". /secrets/.env" in startup
 
         assert vault_agent["image"] == "hashicorp/vault:1.15"
-        assert "VAULT_APP_TOKEN is required" in shell_text(vault_agent["entrypoint"])
+        # AppRole auth (the token_file/VAULT_APP_TOKEN model was retired in the
+        # vault-agent AppRole migration): the agent requires role_id + secret_id.
+        assert "VAULT_ROLE_ID and VAULT_SECRET_ID are required" in shell_text(
+            vault_agent["entrypoint"]
+        )
         assert "exec vault agent -config=/etc/vault/vault-agent.hcl" in shell_text(
             vault_agent["entrypoint"]
         )
         assert "VAULT_ADDR" in vault_agent["environment"]
-        assert "VAULT_APP_TOKEN" in vault_agent["environment"]
+        assert "VAULT_ROLE_ID" in vault_agent["environment"]
+        assert "VAULT_SECRET_ID" in vault_agent["environment"]
         assert "test -s /vault/secrets/.env" in shell_text(
             vault_agent["healthcheck"]["test"]
         )


### PR DESCRIPTION
Updates the vendored infra2 (`repo/`) submodule pointer from `bf95e7e` → `a791e4f` (infra2 latest main, 15 commits).

Includes the recently merged infra2 work: container-breakdown watch (#299), infra2-tailored issue templates (#301), the AppRole-creds-preserve deployer fix (#294), and the rest of the delivery-pipeline / Vault hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)