### PR TITLE
[finance_report_audit] EPIC-005 AC5.18: per-node confidence tier on balance-sheet payloads (#913)

### DIFF
--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -24,6 +24,9 @@ class ReportLine(BaseModel):
     type: AccountType
     parent_id: UUID | None = None
     amount: Decimal
+    # Worst-input confidence tier of the line's contributing facts (Axiom B).
+    # None when the line has no rated contributing fact.
+    confidence_tier: str | None = None
 
 
 class AccountLineageLine(BaseModel):
@@ -65,6 +68,9 @@ class BalanceSheetResponse(BaseModel):
     assets: list[ReportLine]
     liabilities: list[ReportLine]
     equity: list[ReportLine]
+    # Net Worth aggregate confidence: the worst-input tier across rated lines
+    # (defined rollup, not an invented number). None when nothing is rated.
+    confidence_tier: str | None = None
     total_assets: Decimal
     total_liabilities: Decimal
     total_equity: Decimal

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
@@ -27,6 +27,7 @@ from src.models import (
 from src.models.layer3 import ManagedPosition, ManualValuationLiquidityClass, PositionStatus
 from src.services import fx
 from src.services.assets import AssetService
+from src.services.confidence_tier import derive_confidence_tier
 from src.services.fx import (
     FxRateError,
     FxWarning,
@@ -139,9 +140,27 @@ def _iter_periods(start: date, end: date, period: str) -> list[PeriodSpan]:
     return spans
 
 
+# Confidence tiers ranked by trust (vision Axiom B). The worst-input rule rolls a
+# line/aggregate down to its least-trusted contributor — a defined rollup, never
+# an invented number.
+_CONFIDENCE_TIER_RANK: dict[str, int] = {"LOW": 0, "MEDIUM": 1, "HIGH": 2, "TRUSTED": 3}
+
+
+def _worst_confidence_tier(tiers: Iterable[str | None]) -> str | None:
+    """Return the least-trusted tier among the inputs, or None if none are rated."""
+    present = [tier for tier in tiers if tier]
+    if not present:
+        return None
+    return min(present, key=lambda tier: _CONFIDENCE_TIER_RANK.get(tier, 0))
+
+
 def _build_account_lines(
-    accounts: Sequence[Account], balances: dict[UUID, Decimal], filter_type: AccountType
+    accounts: Sequence[Account],
+    balances: dict[UUID, Decimal],
+    filter_type: AccountType,
+    tiers: dict[UUID, str] | None = None,
 ) -> list[dict[str, Any]]:
+    tiers = tiers or {}
     items = [account for account in accounts if account.type == filter_type]
     items.sort(key=lambda acc: acc.name.lower())
     return [
@@ -151,9 +170,41 @@ def _build_account_lines(
             "type": account.type,
             "parent_id": account.parent_id,
             "amount": _quantize_money(balances.get(account.id, Decimal("0"))),
+            "confidence_tier": tiers.get(account.id),
         }
         for account in items
     ]
+
+
+async def _aggregate_account_confidence_tiers(
+    db: AsyncSession,
+    user_id: UUID,
+    account_types: tuple[AccountType, ...],
+    as_of_date: date,
+    *,
+    start_date: date | None = None,
+) -> dict[UUID, str]:
+    """Per-account worst-input confidence tier, derived from contributing entries' source_type."""
+    stmt = (
+        select(Account.id, JournalEntry.source_type)
+        .distinct()
+        .select_from(JournalLine)
+        .join(Account, JournalLine.account_id == Account.id)
+        .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
+        .where(Account.user_id == user_id)
+        .where(Account.type.in_(account_types))
+        .where(JournalEntry.status.in_(_REPORT_STATUSES))
+        .where(JournalEntry.entry_date <= as_of_date)
+    )
+    if start_date:
+        stmt = stmt.where(JournalEntry.entry_date >= start_date)
+
+    result = await db.execute(stmt)
+    tiers: dict[UUID, str] = {}
+    for account_id, source_type in result.all():
+        tier = derive_confidence_tier(source_type)
+        tiers[account_id] = _worst_confidence_tier([tiers.get(account_id), tier]) or tier
+    return tiers
 
 
 def _line_total(lines: Sequence[dict[str, Any]]) -> Decimal:
@@ -623,6 +674,9 @@ async def _build_manual_valuation_lines(
             "type": AccountType.LIABILITY if is_liability else AccountType.ASSET,
             "parent_id": None,
             "amount": _quantize_money(amount),
+            # Manual valuations are user-supplied, explicitly trusted data (vision:
+            # "manual data is explicitly trusted"), mirroring source_type=manual.
+            "confidence_tier": "TRUSTED",
         }
         if is_liability:
             liability_lines.append(line)
@@ -671,9 +725,10 @@ async def generate_balance_sheet(
         if account.id not in balances:
             balances[account.id] = Decimal("0")
 
-    assets = _build_account_lines(accounts, balances, AccountType.ASSET)
-    liabilities = _build_account_lines(accounts, balances, AccountType.LIABILITY)
-    equity = _build_account_lines(accounts, balances, AccountType.EQUITY)
+    tiers = await _aggregate_account_confidence_tiers(db, user_id, account_types, as_of_date)
+    assets = _build_account_lines(accounts, balances, AccountType.ASSET, tiers)
+    liabilities = _build_account_lines(accounts, balances, AccountType.LIABILITY, tiers)
+    equity = _build_account_lines(accounts, balances, AccountType.EQUITY, tiers)
     portfolio_adjustments = await _build_portfolio_market_adjustment_lines(
         db,
         user_id,
@@ -744,12 +799,18 @@ async def generate_balance_sheet(
     total_liab_equity_inc = total_liabilities + total_equity + net_income + unrealized_fx + net_worth_adjustment
     equation_delta = _quantize_money(total_assets - total_liab_equity_inc)
 
+    # Net Worth / balance-sheet aggregate tier: the worst-input tier across every
+    # rated line. Lines with no derivable tier (e.g. market-derived adjustments)
+    # are excluded rather than counted as trusted.
+    aggregate_tier = _worst_confidence_tier(line.get("confidence_tier") for line in (*assets, *liabilities, *equity))
+
     return {
         "as_of_date": as_of_date,
         "currency": target_currency,
         "assets": assets,
         "liabilities": liabilities,
         "equity": equity,
+        "confidence_tier": aggregate_tier,
         "total_assets": total_assets,
         "total_liabilities": total_liabilities,
         "total_equity": total_equity,

--- a/apps/backend/tests/reporting/test_balance_sheet_confidence.py
+++ b/apps/backend/tests/reporting/test_balance_sheet_confidence.py
@@ -1,0 +1,123 @@
+"""Per-node confidence tier on balance-sheet payloads (EPIC-005 AC5.18, issue #913).
+
+Axiom B: confidence is a first-class, measured property. Each balance-sheet line
+carries the confidence tier of its contributing ledger facts, and an aggregate
+(Net Worth) rolls up to the *worst-input* tier — a defined rollup, not an
+invented number.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from src.models import (
+    Account,
+    AccountType,
+    Direction,
+    JournalEntry,
+    JournalEntrySourceType,
+    JournalEntryStatus,
+    JournalLine,
+)
+from src.services.reporting import generate_balance_sheet
+
+
+async def _post(db, user_id, *, debit: Account, credit: Account, amount: Decimal, source_type) -> None:
+    entry = JournalEntry(
+        user_id=user_id,
+        entry_date=date(2026, 1, 15),
+        memo="bs confidence",
+        source_type=source_type,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id, account_id=debit.id, direction=Direction.DEBIT, amount=amount, currency="SGD"
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=credit.id,
+                direction=Direction.CREDIT,
+                amount=amount,
+                currency="SGD",
+            ),
+        ]
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_AC5_18_1_lines_carry_worst_input_confidence_tier(db, test_user):
+    """AC5.18.1: A line's tier is the worst confidence tier among its contributing entries."""
+    cash = Account(user_id=test_user.id, name="Cash A", type=AccountType.ASSET, currency="SGD")
+    savings = Account(user_id=test_user.id, name="Savings B", type=AccountType.ASSET, currency="SGD")
+    salary = Account(user_id=test_user.id, name="Salary", type=AccountType.INCOME, currency="SGD")
+    db.add_all([cash, savings, salary])
+    await db.flush()
+
+    # Cash A built from a manual (TRUSTED) and an auto_parsed (LOW) entry -> worst is LOW.
+    await _post(
+        db, test_user.id, debit=cash, credit=salary, amount=Decimal("100.00"), source_type=JournalEntrySourceType.MANUAL
+    )
+    await _post(
+        db,
+        test_user.id,
+        debit=cash,
+        credit=salary,
+        amount=Decimal("50.00"),
+        source_type=JournalEntrySourceType.AUTO_PARSED,
+    )
+    # Savings B built only from a user_confirmed (HIGH) entry.
+    await _post(
+        db,
+        test_user.id,
+        debit=savings,
+        credit=salary,
+        amount=Decimal("200.00"),
+        source_type=JournalEntrySourceType.USER_CONFIRMED,
+    )
+
+    report = await generate_balance_sheet(db, test_user.id, as_of_date=date(2026, 12, 31))
+
+    lines = {line["name"]: line for line in report["assets"]}
+    assert lines["Cash A"]["confidence_tier"] == "LOW"
+    assert lines["Savings B"]["confidence_tier"] == "HIGH"
+
+
+@pytest.mark.asyncio
+async def test_AC5_18_2_net_worth_rolls_up_to_worst_input_tier(db, test_user):
+    """AC5.18.2: The balance-sheet aggregate tier is the worst tier across its lines; None when there is nothing to rate."""
+    empty = await generate_balance_sheet(db, test_user.id, as_of_date=date(2026, 12, 31))
+    assert empty["confidence_tier"] is None
+    assert empty["assets"] == []
+
+    cash = Account(user_id=test_user.id, name="Cash", type=AccountType.ASSET, currency="SGD")
+    invest = Account(user_id=test_user.id, name="Brokerage", type=AccountType.ASSET, currency="SGD")
+    salary = Account(user_id=test_user.id, name="Salary", type=AccountType.INCOME, currency="SGD")
+    db.add_all([cash, invest, salary])
+    await db.flush()
+
+    # One HIGH line and one LOW line -> aggregate is the worst (LOW).
+    await _post(
+        db,
+        test_user.id,
+        debit=cash,
+        credit=salary,
+        amount=Decimal("100.00"),
+        source_type=JournalEntrySourceType.USER_CONFIRMED,
+    )
+    await _post(
+        db,
+        test_user.id,
+        debit=invest,
+        credit=salary,
+        amount=Decimal("100.00"),
+        source_type=JournalEntrySourceType.AUTO_PARSED,
+    )
+
+    report = await generate_balance_sheet(db, test_user.id, as_of_date=date(2026, 12, 31))
+    assert report["confidence_tier"] == "LOW"

--- a/apps/backend/tests/reporting/test_reporting.py
+++ b/apps/backend/tests/reporting/test_reporting.py
@@ -336,6 +336,7 @@ async def test_reporting_dashboard_fixture_exact_totals(db: AsyncSession, chart_
             "type": AccountType.ASSET,
             "parent_id": None,
             "amount": Decimal("1600.00"),
+            "confidence_tier": "TRUSTED",
         }
     ]
     assert balance_sheet["liabilities"] == [
@@ -345,8 +346,11 @@ async def test_reporting_dashboard_fixture_exact_totals(db: AsyncSession, chart_
             "type": AccountType.LIABILITY,
             "parent_id": None,
             "amount": Decimal("300.00"),
+            "confidence_tier": "TRUSTED",
         }
     ]
+    # AC5.18.2: Net Worth aggregate rolls up to the worst-input tier across lines.
+    assert balance_sheet["confidence_tier"] == "TRUSTED"
 
     assert income_statement["total_income"] == Decimal("500.00")
     assert income_statement["total_expenses"] == Decimal("200.00")

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -287,6 +287,20 @@ action.
 | AC5.17.1 | Balance sheet, income statement, and cash-flow pages download CSV through the authenticated API wrapper, and the backend CSV export supports cash-flow reports with date range and currency filters | `AC5.17.1 downloads cash-flow CSV through authenticated apiDownload`, `test_AC5_17_1_cash_flow_export_returns_csv` | `frontend/src/__tests__/cashFlowPage.test.tsx`, `reporting/test_reports_router.py` | P0 |
 | AC5.17.2 | Personal report package page exposes an authenticated CSV export action after framework selection, using the package export contract and selected framework ID | `AC5.17.2 downloads package CSV through authenticated apiDownload` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
 
+### AC5.18: Per-Node Confidence Tier on Balance-Sheet Payloads
+
+Axiom B makes confidence a first-class, measured property. Each balance-sheet
+line carries the confidence tier of its contributing ledger facts, and the Net
+Worth aggregate rolls up to the worst-input tier (see
+[confirmation-workflow.md](../ssot/confirmation-workflow.md) → Confidence Tier
+Rollup) — a defined rollup, not an invented number. Income statement, cash flow,
+and the monthly cards are a follow-up; provenance (#888) is the co-equal sibling axis.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.18.1 | Each balance-sheet line carries the worst-input confidence tier of its contributing journal entries | `test_AC5_18_1_lines_carry_worst_input_confidence_tier()` | `reporting/test_balance_sheet_confidence.py` | P1 |
+| AC5.18.2 | The Net Worth aggregate rolls up to the worst-input tier across rated lines, and is null when nothing is rated | `test_AC5_18_2_net_worth_rolls_up_to_worst_input_tier()` | `reporting/test_balance_sheet_confidence.py` | P1 |
+
 ## 📏 Acceptance Criteria
 
 ### 🟢 Must Have

--- a/docs/ssot/confirmation-workflow.md
+++ b/docs/ssot/confirmation-workflow.md
@@ -120,6 +120,26 @@ check and the closing transaction-sum check; extraction confidence and Stage 2
 matching may use wider scoring tolerances, but they cannot approve a Stage 1
 statement with either balance-chain check outside the 0.001 USD tolerance.
 
+### Confidence Tier Rollup (resolves OD4)
+
+Confidence tiers rank by trust: `TRUSTED > HIGH > MEDIUM > LOW`. A line or
+aggregate takes the **worst-input tier** — it is only as trustworthy as its
+least-trusted contributing fact. This is a defined rollup (a `min`), never an
+invented blended score.
+
+- A report line's tier is the worst tier among the journal entries contributing
+  to it (tier derived from `source_type` via `confidence_tier`).
+- An aggregate (e.g. Net Worth) takes the worst tier across its rated lines.
+  Lines with no derivable tier (e.g. market-derived adjustments) are excluded
+  from the rollup rather than counted as trusted; the aggregate is `null` when
+  nothing is rated.
+- Manual valuations are user-supplied, explicitly trusted data and surface as
+  `TRUSTED`.
+
+Owned first by the balance sheet (EPIC-005 AC5.18, issue #913). A `% trusted`
+proportion is a separate, additive signal (the North-Star metric, EPIC-018
+AC18.12), not the per-node badge.
+
 ---
 
 ## 6. API Contract


### PR DESCRIPTION
## Summary

Surface **measured confidence on report numbers** (Axiom B). `BalanceSheetResponse`
and its lines carried no trust signal — the headline Net Worth and balance-sheet
lines showed numbers with no indication of how certain they are. Now each line and
the Net Worth aggregate carry a confidence tier.

Closes #913. Part of the #917 audit-gap epic (Axis B); co-equal sibling of #888 (provenance).

## What changed (EPIC-005 AC5.18)

- **`ReportLine.confidence_tier`** + **`BalanceSheetResponse.confidence_tier`** (the Net Worth tier).
- Per-account tier derived from contributing **journal entries' `source_type`** via the existing `confidence_tier` service.
- **Worst-input rollup** — a line/aggregate is only as trusted as its least-trusted contributing fact (`TRUSTED > HIGH > MEDIUM > LOW`, a defined `min`, **not** an invented blended score).
- **Manual valuations** surface as `TRUSTED` (user-supplied trusted data). Lines with no derivable tier (market-derived adjustments) are **excluded** from the rollup rather than counted as trusted; the aggregate is `null` when nothing is rated.

## OD4 resolved

The open "aggregate rollup rule" question (worst-input tier vs `% trusted`) is decided in `docs/ssot/confirmation-workflow.md` → **Confidence Tier Rollup**: **worst-input tier** for the per-node badge. The `% trusted` proportion is a separate, additive signal (the North-Star metric, AC18.12), not the badge.

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-005 — Reporting & Visualization |
| **AC IDs** | AC5.18.1, AC5.18.2 |
| **AC source updated** | `docs/project/EPIC-005.reporting-visualization.md` |

## SSOT

- [x] `docs/ssot/confirmation-workflow.md` — Confidence Tier Rollup contract (resolves OD4).

## TDD Evidence

🔴 Red: both tests failed `KeyError: 'confidence_tier'`. 🟢 Green after: 2/2; updated `test_reporting_dashboard_fixture_exact_totals` for the new line field.

| Test | AC |
|------|----|
| `test_AC5_18_1_lines_carry_worst_input_confidence_tier` | AC5.18.1 |
| `test_AC5_18_2_net_worth_rolls_up_to_worst_input_tier` | AC5.18.2 |

## Scope boundary (follow-ups)

- Income statement / cash flow / monthly-card tiers (same pattern).
- **FE**: render the tier with `ConfidenceBadge` on headline numbers.
- **#888** provenance (Imported/Manual/Derived) — the co-equal axis; shares the FE badge pattern.

## Testing

```bash
python3 tools/test_lifecycle.py --fast tests/reporting/test_balance_sheet_confidence.py   # 2 passed
python3 tools/test_lifecycle.py --fast tests/reporting tests/api/test_personal_report_package_contract.py   # 257 passed

uv run --with pyyaml python tools/generate_ac_registry.py --check   # OK (AC5.18.* registered)
tools/lint_doc_consistency.py / check_manifest.py / check_ssot_ownership.py   # OK
generate_api_reference.py --check                                  # OK
ruff check / format --check                                        # clean
```

## Engineering Audit

- [x] No `float` for money; amounts stay `Decimal`. Tier is a derived string label.
- [x] No `sa.Enum` added; no schema/migration/`NEXT_PUBLIC_`/secret changes (pydantic + service only).
- [x] `repo/` submodule untouched. Additive optional fields (`confidence_tier: str | None = None`) — backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
