### PR TITLE
[finance_report_infra] EPIC-007 #878 P1b: lock staging/prod pull-not-build + data-survives-redeploy

### DIFF
--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -233,6 +233,7 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 
 | ID | Requirement | Test Function | File | Priority |
 |----|-------------|---------------|------|----------|
+| AC7.12.3 | The staging/prod deploy compose (infra2 `10.app/compose.yaml`) cannot local-build the app services (no `build:`, `pull_policy: always`), and the postgres/redis data dirs are bind-mounted via `${DATA_PATH}` (not a named volume Dokploy wipes on redeploy) | `test_AC7_12_3_deploy_compose_pull_not_build`, `test_AC7_12_3_data_dirs_survive_redeploy` | `tests/tooling/test_deploy_compose_contract.py` | P0 |
 | AC7.12.6 | SSOT (`environments.md`) defines the data axis (empty / staging / anonymized prod snapshot) and the four data red lines (RL-DATA-1..4): a PR sha never runs on prod data; prod data is anonymized before leaving prod; non-prod object storage holds no real uploads; a backup is not an anonymized snapshot | `test_AC7_12_6_environments_define_data_axis_and_red_lines` | `tests/tooling/test_data_red_lines_contract.py` | P1 |
 | AC7.12.8 | The published `:<sha>` front-end image is environment-independent (same-origin `/api`, no environment domain baked in); a contract test fails if a concrete environment domain appears in the published image | `test_AC7_12_8_published_frontend_image_has_no_baked_env_domain` | `tests/tooling/test_frontend_same_origin_contract.py` | P0 |
 

--- a/tests/tooling/test_deploy_compose_contract.py
+++ b/tests/tooling/test_deploy_compose_contract.py
@@ -1,0 +1,64 @@
+"""AC7.12.3 (P1b, #878) — the staging/prod deploy path is pull-not-build, data survives redeploy.
+
+Infra consumes the exact artifact digest; it never re-builds. The real staging/prod
+deploy compose is the infra2 submodule ``10.app/compose.yaml`` (deployed via Dokploy
+``STAGING_COMPOSE_ID`` / ``PRODUCTION_COMPOSE_ID``) — NOT the root ``docker-compose.yml``,
+which stays buildable for the App's self-contained run. Investigation (#878) found the
+deploy compose already correct (``pull_policy: always``, no ``build:``) and the data
+dirs already bind-mounted via ``${DATA_PATH}``; these tests lock that so it can't regress.
+
+See EPIC-007 AC7.12.3, root #876. Data-volume safety relates to RL-DATA / Dokploy
+named-volume reset on redeploy.
+"""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+APP_COMPOSE = "repo/finance_report/finance_report/10.app/compose.yaml"
+# data service compose -> the in-container data dir that must persist across redeploys
+DATA_COMPOSES = {
+    "repo/finance_report/finance_report/01.postgres/compose.yaml": "/var/lib/postgresql/data",
+    "repo/finance_report/finance_report/02.redis/compose.yaml": "/data",
+}
+APP_SERVICES = ("backend", "frontend")
+
+
+def load(path: str) -> dict:
+    return yaml.safe_load((ROOT / path).read_text(encoding="utf-8"))
+
+
+def test_AC7_12_3_deploy_compose_pull_not_build():
+    services = load(APP_COMPOSE)["services"]
+    for name in APP_SERVICES:
+        svc = services[name]
+        assert "build" not in svc, (
+            f"{name} in {APP_COMPOSE} must have no `build:` section — Infra consumes the "
+            f"published image, it never re-builds (AC7.12.3, #878)."
+        )
+        assert svc.get("pull_policy") == "always", (
+            f"{name} in {APP_COMPOSE} must set `pull_policy: always` so the deploy pulls "
+            f"the exact digest instead of serving a stale local image (AC7.12.3, #878)."
+        )
+
+
+def test_AC7_12_3_data_dirs_survive_redeploy():
+    for path, data_dir in DATA_COMPOSES.items():
+        services = load(path)["services"]
+        mounts = [
+            v
+            for svc in services.values()
+            for v in (svc.get("volumes") or [])
+            if isinstance(v, str) and v.split(":")[0:2][-1] == data_dir
+        ]
+        assert mounts, (
+            f"{path} must mount a data volume at {data_dir} (AC7.12.3, #878)."
+        )
+        for mount in mounts:
+            source = mount.split(":")[0]
+            assert "DATA_PATH" in source, (
+                f"{path} must bind-mount {data_dir} via ${{DATA_PATH}}, not a named volume "
+                f"that Dokploy wipes on redeploy (AC7.12.3, #878). Found source: {source!r}."
+            )


### PR DESCRIPTION
Closes #878. P1b of #876 — block 2 (Deploy) hardening. **Zero runtime change.**

## Investigation (#878 AC1) — the hazard isn't live on the deploy path
The real staging/prod deploy compose is the **infra2 submodule `repo/finance_report/finance_report/10.app/compose.yaml`** (deployed via Dokploy `STAGING_COMPOSE_ID` / `PRODUCTION_COMPOSE_ID` through `tools/dokploy_deploy.sh`), **not** the root `docker-compose.yml` (which stays buildable for the App's self-contained `e2e` run — removing its `build:` would break the boundary, as flagged in the #878 rev2 note).

That deploy compose is **already correct**:
- `backend`/`frontend`: `image:` + **`pull_policy: always`**, **no `build:`** → pull-not-build.
- `postgres`/`redis`: data dirs bind-mounted via **`${DATA_PATH}`** (not a named volume Dokploy wipes on redeploy).
- URLs are injected as **runtime env** (`NEXT_PUBLIC_API_URL` in compose `environment:`, read server-side), consistent with G1's promote-not-rebuild shared image.

So **D3 is not a live production hazard** — exactly the #878 AC4 outcome ("if Dokploy already pulls-only → downgrade to a hardening PR + land the test so it can't regress").

## Change — regression lock only
`tests/tooling/test_deploy_compose_contract.py` (AC7.12.3):
- `test_AC7_12_3_deploy_compose_pull_not_build` — app services have no `build:` and `pull_policy: always`.
- `test_AC7_12_3_data_dirs_survive_redeploy` — postgres/redis data dirs are `${DATA_PATH}` bind mounts.

**Verified the test catches regressions**: temporarily adding `build:` / removing `pull_policy` → red; restored → green.

## Scope / out of scope
- No compose/workflow/runtime change (current state already correct).
- The `staging-deploy.yml` `build_required` escape hatch (builds a *missing* image, then Dokploy pulls it) is **D4**, owned by P2/#883 — not touched here.
- When C4 (#883) migrates the deploy compose into infra2's own pipeline, this contract travels with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)