### PR TITLE
[finance_report_infra] EPIC-007 #877 G2: pin data axis + four data red lines into SSOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,8 +693,9 @@ jobs:
           cache-to: type=gha,scope=frontend,mode=max
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${{ steps.get_sha.outputs.short_sha }}
           # G1 (#898, AC7.12.8): the published :<sha> image must be environment-independent.
-          # Do NOT bake NEXT_PUBLIC_API_URL/APP_URL here — the front end uses the same-origin
-          # relative /api path, so one image promotes unchanged across staging and prod.
+          # Do NOT bake NEXT_PUBLIC_API_URL or NEXT_PUBLIC_APP_URL here — the front end uses
+          # the same-origin relative /api path, so one image promotes unchanged across
+          # staging and prod.
           build-args: |
             GIT_COMMIT_SHA=${{ steps.get_sha.outputs.short_sha }}
 

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -233,6 +233,7 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 
 | ID | Requirement | Test Function | File | Priority |
 |----|-------------|---------------|------|----------|
+| AC7.12.6 | SSOT (`environments.md`) defines the data axis (empty / staging / anonymized prod snapshot) and the four data red lines (RL-DATA-1..4): a PR sha never runs on prod data; prod data is anonymized before leaving prod; non-prod object storage holds no real uploads; a backup is not an anonymized snapshot | `test_AC7_12_6_environments_define_data_axis_and_red_lines` | `tests/tooling/test_data_red_lines_contract.py` | P1 |
 | AC7.12.8 | The published `:<sha>` front-end image is environment-independent (same-origin `/api`, no environment domain baked in); a contract test fails if a concrete environment domain appears in the published image | `test_AC7_12_8_published_frontend_image_has_no_baked_env_domain` | `tests/tooling/test_frontend_same_origin_contract.py` | P0 |
 
 

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -171,6 +171,49 @@ The production Platform layer (SigNoz, MinIO, Traefik) runs as **Singleton** ser
 
 ---
 
+## Data Axis & Red Lines
+
+An environment is **(code × data)**. The sections above cover the *code* side
+(which image runs where); this section owns the *data* side — **which data an
+environment runs on**. Data is the second input to the deploy primitive
+`deploy(env, code, data)`. Most of this project's risk (financial correctness,
+Alembic migrations) lives here, so the constraints below are **red lines**, not
+preferences.
+
+### Data sources
+
+| Source | What it is | Used by |
+|--------|------------|---------|
+| **empty** | migrations freshly applied, seed/fixtures only | `e2e`, `preview` |
+| **staging** | data accumulated by testing | `staging` |
+| **anonymized prod snapshot** | the *shape* of real data, with amounts/PII anonymized | `rehearsal`, `staging` (fed by `snapshot-sync`) |
+| *(real prod data)* | live data | **`production` only** |
+
+**Default is safe-on-failure**: a non-prod environment defaults to **empty /
+synthetic** data. The anonymized snapshot is an additive opt-in — if anonymization
+ever breaks, the degrade lands on empty/synthetic, **never** on real data.
+
+### Data red lines
+
+These are decided constraints; every environment inherits them. Each has a stable
+label so a reword cannot silently drop it.
+
+- **RL-DATA-1** — Unreviewed code (a **PR** sha) may never run against **prod data**.
+- **RL-DATA-2** — **Prod** data must be **anonymized** before it leaves the prod
+  network into any other environment (this is a financial system — real
+  amounts/PII are an incident, not a convenience).
+- **RL-DATA-3** — Non-prod **object storage** holds **no real uploads**; financial
+  PDFs/scans can't be reliably anonymized, so use a **synthetic** document set.
+- **RL-DATA-4** — A **backup** is **not** an anonymized **snapshot**: disaster
+  recovery needs an encrypted *real-data* backup; the staging feed needs an
+  *anonymized* one. They are two separate pipelines.
+
+> Governance anchor: these red lines are the data-side counterpart of the
+> App/Infra artifact boundary. Tracked by #876 (G2 #877); the migration-rehearsal
+> use of the anonymized snapshot ties to AC7.11.
+
+---
+
 ## Related
 
 - [development.md](./development.md) — Moon commands and local setup

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -182,12 +182,12 @@ preferences.
 
 ### Data sources
 
-| Source | What it is | Used by |
+| Source | What it is | Used by (environment) |
 |--------|------------|---------|
-| **empty** | migrations freshly applied, seed/fixtures only | `e2e`, `preview` |
-| **staging** | data accumulated by testing | `staging` |
-| **anonymized prod snapshot** | the *shape* of real data, with amounts/PII anonymized | `rehearsal`, `staging` (fed by `snapshot-sync`) |
-| *(real prod data)* | live data | **`production` only** |
+| **empty** | migrations freshly applied, seed/fixtures only | GitHub CI, PR Preview |
+| **staging** | data accumulated by testing | Staging |
+| **anonymized prod snapshot** | the *shape* of real data, with amounts/PII anonymized | Staging, and `rehearsal` *(planned, #893)* — fed by `snapshot-sync` |
+| *(real prod data)* | live data | **Production only** |
 
 **Default is safe-on-failure**: a non-prod environment defaults to **empty /
 synthetic** data. The anonymized snapshot is an additive opt-in — if anonymization

--- a/tests/tooling/test_data_red_lines_contract.py
+++ b/tests/tooling/test_data_red_lines_contract.py
@@ -1,0 +1,43 @@
+"""AC7.12.6 (G2, #877) — data red lines pinned in SSOT.
+
+The data axis (which data an environment runs on) is the second input to
+``deploy(env, code, data)``. Most of this project's risk lives on the data side
+(financial correctness, Alembic migrations). These four red lines are *decided
+constraints*; they live in ``environments.md`` (the six-environment SSOT) so every
+environment inherits them. See EPIC-007 AC7.12.6, root #876.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+# Each red line carries a stable label so a doc reword cannot silently drop it,
+# plus keywords that pin its meaning.
+DATA_RED_LINES = {
+    "RL-DATA-1": ["pr", "prod data"],  # unreviewed code never runs on prod data
+    "RL-DATA-2": ["anonymiz", "prod"],  # anonymize before data leaves prod
+    "RL-DATA-3": ["object storage", "synthetic"],  # non-prod holds no real uploads
+    "RL-DATA-4": ["backup", "snapshot"],  # a backup is not an anonymized snapshot
+}
+DATA_SOURCES = ["empty", "anonymized prod snapshot"]
+
+
+def test_AC7_12_6_environments_define_data_axis_and_red_lines():
+    env = read("docs/ssot/environments.md").lower()
+    for src in DATA_SOURCES:
+        assert src in env, (
+            f"environments.md must define the data source '{src}' (AC7.12.6, #877)."
+        )
+    for label, keywords in DATA_RED_LINES.items():
+        assert label.lower() in env, (
+            f"environments.md must state data red line {label} (AC7.12.6, #877)."
+        )
+        for kw in keywords:
+            assert kw in env, (
+                f"data red line {label} must mention '{kw}' (AC7.12.6, #877)."
+            )

--- a/tests/tooling/test_data_red_lines_contract.py
+++ b/tests/tooling/test_data_red_lines_contract.py
@@ -24,15 +24,37 @@ DATA_RED_LINES = {
     "RL-DATA-3": ["object storage", "synthetic"],  # non-prod holds no real uploads
     "RL-DATA-4": ["backup", "snapshot"],  # a backup is not an anonymized snapshot
 }
-DATA_SOURCES = ["empty", "anonymized prod snapshot"]
+# All three data sources (Copilot CR: don't let a regression silently drop one).
+# Checked inside the "Data sources" subsection so a stray mention elsewhere in the
+# SSOT (e.g. the Staging environment) cannot satisfy the assertion.
+DATA_SOURCES = ["empty", "staging", "anonymized prod snapshot"]
+
+
+def _subsection(md: str, header: str) -> str:
+    """Text from ``header`` up to the next same-or-higher-level heading, lowercased."""
+    out, capturing = [], False
+    for line in md.splitlines():
+        if line.strip() == header:
+            capturing = True
+            continue
+        if capturing and line.startswith("### "):
+            break
+        if capturing:
+            out.append(line)
+    return "\n".join(out).lower()
 
 
 def test_AC7_12_6_environments_define_data_axis_and_red_lines():
-    env = read("docs/ssot/environments.md").lower()
+    md = read("docs/ssot/environments.md")
+    sources = _subsection(md, "### Data sources")
+    assert sources, (
+        "environments.md must have a '### Data sources' subsection (AC7.12.6, #877)."
+    )
     for src in DATA_SOURCES:
-        assert src in env, (
-            f"environments.md must define the data source '{src}' (AC7.12.6, #877)."
+        assert src in sources, (
+            f"environments.md '### Data sources' must define '{src}' (AC7.12.6, #877)."
         )
+    env = md.lower()
     for label, keywords in DATA_RED_LINES.items():
         assert label.lower() in env, (
             f"environments.md must state data red line {label} (AC7.12.6, #877)."

--- a/tests/tooling/test_frontend_same_origin_contract.py
+++ b/tests/tooling/test_frontend_same_origin_contract.py
@@ -17,13 +17,25 @@ def read(path: str) -> str:
     return (ROOT / path).read_text(encoding="utf-8")
 
 
-# A concrete absolute host assigned to a NEXT_PUBLIC_*_URL build-arg is baked into the
+# A concrete absolute host assigned to NEXT_PUBLIC_(API|APP)_URL is baked into the
 # bundle at `next build` time and ties the published image to that one environment.
-_BAKED_ENV_DOMAIN = re.compile(r"NEXT_PUBLIC_(?:API|APP)_URL=https?://\S+")
+# Match `=` or `:` assignment with optional surrounding quotes, so a quoted YAML value
+# (NEXT_PUBLIC_API_URL="https://...") cannot slip past (Copilot CR on #901).
+_BAKED_ENV_DOMAIN = re.compile(
+    r"""NEXT_PUBLIC_(?:API|APP)_URL\s*[=:]\s*["']?\s*https?://"""
+)
+
+# Files that contribute to the *published* image. staging-deploy.yml is intentionally
+# excluded — its build-on-missing path is the deploy-side escape hatch owned by P1b/P2.
+_PUBLISH_BUILD_SOURCES = (".github/workflows/ci.yml", "apps/frontend/Dockerfile")
 
 
 def test_AC7_12_8_published_frontend_image_has_no_baked_env_domain():
-    offenders = _BAKED_ENV_DOMAIN.findall(read(".github/workflows/ci.yml"))
+    offenders = {
+        src: hits
+        for src in _PUBLISH_BUILD_SOURCES
+        if (hits := _BAKED_ENV_DOMAIN.findall(read(src)))
+    }
     assert not offenders, (
         "The published :<sha> front-end image bakes an environment domain into the "
         "bundle, coupling the artifact to one environment and breaking promote-not-rebuild "
@@ -32,11 +44,18 @@ def test_AC7_12_8_published_frontend_image_has_no_baked_env_domain():
     )
 
 
+# Accept `||` or `??` and either quote style, so behaviour-preserving edits don't
+# break the contract while the same-origin fallback itself stays enforced (Copilot CR).
+_SAME_ORIGIN_FALLBACK = re.compile(
+    r"""NEXT_PUBLIC_API_URL\s*(?:\|\||\?\?)\s*(?:""|'')"""
+)
+
+
 def test_AC7_12_8_frontend_api_keeps_same_origin_fallback():
     # The same-origin fallback is the invariant that makes the image env-independent;
     # lock it so a future edit cannot silently reintroduce an absolute API base.
     api = read("apps/frontend/src/lib/api.ts")
-    assert 'process.env.NEXT_PUBLIC_API_URL || ""' in api, (
+    assert _SAME_ORIGIN_FALLBACK.search(api), (
         "API_URL must fall back to an empty string (relative same-origin /api) when "
         "NEXT_PUBLIC_API_URL is unset (AC7.12.8, G1 #898)."
     )


### PR DESCRIPTION
Closes #877. Foundation **G2** of #876 — block 3 (Data) precondition. Pure governance/SSOT, zero runtime-behavior change.

## What
A deploy is **(code × data)**. G1 (#898, merged) locked the code/artifact side; G2 pins the **data** side into SSOT so every environment inherits it.

`docs/ssot/environments.md` gains a **Data Axis & Red Lines** section:
- **Data sources**: `empty` / `staging` / `anonymized prod snapshot` (real data only in `production`).
- **Default is safe-on-failure** (Known risk H6): non-prod defaults to empty/synthetic; the anonymized snapshot is additive opt-in. If anonymization breaks, the degrade lands on empty/synthetic, never real data.
- **Four data red lines** (stable labels so a reword can't drop them):
  - `RL-DATA-1` — a PR sha never runs on prod data
  - `RL-DATA-2` — prod data is anonymized before leaving prod
  - `RL-DATA-3` — non-prod object storage holds no real uploads (synthetic set)
  - `RL-DATA-4` — a backup is not an anonymized snapshot (two pipelines)

## Test (TDD red→green)
`tests/tooling/test_data_red_lines_contract.py` (AC7.12.6) asserts `environments.md` carries each data source and each labelled red line. `uv run --with pytest --with pyyaml pytest tests/tooling/test_data_red_lines_contract.py` → 1 passed (was failing before the doc section existed). doc-consistency / registry --check / ac-traceability / ssot-ownership / manifest all green locally.

## ⚠️ Maintainer action — AGENTS.md
AC7.12.6 asks for the red lines in **governance + SSOT**. SSOT is done here. AGENTS.md (= `CLAUDE.md` symlink) is AI-write-protected, so please add this line under **🚨 Security & Red Lines → Quick reference**:

> - **NEVER** run unreviewed code (a PR sha) against prod data, and **NEVER** let prod data enter a non-prod environment un-anonymized (data red lines RL-DATA-1..4 — see `docs/ssot/environments.md` → Data Axis & Red Lines).

## Scope
Pure docs + contract test. No workflow/runtime change. The data *pipeline* (`snapshot-sync`, `rehearsal`) is P3 (#893); this PR only pins the constraints it must obey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)