### PR TITLE
[finance_report_ui] EPIC-022: print / save-as-PDF export for the report package (#867)

### DIFF
--- a/apps/frontend/src/__tests__/cashFlowPage.test.tsx
+++ b/apps/frontend/src/__tests__/cashFlowPage.test.tsx
@@ -117,6 +117,10 @@ describe("CashFlowPage", () => {
     const reconciliation = await screen.findByLabelText("Cash reconciliation")
     expect(reconciliation).toHaveTextContent("⚠ Does not tie")
     expect(screen.getByText(/differs from the reported ending/i)).toBeInTheDocument()
+    // The drift is shown as a positive amount with an explicit direction, never
+    // a confusing negative (reported 6500 > expected 5900).
+    expect(reconciliation).toHaveTextContent("the reported ending is higher than expected")
+    expect(reconciliation).not.toHaveTextContent("-")
   })
 
   it("AC22.7.1 drills a cash-flow amount down to its account lineage", async () => {

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -642,6 +642,19 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.getByText("Loading framework package...")).toBeInTheDocument();
   });
 
+  it("EPIC-022 #867 offers a print / save-as-PDF export of the loaded package", async () => {
+    mockPackageApi();
+    const printMock = vi.fn();
+    window.print = printMock;
+
+    renderPackagePage();
+    fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
+
+    const printButton = await screen.findByRole("button", { name: /Print \/ Save as PDF/i });
+    fireEvent.click(printButton);
+    expect(printMock).toHaveBeenCalled();
+  });
+
   it("AC20.6.1 AC20.7.1 loads readiness and policy result with the selected framework", async () => {
     mockPackageApi();
 

--- a/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
@@ -156,7 +156,8 @@ export default function CashFlowPage() {
             {!reconciles && (
               <p className="mt-2 text-xs text-[var(--warning)]">
                 Expected ending {formatCurrencyLocale(expectedEnding, cur)} differs from the reported ending by{" "}
-                {formatCurrencyLocale(drift, cur)}.
+                {formatCurrencyLocale(drift.abs(), cur)} — the reported ending is{" "}
+                {drift.isPositive() ? "lower" : "higher"} than expected.
               </p>
             )}
           </div>

--- a/apps/frontend/src/app/(main)/reports/package/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/package/page.tsx
@@ -520,7 +520,7 @@ export default function PersonalReportPackagePage() {
           <section key={section.section_id} className="card p-5">
             <div className="flex items-start justify-between gap-3">
               <div>
-                <h2 className="font-semibold mt-1">{section.label}</h2>
+                <h2 className="font-semibold">{section.label}</h2>
               </div>
               <span className="badge badge-muted">{section.status}</span>
             </div>

--- a/apps/frontend/src/app/(main)/reports/package/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/package/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Network, X } from "lucide-react";
+import { Network, Printer, X } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -283,13 +283,25 @@ export default function PersonalReportPackagePage() {
 
       {frameworkSelection}
 
-      <section className="card p-5 mb-6">
+      <section className="card p-5 mb-6 print:hidden">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-xs font-mono text-muted">package_export</p>
-            <h2 className="font-semibold mt-1">Package CSV</h2>
+            <h2 className="font-semibold">Export</h2>
+            <p className="mt-1 text-sm text-muted">
+              Save a readable copy of this package — pinned to the selected framework and report date.
+            </p>
           </div>
-          <ExportCsvButton path={exportPath} />
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="btn-secondary inline-flex items-center gap-2 text-sm"
+            >
+              <Printer className="h-4 w-4" aria-hidden="true" />
+              Print / Save as PDF
+            </button>
+            <ExportCsvButton path={exportPath} />
+          </div>
         </div>
       </section>
 

--- a/apps/frontend/src/components/AppShell.tsx
+++ b/apps/frontend/src/components/AppShell.tsx
@@ -19,13 +19,14 @@ function AppShellContent({ children }: AppShellProps) {
         <div className="min-h-screen">
             <Sidebar />
 
-            {/* Main Content Area */}
+            {/* Main Content Area. On print, drop the sidebar offset so report
+                output uses the full page (EPIC-022 #867 readable export). */}
             <div
-                className={`transition-all duration-300 ease-in-out ${
+                className={`transition-all duration-300 ease-in-out print:!ml-0 ${
                     isCollapsed ? "md:ml-16" : "md:ml-64"
                 }`}
             >
-                <div className="flex min-w-0 items-center border-b border-border bg-surface-card">
+                <div className="flex min-w-0 items-center border-b border-border bg-surface-card print:hidden">
                     <MobileNav />
                     <div className="hidden md:block min-w-0 flex-1">
                         <WorkspaceTabs />

--- a/apps/frontend/src/components/Sidebar.tsx
+++ b/apps/frontend/src/components/Sidebar.tsx
@@ -118,7 +118,7 @@ export function Sidebar() {
         fixed left-0 top-0 z-40 h-screen
         bg-[var(--background-card)] border-r border-[var(--border)]
         transition-all duration-300 ease-in-out
-        hidden md:block
+        hidden md:block print:hidden
         ${isCollapsed ? "w-16" : "w-56"}
       `}
         >


### PR DESCRIPTION
A **frontend-only** readable-export increment of **#867** (the report-package terminal goal) — no backend, no migration.

## What ships

- The report package gains a **"Print / Save as PDF"** button that prints the package **pinned to the selected framework + report date**.
- **Print CSS** (Tailwind `print:` variants) hides the app chrome — sidebar, top bar, and the export controls — so the browser's print-to-PDF produces a clean, full-width report document.

This delivers the **readable-export** facet of #867 via the browser. The pinned-version *snapshot* engine (server-generated, versioned artifact) remains tracked as **#705**.

## Verification

- Full frontend suite **699 passing** (added a package-print test); `tsc` + ESLint clean; coverage **99.49%**.

## Note

No new AC ID is registered here (the AC22.8 section lives in the still-unmerged #886, so registering would conflict). Tracked against #867; an AC can be added when #886 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up CR fixes bundled in this PR

While reviewing the Copilot comments across the merged EPIC-022 slices, two were
still live and are fixed here (kept frontend-only, in keeping with this PR's scope):

- **PR8 (#886)** — dropped the stray `mt-1` on the per-section `{section.label}`
  heading in the report package so its offset matches the other readable headings.
- **PR7 (#882)** — the cash-flow reconciliation drift line no longer shows a
  confusing negative amount ("by -$600.00"); it now shows the absolute drift plus
  an explicit direction (reported ending higher/lower than expected), with the
  cashFlowPage test tightened to lock it in.

> Not bundled: the backend provenance gap from **#889** (`/portfolio/holdings?as_of_date=...`
> serializes `provenance: null` for document-backed snapshots) is a real bug but
> backend-only — it does not belong in this frontend-only PR and should land as its
> own change.