### PR TITLE
[finance_report_hacker] docs(extraction): document intentional brokerage-vs-bank routing (#981)

### DIFF
--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -502,6 +502,12 @@ class ExtractionService:
             else:
                 # For confidence score, we use the original extracted dict to maintain logic.
                 confidence = compute_confidence_score(extracted, balance_result)
+                # Routing differs by document class on purpose (#981): brokerage payloads
+                # reconcile via Layer-2 AtomicPosition snapshots, not a running-balance chain, so
+                # `balance_valid` is not their gating signal — they always go to `parsed`/review.
+                # Bank statements route by `route_by_threshold`, where an invalid balance chain
+                # sends them to `uploaded` (manual entry). Same "balance invalid" input, different
+                # destination by design.
                 status = (
                     BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(confidence, is_valid)
                 )

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -164,14 +164,17 @@ Routing after parsing depends on the document class, on purpose (#981):
 
 - **Bank statements** route via `route_by_threshold(confidence, balance_valid)`: an invalid
   running-balance chain sends them to `uploaded` (manual entry), and high confidence + valid
-  balance can auto-approve.
+  balance can auto-approve. **Exception:** CSV exports without source statement balances take the
+  inferred-balance path (`has_inferred_csv_balances`), which forces `parsed`/review with
+  `balance_valid = False` rather than routing to `uploaded` — so they remain reviewable instead of
+  demanding manual entry.
 - **Brokerage statements** always route to `parsed` (review) regardless of `balance_valid`,
   because they reconcile via `AtomicPosition` position snapshots rather than a running-balance
   chain — `balance_valid` is not a meaningful gating signal for them.
 
-So the same "balance invalid" outcome lands a bank statement in `uploaded` but a brokerage
-statement in `parsed`. This is by design, not a routing bug. Owner: `ExtractionService` status
-selection (`is_brokerage_payload ? PARSED : route_by_threshold(...)`).
+So the same "balance invalid" outcome lands a (non-CSV) bank statement in `uploaded` but a
+brokerage statement in `parsed`. This is by design, not a routing bug. Owner: `ExtractionService`
+status selection (`BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(...)`).
 
 Parsing priority:
 1. Prefer structured `positions`, `holdings`, or `securities` arrays from OCR/LLM output.

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -158,6 +158,21 @@ pending review, and expose the guard reason for human correction.
 
 Brokerage extraction feeds Layer 2 `AtomicPosition` through `apps/backend/src/services/brokerage_positions.py`.
 
+### Post-parse routing (intentional difference vs bank statements)
+
+Routing after parsing depends on the document class, on purpose (#981):
+
+- **Bank statements** route via `route_by_threshold(confidence, balance_valid)`: an invalid
+  running-balance chain sends them to `uploaded` (manual entry), and high confidence + valid
+  balance can auto-approve.
+- **Brokerage statements** always route to `parsed` (review) regardless of `balance_valid`,
+  because they reconcile via `AtomicPosition` position snapshots rather than a running-balance
+  chain — `balance_valid` is not a meaningful gating signal for them.
+
+So the same "balance invalid" outcome lands a bank statement in `uploaded` but a brokerage
+statement in `parsed`. This is by design, not a routing bug. Owner: `ExtractionService` status
+selection (`is_brokerage_payload ? PARSED : route_by_threshold(...)`).
+
 Parsing priority:
 1. Prefer structured `positions`, `holdings`, or `securities` arrays from OCR/LLM output.
 2. For Moomoo, recover money-market fund snapshots from subscription rows when no holdings table is available.


### PR DESCRIPTION
Resolves #981 (triage: confirm + document).

## Finding
A balance-invalid **brokerage** statement routes to `parsed` (review) while a balance-invalid **bank** statement routes to `uploaded` (manual entry). Real-machine staging review flagged this as a possible bug.

## Verdict: intentional, now documented
Brokerage statements reconcile via Layer-2 `AtomicPosition` snapshots, not a running-balance chain, so `balance_valid` is not a meaningful gating signal for them — they always go to review. Bank statements route via `route_by_threshold`, where an invalid balance chain goes to `uploaded`. The code already did the right thing; it was just undocumented and looked like a bug.

## Change (no behavior change)
- Clarifying comment at the `ExtractionService` status-selection branch (`is_brokerage_payload ? PARSED : route_by_threshold(...)`).
- SSOT note in `docs/ssot/extraction.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)