### PR TITLE
[finance_report_vision] fix(extraction): JSON-repair retry for recoverable model responses (#982)

### DIFF
--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -660,23 +660,18 @@ class ExtractionService:
         """Best-effort recovery of a JSON object from a malformed model response.
 
         Models occasionally wrap an otherwise-valid object in a markdown code
-        fence or pad it with prose. Rather than rejecting the upload (#982), strip
-        any fence and extract the outermost balanced ``{...}`` object — tracking
-        string literals so braces inside values do not truncate it. The repair is
-        deterministic and does not invent data; it returns ``None`` when no
-        object can be recovered, leaving the original failure path intact.
+        fence or pad it with prose. Rather than rejecting the upload (#982),
+        extract the outermost balanced ``{...}`` object — tracking string
+        literals so braces inside values do not truncate it. Scanning from the
+        first ``{`` to its matching ``}`` naturally ignores any surrounding fence
+        (including single-line ``` ```json {...}``` ``` blocks) or prose. The
+        repair is deterministic and does not invent data; it returns ``None``
+        when no object can be recovered, leaving the original failure path intact.
         """
         if not content:
             return None
 
         text = content.strip()
-        if text.startswith("```"):
-            # Drop the opening fence line (``` or ```json) and any closing fence.
-            text = text.split("\n", 1)[1] if "\n" in text else ""
-            if text.rstrip().endswith("```"):
-                text = text.rstrip()[: -len("```")]
-            text = text.strip()
-
         start = text.find("{")
         if start == -1:
             return None

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -655,6 +655,55 @@ class ExtractionService:
         )
         return markdown
 
+    @staticmethod
+    def _repair_json_object(content: str) -> str | None:
+        """Best-effort recovery of a JSON object from a malformed model response.
+
+        Models occasionally wrap an otherwise-valid object in a markdown code
+        fence or pad it with prose. Rather than rejecting the upload (#982), strip
+        any fence and extract the outermost balanced ``{...}`` object — tracking
+        string literals so braces inside values do not truncate it. The repair is
+        deterministic and does not invent data; it returns ``None`` when no
+        object can be recovered, leaving the original failure path intact.
+        """
+        if not content:
+            return None
+
+        text = content.strip()
+        if text.startswith("```"):
+            # Drop the opening fence line (``` or ```json) and any closing fence.
+            text = text.split("\n", 1)[1] if "\n" in text else ""
+            if text.rstrip().endswith("```"):
+                text = text.rstrip()[: -len("```")]
+            text = text.strip()
+
+        start = text.find("{")
+        if start == -1:
+            return None
+
+        depth = 0
+        in_string = False
+        escaped = False
+        for i in range(start, len(text)):
+            char = text[i]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
+        return None
+
     async def _extract_json_with_models(
         self,
         messages: list[dict[str, Any]],
@@ -727,6 +776,18 @@ class ExtractionService:
                     return parsed
                 except json.JSONDecodeError as e:
                     from src.constants.error_ids import ErrorIds
+
+                    # A single malformed-but-recoverable response (markdown fence or
+                    # prose around a valid object) should not reject the upload (#982).
+                    repaired = self._repair_json_object(content)
+                    if repaired is not None:
+                        try:
+                            parsed = json.loads(repaired)
+                            if isinstance(parsed, dict):
+                                logger.info("AI extraction recovered via JSON repair", model=model)
+                                return parsed
+                        except json.JSONDecodeError:
+                            pass
 
                     logger.error(
                         "Failed to parse AI JSON",

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -393,23 +393,23 @@ async def test_extract_financial_data_all_models_fail():
 
 
 async def test_extract_financial_data_json_markdown_fallback():
+    """AC13.14.5: a markdown-fenced but otherwise-valid response is salvaged (#982)."""
     service = ExtractionService()
     service.api_key = "test-key"
     service.ocr_model = None
 
-    # Current code rejects markdown wrapping - test that it properly rejects
     content = 'Here is data: ```json\n{"account_last4": "1234"}\n```'
 
     with patch("src.services.extraction.stream_ai_json") as mock_stream:
         mock_stream.return_value = mock_stream_generator(content)
 
-        with pytest.raises(ExtractionError, match="strict JSON object.*no markdown"):
-            await service.extract_financial_data(
-                b"content",
-                "DBS",
-                "pdf",
-                file_url="https://example.com/file.pdf",
-            )
+        result = await service.extract_financial_data(
+            b"content",
+            "DBS",
+            "pdf",
+            file_url="https://example.com/file.pdf",
+        )
+        assert result == {"account_last4": "1234"}
 
 
 async def test_extract_financial_data_invalid_json_all_attempts():

--- a/apps/backend/tests/extraction/test_extraction_flow.py
+++ b/apps/backend/tests/extraction/test_extraction_flow.py
@@ -161,20 +161,19 @@ class TestExtractionServiceFlow:
             assert result == {"test": "data"}
 
     async def test_extract_financial_data_markdown_json(self, service):
-        """Test extract_financial_data rejects markdown wrapped JSON."""
+        """AC13.14.5: markdown-fenced JSON is salvaged, not rejected (#982)."""
         service.api_key = "test-key"
 
-        # Current code rejects markdown-wrapped JSON
         content = 'Here is json:\n```json\n{"test": "markdown"}\n```'
 
         with patch("src.services.extraction.stream_ai_json") as mock_stream:
             mock_stream.return_value = mock_stream_generator(content)
 
-            with pytest.raises(ExtractionError, match="strict JSON object.*no markdown"):
-                await service.extract_financial_data(b"content", "DBS", "png")
+            result = await service.extract_financial_data(b"content", "DBS", "png")
+            assert result == {"test": "markdown"}
 
-    async def test_extract_financial_data_rejects_extra_text(self, service):
-        """Test extract_financial_data rejects extra non-JSON text."""
+    async def test_extract_financial_data_salvages_extra_text(self, service):
+        """AC13.14.2: a valid object padded with prose is salvaged (#982)."""
         service.api_key = "test-key"
 
         content = 'Sure! {"test": "value"}\nThanks!'
@@ -182,8 +181,8 @@ class TestExtractionServiceFlow:
         with patch("src.services.extraction.stream_ai_json") as mock_stream:
             mock_stream.return_value = mock_stream_generator(content)
 
-            with pytest.raises(ExtractionError, match="strict JSON object"):
-                await service.extract_financial_data(b"content", "DBS", "png")
+            result = await service.extract_financial_data(b"content", "DBS", "png")
+            assert result == {"test": "value"}
 
     async def test_extract_financial_data_rejects_array(self, service):
         """Test extract_financial_data rejects JSON arrays."""

--- a/apps/backend/tests/extraction/test_json_repair.py
+++ b/apps/backend/tests/extraction/test_json_repair.py
@@ -29,6 +29,13 @@ class TestRepairJsonObject:
         assert repaired is not None
         assert json.loads(repaired) == {"a": 1, "nested": {"b": 2}}
 
+    def test_strips_single_line_fence(self):
+        """AC13.14.1b: A single-line fenced block (no newline) is recovered."""
+        content = '```json {"institution": "DBS", "transactions": []}```'
+        repaired = ExtractionService._repair_json_object(content)
+        assert repaired is not None
+        assert json.loads(repaired) == {"institution": "DBS", "transactions": []}
+
     def test_clean_object_is_preserved(self):
         """AC13.14.3: An already-clean object round-trips unchanged."""
         content = '{"x": "y"}'

--- a/apps/backend/tests/extraction/test_json_repair.py
+++ b/apps/backend/tests/extraction/test_json_repair.py
@@ -1,0 +1,98 @@
+"""AC13.14: JSON-repair retry for recoverable malformed model responses (#982).
+
+A single model response wrapped in markdown fences or padded with prose should
+not reject an otherwise-valid upload. The extraction loop attempts a bounded,
+deterministic repair before counting the response as a ``json_parse`` failure.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.extraction import ExtractionError, ExtractionService
+
+
+class TestRepairJsonObject:
+    def test_strips_json_code_fence(self):
+        """AC13.14.1: A ```json fenced object is recovered."""
+        content = '```json\n{"institution": "DBS", "transactions": []}\n```'
+        repaired = ExtractionService._repair_json_object(content)
+        assert repaired is not None
+        assert json.loads(repaired) == {"institution": "DBS", "transactions": []}
+
+    def test_strips_bare_code_fence_and_prose(self):
+        """AC13.14.2: Surrounding prose and a bare ``` fence are stripped to the
+        outermost balanced object."""
+        content = 'Here is the result:\n```\n{"a": 1, "nested": {"b": 2}}\n```\nDone.'
+        repaired = ExtractionService._repair_json_object(content)
+        assert repaired is not None
+        assert json.loads(repaired) == {"a": 1, "nested": {"b": 2}}
+
+    def test_clean_object_is_preserved(self):
+        """AC13.14.3: An already-clean object round-trips unchanged."""
+        content = '{"x": "y"}'
+        repaired = ExtractionService._repair_json_object(content)
+        assert repaired is not None
+        assert json.loads(repaired) == {"x": "y"}
+
+    def test_unrecoverable_returns_none(self):
+        """AC13.14.4: Content with no JSON object is unrecoverable."""
+        assert ExtractionService._repair_json_object("totally not json") is None
+        assert ExtractionService._repair_json_object("") is None
+
+    def test_does_not_misread_braces_in_strings(self):
+        """AC13.14.4b: Braces inside string values do not truncate the object."""
+        content = '```json\n{"note": "balance {pending}", "ok": true}\n```'
+        repaired = ExtractionService._repair_json_object(content)
+        assert repaired is not None
+        assert json.loads(repaired) == {"note": "balance {pending}", "ok": True}
+
+
+class TestExtractionSalvagesFencedResponse:
+    async def test_fenced_response_is_salvaged(self):
+        """AC13.14.5: A fenced (otherwise-valid) model response is salvaged by the
+        extraction loop instead of rejecting the upload."""
+        service = ExtractionService()
+        fenced = '```json\n{"institution": "DBS", "transactions": []}\n```'
+
+        with (
+            patch.object(service, "api_key", "test-key"),
+            patch.object(service, "base_url", "https://test.api"),
+            patch("src.services.extraction.stream_ai_json", return_value=MagicMock()),
+            patch("src.services.extraction.accumulate_stream", AsyncMock(return_value=fenced)),
+        ):
+            result = await service._extract_json_with_models(
+                messages=[{"role": "user", "content": "x"}],
+                models=["test-model"],
+                prompt="p",
+                institution="DBS",
+                file_type="pdf",
+                return_raw=False,
+                has_content=True,
+                has_url=False,
+            )
+
+        assert result == {"institution": "DBS", "transactions": []}
+
+    async def test_unrecoverable_response_still_fails(self):
+        """AC13.14.6: A response with no recoverable JSON still fails as before."""
+        service = ExtractionService()
+
+        with (
+            patch.object(service, "api_key", "test-key"),
+            patch.object(service, "base_url", "https://test.api"),
+            patch("src.services.extraction.stream_ai_json", return_value=MagicMock()),
+            patch("src.services.extraction.accumulate_stream", AsyncMock(return_value="not json at all")),
+        ):
+            with pytest.raises(ExtractionError):
+                await service._extract_json_with_models(
+                    messages=[{"role": "user", "content": "x"}],
+                    models=["test-model"],
+                    prompt="p",
+                    institution="DBS",
+                    file_type="pdf",
+                    return_raw=False,
+                    has_content=True,
+                    has_url=False,
+                )

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -197,7 +197,7 @@ Expected routing behavior remains threshold-based (See: `docs/ssot/reconciliatio
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC13.14.1 | A ```json fenced object is recovered | `test_strips_json_code_fence()` | `extraction/test_json_repair.py` | P1 |
+| AC13.14.1 | A markdown json-fenced object (multi-line and single-line) is recovered | `test_strips_json_code_fence()`, `test_strips_single_line_fence()` | `extraction/test_json_repair.py` | P1 |
 | AC13.14.2 | Surrounding prose and a bare fence reduce to the outermost balanced object | `test_strips_bare_code_fence_and_prose()`, `test_extract_financial_data_salvages_extra_text()` | `extraction/test_json_repair.py`, `extraction/test_extraction_flow.py` | P1 |
 | AC13.14.3 | An already-clean object round-trips unchanged | `test_clean_object_is_preserved()` | `extraction/test_json_repair.py` | P1 |
 | AC13.14.4 | Content with no recoverable JSON object returns None; braces inside strings do not truncate | `test_unrecoverable_returns_none()`, `test_does_not_misread_braces_in_strings()` | `extraction/test_json_repair.py` | P1 |

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -193,6 +193,17 @@ Expected routing behavior remains threshold-based (See: `docs/ssot/reconciliatio
 | AC13.9.1 | Test full score with all factors | `test_full_score_with_all_factors()` | `extraction/test_extraction.py` | P0 |
 | AC13.9.2 | Test no new factors caps at 85 | `test_no_new_factors_caps_at_85()` | `extraction/test_extraction.py` | P0 |
 
+### AC13.14: JSON-Repair Retry (issue #982)
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC13.14.1 | A ```json fenced object is recovered | `test_strips_json_code_fence()` | `extraction/test_json_repair.py` | P1 |
+| AC13.14.2 | Surrounding prose and a bare fence reduce to the outermost balanced object | `test_strips_bare_code_fence_and_prose()`, `test_extract_financial_data_salvages_extra_text()` | `extraction/test_json_repair.py`, `extraction/test_extraction_flow.py` | P1 |
+| AC13.14.3 | An already-clean object round-trips unchanged | `test_clean_object_is_preserved()` | `extraction/test_json_repair.py` | P1 |
+| AC13.14.4 | Content with no recoverable JSON object returns None; braces inside strings do not truncate | `test_unrecoverable_returns_none()`, `test_does_not_misread_braces_in_strings()` | `extraction/test_json_repair.py` | P1 |
+| AC13.14.5 | The extraction loop salvages a fenced response instead of rejecting the upload | `test_fenced_response_is_salvaged()`, `test_extract_financial_data_markdown_json()`, `test_extract_financial_data_json_markdown_fallback()` | `extraction/test_json_repair.py`, `extraction/test_extraction_flow.py`, `extraction/test_extraction_error_paths.py` | P1 |
+| AC13.14.6 | A response with no recoverable JSON still fails through the model-chain path | `test_unrecoverable_response_still_fails()` | `extraction/test_json_repair.py` | P1 |
+
 ### AC13.10: Source Type Priority & Conflict Resolution
 
 | ID | Test Case | Test Function | File | Priority |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -211,6 +211,13 @@ S3_PRESIGN_EXPIRY_SECONDS=300
 - **Orphan cleanup**: if DB persistence fails after upload, the uploaded object is deleted.
 - **Periodic orphan sweep**: old statement storage objects without matching DB records are deleted by
   `src/services/storage_sweep.py`; EPIC-003 AC3.8 owns the behavior tests.
+- **JSON-repair retry**: when a model returns an otherwise-valid object wrapped in
+  a markdown code fence or padded with prose, `_extract_json_with_models` performs
+  one deterministic repair pass (strip the fence, extract the outermost balanced
+  `{...}` object, tracking string literals) before counting a `json_parse` failure.
+  This keeps a single malformed-but-recoverable response from rejecting an
+  otherwise-valid upload (#982). The repair never invents data and falls back to the
+  existing model-chain failure path when no object can be recovered.
 - **Stuck job supervisor**: statements stuck in `parsing` longer than 30 minutes are marked `rejected`
   with a validation error so users can retry.
 - **Error handler rollback-first**: `_handle_parse_failure` calls `db.rollback()` before re-fetching


### PR DESCRIPTION
## Summary
Resolves the **vision half of #982** (part of the **#996** lane): *"configure a fallback/secondary model + a JSON-repair retry so a single malformed model response (`All 1 models failed: json_parse`) doesn't reject an otherwise-valid upload."*

Models occasionally return an otherwise-valid object wrapped in a markdown code fence or padded with prose. Previously that response was rejected outright as `json_parse`, failing the whole upload.

## Changes
- New `ExtractionService._repair_json_object(content)`: one **deterministic** repair pass — strip a leading/trailing markdown fence, then extract the **outermost balanced `{...}` object**, tracking string literals so braces inside values don't truncate it. Returns `None` (leaving the original failure path intact) when nothing recoverable is present; never invents data.
- `_extract_json_with_models` calls the repair on `JSONDecodeError` before counting a `json_parse` failure; on success it returns the parsed dict and logs `recovered via JSON repair`.
- Fallback chain is already wired (`[primary_model, *fallback_models]`, `FALLBACK_MODELS` env in SSOT) — repair makes a single recoverable response succeed *without* needing a second model round-trip.

## Tests
- New `extraction/test_json_repair.py` (`AC13.14.1-6`): fenced object, prose-padded object, clean passthrough, unrecoverable → None, braces-in-strings safety, end-to-end salvage via the extraction loop, and unrecoverable-still-fails.
- Three existing tests asserted the **old** reject-on-markdown contract; updated to assert the new salvage contract.
- Full extraction suite passes (455 tests); AC-registry tooling tests pass.

## Out of scope (backend half of #982)
- Persisting an `UploadedDocument` lineage row on hard parse failure is the backend lane's concern, tracked separately under #982; this PR is the vision-lane JSON-repair slice called out by #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)