### PR TITLE
[finance_report_audit] wire the confidence axis live: North-Star recording + load-bearing promotion gate (#919/#930)

### DIFF
--- a/apps/backend/src/routers/metrics.py
+++ b/apps/backend/src/routers/metrics.py
@@ -4,9 +4,10 @@ Surfaces the single measurable expression of the axioms — the low-confidence-d
 proportion — as a live value plus its recorded trend.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, status
 
 from src.deps import CurrentUserId, DbSession
+from src.models.metrics import ConfidenceMetricSnapshot
 from src.schemas.metrics import (
     ConfidenceMetricPoint,
     ConfidenceMetricSnapshotResponse,
@@ -16,6 +17,17 @@ from src.services.confidence_metric import ConfidenceMetricService
 
 router = APIRouter(prefix="/metrics", tags=["metrics"])
 _service = ConfidenceMetricService()
+
+
+def _snapshot_response(snapshot: ConfidenceMetricSnapshot) -> ConfidenceMetricSnapshotResponse:
+    return ConfidenceMetricSnapshotResponse(
+        id=snapshot.id,
+        captured_at=snapshot.created_at,
+        total_count=snapshot.total_count,
+        low_confidence_count=snapshot.low_confidence_count,
+        low_confidence_proportion=snapshot.low_confidence_proportion,
+        tier_breakdown=snapshot.tier_breakdown,
+    )
 
 
 @router.get("/confidence-north-star", response_model=ConfidenceNorthStarResponse)
@@ -30,15 +42,23 @@ async def get_confidence_north_star(user_id: CurrentUserId, db: DbSession) -> Co
             low_confidence_proportion=current.low_confidence_proportion,
             tier_breakdown=current.tier_breakdown,
         ),
-        series=[
-            ConfidenceMetricSnapshotResponse(
-                id=snapshot.id,
-                captured_at=snapshot.created_at,
-                total_count=snapshot.total_count,
-                low_confidence_count=snapshot.low_confidence_count,
-                low_confidence_proportion=snapshot.low_confidence_proportion,
-                tier_breakdown=snapshot.tier_breakdown,
-            )
-            for snapshot in series
-        ],
+        series=[_snapshot_response(snapshot) for snapshot in series],
     )
+
+
+@router.post(
+    "/confidence-north-star/snapshots",
+    response_model=ConfidenceMetricSnapshotResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def record_confidence_north_star_snapshot(
+    user_id: CurrentUserId, db: DbSession
+) -> ConfidenceMetricSnapshotResponse:
+    """Append the current low-confidence proportion to the North-Star series.
+
+    Lets a scheduler (or an operator) record a point on demand, so the trend
+    accumulates even between report-package generations.
+    """
+    snapshot = await _service.record_snapshot(db, user_id)
+    await db.commit()
+    return _snapshot_response(snapshot)

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -65,6 +65,7 @@ from src.schemas import (
     PersonalReportPackageTraceabilityResponse,
     TrendPeriod,
 )
+from src.services.confidence_metric import ConfidenceMetricService
 from src.services.confidence_tier import derive_confidence_tier
 from src.services.evidence_lineage import EvidenceLineageService
 from src.services.framework_policy import derive_user_framework_policy_result
@@ -1729,6 +1730,9 @@ async def generate_personal_report_package_snapshot(
         report_data=snapshot_data,
         ttl_seconds=0,
     )
+    # Record a North-Star confidence point per report-package generation (the
+    # vision's cadence), so the low-confidence-proportion trend accumulates.
+    await ConfidenceMetricService().record_snapshot(db, user_id)
     await db.commit()
     return _package_snapshot_response(snapshot)
 

--- a/apps/backend/src/services/statement_validation.py
+++ b/apps/backend/src/services/statement_validation.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
-from src.services.promotion_gate import STATEMENT_BALANCE_TOLERANCE
+from src.services.promotion_gate import STATEMENT_BALANCE_TOLERANCE, InvariantResult, evaluate_promotion
 
 # Single-owned by the promotion gate (#930); kept as a local alias for readability.
 BALANCE_TOLERANCE = STATEMENT_BALANCE_TOLERANCE
@@ -139,19 +139,43 @@ async def _get_statement_for_update(
 
 
 def _raise_if_balance_chain_invalid(validation_result: dict, *, after_edits: bool = False) -> None:
-    if not validation_result["opening_match"]:
+    # Route the Stage-1 approval decision through the promotion gate: the
+    # balance-chain checks are the deterministic invariants, with no confidence
+    # term (min_confidence=0). The gate disposes; a failed invariant blocks
+    # approval. Behavior is identical to the prior inline checks.
+    verdict = evaluate_promotion(
+        [
+            InvariantResult(
+                name="opening_balance_chain",
+                passed=validation_result["opening_match"],
+                delta=Decimal(validation_result["opening_delta"]),
+                tolerance=BALANCE_TOLERANCE,
+            ),
+            InvariantResult(
+                name="closing_balance_chain",
+                passed=validation_result["closing_match"],
+                delta=Decimal(validation_result["closing_delta"]),
+                tolerance=BALANCE_TOLERANCE,
+            ),
+        ],
+        confidence_rank=0,
+        min_confidence=0,
+    )
+    if verdict.is_authoritative:
+        return
+
+    if verdict.failed_invariant == "opening_balance_chain":
         suffix = " after edits" if after_edits else ""
         raise ValueError(
             f"Opening balance mismatch{suffix}: delta={validation_result['opening_delta']} exceeds tolerance "
             f"{BALANCE_TOLERANCE}"
         )
 
-    if not validation_result["closing_match"]:
-        if after_edits:
-            raise ValueError(f"Balance still invalid after edits: delta={validation_result['closing_delta']}")
-        raise ValueError(
-            f"Balance mismatch: delta={validation_result['closing_delta']} exceeds tolerance {BALANCE_TOLERANCE}"
-        )
+    if after_edits:
+        raise ValueError(f"Balance still invalid after edits: delta={validation_result['closing_delta']}")
+    raise ValueError(
+        f"Balance mismatch: delta={validation_result['closing_delta']} exceeds tolerance {BALANCE_TOLERANCE}"
+    )
 
 
 def _has_unresolved_statement_conflicts(transactions: list[AtomicTransaction]) -> bool:

--- a/apps/backend/tests/api/test_reports_router.py
+++ b/apps/backend/tests/api/test_reports_router.py
@@ -433,10 +433,10 @@ class TestReportsEndpoints:
         for section in ("balance_sheet", "income_statement", "cash_flow"):
             assert section in section_payloads
 
-        # AC18.12.4: generating a report package records a North-Star confidence snapshot.
+        # AC18.12.4: generating a report package records exactly one North-Star snapshot.
         metric_rows = (
             (await db.execute(select(ConfidenceMetricSnapshot).where(ConfidenceMetricSnapshot.user_id == test_user.id)))
             .scalars()
             .all()
         )
-        assert len(metric_rows) >= 1
+        assert len(metric_rows) == 1

--- a/apps/backend/tests/api/test_reports_router.py
+++ b/apps/backend/tests/api/test_reports_router.py
@@ -20,10 +20,12 @@ from uuid import uuid4
 
 from fastapi import status
 from httpx import AsyncClient
+from sqlalchemy import select
 
 from src.models import Account, AccountType, ClassificationRule, User
 from src.models.layer3 import RuleType
 from src.models.layer4 import ReportSnapshot, ReportType
+from src.models.metrics import ConfidenceMetricSnapshot
 
 
 class TestReportsEndpoints:
@@ -430,3 +432,11 @@ class TestReportsEndpoints:
         section_payloads = payload["section_payloads"]
         for section in ("balance_sheet", "income_statement", "cash_flow"):
             assert section in section_payloads
+
+        # AC18.12.4: generating a report package records a North-Star confidence snapshot.
+        metric_rows = (
+            (await db.execute(select(ConfidenceMetricSnapshot).where(ConfidenceMetricSnapshot.user_id == test_user.id)))
+            .scalars()
+            .all()
+        )
+        assert len(metric_rows) >= 1

--- a/apps/backend/tests/metrics/test_confidence_north_star_metric.py
+++ b/apps/backend/tests/metrics/test_confidence_north_star_metric.py
@@ -84,3 +84,16 @@ async def test_AC18_12_3_north_star_endpoint_returns_current_and_series(client):
     assert body["current"]["total_count"] == 0
     assert body["current"]["low_confidence_count"] == 0
     assert isinstance(body["series"], list)
+
+
+@pytest.mark.asyncio
+async def test_AC18_12_4_post_records_a_snapshot_into_the_series(client):
+    """AC18.12.4: POST records a North-Star point on demand, so the trend accumulates."""
+    assert (await client.get("/metrics/confidence-north-star")).json()["series"] == []
+
+    created = await client.post("/metrics/confidence-north-star/snapshots")
+    assert created.status_code == 201
+    assert created.json()["captured_at"]
+
+    series = (await client.get("/metrics/confidence-north-star")).json()["series"]
+    assert len(series) == 1

--- a/apps/backend/tests/review/test_statement_validation.py
+++ b/apps/backend/tests/review/test_statement_validation.py
@@ -25,6 +25,28 @@ from src.services.statement_validation import (
 DEFAULT_ACCOUNT_NAME = "Statement Validation Default Account"
 
 
+def test_AC18_13_5_balance_chain_decision_routes_through_promotion_gate():
+    """AC18.13.5: Stage-1 balance approval is disposed by the promotion gate, preserving the exact messages."""
+    from src.services.statement_validation import _raise_if_balance_chain_invalid
+
+    ok = {"opening_match": True, "closing_match": True, "opening_delta": "0", "closing_delta": "0"}
+    _raise_if_balance_chain_invalid(ok)  # both invariants pass -> authoritative -> no raise
+
+    with pytest.raises(ValueError, match="Opening balance mismatch"):
+        _raise_if_balance_chain_invalid(
+            {"opening_match": False, "closing_match": True, "opening_delta": "0.5", "closing_delta": "0"}
+        )
+    with pytest.raises(ValueError, match="Balance mismatch"):
+        _raise_if_balance_chain_invalid(
+            {"opening_match": True, "closing_match": False, "opening_delta": "0", "closing_delta": "0.5"}
+        )
+    with pytest.raises(ValueError, match="Balance still invalid after edits"):
+        _raise_if_balance_chain_invalid(
+            {"opening_match": True, "closing_match": False, "opening_delta": "0", "closing_delta": "0.5"},
+            after_edits=True,
+        )
+
+
 @pytest.fixture
 def user_id(test_user):
     return test_user.id

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -390,6 +390,7 @@ generation / scheduled) and the per-report-number confidence of #913 are separat
 | AC18.12.1 | Metric | The low-confidence proportion is the deterministic LOW-tier share of posted/reconciled journal entries, with a full TRUSTED/HIGH/MEDIUM/LOW breakdown and a defined zero on an empty ledger | `test_AC18_12_1_low_confidence_proportion_and_tier_breakdown_are_deterministic()` | `metrics/test_confidence_north_star_metric.py` | P1 |
 | AC18.12.2 | Trend | The metric is recorded as an append-only series — snapshots accumulate and read newest-first, never overwritten — so the trend over time is observable | `test_AC18_12_2_metric_is_recorded_as_append_only_series_showing_the_trend()` | `metrics/test_confidence_north_star_metric.py` | P1 |
 | AC18.12.3 | Surface | The current metric and its recorded series are exposed read-only via the API | `test_AC18_12_3_north_star_endpoint_returns_current_and_series()` | `metrics/test_confidence_north_star_metric.py` | P1 |
+| AC18.12.4 | Wired | A North-Star snapshot is recorded when a report package is generated, and on demand via a POST endpoint, so the trend actually accumulates in production | `test_AC18_12_4_post_records_a_snapshot_into_the_series()`, `test_generate_personal_report_package_snapshot` | `metrics/test_confidence_north_star_metric.py`, `api/test_reports_router.py` | P1 |
 
 ### AC18.13: Promotion Gate — Confidence Is Load-Bearing
 
@@ -407,6 +408,7 @@ consolidation.
 | AC18.13.2 | Gate | Invariants pass but confidence below threshold yields a non-authoritative review candidate | `test_AC18_13_2_invariants_pass_but_low_confidence_is_review()` | `services/test_promotion_gate.py` | P1 |
 | AC18.13.3 | Gate | Invariants pass and confidence meets threshold yields authoritative; the same contract carries both tier and reconciliation-score confidence | `test_AC18_13_3_invariants_pass_and_confidence_met_is_authoritative()` | `services/test_promotion_gate.py` | P1 |
 | AC18.13.4 | Consolidation | The previously-scattered thresholds (balance 0.001, reconciliation 85/60) are named, centrally owned, and consumed by the services | `test_AC18_13_4_thresholds_are_centrally_owned_and_consumed_by_services()` | `services/test_promotion_gate.py` | P1 |
+| AC18.13.5 | Wired | Stage-1 statement balance-chain approval is disposed by the promotion gate (balance checks as invariants), making the gate load-bearing for a real decision while preserving behavior | `test_AC18_13_5_balance_chain_decision_routes_through_promotion_gate()` | `review/test_statement_validation.py` | P1 |
 
 ### AC18.14: Correction Feedback Loop — Corrections Drive The Proportion Down
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,7 +5,7 @@
 
 - API title: `Finance Report API`
 - API version: `0.1.0`
-- Endpoint count: `124`
+- Endpoint count: `125`
 - Schema count: `208`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
@@ -26,7 +26,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `income` | 1 |
 | `journal-entries` | 6 |
 | `market-data` | 3 |
-| `metrics` | 1 |
+| `metrics` | 2 |
 | `portfolio` | 13 |
 | `reconciliation` | 11 |
 | `reports` | 21 |
@@ -147,6 +147,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | Method | Path | Auth | Params | Request | Success responses | Summary |
 |---|---|---|---|---|---|---|
 | `GET` | `/metrics/confidence-north-star` | yes | - | - | `200` `ConfidenceNorthStarResponse` | Get Confidence North Star |
+| `POST` | `/metrics/confidence-north-star/snapshots` | yes | - | - | `201` `ConfidenceMetricSnapshotResponse` | Record Confidence North Star Snapshot |
 
 ### portfolio
 


### PR DESCRIPTION
## Summary

The post-merge audit's biggest finding: three audit-epic mechanisms had **no live caller** — scaffolding + unit tests, not operative. This wires **two** of them so the confidence axis actually runs in production.

## What changed

**1. North-Star metric now records (#919, AC18.12.4)**
Previously `record_snapshot` had no caller, so `GET /metrics/confidence-north-star` returned `series: []` forever. Now:
- A `ConfidenceMetricSnapshot` is recorded **when a report package is generated** (the vision's "snapshot per report-package generation" cadence).
- A new `POST /metrics/confidence-north-star/snapshots` records a point on demand (for a scheduler/operator).
The trend now actually accumulates.

**2. Promotion gate is now load-bearing (#930, AC18.13.5)**
Previously `evaluate_promotion` had no caller, so "confidence is load-bearing" was only a unit-tested primitive. Now **Stage-1 statement balance-chain approval routes through the gate**: the opening/closing balance checks become the gate's deterministic invariants (no confidence term). The gate disposes; a failed invariant blocks approval.
- **Behavior-preserving**: same tolerance, same error messages, opening checked before closing — verified by a pure unit test (`test_AC18_13_5_...`).

## Out of scope (tracked follow-up)
Wiring the **correction-loop priors (#931)** into live extraction/classification — the largest of the three; needs the generation path. Left as a follow-up.

## Testing
Local test infra was unusable this session (podman stalls), so:
- The **behavior-preserving gate refactor is verified by a pure unit test** (no DB) — passes locally.
- The DB-backed pieces (POST records a snapshot; report generation records a snapshot) are verified by **CI**:
  - `test_AC18_12_4_post_records_a_snapshot_into_the_series`
  - `test_generate_personal_report_package_snapshot` (now asserts a metric snapshot was recorded)
- AC registry / doc-consistency / manifest / ssot-ownership / ruff — all clean.

## Audit-finding status after this PR
- ✅ #919 record → **wired**
- ✅ #930 gate → **load-bearing** (statement approval; reconciliation's 3-tier score is a separate, riskier mapping left as follow-up)
- ⬜ #931 loop priors → follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)