### PR TITLE
[finance_report_ui] EPIC-022 PR11: everyday-user UX hardening (#836)

### DIFF
--- a/apps/frontend/src/__tests__/attention.test.ts
+++ b/apps/frontend/src/__tests__/attention.test.ts
@@ -66,6 +66,20 @@ describe("attention model (EPIC-022 AC22.6)", () => {
     expect(byId["processing:stalled"]).toBe("/processing");
   });
 
+  it("AC22.11.2 every item explains why it was flagged", () => {
+    const items = buildAttentionItems(sources);
+    const byId = Object.fromEntries(items.map((i) => [i.id, i.reason]));
+    // Every surfaced item carries a non-trivial, plain-language reason.
+    for (const item of items) {
+      expect(item.reason.length).toBeGreaterThan(20);
+    }
+    // The reason is contextual, not boilerplate: a failed-balance statement
+    // reads differently from a clean parsed one.
+    expect(byId["statement:bad"]).toMatch(/balance/i);
+    expect(byId["statement:bad"]).not.toBe(byId["statement:ok"]);
+    expect(byId["reconciliation:unmatched"]).toMatch(/no matching ledger/i);
+  });
+
   it("AC22.6.1 is empty when everything is reconciled and approved", () => {
     expect(
       buildAttentionItems({

--- a/apps/frontend/src/__tests__/attentionQueue.test.tsx
+++ b/apps/frontend/src/__tests__/attentionQueue.test.tsx
@@ -56,6 +56,10 @@ describe("Attention queue (EPIC-022 AC22.6)", () => {
 
     expect(within(rows[1]).getByText("bad.pdf")).toBeInTheDocument();
     expect(within(rows[0]).getByText("0% confidence")).toBeInTheDocument();
+
+    // AC22.11.2: each row explains *why* it was flagged, not just a score.
+    expect(within(rows[0]).getByText(/no matching ledger entry/i)).toBeInTheDocument();
+    expect(within(rows[1]).getByText(/balance didn't reconcile/i)).toBeInTheDocument();
   });
 
   it("AC22.6.1 shows an all-clear empty state when nothing needs attention", async () => {

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -228,7 +228,7 @@ describe("StatementsPage", () => {
     // AC22.11.1: the parsing state is honest — a time expectation, and NO
     // fabricated fixed-percentage progress bar.
     const status = screen.getByRole("status")
-    expect(status).toHaveTextContent(/usually takes ~2.3 minutes/i)
+    expect(status).toHaveTextContent(/usually takes ~2–3 minutes/i)
     expect(status.querySelector('[style*="width: 60%"]')).toBeNull()
   })
 

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -198,7 +198,7 @@ describe("StatementsPage", () => {
     expect(screen.getByText("frobnicating")).toBeInTheDocument()
   })
 
-  it("AC16.14.11 enables polling when parsing statements exist", async () => {
+  it("AC16.14.11 AC22.11.1 enables polling with an honest parsing state (no fabricated progress)", async () => {
     mockedApiFetch.mockResolvedValueOnce({
       items: [
         {
@@ -224,6 +224,12 @@ describe("StatementsPage", () => {
 
     await waitFor(() => expect(screen.getByText("AI Parsing in Progress")).toBeInTheDocument())
     expect(intervalSpy).toHaveBeenCalled()
+
+    // AC22.11.1: the parsing state is honest — a time expectation, and NO
+    // fabricated fixed-percentage progress bar.
+    const status = screen.getByRole("status")
+    expect(status).toHaveTextContent(/usually takes ~2.3 minutes/i)
+    expect(status.querySelector('[style*="width: 60%"]')).toBeNull()
   })
 
   it("AC16.14.12 delete action calls delete API and toast", async () => {

--- a/apps/frontend/src/app/(main)/attention/page.tsx
+++ b/apps/frontend/src/app/(main)/attention/page.tsx
@@ -108,6 +108,8 @@ export default function AttentionPage() {
                   )}
                 </div>
                 <p className="text-xs text-muted mt-0.5">{item.detail}</p>
+                {/* AC22.11.2 — explain why this was flagged, not just a score. */}
+                <p className="text-xs text-muted/80 mt-1 max-w-prose">{item.reason}</p>
               </div>
               <div className="flex flex-shrink-0 items-center gap-3">
                 <Badge variant={confidenceVariant(item.confidence)}>{item.confidence}% confidence</Badge>

--- a/apps/frontend/src/app/(main)/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/upload/page.tsx
@@ -127,24 +127,21 @@ export default function UploadPage() {
                 </Alert>
             )}
 
-            {/* Parsing Progress */}
+            {/* Parsing status — AC22.11.1: an honest indeterminate state. We do
+                not know real percent-complete, so we show activity + a time
+                expectation instead of a fabricated fixed-width progress bar. */}
             {polling && (
-                <div className="mb-4 p-4 border border-[var(--accent)]/30 bg-[var(--accent-muted)] rounded-lg">
-                    <div className="flex items-center gap-3 mb-2">
+                <div
+                    className="mb-4 p-4 border border-[var(--accent)]/30 bg-[var(--accent-muted)] rounded-lg"
+                    role="status"
+                    aria-live="polite"
+                >
+                    <div className="flex items-center gap-3">
                         <div className="w-5 h-5 border-2 border-[var(--accent)] border-t-transparent rounded-full animate-spin" />
                         <div className="flex-1">
                             <div className="text-sm font-medium text-[var(--accent)]">AI Parsing in Progress</div>
-                            <div className="text-xs text-muted">Extracting transactions from your statement...</div>
+                            <div className="text-xs text-muted">Extracting transactions from your statement — this usually takes ~2–3 minutes.</div>
                         </div>
-                    </div>
-                    <div className="h-1.5 bg-[var(--background-muted)] rounded-full overflow-hidden">
-                        <div
-                            className="h-full bg-[var(--accent)] rounded-full animate-pulse"
-                            style={{ width: '60%' }}
-                            role="status"
-                            aria-label="Loading statements"
-                            aria-live="polite"
-                        />
                     </div>
                 </div>
             )}

--- a/apps/frontend/src/lib/attention.ts
+++ b/apps/frontend/src/lib/attention.ts
@@ -25,6 +25,11 @@ export interface AttentionItem {
   kind: AttentionKind;
   title: string;
   detail: string;
+  /**
+   * AC22.11.2 — plain-language explanation of *why* the system flagged this,
+   * so the user understands the blocker rather than just seeing a low score.
+   */
+  reason: string;
   /** 0–100; lower means the system is less sure and the user should look. */
   confidence: number;
   /** Deep-link to the surface where the user can act on this item. */
@@ -68,6 +73,9 @@ export function buildAttentionItems(sources: AttentionSources): AttentionItem[] 
       kind: "statement_review",
       title: statement.original_filename,
       detail: balanceFailed ? "Balance needs review" : "Parsed — ready to review",
+      reason: balanceFailed
+        ? "The statement's closing balance didn't reconcile against the parsed transactions, so the extraction may have missed or misread a line."
+        : "Parsed from your upload and waiting for you to confirm the entries before they post to the ledger.",
       confidence: clampConfidence(balanceFailed ? Math.min(score, 40) : score),
       href: `/statements/${statement.id}/review`,
     });
@@ -84,6 +92,7 @@ export function buildAttentionItems(sources: AttentionSources): AttentionItem[] 
       kind: "reconciliation_review",
       title: `${stats.pending_review} match${stats.pending_review > 1 ? "es" : ""} need review`,
       detail: "Reconciliation review",
+      reason: "Auto-matched to ledger entries but below the confidence bar to post without a human check — confirm or correct each match.",
       confidence: clampConfidence(stats.match_rate ?? 0),
       href: "/reconciliation/review-queue",
     });
@@ -98,6 +107,7 @@ export function buildAttentionItems(sources: AttentionSources): AttentionItem[] 
         stats.unmatched_transactions > 1 ? "s" : ""
       }`,
       detail: "No ledger match yet",
+      reason: "These transactions have no matching ledger entry at all — either new activity you haven't recorded yet, or a reference the matcher couldn't link.",
       confidence: 0,
       href: "/reconciliation/unmatched",
     });
@@ -114,6 +124,7 @@ export function buildAttentionItems(sources: AttentionSources): AttentionItem[] 
       kind: "processing_stalled",
       title: `${stalled.length} transfer${stalled.length > 1 ? "s" : ""} stuck in transit`,
       detail: `Oldest ${oldest} days outstanding`,
+      reason: `Funds left one account but haven't been confirmed arriving in another for over ${PROCESSING_STALE_DAYS} days — the transfer may need a matching deposit or a manual close.`,
       confidence: 30,
       href: "/processing",
     });

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -261,3 +261,22 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
 | AC22.10.1 | A holding whose latest snapshot is backed by a source document is labeled "Imported"; holdings without document evidence carry no provenance label (manual data is never shown as imported, and import is never claimed without proof) | `test_portfolio_service.py`, `holdingsTable.test.tsx` | P1 |
+
+### AC22.11 — Everyday-User UX Hardening
+
+> PR11 slice (#836). Post-merge hardening of the everyday-user surfaces, derived
+> from a UX review of the shipped IA. Two trust seams: the statement-parsing
+> screen showed a **fabricated** fixed-width progress bar (dishonest in a product
+> whose whole pitch is trustworthiness), and attention items showed a confidence
+> score with no explanation of *why* they were flagged (Axiom B asks the human to
+> look only at the low-confidence tail — so the reason must be legible). The
+> `/events`→`/notifications` dedup that #865 scoped is already handled by a
+> `next.config` redirect (so #865 closed); the residual `/events` page is left in
+> place because it still anchors EPIC-019's AC19.3.5. The cross-surface "return to
+> the attention queue after resolving" is split to a follow-up because it touches
+> every review destination.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC22.11.1 | The statement-parsing state shows an honest indeterminate indicator with a typical-duration expectation, and never renders a fabricated fixed-percentage progress bar | `statementsPage.test.tsx` | P1 |
+| AC22.11.2 | Each attention-queue item surfaces a plain-language reason it was flagged — distinct per cause — alongside its confidence score | `attention.test.ts`, `attentionQueue.test.tsx` | P1 |


### PR DESCRIPTION
Post-merge UX hardening of the shipped everyday-user IA, from a review of the live UI against the vision (**Axiom B**: automation by default, human attention only on the low-confidence tail; trustworthy by default). Frontend-only, no backend, no migration.

## What ships

- **AC22.11.1 — honest parsing state.** The upload "AI Parsing in Progress" panel rendered a **fabricated** fixed-width (60%) progress bar. Replaced with an honest indeterminate state (spinner + "this usually takes ~2–3 minutes"). A fake progress bar is the single worst micro-detail in a product whose whole pitch is trustworthiness.
- **AC22.11.2 — explain *why* an item is flagged.** `AttentionItem` now carries a plain-language `reason`, distinct per cause (failed balance check, no ledger match, low-confidence auto-match, stalled transfer), rendered under each item — so the user understands the blocker, not just a `20% confidence` score. This is the legibility Axiom B's "ask the human only on the low-confidence tail" implies.

## Deliberately deferred / out of scope

- **Return-to-queue after resolving** an attention item — touches every review destination surface; split to a follow-up issue.
- **/events dead-page removal** — left in place: it still anchors EPIC-019's `AC19.3.5`, and the `/events`→`/notifications` dedup that #865 scoped is **already delivered by a `next.config` redirect** (which is why #865 was closed as functionally complete).
- **Confidence/provenance on aggregate surfaces** (Net Worth, balance-sheet nodes) — blocked on backend **#888** (no per-node provenance field today); tracked under #868.

## Verification

- Full frontend suite **704 passing**; `tsc` + ESLint clean; **AC traceability gate 100%** (AC22.11.1/.2 proven).

Part of the EPIC-022 root (#836).

🤖 Generated with [Claude Code](https://claude.com/claude-code)