### PR TITLE
[finance_report_ui] #914 net-worth allocation frontend

### DIFF
--- a/apps/frontend/playwright/portfolio-provenance.spec.ts
+++ b/apps/frontend/playwright/portfolio-provenance.spec.ts
@@ -43,6 +43,16 @@ const holdings = [
   },
 ];
 
+const netWorthAllocation = {
+  as_of_date: "2026-06-01",
+  currency: "SGD",
+  include_restricted: true,
+  total_assets: "1775.00",
+  total_liabilities: "0.00",
+  net_worth: "1775.00",
+  rows: [],
+};
+
 async function installPortfolioMocks(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem("finance_user_id", "portfolio-provenance-smoke-user");
@@ -83,6 +93,8 @@ async function installPortfolioMocks(page: Page) {
       body = { xirr: "8.00", time_weighted_return: "6.00", money_weighted_return: "7.00" };
     } else if (path.startsWith("/api/portfolio/allocation/")) {
       body = [];
+    } else if (path === "/api/reports/net-worth/allocation") {
+      body = netWorthAllocation;
     } else if (path === "/api/portfolio/performance/report-schedule") {
       body = {
         period_start: "2026-01-01",

--- a/apps/frontend/src/__tests__/portfolioPage.test.tsx
+++ b/apps/frontend/src/__tests__/portfolioPage.test.tsx
@@ -75,10 +75,13 @@ const mockHolding2: PortfolioHolding = {
   sector: "Automotive",
 }
 
+type NetWorthAllocationMode = "default" | "empty" | "error" | "pending"
+
 function mockPortfolioApi(
   holdings: PortfolioHolding[] = [mockHolding],
-  allocationPercentage = "100.00",
+  allocationPercentage: string | null = "100.00",
   scheduleCurrency = "USD",
+  netWorthAllocationMode: NetWorthAllocationMode = "default",
 ) {
   const mockedApiFetch = vi.mocked(apiFetch)
   mockedApiFetch.mockImplementation((path: string) => {
@@ -138,6 +141,82 @@ function mockPortfolioApi(
         },
         source_links: ["brokerage_statement:aapl"],
         notes: ["Cost basis uses FIFO where available."],
+      })
+    }
+    if (path.startsWith("/api/reports/net-worth/allocation")) {
+      if (netWorthAllocationMode === "pending") {
+        return new Promise(() => undefined)
+      }
+      if (netWorthAllocationMode === "error") {
+        return Promise.reject(new Error("allocation unavailable"))
+      }
+      return Promise.resolve({
+        as_of_date: "2026-12-31",
+        currency: "SGD",
+        include_restricted: !path.includes("include_restricted=false"),
+        total_assets: "2100.00",
+        total_liabilities: "100.00",
+        net_worth: "2000.00",
+        rows: netWorthAllocationMode === "empty" ? [] : [
+          {
+            asset_class: "public_equity",
+            liquidity_class: "liquid",
+            source_currency: "USD",
+            value: "1800.00",
+            percentage_of_net_worth: allocationPercentage,
+            source_line_count: 2,
+            source_lines: [
+              {
+                source_type: "portfolio_market_adjustment",
+                source_id: null,
+                label: "AAPL market value",
+                value: "1800.00",
+                href: "/portfolio/holdings",
+              },
+              {
+                source_type: "manual_component",
+                source_id: null,
+                label: "Manual adjustment",
+                value: "0.00",
+                href: null,
+              },
+            ],
+          },
+          {
+            asset_class: "cash",
+            liquidity_class: "liquid",
+            source_currency: "SGD",
+            value: "300.00",
+            percentage_of_net_worth: "15.00",
+            source_line_count: 1,
+            source_lines: [
+              {
+                source_type: "ledger_account",
+                source_id: "acc1",
+                label: "Main Bank",
+                value: "300.00",
+                href: "/reports/account-lineage?account_id=acc1&as_of_date=2026-12-31&currency=SGD",
+              },
+            ],
+          },
+          {
+            asset_class: "liability",
+            liquidity_class: "liability",
+            source_currency: "SGD",
+            value: "-100.00",
+            percentage_of_net_worth: "-5.00",
+            source_line_count: 1,
+            source_lines: [
+              {
+                source_type: "ledger_account",
+                source_id: "loan1",
+                label: "Loan",
+                value: "-100.00",
+                href: "/reports/account-lineage?account_id=loan1&as_of_date=2026-12-31&currency=SGD",
+              },
+            ],
+          },
+        ],
       })
     }
     if (path.startsWith("/api/portfolio/holdings")) {
@@ -221,7 +300,7 @@ describe("PortfolioPage", () => {
 
     await waitFor(() => expect(screen.getByText("AAPL")).toBeInTheDocument())
 
-    fireEvent.click(screen.getByRole("checkbox"))
+    fireEvent.click(screen.getByRole("checkbox", { name: "Show disposed" }))
 
     await waitFor(() => expect(screen.getByText("TSLA")).toBeInTheDocument())
     expect(mockedApiFetch).toHaveBeenCalledWith("/api/portfolio/holdings?include_disposed=true")
@@ -290,39 +369,99 @@ describe("PortfolioPage", () => {
     expect(screen.getByText("Cost basis uses FIFO where available.")).toBeInTheDocument()
   })
 
-  it("AC17.14.1 renders unified asset allocation from performance schedule", async () => {
+  it("AC17.14.3 renders net-worth allocation from the report schedule", async () => {
     mockPortfolioApi()
 
     render(<PortfolioPage />, { wrapper: createWrapper() })
 
-    const panel = await screen.findByRole("region", { name: "Unified Allocation" })
-    expect(within(panel).getByText("Asset Class")).toBeInTheDocument()
-    expect(within(panel).getByText("Public Equity")).toBeInTheDocument()
-    expect(within(panel).getByText("$1,800.00")).toBeInTheDocument()
+    const panel = await screen.findByRole("region", { name: "Net Worth Allocation" })
+    expect(mockedApiFetch).toHaveBeenCalledWith("/api/reports/net-worth/allocation?currency=SGD&include_restricted=true")
+    expect(within(panel).getByText("Asset Class x Liquidity x Source Currency")).toBeInTheDocument()
+    expect(within(panel).getByText("Source currency")).toBeInTheDocument()
+    expect(await within(panel).findByText("Net worth")).toBeInTheDocument()
+    expect(await within(panel).findByText("Public Equity")).toBeInTheDocument()
+    expect(within(panel).getAllByText("Liquid").length).toBeGreaterThanOrEqual(1)
+    expect(within(panel).getAllByText("USD").length).toBeGreaterThanOrEqual(1)
+    expect(within(panel).getByRole("link", { name: "AAPL market value" })).toHaveAttribute("href", "/portfolio/holdings")
+    expect(within(panel).getByText("Manual adjustment").closest("a")).toBeNull()
+    expect(within(panel).getByText("Manual adjustment").closest("li")).toHaveAttribute("title", "Manual adjustment")
+    expect(within(panel).getByText("Main Bank")).toBeInTheDocument()
     expect(within(panel).getByText("100.0%")).toBeInTheDocument()
-    expect(within(panel).getByText("1 holding")).toBeInTheDocument()
-    expect(within(panel).getByText(/Ties to portfolio value/)).toBeInTheDocument()
+    expect(within(panel).getByText("-5.0%")).toBeInTheDocument()
+    expect(within(panel).getByText("2 sources")).toBeInTheDocument()
+    expect(within(panel).getAllByText("1 source").length).toBeGreaterThanOrEqual(1)
   })
 
-  it("AC17.14.1 labels allocation and portfolio currencies instead of claiming tie-out when they differ", async () => {
+  it("AC17.14.3 shows the net-worth allocation loading state", () => {
+    mockPortfolioApi([mockHolding], "100.00", "USD", "pending")
+
+    render(<PortfolioPage />, { wrapper: createWrapper() })
+
+    const panel = screen.getByRole("region", { name: "Net Worth Allocation" })
+    expect(within(panel).getByText("Loading net worth allocation...")).toBeInTheDocument()
+  })
+
+  it("AC17.14.3 shows the net-worth allocation error state", async () => {
+    mockPortfolioApi([mockHolding], "100.00", "USD", "error")
+
+    render(<PortfolioPage />, { wrapper: createWrapper() })
+
+    const panel = await screen.findByRole("region", { name: "Net Worth Allocation" })
+    expect(await within(panel).findByText("Unable to load net worth allocation")).toBeInTheDocument()
+  })
+
+  it("AC17.14.3 shows the empty net-worth allocation state", async () => {
+    mockPortfolioApi([mockHolding], "100.00", "USD", "empty")
+
+    render(<PortfolioPage />, { wrapper: createWrapper() })
+
+    const panel = await screen.findByRole("region", { name: "Net Worth Allocation" })
+    expect(await within(panel).findByText("No allocation rows available")).toBeInTheDocument()
+  })
+
+  it("AC17.14.1 labels allocation and portfolio currencies instead of claiming a portfolio tie-out", async () => {
     mockPortfolioApi([mockHolding], "100.00", "SGD")
 
     render(<PortfolioPage />, { wrapper: createWrapper() })
 
-    const panel = await screen.findByRole("region", { name: "Unified Allocation" })
-    expect(within(panel).getByText("Schedule currency: SGD")).toBeInTheDocument()
-    expect(within(panel).getByText(/Portfolio value shown in USD/)).toBeInTheDocument()
+    const panel = await screen.findByRole("region", { name: "Net Worth Allocation" })
+    expect(within(panel).getByText("Report currency: SGD")).toBeInTheDocument()
+    expect(await within(panel).findByText("Public Equity")).toBeInTheDocument()
+    expect(panel).toHaveTextContent("Portfolio value shown in USD")
     expect(within(panel).queryByText(/Ties to portfolio value/)).not.toBeInTheDocument()
   })
 
-  it("AC17.14.1 renders invalid allocation percentages as unavailable", async () => {
+  it("AC17.14.3 renders invalid net-worth allocation percentages as unavailable", async () => {
     mockPortfolioApi([mockHolding], "not-a-number")
 
     render(<PortfolioPage />, { wrapper: createWrapper() })
 
-    const panel = await screen.findByRole("region", { name: "Unified Allocation" })
-    expect(within(panel).getByText("Public Equity")).toBeInTheDocument()
+    const panel = await screen.findByRole("region", { name: "Net Worth Allocation" })
+    expect(await within(panel).findByText("Public Equity")).toBeInTheDocument()
     expect(within(panel).getByText("N/A")).toBeInTheDocument()
+  })
+
+  it("AC17.14.3 renders missing net-worth allocation percentages as unavailable", async () => {
+    mockPortfolioApi([mockHolding], null)
+
+    render(<PortfolioPage />, { wrapper: createWrapper() })
+
+    const panel = await screen.findByRole("region", { name: "Net Worth Allocation" })
+    expect(await within(panel).findByText("Public Equity")).toBeInTheDocument()
+    expect(within(panel).getByText("N/A")).toBeInTheDocument()
+  })
+
+  it("AC17.14.3 refetches net-worth allocation when restricted holdings are excluded", async () => {
+    mockPortfolioApi()
+
+    render(<PortfolioPage />, { wrapper: createWrapper() })
+
+    await screen.findByRole("region", { name: "Net Worth Allocation" })
+    fireEvent.click(screen.getByRole("checkbox", { name: "Include restricted holdings in allocation" }))
+
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenCalledWith("/api/reports/net-worth/allocation?currency=SGD&include_restricted=false"),
+    )
   })
 
   it("AC17.8.4 does not show total portfolio value banner when no active holdings", async () => {

--- a/apps/frontend/src/app/(main)/portfolio/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { CalendarDays, X } from "lucide-react";
@@ -12,22 +12,22 @@ import { HoldingsTable } from "@/components/portfolio/HoldingsTable";
 import { AllocationChart } from "@/components/portfolio/AllocationChart";
 import { InvestmentPerformanceSchedule } from "@/components/portfolio/InvestmentPerformanceSchedule";
 import { amountToChartNumber, formatAmount, formatCurrencyLocale, sumAmounts } from "@/lib/currency";
-import type { InvestmentPerformanceAllocationRow, InvestmentPerformanceReportSchedule } from "@/lib/types";
+import type { InvestmentPerformanceReportSchedule, NetWorthAllocationResponse, NetWorthAllocationRow } from "@/lib/types";
 
-function isAssetClassAllocation(row: InvestmentPerformanceAllocationRow): boolean {
-    return row.dimension === "asset_class" || row.dimension === "asset-class";
-}
+const REPORT_CURRENCY = "SGD";
 
-function allocationBarWidth(percentage: string): string {
+function allocationBarWidth(percentage: string | null): string {
+    if (percentage === null) return "0%";
     try {
-        const value = amountToChartNumber(percentage);
+        const value = Math.abs(amountToChartNumber(percentage));
         return `${Math.min(100, Math.max(0, value))}%`;
     } catch {
         return "0%";
     }
 }
 
-function formatAllocationPercent(percentage: string): string {
+function formatAllocationPercent(percentage: string | null): string {
+    if (percentage === null) return "N/A";
     try {
         return `${formatAmount(percentage, 1)}%`;
     } catch {
@@ -35,9 +35,35 @@ function formatAllocationPercent(percentage: string): string {
     }
 }
 
+function formatAllocationLabel(value: string): string {
+    return value
+        .replace(/[_-]+/g, " ")
+        .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function allocationValueClass(row: NetWorthAllocationRow): string {
+    return amountToChartNumber(row.value) < 0 ? "text-[var(--error)]" : "text-[var(--foreground)]";
+}
+
+function allocationBarClass(row: NetWorthAllocationRow): string {
+    return amountToChartNumber(row.value) < 0 ? "bg-[var(--error)]" : "bg-[var(--accent)]";
+}
+
 export default function PortfolioPage() {
     const [showDisposed, setShowDisposed] = useState(false);
     const [asOfDate, setAsOfDate] = useState("");
+    const [includeRestrictedAllocation, setIncludeRestrictedAllocation] = useState(true);
+
+    const netWorthAllocationQueryString = useMemo(() => {
+        const params = new URLSearchParams({
+            currency: REPORT_CURRENCY,
+            include_restricted: includeRestrictedAllocation ? "true" : "false",
+        });
+        if (asOfDate) {
+            params.set("as_of_date", asOfDate);
+        }
+        return params.toString();
+    }, [asOfDate, includeRestrictedAllocation]);
 
     const { data: holdings, isLoading, error, refetch } = useQuery({
         queryKey: ["portfolio-holdings", showDisposed, asOfDate],
@@ -77,21 +103,19 @@ export default function PortfolioPage() {
             return apiFetch<InvestmentPerformanceReportSchedule>(`/api/portfolio/performance/report-schedule?${params}`);
         },
     });
+    const {
+        data: netWorthAllocation,
+        isLoading: isNetWorthAllocationLoading,
+        error: netWorthAllocationError,
+    } = useQuery({
+        queryKey: ["reports-net-worth-allocation", netWorthAllocationQueryString],
+        queryFn: () => apiFetch<NetWorthAllocationResponse>(`/api/reports/net-worth/allocation?${netWorthAllocationQueryString}`),
+    });
 
     const activeHoldings = holdings?.filter((h) => h.status === "active") ?? [];
     const totalPortfolioValue = sumAmounts(activeHoldings.map((holding) => holding.market_value));
     const primaryCurrency = activeHoldings[0]?.currency ?? "USD";
-    const assetClassAllocationRows = (performanceSchedule?.allocation ?? []).filter(isAssetClassAllocation);
-    const unifiedAllocationSchedule =
-        performanceSchedule &&
-        !isPerformanceScheduleLoading &&
-        !performanceScheduleError &&
-        activeHoldings.length > 0 &&
-        assetClassAllocationRows.length > 0
-            ? performanceSchedule
-            : null;
-    const allocationCurrencyMatchesPortfolio =
-        unifiedAllocationSchedule?.currency.toUpperCase() === primaryCurrency.toUpperCase();
+    const allocationRows = netWorthAllocation?.rows ?? [];
 
     return (
         <div className="p-6">
@@ -135,58 +159,116 @@ export default function PortfolioPage() {
                 </div>
             )}
 
-            {unifiedAllocationSchedule ? (
-                <section className="mb-6 card p-5" aria-labelledby="unified-allocation-title">
-                    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                        <div>
-                            <p className="text-xs text-muted uppercase tracking-wide">Asset Class</p>
-                            <h2 id="unified-allocation-title" className="mt-1 text-base font-semibold">
-                                Unified Allocation
-                            </h2>
-                            <p className="mt-1 text-sm text-muted">
-                                {allocationCurrencyMatchesPortfolio
-                                    ? `Ties to portfolio value: ${formatCurrencyLocale(totalPortfolioValue, primaryCurrency)}`
-                                    : `Portfolio value shown in ${primaryCurrency}: ${formatCurrencyLocale(totalPortfolioValue, primaryCurrency)}`}
-                            </p>
-                        </div>
-                        <p className="text-xs text-muted md:text-right">
-                            Schedule currency: {unifiedAllocationSchedule.currency}
+            <section className="mb-6 card p-5" aria-labelledby="net-worth-allocation-title" aria-busy={isNetWorthAllocationLoading}>
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                        <p className="text-xs text-muted uppercase tracking-wide">Asset Class x Liquidity x Source Currency</p>
+                        <h2 id="net-worth-allocation-title" className="mt-1 text-base font-semibold">
+                            Net Worth Allocation
+                        </h2>
+                        <p className="mt-1 text-sm text-muted">
+                            {netWorthAllocation
+                                ? `Reconciles to net worth: ${formatCurrencyLocale(netWorthAllocation.net_worth, netWorthAllocation.currency)}`
+                                : "Reconciles allocation rows to net worth"}
                         </p>
+                        {activeHoldings.length > 0 ? (
+                            <p className="mt-1 text-sm text-muted">
+                                Portfolio value shown in {primaryCurrency}: {formatCurrencyLocale(totalPortfolioValue, primaryCurrency)}
+                            </p>
+                        ) : null}
                     </div>
-
-                    <div className="mt-4 overflow-hidden rounded border border-[var(--border)]">
-                        <div className="hidden grid-cols-[minmax(0,1.5fr)_minmax(7rem,0.7fr)_minmax(5rem,0.5fr)_minmax(6rem,0.5fr)] gap-3 border-b border-[var(--border)] bg-[var(--background-muted)] px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted md:grid">
-                            <span>Asset class</span>
-                            <span className="text-right">Value</span>
-                            <span className="text-right">Share</span>
-                            <span className="text-right">Holdings</span>
+                    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div className="text-xs text-muted md:text-right">
+                            <p>Report currency: {netWorthAllocation?.currency ?? REPORT_CURRENCY}</p>
+                            <p>As of {netWorthAllocation?.as_of_date ?? (asOfDate || "latest")}</p>
                         </div>
-                        {assetClassAllocationRows.map((row) => (
+                        <label className="flex items-center gap-2 rounded border border-[var(--border)] px-3 py-2 text-sm text-muted cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={includeRestrictedAllocation}
+                                onChange={(event) => setIncludeRestrictedAllocation(event.target.checked)}
+                                className="rounded"
+                            />
+                            <span>Include restricted holdings in allocation</span>
+                        </label>
+                    </div>
+                </div>
+
+                {netWorthAllocation ? (
+                    <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-3">
+                        <div className="rounded border border-[var(--border)] p-3">
+                            <dt className="text-xs text-muted uppercase">Total assets</dt>
+                            <dd className="mt-1 font-semibold">{formatCurrencyLocale(netWorthAllocation.total_assets, netWorthAllocation.currency)}</dd>
+                        </div>
+                        <div className="rounded border border-[var(--border)] p-3">
+                            <dt className="text-xs text-muted uppercase">Total liabilities</dt>
+                            <dd className="mt-1 font-semibold">{formatCurrencyLocale(netWorthAllocation.total_liabilities, netWorthAllocation.currency)}</dd>
+                        </div>
+                        <div className="rounded border border-[var(--border)] p-3">
+                            <dt className="text-xs text-muted uppercase">Net worth</dt>
+                            <dd className="mt-1 font-semibold">{formatCurrencyLocale(netWorthAllocation.net_worth, netWorthAllocation.currency)}</dd>
+                        </div>
+                    </dl>
+                ) : null}
+
+                <div className="mt-4 overflow-hidden rounded border border-[var(--border)]">
+                    <div className="hidden grid-cols-[minmax(0,1.4fr)_minmax(6rem,0.6fr)_minmax(6rem,0.6fr)_minmax(5rem,0.4fr)_minmax(8rem,0.8fr)] gap-3 border-b border-[var(--border)] bg-[var(--background-muted)] px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted md:grid">
+                        <span>Asset class</span>
+                        <span className="text-right">Value</span>
+                        <span className="text-right">Share</span>
+                        <span className="text-right">Source currency</span>
+                        <span>Sources</span>
+                    </div>
+                    {isNetWorthAllocationLoading ? (
+                        <div className="px-3 py-4 text-sm text-muted">Loading net worth allocation...</div>
+                    ) : netWorthAllocationError ? (
+                        <div className="px-3 py-4 text-sm text-muted">Unable to load net worth allocation</div>
+                    ) : allocationRows.length === 0 ? (
+                        <div className="px-3 py-4 text-sm text-muted">No allocation rows available</div>
+                    ) : (
+                        allocationRows.map((row) => (
                             <div
-                                key={`${row.dimension}-${row.category}`}
-                                className="grid gap-2 border-b border-[var(--border)] px-3 py-3 last:border-b-0 md:grid-cols-[minmax(0,1.5fr)_minmax(7rem,0.7fr)_minmax(5rem,0.5fr)_minmax(6rem,0.5fr)] md:items-center"
+                                key={`${row.asset_class}-${row.liquidity_class}-${row.source_currency}`}
+                                className="grid gap-2 border-b border-[var(--border)] px-3 py-3 last:border-b-0 md:grid-cols-[minmax(0,1.4fr)_minmax(6rem,0.6fr)_minmax(6rem,0.6fr)_minmax(5rem,0.4fr)_minmax(8rem,0.8fr)] md:items-center"
                             >
                                 <div className="min-w-0">
-                                    <p className="font-medium text-[var(--foreground)]">{row.category}</p>
+                                    <p className="font-medium text-[var(--foreground)]">{formatAllocationLabel(row.asset_class)}</p>
+                                    <p className="mt-1 text-xs text-muted">{formatAllocationLabel(row.liquidity_class)}</p>
                                     <div className="mt-2 h-2 overflow-hidden rounded-full bg-[var(--background-muted)]" aria-hidden="true">
                                         <div
-                                            className="h-full rounded-full bg-[var(--accent)]"
-                                            style={{ width: allocationBarWidth(row.percentage) }}
+                                            className={`h-full rounded-full ${allocationBarClass(row)}`}
+                                            style={{ width: allocationBarWidth(row.percentage_of_net_worth) }}
                                         />
                                     </div>
                                 </div>
-                                <p className="text-sm font-medium md:text-right">
-                                    {formatCurrencyLocale(row.value, unifiedAllocationSchedule.currency)}
+                                <p className={`text-sm font-medium md:text-right ${allocationValueClass(row)}`}>
+                                    {formatCurrencyLocale(row.value, netWorthAllocation?.currency ?? REPORT_CURRENCY)}
                                 </p>
-                                <p className="text-sm text-muted md:text-right">{formatAllocationPercent(row.percentage)}</p>
-                                <p className="text-sm text-muted md:text-right">
-                                    {row.count} holding{row.count === 1 ? "" : "s"}
-                                </p>
+                                <p className="text-sm text-muted md:text-right">{formatAllocationPercent(row.percentage_of_net_worth)}</p>
+                                <p className="text-sm text-muted md:text-right">{row.source_currency}</p>
+                                <div className="min-w-0 text-sm text-muted">
+                                    <p className="font-medium text-[var(--foreground)]">
+                                        {row.source_line_count} source{row.source_line_count === 1 ? "" : "s"}
+                                    </p>
+                                    <ul className="mt-1 space-y-1">
+                                        {row.source_lines.slice(0, 2).map((line) => (
+                                            <li key={`${line.source_type}-${line.source_id ?? line.label}`} className="truncate" title={line.label}>
+                                                {line.href ? (
+                                                    <Link href={line.href} className="hover:text-[var(--foreground)]">
+                                                        {line.label}
+                                                    </Link>
+                                                ) : (
+                                                    line.label
+                                                )}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
                             </div>
-                        ))}
-                    </div>
-                </section>
-            ) : null}
+                        ))
+                    )}
+                </div>
+            </section>
 
             <div className="grid gap-4 md:grid-cols-3 mb-6">
                 <PerformanceCard />

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -726,6 +726,34 @@ export interface NetWorthTimeSeriesResponse {
   points: NetWorthTimeSeriesPoint[];
 }
 
+export interface NetWorthAllocationSourceLine {
+  source_type: string;
+  source_id: string | null;
+  label: string;
+  value: MoneyValue;
+  href: string | null;
+}
+
+export interface NetWorthAllocationRow {
+  asset_class: string;
+  liquidity_class: string;
+  source_currency: string;
+  value: MoneyValue;
+  percentage_of_net_worth: MoneyValue | null;
+  source_line_count: number;
+  source_lines: NetWorthAllocationSourceLine[];
+}
+
+export interface NetWorthAllocationResponse {
+  as_of_date: string;
+  currency: string;
+  include_restricted: boolean;
+  total_assets: MoneyValue;
+  total_liabilities: MoneyValue;
+  net_worth: MoneyValue;
+  rows: NetWorthAllocationRow[];
+}
+
 export interface ReconciliationMatchResponse {
   id: string;
   bank_txn_id: string;

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -241,16 +241,16 @@ redacted, and Decimal-safe.
 
 ### AC17.14: Unified Portfolio Allocation Surface
 
-This is the first frontend slice for #914. It uses the existing investment
-performance report schedule allocation rows to expose a single asset-class
-allocation surface on the portfolio page. Cross-asset liquidity, currency, and
-net-worth reconciliation remain separate #914 follow-up slices because they
-need a broader report contract than the current portfolio schedule provides.
+This started as the first frontend slice for #914 and now uses the report-owned
+net-worth allocation schedule for the allocation surface. The investment
+performance schedule remains the source for period return, unrealized
+market-value gain/loss, and price freshness.
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC17.14.1 | Portfolio page renders a unified asset-class allocation panel from the investment performance schedule with value, percentage, holding count, and tie-out to the displayed portfolio value | `AC17.14.1 renders unified asset allocation from performance schedule` | `apps/frontend/src/__tests__/portfolioPage.test.tsx` | P1 |
+| AC17.14.1 | Portfolio page renders a unified allocation panel without claiming a portfolio-value tie-out when report and holdings currencies differ | `AC17.14.1 labels allocation and portfolio currencies instead of claiming a portfolio tie-out` | `apps/frontend/src/__tests__/portfolioPage.test.tsx` | P1 |
 | AC17.14.2 | Reports expose a net-worth allocation schedule grouped by asset class, liquidity class, and source currency, with signed rows that reconcile to net worth and retain source-line drill-through metadata | `test_AC17_14_2_net_worth_allocation_groups_balance_sheet_sources`, `test_AC17_14_2_net_worth_allocation_endpoint_returns_contract` | `apps/backend/tests/reporting/test_reporting_net_worth_components.py`, `apps/backend/tests/reporting/test_reports_router.py` | P1 |
+| AC17.14.3 | Portfolio page consumes the report-owned net-worth allocation schedule, showing asset class, liquidity, source currency, net-worth share, source labels, and restricted-inclusion filtering | `AC17.14.3 renders net-worth allocation from the report schedule`, `AC17.14.3 shows the net-worth allocation loading state`, `AC17.14.3 shows the net-worth allocation error state`, `AC17.14.3 shows the empty net-worth allocation state`, `AC17.14.3 renders invalid net-worth allocation percentages as unavailable`, `AC17.14.3 renders missing net-worth allocation percentages as unavailable`, `AC17.14.3 refetches net-worth allocation when restricted holdings are excluded` | `apps/frontend/src/__tests__/portfolioPage.test.tsx` | P1 |
 
 ### Brokerage PDF to Asset Report Proof Matrix
 

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -194,6 +194,10 @@ Row rules:
   property and mortgage components are `real_estate`; ESOP, RSU, and stock
   options are `restricted_comp`; tax refunds are `cash`; tax payable and generic
   liabilities are `liability`; other manual components are `other`.
+- Asset-dashboard allocation surfaces that claim net-worth reconciliation use
+  this report-owned schedule. The portfolio performance schedule remains the
+  source for period return, unrealized market-value gain/loss, price freshness,
+  and portfolio-only performance detail.
 
 ### 2.4 Cash Flow Statement
 


### PR DESCRIPTION
## Summary

Wire the portfolio allocation panel to the report-owned net-worth allocation schedule, including asset class, liquidity class, source currency, net-worth share, source labels, and restricted-inclusion filtering.

Refs #914

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-017 — Portfolio Management |
| **AC IDs** | AC17.14.1, AC17.14.3 |
| **AC source updated** | Owning EPIC |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — no ownership change needed
- [x] `docs/ssot/reporting.md` — documents that net-worth allocation surfaces use the report-owned schedule while performance detail remains in the portfolio performance schedule
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | `N/A - local red run before final commit` | `portfolioPage.test.tsx` failed while the page still rendered allocation from the performance schedule |
| Green (passing test) | `85ca6819` | Implemented net-worth allocation consumption and passing frontend/coverage/E2E tests |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no backend enum changes
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A, no env vars
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A, no infra/config changes; pre-commit submodule check passed
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env vars
- [x] `tools/check_manifest.py` passes (if SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] N/A — this PR only changes frontend/reporting docs and tests

---

## Testing

```bash
npm --prefix apps/frontend test -- portfolioPage.test.tsx
npm --prefix apps/frontend test -- --coverage
npm --prefix apps/frontend run typecheck
npm --prefix apps/frontend run test:e2e -- playwright/portfolio-provenance.spec.ts --reporter=line
apps/backend/.venv/bin/python tools/generate_ac_registry.py --check
apps/backend/.venv/bin/python tools/check_ac_traceability.py
apps/backend/.venv/bin/python tools/check_manifest.py
apps/backend/.venv/bin/python tools/lint_doc_consistency.py
npm --prefix apps/frontend run lint
moon run :lint
moon run :test -- --smart
```

---

## Screenshots / Evidence

N/A - covered by portfolio page component tests and Playwright smoke coverage.
