### PR TITLE
[finance_report_infra] EPIC-008: in-runner e2e gate synchronous on pull_request (close merge-gate bypass)

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,20 +1,23 @@
 # PR Test Environment Workflow
 #
-# The default PR preview follows the PR's CI workflow: after the matching CI run
-# completes successfully, this workflow starts the full stack inside the GitHub
-# runner, runs provider-free smoke/E2E, and destroys the stack in the same job.
-# It does not build/push PR preview images and does not create a persistent
-# Dokploy URL. PR close/merge, failed CI, cancelled CI, and timed-out CI runs
-# delete legacy Dokploy preview resources for the PR.
+# The in-runner E2E gate runs SYNCHRONOUSLY on pull_request: it starts the full
+# stack inside the GitHub runner, runs provider-free smoke/E2E, and destroys the
+# stack in the same job. As a synchronous required check it must pass before merge —
+# the old workflow_run trigger fired only after CI and a fast/auto merge could outrun
+# it (a skipped required check counts as passed). It is image-free, builds no PR
+# preview images, and creates no persistent Dokploy URL. PR close triggers cleanup of
+# legacy Dokploy preview resources.
 
 name: PR Test Environment
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  # The in-runner e2e gate runs SYNCHRONOUSLY on pull_request (not via async
+  # workflow_run): workflow_run fires after CI and a fast/auto merge can land before
+  # it ever runs as a required check, so the "merge authority" was bypassable. As a
+  # real pull_request check it must pass before merge. (e2e is image-free — it builds
+  # the stack on the runner — so it needs no CI artifact and can run independently.)
   pull_request:
-    types: [closed]
+    types: [opened, synchronize, reopened, closed]
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -31,7 +34,7 @@ on:
           - cleanup
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.pull_requests[0].number || github.event_name == 'pull_request' && github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -111,34 +114,14 @@ jobs:
               if event.get("action") == "closed":
                   action = "cleanup"
                   action_reason = "pull-request-closed"
-          elif event_name == "workflow_run":
-              workflow_run = event.get("workflow_run") or {}
-              pull_requests = workflow_run.get("pull_requests") or []
-              pr = pull_requests[0] if pull_requests else {}
-              pr_number = str(pr.get("number") or "")
-              head_sha = workflow_run.get("head_sha") or head_sha
-              head_branch = workflow_run.get("head_branch") or head_branch
-              triggering_ci_conclusion = workflow_run.get("conclusion") or ""
-              triggering_ci_event = workflow_run.get("event") or ""
-              head_repository = (workflow_run.get("head_repository") or {}).get(
-                  "full_name"
-              )
-
-              if not pr_number:
-                  action = "skip"
-                  action_reason = "workflow-run-without-pr"
-              elif triggering_ci_event != "pull_request":
-                  action = "skip"
-                  action_reason = f"workflow-run-event-{triggering_ci_event}"
-              elif head_repository and head_repository != repository:
-                  action = "skip"
-                  action_reason = "fork-pr-no-preview-secrets"
-              elif triggering_ci_conclusion == "success":
-                  action = "deploy"
-                  action_reason = "successful-pr-ci"
               else:
-                  action = "cleanup"
-                  action_reason = f"ci-{triggering_ci_conclusion or 'unknown'}"
+                  # opened/synchronize/reopened: run the in-runner e2e gate
+                  # synchronously on this PR commit, so it is a real required check a
+                  # fast/auto merge cannot outrun (the old workflow_run path was async
+                  # and bypassable). Preview is unaffected — deploy-preview stays
+                  # workflow_dispatch-only (P1a-2).
+                  action = "deploy"
+                  action_reason = "pull-request-sync"
 
           compose_name = f"pr-{pr_number}" if pr_number else ""
           commit_slug = preview_commit_slug(head_sha or github_sha)
@@ -491,11 +474,17 @@ jobs:
         with:
           script: |
             const marker = '<!-- pr-preview-status -->';
-            const passed = process.env.E2E_OUTCOME === 'success';
+            const outcome = process.env.E2E_OUTCOME || 'skipped';
+            const passed = outcome === 'success';
+            const wasSkipped = outcome === 'skipped' || outcome === '';
+            // Distinguish skipped from failed: a skipped check (e.g. a non-runtime PR,
+            // or a post-close cleanup run) is NOT a failure and must not read "Failed".
             const title = passed
               ? 'PR Preview Validation Passed'
-              : 'PR Preview Validation Failed';
-            const result = passed ? 'pass' : (process.env.E2E_OUTCOME || 'skipped');
+              : wasSkipped
+                ? 'PR Preview Validation Skipped'
+                : 'PR Preview Validation Failed';
+            const result = passed ? 'pass' : outcome;
             const body = `${marker}
             ## ${title}
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -470,13 +470,19 @@ jobs:
           PR_NUMBER: ${{ needs.setup.outputs.pr_number }}
           HEAD_SHA: ${{ needs.setup.outputs.head_sha }}
           E2E_OUTCOME: ${{ steps.e2e_tests.outcome }}
+          JOB_STATUS: ${{ job.status }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
             const marker = '<!-- pr-preview-status -->';
             const outcome = process.env.E2E_OUTCOME || 'skipped';
             const passed = outcome === 'success';
-            const wasSkipped = outcome === 'skipped' || outcome === '';
+            // A skip is only benign when the JOB itself succeeded (non-runtime PR or
+            // post-close cleanup). If an earlier step failed, e2e_tests is skipped but
+            // the job fails — that must read Failed, not Skipped (Copilot CR).
+            const wasSkipped =
+              (outcome === 'skipped' || outcome === '') &&
+              process.env.JOB_STATUS === 'success';
             // Distinguish skipped from failed: a skipped check (e.g. a non-runtime PR,
             // or a post-close cleanup run) is NOT a failure and must not read "Failed".
             const title = passed
@@ -492,9 +498,9 @@ jobs:
             |------|--------|
             | In-runner full-stack preview | \`${result}\` |
 
-            This in-runner check runs after the matching PR CI workflow succeeds. It starts the full stack inside the GitHub runner, runs provider-free smoke/E2E, and destroys the stack in the same job. It is the merge authority.
+            This in-runner check runs synchronously on this PR (on every push): it starts the full stack inside the GitHub runner, runs provider-free smoke/E2E, and destroys the stack in the same job. It is the merge authority — a required check that must pass before merge.
 
-            When it passes, a non-blocking persistent preview is then built from this PR's source on the Dokploy host (no PR preview image is pushed) and its URL is posted separately.
+            A persistent Dokploy preview is on-demand only (Actions → PR Test Environment → Run workflow → PR number); no PR preview image is pushed, and it is not built automatically.
 
             **Details:**
             - Branch: \`${process.env.BRANCH_NAME}\`

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -359,7 +359,7 @@ job inventories or scenario counts into this EPIC.
 | AC8.13.86 | CI fast feedback jobs start after change classification without waiting for behavior-only backend gates | `test_AC8_13_86_*` | `tests/tooling/test_post_merge_e2e_gates.py` | P1 |
 | AC8.13.87 | Personal report package fixture contract pins brokerage, dividend, and market-price expected outputs as Decimal-safe audit fixtures | `test_AC8_13_87_personal_package_fixture_pins_brokerage_dividend_and_market_price_outputs` | `tests/tooling/test_personal_report_package_fixture_contract.py` | P0 |
 | AC8.13.88 | Personal report package post-merge E2E consumes the audit-grade brokerage, dividend, market-price, and traceability identifier expected outputs | `test_AC8_13_88_personal_package_e2e_consumes_audit_grade_expected_outputs` | `tests/tooling/test_personal_report_package_fixture_contract.py` | P0 |
-| AC8.13.89 | PR preview follows the matching successful PR `CI` `workflow_run`, runs the runner-local full-stack smoke/E2E preview (the merge authority) with the PR head SHA, then deploys a non-blocking persistent Dokploy preview built from the PR source on the host without pushing, preflighting, pulling, or deleting PR preview images | `test_AC8_13_89_pr_preview_follows_ci_without_pr_image_builds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+| AC8.13.89 | The runner-local full-stack smoke/E2E gate runs synchronously on `pull_request` (the merge authority, a real required check, not async via `workflow_run`); the on-demand persistent Dokploy preview is built from the PR source on the host without pushing, preflighting, pulling, or deleting PR preview images | `test_AC8_13_89_pr_preview_follows_ci_without_pr_image_builds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.90 | Frontend exposes `/frontend-version.json` with deployed `git_sha`/`version` metadata for PR preview readiness checks | `AC8.13.90 returns deployed frontend version metadata for PR preview readiness` | `frontendVersionRoute.test.ts` | P0 |
 | AC8.13.91 | Main post-merge staging deploy failures open or update a persistent GitHub Issue alert, and the next successful staging run closes it | `test_AC8_13_91_post_merge_staging_failure_opens_rolling_alert_issue` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.92 | Frontend Vitest coverage keeps a code-owned 98% baseline for line, statement, and function metrics plus an explicit branch floor while representative low-coverage routes and workflow surfaces stay covered | `AC8.13.92*` | `apps/frontend/src/__tests__/coverageBaseline.test.ts`, `apps/frontend/src/__tests__/personalReportPackagePage.test.tsx`, `apps/frontend/src/__tests__/workflowSurfaces.test.tsx`, `apps/frontend/src/__tests__/chatPanelComponent.test.tsx`, `apps/frontend/src/__tests__/investmentPerformanceSchedule.test.tsx`, `apps/frontend/src/__tests__/journalPage.test.tsx`, `apps/frontend/src/__tests__/sankeyChartComponent.test.tsx`, `apps/frontend/src/__tests__/toastProviderComponent.test.tsx`, `apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx` | P0 |
@@ -384,7 +384,7 @@ job inventories or scenario counts into this EPIC.
 | AC8.13.111 | CI change classification structured Env x Stage outputs cover the complete environment axis (`local`, `pr`, `pr-preview`, `staging`, `prd`) while keeping PR heavy gating and deployed-environment gates represented as matrix cells | `test_AC8_13_111_*` | `tests/tooling/test_ci_change_classifier.py` | P0 |
 | AC8.13.112 | Delivery-engine recommendations, SSOT, workflow gates, and contract tests stay aligned around structured Env x Stage consumers while legacy scalar outputs remain compatibility-only shims | `test_AC8_13_112_sparse_matrix_recommendation_tracks_simplification_path`, `test_AC8_13_112_workflows_consume_structured_env_stage_gates` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.113 | Sparse Env x Stage reviews record the three newest successful and three newest failed evidence samples for active delivery lanes, then summarize delivery-speed balance, end-to-end consistency, quality fallback, resource leak candidates, and the safe simplification boundary | `test_AC8_13_113_sparse_matrix_evidence_and_resource_leak_audit_are_recorded` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
-| AC8.13.114 | PR preview starts only from a successful matching PR `CI` `workflow_run`; failed/cancelled/timed-out CI runs trigger cleanup instead of deploy | `test_AC8_13_114_pr_preview_follows_successful_ci_workflow_run` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+| AC8.13.114 | The in-runner E2E gate runs synchronously on `pull_request` as a real required check a fast/auto merge cannot bypass (not async via `workflow_run`, which a merge could outrun); PR close triggers cleanup, not a gate | `test_AC8_13_114_pr_preview_follows_successful_ci_workflow_run` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.115 | Runner preview readiness is bounded before smoke/E2E starts, with stack logs emitted on failure | `test_AC8_13_115_readiness_fail_fast` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.116 | Post-merge → staging start latency is reduced by removing redundant heavy re-run on push to main | `test_AC8_13_116_skip_heavy_ci_on_main_push` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.117 | Staging FIFO worst-case wait is bounded/parameterized and documented; a path to parallel staging is proposed | `test_AC8_13_117_parameterized_staging_fifo_timeout` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
@@ -588,9 +588,12 @@ The simplification priority remains:
 6. If stale resources were not captured, next run latency would accumulate;
    current controls cover PR previews, GHCR tag pruning, host hygiene, and stale
    version visibility in deployment context.
-7. If PR preview ran from PR events instead of the successful `CI`
-   `workflow_run`, preview could race before the merge-authority gate; the
-   workflow_run trigger keeps preview behind completed CI.
+7. The in-runner E2E gate runs synchronously on `pull_request`, not asynchronously
+   via `workflow_run`: a `workflow_run` gate fires only after CI, so a fast or auto
+   merge could land before it ran — and GitHub counts a skipped required check as
+   passed, which made the "merge authority" bypassable. A synchronous `pull_request`
+   check must pass before merge. (The heavier persistent preview stays on-demand via
+   `workflow_dispatch`; the gate is image-free so it needs no CI artifact.)
 8. If staging consumed PR-head SHAs instead of successful `main` merge SHAs, deploy
    reproducibility and release provenance would weaken; staging tracks workflow_run
    SHA and uses successful main SHA gates.

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -358,9 +358,12 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - The serialized GLM gate includes `tests/e2e/test_statement_full_journey.py`, `tests/e2e/test_statement_upload_e2e.py`, `tests/e2e/test_brokerage_upload_to_portfolio_value.py`, `tests/e2e/test_four_asset_net_worth_golden_path.py`, and `tests/e2e/test_personal_financial_report_package.py`. The brokerage test uploads Moomoo and Futu PDF fixtures through `/api/statements/upload`, waits for parsed statements, imports positions through `/api/statements/{id}/brokerage/import`, and verifies `/api/portfolio/holdings` plus `/api/reports/balance-sheet`. The four-asset gate uses an isolated user to combine deterministic bank statement posting, brokerage PDF import, property/mortgage/ESOP manual valuation snapshots, exact as-of net worth, and dashboard/report totals. The personal financial report package gate verifies statements, schedules, notes, restricted-asset treatment, report exports, and source traceability from one fresh user. Failures identify whether OCR parsing, parsed-data state transition, brokerage import, manual valuation, reporting, report packaging, or dashboard aggregation failed. The path-level proof matrix is maintained in [EPIC-017](../project/EPIC-017.portfolio-management.md#brokerage-pdf-to-asset-report-proof-matrix) with the compact entry-point version in the README; critical product proof anchors live in [critical-proof-matrix.yaml](critical-proof-matrix.yaml). Every `post_merge_environment` proof in that matrix that carries the `llm` marker must appear in both `.github/workflows/staging-deploy.yml` and `.github/workflows/staging-ai-ocr-gate.yml`.
 
 **PR preview E2E** (`.github/workflows/pr-test.yml`):
-- PR preview follows the matching successful PR `CI` `workflow_run`; it no
-  longer polls partial CI from inside the preview workflow. Failed, cancelled,
-  timed-out, non-PR, forked, or already-closed CI runs do not create a preview.
+- The in-runner E2E gate runs **synchronously on `pull_request`**
+  (opened/synchronize/reopened), so it is a real required check a fast or auto
+  merge cannot bypass. It no longer follows CI asynchronously via `workflow_run`:
+  that fired only after CI and a quick merge could land before it ran as a gate
+  (GitHub counts a skipped required check as passed). It is image-free, so it needs
+  no CI artifact and runs independently of CI. PR close triggers cleanup, not a gate.
 - PR preview does not inject `ZAI_API_KEY`; it validates app wiring without
   real GLM/OCR provider calls.
 - PR preview does not push, preflight, pull, or delete PR preview images, and it

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -16,7 +16,7 @@
 | **1** | **Local Dev** | `localhost:3000` | Manual<br>`moon run :dev -- --backend` | Source (Host)<br>uvicorn/next dev | Shared Containers<br>(Podman/Docker) | `finance_report` | Container name suffix |
 | **2** | **Local CI** | `localhost:3000` | Manual<br>`moon run :lint && moon run :test` | Source (Host)<br>pytest | Shared Containers<br>(Podman/Docker) | `finance_report_test_{namespace}` | DB/bucket name |
 | **3** | **GitHub CI** | - | Push/PR<br>`ci.yml` | Source (Runner)<br>pytest | GitHub Services<br>(Ephemeral) | `finance_report_test` | Job isolation |
-| **4** | **PR Preview** | `http://localhost:8080` inside GitHub runner<br>**No persistent Dokploy URL** | Successful PR `CI` `workflow_run`<br>`pr-test.yml` | Runner compose stack<br>(local build, no registry push) | GitHub runner containers<br>(Per run) | Ephemeral Postgres/MinIO | `COMPOSE_PROJECT_NAME=fr-e2e-<run>-<attempt>` |
+| **4** | **PR Preview** | `http://localhost:8080` inside GitHub runner<br>**No persistent Dokploy URL** | PR push — synchronous `pull_request`<br>`pr-test.yml` (not async `workflow_run`) | Runner compose stack<br>(local build, no registry push) | GitHub runner containers<br>(Per run) | Ephemeral Postgres/MinIO | `COMPOSE_PROJECT_NAME=fr-e2e-<run>-<attempt>` |
 | **5** | **Staging** | `report-staging.zitian.party` | Push to main<br>`staging-deploy.yml` | **Docker Images**<br>(GHCR) | Dedicated infra2<br>+ Shared Platform | Dedicated DB/Redis | Bucket name<br>`-staging` |
 | **6** | **Production** | `report.zitian.party` | Manual release<br>`production-release.yml` | **Docker Images**<br>(GHCR) | Dedicated infra2<br>+ Shared Platform | Dedicated DB/Redis | Bucket name |
 

--- a/tests/tooling/test_issue_489_deployment_contracts.py
+++ b/tests/tooling/test_issue_489_deployment_contracts.py
@@ -272,9 +272,9 @@ def test_pr_preview_gate_exercises_health_smoke_e2e_and_storage_paths() -> None:
     smoke = read("tools/_lib/shell/smoke_test.sh")
     hard_gate = read("tests/e2e/test_vision_upload_to_dashboard_hard_gate.py")
 
-    assert "workflow_run:" in workflow
-    assert 'workflows: ["CI"]' in workflow
-    assert 'triggering_ci_conclusion == "success"' in workflow
+    assert "workflow_run:" not in workflow
+    assert "types: [opened, synchronize, reopened, closed]" in workflow
+    assert 'action_reason = "pull-request-sync"' in workflow
     assert "name: In-runner Preview E2E" in workflow
     assert "python tools/pr_preview_lifecycle.py" in workflow
     assert "--action cleanup" in workflow
@@ -320,9 +320,9 @@ def test_pr_preview_follows_successful_ci_without_dokploy_deploy() -> None:
     jobs = workflow["jobs"]
 
     assert "preview_opt_in" not in yaml.safe_dump(workflow)
-    assert "workflow_run:" in workflow_text
-    assert 'workflows: ["CI"]' in workflow_text
-    assert 'triggering_ci_conclusion == "success"' in workflow_text
+    assert "workflow_run:" not in workflow_text
+    assert "types: [opened, synchronize, reopened, closed]" in workflow_text
+    assert 'action_reason = "pull-request-sync"' in workflow_text
     assert 'action = "cleanup"' in workflow_text
     assert "build-preview-backend-image" not in jobs
     assert "build-preview-frontend-image" not in jobs
@@ -341,7 +341,7 @@ def test_pr_preview_follows_successful_ci_without_dokploy_deploy() -> None:
     assert "--action cleanup" in cleanup_blob
 
     env_doc = read("docs/ssot/environments.md")
-    assert "workflow_run" in env_doc
+    assert "pull_request" in env_doc
     assert "No persistent Dokploy URL" in env_doc
 
 

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -1627,7 +1627,8 @@ def test_AC8_13_40_pr_ci_dry_runs_staging_image_builds_before_merge() -> None:
 
 
 def test_AC8_13_89_pr_preview_follows_ci_without_pr_image_builds() -> None:
-    """AC8.13.89: PR preview follows successful CI and does not build/push PR images."""
+    """AC8.13.89: the in-runner e2e gate runs synchronously on pull_request (independent
+    of CI) and does not build/push PR images."""
     workflow = read(".github/workflows/pr-test.yml")
     ci_cd = read("docs/ssot/ci-cd.md")
     compose = read("docker-compose.yml")

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -1642,12 +1642,15 @@ def test_AC8_13_89_pr_preview_follows_ci_without_pr_image_builds() -> None:
     pr_preview_compose = read("docker-compose.pr-preview.yml")
     frontend_compose_block = compose.split("  frontend:", 1)[1].split("networks:", 1)[0]
 
-    assert "workflow_run:" in workflow
-    assert 'workflows: ["CI"]' in workflow
-    assert "types: [completed]" in workflow
-    assert 'triggering_ci_conclusion == "success"' in workflow
+    # The in-runner e2e gate runs SYNCHRONOUSLY on pull_request (not async via
+    # workflow_run, which a fast/auto merge could outrun) so it is a real required
+    # check before merge. Preview stays on-demand (deploy-preview = workflow_dispatch).
+    assert "workflow_run:" not in workflow
+    assert "types: [opened, synchronize, reopened, closed]" in workflow
+    assert 'action = "deploy"' in workflow
+    assert 'action_reason = "pull-request-sync"' in workflow
     assert 'action = "cleanup"' in workflow
-    assert "github.event.workflow_run.pull_requests[0].number" in workflow
+    assert "github.event.pull_request.number" in workflow
     assert "gate-cheap-ci:" not in workflow
     assert "tools/wait_for_cheap_ci.py" not in workflow
     # No PR preview IMAGES are built/pushed/preflighted in CI: the persistent
@@ -1698,7 +1701,7 @@ def test_AC8_13_89_pr_preview_follows_ci_without_pr_image_builds() -> None:
     assert "no PR preview image is pushed" in e2e_block
     assert "Delete GHCR images" not in cleanup_block
     assert "pr_preview_images=not-created" in cleanup_block
-    assert "PR preview follows the matching successful PR `CI` `workflow_run`" in ci_cd
+    assert "synchronously on `pull_request`" in ci_cd
     assert "does not push, preflight, pull, or delete PR preview images" in ci_cd
     assert "built from the PR source on the Dokploy host" in ci_cd
     assert "The runner stack waits for `/api/health` before smoke/E2E" in ci_cd
@@ -2932,15 +2935,18 @@ def test_AC8_13_34_ci_and_post_merge_write_timing_summaries() -> None:
 
 
 def test_AC8_13_114_pr_preview_follows_successful_ci_workflow_run() -> None:
-    """AC8.13.114: PR preview starts only from a successful matching CI workflow_run."""
+    """AC8.13.114: the in-runner e2e gate runs synchronously on pull_request, so it is a
+    real required check a fast/auto merge cannot bypass. It no longer follows CI async
+    via workflow_run — that fired after CI and a quick merge could land before it ran as
+    a gate (skipped required checks count as passed). It is image-free, so it needs no
+    CI artifact and runs independently."""
     workflow = read(".github/workflows/pr-test.yml")
-    assert "workflow_run:" in workflow
-    assert 'workflows: ["CI"]' in workflow
-    assert "types: [completed]" in workflow
-    assert 'triggering_ci_event != "pull_request"' in workflow
-    assert 'triggering_ci_conclusion == "success"' in workflow
+    assert "workflow_run:" not in workflow
+    assert "types: [opened, synchronize, reopened, closed]" in workflow
+    assert 'action_reason = "pull-request-sync"' in workflow
     assert 'action = "deploy"' in workflow
-    assert 'action = "cleanup"' in workflow
+    assert 'action = "cleanup"' in workflow  # pull_request closed -> cleanup
+    assert "pr_preview_required == 'true'" in workflow
     assert "tools/wait_for_cheap_ci.py" not in workflow
     assert "gate-cheap-ci:" not in workflow
     assert "build-preview-backend-image:" not in workflow

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -1998,7 +1998,7 @@ def test_AC8_13_100_pr_preview_runner_readiness_is_bounded_and_observable() -> N
     workflow = (ROOT / ".github/workflows/pr-test.yml").read_text()
     e2e_block = workflow.split("  e2e:", 1)[1].split("  cleanup:", 1)[0]
 
-    assert "workflow_run:" in workflow
+    assert "workflow_run:" not in workflow
     assert 'PYTHONUNBUFFERED: "1"' in workflow
     assert "timeout-minutes: 25" in e2e_block
     assert "Wait for stack readiness" in e2e_block


### PR DESCRIPTION
Fixes a real **merge-gate bypass** + a misleading bot comment, found while reviewing why a PR showed "PR Preview Validation Failed".

## The bug (gate bypass)
The in-runner full-stack e2e is the documented "merge authority". It was triggered **async via `workflow_run`** (after CI). But:
- `workflow_run` fires only after CI completes — a fast or **auto-merge** can land the PR before it runs as a gate.
- GitHub counts a **skipped required check as passed**.
- → a runtime PR can merge without the gate ever running. **Observed live: PR #938** (changed `apps/backend/src` + `apps/frontend/src`) merged with `In-runner Preview E2E: skipped`; the only pr-test run was the post-close cleanup.

There was also a **concurrency hazard**: the group keys on PR number with `cancel-in-progress`, so a `workflow_run` run could cancel an in-progress `pull_request` e2e.

## The fix
Run the gate **synchronously on `pull_request`** (opened/synchronize/reopened):
- It's a real required check that must pass before merge — not outrunnable.
- It's **image-free** (builds the stack on the runner), so it needs no CI artifact and runs independently of CI.
- `workflow_run` trigger + setup branch removed (also kills the concurrency cancel).
- **Preview unaffected**: `deploy-preview` stays `workflow_dispatch`-only (P1a-2); `pull_request closed` -> cleanup.

Plus the result comment now reads **"Skipped"** (not "Failed") for a skipped check, so a non-runtime / post-close run stops posting a false failure.

## Verify
- **Automated**: `tests/tooling/test_post_merge_e2e_gates.py::test_AC8_13_89/114`, `test_issue_489_deployment_contracts.py` (2), `test_pr_preview_lifecycle.py::test_AC8_13_100` all assert the synchronous `pull_request` trigger + no `workflow_run`. Full tooling suite **1390 passed**; doc-consistency / ac-traceability / ssot-ownership / ci-metrics all green.
- **Manual (after merge)**: open a runtime PR → `In-runner Preview E2E` appears as a **pending required check immediately on push** (not after CI) → must go green before merge. A docs-only PR shows it **Skipped** (not Failed). On-demand preview unchanged: Actions → Run workflow → PR number.

## Blast radius (all synced in this PR)
`pr-test.yml` (trigger / concurrency / setup action / header / comment), `docs/ssot/ci-cd.md`, `docs/ssot/environments.md`, `docs/project/EPIC-008.testing-strategy.md` (AC8.13.89, AC8.13.114, rationale #7 — which had the trade-off backwards), and 4 contract tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)