### PR TITLE
[finance_report_audit] EPIC-018 AC18.12: North-Star low-confidence-data metric instrument (#919)

### DIFF
--- a/apps/backend/migrations/versions/0036_confidence_metric_snapshots.py
+++ b/apps/backend/migrations/versions/0036_confidence_metric_snapshots.py
@@ -1,0 +1,53 @@
+"""confidence metric snapshots (North-Star series)
+
+Additive append-only table recording the low-confidence-data proportion over
+time (vision North-Star Metric / Axiom B, EPIC-018 AC18.12).
+
+Migration risk: low (additive table, no backfill, no read-path cutover).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0036_confidence_metric_snapshots"
+down_revision = "0035_manual_valuation_versioning"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "confidence_metric_snapshots",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("total_count", sa.Integer(), nullable=False),
+        sa.Column("low_confidence_count", sa.Integer(), nullable=False),
+        sa.Column("low_confidence_proportion", sa.Numeric(precision=6, scale=5), nullable=False),
+        sa.Column("tier_breakdown", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="confidence_metric_snapshots_user_id_fkey",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_confidence_metric_snapshots_user_id",
+        "confidence_metric_snapshots",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_confidence_metric_snapshots_user_created",
+        "confidence_metric_snapshots",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_confidence_metric_snapshots_user_created", table_name="confidence_metric_snapshots")
+    op.drop_index("ix_confidence_metric_snapshots_user_id", table_name="confidence_metric_snapshots")
+    op.drop_table("confidence_metric_snapshots")

--- a/apps/backend/migrations/versions/0036_confidence_metric_snapshots.py
+++ b/apps/backend/migrations/versions/0036_confidence_metric_snapshots.py
@@ -24,7 +24,12 @@ def upgrade() -> None:
         sa.Column("total_count", sa.Integer(), nullable=False),
         sa.Column("low_confidence_count", sa.Integer(), nullable=False),
         sa.Column("low_confidence_proportion", sa.Numeric(precision=6, scale=5), nullable=False),
-        sa.Column("tier_breakdown", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "tier_breakdown",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -41,6 +41,7 @@ from src.routers import (
     income,
     journal,
     market_data,
+    metrics,
     portfolio,
     reports,
     review,
@@ -297,6 +298,7 @@ app.include_router(corrections.router)
 app.include_router(evidence.router)
 app.include_router(journal.router)
 app.include_router(market_data.router)
+app.include_router(metrics.router)
 app.include_router(income.router)
 app.include_router(reports.router)
 app.include_router(statements.router)

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -34,6 +34,7 @@ from src.models.layer3 import (
 )
 from src.models.layer4 import ReportSnapshot, ReportType
 from src.models.market_data import FxRate, MarketDataSyncState, StockPrice
+from src.models.metrics import ConfidenceMetricSnapshot
 from src.models.ping_state import PingState
 from src.models.portfolio import (
     DividendIncome,
@@ -104,6 +105,7 @@ __all__ = [
     "ReconciliationMatch",
     "ReconciliationMatchJournalEntry",
     "ReconciliationStatus",
+    "ConfidenceMetricSnapshot",
     "ReportSnapshot",
     "ReportType",
     "RuleType",

--- a/apps/backend/src/models/metrics.py
+++ b/apps/backend/src/models/metrics.py
@@ -31,4 +31,4 @@ class ConfidenceMetricSnapshot(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     # Proportion in [0, 1]; Decimal (never float) so the metric is exact.
     low_confidence_proportion: Mapped[Decimal] = mapped_column(Numeric(6, 5), nullable=False)
     # Full tier histogram, e.g. {"TRUSTED": 1, "HIGH": 1, "MEDIUM": 1, "LOW": 3}.
-    tier_breakdown: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    tier_breakdown: Mapped[dict[str, int]] = mapped_column(JSONB, nullable=False, default=dict)

--- a/apps/backend/src/models/metrics.py
+++ b/apps/backend/src/models/metrics.py
@@ -1,0 +1,34 @@
+"""Audit-plane metrics: the North-Star confidence measurement series.
+
+Vision names a single North-Star Metric — "the proportion of low-confidence data
+trends down over time." `ConfidenceMetricSnapshot` is the append-only series that
+makes that trend observable (EPIC-018 AC18.12).
+"""
+
+from decimal import Decimal
+
+from sqlalchemy import Index, Integer, Numeric
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.database import Base
+from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
+
+
+class ConfidenceMetricSnapshot(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
+    """A point-in-time capture of a user's low-confidence-data proportion.
+
+    Append-only: each capture is a new row (`created_at` is the series axis);
+    snapshots are never edited in place, so the series read newest-first is the
+    trend the North-Star review watches.
+    """
+
+    __tablename__ = "confidence_metric_snapshots"
+    __table_args__ = (Index("ix_confidence_metric_snapshots_user_created", "user_id", "created_at"),)
+
+    total_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    low_confidence_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Proportion in [0, 1]; Decimal (never float) so the metric is exact.
+    low_confidence_proportion: Mapped[Decimal] = mapped_column(Numeric(6, 5), nullable=False)
+    # Full tier histogram, e.g. {"TRUSTED": 1, "HIGH": 1, "MEDIUM": 1, "LOW": 3}.
+    tier_breakdown: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)

--- a/apps/backend/src/routers/metrics.py
+++ b/apps/backend/src/routers/metrics.py
@@ -1,0 +1,44 @@
+"""North-Star confidence metric endpoint (EPIC-018 AC18.12).
+
+Surfaces the single measurable expression of the axioms — the low-confidence-data
+proportion — as a live value plus its recorded trend.
+"""
+
+from fastapi import APIRouter
+
+from src.deps import CurrentUserId, DbSession
+from src.schemas.metrics import (
+    ConfidenceMetricPoint,
+    ConfidenceMetricSnapshotResponse,
+    ConfidenceNorthStarResponse,
+)
+from src.services.confidence_metric import ConfidenceMetricService
+
+router = APIRouter(prefix="/metrics", tags=["metrics"])
+_service = ConfidenceMetricService()
+
+
+@router.get("/confidence-north-star", response_model=ConfidenceNorthStarResponse)
+async def get_confidence_north_star(user_id: CurrentUserId, db: DbSession) -> ConfidenceNorthStarResponse:
+    """Return the current low-confidence proportion and the recorded trend (newest first)."""
+    current = await _service.compute(db, user_id)
+    series = await _service.list_snapshots(db, user_id)
+    return ConfidenceNorthStarResponse(
+        current=ConfidenceMetricPoint(
+            total_count=current.total_count,
+            low_confidence_count=current.low_confidence_count,
+            low_confidence_proportion=current.low_confidence_proportion,
+            tier_breakdown=current.tier_breakdown,
+        ),
+        series=[
+            ConfidenceMetricSnapshotResponse(
+                id=snapshot.id,
+                captured_at=snapshot.created_at,
+                total_count=snapshot.total_count,
+                low_confidence_count=snapshot.low_confidence_count,
+                low_confidence_proportion=snapshot.low_confidence_proportion,
+                tier_breakdown=snapshot.tier_breakdown,
+            )
+            for snapshot in series
+        ],
+    )

--- a/apps/backend/src/schemas/metrics.py
+++ b/apps/backend/src/schemas/metrics.py
@@ -1,0 +1,30 @@
+"""Schemas for the North-Star confidence metric endpoint (EPIC-018 AC18.12)."""
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class ConfidenceMetricPoint(BaseModel):
+    """A North-Star measurement: the LOW-tier share of posted ledger facts."""
+
+    total_count: int
+    low_confidence_count: int
+    low_confidence_proportion: Decimal
+    tier_breakdown: dict[str, int]
+
+
+class ConfidenceMetricSnapshotResponse(ConfidenceMetricPoint):
+    """A recorded point in the append-only series."""
+
+    id: UUID
+    captured_at: datetime
+
+
+class ConfidenceNorthStarResponse(BaseModel):
+    """The live metric plus its recorded trend (newest first)."""
+
+    current: ConfidenceMetricPoint
+    series: list[ConfidenceMetricSnapshotResponse]

--- a/apps/backend/src/services/confidence_metric.py
+++ b/apps/backend/src/services/confidence_metric.py
@@ -1,0 +1,95 @@
+"""North-Star confidence metric: the low-confidence share of posted ledger facts.
+
+Vision North-Star Metric: "the proportion of low-confidence data trends down over
+time." The measurable node is the posted/reconciled journal entry — the ledger
+fact that backs report numbers — whose confidence tier is derived from its
+source_type (see `confidence_tier.derive_confidence_tier`). LOW-tier entries over
+total are the metric; recording it over time makes the trend observable
+(EPIC-018 AC18.12).
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.journal import JournalEntry, JournalEntryStatus
+from src.models.metrics import ConfidenceMetricSnapshot
+from src.services.confidence_tier import ConfidenceTier, derive_confidence_tier
+
+_PROPORTION_QUANT = Decimal("0.00001")
+_TIERS: tuple[ConfidenceTier, ...] = ("TRUSTED", "HIGH", "MEDIUM", "LOW")
+
+
+@dataclass(frozen=True)
+class ConfidenceMetricResult:
+    """A computed North-Star point (not yet persisted)."""
+
+    total_count: int
+    low_confidence_count: int
+    low_confidence_proportion: Decimal
+    tier_breakdown: dict[str, int]
+
+
+class ConfidenceMetricService:
+    """Computes and records the North-Star low-confidence proportion."""
+
+    async def compute(self, db: AsyncSession, user_id: UUID) -> ConfidenceMetricResult:
+        """Deterministic LOW-tier share over a user's posted/reconciled ledger facts.
+
+        Grouping by source_type (a pure input to tier derivation) keeps this a
+        single read with no row-by-row Python tiering.
+        """
+        rows = await db.execute(
+            select(JournalEntry.source_type, func.count(JournalEntry.id))
+            .where(JournalEntry.user_id == user_id)
+            .where(JournalEntry.status.in_([JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED]))
+            .group_by(JournalEntry.source_type)
+        )
+        breakdown: dict[str, int] = {tier: 0 for tier in _TIERS}
+        for source_type, count in rows.all():
+            breakdown[derive_confidence_tier(source_type)] += int(count)
+
+        total = sum(breakdown.values())
+        low = breakdown["LOW"]
+        proportion = (Decimal(low) / Decimal(total)).quantize(_PROPORTION_QUANT) if total else Decimal("0")
+        return ConfidenceMetricResult(
+            total_count=total,
+            low_confidence_count=low,
+            low_confidence_proportion=proportion,
+            tier_breakdown=breakdown,
+        )
+
+    async def record_snapshot(self, db: AsyncSession, user_id: UUID) -> ConfidenceMetricSnapshot:
+        """Append the current metric as a new (immutable) point in the time series."""
+        result = await self.compute(db, user_id)
+        snapshot = ConfidenceMetricSnapshot(
+            user_id=user_id,
+            total_count=result.total_count,
+            low_confidence_count=result.low_confidence_count,
+            low_confidence_proportion=result.low_confidence_proportion,
+            tier_breakdown=result.tier_breakdown,
+        )
+        db.add(snapshot)
+        await db.flush()
+        await db.refresh(snapshot)
+        return snapshot
+
+    async def list_snapshots(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        *,
+        limit: int = 100,
+    ) -> Sequence[ConfidenceMetricSnapshot]:
+        """Return the recorded series, newest first."""
+        result = await db.execute(
+            select(ConfidenceMetricSnapshot)
+            .where(ConfidenceMetricSnapshot.user_id == user_id)
+            .order_by(ConfidenceMetricSnapshot.created_at.desc(), ConfidenceMetricSnapshot.id.desc())
+            .limit(limit)
+        )
+        return result.scalars().all()

--- a/apps/backend/tests/metrics/test_confidence_north_star_metric.py
+++ b/apps/backend/tests/metrics/test_confidence_north_star_metric.py
@@ -1,0 +1,86 @@
+"""North-Star metric: low-confidence-data proportion over time (EPIC-018 AC18.12).
+
+Vision names a single North-Star Metric — "the proportion of low-confidence data
+trends down over time" — and calls it the single measurable expression of the
+axioms. These tests pin the instrument: a deterministic proportion over the
+ledger facts that back reports, recorded as an append-only series so the trend
+is observable.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from src.models.journal import JournalEntrySourceType
+from src.services.confidence_metric import ConfidenceMetricService
+from tests.accounting._ledger_helpers import create_valid_posted_entry
+
+
+@pytest.mark.asyncio
+async def test_AC18_12_1_low_confidence_proportion_and_tier_breakdown_are_deterministic(db, test_user):
+    """AC18.12.1: The metric is the LOW-tier share of posted ledger facts, with a full tier breakdown."""
+    service = ConfidenceMetricService()
+    # source_type -> confidence tier: manual=TRUSTED, user_confirmed=HIGH,
+    # auto_matched=MEDIUM, auto_parsed/system=LOW.
+    for source_type in (
+        JournalEntrySourceType.MANUAL,
+        JournalEntrySourceType.USER_CONFIRMED,
+        JournalEntrySourceType.AUTO_MATCHED,
+        JournalEntrySourceType.AUTO_PARSED,
+        JournalEntrySourceType.AUTO_PARSED,
+        JournalEntrySourceType.SYSTEM,
+    ):
+        await create_valid_posted_entry(db, test_user.id, source_type=source_type)
+
+    result = await service.compute(db, test_user.id)
+
+    assert result.total_count == 6
+    assert result.low_confidence_count == 3  # 2x auto_parsed + 1x system
+    assert result.low_confidence_proportion == Decimal("0.5")
+    assert result.tier_breakdown == {"TRUSTED": 1, "HIGH": 1, "MEDIUM": 1, "LOW": 3}
+
+
+@pytest.mark.asyncio
+async def test_AC18_12_1_empty_ledger_reports_zero_not_undefined(db, test_user):
+    """AC18.12.1: With no ledger facts the proportion is a defined 0, never a divide-by-zero."""
+    result = await ConfidenceMetricService().compute(db, test_user.id)
+    assert result.total_count == 0
+    assert result.low_confidence_count == 0
+    assert result.low_confidence_proportion == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_AC18_12_2_metric_is_recorded_as_append_only_series_showing_the_trend(db, test_user):
+    """AC18.12.2: Snapshots accumulate (never overwrite) and read newest-first, so the trend is observable."""
+    service = ConfidenceMetricService()
+
+    await create_valid_posted_entry(db, test_user.id, source_type=JournalEntrySourceType.MANUAL)
+    await create_valid_posted_entry(db, test_user.id, source_type=JournalEntrySourceType.AUTO_PARSED)
+    first = await service.record_snapshot(db, test_user.id)
+    await db.commit()
+    assert first.low_confidence_proportion == Decimal("0.5")  # 1 LOW of 2
+
+    # Trust improves: add two TRUSTED facts and record again.
+    await create_valid_posted_entry(db, test_user.id, source_type=JournalEntrySourceType.MANUAL)
+    await create_valid_posted_entry(db, test_user.id, source_type=JournalEntrySourceType.MANUAL)
+    second = await service.record_snapshot(db, test_user.id)
+    await db.commit()
+    assert second.low_confidence_proportion == Decimal("0.25")  # 1 LOW of 4
+
+    series = await service.list_snapshots(db, test_user.id)
+    assert [s.low_confidence_proportion for s in series] == [Decimal("0.25"), Decimal("0.5")]
+    # The earlier point is preserved unedited (append-only, not overwritten).
+    assert series[-1].id == first.id
+    assert series[-1].low_confidence_proportion == Decimal("0.5")
+
+
+@pytest.mark.asyncio
+async def test_AC18_12_3_north_star_endpoint_returns_current_and_series(client):
+    """AC18.12.3: The metric and its series are exposed read-only via the API."""
+    response = await client.get("/metrics/confidence-north-star")
+    assert response.status_code == 200
+    body = response.json()
+    assert "current" in body and "series" in body
+    assert body["current"]["total_count"] == 0
+    assert body["current"]["low_confidence_count"] == 0
+    assert isinstance(body["series"], list)

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -32,6 +32,7 @@ These files are test infrastructure, not behavior proof.
 | `apps/backend/tests/infra/__init__.py` | Package marker |
 | `apps/backend/tests/locustfile.py` | Load-test harness, not AC proof |
 | `apps/backend/tests/market_data/__init__.py` | Package marker |
+| `apps/backend/tests/metrics/__init__.py` | Package marker |
 | `apps/backend/tests/portfolio/__init__.py` | Package marker |
 | `apps/backend/tests/reconciliation/__init__.py` | Package marker |
 | `apps/backend/tests/reporting/__init__.py` | Package marker |

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -374,6 +374,22 @@ Dependencies: AC18.7 Evidence Graph foundation, AC18.8 source-to-report integrat
 |-------|-------|-------------|
 | AC18.6.1 | Framework reporting | AI-generated measurement or disclosure suggestions for US/HK personal report packages must remain structured, source-anchored, confidence-scored, and reviewed before EPIC-020 or EPIC-005 can treat them as trusted report inputs |
 
+### AC18.12: North-Star Confidence Metric
+
+Vision names a single North-Star Metric — *"the proportion of low-confidence data
+trends down over time,"* the single measurable expression of the axioms. This AC
+makes it a measured instrument: a deterministic LOW-tier share of the posted
+ledger facts that back reports (tier derived from journal `source_type` via
+`confidence_tier`), recorded as an append-only series so the trend is observable,
+and surfaced read-only via the API. Recording cadence (on report-package
+generation / scheduled) and the per-report-number confidence of #913 are separate.
+
+| AC ID | Phase | Description | Test | File | Priority |
+|-------|-------|-------------|------|------|----------|
+| AC18.12.1 | Metric | The low-confidence proportion is the deterministic LOW-tier share of posted/reconciled journal entries, with a full TRUSTED/HIGH/MEDIUM/LOW breakdown and a defined zero on an empty ledger | `test_AC18_12_1_low_confidence_proportion_and_tier_breakdown_are_deterministic()` | `metrics/test_confidence_north_star_metric.py` | P1 |
+| AC18.12.2 | Trend | The metric is recorded as an append-only series — snapshots accumulate and read newest-first, never overwritten — so the trend over time is observable | `test_AC18_12_2_metric_is_recorded_as_append_only_series_showing_the_trend()` | `metrics/test_confidence_north_star_metric.py` | P1 |
+| AC18.12.3 | Surface | The current metric and its recorded series are exposed read-only via the API | `test_AC18_12_3_north_star_endpoint_returns_current_and_series()` | `metrics/test_confidence_north_star_metric.py` | P1 |
+
 ---
 
 ## 🚫 Out of Scope (v1)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,8 +5,8 @@
 
 - API title: `Finance Report API`
 - API version: `0.1.0`
-- Endpoint count: `118`
-- Schema count: `197`
+- Endpoint count: `119`
+- Schema count: `200`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 
@@ -26,6 +26,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `income` | 1 |
 | `journal-entries` | 6 |
 | `market-data` | 3 |
+| `metrics` | 1 |
 | `portfolio` | 13 |
 | `reconciliation` | 11 |
 | `reports` | 16 |
@@ -140,6 +141,12 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `GET` | `/market-data/status` | yes | `pairs` (query), `symbols` (query), `include_default_fx` (query) | - | `200` array[`MarketDataStatusResponse`] | Market Data Status Endpoint |
 | `POST` | `/market-data/sync/fx` | yes | - | `MarketDataSyncRequest` | `200` `MarketDataSyncResponse` | Sync Fx Endpoint |
 | `POST` | `/market-data/sync/stocks` | yes | - | `MarketDataSyncRequest` | `200` `MarketDataSyncResponse` | Sync Stocks Endpoint |
+
+### metrics
+
+| Method | Path | Auth | Params | Request | Success responses | Summary |
+|---|---|---|---|---|---|---|
+| `GET` | `/metrics/confidence-north-star` | yes | - | - | `200` `ConfidenceNorthStarResponse` | Get Confidence North Star |
 
 ### portfolio
 

--- a/docs/ssot/migration-risk.yaml
+++ b/docs/ssot/migration-risk.yaml
@@ -175,6 +175,10 @@ migrations:
     risk: medium
     issue: "#845"
     proof: Adds preflight checks plus database CHECK/UNIQUE/partial-index guards for financial facts, statement envelopes, market prices, managed positions, and latest report snapshots; covered by AC11.18 direct DB invariant tests and the PR Alembic contract.
+  0036_confidence_metric_snapshots:
+    file: 0036_confidence_metric_snapshots.py
+    risk: low
+    proof: Additive append-only North-Star confidence metric table; no backfill or read-path cutover; covered by PR Alembic contract.
   0035_manual_valuation_versioning:
     file: 0035_manual_valuation_versioning.py
     risk: medium

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -49,7 +49,7 @@ Examples:
 | DWM | `reconciliation_matches`, `consistency_checks` |
 | DWS | `managed_positions`, `investment_lots`, derived balances and period aggregates |
 | ADS | `report_snapshots` |
-| Application / audit plane | `users`, chat/workflow tables, evidence graph tables, feedback/correction tables |
+| Application / audit plane | `users`, chat/workflow tables, evidence graph tables, feedback/correction tables, `confidence_metric_snapshots` (append-only North-Star metric series) |
 
 The generated DB reference owns the current table inventory. Keep the layer list
 above as domain vocabulary and examples, not as a second column-by-column schema


### PR DESCRIPTION
## Summary

Add the **North-Star metric instrument**: a deterministic, read-only measure of
**the low-confidence-data proportion**, recorded as an append-only series so its
trend over time is observable.

Vision names exactly one North-Star Metric — *"the proportion of low-confidence
data trends down over time,"* the *"single measurable expression of the axioms."*
Until now nothing computed it, so **Axiom B was unfalsifiable** — we could not
show whether the mission ("drive the low-confidence proportion down") was being
met. This builds the instrument.

Closes #919. Part of the #917 audit-gap epic (Axis B).

## What changed (EPIC-018 AC18.12)

- **`ConfidenceMetricService.compute`** — the LOW-tier share of a user's
  posted/reconciled `JournalEntry` facts (the ledger facts that back report
  numbers). Tier is derived from `source_type` via the existing
  `confidence_tier`; returns a full `{TRUSTED, HIGH, MEDIUM, LOW}` breakdown and
  a **defined `0` on an empty ledger** (no divide-by-zero). `Decimal`, never float.
- **`ConfidenceMetricSnapshot`** — an **append-only** series table.
  `record_snapshot` appends a point; `list_snapshots` reads newest-first, so the
  trend (ideally downward) is observable and never overwritten.
- **`GET /metrics/confidence-north-star`** — live metric `current` + recorded
  `series`.

## Why posted journal entries

They are the ledger facts that actually back report numbers, and they already
carry a derivable confidence tier (`JournalEntry.confidence_tier` →
`derive_confidence_tier(source_type)`). Grouping by `source_type` keeps `compute`
a single deterministic read.

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-018 — AI-Driven Data Pipeline |
| **AC IDs** | AC18.12.1, AC18.12.2, AC18.12.3 |
| **AC source updated** | `docs/project/EPIC-018.ai-driven-pipeline.md` |

## SSOT / generated refs

- [x] `docs/ssot/schema.md` — registers `confidence_metric_snapshots` (append-only, audit plane).
- [x] `docs/ssot/migration-risk.yaml` — `0036` (low risk, additive).
- [x] `docs/reference/api.md` — regenerated for the new endpoint.

## TDD Evidence

🔴 Red: tests failed with `ModuleNotFoundError: src.services.confidence_metric`
before implementation. 🟢 Green after: 4/4.

| Test | AC |
|------|----|
| `test_AC18_12_1_low_confidence_proportion_and_tier_breakdown_are_deterministic` + `..._empty_ledger_reports_zero_not_undefined` | AC18.12.1 |
| `test_AC18_12_2_metric_is_recorded_as_append_only_series_showing_the_trend` | AC18.12.2 |
| `test_AC18_12_3_north_star_endpoint_returns_current_and_series` | AC18.12.3 |

## Scope boundary (out of scope here)

- Recording **cadence** (auto-snapshot on report-package generation / scheduled) — `record_snapshot` is callable + tested; wiring is a follow-up.
- **#913** per-report-number confidence (a different axis); this aggregates ledger-fact confidence.

## Testing

```bash
python3 tools/test_lifecycle.py --fast tests/metrics/test_confidence_north_star_metric.py   # 4 passed
python3 tools/test_lifecycle.py --fast tests/metrics tests/accounting/test_journal_service.py \
  tests/api/test_personal_report_package_contract.py                                          # 27 passed

alembic upgrade head && alembic check     # no drift; downgrade -1 reversible
uv run --with pyyaml python tools/generate_ac_registry.py --check     # OK (AC18.12.* registered)
uv run python ../../tools/generate_db_schema_reference.py --check     # OK
uv run python ../../tools/generate_api_reference.py --check           # OK
tools/check_manifest.py / lint_doc_consistency.py / check_migration_risk.py   # OK
ruff check / format --check                                          # clean
```

## Engineering Audit

- [x] `low_confidence_proportion` is `Decimal` (`Numeric(6,5)`), never float.
- [x] No `sa.Enum` added; no `NEXT_PUBLIC_`/secret changes.
- [x] `repo/` submodule untouched; additive table only, reversible migration, alembic-drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
