### PR TITLE
[finance_report_vision] feat: guided opening balances (#949) + year-scale reporting validation (#951)

### DIFF
--- a/apps/backend/src/routers/accounts.py
+++ b/apps/backend/src/routers/accounts.py
@@ -21,6 +21,8 @@ from src.schemas import (
     ProcessingPendingListResponse,
     ProcessingSummaryResponse,
 )
+from src.schemas.account import OpeningBalanceRequest
+from src.schemas.journal import JournalEntryResponse
 from src.services import (
     AccountNotFoundError,
     account_service,
@@ -28,6 +30,7 @@ from src.services import (
     calculate_account_balances,
 )
 from src.services.account_coverage import DEFAULT_STALE_AFTER_DAYS, get_account_statement_coverage
+from src.services.accounting import ValidationError, post_opening_balance_entry
 from src.services.processing_account import (
     find_transfer_pairs,
     get_processing_balance,
@@ -39,6 +42,35 @@ from src.utils.money import to_money
 
 router = APIRouter(prefix="/accounts", tags=["accounts"])
 logger = get_logger(__name__)
+
+
+@router.post("/opening-balances", response_model=JournalEntryResponse, status_code=status.HTTP_201_CREATED)
+async def post_opening_balances(
+    payload: OpeningBalanceRequest,
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> JournalEntryResponse:
+    """Guided opening-balance flow (#949): establish year-start account balances.
+
+    Posts one balanced journal entry that increases each supplied account to its
+    opening balance and offsets the net into the system Opening Balance Equity
+    account, so a cross-year balance sheet is complete from the start.
+    """
+    try:
+        entry = await post_opening_balance_entry(
+            db,
+            user_id,
+            entry_date=payload.entry_date,
+            balances=payload.balances,
+            currency=(payload.currency or settings.base_currency),
+            memo=payload.memo,
+        )
+        await db.commit()
+        await db.refresh(entry, ["lines"])
+    except ValidationError as exc:
+        await db.rollback()
+        raise_bad_request(str(exc), cause=exc)
+    return JournalEntryResponse.model_validate(entry)
 
 
 @router.post("", response_model=AccountResponse, status_code=status.HTTP_201_CREATED)

--- a/apps/backend/src/schemas/account.py
+++ b/apps/backend/src/schemas/account.py
@@ -12,6 +12,19 @@ from src.models.account import AccountType
 from src.schemas.base import BaseResponse, ListResponse
 
 
+class OpeningBalanceRequest(BaseModel):
+    """Guided opening-balance request (#949): map accounts to year-start balances.
+
+    Each account is increased to its balance on its normal side; the net offsets
+    into the system Opening Balance Equity account so the entry stays balanced.
+    """
+
+    entry_date: date
+    balances: dict[UUID, Annotated[Decimal, Field(gt=Decimal("0"), decimal_places=2)]]
+    currency: str | None = None
+    memo: Annotated[str, Field(min_length=1, max_length=500)] = "Opening balances"
+
+
 class AccountBase(BaseModel):
     """Base account schema."""
 

--- a/apps/backend/src/schemas/account.py
+++ b/apps/backend/src/schemas/account.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from src.models.account import AccountType
 from src.schemas.base import BaseResponse, ListResponse
@@ -21,8 +21,13 @@ class OpeningBalanceRequest(BaseModel):
 
     entry_date: date
     balances: dict[UUID, Annotated[Decimal, Field(gt=Decimal("0"), decimal_places=2)]]
-    currency: str | None = None
+    currency: Annotated[str, Field(min_length=3, max_length=3)] | None = None
     memo: Annotated[str, Field(min_length=1, max_length=500)] = "Opening balances"
+
+    @field_validator("currency")
+    @classmethod
+    def normalize_currency(cls, value: str | None) -> str | None:
+        return value.upper() if value else value
 
 
 class AccountBase(BaseModel):

--- a/apps/backend/src/schemas/account.py
+++ b/apps/backend/src/schemas/account.py
@@ -24,10 +24,14 @@ class OpeningBalanceRequest(BaseModel):
     currency: Annotated[str, Field(min_length=3, max_length=3)] | None = None
     memo: Annotated[str, Field(min_length=1, max_length=500)] = "Opening balances"
 
-    @field_validator("currency")
+    @field_validator("currency", mode="before")
     @classmethod
-    def normalize_currency(cls, value: str | None) -> str | None:
-        return value.upper() if value else value
+    def normalize_currency(cls, value: object) -> object:
+        # Strip + uppercase before the length check so " sgd " normalizes to "SGD",
+        # consistent with currency normalization elsewhere (e.g. reporting).
+        if isinstance(value, str):
+            return value.strip().upper()
+        return value
 
 
 class AccountBase(BaseModel):

--- a/apps/backend/src/services/account_service.py
+++ b/apps/backend/src/services/account_service.py
@@ -78,7 +78,9 @@ async def get_or_create_opening_balance_equity_account(
             Account.code == "3199",
         )
     )
-    account = result.scalar_one_or_none()
+    # Tolerant fetch: a rare duplicate (e.g. concurrent first-time creates without
+    # a DB uniqueness constraint) must not break opening-balance posting.
+    account = result.scalars().first()
     if not account:
         account = Account(
             user_id=user_id,

--- a/apps/backend/src/services/account_service.py
+++ b/apps/backend/src/services/account_service.py
@@ -62,6 +62,39 @@ async def get_or_create_processing_account(db: AsyncSession, user_id: UUID, curr
     return account
 
 
+async def get_or_create_opening_balance_equity_account(
+    db: AsyncSession, user_id: UUID, currency: str = "SGD"
+) -> Account:
+    """Get or create the Opening Balance Equity account for a user (#949).
+
+    Guided opening balances offset into this system-managed equity account so a
+    user's starting position is captured as a balanced journal entry and the
+    accounting equation holds (Assets = Liabilities + Equity) from day one.
+    """
+    result = await db.execute(
+        select(Account).where(
+            Account.user_id == user_id,
+            Account.is_system == True,  # noqa: E712
+            Account.code == "3199",
+        )
+    )
+    account = result.scalar_one_or_none()
+    if not account:
+        account = Account(
+            user_id=user_id,
+            name="Opening Balance Equity",
+            code="3199",
+            type=AccountType.EQUITY,
+            currency=currency,
+            is_system=True,
+            description="System-managed equity account for year-start opening balance entries",
+        )
+        db.add(account)
+        await db.flush()
+        await db.refresh(account)
+    return account
+
+
 async def list_accounts(
     db: AsyncSession,
     user_id: UUID,

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -318,7 +318,7 @@ async def post_opening_balance_entry(
     if not balances:
         raise ValidationError("At least one opening balance is required")
 
-    normalized_currency = currency.upper()
+    normalized_currency = currency.strip().upper()
     account_ids = list(balances.keys())
     result = await db.execute(select(Account).where(Account.id.in_(account_ids), Account.user_id == user_id))
     accounts = {account.id: account for account in result.scalars().all()}
@@ -333,7 +333,7 @@ async def post_opening_balance_entry(
     if system_targets:
         raise ValidationError(f"Opening balances cannot target system accounts: {system_targets}")
 
-    base_currency = settings.base_currency.upper()
+    base_currency = settings.base_currency.strip().upper()
     if normalized_currency != base_currency:
         raise ValidationError(
             f"Opening balances are supported only in the base currency ({base_currency}); got {normalized_currency}."
@@ -365,7 +365,7 @@ async def post_opening_balance_entry(
         if amount <= Decimal("0"):
             raise ValidationError("Opening balance amounts must be positive")
         account = accounts[account_id]
-        if (account.currency or "").upper() != normalized_currency:
+        if (account.currency or "").strip().upper() != normalized_currency:
             raise ValidationError(
                 f"Opening balance currency {normalized_currency} does not match the currency "
                 f"of account {account_id} ({account.currency}); lines must not be mis-stamped."

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -326,6 +326,13 @@ async def post_opening_balance_entry(
     if missing:
         raise ValidationError(f"Unknown or non-owned account(s): {sorted(missing)}")
 
+    # The posted entry is SYSTEM-typed (it offsets into the system equity account),
+    # which would otherwise let a caller target any system account (e.g. Processing).
+    # Opening balances may only target user-managed accounts.
+    system_targets = sorted(str(account.id) for account in accounts.values() if account.is_system)
+    if system_targets:
+        raise ValidationError(f"Opening balances cannot target system accounts: {system_targets}")
+
     base_currency = settings.base_currency.upper()
     if normalized_currency != base_currency:
         raise ValidationError(

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -358,6 +358,11 @@ async def post_opening_balance_entry(
         if amount <= Decimal("0"):
             raise ValidationError("Opening balance amounts must be positive")
         account = accounts[account_id]
+        if (account.currency or "").upper() != normalized_currency:
+            raise ValidationError(
+                f"Opening balance currency {normalized_currency} does not match the currency "
+                f"of account {account_id} ({account.currency}); lines must not be mis-stamped."
+            )
         if account.type in (AccountType.ASSET, AccountType.EXPENSE):
             direction = Direction.DEBIT
             total_debit += amount

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -20,7 +20,6 @@ from src.models import (
     JournalLine,
 )
 from src.services.source_type_priority import normalize_source_type
-from src.utils.money import to_money
 
 
 class AccountingError(Exception):
@@ -311,7 +310,10 @@ async def post_opening_balance_entry(
     is offset into the system Opening Balance Equity account so the entry
     balances and the accounting equation holds. All amounts are ``Decimal``.
     """
+    # Imported lazily so importing this module stays free of the FastAPI/util
+    # dependency graph (tooling tests import accounting without those installed).
     from src.services.account_service import get_or_create_opening_balance_equity_account
+    from src.utils.money import to_money
 
     if not balances:
         raise ValidationError("At least one opening balance is required")

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -20,6 +20,7 @@ from src.models import (
     JournalLine,
 )
 from src.services.source_type_priority import normalize_source_type
+from src.utils.money import to_money
 
 
 class AccountingError(Exception):
@@ -292,6 +293,78 @@ async def validate_line_account_ownership(
         raise ValidationError("Account does not belong to user")
 
     return accounts
+
+
+async def post_opening_balance_entry(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    entry_date: date,
+    balances: dict[UUID, Decimal],
+    currency: str,
+    memo: str = "Opening balances",
+) -> JournalEntry:
+    """Post a balanced opening-balance entry establishing year-start positions (#949).
+
+    Each supplied account is increased to its opening balance per its normal
+    side (assets/expenses debited, liabilities/equity/income credited); the net
+    is offset into the system Opening Balance Equity account so the entry
+    balances and the accounting equation holds. All amounts are ``Decimal``.
+    """
+    from src.services.account_service import get_or_create_opening_balance_equity_account
+
+    if not balances:
+        raise ValidationError("At least one opening balance is required")
+
+    normalized_currency = currency.upper()
+    account_ids = list(balances.keys())
+    result = await db.execute(select(Account).where(Account.id.in_(account_ids), Account.user_id == user_id))
+    accounts = {account.id: account for account in result.scalars().all()}
+    missing = [str(account_id) for account_id in account_ids if account_id not in accounts]
+    if missing:
+        raise ValidationError(f"Unknown or non-owned account(s): {sorted(missing)}")
+
+    lines_data: list[dict] = []
+    total_debit = Decimal("0")
+    total_credit = Decimal("0")
+    for account_id, raw_amount in balances.items():
+        amount = to_money(raw_amount)
+        if amount <= Decimal("0"):
+            raise ValidationError("Opening balance amounts must be positive")
+        account = accounts[account_id]
+        if account.type in (AccountType.ASSET, AccountType.EXPENSE):
+            direction = Direction.DEBIT
+            total_debit += amount
+        else:
+            direction = Direction.CREDIT
+            total_credit += amount
+        lines_data.append(
+            {"account_id": account_id, "direction": direction, "amount": amount, "currency": normalized_currency}
+        )
+
+    net = total_debit - total_credit
+    if net != Decimal("0"):
+        equity_account = await get_or_create_opening_balance_equity_account(db, user_id, normalized_currency)
+        lines_data.append(
+            {
+                "account_id": equity_account.id,
+                "direction": Direction.CREDIT if net > 0 else Direction.DEBIT,
+                "amount": abs(net),
+                "currency": normalized_currency,
+            }
+        )
+
+    # SYSTEM-typed: the guided flow orchestrates this entry and it offsets into
+    # the system Opening Balance Equity account, which manual entries may not touch.
+    entry = await create_journal_entry(
+        db,
+        user_id,
+        entry_date=entry_date,
+        memo=memo,
+        lines_data=lines_data,
+        source_type=JournalEntrySourceType.SYSTEM,
+    )
+    return await post_journal_entry(db, entry.id, user_id)
 
 
 async def create_journal_entry(

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -326,6 +326,30 @@ async def post_opening_balance_entry(
     if missing:
         raise ValidationError(f"Unknown or non-owned account(s): {sorted(missing)}")
 
+    base_currency = settings.base_currency.upper()
+    if normalized_currency != base_currency:
+        raise ValidationError(
+            f"Opening balances are supported only in the base currency ({base_currency}); got {normalized_currency}."
+        )
+
+    # An opening balance establishes a starting position, not a delta: reject when
+    # any affected account already has posted/reconciled activity before entry_date,
+    # otherwise the posted amount would stack on top of an existing balance.
+    prior = await db.execute(
+        select(JournalLine.id)
+        .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
+        .where(JournalLine.account_id.in_(account_ids))
+        .where(JournalEntry.user_id == user_id)
+        .where(JournalEntry.status.in_([JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED]))
+        .where(JournalEntry.entry_date < entry_date)
+        .limit(1)
+    )
+    if prior.first() is not None:
+        raise ValidationError(
+            "Opening balances must precede all activity for the affected accounts; "
+            "one or more already have posted entries before the opening date."
+        )
+
     lines_data: list[dict] = []
     total_debit = Decimal("0")
     total_credit = Decimal("0")

--- a/apps/backend/tests/accounting/test_opening_balance.py
+++ b/apps/backend/tests/accounting/test_opening_balance.py
@@ -65,3 +65,32 @@ async def test_AC2_15_3_unknown_account_is_rejected(client):
         json={"entry_date": "2026-01-01", "balances": {str(uuid4()): "100.00"}},
     )
     assert resp.status_code == 400
+
+
+async def test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists(client):
+    """AC2.15.4: an opening balance establishes a starting position, not a delta,
+    so it is rejected when an affected account already has posted activity before
+    the opening date."""
+    bank = await _account(client, "Bank", "ASSET")
+    first = await client.post(
+        "/accounts/opening-balances",
+        json={"entry_date": "2026-01-01", "balances": {bank: "1000.00"}},
+    )
+    assert first.status_code == 201, first.text
+    # A later opening on the same account now has prior activity before it.
+    second = await client.post(
+        "/accounts/opening-balances",
+        json={"entry_date": "2026-06-01", "balances": {bank: "2000.00"}},
+    )
+    assert second.status_code == 400
+
+
+async def test_AC2_15_5_non_base_currency_is_rejected(client):
+    """AC2.15.5: opening balances are accepted only in the base currency (MVP),
+    with a clear error rather than a confusing FX-rate failure."""
+    bank = await _account(client, "Bank", "ASSET")
+    resp = await client.post(
+        "/accounts/opening-balances",
+        json={"entry_date": "2026-01-01", "balances": {bank: "1000.00"}, "currency": "USD"},
+    )
+    assert resp.status_code == 400

--- a/apps/backend/tests/accounting/test_opening_balance.py
+++ b/apps/backend/tests/accounting/test_opening_balance.py
@@ -9,14 +9,16 @@ sheet is complete and the accounting equation holds.
 from decimal import Decimal
 from uuid import uuid4
 
+from httpx import AsyncClient
 
-async def _account(client, name: str, account_type: str) -> str:
+
+async def _account(client: AsyncClient, name: str, account_type: str) -> str:
     resp = await client.post("/accounts", json={"name": name, "type": account_type, "currency": "SGD"})
     assert resp.status_code == 201, resp.text
     return resp.json()["id"]
 
 
-async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet(client):
+async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet(client: AsyncClient) -> None:
     """AC2.15.1: a guided opening-balance request posts a balanced entry and the
     as-of balance sheet reflects the starting position with the equation intact."""
     bank = await _account(client, "Bank", "ASSET")
@@ -42,7 +44,7 @@ async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sh
     assert Decimal(bs["total_equity"]) == Decimal("5000.00")
 
 
-async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client):
+async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client: AsyncClient) -> None:
     """AC2.15.2: a single asset opening balance is offset entirely into Opening
     Balance Equity, keeping the entry balanced."""
     savings = await _account(client, "Savings", "ASSET")
@@ -58,7 +60,7 @@ async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client)
     assert Decimal(bs["total_equity"]) == Decimal("8000.00")
 
 
-async def test_AC2_15_3_unknown_account_is_rejected(client):
+async def test_AC2_15_3_unknown_account_is_rejected(client: AsyncClient) -> None:
     """AC2.15.3: an opening balance for a non-owned/unknown account is rejected."""
     resp = await client.post(
         "/accounts/opening-balances",
@@ -67,7 +69,7 @@ async def test_AC2_15_3_unknown_account_is_rejected(client):
     assert resp.status_code == 400
 
 
-async def test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists(client):
+async def test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists(client: AsyncClient) -> None:
     """AC2.15.4: an opening balance establishes a starting position, not a delta,
     so it is rejected when an affected account already has posted activity before
     the opening date."""
@@ -85,7 +87,7 @@ async def test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists(clie
     assert second.status_code == 400
 
 
-async def test_AC2_15_5_non_base_currency_is_rejected(client):
+async def test_AC2_15_5_non_base_currency_is_rejected(client: AsyncClient) -> None:
     """AC2.15.5: opening balances are accepted only in the base currency (MVP),
     with a clear error rather than a confusing FX-rate failure."""
     bank = await _account(client, "Bank", "ASSET")
@@ -96,7 +98,7 @@ async def test_AC2_15_5_non_base_currency_is_rejected(client):
     assert resp.status_code == 400
 
 
-async def test_AC2_15_6_account_currency_mismatch_is_rejected(client):
+async def test_AC2_15_6_account_currency_mismatch_is_rejected(client: AsyncClient) -> None:
     """AC2.15.6: an opening balance into an account whose currency differs from the
     request (base) currency is rejected, so journal lines cannot be mis-stamped."""
     resp_acc = await client.post("/accounts", json={"name": "USD Bank", "type": "ASSET", "currency": "USD"})
@@ -106,5 +108,28 @@ async def test_AC2_15_6_account_currency_mismatch_is_rejected(client):
     resp = await client.post(
         "/accounts/opening-balances",
         json={"entry_date": "2026-01-01", "balances": {usd_bank: "1000.00"}},
+    )
+    assert resp.status_code == 400
+
+
+async def test_AC2_15_7_system_account_target_is_rejected(client: AsyncClient, db, test_user) -> None:
+    """AC2.15.7: opening balances may only target user-managed accounts; a system
+    account (e.g. Processing) cannot be set via this endpoint."""
+    from src.models import Account, AccountType
+
+    system_account = Account(
+        user_id=test_user.id,
+        name="Processing",
+        code="1199",
+        type=AccountType.ASSET,
+        currency="SGD",
+        is_system=True,
+    )
+    db.add(system_account)
+    await db.commit()
+
+    resp = await client.post(
+        "/accounts/opening-balances",
+        json={"entry_date": "2026-01-01", "balances": {str(system_account.id): "100.00"}},
     )
     assert resp.status_code == 400

--- a/apps/backend/tests/accounting/test_opening_balance.py
+++ b/apps/backend/tests/accounting/test_opening_balance.py
@@ -94,3 +94,17 @@ async def test_AC2_15_5_non_base_currency_is_rejected(client):
         json={"entry_date": "2026-01-01", "balances": {bank: "1000.00"}, "currency": "USD"},
     )
     assert resp.status_code == 400
+
+
+async def test_AC2_15_6_account_currency_mismatch_is_rejected(client):
+    """AC2.15.6: an opening balance into an account whose currency differs from the
+    request (base) currency is rejected, so journal lines cannot be mis-stamped."""
+    resp_acc = await client.post("/accounts", json={"name": "USD Bank", "type": "ASSET", "currency": "USD"})
+    assert resp_acc.status_code == 201, resp_acc.text
+    usd_bank = resp_acc.json()["id"]
+    # Request currency defaults to base (SGD), which mismatches the USD account.
+    resp = await client.post(
+        "/accounts/opening-balances",
+        json={"entry_date": "2026-01-01", "balances": {usd_bank: "1000.00"}},
+    )
+    assert resp.status_code == 400

--- a/apps/backend/tests/accounting/test_opening_balance.py
+++ b/apps/backend/tests/accounting/test_opening_balance.py
@@ -1,0 +1,67 @@
+"""Guided opening-balance flow (#949, EPIC-002 AC2.15).
+
+A user with pre-existing assets/liabilities on day one can establish year-start
+balances via one guided request; the system posts a balanced journal entry that
+offsets the net into an Opening Balance Equity account, so a cross-year balance
+sheet is complete and the accounting equation holds.
+"""
+
+from decimal import Decimal
+from uuid import uuid4
+
+
+async def _account(client, name: str, account_type: str) -> str:
+    resp = await client.post("/accounts", json={"name": name, "type": account_type, "currency": "SGD"})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet(client):
+    """AC2.15.1: a guided opening-balance request posts a balanced entry and the
+    as-of balance sheet reflects the starting position with the equation intact."""
+    bank = await _account(client, "Bank", "ASSET")
+    mortgage = await _account(client, "Mortgage", "LIABILITY")
+
+    resp = await client.post(
+        "/accounts/opening-balances",
+        json={"entry_date": "2026-01-01", "balances": {bank: "10000.00", mortgage: "5000.00"}},
+    )
+    assert resp.status_code == 201, resp.text
+    entry = resp.json()
+
+    # The posted entry is balanced (debits == credits), Decimal-safe.
+    debit = sum(Decimal(line["amount"]) for line in entry["lines"] if line["direction"] == "DEBIT")
+    credit = sum(Decimal(line["amount"]) for line in entry["lines"] if line["direction"] == "CREDIT")
+    assert debit == credit == Decimal("10000.00")
+
+    bs = (await client.get("/reports/balance-sheet", params={"as_of_date": "2026-12-31", "currency": "SGD"})).json()
+    assert bs["is_balanced"] is True
+    assert Decimal(bs["equation_delta"]) == Decimal("0.00")
+    assert Decimal(bs["total_assets"]) == Decimal("10000.00")
+    # Net worth (assets - liabilities) is captured as Opening Balance Equity.
+    assert Decimal(bs["total_equity"]) == Decimal("5000.00")
+
+
+async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client):
+    """AC2.15.2: a single asset opening balance is offset entirely into Opening
+    Balance Equity, keeping the entry balanced."""
+    savings = await _account(client, "Savings", "ASSET")
+    resp = await client.post(
+        "/accounts/opening-balances",
+        json={"entry_date": "2026-01-01", "balances": {savings: "8000.00"}},
+    )
+    assert resp.status_code == 201, resp.text
+
+    bs = (await client.get("/reports/balance-sheet", params={"as_of_date": "2026-12-31", "currency": "SGD"})).json()
+    assert bs["is_balanced"] is True
+    assert Decimal(bs["total_assets"]) == Decimal("8000.00")
+    assert Decimal(bs["total_equity"]) == Decimal("8000.00")
+
+
+async def test_AC2_15_3_unknown_account_is_rejected(client):
+    """AC2.15.3: an opening balance for a non-owned/unknown account is rejected."""
+    resp = await client.post(
+        "/accounts/opening-balances",
+        json={"entry_date": "2026-01-01", "balances": {str(uuid4()): "100.00"}},
+    )
+    assert resp.status_code == 400

--- a/apps/backend/tests/reporting/test_year_scale_reporting.py
+++ b/apps/backend/tests/reporting/test_year_scale_reporting.py
@@ -1,0 +1,77 @@
+"""Year-scale reporting validation (#951, EPIC-005 AC5.20).
+
+A single user's full year of activity is low-thousands of journal lines. This
+gates (in the default CI lane) that the balance sheet, income statement, and
+cash flow still produce correct, tied-out numbers at that volume — guarding the
+income-statement Python-side aggregation against a silent O(n^2) regression — and
+keeps generation under a generous wall-clock backstop.
+"""
+
+import time
+from datetime import date, timedelta
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import (
+    Account,
+    AccountType,
+    Direction,
+    JournalEntry,
+    JournalEntrySourceType,
+    JournalEntryStatus,
+    JournalLine,
+)
+from src.services.reporting import generate_balance_sheet, generate_cash_flow, generate_income_statement
+
+ENTRY_COUNT = 1000
+AMOUNT = Decimal("100.00")
+LATENCY_BUDGET_SECONDS = 30.0  # generous regression backstop, not a benchmark
+
+
+async def test_AC5_20_year_scale_reporting_ties_out_within_budget(db: AsyncSession, test_user) -> None:
+    """AC5.20.1: at a full year's transaction volume the three core statements
+    tie out and generate within a generous wall-clock budget."""
+    user_id = test_user.id
+    bank = Account(user_id=user_id, name="Bank", code="1001", type=AccountType.ASSET, currency="SGD")
+    salary = Account(user_id=user_id, name="Salary", code="4001", type=AccountType.INCOME, currency="SGD")
+    db.add_all([bank, salary])
+    await db.flush()
+
+    start = date(2026, 1, 1)
+    entries = []
+    for i in range(ENTRY_COUNT):
+        entry = JournalEntry(
+            user_id=user_id,
+            entry_date=start + timedelta(days=i % 365),
+            memo=f"txn {i}",
+            source_type=JournalEntrySourceType.MANUAL,
+            status=JournalEntryStatus.POSTED,
+        )
+        entry.lines = [
+            JournalLine(account_id=bank.id, direction=Direction.DEBIT, amount=AMOUNT, currency="SGD"),
+            JournalLine(account_id=salary.id, direction=Direction.CREDIT, amount=AMOUNT, currency="SGD"),
+        ]
+        entries.append(entry)
+    db.add_all(entries)
+    await db.commit()
+
+    period_start = date(2026, 1, 1)
+    period_end = date(2026, 12, 31)
+    started = time.perf_counter()
+    balance_sheet = await generate_balance_sheet(db, user_id, as_of_date=period_end, currency="SGD")
+    income_statement = await generate_income_statement(
+        db, user_id, start_date=period_start, end_date=period_end, currency="SGD"
+    )
+    cash_flow = await generate_cash_flow(db, user_id, start_date=period_start, end_date=period_end, currency="SGD")
+    elapsed = time.perf_counter() - started
+
+    expected_total = AMOUNT * ENTRY_COUNT  # 100000.00
+    assert income_statement["total_income"] == expected_total
+    assert income_statement["net_income"] == expected_total
+    assert balance_sheet["total_assets"] == expected_total
+    assert balance_sheet["is_balanced"] is True
+    assert cash_flow["summary"]["ending_cash"] == expected_total
+    assert elapsed < LATENCY_BUDGET_SECONDS, (
+        f"year-scale reporting took {elapsed:.2f}s (budget {LATENCY_BUDGET_SECONDS}s)"
+    )

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -223,6 +223,16 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 | AC2.14.4 | PostgreSQL blocks direct update/delete of posted/reconciled entries and lines while draft entries remain editable | `test_AC2_14_4_posted_entries_and_lines_are_immutable_but_drafts_are_editable()` | `accounting/test_ledger_schema_invariants.py` | P0 |
 | AC2.14.5 | Voiding a posted entry preserves a non-null immutable reversal relationship instead of deleting or editing posted lines | `test_AC2_14_5_void_transition_requires_reversal_relationship()` | `accounting/test_ledger_schema_invariants.py` | P0 |
 
+### AC2.15: Guided Opening Balances ([#949](https://github.com/wangzitian0/finance_report/issues/949))
+
+A user with pre-existing assets/liabilities can establish year-start balances via one guided request, so a cross-year balance sheet is complete from the start instead of silently omitting the opening position.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC2.15.1 | `POST /api/accounts/opening-balances` posts one balanced entry that increases each account to its opening balance on its normal side and offsets the net into a system Opening Balance Equity account; the as-of balance sheet reflects the starting position with the accounting equation intact | `test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet` | `accounting/test_opening_balance.py` | P0 |
+| AC2.15.2 | A single asset opening balance offsets entirely into Opening Balance Equity, keeping the entry balanced | `test_AC2_15_2_single_asset_opening_balance_offsets_into_equity` | `accounting/test_opening_balance.py` | P0 |
+| AC2.15.3 | An opening balance for a non-owned or unknown account is rejected | `test_AC2_15_3_unknown_account_is_rejected` | `accounting/test_opening_balance.py` | P0 |
+
 ## 📏 Acceptance Criteria
 
 > ℹ️ **Non-contiguous AC numbering**: Gaps in `AC2.x.y` numbers reflect deprecated or merged ACs preserved through generated registry indexes plus explicit overrides. Do **not** renumber. New ACs append to the next available index in this EPIC.

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -232,6 +232,8 @@ A user with pre-existing assets/liabilities can establish year-start balances vi
 | AC2.15.1 | `POST /api/accounts/opening-balances` posts one balanced entry that increases each account to its opening balance on its normal side and offsets the net into a system Opening Balance Equity account; the as-of balance sheet reflects the starting position with the accounting equation intact | `test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet` | `accounting/test_opening_balance.py` | P0 |
 | AC2.15.2 | A single asset opening balance offsets entirely into Opening Balance Equity, keeping the entry balanced | `test_AC2_15_2_single_asset_opening_balance_offsets_into_equity` | `accounting/test_opening_balance.py` | P0 |
 | AC2.15.3 | An opening balance for a non-owned or unknown account is rejected | `test_AC2_15_3_unknown_account_is_rejected` | `accounting/test_opening_balance.py` | P0 |
+| AC2.15.4 | An opening balance establishes a starting position, not a delta: it is rejected when an affected account already has posted activity before the opening date | `test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists` | `accounting/test_opening_balance.py` | P0 |
+| AC2.15.5 | Opening balances are accepted only in the base currency, with a clear error rather than a confusing FX-rate failure | `test_AC2_15_5_non_base_currency_is_rejected` | `accounting/test_opening_balance.py` | P0 |
 
 ## 📏 Acceptance Criteria
 

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -234,6 +234,7 @@ A user with pre-existing assets/liabilities can establish year-start balances vi
 | AC2.15.3 | An opening balance for a non-owned or unknown account is rejected | `test_AC2_15_3_unknown_account_is_rejected` | `accounting/test_opening_balance.py` | P0 |
 | AC2.15.4 | An opening balance establishes a starting position, not a delta: it is rejected when an affected account already has posted activity before the opening date | `test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists` | `accounting/test_opening_balance.py` | P0 |
 | AC2.15.5 | Opening balances are accepted only in the base currency, with a clear error rather than a confusing FX-rate failure | `test_AC2_15_5_non_base_currency_is_rejected` | `accounting/test_opening_balance.py` | P0 |
+| AC2.15.6 | An opening balance into an account whose currency differs from the request currency is rejected, so journal lines cannot be mis-stamped | `test_AC2_15_6_account_currency_mismatch_is_rejected` | `accounting/test_opening_balance.py` | P0 |
 
 ## 📏 Acceptance Criteria
 

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -235,6 +235,7 @@ A user with pre-existing assets/liabilities can establish year-start balances vi
 | AC2.15.4 | An opening balance establishes a starting position, not a delta: it is rejected when an affected account already has posted activity before the opening date | `test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists` | `accounting/test_opening_balance.py` | P0 |
 | AC2.15.5 | Opening balances are accepted only in the base currency, with a clear error rather than a confusing FX-rate failure | `test_AC2_15_5_non_base_currency_is_rejected` | `accounting/test_opening_balance.py` | P0 |
 | AC2.15.6 | An opening balance into an account whose currency differs from the request currency is rejected, so journal lines cannot be mis-stamped | `test_AC2_15_6_account_currency_mismatch_is_rejected` | `accounting/test_opening_balance.py` | P0 |
+| AC2.15.7 | Opening balances may only target user-managed accounts; a system account (e.g. Processing) cannot be set via this endpoint even though the entry is SYSTEM-typed | `test_AC2_15_7_system_account_target_is_rejected` | `accounting/test_opening_balance.py` | P0 |
 
 ## 📏 Acceptance Criteria
 

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -316,6 +316,12 @@ same package after later ledger or market-data changes.
 | AC5.19.3 | Package JSON and CSV downloads are derived from a saved snapshot rather than recalculating live data | `test_AC5_19_3_package_snapshot_exports_are_snapshot_derived` | `api/test_personal_report_package_contract.py` | P0 |
 | AC5.19.4 | The package page shows recent snapshots, can generate a new snapshot, and downloads JSON/CSV from the saved snapshot artifact | `AC5.19.4 generates and downloads package snapshots` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
 
+### AC5.20: Year-Scale Reporting Validation ([#951](https://github.com/wangzitian0/finance_report/issues/951))
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.20.1 | At a full year's transaction volume (~1000 entries) the balance sheet, income statement, and cash flow tie out and generate within a generous wall-clock backstop — guarding the income-statement aggregation against a silent O(n^2) regression | `test_AC5_20_year_scale_reporting_ties_out_within_budget` | `reporting/test_year_scale_reporting.py` | P1 |
+
 ## 📏 Acceptance Criteria
 
 ### 🟢 Must Have

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,8 +5,8 @@
 
 - API title: `Finance Report API`
 - API version: `0.1.0`
-- Endpoint count: `126`
-- Schema count: `210`
+- Endpoint count: `127`
+- Schema count: `211`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,8 +5,8 @@
 
 - API title: `Finance Report API`
 - API version: `0.1.0`
-- Endpoint count: `125`
-- Schema count: `209`
+- Endpoint count: `126`
+- Schema count: `210`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 
@@ -14,7 +14,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 
 | Group | Endpoints |
 |---|---:|
-| `accounts` | 8 |
+| `accounts` | 9 |
 | `ai` | 1 |
 | `ai-feedback` | 2 |
 | `assets` | 11 |
@@ -46,6 +46,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `GET` | `/accounts` | yes | `account_type` (query), `is_active` (query), `include_balance` (query), `limit` (query), `offset` (query) | - | `200` `ListResponse_AccountResponse_` | List Accounts |
 | `POST` | `/accounts` | yes | - | `AccountCreate` | `201` `AccountResponse` | Create Account |
 | `GET` | `/accounts/coverage` | yes | `as_of` (query), `stale_after_days` (query) | - | `200` `AccountCoverageListResponse` | List Account Statement Coverage |
+| `POST` | `/accounts/opening-balances` | yes | - | `OpeningBalanceRequest` | `201` `JournalEntryResponse` | Post Opening Balances |
 | `GET` | `/accounts/processing/pending` | yes | - | - | `200` `ListResponse_ProcessingPendingItem_` | List Processing Pending |
 | `GET` | `/accounts/processing/summary` | yes | - | - | `200` `ProcessingSummaryResponse` | Get Processing Summary |
 | `GET` | `/accounts/{account_id}` | yes | `account_id`* (path) | - | `200` `AccountResponse` | Get Account |


### PR DESCRIPTION
## Linked EPIC and ACs
| Field | Value |
|-------|-------|
| **EPIC** | EPIC-002 (double-entry) + EPIC-005 (reporting) |
| **AC IDs** | AC2.15.1–2.15.3, AC5.20.1 |
| **AC source updated** | Owning EPICs (EPIC-002, EPIC-005) |

Two independent backend Usable-milestone items bundled into one PR (to amortize this repo's per-PR CI overhead — api.md regen, etc.), each as its own commit + AC group.

## #949 — Guided opening-balance flow (AC2.15)
`POST /api/accounts/opening-balances` posts **one balanced journal entry** that raises each account to its opening balance on its normal side and offsets the net into a system **Opening Balance Equity** account (code 3199). A cross-year balance sheet is then complete from day one instead of silently omitting the starting position.
- SYSTEM-typed entry (it touches the system equity account); all amounts `Decimal`; **no migration** (reuses Account/JournalEntry).
- Tests: balanced post + balance-sheet reflection (equation intact), single-asset equity offset, unknown-account rejection.

## #951 — Year-scale reporting validation (AC5.20)
A **CI-gated** test builds ~1000 posted entries (a single user's year) and asserts BS/IS/CF **tie out** within a generous wall-clock backstop — guarding the income-statement Python aggregation against a silent O(n²) regression at realistic volume. (A `perf`-marked benchmark would be local-only; this gates.)

## Verification (local)
- New tests pass; `tests/accounting` + `tests/reporting` regression: **439 passed**.
- `ruff` clean; **AC traceability gate 100%, 0 missing** (AC2.15.x + AC5.20.1 recognized); `docs/reference/api.md` regenerated for the new endpoint.
- No migration → no migration-risk/dual-head exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)