### PR TITLE
[finance_report_audit] audit-review fixes: restricted heads filter + provenance distinct + time-series scan amplification

### DIFF
--- a/apps/backend/src/routers/assets.py
+++ b/apps/backend/src/routers/assets.py
@@ -232,6 +232,8 @@ async def list_restricted_holdings(
         .where(ManualValuationSnapshot.as_of_date <= report_date)
         .where(ManualValuationSnapshot.component_type.in_(restricted_types))
         .where(ManualValuationSnapshot.liquidity_class == ManualValuationLiquidityClass.RESTRICTED)
+        # Current heads only; superseded corrections must not surface as phantom holdings.
+        .where(ManualValuationSnapshot.superseded_by_id.is_(None))
         .order_by(ManualValuationSnapshot.as_of_date.desc(), ManualValuationSnapshot.created_at.desc())
     )
 

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -475,6 +475,8 @@ async def _aggregate_account_provenance(
 
     stmt = (
         select(Account.id.label("account_id"), JournalEntry.source_type)
+        # Distinct (account, source_type): provenance only needs the set, not one row per line.
+        .distinct()
         .join(JournalLine, JournalLine.account_id == Account.id)
         .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
         .where(Account.user_id == user_id)
@@ -874,8 +876,15 @@ async def generate_balance_sheet(
     currency: str | None = None,
     include_restricted: bool = True,
     include_allocation_metadata: bool = False,
+    include_trust_signals: bool = True,
 ) -> dict[str, object]:
-    """Generate balance sheet report as of a given date."""
+    """Generate balance sheet report as of a given date.
+
+    ``include_trust_signals`` gates the two extra per-account ledger scans that
+    derive confidence tier and provenance. Callers that do not render per-line
+    trust badges (net-worth time series, the income statement's internal balance
+    sheets) pass False to avoid amplifying those scans.
+    """
     target_currency = _normalize_currency(currency)
     fx_warnings: list[FxWarning] = []
     account_types = (AccountType.ASSET, AccountType.LIABILITY, AccountType.EQUITY)
@@ -906,20 +915,23 @@ async def generate_balance_sheet(
         if account.id not in balances:
             balances[account.id] = Decimal("0")
 
-    tiers = await _aggregate_account_confidence_tiers(
-        db,
-        user_id,
-        account_types,
-        as_of_date,
-        included_currencies=included_ledger_currencies,
-    )
-    provenance_by_account = await _aggregate_account_provenance(
-        db,
-        user_id,
-        account_types,
-        as_of_date,
-        included_currencies=included_ledger_currencies,
-    )
+    tiers: dict[UUID, str] = {}
+    provenance_by_account: dict[UUID, DataProvenance | None] = {}
+    if include_trust_signals:
+        tiers = await _aggregate_account_confidence_tiers(
+            db,
+            user_id,
+            account_types,
+            as_of_date,
+            included_currencies=included_ledger_currencies,
+        )
+        provenance_by_account = await _aggregate_account_provenance(
+            db,
+            user_id,
+            account_types,
+            as_of_date,
+            included_currencies=included_ledger_currencies,
+        )
 
     assets = _build_account_lines(
         accounts,
@@ -1473,9 +1485,11 @@ async def generate_income_statement(
     # Calculate Unrealized FX Gain/Loss for the period
     # This requires balance sheets at both points
     bs_start = await generate_balance_sheet(
-        db, user_id, as_of_date=start_date - timedelta(days=1), currency=target_currency
+        db, user_id, as_of_date=start_date - timedelta(days=1), currency=target_currency, include_trust_signals=False
     )
-    bs_end = await generate_balance_sheet(db, user_id, as_of_date=end_date, currency=target_currency)
+    bs_end = await generate_balance_sheet(
+        db, user_id, as_of_date=end_date, currency=target_currency, include_trust_signals=False
+    )
 
     unrealized_fx_change = _quantize_money(
         Decimal(str(bs_end["unrealized_fx_gain_loss"])) - Decimal(str(bs_start["unrealized_fx_gain_loss"]))
@@ -1685,7 +1699,9 @@ async def get_net_worth_timeseries(
     points: list[dict[str, object]] = []
     for span in spans:
         point_date = span.start if granularity == "daily" else span.end
-        balance_sheet = await generate_balance_sheet(db, user_id, as_of_date=point_date, currency=target_currency)
+        balance_sheet = await generate_balance_sheet(
+            db, user_id, as_of_date=point_date, currency=target_currency, include_trust_signals=False
+        )
         total_assets = _quantize_money(Decimal(str(balance_sheet["total_assets"])))
         total_liabilities = _quantize_money(Decimal(str(balance_sheet["total_liabilities"])))
         points.append(

--- a/apps/backend/tests/assets/test_manual_valuation_snapshots.py
+++ b/apps/backend/tests/assets/test_manual_valuation_snapshots.py
@@ -349,6 +349,28 @@ async def test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth(
     assert snapshots[0].value == Decimal("1100000.00")
 
 
+@pytest.mark.asyncio
+async def test_restricted_holdings_exclude_superseded_currency_correction(client):
+    """Audit review: a currency-changing correction must not surface as a phantom restricted holding."""
+    base = {
+        "component_type": "rsu",
+        "as_of_date": "2026-05-18",
+        "source": "Acme RSU",
+        "value": "1000.00",
+    }
+    assert (await client.post("/assets/valuation-snapshots", json={**base, "currency": "USD"})).status_code == 201
+    # Correct it, changing currency — supersedes the prior version (same component/source/as_of_date).
+    assert (
+        await client.post("/assets/valuation-snapshots", json={**base, "currency": "SGD", "value": "1100.00"})
+    ).status_code == 201
+
+    response = await client.get("/assets/restricted")
+    assert response.status_code == 200
+    holdings = response.json()
+    assert len(holdings) == 1, "superseded version must not appear as a second holding"
+    assert holdings[0]["ticker"] == "Acme RSU"
+
+
 def test_manual_valuation_snapshot_schema_normalizes_currency():
     """AC11.9.1: Manual valuation schemas normalize currency codes before service use."""
     create_payload = ManualValuationSnapshotCreate(

--- a/apps/backend/tests/reporting/test_balance_sheet_confidence.py
+++ b/apps/backend/tests/reporting/test_balance_sheet_confidence.py
@@ -121,3 +121,24 @@ async def test_AC5_18_2_net_worth_rolls_up_to_worst_input_tier(db, test_user):
 
     report = await generate_balance_sheet(db, test_user.id, as_of_date=date(2026, 12, 31))
     assert report["confidence_tier"] == "LOW"
+
+
+@pytest.mark.asyncio
+async def test_include_trust_signals_false_skips_tier_and_provenance(db, test_user):
+    """Audit review (perf): callers that don't render badges can skip the two extra scans.
+
+    The net-worth time series and the income statement's internal balance sheets pass
+    include_trust_signals=False so they don't amplify the per-account ledger scans.
+    """
+    cash = Account(user_id=test_user.id, name="Cash", type=AccountType.ASSET, currency="SGD")
+    salary = Account(user_id=test_user.id, name="Salary", type=AccountType.INCOME, currency="SGD")
+    db.add_all([cash, salary])
+    await db.flush()
+    await _post(
+        db, test_user.id, debit=cash, credit=salary, amount=Decimal("100.00"), source_type=JournalEntrySourceType.MANUAL
+    )
+
+    report = await generate_balance_sheet(db, test_user.id, as_of_date=date(2026, 12, 31), include_trust_signals=False)
+
+    assert report["confidence_tier"] is None
+    assert all(line["confidence_tier"] is None and line["provenance"] is None for line in report["assets"])

--- a/apps/backend/tests/reporting/test_net_worth_timeseries.py
+++ b/apps/backend/tests/reporting/test_net_worth_timeseries.py
@@ -179,7 +179,7 @@ async def test_net_worth_timeseries_monthly_uses_period_end_and_normalizes_curre
     captured_dates: list[date] = []
     captured_currencies: list[str] = []
 
-    async def fake_balance_sheet(db, requested_user_id, *, as_of_date, currency):
+    async def fake_balance_sheet(db, requested_user_id, *, as_of_date, currency, include_trust_signals=True):
         assert requested_user_id == user_id
         captured_dates.append(as_of_date)
         captured_currencies.append(currency)


### PR DESCRIPTION
## Summary

Fixes the three confirmed issues from a post-merge audit review of this session's reporting/versioning work (#918/#913/#888). One correctness bug (wrong user-facing numbers) and two performance regressions.

## Fixes

**1. `/restricted` holdings double-counted superseded valuations** — `routers/assets.py`
Every `ManualValuationSnapshot` reader got the `superseded_by_id IS NULL` heads-only filter in #918 **except** this one. A manual-valuation correction that **changes currency** (supported since #924) leaves the superseded row under a different `(component_type, source, currency)` dedup key → it surfaced as a **phantom restricted holding** (ESOP/RSU). Added the filter + a regression test.

**2. Provenance aggregation scanned per-line (O(ledger) memory)** — `reporting.py`
`_aggregate_account_provenance` appended every contributing journal line into a Python list before collapsing to a distinct set; its confidence-tier sibling already used `.distinct()`. Added `.distinct()`.

**3. Net-worth time series amplified the extra scans** — `reporting.py`
`generate_balance_sheet` runs two extra full-ledger scans (tier + provenance). `get_net_worth_timeseries` calls it once per point (≤366) and the income statement twice → up to ~732 extra scans for a daily 1-year chart. Added `include_trust_signals` (default `True`); the time-series and income-statement internal calls pass `False` so they skip the scans where per-line badges aren't rendered. Updated the `net_worth_timeseries` mock for the new kwarg + a regression test.

## Out of scope (noted, not fixed here)
- The aggregate **provenance** is computed per-line but never set as a top-level field on the balance-sheet dict (a #938 gap; `BalanceSheetResponse.provenance` is always None). Tracked separately.
- The "mechanism vs. wired" gaps surfaced in review (promotion gate / record_snapshot / correction loop have no live callers) are documented EPIC follow-ups.

## Testing
Local test infra was unusable this session (podman/postgres stalls), so the new + affected tests are verified by **CI**:
- `test_restricted_holdings_exclude_superseded_currency_correction` (new)
- `test_include_trust_signals_false_skips_tier_and_provenance` (new)
- `test_net_worth_timeseries_*` (mock updated for the new kwarg)
- ruff check/format clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)