### PR TITLE
[finance_report_test_and_doc] test(core): raise core financial-module coverage toward 99% / backend 98%

### DIFF
--- a/apps/backend/tests/accounting/test_core_unit_coverage.py
+++ b/apps/backend/tests/accounting/test_core_unit_coverage.py
@@ -1,0 +1,122 @@
+"""Unit coverage for core financial helpers (no DB).
+
+Covers small pure-logic branches in reporting helpers and investment-accounting
+validation that integration tests do not exercise directly.
+"""
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from src.models.journal import Direction, JournalEntrySourceType
+from src.schemas.journal import JournalEntryCreate, JournalLineCreate
+from src.services.investment_accounting import (
+    InvestmentAccountingService,
+    InvestmentAccountingValidationError,
+)
+from src.services.reporting import (
+    _provenance_from_source_type,
+    _quantize_money,
+    income_bucket,
+)
+
+
+class TestReportingHelpers:
+    def test_income_bucket_classifies_known_keywords(self):
+        assert income_bucket("Monthly Salary") == "salary"
+        assert income_bucket("Annual Bonus") == "bonus"
+        assert income_bucket("Dividend payout") == "dividend"
+
+    def test_income_bucket_returns_none_for_unknown(self):
+        assert income_bucket("grocery refund") is None
+
+    def test_quantize_money_coerces_int(self):
+        result = _quantize_money(5)
+        assert result == Decimal("5.00")
+
+    def test_quantize_money_rounds_decimal(self):
+        assert _quantize_money(Decimal("1.005")) == Decimal("1.00")  # banker's rounding
+
+    @pytest.mark.parametrize(
+        ("source_type", "expected"),
+        [
+            (JournalEntrySourceType.MANUAL, "manual"),
+            (JournalEntrySourceType.BANK_STATEMENT, "imported"),
+            (JournalEntrySourceType.SYSTEM, "derived"),
+            (JournalEntrySourceType.FX_REVALUATION, "derived"),
+            ("manual", "manual"),
+            (None, None),
+            ("not-a-valid-source", None),
+        ],
+    )
+    def test_provenance_from_source_type(self, source_type, expected):
+        assert _provenance_from_source_type(source_type) == expected
+
+
+class TestJournalEntrySchema:
+    def test_cross_currency_entry_balances_via_fx_rate(self):
+        """Non-base-currency lines convert through fx_rate when checking balance."""
+        debit, credit = uuid4(), uuid4()
+        entry = JournalEntryCreate(
+            entry_date=date(2026, 1, 1),
+            memo="USD transfer",
+            lines=[
+                JournalLineCreate(
+                    account_id=debit,
+                    direction=Direction.DEBIT,
+                    amount=Decimal("100.00"),
+                    currency="USD",
+                    fx_rate=Decimal("1.350000"),
+                ),
+                JournalLineCreate(
+                    account_id=credit,
+                    direction=Direction.CREDIT,
+                    amount=Decimal("100.00"),
+                    currency="USD",
+                    fx_rate=Decimal("1.350000"),
+                ),
+            ],
+        )
+        assert len(entry.lines) == 2
+
+    def test_cross_currency_entry_requires_fx_rate(self):
+        """A non-base-currency line without fx_rate fails balance validation."""
+        with pytest.raises(ValueError, match="fx_rate required"):
+            JournalEntryCreate(
+                entry_date=date(2026, 1, 1),
+                memo="bad fx",
+                lines=[
+                    JournalLineCreate(
+                        account_id=uuid4(),
+                        direction=Direction.DEBIT,
+                        amount=Decimal("100.00"),
+                        currency="USD",
+                    ),
+                    JournalLineCreate(
+                        account_id=uuid4(),
+                        direction=Direction.CREDIT,
+                        amount=Decimal("100.00"),
+                        currency="USD",
+                    ),
+                ],
+            )
+
+
+class TestInvestmentValidation:
+    def test_validate_positive_rejects_zero(self):
+        service = InvestmentAccountingService()
+        with pytest.raises(InvestmentAccountingValidationError, match="must be positive"):
+            service._validate_positive(Decimal("0"), "quantity")
+
+    def test_validate_positive_accepts_positive(self):
+        InvestmentAccountingService()._validate_positive(Decimal("1"), "quantity")
+
+    def test_validate_non_negative_rejects_negative(self):
+        service = InvestmentAccountingService()
+        with pytest.raises(InvestmentAccountingValidationError, match="cannot be negative"):
+            service._validate_non_negative(Decimal("-1"), "fees")
+
+    def test_validate_non_negative_accepts_zero(self):
+        InvestmentAccountingService()._validate_non_negative(Decimal("0"), "fees")

--- a/apps/backend/tests/accounting/test_core_unit_coverage.py
+++ b/apps/backend/tests/accounting/test_core_unit_coverage.py
@@ -24,6 +24,8 @@ from src.services.reporting import (
 
 
 class TestReportingHelpers:
+    """AC11.8.1: income classification and amount provenance helpers."""
+
     def test_income_bucket_classifies_known_keywords(self):
         assert income_bucket("Monthly Salary") == "salary"
         assert income_bucket("Annual Bonus") == "bonus"
@@ -33,6 +35,7 @@ class TestReportingHelpers:
         assert income_bucket("grocery refund") is None
 
     def test_quantize_money_coerces_int(self):
+        """AC2.8.1: canonical money rounding accepts int and quantizes to 2dp."""
         result = _quantize_money(5)
         assert result == Decimal("5.00")
 
@@ -56,6 +59,8 @@ class TestReportingHelpers:
 
 
 class TestJournalEntrySchema:
+    """AC2.8.1: multi-currency journal balance validation via fx_rate."""
+
     def test_cross_currency_entry_balances_via_fx_rate(self):
         """Non-base-currency lines convert through fx_rate when checking balance."""
         debit, credit = uuid4(), uuid4()
@@ -105,6 +110,8 @@ class TestJournalEntrySchema:
 
 
 class TestInvestmentValidation:
+    """AC17.1.2: investment transaction amount validation guards."""
+
     def test_validate_positive_rejects_zero(self):
         service = InvestmentAccountingService()
         with pytest.raises(InvestmentAccountingValidationError, match="must be positive"):

--- a/apps/backend/tests/accounting/test_core_unit_coverage.py
+++ b/apps/backend/tests/accounting/test_core_unit_coverage.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError as PydanticValidationError
 
 from src.models.journal import Direction, JournalEntrySourceType
 from src.schemas.journal import JournalEntryCreate, JournalLineCreate
@@ -62,18 +63,22 @@ class TestJournalEntrySchema:
     """AC2.8.1: multi-currency journal balance validation via fx_rate."""
 
     def test_cross_currency_entry_balances_via_fx_rate(self):
-        """Non-base-currency lines convert through fx_rate when checking balance."""
+        """A base-currency debit balances a foreign credit only via fx_rate conversion.
+
+        Base currency is SGD: a 135.00 SGD debit balances a 100.00 USD credit only
+        because 100.00 * 1.35 == 135.00. If the validator ignored fx_rate it would
+        compare 135 vs 100 and reject — so this proves the conversion is applied.
+        """
         debit, credit = uuid4(), uuid4()
         entry = JournalEntryCreate(
             entry_date=date(2026, 1, 1),
-            memo="USD transfer",
+            memo="SGD<->USD transfer",
             lines=[
                 JournalLineCreate(
                     account_id=debit,
                     direction=Direction.DEBIT,
-                    amount=Decimal("100.00"),
-                    currency="USD",
-                    fx_rate=Decimal("1.350000"),
+                    amount=Decimal("135.00"),
+                    currency="SGD",
                 ),
                 JournalLineCreate(
                     account_id=credit,
@@ -88,7 +93,7 @@ class TestJournalEntrySchema:
 
     def test_cross_currency_entry_requires_fx_rate(self):
         """A non-base-currency line without fx_rate fails balance validation."""
-        with pytest.raises(ValueError, match="fx_rate required"):
+        with pytest.raises(PydanticValidationError, match="fx_rate required"):
             JournalEntryCreate(
                 entry_date=date(2026, 1, 1),
                 memo="bad fx",

--- a/apps/backend/tests/accounting/test_journal_router_errors.py
+++ b/apps/backend/tests/accounting/test_journal_router_errors.py
@@ -56,6 +56,24 @@ class TestJournalRouterErrors:
         error_msg = str(response_data).lower()
         assert "balance" in error_msg or "debit" in error_msg or "credit" in error_msg
 
+    async def test_create_entry_service_validation_error_returns_400(self, client, db, test_user):
+        """
+        GIVEN a schema-valid balanced entry referencing a non-existent account
+        WHEN creating the entry
+        THEN the service ValidationError surfaces as 400 (router except path)
+        """
+        entry_data = {
+            "entry_date": str(date.today()),
+            "memo": "Unknown account",
+            "lines": [
+                {"account_id": str(uuid4()), "direction": "DEBIT", "amount": "100.00", "currency": "SGD"},
+                {"account_id": str(uuid4()), "direction": "CREDIT", "amount": "100.00", "currency": "SGD"},
+            ],
+        }
+        response = await client.post("/journal-entries", json=entry_data)
+        assert response.status_code == 400
+        assert "not found" in str(response.json()).lower()
+
     async def test_post_entry_validation_error(self, client, db, test_user):
         """
         GIVEN a draft journal entry that fails validation on posting

--- a/apps/backend/tests/accounting/test_journal_router_errors.py
+++ b/apps/backend/tests/accounting/test_journal_router_errors.py
@@ -72,7 +72,7 @@ class TestJournalRouterErrors:
         }
         response = await client.post("/journal-entries", json=entry_data)
         assert response.status_code == 400
-        assert "not found" in str(response.json()).lower()
+        assert "not found" in response.json()["detail"].lower()
 
     async def test_post_entry_validation_error(self, client, db, test_user):
         """


### PR DESCRIPTION
Raises coverage on core financial code (non-tool) toward the 99%/98% target.

Tests added (real behavior, no source-logic change):
- reporting helpers: income_bucket, _quantize_money(int), _provenance_from_source_type (all branches)
- investment_accounting: _validate_positive / _validate_non_negative guards
- journal schema: cross-currency balance via fx_rate + missing-fx_rate error
- journal router: service ValidationError → 400 (unknown account)

The coverage-gate raise (backend `--cov-fail-under`) is applied in this PR once CI reports the achieved level.