### PR TITLE
[finance_report_vision] docs(skills): fix command/equation drift in development, auditor, infra-operations

### DIFF
--- a/.opencode/skills/domain/development/SKILL.md
+++ b/.opencode/skills/domain/development/SKILL.md
@@ -9,22 +9,28 @@ description: Development environment, testing, CI/CD, and deployment procedures.
 
 ## Moon Commands (Primary Interface)
 
+All commands go through root tasks (`:dev`, `:test`, `:lint`, `:build`); the
+`apps/*` projects declare no tasks of their own. Sub-targets are passed via `--`.
+
 ```bash
 # Development
-moon run :dev -- --backend        # FastAPI on :8000
-moon run frontend:dev       # Next.js on :3000
+moon run :dev -- --infra          # Start local infra
+moon run :dev -- --backend        # FastAPI on :8000 (after infra)
+moon run :dev -- --frontend       # Next.js on :3000
 
-# Testing
-moon run :test              # All tests
-moon run :test       # Backend tests (auto-manages DB)
-moon run :smoke             # Smoke tests
+# Testing (all via :test; auto-manages DB)
+moon run :test                    # All tests
+moon run :test -- --fast          # Fast TDD loop (no coverage)
+moon run :test -- --smart         # Coverage on changed files only
+moon run :test -- tests/accounting/   # Specific module/file
+bash tools/smoke_test.sh          # Unified smoke tests (no moon task)
 
 # Code Quality
-moon run :lint              # Lint all
-moon run :lint -- --fix     # Format Python
+moon run :lint                    # Lint all
+moon run :lint -- --fix           # Format/auto-fix
 
 # Build
-moon run :build             # Build all
+moon run :build                   # Build all
 ```
 
 ## Database Lifecycle

--- a/.opencode/skills/domain/development/SKILL.md
+++ b/.opencode/skills/domain/development/SKILL.md
@@ -9,8 +9,9 @@ description: Development environment, testing, CI/CD, and deployment procedures.
 
 ## Moon Commands (Primary Interface)
 
-All commands go through root tasks (`:dev`, `:test`, `:lint`, `:build`); the
-`apps/*` projects declare no tasks of their own. Sub-targets are passed via `--`.
+Day-to-day work goes through root tasks (`:dev`, `:test`, `:lint`, `:build`); the
+`apps/*` projects declare no tasks of their own, and sub-targets are passed via
+`--`. A few helpers run as plain scripts (e.g. smoke tests), noted inline below.
 
 ```bash
 # Development

--- a/.opencode/skills/domain/infra-operations/SKILL.md
+++ b/.opencode/skills/domain/infra-operations/SKILL.md
@@ -358,4 +358,4 @@ curl https://report.zitian.party/health
 - [AGENTS.md](../../../AGENTS.md) — Behavioral guidelines
 - [development.md](../../../docs/ssot/development.md) — Dev workflows
 - [observability.md](../../../docs/ssot/observability.md) — Logging
-- [secrets-management](../secrets-management/skill.md) — Env vars
+- [secrets-management](../secrets-management/SKILL.md) — Env vars

--- a/.opencode/skills/domain/infra-operations/SKILL.md
+++ b/.opencode/skills/domain/infra-operations/SKILL.md
@@ -46,17 +46,23 @@ python tools/debug.py logs backend --env production --method signoz
 
 ### Container Naming
 
-⚠️ **Production uses underscore**: `finance_report-*` (not hyphen)
+⚠️ **Staging & Production use underscore**: `finance_report-{service}${ENV_SUFFIX}`
+(from the infra2 IaC compose, not the local `docker-compose.yml`). DB service is
+`postgres`, not `db`. SSOT: [environments.md](../../../docs/ssot/environments.md).
 
 | Environment | Backend | PostgreSQL | Redis |
 |-------------|---------|------------|-------|
 | **Production** | `finance_report-backend` | `finance_report-postgres` | `finance_report-redis` |
-| Staging | `finance-report-backend-staging` | `finance-report-db-staging` | `finance-report-redis-staging` |
-| PR | `finance-report-backend-pr-47` | `finance-report-db-pr-47` | `finance-report-redis-pr-47` |
+| Staging | `finance_report-backend-staging` | `finance_report-postgres-staging` | `finance_report-redis-staging` |
+| PR Preview | service DNS (no fixed name) | service DNS | service DNS |
 
-**Critical**: Container name = hostname in Dokploy network.
+**Critical**: For staging/prod, container name = hostname in the Dokploy network;
+the backend's `DATABASE_URL`/`REDIS_URL` (from `10.app/secrets.ctmpl`) resolve to
+these exact names. PR Preview raw compose drops fixed `container_name` and uses
+compose service DNS.
 
-**Note**: `tools/debug.py` currently only supports hyphenated patterns (staging/PR).
+**Note**: `tools/debug.py` (`CONTAINER_PATTERNS`) maps these underscore names for
+staging/production and the hyphenated `finance-report-*` names for local/CI.
 For production, use direct SSH: `ssh root@$VPS_HOST "docker logs finance_report-backend"`
 
 ---

--- a/.opencode/skills/professional/auditor/SKILL.md
+++ b/.opencode/skills/professional/auditor/SKILL.md
@@ -64,9 +64,15 @@ You are an Auditor, responsible for the integrity of the financial system. Your 
 ### 3. Financial Statement Logic
 
 #### Balance Sheet (Point in Time)
-- **Equation**: `Total Assets = Total Liabilities + Total Equity + Net Income
-  + Unrealized FX Gain/Loss + Net Worth Adjustment Gain/Loss`. The last three are
-  explicit components, not plugs — `unrealized_fx_gain_loss` is computed from
+- **Equation**:
+
+  ```
+  Total Assets = Total Liabilities + Total Equity + Net Income
+               + Unrealized FX Gain/Loss + Net Worth Adjustment Gain/Loss
+  ```
+
+  The last three are explicit components, not plugs — `unrealized_fx_gain_loss`
+  is computed from
   foreign-currency accounts (excluding `FX_REVALUATION` entries), and
   `net_worth_adjustment_gain_loss` from non-ledger value (portfolio adjustments +
   manual valuation snapshots).
@@ -94,7 +100,7 @@ You are an Auditor, responsible for the integrity of the financial system. Your 
 - **Pattern Shift**: New counterparty or category usage significantly different from historical profile.
 
 ### Verification Checklist
-- [ ] **Equation Check**: Does `Assets = Liabilities + Equity` hold at the reporting date?
+- [ ] **Equation Check**: Does `Total Assets = Total Liabilities + Total Equity + Net Income + Unrealized FX Gain/Loss + Net Worth Adjustment Gain/Loss` hold at the reporting date?
 - [ ] **Ledger vs Statement**: Do account balances match bank statement ending balances?
 - [ ] **Unreconciled Items**: Are all large unmatched transactions explained?
 - [ ] **FX Gains/Losses**: Are realized and unrealized FX gains correctly calculated?

--- a/.opencode/skills/professional/auditor/SKILL.md
+++ b/.opencode/skills/professional/auditor/SKILL.md
@@ -64,7 +64,15 @@ You are an Auditor, responsible for the integrity of the financial system. Your 
 ### 3. Financial Statement Logic
 
 #### Balance Sheet (Point in Time)
-- **Equation**: `Total Assets == Total Liabilities + Total Equity`.
+- **Equation**: `Total Assets = Total Liabilities + Total Equity + Net Income
+  + Unrealized FX Gain/Loss + Net Worth Adjustment Gain/Loss`. The last three are
+  explicit components, not plugs — `unrealized_fx_gain_loss` is computed from
+  foreign-currency accounts (excluding `FX_REVALUATION` entries), and
+  `net_worth_adjustment_gain_loss` from non-ledger value (portfolio adjustments +
+  manual valuation snapshots).
+- **Net-worth sources**: journal lines, active portfolio positions (market-value
+  delta), and manual valuation snapshots. Restricted holdings are excluded by
+  default (`include_restricted=false`).
 - **FX Rate**: Use **period-end rate** for consolidation.
 
 #### Income Statement (Period Performance)
@@ -112,7 +120,9 @@ You are an Auditor, responsible for the integrity of the financial system. Your 
 ---
 
 ## Workflow: Statement Reconciliation
-1. **Import**: Parse statement into `BankStatementTransaction`.
+1. **Import**: Extract the statement into `AtomicTransaction` (DWD). The legacy
+   `bank_statement*` ODS tables were removed (EPIC-011 Stage 3); reconciliation
+   reads Layer 2 and links matches via `ReconciliationMatch.atomic_txn_id`.
 2. **Match**: Generate candidate entries and calculate multi-dimensional scores.
 3. **Execute**: 
    - Auto-post matches ≥ 85.

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -125,10 +125,22 @@ PR validation is split into two independent things (issue #839):
 | **Local CI** | *(uses Local Dev containers)* | *(uses Local Dev containers)* | `finance_report_test_{namespace}` | `statements-{namespace}` |
 | **GitHub CI** | *(GitHub Services)* | *(N/A)* | `finance_report_test` | `statements` (mock) |
 | **PR Preview** | Runner compose backend service | Runner compose frontend service | `postgres` service DNS | `minio` service DNS |
-| **Staging** | `finance-report-backend-staging` | `finance-report-frontend-staging` | `finance-report-db-staging` | `finance-report-staging` |
-| **Production** | `finance-report-backend` | `finance-report-frontend` | `finance-report-db` | `finance-report-production` |
+| **Staging** | `finance_report-backend-staging` | `finance_report-frontend-staging` | `finance_report-postgres-staging` | `finance-report-staging` |
+| **Production** | `finance_report-backend` | `finance_report-frontend` | `finance_report-postgres` | `finance-report-production` |
 
-**Note**: Container names follow the pattern `finance-report-{service}${ENV_SUFFIX}` from `docker-compose.yml` for fixed-name environments. PR Preview raw compose removes fixed container names and uses compose service DNS on a project-scoped internal network, because Dokploy compose project names can change across retries while the PR route remains stable. `ENV_SUFFIX` is `-pr-{N}` for PR Preview and `-staging` for Staging; empty for Production.
+**Note**: Two distinct conventions — do not conflate them.
+- **Local Dev / CI** use the local `docker-compose.yml` pattern
+  `finance-report-{service}${ENV_SUFFIX:-}` (**hyphen**, DB service `db`).
+- **Staging / Production** are deployed by the infra2 IaC compose files
+  (`repo/finance_report/finance_report/{01.postgres,02.redis,10.app}/compose.yaml`),
+  whose `container_name` is `finance_report-{service}${ENV_SUFFIX}` (**underscore**,
+  DB service `postgres`). The backend connects to these underscore hostnames — see
+  `10.app/secrets.ctmpl` (`DATABASE_URL` → `finance_report-postgres${suffix}`,
+  `REDIS_URL` → `finance_report-redis${suffix}`). `ENV_SUFFIX` is `-staging` for
+  Staging, empty for Production.
+- **PR Preview** raw compose removes fixed container names and uses compose service
+  DNS on a project-scoped internal network, because Dokploy compose project names
+  can change across retries while the PR route remains stable.
 
 ---
 


### PR DESCRIPTION
## What

Second drift pass over the remaining project-specific skills (the first pass, #934, covered schema/accounting/reporting/extraction/reconciliation), plus the SSOT correction it surfaced.

| File | Fix |
|------|-----|
| **development** skill | moon refactor moved all tasks to root targets. Replace non-existent `moon run frontend:dev` → `moon run :dev -- --frontend` and `moon run :smoke` → `bash tools/smoke_test.sh`; document `:test -- --fast/--smart/<path>` |
| **auditor** skill | Complete the balance-sheet equation (Net Income + Unrealized FX + Net Worth Adjustment) per `reporting.md`; add net-worth source classes + restricted default; replace removed `BankStatementTransaction` with `AtomicTransaction` (DWD) |
| **infra-operations** skill | Fix dead link case; correct the staging container row to underscore + clarify the debug.py note |
| **environments.md** (SSOT) | Correct Staging/Production container names to the real IaC convention (see below) |

## Container-naming investigation (resolved)

The container-naming guidance was a genuine source-of-truth conflict. Investigated and verified directly:

- **Staging & Production** are deployed by the **infra2 IaC** compose (`repo/finance_report/finance_report/{01.postgres,02.redis,10.app}/compose.yaml`), whose `container_name` is `finance_report-{service}${ENV_SUFFIX}` — **underscore**, DB service `postgres`. The backend's `DATABASE_URL`/`REDIS_URL` (`10.app/secrets.ctmpl`) resolve to those exact hostnames (`finance_report-postgres${suffix}`).
- The hyphenated `finance-report-*` / `finance-report-db` names are the **local `docker-compose.yml`** convention only (Local Dev / CI).
- `tools/_lib/dev/debug.py` was **already correct** (underscore for staging/prod) — **left unchanged**.
- `docs/ssot/environments.md` was the drift (it showed hyphen for staging/prod) — **corrected here**.

## Audited but clean

`github-operations`, `secrets-management` (no changes). Generic `professional/*` and `meta/*` skills aren't codebase-bound — out of scope.

## Scope

Docs/SSOT only — no code or runtime behavior change. Copilot review comments addressed and threads resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)