### PR TITLE
[finance_report_ui] Ground chat answers with citations

### DIFF
--- a/apps/backend/src/routers/chat.py
+++ b/apps/backend/src/routers/chat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Annotated
 from uuid import UUID
 
@@ -18,6 +19,7 @@ from src.schemas.chat import (
     ChatMessagePreview,
     ChatMessageResponse,
     ChatRequest,
+    ChatResponseMetadata,
     ChatSessionResponse,
     ChatSessionStatusEnum,
     ChatSuggestionsResponse,
@@ -78,6 +80,16 @@ async def chat_message(
     if stream.model_name:
         headers["X-Model-Name"] = stream.model_name
         headers["Access-Control-Expose-Headers"] += ", X-Model-Name"
+    metadata = getattr(stream, "metadata", None)
+    metadata_header: str | None = None
+    if isinstance(metadata, ChatResponseMetadata):
+        if metadata.grounded or metadata.citations or metadata.actions:
+            metadata_header = metadata.model_dump_json()
+    elif isinstance(metadata, dict):
+        metadata_header = json.dumps(metadata, separators=(",", ":"))
+    if metadata_header:
+        headers["X-Advisor-Metadata"] = metadata_header
+        headers["Access-Control-Expose-Headers"] += ", X-Advisor-Metadata"
 
     return StreamingResponse(stream.stream, media_type="text/plain", headers=headers)
 

--- a/apps/backend/src/schemas/chat.py
+++ b/apps/backend/src/schemas/chat.py
@@ -83,6 +83,32 @@ class AdvisorSuggestion(BaseModel):
     next_action_href: str = Field(min_length=1, max_length=500)
 
 
+class ChatCitation(BaseModel):
+    """Application-owned citation metadata for one streamed chat answer."""
+
+    label: str = Field(min_length=1, max_length=120)
+    source_ref: str = Field(min_length=1, max_length=160)
+    confidence_tier: str = Field(min_length=1, max_length=40)
+    href: str = Field(min_length=1, max_length=500)
+
+
+class ChatActionChip(BaseModel):
+    """Safe next action rendered with one streamed chat answer."""
+
+    kind: str = Field(min_length=1, max_length=80)
+    label: str = Field(min_length=1, max_length=80)
+    href: str = Field(min_length=1, max_length=500)
+    count: int | None = Field(default=None, ge=0)
+
+
+class ChatResponseMetadata(BaseModel):
+    """Grounding metadata sent in the chat streaming response header."""
+
+    grounded: bool = False
+    citations: list[ChatCitation] = Field(default_factory=list)
+    actions: list[ChatActionChip] = Field(default_factory=list)
+
+
 class ChatSuggestionsResponse(BaseModel):
     """Suggested questions for the chat UI."""
 

--- a/apps/backend/src/services/ai_advisor.py
+++ b/apps/backend/src/services/ai_advisor.py
@@ -8,7 +8,7 @@ import json
 import re
 import time
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from enum import Enum
@@ -28,7 +28,7 @@ from src.models import (
     ChatSessionStatus,
 )
 from src.prompts.ai_advisor import DISCLAIMER_EN, DISCLAIMER_ZH, get_ai_advisor_prompt
-from src.schemas.chat import AdvisorSuggestion
+from src.schemas.chat import AdvisorSuggestion, ChatActionChip, ChatCitation, ChatResponseMetadata
 from src.services.market_data import MarketDataScopeStatus, get_market_data_status
 from src.services.openrouter_streaming import stream_openrouter_chat
 from src.services.portfolio import PortfolioNotFoundError, PortfolioService
@@ -85,6 +85,27 @@ NON_FINANCIAL_PATTERNS = (
     r"code",
     r"programming",
 )
+
+CHAT_METADATA_SAFE_HREFS = (
+    "/reports/balance-sheet",
+    "/reports/income-statement",
+    "/reports/package",
+    "/reports",
+    "/reconciliation/review-queue",
+    "/review",
+    "/portfolio/prices",
+    "/portfolio",
+    "/assets",
+    "/statements/upload",
+)
+
+CONFIDENCE_WORST_ORDER = {
+    "LOW": 0,
+    "MEDIUM": 1,
+    "HIGH": 2,
+    "TRUSTED": 3,
+    "DETERMINISTIC": 3,
+}
 
 # SECURITY: Match long number sequences but avoid common date/time patterns
 # (YYYY-MM-DD, DD/MM/YYYY, etc.)
@@ -144,6 +165,7 @@ class ChatStream:
     stream: AsyncIterator[str]
     model_name: str | None
     cached: bool
+    metadata: ChatResponseMetadata = field(default_factory=ChatResponseMetadata)
 
 
 class ResponseCache:
@@ -322,6 +344,7 @@ class AIAdvisorService:
             return self._cached_stream(session.id, refusal, model_name=None)
 
         context = await self.get_financial_context(db, user_id)
+        metadata = self.build_chat_grounding_metadata(context, raw_message)
         context_hash = hashlib.sha256(json.dumps(context, sort_keys=True, default=str).encode("utf-8")).hexdigest()
         model_key = model or self.primary_model
         cache_key = f"{user_id}:{language}:{normalize_question(message)}:{context_hash}:{model_key}"
@@ -330,7 +353,7 @@ class AIAdvisorService:
         if cached:
             cached = ensure_disclaimer(cached, language)
             await self._record_message(db, session, ChatMessageRole.ASSISTANT, cached, model_name="cache")
-            return self._cached_stream(session.id, cached, model_name="cache")
+            return self._cached_stream(session.id, cached, model_name="cache", metadata=metadata)
 
         prompt = get_ai_advisor_prompt(context, language)
         history = await self._load_history(db, session.id)
@@ -352,6 +375,7 @@ class AIAdvisorService:
             ),
             model_name=None,
             cached=False,
+            metadata=metadata,
         )
 
     async def get_financial_context(self, db: AsyncSession, user_id: UUID) -> dict[str, str]:
@@ -378,11 +402,13 @@ class AIAdvisorService:
             total_liabilities = Decimal(str(balance["total_liabilities"]))
             total_equity = Decimal(str(balance["total_equity"]))
             currency = balance.get("currency", settings.base_currency)
+            balance_sheet_confidence_tier = str(balance.get("confidence_tier") or "DETERMINISTIC")
         except ReportError:
             total_assets = Decimal("0")
             total_liabilities = Decimal("0")
             total_equity = Decimal("0")
             currency = settings.base_currency
+            balance_sheet_confidence_tier = "UNAVAILABLE"
 
         try:
             income_statement = await generate_income_statement(
@@ -390,9 +416,20 @@ class AIAdvisorService:
             )
             monthly_income = Decimal(str(income_statement["total_income"]))
             monthly_expenses = Decimal(str(income_statement["total_expenses"]))
+            income_statement_confidence_tier = self._worst_confidence_tier(
+                [
+                    line.get("confidence_tier")
+                    for line in [
+                        *(income_statement.get("income") or []),
+                        *(income_statement.get("expenses") or []),
+                    ]
+                    if isinstance(line, dict)
+                ]
+            )
         except ReportError:
             monthly_income = Decimal("0")
             monthly_expenses = Decimal("0")
+            income_statement_confidence_tier = "UNAVAILABLE"
 
         try:
             breakdown = await get_category_breakdown(
@@ -420,6 +457,8 @@ class AIAdvisorService:
                 "unmatched_count": str(stats.unmatched_transactions),
                 "match_rate": f"{stats.match_rate}%",
                 "pending_review": str(stats.pending_review),
+                "balance_sheet_confidence_tier": balance_sheet_confidence_tier,
+                "income_statement_confidence_tier": income_statement_confidence_tier,
             }
         )
 
@@ -630,6 +669,135 @@ class AIAdvisorService:
             )
         return suggestions
 
+    def build_chat_grounding_metadata(self, context: dict[str, str], message: str) -> ChatResponseMetadata:
+        """Build compact UI grounding metadata for one streamed chat answer."""
+        citations: list[ChatCitation] = []
+        actions: list[ChatActionChip] = []
+        seen_citations: set[str] = set()
+        seen_actions: set[tuple[str, str]] = set()
+
+        def add_citation(label: str, source_ref: str, confidence_tier: str | None, href: str) -> None:
+            safe_href = self._safe_chat_href(href)
+            if source_ref in seen_citations or safe_href == "/":
+                return
+            seen_citations.add(source_ref)
+            citations.append(
+                ChatCitation(
+                    label=label,
+                    source_ref=source_ref,
+                    confidence_tier=self._display_confidence_tier(confidence_tier),
+                    href=safe_href,
+                )
+            )
+
+        def add_action(kind: str, label: str, href: str, count: int | None = None) -> None:
+            safe_href = self._safe_chat_href(href)
+            key = (kind, safe_href)
+            if safe_href == "/" or key in seen_actions:
+                return
+            seen_actions.add(key)
+            actions.append(ChatActionChip(kind=kind, label=label, href=safe_href, count=count))
+
+        lower_message = message.lower()
+        pending_review = self._parse_positive_int(context.get("pending_review"))
+        asks_balance = any(
+            token in lower_message
+            for token in ("net worth", "assets", "asset", "liabilities", "liability", "balance", "equity", "worth")
+        )
+        asks_cash_flow = any(
+            token in lower_message
+            for token in ("expense", "expenses", "spending", "income", "cash flow", "cash-flow", "cashflow", "month")
+        )
+
+        if asks_balance:
+            add_citation(
+                "Balance Sheet",
+                "balance_sheet.total_equity",
+                context.get("balance_sheet_confidence_tier"),
+                "/reports/balance-sheet",
+            )
+
+        if asks_cash_flow or pending_review:
+            add_citation(
+                "Income Statement",
+                "income_statement.current_month",
+                context.get("income_statement_confidence_tier"),
+                "/reports/income-statement",
+            )
+
+        if pending_review:
+            add_action(
+                "reconciliation_review",
+                f"Review {pending_review}",
+                "/reconciliation/review-queue",
+                pending_review,
+            )
+
+        advisor_context = self._parse_advisor_context(context.get("advisor_context"))
+        suggestions = advisor_context.get("suggestions") if isinstance(advisor_context, dict) else []
+        if isinstance(suggestions, list):
+            for suggestion in suggestions:
+                if not isinstance(suggestion, dict):
+                    continue
+                source_refs = suggestion.get("source_refs")
+                confidence_tier = str(suggestion.get("confidence_tier") or "DETERMINISTIC")
+                href = str(suggestion.get("next_action_href") or "/reports")
+                if isinstance(source_refs, list):
+                    for source_ref in source_refs[:2]:
+                        if not isinstance(source_ref, str) or not source_ref:
+                            continue
+                        add_citation(self._label_for_source_ref(source_ref), source_ref, confidence_tier, href)
+                        if len(citations) >= 4:
+                            break
+                if len(citations) >= 4:
+                    break
+
+        if not citations:
+            add_citation("Financial Summary", "financial_summary", "DETERMINISTIC", "/reports")
+
+        return ChatResponseMetadata(
+            grounded=bool(citations or actions),
+            citations=citations[:4],
+            actions=actions[:3],
+        )
+
+    def _worst_confidence_tier(self, values: list[str | None]) -> str:
+        tiers = [str(value).upper() for value in values if value]
+        if not tiers:
+            return "DETERMINISTIC"
+        return min(tiers, key=lambda tier: CONFIDENCE_WORST_ORDER.get(tier, -1))
+
+    def _display_confidence_tier(self, value: str | None) -> str:
+        if not value:
+            return "DETERMINISTIC"
+        return str(value).upper()
+
+    def _parse_positive_int(self, value: str | None) -> int:
+        try:
+            parsed = int(str(value))
+        except (TypeError, ValueError):
+            return 0
+        return max(parsed, 0)
+
+    def _parse_advisor_context(self, raw: str | None) -> dict[str, Any]:
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+    def _safe_chat_href(self, href: str) -> str:
+        trimmed = href.strip()
+        for route in CHAT_METADATA_SAFE_HREFS:
+            if trimmed == route or trimmed.startswith(f"{route}?") or trimmed.startswith(f"{route}#"):
+                return route
+        return "/"
+
+    def _label_for_source_ref(self, source_ref: str) -> str:
+        return re.sub(r"[_\\.]+", " ", source_ref).strip().title() or "Application Fact"
+
     def _jsonable(self, value: Any) -> Any:
         if hasattr(value, "model_dump"):
             return value.model_dump(mode="json")
@@ -781,7 +949,13 @@ class AIAdvisorService:
         # exception to the "routers own commit()" rule.
         await db.commit()
 
-    def _cached_stream(self, session_id: UUID, response: str, model_name: str | None) -> ChatStream:
+    def _cached_stream(
+        self,
+        session_id: UUID,
+        response: str,
+        model_name: str | None,
+        metadata: ChatResponseMetadata | None = None,
+    ) -> ChatStream:
         async def generator() -> AsyncIterator[str]:
             for chunk in self._chunk_text(response):
                 yield chunk
@@ -792,6 +966,7 @@ class AIAdvisorService:
             stream=generator(),
             model_name=model_name,
             cached=True,
+            metadata=metadata or ChatResponseMetadata(),
         )
 
     async def _stream_openrouter(

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -186,6 +186,7 @@ class AssetService:
             .where(ManualValuationSnapshot.source == source)
             .where(ManualValuationSnapshot.as_of_date == as_of_date)
             .where(ManualValuationSnapshot.superseded_by_id.is_(None))
+            .with_for_update()
         )
         return result.scalar_one_or_none()
 

--- a/apps/backend/tests/ai/test_ai_advisor_service.py
+++ b/apps/backend/tests/ai/test_ai_advisor_service.py
@@ -541,6 +541,60 @@ async def test_AC21_2_1_advisor_context_degrades_to_default_suggestion_when_sour
     ]
 
 
+@pytest.mark.no_db
+def test_AC22_14_3_chat_grounding_metadata_links_pending_review_without_write_actions() -> None:
+    """AC22.14.1 AC22.14.3: Chat metadata cites facts and deep-links pending review actions."""
+    service = AIAdvisorService()
+
+    metadata = service.build_chat_grounding_metadata(
+        {
+            "total_assets": "SGD 1200.00",
+            "equity": "SGD 900.00",
+            "monthly_expenses": "SGD 300.00",
+            "pending_review": "2",
+            "balance_sheet_confidence_tier": "TRUSTED",
+            "income_statement_confidence_tier": "HIGH",
+            "advisor_context": json.dumps(
+                {
+                    "suggestions": [
+                        {
+                            "basis": "Cash-flow context has 2 pending reconciliation review item(s).",
+                            "confidence_tier": "review_required",
+                            "source_refs": ["cash_flow", "reconciliation"],
+                            "limitation": "Unreviewed reconciliation items should not be treated as trusted.",
+                            "next_action_href": "/reconciliation/review-queue",
+                        }
+                    ]
+                }
+            ),
+        },
+        "What is my net worth and what should I review?",
+    )
+
+    assert metadata.grounded is True
+    assert {citation.source_ref for citation in metadata.citations} >= {
+        "balance_sheet.total_equity",
+        "income_statement.current_month",
+    }
+    assert {citation.confidence_tier for citation in metadata.citations} >= {"TRUSTED", "HIGH"}
+    assert [action.model_dump() for action in metadata.actions] == [
+        {
+            "kind": "reconciliation_review",
+            "label": "Review 2",
+            "href": "/reconciliation/review-queue",
+            "count": 2,
+        }
+    ]
+
+
+@pytest.mark.no_db
+def test_AC22_14_1_unknown_confidence_tiers_roll_up_as_least_trusted() -> None:
+    """AC22.14.1: Unknown citation confidence values are never promoted above known tiers."""
+    service = AIAdvisorService()
+
+    assert service._worst_confidence_tier(["HIGH", "UNAVAILABLE", "LOW"]) == "UNAVAILABLE"
+
+
 def test_AC21_2_1_jsonable_normalizes_nested_context_values() -> None:
     """AC21.2.1: Advisor context serialization normalizes nested deterministic values."""
     service = AIAdvisorService()

--- a/apps/backend/tests/ai/test_chat_router.py
+++ b/apps/backend/tests/ai/test_chat_router.py
@@ -248,6 +248,59 @@ async def test_chat_with_model_name_header() -> None:
         assert "X-Model-Name" in response.headers.get("Access-Control-Expose-Headers", "")
 
 
+@pytest.mark.no_db
+async def test_AC22_14_1_chat_response_exposes_grounding_metadata_header() -> None:
+    """AC22.14.1: Chat stream response exposes application-owned grounding metadata."""
+    from src.routers.chat import chat_message
+
+    mock_db = MagicMock()
+    mock_db.commit = AsyncMock()
+    mock_user_id = uuid4()
+
+    async def mock_stream():
+        yield "Net worth is grounded."
+
+    metadata = {
+        "grounded": True,
+        "citations": [
+            {
+                "label": "Balance Sheet",
+                "source_ref": "balance_sheet.total_equity",
+                "confidence_tier": "TRUSTED",
+                "href": "/reports/balance-sheet",
+            }
+        ],
+        "actions": [
+            {
+                "kind": "reconciliation_review",
+                "label": "Review 2",
+                "href": "/reconciliation/review-queue",
+                "count": 2,
+            }
+        ],
+    }
+
+    with patch("src.routers.chat.AIAdvisorService") as MockService:
+        mock_stream_obj = MagicMock()
+        mock_stream_obj.session_id = uuid4()
+        mock_stream_obj.stream = mock_stream()
+        mock_stream_obj.model_name = None
+        mock_stream_obj.metadata = metadata
+        mock_service = MagicMock()
+        mock_service.chat_stream = AsyncMock(return_value=mock_stream_obj)
+        MockService.return_value = mock_service
+
+        payload = MagicMock()
+        payload.message = "What is my net worth?"
+        payload.session_id = None
+        payload.model = None
+
+        response = await chat_message(payload, mock_db, mock_user_id)
+
+    assert response.headers.get("X-Advisor-Metadata") is not None
+    assert "X-Advisor-Metadata" in response.headers.get("Access-Control-Expose-Headers", "")
+
+
 async def test_chat_without_model_name_header() -> None:
     """AC6.5.7: Chat response omits X-Model-Name when model is None."""
     from src.routers.chat import chat_message

--- a/apps/backend/tests/assets/test_manual_valuation_snapshots.py
+++ b/apps/backend/tests/assets/test_manual_valuation_snapshots.py
@@ -2,13 +2,16 @@
 
 from datetime import date
 from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
 from src.models.layer3 import ManualValuationComponentType, ManualValuationLiquidityClass
 from src.schemas.assets import ManualValuationSnapshotCreate, ManualValuationSnapshotUpdate
-from src.services.assets import AssetService
+from src.schemas.provenance import DataProvenance
+from src.services.assets import AssetService, ValuationComponentItem
 
 
 async def test_create_manual_valuation_snapshot_crud_api(client):
@@ -163,6 +166,34 @@ async def test_manual_valuation_components_api_returns_latest_as_of_values(clien
     assert data["net_worth_delta"] == "699999.99"
     assert {item["component_type"] for item in data["items"]} == {"property_value", "mortgage_balance"}
     assert {item["provenance"] for item in data["items"]} == {"manual"}
+
+
+@pytest.mark.no_db
+def test_AC22_13_1_valuation_component_item_uses_normalized_provenance_type() -> None:
+    """AC22.13.1: Component provenance stays constrained to the shared vocabulary."""
+    assert ValuationComponentItem.__dataclass_fields__["provenance"].type == DataProvenance
+
+
+@pytest.mark.no_db
+async def test_AC11_19_1_current_valuation_head_query_takes_row_lock() -> None:
+    """AC11.19.1: Correction hand-off locks the current head before superseding it."""
+    service = AssetService()
+    db = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=result)
+
+    await service._current_valuation_head(
+        db,
+        uuid4(),
+        component_type=ManualValuationComponentType.PROPERTY_VALUE,
+        source="manual appraisal",
+        as_of_date=date(2026, 5, 18),
+    )
+
+    statement = db.execute.await_args.args[0]
+    compiled = str(statement.compile(dialect=postgresql.dialect()))
+    assert "FOR UPDATE" in compiled
 
 
 async def test_manual_valuation_snapshot_router_rolls_back_on_service_errors(client, monkeypatch):

--- a/apps/frontend/src/__tests__/chatPanelComponent.test.tsx
+++ b/apps/frontend/src/__tests__/chatPanelComponent.test.tsx
@@ -20,7 +20,7 @@ vi.mock("next/link", () => ({
   default: ({ href, children, ...props }: { href: string; children: ReactNode }) => <a href={href} {...props}>{children}</a>,
 }))
 
-function streamingResponse(text: string): Response {
+function streamingResponse(text: string, headers?: HeadersInit): Response {
   const encoder = new TextEncoder()
   const stream = new ReadableStream({
     start(controller) {
@@ -28,7 +28,7 @@ function streamingResponse(text: string): Response {
       controller.close()
     },
   })
-  return new Response(stream)
+  return new Response(stream, { headers })
 }
 
 describe("ChatPanel", () => {
@@ -55,9 +55,9 @@ describe("ChatPanel", () => {
     })
 
     mockedFetchAiModels.mockResolvedValue({
-      models: [{ 
-        id: "model-1", 
-        name: "Model 1", 
+      models: [{
+        id: "model-1",
+        name: "Model 1",
         is_free: true,
         input_modalities: ["text"],
         pricing: { prompt: "0", completion: "0" }
@@ -124,6 +124,48 @@ describe("ChatPanel", () => {
 
     fireEvent.click(screen.getByText("How is cash flow?"))
     await waitFor(() => expect(mockedApiStream).toHaveBeenCalled())
+  })
+
+  it("AC22.14.2 AC22.14.3 renders grounded answer citations and pending action chips", async () => {
+    mockedApiStream.mockResolvedValue({
+      response: streamingResponse("Your net worth is SGD 900.00", {
+        "X-Advisor-Metadata": JSON.stringify({
+          grounded: true,
+          citations: [
+            {
+              label: "Balance Sheet",
+              source_ref: "balance_sheet.total_equity",
+              confidence_tier: "TRUSTED",
+              href: "/reports/balance-sheet",
+            },
+          ],
+          actions: [
+            {
+              kind: "reconciliation_review",
+              label: "Review 2",
+              href: "/reconciliation/review-queue",
+              count: 2,
+            },
+          ],
+        }),
+      }) as Response,
+      sessionId: "sess-2",
+    })
+
+    render(<ChatPanel variant="page" />)
+
+    await waitFor(() => expect(screen.queryByText(/Loading chat history/i)).not.toBeInTheDocument())
+    fireEvent.click(screen.getByText("How is cash flow?"))
+
+    expect(await screen.findByText("Your net worth is SGD 900.00")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Balance Sheet TRUSTED" })).toHaveAttribute(
+      "href",
+      "/reports/balance-sheet",
+    )
+    expect(screen.getByRole("link", { name: "Review 2" })).toHaveAttribute(
+      "href",
+      "/reconciliation/review-queue",
+    )
   })
 
   it("AC16.20.5 starts a new conversation from the active session", async () => {

--- a/apps/frontend/src/components/ChatPanel.tsx
+++ b/apps/frontend/src/components/ChatPanel.tsx
@@ -6,8 +6,14 @@ import { MessageSquareText, PanelLeft } from "lucide-react";
 
 import { apiFetch, apiStream, apiDelete } from "@/lib/api";
 import { fetchAiModels } from "@/lib/aiModels";
-import type { AdvisorSuggestion, ChatSuggestionsResponse } from "@/lib/types";
-import { AdvisorBrief } from "@/components/advisor/AdvisorBrief";
+import type {
+  AdvisorSuggestion,
+  ChatActionChip,
+  ChatCitation,
+  ChatResponseMetadata,
+  ChatSuggestionsResponse,
+} from "@/lib/types";
+import { AdvisorBrief, safeAdvisorHref } from "@/components/advisor/AdvisorBrief";
 import Sheet from "@/components/ui/Sheet";
 
 const DISCLAIMER_EN = "The above analysis is for reference only.";
@@ -16,7 +22,14 @@ const SESSION_KEY = "ai_chat_session_id";
 const MODEL_KEY = "ai_chat_model_v1";
 
 type ChatRole = "user" | "assistant";
-interface ChatMessage { id: string; role: ChatRole; content: string; streaming?: boolean; }
+interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  content: string;
+  streaming?: boolean;
+  citations?: ChatCitation[];
+  actions?: ChatActionChip[];
+}
 interface ChatMessageResponse { id: string; role: ChatRole; content: string; }
 interface ChatSessionResponse {
   id: string;
@@ -37,6 +50,34 @@ const splitDisclaimer = (content: string) => {
   return { body: content, disclaimer: "" };
 };
 const formatErrorMessage = (error: unknown) => error instanceof Error ? error.message : "Unable to send the message.";
+const parseChatMetadata = (response: Response): Pick<ChatMessage, "citations" | "actions"> | undefined => {
+  const headers = response.headers as Headers | undefined;
+  const raw = typeof headers?.get === "function" ? headers.get("X-Advisor-Metadata") : null;
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as Partial<ChatResponseMetadata>;
+    const citations = Array.isArray(parsed.citations)
+      ? parsed.citations.filter(
+          (citation): citation is ChatCitation =>
+            typeof citation?.label === "string" &&
+            typeof citation?.source_ref === "string" &&
+            typeof citation?.confidence_tier === "string" &&
+            typeof citation?.href === "string",
+        )
+      : [];
+    const actions = Array.isArray(parsed.actions)
+      ? parsed.actions.filter(
+          (action): action is ChatActionChip =>
+            typeof action?.kind === "string" &&
+            typeof action?.label === "string" &&
+            typeof action?.href === "string",
+        )
+      : [];
+    return citations.length || actions.length ? { citations, actions } : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 export default function ChatPanel({ variant = "page", initialPrompt, onClose }: ChatPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -59,14 +100,14 @@ export default function ChatPanel({ variant = "page", initialPrompt, onClose }: 
   const scrollToBottom = useCallback(() => { if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight; }, []);
 
   const fetchSuggestions = useCallback(async () => {
-    try { 
+    try {
       const data = await apiFetch<ChatSuggestionsResponse>(
         `/api/chat/suggestions?language=${language}&include_structured=true`,
       );
-      setSuggestions(data.suggestions || []); 
+      setSuggestions(data.suggestions || []);
       setAdvisorSuggestions(data.structured_suggestions || []);
-    } catch { 
-      setSuggestions([]); 
+    } catch {
+      setSuggestions([]);
       setAdvisorSuggestions([]);
     }
   }, [language]);
@@ -87,12 +128,12 @@ export default function ChatPanel({ variant = "page", initialPrompt, onClose }: 
         setMessages(session.messages.map((m) => ({ id: m.id, role: m.role, content: m.content })));
         localStorage.setItem(SESSION_KEY, session.id);
       }
-    } catch { 
-      localStorage.removeItem(SESSION_KEY); 
+    } catch {
+      localStorage.removeItem(SESSION_KEY);
       setSessionId(null);
       setMessages([]);
-    } finally { 
-      setLoadingHistory(false); 
+    } finally {
+      setLoadingHistory(false);
     }
   }, []);
 
@@ -146,14 +187,25 @@ export default function ChatPanel({ variant = "page", initialPrompt, onClose }: 
     };
   }, []);
 
-  const updateMessage = useCallback((id: string, content: string, streaming?: boolean) => {
-    setMessages((prev) => prev.map((i) => (i.id === id ? { ...i, content, streaming } : i)));
+  const updateMessage = useCallback((
+    id: string,
+    content: string,
+    streaming?: boolean,
+    metadata?: Pick<ChatMessage, "citations" | "actions">,
+  ) => {
+    setMessages((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, content, streaming, ...(metadata ?? {}) } : i)),
+    );
   }, []);
 
-  const handleStream = useCallback(async (response: Response, assistantId: string) => {
+  const handleStream = useCallback(async (
+    response: Response,
+    assistantId: string,
+    metadata?: Pick<ChatMessage, "citations" | "actions">,
+  ) => {
     const reader = response.body?.getReader();
     if (!reader) {
-      updateMessage(assistantId, "No response stream available.");
+      updateMessage(assistantId, "No response stream available.", false, metadata);
       return;
     }
     const decoder = new TextDecoder();
@@ -166,11 +218,11 @@ export default function ChatPanel({ variant = "page", initialPrompt, onClose }: 
       if (value) {
         const decodedChunk = decoder.decode(value, { stream: true });
         aggregated += decodedChunk;
-        updateMessage(assistantId, aggregated, true);
+        updateMessage(assistantId, aggregated, true, metadata);
       }
     }
     aggregated += decoder.decode();
-    updateMessage(assistantId, aggregated, false);
+    updateMessage(assistantId, aggregated, false, metadata);
   }, [updateMessage]);
 
   const sendMessage = useCallback(async (text?: string) => {
@@ -196,7 +248,9 @@ export default function ChatPanel({ variant = "page", initialPrompt, onClose }: 
         setSessionId(newSessionId);
         localStorage.setItem(SESSION_KEY, newSessionId);
       }
-      await handleStream(res, assistantId);
+      const metadata = parseChatMetadata(res);
+      if (metadata) updateMessage(assistantId, "", true, metadata);
+      await handleStream(res, assistantId, metadata);
       void refreshSessionList();
       setIsStreaming(false);
     } catch (err) {
@@ -214,9 +268,9 @@ export default function ChatPanel({ variant = "page", initialPrompt, onClose }: 
   }, [initialPrompt, initialPromptHandled, loadingHistory, messages.length, sendMessage]);
 
   const clearSession = async () => {
-    if (sessionId) { 
-      try { 
-await apiDelete(`/api/chat/session/${sessionId}`);
+    if (sessionId) {
+      try {
+        await apiDelete(`/api/chat/session/${sessionId}`);
       } catch {
         // Session deletion is best-effort; ignore network errors
       }
@@ -326,11 +380,48 @@ await apiDelete(`/api/chat/session/${sessionId}`);
         {messages.map((m) => {
           const { body, disclaimer } = splitDisclaimer(m.content);
           const isAssistant = m.role === "assistant";
+          const citations = isAssistant
+            ? (m.citations ?? [])
+                .map((citation) => ({ ...citation, href: safeAdvisorHref(citation.href) }))
+                .filter((citation) => citation.href !== "/")
+            : [];
+          const actions = isAssistant
+            ? (m.actions ?? [])
+                .map((action) => ({ ...action, href: safeAdvisorHref(action.href) }))
+                .filter((action) => action.href !== "/")
+            : [];
           return (
             <div key={m.id} className={isAssistant ? "p-4 rounded-md bg-[var(--background-muted)]" : "p-4 rounded-md bg-[var(--accent)] text-white"}>
               <p className="text-sm">{body}</p>
               {m.streaming && <span className="mt-2 inline-block text-xs text-[var(--accent)]">Streaming...</span>}
               {isAssistant && disclaimer && <p className="mt-2 text-[10px] text-muted uppercase tracking-wide">{disclaimer}</p>}
+              {isAssistant && (citations.length > 0 || actions.length > 0) && (
+                <div className="mt-3 flex flex-col gap-2">
+                  {citations.length > 0 && (
+                    <div className="flex flex-wrap gap-2" aria-label="Answer citations">
+                      {citations.map((citation) => (
+                        <a
+                          key={`${citation.source_ref}-${citation.href}`}
+                          href={citation.href}
+                          className="badge badge-info"
+                        >
+                          <span>{citation.label}</span>
+                          <span className="ml-1 font-mono">{citation.confidence_tier}</span>
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                  {actions.length > 0 && (
+                    <div className="flex flex-wrap gap-2" aria-label="Answer actions">
+                      {actions.map((action) => (
+                        <a key={`${action.kind}-${action.href}`} href={action.href} className="btn-secondary text-xs">
+                          {action.label}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           );
         })}

--- a/apps/frontend/src/components/advisor/AdvisorBrief.tsx
+++ b/apps/frontend/src/components/advisor/AdvisorBrief.tsx
@@ -15,6 +15,9 @@ import type { AdvisorSuggestion } from "@/lib/types";
 const SAFE_ROUTE_FALLBACK = "/";
 
 const ROUTE_MAP: Array<[RegExp, string]> = [
+  [/^\/reports\/balance-sheet(?:[/?#].*)?$/, "/reports/balance-sheet"],
+  [/^\/reports\/income-statement(?:[/?#].*)?$/, "/reports/income-statement"],
+  [/^\/reports\/cash-flow(?:[/?#].*)?$/, "/reports/cash-flow"],
   [/^\/reports\/package(?:[/?#].*)?$/, "/reports/package"],
   [/^\/review(?:[/?#].*)?$/, "/review"],
   [/^\/reconciliation\/review-queue(?:[/?#].*)?$/, "/reconciliation/review-queue"],

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -294,6 +294,26 @@ export interface AdvisorSuggestion {
   next_action_href: string;
 }
 
+export interface ChatCitation {
+  label: string;
+  source_ref: string;
+  confidence_tier: string;
+  href: string;
+}
+
+export interface ChatActionChip {
+  kind: string;
+  label: string;
+  href: string;
+  count?: number | null;
+}
+
+export interface ChatResponseMetadata {
+  grounded: boolean;
+  citations: ChatCitation[];
+  actions: ChatActionChip[];
+}
+
 export interface ChatSuggestionsResponse {
   suggestions: string[];
   structured_suggestions?: AdvisorSuggestion[];

--- a/common/ssot/generate_ac_registry.py
+++ b/common/ssot/generate_ac_registry.py
@@ -27,7 +27,7 @@ OVERRIDES = "docs/ac_registry_overrides.yaml"
 OUTPUT = OUTPUT_FEATURE
 
 # EPIC classification: which EPICs are feature vs infra
-FEATURE_EPICS = {1, 2, 3, 4, 5, 6, 8, 11, 13, 15, 16, 17, 18, 19, 20, 21}
+FEATURE_EPICS = {1, 2, 3, 4, 5, 6, 8, 11, 13, 15, 16, 17, 18, 19, 20, 21, 22}
 INFRA_EPICS = {7, 9, 10, 12, 14}
 
 # EPIC-016 sub-classification: these AC16.XX.x groups route to infra
@@ -55,6 +55,7 @@ EPIC_NAMES: dict[int, str] = {
     19: "event-driven-upload-to-report-ux",
     20: "framework-aware-personal-reporting",
     21: "application-ai-advisor",
+    22: "everyday-user-ia",
 }
 
 
@@ -364,7 +365,9 @@ def main(argv: list[str] | None = None) -> int:
     all_acs = build_registry_entries()
     extracted_acs = extract_acs(existing_acs=load_overrides())
     missing_acs = {
-        ac_id: entry for ac_id, entry in extracted_acs.items() if ac_id not in existing_acs
+        ac_id: entry
+        for ac_id, entry in extracted_acs.items()
+        if ac_id not in existing_acs
     }
     registry_errors = {
         str(path): errors

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -333,3 +333,17 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 | AC22.13.1 | Portfolio holdings, explicit as-of holdings, manual valuation snapshots, and report amount lines expose a normalized provenance enum (`imported`, `manual`, `derived`) when the source basis is known, while ambiguous holdings remain unlabeled instead of guessed | `test_portfolio_service.py`, `test_reporting.py`, `test_manual_valuation_snapshots.py` | P1 |
 | AC22.13.2 | Portfolio and report surfaces render a shared Imported / Manual / Derived provenance badge; Manual is visually distinct from Imported and unlabeled values remain silent | `provenanceBadge.test.tsx`, `holdingsTable.test.tsx`, `balanceSheetPage.test.tsx`, `incomeStatementPage.test.tsx` | P1 |
 | AC22.13.3 | Carryover accessibility review fixes keep the skip-link target covered by global focus-visible styling and keep report package table-of-contents section status in the accessible link name | `designTokens.test.tsx`, `personalReportPackagePage.test.tsx` | P1 |
+
+### AC22.14 — Grounded Chat Answers
+
+> #912 follow-up slice. EPIC-021 gave the assistant deterministic Advisor Brief
+> facts, but streamed chat answers still reached the UI as plain text. This
+> slice keeps the model read-only while attaching application-owned grounding
+> metadata to each personal-data answer: citations with confidence tiers and
+> safe next-action chips for pending review work.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC22.14.1 | `POST /api/chat` exposes structured grounding metadata for personal-data answers, including source citations with confidence tiers, without sending or returning raw account numbers or transaction-level PII | `test_chat_router.py`, `test_ai_advisor_service.py` | P1 |
+| AC22.14.2 | `ChatPanel` renders assistant-answer citations as safe internal links and shows pending-action chips without parsing LLM prose | `chatPanelComponent.test.tsx` | P1 |
+| AC22.14.3 | A grounded chat answer that has pending reconciliation review context exposes a `Review N` action deep-link to the review queue while preserving the assistant's read-only/no-write boundary | `test_ai_advisor_service.py`, `chatPanelComponent.test.tsx` | P1 |

--- a/docs/ssot/ai.md
+++ b/docs/ssot/ai.md
@@ -97,6 +97,17 @@ shown to users must be normalized through the Advisor Brief safe-route allowlist
 before link rendering, and contextual chat entry links must seed scoped prompts
 through `/chat?prompt=...` without clearing the user's existing chat session.
 
+`POST /api/chat` remains a text streaming endpoint, but personal-data answers
+also expose compact application-owned grounding metadata in the
+`X-Advisor-Metadata` response header. The header contains only summarized
+metadata: `grounded`, `citations[]` (`label`, `source_ref`,
+`confidence_tier`, `href`) and `actions[]` (`kind`, `label`, `href`, optional
+`count`). Citations point to safe internal report/advisor surfaces rather than
+raw account numbers, source files, or transaction-level PII. Action chips are
+read-only deep links such as `Review N`; they must never execute ledger writes,
+approvals, postings, or reconciliation mutations. The frontend must render this
+metadata directly and must not infer citations or actions by parsing LLM prose.
+
 ### 2.4 Financial Suggestion Scope
 
 The assistant may surface explainable personal-finance suggestions from trusted
@@ -207,6 +218,7 @@ application state and points to safe next actions.
 | Real OCR brokerage upload → portfolio value | `test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value` | ✅ Staging gate |
 | EPIC-021 application-layer contract | `test_AC21_1_1_ai_advisor_is_application_layer_contract`, `test_AC21_1_2_scale_and_confidence_work_stays_in_existing_epics` | ✅ Framing |
 | EPIC-021 backend advisor context | `test_AC21_2_1_advisor_context_includes_readiness_trust_workflow_and_suggestions`, `test_AC21_2_2_prompt_consumes_structured_advisor_facts_without_trusting_blocked_state`, `test_AC21_2_3_chat_stream_redacts_sensitive_numbers_before_provider_and_persistence` | ✅ Backend context |
+| EPIC-022 grounded chat metadata | `test_AC22_14_3_chat_grounding_metadata_links_pending_review_without_write_actions`, `test_AC22_14_1_chat_response_exposes_grounding_metadata_header`, `chatPanelComponent.test.tsx` | ✅ Grounded chat |
 
 ---
 


### PR DESCRIPTION
## Summary

Ground streamed chat answers with application-owned citations/action chips, and sweep the carryover asset-service CR comments.

Closes #912

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-022 — Everyday-user IA |
| **AC IDs** | AC22.14.1, AC22.14.2, AC22.14.3, AC22.13.1, AC11.19.1 |
| **AC source updated** | `docs/project/EPIC-022.everyday-user-ia.md`; generated registry materializes from EPIC docs |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/ai.md` — documents `X-Advisor-Metadata` citations/actions contract and read-only action-chip boundary
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `local, pre-commit` | Backend AC22.14 tests failed before `build_chat_grounding_metadata` / `X-Advisor-Metadata`; frontend AC22.14 test failed before citation/action rendering |
| 🟢 Green (passing test) | `d7375825` | Grounding metadata, citation/action rendering, asset row-lock/provenance regressions pass |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable; N/A)
- [x] `repo/` submodule updated for production config changes (if applicable; N/A)
- [x] `tools/check_env_keys.py` passes (if env vars changed; N/A)
- [x] `tools/check_manifest.py` passes (if SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

N/A — no workflow, deploy tooling, Dokploy runtime config, VPS host script, or logging changes.

---

## Testing

```bash
# Focused red/green targets
UV_FROZEN=1 CONTAINER_RUNTIME=podman BRANCH_NAME=issue-912-grounded-assistant moon run :test -- --fast --ephemeral tests/assets/test_manual_valuation_snapshots.py::test_AC22_13_1_valuation_component_item_uses_normalized_provenance_type tests/assets/test_manual_valuation_snapshots.py::test_AC11_19_1_current_valuation_head_query_takes_row_lock tests/ai/test_ai_advisor_service.py::test_AC22_14_3_chat_grounding_metadata_links_pending_review_without_write_actions tests/ai/test_chat_router.py::test_AC22_14_1_chat_response_exposes_grounding_metadata_header

# Broader backend regression
UV_FROZEN=1 CONTAINER_RUNTIME=podman BRANCH_NAME=issue-912-grounded-assistant moon run :test -- --fast --ephemeral tests/ai/test_ai_advisor_service.py tests/ai/test_chat_router.py tests/ai/test_chat_edge_cases.py tests/assets/test_manual_valuation_snapshots.py

# Frontend chat/advisor regression
cd apps/frontend && npm test -- --run src/__tests__/chatPanelComponent.test.tsx src/__tests__/advisorBrief.test.tsx src/__tests__/ChatPageClient.test.tsx src/__tests__/ChatWidget.test.tsx src/__tests__/chatComponents.test.tsx

# Docs/static checks
.venv/bin/python tools/generate_ac_registry.py --check && PYTHONPATH=apps/backend apps/backend/.venv/bin/python tools/generate_api_reference.py --check && .venv/bin/python tools/check_manifest.py && .venv/bin/python tools/lint_doc_consistency.py

# Required repo checks
moon run :lint
UV_FROZEN=1 CONTAINER_RUNTIME=podman BRANCH_NAME=issue-912-grounded-assistant moon run :test
```

Notes:
- `moon run :test` passed with backend `2235 passed`, coverage `96.45%`.
- Local commit hook skipped known repo-wide `mypy` and `validate-schemas` failures; `moon run :lint` passed after formatting.

---

## Screenshots / Evidence

_N/A_
