### PR TITLE
[finance_report_vision] docs(vision): add Axiom D — model generalizes, code guarantees, nodes keep slack

### DIFF
--- a/vision.md
+++ b/vision.md
@@ -38,7 +38,7 @@ At any time, the system should help answer:
 - What should my assistant surface from trusted data, known limitations, and
   pending actions?
 
-## The Three Axioms
+## The Axioms
 
 These are the irreducible bets. When a product or architecture choice is
 ambiguous, derive the answer from these axioms first, then from the
@@ -85,6 +85,26 @@ Our hard constraints are managed as risk, not absolutes.
   already generalized the fancy operations; we align to that standard rather
   than invent our own. Minor representational gaps are tolerable.
 
+### Axiom D — The model generalizes; code guarantees the number; key nodes keep slack
+
+We are an AI-driven product, and the division of labor is drawn on purpose:
+
+- **Reach for the model where a decision needs generalization.** Parsing,
+  classifying, matching, explaining, judging the ambiguous case — default to the
+  model, because that is where generalization beats hand-tuned rules. An
+  AI-driven product pushes decisions *toward* the model, not away from it; a wall
+  of brittle thresholds where a model would generalize is a smell, not a safeguard.
+- **Code guarantees the number.** Money, accounting caliber, standardization, and
+  every report line are owned by deterministic code — Decimal-safe, balanced,
+  versioned. The model may *propose*; only code *disposes* a value into the ledger
+  or a report. (This is the bound in [Trade-off Rule 5](#trade-off-rules);
+  confidence governs the handoff per Axiom B.)
+- **Key nodes keep slack.** A critical node carries tolerance instead of chasing
+  infinite precision. We would rather bend and flag for review than hard-fail on a
+  sub-cent drift or a transient hiccup. The slack lives in *thresholds and flow* —
+  whether to auto-accept or escalate — never in the correctness of the number
+  itself. Brittleness from over-specified detail is a defect, not rigor.
+
 ## North-Star Metric
 
 **The proportion of low-confidence data trends down over time.** This is the
@@ -110,6 +130,12 @@ When two goods conflict, the higher rule wins.
 5. **Deterministic logic owns the number.** Anything that lands a value in the
    ledger or a report line is deterministic. AI may parse, classify, explain, and
    suggest; it is measured by confidence and never becomes the source of record.
+   (Axiom D)
+6. **Tolerance over infinite detail at a node.** When a node can either hard-fail
+   on perfect precision or bend within a bounded tolerance and escalate, it bends:
+   slack that degrades to review beats rigidity that breaks. This never overrides
+   Rule 5 — the bend is in thresholds and flow, never in whether the ledger
+   balances or a number is correct. (Axiom D)
 
 If a choice still feels balanced after these rules, run the Decision Filter and
 take the smaller step that improves proof quality.


### PR DESCRIPTION
## What

Records our AI-driven design philosophy in `vision.md` as a first-class axiom.

Adds **Axiom D — The model generalizes; code guarantees the number; key nodes keep slack**, plus **Trade-off Rule 6** (tolerance over infinite detail), and renames *The Three Axioms* → *The Axioms*.

## Why

The product's defining stance — *where the model belongs, where code belongs, and that critical nodes carry give* — was only partially captured:

- **Reach for the model (Principle 1)** existed only defensively (Rule 5's "AI *may* parse/classify/suggest"). Axiom D adds the affirmative duty: push decisions *toward* the model where generalization beats hand-tuned rules.
- **Code guarantees the number (Principle 2)** was already covered by Rule 5 + the "no LLM accounting" Non-Goal. Axiom D restates it briefly and **cross-references** Rule 5 / Axiom B to stay DRY.
- **Key nodes keep slack (Principle 3)** was genuinely missing. Axiom C only granted tolerance to *external* boundaries (privacy, schema); nothing said internal critical nodes should bend rather than hard-fail. Rule 6 makes this operational, with an explicit guard that the slack lives in *thresholds and flow*, never in whether the ledger balances (so it never overrides Rule 5 / Axiom A).

## Scope

- `vision.md` only. Culture/directional change; no contracts, status, or code touched.
- Relates to the #917 vision-axiom epic (children #930 promotion gate, #931 confidence feedback loop operationalize Axiom B/D downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
