### PR TITLE
[finance_report_test_and_doc] feat(coverage): guard against unregistered source trees bypassing coverage

### DIFF
--- a/common/coverage/policy.py
+++ b/common/coverage/policy.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
@@ -168,3 +169,97 @@ def parse_lcov_sources(
             if line.startswith("SF:"):
                 sources.add(component.normalize_lcov_source(line[3:], repo_root))
     return sources
+
+
+# --- Coverage registration guard ---------------------------------------------
+#
+# `expected_sources()` makes each component recursive, so a new file *inside* a
+# component source root (e.g. apps/backend/src/<anything>) is automatically
+# measured. The remaining bypass is code placed *outside* every component root
+# (a new top-level package, apps/<new-app>/, or a loose module next to src/).
+# Such a tree is invisible to the per-component audit, so it could ship with
+# zero coverage while the gate stays green.
+#
+# `find_unregistered_sources()` closes that hole: every tracked source file must
+# be either (a) under a CoverageComponent source root, or (b) matched by an
+# explicit exempt pattern below. Adding an unlisted code directory makes the
+# guard fail until the author either moves it under a covered root or registers
+# it here in a reviewable diff — coverage cannot be skipped by "not registering".
+
+SOURCE_EXTENSIONS: tuple[str, ...] = (".py", ".ts", ".tsx")
+
+# Repo-relative globs (matched against the full path and the basename) for
+# source that is intentionally NOT subject to line coverage. Keep this list
+# minimal and justified — broadening it re-opens the bypass.
+COVERAGE_EXEMPT_PATTERNS: tuple[str, ...] = (
+    # Test code — gated behaviorally, not counted as product source.
+    "test_*.py",
+    "conftest.py",
+    "*.test.ts",
+    "*.test.tsx",
+    "*.spec.ts",
+    "*.spec.tsx",
+    "tests/**",
+    "**/tests/**",
+    "**/__tests__/**",
+    "apps/frontend/playwright/**",
+    # Build/runtime configuration and type declarations, not product logic.
+    "*.config.ts",
+    "*.config.js",
+    "*.config.mjs",
+    "*.config.cjs",
+    "*.d.ts",
+    "apps/frontend/vitest.setup.ts",
+    # Alembic data migrations.
+    "apps/backend/migrations/**",
+    # Agent tooling / skills — not shipped product runtime.
+    ".opencode/**",
+    # Docs build tooling.
+    "docs/**",
+    # Vendored submodule — owns its own coverage in its own repo.
+    "repo/**",
+)
+
+
+def component_source_prefixes(repo_root: Path = ROOT_DIR) -> tuple[str, ...]:
+    """Repo-relative, slash-terminated source roots of every coverage component."""
+    return tuple(
+        component.source_path(repo_root).relative_to(repo_root).as_posix().rstrip("/")
+        + "/"
+        for component in COMPONENTS
+    )
+
+
+def is_registered_source(rel_path: str, repo_root: Path = ROOT_DIR) -> bool:
+    """True if a repo-relative source path is claimed by a component or exempt.
+
+    "Claimed" means it lives under a component source root (covered, even if the
+    component then excludes it from the percentage — it is still visible). Files
+    matched by ``COVERAGE_EXEMPT_PATTERNS`` are deliberately out of scope.
+    """
+    path = rel_path.replace("\\", "/")
+    if any(path.startswith(prefix) for prefix in component_source_prefixes(repo_root)):
+        return True
+    basename = path.rsplit("/", 1)[-1]
+    return any(
+        fnmatch(path, pattern) or fnmatch(basename, pattern)
+        for pattern in COVERAGE_EXEMPT_PATTERNS
+    )
+
+
+def find_unregistered_sources(
+    candidate_files: Iterable[str], repo_root: Path = ROOT_DIR
+) -> list[str]:
+    """Return source files that escape both component scopes and the exempt list.
+
+    ``candidate_files`` is an iterable of repo-relative paths (e.g. ``git
+    ls-files`` output). Non-source extensions are ignored. A non-empty result
+    means coverage could be bypassed by those paths.
+    """
+    orphans = [
+        path.replace("\\", "/")
+        for raw in candidate_files
+        if (path := raw.replace("\\", "/")).endswith(SOURCE_EXTENSIONS)
+        and not is_registered_source(path, repo_root)
+    ]
+    return sorted(orphans)

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -399,6 +399,9 @@ concepts:
     cross_refs:
       - docs/ssot/tdd.md
       - docs/ssot/ci-cd.md
+    proofs:
+      - tests/tooling/test_coverage_policy.py
+      - tests/tooling/test_calculate_unified_coverage.py
 
   # ── TDD ───────────────────────────────────────────────────────────────
   tdd_workflow:

--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -62,6 +62,25 @@ The authoritative component/file policy lives in `common/coverage/policy.py`. Co
 
 `tools/check_coverage_policy.py` compares the source tree against LCOV `SF:` entries in CI. It fails when an eligible source file is missing from LCOV, or when an excluded/nonexistent file appears in LCOV. This is the guardrail that keeps new modules on the same coverage denominator automatically.
 
+### Registration guard (no unregistered source trees)
+
+The per-component audit above is recursive *inside* each source root, so a new
+file under `apps/backend/src/...` is measured automatically. The remaining
+bypass is code placed **outside every component root** — a new top-level
+package, a new `apps/<app>/`, or a loose module next to `src/`. Such a tree is
+invisible to the per-component audit and could ship at 0% while the gate stays
+green.
+
+`tools/check_coverage_policy.py` therefore also runs a **registration guard**
+(`audit_unregistered_sources`): every tracked `.py`/`.ts`/`.tsx` file must be
+either under a component source root **or** matched by an explicit exempt
+pattern in `common/coverage/policy.py::COVERAGE_EXEMPT_PATTERNS` (tests, config,
+migrations, agent skills, docs, the vendored submodule). Adding an unlisted code
+directory fails the audit until the author either moves it under a covered root
+or registers it in that list via a reviewable diff. You cannot skip coverage by
+"just not registering" a folder. Exempting genuinely one-off tooling is allowed,
+but it must be an explicit, justified entry — never a silent omission.
+
 `tools/build_unified_lcov.py` rewrites component-relative LCOV paths into repository-root-relative paths before uploading the main-branch unified report to Coveralls. For example, backend `SF:src/services/example.py` becomes `SF:apps/backend/src/services/example.py`, and frontend `SF:src/app/page.tsx` becomes `SF:apps/frontend/src/app/page.tsx`.
 
 Coveralls upload LCOV files are line-only. CI strips `BRDA:`, `BRF:`, and

--- a/tests/tooling/test_coverage_policy.py
+++ b/tests/tooling/test_coverage_policy.py
@@ -12,8 +12,19 @@ sys.path.insert(0, str(ROOT))
 
 from tools._lib.coverage import build_unified_lcov  # noqa: E402
 from tools._lib.coverage import check_policy  # noqa: E402
-from tools._lib.coverage.check_policy import compare_component, main, run_audit  # noqa: E402
-from common.coverage.policy import CoverageComponent, parse_lcov_sources  # noqa: E402
+from tools._lib.coverage.check_policy import (  # noqa: E402
+    audit_unregistered_sources,
+    compare_component,
+    main,
+    run_audit,
+    tracked_source_files,
+)
+from common.coverage.policy import (  # noqa: E402
+    CoverageComponent,
+    find_unregistered_sources,
+    is_registered_source,
+    parse_lcov_sources,
+)
 
 
 def _component(
@@ -45,7 +56,9 @@ def test_expected_sources_include_new_modules_by_default(tmp_path):
     assert component.expected_sources(tmp_path) == {"src/services/new_module.py"}
 
 
-def test_expected_sources_recursively_include_all_eligible_files_except_exclusions(tmp_path):
+def test_expected_sources_recursively_include_all_eligible_files_except_exclusions(
+    tmp_path,
+):
     """AC8.13.15: Coverage scope is recursive and deny-list based."""
     component = _component(
         tmp_path,
@@ -293,6 +306,66 @@ def test_build_unified_lcov_main_exits_with_builder_result(tmp_path, monkeypatch
     assert calls == [
         (tmp_path / "coverage" / "unified.lcov", tmp_path.resolve(), False)
     ]
+
+
+def test_unregistered_guard_flags_code_outside_every_component():
+    """A new top-level package or loose module outside src is flagged."""
+    orphans = find_unregistered_sources(
+        [
+            "apps/backend/src/services/ok.py",  # claimed by backend
+            "apps/frontend/src/lib/ok.ts",  # claimed by frontend
+            "tools/ok.py",  # claimed by tools
+            "common/ok.py",  # claimed by common
+            "apps/worker/src/handler.py",  # ORPHAN: new app
+            "libs/util.py",  # ORPHAN: new top-level package
+            "apps/backend/rogue.py",  # ORPHAN: inside component dir but outside src
+        ]
+    )
+    assert orphans == [
+        "apps/backend/rogue.py",
+        "apps/worker/src/handler.py",
+        "libs/util.py",
+    ]
+
+
+def test_unregistered_guard_exempts_tests_config_and_non_product_trees():
+    """Test files, config, migrations, skills and docs are not product source."""
+    candidates = [
+        "apps/backend/tests/test_x.py",
+        "tests/tooling/test_y.py",
+        "apps/frontend/src/__tests__/z.test.tsx",
+        "apps/frontend/playwright/flow.spec.ts",
+        "apps/frontend/vitest.config.ts",
+        "apps/frontend/vitest.setup.ts",
+        "apps/backend/migrations/versions/0001_x.py",
+        ".opencode/skills/professional/qa-testing/scripts/gen.py",
+        "docs/hooks.py",
+        "newpkg/foo.go",  # not a tracked source extension we measure
+    ]
+    assert find_unregistered_sources(candidates) == []
+
+
+def test_is_registered_source_distinguishes_covered_from_orphan():
+    assert is_registered_source("apps/backend/src/main.py") is True
+    assert is_registered_source("common/coverage/policy.py") is True
+    assert is_registered_source("apps/newservice/handler.py") is False
+
+
+def test_real_repo_has_no_unregistered_source_trees():
+    """Live gate: every tracked source file is covered or explicitly exempt.
+
+    If this fails, a code directory was added without registering it for
+    coverage. Either move it under a coverage component source root, or add an
+    explicit, justified entry to COVERAGE_EXEMPT_PATTERNS.
+    """
+    orphans = find_unregistered_sources(tracked_source_files(ROOT), ROOT)
+    assert orphans == [], "Unregistered source trees escape coverage: " + ", ".join(
+        orphans
+    )
+
+
+def test_audit_unregistered_sources_passes_on_current_repo():
+    assert audit_unregistered_sources(ROOT) == 0
 
 
 def test_AC8_13_56_tools_policy_tracks_python_command_entrypoints(tmp_path):

--- a/tools/_lib/coverage/check_policy.py
+++ b/tools/_lib/coverage/check_policy.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import subprocess
 import sys
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from common.coverage.policy import (
     COMPONENTS,
     ROOT_DIR,
     CoverageComponent,
+    find_unregistered_sources,
     parse_lcov_sources,
 )
 
@@ -69,13 +71,49 @@ def run_audit(
     return 0
 
 
+def tracked_source_files(repo_root: Path = ROOT_DIR) -> list[str]:
+    """Repo-relative tracked Python/TypeScript source paths (git is the truth)."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "*.py", "*.ts", "*.tsx"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def audit_unregistered_sources(repo_root: Path = ROOT_DIR) -> int:
+    """Fail when a tracked source tree is neither covered nor explicitly exempt."""
+    orphans = find_unregistered_sources(tracked_source_files(repo_root), repo_root)
+    if orphans:
+        print(
+            f"::error title=Unregistered source tree::{len(orphans)} tracked source "
+            "file(s) live outside every coverage component and are not exempt; "
+            "move them under a covered root or register them in "
+            "common/coverage/policy.py::COVERAGE_EXEMPT_PATTERNS"
+        )
+        for path in orphans[:50]:
+            print(f"  unregistered: {path}")
+        if len(orphans) > 50:
+            print(f"  ... {len(orphans) - 50} more unregistered files")
+        return 1
+    print(
+        "Coverage registration audit passed: all tracked source is covered or exempt."
+    )
+    return 0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Check source tree vs LCOV coverage policy."
     )
     parser.add_argument("--repo-root", type=Path, default=ROOT_DIR)
     args = parser.parse_args()
-    sys.exit(run_audit(args.repo_root.resolve()))
+    repo_root = args.repo_root.resolve()
+    result = run_audit(repo_root)
+    if result == 0:
+        result = audit_unregistered_sources(repo_root)
+    sys.exit(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

You asked: *ensure that adding a new folder without registering it cannot bypass coverage.* It could.

The existing per-component audit (`tools/check_coverage_policy.py`) is recursive **inside** each of the four component source roots (`apps/backend/src`, `apps/frontend/src`, `tools`, `common`), so a new file under `apps/backend/src/...` is measured automatically. But code placed **outside every component root** — a new top-level package (`libs/`), a new `apps/<app>/`, or a loose module next to `src/` (`apps/backend/rogue.py`) — was invisible to the audit. It could ship at **0% coverage while the gate stayed green**.

## Fix — registration guard

Every tracked `.py`/`.ts`/`.tsx` file must be **either** under a coverage-component source root **or** matched by an explicit, justified exempt pattern. Adding an unlisted code directory fails the audit until the author moves it under a covered root or registers it in a reviewable diff. You cannot skip coverage by "just not registering" a folder.

- **`common/coverage/policy.py`**: `find_unregistered_sources()` + `is_registered_source()` + `COVERAGE_EXEMPT_PATTERNS` (tests, config, migrations, agent skills, docs, vendored submodule). One-off tooling *may* be exempted — per your call — but only as a visible entry, never a silent omission.
- **`tools/_lib/coverage/check_policy.py`**: `audit_unregistered_sources()` runs in the same CI job right after the per-component audit, failing with an actionable message pointing at the exempt list.
- **`docs/ssot/coverage.md`**: documents the new gate.

## Verification

- New unit tests prove the guard **flags** new packages / loose modules / code outside `src`, and **exempts** non-product trees (tests/config/migrations/skills/docs).
- A **live test** asserts the current repo (837 tracked source files) has **zero** unregistered trees — so this is green on `main` while blocking future additions.
- End-to-end: staging a real `apps/worker/src/handler.py` makes `audit_unregistered_sources` exit 1 with `::error title=Unregistered source tree::`.
- `test_coverage_policy.py`: **20/20 pass**; ruff check + format clean.

> Note on philosophy: this PR makes the gate *stricter*, not looser — aligned with your TDD direction. It does not touch `--cov-fail-under=96`.

Refs #896.

🤖 Generated with [Claude Code](https://claude.com/claude-code)