### PR TITLE
[finance_report_ui] fix: reports cockpit showed match_rate as 9200% not 92%

### DIFF
--- a/apps/frontend/src/__tests__/reportsCockpit.test.tsx
+++ b/apps/frontend/src/__tests__/reportsCockpit.test.tsx
@@ -22,7 +22,8 @@ beforeEach(() => {
       return Promise.resolve({ annualized_total: "120000.00", currency: "SGD" })
     }
     if (path === "/api/reconciliation/stats") {
-      return Promise.resolve({ match_rate: 0.92, unmatched_transactions: 3 })
+      // match_rate is a 0–100 percentage from the backend, not a fraction.
+      return Promise.resolve({ match_rate: 92, unmatched_transactions: 3 })
     }
     return Promise.resolve({})
   })

--- a/apps/frontend/src/__tests__/reportsPage.test.tsx
+++ b/apps/frontend/src/__tests__/reportsPage.test.tsx
@@ -22,7 +22,8 @@ beforeEach(() => {
       return Promise.resolve({ annualized_total: "120000.00", currency: "SGD" })
     }
     if (path === "/api/reconciliation/stats") {
-      return Promise.resolve({ match_rate: 0.92, unmatched_transactions: 3 })
+      // match_rate is a 0–100 percentage from the backend, not a fraction.
+      return Promise.resolve({ match_rate: 92, unmatched_transactions: 3 })
     }
     return Promise.resolve({})
   })

--- a/apps/frontend/src/app/(main)/reports/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/page.tsx
@@ -34,7 +34,9 @@ export default function ReportsPage() {
         };
     }, []);
 
-    const matchRate = stats ? Math.round((stats.match_rate ?? 0) * 100) : null;
+    // `match_rate` is already a 0–100 percentage from the backend
+    // (matched / total * 100), so it must not be multiplied by 100 again.
+    const matchRate = stats ? Math.round(stats.match_rate ?? 0) : null;
 
     return (
         <div className="p-6">


### PR DESCRIPTION
## Bug

`ReconciliationStatsResponse.match_rate` is already a **0–100 percentage** from the backend (`reconciliation.py`: `match_rate = round(matched / total * 100, 2)`), but the Reports cockpit multiplied it by 100 again:

```ts
const matchRate = stats ? Math.round((stats.match_rate ?? 0) * 100) : null;
```

So a real 92% reconciliation coverage rendered as **"9200% matched"** in production. The bug was masked because the cockpit tests mocked `match_rate` as a `0.92` fraction (which `* 100` happened to turn back into 92).

## Fix

- Use `match_rate` directly (`Math.round(stats.match_rate ?? 0)`).
- Update the two reports test mocks (`reportsCockpit.test.tsx`, `reportsPage.test.tsx`) to the realistic 0–100 scale (`92`), so they now guard against the regression instead of hiding it.

`components/reconciliation/Workbench.tsx` already used `match_rate` correctly (as a 0–100 percentage); no change there.

## Context

Surfaced by Copilot review on #874, where `lib/attention.ts` had the same `* 100` mistake (fixed in that PR). This fixes the sibling occurrence in the already-merged cockpit code.

## Verification

- Full frontend suite **697 passing**; `tsc --noEmit` clean; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)