### PR TITLE
[finance_report_audit] close the deterministic audit-review follow-ups (provenance, PATCH append-only, guard, metric docs)

### DIFF
--- a/apps/backend/src/routers/assets.py
+++ b/apps/backend/src/routers/assets.py
@@ -168,6 +168,9 @@ async def update_valuation_snapshot(
             values=payload.model_dump(exclude_unset=True),
         )
         await db.commit()
+    except AssetServiceError as e:
+        await db.rollback()
+        raise_bad_request(str(e), cause=e)
     except Exception as e:
         logger.error("Manual valuation snapshot update failed", error=str(e), user_id=str(user_id))
         await db.rollback()

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -278,10 +278,17 @@ class AssetService:
         *,
         values: dict,
     ) -> ManualValuationSnapshot | None:
-        """Update a manual valuation snapshot."""
+        """Update a manual valuation snapshot.
+
+        Superseded versions are frozen history (vision Axiom A): a recorded fact is
+        never edited in place. Editing one is rejected; corrections re-submit a new
+        version via create_valuation_snapshot.
+        """
         snapshot = await self.get_valuation_snapshot(db, user_id, snapshot_id)
         if not snapshot:
             return None
+        if snapshot.superseded_by_id is not None:
+            raise AssetServiceError("Cannot edit a superseded valuation version; submit a correction instead")
 
         if "component_type" in values and values["component_type"] is not None:
             snapshot.component_type = values["component_type"]

--- a/apps/backend/src/services/confidence_metric.py
+++ b/apps/backend/src/services/confidence_metric.py
@@ -42,6 +42,11 @@ class ConfidenceMetricService:
 
         Grouping by source_type (a pure input to tier derivation) keeps this a
         single read with no row-by-row Python tiering.
+
+        Semantics: this is a **cumulative** lifetime ratio over all posted/reconciled
+        entries to date — a stock, not a per-period flow. As history grows the ratio
+        becomes less sensitive to recent improvements; a trailing-window variant is a
+        deliberate future option, not the current contract.
         """
         rows = await db.execute(
             select(JournalEntry.source_type, func.count(JournalEntry.id))

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -1028,6 +1028,10 @@ async def generate_balance_sheet(
     # rated line. Lines with no derivable tier (e.g. market-derived adjustments)
     # are excluded rather than counted as trusted.
     aggregate_tier = _worst_confidence_tier(line.get("confidence_tier") for line in (*assets, *liabilities, *equity))
+    # Aggregate provenance: the shared provenance across rated lines, or "derived"
+    # when sources mix. Mirrors the per-line provenance so the schema field is
+    # populated rather than always None.
+    aggregate_provenance = _combine_provenance([line.get("provenance") for line in (*assets, *liabilities, *equity)])
     response_assets = assets if include_allocation_metadata else _strip_allocation_metadata(assets)
     response_liabilities = liabilities if include_allocation_metadata else _strip_allocation_metadata(liabilities)
     response_equity = equity if include_allocation_metadata else _strip_allocation_metadata(equity)
@@ -1039,6 +1043,7 @@ async def generate_balance_sheet(
         "liabilities": response_liabilities,
         "equity": response_equity,
         "confidence_tier": aggregate_tier,
+        "provenance": aggregate_provenance,
         "total_assets": total_assets,
         "total_liabilities": total_liabilities,
         "total_equity": total_equity,

--- a/apps/backend/tests/assets/test_manual_valuation_snapshots.py
+++ b/apps/backend/tests/assets/test_manual_valuation_snapshots.py
@@ -11,7 +11,7 @@ from sqlalchemy.dialects import postgresql
 from src.models.layer3 import ManualValuationComponentType, ManualValuationLiquidityClass
 from src.schemas.assets import ManualValuationSnapshotCreate, ManualValuationSnapshotUpdate
 from src.schemas.provenance import DataProvenance
-from src.services.assets import AssetService, ValuationComponentItem
+from src.services.assets import AssetService, AssetServiceError, ValuationComponentItem
 
 
 async def test_create_manual_valuation_snapshot_crud_api(client):
@@ -347,6 +347,27 @@ async def test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth(
     snapshots, total = await service.list_valuation_snapshots(db, test_user.id)
     assert total == 1, "list returns only current heads"
     assert snapshots[0].value == Decimal("1100000.00")
+
+
+@pytest.mark.asyncio
+async def test_editing_a_superseded_valuation_is_rejected(db, test_user):
+    """Audit review: PATCH must not edit frozen history (Axiom A); superseded versions are read-only."""
+    service = AssetService()
+    identity = dict(
+        component_type=ManualValuationComponentType.PROPERTY_VALUE,
+        as_of_date=date(2026, 5, 18),
+        source="manual appraisal",
+    )
+    first = await service.create_valuation_snapshot(
+        db, user_id=test_user.id, value=Decimal("1000000.00"), currency="SGD", **identity
+    )
+    await service.create_valuation_snapshot(
+        db, user_id=test_user.id, value=Decimal("1100000.00"), currency="SGD", **identity
+    )  # supersedes `first`
+    await db.commit()
+
+    with pytest.raises(AssetServiceError, match="superseded"):
+        await service.update_valuation_snapshot(db, test_user.id, first.id, values={"value": Decimal("999.00")})
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/reporting/test_balance_sheet_confidence.py
+++ b/apps/backend/tests/reporting/test_balance_sheet_confidence.py
@@ -142,3 +142,36 @@ async def test_include_trust_signals_false_skips_tier_and_provenance(db, test_us
 
     assert report["confidence_tier"] is None
     assert all(line["confidence_tier"] is None and line["provenance"] is None for line in report["assets"])
+
+
+@pytest.mark.asyncio
+async def test_balance_sheet_aggregate_provenance_is_populated(db, test_user):
+    """Audit review: the aggregate provenance is exposed on the payload, not always None (#938 gap)."""
+    cash = Account(user_id=test_user.id, name="Cash", type=AccountType.ASSET, currency="SGD")
+    salary = Account(user_id=test_user.id, name="Salary", type=AccountType.INCOME, currency="SGD")
+    db.add_all([cash, salary])
+    await db.flush()
+    await _post(
+        db,
+        test_user.id,
+        debit=cash,
+        credit=salary,
+        amount=Decimal("100.00"),
+        source_type=JournalEntrySourceType.AUTO_PARSED,
+    )
+    single = await generate_balance_sheet(db, test_user.id, as_of_date=date(2026, 12, 31))
+    assert single["provenance"] == "imported"
+
+    wallet = Account(user_id=test_user.id, name="Wallet", type=AccountType.ASSET, currency="SGD")
+    db.add(wallet)
+    await db.flush()
+    await _post(
+        db,
+        test_user.id,
+        debit=wallet,
+        credit=salary,
+        amount=Decimal("50.00"),
+        source_type=JournalEntrySourceType.MANUAL,
+    )
+    mixed = await generate_balance_sheet(db, test_user.id, as_of_date=date(2026, 12, 31))
+    assert mixed["provenance"] == "derived"

--- a/common/testing/detached_owner_guard.py
+++ b/common/testing/detached_owner_guard.py
@@ -65,13 +65,24 @@ def _relative_path(path: Path, repo_root: Path) -> str:
         return path.as_posix()
 
 
+_PERSIST_METHODS = ("add", "add_all", "merge", "bulk_save_objects")
+
+
 def _persisted_construction_ids(scope: ast.AST) -> set[int]:
-    """Return ids of model-construction Call nodes persisted via db.add / db.add_all.
+    """Return ids of model-construction Call nodes persisted via a session write.
 
     Only persisted rows carry the production foreign key, so only they can hide the
     ownership / cascade / cross-user bugs this guard exists to catch. A
     ``user_id=uuid4()`` on a transient in-memory object or a bare service argument
     is not a detached-owner shortcut — it never reaches the database.
+
+    Persistence is detected for ``add`` / ``add_all`` / ``merge`` /
+    ``bulk_save_objects`` calls, including rows collected into a list variable and
+    bulk-added later. This is a deliberate **lower bound**: a row persisted only
+    through a cross-function helper or factory (``db.add(make_row())``) is not
+    counted, so the budget bounds the *directly-visible* detached owners, not the
+    total. The durable fix is keeping the test ``users`` foreign key and owning
+    rows with the ``test_user`` fixture.
     """
     added_var_names: set[str] = set()
     construction_ids: set[int] = set()
@@ -98,7 +109,7 @@ def _persisted_construction_ids(scope: ast.AST) -> set[int]:
     # records the variable so rows collected into a list and bulk-added later are
     # still treated as persisted.
     for node in ast.walk(scope):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr in ("add", "add_all"):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr in _PERSIST_METHODS:
             for arg in node.args:
                 _collect_added(arg)
 

--- a/tests/tooling/test_detached_owner_guard.py
+++ b/tests/tooling/test_detached_owner_guard.py
@@ -139,6 +139,35 @@ def test_add_all_via_append(db):
     assert any("Appended" in name for name in names)
 
 
+def test_AC8_13_130_counts_merge_and_bulk_save_persisted_owners(tmp_path: Path) -> None:
+    """AC8.13.130: persistence via merge / bulk_save_objects is also counted, not just add/add_all."""
+    test_file = tmp_path / "apps" / "backend" / "tests" / "test_persist.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        """
+from uuid import uuid4
+
+from src.models import Account
+
+
+def test_merge(db):
+    db.merge(Account(user_id=uuid4(), name="Merged", type="ASSET", currency="SGD"))
+
+
+def test_bulk(db):
+    db.bulk_save_objects([Account(user_id=uuid4(), name="Bulk", type="ASSET", currency="SGD")])
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = detached_owner_guard.scan_paths([tmp_path / "apps" / "backend" / "tests"], repo_root=tmp_path)
+
+    names = {finding.source for finding in findings}
+    assert len(findings) == 2
+    assert any("Merged" in name for name in names)
+    assert any("Bulk" in name for name in names)
+
+
 def test_AC8_13_128_ignores_non_uuid4_user_ids(tmp_path: Path) -> None:
     """AC8.13.128: only direct uuid4 owner shortcuts count against the budget."""
     test_file = tmp_path / "apps" / "backend" / "tests" / "test_safe.py"


### PR DESCRIPTION
## Summary

Closes the **deterministic, bounded** follow-ups from the post-merge audit review, in one pass. (The bigger/riskier items — #931 priors into live extraction, the reconciliation gate, the #896 shim burn-down — are deliberately **not** crammed; see below.)

## Fixes (each with a test)

1. **Aggregate provenance is exposed** (`reporting.py`) — the balance-sheet payload now sets a top-level `provenance` (`_combine_provenance` over the rated lines). It was always absent/None despite the schema field (a #938 gap). Test: single imported source → `imported`; mixed → `derived`.
2. **PATCH append-only hole closed** (`assets.py` + `routers/assets.py`) — editing a **superseded** `ManualValuationSnapshot` is rejected (`AssetServiceError` → 400). Frozen history can no longer be rewritten in place (Axiom A); corrections re-submit a new version. Test: editing a superseded version raises.
3. **Detached-owner guard extended + honest docstring** (`detached_owner_guard.py`) — now counts persistence via `merge` / `bulk_save_objects` (not only `add`/`add_all`), and documents that the count is a deliberate **lower bound** (cross-function/factory persistence isn't caught) so it no longer implies total coverage. Real-repo count stays **2**. Pure test added (passes locally).
4. **North-Star metric semantics documented** (`confidence_metric.py`) — clarifies it's a **cumulative lifetime ratio** (a stock), with a trailing-window variant a future option, not the current contract.

## Explicitly out of scope (separate, not crammed)
- **#931 priors → live extraction** — overlaps the existing `get_few_shot_examples` few-shot path; needs a design decision before wiring.
- **Reconciliation promotion-gate wiring** — reconciliation's 3-tier score (85/60) doesn't map onto the binary gate; needs a gate extension (a review floor) first.
- **#896 shim burn-down** — multi-surface tendrils (`statement_id` in router+schema, `staging_required` in 17 CI conditions, `bank_statement` enum needs a data migration); one PR each.

## Testing
- Guard change verified by a **pure unit test** locally (no DB).
- The DB-backed tests (aggregate provenance; superseded-edit rejection) are verified by **CI** (local podman infra unusable this session).
- ruff / api-ref / ac-registry / doc-consistency — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)