### PR TITLE
[finance_report_test_and_doc] refactor(backend): finish to_money() migration + dedup cleanup

### DIFF
--- a/apps/backend/src/routers/accounts.py
+++ b/apps/backend/src/routers/accounts.py
@@ -35,6 +35,7 @@ from src.services.processing_account import (
     list_processing_transfer_legs,
 )
 from src.utils import raise_bad_request, raise_not_found
+from src.utils.money import to_money
 
 router = APIRouter(prefix="/accounts", tags=["accounts"])
 logger = get_logger(__name__)
@@ -99,8 +100,8 @@ async def get_processing_summary(
     pending_count = len(unpaired)
     debits = sum((item["amount"] for item in unpaired if item["direction"] == "OUT"), start=Decimal("0"))
     credits = sum((item["amount"] for item in unpaired if item["direction"] == "IN"), start=Decimal("0"))
-    pending_total = abs(debits - credits).quantize(Decimal("0.01"))
-    current_balance = (await get_processing_balance(db, user_id)).quantize(Decimal("0.01"))
+    pending_total = to_money(abs(debits - credits))
+    current_balance = to_money(await get_processing_balance(db, user_id))
     oldest_pending_date = min((item["date"] for item in unpaired), default=None)
     return ProcessingSummaryResponse(
         pending_count=pending_count,

--- a/apps/backend/src/routers/assets.py
+++ b/apps/backend/src/routers/assets.py
@@ -31,6 +31,7 @@ from src.schemas.assets import (
 )
 from src.services.assets import AssetService, AssetServiceError
 from src.utils import raise_bad_request, raise_internal_error, raise_not_found
+from src.utils.money import to_money
 
 router = APIRouter(prefix="/assets", tags=["assets"])
 logger = get_logger(__name__)
@@ -245,7 +246,7 @@ async def list_restricted_holdings(
             quantity=Decimal("1.000000"),
             vesting_schedule=snapshot.notes,
             unlock_date=snapshot.reminder_date,
-            fair_value=snapshot.value.quantize(Decimal("0.01")),
+            fair_value=to_money(snapshot.value),
             currency=snapshot.currency,
         )
         for snapshot in holdings.values()

--- a/apps/backend/src/routers/income.py
+++ b/apps/backend/src/routers/income.py
@@ -13,6 +13,7 @@ from src.schemas.income import AnnualizedIncomeResponse
 from src.services.fx import FxRateError, convert_amount
 from src.services.reporting import income_bucket
 from src.utils import raise_bad_request
+from src.utils.money import to_money
 
 router = APIRouter(prefix="/income", tags=["income"])
 
@@ -66,10 +67,10 @@ async def get_annualized_income(
         totals["total"] += signed_amount
 
     return AnnualizedIncomeResponse(
-        annualized_salary=totals["salary"].quantize(Decimal("0.01")),
-        annualized_bonus=totals["bonus"].quantize(Decimal("0.01")),
-        annualized_dividend=totals["dividend"].quantize(Decimal("0.01")),
-        annualized_total=totals["total"].quantize(Decimal("0.01")),
+        annualized_salary=to_money(totals["salary"]),
+        annualized_bonus=to_money(totals["bonus"]),
+        annualized_dividend=to_money(totals["dividend"]),
+        annualized_total=to_money(totals["total"]),
         currency=currency,
         as_of=report_date,
     )

--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -264,8 +264,8 @@ async def get_portfolio_summary(
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
 
     data = summary.model_dump()
-    data["realized_pnl_ytd"] = Decimal(realized_pnl_ytd).quantize(Decimal("0.01"))
-    data["dividend_income_ytd"] = Decimal(dividend_income_ytd).quantize(Decimal("0.01"))
+    data["realized_pnl_ytd"] = to_money(Decimal(realized_pnl_ytd))
+    data["dividend_income_ytd"] = to_money(Decimal(dividend_income_ytd))
     return PortfolioSummaryDashboardResponse(**data)
 
 
@@ -360,9 +360,9 @@ async def get_holding_realized_lots(
                 acquired_date=acquired_date,
                 sold_date=txn.transaction_date,
                 quantity=txn.quantity or Decimal("0.000000"),
-                basis=(txn.cost_basis or Decimal("0.00")).quantize(Decimal("0.01")),
-                proceeds=(txn.gross_amount - txn.fees).quantize(Decimal("0.01")),
-                gain_loss=(txn.realized_pnl or Decimal("0.00")).quantize(Decimal("0.01")),
+                basis=to_money(txn.cost_basis or Decimal("0.00")),
+                proceeds=to_money(txn.gross_amount - txn.fees),
+                gain_loss=to_money(txn.realized_pnl or Decimal("0.00")),
                 holding_period=holding_period,
                 currency=txn.currency,
             )

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -75,6 +75,7 @@ from src.services.reporting import (
     income_bucket,
 )
 from src.utils import raise_bad_request, raise_not_found
+from src.utils.money import to_money
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 logger = get_logger(__name__)
@@ -1351,7 +1352,7 @@ async def annualized_income_schedule(
             AnnualizedIncomeScheduleHolding(
                 ticker=snapshot.source,
                 compensation_type=snapshot.component_type.value,
-                fair_value=snapshot.value.quantize(Decimal("0.01")),
+                fair_value=to_money(snapshot.value),
                 currency=snapshot.currency,
                 valuation_basis="manual_valuation_snapshot",
                 vesting_schedule=snapshot.notes,
@@ -1371,7 +1372,7 @@ async def annualized_income_schedule(
             )
         except FxRateError as exc:
             raise_bad_request(str(exc), cause=exc)
-    restricted_total = restricted_total.quantize(Decimal("0.01"))
+    restricted_total = to_money(restricted_total)
 
     return AnnualizedIncomeScheduleResponse(
         section_id="annualized_income_long_term",
@@ -1381,10 +1382,10 @@ async def annualized_income_schedule(
         trailing_period_end=report_date,
         trailing_period_days=365,
         income=AnnualizedIncomeScheduleIncome(
-            annualized_salary=totals["salary"].quantize(Decimal("0.01")),
-            annualized_bonus=totals["bonus"].quantize(Decimal("0.01")),
-            annualized_dividend=totals["dividend"].quantize(Decimal("0.01")),
-            annualized_total=totals["total"].quantize(Decimal("0.01")),
+            annualized_salary=to_money(totals["salary"]),
+            annualized_bonus=to_money(totals["bonus"]),
+            annualized_dividend=to_money(totals["dividend"]),
+            annualized_total=to_money(totals["total"]),
             currency=currency,
             calculation_basis="posted_or_reconciled_income_journal_lines_trailing_12_months",
         ),

--- a/apps/backend/src/services/ai_advisor.py
+++ b/apps/backend/src/services/ai_advisor.py
@@ -41,6 +41,7 @@ from src.services.reporting import (
     get_category_breakdown,
 )
 from src.services.workflow_events import get_workflow_status
+from src.utils.money import to_money
 
 logger = get_logger(__name__)
 
@@ -850,7 +851,7 @@ class AIAdvisorService:
             yield chunk
 
     def _format_money(self, amount: Decimal, currency: str) -> str:
-        quantized = amount.quantize(Decimal("0.01"))
+        quantized = to_money(amount)
         return f"{currency} {quantized}"
 
     def _chunk_text(self, text: str, size: int = 48) -> list[str]:

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -21,6 +21,7 @@ from src.models.layer3 import (
     ManualValuationSnapshot,
     PositionStatus,
 )
+from src.utils.money import to_money
 
 logger = get_logger(__name__)
 
@@ -119,7 +120,7 @@ class AssetService:
             component_type=component_type,
             liquidity_class=liquidity_class or _DEFAULT_LIQUIDITY_CLASS[component_type],
             as_of_date=as_of_date,
-            value=value.quantize(Decimal("0.01")),
+            value=to_money(value),
             currency=currency.upper(),
             source=source,
             notes=notes,
@@ -199,7 +200,7 @@ class AssetService:
         if "as_of_date" in values and values["as_of_date"] is not None:
             snapshot.as_of_date = values["as_of_date"]
         if "value" in values and values["value"] is not None:
-            snapshot.value = values["value"].quantize(Decimal("0.01"))
+            snapshot.value = to_money(values["value"])
         if "currency" in values and values["currency"] is not None:
             snapshot.currency = values["currency"].upper()
         if "source" in values and values["source"] is not None:
@@ -274,7 +275,7 @@ class AssetService:
             ):
                 continue
 
-            value = snapshot.value.quantize(Decimal("0.01"))
+            value = to_money(snapshot.value)
             if snapshot.liquidity_class == ManualValuationLiquidityClass.LIABILITY:
                 total_liabilities += value
             else:
@@ -292,13 +293,13 @@ class AssetService:
                 )
             )
 
-        total_assets = total_assets.quantize(Decimal("0.01"))
-        total_liabilities = total_liabilities.quantize(Decimal("0.01"))
+        total_assets = to_money(total_assets)
+        total_liabilities = to_money(total_liabilities)
         return ValuationComponentsResult(
             items=items,
             total_assets=total_assets,
             total_liabilities=total_liabilities,
-            net_worth_delta=(total_assets - total_liabilities).quantize(Decimal("0.01")),
+            net_worth_delta=to_money(total_assets - total_liabilities),
         )
 
     async def get_position(
@@ -566,9 +567,9 @@ class AssetService:
         return DepreciationResult(
             position_id=position.id,
             asset_identifier=position.asset_identifier,
-            period_depreciation=period_depreciation.quantize(Decimal("0.01")),
-            accumulated_depreciation=accumulated.quantize(Decimal("0.01")),
-            book_value=book_value.quantize(Decimal("0.01")),
+            period_depreciation=to_money(period_depreciation),
+            accumulated_depreciation=to_money(accumulated),
+            book_value=to_money(book_value),
             method=method,
             useful_life_years=useful_life_years,
             salvage_value=salvage_value,

--- a/apps/backend/src/services/brokerage_positions.py
+++ b/apps/backend/src/services/brokerage_positions.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.layer2 import AssetType, AtomicPosition
 from src.services.assets import AssetService
+from src.utils.money import to_money
 
 
 @dataclass(frozen=True)
@@ -196,7 +197,7 @@ def _parse_structured_positions(
                 asset_identifier=str(identifier).strip(),
                 broker=str(item.get("broker") or broker),
                 quantity=quantity,
-                market_value=market_value.quantize(Decimal("0.01")),
+                market_value=to_money(market_value),
                 currency=str(item.get("currency") or default_currency).upper(),
                 asset_type=_asset_type(item.get("asset_type") or item.get("asset_class")),
                 sector=str(item["sector"]).strip() if item.get("sector") else None,
@@ -226,7 +227,7 @@ def _parse_moomoo_subscription_positions(
                     asset_identifier=description.strip(),
                     broker=broker,
                     quantity=Decimal("1"),
-                    market_value=amount.quantize(Decimal("0.01")),
+                    market_value=to_money(amount),
                     currency=_payload_currency(payload),
                     asset_type=AssetType.MUTUAL_FUND,
                 )
@@ -243,7 +244,7 @@ def _parse_moomoo_subscription_positions(
                 asset_identifier=match.group("name").strip(),
                 broker=broker,
                 quantity=quantity,
-                market_value=market_value.quantize(Decimal("0.01")),
+                market_value=to_money(market_value),
                 currency=match.group("currency").upper(),
                 asset_type=AssetType.MUTUAL_FUND,
             )
@@ -298,7 +299,7 @@ def _parse_moomoo_margin_history_positions(
             asset_identifier=asset_identifier,
             broker=broker,
             quantity=aggregate["quantity"],
-            market_value=aggregate["market_value"].quantize(Decimal("0.01")),
+            market_value=to_money(aggregate["market_value"]),
             currency=aggregate["currency"],
             asset_type=AssetType.STOCK,
             sector=aggregate["sector"],
@@ -331,7 +332,7 @@ def _parse_futu_aggregate_position(
             asset_identifier="FUTU_STOCK_AND_OPTIONS",
             broker=broker,
             quantity=Decimal("1"),
-            market_value=best_value.quantize(Decimal("0.01")),
+            market_value=to_money(best_value),
             currency=_payload_currency(payload, "HKD"),
             asset_type=AssetType.OTHER,
         )

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -34,7 +34,6 @@ from src.services.validation import (
     compute_confidence_score,
     normalize_amount_direction,
     route_by_threshold,
-    validate_balance,
     validate_balance_explicit,
 )
 
@@ -112,14 +111,6 @@ class ExtractionService:
             return None
         alphanumeric_only = re.sub(r"[^a-zA-Z0-9]", "", value)
         return alphanumeric_only[-4:] if alphanumeric_only else None
-
-    def _validate_balance(self, extracted: dict[str, Any]) -> dict[str, Any]:
-        """Wrapper for test compatibility."""
-        return validate_balance(extracted)
-
-    def _compute_confidence(self, extracted: dict[str, Any], balance_result: dict[str, Any]) -> int:
-        """Wrapper for test compatibility."""
-        return compute_confidence_score(extracted, balance_result)
 
     def _is_zai_provider(self) -> bool:
         return settings.ai_provider.lower() in {"zai", "glm"}

--- a/apps/backend/src/services/portfolio.py
+++ b/apps/backend/src/services/portfolio.py
@@ -24,6 +24,7 @@ from src.schemas.portfolio import (
     UnrealizedPnLResponse,
 )
 from src.services import fx
+from src.utils.money import to_money
 
 logger = get_logger(__name__)
 
@@ -158,11 +159,11 @@ class PortfolioService:
                 converted_cost = position.cost_basis
                 currency = position.currency
 
-            converted_value = converted_value.quantize(Decimal("0.01"))
-            converted_cost = converted_cost.quantize(Decimal("0.01"))
+            converted_value = to_money(converted_value)
+            converted_cost = to_money(converted_cost)
 
             # Calculate P&L (unrealized: market_value - cost_basis)
-            unrealized_pnl = (converted_value - converted_cost).quantize(Decimal("0.01"))
+            unrealized_pnl = to_money(converted_value - converted_cost)
             if converted_cost != Decimal("0"):
                 unrealized_pnl_percent = (unrealized_pnl / converted_cost) * Decimal("100")
             else:
@@ -296,10 +297,10 @@ class PortfolioService:
             else:
                 converted_cost_basis = cost_basis
 
-            converted_market_value = converted_market_value.quantize(Decimal("0.01"))
-            converted_cost_basis = converted_cost_basis.quantize(Decimal("0.01"))
+            converted_market_value = to_money(converted_market_value)
+            converted_cost_basis = to_money(converted_cost_basis)
 
-            unrealized_pnl = (converted_market_value - converted_cost_basis).quantize(Decimal("0.01"))
+            unrealized_pnl = to_money(converted_market_value - converted_cost_basis)
             if converted_cost_basis != Decimal("0"):
                 unrealized_pnl_percent = (unrealized_pnl / converted_cost_basis) * Decimal("100")
             else:
@@ -484,7 +485,7 @@ class PortfolioService:
         return RealizedPnLResponse(
             period_start=period_start,
             period_end=period_end,
-            total_realized_pnl=total_realized_pnl.quantize(Decimal("0.01")),
+            total_realized_pnl=to_money(total_realized_pnl),
             total_realized_pnl_percent=total_realized_pnl_percent.quantize(Decimal("0.01")),
             positions_count=len(disposed_positions),
             details=details,
@@ -595,10 +596,10 @@ class PortfolioService:
         await db.flush()
         return UnrealizedPnLResponse(
             as_of_date=eval_date,
-            total_unrealized_pnl=total_unrealized_pnl.quantize(Decimal("0.01")),
+            total_unrealized_pnl=to_money(total_unrealized_pnl),
             total_unrealized_pnl_percent=total_unrealized_pnl_percent.quantize(Decimal("0.01")),
-            total_market_value=total_market_value.quantize(Decimal("0.01")),
-            total_cost_basis=total_cost_basis.quantize(Decimal("0.01")),
+            total_market_value=to_money(total_market_value),
+            total_cost_basis=to_money(total_cost_basis),
             holdings_count=len(positions),
             details=details,
         )
@@ -721,13 +722,13 @@ class PortfolioService:
             net_pnl_percent = Decimal("0")
 
         return PortfolioSummaryResponse(
-            total_market_value=total_market_value.quantize(Decimal("0.01")),
-            total_cost_basis=total_cost_basis.quantize(Decimal("0.01")),
-            total_unrealized_pnl=total_unrealized_pnl.quantize(Decimal("0.01")),
+            total_market_value=to_money(total_market_value),
+            total_cost_basis=to_money(total_cost_basis),
+            total_unrealized_pnl=to_money(total_unrealized_pnl),
             total_unrealized_pnl_percent=net_pnl_percent.quantize(Decimal("0.01")),
             total_realized_pnl=Decimal("0"),  # Phase 1 only
             total_realized_pnl_percent=Decimal("0"),
-            net_pnl=net_pnl.quantize(Decimal("0.01")),
+            net_pnl=to_money(net_pnl),
             net_pnl_percent=net_pnl_percent.quantize(Decimal("0.01")),
             holdings_count=len(holdings),
             active_positions_count=active_positions_count,

--- a/apps/backend/src/services/processing_account.py
+++ b/apps/backend/src/services/processing_account.py
@@ -59,6 +59,14 @@ HISTORY_WEIGHT = Decimal("0.10")
 MAX_DATE_DIFF_DAYS = 7
 
 
+def _validate_transfer_params(amount: Decimal, description: str) -> None:
+    """Validate shared inputs for Transfer IN/OUT journal entries."""
+    if amount <= Decimal("0"):
+        raise ValueError("Transfer amount must be positive")
+    if not description or not description.strip():
+        raise ValueError("Transfer description must not be empty")
+
+
 @dataclass
 class TransferPair:
     """Represents a matched pair of transfer transactions."""
@@ -348,10 +356,7 @@ async def create_transfer_out_entry(
     Returns:
         Created JournalEntry (not yet committed)
     """
-    if amount <= Decimal("0"):
-        raise ValueError("Transfer amount must be positive")
-    if not description or not description.strip():
-        raise ValueError("Transfer description must not be empty")
+    _validate_transfer_params(amount, description)
 
     processing_account = await get_or_create_processing_account(db, user_id)
 
@@ -409,10 +414,7 @@ async def create_transfer_in_entry(
     Returns:
         Created JournalEntry (not yet committed)
     """
-    if amount <= Decimal("0"):
-        raise ValueError("Transfer amount must be positive")
-    if not description or not description.strip():
-        raise ValueError("Transfer description must not be empty")
+    _validate_transfer_params(amount, description)
 
     processing_account = await get_or_create_processing_account(db, user_id)
 

--- a/apps/backend/src/services/report_readiness.py
+++ b/apps/backend/src/services/report_readiness.py
@@ -42,6 +42,7 @@ from src.schemas.reporting import (
 )
 from src.services.framework_policy import derive_user_framework_policy_result
 from src.services.fx import FxRateError, convert_amount
+from src.utils.money import to_money
 
 PACKAGE_ID = "personal-financial-report-package"
 MARKET_DATA_STALE_AFTER_DAYS = 90
@@ -573,7 +574,7 @@ async def get_personal_report_package_readiness(
         )
 
     try:
-        processing_balance = (await _processing_account_balance(db, user_id)).quantize(Decimal("0.01"))
+        processing_balance = to_money(await _processing_account_balance(db, user_id))
     except FxRateError as exc:
         blockers.append(
             _blocker(

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -37,6 +37,7 @@ from src.services.fx import (
 )
 from src.services.fx_revaluation import RevaluationError, calculate_unrealized_fx_gains
 from src.services.portfolio import AssetNotFoundError, PortfolioService
+from src.utils.money import to_money
 
 logger = get_logger(__name__)
 
@@ -81,7 +82,7 @@ def income_bucket(account_name: str) -> str | None:
 def _quantize_money(amount: Decimal | int) -> Decimal:
     if isinstance(amount, int):
         amount = Decimal(amount)
-    return amount.quantize(Decimal("0.01"))
+    return to_money(amount)
 
 
 def _month_start(value: date) -> date:

--- a/apps/backend/src/services/validation.py
+++ b/apps/backend/src/services/validation.py
@@ -28,7 +28,8 @@ def normalize_amount_direction(amount: Decimal, direction_value: Any = None) -> 
 def validate_balance(extracted: dict[str, Any]) -> dict[str, Any]:
     """Validate that opening + transactions ~= closing within tolerance.
 
-    Legacy interface for backward compatibility.
+    Dict-based entry point used by extraction; ``validate_balance_explicit``
+    is the Decimal-based variant.
     """
     try:
         opening = Decimal(str(extracted.get("opening_balance") or "0"))

--- a/apps/backend/tests/extraction/test_extraction.py
+++ b/apps/backend/tests/extraction/test_extraction.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import pytest
 
 from src.services.extraction import ExtractionError, ExtractionService
+from src.services.validation import compute_confidence_score, validate_balance
 
 # Get fixtures directory
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
@@ -29,7 +30,7 @@ class TestBalanceValidation:
                 {"amount": "100.00", "direction": "OUT"},
             ],
         }
-        result = self.service._validate_balance(extracted)
+        result = validate_balance(extracted)
         assert result["balance_valid"] is True
         assert result["difference"] == "0.00"
 
@@ -42,7 +43,7 @@ class TestBalanceValidation:
                 {"amount": "100.00", "direction": "IN"},
             ],
         }
-        result = self.service._validate_balance(extracted)
+        result = validate_balance(extracted)
         assert result["balance_valid"] is False
         assert "mismatch" in result["notes"].lower()
 
@@ -55,7 +56,7 @@ class TestBalanceValidation:
                 {"amount": "100.00", "direction": "IN"},
             ],
         }
-        result = self.service._validate_balance(extracted)
+        result = validate_balance(extracted)
         # Should pass with 0.10 tolerance
         assert result["balance_valid"] is True
 
@@ -79,7 +80,7 @@ class TestConfidenceScoring:
             ],
         }
         validation = {"balance_valid": True, "difference": "0.00"}
-        score = self.service._compute_confidence(extracted, validation)
+        score = compute_confidence_score(extracted, validation)
         assert score >= 85, f"Expected high confidence, got {score}"
 
     def test_medium_confidence(self):
@@ -95,7 +96,7 @@ class TestConfidenceScoring:
             ],
         }
         validation = {"balance_valid": False, "difference": "5.00"}
-        score = self.service._compute_confidence(extracted, validation)
+        score = compute_confidence_score(extracted, validation)
         assert 60 <= score < 85, f"Expected medium confidence, got {score}"
 
     def test_low_confidence_empty_transactions(self):
@@ -109,7 +110,7 @@ class TestConfidenceScoring:
             "transactions": [],  # No transactions
         }
         validation = {"balance_valid": False, "difference": "100.00"}
-        score = self.service._compute_confidence(extracted, validation)
+        score = compute_confidence_score(extracted, validation)
         assert score < 60, "Low-confidence statements should require manual review"
 
 
@@ -446,7 +447,7 @@ class TestExtractionServiceHelpers:
             "closing_balance": "0",
         }
         validation = {"balance_valid": True, "difference": "0.00"}
-        score = self.service._compute_confidence(extracted, validation)
+        score = compute_confidence_score(extracted, validation)
         assert 0 <= score <= 100
 
     @pytest.mark.asyncio

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -1047,7 +1047,7 @@ async def test_extract_no_models_tried_fallback_error():
 
 # ---------------------------------------------------------------------------
 # Additional coverage tests: _safe_date None, _extract_status_code,
-# _validate_balance/_compute_confidence wrappers, _build_media_payload image,
+# _build_media_payload image,
 # OUT direction, OpenRouterStreamError timeout/generic, non-dict JSON,
 # ExtractionError re-raise, PDF/image with valid external URL
 # ---------------------------------------------------------------------------
@@ -1069,32 +1069,6 @@ def test_extract_status_code():
     assert service._extract_status_code("HTTP 500 Internal Server Error") == "500"
     assert service._extract_status_code("no status code here") is None
     assert service._extract_status_code("") is None
-
-
-def test_validate_balance_wrapper():
-    """_validate_balance delegates to validate_balance (line 112-113)."""
-    service = ExtractionService()
-    result = service._validate_balance(
-        {
-            "opening_balance": "100.00",
-            "closing_balance": "200.00",
-            "transactions": [{"amount": "100.00", "direction": "IN"}],
-        }
-    )
-    assert isinstance(result, dict)
-
-
-def test_compute_confidence_wrapper():
-    """_compute_confidence delegates to compute_confidence_score (line 116-117)."""
-    service = ExtractionService()
-    balance_result = {"balance_valid": True, "opening": "100.00", "closing": "200.00"}
-    extracted = {
-        "opening_balance": "100.00",
-        "closing_balance": "200.00",
-        "transactions": [{"amount": "100.00", "direction": "IN", "date": "2023-01-15", "description": "Test"}],
-    }
-    score = service._compute_confidence(extracted, balance_result)
-    assert isinstance(score, int)
 
 
 def test_build_media_payload_image():


### PR DESCRIPTION
## What & why

Mechanical backend simplification surfaced by the \"where can we simplify\" audit. **No behavior change.**

### 1. Finish the `to_money()` migration (the headline)
PR #904 introduced the canonical `to_money()` (banker's rounding, `src/utils/money.py`) but **49 inline `<expr>.quantize(Decimal("0.01"))` currency call-sites remained** across `services/portfolio.py`, `assets.py`, `brokerage_positions.py`, `reporting.py`, `report_readiness.py`, `ai_advisor.py`, and the `reports`/`portfolio`/`income`/`accounts` routers. All currency call-sites now use `to_money()`.

- **Behavior-preserving:** the default `Decimal` context rounding is `ROUND_HALF_EVEN` (never overridden globally) — identical to `to_money()`. Verified analytically and by tests.
- **Deliberately untouched:** percent/ratio quantizes (`*_pnl_percent`, dividend-yield in `performance.py`) are **not currency** and are excluded per the `money.py` docstring.
- `reporting.py`'s local `_quantize_money` now delegates to `to_money` (keeps its int-coercion convenience).

### 2. Dedup duplicated transfer validation
`processing_account.py` had the same 4-line positive-amount / non-empty-description check verbatim in `create_transfer_out_entry` and `create_transfer_in_entry` → extracted `_validate_transfer_params()`.

### 3. Remove test-only shims in extraction
Dropped the `_validate_balance` / `_compute_confidence` \"for test compatibility\" wrapper methods on `ExtractionService`; repointed the behavior tests to call the module functions directly and deleted the 2 tautological wrapper-only tests. `validation.validate_balance` is **kept** (it is production-used by extraction) with a corrected, non-misleading docstring.

## Out of scope (flagged, not changed)
- `routers/portfolio.py:88` still uses `ROUND_HALF_UP`, a **pre-existing inconsistency** with the canonical banker's rounding. Changing it alters behavior and deserves separate sign-off.
- Unifying the two account-ownership idioms (`accounting.py` fetch-then-validate vs the in-query `user_id` filter used elsewhere) is a **behavior change** (the distinct "does not belong to user" message is a minor info-leak) — not the mechanical dedup it first appeared to be, so left alone.

## Verification
- `ruff check` + `ruff format --check` clean across `src` + `tests`.
- Affected suites pass (extraction, validation, portfolio, reporting, assets, accounting, services, api) when run per-file.
- The full combined local batch shows the **identical 47 pre-existing test-isolation failures with and without this change** (852 passed either way) → **zero regressions**. (Those failures hit files this PR never touches and pass in isolation; CI shards via pytest-split/xdist.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)