### PR TITLE
[finance_report_audit] EPIC-011 AC11.19: append-only versioning for manual valuation facts (#918)

### DIFF
--- a/apps/backend/migrations/versions/0035_manual_valuation_versioning.py
+++ b/apps/backend/migrations/versions/0035_manual_valuation_versioning.py
@@ -1,0 +1,75 @@
+"""manual valuation append-only versioning
+
+Adds an append-only version chain to manual_valuation_snapshots so that a
+correction for an existing (user_id, component_type, source, as_of_date) appends
+a new version and supersedes the prior one instead of editing the fact in place
+(vision Axiom A). Uniqueness is moved to a partial unique index over current
+heads (superseded_by_id IS NULL) so superseded history rows can accumulate.
+
+Migration risk: medium (index/constraint change + additive columns). Existing
+rows all become version 1 heads (superseded_by_id NULL); the partial unique
+index cannot conflict because the prior full unique constraint already forbade
+duplicate keys.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0035_manual_valuation_versioning"
+down_revision = "0034_audit_anchor_ri"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "manual_valuation_snapshots",
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "manual_valuation_snapshots",
+        sa.Column("superseded_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "manual_valuation_snapshots_superseded_by_id_fkey",
+        "manual_valuation_snapshots",
+        "manual_valuation_snapshots",
+        ["superseded_by_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # Uniqueness now applies only to the current head per key, so corrections can
+    # accumulate as superseded history rows.
+    op.drop_constraint(
+        "uq_manual_valuation_user_component_source_date",
+        "manual_valuation_snapshots",
+        type_="unique",
+    )
+    op.create_index(
+        "uq_manual_valuation_user_component_source_date",
+        "manual_valuation_snapshots",
+        ["user_id", "component_type", "source", "as_of_date"],
+        unique=True,
+        postgresql_where=sa.text("superseded_by_id IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_manual_valuation_user_component_source_date",
+        table_name="manual_valuation_snapshots",
+    )
+    op.create_unique_constraint(
+        "uq_manual_valuation_user_component_source_date",
+        "manual_valuation_snapshots",
+        ["user_id", "component_type", "source", "as_of_date"],
+    )
+    op.drop_constraint(
+        "manual_valuation_snapshots_superseded_by_id_fkey",
+        "manual_valuation_snapshots",
+        type_="foreignkey",
+    )
+    op.drop_column("manual_valuation_snapshots", "superseded_by_id")
+    op.drop_column("manual_valuation_snapshots", "version")

--- a/apps/backend/src/models/layer3.py
+++ b/apps/backend/src/models/layer3.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -267,12 +268,18 @@ class ManualValuationSnapshot(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
             "recurrence_days IS NULL OR recurrence_days > 0",
             name="ck_manual_valuation_snapshots_recurrence_days_positive",
         ),
-        UniqueConstraint(
+        # Append-only versioning (Axiom A): a correction for an existing
+        # (component_type, source, as_of_date) appends a new version and supersedes
+        # the prior one. Uniqueness therefore applies only to the *current* head
+        # (superseded_by_id IS NULL); superseded history rows accumulate freely.
+        Index(
+            "uq_manual_valuation_user_component_source_date",
             "user_id",
             "component_type",
             "source",
             "as_of_date",
-            name="uq_manual_valuation_user_component_source_date",
+            unique=True,
+            postgresql_where=text("superseded_by_id IS NULL"),
         ),
         Index("ix_manual_valuation_snapshots_user_as_of", "user_id", "as_of_date"),
     )
@@ -300,3 +307,13 @@ class ManualValuationSnapshot(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     recurrence_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
     reminder_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+
+    # Append-only version chain (Axiom A). version is a monotonic per-key counter;
+    # superseded_by_id points forward from a corrected fact to the version that
+    # replaced it. The current value is the head of the chain (superseded_by_id IS NULL).
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
+    superseded_by_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("manual_valuation_snapshots.id", ondelete="SET NULL"),
+        nullable=True,
+    )

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -973,6 +973,7 @@ async def _personal_report_package_traceability_payload(
         select(ManualValuationSnapshot)
         .where(ManualValuationSnapshot.user_id == user_id)
         .where(ManualValuationSnapshot.as_of_date <= report_as_of)
+        .where(ManualValuationSnapshot.superseded_by_id.is_(None))
         .order_by(ManualValuationSnapshot.as_of_date.desc(), ManualValuationSnapshot.created_at.desc())
     )
     manual_snapshots = list(manual_result.scalars().all())
@@ -1337,6 +1338,7 @@ async def annualized_income_schedule(
         .where(ManualValuationSnapshot.as_of_date <= report_date)
         .where(ManualValuationSnapshot.component_type.in_(restricted_types))
         .where(ManualValuationSnapshot.liquidity_class == ManualValuationLiquidityClass.RESTRICTED)
+        .where(ManualValuationSnapshot.superseded_by_id.is_(None))
         .order_by(ManualValuationSnapshot.as_of_date.desc(), ManualValuationSnapshot.created_at.desc())
     )
 

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
 from typing import Literal
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -114,23 +114,98 @@ class AssetService:
         recurrence_days: int | None = None,
         reminder_date: date | None = None,
     ) -> ManualValuationSnapshot:
-        """Create a manual valuation snapshot."""
+        """Record a manual valuation as an append-only versioned fact.
+
+        Vision Axiom A: a recorded fact is never edited in place. If a current
+        version already exists for the same (component_type, source, as_of_date),
+        this appends a new version and supersedes the prior one instead of
+        overwriting it, so the full correction history stays retrievable.
+        """
+        normalized_currency = currency.upper()
+        head = await self._current_valuation_head(
+            db,
+            user_id,
+            component_type=component_type,
+            source=source,
+            as_of_date=as_of_date,
+            currency=normalized_currency,
+        )
+
         snapshot = ManualValuationSnapshot(
+            id=uuid4(),
             user_id=user_id,
             component_type=component_type,
             liquidity_class=liquidity_class or _DEFAULT_LIQUIDITY_CLASS[component_type],
             as_of_date=as_of_date,
             value=to_money(value),
-            currency=currency.upper(),
+            currency=normalized_currency,
             source=source,
             notes=notes,
             recurrence_days=recurrence_days,
             reminder_date=reminder_date,
+            version=(head.version + 1) if head is not None else 1,
+            # Park the new row under the prior head so there is never a moment with
+            # two current heads for the same key (the partial unique index is
+            # checked per statement). Promoted to head below once the prior head
+            # has been demoted to point at it.
+            superseded_by_id=head.id if head is not None else None,
         )
         db.add(snapshot)
         await db.flush()
+        if head is not None:
+            # Ordered hand-off, each flush valid under both the self-FK and the
+            # partial unique index: demote the old head (0 heads), then promote
+            # the new row (1 head).
+            head.superseded_by_id = snapshot.id
+            await db.flush()
+            snapshot.superseded_by_id = None
+            await db.flush()
         await db.refresh(snapshot)
         return snapshot
+
+    async def _current_valuation_head(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        *,
+        component_type: ManualValuationComponentType,
+        source: str,
+        as_of_date: date,
+        currency: str,
+    ) -> ManualValuationSnapshot | None:
+        """Return the current (non-superseded) version for a valuation key, if any."""
+        result = await db.execute(
+            select(ManualValuationSnapshot)
+            .where(ManualValuationSnapshot.user_id == user_id)
+            .where(ManualValuationSnapshot.component_type == component_type)
+            .where(ManualValuationSnapshot.source == source)
+            .where(ManualValuationSnapshot.as_of_date == as_of_date)
+            .where(ManualValuationSnapshot.currency == currency)
+            .where(ManualValuationSnapshot.superseded_by_id.is_(None))
+        )
+        return result.scalar_one_or_none()
+
+    async def list_valuation_versions(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        *,
+        component_type: ManualValuationComponentType,
+        source: str,
+        as_of_date: date,
+        currency: str,
+    ) -> Sequence[ManualValuationSnapshot]:
+        """Return the full append-only version history for a valuation key, newest first."""
+        result = await db.execute(
+            select(ManualValuationSnapshot)
+            .where(ManualValuationSnapshot.user_id == user_id)
+            .where(ManualValuationSnapshot.component_type == component_type)
+            .where(ManualValuationSnapshot.source == source)
+            .where(ManualValuationSnapshot.as_of_date == as_of_date)
+            .where(ManualValuationSnapshot.currency == currency.upper())
+            .order_by(ManualValuationSnapshot.version.desc())
+        )
+        return result.scalars().all()
 
     async def list_valuation_snapshots(
         self,
@@ -143,9 +218,18 @@ class AssetService:
         offset: int = 0,
     ) -> tuple[Sequence[ManualValuationSnapshot], int]:
         """List manual valuation snapshots for a user."""
-        query = select(ManualValuationSnapshot).where(ManualValuationSnapshot.user_id == user_id)
+        # Only current heads (superseded_by_id IS NULL); superseded history rows
+        # are reachable via list_valuation_versions, not the default listing.
+        query = (
+            select(ManualValuationSnapshot)
+            .where(ManualValuationSnapshot.user_id == user_id)
+            .where(ManualValuationSnapshot.superseded_by_id.is_(None))
+        )
         count_query = (
-            select(func.count()).select_from(ManualValuationSnapshot).where(ManualValuationSnapshot.user_id == user_id)
+            select(func.count())
+            .select_from(ManualValuationSnapshot)
+            .where(ManualValuationSnapshot.user_id == user_id)
+            .where(ManualValuationSnapshot.superseded_by_id.is_(None))
         )
         if as_of_date is not None:
             query = query.where(ManualValuationSnapshot.as_of_date <= as_of_date)
@@ -253,6 +337,7 @@ class AssetService:
             )
             .where(ManualValuationSnapshot.user_id == user_id)
             .where(ManualValuationSnapshot.as_of_date <= as_of_date)
+            .where(ManualValuationSnapshot.superseded_by_id.is_(None))
             .subquery()
         )
 

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -128,7 +128,6 @@ class AssetService:
             component_type=component_type,
             source=source,
             as_of_date=as_of_date,
-            currency=normalized_currency,
         )
 
         snapshot = ManualValuationSnapshot(
@@ -171,16 +170,19 @@ class AssetService:
         component_type: ManualValuationComponentType,
         source: str,
         as_of_date: date,
-        currency: str,
     ) -> ManualValuationSnapshot | None:
-        """Return the current (non-superseded) version for a valuation key, if any."""
+        """Return the current (non-superseded) version for a valuation key, if any.
+
+        The key matches the partial unique index exactly
+        (user_id, component_type, source, as_of_date) — currency is a corrigible
+        attribute of the fact, not part of its version-chain identity.
+        """
         result = await db.execute(
             select(ManualValuationSnapshot)
             .where(ManualValuationSnapshot.user_id == user_id)
             .where(ManualValuationSnapshot.component_type == component_type)
             .where(ManualValuationSnapshot.source == source)
             .where(ManualValuationSnapshot.as_of_date == as_of_date)
-            .where(ManualValuationSnapshot.currency == currency)
             .where(ManualValuationSnapshot.superseded_by_id.is_(None))
         )
         return result.scalar_one_or_none()
@@ -193,16 +195,19 @@ class AssetService:
         component_type: ManualValuationComponentType,
         source: str,
         as_of_date: date,
-        currency: str,
     ) -> Sequence[ManualValuationSnapshot]:
-        """Return the full append-only version history for a valuation key, newest first."""
+        """Return the full append-only version history for a valuation key, newest first.
+
+        Keyed by the same identity as the head index
+        (user_id, component_type, source, as_of_date), so a correction that also
+        changes currency is still part of one history chain.
+        """
         result = await db.execute(
             select(ManualValuationSnapshot)
             .where(ManualValuationSnapshot.user_id == user_id)
             .where(ManualValuationSnapshot.component_type == component_type)
             .where(ManualValuationSnapshot.source == source)
             .where(ManualValuationSnapshot.as_of_date == as_of_date)
-            .where(ManualValuationSnapshot.currency == currency.upper())
             .order_by(ManualValuationSnapshot.version.desc())
         )
         return result.scalars().all()

--- a/apps/backend/src/services/framework_policy.py
+++ b/apps/backend/src/services/framework_policy.py
@@ -560,6 +560,7 @@ async def framework_policy_facts_for_user(
         select(ManualValuationSnapshot)
         .where(ManualValuationSnapshot.user_id == user_id)
         .where(ManualValuationSnapshot.as_of_date <= as_of_date)
+        .where(ManualValuationSnapshot.superseded_by_id.is_(None))
         .order_by(ManualValuationSnapshot.as_of_date.desc(), ManualValuationSnapshot.created_at.desc())
     )
     seen_manual: set[tuple[ManualValuationComponentType, str]] = set()

--- a/apps/backend/src/services/report_readiness.py
+++ b/apps/backend/src/services/report_readiness.py
@@ -267,6 +267,7 @@ async def _missing_valuation_basis_count(db: AsyncSession, user_id: UUID, *, as_
         select(ManualValuationSnapshot.notes)
         .where(ManualValuationSnapshot.user_id == user_id)
         .where(ManualValuationSnapshot.as_of_date <= as_of_date)
+        .where(ManualValuationSnapshot.superseded_by_id.is_(None))
     )
     return sum(1 for notes in rows.scalars().all() if notes is None or not notes.strip())
 
@@ -394,7 +395,9 @@ async def get_personal_report_package_readiness(
     )
     manual_valuation_count = await _count(
         db,
-        select(func.count(ManualValuationSnapshot.id)).where(ManualValuationSnapshot.user_id == user_id),
+        select(func.count(ManualValuationSnapshot.id))
+        .where(ManualValuationSnapshot.user_id == user_id)
+        .where(ManualValuationSnapshot.superseded_by_id.is_(None)),
     )
     dividend_count = await _count(
         db,

--- a/apps/backend/tests/assets/test_manual_valuation_snapshots.py
+++ b/apps/backend/tests/assets/test_manual_valuation_snapshots.py
@@ -252,6 +252,67 @@ async def test_manual_valuation_snapshot_service_updates_optional_fields_and_mis
     assert await service.delete_valuation_snapshot(db, test_user.id, missing_id) is False
 
 
+@pytest.mark.asyncio
+async def test_AC11_19_1_manual_valuation_correction_appends_version_and_preserves_history(db, test_user):
+    """AC11.19.1: Correcting a manual valuation appends a new version and never edits the prior fact in place.
+
+    Vision Axiom A: a recorded fact is never changed in place; a later correction
+    accumulates as a new version, and one version maps to exactly one value.
+    """
+    service = AssetService()
+    key = dict(
+        component_type=ManualValuationComponentType.PROPERTY_VALUE,
+        as_of_date=date(2026, 5, 18),
+        currency="SGD",
+        source="manual appraisal",
+    )
+
+    first = await service.create_valuation_snapshot(db, user_id=test_user.id, value=Decimal("1000000.00"), **key)
+    corrected = await service.create_valuation_snapshot(db, user_id=test_user.id, value=Decimal("1100000.00"), **key)
+    await db.commit()
+
+    # The prior fact is preserved unedited and points forward to its successor (append-only chain).
+    await db.refresh(first)
+    assert first.value == Decimal("1000000.00"), "prior fact must not be edited in place"
+    assert first.version == 1
+    assert first.superseded_by_id == corrected.id
+
+    # The correction is the new current head: one version -> one value.
+    assert corrected.value == Decimal("1100000.00")
+    assert corrected.version == 2
+    assert corrected.superseded_by_id is None
+
+    # Full history is retrievable, newest first.
+    history = await service.list_valuation_versions(db, test_user.id, **key)
+    assert [(h.version, h.value) for h in history] == [
+        (2, Decimal("1100000.00")),
+        (1, Decimal("1000000.00")),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth(db, test_user):
+    """AC11.19.2: Heads-only reads use the current version, so a correction never double-counts."""
+    service = AssetService()
+    key = dict(
+        component_type=ManualValuationComponentType.PROPERTY_VALUE,
+        as_of_date=date(2026, 5, 18),
+        currency="SGD",
+        source="manual appraisal",
+    )
+
+    await service.create_valuation_snapshot(db, user_id=test_user.id, value=Decimal("1000000.00"), **key)
+    await service.create_valuation_snapshot(db, user_id=test_user.id, value=Decimal("1100000.00"), **key)
+    await db.commit()
+
+    components = await service.get_latest_valuation_components(db, test_user.id, as_of_date=date(2026, 5, 18))
+    assert components.total_assets == Decimal("1100000.00"), "superseded version must be excluded"
+
+    snapshots, total = await service.list_valuation_snapshots(db, test_user.id)
+    assert total == 1, "list returns only current heads"
+    assert snapshots[0].value == Decimal("1100000.00")
+
+
 def test_manual_valuation_snapshot_schema_normalizes_currency():
     """AC11.9.1: Manual valuation schemas normalize currency codes before service use."""
     create_payload = ManualValuationSnapshotCreate(

--- a/apps/backend/tests/assets/test_manual_valuation_snapshots.py
+++ b/apps/backend/tests/assets/test_manual_valuation_snapshots.py
@@ -260,15 +260,22 @@ async def test_AC11_19_1_manual_valuation_correction_appends_version_and_preserv
     accumulates as a new version, and one version maps to exactly one value.
     """
     service = AssetService()
-    key = dict(
+    # The version-chain identity matches the partial unique index exactly
+    # (component_type, source, as_of_date) — currency is not part of it.
+    identity = dict(
         component_type=ManualValuationComponentType.PROPERTY_VALUE,
         as_of_date=date(2026, 5, 18),
-        currency="SGD",
         source="manual appraisal",
     )
 
-    first = await service.create_valuation_snapshot(db, user_id=test_user.id, value=Decimal("1000000.00"), **key)
-    corrected = await service.create_valuation_snapshot(db, user_id=test_user.id, value=Decimal("1100000.00"), **key)
+    first = await service.create_valuation_snapshot(
+        db, user_id=test_user.id, value=Decimal("1000000.00"), currency="SGD", **identity
+    )
+    # A correction that also re-denominates the currency is still the same fact:
+    # it must supersede, not collide on the (currency-less) unique index.
+    corrected = await service.create_valuation_snapshot(
+        db, user_id=test_user.id, value=Decimal("1100000.00"), currency="USD", **identity
+    )
     await db.commit()
 
     # The prior fact is preserved unedited and points forward to its successor (append-only chain).
@@ -279,11 +286,12 @@ async def test_AC11_19_1_manual_valuation_correction_appends_version_and_preserv
 
     # The correction is the new current head: one version -> one value.
     assert corrected.value == Decimal("1100000.00")
+    assert corrected.currency == "USD"
     assert corrected.version == 2
     assert corrected.superseded_by_id is None
 
-    # Full history is retrievable, newest first.
-    history = await service.list_valuation_versions(db, test_user.id, **key)
+    # Full history is retrievable, newest first, keyed by the currency-less identity.
+    history = await service.list_valuation_versions(db, test_user.id, **identity)
     assert [(h.version, h.value) for h in history] == [
         (2, Decimal("1100000.00")),
         (1, Decimal("1000000.00")),

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -238,6 +238,22 @@ quantity is allowed, while market value and cost facts stay non-negative.
 | AC11.18.5 | Market-data facts enforce positive rates/prices and stock prices are unique by symbol, currency, provider source, and date | `test_AC11_18_5_market_data_constraints_and_stock_price_uniqueness()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
 | AC11.18.6 | The constraint migration declares preflight checks and migration-risk classification for existing data compatibility | `test_AC11_18_6_migration_preflights_and_risk_contract_are_declared()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
 
+### AC11.19: Append-Only Manual Valuation Facts (Axiom A)
+
+Manual valuation snapshots are user-supplied source facts. Per vision Axiom A a
+recorded fact is never edited in place: correcting a valuation for an existing
+`(component_type, source, as_of_date)` appends a new version and supersedes the
+prior one, so the correction history stays retrievable and one version maps to
+exactly one value. Uniqueness applies to the current head only (a partial unique
+index over `superseded_by_id IS NULL`); read paths and net-worth aggregation use
+the current head so a correction never double-counts. (In-place value editing via
+the PATCH endpoint is the documented next slice; see #918.)
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.19.1 | Correcting a manual valuation appends a new version and preserves the prior fact unedited as a retrievable superseded version | `test_AC11_19_1_manual_valuation_correction_appends_version_and_preserves_history()` | `assets/test_manual_valuation_snapshots.py` | P1 |
+| AC11.19.2 | Heads-only reads use the current version so a corrected valuation is never double-counted in net worth or listings | `test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth()` | `assets/test_manual_valuation_snapshots.py` | P1 |
+
 ## Implementation Pattern Ownership
 
 Do not copy reusable code patterns, router examples, migration guardrails, or

--- a/docs/ssot/migration-risk.yaml
+++ b/docs/ssot/migration-risk.yaml
@@ -175,6 +175,10 @@ migrations:
     risk: medium
     issue: "#845"
     proof: Adds preflight checks plus database CHECK/UNIQUE/partial-index guards for financial facts, statement envelopes, market prices, managed positions, and latest report snapshots; covered by AC11.18 direct DB invariant tests and the PR Alembic contract.
+  0035_manual_valuation_versioning:
+    file: 0035_manual_valuation_versioning.py
+    risk: medium
+    proof: Adds append-only version columns and converts manual valuation uniqueness to a partial unique index over current heads; staging should exercise manual valuation create/correct and net-worth read paths.
   0034_audit_anchor_ri:
     file: 0034_audit_anchor_referential_integrity.py
     risk: high

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -75,6 +75,30 @@ catalog.
 > Layer-0 read path were removed. See
 > [EPIC-011](../project/EPIC-011.asset-lifecycle.md).
 
+### Append-Only Fact Versioning (Axiom A)
+
+A stored *fact* — the recorded value of a financial quantity — is never edited in
+place. When a fact is corrected, a new version is appended and the prior one is
+superseded; the live value is the head of the chain, history stays retrievable,
+and one version maps to exactly one value (vision Axiom A).
+
+- **Version-bearing unit.** The fact row itself carries the version. The native
+  idiom is a `version` integer plus a self-referential `superseded_by_id`
+  (as on `reconciliation_matches` and `transaction_classification`), not
+  bitemporal `valid_from`/`valid_to` columns and not a separate version table.
+- **Current head.** The head of a chain has `superseded_by_id IS NULL`. Where a
+  key must stay unique, enforce it with a **partial unique index over the head**
+  (`WHERE superseded_by_id IS NULL`) so superseded history rows accumulate
+  freely. Default read and aggregation paths filter to the head.
+- **Fact vs. review-state.** Append-only applies to *facts* (recorded values).
+  Working review-state and annotations (status transitions, notes, reminders)
+  may stay mutable in place. Draw this line per table; do not make review
+  workflow append-only just because it shares a row with a fact.
+
+Owner of the first applied instance: `manual_valuation_snapshots` (ODS), where a
+re-submitted `(component_type, source, as_of_date)` appends a new version. See
+[EPIC-011 AC11.19](../project/EPIC-011.asset-lifecycle.md) and issue #918.
+
 ---
 
 <a id="er-model"></a>

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -83,9 +83,10 @@ superseded; the live value is the head of the chain, history stays retrievable,
 and one version maps to exactly one value (vision Axiom A).
 
 - **Version-bearing unit.** The fact row itself carries the version. The native
-  idiom is a `version` integer plus a self-referential `superseded_by_id`
-  (as on `reconciliation_matches` and `transaction_classification`), not
-  bitemporal `valid_from`/`valid_to` columns and not a separate version table.
+  idiom is a `version` integer plus a self-referential `superseded_by_id` (as on
+  `reconciliation_matches`; `transaction_classification` uses the
+  `superseded_by_id` supersede chain alone), not bitemporal `valid_from`/`valid_to`
+  columns and not a separate version table.
 - **Current head.** The head of a chain has `superseded_by_id IS NULL`. Where a
   key must stay unique, enforce it with a **partial unique index over the head**
   (`WHERE superseded_by_id IS NULL`) so superseded history rows accumulate


### PR DESCRIPTION
## Summary

Make `ManualValuationSnapshot` an **append-only, version-bearing fact** so a
corrected valuation accumulates as a new version instead of being edited in
place — the first applied instance of vision **Axiom A** ("a recorded fact is
never changed in place; one version maps to exactly one value").

Manual valuations were the cleanest violation: the full unique constraint on
`(user_id, component_type, source, as_of_date)` made a same-key correction
**hard-fail** with a `UniqueViolationError`, so corrections could not be recorded
as history at all.

Closes #918 (first slice). Part of the #917 audit-gap epic (Axis A).

## What changed

- **Model** (`manual_valuation_snapshots`): add `version` + self-referential
  `superseded_by_id` — the codebase's native versioning idiom (as on
  `reconciliation_matches` / `transaction_classification`), not bitemporal
  `valid_from/valid_to`, not a separate version table. Uniqueness moves to a
  **partial unique index over the current head** (`WHERE superseded_by_id IS NULL`)
  so superseded history rows accumulate freely.
- **Service** `create_valuation_snapshot`: append-and-supersede via an ordered
  hand-off (park new under old head → demote old → promote new) that never
  violates the self-FK or the single-head invariant under per-statement checking.
  Adds `list_valuation_versions` for retrievable history.
- **Heads-only reads** on every current-truth path so a correction never
  double-counts: `AssetService` list/aggregate, `framework_policy`,
  `report_readiness`, and the `reports` router.
- **Migration 0035** (medium risk, reversible) — verified `alembic upgrade head`,
  `alembic downgrade -1`, and `alembic check` → **no drift**.

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-011 — Asset Lifecycle Management |
| **AC IDs** | AC11.19.1, AC11.19.2 |
| **AC source updated** | `docs/project/EPIC-011.asset-lifecycle.md` |

## SSOT Changes

- [x] `docs/ssot/schema.md` — new **Append-Only Fact Versioning (Axiom A)**
  contract: version-bearing unit, current-head partial-unique rule, and the
  explicit **fact vs. review-state** line.
- [x] `docs/ssot/migration-risk.yaml` — registers `0035_manual_valuation_versioning`
  (medium).

## TDD Evidence

🔴 Red: both new tests failed with `UniqueViolationError` (same-key correction
forbidden) before the schema/service change. 🟢 Green after: 11/11 in the file.

| Test | AC |
|------|----|
| `test_AC11_19_1_manual_valuation_correction_appends_version_and_preserves_history` | AC11.19.1 |
| `test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth` | AC11.19.2 |

## Scope boundary (next slice)

PATCH `update_valuation_snapshot` still edits `value` in place. Splitting
fact-correction (append) from annotation edits (notes/reminder, mutable) is the
documented follow-up under #918 — kept out here to keep the slice bounded.

## Testing

```bash
# Red→green + no regression in the blast radius
python3 tools/test_lifecycle.py --fast tests/assets/test_manual_valuation_snapshots.py   # 11 passed
python3 tools/test_lifecycle.py --fast tests/assets tests/reporting \
  tests/infra/test_financial_fact_schema_invariants.py                                    # 305 passed
python3 tools/test_lifecycle.py --fast tests/ai/test_ai_advisor_service.py \
  tests/api/test_personal_report_package_contract.py \
  tests/reporting/test_framework_package_integration.py tests/reporting/test_framework_policy.py  # 84 passed

# Schema/migration contract
alembic upgrade head && alembic check        # no drift; downgrade -1 reversible

# Governance gates
uv run --with pyyaml python tools/generate_ac_registry.py --check   # OK
uv run --with pyyaml python tools/check_manifest.py                 # OK
uv run --with pyyaml python tools/lint_doc_consistency.py           # OK
uv run --with pyyaml python tools/check_migration_risk.py           # OK
ruff check / ruff format --check                                    # clean
```

## Engineering Audit

- [x] No `float` for monetary amounts; `value` stays `Decimal` via `to_money`.
- [x] No `sa.Enum` added/changed without explicit `name=`.
- [x] No `NEXT_PUBLIC_` vars; no `.env`/secret changes.
- [x] `repo/` submodule not touched; no deploy/runtime config in scope.
- [x] Migration declares risk classification; reversible; alembic-drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
