### PR TITLE
[finance_report_vision] fix(pr-preview): scope compose project to Dokploy appName so compose.delete reaps containers

### DIFF
--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -30,6 +30,14 @@ The `/repo/` directory is a git submodule pointing to [`infra2`](https://github.
   and builds backend/frontend from source on the host (`up -d --build`); no GHCR
   image is pulled or pushed. The preview persists until PR close, then is removed
   by native `compose.delete`.
+- **Preview compose project MUST equal Dokploy's `appName`.** `compose.delete`
+  tears the stack down with `docker compose down` scoped to the `appName`. The
+  preview `up` command therefore passes `-p <appName>` (read back from
+  `compose.one`), and the deploy env MUST NOT set `COMPOSE_PROJECT_NAME`.
+  Overriding the project (e.g. to `finance_report_pr_<n>`) desyncs `up` from
+  `down`: `compose.delete` removes the Dokploy record and on-disk compose
+  directory but `down` matches no containers, orphaning the whole stack with
+  nothing left to reap it.
 
 ---
 

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -34,7 +34,10 @@ def test_AC8_13_71_preview_env_contains_stable_metadata() -> None:
     assert env["PR_PREVIEW_PR_NUMBER"] == "591"
     assert env["PR_PREVIEW_COMPOSE_NAME"] == "pr-591"
     assert env["PR_PREVIEW_COMPOSE_PROJECT"] == "finance_report_pr_591"
-    assert env["COMPOSE_PROJECT_NAME"] == "finance_report_pr_591"
+    # COMPOSE_PROJECT_NAME is no longer injected: the docker compose project is
+    # Dokploy's appName (see preview_compose_command), so overriding it here is
+    # what orphaned merged-PR containers (compose.delete downs by appName).
+    assert "COMPOSE_PROJECT_NAME" not in env
     assert env["PR_PREVIEW_CREATED_BY"] == "github-actions"
     assert env["IMAGE_TAG"] == "pr-591-abc123"
     assert env["GIT_COMMIT_SHA"] == "abc123"
@@ -65,9 +68,16 @@ def test_AC8_13_101_preview_app_url_prefers_stable_alias() -> None:
     assert lifecycle.preview_port_offset(
         591, "abc123"
     ) != lifecycle.preview_port_offset(591, "def456")
-    assert lifecycle.preview_compose_command(591) == (
-        "compose -p finance_report_pr_591 -f docker-compose.pr-preview.yml "
+    # The compose project MUST be Dokploy's appName so compose.delete (which
+    # downs the stack by appName) reaps every container instead of orphaning it.
+    assert lifecycle.preview_compose_command("compose-pr-591-xyz") == (
+        "compose -p compose-pr-591-xyz -f docker-compose.pr-preview.yml "
         "up -d --build --remove-orphans"
+    )
+    # The project-less placeholder (create-time only) carries no `-p`; it is
+    # always overwritten by update_compose_source before any deploy.
+    assert lifecycle.preview_compose_command() == (
+        "compose -f docker-compose.pr-preview.yml up -d --build --remove-orphans"
     )
 
 
@@ -849,8 +859,13 @@ def test_AC8_13_102_preview_source_disables_dokploy_auto_deploy(
         expected_status=200,
     ) -> str:
         assert config.api_url == "https://cloud.example/api"
-        assert method == "POST"
         assert expected_status == 200
+        # update_compose_source reads the appName via GET compose.one to scope
+        # the deploy command; everything else is a POST mutation.
+        if endpoint.startswith("compose.one"):
+            assert method == "GET"
+            return '{"appName":"compose-pr-591-app"}'
+        assert method == "POST"
         if endpoint in {"compose.create", "compose.update"}:
             assert payload is not None
             payloads.append(payload)
@@ -871,12 +886,19 @@ def test_AC8_13_102_preview_source_disables_dokploy_auto_deploy(
     lifecycle.update_compose_source(
         lifecycle.DokployConfig("https://cloud.example/api", "secret"),
         compose_id="cmp-591",
-        pr_number=591,
         branch="feature",
         github_integration_id="ghid",
     )
 
+    # create uses the project-less placeholder; update rewrites it with the
+    # appName-scoped command so teardown can reap the stack.
     assert [payload["autoDeploy"] for payload in payloads] == [False, False]
+    create_payload, update_payload = payloads
+    assert "-p " not in create_payload["command"]
+    assert update_payload["command"] == (
+        "compose -p compose-pr-591-app -f docker-compose.pr-preview.yml "
+        "up -d --build --remove-orphans"
+    )
 
 
 def test_AC8_13_71_get_or_create_reuses_existing_compose(
@@ -1083,7 +1105,7 @@ def test_AC8_13_72_deploy_action_reads_effective_env_before_deploy(
             return subprocess.CompletedProcess(
                 cmd,
                 0,
-                stdout=json.dumps({"env": effective_env, "composeStatus": "running"}),
+                stdout=json.dumps({"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "running"}),
                 stderr="",
             )
         return subprocess.CompletedProcess(cmd, 0, stdout='{"ok":true}', stderr="")
@@ -1167,7 +1189,7 @@ def test_AC8_13_102_new_preview_redeploys_when_initial_deploy_record_is_missing(
                 cmd,
                 0,
                 stdout=json.dumps(
-                    {"env": effective_env, "composeStatus": "idle", "deployments": []}
+                    {"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "idle", "deployments": []}
                 ),
                 stderr="",
             )
@@ -1258,7 +1280,7 @@ def test_AC8_13_102_existing_preview_without_deployments_is_recreated(
                 cmd,
                 0,
                 stdout=json.dumps(
-                    {"env": effective_env, "composeStatus": "idle", "deployments": []}
+                    {"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "idle", "deployments": []}
                 ),
                 stderr="",
             )
@@ -1340,7 +1362,7 @@ def test_AC8_13_102_existing_preview_rollout_tracks_new_deployment_ids(
                 0,
                 stdout=json.dumps(
                     {
-                        "env": effective_env,
+                        "appName": "compose-pr-591-app", "env": effective_env,
                         "composeStatus": "running",
                         "deployments": [{"deploymentId": "old-dep-591"}],
                     }
@@ -1433,7 +1455,7 @@ def test_AC8_13_102_existing_preview_missing_deploy_record_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "env": effective_env,
+                        "appName": "compose-pr-591-app", "env": effective_env,
                         "composeStatus": "idle",
                         "deployments": [],
                     }
@@ -1446,7 +1468,7 @@ def test_AC8_13_102_existing_preview_missing_deploy_record_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "env": effective_env,
+                        "appName": "compose-pr-591-app", "env": effective_env,
                         "composeStatus": "idle",
                         "deployments": [{"deploymentId": "old-dep-591"}],
                     }
@@ -1545,7 +1567,7 @@ def test_AC8_13_102_recreated_preview_missing_record_fails_before_readiness(
             0,
             stdout=json.dumps(
                 {
-                    "env": effective_env,
+                    "appName": "compose-pr-591-app", "env": effective_env,
                     "composeStatus": "idle",
                     "deployments": [],
                 }
@@ -1646,7 +1668,7 @@ def test_AC8_13_102_existing_preview_rollout_error_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "env": effective_env,
+                        "appName": "compose-pr-591-app", "env": effective_env,
                         "composeStatus": "idle",
                         "deployments": [],
                     }
@@ -1659,7 +1681,7 @@ def test_AC8_13_102_existing_preview_rollout_error_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "env": effective_env,
+                        "appName": "compose-pr-591-app", "env": effective_env,
                         "composeStatus": "error",
                         "deployments": [{"deploymentId": "dep-591", "status": "error"}],
                     }
@@ -1756,7 +1778,7 @@ def test_AC8_13_102_new_preview_missing_after_redeploy_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "env": effective_env,
+                        "appName": "compose-pr-591-app", "env": effective_env,
                         "composeStatus": "idle",
                         "deployments": [],
                     }
@@ -1852,7 +1874,7 @@ def test_AC8_13_102_new_preview_rollout_error_still_fails(
             return subprocess.CompletedProcess(
                 cmd,
                 0,
-                stdout=json.dumps({"env": effective_env, "composeStatus": "error"}),
+                stdout=json.dumps({"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "error"}),
                 stderr="",
             )
         return subprocess.CompletedProcess(cmd, 0, stdout='{"ok":true}', stderr="")
@@ -1932,7 +1954,7 @@ def test_AC8_13_98_existing_preview_compose_is_redeployed_without_pre_stop(
             return subprocess.CompletedProcess(
                 cmd,
                 0,
-                stdout=json.dumps({"env": effective_env, "composeStatus": "running"}),
+                stdout=json.dumps({"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "running"}),
                 stderr="",
             )
         return subprocess.CompletedProcess(cmd, 0, stdout='{"ok":true}', stderr="")

--- a/tools/_lib/dev/pr_preview_lifecycle.py
+++ b/tools/_lib/dev/pr_preview_lifecycle.py
@@ -25,7 +25,6 @@ ALLOWLIST_ENV_KEYS = (
     "IMAGE_TAG",
     "GIT_COMMIT_SHA",
     "IAC_CONFIG_HASH",
-    "COMPOSE_PROJECT_NAME",
     "ENV_SUFFIX",
     "ENV_DOMAIN_SUFFIX",
     "NETWORK_SUFFIX",
@@ -321,13 +320,23 @@ def preview_app_url(pr_number: int, commit_sha: str, internal_domain: str) -> st
     return preview_stable_app_url(pr_number, internal_domain)
 
 
-def preview_compose_command(pr_number: int) -> str:
+def preview_compose_command(project_name: str | None = None) -> str:
     # Build the PR's source on the Dokploy host (GitHub-source deploy) instead of
     # pulling a CI-pushed image. PR previews never push images; image building +
     # promotion happens only post-merge (staging-deploy). `--build` rebuilds the
     # backend/frontend contexts that the preview compose now declares.
+    #
+    # The `-p` project name MUST equal Dokploy's own appName for this compose.
+    # Dokploy's compose.delete tears the stack down with `docker compose down`
+    # scoped to appName; if `up` runs under a different project, delete removes
+    # the Dokploy record but leaves the containers orphaned (no `docker compose
+    # down` ever targets them, and nothing else reaps them). Callers pass the
+    # appName via get_compose_app_name(); the project-less form is only a
+    # create-time placeholder that update_compose_source() always overwrites
+    # before any deploy.
+    project_flag = f"-p {project_name} " if project_name else ""
     return (
-        f"compose -p {preview_compose_project(pr_number)} "
+        f"compose {project_flag}"
         f"-f {PR_PREVIEW_COMPOSE_PATH} up -d --build --remove-orphans"
     )
 
@@ -437,13 +446,15 @@ def build_preview_env(
     return {
         "PR_PREVIEW_PR_NUMBER": str(pr_number),
         "PR_PREVIEW_COMPOSE_NAME": f"pr-{pr_number}",
+        # Informational label only. The real docker compose project is Dokploy's
+        # appName (set via the `-p` flag in preview_compose_command); this stable
+        # per-PR identifier is NOT wired to COMPOSE_PROJECT_NAME anymore.
         "PR_PREVIEW_COMPOSE_PROJECT": preview_compose_project(pr_number),
         "PR_PREVIEW_CREATED_BY": "github-actions",
         "GIT_COMMIT_SHA": commit_sha,
         "REGISTRY": registry,
         "IMAGE_PREFIX": image_prefix,
         "IMAGE_TAG": preview_image_tag(pr_number, commit_sha),
-        "COMPOSE_PROJECT_NAME": preview_compose_project(pr_number),
         "ENV_SUFFIX": env_suffix,
         "ENV_DOMAIN_SUFFIX": env_suffix,
         "NETWORK_SUFFIX": f"-pr-{pr_number}",
@@ -632,7 +643,10 @@ def create_compose(
             "branch": branch,
             "composePath": PR_PREVIEW_COMPOSE_PATH,
             "githubId": github_integration_id,
-            "command": preview_compose_command(pr_number),
+            # Placeholder: appName does not exist until Dokploy assigns it during
+            # compose.create. update_compose_source() rewrites this with the
+            # appName-scoped command before any deploy.
+            "command": preview_compose_command(),
             "autoDeploy": False,
         },
     )
@@ -696,10 +710,12 @@ def update_compose_source(
     config: DokployConfig,
     *,
     compose_id: str,
-    pr_number: int,
     branch: str,
     github_integration_id: str,
 ) -> None:
+    # Scope `up` to Dokploy's own appName so compose.delete (which downs the
+    # stack by appName) reaps every container. See preview_compose_command().
+    app_name = get_compose_app_name(config, compose_id=compose_id)
     dokploy_api_call(
         config,
         "POST",
@@ -713,7 +729,7 @@ def update_compose_source(
             "branch": branch,
             "composePath": PR_PREVIEW_COMPOSE_PATH,
             "githubId": github_integration_id,
-            "command": preview_compose_command(pr_number),
+            "command": preview_compose_command(app_name),
             "autoDeploy": False,
         },
     )
@@ -728,6 +744,19 @@ def get_compose_data(config: DokployConfig, *, compose_id: str) -> dict[str, obj
     )
     data = json.loads(body or "{}")
     return data if isinstance(data, dict) else {}
+
+
+def get_compose_app_name(config: DokployConfig, *, compose_id: str) -> str:
+    # Dokploy derives the docker compose project from this appName, and
+    # compose.delete downs the stack by it. Fail loud rather than deploy a
+    # preview whose teardown cannot reap its containers (the orphan-leak bug).
+    app_name = str(get_compose_data(config, compose_id=compose_id).get("appName") or "")
+    if not app_name:
+        raise RuntimeError(
+            f"Dokploy compose {compose_id} has no appName; cannot align the "
+            "compose project name with teardown"
+        )
+    return app_name
 
 
 def print_compose_summary(
@@ -775,7 +804,6 @@ def configure_preview_compose(
     update_compose_source(
         config,
         compose_id=compose_id,
-        pr_number=args.pr_number,
         branch=args.branch,
         github_integration_id=args.github_integration_id,
     )


### PR DESCRIPTION
## Problem

PR preview containers leak after merge. Confirmed live on vps-01: PRs **#882 / #886 / #889** left **12 running containers** (`backend`/`db`/`frontend`/`minio` × 3) ~30–40 min after merge, with their Dokploy compose dirs already gone from `/etc/dokploy/compose/`.

### Root cause

The preview deploy injected `COMPOSE_PROJECT_NAME=finance_report_pr_<n>` and passed `-p finance_report_pr_<n>` to `up`, so containers ran under project `finance_report_pr_882`. But Dokploy's own **appName** for that compose was a different slug (e.g. `compose-navigate-cross-platform-program-2sytpc`).

Dokploy's `compose.delete` tears the stack down with `docker compose down` scoped to the **appName**. On PR close it therefore:
1. removed the Dokploy record + on-disk compose dir, but
2. `down` matched **zero** containers (wrong project) → the whole stack orphaned.

Nothing reaps the orphans afterward: the schedule-based reconcile (`pr_preview_lifecycle.py --action reconcile`) only sees Dokploy-*tracked* composes, and the host-side name-matching reaper was removed in #859 on the (isolation-test-only) assumption that native `compose.delete` is sufficient — which holds **only when up's project == appName**. Vanilla composes (e.g. openpanel) reap fine precisely because they run under appName; our override broke that invariant.

## Fix

- `up` runs under Dokploy's **appName** (read back from `compose.one`) so `up == down` and `compose.delete` reaps every container.
- Stop overriding `COMPOSE_PROJECT_NAME` (removed from the deploy env and from `ALLOWLIST_ENV_KEYS`).
- `create_compose` sets a project-less placeholder command; `update_compose_source` (always runs before any deploy) rewrites it with the appName-scoped command.
- `get_compose_app_name` **fails loud** if appName is absent rather than deploying an unreapable preview.

## Tests

- `tests/tooling/test_pr_preview_lifecycle.py` — **70/70 pass**, including new regression guards: create command carries no `-p`, and `update_compose_source` sets `-p <appName>`.
- Full tooling suite green except pre-existing `pdfplumber`-missing PDF tests (unrelated). `ruff` clean.

## SSOT

`docs/ssot/deployment.md` documents the new invariant: **preview compose project MUST equal Dokploy's appName**; overriding it orphans the stack.

## Follow-ups (not in this PR)

- **Live verification**: this PR's own preview deploys under the new code — its container project should be the appName, and on PR close `compose.delete` should reap it to zero.
- **Existing orphans** (#882/#886/#889/#890, ~12–16 containers): this forward-looking fix can't reap already-orphaned stacks (their Dokploy records are gone); they need a one-time manual `docker compose down`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)