### PR TITLE
[finance_report_infra] SSOT: delivery-gates manifest — single owner for gate triggers (decouple the restate)

### DIFF
--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -118,6 +118,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_check_manifest.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_check_ssot_ownership.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_coverage_analyzer.py` | `docs/ssot/coverage.md` |
+| `tests/tooling/test_delivery_gates_contract.py` | `docs/ssot/delivery-gates.yaml` |
 | `tests/tooling/test_dokploy_failure_snapshot.py` | `docs/ssot/ci-cd.md` |
 | `tests/tooling/test_generate_fixtures.py` | `docs/ssot/extraction.md` |
 | `tests/tooling/test_github_workflow_timing_summary.py` | `docs/ssot/ci-cd.md` |

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -369,6 +369,19 @@ concepts:
       - docs/ssot/coverage.md
       - .github/workflows/ci.yml
 
+  delivery_gate_triggers:
+    owner: docs/ssot/delivery-gates.yaml
+    description: How each delivery CI gate triggers and whether it blocks merge — the single source for trigger/blocking contracts (so a trigger change is one edit, not a fact restated across docs/tests).
+    cross_refs:
+      - docs/ssot/ci-cd.md
+      - docs/ssot/environments.md
+      - docs/project/EPIC-008.testing-strategy.md
+      - .github/workflows/pr-test.yml
+      - .github/workflows/staging-deploy.yml
+      - .github/workflows/production-release.yml
+    proofs:
+      - tests/tooling/test_delivery_gates_contract.py
+
   test_optimization:
     owner: docs/ssot/ci-cd.md#test-optimization
     description: Smart/fast/full test modes and 4-way sharding strategy.

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -371,6 +371,8 @@ concepts:
 
   delivery_gate_triggers:
     owner: docs/ssot/delivery-gates.yaml
+    family: delivery
+    kind: matrix
     description: How each delivery CI gate triggers and whether it blocks merge — the single source for trigger/blocking contracts (so a trigger change is one edit, not a fact restated across docs/tests).
     cross_refs:
       - docs/ssot/ci-cd.md

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -358,6 +358,12 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - The serialized GLM gate includes `tests/e2e/test_statement_full_journey.py`, `tests/e2e/test_statement_upload_e2e.py`, `tests/e2e/test_brokerage_upload_to_portfolio_value.py`, `tests/e2e/test_four_asset_net_worth_golden_path.py`, and `tests/e2e/test_personal_financial_report_package.py`. The brokerage test uploads Moomoo and Futu PDF fixtures through `/api/statements/upload`, waits for parsed statements, imports positions through `/api/statements/{id}/brokerage/import`, and verifies `/api/portfolio/holdings` plus `/api/reports/balance-sheet`. The four-asset gate uses an isolated user to combine deterministic bank statement posting, brokerage PDF import, property/mortgage/ESOP manual valuation snapshots, exact as-of net worth, and dashboard/report totals. The personal financial report package gate verifies statements, schedules, notes, restricted-asset treatment, report exports, and source traceability from one fresh user. Failures identify whether OCR parsing, parsed-data state transition, brokerage import, manual valuation, reporting, report packaging, or dashboard aggregation failed. The path-level proof matrix is maintained in [EPIC-017](../project/EPIC-017.portfolio-management.md#brokerage-pdf-to-asset-report-proof-matrix) with the compact entry-point version in the README; critical product proof anchors live in [critical-proof-matrix.yaml](critical-proof-matrix.yaml). Every `post_merge_environment` proof in that matrix that carries the `llm` marker must appear in both `.github/workflows/staging-deploy.yml` and `.github/workflows/staging-ai-ocr-gate.yml`.
 
 **PR preview E2E** (`.github/workflows/pr-test.yml`):
+
+> The trigger/blocking contract for every delivery gate is the SSOT
+> [`delivery-gates.yaml`](./delivery-gates.yaml) (verified by
+> `tests/tooling/test_delivery_gates_contract.py`). This section describes the
+> *behavior*; it does not own the trigger *mechanism* — change a trigger there.
+
 - The in-runner E2E gate runs **synchronously on `pull_request`**
   (opened/synchronize/reopened), so it is a real required check a fast or auto
   merge cannot bypass. It no longer follows CI asynchronously via `workflow_run`:

--- a/docs/ssot/delivery-gates.yaml
+++ b/docs/ssot/delivery-gates.yaml
@@ -9,7 +9,7 @@
 # and a comment reword broke unrelated tests. Now:
 #   - this manifest declares the trigger/blocking contract (one edit),
 #   - the workflow implements it (one edit),
-#   - tools/test_delivery_gates_contract.py verifies the workflow matches THIS file
+#   - tests/tooling/test_delivery_gates_contract.py verifies the workflow matches THIS file
 #     by parsing `on:`/job structure — not by grepping prose,
 #   - ci-cd.md / environments.md / EPIC-008 describe the *behavior* and cross-ref here
 #     instead of re-stating the mechanism.

--- a/docs/ssot/delivery-gates.yaml
+++ b/docs/ssot/delivery-gates.yaml
@@ -1,0 +1,65 @@
+# Delivery Gate Triggers — SSOT
+#
+# Single source of truth for HOW each delivery CI gate is triggered and WHETHER it
+# blocks merge. The behavior contract lives HERE, in one machine-readable place.
+#
+# Why this file exists: the "in-runner e2e is a synchronous required gate" fact used
+# to be restated across ci-cd.md, environments.md, EPIC-008, the pr-test.yml comment,
+# and a dozen string-grep contract tests. Changing one trigger meant editing 7+ files,
+# and a comment reword broke unrelated tests. Now:
+#   - this manifest declares the trigger/blocking contract (one edit),
+#   - the workflow implements it (one edit),
+#   - tools/test_delivery_gates_contract.py verifies the workflow matches THIS file
+#     by parsing `on:`/job structure — not by grepping prose,
+#   - ci-cd.md / environments.md / EPIC-008 describe the *behavior* and cross-ref here
+#     instead of re-stating the mechanism.
+#
+# Validated by: tests/tooling/test_delivery_gates_contract.py
+# Owner concept in docs/ssot/MANIFEST.yaml: delivery_gate_triggers
+#
+# trigger values:
+#   pull_request      — synchronous PR check (cannot be outrun by a fast/auto merge)
+#   workflow_run      — async, after another workflow (e.g. main CI) completes
+#   workflow_dispatch — manual / on-demand
+#   tag               — on push of a release tag (on.push.tags)
+
+version: "1.0"
+
+gates:
+  - id: pr-in-runner-e2e
+    workflow: .github/workflows/pr-test.yml
+    job: e2e
+    trigger: pull_request          # synchronous — NOT workflow_run (#943)
+    blocking: true                 # the merge authority: a required check before merge
+    image_free: true              # builds the full stack on the runner; needs no CI artifact
+    description: >
+      Full-stack provider-free smoke/E2E inside the GitHub runner — the merge authority.
+      Runs synchronously on pull_request so a fast or auto merge cannot land before it
+      runs as a required check (a skipped required check counts as passed).
+
+  - id: pr-persistent-preview
+    workflow: .github/workflows/pr-test.yml
+    job: deploy-preview
+    trigger: workflow_dispatch     # on-demand only (P1a-2, #879); never per-PR auto
+    blocking: false
+    image_free: false             # builds PR source on the Dokploy host (D1, until P2/#883)
+    description: >
+      On-demand persistent Dokploy preview. Non-blocking; one click via Run workflow.
+
+  - id: staging-deploy
+    workflow: .github/workflows/staging-deploy.yml
+    job: build-and-deploy
+    trigger: workflow_run          # after a successful main CI run
+    blocking: false
+    image_free: false
+    description: >
+      Post-merge micro-soak on staging before prod. Promotes the main-CI :<sha> image.
+
+  - id: production-release
+    workflow: .github/workflows/production-release.yml
+    job: deploy
+    trigger: tag                   # vX.Y.Z release tag (manual dispatch is a recovery path)
+    blocking: false
+    image_free: true              # pure promote of an existing :<sha> digest — no rebuild
+    description: >
+      Promote the staging-validated digest to a release (staging-first, promote-not-rebuild).

--- a/tests/tooling/test_delivery_gates_contract.py
+++ b/tests/tooling/test_delivery_gates_contract.py
@@ -1,0 +1,70 @@
+"""Contract: each delivery gate's workflow matches its declared trigger in
+docs/ssot/delivery-gates.yaml (the SSOT).
+
+This is the verifier half of the "one manifest, derive everywhere" decoupling. It
+parses each workflow's `on:`/`jobs:` STRUCTURE and checks it against the manifest, so a
+trigger change is one manifest edit + one workflow edit — and prose rewording (job
+comments, the PR-status comment body) can never break it. Behavioral docs (ci-cd.md,
+environments.md, EPIC-008) cross-ref the manifest instead of re-stating the mechanism.
+"""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(path: str) -> dict:
+    return yaml.safe_load((ROOT / path).read_text(encoding="utf-8"))
+
+
+def _workflow_on(wf: dict) -> dict:
+    # PyYAML parses the GitHub Actions `on:` key as the boolean True.
+    return wf.get(True) or wf.get("on") or {}
+
+
+# manifest trigger -> the `on:` key the workflow must declare
+_TRIGGER_ON_KEY = {
+    "pull_request": "pull_request",
+    "workflow_run": "workflow_run",
+    "workflow_dispatch": "workflow_dispatch",
+    "tag": "push",  # release tags live under on.push.tags
+}
+
+GATES = _load("docs/ssot/delivery-gates.yaml")["gates"]
+
+
+def test_every_gate_workflow_declares_its_manifest_trigger():
+    for gate in GATES:
+        on = _workflow_on(_load(gate["workflow"]))
+        key = _TRIGGER_ON_KEY[gate["trigger"]]
+        assert key in on, (
+            f"gate {gate['id']!r} declares trigger={gate['trigger']} but "
+            f"{gate['workflow']} `on:` has no `{key}` (delivery-gates.yaml is the SSOT)."
+        )
+        if gate["trigger"] == "tag":
+            assert (on.get("push") or {}).get("tags"), (
+                f"gate {gate['id']!r} is tag-triggered but on.push has no tags filter."
+            )
+
+
+def test_merge_authority_gate_is_synchronous_not_bypassable():
+    """The blocking PR e2e gate must be a synchronous pull_request check, never async
+    workflow_run — that could be outrun by a fast/auto merge (#943)."""
+    gate = next(g for g in GATES if g["id"] == "pr-in-runner-e2e")
+    assert gate["trigger"] == "pull_request"
+    assert gate["blocking"] is True
+    on = _workflow_on(_load(gate["workflow"]))
+    assert "workflow_run" not in on, (
+        "the merge-authority e2e gate must not use async workflow_run; a fast/auto "
+        "merge could land before it runs as a required check (delivery-gates.yaml)."
+    )
+
+
+def test_every_referenced_workflow_and_job_exists():
+    for gate in GATES:
+        jobs = _load(gate["workflow"]).get("jobs") or {}
+        assert gate["job"] in jobs, (
+            f"gate {gate['id']!r} references job {gate['job']!r} not in {gate['workflow']}."
+        )


### PR DESCRIPTION
Answers the question raised on #943: *"changing one fact touched 7 files — is this SSOT done badly?"* Yes, for one specific reason, now fixed.

## The smell
"The in-runner e2e is a synchronous required gate" was **restated** across `pr-test.yml`, `ci-cd.md`, `environments.md`, `EPIC-008`, and ~6 string-grep contract tests. So:
- changing one trigger meant editing **7+ files**, and
- a comment/body **reword broke unrelated tests** (they asserted prose verbatim, e.g. `"no PR preview image is pushed" in body`).

Root cause: the **implementation mechanism** (how a gate triggers) leaked into SSOT docs and into tests as verbatim string matches.

## The fix — apply the repo's own yaml-manifest SSOT pattern
This repo already does "one yaml manifest, derive everywhere" (`test-execution-matrix.yaml`, `critical-proof-matrix.yaml`). Use it for gate triggers:

- **`docs/ssot/delivery-gates.yaml`** — declares each gate's `trigger` + `blocking` + `image_free` in ONE place (pr e2e gate, on-demand preview, staging, prod).
- **`tests/tooling/test_delivery_gates_contract.py`** — verifies each workflow's `on:`/`jobs:` **structure** matches the manifest (parses yaml, **never greps prose**). A reworded comment/body can't break it. Includes the #943 invariant: the merge-authority gate must be `pull_request`, never async `workflow_run`.
- **`MANIFEST.yaml`** — registers `delivery_gate_triggers` with the manifest as **owner**; `ci-cd.md` / `environments.md` / `EPIC-008` / the workflows become **cross-refs** that describe behavior, not owners of the mechanism (the single-owner-per-concept rule then prevents drift).
- **`ci-cd.md`** points at the manifest as the trigger SSOT.

## Result
A trigger change is now **one manifest edit + one workflow edit**; docs describe behavior and cross-ref the manifest; the contract test derives from it structurally.

Existing AC string-grep tests are left in place (incremental migration, not a big-bang rewrite) — new trigger assertions derive from the manifest going forward.

## Verify
`uv run pytest tests/tooling/test_delivery_gates_contract.py` → 3 passed. Full tooling suite **1393 passed**; `check_manifest` / `lint_doc_consistency` / `check_ssot_ownership` / `ci-metrics` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)