### PR TITLE
[finance_report_audit] #896: drop openrouter_* config aliases, use ai_* directly

### DIFF
--- a/apps/backend/src/boot.py
+++ b/apps/backend/src/boot.py
@@ -255,7 +255,7 @@ class Bootloader:
     @staticmethod
     async def _check_ai_provider() -> ServiceStatus:
         """Validate AI API key."""
-        api_key = getattr(settings, "ai_api_key", None) or getattr(settings, "openrouter_api_key", None)
+        api_key = getattr(settings, "ai_api_key", None)
         if not isinstance(api_key, str) or not api_key:
             return ServiceStatus("ai_provider", "skipped", "Not configured")
 
@@ -272,8 +272,6 @@ class Bootloader:
         start = time.perf_counter()
         try:
             base_url = getattr(settings, "ai_base_url", None)
-            if not isinstance(base_url, str) or not base_url:
-                base_url = getattr(settings, "openrouter_base_url", None)
             if not isinstance(base_url, str) or not base_url:
                 return ServiceStatus("ai_provider", "error", "Base URL not configured")
             async with httpx.AsyncClient(timeout=5.0) as client:

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -235,32 +235,5 @@ class Settings(BaseSettings):
             ],
         )
 
-    @property
-    def openrouter_api_key(self) -> str:
-        """Backward-compatible alias for legacy internal call sites/tests."""
-        return self.ai_api_key
-
-    @openrouter_api_key.setter
-    def openrouter_api_key(self, value: str) -> None:
-        self.ai_api_key = value
-
-    @property
-    def openrouter_base_url(self) -> str:
-        """Backward-compatible alias for legacy internal call sites/tests."""
-        return self.ai_base_url
-
-    @openrouter_base_url.setter
-    def openrouter_base_url(self, value: str) -> None:
-        self.ai_base_url = value
-
-    @property
-    def openrouter_daily_limit_usd(self) -> int | None:
-        """Backward-compatible alias for legacy internal call sites/tests."""
-        return self.ai_daily_limit_usd
-
-    @openrouter_daily_limit_usd.setter
-    def openrouter_daily_limit_usd(self, value: int | None) -> None:
-        self.ai_daily_limit_usd = value
-
 
 settings = Settings()

--- a/apps/backend/src/services/openrouter_streaming.py
+++ b/apps/backend/src/services/openrouter_streaming.py
@@ -57,15 +57,11 @@ async def _stream_openrouter_base(
     """
     if not api_key:
         api_key = getattr(settings, "ai_api_key", None)
-        if not isinstance(api_key, str) or not api_key:
-            api_key = getattr(settings, "openrouter_api_key", None)
     if not isinstance(api_key, str) or not api_key:
         raise OpenRouterStreamError("AI provider API key not configured", retryable=False)
 
     if not base_url:
         base_url = getattr(settings, "ai_base_url", None)
-        if not isinstance(base_url, str) or not base_url:
-            base_url = getattr(settings, "openrouter_base_url", None)
     if not isinstance(base_url, str) or not base_url:
         raise OpenRouterStreamError("AI provider base URL not configured", retryable=False)
 

--- a/apps/backend/tests/ai/test_openrouter_streaming.py
+++ b/apps/backend/tests/ai/test_openrouter_streaming.py
@@ -62,8 +62,8 @@ class TestStreamApiKeyFallback:
                 mock_aconnect.return_value.__aenter__.return_value = mock_event_source
 
                 with patch("src.services.openrouter_streaming.settings") as mock_settings:
-                    mock_settings.openrouter_api_key = "settings-api-key"
-                    mock_settings.openrouter_base_url = "https://test.openrouter.ai/api/v1"
+                    mock_settings.ai_api_key = "settings-api-key"
+                    mock_settings.ai_base_url = "https://test.openrouter.ai/api/v1"
 
                     chunks = []
                     async for chunk in stream_openrouter_chat(
@@ -77,7 +77,7 @@ class TestStreamApiKeyFallback:
     async def test_stream_raises_when_no_api_key_available(self):
         """AC6.7.3: Stream raises error when no API key available."""
         with patch("src.services.openrouter_streaming.settings") as mock_settings:
-            mock_settings.openrouter_api_key = None
+            mock_settings.ai_api_key = None
 
             with pytest.raises(OpenRouterStreamError) as exc_info:
                 async for _ in stream_openrouter_chat(

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -18,7 +18,7 @@ def mock_settings():
     with patch("src.boot.settings") as mock:
         mock.database_url = "postgresql+asyncpg://test:test@localhost/test"
         mock.ai_api_key = None
-        mock.openrouter_api_key = None
+        mock.ai_api_key = None
         mock.s3_endpoint = "http://localhost:9000"
         mock.s3_access_key = "minio"
         mock.s3_secret_key = "minio123"
@@ -36,7 +36,7 @@ def mock_settings():
         mock.cors_origin_regex = ".*"
         mock.otel_exporter_otlp_endpoint = None
         mock.otel_service_name = "test"
-        mock.openrouter_base_url = ZAI_CODING_BASE_URL
+        mock.ai_base_url = ZAI_CODING_BASE_URL
         yield mock
 
 
@@ -409,7 +409,7 @@ class TestBootloaderS3:
 
 class TestBootloaderOpenrouter:
     async def test_check_openrouter_skipped(self, mock_settings):
-        mock_settings.openrouter_api_key = None
+        mock_settings.ai_api_key = None
         mock_settings.ai_api_key = None
 
         status = await Bootloader._check_openrouter()
@@ -418,7 +418,7 @@ class TestBootloaderOpenrouter:
         assert status.service == "ai_provider"
 
     async def test_check_openrouter_success(self, mock_settings):
-        mock_settings.openrouter_api_key = "test-key"
+        mock_settings.ai_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
         mock_settings.ai_base_url = ZAI_CODING_BASE_URL
 
@@ -435,7 +435,7 @@ class TestBootloaderOpenrouter:
             assert status.service == "ai_provider"
 
     async def test_check_openrouter_configured_catalog_skips_network_probe(self, mock_settings):
-        mock_settings.openrouter_api_key = "test-key"
+        mock_settings.ai_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
         mock_settings.ai_model_catalog_source = "configured"
 
@@ -445,10 +445,10 @@ class TestBootloaderOpenrouter:
         assert "Configured provider=" in status.message
 
     async def test_check_openrouter_remote_catalog_requires_base_url(self, mock_settings):
-        mock_settings.openrouter_api_key = "test-key"
+        mock_settings.ai_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
         mock_settings.ai_base_url = None
-        mock_settings.openrouter_base_url = None
+        mock_settings.ai_base_url = None
 
         status = await Bootloader._check_openrouter()
 
@@ -456,7 +456,7 @@ class TestBootloaderOpenrouter:
         assert status.message == "Base URL not configured"
 
     async def test_check_openrouter_auth_failure(self, mock_settings):
-        mock_settings.openrouter_api_key = "test-key"
+        mock_settings.ai_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
         mock_settings.ai_base_url = ZAI_CODING_BASE_URL
 
@@ -473,7 +473,7 @@ class TestBootloaderOpenrouter:
             assert "401" in status.message
 
     async def test_check_openrouter_exception(self, mock_settings):
-        mock_settings.openrouter_api_key = "test-key"
+        mock_settings.ai_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
         mock_settings.ai_base_url = ZAI_CODING_BASE_URL
 

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -18,7 +18,6 @@ def mock_settings():
     with patch("src.boot.settings") as mock:
         mock.database_url = "postgresql+asyncpg://test:test@localhost/test"
         mock.ai_api_key = None
-        mock.ai_api_key = None
         mock.s3_endpoint = "http://localhost:9000"
         mock.s3_access_key = "minio"
         mock.s3_secret_key = "minio123"
@@ -410,7 +409,6 @@ class TestBootloaderS3:
 class TestBootloaderOpenrouter:
     async def test_check_openrouter_skipped(self, mock_settings):
         mock_settings.ai_api_key = None
-        mock_settings.ai_api_key = None
 
         status = await Bootloader._check_openrouter()
 
@@ -418,7 +416,6 @@ class TestBootloaderOpenrouter:
         assert status.service == "ai_provider"
 
     async def test_check_openrouter_success(self, mock_settings):
-        mock_settings.ai_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
         mock_settings.ai_base_url = ZAI_CODING_BASE_URL
 
@@ -436,7 +433,6 @@ class TestBootloaderOpenrouter:
 
     async def test_check_openrouter_configured_catalog_skips_network_probe(self, mock_settings):
         mock_settings.ai_api_key = "test-key"
-        mock_settings.ai_api_key = "test-key"
         mock_settings.ai_model_catalog_source = "configured"
 
         status = await Bootloader._check_openrouter()
@@ -446,8 +442,6 @@ class TestBootloaderOpenrouter:
 
     async def test_check_openrouter_remote_catalog_requires_base_url(self, mock_settings):
         mock_settings.ai_api_key = "test-key"
-        mock_settings.ai_api_key = "test-key"
-        mock_settings.ai_base_url = None
         mock_settings.ai_base_url = None
 
         status = await Bootloader._check_openrouter()
@@ -456,7 +450,6 @@ class TestBootloaderOpenrouter:
         assert status.message == "Base URL not configured"
 
     async def test_check_openrouter_auth_failure(self, mock_settings):
-        mock_settings.ai_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
         mock_settings.ai_base_url = ZAI_CODING_BASE_URL
 
@@ -473,7 +466,6 @@ class TestBootloaderOpenrouter:
             assert "401" in status.message
 
     async def test_check_openrouter_exception(self, mock_settings):
-        mock_settings.ai_api_key = "test-key"
         mock_settings.ai_api_key = "test-key"
         mock_settings.ai_base_url = ZAI_CODING_BASE_URL
 

--- a/apps/backend/tests/infra/test_config_contract.py
+++ b/apps/backend/tests/infra/test_config_contract.py
@@ -133,17 +133,3 @@ class TestConfigContract:
 
         s = Settings()
         assert s.db_pool_max_overflow == 25
-
-    def test_legacy_openrouter_alias_setters(self, monkeypatch):
-        """Legacy OpenRouter config aliases remain writable for old call sites."""
-        monkeypatch.setenv("AI_API_KEY", "initial-key")
-        from src.config import Settings
-
-        s = Settings()
-        s.openrouter_api_key = "updated-key"
-        s.openrouter_base_url = "https://example.test/api"
-        s.openrouter_daily_limit_usd = 12
-
-        assert s.ai_api_key == "updated-key"
-        assert s.ai_base_url == "https://example.test/api"
-        assert s.ai_daily_limit_usd == 12


### PR DESCRIPTION
## Summary

Retire the first compatibility-shim item from **#896**: the three backward-compat `openrouter_api_key` / `openrouter_base_url` / `openrouter_daily_limit_usd` `@property` aliases on `Settings`. They were **pure delegations** to the real env-bound `ai_*` fields — provider-neutral cleanup as the codebase has moved off the "openrouter" naming.

Part of #896 (one checklist item; the issue stays open as the tracker for the rest).

## What changed

- **`config.py`** — removed the 3 alias property/setter pairs.
- **`boot.py`** (×2) / **`services/openrouter_streaming.py`** (×2) — the 4 call sites now read `ai_*` directly, dropping the now-redundant `openrouter_*` fallbacks.
- **Tests** — migrated the mock `Settings` to `ai_*` (`test_boot.py`, `test_openrouter_streaming.py`) and removed `test_legacy_openrouter_alias_setters` (it tested the deleted aliases).

## Safety

- **Env binding is unchanged** — the aliases only delegated to `ai_api_key`/`ai_base_url`/`ai_daily_limit_usd`, which are the real `AI_*`-bound config fields. No env var or runtime config behavior changes.
- All `openrouter_*` alias references across `src` and `tests` are gone (verified by grep).
- The removed test had no AC reference, so AC traceability is unaffected.

## Testing

```bash
pytest tests/infra/test_config_contract.py tests/infra/test_boot.py tests/ai/test_openrouter_streaming.py   # 68 passed
ruff check / format --check                                                                                  # clean
tools/generate_ac_registry.py --check / lint_doc_consistency.py / check_manifest.py                          # OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)