### PR TITLE
[finance_report_test_and_doc] docs(ssot): opening-balance semantics (#949) + balance_after dedup sync

### DIFF
--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -73,9 +73,14 @@ write path and no dual-write flag.
 - Status tracking: `uploaded` → `processing` → `completed`
 
 **DWD: Atomic Data (`AtomicTransaction`, `AtomicPosition`)**
-- Deduplicated via SHA256 hash of core fields. For transactions the hash includes
-  the statement running balance (`balance_after`), so two real but otherwise
-  identical transactions stay distinct while genuine duplicate extractions collapse.
+- Deduplicated via SHA256 hash of core fields
+  (`SHA256(user_id|date|amount|direction|description|reference|disambiguator)`).
+  The disambiguator is the persisted statement running balance (`balance_after`)
+  when the model supplies it, else a per-occurrence `#occurrence_index` fallback
+  (`DeduplicationService.calculate_transaction_hash`). Either way two real but
+  otherwise-identical transactions stay distinct, while a genuine duplicate
+  extraction of the same row collapses onto the existing record. `balance_after`
+  is persisted on the row so the hash is reproducible on re-import.
 - Per-transaction fields (`txn_date`, `amount`, `direction`, `description`,
   `reference`, `currency`, `balance_after`) live on `AtomicTransaction`. Atomic
   rows are source-pure: they carry no per-transaction status, confidence, or

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -117,6 +117,45 @@ Total Assets =
   + Net Worth Adjustment Gain/Loss
 ```
 
+#### 2.1.1 Opening Balances (Year-Start Positions)
+
+A balance sheet built only from imported statement activity is incomplete: an
+everyday user who starts tracking mid-life has real assets and liabilities that
+predate their first uploaded statement. The **guided opening-balance flow**
+([#949](https://github.com/wangzitian0/finance_report/issues/949), AC2.15.x)
+establishes those starting positions so the as-of balance sheet is not silently
+understated.
+
+Semantics (the contract the balance sheet relies on):
+
+- **One balanced entry.** `POST /api/accounts/opening-balances` posts a single
+  journal entry that increases each supplied account to its opening balance on
+  its normal side (assets/expenses debited, liabilities/equity/income credited).
+  The net is offset into a **system Opening Balance Equity account** so the entry
+  balances and the accounting equation holds (AC2.15.1, AC2.15.2). Opening Balance
+  Equity surfaces inside the balance sheet's `EQUITY` section, not as an asset or
+  liability.
+- **A starting position, not a delta.** An opening balance is rejected when an
+  affected account already has posted activity *before* the opening date, so the
+  posted amount can never stack on top of an existing balance (AC2.15.4). It
+  establishes where the account *was*, then statement imports take over.
+- **Base currency only.** Opening balances are accepted only in the report base
+  currency, with a clear error instead of a confusing downstream FX-rate failure
+  (AC2.15.5); a referenced account whose currency differs from the request is
+  rejected so journal lines cannot be mis-stamped (AC2.15.6).
+- **User-managed accounts only.** Even though the entry is SYSTEM-typed (it
+  touches the system equity account), the request may only target user-managed
+  accounts — a system account such as Processing cannot be seeded this way
+  (AC2.15.3, AC2.15.7).
+
+Because opening balances are ordinary posted journal entries, every downstream
+report (net-worth time-series, cash-flow opening position) reads them through the
+same ledger path — there is no separate "opening balance" report code path.
+
+> Mechanics of the posting (account resolution, equity offset) are owned by
+> [`accounting.md`](accounting.md); this section owns only how the resulting
+> positions present in the balance sheet.
+
 ### 2.2 Income Statement (Profit & Loss)
 
 Shows income and expenses over a period.


### PR DESCRIPTION
## What

Resolves **#997 fix-order item 3 (SSOT docs)** for the two parts owned by the test_and_doc lane. Doc-only.

### 1. `reporting.md` §2.1.1 — Opening Balances (Year-Start Positions) — item 3(b)

The SSOT described **no** balance-sheet opening-balance semantics, so a user who starts tracking mid-life had a silently understated balance sheet. This documents the guided opening-balance contract shipped in #949 (#985):

- One balanced journal entry increases each account to its opening balance on its normal side, offsetting the net into a **system Opening Balance Equity** account (AC2.15.1–AC2.15.2).
- A **starting position, not a delta** — rejected when an account already has activity before the opening date (AC2.15.4).
- **Base currency only** (AC2.15.5–AC2.15.6); **user-managed accounts only** (AC2.15.3, AC2.15.7).

Posting mechanics stay owned by `accounting.md`; this section owns only how the positions present in the balance sheet (cross-linked, no ownership drift).

### 2. `extraction.md` — `balance_after` dedup sync — item 3(c)

The dedup-hash description named only `balance_after`. Synced it with the shipped persistence: the disambiguator is the running `balance_after` when present, **else a per-occurrence `#occurrence_index` fallback** (`DeduplicationService.calculate_transaction_hash`, see `models/layer2.py`).

## Verification

- `tools/lint_doc_consistency.py` → exit 0
- `tools/check_ssot_ownership.py` → exit 0
- `tools/check_manifest.py` → exit 0

Part of #997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)