### PR TITLE
[finance_report_test_and_doc] feat(money): canonical banker's-rounding policy via to_money()

### DIFF
--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -38,6 +38,7 @@ from src.services.brokerage_positions import BrokeragePositionImportService
 from src.services.fx import FxRateError, convert_amount
 from src.services.performance import InsufficientDataError, PerformanceError
 from src.services.portfolio import AssetNotFoundError, PortfolioNotFoundError, PortfolioService
+from src.utils.money import to_money
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
 logger = get_logger(__name__)
@@ -77,7 +78,8 @@ class DividendCreateRequest(BaseModel):
 
 
 def _money(value: Decimal) -> Decimal:
-    return Decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    # Canonical money rounding (banker's / HALF_EVEN). See docs/ssot/accounting.md#decimal-rule.
+    return to_money(Decimal(value))
 
 
 def _percent(value: Decimal | None) -> Decimal | None:

--- a/apps/backend/src/services/investment_accounting.py
+++ b/apps/backend/src/services/investment_accounting.py
@@ -19,8 +19,8 @@ from src.models.portfolio import (
     InvestmentTransactionType,
 )
 from src.services.accounting import create_journal_entry, post_journal_entry
+from src.utils.money import to_money
 
-MONEY = Decimal("0.01")
 QUANTITY = Decimal("0.000001")
 
 
@@ -42,7 +42,8 @@ class InvestmentAccountingResult:
 
 
 def _money(value: Decimal) -> Decimal:
-    return value.quantize(MONEY, rounding=ROUND_HALF_UP)
+    # Canonical money rounding (banker's / HALF_EVEN). See docs/ssot/accounting.md#decimal-rule.
+    return to_money(value)
 
 
 def _quantity(value: Decimal) -> Decimal:

--- a/apps/backend/src/utils/__init__.py
+++ b/apps/backend/src/utils/__init__.py
@@ -11,8 +11,10 @@ from .exceptions import (
     raise_too_many_requests,
     raise_unauthorized,
 )
+from .money import MONEY_QUANTUM, to_money
 
 __all__ = [
+    "MONEY_QUANTUM",
     "raise_bad_request",
     "raise_conflict",
     "raise_gateway_timeout",
@@ -22,4 +24,5 @@ __all__ = [
     "raise_too_large",
     "raise_too_many_requests",
     "raise_unauthorized",
+    "to_money",
 ]

--- a/apps/backend/src/utils/money.py
+++ b/apps/backend/src/utils/money.py
@@ -1,0 +1,28 @@
+"""Canonical monetary rounding policy.
+
+Currency amounts are quantized to 2 decimal places using banker's rounding
+(``ROUND_HALF_EVEN``). This is the single source of truth for money rounding;
+see ``docs/ssot/accounting.md#decimal-rule``.
+
+Out of scope (deliberately use their own quantization):
+- FX rates and security prices: 6 dp (``services/market_data.py``).
+- Share quantities: 6 dp (``services/investment_accounting.py``).
+- Percentages / performance ratios (XIRR, TWR, MWR, allocation %): not currency.
+"""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_EVEN, Decimal
+
+# 2-decimal-place currency quantum.
+MONEY_QUANTUM: Decimal = Decimal("0.01")
+
+
+def to_money(value: Decimal) -> Decimal:
+    """Quantize a Decimal currency amount to 2 dp using banker's rounding.
+
+    Banker's rounding (round-half-to-even) is the project-wide canonical policy
+    for currency amounts. Pass a ``Decimal`` (never ``float`` — see the decimal
+    rule in the accounting SSOT).
+    """
+    return value.quantize(MONEY_QUANTUM, rounding=ROUND_HALF_EVEN)

--- a/apps/backend/tests/accounting/test_money.py
+++ b/apps/backend/tests/accounting/test_money.py
@@ -1,0 +1,44 @@
+"""Canonical money rounding policy tests (docs/ssot/accounting.md#decimal-rule)."""
+
+from decimal import Decimal
+
+import pytest
+
+from src.utils.money import MONEY_QUANTUM, to_money
+
+pytestmark = pytest.mark.no_db
+
+
+def test_money_quantum_is_two_decimal_places():
+    assert MONEY_QUANTUM == Decimal("0.01")
+
+
+def test_to_money_quantizes_to_two_decimal_places():
+    assert to_money(Decimal("10")) == Decimal("10.00")
+    assert to_money(Decimal("3.14159")) == Decimal("3.14")
+    assert to_money(Decimal("0.1")) == Decimal("0.10")
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Exact-half cases distinguish banker's rounding from round-half-up.
+        ("0.125", "0.12"),  # half to even (2 is even) — HALF_UP would give 0.13
+        ("0.135", "0.14"),  # half to even (4 is even)
+        ("0.145", "0.14"),  # half to even (4 is even) — HALF_UP would give 0.15
+        ("0.155", "0.16"),  # half to even (6 is even)
+        ("2.005", "2.00"),  # half to even (0 is even) — HALF_UP would give 2.01
+    ],
+)
+def test_to_money_uses_banker_rounding_half_to_even(value, expected):
+    assert to_money(Decimal(value)) == Decimal(expected)
+
+
+def test_to_money_banker_rounding_is_symmetric_for_negatives():
+    assert to_money(Decimal("-0.125")) == Decimal("-0.12")
+    assert to_money(Decimal("-0.145")) == Decimal("-0.14")
+
+
+def test_to_money_preserves_already_rounded_values():
+    assert to_money(Decimal("99.99")) == Decimal("99.99")
+    assert to_money(Decimal("-42.00")) == Decimal("-42.00")

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -49,6 +49,7 @@ explicit AC IDs for the behavior.
 
 | Path | Owner |
 |---|---|
+| `apps/backend/tests/accounting/test_money.py` | `docs/ssot/accounting.md` |
 | `apps/backend/tests/accounting/test_processing_account_endpoints.py` | `docs/ssot/processing_account.md` |
 | `apps/backend/tests/api/test_ai_feedback_router_extra.py` | `docs/ssot/ai.md` |
 | `apps/backend/tests/assets/test_assets_positions_and_depreciation.py` | `docs/ssot/assets.md` |

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -25,11 +25,14 @@ concepts:
   # ── Accounting domain ──────────────────────────────────────────────────
   decimal_monetary_rule:
     owner: docs/ssot/accounting.md#decimal-rule
-    description: All monetary amounts MUST use Python Decimal, never float.
+    description: All monetary amounts MUST use Python Decimal, never float; money rounds via banker's HALF_EVEN.
     cross_refs:
       - AGENTS.md
       - docs/agents/red-lines.md
       - apps/backend/tests/accounting/test_decimal_safety.py
+    proofs:
+      - apps/backend/tests/accounting/test_decimal_safety.py
+      - apps/backend/tests/accounting/test_money.py
 
   accounting_equation:
     owner: docs/ssot/accounting.md#accounting-equation

--- a/docs/ssot/accounting.md
+++ b/docs/ssot/accounting.md
@@ -101,6 +101,11 @@ when the entry moves from `posted` to `reconciled`.
     -   **Enforcement**: All Pydantic models use `Decimal`. API clients parse JSON numbers as strings or Decimals, never floats.
     -   **Guardrail**: `apps/backend/tests/accounting/test_decimal_safety.py` fuzzes models with float inputs to ensure strictness.
 
+- **Rule A2 — Canonical money rounding**: Currency amounts are quantized to **2 decimal places using banker's rounding (`ROUND_HALF_EVEN`)**. This is the single project-wide rounding mode for money.
+    -   **Enforcement**: round money through the one helper `apps/backend/src/utils/money.py::to_money()` (exposed as `src.utils.to_money`). Do not hand-roll `quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)` for currency.
+    -   **Scope**: currency amounts only. Intentionally **out of scope** (they keep their own quantization/rounding): FX rates & security prices (6 dp), share quantities (6 dp), and percentages / performance ratios (XIRR, TWR, MWR, allocation %).
+    -   **Guardrail**: `apps/backend/tests/accounting/test_money.py`.
+
 <a id="entry-balance"></a>
 
 - **Anti-pattern B**: **NEVER** allow unbalanced debit/credit entries. See: `apps/backend/tests/accounting/test_accounting_integration.py::test_post_unbalanced_entry_rejected`


### PR DESCRIPTION
## Summary

Money rounding was inconsistent and undocumented — and you chose **ROUND_HALF_EVEN (banker's rounding) as canonical, plus build the SSOT.** This PR does exactly that.

### The real picture (verified, corrects the original "58 vs 2" scan)
- 58 sites used Python's **default** `ROUND_HALF_EVEN` (bare `.quantize(Decimal("0.01"))`).
- `ROUND_HALF_UP` wasn't 2 strays — it's a deliberate convention in `investment_accounting._money`, `portfolio._money`, plus `market_data` rates and `_quantity` (the latter two are **6dp, not money**).
- No SSOT defined the canonical money mode.

### What this PR does
- **`src/utils/money.py::to_money()`** — the single 2dp currency helper (HALF_EVEN), exposed as `src.utils.to_money`. Unit-tested with exact-half cases that distinguish banker's rounding from half-up (`0.125→0.12`, `0.145→0.14`, `2.005→2.00`).
- **SSOT**: `docs/ssot/accounting.md#decimal-rule` gains "Rule A2 — Canonical money rounding" with scope, and a `proofs:` entry in `MANIFEST.yaml`.

### ⚠️ Behavior change — please review these two
The two deliberate-HALF_UP **money** helpers now route through `to_money()`, flipping `HALF_UP → HALF_EVEN`:
- `services/investment_accounting.py::_money` — **affects all its callers** (cost basis, gains).
- `routers/portfolio.py::_money`.

Half-case amounts now round to even (e.g. `0.145 → 0.14`, was `0.15`; `2.005 → 2.00`, was `2.01`). If any financial test asserts the old half-up values, CI will surface them and the expected values should update to encode the new policy.

### Deliberately OUT of scope (not currency — kept as-is)
6dp FX rates & security prices (`market_data`), 6dp share quantities (`_quantity`), and percentages / performance ratios (`_percent`, XIRR, TWR, MWR, allocation %). The SSOT says so explicitly.

### Follow-up (not here)
The 58 already-HALF_EVEN bare-quantize sites already comply; routing them through `to_money()` + a static guard forbidding raw money `.quantize()` is a mechanical follow-up once this policy lands.

## Verification
- `to_money` rounding cases verified correct (exact-half banker's behavior).
- Imports clean; both `_money` helpers confirmed banker-rounding; ruff check + format clean.
- **SSOT governance gate + `check_manifest` + `check_ssot_ownership` all PASS locally** (reproduced the gate that failed #899).

> Backend tests need Postgres (unavailable locally); the `to_money` unit tests are marked `no_db` and run in CI. CI is the gate for the financial-suite validation of the behavior change.

Refs #896.

🤖 Generated with [Claude Code](https://claude.com/claude-code)