### PR TITLE
[finance_report_vision] fix(extraction): penalize implausibly-low brokerage txn counts (#967)

### DIFF
--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -496,12 +496,19 @@ class ExtractionService:
                         "balance_proof_available": False,
                         "notes": CSV_INFERRED_BALANCE_REVIEW_NOTE,
                     },
+                    is_brokerage=is_brokerage_payload,
+                    effective_txn_count=len(transactions),
                 )
                 status = BankStatementStatus.PARSED
                 is_valid = False
             else:
                 # For confidence score, we use the original extracted dict to maintain logic.
-                confidence = compute_confidence_score(extracted, balance_result)
+                confidence = compute_confidence_score(
+                    extracted,
+                    balance_result,
+                    is_brokerage=is_brokerage_payload,
+                    effective_txn_count=len(transactions),
+                )
                 # Routing differs by document class on purpose (#981): brokerage payloads
                 # reconcile via Layer-2 AtomicPosition snapshots, not a running-balance chain, so
                 # `balance_valid` is not their gating signal — they always go to `parsed`/review.

--- a/apps/backend/src/services/validation.py
+++ b/apps/backend/src/services/validation.py
@@ -12,6 +12,12 @@ BALANCE_TOLERANCE = Decimal("0.10")
 IN_DIRECTION_ALIASES = {"IN", "CREDIT", "CR", "DEPOSIT", "INFLOW"}
 OUT_DIRECTION_ALIASES = {"OUT", "DEBIT", "DR", "WITHDRAWAL", "WITHDRAW", "OUTFLOW", "PAYMENT"}
 
+# Under-extraction guard (issue #967). A brokerage statement that yields at most
+# one transaction is a strong under-capture signal — comparable brokerage
+# statements extract ~10 rows — so its confidence must not present as high.
+BROKERAGE_MIN_PLAUSIBLE_TXNS = 2
+UNDER_EXTRACTION_SCORE_CAP = 60
+
 
 def normalize_amount_direction(amount: Decimal, direction_value: Any = None) -> tuple[Decimal, str]:
     """Return absolute amount plus canonical IN/OUT direction."""
@@ -86,11 +92,26 @@ def compute_confidence_score(
     extracted: dict[str, Any],
     balance_result: dict[str, Any],
     missing_fields: list[str] | None = None,
+    *,
+    is_brokerage: bool = False,
+    effective_txn_count: int | None = None,
 ) -> int:
     """Compute confidence score (0-100) based on SSOT V2 weights.
 
     Weights: Balance 35% | Completeness 25% | Format 15% | Txn Count 10%
            | Balance Progression 10% | Currency Consistency 5%
+
+    The Balance Progression component (10%) is only awarded when transactions
+    carry a per-line running ``balance_after`` chain. Statements without that
+    chain therefore top out near 90 even when otherwise clean — this is the
+    documented ceiling, not a bug (issue #967).
+
+    When ``is_brokerage`` is set and the parse yields an implausibly low
+    transaction count (``< BROKERAGE_MIN_PLAUSIBLE_TXNS``), the score is capped
+    at ``UNDER_EXTRACTION_SCORE_CAP`` so under-capture does not present as high
+    confidence. The under-extraction check uses ``effective_txn_count`` when
+    provided — the count of *persisted* transactions after skipped/invalid rows
+    — falling back to the raw extracted-payload count otherwise.
     """
     if missing_fields is None:
         missing_fields = validate_completeness(extracted)
@@ -144,7 +165,18 @@ def compute_confidence_score(
     header_currency = extracted.get("currency")
     score += _score_currency_consistency(transactions, header_currency)
 
-    return min(100, score)
+    score = min(100, score)
+
+    # Under-extraction penalty (issue #967): a brokerage statement with an
+    # implausibly low transaction count is likely an under-capture, so cap the
+    # score below the auto-approve band regardless of how clean the captured
+    # rows look. Prefer the persisted count (after skipped/invalid rows) so a
+    # payload that extracts 2 rows but persists only 1 still trips the cap.
+    txn_count = effective_txn_count if effective_txn_count is not None else len(transactions)
+    if is_brokerage and txn_count < BROKERAGE_MIN_PLAUSIBLE_TXNS:
+        score = min(score, UNDER_EXTRACTION_SCORE_CAP)
+
+    return score
 
 
 def _score_balance_progression(transactions: list[dict[str, Any]]) -> int:

--- a/apps/backend/tests/extraction/test_extraction.py
+++ b/apps/backend/tests/extraction/test_extraction.py
@@ -627,3 +627,106 @@ class TestConfidenceScoringV2:
 
         score = compute_confidence_score(extracted, balance_result)
         assert score == 85
+
+
+class TestUnderExtractionPenalty:
+    """AC13.15: Penalize implausibly-low transaction counts (issue #967)."""
+
+    @staticmethod
+    def _brokerage_extracted(transactions):
+        return {
+            "institution": "Futu",
+            "period_start": "2025-06-01",
+            "period_end": "2025-06-30",
+            "opening_balance": "0.00",
+            "closing_balance": "100.00",
+            "currency": "HKD",
+            "transactions": transactions,
+        }
+
+    def test_brokerage_single_txn_penalized(self):
+        """AC13.15.1: A brokerage statement yielding a single transaction is an
+        under-capture signal and must not present as high confidence."""
+        extracted = self._brokerage_extracted(
+            [
+                {
+                    "date": "2025-06-15",
+                    "description": "Aggregate",
+                    "amount": "100.00",
+                    "direction": "IN",
+                    "currency": "HKD",
+                }
+            ]
+        )
+        balance_result = {"balance_valid": True, "difference": "0.00"}
+
+        unpenalized = compute_confidence_score(extracted, balance_result, is_brokerage=False)
+        penalized = compute_confidence_score(extracted, balance_result, is_brokerage=True)
+
+        assert penalized < unpenalized, "Under-capture should lower confidence vs the un-penalized score"
+        assert penalized <= 60, f"1-txn brokerage should stay in review band, got {penalized}"
+
+    def test_brokerage_sufficient_txns_not_penalized(self):
+        """AC13.15.2: A brokerage statement with a plausible transaction count is
+        not penalized."""
+        txns = [
+            {"date": "2025-06-10", "description": "Buy", "amount": "40.00", "direction": "OUT", "currency": "HKD"},
+            {"date": "2025-06-20", "description": "Sell", "amount": "140.00", "direction": "IN", "currency": "HKD"},
+        ]
+        extracted = self._brokerage_extracted(txns)
+        balance_result = {"balance_valid": True, "difference": "0.00"}
+
+        score = compute_confidence_score(extracted, balance_result, is_brokerage=True)
+        assert score > 60, f"Plausible brokerage parse should not be penalized, got {score}"
+
+    def test_bank_single_txn_not_penalized(self):
+        """AC13.15.3: A non-brokerage (bank) statement with one transaction keeps
+        its existing score — a single-transaction bank month is legitimate."""
+        extracted = {
+            "institution": "DBS",
+            "period_start": "2025-01-01",
+            "period_end": "2025-01-31",
+            "opening_balance": "0.00",
+            "closing_balance": "100.00",
+            "transactions": [
+                {"date": "2025-01-01", "description": "A", "amount": "100.00", "direction": "IN"},
+            ],
+        }
+        balance_result = {"balance_valid": True, "difference": "0.00"}
+
+        assert compute_confidence_score(extracted, balance_result, is_brokerage=False) == 85
+
+    def test_default_is_not_brokerage(self):
+        """AC13.15.4: is_brokerage defaults to False so existing callers are
+        unaffected."""
+        extracted = self._brokerage_extracted(
+            [
+                {
+                    "date": "2025-06-15",
+                    "description": "Aggregate",
+                    "amount": "100.00",
+                    "direction": "IN",
+                    "currency": "HKD",
+                }
+            ]
+        )
+        balance_result = {"balance_valid": True, "difference": "0.00"}
+
+        assert compute_confidence_score(extracted, balance_result) == compute_confidence_score(
+            extracted, balance_result, is_brokerage=False
+        )
+
+    def test_effective_count_uses_persisted_not_extracted(self):
+        """AC13.15.5: the cap uses the persisted count, so a payload that extracts
+        2 rows but persists only 1 (a row skipped) still trips the cap."""
+        txns = [
+            {"date": "2025-06-10", "description": "Buy", "amount": "40.00", "direction": "OUT", "currency": "HKD"},
+            {"date": "2025-06-20", "description": "Sell", "amount": "140.00", "direction": "IN", "currency": "HKD"},
+        ]
+        extracted = self._brokerage_extracted(txns)
+        balance_result = {"balance_valid": True, "difference": "0.00"}
+
+        # Raw extracted count is 2 -> not capped; persisted count is 1 -> capped.
+        not_capped = compute_confidence_score(extracted, balance_result, is_brokerage=True)
+        capped = compute_confidence_score(extracted, balance_result, is_brokerage=True, effective_txn_count=1)
+        assert capped <= 60 < not_capped

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -193,6 +193,16 @@ Expected routing behavior remains threshold-based (See: `docs/ssot/reconciliatio
 | AC13.9.1 | Test full score with all factors | `test_full_score_with_all_factors()` | `extraction/test_extraction.py` | P0 |
 | AC13.9.2 | Test no new factors caps at 85 | `test_no_new_factors_caps_at_85()` | `extraction/test_extraction.py` | P0 |
 
+### AC13.15: Under-Extraction Penalty (issue #967)
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC13.15.1 | Brokerage statement with a single transaction is penalized below the review/auto-approve band | `test_brokerage_single_txn_penalized()` | `extraction/test_extraction.py` | P1 |
+| AC13.15.2 | Brokerage statement with a plausible transaction count is not penalized | `test_brokerage_sufficient_txns_not_penalized()` | `extraction/test_extraction.py` | P1 |
+| AC13.15.3 | Non-brokerage (bank) statement with one transaction keeps its existing score | `test_bank_single_txn_not_penalized()` | `extraction/test_extraction.py` | P1 |
+| AC13.15.4 | `is_brokerage` defaults to False so existing callers are unaffected | `test_default_is_not_brokerage()` | `extraction/test_extraction.py` | P1 |
+| AC13.15.5 | The cap uses the persisted transaction count (after skipped rows), not the raw extracted count | `test_effective_count_uses_persisted_not_extracted()` | `extraction/test_extraction.py` | P1 |
+
 ### AC13.14: JSON-Repair Retry (issue #982)
 
 | ID | Test Case | Test Function | File | Priority |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -119,9 +119,30 @@ no source statement balances were provided.
 - 60-84: Review queue
 - <60: Manual entry required
 
+**The ~90 ceiling.** The Balance Progression component (10%) is only awarded
+when transactions carry a per-line running `balance_after` chain. Statements
+that omit per-line balances (most bank/brokerage PDFs) therefore top out near 90
+even when every other factor is perfect. This is an inherent ceiling of the
+weighting, not a scoring defect — a higher score requires source data that
+exposes the running balance per row.
+
+**Under-extraction guard.** A brokerage statement that yields fewer than
+`BROKERAGE_MIN_PLAUSIBLE_TXNS` (2) transactions is a strong under-capture signal
+— comparable brokerage statements extract ~10 rows. `compute_confidence_score`
+caps such parses at `UNDER_EXTRACTION_SCORE_CAP` (60) so under-capture never
+presents as high confidence.
+
 If a high-confidence statement fails any Stage 1 posting guard, the parser must
 preserve the extracted statement and transactions, set the statement to parsed
 pending review, and expose the guard reason for human correction.
+
+**CSV without source balances never auto-approves.** A CSV export that carries
+no source statement opening/closing balances is parsed with
+`balance_source = inferred_from_csv_transactions`; the parser forces the
+statement to `parsed` (review) with `balance_validated = false`, and the
+confidence score excludes the balance-validation component
+(`balance_proof_available = false`). Inferred `0 + transactions = closing` is
+not balance proof and must not satisfy the auto-approve precondition.
 
 ## API Endpoints
 


### PR DESCRIPTION
## Summary
Resolves **#967** (part of the **#996** vision/OCR lane).

A brokerage statement that extracts **fewer than 2 transactions** is a strong under-capture signal (comparable Moomoo/Futu statements yield ~10), yet such parses scored **90** with `balance_validated=true` — presenting under-capture as high confidence.

## Changes
- `compute_confidence_score` gains a keyword-only `is_brokerage` flag (defaults `False`). When set and `len(transactions) < BROKERAGE_MIN_PLAUSIBLE_TXNS (2)`, the score is capped at `UNDER_EXTRACTION_SCORE_CAP (60)` so under-capture cannot present as high confidence.
- The flag is threaded from `ExtractionService.parse_document`, where the brokerage payload is already detected (`is_brokerage_payload`). Other callers are unaffected by the default.
- **SSOT `docs/ssot/extraction.md`**: documents the inherent **~90 ceiling** (the Balance Progression 10% component is only awarded when transactions carry a per-line running `balance_after` chain), and confirms the existing guard that **CSV imports without source balances never auto-approve** (relates to **#965**, which is already enforced in code).

## Tests
- `AC13.13.1-4` in `extraction/test_extraction.py` (`TestUnderExtractionPenalty`): 1-txn brokerage is penalized ≤60; plausible brokerage parses and single-txn **bank** statements are unaffected; default behavior preserved.
- Full extraction + validation suites pass (492 tests); AC-registry tooling tests pass.

## Notes on #996 scope
- **#965** (CSV auto-approve policy) is **already enforced** on `main`: CSV with inferred balances routes to `parsed`/review with `balance_validated=false` and `balance_proof_available=false` — never auto-approved. This PR documents that contract; no behavior change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)