### PR TITLE
[finance_report_test_and_doc] test(reports): cover untested report-package/lineage/export branches

### DIFF
--- a/apps/backend/tests/api/test_reports_router.py
+++ b/apps/backend/tests/api/test_reports_router.py
@@ -380,3 +380,39 @@ class TestReportsEndpoints:
         body = response.json()
         assert isinstance(body, list)
         assert any(s["report_type"] == ReportType.BALANCE_SHEET.value for s in body)
+
+    async def test_account_lineage_unknown_account_returns_404(self, client: AsyncClient, db, test_user: User):
+        """Account-lineage drill-down maps a missing account to 404 (ReportError path)."""
+        response = await client.get(f"/reports/account-lineage?account_id={uuid4()}")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    async def test_account_lineage_returns_payload_for_known_account(self, client: AsyncClient, db, test_user: User):
+        """Account-lineage returns the lineage payload for an owned account."""
+        account = Account(
+            user_id=test_user.id,
+            name="Lineage Cash",
+            type=AccountType.ASSET,
+            currency="SGD",
+        )
+        db.add(account)
+        await db.commit()
+        await db.refresh(account)
+
+        response = await client.get(f"/reports/account-lineage?account_id={account.id}&currency=SGD")
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.json(), dict)
+
+    async def test_export_cash_flow_missing_dates_returns_400(self, client: AsyncClient, db, test_user: User):
+        """Cash-flow export without start/end dates is a 400."""
+        response = await client.get("/reports/export?report_type=cash-flow&format=csv")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    async def test_generate_personal_report_package_snapshot(self, client: AsyncClient, db, test_user: User):
+        """POST /reports/package/generate builds all section payloads and persists a snapshot."""
+        today = date.today()
+        start = today - timedelta(days=30)
+        response = await client.post(
+            f"/reports/package/generate?start_date={start}&end_date={today}&as_of_date={today}&currency=SGD"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.json(), dict)

--- a/apps/backend/tests/api/test_reports_router.py
+++ b/apps/backend/tests/api/test_reports_router.py
@@ -400,7 +400,12 @@ class TestReportsEndpoints:
 
         response = await client.get(f"/reports/account-lineage?account_id={account.id}&currency=SGD")
         assert response.status_code == status.HTTP_200_OK
-        assert isinstance(response.json(), dict)
+        body = response.json()
+        assert body["account_id"] == str(account.id)
+        assert body["account_name"] == "Lineage Cash"
+        assert body["currency"] == "SGD"
+        assert isinstance(body["lines"], list)
+        assert "total" in body
 
     async def test_export_cash_flow_missing_dates_returns_400(self, client: AsyncClient, db, test_user: User):
         """Cash-flow export without start/end dates is a 400."""
@@ -415,4 +420,13 @@ class TestReportsEndpoints:
             f"/reports/package/generate?start_date={start}&end_date={today}&as_of_date={today}&currency=SGD"
         )
         assert response.status_code == status.HTTP_200_OK
-        assert isinstance(response.json(), dict)
+        body = response.json()
+        # Persisted snapshot metadata + frozen payload with all generated sections.
+        assert body["id"]
+        assert body["currency"] == "SGD"
+        assert body["status"]
+        payload = body["payload"]
+        assert isinstance(payload, dict)
+        section_payloads = payload["section_payloads"]
+        for section in ("balance_sheet", "income_statement", "cash_flow"):
+            assert section in section_payloads


### PR DESCRIPTION
Increment 1 toward core-module 99% coverage (non-tool product code).

Adds integration tests for the largest uncovered file (`routers/reports.py`, was 93.1%):
- `POST /reports/package/generate` — exercises the section-payload aggregator (~43 lines).
- `GET /reports/account-lineage` — known-account payload + unknown-account → 404 (ReportError path).
- `GET /reports/export` cash-flow without dates → 400 branch.

Pure additive tests, no source changes. Full pre-push suite green.

Part of the core-modules-to-99% / backend-to-98% effort; subsequent increments cover reconciliation, reporting, review_queue, then raise the coverage gate.