### PR TITLE
[finance_report_audit] make the correction feedback loop observable (#931) + audit-tail cleanup (#979 CR, #896)

### DIFF
--- a/apps/backend/src/routers/metrics.py
+++ b/apps/backend/src/routers/metrics.py
@@ -12,11 +12,14 @@ from src.schemas.metrics import (
     ConfidenceMetricPoint,
     ConfidenceMetricSnapshotResponse,
     ConfidenceNorthStarResponse,
+    CorrectionLoopReplayResponse,
 )
 from src.services.confidence_metric import ConfidenceMetricService
+from src.services.correction_loop import CorrectionLoopService
 
 router = APIRouter(prefix="/metrics", tags=["metrics"])
 _service = ConfidenceMetricService()
+_correction_loop = CorrectionLoopService()
 
 
 def _snapshot_response(snapshot: ConfidenceMetricSnapshot) -> ConfidenceMetricSnapshotResponse:
@@ -62,3 +65,22 @@ async def record_confidence_north_star_snapshot(
     snapshot = await _service.record_snapshot(db, user_id)
     await db.commit()
     return _snapshot_response(snapshot)
+
+
+@router.get("/correction-loop/replay", response_model=CorrectionLoopReplayResponse)
+async def get_correction_loop_replay(user_id: CurrentUserId, db: DbSession) -> CorrectionLoopReplayResponse:
+    """Surface the held-out replay of the live correction corpus (read-only).
+
+    Makes the feedback loop's effect on the North-Star proportion auditable: how
+    much recurring-correction priors lower the held-out low-confidence proportion.
+    Records nothing and grounds no live generation — the corpus stays a projection
+    of `CorrectionLog`.
+    """
+    result = await _correction_loop.replay(db, user_id)
+    return CorrectionLoopReplayResponse(
+        holdout_size=result.holdout_size,
+        grounded=result.grounded,
+        proportion_before=result.proportion_before,
+        proportion_after=result.proportion_after,
+        reduced=result.reduced,
+    )

--- a/apps/backend/src/schemas/metrics.py
+++ b/apps/backend/src/schemas/metrics.py
@@ -28,3 +28,18 @@ class ConfidenceNorthStarResponse(BaseModel):
 
     current: ConfidenceMetricPoint
     series: list[ConfidenceMetricSnapshotResponse]
+
+
+class CorrectionLoopReplayResponse(BaseModel):
+    """The held-out replay of the live correction corpus (EPIC-018 AC18.14).
+
+    The furnace made observable: how much the recurring-correction priors lower the
+    held-out low-confidence proportion. `reduced` is the auditable yes/no of whether
+    the loop measurably improved the proportion over this corpus.
+    """
+
+    holdout_size: int
+    grounded: int
+    proportion_before: Decimal
+    proportion_after: Decimal
+    reduced: bool

--- a/apps/backend/src/services/correction_loop.py
+++ b/apps/backend/src/services/correction_loop.py
@@ -126,3 +126,20 @@ class CorrectionLoopService:
             .order_by(CorrectionLog.created_at, CorrectionLog.id)
         )
         return build_corpus_from_corrections(result.scalars().all())
+
+    async def replay(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        *,
+        train_ratio: Decimal = Decimal("0.5"),
+    ) -> ReplayResult:
+        """Build the live corpus and replay it, surfacing the held-out reduction.
+
+        This is the loop made *observable*: a read-only measurement over the
+        current corpus, so the furnace's effect on the north-star proportion is
+        auditable. It records nothing and grounds no live generation — the corpus
+        stays a projection of ``CorrectionLog`` (no second source of truth).
+        """
+        corpus = await self.build_corpus(db, user_id)
+        return replay_low_confidence_reduction(corpus, train_ratio=train_ratio)

--- a/apps/backend/tests/metrics/test_correction_loop_replay.py
+++ b/apps/backend/tests/metrics/test_correction_loop_replay.py
@@ -1,0 +1,23 @@
+"""Correction feedback loop: the replay is observable read-only (EPIC-018 AC18.14, #931).
+
+AC18.12 makes the thermometer (the low-confidence proportion) observable; this
+endpoint makes the furnace observable — the held-out replay of the live correction
+corpus, so the loop's effect on the proportion is auditable. It adds no second
+source of truth: the corpus is still a projection of `CorrectionLog`.
+"""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_AC18_14_4_replay_endpoint_surfaces_the_loop_effect(client):
+    """AC18.14.4: the held-out replay result is exposed read-only via the API."""
+    response = await client.get("/metrics/correction-loop/replay")
+    assert response.status_code == 200
+    body = response.json()
+    # Empty corpus is a defined, observable zero — never a divide-by-zero.
+    assert body["holdout_size"] == 0
+    assert body["grounded"] == 0
+    assert body["reduced"] is False
+    assert body["proportion_before"] == "0"
+    assert body["proportion_after"] == "0"

--- a/apps/backend/tests/services/test_correction_loop.py
+++ b/apps/backend/tests/services/test_correction_loop.py
@@ -109,3 +109,44 @@ async def test_AC18_14_3_service_builds_corpus_from_persisted_corrections(db, te
     assert len(corpus) == 1
     assert corpus[0].key == "netflix"
     assert corpus[0].corrected_category == "Entertainment"
+
+
+@pytest.mark.asyncio
+async def test_AC18_14_4_service_replay_measures_held_out_reduction(db, test_user):
+    """AC18.14.4: the service replays the live corpus, surfacing the held-out reduction.
+
+    This is the loop being *observed* end-to-end against persisted data: corrections
+    whose pattern recurs ground the held-out split, so the measured low-confidence
+    proportion strictly drops — the auditable evidence the furnace works.
+    """
+    from tests.factories import AtomicTransactionFactory, UploadedDocumentFactory
+
+    document = await UploadedDocumentFactory.create_async(db, user_id=test_user.id)
+    # Two recurring patterns (Netflix, Spotify) interleaved so a 0.5 split grounds
+    # every held-out item from the train split.
+    for description, original, corrected in [
+        ("Netflix", "Utilities", "Entertainment"),
+        ("Spotify", "Utilities", "Entertainment"),
+        ("Netflix", "Utilities", "Entertainment"),
+        ("Spotify", "Utilities", "Entertainment"),
+    ]:
+        txn = await AtomicTransactionFactory.create_async(
+            db, test_user.id, source_doc_id=document.id, description=description
+        )
+        db.add(
+            CorrectionLog(
+                user_id=test_user.id,
+                transaction_id=txn.id,
+                original_category=original,
+                corrected_category=corrected,
+                transaction_description=description,
+            )
+        )
+    await db.commit()
+
+    result = await CorrectionLoopService().replay(db, test_user.id, train_ratio=Decimal("0.5"))
+
+    assert result.holdout_size == 2
+    assert result.grounded == 2
+    assert result.reduced is True
+    assert result.proportion_after < result.proportion_before

--- a/common/ssot/generate_ac_registry.py
+++ b/common/ssot/generate_ac_registry.py
@@ -23,8 +23,6 @@ EPIC_DIR = "docs/project"
 OUTPUT_FEATURE = "docs/ac_registry.yaml"
 OUTPUT_INFRA = "docs/infra_registry.yaml"
 OVERRIDES = "docs/ac_registry_overrides.yaml"
-# Backward-compat alias used by tests
-OUTPUT = OUTPUT_FEATURE
 
 # EPIC classification: which EPICs are feature vs infra
 FEATURE_EPICS = {1, 2, 3, 4, 5, 6, 8, 11, 13, 15, 16, 17, 18, 19, 20, 21, 22}
@@ -208,7 +206,7 @@ def classify_ac(ac_id: str, entry: dict) -> str:
 
 def write_registry(all_acs: dict[str, dict], output_path: str | None = None) -> None:
     if output_path is None:
-        output_path = OUTPUT
+        output_path = OUTPUT_FEATURE
     _require_yaml()
     groups: dict[str, dict[str, list[dict]]] = {}
     for ac_id in sorted(all_acs.keys(), key=sort_key):

--- a/common/testing/detached_owner_guard.py
+++ b/common/testing/detached_owner_guard.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 DEFAULT_TEST_ROOTS = (Path("apps/backend/tests"),)
-# Counts only persisted (db.add'd) detached owners — the real foreign-key risk.
+# Counts only persisted (session-written) detached owners — the real foreign-key risk.
 # The two remaining are intentional cross-user isolation tests that must own a
 # different user's row; transient in-memory / service-argument uses do not count.
 DEFAULT_MAX_DETACHED_OWNER_SHORTCUTS = 2
@@ -88,7 +88,7 @@ def _persisted_construction_ids(scope: ast.AST) -> set[int]:
     construction_ids: set[int] = set()
 
     def _collect_added(node: ast.expr) -> None:
-        """From an add/add_all argument: record variable names and mark constructions."""
+        """From a session-write argument: record variable names and mark constructions."""
         if isinstance(node, ast.Name):
             added_var_names.add(node.id)
         elif isinstance(node, ast.Call):
@@ -105,9 +105,9 @@ def _persisted_construction_ids(scope: ast.AST) -> set[int]:
             for element in node.elts:
                 _mark_constructions(element)
 
-    # db.add(x) / db.add_all([...] | var). A Name argument (or Name list element)
-    # records the variable so rows collected into a list and bulk-added later are
-    # still treated as persisted.
+    # Any session write in _PERSIST_METHODS (db.add / db.add_all / db.merge /
+    # db.bulk_save_objects). A Name argument (or Name list element) records the
+    # variable so rows collected into a list and bulk-added later are still persisted.
     for node in ast.walk(scope):
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr in _PERSIST_METHODS:
             for arg in node.args:
@@ -138,9 +138,10 @@ def _persisted_construction_ids(scope: ast.AST) -> set[int]:
 def scan_file(path: Path, *, repo_root: Path) -> list[DetachedOwnerFinding]:
     """Return persisted detached-owner shortcuts found in one Python file.
 
-    A finding is counted only when its enclosing model construction is added to a
-    session (``db.add`` / ``db.add_all``) — the real foreign-key risk. Transient
-    in-memory constructions and bare service arguments are not counted.
+    A finding is counted only when its enclosing model construction is written to a
+    session (``db.add`` / ``db.add_all`` / ``db.merge`` / ``db.bulk_save_objects``) —
+    the real foreign-key risk. Transient in-memory constructions and bare service
+    arguments are not counted.
     """
     source_text = path.read_text(encoding="utf-8")
     tree = ast.parse(source_text, filename=str(path))

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -417,15 +417,20 @@ correction that overrode an AI proposal is labeled signal. Derived as a corpus
 from the append-only `CorrectionLog` (a projection of the provenance substrate, not
 a sidecar) and replayed as priors, a recurring correction grounds future instances
 of the same pattern so they are no longer low-confidence — measurably driving the
-proportion down. This AC owns the corpus and the measurable replay; wiring the
-priors into live generation, calibrating the promotion-gate thresholds (#930) from
-the corpus, and the runtime that dispatches AI attempts are follow-ups.
+proportion down. This AC owns the corpus, the measurable replay, and making that
+replay **observable** over the live corpus (mirroring how AC18.12 makes the
+thermometer observable); calibrating the promotion-gate thresholds (#930) from the
+corpus, and wiring the priors into live generation, are follow-ups. (Live
+correction grounding of extraction already exists today via the few-shot path —
+AC18.2.3 — so this AC adds the *audit* view of the loop's effect, not a second
+grounding mechanism.)
 
 | ID | Phase | Description | Test | File | Priority |
 |----|-------|-------------|------|------|----------|
 | AC18.14.1 | Corpus | The correction corpus is derived from `CorrectionLog` (no sidecar), keyed by the transaction pattern, capturing proposed vs corrected | `test_AC18_14_1_corpus_is_derived_from_corrections_keyed_by_pattern()` | `services/test_correction_loop.py` | P1 |
 | AC18.14.2 | Replay | Replaying the corpus as priors strictly lowers the held-out low-confidence proportion when correction patterns recur, and invents no reduction when they do not | `test_AC18_14_2_replay_lowers_low_confidence_proportion_when_patterns_recur()`, `test_AC18_14_2_replay_does_not_invent_reduction_without_recurrence()` | `services/test_correction_loop.py` | P1 |
 | AC18.14.3 | Substrate | The service builds the corpus from the persisted correction store, scoped to the user | `test_AC18_14_3_service_builds_corpus_from_persisted_corrections()` | `services/test_correction_loop.py` | P1 |
+| AC18.14.4 | Observable | The held-out replay result is surfaced read-only over the live corpus, so the loop's effect on the low-confidence proportion is auditable (no new source of truth) | `test_AC18_14_4_service_replay_measures_held_out_reduction()`, `test_AC18_14_4_replay_endpoint_surfaces_the_loop_effect()` | `services/test_correction_loop.py`, `metrics/test_correction_loop_replay.py` | P1 |
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,8 +5,8 @@
 
 - API title: `Finance Report API`
 - API version: `0.1.0`
-- Endpoint count: `125`
-- Schema count: `209`
+- Endpoint count: `126`
+- Schema count: `210`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 
@@ -26,7 +26,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `income` | 1 |
 | `journal-entries` | 6 |
 | `market-data` | 3 |
-| `metrics` | 2 |
+| `metrics` | 3 |
 | `portfolio` | 13 |
 | `reconciliation` | 11 |
 | `reports` | 21 |
@@ -148,6 +148,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 |---|---|---|---|---|---|---|
 | `GET` | `/metrics/confidence-north-star` | yes | - | - | `200` `ConfidenceNorthStarResponse` | Get Confidence North Star |
 | `POST` | `/metrics/confidence-north-star/snapshots` | yes | - | - | `201` `ConfidenceMetricSnapshotResponse` | Record Confidence North Star Snapshot |
+| `GET` | `/metrics/correction-loop/replay` | yes | - | - | `200` `CorrectionLoopReplayResponse` | Get Correction Loop Replay |
 
 ### portfolio
 

--- a/tests/tooling/test_generate_ac_registry.py
+++ b/tests/tooling/test_generate_ac_registry.py
@@ -251,12 +251,12 @@ class TestWriteRegistry:
 
         assert "It's done" in content
 
-    def test_default_output_alias_and_extra_metadata_are_preserved(
+    def test_default_output_and_extra_metadata_are_preserved(
         self, tmp_path, monkeypatch
     ):
         """AC8.13.17: Generated grouped registries keep canonical metadata."""
         out = tmp_path / "ac_registry.yaml"
-        monkeypatch.setattr(gar, "OUTPUT", str(out))
+        monkeypatch.setattr(gar, "OUTPUT_FEATURE", str(out))
 
         gar.write_registry(
             {


### PR DESCRIPTION
## Summary

Closes the audit-tail follow-ups across three orthogonal surfaces, all CI-gated. The user asked to bundle the #979 CR comment with finishing #931 and #896.

### #931 — observable correction-loop replay (EPIC-018 **AC18.14.4**)

The comprehensive audit flagged `correction_loop` as *"deployed but not called."* I let **vision** decide the lever (its Decision Filter: *"take the smaller step that improves proof quality"*):

- The **live** correction→extraction loop **already exists** via the few-shot path (**AC18.2.3**: `get_few_shot_examples` injects past corrections into the extraction prompt). So `correction_loop` is a redundant, unwired *twin* of an already-live mechanism — its real value is the **audit** view, not a second grounding.
- Added `CorrectionLoopService.replay()` + `GET /metrics/correction-loop/replay`: a **read-only** held-out replay over the live corpus, mirroring how AC18.12 makes the north-star *thermometer* observable. This makes the *furnace* observable too.
- Records nothing, grounds no live generation — the corpus stays a projection of `CorrectionLog` (**no second source of truth**).
- **Explicit follow-up (not this PR):** unifying few-shot + `correction_loop` onto one corpus builder is the *larger* step (touches the live extraction path), so per the Decision Filter it is deferred and documented in the AC18.14 note.

### #979 CR comment — guard docstring consistency

`detached_owner_guard` counts persistence via `add`/`add_all`/`merge`/`bulk_save_objects`, but four comments/docstrings still named only `db.add`/`db.add_all`. Synced them to the full `_PERSIST_METHODS` set. **Comment-only**; guard behavior unchanged (57 tooling tests pass). `common/` is not ruff-formatted by any gate, so the lines keep the file's existing 120-col style.

### #896 — retire `OUTPUT = OUTPUT_FEATURE` alias

`generate_ac_registry.py`: migrated the one default-arg use to `OUTPUT_FEATURE` and the one test monkeypatch; deleted the back-compat alias. (Ticks one Tier-B box on #896.)

## Test plan

- 🟢 `ac-registry --check`, `api-reference --check` (api.md regenerated: +1 endpoint), `lint_doc_consistency`, `check_manifest`, `check_ssot_ownership`
- 🟢 `ruff check` / `ruff format --check` on `apps/backend/{src,tests}`
- 🟢 `tests/tooling/` — 57 passed (guard docstring + OUTPUT alias migration)
- 🟢 pure replay logic verified locally; DB service test (`AC18.14.4`) + endpoint test (`AC18.14.4`) follow existing AC18.12/AC18.14 patterns and run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)