### PR TITLE
[finance_report_vision] fix(extraction): deterministic decoding seed for reproducible parsing (#989)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ AI_DAILY_LIMIT_USD=2
 AI_JSON_DISABLE_THINKING=true
 # Max tokens for AI JSON completion calls.
 AI_JSON_MAX_TOKENS=8192
+# Fixed decoding seed for reproducible AI extraction (empty to omit).
+AI_JSON_SEED=42
 # Timeout (seconds) for AI JSON completion calls.
 AI_JSON_TIMEOUT_SECONDS=360
 # Layout-parsing path appended to the AI base URL.

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -8,7 +8,7 @@ Environment Variable Strategy:
 
 from functools import cached_property
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -377,6 +377,28 @@ class Settings(BaseSettings):
         description="Daily AI spend limit in USD (None to disable).",
         json_schema_extra={"group": "AI Provider"},
     )
+    # Deterministic decoding for OCR/extraction (#989): a fixed seed makes the
+    # provider decode reproducibly so the same statement does not sometimes
+    # reconcile and sometimes not. Set AI_JSON_SEED= (empty) to omit it for
+    # providers that reject the field.
+    ai_json_seed: int | None = Field(
+        default=42,
+        validation_alias="AI_JSON_SEED",
+        description="Fixed decoding seed for reproducible AI extraction (empty to omit).",
+        json_schema_extra={"group": "AI Provider"},
+    )
+
+    @field_validator("ai_json_seed", mode="before")
+    @classmethod
+    def _empty_seed_is_none(cls, value: object) -> object:
+        """Treat an empty/whitespace AI_JSON_SEED as omitted (None).
+
+        Pydantic cannot parse "" as int, so an empty env value would otherwise
+        raise at startup and the seed could never actually be omitted via env.
+        """
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
 
     # S3 optional settings
     s3_region: str = Field(

--- a/apps/backend/src/services/ai_streaming.py
+++ b/apps/backend/src/services/ai_streaming.py
@@ -46,6 +46,7 @@ async def _stream_ai_base(
     max_tokens: int | None = None,
     temperature: float | None = None,
     do_sample: bool | None = None,
+    seed: int | None = None,
     thinking: dict[str, Any] | None = None,
     response_format: dict[str, str] | None = None,
     mode_label: str = "streaming",
@@ -83,6 +84,8 @@ async def _stream_ai_base(
         payload["temperature"] = temperature
     if do_sample is not None:
         payload["do_sample"] = do_sample
+    if seed is not None:
+        payload["seed"] = seed
     if thinking is not None:
         payload["thinking"] = thinking
 
@@ -239,6 +242,7 @@ async def stream_ai_json(
     max_tokens: int | None = None,
     temperature: float | None = None,
     do_sample: bool | None = None,
+    seed: int | None = None,
     thinking: dict[str, Any] | None = None,
 ) -> AsyncIterator[str]:
     """
@@ -262,6 +266,7 @@ async def stream_ai_json(
         max_tokens=max_tokens,
         temperature=temperature,
         do_sample=do_sample,
+        seed=seed,
         thinking=thinking,
         response_format=None,
         mode_label="JSON extraction",

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -741,6 +741,7 @@ class ExtractionService:
                     max_tokens=settings.ai_json_max_tokens,
                     temperature=0.0,
                     do_sample=False,
+                    seed=settings.ai_json_seed,
                     thinking={"type": "disabled"} if settings.ai_json_disable_thinking else None,
                 )
 

--- a/apps/backend/tests/ai/test_ai_streaming.py
+++ b/apps/backend/tests/ai/test_ai_streaming.py
@@ -327,6 +327,38 @@ class TestStreamAIJson:
                 assert payload["temperature"] == 0.0
                 assert payload["do_sample"] is False
                 assert payload["thinking"] == {"type": "disabled"}
+                assert "seed" not in payload
+
+    async def test_stream_ai_json_includes_seed_when_provided(self):
+        """AC13.16.1: A provided seed is forwarded in the request payload for
+        deterministic decoding (#989)."""
+        events = [ServerSentEvent(data="[DONE]")]
+
+        mock_event_source = MagicMock()
+        mock_event_source.response.status_code = 200
+        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.__aenter__.return_value = mock_client
+
+        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
+            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
+                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
+
+                async for _ in stream_ai_json(
+                    messages=[{"role": "user", "content": "Hi"}],
+                    model="test-model",
+                    api_key="test-key",
+                    timeout=360.0,
+                    max_tokens=8192,
+                    temperature=0.0,
+                    do_sample=False,
+                    seed=42,
+                ):
+                    pass
+
+                payload = mock_aconnect.call_args.kwargs["json"]
+                assert payload["seed"] == 42
 
 
 class TestStreamErrorHandling:

--- a/apps/backend/tests/extraction/test_seed_determinism.py
+++ b/apps/backend/tests/extraction/test_seed_determinism.py
@@ -1,0 +1,76 @@
+"""AC13.16: Deterministic decoding for statement extraction (#989).
+
+Same source must not sometimes reconcile and sometimes not. Extraction already
+pins temperature 0 / do_sample False; this adds a configurable request ``seed``
+so the model decodes reproducibly. These tests assert the seed is threaded from
+settings into the streaming call.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.config import settings
+from src.services.extraction import ExtractionService
+
+
+async def test_extraction_forwards_configured_seed():
+    """AC13.16.2: _extract_json_with_models forwards settings.ai_json_seed."""
+    service = ExtractionService()
+
+    mock_stream = MagicMock()
+    with (
+        patch.object(service, "api_key", "test-key"),
+        patch.object(service, "base_url", "https://test.api"),
+        patch.object(settings, "ai_json_seed", 1234),
+        patch("src.services.extraction.stream_ai_json", return_value=mock_stream) as mock_stream_fn,
+        patch("src.services.extraction.accumulate_stream", AsyncMock(return_value='{"ok": true}')),
+    ):
+        result = await service._extract_json_with_models(
+            messages=[{"role": "user", "content": "x"}],
+            models=["test-model"],
+            prompt="p",
+            institution="DBS",
+            file_type="pdf",
+            return_raw=False,
+            has_content=True,
+            has_url=False,
+        )
+
+    assert result == {"ok": True}
+    assert mock_stream_fn.call_args.kwargs["seed"] == 1234
+
+
+async def test_extraction_decoding_is_deterministic_by_default():
+    """AC13.16.3: temperature 0 / do_sample False are pinned alongside the seed."""
+    service = ExtractionService()
+
+    mock_stream = MagicMock()
+    with (
+        patch.object(service, "api_key", "test-key"),
+        patch.object(service, "base_url", "https://test.api"),
+        patch("src.services.extraction.stream_ai_json", return_value=mock_stream) as mock_stream_fn,
+        patch("src.services.extraction.accumulate_stream", AsyncMock(return_value='{"ok": true}')),
+    ):
+        await service._extract_json_with_models(
+            messages=[{"role": "user", "content": "x"}],
+            models=["test-model"],
+            prompt="p",
+            institution="DBS",
+            file_type="pdf",
+            return_raw=False,
+            has_content=True,
+            has_url=False,
+        )
+
+    kwargs = mock_stream_fn.call_args.kwargs
+    assert kwargs["temperature"] == 0.0
+    assert kwargs["do_sample"] is False
+
+
+def test_empty_seed_env_is_treated_as_none():
+    """AC13.16.4: AI_JSON_SEED= (empty) parses as None instead of raising, so the
+    seed can be omitted for providers that reject it (#989)."""
+    from src.config import Settings
+
+    assert Settings(AI_JSON_SEED="").ai_json_seed is None
+    assert Settings(AI_JSON_SEED="   ").ai_json_seed is None
+    assert Settings(AI_JSON_SEED="7").ai_json_seed == 7

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -280,3 +280,17 @@ this gate.
 | AC13.13.1 | Pure scoring + routing functions return identical results across N runs on the same input. | `test_scoring_and_routing_are_deterministic` | `extraction/test_extraction_determinism.py` | P0 |
 | AC13.13.2 | Re-parsing identical model output yields identical confidence/status/validation_error across N parses. | `test_repeated_parse_yields_identical_confidence_status_validation` | `extraction/test_extraction_determinism.py` | P0 |
 | AC13.13.3 | Each payload class (bank-valid, bank-balance-invalid, brokerage) routes consistently across N parses. | `test_routing_is_consistent_per_payload_class` | `extraction/test_extraction_determinism.py` | P0 |
+
+### AC13.16: Deterministic Decoding — Request Seed (issue #989)
+
+Complements AC13.13 (downstream determinism). AC13.13 pins everything *after* the
+model response; this AC pins the *request* so the model itself decodes
+reproducibly: temperature 0 / `do_sample` false plus a fixed `seed`
+(`AI_JSON_SEED`, default 42) forwarded to the provider.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC13.16.1 | A provided seed is forwarded in the streaming request payload | `test_stream_ai_json_includes_seed_when_provided()` | `ai/test_ai_streaming.py` | P1 |
+| AC13.16.2 | Extraction forwards the configured `ai_json_seed` to the model call | `test_extraction_forwards_configured_seed()` | `extraction/test_seed_determinism.py` | P1 |
+| AC13.16.3 | Extraction pins `temperature=0` / `do_sample=False` alongside the seed | `test_extraction_decoding_is_deterministic_by_default()` | `extraction/test_seed_determinism.py` | P1 |
+| AC13.16.4 | Empty `AI_JSON_SEED` parses as None (omitted) instead of raising | `test_empty_seed_env_is_treated_as_none()` | `extraction/test_seed_determinism.py` | P1 |

--- a/docs/ssot/env-reference.generated.md
+++ b/docs/ssot/env-reference.generated.md
@@ -26,6 +26,7 @@ Where a field's `.env.example` value intentionally differs from its code default
 | `AI_DAILY_LIMIT_USD` | `2` |  |  | AI Provider | Daily AI spend limit in USD (None to disable). |
 | `AI_JSON_DISABLE_THINKING` | `true` |  |  | AI Provider | Disable provider 'thinking' mode for AI JSON completion calls. |
 | `AI_JSON_MAX_TOKENS` | `8192` |  |  | AI Provider | Max tokens for AI JSON completion calls. |
+| `AI_JSON_SEED` | `42` |  |  | AI Provider | Fixed decoding seed for reproducible AI extraction (empty to omit). |
 | `AI_JSON_TIMEOUT_SECONDS` | `360` |  |  | AI Provider | Timeout (seconds) for AI JSON completion calls. |
 | `AI_LAYOUT_PARSING_PATH` | `/layout_parsing` |  |  | AI Provider | Layout-parsing path appended to the AI base URL. |
 | `AI_MODEL_CATALOG_SOURCE` | `configured` |  |  | AI Provider | Source of the AI model catalog. |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -217,6 +217,7 @@ FALLBACK_MODELS=glm-5-turbo,glm-5
 AI_JSON_TIMEOUT_SECONDS=360
 AI_JSON_MAX_TOKENS=8192
 AI_JSON_DISABLE_THINKING=true
+AI_JSON_SEED=42
 AI_DAILY_LIMIT_USD=2
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minio
@@ -230,6 +231,12 @@ S3_PRESIGN_EXPIRY_SECONDS=300
 
 ## Parsing Resilience
 
+- **Deterministic decoding**: JSON extraction pins `temperature=0` and
+  `do_sample=false`, and forwards a fixed request `seed` (`AI_JSON_SEED`,
+  default `42`) so the same statement decodes reproducibly. This keeps
+  `balance_validated`, `confidence_score`, and Stage-1 routing from flipping
+  between uploads of the same source (#989). Set `AI_JSON_SEED=` (empty) to omit
+  the seed for providers that reject it.
 - **Bucket auto-create**: storage ensures the bucket exists before upload.
 - **Orphan cleanup**: if DB persistence fails after upload, the uploaded object is deleted.
 - **Periodic orphan sweep**: old statement storage objects without matching DB records are deleted by


### PR DESCRIPTION
## Summary
Resolves **#989 Step A** (the quick, high-ROI slice in the **#996** lane): make OCR/extraction decoding **deterministic** so the same PDF doesn't sometimes reconcile (conf 100 / `parsed`) and sometimes not (conf 64 / `uploaded`).

Temperature was already pinned to `0` with `do_sample=False`; the remaining non-determinism is unseeded sampling. This forwards a fixed request `seed`.

## Changes
- New setting `ai_json_seed` (`AI_JSON_SEED`, default `42`; set empty to omit for providers that reject the field).
- `seed` threaded through `stream_ai_json` → `_stream_ai_base`, added to the request payload only when set (mirrors `temperature`/`do_sample`).
- `_extract_json_with_models` passes `seed=settings.ai_json_seed`.
- SSOT `docs/ssot/extraction.md` (Parsing Resilience + Configuration) and `.env.example` updated.

## Tests
- `AC13.15.1` (`ai/test_ai_streaming.py`): seed appears in the request payload when provided, and is absent when not.
- `AC13.15.2-3` (`extraction/test_seed_determinism.py`): extraction forwards the configured seed and keeps `temperature=0` / `do_sample=False`.
- Extraction + AI suites pass (592 tests). Two `tests/infra/test_config_contract.py` and one `test_fallback_models_format` failure on my machine are **env-driven** (local `.env` points `PRIMARY_MODEL`/`FALLBACK_MODELS` at non-`glm` models) and pre-exist this change; they pass under CI's `glm-*` env.

## Follow-up (out of scope)
- **#989 Step B** (balance-aware re-extract / self-consistency retry when the running-balance chain fails before routing to `uploaded`) is the larger second step and is intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)