### PR TITLE
[finance_report_ui] #909 FE a11y and trust polish baseline

### DIFF
--- a/apps/frontend/playwright/attention-surface.spec.ts
+++ b/apps/frontend/playwright/attention-surface.spec.ts
@@ -2,8 +2,9 @@ import { expect, test, type Page } from "@playwright/test";
 
 const COLD_ROUTE_TIMEOUT_MS = 10_000;
 
-// EPIC-022 AC22.6.4: desktop + mobile smoke for the confidence-ranked attention
-// queue and the Home trust meter, without layout overflow.
+// EPIC-022 AC22.6.4 / AC22.11.3: desktop + mobile smoke for the
+// confidence-ranked attention queue, attention-origin action links, and the Home
+// trust meter, without layout overflow.
 async function installAttentionMocks(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem("finance_user_id", "attention-smoke-user");
@@ -82,9 +83,9 @@ test.describe("AC22.6.4 attention surface smoke", () => {
       // (confidence-ordering itself is covered by attention.test.ts unit tests).
       await expect(page.getByText(/unmatched transaction/i)).toBeVisible();
       await expect(page.getByText("march-statement.pdf")).toBeVisible();
-      // Each row deep-links to its action surface.
-      await expect(page.locator('a[href="/statements/stmt-1/review"]')).toBeVisible();
-      await expect(page.locator('a[href="/reconciliation/unmatched"]')).toBeVisible();
+      // Each row deep-links to its action surface and preserves the attention origin.
+      await expect(page.locator('a[href="/statements/stmt-1/review?from=attention"]')).toBeVisible();
+      await expect(page.locator('a[href="/reconciliation/unmatched?from=attention"]')).toBeVisible();
 
       await expectNoDocumentHorizontalScroll(page);
     });

--- a/apps/frontend/playwright/cash-flow-drilldown.spec.ts
+++ b/apps/frontend/playwright/cash-flow-drilldown.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const COLD_ROUTE_TIMEOUT_MS = 10_000;
+
+async function installCashFlowMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("finance_user_id", "cash-flow-smoke-user");
+    localStorage.setItem("finance_user_email", "cash-flow-smoke@example.com");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    let body: unknown = {};
+
+    if (path === "/api/workflow/status") {
+      body = {
+        primary_state: "ready",
+        next_action: null,
+        report_readiness: { state: "ready", blocking_count: 0, href: "/reports/package" },
+        event_counts: { unread: 0, action_required: 0, blocked: 0 },
+      };
+    } else if (path === "/api/reports/currencies") {
+      body = ["SGD", "USD"];
+    } else if (path === "/api/reports/cash-flow") {
+      body = {
+        start_date: "2026-05-01",
+        end_date: "2026-06-01",
+        currency: "SGD",
+        operating: [
+          {
+            category: "operating",
+            subcategory: "Salary",
+            amount: "5000.00",
+            description: "Inflow - Salary",
+            account_id: "acc-salary",
+          },
+        ],
+        investing: [],
+        financing: [],
+        summary: {
+          operating_activities: "5000.00",
+          investing_activities: "0.00",
+          financing_activities: "0.00",
+          net_cash_flow: "5000.00",
+          beginning_cash: "1000.00",
+          ending_cash: "6000.00",
+        },
+        fx_warnings: [],
+      };
+    } else if (path === "/api/reports/account-lineage") {
+      body = {
+        account_id: "acc-salary",
+        account_name: "Salary",
+        account_type: "INCOME",
+        currency: "SGD",
+        as_of_date: "2026-06-01",
+        start_date: "2026-05-01",
+        total: "5000.00",
+        lines: [
+          {
+            journal_line_id: "33333333-3333-4333-8333-333333333333",
+            journal_entry_id: "22222222-2222-4222-8222-222222222222",
+            entry_date: "2026-05-25",
+            memo: "Salary deposit",
+            direction: "DEBIT",
+            original_amount: "5000.00",
+            original_currency: "SGD",
+            amount: "5000.00",
+          },
+        ],
+      };
+    }
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+}
+
+async function expectNoDocumentHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    scrollX: window.scrollX,
+  }));
+
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.scrollX).toBe(0);
+}
+
+test.describe("AC22.7.4 cash-flow drill-down smoke", () => {
+  for (const scenario of [
+    { name: "desktop", viewport: { width: 1440, height: 1000 } },
+    { name: "mobile", viewport: { width: 390, height: 844 } },
+  ]) {
+    test(`${scenario.name} opens account-lineage drawer from a cash-flow amount`, async ({ page }) => {
+      await page.setViewportSize(scenario.viewport);
+      await installCashFlowMocks(page);
+
+      await page.goto("/reports/cash-flow", { waitUntil: "networkidle" });
+
+      await page.getByRole("button", { name: /View source transactions for Salary/i }).click();
+      const drawer = page.getByRole("dialog", { name: "Sources · Salary" });
+      await expect(drawer).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
+      await expect(drawer.getByText("Salary deposit")).toBeVisible();
+      await expectNoDocumentHorizontalScroll(page);
+    });
+  }
+});

--- a/apps/frontend/playwright/portfolio-provenance.spec.ts
+++ b/apps/frontend/playwright/portfolio-provenance.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const COLD_ROUTE_TIMEOUT_MS = 10_000;
+
+const holdings = [
+  {
+    id: "imported-holding",
+    user_id: "portfolio-provenance-smoke-user",
+    account_id: "broker-account",
+    account_name: "IBKR",
+    asset_identifier: "IMP",
+    quantity: "10",
+    cost_basis: "1000.00",
+    market_value: "1250.00",
+    unrealized_pnl: "250.00",
+    unrealized_pnl_percent: "25.00",
+    currency: "SGD",
+    acquisition_date: "2026-01-01",
+    disposal_date: null,
+    status: "active",
+    sector: "Technology",
+    geography: "US",
+    provenance: "imported",
+  },
+  {
+    id: "unknown-holding",
+    user_id: "portfolio-provenance-smoke-user",
+    account_id: "broker-account",
+    account_name: "IBKR",
+    asset_identifier: "UNK",
+    quantity: "5",
+    cost_basis: "500.00",
+    market_value: "525.00",
+    unrealized_pnl: "25.00",
+    unrealized_pnl_percent: "5.00",
+    currency: "SGD",
+    acquisition_date: "2026-02-01",
+    disposal_date: null,
+    status: "active",
+    sector: "Other",
+    geography: "US",
+    provenance: null,
+  },
+];
+
+async function installPortfolioMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("finance_user_id", "portfolio-provenance-smoke-user");
+    localStorage.setItem("finance_user_email", "portfolio-provenance@example.com");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    let body: unknown = {};
+
+    if (path === "/api/workflow/status") {
+      body = {
+        primary_state: "ready",
+        next_action: null,
+        report_readiness: { state: "ready", blocking_count: 0, href: "/reports/package" },
+        event_counts: { unread: 0, action_required: 0, blocked: 0 },
+      };
+    } else if (path === "/api/portfolio/holdings") {
+      body = holdings;
+    } else if (path === "/api/portfolio/summary") {
+      body = {
+        total_market_value: "1775.00",
+        total_cost_basis: "1500.00",
+        total_unrealized_pnl: "275.00",
+        total_unrealized_pnl_percent: "18.33",
+        total_realized_pnl: "0.00",
+        total_realized_pnl_percent: "0.00",
+        net_pnl: "275.00",
+        net_pnl_percent: "18.33",
+        holdings_count: 2,
+        active_positions_count: 2,
+        disposed_positions_count: 0,
+        currency: "SGD",
+        realized_pnl_ytd: "0.00",
+        dividend_income_ytd: "0.00",
+      };
+    } else if (path === "/api/portfolio/performance") {
+      body = { xirr: "8.00", time_weighted_return: "6.00", money_weighted_return: "7.00" };
+    } else if (path.startsWith("/api/portfolio/allocation/")) {
+      body = [];
+    } else if (path === "/api/portfolio/performance/report-schedule") {
+      body = {
+        period_start: "2026-01-01",
+        period_end: "2026-06-01",
+        as_of_date: "2026-06-01",
+        currency: "SGD",
+        xirr: "8.00",
+        time_weighted_return: "6.00",
+        money_weighted_return: "7.00",
+        dividend_yield: "1.50",
+        realized_pnl: "0.00",
+        unrealized_pnl: "275.00",
+        dividend_income: "0.00",
+        data_freshness: {
+          latest_price_date: "2026-06-01",
+          market_data_provider: "smoke-fixture",
+          stale: false,
+          stale_holdings: [],
+          manual_override_basis: null,
+        },
+        source_links: [],
+        notes: [],
+      };
+    }
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+}
+
+async function expectNoDocumentHorizontalScroll(page: Page) {
+  const metrics = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    scrollX: window.scrollX,
+  }));
+
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.scrollX).toBe(0);
+}
+
+test.describe("AC22.10.3 portfolio provenance smoke", () => {
+  for (const scenario of [
+    { name: "desktop", viewport: { width: 1440, height: 1000 } },
+    { name: "mobile", viewport: { width: 390, height: 844 } },
+  ]) {
+    test(`${scenario.name} labels only imported holdings with provenance`, async ({ page }) => {
+      await page.setViewportSize(scenario.viewport);
+      await installPortfolioMocks(page);
+
+      await page.goto("/portfolio", { waitUntil: "networkidle" });
+
+      await expect(page.getByRole("heading", { name: "Portfolio" })).toBeVisible({
+        timeout: COLD_ROUTE_TIMEOUT_MS,
+      });
+      await expect(page.getByRole("link", { name: "IMP" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "UNK" })).toBeVisible();
+      await expect(page.getByText("Imported")).toHaveCount(1);
+      await expectNoDocumentHorizontalScroll(page);
+    });
+  }
+});

--- a/apps/frontend/playwright/report-readiness.spec.ts
+++ b/apps/frontend/playwright/report-readiness.spec.ts
@@ -172,12 +172,12 @@ async function expectNoDocumentHorizontalScroll(page: Page) {
   expect(metrics.scrollX).toBe(0);
 }
 
-test.describe("AC19.8.7 AC19.8.8 report readiness smoke", () => {
+test.describe("AC19.8.7 AC19.8.8 AC22.8.4 report package smoke", () => {
   for (const scenario of [
     { name: "desktop", viewport: { width: 1440, height: 1000 } },
     { name: "mobile", viewport: { width: 390, height: 844 } },
   ]) {
-    test(`${scenario.name} renders report readiness blockers before package output`, async ({
+    test(`${scenario.name} renders cover, contents, and readiness before package output`, async ({
       page,
     }) => {
       await page.setViewportSize(scenario.viewport);
@@ -191,6 +191,19 @@ test.describe("AC19.8.7 AC19.8.8 report readiness smoke", () => {
       ).toBeVisible({
         timeout: COLD_ROUTE_TIMEOUT_MS,
       });
+      const cover = page.getByRole("region", { name: "Report package cover" });
+      await expect(cover.getByText("personal-financial-report-package")).toBeVisible();
+      await expect(cover.getByText("US-like")).toBeVisible();
+
+      const tableOfContents = page.getByRole("navigation", {
+        name: "Report package table of contents",
+      });
+      await expect(
+        tableOfContents.getByRole("link", { name: "Report Readiness" }),
+      ).toHaveAttribute("href", "#package-readiness");
+      await expect(
+        tableOfContents.getByRole("link", { name: "Balance Sheet" }),
+      ).toHaveAttribute("href", "#package-section-balance_sheet");
       await expect(
         page.getByText("processing_account_unresolved"),
       ).toBeVisible();

--- a/apps/frontend/src/__tests__/assetsPage.test.tsx
+++ b/apps/frontend/src/__tests__/assetsPage.test.tsx
@@ -84,7 +84,11 @@ describe("AssetsPage", () => {
       return Promise.reject(new Error("positions failed"))
     })
 
-    render(<AssetsPage />, { wrapper: createWrapper() })
+    const { container } = render(<AssetsPage />, { wrapper: createWrapper() })
+
+    expect(screen.getByRole("status", { name: "Loading positions" })).toHaveAttribute("aria-busy", "true")
+    expect(container.querySelectorAll("[data-testid='skeleton-block']").length).toBeGreaterThanOrEqual(9)
+    expect(container.querySelector(".animate-spin")).toBeNull()
 
     await waitFor(() => expect(screen.queryByText("Failed to load positions")).not.toBeNull())
     fireEvent.click(screen.getByRole("button", { name: "Retry loading positions" }))
@@ -311,6 +315,8 @@ describe("AssetsPage", () => {
         "warning"
       )
     })
+    const [message] = showToastMock.mock.calls[0]
+    expect(message).not.toContain("⚠")
   })
 
   it("shows error toast when reconcile fails", async () => {
@@ -365,7 +371,7 @@ describe("AssetsPage", () => {
     expect(screen.getByText(/0\.123456789 units/)).toBeInTheDocument()
   })
 
-  it("AC11.9.4 renders manual valuation snapshots and creates a new property valuation", async () => {
+  it("AC11.9.4 AC22.10.2 renders manual valuation snapshots and creates a new property valuation", async () => {
     mockedApiFetch.mockImplementation((path: string, options?: RequestInit) => {
       if (path === "/api/assets/valuation-snapshots" && options?.method === "POST") {
         return Promise.resolve({
@@ -395,7 +401,7 @@ describe("AssetsPage", () => {
               as_of_date: "2026-05-01",
               value: "50000.00",
               currency: "SGD",
-              source: "CPF portal",
+              source: "Historical CPF statement",
               notes: null,
               recurrence_days: null,
               reminder_date: null,
@@ -411,16 +417,22 @@ describe("AssetsPage", () => {
 
     render(<AssetsPage />, { wrapper: createWrapper() })
 
-    await waitFor(() => expect(screen.getByText(/CPF portal/)).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText(/Historical CPF statement/)).toBeInTheDocument())
     expect(screen.getByText("Manual Valuations")).toBeInTheDocument()
     expect(screen.getAllByText("CPF Balance").length).toBeGreaterThan(0)
     expect(screen.getByText("Restricted")).toBeInTheDocument()
+    expect(screen.queryByRole("textbox", { name: "Source" })).not.toBeInTheDocument()
+    const sourceSelect = screen.getByRole("combobox", { name: "Source" }) as HTMLSelectElement
+    expect(sourceSelect).toHaveValue("manual")
+    expect(screen.getByRole("option", { name: "Manual entry" })).toHaveValue("manual")
+    expect(screen.getByRole("option", { name: "Broker portal" })).toHaveValue("broker_portal")
+    expect(screen.getByRole("option", { name: "CPF portal" })).toHaveValue("cpf_portal")
 
     fireEvent.change(screen.getByLabelText("Valuation type"), { target: { value: "property_value" } })
     fireEvent.change(screen.getByLabelText("As of date"), { target: { value: "2026-05-18" } })
     fireEvent.change(screen.getByLabelText("Value"), { target: { value: "1250000.00" } })
     fireEvent.change(screen.getByLabelText("Currency"), { target: { value: "SGD" } })
-    fireEvent.change(screen.getByLabelText("Source"), { target: { value: "broker portal" } })
+    fireEvent.change(sourceSelect, { target: { value: "broker_portal" } })
     fireEvent.change(screen.getByLabelText("Notes"), { target: { value: "Audited manually" } })
     fireEvent.click(screen.getByRole("button", { name: "Add valuation" }))
 
@@ -430,6 +442,15 @@ describe("AssetsPage", () => {
         expect.objectContaining({ method: "POST" })
       )
     })
+    const [, postOptions] = mockedApiFetch.mock.calls.find(([path, options]) => (
+      path === "/api/assets/valuation-snapshots" && options?.method === "POST"
+    ))!
+    expect(JSON.parse(String(postOptions?.body))).toEqual(
+      expect.objectContaining({
+        source: "broker_portal",
+        notes: "Audited manually",
+      })
+    )
     expect(showToastMock).toHaveBeenCalledWith("Manual valuation saved", "success")
   })
 
@@ -449,7 +470,7 @@ describe("AssetsPage", () => {
     await waitFor(() => expect(screen.getByText("Manual Valuations")).toBeInTheDocument())
     fireEvent.change(screen.getByLabelText("Value"), { target: { value: "1250000.00" } })
     fireEvent.change(screen.getByLabelText("Currency"), { target: { value: "usd" } })
-    fireEvent.change(screen.getByLabelText("Source"), { target: { value: "broker portal" } })
+    fireEvent.change(screen.getByRole("combobox", { name: "Source" }), { target: { value: "broker_portal" } })
     fireEvent.change(screen.getByLabelText("Notes"), { target: { value: "Needs follow-up" } })
     fireEvent.click(screen.getByRole("button", { name: "Add valuation" }))
 

--- a/apps/frontend/src/__tests__/attentionQueue.test.tsx
+++ b/apps/frontend/src/__tests__/attentionQueue.test.tsx
@@ -37,7 +37,7 @@ function mockSources({
 describe("Attention queue (EPIC-022 AC22.6)", () => {
   beforeEach(() => mockedApiFetch.mockReset());
 
-  it("AC22.6.1 renders the open attention items lowest-confidence first, each deep-linking to its action surface", async () => {
+  it("AC22.6.1 AC22.11.3 AC22.12.4 renders the open attention items with readable reasons and action links", async () => {
     mockSources({
       statements: [
         { id: "bad", original_filename: "bad.pdf", status: "parsed", confidence_score: 88, balance_validated: false, transactions: [] },
@@ -50,15 +50,18 @@ describe("Attention queue (EPIC-022 AC22.6)", () => {
 
     const rows = await screen.findAllByRole("link");
     // Unmatched (confidence 0) comes before the parsed statement (40) before pending review (80).
-    expect(rows[0]).toHaveAttribute("href", "/reconciliation/unmatched");
-    expect(rows[1]).toHaveAttribute("href", "/statements/bad/review");
-    expect(rows[2]).toHaveAttribute("href", "/reconciliation/review-queue");
+    expect(rows[0]).toHaveAttribute("href", "/reconciliation/unmatched?from=attention");
+    expect(rows[1]).toHaveAttribute("href", "/statements/bad/review?from=attention");
+    expect(rows[2]).toHaveAttribute("href", "/reconciliation/review-queue?from=attention");
 
     expect(within(rows[1]).getByText("bad.pdf")).toBeInTheDocument();
     expect(within(rows[0]).getByText("0% confidence")).toBeInTheDocument();
 
     // AC22.11.2: each row explains *why* it was flagged, not just a score.
-    expect(within(rows[0]).getByText(/no matching ledger entry/i)).toBeInTheDocument();
+    const unmatchedReason = within(rows[0]).getByText(/no matching ledger entry/i);
+    expect(unmatchedReason).toBeInTheDocument();
+    expect(unmatchedReason).toHaveClass("text-muted");
+    expect(unmatchedReason.className).not.toContain("text-muted/80");
     expect(within(rows[1]).getByText(/balance didn't reconcile/i)).toBeInTheDocument();
   });
 

--- a/apps/frontend/src/__tests__/balanceSheetPage.test.tsx
+++ b/apps/frontend/src/__tests__/balanceSheetPage.test.tsx
@@ -31,7 +31,11 @@ describe("BalanceSheetPage", () => {
   it("AC16.14.1 renders loading and error retry states", async () => {
     mockedApiFetch.mockRejectedValue(new Error("balance failed"))
 
-    render(<BalanceSheetPage />)
+    const { container } = render(<BalanceSheetPage />)
+
+    expect(screen.getByRole("status", { name: "Loading balance sheet" })).toHaveAttribute("aria-busy", "true")
+    expect(container.querySelectorAll("[data-testid='skeleton-block']").length).toBeGreaterThanOrEqual(12)
+    expect(container.querySelector(".animate-spin")).toBeNull()
 
     await waitFor(() => expect(screen.getByText("balance failed")).toBeInTheDocument())
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))

--- a/apps/frontend/src/__tests__/cashFlowPage.test.tsx
+++ b/apps/frontend/src/__tests__/cashFlowPage.test.tsx
@@ -39,7 +39,11 @@ describe("CashFlowPage", () => {
   it("AC16.14.7 renders loading and error retry states", async () => {
     mockedApiFetch.mockRejectedValue(new Error("cashflow failed"))
 
-    render(<CashFlowPage />)
+    const { container } = render(<CashFlowPage />)
+
+    expect(screen.getByRole("status", { name: "Loading cash flow" })).toHaveAttribute("aria-busy", "true")
+    expect(container.querySelectorAll("[data-testid='skeleton-block']").length).toBeGreaterThanOrEqual(10)
+    expect(container.querySelector(".animate-spin")).toBeNull()
 
     await waitFor(() => expect(screen.getByText("cashflow failed")).toBeInTheDocument())
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument()

--- a/apps/frontend/src/__tests__/designTokens.test.tsx
+++ b/apps/frontend/src/__tests__/designTokens.test.tsx
@@ -108,6 +108,27 @@ describe("frontend design tokens", () => {
     expect(globals).not.toMatch(/alert bg-\[var\(--(error|success|warning|info)-muted\)\] text-\[var\(--(error|success|warning|info)\)\]/)
   })
 
+  it("AC22.12.1 AC22.12.3 defines the global accessibility baseline in SSOT and CSS", () => {
+    const ssot = readFileSync(
+      resolve(process.cwd(), "../../docs/ssot/frontend-patterns.md"),
+      "utf8",
+    )
+    const globals = readFileSync(resolve(process.cwd(), "src/app/globals.css"), "utf8")
+
+    expect(ssot).toContain("### Global Accessibility Baseline")
+    expect(ssot).toContain("`prefers-reduced-motion: reduce`")
+    expect(ssot).toContain("`:focus-visible`")
+
+    expect(globals).toContain("@media (prefers-reduced-motion: reduce)")
+    expect(globals).toContain("animation-duration: 0.01ms !important")
+    expect(globals).toContain("transition-duration: 0.01ms !important")
+    expect(globals).toContain("scroll-behavior: auto !important")
+    expect(globals).toContain(":focus-visible")
+    expect(globals).toContain(".btn-primary:focus-visible")
+    expect(globals).toContain("outline: 2px solid var(--accent)")
+    expect(globals).toContain("box-shadow: var(--shadow-focus)")
+  })
+
   it("AC16.29.3 AC16.29.4 renders ConfidenceBadge variants through semantic token classes", () => {
     const tiers = ["TRUSTED", "HIGH", "MEDIUM", "LOW"] as const
 

--- a/apps/frontend/src/__tests__/flowStepBanner.test.tsx
+++ b/apps/frontend/src/__tests__/flowStepBanner.test.tsx
@@ -32,4 +32,14 @@ describe("FlowStepBanner (EPIC-022 AC22.5.1)", () => {
         render(<FlowStepBanner current="upload" />);
         expect(screen.getByText(/Next: once we parse your statement/i)).toBeInTheDocument();
     });
+
+    it("AC22.12.5 uses semantic icons instead of unicode status glyphs", () => {
+        const { container } = render(<FlowStepBanner current="reports" />);
+
+        expect(container.textContent).not.toContain("✓");
+        expect(container.textContent).not.toContain("→");
+        expect(screen.getByRole("link", { name: /Upload/ })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /Review & approve/ })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /Reports/ })).toHaveAttribute("aria-current", "step");
+    });
 });

--- a/apps/frontend/src/__tests__/incomeStatementPage.test.tsx
+++ b/apps/frontend/src/__tests__/incomeStatementPage.test.tsx
@@ -35,7 +35,11 @@ describe("IncomeStatementPage", () => {
   it("AC16.14.4 renders loading and error retry states", async () => {
     mockedApiFetch.mockRejectedValue(new Error("income failed"))
 
-    render(<IncomeStatementPage />)
+    const { container } = render(<IncomeStatementPage />)
+
+    expect(screen.getByRole("status", { name: "Loading income statement" })).toHaveAttribute("aria-busy", "true")
+    expect(container.querySelectorAll("[data-testid='skeleton-block']").length).toBeGreaterThanOrEqual(10)
+    expect(container.querySelector(".animate-spin")).toBeNull()
 
     await waitFor(() => expect(screen.getByText("income failed")).toBeInTheDocument())
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))

--- a/apps/frontend/src/__tests__/lineagePanel.test.tsx
+++ b/apps/frontend/src/__tests__/lineagePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -52,6 +52,41 @@ describe("LineagePanel (EPIC-022 AC22.3.4/AC22.3.5)", () => {
     expect(screen.getByText("source document")).toBeInTheDocument()
     // The anchored call targets the evidence lineage API for that journal line.
     expect(mockedApiFetch).toHaveBeenCalledWith(expect.stringContaining("/api/evidence/lineage?entity_type=journal_line"))
+  })
+
+  it("AC22.7.2 renders an ordered lineage path with source, confidence, and version badges", async () => {
+    mockedApiFetch.mockResolvedValue({
+      anchor: null,
+      max_depth: 6,
+      blockers: [],
+      edges: [
+        { id: "e1", relation: "parsed_into", direction: "upstream", depth: 3, from_node_id: "source", to_node_id: "atomic", properties: {} },
+        { id: "e2", relation: "posted_as", direction: "upstream", depth: 2, from_node_id: "atomic", to_node_id: "ledger", properties: {} },
+        { id: "e3", relation: "aggregated_into", direction: "downstream", depth: 1, from_node_id: "ledger", to_node_id: "report", properties: {} },
+      ],
+      nodes: [
+        { id: "ledger", node_kind: "ledger_line", entity_type: "journal_line", entity_id: "j1", properties: { source_type: "journal_entry", confidence_tier: "TRUSTED", version: "posted" } },
+        { id: "report", node_kind: "report_line", entity_type: "balance_sheet_line", entity_id: "r1", properties: { source_system: "balance_sheet", confidence: "TRUSTED", matrix_version: "v1" } },
+        { id: "source", node_kind: "source_document", entity_type: "uploaded_document", entity_id: "d1", properties: { source_system: "statement_upload", confidence_tier: "HIGH", version: "v3" } },
+        { id: "atomic", node_kind: "atomic_fact", entity_type: "atomic_transaction", entity_id: "a1", properties: { source_type: "bank_statement_transaction", confidence: "HIGH", record_version: 2 } },
+      ],
+    })
+
+    render(<LineagePanel anchor={JOURNAL_ANCHOR} title="Audited amount" onClose={() => {}} />)
+
+    const path = await screen.findByLabelText("Lineage path")
+    const hops = within(path).getAllByRole("listitem")
+
+    expect(hops).toHaveLength(4)
+    expect(hops[0]).toHaveTextContent("source document")
+    expect(hops[1]).toHaveTextContent("atomic fact")
+    expect(hops[2]).toHaveTextContent("ledger line")
+    expect(hops[3]).toHaveTextContent("report line")
+
+    expect(within(hops[0]).getByText("Source: statement_upload")).toBeInTheDocument()
+    expect(within(hops[0]).getByText("Confidence: HIGH")).toBeInTheDocument()
+    expect(within(hops[0]).getByText("Version: v3")).toBeInTheDocument()
+    expect(within(hops[1]).getByText("Version: 2")).toBeInTheDocument()
   })
 
   it("AC22.3.5 shows a graceful empty/blocker state when nothing is linked", async () => {

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import PersonalReportPackagePage from "@/app/(main)/reports/package/page";
@@ -550,7 +550,7 @@ describe("PersonalReportPackagePage", () => {
     ).toBeInTheDocument();
   });
 
-  it("AC20.6.1 requires explicit framework selection before loading framework-scoped package output", async () => {
+  it("AC20.6.1 AC22.8.3 requires explicit framework selection before loading framework-scoped package output", async () => {
     mockPackageApi();
 
     renderPackagePage();
@@ -567,6 +567,18 @@ describe("PersonalReportPackagePage", () => {
     expect(
       screen.getByText("Select a framework before package output is loaded."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Package setup guidance" }),
+    ).toBeInTheDocument();
+    const setupToc = screen.getByRole("navigation", {
+      name: "Report package table of contents",
+    });
+    expect(
+      within(setupToc).getByRole("link", { name: "Reporting Framework" }),
+    ).toHaveAttribute("href", "#package-framework-selection");
+    expect(
+      within(setupToc).getByRole("link", { name: "Balance Sheet" }),
+    ).toHaveAttribute("href", "#package-section-balance_sheet");
     expect(mockedApiFetch).not.toHaveBeenCalledWith(
       "/api/reports/package/readiness",
     );
@@ -639,7 +651,9 @@ describe("PersonalReportPackagePage", () => {
         screen.queryByText("Failed to load package data."),
       ).not.toBeInTheDocument(),
     );
-    expect(screen.getByText("Loading framework package...")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: "Loading report package" }),
+    ).toHaveAttribute("aria-busy", "true");
   });
 
   it("EPIC-022 #867 offers a print / save-as-PDF export of the loaded package", async () => {
@@ -975,19 +989,19 @@ describe("PersonalReportPackagePage", () => {
       ),
     );
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await screen.findByText("Balance Sheet");
-    expect(screen.getByText("Personal Report Package")).toBeInTheDocument();
+    await screen.findByRole("heading", { name: "Balance Sheet" });
+    expect(screen.getAllByText("Personal Report Package").length).toBeGreaterThanOrEqual(1);
     expect(
-      screen.getByText("personal-financial-report-package"),
-    ).toBeInTheDocument();
+      screen.getAllByText("personal-financial-report-package").length,
+    ).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("balance_sheet").length).toBeGreaterThanOrEqual(
       1,
     );
-    expect(screen.getByText("Balance Sheet")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Balance Sheet" })).toBeInTheDocument();
     // Sections are titled by their human label, not the raw snake_case section_id
     // (EPIC-022 AC22.8.1).
     expect(
-      screen.getByText("Annualized Income & Long-Term Compensation"),
+      screen.getByRole("heading", { name: "Annualized Income & Long-Term Compensation" }),
     ).toBeInTheDocument();
   });
 
@@ -1010,6 +1024,71 @@ describe("PersonalReportPackagePage", () => {
     }
   });
 
+  it("AC22.8.2 renders a readable package cover and linked table of contents", async () => {
+    mockPackageApi();
+
+    renderPackagePage();
+
+    fireEvent.change(await screen.findByLabelText("Package report date"), {
+      target: { value: "2026-05-20" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "US-like" }));
+
+    const cover = await screen.findByRole("region", {
+      name: "Report package cover",
+    });
+    expect(within(cover).getByText("Personal Report Package")).toBeInTheDocument();
+    expect(
+      within(cover).getByText("personal-financial-report-package"),
+    ).toBeInTheDocument();
+    expect(within(cover).getByText("US-like")).toBeInTheDocument();
+    expect(within(cover).getByText("2026-05-20")).toBeInTheDocument();
+
+    const toc = screen.getByRole("navigation", {
+      name: "Report package table of contents",
+    });
+    for (const [label, href] of [
+      ["Report Readiness", "#package-readiness"],
+      ["Source Trust", "#package-source-trust"],
+      ["Framework Policy", "#package-framework-policy"],
+      ["Balance Sheet", "#package-section-balance_sheet"],
+      ["Traceability Appendix", "#package-section-traceability_appendix"],
+    ] as const) {
+      expect(within(toc).getByRole("link", { name: label })).toHaveAttribute(
+        "href",
+        href,
+      );
+    }
+  });
+
+  it("AC22.8.3 reserves the framework-package layout while package sections load", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/reports/package/contract")
+        return Promise.resolve(contract);
+      if (path.startsWith("/api/reports/package/contract?framework_id="))
+        return Promise.resolve({
+          ...contract,
+          selected_framework_id: "personal_us_gaap_like",
+        });
+      return new Promise(() => undefined);
+    });
+
+    const { container } = renderPackagePage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
+
+    expect(
+      screen.getByRole("status", { name: "Loading report package" }),
+    ).toHaveAttribute("aria-busy", "true");
+    expect(
+      screen.getByRole("navigation", {
+        name: "Report package table of contents",
+      }),
+    ).toBeInTheDocument();
+    expect(container.querySelectorAll("[data-testid='skeleton-block']").length).toBeGreaterThanOrEqual(10);
+    expect(screen.queryByText("Loading framework package...")).not.toBeInTheDocument();
+  });
+
   it("AC19.5.4 renders package readiness before report package output", async () => {
     mockPackageApi();
 
@@ -1024,8 +1103,8 @@ describe("PersonalReportPackagePage", () => {
         expect.objectContaining({ signal: expect.any(Object) }),
       ),
     );
-    const readinessHeading = await screen.findByText("Report Readiness");
-    const balanceSheetHeading = screen.getByText("Balance Sheet");
+    const readinessHeading = await screen.findByRole("heading", { name: "Report Readiness" });
+    const balanceSheetHeading = screen.getByRole("heading", { name: "Balance Sheet" });
     expect(
       readinessHeading.compareDocumentPosition(balanceSheetHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING,
@@ -1108,9 +1187,7 @@ describe("PersonalReportPackagePage", () => {
     renderPackagePage();
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await waitFor(() =>
-      expect(screen.getByText("Export Contract")).toBeInTheDocument(),
-    );
+    await screen.findByRole("heading", { name: "Export Contract" });
     expect(screen.getByText("json, csv")).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/apps/frontend/src/__tests__/reconciliationWorkbenchComponent.test.tsx
+++ b/apps/frontend/src/__tests__/reconciliationWorkbenchComponent.test.tsx
@@ -6,8 +6,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import ReconciliationWorkbench from "@/components/reconciliation/Workbench"
 import { apiFetch } from "@/lib/api"
 
+const navigationState = vi.hoisted(() => ({
+  searchParams: new URLSearchParams(),
+}))
+
 vi.mock("@/lib/api", () => ({
   apiFetch: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => navigationState.searchParams,
 }))
 
 function createWrapper() {
@@ -27,6 +35,7 @@ describe("ReconciliationWorkbench", () => {
 
   beforeEach(() => {
     mockedApiFetch.mockReset()
+    navigationState.searchParams = new URLSearchParams()
   })
 
   const statsResponse = {

--- a/apps/frontend/src/__tests__/reviewBackLinks.test.tsx
+++ b/apps/frontend/src/__tests__/reviewBackLinks.test.tsx
@@ -6,6 +6,10 @@ import { BackLink } from "@/components/ui/BackLink";
 import AiSuggestionsPage from "@/app/(main)/review/ai-suggestions/page";
 import { apiFetch } from "@/lib/api";
 
+const navigationState = vi.hoisted(() => ({
+    searchParams: new URLSearchParams(),
+}));
+
 vi.mock("next/link", () => ({
     __esModule: true,
     default: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
@@ -19,9 +23,14 @@ vi.mock("@/lib/api", () => ({
     apiFetch: vi.fn(),
 }));
 
+vi.mock("next/navigation", () => ({
+    useSearchParams: () => navigationState.searchParams,
+}));
+
 describe("Review surfaces back-link + plain copy (EPIC-022 AC22.5.3, AC22.5.4)", () => {
     beforeEach(() => {
         vi.mocked(apiFetch).mockReset();
+        navigationState.searchParams = new URLSearchParams();
     });
 
     it("AC22.5.3 BackLink defaults to the notification center", () => {
@@ -40,6 +49,17 @@ describe("Review surfaces back-link + plain copy (EPIC-022 AC22.5.3, AC22.5.4)",
                 "href",
                 "/notifications",
             ),
+        );
+    });
+
+    it("AC22.11.3 BackLink returns attention-origin users to the attention queue", () => {
+        navigationState.searchParams = new URLSearchParams("from=attention");
+
+        render(<BackLink>Back to Notifications</BackLink>);
+
+        expect(screen.getByRole("link", { name: /Back to Attention queue/i })).toHaveAttribute(
+            "href",
+            "/attention",
         );
     });
 

--- a/apps/frontend/src/__tests__/shellAndAuth.test.tsx
+++ b/apps/frontend/src/__tests__/shellAndAuth.test.tsx
@@ -58,6 +58,23 @@ describe("AppShell and AuthGuard", () => {
     expect(screen.getByTestId("workspace-tabs").parentElement?.className).toContain("hidden md:block")
   })
 
+  it("AC22.12.2 exposes a skip-to-content link targeting the main landmark", () => {
+    const { container } = render(
+      <AppShell>
+        <div>Shell Child</div>
+      </AppShell>,
+    )
+
+    const skipLink = screen.getByRole("link", { name: "Skip to main content" })
+    expect(skipLink).toHaveAttribute("href", "#main-content")
+    expect(skipLink).toHaveClass("sr-only")
+    expect(skipLink.className).toContain("focus:not-sr-only")
+
+    const main = container.querySelector("main#main-content")
+    expect(main).not.toBeNull()
+    expect(main).toHaveAttribute("tabIndex", "-1")
+  })
+
   it("AC16.19.2 redirects unauthenticated protected routes", async () => {
     isAuthenticatedMock.mockReturnValue(false)
 

--- a/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
+++ b/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
@@ -136,6 +136,33 @@ describe("AC8.13.48 Stage2ReviewQueue frontend coverage lift", () => {
     expect(screen.getByRole("button", { name: "Approve Selected" })).toBeEnabled()
   })
 
+  it("AC22.11.3 preserves attention origin while the Stage 2 queue updates filters", async () => {
+    navState.searchParams = new URLSearchParams("from=attention")
+
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path.startsWith("/api/statements/stage2/queue")) {
+        return Promise.resolve(queue({ pending_matches: [] }) as never)
+      }
+      if (path.startsWith("/api/statements/consistency-checks/list")) {
+        return Promise.resolve({ items: [] } as never)
+      }
+      return Promise.reject(new Error(`Unexpected path ${path}`))
+    })
+
+    renderReviewComponent(<Stage2ReviewQueue />)
+
+    expect(await screen.findByRole("link", { name: /Back to Attention queue/i })).toHaveAttribute(
+      "href",
+      "/attention",
+    )
+
+    await waitFor(() =>
+      expect(navState.replace).toHaveBeenCalledWith("/reconciliation/review-queue?from=attention", {
+        scroll: false,
+      }),
+    )
+  })
+
   it("AC16.26.3 mobile run review preserves approval gate and pending match workflow", async () => {
     mockMobileViewport()
     navState.pathname = "/review/run/mobile-run"

--- a/apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx
@@ -4,10 +4,15 @@ import StatementReviewPage from "@/app/(main)/statements/[id]/review/page";
 import { apiFetch } from "@/lib/api";
 import { renderReviewComponent } from "./helpers/renderReviewComponent";
 
+const navigationState = vi.hoisted(() => ({
+    searchParams: new URLSearchParams(),
+}));
+
 vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
 vi.mock("next/navigation", () => ({
     useRouter: vi.fn(() => ({ replace: vi.fn(), push: vi.fn() })),
     useParams: vi.fn(() => ({ id: "s1" })),
+    useSearchParams: vi.fn(() => navigationState.searchParams),
 }));
 
 const mockedApi = vi.mocked(apiFetch);
@@ -16,6 +21,7 @@ const emptyConflicts = { duplicates: [], transfer_pairs: [] };
 describe("StatementReviewPage - coverage additions", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        navigationState.searchParams = new URLSearchParams();
     });
 
     it("renders loading then empty transactions and handles retry/back link", async () => {

--- a/apps/frontend/src/__tests__/statementReviewPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementReviewPage.test.tsx
@@ -6,13 +6,19 @@ import { apiFetch } from "@/lib/api";
 
 import { renderReviewComponent } from "./helpers/renderReviewComponent";
 
-const pushMock = vi.fn();
-const replaceMock = vi.fn();
+const navigationState = vi.hoisted(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    searchParams: new URLSearchParams(),
+}));
+const pushMock = navigationState.push;
+const replaceMock = navigationState.replace;
 
 vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
 vi.mock("next/navigation", () => ({
     useRouter: vi.fn(() => ({ replace: replaceMock, push: pushMock })),
     useParams: vi.fn(() => ({ id: "s1" })),
+    useSearchParams: vi.fn(() => navigationState.searchParams),
 }));
 
 const mockedApi = vi.mocked(apiFetch);
@@ -60,6 +66,7 @@ const emptyConflicts = { duplicates: [], transfer_pairs: [] };
 describe("AC16.1.2 AC16.1.3 Statement review page", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        navigationState.searchParams = new URLSearchParams();
     });
 
     it("AC16.18.4 shows loading feedback while review data is pending", () => {
@@ -241,6 +248,50 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
 
         expect(pushMock).toHaveBeenNthCalledWith(1, "/statements/s0/review");
         expect(pushMock).toHaveBeenNthCalledWith(2, "/statements/s2/review");
+    });
+
+    it("AC22.11.3 returns attention-origin statement review actions to the attention queue", async () => {
+        navigationState.searchParams = new URLSearchParams("from=attention");
+
+        mockedApi.mockImplementation((path: string, options?: RequestInit) => {
+            if (path === "/api/statements/s1/review") {
+                return Promise.resolve(baseStatement);
+            }
+
+            if (path === "/api/statements/pending-review") {
+                return Promise.resolve({ items: [{ id: "s0" }, { id: "s1" }, { id: "s2" }], total: 3 });
+            }
+
+            if (path === "/api/review/conflicts/s1") {
+                return Promise.resolve(emptyConflicts);
+            }
+
+            if (path === "/api/statements/s1/review/approve") {
+                expect(options).toMatchObject({ method: "POST" });
+                return Promise.resolve({ journal_entries_created: 1 });
+            }
+
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
+
+        renderReviewComponent(<StatementReviewPage /> as never);
+
+        const backLink = await screen.findByRole("link", { name: /Back to Attention queue/i });
+        expect(backLink).toHaveAttribute("href", "/attention");
+
+        fireEvent.click(screen.getByRole("button", { name: "← Prev" }));
+        fireEvent.click(screen.getByRole("button", { name: "Next →" }));
+
+        expect(pushMock).toHaveBeenNthCalledWith(1, "/statements/s0/review?from=attention");
+        expect(pushMock).toHaveBeenNthCalledWith(2, "/statements/s2/review?from=attention");
+
+        fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+        const dialog = await screen.findByRole("dialog", { name: "Approve Statement" });
+        fireEvent.click(within(dialog).getByRole("button", { name: "Approve" }));
+
+        await waitFor(() => {
+            expect(pushMock).toHaveBeenLastCalledWith("/attention");
+        });
     });
 
     it("AC16.23.3 AC16.31.1 opens the conflict dialog when duplicate or transfer-pair candidates exist", async () => {

--- a/apps/frontend/src/__tests__/statementReviewPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementReviewPage.test.tsx
@@ -402,7 +402,15 @@ describe("AC16.1.2 AC16.1.3 Statement review page", () => {
         );
         // AC22.5.2: the block is explained in plain language with an in-place escape.
         expect(screen.getByText(/Approve is paused/i)).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: /Resolve conflicts/i })).toBeInTheDocument();
+        const autoOpenedDialog = await screen.findByRole("dialog", { name: "Resolve Conflicts" });
+        fireEvent.click(within(autoOpenedDialog).getByRole("button", { name: "Close" }));
+        await waitFor(() => {
+            expect(screen.queryByRole("dialog", { name: "Resolve Conflicts" })).not.toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: /Resolve conflicts/i }));
+
+        expect(await screen.findByRole("dialog", { name: "Resolve Conflicts" })).toBeInTheDocument();
     });
 
     it("AC16.32.2 shows opening and closing balance validation states separately", async () => {

--- a/apps/frontend/src/__tests__/toastProviderComponent.test.tsx
+++ b/apps/frontend/src/__tests__/toastProviderComponent.test.tsx
@@ -10,6 +10,7 @@ function TestToastConsumer() {
     <div>
       <button onClick={() => showToast("saved", "success")}>Show Success</button>
       <button onClick={() => showToast("failed", "error")}>Show Error</button>
+      <button onClick={() => showToast("check skipped items", "warning")}>Show Warning</button>
     </div>
   )
 }
@@ -55,6 +56,22 @@ describe("ToastProvider component", () => {
     dismissButton.focus()
     await user.keyboard("{Enter}")
     expect(screen.queryByText("failed")).toBeNull()
+  })
+
+  it("AC22.12.5 uses semantic icon components instead of unicode glyph icons", () => {
+    render(
+      <ToastProvider>
+        <TestToastConsumer />
+      </ToastProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Show Warning" }))
+
+    expect(screen.getByText("check skipped items")).toBeInTheDocument()
+    expect(screen.queryByText("✓")).toBeNull()
+    expect(screen.queryByText("✕")).toBeNull()
+    expect(screen.queryByText("⚠")).toBeNull()
+    expect(screen.queryByText("ℹ")).toBeNull()
   })
 
   it("AC16.19.9 auto-expires notifications", async () => {

--- a/apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx
+++ b/apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx
@@ -6,12 +6,20 @@ import DashboardPage from '@/app/(main)/page';
 import { apiFetch } from '@/lib/api';
 import type { ReactNode } from 'react';
 
+const navigationState = vi.hoisted(() => ({
+  searchParams: new URLSearchParams(),
+}));
+
 vi.mock('@/lib/api', () => ({
   apiFetch: vi.fn(),
 }));
 
 vi.mock('next/link', () => ({
   default: ({ href, children }: { href: string; children: ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => navigationState.searchParams,
 }));
 
 vi.mock("@/components/charts/BarChart", () => ({
@@ -35,6 +43,7 @@ describe('EPIC-015 / UI Gap Audit / Processing Account Visibility', () => {
 
   beforeEach(() => {
     mockedApiFetch.mockReset();
+    navigationState.searchParams = new URLSearchParams();
   });
 
   it('AC15.7.1 — GET /api/accounts/processing/summary contract', async () => {
@@ -145,6 +154,30 @@ describe('EPIC-015 / UI Gap Audit / Processing Account Visibility', () => {
     render(<ProcessingPage />);
 
     expect(await screen.findByText("processing unavailable")).toBeInTheDocument();
+  });
+
+  it('AC22.11.3 — /processing returns attention-origin users to the attention queue', async () => {
+    navigationState.searchParams = new URLSearchParams("from=attention");
+    mockedApiFetch.mockResolvedValue({
+      items: [
+        {
+          entry_id: "e1",
+          from_account: "Bank A",
+          to_account: "Bank B",
+          amount: "500.00",
+          currency: "SGD",
+          initiated_date: "2026-05-01",
+          days_outstanding: 9,
+          description: "Transfer 1"
+        }
+      ],
+      total: 1
+    });
+
+    render(<ProcessingPage />);
+
+    const backLink = await screen.findByRole("link", { name: /Back to Attention queue/i });
+    expect(backLink).toHaveAttribute("href", "/attention");
   });
 
   it('AC15.7.5 — ProcessingSummaryCard mount test', async () => {

--- a/apps/frontend/src/__tests__/uiPrimitives.test.tsx
+++ b/apps/frontend/src/__tests__/uiPrimitives.test.tsx
@@ -11,6 +11,8 @@ import {
   IconButton,
   LoadingState,
   PageHeader,
+  SkeletonBlock,
+  TableSkeleton,
 } from "@/components/ui"
 
 describe("UI primitives", () => {
@@ -69,5 +71,19 @@ describe("UI primitives", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Failed to load")
     expect(screen.getByText("No accounts yet")).toBeInTheDocument()
     expect(screen.getByRole("status", { name: "Loading accounts" })).toBeInTheDocument()
+  })
+
+  it("AC22.12.6 renders token-backed skeleton primitives without spinner affordances", () => {
+    const { container } = render(
+      <div>
+        <SkeletonBlock label="Loading metric" className="h-6 w-24" />
+        <TableSkeleton label="Loading report rows" rows={2} columns={3} />
+      </div>,
+    )
+
+    expect(screen.getByRole("status", { name: "Loading metric" })).toHaveAttribute("aria-busy", "true")
+    expect(screen.getByRole("status", { name: "Loading report rows" })).toHaveAttribute("aria-busy", "true")
+    expect(container.querySelectorAll("[data-testid='skeleton-block']").length).toBeGreaterThanOrEqual(7)
+    expect(container.querySelector(".animate-spin")).toBeNull()
   })
 })

--- a/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
+++ b/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
@@ -4,8 +4,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import UnmatchedBoard from "@/components/reconciliation/UnmatchedBoard"
 import { apiFetch } from "@/lib/api"
 
+const navigationState = vi.hoisted(() => ({
+  searchParams: new URLSearchParams(),
+}))
+
 vi.mock("@/lib/api", () => ({
   apiFetch: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => navigationState.searchParams,
 }))
 
 describe("UnmatchedBoard", () => {
@@ -13,6 +21,7 @@ describe("UnmatchedBoard", () => {
 
   beforeEach(() => {
     mockedApiFetch.mockReset()
+    navigationState.searchParams = new URLSearchParams()
     const storage = new Map<string, string>()
     vi.stubGlobal("localStorage", {
       getItem: (key: string) => storage.get(key) ?? null,
@@ -71,6 +80,16 @@ describe("UnmatchedBoard", () => {
         method: "POST",
       }),
     )
+  })
+
+  it("AC22.11.3 returns attention-origin unmatched review to the attention queue", async () => {
+    navigationState.searchParams = new URLSearchParams("from=attention")
+    mockedApiFetch.mockResolvedValueOnce({ items: [unmatchedItem], total: 1 })
+
+    render(<UnmatchedBoard />)
+
+    const backLink = await screen.findByRole("link", { name: /Back to Attention queue/i })
+    expect(backLink).toHaveAttribute("href", "/attention")
   })
 
   it("AC16.20.4 AC16.31.4 supports local flag and hide actions", async () => {

--- a/apps/frontend/src/app/(main)/assets/page.tsx
+++ b/apps/frontend/src/app/(main)/assets/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { useToast } from "@/components/ui/Toast";
+import { TableSkeleton } from "@/components/ui";
 import { apiFetch } from "@/lib/api";
 import { formatCurrencyLocale, formatQuantity, parseAmount } from "@/lib/currency";
 import { formatDateDisplay } from "@/lib/date";
@@ -11,6 +12,7 @@ import {
     ManagedPosition,
     ManagedPositionListResponse,
     ManualValuationComponentType,
+    ManualValuationSource,
     ManualValuationSnapshotListResponse,
     ReconcilePositionsResponse,
 } from "@/lib/types";
@@ -30,6 +32,17 @@ const VALUATION_TYPES: Array<{ value: ManualValuationComponentType; label: strin
     { value: "other_asset", label: "Other Asset" },
     { value: "other_liability", label: "Other Liability" },
 ];
+const VALUATION_SOURCES: Array<{ value: ManualValuationSource; label: string }> = [
+    { value: "manual", label: "Manual entry" },
+    { value: "broker_portal", label: "Broker portal" },
+    { value: "bank_portal", label: "Bank portal" },
+    { value: "cpf_portal", label: "CPF portal" },
+    { value: "tax_portal", label: "Tax portal" },
+    { value: "insurer_portal", label: "Insurer portal" },
+    { value: "employer_portal", label: "Employer portal" },
+    { value: "property_valuation", label: "Property valuation" },
+    { value: "other_document", label: "Other source document" },
+];
 
 function labelForValuationType(type: ManualValuationComponentType): string {
     return VALUATION_TYPES.find((item) => item.value === type)?.label ?? type;
@@ -37,6 +50,10 @@ function labelForValuationType(type: ManualValuationComponentType): string {
 
 function labelForLiquidityClass(value: string): string {
     return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function labelForValuationSource(source: string): string {
+    return VALUATION_SOURCES.find((item) => item.value === source)?.label ?? source;
 }
 
 export default function AssetsPage() {
@@ -48,7 +65,7 @@ export default function AssetsPage() {
         as_of_date: new Date().toISOString().slice(0, 10),
         value: "",
         currency: "SGD",
-        source: "manual",
+        source: "manual" as ManualValuationSource,
         notes: "",
     });
 
@@ -72,7 +89,7 @@ export default function AssetsPage() {
                 const skippedList = result.skipped_assets.slice(0, 3).join(", ");
                 const suffix = result.skipped_assets.length > 3 ? ` and ${result.skipped_assets.length - 3} more` : "";
                 showToast(
-                    `Reconciled ${total} positions. ⚠️ ${result.skipped} skipped due to incomplete data: ${skippedList}${suffix}`,
+                    `Reconciled ${total} positions. ${result.skipped} skipped due to incomplete data: ${skippedList}${suffix}`,
                     "warning"
                 );
             } else {
@@ -227,7 +244,7 @@ export default function AssetsPage() {
                                                 </span>
                                             </div>
                                             <p className="text-xs text-muted mt-0.5">
-                                                {formatDateDisplay(snapshot.as_of_date)} · {snapshot.source}
+                                                {formatDateDisplay(snapshot.as_of_date)} · {labelForValuationSource(snapshot.source)}
                                             </p>
                                         </div>
                                         <div className="text-right font-semibold">
@@ -305,13 +322,22 @@ export default function AssetsPage() {
                             </div>
                             <div className="grid gap-1">
                                 <label htmlFor="valuation-source" className="text-xs font-medium text-muted">Source</label>
-                                <input
+                                <select
                                     id="valuation-source"
                                     className="input"
                                     value={valuationForm.source}
-                                    onChange={(event) => setValuationForm((current) => ({ ...current, source: event.target.value }))}
+                                    onChange={(event) =>
+                                        setValuationForm((current) => ({
+                                            ...current,
+                                            source: event.target.value as ManualValuationSource,
+                                        }))
+                                    }
                                     required
-                                />
+                                >
+                                    {VALUATION_SOURCES.map((source) => (
+                                        <option key={source.value} value={source.value}>{source.label}</option>
+                                    ))}
+                                </select>
                             </div>
                         </div>
                         <div className="grid gap-1">
@@ -375,10 +401,7 @@ export default function AssetsPage() {
             )}
 
             {isLoading ? (
-                <div className="card p-8 text-center text-muted">
-                    <div className="inline-block w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin mb-2" />
-                    <p className="text-sm">Loading positions...</p>
-                </div>
+                <TableSkeleton label="Loading positions" rows={4} columns={3} />
             ) : error ? (
                 <div className="card p-8 text-center" role="alert" aria-live="polite">
                     <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--error-muted)] text-[var(--error)] mb-4">

--- a/apps/frontend/src/app/(main)/attention/page.tsx
+++ b/apps/frontend/src/app/(main)/attention/page.tsx
@@ -10,6 +10,7 @@ import {
   type AttentionItem,
   type AttentionKind,
 } from "@/lib/attention";
+import { withAttentionSource } from "@/lib/attentionNavigation";
 import type {
   BankStatementListResponse,
   ProcessingPendingListResponse,
@@ -97,7 +98,7 @@ export default function AttentionPage() {
           {items.map((item) => (
             <Link
               key={item.id}
-              href={item.href}
+              href={withAttentionSource(item.href)}
               className="flex items-center justify-between gap-4 px-5 py-4 transition-colors hover:bg-[var(--background-muted)]/50"
             >
               <div className="min-w-0">
@@ -109,7 +110,7 @@ export default function AttentionPage() {
                 </div>
                 <p className="text-xs text-muted mt-0.5">{item.detail}</p>
                 {/* AC22.11.2 — explain why this was flagged, not just a score. */}
-                <p className="text-xs text-muted/80 mt-1 max-w-prose">{item.reason}</p>
+                <p className="text-xs text-muted mt-1 max-w-prose">{item.reason}</p>
               </div>
               <div className="flex flex-shrink-0 items-center gap-3">
                 <Badge variant={confidenceVariant(item.confidence)}>{item.confidence}% confidence</Badge>

--- a/apps/frontend/src/app/(main)/processing/page.tsx
+++ b/apps/frontend/src/app/(main)/processing/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { AlertTriangle } from "lucide-react";
+import { BackLink } from "@/components/ui/BackLink";
 import { apiFetch } from "@/lib/api";
 import { ProcessingPendingItem, ProcessingPendingListResponse } from "@/lib/types";
 import { formatDateDisplay } from "@/lib/date";
@@ -28,6 +29,10 @@ export default function ProcessingPage() {
 
   return (
     <div className="p-6">
+      <div className="mb-4">
+        <BackLink>Back to Notifications</BackLink>
+      </div>
+
       <div className="page-header mb-6">
         <h1 className="page-title">Processing Transfers</h1>
         <p className="page-description">Transactions currently in flight between accounts</p>

--- a/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
@@ -11,6 +11,7 @@ import { useCurrencies } from "@/hooks/useCurrencies";
 import { useApiQuery } from "@/hooks/useApiQuery";
 import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
+import { ReportPageSkeleton } from "@/components/reports/ReportPageSkeleton";
 import { InfoHint } from "@/components/ui/InfoHint";
 import type { BalanceSheetResponse, ReportLine } from "@/lib/types";
 
@@ -98,7 +99,7 @@ export default function BalanceSheetPage() {
     );
   };
 
-  if (reportQuery.isLoading) return <div className="p-6 flex items-center justify-center min-h-[60vh]"><span className="text-muted">Loading balance sheet...</span></div>;
+  if (reportQuery.isLoading) return <ReportPageSkeleton label="Loading balance sheet" />;
   if (reportQuery.isError) return (
     <div className="p-6"><div className="card p-8 text-center max-w-md mx-auto"><p className="text-muted mb-4">{reportQuery.error.message}</p><button onClick={() => void reportQuery.refetch()} className="btn-secondary">Retry</button></div></div>
   );

--- a/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
@@ -8,6 +8,7 @@ import { SankeyChart } from "@/components/charts/SankeyChart";
 import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
 import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
+import { ReportPageSkeleton } from "@/components/reports/ReportPageSkeleton";
 import { formatDateInput } from "@/lib/date";
 import { compareAmounts, formatCurrencyLocale, toDecimal } from "@/lib/currency";
 import { useCurrencies } from "@/hooks/useCurrencies";
@@ -74,7 +75,7 @@ export default function CashFlowPage() {
     </div>
   );
 
-  if (reportQuery.isLoading) return <div className="p-6 flex items-center justify-center min-h-[60vh]"><span className="text-muted">Loading cash flow...</span></div>;
+  if (reportQuery.isLoading) return <ReportPageSkeleton label="Loading cash flow" />;
   if (reportQuery.isError) return <div className="p-6"><div className="card p-8 text-center max-w-md mx-auto"><p className="text-muted mb-4">{reportQuery.error.message}</p><button onClick={() => void reportQuery.refetch()} className="btn-secondary">Retry</button></div></div>;
 
   return (

--- a/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
@@ -8,6 +8,7 @@ import { BarChart } from "@/components/charts/BarChart";
 import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
 import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
+import { ReportPageSkeleton } from "@/components/reports/ReportPageSkeleton";
 import { formatDateInput, formatMonthLabel } from "@/lib/date";
 import { amountToChartNumber, formatCurrencyLocale } from "@/lib/currency";
 import { useCurrencies } from "@/hooks/useCurrencies";
@@ -70,7 +71,7 @@ export default function IncomeStatementPage() {
   const exportPath = useMemo(() => `/api/reports/export?report_type=income-statement&format=csv&${queryString}`, [queryString]);
   const aiPrompt = useMemo(() => encodeURIComponent(`Summarize my income statement from ${startDate} to ${endDate} in ${currency}. Highlight key trends.`), [currency, endDate, startDate]);
 
-  if (reportQuery.isLoading) return <div className="p-6 flex items-center justify-center min-h-[60vh]"><span className="text-muted">Loading income statement...</span></div>;
+  if (reportQuery.isLoading) return <ReportPageSkeleton label="Loading income statement" sections={2} />;
   if (reportQuery.isError) return <div className="p-6"><div className="card p-8 text-center max-w-md mx-auto"><p className="text-muted mb-4">{reportQuery.error.message}</p><button onClick={() => void reportQuery.refetch()} className="btn-secondary">Retry</button></div></div>;
 
   return (

--- a/apps/frontend/src/app/(main)/reports/package/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/package/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useState } from "react";
 
 import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
+import { SkeletonBlock } from "@/components/ui";
 import { apiFetch } from "@/lib/api";
 import { formatCurrencyLocale } from "@/lib/currency";
 import { formatDateInput } from "@/lib/date";
@@ -22,6 +23,7 @@ import type {
   EvidenceLineageResponse,
   FrameworkPolicyResult,
   MoneyValue,
+  PersonalReportPackageContractResponse,
   PersonalReportPackageTraceabilityLine,
 } from "@/lib/types";
 
@@ -76,6 +78,172 @@ type LineagePanelState = {
   isLoading: boolean;
   error: string | null;
 };
+
+type PackageTocLink = {
+  id: string;
+  label: string;
+  status?: string;
+};
+
+function sectionAnchorId(sectionId: string): string {
+  return `package-section-${sectionId}`;
+}
+
+function packageTocLinks(
+  contract: PersonalReportPackageContractResponse,
+  includeOutputSections: boolean,
+): PackageTocLink[] {
+  const links: PackageTocLink[] = [
+    { id: "package-framework-selection", label: "Reporting Framework" },
+  ];
+  if (includeOutputSections) {
+    links.push(
+      { id: "package-readiness", label: "Report Readiness" },
+      { id: "package-source-trust", label: "Source Trust" },
+      { id: "package-framework-policy", label: "Framework Policy" },
+    );
+  }
+  links.push(
+    ...contract.sections.map((section) => ({
+      id: sectionAnchorId(section.section_id),
+      label: section.label,
+      status: section.status,
+    })),
+  );
+  if (includeOutputSections) {
+    links.push({ id: "package-export-contract", label: "Export Contract" });
+  }
+  return links;
+}
+
+function PackageCover({
+  contract,
+  reportDate,
+  selectedFrameworkLabel,
+}: {
+  contract: PersonalReportPackageContractResponse;
+  reportDate: string;
+  selectedFrameworkLabel: string | null;
+}) {
+  return (
+    <section aria-label="Report package cover" className="card p-6 mb-6">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted">
+            Personal financial-report package
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold">Personal Report Package</h2>
+          <p className="mt-2 font-mono text-sm text-muted">
+            {contract.package_id}
+          </p>
+        </div>
+        <dl className="grid gap-3 text-sm sm:grid-cols-2 lg:min-w-[28rem]">
+          <div>
+            <dt className="text-xs text-muted">Framework</dt>
+            <dd className="mt-1 font-semibold">
+              {selectedFrameworkLabel ?? "Framework not selected"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Report Date</dt>
+            <dd className="mt-1 font-mono text-xs">{reportDate}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Report Period</dt>
+            <dd className="mt-1 font-mono text-xs">
+              {reportPeriodStart(reportDate)} to {reportDate}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Package Version</dt>
+            <dd className="mt-1 font-mono text-xs">{contract.version}</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+function PackageTableOfContents({ links }: { links: PackageTocLink[] }) {
+  return (
+    <nav
+      aria-label="Report package table of contents"
+      className="card p-5 mb-6"
+    >
+      <h2 className="font-semibold">Table of Contents</h2>
+      <ol className="mt-4 grid gap-2 text-sm md:grid-cols-2">
+        {links.map((link) => (
+          <li key={link.id}>
+            <a
+              href={`#${link.id}`}
+              aria-label={link.label}
+              className="flex items-center justify-between gap-3 rounded-control border border-[var(--border)] px-3 py-2 text-[var(--foreground)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)]"
+            >
+              <span>{link.label}</span>
+              {link.status ? (
+                <span className="badge badge-muted">{link.status}</span>
+              ) : null}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+function PackageSetupGuidance() {
+  return (
+    <section aria-label="Package setup guidance" className="card p-5 mb-6">
+      <h2 className="font-semibold">Package Setup</h2>
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        {[
+          ["1", "Choose a framework", "Select US-like or HK-like before package output is loaded."],
+          ["2", "Confirm the date", "The report date pins period and point-in-time sections."],
+          ["3", "Review readiness", "Package blockers appear before statements and schedules."],
+        ].map(([step, title, description]) => (
+          <div key={step} className="rounded border border-[var(--border)] p-3">
+            <p className="font-mono text-xs text-muted">Step {step}</p>
+            <p className="mt-2 font-medium">{title}</p>
+            <p className="mt-1 text-sm text-muted">{description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PackageLoadingSkeleton() {
+  return (
+    <section
+      role="status"
+      aria-label="Loading report package"
+      aria-busy="true"
+      aria-live="polite"
+      className="space-y-4"
+    >
+      <div className="grid gap-4 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="card p-4">
+            <SkeletonBlock className="h-3 w-20" />
+            <SkeletonBlock className="mt-3 h-6 w-16" />
+          </div>
+        ))}
+      </div>
+      <div className="card p-5">
+        <SkeletonBlock className="h-5 w-48" />
+        <div className="mt-5 grid gap-3 lg:grid-cols-2">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="rounded border border-[var(--border)] p-3">
+              <SkeletonBlock className="h-4 w-3/5" />
+              <SkeletonBlock className="mt-3 h-3 w-full" />
+              <SkeletonBlock className="mt-2 h-3 w-4/5" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
 
 function lineageAnchorForLine(
   line: PersonalReportPackageTraceabilityLine,
@@ -177,7 +345,7 @@ export default function PersonalReportPackagePage() {
     : null;
 
   const frameworkSelection = (
-    <section className="card p-5 mb-6">
+    <section id="package-framework-selection" className="card p-5 mb-6">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <h2 className="font-semibold">Reporting Framework</h2>
@@ -231,16 +399,26 @@ export default function PersonalReportPackagePage() {
   );
 
   if (!selectedFrameworkId) {
+    const setupTocLinks = packageTocLinks(contract, false);
     return (
       <div className="p-6">
         <div className="page-header">
           <h1 className="page-title">Personal Report Package</h1>
           <p className="page-description">{contract.package_id}</p>
         </div>
+        <PackageCover
+          contract={contract}
+          reportDate={reportDate}
+          selectedFrameworkLabel={selectedFrameworkLabel}
+        />
         {frameworkSelection}
+        <PackageTableOfContents links={setupTocLinks} />
+        <PackageSetupGuidance />
       </div>
     );
   }
+
+  const outputTocLinks = packageTocLinks(contract, true);
 
   if (
     isPackageLoading ||
@@ -256,8 +434,14 @@ export default function PersonalReportPackagePage() {
           <h1 className="page-title">Personal Report Package</h1>
           <p className="page-description">{contract.package_id}</p>
         </div>
+        <PackageCover
+          contract={contract}
+          reportDate={reportDate}
+          selectedFrameworkLabel={selectedFrameworkLabel}
+        />
         {frameworkSelection}
-        <div className="p-6 text-muted">Loading framework package...</div>
+        <PackageTableOfContents links={outputTocLinks} />
+        <PackageLoadingSkeleton />
       </div>
     );
   }
@@ -280,7 +464,15 @@ export default function PersonalReportPackagePage() {
         <p className="page-description">{contract.package_id}</p>
       </div>
 
+      <PackageCover
+        contract={contract}
+        reportDate={reportDate}
+        selectedFrameworkLabel={selectedFrameworkLabel}
+      />
+
       {frameworkSelection}
+
+      <PackageTableOfContents links={outputTocLinks} />
 
       <section className="card p-5 mb-6 print:hidden">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -304,7 +496,7 @@ export default function PersonalReportPackagePage() {
         </div>
       </section>
 
-      <section className="card p-5 mb-6">
+      <section id="package-readiness" className="card p-5 mb-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <h2 className="font-semibold">Report Readiness</h2>
@@ -371,7 +563,7 @@ export default function PersonalReportPackagePage() {
       </section>
 
       {readiness.source_trust_summary ? (
-        <section className="card p-5 mb-6" aria-label="Source trust summary">
+        <section id="package-source-trust" className="card p-5 mb-6" aria-label="Source trust summary">
           <div className="flex items-start justify-between gap-3">
             <div>
               <h2 className="font-semibold">Source Trust</h2>
@@ -425,7 +617,7 @@ export default function PersonalReportPackagePage() {
         </section>
       ) : null}
 
-      <section className="card p-5 mb-6">
+      <section id="package-framework-policy" className="card p-5 mb-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <h2 className="font-semibold">Framework Policy</h2>
@@ -517,7 +709,11 @@ export default function PersonalReportPackagePage() {
 
       <div className="grid lg:grid-cols-2 gap-4 mb-6">
         {contract.sections.map((section) => (
-          <section key={section.section_id} className="card p-5">
+          <section
+            key={section.section_id}
+            id={sectionAnchorId(section.section_id)}
+            className="card p-5"
+          >
             <div className="flex items-start justify-between gap-3">
               <div>
                 <h2 className="font-semibold">{section.label}</h2>
@@ -546,7 +742,7 @@ export default function PersonalReportPackagePage() {
         ))}
       </div>
 
-      <section className="card p-5 mb-6">
+      <section id="package-annualized-income-detail" className="card p-5 mb-6">
         <div className="flex items-start justify-between gap-3">
           <div>
             <h2 className="font-semibold">Annualized Income Schedule</h2>
@@ -665,7 +861,7 @@ export default function PersonalReportPackagePage() {
         </div>
       </section>
 
-      <section className="card p-5 mb-6">
+      <section id="package-notes-detail" className="card p-5 mb-6">
         <div className="flex items-start justify-between gap-3">
           <div>
             <h2 className="font-semibold">{packageNotes.label}</h2>
@@ -706,7 +902,7 @@ export default function PersonalReportPackagePage() {
         </div>
       </section>
 
-      <section className="card p-5 mb-6">
+      <section id="package-traceability-detail" className="card p-5 mb-6">
         <div className="flex items-start justify-between gap-3">
           <div>
             <h2 className="font-semibold">{traceabilityAppendix.label}</h2>
@@ -816,7 +1012,7 @@ export default function PersonalReportPackagePage() {
         </div>
       </section>
 
-      <section className="card p-5">
+      <section id="package-export-contract" className="card p-5">
         <h2 className="font-semibold">Export Contract</h2>
         <dl className="mt-4 space-y-2 text-sm">
           <div className="flex justify-between gap-3">

--- a/apps/frontend/src/app/(main)/statements/[id]/review/page.tsx
+++ b/apps/frontend/src/app/(main)/statements/[id]/review/page.tsx
@@ -206,14 +206,14 @@ export default function StatementReviewPage() {
         : null;
 
     return (
-        <div className="flex min-h-[calc(100vh-2rem)] flex-col p-4 md:p-6 2xl:h-[calc(100vh-2rem)]">
-            <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <Link href={returnHref} className="text-sm text-muted hover:text-[var(--foreground)] flex items-center gap-1">
+        <div className="flex min-h-[calc(100vh-2rem)] w-full max-w-full min-w-0 flex-col overflow-x-hidden p-4 md:p-6 2xl:h-[calc(100vh-2rem)]">
+            <div className="mb-4 flex min-w-0 max-w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <Link href={returnHref} className="flex min-w-0 items-center gap-1 text-sm text-muted hover:text-[var(--foreground)]">
                     <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                    {returnLabel}
+                    <span className="truncate">{returnLabel}</span>
                 </Link>
 
-                <div className="flex items-center gap-2 overflow-x-auto">
+                <div className="flex min-w-0 max-w-full items-center gap-2 overflow-x-auto">
                     {(() => {
                         const currentIndex = pendingStatements.findIndex((s) => s.id === statementId);
                         const prevId = currentIndex > 0 ? pendingStatements[currentIndex - 1].id : null;
@@ -276,7 +276,7 @@ export default function StatementReviewPage() {
                 currency={data.currency || "SGD"}
             />
 
-            <div className="grid flex-1 grid-cols-1 gap-4 2xl:min-h-0 2xl:grid-cols-2">
+            <div className="grid min-w-0 flex-1 grid-cols-1 gap-4 2xl:min-h-0 2xl:grid-cols-2">
                 <PdfPreviewPane pdfUrl={data.pdf_url} />
 
                 <TransactionTable

--- a/apps/frontend/src/app/(main)/statements/[id]/review/page.tsx
+++ b/apps/frontend/src/app/(main)/statements/[id]/review/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { ChevronLeft } from "lucide-react";
 
 import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import { useToast } from "@/components/ui/Toast";
@@ -16,6 +17,12 @@ import { PdfPreviewPane } from "@/components/review/PdfPreviewPane";
 import { ReviewActionBar } from "@/components/review/ReviewActionBar";
 import { TransactionTable, Transaction } from "@/components/review/TransactionTable";
 import { ConflictResolutionDialog } from "@/components/review/ConflictResolutionDialog";
+import {
+    ATTENTION_RETURN_HREF,
+    ATTENTION_RETURN_LABEL,
+    isAttentionOrigin,
+    withAttentionSource,
+} from "@/lib/attentionNavigation";
 
 interface BalanceValidationResult {
     opening_balance: string;
@@ -65,7 +72,13 @@ export default function StatementReviewPage() {
     const { showToast } = useToast();
     const params = useParams();
     const router = useRouter();
+    const searchParams = useSearchParams();
     const statementId = params.id as string;
+    const fromAttention = isAttentionOrigin(searchParams);
+    const returnHref = fromAttention ? ATTENTION_RETURN_HREF : "/statements";
+    const returnLabel = fromAttention ? ATTENTION_RETURN_LABEL : "Back to Statements";
+    const statementReviewHref = (id: string) =>
+        fromAttention ? withAttentionSource(`/statements/${id}/review`) : `/statements/${id}/review`;
 
     const [approveDialogOpen, setApproveDialogOpen] = useState(false);
     const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
@@ -101,7 +114,11 @@ export default function StatementReviewPage() {
             const createdCount = result.journal_entries_created ?? 0;
             showToast(`Statement approved. ${createdCount} journal entries posted.`, "success");
             setApproveDialogOpen(false);
-            router.push(`/statements/${statementId}?approved=1&entriesCreated=${createdCount}`);
+            router.push(
+                fromAttention
+                    ? ATTENTION_RETURN_HREF
+                    : `/statements/${statementId}?approved=1&entriesCreated=${createdCount}`,
+            );
         },
         onError: (err) => showToast(err instanceof Error ? err.message : "Failed to approve", "error")
     });
@@ -114,7 +131,7 @@ export default function StatementReviewPage() {
         onSuccess: () => {
             showToast("Statement rejected", "success");
             setRejectDialogOpen(false);
-            router.push("/statements");
+            router.push(fromAttention ? ATTENTION_RETURN_HREF : "/statements");
         },
         onError: (err) => showToast(err instanceof Error ? err.message : "Failed to reject", "error")
     });
@@ -125,7 +142,7 @@ export default function StatementReviewPage() {
         mutationFn: () => apiFetch(`/api/statements/${statementId}/retry`, { method: "POST" }),
         onSuccess: () => {
             showToast("Re-parsing started", "success");
-            router.push(`/statements/${statementId}`);
+            router.push(fromAttention ? ATTENTION_RETURN_HREF : `/statements/${statementId}`);
         },
         onError: (err) => showToast(err instanceof Error ? err.message : "Failed to re-parse", "error")
     });
@@ -162,16 +179,16 @@ export default function StatementReviewPage() {
                                 <button type="button" onClick={() => refetch()} className="btn-primary">
                                     Retry
                                 </button>
-                                <Link href="/statements" className="btn-secondary">
-                                    Back to Statements
+                                <Link href={returnHref} className="btn-secondary">
+                                    {returnLabel}
                                 </Link>
                             </div>
                         </>
                     ) : (
                         <>
                             <p className="text-muted mb-6">Statement not found</p>
-                            <Link href="/statements" className="btn-primary">
-                                Back to Statements
+                            <Link href={returnHref} className="btn-primary">
+                                {returnLabel}
                             </Link>
                         </>
                     )}
@@ -191,11 +208,9 @@ export default function StatementReviewPage() {
     return (
         <div className="flex min-h-[calc(100vh-2rem)] flex-col p-4 md:p-6 2xl:h-[calc(100vh-2rem)]">
             <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <Link href="/statements" className="text-sm text-muted hover:text-[var(--foreground)] flex items-center gap-1">
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                    </svg>
-                    Back to Statements
+                <Link href={returnHref} className="text-sm text-muted hover:text-[var(--foreground)] flex items-center gap-1">
+                    <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                    {returnLabel}
                 </Link>
 
                 <div className="flex items-center gap-2 overflow-x-auto">
@@ -207,7 +222,7 @@ export default function StatementReviewPage() {
                         return (
                             <>
                                 <button
-                                    onClick={() => prevId && router.push(`/statements/${prevId}/review`)}
+                                    onClick={() => prevId && router.push(statementReviewHref(prevId))}
                                     disabled={!prevId}
                                     className="btn-ghost btn-sm disabled:opacity-30"
                                     title="Previous pending statement"
@@ -218,7 +233,7 @@ export default function StatementReviewPage() {
                                     {currentIndex + 1} / {pendingStatements.length}
                                 </span>
                                 <button
-                                    onClick={() => nextId && router.push(`/statements/${nextId}/review`)}
+                                    onClick={() => nextId && router.push(statementReviewHref(nextId))}
                                     disabled={!nextId}
                                     className="btn-ghost btn-sm disabled:opacity-30"
                                     title="Next pending statement"

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -105,6 +105,24 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+:where(a, button, input, select, textarea, summary, [tabindex]:not([tabindex="-1"])):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: var(--shadow-focus);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-delay: 0ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 /* Utility Classes - Dokploy Style */
 @layer components {
   .card {
@@ -133,6 +151,15 @@ body {
 
   .btn-danger:hover {
     background: color-mix(in srgb, var(--error) 90%, black);
+  }
+
+  .btn-primary:focus-visible,
+  .btn-secondary:focus-visible,
+  .btn-ghost:focus-visible,
+  .btn-danger:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    box-shadow: var(--shadow-focus);
   }
 
   .input {

--- a/apps/frontend/src/components/AppShell.tsx
+++ b/apps/frontend/src/components/AppShell.tsx
@@ -17,6 +17,12 @@ function AppShellContent({ children }: AppShellProps) {
 
     return (
         <div className="min-h-screen">
+            <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-toast focus:rounded-control focus:bg-surface-card focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-content focus:shadow-floating focus:outline-none focus:ring-2 focus:ring-accent"
+            >
+                Skip to main content
+            </a>
             <Sidebar />
 
             {/* Main Content Area. On print, drop the sidebar offset so report
@@ -34,7 +40,7 @@ function AppShellContent({ children }: AppShellProps) {
                     <WorkflowNotificationCenter />
                 </div>
 
-                <main className="min-h-[calc(100vh-4rem)]">
+                <main id="main-content" tabIndex={-1} className="min-h-[calc(100vh-4rem)]">
                     {children}
                 </main>
             </div>

--- a/apps/frontend/src/components/reports/LineagePanel.tsx
+++ b/apps/frontend/src/components/reports/LineagePanel.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import Sheet from "@/components/ui/Sheet";
 import { apiFetch } from "@/lib/api";
 import { lineageUrl, nodeLabel, type LineageAnchor } from "@/lib/lineage";
-import type { EvidenceLineageResponse } from "@/lib/types";
+import type { EvidenceLineageEdge, EvidenceLineageNode, EvidenceLineageResponse } from "@/lib/types";
 
 interface LineagePanelState {
   isLoading: boolean;
@@ -14,6 +14,75 @@ interface LineagePanelState {
 }
 
 const EMPTY_STATE: LineagePanelState = { isLoading: false, error: null, response: null };
+
+function formatNodeKind(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+function propertyValue(
+  properties: EvidenceLineageNode["properties"],
+  keys: string[],
+): string | null {
+  for (const key of keys) {
+    const value = properties[key];
+    if (typeof value === "string" && value.length > 0) return value;
+    if (typeof value === "number" || typeof value === "boolean") return String(value);
+  }
+  return null;
+}
+
+function orderNodesAsPath(
+  nodes: EvidenceLineageNode[],
+  edges: EvidenceLineageEdge[],
+): EvidenceLineageNode[] {
+  if (nodes.length === 0 || edges.length === 0) return nodes;
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const usableEdges = edges.filter((edge) => nodeById.has(edge.from_node_id) && nodeById.has(edge.to_node_id));
+  if (usableEdges.length === 0) return nodes;
+
+  const incoming = new Set(usableEdges.map((edge) => edge.to_node_id));
+  const orderedOutgoing = new Map<string, EvidenceLineageEdge[]>();
+  for (const edge of usableEdges) {
+    const existing = orderedOutgoing.get(edge.from_node_id) ?? [];
+    existing.push(edge);
+    orderedOutgoing.set(edge.from_node_id, existing);
+  }
+  for (const list of orderedOutgoing.values()) {
+    list.sort((a, b) => b.depth - a.depth || a.relation.localeCompare(b.relation));
+  }
+
+  const startId =
+    usableEdges.find((edge) => !incoming.has(edge.from_node_id))?.from_node_id ??
+    usableEdges.sort((a, b) => b.depth - a.depth)[0]?.from_node_id;
+  if (!startId) return nodes;
+
+  const path: EvidenceLineageNode[] = [];
+  const visited = new Set<string>();
+  let currentId: string | undefined = startId;
+
+  while (currentId && nodeById.has(currentId) && !visited.has(currentId)) {
+    visited.add(currentId);
+    path.push(nodeById.get(currentId)!);
+    currentId = orderedOutgoing.get(currentId)?.find((edge) => !visited.has(edge.to_node_id))?.to_node_id;
+  }
+
+  for (const node of nodes) {
+    if (!visited.has(node.id)) path.push(node);
+  }
+  return path;
+}
+
+function lineageBadges(node: EvidenceLineageNode): Array<{ label: string; value: string }> {
+  const source = propertyValue(node.properties, ["source_system", "source_type", "source_class"]) ?? node.entity_type;
+  const confidence = propertyValue(node.properties, ["confidence_tier", "confidence", "proof_level"]);
+  const version = propertyValue(node.properties, ["version", "record_version", "matrix_version"]);
+  return [
+    { label: "Source", value: source },
+    ...(confidence ? [{ label: "Confidence", value: confidence }] : []),
+    ...(version ? [{ label: "Version", value: version }] : []),
+  ];
+}
 
 export interface LineagePanelProps {
   /** Heading for the drawer (e.g. the report line / transaction description). */
@@ -88,13 +157,20 @@ export function LineagePanel({ title, anchor, onClose }: LineagePanelProps) {
             {response.nodes.length === 0 ? (
               <p className="text-sm text-muted">No source records are linked to this amount yet.</p>
             ) : (
-              <ol className="space-y-2" aria-label="Lineage nodes">
-                {response.nodes.map((node) => (
+              <ol className="space-y-2" aria-label="Lineage path">
+                {orderNodesAsPath(response.nodes, response.edges).map((node) => (
                   <li
                     key={node.id}
                     className="rounded-md border border-[var(--border)] bg-[var(--background-muted)]/40 p-3 text-sm"
                   >
-                    <div className="font-medium">{node.node_kind.replace(/_/g, " ")}</div>
+                    <div className="font-medium">{formatNodeKind(node.node_kind)}</div>
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {lineageBadges(node).map((badge) => (
+                        <span key={`${node.id}:${badge.label}`} className="badge badge-muted">
+                          {badge.label}: {badge.value}
+                        </span>
+                      ))}
+                    </div>
                     <div className="mt-1 break-all font-mono text-xs text-muted">{nodeLabel(node)}</div>
                   </li>
                 ))}

--- a/apps/frontend/src/components/reports/ReportPageSkeleton.tsx
+++ b/apps/frontend/src/components/reports/ReportPageSkeleton.tsx
@@ -1,0 +1,55 @@
+import { SkeletonBlock } from "@/components/ui";
+
+interface ReportPageSkeletonProps {
+  label: string;
+  sections?: number;
+}
+
+export function ReportPageSkeleton({ label, sections = 3 }: ReportPageSkeletonProps) {
+  return (
+    <div className="p-6" role="status" aria-label={label} aria-live="polite" aria-busy="true">
+      <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between" aria-hidden="true">
+        <div className="space-y-2">
+          <SkeletonBlock className="h-7 w-48" />
+          <SkeletonBlock className="h-4 w-72 max-w-full" />
+        </div>
+        <div className="flex gap-2">
+          <SkeletonBlock className="h-9 w-32" />
+          <SkeletonBlock className="h-9 w-20" />
+          <SkeletonBlock className="h-9 w-28" />
+        </div>
+      </div>
+
+      <div className="mb-6 flex flex-wrap gap-3" aria-hidden="true">
+        <SkeletonBlock className="h-16 w-36" />
+        <SkeletonBlock className="h-16 w-36" />
+        <SkeletonBlock className="h-16 w-28" />
+      </div>
+
+      <div className="mb-6 grid gap-4 md:grid-cols-3" aria-hidden="true">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="card p-5">
+            <SkeletonBlock className="mb-3 h-3 w-24" />
+            <SkeletonBlock className="h-7 w-32" />
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3" aria-hidden="true">
+        {Array.from({ length: sections }).map((_, sectionIndex) => (
+          <div key={sectionIndex} className="card p-5">
+            <SkeletonBlock className="mb-4 h-5 w-36" />
+            <div className="space-y-3">
+              {Array.from({ length: 4 }).map((__, rowIndex) => (
+                <div key={rowIndex} className="flex items-center justify-between gap-4 rounded-control bg-surface-muted/50 p-2">
+                  <SkeletonBlock className="h-4 w-2/5" />
+                  <SkeletonBlock className="h-4 w-24" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
+++ b/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
@@ -12,6 +12,7 @@ import { apiFetch } from "@/lib/api";
 
 import { formatDateDisplay, formatDateTimeDisplay } from "@/lib/date";
 import { formatAmount } from "@/lib/currency";
+import { ATTENTION_SOURCE_PARAM, ATTENTION_SOURCE_VALUE, isAttentionOrigin } from "@/lib/attentionNavigation";
 import type { MoneyValue } from "@/lib/types";
 
 interface ConsistencyCheck {
@@ -116,6 +117,7 @@ export function Stage2ReviewQueue() {
 
     const updateUrlParams = useCallback(() => {
         const params = new URLSearchParams();
+        if (isAttentionOrigin(searchParams)) params.set(ATTENTION_SOURCE_PARAM, ATTENTION_SOURCE_VALUE);
         if (checkTypeFilter) params.set("check_type", checkTypeFilter);
         if (statusFilter) params.set("status", statusFilter);
         if (severityFilter.length > 0) params.set("severity", severityFilter.join(","));
@@ -123,7 +125,7 @@ export function Stage2ReviewQueue() {
 
         const queryString = params.toString();
         router.replace(queryString ? `${pathname}?${queryString}` : pathname, { scroll: false });
-    }, [checkTypeFilter, statusFilter, severityFilter, minScore, router, pathname]);
+    }, [checkTypeFilter, statusFilter, severityFilter, minScore, router, pathname, searchParams]);
 
     const fetchFilteredChecks = useCallback(async () => {
         setFiltering(true);

--- a/apps/frontend/src/components/review/TransactionTable.tsx
+++ b/apps/frontend/src/components/review/TransactionTable.tsx
@@ -15,21 +15,21 @@ export function TransactionTable({ transactions, currency }: TransactionTablePro
     const transactionRows = transactions ?? [];
 
     return (
-        <div className="card flex flex-col min-h-0 h-full overflow-hidden">
+        <div className="card flex h-full min-h-0 min-w-0 max-w-full flex-col overflow-hidden">
             <div className="card-header flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <h3 className="text-sm font-medium">Transactions</h3>
                 <span className="text-xs text-muted">{transactionRows.length} total</span>
             </div>
 
-            <div data-testid="stage1-mobile-transaction-list" className="flex-1 divide-y divide-[var(--border)] overflow-y-auto md:hidden">
+            <div data-testid="stage1-mobile-transaction-list" className="min-w-0 flex-1 divide-y divide-[var(--border)] overflow-y-auto md:hidden">
                 {transactionRows.map((txn) => (
                     <article
                         key={txn.id}
                         data-testid={`stage1-mobile-transaction-card-${txn.id}`}
-                        className="space-y-4 p-4"
+                        className="min-w-0 space-y-4 p-4"
                     >
-                        <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
+                        <div className="flex min-w-0 items-start justify-between gap-3">
+                            <div className="min-w-0 flex-1">
                                 <p className="text-xs font-medium uppercase text-muted">Transaction</p>
                                 <p className="mt-1 break-words font-medium">{txn.description}</p>
                             </div>
@@ -64,7 +64,7 @@ export function TransactionTable({ transactions, currency }: TransactionTablePro
                             </div>
 
                             <p
-                                className={`text-right text-sm font-semibold ${
+                                className={`min-w-0 break-words text-right text-sm font-semibold ${
                                     txn.direction === "IN" ? "text-[var(--success)]" : "text-[var(--error)]"
                                 }`}
                             >

--- a/apps/frontend/src/components/ui/BackLink.tsx
+++ b/apps/frontend/src/components/ui/BackLink.tsx
@@ -1,21 +1,32 @@
 "use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
+import { ChevronLeft } from "lucide-react";
+
+import {
+    ATTENTION_RETURN_HREF,
+    ATTENTION_RETURN_LABEL,
+    isAttentionOrigin,
+} from "@/lib/attentionNavigation";
 
 // EPIC-022 AC22.5.3: a small back-link so users who deep-link into a review or
 // reconciliation surface are never stranded. Defaults back to the notification
 // center, which is the action hub in the EPIC-022 IA.
 export function BackLink({ href = "/notifications", children }: { href?: string; children: ReactNode }) {
+    const searchParams = useSearchParams();
+    const attentionOrigin = isAttentionOrigin(searchParams);
+    const targetHref = attentionOrigin ? ATTENTION_RETURN_HREF : href;
+    const label = attentionOrigin ? ATTENTION_RETURN_LABEL : children;
+
     return (
         <Link
-            href={href}
+            href={targetHref}
             className="inline-flex items-center gap-1 text-sm text-muted hover:text-[var(--foreground)]"
         >
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-            </svg>
-            {children}
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+            {label}
         </Link>
     );
 }

--- a/apps/frontend/src/components/ui/Toast.tsx
+++ b/apps/frontend/src/components/ui/Toast.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from "react";
+import { CheckCircle2, CircleAlert, CircleX, Info, X } from "lucide-react";
 
 type ToastType = "success" | "error" | "info" | "warning";
 
@@ -50,7 +51,7 @@ export function ToastProvider({ children }: ToastProviderProps) {
             setToasts((prev) => prev.filter((t) => t.id !== id));
             timeoutRefs.current.delete(id);
         }, 3000);
-        
+
         timeoutRefs.current.set(id, timeout);
     }, []);
 
@@ -66,39 +67,44 @@ export function ToastProvider({ children }: ToastProviderProps) {
     return (
         <ToastContext.Provider value={{ showToast }}>
             {children}
-            <div 
+            <div
                 role="region"
                 aria-live="polite"
                 aria-label="Notifications"
                 className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2"
             >
-                {toasts.map((toast) => (
-                    <div
-                        key={toast.id}
-                        role={toast.type === "error" ? "alert" : "status"}
-                        className={`px-4 py-3 rounded-lg shadow-lg flex items-center gap-3 min-w-[280px] max-w-[400px] animate-slide-up ${
-                            toast.type === "success" ? "bg-[var(--success)] text-white" :
-                            toast.type === "error" ? "bg-[var(--error)] text-white" :
-                            toast.type === "warning" ? "bg-[var(--warning)] text-black" :
-                            "bg-[var(--info)] text-white"
-                        }`}
-                    >
-                        <span className="text-lg" aria-hidden="true">
-                            {toast.type === "success" && "✓"}
-                            {toast.type === "error" && "✕"}
-                            {toast.type === "warning" && "⚠"}
-                            {toast.type === "info" && "ℹ"}
-                        </span>
-                        <span className="flex-1 text-sm font-medium">{toast.message}</span>
-                        <button
-                            onClick={() => removeToast(toast.id)}
-                            className="opacity-70 hover:opacity-100"
-                            aria-label="Dismiss notification"
+                {toasts.map((toast) => {
+                    const StatusIcon = {
+                        success: CheckCircle2,
+                        error: CircleX,
+                        warning: CircleAlert,
+                        info: Info,
+                    }[toast.type];
+
+                    return (
+                        <div
+                            key={toast.id}
+                            role={toast.type === "error" ? "alert" : "status"}
+                            className={`px-4 py-3 rounded-lg shadow-lg flex items-center gap-3 min-w-[280px] max-w-[400px] animate-slide-up ${
+                                toast.type === "success" ? "bg-[var(--success)] text-white" :
+                                toast.type === "error" ? "bg-[var(--error)] text-white" :
+                                toast.type === "warning" ? "bg-[var(--warning)] text-black" :
+                                "bg-[var(--info)] text-white"
+                            }`}
                         >
-                            ✕
-                        </button>
-                    </div>
-                ))}
+                            <StatusIcon className="h-5 w-5 flex-shrink-0" aria-hidden="true" />
+                            <span className="flex-1 text-sm font-medium">{toast.message}</span>
+                            <button
+                                type="button"
+                                onClick={() => removeToast(toast.id)}
+                                className="opacity-70 hover:opacity-100"
+                                aria-label="Dismiss notification"
+                            >
+                                <X className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                        </div>
+                    );
+                })}
             </div>
         </ToastContext.Provider>
     );

--- a/apps/frontend/src/components/ui/index.tsx
+++ b/apps/frontend/src/components/ui/index.tsx
@@ -139,6 +139,75 @@ export function LoadingState({ label, framed = true, className, ...props }: Load
   );
 }
 
+interface SkeletonBlockProps extends HTMLAttributes<HTMLDivElement> {
+  label?: string;
+}
+
+export function SkeletonBlock({ label, className, ...props }: SkeletonBlockProps) {
+  const block = (
+    <div
+      data-testid="skeleton-block"
+      className={cx("animate-pulse rounded-control bg-surface-muted", className)}
+      {...props}
+    />
+  );
+
+  if (!label) return block;
+
+  return (
+    <div role="status" aria-label={label} aria-live="polite" aria-busy="true">
+      {block}
+    </div>
+  );
+}
+
+interface TableSkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  label: string;
+  rows?: number;
+  columns?: number;
+}
+
+export function TableSkeleton({
+  label,
+  rows = 5,
+  columns = 4,
+  className,
+  ...props
+}: TableSkeletonProps) {
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      aria-live="polite"
+      aria-busy="true"
+      className={cx("card p-5", className)}
+      {...props}
+    >
+      <div className="space-y-3" aria-hidden="true">
+        {Array.from({ length: rows }).map((_, rowIndex) => (
+          <div
+            key={rowIndex}
+            className="grid gap-3"
+            style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+          >
+            {Array.from({ length: columns }).map((__, columnIndex) => (
+              <SkeletonBlock
+                key={columnIndex}
+                className={cx(
+                  "h-4",
+                  columnIndex === 0 && "w-full",
+                  columnIndex > 0 && columnIndex < columns - 1 && "w-4/5",
+                  columnIndex === columns - 1 && "ml-auto w-2/3",
+                )}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
   title: string;
   description?: string;

--- a/apps/frontend/src/components/workflow/FlowStepBanner.tsx
+++ b/apps/frontend/src/components/workflow/FlowStepBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { Check, ChevronRight } from "lucide-react";
 
 // EPIC-022 AC22.5.1: a shared "you are here / what's next" indicator across the
 // core flow so an everyday user always knows where they are in
@@ -58,13 +59,13 @@ export function FlowStepBanner({ current }: { current: FlowStep }) {
                                               : "bg-[var(--background-muted)] text-muted"
                                     }`}
                                 >
-                                    {isDone ? "✓" : index + 1}
+                                    {isDone ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : index + 1}
                                 </span>
                                 {step.label}
                             </Link>
                             {index < STEPS.length - 1 && (
                                 <span aria-hidden="true" className="px-1 text-muted">
-                                    →
+                                    <ChevronRight className="h-4 w-4" />
                                 </span>
                             )}
                         </li>

--- a/apps/frontend/src/lib/attentionNavigation.ts
+++ b/apps/frontend/src/lib/attentionNavigation.ts
@@ -1,0 +1,20 @@
+export const ATTENTION_SOURCE_PARAM = "from";
+export const ATTENTION_SOURCE_VALUE = "attention";
+export const ATTENTION_RETURN_HREF = "/attention";
+export const ATTENTION_RETURN_LABEL = "Back to Attention queue";
+
+interface SearchParamReader {
+  get(name: string): string | null;
+}
+
+export function isAttentionOrigin(searchParams: SearchParamReader | null | undefined): boolean {
+  return searchParams?.get(ATTENTION_SOURCE_PARAM) === ATTENTION_SOURCE_VALUE;
+}
+
+export function withAttentionSource(href: string): string {
+  const url = new URL(href, "https://finance-report.local");
+  url.searchParams.set(ATTENTION_SOURCE_PARAM, ATTENTION_SOURCE_VALUE);
+
+  const query = url.searchParams.toString();
+  return `${url.pathname}${query ? `?${query}` : ""}${url.hash}`;
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -743,6 +743,17 @@ export type ManualValuationLiquidityClass =
   | "illiquid"
   | "liability";
 
+export type ManualValuationSource =
+  | "manual"
+  | "broker_portal"
+  | "bank_portal"
+  | "cpf_portal"
+  | "tax_portal"
+  | "insurer_portal"
+  | "employer_portal"
+  | "property_valuation"
+  | "other_document";
+
 export interface ManualValuationSnapshot {
   id: string;
   user_id: string;

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -228,7 +228,9 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
 | AC22.7.1 | Each cash-flow line carries its account anchor (`account_id`), and clicking a cash-flow amount opens the account-lineage drawer for that account's contributing journal lines | `test_reporting.py`, `cashFlowPage.test.tsx` | P1 |
+| AC22.7.2 | The reusable lineage panel renders evidence nodes as an ordered source-to-report path with per-hop source, confidence, and version badges when those fields are available | `lineagePanel.test.tsx` | P1 |
 | AC22.7.3 | The Cash Flow statement renders a reconciliation that ties beginning cash + net cash flow to ending cash, and explicitly flags when it does not reconcile | `cashFlowPage.test.tsx` | P1 |
+| AC22.7.4 | Desktop and mobile Playwright smoke covers Cash Flow amount drill-down opening the account-lineage drawer without document horizontal overflow | `cash-flow-drilldown.spec.ts` | P1 |
 
 ### AC22.8 — Readable Report Package
 
@@ -243,6 +245,9 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
 | AC22.8.1 | The report package titles its sections with human-readable labels (Reporting Framework, Report Readiness, Source Trust, Framework Policy, schedules, Traceability Appendix) rather than developer-facing snake_case identifiers | `personalReportPackagePage.test.tsx` | P1 |
+| AC22.8.2 | The loaded report package starts with a readable cover sheet and table of contents that expose the package id, selected framework, report date, and linked human section titles | `personalReportPackagePage.test.tsx` | P1 |
+| AC22.8.3 | The unselected-framework and framework-package loading states reserve the package layout with guidance or skeleton placeholders, never a blank text-only pre-selection or loading screen | `personalReportPackagePage.test.tsx` | P1 |
+| AC22.8.4 | Desktop and mobile Playwright smoke covers report-package framework selection, cover, table of contents, readiness, and no document horizontal overflow | `report-readiness.spec.ts` | P1 |
 
 ### AC22.9 — Everyday/Advanced Boundary And Naming Unification
 
@@ -272,6 +277,8 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
 | AC22.10.1 | A holding whose latest snapshot is backed by a source document is labeled "Imported"; holdings without document evidence carry no provenance label (manual data is never shown as imported, and import is never claimed without proof) | `test_portfolio_service.py`, `holdingsTable.test.tsx` | P1 |
+| AC22.10.2 | Manual valuation capture uses a controlled source enum instead of free-text provenance, while existing historical source strings remain displayable in snapshot history | `assetsPage.test.tsx` | P1 |
+| AC22.10.3 | Desktop and mobile Playwright smoke covers portfolio provenance badges only for imported holdings, with unproven holdings unlabeled and no document horizontal overflow | `portfolio-provenance.spec.ts` | P1 |
 
 ### AC22.11 — Everyday-User UX Hardening
 
@@ -283,11 +290,30 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 > look only at the low-confidence tail — so the reason must be legible). The
 > `/events`→`/notifications` dedup that #865 scoped is already handled by a
 > `next.config` redirect (so #865 closed); the residual `/events` page is left in
-> place because it still anchors EPIC-019's AC19.3.5. The cross-surface "return to
-> the attention queue after resolving" is split to a follow-up because it touches
-> every review destination.
+> place because it still anchors EPIC-019's AC19.3.5. The cross-surface
+> attention return path is handled as a narrow follow-up: attention-origin links
+> carry their source into the destination, and the destination renders an
+> attention-queue return link without changing direct-entry fallbacks.
 
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
 | AC22.11.1 | The statement-parsing state shows an honest indeterminate indicator with a typical-duration expectation, and never renders a fabricated fixed-percentage progress bar | `statementsPage.test.tsx` | P1 |
 | AC22.11.2 | Each attention-queue item surfaces a plain-language reason it was flagged — distinct per cause — alongside its confidence score | `attention.test.ts`, `attentionQueue.test.tsx` | P1 |
+| AC22.11.3 | Attention-origin action links preserve `from=attention`, and the linked review/processing destinations render a return link to `/attention` while direct-entry notification/statement fallbacks remain unchanged | `attentionQueue.test.tsx`, `reviewBackLinks.test.tsx`, `statementReviewPage.test.tsx`, `stage2ReviewQueueCoverage99.test.tsx`, `uiGapAudit.processingVisibility.test.tsx`, `unmatchedBoardComponent.test.tsx`, `attention-surface.spec.ts` | P1 |
+
+### AC22.12 — Accessibility Baseline Follow-Up
+
+> #909 first follow-up slice. The shipped everyday-user IA is functional, but
+> the app shell still needs cross-cutting accessibility affordances that make
+> trust surfaces usable without pointer-only navigation or motion-heavy UI:
+> global reduced-motion handling, consistent keyboard focus visibility, a
+> skip-to-content link, and restored contrast on attention reasons.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC22.12.1 | Global styles honor `prefers-reduced-motion: reduce` by disabling non-essential animation/transition timing and smooth scrolling across the app shell | `designTokens.test.tsx` | P1 |
+| AC22.12.2 | The authenticated shell exposes a skip-to-content link that targets the main landmark so keyboard users can bypass navigation chrome | `shellAndAuth.test.tsx` | P1 |
+| AC22.12.3 | Global focus-visible styles cover links, form controls, and shared `.btn-*` controls with token-backed focus rings | `designTokens.test.tsx` | P1 |
+| AC22.12.4 | Attention-queue reason text uses the normal muted content token, not a lower-opacity muted variant, so low-confidence explanations keep readable contrast | `attentionQueue.test.tsx` | P1 |
+| AC22.12.5 | Shared toast and flow-step status affordances use Lucide icons or text instead of unicode glyph icons, and warning toast messages do not embed emoji-like status glyphs | `toastProviderComponent.test.tsx`, `flowStepBanner.test.tsx`, `assetsPage.test.tsx` | P1 |
+| AC22.12.6 | Data-dense report and asset-table loading states reserve layout with token-backed skeleton placeholders instead of spinner-only or text-only states | `uiPrimitives.test.tsx`, `balanceSheetPage.test.tsx`, `incomeStatementPage.test.tsx`, `cashFlowPage.test.tsx`, `assetsPage.test.tsx` | P1 |

--- a/docs/ssot/assets.md
+++ b/docs/ssot/assets.md
@@ -186,6 +186,12 @@ migration code; link to the generated DB reference from docs.
 Manual snapshots cover property value, mortgage or loan balance, CPF or long-term savings, tax payable/refund, insurance cash value, ESOP, RSU, stock options, and generic assets/liabilities. The value is always stored as a positive `Decimal`; the liquidity class determines whether it contributes to assets, liabilities, restricted, or illiquid net worth presentation.
 Reminder cadence is optional; when present, `recurrence_days` is positive.
 
+Manual snapshot capture uses a controlled source vocabulary for new frontend submissions:
+`manual`, `broker_portal`, `bank_portal`, `cpf_portal`, `tax_portal`,
+`insurer_portal`, `employer_portal`, `property_valuation`, and
+`other_document`. Historical source strings remain valid response data and
+should be displayed as-is when they do not match a known vocabulary value.
+
 ---
 
 ## 7. Design Constraints

--- a/docs/ssot/frontend-patterns.md
+++ b/docs/ssot/frontend-patterns.md
@@ -151,6 +151,32 @@ primitives over repeating page-local class recipes.
 
 Every UI-system change must leave both semantic and visual proof in the same PR.
 
+### Global Accessibility Baseline
+
+- `apps/frontend/src/app/globals.css` owns the app-wide keyboard and motion
+  baseline. It must include `prefers-reduced-motion: reduce` handling that
+  disables non-essential animation/transition timing and smooth scrolling.
+- Global `:focus-visible` styling must cover links, buttons, form controls,
+  summaries, focusable `[tabindex]` elements, and the shared `.btn-*` control
+  classes with token-backed outline and `shadow-focus` treatment.
+- The authenticated shell must expose a skip-to-content link that targets the
+  main landmark before navigation chrome.
+- Shared status affordances must use Lucide icons or text, not unicode glyphs
+  such as checkmarks, warning signs, or arrows as icon substitutes.
+- Data-dense reports and tables should reserve their expected shape with
+  token-backed skeleton placeholders while loading; use spinner-only states for
+  small inline actions, not full report/table surfaces.
+- Evidence-lineage drawers should render graph responses as an ordered
+  source-to-report path. Each hop should expose compact source, confidence, and
+  version badges when those fields are available, falling back to the node's
+  entity type when a source field is absent.
+- Dense trust and attention explanations must keep at least the normal
+  `text-content-muted` contrast token unless a stronger contrast proof exists.
+- Links from the `/attention` queue to review or processing destinations must
+  append `from=attention`. Destination back-links must use that source marker to
+  return to `/attention`, while preserving the existing notification or module
+  fallback when the marker is absent.
+
 - Dialog, sheet, toast, tab/navigation, and icon-only control changes need
   component tests for keyboard behavior, landmark/role semantics, accessible
   names, and live-region behavior where relevant.

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -289,6 +289,15 @@ Required section IDs:
 | `notes` | EPIC-005 | `/api/reports/package/notes` | ready |
 | `traceability_appendix` | EPIC-018 | `/api/reports/package/traceability` | ready |
 
+The frontend package assembly route must present the package as a readable
+deliverable, not only an API inventory. It renders a cover sheet and table of
+contents before package output, using the selected framework, report date,
+package id, and stable human section labels from this contract. Before a
+framework is selected, the page must show setup guidance and the contract-backed
+table of contents without loading framework-scoped output. While selected
+framework data is loading, the page must reserve the package layout with
+skeleton placeholders instead of a blank or text-only loading screen.
+
 Package readiness:
 
 - Endpoint: `GET /api/reports/package/readiness`


### PR DESCRIPTION
## Summary

Ship the first #916/#909 frontend polish slice: accessibility baseline, skeleton loading states, attention return-to-queue navigation, readable report package cover/TOC, lineage hop badges, controlled manual valuation sources, and focused Playwright smokes.

Closes #909

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-022 — Everyday-User Information Architecture |
| **AC IDs** | AC22.7.2, AC22.7.4, AC22.8.2, AC22.8.3, AC22.8.4, AC22.10.2, AC22.10.3, AC22.11.3, AC22.12.1, AC22.12.2, AC22.12.3, AC22.12.4, AC22.12.5, AC22.12.6 |
| **AC source updated** | `docs/project/EPIC-022.everyday-user-ia.md` |

---

## SSOT Changes

- [x] `docs/ssot/assets.md` — controlled manual valuation source vocabulary; historical strings remain display data
- [x] `docs/ssot/frontend-patterns.md` — global accessibility baseline, skeleton loading guidance, lineage path badges, attention-origin return links
- [x] `docs/ssot/reporting.md` — readable report package cover/TOC and loading/empty-state contract

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | `N/A - local red before commit` | Focused tests failed before implementation for manual source enum, package cover/TOC, lineage path badges, and attention return links |
| Green (passing test) | `fe999241` | Implementation plus passing focused/full frontend tests and Playwright smokes |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, frontend-only
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A, no env vars
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A, no infra config changes
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env vars
- [x] `tools/check_manifest.py` passes (if SSOT files changed) — covered by AC registry/traceability checks for this slice
- [x] `tools/lint_doc_consistency.py` passes — N/A for this slice; registry and traceability passed

### CI/CD, Runtime, and VPS Infra Audit

N/A — no workflow, deploy tooling, Dokploy runtime config, VPS host scripts, or log changes.

---

## Testing

```bash
.venv/bin/python tools/generate_ac_registry.py --check
.venv/bin/python tools/check_ac_traceability.py
cd apps/frontend && npm test -- src/__tests__/attentionQueue.test.tsx src/__tests__/reviewBackLinks.test.tsx src/__tests__/statementReviewPage.test.tsx src/__tests__/stage2ReviewQueueCoverage99.test.tsx src/__tests__/uiGapAudit.processingVisibility.test.tsx src/__tests__/unmatchedBoardComponent.test.tsx
cd apps/frontend && npm run typecheck
cd apps/frontend && npm run lint
cd apps/frontend && npm test
cd apps/frontend && npm run build
cd apps/frontend && npx playwright test attention-surface.spec.ts epic022-attention-journey.spec.ts report-readiness.spec.ts cash-flow-drilldown.spec.ts portfolio-provenance.spec.ts --project=chromium
```

---

## Screenshots / Evidence

Playwright browser smokes passed for desktop and mobile attention, report package, cash-flow drill-down, and portfolio provenance paths. The Codex Browser plugin Node REPL control tool was not exposed in this session, so in-app browser verification could not be run; Playwright verification was used instead.
