### PR TITLE
[finance_report_ui] EPIC-022 PR6: confidence & attention as a first-class surface

### DIFF
--- a/apps/frontend/src/__tests__/attention.test.ts
+++ b/apps/frontend/src/__tests__/attention.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAttentionItems, summarizeTrust, type AttentionSources } from "@/lib/attention";
+import type { BankStatement } from "@/lib/types";
+
+function statement(overrides: Partial<BankStatement>): BankStatement {
+  return {
+    id: "s1",
+    user_id: "u1",
+    file_path: "/x",
+    original_filename: "stmt.pdf",
+    institution: "DBS",
+    status: "parsed",
+    confidence_score: 90,
+    balance_validated: true,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+    transactions: [],
+    ...overrides,
+  } as BankStatement;
+}
+
+const sources: AttentionSources = {
+  statements: [
+    statement({ id: "ok", original_filename: "ok.pdf", confidence_score: 90, balance_validated: true }),
+    statement({ id: "bad", original_filename: "bad.pdf", confidence_score: 88, balance_validated: false }),
+    statement({ id: "approved", status: "approved" }),
+  ],
+  stats: {
+    total_transactions: 100,
+    matched_transactions: 80,
+    unmatched_transactions: 5,
+    pending_review: 3,
+    auto_accepted: 70,
+    match_rate: 80,
+    score_distribution: {},
+  },
+  processing: [
+    { entry_id: "p1", from_account: "A", to_account: "B", amount: "100", currency: "SGD", initiated_date: "2026-01-01", days_outstanding: 9, description: "transfer" },
+    { entry_id: "p2", from_account: "A", to_account: "B", amount: "50", currency: "SGD", initiated_date: "2026-05-01", days_outstanding: 2, description: "fresh" },
+  ],
+};
+
+describe("attention model (EPIC-022 AC22.6)", () => {
+  it("AC22.6.1 folds the open attention sources into one list sorted by ascending confidence", () => {
+    const items = buildAttentionItems(sources);
+
+    // Approved statement and the fresh (<7d) transfer are not attention items.
+    expect(items.map((i) => i.id)).toEqual([
+      "reconciliation:unmatched", // confidence 0
+      "processing:stalled", // 30
+      "statement:bad", // min(88,40)=40 (balance failed)
+      "reconciliation:pending", // 80
+      "statement:ok", // 90
+    ]);
+    // Ascending confidence.
+    const confidences = items.map((i) => i.confidence);
+    expect(confidences).toEqual([...confidences].sort((a, b) => a - b));
+  });
+
+  it("AC22.6.1 every item deep-links to the surface where the user can act", () => {
+    const byId = Object.fromEntries(buildAttentionItems(sources).map((i) => [i.id, i.href]));
+    expect(byId["statement:bad"]).toBe("/statements/bad/review");
+    expect(byId["reconciliation:pending"]).toBe("/reconciliation/review-queue");
+    expect(byId["reconciliation:unmatched"]).toBe("/reconciliation/unmatched");
+    expect(byId["processing:stalled"]).toBe("/processing");
+  });
+
+  it("AC22.6.1 is empty when everything is reconciled and approved", () => {
+    expect(
+      buildAttentionItems({
+        statements: [statement({ status: "approved" })],
+        stats: { total_transactions: 10, matched_transactions: 10, unmatched_transactions: 0, pending_review: 0, auto_accepted: 10, match_rate: 100, score_distribution: {} },
+        processing: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("AC22.6.2 summarizes trust into trusted / needs-confirmation / low-confidence buckets", () => {
+    const items = buildAttentionItems(sources);
+    const summary = summarizeTrust(items, sources.stats);
+    expect(summary.trusted).toBe(80);
+    expect(summary.needsConfirmation).toBe(items.length);
+    // unmatched(0), processing(30), statement:bad(40) are below the 50 threshold.
+    expect(summary.lowConfidence).toBe(3);
+  });
+});

--- a/apps/frontend/src/__tests__/attentionQueue.test.tsx
+++ b/apps/frontend/src/__tests__/attentionQueue.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AttentionPage from "@/app/(main)/attention/page";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function mockSources({
+  statements = [],
+  stats = null,
+  processing = [],
+}: {
+  statements?: unknown[];
+  stats?: unknown;
+  processing?: unknown[];
+}) {
+  mockedApiFetch.mockImplementation((path: string) => {
+    if (path === "/api/statements") return Promise.resolve({ items: statements, total: statements.length });
+    if (path === "/api/reconciliation/stats") return Promise.resolve(stats);
+    if (path === "/api/accounts/processing/pending") return Promise.resolve({ items: processing, total: processing.length });
+    return Promise.resolve(null);
+  });
+}
+
+describe("Attention queue (EPIC-022 AC22.6)", () => {
+  beforeEach(() => mockedApiFetch.mockReset());
+
+  it("AC22.6.1 renders the open attention items lowest-confidence first, each deep-linking to its action surface", async () => {
+    mockSources({
+      statements: [
+        { id: "bad", original_filename: "bad.pdf", status: "parsed", confidence_score: 88, balance_validated: false, transactions: [] },
+      ],
+      stats: { total_transactions: 100, matched_transactions: 80, unmatched_transactions: 5, pending_review: 3, auto_accepted: 70, match_rate: 80, score_distribution: {} },
+      processing: [],
+    });
+
+    render(<AttentionPage />);
+
+    const rows = await screen.findAllByRole("link");
+    // Unmatched (confidence 0) comes before the parsed statement (40) before pending review (80).
+    expect(rows[0]).toHaveAttribute("href", "/reconciliation/unmatched");
+    expect(rows[1]).toHaveAttribute("href", "/statements/bad/review");
+    expect(rows[2]).toHaveAttribute("href", "/reconciliation/review-queue");
+
+    expect(within(rows[1]).getByText("bad.pdf")).toBeInTheDocument();
+    expect(within(rows[0]).getByText("0% confidence")).toBeInTheDocument();
+  });
+
+  it("AC22.6.1 shows an all-clear empty state when nothing needs attention", async () => {
+    mockSources({
+      statements: [{ id: "x", original_filename: "ok.pdf", status: "approved", transactions: [] }],
+      stats: { total_transactions: 10, matched_transactions: 10, unmatched_transactions: 0, pending_review: 0, auto_accepted: 10, match_rate: 100, score_distribution: {} },
+      processing: [],
+    });
+
+    render(<AttentionPage />);
+
+    await waitFor(() => expect(screen.getByText("All clear")).toBeInTheDocument());
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+
+  it("AC22.6.1 surfaces a retryable error state when the sources fail to load", async () => {
+    // Reject one source and resolve the rest so Promise.all rejects without
+    // leaving sibling promises unhandled.
+    mockedApiFetch.mockImplementation((path: string) =>
+      path === "/api/statements" ? Promise.reject(new Error("offline")) : Promise.resolve(null),
+    );
+
+    render(<AttentionPage />);
+
+    await waitFor(() => expect(screen.getByText("Couldn't load your attention items")).toBeInTheDocument());
+    expect(screen.getByText("offline")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/__tests__/dashboardTrustMeter.test.tsx
+++ b/apps/frontend/src/__tests__/dashboardTrustMeter.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TrustMeter } from "@/components/home/TrustMeter";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function mockSources(stats: unknown, statements: unknown[] = [], processing: unknown[] = []) {
+  mockedApiFetch.mockImplementation((path: string) => {
+    if (path === "/api/statements") return Promise.resolve({ items: statements, total: statements.length });
+    if (path === "/api/reconciliation/stats") return Promise.resolve(stats);
+    if (path === "/api/accounts/processing/pending") return Promise.resolve({ items: processing, total: processing.length });
+    return Promise.resolve(null);
+  });
+}
+
+describe("Home trust meter (EPIC-022 AC22.6.2)", () => {
+  beforeEach(() => mockedApiFetch.mockReset());
+
+  it("AC22.6.2 renders trusted / needs-confirmation / low-confidence counts and links to the attention queue", async () => {
+    mockSources(
+      { total_transactions: 100, matched_transactions: 80, unmatched_transactions: 5, pending_review: 3, auto_accepted: 70, match_rate: 80, score_distribution: {} },
+    );
+
+    render(<TrustMeter />);
+
+    await waitFor(() => expect(screen.getByText("Data trust")).toBeInTheDocument());
+    expect(screen.getByText("Trusted").previousSibling).toHaveTextContent("80");
+    // unmatched (1 item) + pending review (1 item) = 2 needing confirmation.
+    expect(screen.getByText("Needs your confirmation").previousSibling).toHaveTextContent("2");
+    // unmatched is below the low-confidence threshold.
+    expect(screen.getByText("Low confidence").previousSibling).toHaveTextContent("1");
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/attention");
+  });
+
+  it("AC22.6.2 stays silent when nothing needs attention", async () => {
+    mockSources(
+      { total_transactions: 10, matched_transactions: 10, unmatched_transactions: 0, pending_review: 0, auto_accepted: 10, match_rate: 100, score_distribution: {} },
+    );
+
+    const { container } = render(<TrustMeter />);
+
+    // Give the effect a tick to resolve, then assert nothing rendered.
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it("AC22.6.2 stays silent (no crash) when the sources fail to load", async () => {
+    // Reject one source and resolve the rest so Promise.all rejects without
+    // leaving sibling promises unhandled.
+    mockedApiFetch.mockImplementation((path: string) =>
+      path === "/api/statements" ? Promise.reject(new Error("offline")) : Promise.resolve(null),
+    );
+
+    const { container } = render(<TrustMeter />);
+
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+});

--- a/apps/frontend/src/app/(main)/attention/page.tsx
+++ b/apps/frontend/src/app/(main)/attention/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { ArrowRight, ShieldCheck } from "lucide-react";
+
+import { apiFetch } from "@/lib/api";
+import {
+  buildAttentionItems,
+  type AttentionItem,
+  type AttentionKind,
+} from "@/lib/attention";
+import type {
+  BankStatementListResponse,
+  ProcessingPendingListResponse,
+  ReconciliationStatsResponse,
+} from "@/lib/types";
+import { Badge, EmptyState, LoadingState, PageHeader, type BadgeVariant } from "@/components/ui";
+import { InfoHint, type GlossaryTerm } from "@/components/ui/InfoHint";
+
+// Each attention kind borrows the closest plain-language glossary term so the
+// jargon stays explained inline (EPIC-022 AC22.5.5 reuse).
+const KIND_TERM: Partial<Record<AttentionKind, GlossaryTerm>> = {
+  statement_review: "needs_review",
+  reconciliation_review: "match_score",
+};
+
+function confidenceVariant(confidence: number): BadgeVariant {
+  if (confidence < 40) return "error";
+  if (confidence < 70) return "warning";
+  return "info";
+}
+
+export default function AttentionPage() {
+  const [items, setItems] = useState<AttentionItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAttention = useCallback(async () => {
+    // Reset to the loading state so a refresh/retry never shows stale items or a
+    // misleading "all clear" while the new data is in flight.
+    setItems(null);
+    setError(null);
+    try {
+      const [statements, stats, processing] = await Promise.all([
+        apiFetch<BankStatementListResponse>("/api/statements"),
+        apiFetch<ReconciliationStatsResponse>("/api/reconciliation/stats"),
+        apiFetch<ProcessingPendingListResponse>("/api/accounts/processing/pending"),
+      ]);
+      setItems(
+        buildAttentionItems({
+          statements: statements?.items ?? [],
+          stats: stats ?? null,
+          processing: processing?.items ?? [],
+        }),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load attention items");
+      setItems([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAttention();
+  }, [fetchAttention]);
+
+  return (
+    <div className="p-6">
+      <PageHeader
+        title="Needs your attention"
+        description="The lowest-confidence items first — the few things the system could not settle on its own. Everything else is already handled automatically."
+      />
+
+      {items === null && !error && <LoadingState label="Loading attention items" />}
+
+      {error && (
+        <EmptyState
+          role="alert"
+          title="Couldn't load your attention items"
+          description={error}
+          action={
+            <button onClick={fetchAttention} className="btn-secondary text-sm">
+              Retry
+            </button>
+          }
+        />
+      )}
+
+      {items !== null && !error && items.length === 0 && (
+        <EmptyState
+          title="All clear"
+          description="Nothing needs your review right now — the system trusts the rest of your data."
+        />
+      )}
+
+      {items !== null && items.length > 0 && (
+        <div className="card divide-y divide-[var(--border)]">
+          {items.map((item) => (
+            <Link
+              key={item.id}
+              href={item.href}
+              className="flex items-center justify-between gap-4 px-5 py-4 transition-colors hover:bg-[var(--background-muted)]/50"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium truncate">{item.title}</span>
+                  {KIND_TERM[item.kind] && (
+                    <InfoHint term={KIND_TERM[item.kind] as GlossaryTerm} label={item.detail} />
+                  )}
+                </div>
+                <p className="text-xs text-muted mt-0.5">{item.detail}</p>
+              </div>
+              <div className="flex flex-shrink-0 items-center gap-3">
+                <Badge variant={confidenceVariant(item.confidence)}>{item.confidence}% confidence</Badge>
+                <ArrowRight className="h-4 w-4 text-muted" aria-hidden="true" />
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {items !== null && items.length > 0 && (
+        <p className="mt-4 inline-flex items-center gap-1.5 text-xs text-muted">
+          <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+          Sorted by confidence — clearing these drives your low-confidence data down.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/(main)/page.tsx
+++ b/apps/frontend/src/app/(main)/page.tsx
@@ -6,6 +6,7 @@ import { Landmark, FileText, BookOpen } from "lucide-react";
 import ProcessingSummaryCard from "@/components/ProcessingSummaryCard";
 import { UploadToReportHomePanel } from "@/components/workflow/WorkflowNotifications";
 import { AdvisorBrief } from "@/components/advisor/AdvisorBrief";
+import { TrustMeter } from "@/components/home/TrustMeter";
 import { InfoHint } from "@/components/ui/InfoHint";
 
 import { apiFetch } from "@/lib/api";
@@ -246,6 +247,10 @@ export default function HomePage() {
     <div className="p-6">
       <div className="mb-6">
         <UploadToReportHomePanel />
+      </div>
+
+      <div className="mb-6">
+        <TrustMeter />
       </div>
 
       {advisorSuggestions.length > 0 ? (

--- a/apps/frontend/src/components/home/TrustMeter.tsx
+++ b/apps/frontend/src/components/home/TrustMeter.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { ArrowRight, ShieldCheck } from "lucide-react";
+
+import { apiFetch } from "@/lib/api";
+import { buildAttentionItems, summarizeTrust, type TrustSummary } from "@/lib/attention";
+import type {
+  BankStatementListResponse,
+  ProcessingPendingListResponse,
+  ReconciliationStatsResponse,
+} from "@/lib/types";
+
+// EPIC-022 PR6 (#864) AC22.6.2: a compact, always-honest view of the trust
+// posture — how much is trusted vs. how much still needs the user — that makes
+// the north-star (low-confidence data trending down) visible on Home. It stays
+// silent when nothing needs attention.
+export function TrustMeter() {
+  const [summary, setSummary] = useState<TrustSummary | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const [statements, stats, processing] = await Promise.all([
+          apiFetch<BankStatementListResponse>("/api/statements"),
+          apiFetch<ReconciliationStatsResponse>("/api/reconciliation/stats"),
+          apiFetch<ProcessingPendingListResponse>("/api/accounts/processing/pending"),
+        ]);
+        if (!active) return;
+        const items = buildAttentionItems({
+          statements: statements?.items ?? [],
+          stats: stats ?? null,
+          processing: processing?.items ?? [],
+        });
+        setSummary(summarizeTrust(items, stats ?? null));
+      } catch {
+        // Stay silent on failure — the meter is non-critical chrome on Home.
+        if (active) setSummary(null);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Silent when nothing needs attention (AC22.6.2).
+  if (!summary || summary.needsConfirmation === 0) return null;
+
+  return (
+    <Link
+      href="/attention"
+      aria-label="Items that need your attention"
+      className="card block p-5 transition-colors hover:border-[var(--accent)]"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="inline-flex items-center gap-2">
+          <ShieldCheck className="h-4 w-4 text-[var(--accent)]" aria-hidden="true" />
+          <h2 className="font-semibold">Data trust</h2>
+        </div>
+        <span className="inline-flex items-center gap-1 text-sm text-[var(--accent)]">
+          Review <ArrowRight className="h-4 w-4" aria-hidden="true" />
+        </span>
+      </div>
+      <div className="mt-4 grid grid-cols-3 gap-3 text-center">
+        <Bucket label="Trusted" value={summary.trusted} tone="success" />
+        <Bucket label="Needs your confirmation" value={summary.needsConfirmation} tone="warning" />
+        <Bucket label="Low confidence" value={summary.lowConfidence} tone="error" />
+      </div>
+    </Link>
+  );
+}
+
+function Bucket({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "success" | "warning" | "error";
+}) {
+  const color =
+    tone === "success" ? "var(--success)" : tone === "warning" ? "var(--warning)" : "var(--error)";
+  return (
+    <div className="rounded-md bg-[var(--background-muted)] p-3">
+      <p className="text-2xl font-semibold" style={{ color }}>
+        {value}
+      </p>
+      <p className="mt-1 text-xs text-muted">{label}</p>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/navigation.ts
+++ b/apps/frontend/src/components/navigation.ts
@@ -8,6 +8,7 @@ import {
     Landmark,
     Link2,
     MessageSquare,
+    ShieldCheck,
     SlidersHorizontal,
     UploadCloud,
     Wallet,
@@ -48,6 +49,7 @@ export const ROUTE_CONFIG: Record<string, RouteConfig> = {
     "/": { label: "Home", Icon: Home },
     "/upload": { label: "Upload", Icon: UploadCloud },
     "/notifications": { label: "Notifications", Icon: Bell },
+    "/attention": { label: "Needs attention", Icon: ShieldCheck },
     // Legacy routes redirect to the new IA; keep label/icon mappings so any
     // persisted workspace tabs or breadcrumbs render with the new names.
     "/dashboard": { label: "Home", Icon: Home },

--- a/apps/frontend/src/lib/attention.ts
+++ b/apps/frontend/src/lib/attention.ts
@@ -1,0 +1,147 @@
+// EPIC-022 PR6 (#864): make confidence a first-class, navigable concept.
+//
+// Today "what needs my attention" is scattered across statement confidence
+// scores, balance validation, reconciliation review, unmatched transactions,
+// and stalled processing transfers — each with its own page and vocabulary.
+// This module folds those existing read-API signals into one list ranked by
+// confidence (lower = more uncertain = higher in the queue), which is exactly
+// the low-confidence tail Axiom B says a human should look at.
+
+import type {
+  BankStatement,
+  ProcessingPendingItem,
+  ReconciliationStatsResponse,
+} from "@/lib/types";
+
+export type AttentionKind =
+  | "statement_review"
+  | "reconciliation_review"
+  | "unmatched_transactions"
+  | "processing_stalled";
+
+export interface AttentionItem {
+  /** Stable id so the list can dedupe/key without re-sync churn. */
+  id: string;
+  kind: AttentionKind;
+  title: string;
+  detail: string;
+  /** 0–100; lower means the system is less sure and the user should look. */
+  confidence: number;
+  /** Deep-link to the surface where the user can act on this item. */
+  href: string;
+}
+
+export interface AttentionSources {
+  statements?: BankStatement[] | null;
+  stats?: ReconciliationStatsResponse | null;
+  processing?: ProcessingPendingItem[] | null;
+}
+
+/** A processing transfer is "stuck" once it has been in transit this long. */
+export const PROCESSING_STALE_DAYS = 7;
+
+/** Below this, an item is surfaced as low-confidence in the trust meter. */
+export const LOW_CONFIDENCE_THRESHOLD = 50;
+
+function clampConfidence(value: number): number {
+  // `value || 0` folds NaN/undefined to 0 without a separate branch.
+  return Math.max(0, Math.min(100, Math.round(value || 0)));
+}
+
+/**
+ * Fold the available attention signals into a single list, sorted by ascending
+ * confidence (the most uncertain items first). Ties break by id for a stable
+ * order across re-syncs.
+ */
+export function buildAttentionItems(sources: AttentionSources): AttentionItem[] {
+  const items: AttentionItem[] = [];
+
+  // Stage 1 — parsed statements awaiting human review. A failed balance check
+  // means lower confidence than the raw extraction score alone.
+  for (const statement of sources.statements ?? []) {
+    if (statement.status !== "parsed") continue;
+    const score =
+      typeof statement.confidence_score === "number" ? statement.confidence_score : 0;
+    const balanceFailed = statement.balance_validated === false;
+    items.push({
+      id: `statement:${statement.id}`,
+      kind: "statement_review",
+      title: statement.original_filename,
+      detail: balanceFailed ? "Balance needs review" : "Parsed — ready to review",
+      confidence: clampConfidence(balanceFailed ? Math.min(score, 40) : score),
+      href: `/statements/${statement.id}/review`,
+    });
+  }
+
+  const stats = sources.stats;
+
+  // Stage 2 — reconciliation matches awaiting review. Confidence tracks the
+  // overall match rate for the batch they belong to. `match_rate` is already a
+  // 0–100 percentage from the backend (matched / total * 100), not a fraction.
+  if (stats && stats.pending_review > 0) {
+    items.push({
+      id: "reconciliation:pending",
+      kind: "reconciliation_review",
+      title: `${stats.pending_review} match${stats.pending_review > 1 ? "es" : ""} need review`,
+      detail: "Reconciliation review",
+      confidence: clampConfidence(stats.match_rate ?? 0),
+      href: "/reconciliation/review-queue",
+    });
+  }
+
+  // Unmatched transactions have no ledger match at all — the lowest confidence.
+  if (stats && stats.unmatched_transactions > 0) {
+    items.push({
+      id: "reconciliation:unmatched",
+      kind: "unmatched_transactions",
+      title: `${stats.unmatched_transactions} unmatched transaction${
+        stats.unmatched_transactions > 1 ? "s" : ""
+      }`,
+      detail: "No ledger match yet",
+      confidence: 0,
+      href: "/reconciliation/unmatched",
+    });
+  }
+
+  // In-transit funds stuck in a processing account past the stale threshold.
+  const stalled = (sources.processing ?? []).filter(
+    (item) => item.days_outstanding >= PROCESSING_STALE_DAYS,
+  );
+  if (stalled.length > 0) {
+    const oldest = stalled.reduce((max, item) => Math.max(max, item.days_outstanding), 0);
+    items.push({
+      id: "processing:stalled",
+      kind: "processing_stalled",
+      title: `${stalled.length} transfer${stalled.length > 1 ? "s" : ""} stuck in transit`,
+      detail: `Oldest ${oldest} days outstanding`,
+      confidence: 30,
+      href: "/processing",
+    });
+  }
+
+  return items.sort((a, b) => a.confidence - b.confidence || a.id.localeCompare(b.id));
+}
+
+export interface TrustSummary {
+  /** Transactions the system already reconciled and trusts. */
+  trusted: number;
+  /** Open attention items the user should confirm. */
+  needsConfirmation: number;
+  /** Subset of attention items the system is least sure about. */
+  lowConfidence: number;
+}
+
+/**
+ * Summarise the trust posture for the Home trust meter. The north-star is to
+ * drive `lowConfidence` down over time (Axiom B).
+ */
+export function summarizeTrust(
+  items: AttentionItem[],
+  stats?: ReconciliationStatsResponse | null,
+): TrustSummary {
+  return {
+    trusted: stats?.matched_transactions ?? 0,
+    needsConfirmation: items.length,
+    lowConfidence: items.filter((item) => item.confidence < LOW_CONFIDENCE_THRESHOLD).length,
+  };
+}

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -188,6 +188,21 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 | AC22.5.5 | Core jargon terms (balance "drift"/"balanced", "needs review", transfer pair, anomaly, duplicate, consistency check, match score) expose a plain-language explanation through an accessible `InfoHint` affordance | `infoHint.test.tsx` | P1 |
 | AC22.5.6 | The Home surfaces a single primary next-action with overlapping reconciliation links de-duplicated, and the Chat page heading reads "AI Advisor" | `dashboardPage.test.tsx`, `ChatPageClient.test.tsx` | P1 |
 
+### AC22.6 — Confidence & Attention As A First-Class Surface
+
+> PR6 slice (#864). "What needs my attention" was scattered across statement
+> confidence scores, balance validation, reconciliation review, unmatched
+> transactions, and stalled processing transfers — each with its own page and
+> vocabulary. This slice folds those existing read-API signals into one
+> confidence-ranked queue and a Home trust meter, making the low-confidence tail
+> (Axiom B) navigable. The header bell consistency and smoke coverage land in a
+> follow-up.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC22.6.1 | The `/attention` page folds the open attention sources (Stage 1 statement review, reconciliation review, unmatched transactions, stalled processing transfers) into a single list sorted by ascending confidence, each row deep-linking to its action surface, with an all-clear empty state when nothing needs attention | `attention.test.ts`, `attentionQueue.test.tsx` | P1 |
+| AC22.6.2 | The Home renders a trust meter (trusted / needs-confirmation / low-confidence counts) derived from the same attention model and linking to `/attention`, and stays silent when nothing needs attention | `attention.test.ts`, `dashboardTrustMeter.test.tsx` | P1 |
+
 ### AC22.9 — Everyday/Advanced Boundary And Naming Unification
 
 > PR9 slice (#865). The IA folds accounting modules into Advanced, but the


### PR DESCRIPTION
Implements **#864** (EPIC-022 PR6, P0), a sub-issue of root **#836**.

> **Stacked on #869** (the EPIC-022 PR6–PR10 doc/tracking PR). Merge #869 first, or merge this — it contains #869's doc commit plus the AC22.6 implementation.

## Why (vision)

Serves **Axiom B** (automation by default; attention only on the low-confidence tail) and the **north-star** (proportion of low-confidence data trends down). Today "what needs my attention" is scattered across statement confidence scores, balance validation, reconciliation review, unmatched transactions, and stalled processing transfers — each with its own page and vocabulary. There is no single, confidence-ranked place that answers *"what does the system still not trust, and what must I look at?"*

## What (AC22.6)

- **AC22.6.1** — New **`/attention`** page folds the open attention sources into one list **sorted by ascending confidence**, each row deep-linking to its action surface (statement review, reconciliation review-queue, unmatched, processing). All-clear empty state when nothing needs attention.
- **AC22.6.2** — Home renders a **trust meter** (Trusted / Needs your confirmation / Low confidence) from the same model, linking to `/attention`, and **stays silent** when nothing needs attention.

Core aggregation is a pure, fully-unit-tested `lib/attention.ts` (`buildAttentionItems` + `summarizeTrust`), reusing existing read APIs only — **no backend changes**.

## Scope / follow-up

This PR delivers AC22.6.1 + AC22.6.2. The **header-bell consistency (AC22.6.3)** and **desktop/mobile smoke (AC22.6.4)** are deliberately deferred to a follow-up (kept open on #864) to keep this reviewable.

## Verification

- Full frontend suite **694 passing**; `tsc --noEmit` clean; ESLint clean.
- Coverage **99.49%** (≥ baseline; global 98% threshold held).
- AC traceability: `registered=1408, untested=0, invalid_real=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)