### PR TITLE
[finance_report_test_and_doc] fix(test): isolate shared rate-limiter state between tests (#410)

### DIFF
--- a/apps/backend/src/rate_limit.py
+++ b/apps/backend/src/rate_limit.py
@@ -76,6 +76,11 @@ class RateLimiter:
             if key in self._local_state:
                 del self._local_state[key]
 
+    def clear(self) -> None:
+        """Drop all rate-limit state (every key). Used for test isolation."""
+        with self._lock:
+            self._local_state.clear()
+
 
 # Global rate limiters for auth endpoints
 auth_rate_limiter = RateLimiter(

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -69,6 +69,28 @@ def cleanup_fx_cache():
     clear_fx_cache()
 
 
+# --- Rate-limiter isolation (#410) ---
+@pytest.fixture(autouse=True)
+def reset_rate_limiters():
+    """Drop in-memory rate-limiter state before/after each test.
+
+    The limiters are process-global singletons keyed by client IP; without this
+    the per-IP counters accumulate across the whole session and trip a 429
+    cascade once the global API limit is exceeded (tests share one client IP).
+    """
+    from src.rate_limit import (
+        api_rate_limiter,
+        auth_rate_limiter,
+        register_rate_limiter,
+    )
+
+    for limiter in (api_rate_limiter, auth_rate_limiter, register_rate_limiter):
+        limiter.clear()
+    yield
+    for limiter in (api_rate_limiter, auth_rate_limiter, register_rate_limiter):
+        limiter.clear()
+
+
 @pytest.fixture(autouse=True)
 def disable_external_market_data_fetch(monkeypatch):
     """Keep tests deterministic unless a test explicitly enables provider fetches."""


### PR DESCRIPTION
Closes #410.

## Problem
The `api`/`auth`/`register` rate limiters (`src/rate_limit.py`) are process-global singletons keyed by client IP. Tests share one client IP, so the per-IP counters accumulated across the whole session and tripped a **429 cascade** once the global API limit (300/60s) was exceeded. Symptom: tests pass alone but fail in the full suite; a latent CI-shard flake; locally every full run needed `API_RATE_LIMIT_REQUESTS=1000000` to work around it.

## Fix
- Add `RateLimiter.clear()` (drops all keys).
- Add an autouse conftest fixture that clears all three limiters before and after each test (mirrors the existing `cleanup_fx_cache`).

## Verification
The exact directory combination that previously produced **47 × HTTP 429** failures now passes **905/905 with no rate-limit override**. Full pre-push suite green without the workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)