### PR TITLE
[finance_report_hacker] fix(extraction): Stage-1 state hygiene — doc status + stage1_status (#964, #966)

### DIFF
--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.logger import get_logger
-from src.models.layer1 import DocumentType, UploadedDocument
+from src.models.layer1 import DocumentStatus, DocumentType, UploadedDocument
 from src.models.layer2 import (
     AtomicPosition,
     AtomicPositionSourceDocument,
@@ -570,6 +570,11 @@ async def dual_write_layer2(
         else:
             statement.uploaded_document_id = uploaded_doc.id
             db.add(statement)
+        # Reaching here means the parse succeeded and its facts are persisted, so the ODS document
+        # advances out of 'uploaded'. Without this the status never progresses and every document
+        # appears perpetually un-processed.
+        uploaded_doc.status = DocumentStatus.COMPLETED
+        db.add(uploaded_doc)
         await db.flush()
 
         logger.info(

--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -565,6 +565,12 @@ async def dual_write_layer2(
             existing.balance_validated = statement.balance_validated
             existing.validation_error = statement.validation_error
             existing.status = statement.status
+            # parse_document builds a fresh StatementSummary and sets stage1_status there, but this
+            # reused envelope is the row that gets persisted. Mirror the freshly-computed
+            # pending-review marker onto it, without clobbering a state that was already reviewed
+            # (approved/rejected) on a re-parse.
+            if existing.stage1_status is None:
+                existing.stage1_status = statement.stage1_status
             existing.uploaded_document_id = uploaded_doc.id
             db.add(existing)
         else:

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -18,7 +18,7 @@ from src.config import settings
 from src.logger import get_logger
 from src.models import DocumentType
 from src.models.layer2 import AtomicTransaction, TransactionDirection
-from src.models.statement_enums import BankStatementStatus
+from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
 from src.prompts import get_parsing_prompt
 from src.services.brokerage_positions import looks_like_brokerage_payload
@@ -515,6 +515,11 @@ class ExtractionService:
                 statement.validation_error = balance_result["notes"]
             statement.confidence_score = confidence
             statement.status = status
+            # A statement that lands in review must carry an explicit pending_review marker so the
+            # queue does not rely on a NULL fallback. The auto-approve path owns the approved/None
+            # transitions for APPROVED rows, so only set this for review-bound PARSED statements.
+            if status == BankStatementStatus.PARSED:
+                statement.stage1_status = Stage1Status.PENDING_REVIEW
 
             logger.info(
                 "Parsing validation completed",

--- a/apps/backend/tests/extraction/test_dual_write_layer2.py
+++ b/apps/backend/tests/extraction/test_dual_write_layer2.py
@@ -11,6 +11,8 @@ from sqlalchemy import select
 
 from src.models.layer1 import DocumentStatus, DocumentType, UploadedDocument
 from src.models.layer2 import AtomicTransaction, TransactionDirection
+from src.models.statement_enums import BankStatementStatus, Stage1Status
+from src.models.statement_summary import StatementSummary
 from src.services.extraction import ExtractionService
 
 
@@ -125,6 +127,45 @@ class TestDualWriteLayer2:
             await db.execute(select(UploadedDocument).where(UploadedDocument.user_id == test_user.id))
         ).scalar_one()
         assert uploaded_doc.status == DocumentStatus.COMPLETED
+
+    async def test_dual_write_persists_pending_review_onto_reused_envelope(
+        self, db, test_user, mock_ai_response, sample_file_content
+    ):
+        """AC16.22.8: in the real flow the upload pre-creates a StatementSummary envelope, so
+        dual_write reconciles onto that reused row. The freshly-computed stage1_status=pending_review
+        must be persisted there, not dropped (the no-db unit path hid this)."""
+        service = ExtractionService()
+        file_hash = hashlib.sha256(sample_file_content).hexdigest()
+
+        # Pre-create the envelope exactly as the upload endpoint does (reused by user_id+file_hash).
+        pre = StatementSummary(
+            user_id=test_user.id,
+            file_hash=file_hash,
+            institution="DBS",
+            currency="SGD",
+            status=BankStatementStatus.UPLOADED,
+            stage1_status=None,
+        )
+        db.add(pre)
+        await db.flush()
+
+        with patch.object(service, "extract_financial_data", return_value=mock_ai_response):
+            await service.parse_document(
+                file_path=Path("test_statement.pdf"),
+                institution="DBS",
+                user_id=test_user.id,
+                file_content=sample_file_content,
+                file_hash=file_hash,
+                original_filename="test_statement.pdf",
+                db=db,
+            )
+        await db.commit()
+
+        persisted = (
+            await db.execute(select(StatementSummary).where(StatementSummary.file_hash == file_hash))
+        ).scalar_one()
+        assert persisted.status == BankStatementStatus.PARSED
+        assert persisted.stage1_status == Stage1Status.PENDING_REVIEW
 
     async def test_dual_write_persists_brokerage_extraction_metadata(
         self, db, test_user, sample_file_content, monkeypatch

--- a/apps/backend/tests/extraction/test_dual_write_layer2.py
+++ b/apps/backend/tests/extraction/test_dual_write_layer2.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import select
 
-from src.models.layer1 import DocumentType, UploadedDocument
+from src.models.layer1 import DocumentStatus, DocumentType, UploadedDocument
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.services.extraction import ExtractionService
 
@@ -102,6 +102,29 @@ class TestDualWriteLayer2:
         assert uploaded_doc.original_filename == "test_statement.pdf"
         assert uploaded_doc.document_type == DocumentType.BANK_STATEMENT
         assert uploaded_doc.extraction_metadata is None
+
+    async def test_dual_write_marks_document_completed(self, db, test_user, mock_ai_response, sample_file_content):
+        """AC16.22.9: a successfully parsed-and-persisted document advances to status=completed
+        instead of staying stuck at 'uploaded'."""
+        service = ExtractionService()
+
+        with patch.object(service, "extract_financial_data", return_value=mock_ai_response):
+            await service.parse_document(
+                file_path=Path("test_statement.pdf"),
+                institution="DBS",
+                user_id=test_user.id,
+                file_content=sample_file_content,
+                file_hash=hashlib.sha256(sample_file_content).hexdigest(),
+                original_filename="test_statement.pdf",
+                db=db,
+            )
+
+        await db.commit()
+
+        uploaded_doc = (
+            await db.execute(select(UploadedDocument).where(UploadedDocument.user_id == test_user.id))
+        ).scalar_one()
+        assert uploaded_doc.status == DocumentStatus.COMPLETED
 
     async def test_dual_write_persists_brokerage_extraction_metadata(
         self, db, test_user, sample_file_content, monkeypatch

--- a/apps/backend/tests/extraction/test_extraction_flow.py
+++ b/apps/backend/tests/extraction/test_extraction_flow.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from src.models.statement_enums import BankStatementStatus
+from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.services.extraction import ExtractionError, ExtractionService
 
 
@@ -80,6 +80,34 @@ class TestExtractionServiceFlow:
 
             assert stmt.status == BankStatementStatus.PARSED  # Medium confidence requires review
             assert len(events) == 0
+
+    async def test_parsed_statement_sets_stage1_pending_review(self, service, tmp_path):
+        """AC16.22.8: a statement routed to parsed/review carries stage1_status=pending_review
+        explicitly, so the pending-review queue does not depend on a NULL fallback."""
+        csv_file = tmp_path / "review.csv"
+        csv_file.write_bytes(b"dummy csv")
+
+        mock_data = {
+            "period_start": "2025-01-01",
+            "period_end": "2025-01-31",
+            "opening_balance": "0.00",
+            "closing_balance": "0.00",
+            "transactions": [],
+        }
+
+        with patch.object(service, "_parse_csv_content", new_callable=AsyncMock) as mock_csv:
+            mock_csv.return_value = mock_data
+
+            stmt, _events = await service.parse_document(
+                csv_file,
+                "DBS",
+                user_id=UUID("00000000-0000-0000-0000-000000000002"),
+                file_type="csv",
+                file_content=csv_file.read_bytes(),
+            )
+
+        assert stmt.status == BankStatementStatus.PARSED
+        assert stmt.stage1_status == Stage1Status.PENDING_REVIEW
 
     async def test_parse_document_csv_without_statement_balances_remains_reviewable(self, service, tmp_path):
         """AC3.2.5: CSV transaction exports without statement balances remain reviewable."""

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -418,6 +418,8 @@ balance validation, visual diff, keyboard shortcuts, and CSV export.
 | AC16.22.5 | Stage 1 tolerance is 0.001 USD (not 0.10 USD from Stage 2) | `test_validate_balance_chain_within_tolerance` | `review/test_statement_validation.py` | P0 |
 | AC16.22.6 | All service methods mutating `pending_review` enforce `user_id` ownership | `test_get_statement_for_update_wrong_user_raises` | `review/test_statement_validation.py` | P1 |
 | AC16.22.7 | Stage 1 approval tolerance and extraction/reconciliation scoring tolerance remain separate documented policies | `test_ac16_22_7_tolerance_policy_constants_are_intentional` | `review/test_tolerance_policy.py` | P0 |
+| AC16.22.8 | A statement routed to `parsed`/review carries `stage1_status = pending_review` explicitly (never NULL) | `test_parsed_statement_sets_stage1_pending_review` | `extraction/test_extraction_flow.py` | P1 |
+| AC16.22.9 | `UploadedDocument.status` advances to `completed` once a successful parse is persisted (no longer stuck at `uploaded`) | `test_dual_write_marks_document_completed` | `extraction/test_dual_write_layer2.py` | P1 |
 
 ### AC16.25 — Mobile Review UX Hardening
 


### PR DESCRIPTION
Batches two clean, independent Stage-1 state-machine fixes found during the staging Stage-1 review. No schema change (both columns already exist).

## #964 — UploadedDocument.status never advances past `uploaded` (AC16.22.9)
On staging, **42/42** `uploaded_documents` were stuck at `status='uploaded'`, including ones whose statement is `approved`/posted. The `UploadedDocument` is created during `dual_write_layer2` (not at upload time), so the fix marks it `completed` there once the parse facts are persisted — i.e. exactly when a successful parse is committed.

- `apps/backend/src/services/deduplication.py`: set `uploaded_doc.status = DocumentStatus.COMPLETED` before the final flush in `dual_write_layer2`.

## #966 — PARSED statements carried `stage1_status = NULL` (AC16.22.8)
Statements routed to review sat with `stage1_status=NULL`, so the pending-review queue only worked via a `stage1_status IS NULL` fallback. Now set `pending_review` explicitly when a statement lands in `PARSED` (the auto-approve path still owns the `APPROVED` transitions, so this only touches review-bound rows).

- `apps/backend/src/services/extraction.py`: set `stage1_status = PENDING_REVIEW` when `status == PARSED`.

## Tests (TDD: EPIC-016 → AC → test → code)
- `AC16.22.8` `test_parsed_statement_sets_stage1_pending_review` — parsed CSV carries `stage1_status=pending_review`.
- `AC16.22.9` `test_dual_write_marks_document_completed` — persisted doc reaches `status=completed`.
- Verified locally: `tests/extraction/` + `tests/review/` + `tests/api/test_statements_router.py` = 595 passed; lint/format clean; AC traceability sees both ACs. (Two unrelated local failures are `ModuleNotFoundError: fitz` — PyMuPDF is only installed in the packaged/CI runtime — and fail on `main` too.)

## Not included (deliberately, each needs a non-mechanical decision)
- **#963** PDF preview: deeper than CSP — staging `S3_PUBLIC_ENDPOINT` is empty so `pdf_url` is generated against the internal endpoint (browser-unreachable), *plus* the missing `frame-src`. Needs an infra config + proxy/CSP decision.
- **#965** CSV auto-approve policy: product decision.
- **#967** confidence cap at 90: explained (brokerage statements lack per-line running balance → balance-progression component scores 0); penalising under-extraction is a scoring-design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)