### PR TITLE
[finance_report_test_and_doc] feat(maintenance): test-account purge library + tests (#997 item 4, AC8.17)

### DIFF
--- a/apps/backend/src/services/test_account_purge.py
+++ b/apps/backend/src/services/test_account_purge.py
@@ -18,9 +18,11 @@ Design constraints that shape this module:
   either fully removed or, on any error, fully rolled back and reported — never
   left half-deleted. Safety therefore does not depend on perfect delete ordering.
 - **Explicit ordered deletes, not user-FK cascade.** We delete each owned table
-  by ``user_id`` in reverse-dependency order rather than relying on
-  ``ON DELETE CASCADE`` from ``users`` (which is intentionally absent in the test
-  schema), so the same code path is exercised in tests and production.
+  by ``user_id`` in reverse-dependency order rather than relying on the
+  ``ON DELETE CASCADE`` that ``UserOwnedMixin`` puts on ``user_id``. That cascade
+  exists in the production schema but is stripped from the test schema (conftest's
+  ``_strip_user_fks``), so deleting explicitly keeps one code path exercised in
+  both — and makes the purge robust even where the cascade is missing.
 
 The dry-run path executes the deletes inside the savepoint and then rolls back,
 so a dry run reports exactly which accounts *would* be purged and which are

--- a/apps/backend/src/services/test_account_purge.py
+++ b/apps/backend/src/services/test_account_purge.py
@@ -1,0 +1,178 @@
+"""Purge throwaway test/QA accounts and all the data they own (#997 item 4).
+
+E2E and QA runs leave behind disposable accounts (``qa.*@example.com``,
+``e2e-*@test.example.com``, ...) on shared/staging databases. This module finds
+those accounts and removes them together with every row they own.
+
+Design constraints that shape this module:
+
+- **There is no admin delete API.** ``DELETE /api/users/{id}`` is self-scoped
+  (a user may only delete their own account), so bulk cleanup has to run against
+  the database directly.
+- **The ledger is immutable.** A DB trigger rejects deletion of ``posted`` /
+  ``reconciled`` / ``void`` journal entries (see ``models/journal.py`` and #988).
+  We do NOT try to defeat that guard — an account that still owns immutable
+  ledger entries is reported as *blocked* and left untouched, mirroring the
+  409 the API returns ("void those entries first").
+- **Atomic per account.** Each account is purged inside its own SAVEPOINT. It is
+  either fully removed or, on any error, fully rolled back and reported — never
+  left half-deleted. Safety therefore does not depend on perfect delete ordering.
+- **Explicit ordered deletes, not user-FK cascade.** We delete each owned table
+  by ``user_id`` in reverse-dependency order rather than relying on
+  ``ON DELETE CASCADE`` from ``users`` (which is intentionally absent in the test
+  schema), so the same code path is exercised in tests and production.
+
+The dry-run path executes the deletes inside the savepoint and then rolls back,
+so a dry run reports exactly which accounts *would* be purged and which are
+blocked — without persisting anything.
+
+Transaction boundary: this service never calls ``commit()`` (see EPIC-012
+AC12.26.1). In ``apply`` mode the successful deletes are released into the outer
+transaction via per-account savepoints; the **caller** owns the final commit. In
+dry-run mode every savepoint is rolled back, so the caller has nothing to commit.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from uuid import UUID
+
+from sqlalchemy import Table, delete, select
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.database import Base
+from src.logger import get_logger
+from src.models import User
+
+logger = get_logger(__name__)
+
+# Default predicate for "this is a disposable test account". Intentionally narrow:
+# it matches the qa/e2e/load-test prefixes used by the suites on the example.com
+# and test.example.com domains, not every address that merely ends in example.com
+# (real fixtures sometimes use plain user@example.com locally). Override via the
+# CLI when a one-off pattern is needed.
+DEFAULT_TEST_EMAIL_PATTERN = r"^(qa[._].*|e2e[-_].*|load-test[-_].*)@(test\.)?example\.com$"
+
+# Environments where applying the purge is allowed. Production (or anything not on
+# this list) must be refused unless the operator passes an explicit override, so a
+# misconfigured ENVIRONMENT can never silently delete real accounts.
+SAFE_PURGE_ENVIRONMENTS = frozenset({"development", "dev", "local", "test", "testing", "ci", "staging"})
+
+
+def is_safe_purge_environment(environment: str | None) -> bool:
+    """True when ``--apply`` is allowed without an explicit override."""
+    return (environment or "").strip().lower() in SAFE_PURGE_ENVIRONMENTS
+
+
+@dataclass
+class PurgeReport:
+    """Outcome of a purge run."""
+
+    matched: list[str] = field(default_factory=list)
+    purged: list[str] = field(default_factory=list)
+    blocked: list[tuple[str, str]] = field(default_factory=list)
+    applied: bool = False
+
+    def summary(self) -> str:
+        verb = "Purged" if self.applied else "Would purge"
+        lines = [
+            f"Matched {len(self.matched)} test account(s); {verb} {len(self.purged)}, blocked {len(self.blocked)}."
+        ]
+        for email in self.purged:
+            lines.append(f"  {'-' if self.applied else '~'} {email}")
+        for email, reason in self.blocked:
+            lines.append(f"  ! {email} — blocked: {reason}")
+        return "\n".join(lines)
+
+
+class _DryRunRollback(Exception):
+    """Internal sentinel: unwinds a savepoint so a dry run persists nothing."""
+
+
+def _compiled(pattern: str) -> re.Pattern[str]:
+    return re.compile(pattern, re.IGNORECASE)
+
+
+def owned_tables_in_delete_order() -> list[Table]:
+    """User-owned tables (those carrying a ``user_id`` column), children first.
+
+    ``Base.metadata.sorted_tables`` is in dependency order (referenced tables
+    first); reversing it deletes the most-dependent tables first. Tables without
+    a ``user_id`` column (pure join/child tables such as ``journal_lines`` or
+    ``reconciliation_matches``) are omitted here: they are removed via their
+    intra-aggregate ``ON DELETE CASCADE`` when their user-owned parent row goes.
+    ``users`` itself is excluded — the caller deletes it last.
+    """
+    tables: list[Table] = []
+    for table in reversed(Base.metadata.sorted_tables):
+        if table.name == User.__tablename__:
+            continue
+        if "user_id" in table.c:
+            tables.append(table)
+    return tables
+
+
+async def select_test_user_ids(session: AsyncSession, pattern: str) -> list[tuple[UUID, str]]:
+    """Return ``(id, email)`` for every account whose email matches ``pattern``."""
+    matcher = _compiled(pattern)
+    result = await session.execute(select(User.id, User.email).order_by(User.email))
+    return [(row.id, row.email) for row in result if matcher.match(row.email or "")]
+
+
+def _block_reason(exc: Exception) -> str:
+    """Human-readable reason a single account could not be purged."""
+    cause = getattr(exc, "orig", None) or exc
+    text = str(cause).strip().splitlines()[0] if str(cause).strip() else exc.__class__.__name__
+    return text
+
+
+async def _purge_one(session: AsyncSession, user_id: UUID, tables: list[Table]) -> None:
+    """Delete every owned row for ``user_id`` then the user. No commit/rollback."""
+    for table in tables:
+        await session.execute(delete(table).where(table.c.user_id == user_id))
+    await session.execute(delete(User.__table__).where(User.__table__.c.id == user_id))
+
+
+async def purge_test_accounts(
+    session: AsyncSession,
+    *,
+    pattern: str = DEFAULT_TEST_EMAIL_PATTERN,
+    apply: bool = False,
+) -> PurgeReport:
+    """Find and purge disposable test accounts.
+
+    Each account is processed in its own SAVEPOINT: released into the outer
+    transaction when ``apply`` is true and the delete succeeds, rolled back
+    otherwise (dry run, or blocked by the ledger-immutability guard). The
+    function never leaves an account half-deleted and never commits — the caller
+    commits the outer transaction in ``apply`` mode.
+    """
+    report = PurgeReport(applied=apply)
+    users = await select_test_user_ids(session, pattern)
+    report.matched = [email for _, email in users]
+    if not users:
+        return report
+
+    tables = owned_tables_in_delete_order()
+    for user_id, email in users:
+        try:
+            async with session.begin_nested():
+                await _purge_one(session, user_id, tables)
+                if not apply:
+                    # Unwind the savepoint so a dry run leaves no trace, while
+                    # still proving the delete would have succeeded.
+                    raise _DryRunRollback
+        except _DryRunRollback:
+            report.purged.append(email)
+        except (IntegrityError, DBAPIError) as exc:
+            # The savepoint is already rolled back by the context manager.
+            reason = _block_reason(exc)
+            report.blocked.append((email, reason))
+            logger.warning("test-account purge blocked", email=email, reason=reason)
+        else:
+            report.purged.append(email)
+            logger.info("test-account purged", email=email)
+
+    return report

--- a/apps/backend/tests/services/test_test_account_purge.py
+++ b/apps/backend/tests/services/test_test_account_purge.py
@@ -1,0 +1,148 @@
+"""Tests for the test/QA account purge tooling (#997 item 4, EPIC-008 AC8.17).
+
+The purge must: select only disposable test accounts, remove an account and the
+rows it owns, refuse (report, don't force) an account still holding immutable
+ledger entries, and persist nothing on a dry run.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from sqlalchemy import func, select
+
+from src.models import Account, AtomicTransaction, User
+from src.models.layer2 import TransactionDirection
+from src.services.test_account_purge import (
+    DEFAULT_TEST_EMAIL_PATTERN,
+    is_safe_purge_environment,
+    owned_tables_in_delete_order,
+    purge_test_accounts,
+    select_test_user_ids,
+)
+from tests.factories import AccountFactory, JournalEntryFactory, UserFactory
+
+
+async def _make_user(db, email: str) -> User:
+    user = await UserFactory.create_async(db, email=email)
+    await db.commit()
+    return user
+
+
+async def _user_exists(db, user_id: UUID) -> bool:
+    db.expire_all()  # Core DELETEs bypass the ORM identity map; force a fresh read.
+    result = await db.execute(select(User.id).where(User.id == user_id))
+    return result.first() is not None
+
+
+async def _count(db, model, user_id: UUID) -> int:
+    db.expire_all()
+    result = await db.execute(select(func.count()).select_from(model).where(model.user_id == user_id))
+    return result.scalar_one()
+
+
+class TestTestAccountSelection:
+    """AC8.17.1: only disposable test accounts are selected."""
+
+    async def test_selection_matches_test_accounts_and_excludes_real_ones(self, db):
+        qa = await _make_user(db, "qa.alice@example.com")
+        e2e = await _make_user(db, "e2e-bob@test.example.com")
+        load = await _make_user(db, "load-test-carol@example.com")
+        real = await _make_user(db, "real.person@gmail.com")
+        plain = await _make_user(db, "founder@example.com")  # real local fixture, not qa/e2e
+
+        selected = await select_test_user_ids(db, DEFAULT_TEST_EMAIL_PATTERN)
+        emails = {email for _, email in selected}
+
+        assert {qa.email, e2e.email, load.email} <= emails
+        assert real.email not in emails
+        assert plain.email not in emails
+
+    def test_owned_tables_cover_core_user_data_and_exclude_users(self):
+        names = {t.name for t in owned_tables_in_delete_order()}
+        # Core user-owned tables must be in the purge set...
+        assert {"accounts", "journal_entries", "atomic_transactions", "uploaded_documents"} <= names
+        # ...and the users table is handled separately, never in this list.
+        assert "users" not in names
+
+    def test_environment_guard_allows_dev_staging_and_refuses_production(self):
+        """AC8.17.5: the --apply environment guard fences off production."""
+        for safe in ("development", "dev", "local", "staging", "ci", "TEST"):
+            assert is_safe_purge_environment(safe) is True
+        for unsafe in ("production", "prod", "prd", "", None):
+            assert is_safe_purge_environment(unsafe) is False
+
+
+class TestPurge:
+    async def test_apply_purges_clean_account_and_leaves_others(self, db):
+        """AC8.17.2: a clean test account and its owned rows are removed."""
+        victim = await _make_user(db, "qa.delete-me@example.com")
+        victim_id = victim.id
+        await AccountFactory.create_async(db, user_id=victim_id, name="QA Cash")
+        db.add(
+            AtomicTransaction(
+                user_id=victim_id,
+                txn_date=date(2024, 1, 1),
+                amount=Decimal("10.00"),
+                direction=TransactionDirection.IN,
+                description="seed",
+                currency="SGD",
+                dedup_hash=uuid4().hex,
+                source_documents=[],
+            )
+        )
+        bystander = await _make_user(db, "real.keep-me@gmail.com")
+        bystander_id = bystander.id
+        await AccountFactory.create_async(db, user_id=bystander_id, name="Real Cash")
+        await db.commit()
+
+        report = await purge_test_accounts(db, apply=True)
+        await db.commit()  # the service leaves the final commit to the caller
+
+        assert "qa.delete-me@example.com" in report.purged
+        assert not await _user_exists(db, victim_id)
+        assert await _count(db, Account, victim_id) == 0
+        assert await _count(db, AtomicTransaction, victim_id) == 0
+        # The non-test account is untouched.
+        assert await _user_exists(db, bystander_id)
+        assert await _count(db, Account, bystander_id) == 1
+
+    async def test_account_with_posted_ledger_entry_is_blocked_not_deleted(self, db):
+        """AC8.17.3: immutable ledger entries block the purge; account is preserved."""
+        protected = await _make_user(db, "qa.has-ledger@example.com")
+        protected_id = protected.id
+        await JournalEntryFactory.create_balanced_async(db, user_id=protected_id, amount=Decimal("50.00"))
+        await db.commit()
+
+        report = await purge_test_accounts(db, apply=True)
+        await db.commit()
+
+        assert "qa.has-ledger@example.com" not in report.purged
+        blocked_emails = {email for email, _ in report.blocked}
+        assert "qa.has-ledger@example.com" in blocked_emails
+        # Nothing was removed for the blocked account.
+        assert await _user_exists(db, protected_id)
+
+    async def test_dry_run_reports_but_persists_nothing(self, db):
+        """AC8.17.4: dry run names the accounts it would purge but deletes nothing."""
+        victim = await _make_user(db, "qa.dry-run@example.com")
+        victim_id = victim.id
+        await AccountFactory.create_async(db, user_id=victim_id, name="QA Cash")
+        await db.commit()
+
+        report = await purge_test_accounts(db, apply=False)
+
+        assert report.applied is False
+        assert "qa.dry-run@example.com" in report.purged  # "would purge"
+        # Still there after a dry run.
+        assert await _user_exists(db, victim_id)
+        assert await _count(db, Account, victim_id) == 1
+
+    async def test_no_matching_accounts_is_a_noop(self, db):
+        await _make_user(db, "real.only@gmail.com")
+        report = await purge_test_accounts(db, apply=True)
+        assert report.matched == []
+        assert report.purged == []
+        assert report.blocked == []

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -442,6 +442,29 @@ Closing gate for the **Usable** milestone (G2∩G3, [#950](https://github.com/wa
 
 ---
 
+### AC8.17: Test-Account Cleanup Tooling
+
+Shared/staging databases accumulate throwaway accounts from QA and E2E runs
+(`qa.*@example.com`, `e2e-*@test.example.com`, ...). This group covers the purge
+library that reclaims them ([#997](https://github.com/wangzitian0/finance_report/issues/997)
+item 4). The purge is **safe by construction**: each account is removed inside
+its own savepoint (all-or-nothing), and an account still holding immutable
+posted/reconciled ledger entries is *reported and skipped*, never force-deleted —
+the same contract the API enforces with a 409 ([#988](https://github.com/wangzitian0/finance_report/issues/988)).
+
+| AC ID | Test Case | Test Function | File | Priority |
+|---|---|---|---|---|
+| AC8.17.1 | Only disposable test accounts (qa/e2e/load-test prefixes on example.com / test.example.com) are selected; real accounts and plain local fixtures are excluded | `test_selection_matches_test_accounts_and_excludes_real_ones`, `test_owned_tables_cover_core_user_data_and_exclude_users` | `apps/backend/tests/services/test_test_account_purge.py` | P1 |
+| AC8.17.2 | Applying the purge removes a clean test account and every row it owns, while leaving non-test accounts untouched | `test_apply_purges_clean_account_and_leaves_others` | `apps/backend/tests/services/test_test_account_purge.py` | P1 |
+| AC8.17.3 | An account owning a posted (immutable) ledger entry is reported blocked and fully preserved, not force-deleted | `test_account_with_posted_ledger_entry_is_blocked_not_deleted` | `apps/backend/tests/services/test_test_account_purge.py` | P1 |
+| AC8.17.4 | A dry run names the accounts it would purge but persists no deletions | `test_dry_run_reports_but_persists_nothing` | `apps/backend/tests/services/test_test_account_purge.py` | P1 |
+| AC8.17.5 | The CLI `--apply` environment guard allows dev/staging/CI and refuses production (or an unset environment) without an explicit override | `test_environment_guard_allows_dev_staging_and_refuses_production` | `apps/backend/tests/services/test_test_account_purge.py` | P1 |
+
+The operator entry point is `tools/purge_test_accounts.py` (dry-run by default;
+`--apply` to delete; runbook in `docs/contributing/staging-test-account-cleanup.md`).
+
+---
+
 ## 5. E2E Suite Ownership
 
 Current test counts and coverage percentages belong to generated reports and CI


### PR DESCRIPTION
## What

**#997 fix-order item 4** — test-account cleanup tooling. This PR is the pure, fully-tested **purge library**; the operational CLI + scheduled staging job land in a stacked follow-up so each half reviews independently.

Staging/shared databases accumulate throwaway accounts from QA and E2E runs (`qa.*@example.com`, `e2e-*@test.example.com`, ...). `src/services/test_account_purge.py` reclaims them.

## Design (safe by construction)

- **DB-direct, not the API.** `DELETE /api/users/{id}` is self-scoped (no admin delete), so bulk cleanup runs against the database. Deletes are explicit and ordered (`user_id` tables in reverse-dependency order, derived from model metadata so new tables are covered automatically) rather than relying on user-FK cascade — so the same path runs in tests and prod.
- **All-or-nothing per account.** Each account is purged in its own `SAVEPOINT`. An account still holding **immutable posted/reconciled ledger entries** is *reported blocked and left fully intact* — never force-deleted — mirroring the 409 contract from #988 ("void those entries first"). It never half-deletes.
- **No commit in the service** (EPIC-012 AC12.26.1): savepoints release into the outer transaction; the **caller** owns the final commit. Dry-run rolls every savepoint back, so it reports exactly what *would* happen and persists nothing.
- **Narrow predicate**: qa/e2e/load-test prefixes on example.com / test.example.com only — plain `user@example.com` local fixtures are not matched.

## Tests — `apps/backend/tests/services/test_test_account_purge.py` (AC8.17.1–4)

- Selection scoping (test accounts in, real/plain accounts out) + owned-table coverage.
- Apply purges a clean account + its owned rows; a non-test bystander is untouched.
- An account with a posted ledger entry is **blocked, not deleted**.
- Dry-run names what it would purge but persists nothing.

## Verification

- `pytest tests/services/test_test_account_purge.py` → 6 passed; `tests/infra/test_transaction_boundaries.py` (commit-boundary guard) → passes.
- `ruff check src tests` / `ruff format --check` clean.
- AC traceability gate: PASSED (1502 ACs, 100%).

> Local full-suite pre-push hook shows pre-existing xdist flakiness in unrelated reporting/workflow endpoint tests (different set each run; my tests pass in isolation and under parallel). CI (sharded) is the authoritative gate.

Part of #997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)