### PR TITLE
[finance_report_hacker] fix(users): 409 instead of 500 when ledger immutability blocks account deletion (#988)

### DIFF
--- a/apps/backend/src/routers/users.py
+++ b/apps/backend/src/routers/users.py
@@ -4,11 +4,12 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, status
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 
 from src.deps import CurrentUserId, DbSession
 from src.models import User
 from src.schemas import UserCreate, UserListResponse, UserResponse, UserUpdate
-from src.utils import raise_bad_request, raise_not_found
+from src.utils import raise_bad_request, raise_conflict, raise_not_found
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -114,4 +115,13 @@ async def delete_user(
         raise_not_found("User")
 
     await db.delete(user)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        # The ledger immutability invariant (posted/reconciled journal entries cannot be
+        # deleted) blocks the cascade. Surface it as a clear 409 instead of leaking a 500.
+        await db.rollback()
+        raise_conflict(
+            "Cannot delete this account while it has posted or reconciled ledger entries. Void those entries first.",
+            cause=exc,
+        )

--- a/apps/backend/tests/api/test_users_router.py
+++ b/apps/backend/tests/api/test_users_router.py
@@ -1,10 +1,12 @@
 """API tests for user management endpoints."""
 
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import User
@@ -47,3 +49,25 @@ async def test_delete_user_does_not_allow_cross_user_deletion(
 
     assert response.status_code == 404
     assert await db.scalar(select(User.id).where(User.id == other_user.id)) == other_user.id
+
+
+async def test_delete_user_with_immutable_entries_returns_409(
+    client: AsyncClient,
+    test_user: User,
+) -> None:
+    """AC2.14.6: when the cascade is blocked by the ledger immutability invariant
+    (posted/reconciled entries), account deletion returns a clean 409, not a leaked 500.
+
+    The invariant is a DB trigger present only on the migrated database, not the
+    metadata-built test schema, so we inject the IntegrityError it raises and assert the
+    endpoint surfaces it as a 409 (see #988: the same condition leaks a 500 on staging).
+    """
+    immutable_violation = IntegrityError(
+        "DELETE FROM users WHERE users.id = $1::UUID",
+        {},
+        Exception("cannot delete immutable journal entry ... with status reconciled"),
+    )
+    with patch.object(AsyncSession, "commit", new_callable=AsyncMock, side_effect=immutable_violation):
+        response = await client.delete(f"/users/{test_user.id}")
+
+    assert response.status_code == 409

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -222,7 +222,7 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 | AC2.14.3 | PostgreSQL rejects posted/reconciled non-base-currency lines without a positive FX rate | `test_AC2_14_3_non_base_posted_lines_require_positive_fx_rate()` | `accounting/test_ledger_schema_invariants.py` | P0 |
 | AC2.14.4 | PostgreSQL blocks direct update/delete of posted/reconciled entries and lines while draft entries remain editable | `test_AC2_14_4_posted_entries_and_lines_are_immutable_but_drafts_are_editable()` | `accounting/test_ledger_schema_invariants.py` | P0 |
 | AC2.14.5 | Voiding a posted entry preserves a non-null immutable reversal relationship instead of deleting or editing posted lines | `test_AC2_14_5_void_transition_requires_reversal_relationship()` | `accounting/test_ledger_schema_invariants.py` | P0 |
-| AC2.14.6 | Account deletion blocked by the immutability invariant (posted/reconciled entries) returns a clean HTTP 409, not a leaked 500 | `test_delete_user_with_immutable_entries_returns_409` | `apps/backend/tests/api/test_users_router.py` | P1 |
+| AC2.14.6 | Account deletion blocked by the immutability invariant (posted/reconciled entries) returns a clean HTTP 409, not a leaked 500 | `test_delete_user_with_immutable_entries_returns_409()` | `apps/backend/tests/api/test_users_router.py` | P1 |
 
 ## 📏 Acceptance Criteria
 

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -222,6 +222,7 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 | AC2.14.3 | PostgreSQL rejects posted/reconciled non-base-currency lines without a positive FX rate | `test_AC2_14_3_non_base_posted_lines_require_positive_fx_rate()` | `accounting/test_ledger_schema_invariants.py` | P0 |
 | AC2.14.4 | PostgreSQL blocks direct update/delete of posted/reconciled entries and lines while draft entries remain editable | `test_AC2_14_4_posted_entries_and_lines_are_immutable_but_drafts_are_editable()` | `accounting/test_ledger_schema_invariants.py` | P0 |
 | AC2.14.5 | Voiding a posted entry preserves a non-null immutable reversal relationship instead of deleting or editing posted lines | `test_AC2_14_5_void_transition_requires_reversal_relationship()` | `accounting/test_ledger_schema_invariants.py` | P0 |
+| AC2.14.6 | Account deletion blocked by the immutability invariant (posted/reconciled entries) returns a clean HTTP 409, not a leaked 500 | `test_delete_user_with_immutable_entries_returns_409` | `apps/backend/tests/api/test_users_router.py` | P1 |
 
 ## 📏 Acceptance Criteria
 


### PR DESCRIPTION
Closes #988. First PR off the #994 (hacker/backend) ROI list.

## Problem
`DELETE /users/{id}` did `db.delete(user); db.commit()` with no error handling. When the cascade hits the ledger immutability invariant (posted/reconciled journal entries cannot be deleted), the DB CheckViolation leaked as an HTTP **500** — observed on staging (#988), and it also breaks E2E test-account teardown.

## Change
Catch `IntegrityError`, roll back, and return a clear **409 Conflict**: _"Cannot delete this account while it has posted or reconciled ledger entries. Void those entries first."_ The immutability invariant itself is correct and unchanged.

## Test (EPIC-002 AC2.14.6)
The delete-immutability trigger lives in the **migrated** schema, not the metadata-built unit-test DB (which `create_all`s and does not carry it), so the test injects the `IntegrityError` the trigger raises and asserts the endpoint maps it to 409. Existing delete tests (success 204, cross-user 404) still pass.

## Verify
`tests/api/test_users_router.py` 3 passed; ruff clean; AC2.14.6 traceable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)