### PR TITLE
[finance_report_hacker] fix(extraction): persist failed-parse document lineage (#982)

### DIFF
--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 import structlog
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.logger import get_logger
@@ -138,6 +139,22 @@ async def import_brokerage_payload_if_present(
         await db.commit()
 
 
+def _mark_document_failed_unless_completed(document: UploadedDocument) -> None:
+    """Mark a document failed, but never downgrade one a successful parse already completed."""
+    if document.status != DocumentStatus.COMPLETED:
+        document.status = DocumentStatus.FAILED
+
+
+async def _find_document_by_hash(db: AsyncSession, user_id: UUID, file_hash: str) -> UploadedDocument | None:
+    return (
+        await db.execute(
+            select(UploadedDocument)
+            .where(UploadedDocument.user_id == user_id)
+            .where(UploadedDocument.file_hash == file_hash)
+        )
+    ).scalar_one_or_none()
+
+
 async def _ensure_failed_document_lineage(
     db: AsyncSession,
     statement: StatementSummary,
@@ -154,17 +171,12 @@ async def _ensure_failed_document_lineage(
     (#982). The document type is unknown for a failed parse, so it defaults to ``bank_statement``;
     a later successful reparse reconciles the same ``(user_id, file_hash)`` row via dual-write.
     """
-    existing = (
-        await db.execute(
-            select(UploadedDocument)
-            .where(UploadedDocument.user_id == statement.user_id)
-            .where(UploadedDocument.file_hash == file_hash)
-        )
-    ).scalar_one_or_none()
+    existing = await _find_document_by_hash(db, statement.user_id, file_hash)
     if existing is not None:
-        existing.status = DocumentStatus.FAILED
+        _mark_document_failed_unless_completed(existing)
         statement.uploaded_document_id = existing.id
         return
+
     document = UploadedDocument(
         user_id=statement.user_id,
         file_path=storage_key,
@@ -173,8 +185,18 @@ async def _ensure_failed_document_lineage(
         document_type=DocumentType.BANK_STATEMENT,
         status=DocumentStatus.FAILED,
     )
-    db.add(document)
-    await db.flush()
+    try:
+        # Insert inside a savepoint so losing the unique-key race does not poison the outer
+        # transaction (which still needs to commit the statement rejection).
+        async with db.begin_nested():
+            db.add(document)
+            await db.flush()
+    except IntegrityError:
+        raced = await _find_document_by_hash(db, statement.user_id, file_hash)
+        if raced is not None:
+            _mark_document_failed_unless_completed(raced)
+            statement.uploaded_document_id = raced.id
+        return
     statement.uploaded_document_id = document.id
 
 

--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -8,10 +8,12 @@ from uuid import UUID, uuid4
 
 import structlog
 from fastapi.concurrency import run_in_threadpool
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.logger import get_logger
 from src.models import BankStatementStatus
+from src.models.layer1 import DocumentStatus, DocumentType, UploadedDocument
 from src.models.statement_summary import StatementSummary
 from src.services import ExtractionError, ExtractionService, StorageError, StorageService
 from src.services.brokerage_positions import BrokeragePositionImportService, looks_like_brokerage_payload
@@ -136,6 +138,46 @@ async def import_brokerage_payload_if_present(
         await db.commit()
 
 
+async def _ensure_failed_document_lineage(
+    db: AsyncSession,
+    statement: StatementSummary,
+    *,
+    file_hash: str,
+    storage_key: str,
+    original_filename: str,
+) -> None:
+    """Persist an ODS ``UploadedDocument`` (status ``failed``) for a parse that never reached
+    ``dual_write_layer2`` (which is the normal create path on success).
+
+    Without this, a hard parse failure leaves no document row, so the uploaded raw file — the
+    thing a human most needs to inspect for a failed parse — is unreachable from the statement
+    (#982). The document type is unknown for a failed parse, so it defaults to ``bank_statement``;
+    a later successful reparse reconciles the same ``(user_id, file_hash)`` row via dual-write.
+    """
+    existing = (
+        await db.execute(
+            select(UploadedDocument)
+            .where(UploadedDocument.user_id == statement.user_id)
+            .where(UploadedDocument.file_hash == file_hash)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        existing.status = DocumentStatus.FAILED
+        statement.uploaded_document_id = existing.id
+        return
+    document = UploadedDocument(
+        user_id=statement.user_id,
+        file_path=storage_key,
+        file_hash=file_hash,
+        original_filename=original_filename,
+        document_type=DocumentType.BANK_STATEMENT,
+        status=DocumentStatus.FAILED,
+    )
+    db.add(document)
+    await db.flush()
+    statement.uploaded_document_id = document.id
+
+
 async def handle_parse_failure(
     statement: StatementSummary,
     db: AsyncSession,
@@ -146,6 +188,9 @@ async def handle_parse_failure(
     model_to_use: str | None = None,
     error_type: str | None = None,
     request_id: str | None = None,
+    file_hash: str | None = None,
+    storage_key: str | None = None,
+    original_filename: str | None = None,
 ) -> None:
     """Handle parse failure by marking statement as REJECTED.
 
@@ -182,6 +227,14 @@ async def handle_parse_failure(
         refreshed.validation_error = message[:500] if message else message
         refreshed.confidence_score = 0
         refreshed.balance_validated = False
+        if file_hash and storage_key:
+            await _ensure_failed_document_lineage(
+                db,
+                refreshed,
+                file_hash=file_hash,
+                storage_key=storage_key,
+                original_filename=original_filename or file_hash,
+            )
         await db.commit()
         logger.error(
             "statement.parse.failed",
@@ -223,6 +276,9 @@ async def _handle_parse_failure(
     model_to_use: str | None,
     error_type: str | None,
     request_id: str,
+    file_hash: str | None = None,
+    storage_key: str | None = None,
+    original_filename: str | None = None,
 ) -> None:
     await handle_parse_failure(
         statement,
@@ -235,6 +291,9 @@ async def _handle_parse_failure(
                 "model_to_use": model_to_use,
                 "error_type": error_type,
                 "request_id": request_id,
+                "file_hash": file_hash,
+                "storage_key": storage_key,
+                "original_filename": original_filename,
             }
         ),
     )
@@ -375,6 +434,9 @@ async def parse_statement_background(
                 model_to_use=model_to_use,
                 error_type=type(exc).__name__,
                 request_id=request_id,
+                file_hash=file_hash,
+                storage_key=storage_key,
+                original_filename=filename,
             )
             return
         except Exception as exc:
@@ -395,6 +457,9 @@ async def parse_statement_background(
                 model_to_use=model_to_use,
                 error_type=type(exc).__name__,
                 request_id=request_id,
+                file_hash=file_hash,
+                storage_key=storage_key,
+                original_filename=filename,
             )
             return
 
@@ -449,4 +514,7 @@ async def parse_statement_background(
                 model_to_use=model_to_use,
                 error_type=type(exc).__name__,
                 request_id=request_id,
+                file_hash=file_hash,
+                storage_key=storage_key,
+                original_filename=filename,
             )

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -6,17 +6,53 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
+from src.models.layer1 import DocumentStatus, UploadedDocument
 from src.models.statement_enums import BankStatementStatus
+from src.models.statement_summary import StatementSummary
 from src.services.deduplication import dual_write_layer2
 from src.services.extraction import ExtractionError, ExtractionService
+from src.services.statement_parsing import handle_parse_failure
 from tests.factories import StatementSummaryFactory
 
 
 async def mock_stream_generator(content: str):
     """Helper to create async generator for streaming mock."""
     yield content
+
+
+async def test_handle_parse_failure_persists_failed_document_lineage(db, test_user):
+    """AC16.22.10: a hard parse failure persists an UploadedDocument(failed) so the uploaded raw
+    file stays traceable from the rejected statement (#982). The document is normally created on
+    success in dual_write; a failure happens before that, so without this the raw file is orphaned.
+    """
+    statement = await StatementSummaryFactory.create_async(db, user_id=test_user.id, status=BankStatementStatus.PARSING)
+    await db.commit()
+
+    await handle_parse_failure(
+        statement,
+        db,
+        message="All 1 models failed. Breakdown: 1 json_parse.",
+        file_hash=statement.file_hash,
+        storage_key=f"statements/{statement.id}/abc123.pdf",
+        original_filename="futu-2506.pdf",
+    )
+
+    doc = (
+        await db.execute(
+            select(UploadedDocument)
+            .where(UploadedDocument.user_id == test_user.id)
+            .where(UploadedDocument.file_hash == statement.file_hash)
+        )
+    ).scalar_one()
+    assert doc.status == DocumentStatus.FAILED
+    assert doc.original_filename == "futu-2506.pdf"
+
+    refreshed = await db.get(StatementSummary, statement.id)
+    assert refreshed.status == BankStatementStatus.REJECTED
+    assert refreshed.uploaded_document_id == doc.id
 
 
 async def test_parse_document_csv_no_content():

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -49,6 +49,8 @@ async def test_handle_parse_failure_persists_failed_document_lineage(db, test_us
     ).scalar_one()
     assert doc.status == DocumentStatus.FAILED
     assert doc.original_filename == "futu-2506.pdf"
+    # The raw file must stay retrievable: the document points at the storage key we uploaded to.
+    assert doc.file_path == f"statements/{statement.id}/abc123.pdf"
 
     refreshed = await db.get(StatementSummary, statement.id)
     assert refreshed.status == BankStatementStatus.REJECTED

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -440,6 +440,7 @@ balance validation, visual diff, keyboard shortcuts, and CSV export.
 | AC16.22.7 | Stage 1 approval tolerance and extraction/reconciliation scoring tolerance remain separate documented policies | `test_ac16_22_7_tolerance_policy_constants_are_intentional` | `review/test_tolerance_policy.py` | P0 |
 | AC16.22.8 | A statement routed to `parsed`/review carries `stage1_status = pending_review` explicitly (never NULL) | `test_parsed_statement_sets_stage1_pending_review` | `extraction/test_extraction_flow.py` | P1 |
 | AC16.22.9 | `UploadedDocument.status` advances to `completed` once a successful parse is persisted (no longer stuck at `uploaded`) | `test_dual_write_marks_document_completed` | `extraction/test_dual_write_layer2.py` | P1 |
+| AC16.22.10 | A hard parse failure persists an `UploadedDocument` (status `failed`) so the uploaded raw file stays traceable from the rejected statement | `test_handle_parse_failure_persists_failed_document_lineage` | `extraction/test_extraction_error_paths.py` | P1 |
 
 ### AC16.25 — Mobile Review UX Hardening
 


### PR DESCRIPTION
Resolves the backend half of #982. Next item off the #994 (hacker) ROI list.

## Problem
A hard parse failure marked the statement `rejected` but created **no `UploadedDocument`**. The ODS document is created in `dual_write_layer2`, which only runs on a **successful** parse — so a failure (e.g. `All 1 models failed: json_parse`) left the uploaded raw file orphaned and unreachable from the statement, exactly when a human most needs to inspect it. Confirmed on staging (#982: `3754dc50` rejected with `uploaded_document_id = NULL`).

## Change
In `handle_parse_failure`, persist an `UploadedDocument(status=failed)` using the `storage_key` / `file_hash` / `filename` already passed into the parse background task, and link it to the rejected statement. Get-or-create by `(user_id, file_hash)` so a reparse failure reuses the row; `document_type` defaults to `bank_statement` (unknown for a failed parse) and a later successful reparse reconciles it via dual-write.

## Test (EPIC-016 AC16.22.10)
`test_handle_parse_failure_persists_failed_document_lineage`: a failed parse yields an `UploadedDocument(failed)` linked to the now-`rejected` statement. Verified locally: extraction error-paths + dual-write + statements-router = 112 passed; ruff clean; AC16.22.10 traceable. (The one unrelated local failure is `ModuleNotFoundError: fitz` — PyMuPDF, CI-only — which fails on `main` too.)

## Out of scope
The **no-fallback-model / JSON-repair-retry** half of #982 is an AI/OCR concern owned by the vision lane (#996).

🤖 Generated with [Claude Code](https://claude.com/claude-code)