### PR TITLE
[finance_report_hacker] feat(review): Stage-1 conflict acknowledgement endpoint (#962 slice 2)

### DIFF
--- a/apps/backend/migrations/versions/0039_conflicts_acknowledged.py
+++ b/apps/backend/migrations/versions/0039_conflicts_acknowledged.py
@@ -1,0 +1,33 @@
+"""statement conflicts acknowledged
+
+Add ``statement_summaries.conflicts_acknowledged_at`` so a Stage-1 reviewer can
+confirm that the surfaced duplicate / transfer-pair candidates are intentional,
+letting approval proceed instead of being permanently blocked (#962). NULL means
+unacknowledged, which preserves the existing blocking behavior for every row.
+
+Migration risk: low (additive nullable timestamp column, no backfill).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0039_conflicts_acknowledged"
+down_revision = "a14bb9204a08"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "statement_summaries",
+        sa.Column(
+            "conflicts_acknowledged_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="When a reviewer confirmed the duplicate/transfer-pair candidates are intentional (#962)",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("statement_summaries", "conflicts_acknowledged_at")

--- a/apps/backend/src/models/statement_summary.py
+++ b/apps/backend/src/models/statement_summary.py
@@ -122,4 +122,7 @@ class StatementSummary(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     validation_error: Mapped[str | None] = mapped_column(Text, nullable=True)
     balance_validation_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
     stage1_reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Set when a reviewer confirms the surfaced duplicate / transfer-pair candidates are
+    # intentional, so Stage-1 approval no longer blocks on them (#962). NULL = unacknowledged.
+    conflicts_acknowledged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     extraction_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)

--- a/apps/backend/src/routers/review.py
+++ b/apps/backend/src/routers/review.py
@@ -1,5 +1,6 @@
 """Stage 2 review endpoints for bank statement reconciliation."""
 
+from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
@@ -41,33 +42,23 @@ router = APIRouter(prefix="/statements", tags=["review"])
 conflicts_router = APIRouter(prefix="/review", tags=["review"])
 
 
-@conflicts_router.get("/conflicts/{statement_id}", response_model=ReviewConflictsResponse)
-async def get_review_conflicts(
-    statement_id: UUID,
-    db: DbSession,
-    user_id: CurrentUserId,
-) -> ReviewConflictsResponse:
-    """Return duplicate and transfer-pair candidates for a statement."""
-    statement_result = await db.execute(
-        select(StatementSummary).where(StatementSummary.id == statement_id).where(StatementSummary.user_id == user_id)
+def _conflict_candidate(txn: AtomicTransaction) -> ReviewConflictCandidate:
+    return ReviewConflictCandidate(
+        id=txn.id,
+        txn_date=txn.txn_date,
+        description=txn.description,
+        amount=txn.amount,
+        direction=txn.direction.value if hasattr(txn.direction, "value") else str(txn.direction),
     )
-    statement = statement_result.scalar_one_or_none()
-    if not statement:
-        raise_not_found("Statement")
 
-    transactions = await resolve_statement_transactions(db, statement)
 
-    def _candidate(txn: AtomicTransaction) -> ReviewConflictCandidate:
-        return ReviewConflictCandidate(
-            id=txn.id,
-            txn_date=txn.txn_date,
-            description=txn.description,
-            amount=txn.amount,
-            direction=txn.direction.value if hasattr(txn.direction, "value") else str(txn.direction),
-        )
-
+def _detect_conflicts(
+    transactions: list[AtomicTransaction],
+) -> tuple[list[ReviewConflictCandidate], list[ReviewConflictCandidate]]:
+    """Surface duplicate and transfer-pair candidates, consistent with the approval guard."""
     duplicates: list[ReviewConflictCandidate] = []
     transfer_pairs: list[ReviewConflictCandidate] = []
+
     seen: dict[tuple, AtomicTransaction] = {}
     for txn in transactions:
         # Keep duplicate detection consistent with the approval guard / dedup disambiguator:
@@ -75,7 +66,7 @@ async def get_review_conflicts(
         balance_key = None if txn.balance_after is None else txn.balance_after.normalize()
         key = (txn.txn_date, txn.description.casefold(), txn.amount.copy_abs(), txn.direction, balance_key)
         if key in seen:
-            duplicates.extend([_candidate(seen[key]), _candidate(txn)])
+            duplicates.extend([_conflict_candidate(seen[key]), _conflict_candidate(txn)])
         else:
             seen[key] = txn
 
@@ -84,11 +75,62 @@ async def get_review_conflicts(
         key = (txn.txn_date, txn.amount.copy_abs())
         paired = by_abs_amount.get(key)
         if paired and paired.direction != txn.direction:
-            transfer_pairs.extend([_candidate(paired), _candidate(txn)])
+            transfer_pairs.extend([_conflict_candidate(paired), _conflict_candidate(txn)])
         else:
             by_abs_amount[key] = txn
 
-    return ReviewConflictsResponse(duplicates=duplicates, transfer_pairs=transfer_pairs)
+    return duplicates, transfer_pairs
+
+
+async def _load_statement_or_404(db: DbSession, statement_id: UUID, user_id: UUID) -> StatementSummary:
+    statement = (
+        await db.execute(
+            select(StatementSummary)
+            .where(StatementSummary.id == statement_id)
+            .where(StatementSummary.user_id == user_id)
+        )
+    ).scalar_one_or_none()
+    if not statement:
+        raise_not_found("Statement")
+    return statement
+
+
+@conflicts_router.get("/conflicts/{statement_id}", response_model=ReviewConflictsResponse)
+async def get_review_conflicts(
+    statement_id: UUID,
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> ReviewConflictsResponse:
+    """Return duplicate and transfer-pair candidates for a statement."""
+    statement = await _load_statement_or_404(db, statement_id, user_id)
+    transactions = await resolve_statement_transactions(db, statement)
+    duplicates, transfer_pairs = _detect_conflicts(transactions)
+    return ReviewConflictsResponse(
+        duplicates=duplicates,
+        transfer_pairs=transfer_pairs,
+        acknowledged_at=statement.conflicts_acknowledged_at,
+    )
+
+
+@conflicts_router.post("/conflicts/{statement_id}/acknowledge", response_model=ReviewConflictsResponse)
+async def acknowledge_review_conflicts(
+    statement_id: UUID,
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> ReviewConflictsResponse:
+    """Confirm the surfaced duplicate/transfer-pair candidates are intentional so Stage-1
+    approval no longer blocks on them (#962). Idempotent: the timestamp is refreshed each call.
+    """
+    statement = await _load_statement_or_404(db, statement_id, user_id)
+    statement.conflicts_acknowledged_at = datetime.now(UTC)
+    await db.commit()
+    transactions = await resolve_statement_transactions(db, statement)
+    duplicates, transfer_pairs = _detect_conflicts(transactions)
+    return ReviewConflictsResponse(
+        duplicates=duplicates,
+        transfer_pairs=transfer_pairs,
+        acknowledged_at=statement.conflicts_acknowledged_at,
+    )
 
 
 @router.get("/stage2/queue", response_model=Stage2ReviewQueueResponse)

--- a/apps/backend/src/schemas/review.py
+++ b/apps/backend/src/schemas/review.py
@@ -154,3 +154,4 @@ class ReviewConflictsResponse(BaseModel):
 
     duplicates: list[ReviewConflictCandidate] = Field(default_factory=list)
     transfer_pairs: list[ReviewConflictCandidate] = Field(default_factory=list)
+    acknowledged_at: datetime | None = None

--- a/apps/backend/src/services/statement_validation.py
+++ b/apps/backend/src/services/statement_validation.py
@@ -239,7 +239,10 @@ async def approve_statement(
     transactions = await resolve_statement_transactions(db, statement)
 
     _raise_if_balance_chain_invalid(validation_result)
-    _raise_if_statement_conflicts_unresolved(transactions)
+    # A reviewer can acknowledge that the surfaced duplicate / transfer-pair candidates are
+    # intentional (#962); once acknowledged, approval no longer blocks on them.
+    if statement.conflicts_acknowledged_at is None:
+        _raise_if_statement_conflicts_unresolved(transactions)
 
     statement.stage1_status = Stage1Status.APPROVED
     statement.stage1_reviewed_at = datetime.now(UTC)

--- a/apps/backend/tests/review/test_review_conflicts_router.py
+++ b/apps/backend/tests/review/test_review_conflicts_router.py
@@ -111,3 +111,74 @@ async def test_review_conflicts_returns_404_for_missing_statement(client: AsyncC
     response = await client.get("/review/conflicts/00000000-0000-0000-0000-000000000000")
 
     assert response.status_code == 404
+
+
+async def test_acknowledge_conflicts_records_and_surfaces_acknowledged_at(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+):
+    """AC16.22.11: POST /review/conflicts/{id}/acknowledge records the acknowledgement so the
+    candidates no longer block Stage-1 approval; GET reflects acknowledged_at (#962)."""
+    account = Account(user_id=test_user.id, name=f"Ack {uuid4()}", type=AccountType.ASSET, currency="SGD")
+    doc = UploadedDocument(
+        id=uuid4(),
+        user_id=test_user.id,
+        file_path="/tmp/ack.pdf",
+        file_hash=f"ack-{uuid4().hex}",
+        original_filename="ack.pdf",
+        document_type=DocumentType.BANK_STATEMENT,
+    )
+    db.add_all([account, doc])
+    await db.flush()
+
+    statement = StatementSummary(
+        id=uuid4(),
+        user_id=test_user.id,
+        uploaded_document_id=doc.id,
+        file_hash=doc.file_hash,
+        account_id=account.id,
+        institution="DBS",
+        currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 31),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("0.00"),
+        status=BankStatementStatus.PARSED,
+    )
+    db.add(statement)
+    await db.flush()
+    for _ in range(2):
+        db.add(
+            AtomicTransaction(
+                id=uuid4(),
+                user_id=test_user.id,
+                txn_date=date(2026, 5, 1),
+                description="Coffee",
+                amount=Decimal("4.20"),
+                direction=TransactionDirection.OUT,
+                currency="SGD",
+                dedup_hash=uuid4().hex + uuid4().hex,
+                source_documents=[{"doc_id": str(doc.id), "doc_type": DocumentType.BANK_STATEMENT.value}],
+            )
+        )
+    await db.commit()
+
+    before = await client.get(f"/review/conflicts/{statement.id}")
+    assert before.status_code == 200
+    assert before.json()["acknowledged_at"] is None
+    assert len(before.json()["duplicates"]) == 2
+
+    ack = await client.post(f"/review/conflicts/{statement.id}/acknowledge")
+    assert ack.status_code == 200
+    assert ack.json()["acknowledged_at"] is not None
+    assert len(ack.json()["duplicates"]) == 2  # still surfaced, just acknowledged
+
+    after = await client.get(f"/review/conflicts/{statement.id}")
+    assert after.json()["acknowledged_at"] is not None
+
+
+async def test_acknowledge_conflicts_returns_404_for_missing_statement(client: AsyncClient):
+    """AC16.22.11: acknowledge endpoint is user-scoped and 404s for an unknown statement."""
+    response = await client.post("/review/conflicts/00000000-0000-0000-0000-000000000000/acknowledge")
+    assert response.status_code == 404

--- a/apps/backend/tests/review/test_statement_validation.py
+++ b/apps/backend/tests/review/test_statement_validation.py
@@ -1,6 +1,6 @@
 """Stage 1 statement validation transition tests (DWD conform model)."""
 
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from uuid import uuid4
 
@@ -669,3 +669,30 @@ class TestEditAndApproveSelectiveFields:
                 user_id,
                 [{"txn_id": str(txn.id), "txn_date": date(2024, 1, 9), "reference": "R-9"}],
             )
+
+
+async def test_approve_with_acknowledged_conflicts_succeeds(db, user_id):
+    """AC16.22.11: acknowledging the surfaced conflict candidates lets approve_statement proceed
+    past the duplicate/transfer-pair guard, while an unacknowledged statement stays blocked (#962).
+    """
+    stmt = await _make_statement(
+        db,
+        user_id,
+        file_hash="ack-conflict-hash",
+        opening_balance=Decimal("1000.00"),
+        closing_balance=Decimal("1200.00"),
+    )
+    # Two identical deposits (no running balance) are flagged as a duplicate candidate.
+    await _add_txn(db, stmt, amount=Decimal("100.00"), direction=TransactionDirection.IN, description="Deposit")
+    await _add_txn(db, stmt, amount=Decimal("100.00"), direction=TransactionDirection.IN, description="Deposit")
+
+    # Unacknowledged: approval is blocked by the conflict guard.
+    with pytest.raises(ValueError, match="duplicate or transfer-pair"):
+        await approve_statement(db, stmt.id, user_id)
+
+    # Acknowledge, then approval proceeds.
+    stmt.conflicts_acknowledged_at = datetime.now(UTC)
+    await db.flush()
+    approved = await approve_statement(db, stmt.id, user_id)
+    assert approved.status == BankStatementStatus.APPROVED
+    assert approved.stage1_status == Stage1Status.APPROVED

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -440,6 +440,7 @@ balance validation, visual diff, keyboard shortcuts, and CSV export.
 | AC16.22.7 | Stage 1 approval tolerance and extraction/reconciliation scoring tolerance remain separate documented policies | `test_ac16_22_7_tolerance_policy_constants_are_intentional` | `review/test_tolerance_policy.py` | P0 |
 | AC16.22.8 | A statement routed to `parsed`/review carries `stage1_status = pending_review` explicitly (never NULL) | `test_parsed_statement_sets_stage1_pending_review` | `extraction/test_extraction_flow.py` | P1 |
 | AC16.22.9 | `UploadedDocument.status` advances to `completed` once a successful parse is persisted (no longer stuck at `uploaded`) | `test_dual_write_marks_document_completed` | `extraction/test_dual_write_layer2.py` | P1 |
+| AC16.22.11 | A reviewer can acknowledge the surfaced duplicate/transfer-pair candidates (`POST /review/conflicts/{id}/acknowledge`); once acknowledged, Stage-1 approval no longer blocks on them | `test_acknowledge_conflicts_records_and_surfaces_acknowledged_at`; `test_approve_with_acknowledged_conflicts_succeeds` | `review/test_review_conflicts_router.py`; `review/test_statement_validation.py` | P1 |
 
 ### AC16.25 — Mobile Review UX Hardening
 


### PR DESCRIPTION
Slice 2 of #962. Next item off the #994 (hacker) ROI list.

## Problem
A statement with a duplicate / transfer-pair candidate is permanently blocked at Stage-1 approval (`_raise_if_statement_conflicts_unresolved`), and there was **no backend way to resolve it** — the `/review/conflicts` endpoint only *detected* candidates. So genuinely-distinct-but-identical transactions (e.g. two real NIO buys with no per-line running balance) get stuck with no escape.

## Change
- `StatementSummary.conflicts_acknowledged_at` (migration `0039`, additive nullable — `NULL` preserves the existing blocking behavior for every row).
- **`POST /review/conflicts/{id}/acknowledge`** records the acknowledgement (user-scoped, idempotent) and returns the candidates + `acknowledged_at`. `GET /review/conflicts` now also surfaces `acknowledged_at`.
- `approve_statement` skips the duplicate/transfer-pair guard once acknowledged, so a reviewer can confirm the candidates are intentional and proceed.

## Tests (EPIC-016 AC16.22.11)
- `test_acknowledge_conflicts_records_and_surfaces_acknowledged_at` — endpoint sets + surfaces the flag.
- `test_approve_with_acknowledged_conflicts_succeeds` — unacknowledged blocks, acknowledged proceeds.
- Verified: review + statements-router suites (137 passed), migrations + schema-drift + migration-risk contract green, ruff clean, AC16.22.11 traceable.

## Out of scope (slice 3, UI lane)
Wiring the dead `Resolve` / `Link Pair` buttons in `ConflictResolutionDialog.tsx` to this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)