### PR TITLE
[finance_report_audit] EPIC-018 AC18.14: correction feedback loop drives the low-confidence proportion down (#931)

### DIFF
--- a/apps/backend/src/services/correction_loop.py
+++ b/apps/backend/src/services/correction_loop.py
@@ -65,7 +65,9 @@ def build_corpus_from_corrections(corrections: Iterable[CorrectionLog]) -> list[
     """
     records: list[CorrectionRecord] = []
     for correction in corrections:
-        key = _normalize_key(correction.transaction_description or correction.original_category)
+        # Normalize each candidate independently: a whitespace-only description must
+        # fall back to original_category rather than yield an empty key.
+        key = _normalize_key(correction.transaction_description) or _normalize_key(correction.original_category)
         if not key:
             continue
         records.append(
@@ -118,6 +120,9 @@ class CorrectionLoopService:
     async def build_corpus(self, db: AsyncSession, user_id: UUID) -> list[CorrectionRecord]:
         """Project a user's append-only corrections into the replayable corpus."""
         result = await db.execute(
-            select(CorrectionLog).where(CorrectionLog.user_id == user_id).order_by(CorrectionLog.created_at)
+            select(CorrectionLog)
+            .where(CorrectionLog.user_id == user_id)
+            # id breaks created_at ties so the corpus order — and the replay split — is deterministic.
+            .order_by(CorrectionLog.created_at, CorrectionLog.id)
         )
         return build_corpus_from_corrections(result.scalars().all())

--- a/apps/backend/src/services/correction_loop.py
+++ b/apps/backend/src/services/correction_loop.py
@@ -1,0 +1,123 @@
+"""Correction feedback loop: turn human corrections into priors that lower the
+low-confidence proportion (#931, Axiom B).
+
+B3 (#919) measures the low-confidence-data proportion — the thermometer. This is
+the furnace: every human correction that overrode an AI proposal (a
+Manual-supersedes-Derived signal recorded in the append-only ``CorrectionLog``)
+is labeled signal about where the system was wrong. Replayed as priors, a recurring
+correction grounds future instances of the same pattern so they are no longer
+low-confidence — measurably driving the north-star proportion down.
+
+Scope of this slice: the corpus (derived from the provenance substrate, not a
+sidecar) and the deterministic measurable replay. Wiring the priors into live
+extraction/classification generation, and calibrating the promotion-gate
+thresholds (#930) from the corpus, are follow-ups; the runtime that dispatches AI
+attempts is a separate EPIC.
+"""
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.correction import CorrectionLog
+
+_QUANT = Decimal("0.00001")
+
+
+def _normalize_key(text: str | None) -> str:
+    """Collapse a transaction pattern to a stable prior key."""
+    return " ".join((text or "").lower().split())
+
+
+@dataclass(frozen=True)
+class CorrectionRecord:
+    """One labeled correction derived from provenance: a human overrode an AI proposal."""
+
+    key: str
+    corrected_category: str
+    proposed_category: str | None
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """The measurable outcome of replaying the corpus against a held-out split."""
+
+    holdout_size: int
+    grounded: int
+    proportion_before: Decimal
+    proportion_after: Decimal
+
+    @property
+    def reduced(self) -> bool:
+        return self.proportion_after < self.proportion_before
+
+
+def build_corpus_from_corrections(corrections: Iterable[CorrectionLog]) -> list[CorrectionRecord]:
+    """Derive the correction corpus from ``CorrectionLog``, keyed by the transaction pattern.
+
+    No sidecar: the corpus is a projection of the existing append-only correction
+    store (the provenance-tagged Manual-supersedes-Derived signal), not a separate
+    source of truth. Corrections with no usable pattern are skipped.
+    """
+    records: list[CorrectionRecord] = []
+    for correction in corrections:
+        key = _normalize_key(correction.transaction_description or correction.original_category)
+        if not key:
+            continue
+        records.append(
+            CorrectionRecord(
+                key=key,
+                corrected_category=correction.corrected_category,
+                proposed_category=correction.original_category,
+            )
+        )
+    return records
+
+
+def replay_low_confidence_reduction(
+    corpus: Sequence[CorrectionRecord],
+    *,
+    train_ratio: Decimal = Decimal("0.5"),
+) -> ReplayResult:
+    """Held-out replay: build priors from a train split and measure the held-out proportion.
+
+    Each held-out correction is, by definition, a low-confidence proposal the AI
+    got wrong. A held-out item whose key was already corrected in the train split
+    is grounded by the prior — its answer is known — so it is no longer
+    low-confidence. The proportion strictly drops exactly when correction patterns
+    recur, which is the loop measurably improving (and never an invented gain when
+    they do not).
+    """
+    ordered = list(corpus)
+    split = int(len(ordered) * train_ratio)
+    prior_keys = {record.key for record in ordered[:split]}
+    holdout = ordered[split:]
+
+    holdout_size = len(holdout)
+    grounded = sum(1 for record in holdout if record.key in prior_keys)
+    low_after = holdout_size - grounded
+
+    def _proportion(count: int) -> Decimal:
+        return (Decimal(count) / Decimal(holdout_size)).quantize(_QUANT) if holdout_size else Decimal("0")
+
+    return ReplayResult(
+        holdout_size=holdout_size,
+        grounded=grounded,
+        proportion_before=_proportion(holdout_size),
+        proportion_after=_proportion(low_after),
+    )
+
+
+class CorrectionLoopService:
+    """Builds the correction corpus from the provenance substrate."""
+
+    async def build_corpus(self, db: AsyncSession, user_id: UUID) -> list[CorrectionRecord]:
+        """Project a user's append-only corrections into the replayable corpus."""
+        result = await db.execute(
+            select(CorrectionLog).where(CorrectionLog.user_id == user_id).order_by(CorrectionLog.created_at)
+        )
+        return build_corpus_from_corrections(result.scalars().all())

--- a/apps/backend/tests/services/test_correction_loop.py
+++ b/apps/backend/tests/services/test_correction_loop.py
@@ -36,12 +36,15 @@ def test_AC18_14_1_corpus_is_derived_from_corrections_keyed_by_pattern():
     corrections = [
         _correction(description="  Starbucks  COFFEE ", original="Travel", corrected="Meals"),
         _correction(description=None, original="Misc", corrected="Software"),  # falls back to original_category key
-        _correction(description="   ", original=None, corrected="Ignored"),  # empty key -> skipped
+        _correction(
+            description="   ", original="Groceries", corrected="Food"
+        ),  # whitespace desc -> falls back, not dropped
+        _correction(description="   ", original=None, corrected="Ignored"),  # no usable pattern -> skipped
     ]
 
     corpus = build_corpus_from_corrections(corrections)
 
-    assert [record.key for record in corpus] == ["starbucks coffee", "misc"]
+    assert [record.key for record in corpus] == ["starbucks coffee", "misc", "groceries"]
     assert corpus[0].corrected_category == "Meals"
     assert corpus[0].proposed_category == "Travel"
 

--- a/apps/backend/tests/services/test_correction_loop.py
+++ b/apps/backend/tests/services/test_correction_loop.py
@@ -1,0 +1,108 @@
+"""Correction feedback loop: corrections measurably lower the low-confidence proportion (EPIC-018 AC18.14, #931).
+
+B3 (#919) is a thermometer; this is the furnace. Each human correction that
+overrode an AI proposal is labeled signal; replayed as priors it grounds
+recurring patterns so future instances are no longer low-confidence — measurably
+driving the north-star proportion down.
+"""
+
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from src.models.correction import CorrectionLog
+from src.services.correction_loop import (
+    CorrectionLoopService,
+    CorrectionRecord,
+    build_corpus_from_corrections,
+    replay_low_confidence_reduction,
+)
+
+
+def _correction(*, description=None, original=None, corrected="Office Supplies") -> CorrectionLog:
+    # In-memory only (never persisted) — a fixture for the pure derivation logic.
+    return CorrectionLog(
+        user_id=uuid4(),
+        transaction_id=uuid4(),
+        original_category=original,
+        corrected_category=corrected,
+        transaction_description=description,
+    )
+
+
+def test_AC18_14_1_corpus_is_derived_from_corrections_keyed_by_pattern():
+    """AC18.14.1: the corpus is a provenance projection of CorrectionLog, keyed by the transaction pattern."""
+    corrections = [
+        _correction(description="  Starbucks  COFFEE ", original="Travel", corrected="Meals"),
+        _correction(description=None, original="Misc", corrected="Software"),  # falls back to original_category key
+        _correction(description="   ", original=None, corrected="Ignored"),  # empty key -> skipped
+    ]
+
+    corpus = build_corpus_from_corrections(corrections)
+
+    assert [record.key for record in corpus] == ["starbucks coffee", "misc"]
+    assert corpus[0].corrected_category == "Meals"
+    assert corpus[0].proposed_category == "Travel"
+
+
+def test_AC18_14_2_replay_lowers_low_confidence_proportion_when_patterns_recur():
+    """AC18.14.2: replaying the corpus as priors strictly lowers the held-out low-confidence proportion when patterns recur."""
+    corpus = [
+        CorrectionRecord(key="rent", corrected_category="Housing", proposed_category="Misc"),
+        CorrectionRecord(key="salary", corrected_category="Income", proposed_category=None),
+        CorrectionRecord(key="rent", corrected_category="Housing", proposed_category="Misc"),  # recurs in holdout
+        CorrectionRecord(key="coffee", corrected_category="Meals", proposed_category="Travel"),  # novel
+    ]
+
+    result = replay_low_confidence_reduction(corpus, train_ratio=Decimal("0.5"))
+
+    # Holdout = ["rent", "coffee"]; "rent" was learned from the train split -> grounded.
+    assert result.holdout_size == 2
+    assert result.grounded == 1
+    assert result.proportion_before == Decimal("1")
+    assert result.proportion_after == Decimal("0.5")
+    assert result.reduced is True
+
+
+def test_AC18_14_2_replay_does_not_invent_reduction_without_recurrence():
+    """AC18.14.2: with no recurring patterns the corpus grounds nothing — no invented improvement."""
+    corpus = [
+        CorrectionRecord(key="a", corrected_category="A", proposed_category=None),
+        CorrectionRecord(key="b", corrected_category="B", proposed_category=None),
+        CorrectionRecord(key="c", corrected_category="C", proposed_category=None),
+        CorrectionRecord(key="d", corrected_category="D", proposed_category=None),
+    ]
+
+    result = replay_low_confidence_reduction(corpus, train_ratio=Decimal("0.5"))
+
+    assert result.grounded == 0
+    assert result.proportion_after == result.proportion_before
+    assert result.reduced is False
+
+
+@pytest.mark.asyncio
+async def test_AC18_14_3_service_builds_corpus_from_persisted_corrections(db, test_user):
+    """AC18.14.3: the service derives the corpus from the persisted CorrectionLog store (no sidecar)."""
+    from tests.factories import AtomicTransactionFactory, UploadedDocumentFactory
+
+    document = await UploadedDocumentFactory.create_async(db, user_id=test_user.id)
+    txn = await AtomicTransactionFactory.create_async(
+        db, test_user.id, source_doc_id=document.id, description="Netflix"
+    )
+    db.add(
+        CorrectionLog(
+            user_id=test_user.id,
+            transaction_id=txn.id,
+            original_category="Utilities",
+            corrected_category="Entertainment",
+            transaction_description="Netflix",
+        )
+    )
+    await db.commit()
+
+    corpus = await CorrectionLoopService().build_corpus(db, test_user.id)
+
+    assert len(corpus) == 1
+    assert corpus[0].key == "netflix"
+    assert corpus[0].corrected_category == "Entertainment"

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -408,6 +408,23 @@ consolidation.
 | AC18.13.3 | Gate | Invariants pass and confidence meets threshold yields authoritative; the same contract carries both tier and reconciliation-score confidence | `test_AC18_13_3_invariants_pass_and_confidence_met_is_authoritative()` | `services/test_promotion_gate.py` | P1 |
 | AC18.13.4 | Consolidation | The previously-scattered thresholds (balance 0.001, reconciliation 85/60) are named, centrally owned, and consumed by the services | `test_AC18_13_4_thresholds_are_centrally_owned_and_consumed_by_services()` | `services/test_promotion_gate.py` | P1 |
 
+### AC18.14: Correction Feedback Loop — Corrections Drive The Proportion Down
+
+The North-Star metric (AC18.12) is a thermometer; this is the furnace. Every human
+correction that overrode an AI proposal is labeled signal. Derived as a corpus
+from the append-only `CorrectionLog` (a projection of the provenance substrate, not
+a sidecar) and replayed as priors, a recurring correction grounds future instances
+of the same pattern so they are no longer low-confidence — measurably driving the
+proportion down. This AC owns the corpus and the measurable replay; wiring the
+priors into live generation, calibrating the promotion-gate thresholds (#930) from
+the corpus, and the runtime that dispatches AI attempts are follow-ups.
+
+| ID | Phase | Description | Test | File | Priority |
+|----|-------|-------------|------|------|----------|
+| AC18.14.1 | Corpus | The correction corpus is derived from `CorrectionLog` (no sidecar), keyed by the transaction pattern, capturing proposed vs corrected | `test_AC18_14_1_corpus_is_derived_from_corrections_keyed_by_pattern()` | `services/test_correction_loop.py` | P1 |
+| AC18.14.2 | Replay | Replaying the corpus as priors strictly lowers the held-out low-confidence proportion when correction patterns recur, and invents no reduction when they do not | `test_AC18_14_2_replay_lowers_low_confidence_proportion_when_patterns_recur()`, `test_AC18_14_2_replay_does_not_invent_reduction_without_recurrence()` | `services/test_correction_loop.py` | P1 |
+| AC18.14.3 | Substrate | The service builds the corpus from the persisted correction store, scoped to the user | `test_AC18_14_3_service_builds_corpus_from_persisted_corrections()` | `services/test_correction_loop.py` | P1 |
+
 ---
 
 ## 🚫 Out of Scope (v1)

--- a/docs/ssot/confirmation-workflow.md
+++ b/docs/ssot/confirmation-workflow.md
@@ -164,6 +164,23 @@ disposes. Wiring each decision site to call the gate (vs. consuming the shared
 constants) is incremental; the runtime that *generates* Derived versions or
 dispatches escalations is a separate EPIC.
 
+### Correction Feedback Loop (drives the proportion down)
+
+The North-Star metric (EPIC-018 AC18.12) measures the low-confidence proportion;
+this is the mechanism that *moves* it. Owned by `services/correction_loop.py`
+(EPIC-018 AC18.14, issue #931):
+
+- Every human correction that overrode an AI proposal is labeled signal, recorded
+  append-only in `CorrectionLog`.
+- The **corpus** is a projection of that store keyed by the transaction pattern —
+  not a sidecar decision table that would drift from the provenance graph.
+- A deterministic **held-out replay** builds priors from a train split and grounds
+  recurring held-out patterns, so the low-confidence proportion strictly drops
+  exactly when corrections recur (and never invents a gain when they do not).
+
+Live grounding of generation, threshold calibration of the promotion gate from the
+corpus, and the dispatch runtime are follow-ups.
+
 ---
 
 ## 6. API Contract


### PR DESCRIPTION
## Summary

Close the confidence loop. B3 (#919) **measures** the low-confidence proportion — the thermometer — but no issue **moved** it. This is the furnace: every human correction that overrode an AI proposal is labeled signal, and replaying it as priors grounds recurring patterns so future instances are no longer low-confidence — **measurably** driving the north-star proportion down.

Closes #931 (the corpus + measurable replay). Part of the #917 audit epic — the last Axis-B piece; all deps (#888/#913/#919/#930) are merged.

## What changed (EPIC-018 AC18.14)

- **`build_corpus_from_corrections` / `CorrectionLoopService.build_corpus`** — derive the correction **corpus** from the append-only `CorrectionLog` (the Manual-supersedes-Derived signal), keyed by the transaction pattern. It is a **projection of the provenance substrate, not a sidecar** decision table that would drift from the graph.
- **`replay_low_confidence_reduction`** — a deterministic **held-out replay**: build priors from a train split, ground the held-out corrections whose pattern recurs, and measure the low-confidence proportion before vs after. The proportion **strictly drops exactly when correction patterns recur**, and invents no gain when they do not — the measurable loop the issue requires.

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-018 — AI-Driven Data Pipeline (owns the feedback-learning loop) |
| **AC IDs** | AC18.14.1, AC18.14.2, AC18.14.3 |
| **AC source updated** | `docs/project/EPIC-018.ai-driven-pipeline.md` |

## SSOT

- [x] `docs/ssot/confirmation-workflow.md` — **Correction Feedback Loop** documented beside the North-Star metric and the promotion gate.

## TDD Evidence

🔴 Red: `ModuleNotFoundError: src.services.correction_loop`. 🟢 Green:
- AC18.14.1 (corpus derivation) and AC18.14.2 (measurable replay, both the recurrence and no-recurrence cases) are **pure** and verified locally (3 passed).
- AC18.14.3 (the thin DB wrapper) mirrors the exact working factory pattern in `tests/api/test_corrections_router.py`; **verified by CI** (local podman infra was collision-flaky this session, so I'm relying on CI for the DB lane).

## Scope boundary (explicit follow-ups)

- Wiring the priors into **live** extraction/classification/reconciliation generation (few-shot grounding already exists for categories via `get_few_shot_examples`).
- **Calibrating the promotion-gate thresholds (#930)** from the corpus.
- The runtime that **dispatches** AI attempts — a separate EPIC.
- Accounting-core invariants — audited as sound, not reopened.

## Engineering Audit

- [x] Decimal proportions (no float for the metric); deterministic replay.
- [x] No new table / migration / `sa.Enum` / `NEXT_PUBLIC_` / secret changes — a pure service + a read of the existing `CorrectionLog`.
- [x] Corpus is a projection of the append-only correction store (auditable, no sidecar). `repo/` submodule untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)