### PR TITLE
[finance_report_vision] docs(skills): sync domain skills with current SSOT and code

### DIFF
--- a/.opencode/skills/domain/accounting/SKILL.md
+++ b/.opencode/skills/domain/accounting/SKILL.md
@@ -6,6 +6,7 @@ description: Double-entry bookkeeping rules, accounting equation validation, ent
 # Double-Entry Bookkeeping Domain Model
 
 > **Core Definition**: Accounting equation, account classification, and entry rules for double-entry bookkeeping.
+> **SSOT**: [`docs/ssot/accounting.md`](../../../../docs/ssot/accounting.md) is authoritative for every rule below.
 
 ## Accounting Equation
 
@@ -14,6 +15,29 @@ Assets = Liabilities + Equity + (Income - Expenses)
 ```
 
 **At any moment, all `posted` entries must satisfy this equation.**
+
+## Money Rules (read before touching any amount)
+
+- **Decimal only** — NEVER use `float` to store, calculate, or transfer money.
+- **Rule A2 — canonical rounding**: currency amounts are quantized to **2 dp with
+  banker's rounding (`ROUND_HALF_EVEN`)**. Always round through the one helper
+  `apps/backend/src/utils/money.py::to_money()` (exposed as `src.utils.to_money`).
+  Do NOT hand-roll `quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)` for money.
+  Out of scope (keep their own quantization): FX rates & security prices (6 dp),
+  share quantities (6 dp), percentages/ratios (XIRR, TWR, MWR, allocation %).
+  Guardrail: `apps/backend/tests/accounting/test_money.py`.
+
+## Multi-Currency Journal Balance
+
+Balance is measured in the configured **base currency** (`SGD` by default), not
+raw nominal line amounts. A non-base-currency line MUST carry `fx_rate`:
+
+```
+base_amount = line.amount * line.fx_rate
+```
+
+Debit and credit totals are valid only when their converted **base** amounts
+differ by ≤ `0.01`. NEVER validate by comparing raw original-currency nominals.
 
 ## Account Classification and Debit/Credit Rules
 
@@ -29,15 +53,37 @@ Assets = Liabilities + Equity + (Income - Expenses)
 
 ### ✅ Recommended Patterns
 
-- **Pattern A**: Each entry has at least 2 lines, debit/credit balanced
-- **Pattern B**: Use Decimal for precise calculations, tolerance < 0.01
-- **Pattern C**: Posted entries can only be voided, not directly modified
+- **Pattern A**: Each entry has at least 2 lines, debit/credit balanced.
+- **Pattern B**: Use Decimal; round money via `to_money()` (Rule A2 above).
+- **Pattern C**: Posted entries can only be voided, not directly modified.
+- **Pattern D**: Multi-currency entries validate balance **after** base-currency conversion.
+- **Pattern E**: Account authorization is a domain invariant — services must
+  validate every `JournalLine.account_id` belongs to the same `user_id` as the
+  `JournalEntry`. HTTP middleware is not sufficient (services and background
+  tasks write without a request object).
+- **Pattern F**: Posted/reconciled invariants are enforced at **both** the
+  service and the database boundary (DB triggers reject ledger violations).
+- **Pattern G**: The only non-fact update allowed on a posted/reconciled entry is
+  source-type promotion from `auto_parsed`/`bank_statement`/`auto_matched` →
+  `user_confirmed`, with `source_id` and every accounting fact unchanged.
 
 ### ⛔ Prohibited Patterns
 
 - **NEVER** use FLOAT to store, calculate, or transfer monetary amounts.
-- **NEVER** allow unbalanced debit/credit entries
-- **NEVER** skip validation when writing posted status
+- **NEVER** allow unbalanced debit/credit entries (base-currency totals).
+- **NEVER** skip validation when writing posted status.
+- **NEVER** directly update or delete posted/reconciled/void ledger facts — use
+  the void/reversal workflow.
+- **NEVER** create, post, or aggregate journal lines across user boundaries.
+- **NEVER** downgrade `source_type` or change `source_id` after posting.
+
+### Async Transaction Boundary
+
+Services that receive `db: AsyncSession` from a router use `flush()` (assign IDs,
+validate constraints); the **router** calls `commit()`. Exceptions that own their
+own commit: background tasks with their own session, and streaming generators
+that outlive the router response. Enforcement:
+`apps/backend/tests/ai/test_commit_boundary.py`.
 
 ## Standard Operating Procedures
 

--- a/.opencode/skills/domain/extraction/SKILL.md
+++ b/.opencode/skills/domain/extraction/SKILL.md
@@ -26,14 +26,18 @@ flowchart TB
     H --> J
 ```
 
-## Confidence Scoring
+## Confidence Scoring (SSOT V2 weights)
+
+Authoritative weights live in `apps/backend/src/services/validation.py::compute_confidence_score`:
 
 | Factor | Weight | Criteria |
 |--------|--------|----------|
-| Balance Check | 40% | opening + Σtxn ≈ closing (±0.1) |
-| Field Completeness | 30% | Required fields present |
-| Format Consistency | 20% | Valid date/amount formats |
+| Balance Check | 35% | opening + Σtxn ≈ closing (±0.1); partial credit for small diffs |
+| Field Completeness | 25% | Required fields present |
+| Format Consistency | 15% | Valid date/amount formats |
 | Transaction Count | 10% | Reasonable (1-500) |
+| Balance Progression | 10% | Running balances monotonically consistent |
+| Currency Consistency | 5% | Single/expected currency across lines |
 
 **Thresholds**:
 - ≥85: Auto-accept
@@ -42,17 +46,16 @@ flowchart TB
 
 ## Supported Institutions
 
-| Institution | Format | Tier |
-|-------------|--------|------|
-| DBS/POSB | PDF | v1 |
-| CMB (China Merchants Bank) | PDF | v1 |
-| Maybank | PDF | v1 |
-| Wise | PDF/CSV | v1 |
-| Brokerage (generic) | PDF/CSV | v1 |
-| Insurance (generic) | PDF | v1 |
-| OCBC | PDF | Extended |
-| MariBank | PDF | Extended |
-| GXS | PDF | Extended |
+Two distinct support tiers — do not conflate them:
+
+- **Tier-1 structured CSV parsers** (deterministic, in `extraction.py`): DBS,
+  POSB, Wise, OCBC, UOB, Standard Chartered, Citibank.
+- **AI-detected via prompt hints** (`src/prompts/statement.py`, PDF/image, no
+  deterministic parser): DBS, CMB, Maybank, Wise, Moomoo, Futu, IBKR, GXS,
+  MariBank, plus generic brokerage and insurance.
+
+Any other institution falls back to generic AI auto-detection. Treat this list
+as illustrative — the prompt-hint and CSV-parser source files are authoritative.
 
 ## Data Integrity
 

--- a/.opencode/skills/domain/extraction/SKILL.md
+++ b/.opencode/skills/domain/extraction/SKILL.md
@@ -36,7 +36,7 @@ Authoritative weights live in `apps/backend/src/services/validation.py::compute_
 | Field Completeness | 25% | Required fields present |
 | Format Consistency | 15% | Valid date/amount formats |
 | Transaction Count | 10% | Reasonable (1-500) |
-| Balance Progression | 10% | Running balances monotonically consistent |
+| Balance Progression | 10% | `balance_after` chain is arithmetically consistent: `balance_after[n] == balance_after[n-1] ± amount[n]` (±0.10) |
 | Currency Consistency | 5% | Single/expected currency across lines |
 
 **Thresholds**:

--- a/.opencode/skills/domain/reconciliation/SKILL.md
+++ b/.opencode/skills/domain/reconciliation/SKILL.md
@@ -69,8 +69,12 @@ scoring:
 - **Pattern A**: Auto-matches must record `score_breakdown` for audit
 - **Pattern B**: One-to-many matches must verify amount totals
 - **Pattern C**: Cross-period matches extend date tolerance to ±7 days
-- **Pattern D**: Review queue updates use row-level locking and increment `version`
-- **Pattern E (Performance)**: Pre-fetch candidates for entire statement period
+- **Pattern D**: Match facts are append-only (Axiom A). `reconciliation_matches`
+  is the canonical example — `version` integer + self-referential
+  `superseded_by_id`; the live match is the head (`superseded_by_id IS NULL`),
+  enforced by a partial unique index. Replacing a match appends a new version and
+  marks the prior one `superseded`. See [`schema`](../schema/SKILL.md#append-only-fact-versioning-axiom-a).
+- **Pattern E (Performance)**: Pre-fetch candidates for entire statement period.
 
 ### ⛔ Prohibited Patterns
 

--- a/.opencode/skills/domain/reconciliation/SKILL.md
+++ b/.opencode/skills/domain/reconciliation/SKILL.md
@@ -70,10 +70,14 @@ scoring:
 - **Pattern B**: One-to-many matches must verify amount totals
 - **Pattern C**: Cross-period matches extend date tolerance to ±7 days
 - **Pattern D**: Match facts are append-only (Axiom A). `reconciliation_matches`
-  is the canonical example — `version` integer + self-referential
-  `superseded_by_id`; the live match is the head (`superseded_by_id IS NULL`),
-  enforced by a partial unique index. Replacing a match appends a new version and
-  marks the prior one `superseded`. See [`schema`](../schema/SKILL.md#append-only-fact-versioning-axiom-a).
+  carries a `version` integer and a self-referential `superseded_by_id`.
+  Replacing a match sets the prior match's `status = superseded` and its
+  `superseded_by_id` to the new match; the active match is resolved **in the
+  service** via `_get_existing_active_match` (`status != superseded AND
+  superseded_by_id IS NULL`), not by a DB partial unique index, and the
+  replacement does not increment `version`. (The partial-unique-index head
+  enforcement is applied on `manual_valuation_snapshots` — see
+  [`schema`](../schema/SKILL.md#append-only-fact-versioning-axiom-a).)
 - **Pattern E (Performance)**: Pre-fetch candidates for entire statement period.
 
 ### ⛔ Prohibited Patterns

--- a/.opencode/skills/domain/reporting/SKILL.md
+++ b/.opencode/skills/domain/reporting/SKILL.md
@@ -6,12 +6,35 @@ description: Financial report generation including balance sheet, income stateme
 # Financial Reporting
 
 > **Core Definition**: Financial report generation logic, report types, and calculation rules.
+> **SSOT**: [`docs/ssot/reporting.md`](../../../../docs/ssot/reporting.md) is authoritative.
 
 ## Report Types
 
 ### Balance Sheet
 Shows assets, liabilities, and equity at a point in time.
 - **Validation**: `Total Assets = Total Liabilities + Total Equity`
+
+#### Three net-worth source classes
+
+| Source | Rule |
+|--------|------|
+| Journal lines | Aggregate posted/reconciled asset/liability/equity balances through the report date |
+| Active portfolio positions | Add a per-broker market-value **adjustment** = `current market value − ledger-backed cost basis` (only the delta, to avoid double counting) |
+| Manual valuation snapshots | Add latest in-scope `manual_valuation_snapshots` as synthetic report lines (EPIC-011), gated by `include_in_total_net_worth` |
+
+- `net_worth_adjustment_gain_loss` is the **explicit balancing component** for
+  non-ledger value (portfolio adjustments + manual valuations). Compute it from
+  those added report lines, **not** from the remaining balance-sheet delta.
+- `unrealized_fx_gain_loss` is **not a plug**. Compute as
+  `native balance × report-date spot − historical base-currency cost from
+  posted/reconciled non-revaluation lines`. Posted `FX_REVALUATION` entries are
+  **excluded** from both native balance and historical cost.
+
+#### Restricted-liquidity toggle (EPIC-011)
+
+Restricted holdings are excluded by default. `/reports/balance-sheet` and the
+Balance Sheet page MUST default `include_restricted=false`. Manual valuations
+carry a `liquidity_class` (LIQUID / RESTRICTED / ILLIQUID / LIABILITY).
 
 ### Income Statement (P&L)
 Shows income and expenses over a period.
@@ -27,16 +50,38 @@ Shows cash movements by category:
 
 - **Base Currency**: User configurable (default: SGD)
 - **Balance Sheet**: Use period-end FX rate
-- **Income Statement**: Use average FX rate
-- Record unrealized FX gains/losses separately
+- **Income Statement**: Use trailing/average FX rate
+- Round through the canonical helper `to_money()` (banker's rounding,
+  `ROUND_HALF_EVEN`) — see [`accounting`](../accounting/SKILL.md) Rule A2. Do NOT
+  hand-roll `quantize(Decimal("0.01"))` without the canonical mode.
 
 ```python
+from src.utils import to_money
+
 def consolidate_amount(amount: Decimal, currency: str, target: str, date: date) -> Decimal:
     if currency == target:
         return amount
     rate = get_fx_rate(currency, target, date)
-    return (amount * rate).quantize(Decimal("0.01"))
+    return to_money(amount * rate)
 ```
+
+## Annualized Income Schedule (EPIC-011)
+
+- Endpoint: `GET /api/reports/package/annualized-income-schedule`
+- Trailing **365 days** ending at `as_of_date` (defaults to request date).
+- Buckets posted/reconciled income lines into salary / bonus / dividend / total.
+- Convert each line to the schedule currency **before** aggregation (trailing
+  average FX for the window); NEVER add mixed-currency nominals raw.
+- Restricted-comp basis: latest as-of snapshots for `esop`/`rsu`/`stock_options`
+  with `liquidity_class=restricted`.
+
+## Notes & Disclosures
+
+- Endpoint: `GET /api/reports/package/notes`. Required IDs: `basis-of-preparation`,
+  `reporting-period-and-currency`, `valuation-basis` (EPIC-011),
+  `investment-market-data`, `source-confidence-review`, `restricted-asset-treatment`.
+- The package non-compliance statement must state the report is not a regulated
+  filing, audit opinion, legal, or tax advice.
 
 ## Design Constraints
 

--- a/.opencode/skills/domain/schema/SKILL.md
+++ b/.opencode/skills/domain/schema/SKILL.md
@@ -5,56 +5,99 @@ description: PostgreSQL database schema, table structures, relationships, and mi
 
 # Database Schema
 
-> **Core Definition**: PostgreSQL core table structures and relationships.
+> **Core Definition**: PostgreSQL table structures, the data-layering model, and
+> migration/versioning rules.
+> **SSOT**: [`docs/ssot/schema.md`](../../../../docs/ssot/schema.md) is authoritative.
+> The full table/column/enum/index inventory is generated, not hand-maintained
+> here — see the [Generated DB Schema Reference](../../../../docs/reference/db-schema.md)
+> (`python tools/generate_db_schema_reference.py`).
 
-## Key Tables
+## Data Layering (DIM / ODS / DWD / DWM / DWS / ADS)
 
-- **Users**: User accounts with email/password
-- **Accounts**: Chart of accounts (ASSET/LIABILITY/EQUITY/INCOME/EXPENSE)
-- **JournalEntries**: Journal entry headers
-- **JournalLines**: Journal entry lines (debit/credit)
-- **BankStatements**: Imported statement headers
-- **BankStatementTransactions**: Statement transactions
-- **ReconciliationMatches**: Match records
-- **ChatSessions/ChatMessages**: AI chat history
+- **Account is a DIM, conformed at DWD.** `account_id` is assigned when a DWD
+  fact is built (`transaction_classification.account_id`,
+  `journal_lines.account_id`, `statement_summaries.account_id`).
+- **DWM/DWS/ADS resolve dimensions from DWD/DIM, never from ODS.** Matching,
+  transfer logic, summaries, and reports must not reach back to a source-file row
+  for account authority.
+- **No reference data in code.** Non-user reference data that affects ADS lives
+  in DIM tables or generated/config-owned contracts, not hard-coded constants.
+- The legacy `bank_statement*` ODS tables and Layer-0 read path were **removed**
+  (EPIC-011 Stage 3); transfer detection resolves custody from
+  `statement_summaries` via `resolve_custody_account_id`.
+
+## Append-Only Fact Versioning (Axiom A)
+
+A stored *fact* (the recorded value of a financial quantity) is never edited in
+place. Corrections append a new version and supersede the prior one; the live
+value is the head of the chain.
+
+- **Version-bearing unit**: the fact row carries a `version` integer plus a
+  self-referential `superseded_by_id` (as on `reconciliation_matches`;
+  `transaction_classification` uses the `superseded_by_id` chain alone). Not
+  bitemporal `valid_from`/`valid_to`, not a separate version table.
+- **Current head**: `superseded_by_id IS NULL`. Enforce key uniqueness with a
+  **partial unique index over the head** (`WHERE superseded_by_id IS NULL`) so
+  history rows accumulate freely. Default reads/aggregations filter to the head.
+- **Fact vs. review-state**: append-only applies to *facts*. Mutable working
+  state (status transitions, notes, reminders) may stay editable in place.
+- First applied instance: `manual_valuation_snapshots` (ODS) — a re-submitted
+  `(component_type, source, as_of_date)` appends a new version. See
+  [EPIC-011 AC11.19](../../../../docs/project/EPIC-011.asset-lifecycle.md), #918.
+
+## Core Entities
+
+- **Users**, **Accounts** (chart of accounts: ASSET/LIABILITY/EQUITY/INCOME/EXPENSE)
+- **JournalEntries** / **JournalLines** (debit/credit ledger facts)
+- **ReconciliationMatches** (versioned match facts)
+- **ManualValuationSnapshot** (versioned ODS valuation facts)
+
+This is not the full inventory — consult the generated reference for the
+complete table/column/enum list.
 
 ## Design Constraints
 
 ### Naming Conventions
 
-- **Explicit Enums**: ALWAYS provide `name` parameter to SQLAlchemy `Enum`
-  - ❌ Bad: `sa.Column(sa.Enum(Status))`
-  - ✅ Good: `sa.Column(sa.Enum(Status, name="journal_entry_status"))`
-- **Migration Length**: Keep Alembic migration descriptions < 100 characters
+- **Explicit Enums**: ALWAYS provide `name=` to SQLAlchemy `Enum`.
+  - ❌ `sa.Column(sa.Enum(Status))`
+  - ✅ `sa.Column(sa.Enum(Status, name="journal_entry_status"))`
+  - Proof: `apps/backend/tests/infra/test_schema_guardrails.py::test_enums_have_explicit_names`
+- **Migration IDs/descriptions**: keep short for filesystem/Docker-volume limits.
 
 ### Async Session Management
 
-1. Use `get_db` FastAPI dependency for routers
-2. Routers handle commit/rollback; Services use `flush()`
-3. Ensure every session is closed
+1. Use the `get_db` FastAPI dependency for routers.
+2. Routers handle commit/rollback; services use `flush()`
+   (see [`accounting`](../accounting/SKILL.md) async-tx-boundary rule).
+3. Ensure every session is closed.
 
 ### Recommended Patterns
 
-- Use `DECIMAL(18,2)` for amounts
-- Use `created_at`/`updated_at` audit fields
-- Use UUID primary keys
+- `DECIMAL(18,2)` for monetary amounts; `created_at`/`updated_at` audit fields; UUID PKs.
 
 ### Prohibited Patterns
 
-- **NEVER** use FLOAT for monetary amounts
-- **NEVER** directly delete posted entries, only void
+- **NEVER** use FLOAT for monetary amounts.
+- **NEVER** directly delete posted entries — only void.
 
-## Index Strategy
+## Migration Contract
 
-```sql
-CREATE INDEX idx_accounts_user_id ON accounts(user_id);
-CREATE INDEX idx_journal_entries_user_id ON journal_entries(user_id);
-CREATE INDEX idx_journal_entries_status ON journal_entries(status);
-CREATE INDEX idx_journal_entries_date ON journal_entries(entry_date);
+The authoritative build proof is **Alembic against Postgres**, not
+`Base.metadata.create_all()` in unit fixtures. PR CI (`schema-migrations`) runs:
+
+```bash
+cd apps/backend
+uv run alembic upgrade head
+uv run alembic check
 ```
+
+Preview/staging must not be the first environments to discover a broken chain or
+model/migration drift.
 
 ## Source Files
 
 - **Models**: `apps/backend/src/models/`
 - **Migrations**: `apps/backend/migrations/`
 - **Schemas**: `apps/backend/src/schemas/`
+- **Generated reference**: `docs/reference/db-schema.md` (build output, git-ignored)


### PR DESCRIPTION
## What

Correct drift in five domain skills under `.opencode/skills/domain/` against the
current SSOT (`docs/ssot/`) and backend implementation. Most had not been touched
since Jan 2026 and described removed tables, wrong weights, and missing rules.

| Skill | Fix |
|-------|-----|
| **schema** | Drop removed `bank_statement*` tables; add DIM/ODS/DWD layering + append-only fact versioning (Axiom A, EPIC-011 AC11.19); point inventory at the generated DB reference; add Alembic migration contract |
| **accounting** | Add Rule A2 canonical money rounding (`to_money` / `ROUND_HALF_EVEN`), multi-currency base-currency balance, posted-entry immutability + void + source-type promotion, user-scoped account authorization, async tx boundary |
| **reporting** | Fix `consolidate_amount` to use `to_money()`; add the three balance-sheet net-worth source classes, unrealized-FX (non-plug, excludes `FX_REVALUATION`), `net_worth_adjustment_gain_loss`, restricted-liquidity toggle, annualized income schedule, notes/disclosures |
| **extraction** | Correct confidence weights to 35/25/15/10/10/5; split institutions into Tier-1 CSV parsers vs AI prompt-hint detection (add Moomoo/Futu/IBKR) |
| **reconciliation** | Already accurate; add append-only versioning cross-reference (`reconciliation_matches` is the canonical example) |

## Why

These skills are agent-facing guidance. Stale entries actively mislead — e.g. the
accounting skill omitted canonical money rounding and immutability (red-line
adjacent), and the schema skill documented tables removed in EPIC-011 Stage 3.

## Scope

Docs only — no code or runtime behavior change. Each rule is sourced from its
authoritative `docs/ssot/` file and linked accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)