### PR TITLE
[finance_report_test_and_doc] feat(migrations): auto-classify Alembic migration risk (AC7.11.5)

### DIFF
--- a/common/ci/migration_risk.py
+++ b/common/ci/migration_risk.py
@@ -41,6 +41,13 @@ DATA_MUTATION_UPGRADE_PATTERNS = (
     r"\bINSERT\s+INTO\b",
     r"\bDELETE\s+FROM\b",
 )
+SCHEMA_SENSITIVE_UPGRADE_PATTERNS = (
+    r"\bop\.alter_column\s*\(",
+    r"\bop\.drop_constraint\s*\(",
+    r"\bop\.drop_index\s*\(",
+    r"\bALTER\s+TYPE\b",
+    r"\bADD\s+VALUE\b",
+)
 
 
 @dataclass(frozen=True)
@@ -143,6 +150,23 @@ def _matches_any(source: str, patterns: tuple[str, ...]) -> bool:
     return any(re.search(pattern, source, flags=re.IGNORECASE) for pattern in patterns)
 
 
+def classify_risk(upgrade_source: str) -> str:
+    """Auto-classify migration risk from the ``upgrade()`` source.
+
+    Destructive drops set a critical floor, data mutations a high floor, and
+    compatibility-sensitive schema changes default to medium; anything else
+    (additive tables/columns, clean-schema DDL) is low. The manifest only needs
+    to carry entries that raise risk above this floor or attach release proof.
+    """
+    if _matches_any(upgrade_source, DESTRUCTIVE_UPGRADE_PATTERNS):
+        return "critical"
+    if _matches_any(upgrade_source, DATA_MUTATION_UPGRADE_PATTERNS):
+        return "high"
+    if _matches_any(upgrade_source, SCHEMA_SENSITIVE_UPGRADE_PATTERNS):
+        return "medium"
+    return "low"
+
+
 def _entry_text(entry: dict[str, Any], field: str) -> str:
     value = entry.get(field)
     return value.strip() if isinstance(value, str) else ""
@@ -242,8 +266,23 @@ def validate(*, manifest_path: Path, migrations_dir: Path) -> ValidationResult:
 
     records: dict[str, MigrationRecord] = {}
     for revision, parsed in parsed_by_revision.items():
+        auto_risk = classify_risk(parsed.upgrade_source)
         if revision not in manifest_entries:
-            errors.append(f"{revision}: missing migration risk manifest entry")
+            if auto_risk in {"high", "critical"}:
+                errors.append(
+                    f"{revision}: auto-classified {auto_risk} migration requires a "
+                    f"manifest entry with release proof in {manifest_path.name}"
+                )
+                continue
+            records[revision] = MigrationRecord(
+                revision=revision,
+                file_name=parsed.file_name,
+                risk=auto_risk,
+                proof=(
+                    f"Auto-classified {auto_risk} from upgrade operations; "
+                    "covered by the PR Alembic contract."
+                ),
+            )
             continue
         record, entry_errors = _validate_entry(
             revision, parsed, manifest_entries[revision]

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -226,6 +226,7 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 | AC7.11.2 | High and critical migration risk entries require release proof notes for staging, production preflight, and rollback/expand-contract strategy | `test_AC7_11_2_high_and_critical_migrations_require_release_proof` | `tests/tooling/test_migration_risk_contract.py` | P0 |
 | AC7.11.3 | Destructive upgrade operations cannot be classified below critical risk | `test_AC7_11_3_destructive_migrations_must_be_classified_critical` | `tests/tooling/test_migration_risk_contract.py` | P0 |
 | AC7.11.4 | CI lint and production release dry-run execute the migration risk contract and publish release context | `test_AC7_11_4_ci_and_release_dry_run_execute_migration_risk_contract` | `tests/tooling/test_migration_risk_contract.py` | P0 |
+| AC7.11.5 | Risk is auto-classified from each migration's `upgrade()` body (destructive→critical, data-mutation→high, compatibility-sensitive→medium, else low); low/medium migrations need no manifest entry, while auto-classified high/critical migrations require an explicit release-proof entry | `test_AC7_11_5_low_and_medium_migrations_are_auto_classified` | `tests/tooling/test_migration_risk_contract.py` | P0 |
 
 ### AC7.12: Delivery App/Infra-boundary calibration (#876)
 

--- a/docs/ssot/migration-risk.yaml
+++ b/docs/ssot/migration-risk.yaml
@@ -3,9 +3,22 @@
 # Owner issue: #815
 # Validated by: tools/check_migration_risk.py
 #
+# Risk is AUTO-CLASSIFIED from each migration's upgrade() body:
+#   - destructive drops (drop_table/drop_column/DROP TABLE/DROP COLUMN/TRUNCATE) -> critical
+#   - data mutations (UPDATE/INSERT INTO/DELETE FROM)                            -> high
+#   - compatibility-sensitive schema (alter_column/drop_constraint/drop_index/
+#     ALTER TYPE/ADD VALUE)                                                      -> medium
+#   - otherwise (additive tables/columns, clean-schema DDL)                      -> low
+#
+# Most migrations therefore need NO entry below. List a migration only to:
+#   1. carry release proof for an auto-classified high/critical migration
+#      (required: an entry with proof + the high/critical fields), or
+#   2. raise risk above the auto floor (e.g. medium for an additive change whose
+#      production impact the author judges compatibility-sensitive).
+#
 # This manifest does not guarantee production data migration safety. It records
-# the right-sized proof expected before release and prevents new migrations from
-# bypassing risk classification.
+# the right-sized proof expected before release and prevents destructive or
+# data-mutating migrations from shipping without classified release evidence.
 
 version: 1
 
@@ -21,128 +34,27 @@ high_risk_defaults: &historical_high_risk
   production_preflight: Historical baseline only; future high-risk revisions must define production preflight or rollout controls.
   rollback_strategy: Historical baseline only; future high-risk revisions must define backup, rollback, or expand/contract strategy.
 
+# Only the migrations whose risk is not fully captured by auto-classification are
+# listed here (auto-classified high/critical needing proof, or a human raise
+# above the auto floor). Everything else is classified from its upgrade() body.
 migrations:
-  0001_initial_schema:
-    file: 0001_initial_schema.py
-    risk: low
-    proof: Initial clean-schema baseline; covered by PR Alembic contract.
-  0002_add_chat_tables:
-    file: 0002_add_chat_tables.py
-    risk: low
-    proof: Additive chat tables and indexes; covered by PR Alembic contract.
-  0003_add_users_table:
-    file: 0003_add_users_table.py
-    risk: low
-    proof: Additive users table baseline; covered by PR Alembic contract.
-  0004_add_name_to_users:
-    file: 0004_add_name_to_users.py
-    risk: low
-    proof: Additive nullable user profile column; covered by PR Alembic contract.
-  0005_fix_txn_status_enum:
-    file: 0005_fix_txn_status_enum.py
-    risk: medium
-    proof: Enum type normalization; staging should exercise statement transaction status paths.
-  0006_parse_nullable_fields:
-    file: 0006_parse_nullable_fields.py
-    risk: medium
-    proof: Statement field nullability relaxation; staging should exercise statement parsing paths.
-  0007_normalize_all_enums:
-    file: 0007_normalize_all_enums.py
-    risk: medium
-    proof: Enum normalization across existing tables; staging should exercise core write/read paths.
-  0008_layer12:
-    file: 0008_add_layer1_layer2_tables.py
-    risk: low
-    proof: Additive Layer 1/2 tables; covered by PR Alembic contract.
-  0009_fx_reval:
-    file: 0009_add_fx_revaluation_source_type.py
-    risk: medium
-    proof: Journal source enum expansion; staging should exercise journal source serialization.
-  0010_add_parsing_progress:
-    file: 0010_add_parsing_progress.py
-    risk: low
-    proof: Additive parsing progress column; covered by PR Alembic contract.
-  0010_ai_category:
-    file: 0010_add_ai_category_fields.py
-    risk: low
-    proof: Additive AI category fields; covered by PR Alembic contract.
-  0011_add_txn_currency_balance:
-    file: 0011_add_txn_currency_balance.py
-    risk: low
-    proof: Additive transaction currency/balance fields; covered by PR Alembic contract.
   0012_add_stage1_review:
     file: 0012_add_stage1_review.py
     risk: medium
     proof: Stage-1 enum and statement review columns; staging should exercise statement review paths.
-  0013_add_consistency_checks:
-    file: 0013_add_consistency_checks.py
-    risk: low
-    proof: Additive consistency check table; covered by PR Alembic contract.
-  0014_add_correction_logs:
-    file: 0014_add_correction_logs.py
-    risk: low
-    proof: Additive correction log table; covered by PR Alembic contract.
-  0015_ai_ui_feedback_audit:
-    file: 0015_ai_ui_feedback_audit.py
-    risk: low
-    proof: Additive AI feedback/audit tables and user settings column; covered by PR Alembic contract.
-  0016_manual_valuation_snapshots:
-    file: 0016_manual_valuation_snapshots.py
-    risk: low
-    proof: Additive manual valuation snapshot table; covered by PR Alembic contract.
-  0017_investment_accounting:
-    file: 0017_investment_accounting.py
-    risk: low
-    proof: Additive investment accounting structures; covered by PR Alembic contract.
   0018_source_type_priority:
     <<: *historical_high_risk
     file: 0018_source_type_priority.py
     risk: high
     proof: Forward upgrade rewrites journal_entries.source_type after enum expansion.
-  0019_add_stock_prices:
-    file: 0019_add_stock_prices.py
-    risk: low
-    proof: Additive stock price table and lookup index; covered by PR Alembic contract.
-  0020_add_market_data_sync_state:
-    file: 0020_add_market_data_sync_state.py
-    risk: low
-    proof: Additive market data sync state table; covered by PR Alembic contract.
-  0021_add_workflow_events:
-    file: 0021_add_workflow_events.py
-    risk: low
-    proof: Additive workflow event table; covered by PR Alembic contract.
   0022_harden_workflow_contract:
     file: 0022_harden_workflow_contract.py
     risk: medium
     proof: Workflow event contract hardening; staging should exercise upload-to-report event paths.
-  0023_stmt_extract_metadata:
-    file: 0023_stmt_extract_metadata.py
-    risk: low
-    proof: Additive statement extraction metadata field; covered by PR Alembic contract.
-  0024_add_workflow_sessions:
-    file: 0024_add_workflow_sessions.py
-    risk: low
-    proof: Additive workflow session table and nullable event link; covered by PR Alembic contract.
-  0025_add_evidence_lineage:
-    file: 0025_add_evidence_lineage.py
-    risk: low
-    proof: Additive evidence graph tables and indexes; covered by PR Alembic contract.
   0026_user_email_norm_idx:
     file: 0026_user_email_norm_idx.py
     risk: medium
     proof: Email normalization index; staging should exercise auth/user lookup paths.
-  0026_add_review_run_scope:
-    file: 0026_add_review_run_scope.py
-    risk: low
-    proof: Additive review run scope fields; covered by PR Alembic contract.
-  0027_merge_review_email_heads:
-    file: 0027_merge_review_email_heads.py
-    risk: low
-    proof: Alembic merge revision only; covered by PR Alembic contract.
-  0028_statement_summaries:
-    file: 0028_statement_summaries.py
-    risk: low
-    proof: Additive StatementSummary conform table; covered by PR Alembic contract.
   0029_drop_bank_statement_tables:
     file: 0029_drop_bank_statement_tables.py
     risk: critical
@@ -161,10 +73,6 @@ migrations:
     production_preflight: Production has no real data yet; confirm reconciliation_matches and correction_logs are empty before applying.
     rollback_strategy: Restore from pre-migration snapshot; the column/FK changes are recreatable from the prior schema revision and no production data is affected.
     destructive_confirmation: Confirmed destructive drop of reconciliation_matches.bank_txn_id column and FK repoint; no production data exists.
-  0031_drop_orphan_stage1_enum:
-    file: 0031_drop_orphan_stage1_status_enum.py
-    risk: low
-    proof: "Drops the orphaned stage1_status_enum left after EPIC-011 Stage 3 dropped bank_statements; no column references it."
   0032_ledger_invariants:
     file: 0032_ledger_invariants.py
     risk: medium
@@ -175,24 +83,6 @@ migrations:
     risk: medium
     issue: "#845"
     proof: Adds preflight checks plus database CHECK/UNIQUE/partial-index guards for financial facts, statement envelopes, market prices, managed positions, and latest report snapshots; covered by AC11.18 direct DB invariant tests and the PR Alembic contract.
-  0036_confidence_metric_snapshots:
-    file: 0036_confidence_metric_snapshots.py
-    risk: low
-    proof: Additive append-only North-Star confidence metric table; no backfill or read-path cutover; covered by PR Alembic contract.
-  0037_report_package_snapshots:
-    file: 0037_report_package_snapshots.py
-    risk: medium
-    issue: "#705"
-    proof: Adds a report_type_enum value for package snapshots and relaxes report_snapshots.rule_version_id to nullable for package artifacts; covered by AC5.19 snapshot tests and PR Alembic contract.
-  0038_atomic_txn_balance_after:
-    file: 0038_atomic_txn_balance_after.py
-    risk: low
-    issue: "#962"
-    proof: Additive nullable atomic_transactions.balance_after column plus a dedup_hash comment sync; no backfill, existing rows stay NULL. Covered by AC4.6.6/4.6.8 and the PR Alembic contract.
-  0035_manual_valuation_versioning:
-    file: 0035_manual_valuation_versioning.py
-    risk: medium
-    proof: Adds append-only version columns and converts manual valuation uniqueness to a partial unique index over current heads; staging should exercise manual valuation create/correct and net-worth read paths.
   0034_audit_anchor_ri:
     file: 0034_audit_anchor_referential_integrity.py
     risk: high
@@ -201,48 +91,7 @@ migrations:
     staging_validation: Deploy to staging and exercise upload -> parse -> evidence materialization -> reconciliation accept against normalized anchor links; confirm unresolved legacy anchors produce blockers instead of trusted source nodes.
     production_preflight: Count legacy JSONB audit anchors and cross-tenant/account references before upgrade; abort if any preflight query in revision 0034_audit_anchor_ri returns rows.
     rollback_strategy: Restore from pre-migration snapshot if the tenant-scope constraints reject existing data unexpectedly; normalized links are derived from legacy anchors and can be rebuilt after correcting source data.
-  51aa128d8189:
-    file: 51aa128d8189_remove_report_snapshot_constraint.py
-    risk: medium
-    proof: Constraint compatibility change on report snapshots; staging should exercise report snapshot paths.
-  5e7857c97b74:
-    file: 5e7857c97b74_epic17_add_portfolio_models_and_extend_.py
-    risk: medium
-    proof: Broad portfolio schema extension with index/FK compatibility repairs; staging should exercise portfolio and statement paths.
-  76c3ccfe844b:
-    file: 76c3ccfe844b_add_managed_positions.py
-    risk: low
-    proof: Additive managed positions table; covered by PR Alembic contract.
-  a14bb9204a08:
-    file: a14bb9204a08_add_valuation_basis_to_manual_valuations.py
-    risk: low
-    issue: "#706"
-    proof: Additive nullable manual_valuation_snapshots.valuation_basis column plus a new manual_valuation_basis enum type; no backfill, existing rows stay NULL. Covered by AC11.9.5 and the PR Alembic contract.
-  ba0777d5eb6c:
-    file: ba0777d5eb6c_fix_ensure_bank_statement_status_enum_.py
-    risk: medium
-    proof: Bank statement enum compatibility repair; staging should exercise statement status paths.
-  bb0888e6fc7d:
-    file: bb0888e6fc7d_add_updated_at_to_journal_lines.py
-    risk: low
-    proof: Additive journal line timestamp column; covered by PR Alembic contract.
-  bc9a8105e644:
-    file: bc9a8105e644_restore_cascading_fks.py
-    risk: medium
-    proof: Restores cascading foreign keys; staging should exercise user-owned data deletion and ownership paths.
-  bcd695dcaf71:
-    file: bcd695dcaf71_add_layer4_reporting.py
-    risk: low
-    proof: Additive Layer-4 reporting tables; covered by PR Alembic contract.
   c955c65dcc1f:
     file: c955c65dcc1f_add_is_system_to_accounts.py
     risk: medium
     proof: Adds non-null account flag with server default; staging should exercise account reads and writes.
-  cec0bf343b59:
-    file: cec0bf343b59_add_layer3_tables.py
-    risk: low
-    proof: Additive Layer-3 tables; covered by PR Alembic contract.
-  e40975f66f7f:
-    file: e40975f66f7f_add_atomic_txn_id_to_matches.py
-    risk: low
-    proof: Additive reconciliation match link; covered by PR Alembic contract.

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -203,7 +203,11 @@ volume, and edge cases that CI and staging will never reproduce perfectly.
 
 The machine-readable owner for migration risk is
 [migration-risk.yaml](./migration-risk.yaml), validated by
-`tools/check_migration_risk.py`.
+`tools/check_migration_risk.py`. Risk is **auto-classified** from each
+migration's `upgrade()` body (destructive drops → critical, data mutation →
+high, compatibility-sensitive schema changes → medium, otherwise low), so the
+manifest only lists migrations that carry release proof for an auto-classified
+high/critical change or that deliberately raise risk above the auto floor.
 
 | Risk | Meaning | Default proof |
 |---|---|---|

--- a/tests/tooling/test_migration_risk_contract.py
+++ b/tests/tooling/test_migration_risk_contract.py
@@ -257,11 +257,13 @@ def test_AC7_11_3_migration_file_parse_errors_are_reported(
     write(
         migrations_dir / "missing_manifest.py",
         """
+        from alembic import op
+
         revision = "missing_manifest"
         down_revision = None
 
         def upgrade():
-            pass
+            op.drop_table("legacy_rows")
         """,
     )
 
@@ -307,7 +309,8 @@ def test_AC7_11_3_migration_file_parse_errors_are_reported(
     )
     assert any("duplicate Alembic revision" in error for error in result.errors)
     assert any(
-        "missing_manifest: missing migration risk manifest entry" in error
+        "missing_manifest: auto-classified critical migration requires a manifest entry"
+        in error
         for error in result.errors
     )
     assert any(
@@ -530,3 +533,75 @@ def test_AC7_11_4_ci_and_release_dry_run_execute_migration_risk_contract() -> No
     assert "python tools/check_migration_risk.py" in ci
     assert "Validate Migration Risk Contract" in release
     assert "production-migration-risk-context.md" in release
+
+
+def test_AC7_11_5_low_and_medium_migrations_are_auto_classified(tmp_path: Path) -> None:
+    """AC7.11.5: Risk is auto-classified from upgrade(); low/medium need no manifest entry while high/critical still require explicit release proof."""
+
+    assert migration_risk.classify_risk('op.create_table("t")') == "low"
+    assert migration_risk.classify_risk("op.add_column('t', c)") == "low"
+    assert migration_risk.classify_risk('op.alter_column("t", "c")') == "medium"
+    assert (
+        migration_risk.classify_risk('op.execute("ALTER TYPE e ADD VALUE x")')
+        == "medium"
+    )
+    assert migration_risk.classify_risk('op.execute("UPDATE t SET c = 1")') == "high"
+    assert migration_risk.classify_risk('op.drop_table("t")') == "critical"
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    write(
+        migrations_dir / "additive.py",
+        """
+        from alembic import op
+
+        revision = "additive"
+        down_revision = None
+
+        def upgrade():
+            op.create_table("widgets")
+        """,
+    )
+    write(
+        migrations_dir / "altered.py",
+        """
+        from alembic import op
+
+        revision = "altered"
+        down_revision = "additive"
+
+        def upgrade():
+            op.alter_column("widgets", "name")
+        """,
+    )
+    write(
+        migrations_dir / "mutated.py",
+        """
+        from alembic import op
+
+        revision = "mutated"
+        down_revision = "altered"
+
+        def upgrade():
+            op.execute("UPDATE widgets SET name = name")
+        """,
+    )
+    manifest = tmp_path / "migration-risk.yaml"
+    write_manifest(manifest, {})
+
+    result = migration_risk.validate(
+        manifest_path=manifest, migrations_dir=migrations_dir
+    )
+
+    # Additive and compatibility-sensitive migrations are auto-classified, no entry needed.
+    assert result.migrations["additive"].risk == "low"
+    assert result.migrations["altered"].risk == "medium"
+    assert all("additive" not in error for error in result.errors)
+    assert all("altered" not in error for error in result.errors)
+
+    # A data-mutating migration without an entry is rejected until proof is declared.
+    assert "mutated" not in result.migrations
+    assert any(
+        "mutated: auto-classified high migration requires a manifest entry" in error
+        for error in result.errors
+    )


### PR DESCRIPTION
## What

Risk classification for Alembic migrations is now **derived from each migration's `upgrade()` body** instead of hand-declared per migration:

- destructive drops (`drop_table`/`drop_column`/`DROP TABLE`/`DROP COLUMN`/`TRUNCATE`) → **critical**
- data mutations (`UPDATE`/`INSERT INTO`/`DELETE FROM`) → **high**
- compatibility-sensitive schema (`alter_column`/`drop_constraint`/`drop_index`/`ALTER TYPE`/`ADD VALUE`) → **medium**
- otherwise (additive tables/columns, clean-schema DDL) → **low**

`docs/ssot/migration-risk.yaml` now only lists migrations that (1) are auto-classified high/critical and must carry release proof, (2) a human raises above the auto floor, or (3) a sibling test pins (0033 / AC11.18.6). **248 → 97 lines (51 → 10 entries).**

## Why

The contract gets *stronger*, not weaker: an undocumented destructive or data-mutating migration now **fails** the gate instead of passing with a hand-typed `risk: low`. Low/medium additive migrations no longer need a manual entry at all.

## Scope
- `common/ci/migration_risk.py` — `classify_risk()` + optional-entry validation
- `docs/ssot/migration-risk.yaml` — trimmed to exceptions/proof-carriers
- `tests/tooling/test_migration_risk_contract.py` — new AC7.11.5 test + updated contract
- `docs/project/EPIC-007.deployment.md` — AC7.11.5
- `docs/ssot/schema.md` — documents auto-classification

## Test plan
- `pytest tests/tooling/test_migration_risk_contract.py` — 9 passed
- `validate_repository` — 51 migrations, ok
- AC gates (generate --check / lint / traceability / proof-matrix) — pass
- Full backend suite (pre-push) — 2287 passed, coverage 96.55%

🤖 Generated with [Claude Code](https://claude.com/claude-code)