### PR TITLE
[finance_report_audit] EPIC-018 AC18.13: deterministic confidence promotion gate (#930)

### DIFF
--- a/apps/backend/src/services/promotion_gate.py
+++ b/apps/backend/src/services/promotion_gate.py
@@ -1,0 +1,109 @@
+"""Promotion gate: the deterministic trust boundary (#930, Axiom B made load-bearing).
+
+A versioned fact (#918) carrying a provenance (#888) and a measured confidence
+(#913) becomes **authoritative only if** its deterministic invariant(s) pass
+**and** its confidence meets the named threshold; otherwise it stays a
+non-authoritative candidate and is escalated for review:
+
+    authoritative  ⇔  invariants_pass  ∧  confidence ≥ τ
+
+AI / Derived versions may only *propose*; this gate (strong code) *disposes*. The
+named thresholds below are the single owner of what were magic numbers scattered
+across services (statement balance tolerance, reconciliation auto-accept/review).
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
+
+# --- Named, centrally-owned thresholds (consolidates the scattered magic numbers) ---
+STATEMENT_BALANCE_TOLERANCE = Decimal("0.001")
+RECONCILIATION_AUTO_ACCEPT_SCORE = 85
+RECONCILIATION_REVIEW_SCORE = 60
+
+# Confidence tier ranks, lowest -> highest trust (the #913 axis), so a tier can be
+# compared against a minimum-tier threshold with the same contract as a score.
+_TIER_RANK: dict[str, int] = {"LOW": 0, "MEDIUM": 1, "HIGH": 2, "TRUSTED": 3}
+
+
+def tier_rank(tier: str | None) -> int:
+    """Numeric rank of a confidence tier (unknown/None -> lowest)."""
+    return _TIER_RANK.get((tier or "").upper(), 0)
+
+
+class PromotionDecision(str, Enum):
+    """What the gate decided a version may become."""
+
+    AUTHORITATIVE = "authoritative"  # invariants pass AND confidence >= threshold
+    REVIEW = "review"  # invariants pass but confidence below threshold -> escalate
+    REJECTED = "rejected"  # a deterministic invariant failed -> cannot become truth
+
+
+@dataclass(frozen=True)
+class InvariantResult:
+    """One deterministic invariant the gate consumes (e.g. the balance-chain check)."""
+
+    name: str
+    passed: bool
+    delta: Decimal | None = None  # computed magnitude, when the check is a tolerance comparison
+    tolerance: Decimal | None = None  # the tolerance it was checked against
+
+
+@dataclass(frozen=True)
+class PromotionVerdict:
+    """The gate's decision plus a queryable escalation reason (not a bare status)."""
+
+    decision: PromotionDecision
+    invariants_pass: bool
+    confidence_ok: bool
+    reason: str
+    failed_invariant: str | None = None
+    detail: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def is_authoritative(self) -> bool:
+        return self.decision is PromotionDecision.AUTHORITATIVE
+
+
+def evaluate_promotion(
+    invariants: Sequence[InvariantResult],
+    *,
+    confidence_rank: int,
+    min_confidence: int,
+    confidence_label: str = "confidence",
+) -> PromotionVerdict:
+    """Decide whether a version may become authoritative.
+
+    Invariants are checked first: a single deterministic failure rejects the
+    version regardless of confidence (strong code is never overridden by a high
+    score). Only when every invariant passes does confidence gate promotion.
+    """
+    failed = next((invariant for invariant in invariants if not invariant.passed), None)
+    if failed is not None:
+        detail: dict[str, str] = {}
+        if failed.delta is not None and failed.tolerance is not None:
+            detail = {"delta": str(failed.delta), "tolerance": str(failed.tolerance)}
+        return PromotionVerdict(
+            decision=PromotionDecision.REJECTED,
+            invariants_pass=False,
+            confidence_ok=confidence_rank >= min_confidence,
+            reason=f"invariant '{failed.name}' failed",
+            failed_invariant=failed.name,
+            detail=detail,
+        )
+
+    if confidence_rank < min_confidence:
+        return PromotionVerdict(
+            decision=PromotionDecision.REVIEW,
+            invariants_pass=True,
+            confidence_ok=False,
+            reason=f"{confidence_label} {confidence_rank} below promotion threshold {min_confidence}",
+        )
+
+    return PromotionVerdict(
+        decision=PromotionDecision.AUTHORITATIVE,
+        invariants_pass=True,
+        confidence_ok=True,
+        reason="invariants pass and confidence meets threshold",
+    )

--- a/apps/backend/src/services/reconciliation.py
+++ b/apps/backend/src/services/reconciliation.py
@@ -38,6 +38,7 @@ from src.services.processing_account import (
     detect_transfer_pattern,
     find_transfer_pairs,
 )
+from src.services.promotion_gate import RECONCILIATION_AUTO_ACCEPT_SCORE, RECONCILIATION_REVIEW_SCORE
 from src.services.source_type_priority import promote_entry_source_type, source_type_rank
 from src.services.statement_summary import resolve_custody_account_id
 
@@ -239,8 +240,8 @@ DEFAULT_CONFIG = ReconciliationConfig(
     weight_description=Decimal("0.20"),
     weight_business=Decimal("0.10"),
     weight_history=Decimal("0.05"),
-    auto_accept=85,
-    pending_review=60,
+    auto_accept=RECONCILIATION_AUTO_ACCEPT_SCORE,
+    pending_review=RECONCILIATION_REVIEW_SCORE,
     amount_percent=Decimal("0.005"),
     amount_absolute=Decimal("0.10"),
     date_days=7,

--- a/apps/backend/src/services/statement_validation.py
+++ b/apps/backend/src/services/statement_validation.py
@@ -16,8 +16,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
+from src.services.promotion_gate import STATEMENT_BALANCE_TOLERANCE
 
-BALANCE_TOLERANCE = Decimal("0.001")
+# Single-owned by the promotion gate (#930); kept as a local alias for readability.
+BALANCE_TOLERANCE = STATEMENT_BALANCE_TOLERANCE
 
 
 def pending_stage1_review_filter():

--- a/apps/backend/tests/services/test_promotion_gate.py
+++ b/apps/backend/tests/services/test_promotion_gate.py
@@ -1,0 +1,92 @@
+"""Promotion gate: the deterministic trust boundary (EPIC-018 AC18.13, issue #930).
+
+Vision Axiom B requires confidence to be *co-equal with traceability* — it must
+gate what becomes truth, not merely be displayed. A versioned fact becomes
+authoritative ONLY IF its deterministic invariants pass AND confidence meets the
+named threshold; otherwise it stays a candidate and is escalated. AI/Derived
+versions may propose; the gate (strong code) disposes.
+"""
+
+from decimal import Decimal
+
+from src.services.promotion_gate import (
+    RECONCILIATION_AUTO_ACCEPT_SCORE,
+    RECONCILIATION_REVIEW_SCORE,
+    STATEMENT_BALANCE_TOLERANCE,
+    InvariantResult,
+    PromotionDecision,
+    evaluate_promotion,
+    tier_rank,
+)
+
+
+def test_AC18_13_1_failed_invariant_is_rejected_with_queryable_reason():
+    """AC18.13.1: A failed deterministic invariant is REJECTED (never authoritative), with a queryable reason."""
+    verdict = evaluate_promotion(
+        [
+            InvariantResult(
+                name="balance_chain",
+                passed=False,
+                delta=Decimal("0.05"),
+                tolerance=STATEMENT_BALANCE_TOLERANCE,
+            )
+        ],
+        confidence_rank=tier_rank("TRUSTED"),  # even max confidence cannot override a failed invariant
+        min_confidence=tier_rank("HIGH"),
+    )
+    assert verdict.decision is PromotionDecision.REJECTED
+    assert verdict.is_authoritative is False
+    assert verdict.failed_invariant == "balance_chain"
+    assert verdict.detail == {"delta": "0.05", "tolerance": "0.001"}
+
+
+def test_AC18_13_2_invariants_pass_but_low_confidence_is_review():
+    """AC18.13.2: Invariants pass but confidence below threshold -> REVIEW candidate, not authoritative."""
+    verdict = evaluate_promotion(
+        [InvariantResult(name="balance_chain", passed=True)],
+        confidence_rank=tier_rank("LOW"),
+        min_confidence=tier_rank("HIGH"),
+    )
+    assert verdict.decision is PromotionDecision.REVIEW
+    assert verdict.is_authoritative is False
+    assert verdict.invariants_pass is True
+    assert verdict.confidence_ok is False
+    assert "threshold" in verdict.reason
+
+
+def test_AC18_13_3_invariants_pass_and_confidence_met_is_authoritative():
+    """AC18.13.3: Invariants pass AND confidence >= threshold -> AUTHORITATIVE. Same contract for tier and score."""
+    by_tier = evaluate_promotion(
+        [InvariantResult(name="balance_chain", passed=True)],
+        confidence_rank=tier_rank("HIGH"),
+        min_confidence=tier_rank("HIGH"),
+    )
+    assert by_tier.decision is PromotionDecision.AUTHORITATIVE
+    assert by_tier.is_authoritative is True
+
+    # The same gate carries the reconciliation score decision: 70 < 85 -> review, 90 -> authoritative.
+    review = evaluate_promotion(
+        [InvariantResult(name="entry_balanced", passed=True)],
+        confidence_rank=70,
+        min_confidence=RECONCILIATION_AUTO_ACCEPT_SCORE,
+    )
+    assert review.decision is PromotionDecision.REVIEW
+    cleared = evaluate_promotion(
+        [InvariantResult(name="entry_balanced", passed=True)],
+        confidence_rank=90,
+        min_confidence=RECONCILIATION_AUTO_ACCEPT_SCORE,
+    )
+    assert cleared.decision is PromotionDecision.AUTHORITATIVE
+
+
+def test_AC18_13_4_thresholds_are_centrally_owned_and_consumed_by_services():
+    """AC18.13.4: The previously-scattered thresholds are named, centrally owned, and consumed by the services."""
+    assert STATEMENT_BALANCE_TOLERANCE == Decimal("0.001")
+    assert RECONCILIATION_AUTO_ACCEPT_SCORE == 85
+    assert RECONCILIATION_REVIEW_SCORE == 60
+
+    from src.services import reconciliation, statement_validation
+
+    assert statement_validation.BALANCE_TOLERANCE is STATEMENT_BALANCE_TOLERANCE
+    assert reconciliation.DEFAULT_CONFIG.auto_accept == RECONCILIATION_AUTO_ACCEPT_SCORE
+    assert reconciliation.DEFAULT_CONFIG.pending_review == RECONCILIATION_REVIEW_SCORE

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -390,6 +390,23 @@ generation / scheduled) and the per-report-number confidence of #913 are separat
 | AC18.12.2 | Trend | The metric is recorded as an append-only series — snapshots accumulate and read newest-first, never overwritten — so the trend over time is observable | `test_AC18_12_2_metric_is_recorded_as_append_only_series_showing_the_trend()` | `metrics/test_confidence_north_star_metric.py` | P1 |
 | AC18.12.3 | Surface | The current metric and its recorded series are exposed read-only via the API | `test_AC18_12_3_north_star_endpoint_returns_current_and_series()` | `metrics/test_confidence_north_star_metric.py` | P1 |
 
+### AC18.13: Promotion Gate — Confidence Is Load-Bearing
+
+The deterministic trust boundary that makes confidence consequential, not merely
+displayed: `authoritative ⇔ invariants_pass ∧ confidence ≥ τ` (see
+[confirmation-workflow.md](../ssot/confirmation-workflow.md) → Promotion Gate).
+AI / Derived versions may propose; the gate (strong code) disposes. Wiring each
+decision site to call the gate, and persisting the verdict on the version node,
+are incremental follow-ups; this AC owns the contract and the threshold
+consolidation.
+
+| ID | Phase | Description | Test | File | Priority |
+|----|-------|-------------|------|------|----------|
+| AC18.13.1 | Gate | A failed deterministic invariant rejects the version regardless of confidence, with a queryable reason (failing invariant + delta vs tolerance) | `test_AC18_13_1_failed_invariant_is_rejected_with_queryable_reason()` | `services/test_promotion_gate.py` | P1 |
+| AC18.13.2 | Gate | Invariants pass but confidence below threshold yields a non-authoritative review candidate | `test_AC18_13_2_invariants_pass_but_low_confidence_is_review()` | `services/test_promotion_gate.py` | P1 |
+| AC18.13.3 | Gate | Invariants pass and confidence meets threshold yields authoritative; the same contract carries both tier and reconciliation-score confidence | `test_AC18_13_3_invariants_pass_and_confidence_met_is_authoritative()` | `services/test_promotion_gate.py` | P1 |
+| AC18.13.4 | Consolidation | The previously-scattered thresholds (balance 0.001, reconciliation 85/60) are named, centrally owned, and consumed by the services | `test_AC18_13_4_thresholds_are_centrally_owned_and_consumed_by_services()` | `services/test_promotion_gate.py` | P1 |
+
 ---
 
 ## 🚫 Out of Scope (v1)

--- a/docs/ssot/confirmation-workflow.md
+++ b/docs/ssot/confirmation-workflow.md
@@ -111,7 +111,7 @@ The following diagram shows how a bank statement travels from upload through to 
 | Context | Tolerance | Source |
 |---------|-----------|--------|
 | Stage 1 balance chain validation | 0.001 USD | `promotion_gate.STATEMENT_BALANCE_TOLERANCE` (#930) |
-| Stage 2 reconciliation auto-accept / review | 85 / 60 | `promotion_gate.RECONCILIATION_AUTO_ACCEPT_SCORE` / `_REVIEW_SCORE` (#930) |
+| Stage 2 reconciliation auto-accept / review | 85 / 60 | `promotion_gate.RECONCILIATION_AUTO_ACCEPT_SCORE` / `promotion_gate.RECONCILIATION_REVIEW_SCORE` (#930) |
 | Stage 2 reconciliation match (amount score) | 0.10 USD | AGENTS.md, reconciliation.md |
 | Reconciliation statistics comparison | 1% | AGENTS.md |
 

--- a/docs/ssot/confirmation-workflow.md
+++ b/docs/ssot/confirmation-workflow.md
@@ -110,7 +110,8 @@ The following diagram shows how a bank statement travels from upload through to 
 
 | Context | Tolerance | Source |
 |---------|-----------|--------|
-| Stage 1 balance chain validation | 0.001 USD | EPIC-016 Q1 user decision |
+| Stage 1 balance chain validation | 0.001 USD | `promotion_gate.STATEMENT_BALANCE_TOLERANCE` (#930) |
+| Stage 2 reconciliation auto-accept / review | 85 / 60 | `promotion_gate.RECONCILIATION_AUTO_ACCEPT_SCORE` / `_REVIEW_SCORE` (#930) |
 | Stage 2 reconciliation match (amount score) | 0.10 USD | AGENTS.md, reconciliation.md |
 | Reconciliation statistics comparison | 1% | AGENTS.md |
 
@@ -139,6 +140,29 @@ invented blended score.
 Owned first by the balance sheet (EPIC-005 AC5.18, issue #913). A `% trusted`
 proportion is a separate, additive signal (the North-Star metric, EPIC-018
 AC18.12), not the per-node badge.
+
+### Promotion Gate (makes confidence load-bearing)
+
+The single deterministic contract that decides whether a versioned fact (see
+[schema.md → Append-Only Fact Versioning](schema.md)) may become authoritative.
+Owned by `services/promotion_gate.py` (EPIC-018 AC18.13, issue #930):
+
+> **authoritative ⇔ invariants_pass ∧ confidence ≥ τ**
+
+- **Invariants first.** A single failed deterministic invariant (e.g. the
+  balance-chain check outside `STATEMENT_BALANCE_TOLERANCE`) → `rejected`,
+  regardless of confidence. Strong code is never overridden by a high score.
+- **Then confidence.** All invariants pass but confidence below the named
+  threshold → `review` (a non-authoritative candidate, escalated for a human).
+- **Both pass** → `authoritative`.
+- The verdict records the failing invariant and its `delta` vs `tolerance`, so the
+  escalation reason is queryable — not a bare status string.
+
+The thresholds in the table above are named constants owned here, not magic
+numbers buried in services. AI / Derived versions may only *propose*; the gate
+disposes. Wiring each decision site to call the gate (vs. consuming the shared
+constants) is incremental; the runtime that *generates* Derived versions or
+dispatches escalations is a separate EPIC.
 
 ---
 


### PR DESCRIPTION
## Summary

Make measured confidence **load-bearing**. Axiom B requires confidence to *gate
what becomes truth*, not merely be displayed. After #918 gave every value a
versioned identity and #913 attached a measured confidence, nothing **bound**
them — the "may this value become authoritative" decision was scattered and
hardcoded (statement balance `0.001`, reconciliation `85/60`, the journal
source_type trigger). So confidence was measured but **not consequential**.

This adds the single deterministic contract:

> **authoritative ⇔ invariants_pass ∧ confidence ≥ τ**

Closes #930 (the gate; wiring/escalation runtime are follow-ups). Part of the #917 audit epic — the A∩B seam.

## What changed (EPIC-018 AC18.13)

- **`src/services/promotion_gate.py`** — `evaluate_promotion(invariants, *, confidence_rank, min_confidence)`:
  - **Invariants first**: a single failed deterministic invariant → `rejected`, *regardless of confidence* (strong code is never overridden by a high score).
  - **Then confidence**: invariants pass but confidence below the named threshold → `review` (a non-authoritative candidate, escalated for a human).
  - **Both pass** → `authoritative`.
  - The `PromotionVerdict` records the failing invariant and its `delta` vs `tolerance`, so the **escalation reason is queryable**, not a bare status. One contract carries both tier confidence (#913) and reconciliation **score** confidence.
- **Threshold consolidation** — the scattered magic numbers are now **named, centrally-owned constants** the services consume (behavior-neutral): `statement_validation.BALANCE_TOLERANCE` and `reconciliation.DEFAULT_CONFIG.{auto_accept,pending_review}`.

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-018 — AI-Driven Data Pipeline (core principle: "confidence thresholds determine auto-accept vs. human review") |
| **AC IDs** | AC18.13.1–.4 |
| **AC source updated** | `docs/project/EPIC-018.ai-driven-pipeline.md` |

## SSOT

- [x] `docs/ssot/confirmation-workflow.md` — **Promotion Gate** contract + the tolerance table now points at `promotion_gate` as the owner.

## TDD Evidence

🔴 Red: `ModuleNotFoundError: src.services.promotion_gate`. 🟢 Green after: 4/4, plus **414** reconciliation/accounting + statement-validation tests still pass (consolidation is behavior-neutral).

| Test | AC |
|------|----|
| `test_AC18_13_1_failed_invariant_is_rejected_with_queryable_reason` | AC18.13.1 |
| `test_AC18_13_2_invariants_pass_but_low_confidence_is_review` | AC18.13.2 |
| `test_AC18_13_3_invariants_pass_and_confidence_met_is_authoritative` | AC18.13.3 |
| `test_AC18_13_4_thresholds_are_centrally_owned_and_consumed_by_services` | AC18.13.4 |

## Scope boundary (explicit follow-ups)

- Wiring each decision site (statement approval, reconciliation accept) to **call** the gate rather than consume the shared constants.
- Persisting the verdict on the version node so escalation reason is queryable in the DB.
- The runtime that *generates* Derived versions or *dispatches* escalations — a separate EPIC. This PR owns the **contract**, not the loop.
- Accounting-core invariants themselves (double-entry, immutability, FX, scoring) — audited as sound, not reopened.

## Testing

```bash
python3 tools/test_lifecycle.py --fast tests/services/test_promotion_gate.py          # 4 passed
python3 tools/test_lifecycle.py --fast tests/accounting tests/reconciliation          # 414 passed
python3 tools/test_lifecycle.py --fast tests/review tests/api/test_statements_router.py  # green
tools/generate_ac_registry.py --check / lint_doc_consistency.py / check_manifest.py / check_ssot_ownership.py  # OK
ruff check / format --check                                                            # clean
```

## Engineering Audit

- [x] `Decimal` for the balance tolerance; scores are int ranks (not money). No float for money.
- [x] No `sa.Enum`/migration/schema/`NEXT_PUBLIC_`/secret changes — a pure service + two constant references.
- [x] No import cycle (`promotion_gate` imports only stdlib). `repo/` submodule untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
