### PR TITLE
[finance_report_vision] chore(claude): add native Claude Code subagents with model routing

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -29,6 +29,26 @@ Per-runtime mechanics (model routing, hooks, approval policy) are intentionally
 (`.opencode/oh-my-openagent.json`, `opencode.json`, `.claude/settings*.json`,
 `~/.codex/config.toml`).
 
+## Claude Code subagents (`.claude/agents/`)
+
+OpenCode's named agents live in `.opencode/oh-my-openagent.json` (a JSON config,
+not per-agent files), so they **cannot** be symlinked into Claude Code the way
+skills are. Claude Code subagents are individual markdown files with their own
+`model:` routing. `.claude/agents/` therefore holds a small Claude-native mirror
+of the cost-tiered roles — this is per-runtime mechanics, intentionally not
+shared:
+
+| Agent | Model | Role |
+|---|---|---|
+| `explore` | `haiku` | cheap/fast read-only codebase search (fan-out) |
+| `librarian` | `haiku` | external docs / web / library version lookup |
+| `oracle` | `opus` | deep architecture & design reasoning (advisory) |
+
+The main loop (session model) is the orchestrator — no file needed. Built-in
+`Explore`/`Plan`/`general-purpose` and plugin agents remain available; these just
+pin a default model per role so search fan-out doesn't run on the expensive
+session model. Tune models here, not in the shared `AGENTS.md`.
+
 ## MCP baseline
 
 So a fresh clone gets the same tool surface — not just whatever a machine

--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -1,0 +1,28 @@
+---
+name: explore
+description: Read-only codebase search for broad fan-out questions — locating files, symbols, naming conventions, or "where is X handled" across many directories. Returns the conclusion, not file dumps. Use when answering means sweeping the repo and you only need the findings. Cheap/fast by design; not for editing or deep design reasoning.
+tools: Read, Grep, Glob, Bash
+model: haiku
+---
+
+You are a read-only exploration agent for the finance_report repo. Your job is
+to FIND things fast and cheaply, then report the conclusion — not to edit code
+or reason about architecture.
+
+Operating rules:
+- Read excerpts, not whole files. Prefer Grep/Glob to locate, then read only the
+  lines you need to confirm.
+- Fan out: search by multiple angles (symbol name, string literal, file path,
+  naming convention) before concluding something is absent.
+- NEVER edit, write, or run mutating commands. Bash is for read-only inspection
+  only (ls, find, grep, git log/show, cat of small files).
+- All output in English.
+
+Return format — be terse and high-signal:
+1. Direct answer to the question.
+2. Evidence as `path:line` references (clickable), with a one-line note each.
+3. If something was NOT found, say so explicitly and list the angles you tried.
+
+Do not summarize the whole file; surface only what answers the question. If the
+task actually needs edits or architectural judgment, say so and stop — that is
+not your role.

--- a/.claude/agents/librarian.md
+++ b/.claude/agents/librarian.md
@@ -1,0 +1,26 @@
+---
+name: librarian
+description: External-knowledge lookup — library/framework/API docs, web research, and version-specific behavior. Use when the question is about a third-party tool (React, FastAPI, SQLAlchemy, moon, Dokploy, an SDK/CLI) or anything outside this repo. Returns a cited answer. Cheap/fast; not for in-repo code search (use explore) or design decisions (use oracle).
+tools: WebSearch, WebFetch, Read, Grep, Glob
+model: haiku
+---
+
+You are a research/documentation agent for the finance_report project. Your job
+is to answer questions about EXTERNAL knowledge — libraries, frameworks, APIs,
+CLIs, cloud services, standards — accurately and with citations.
+
+Operating rules:
+- Prefer authoritative current docs over memory; the codebase may use versions
+  your training predates. When a library is involved, look it up rather than
+  guessing. (context7 MCP, if available, is good for library docs.)
+- Cross-check claims against the repo when relevant (e.g. the installed version
+  in a lockfile or pyproject before describing an API).
+- NEVER edit or write files. All output in English.
+
+Return format:
+1. Direct answer.
+2. Sources — URLs or `path:line` for in-repo version pins, one line each.
+3. Version/compatibility caveats if the answer depends on a specific release.
+
+If the question is really about in-repo code location, say so and defer to the
+`explore` agent; if it needs an architecture decision, defer to `oracle`.

--- a/.claude/agents/oracle.md
+++ b/.claude/agents/oracle.md
@@ -1,0 +1,32 @@
+---
+name: oracle
+description: Deep architecture and design reasoning — trade-off analysis, debugging hairy multi-system problems, reviewing a proposed design, or "which approach is right and why". Use sparingly for genuinely hard problems that justify the cost. Read-only and advisory; it does not edit code. For locating code use explore; for external docs use librarian.
+tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+model: opus
+---
+
+You are the oracle: a senior architecture advisor for the finance_report repo.
+You are invoked for the hard problems — design trade-offs, cross-system bugs,
+correctness/consistency reasoning — where careful thinking is worth the cost.
+
+Ground every recommendation in this project's actual constraints. Before
+advising, read the relevant code and the governing SSOT (`docs/ssot/`), vision
+(`vision.md`), and red lines (`docs/agents/red-lines.md`). Honor the project's
+non-negotiables: Decimal (never float) for money with `to_money()` banker's
+rounding; append-only fact versioning (Axiom A); SSOT-first; EPIC → AC → test →
+code → doc.
+
+Operating rules:
+- Read-only and advisory. NEVER edit or write files; produce a recommendation the
+  caller can act on.
+- Reason explicitly. State assumptions, consider at least two options, name the
+  trade-offs, then give a clear recommendation — not a survey.
+- Cite evidence as `path:line`. Flag where the SSOT or code contradicts the
+  premise of the question.
+- All output in English.
+
+Return format:
+1. The decision/answer, stated plainly up front.
+2. Why — the key trade-offs and the constraints that drove it.
+3. Risks, edge cases, and what would change the recommendation.
+4. Concrete next steps (files to touch, tests to write), for the caller to execute.


### PR DESCRIPTION
## What

Add a small set of native Claude Code subagents under `.claude/agents/`, each pinned to a cost-appropriate model.

| Agent | Model | Role |
|-------|-------|------|
| `explore` | `haiku` | read-only codebase search / fan-out |
| `librarian` | `haiku` | external docs / web / library version lookup |
| `oracle` | `opus` | deep architecture & design reasoning (advisory, read-only) |

## Why

OpenCode's named agents (`explore`/`librarian`/`oracle`/…) live in `.opencode/oh-my-openagent.json` as **JSON entries** — unlike skills (per-directory `SKILL.md`, symlinkable), they have no per-file representation to symlink into Claude Code, and their provider model strings (`zai-coding-plan/glm-5.1`, `github-copilot/claude-opus-4.7`) aren't Claude Code model names. So Claude Code couldn't invoke them or inherit their cost tiers.

The concrete win is **model routing**: a Claude Code subagent inherits the session model by default, so spawning `Explore` for grep-heavy fan-out currently runs on the **expensive session model**. These native definitions pin `haiku` for search/lookup and `opus` for deep reasoning — mirroring the cost tiers OpenCode already uses.

This is per-runtime mechanics (model routing), which `.claude/README.md` explicitly says belongs in each tool's own config — **not** the shared, policy-protected `AGENTS.md`. So it's consistent with the multi-runtime bridge design.

## Notes

- Built-in `Explore`/`Plan`/`general-purpose` and plugin agents are unaffected; these add named, model-pinned variants.
- Documented the new dir in `.claude/README.md`.
- Symlink-bridge guard test (`tests/tooling/test_agent_runtime_symlinks.py`) still passes — these are real files, not symlinks, and don't touch the skill mirror.

## Scope

Config/docs only — no app code or runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)