### PR TITLE
[finance_report_ui] feat(#949): opening-balance readiness nudge (AC2.16)

### DIFF
--- a/apps/backend/src/routers/accounts.py
+++ b/apps/backend/src/routers/accounts.py
@@ -21,7 +21,7 @@ from src.schemas import (
     ProcessingPendingListResponse,
     ProcessingSummaryResponse,
 )
-from src.schemas.account import OpeningBalanceRequest
+from src.schemas.account import OpeningBalanceReadinessResponse, OpeningBalanceRequest
 from src.schemas.journal import JournalEntryResponse
 from src.services import (
     AccountNotFoundError,
@@ -30,7 +30,11 @@ from src.services import (
     calculate_account_balances,
 )
 from src.services.account_coverage import DEFAULT_STALE_AFTER_DAYS, get_account_statement_coverage
-from src.services.accounting import ValidationError, post_opening_balance_entry
+from src.services.accounting import (
+    ValidationError,
+    get_opening_balance_readiness,
+    post_opening_balance_entry,
+)
 from src.services.processing_account import (
     find_transfer_pairs,
     get_processing_balance,
@@ -71,6 +75,21 @@ async def post_opening_balances(
         await db.rollback()
         raise_bad_request(str(exc), cause=exc)
     return JournalEntryResponse.model_validate(entry)
+
+
+@router.get("/opening-balance-readiness", response_model=OpeningBalanceReadinessResponse)
+async def get_opening_balance_readiness_status(
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> OpeningBalanceReadinessResponse:
+    """Readiness nudge (#949): is the balance sheet at risk of being incomplete?
+
+    Returns ``needs_opening_balance=True`` when the user has posted activity but no
+    opening-balance entry on or before its earliest date, so the UI can warn before
+    they ship a silently-incomplete balance sheet.
+    """
+    readiness = await get_opening_balance_readiness(db, user_id)
+    return OpeningBalanceReadinessResponse.model_validate(readiness)
 
 
 @router.post("", response_model=AccountResponse, status_code=status.HTTP_201_CREATED)

--- a/apps/backend/src/schemas/account.py
+++ b/apps/backend/src/schemas/account.py
@@ -34,6 +34,20 @@ class OpeningBalanceRequest(BaseModel):
         return value
 
 
+class OpeningBalanceReadinessResponse(BaseModel):
+    """Whether the user should be nudged to record opening balances (#949 / AC2.16.1).
+
+    ``needs_opening_balance`` is true when the user has posted activity but no
+    opening-balance entry on or before the earliest such activity, so a cumulative
+    balance sheet would silently omit the starting position.
+    """
+
+    needs_opening_balance: bool
+    has_activity: bool
+    has_opening_entry: bool
+    earliest_activity_date: date | None = None
+
+
 class AccountBase(BaseModel):
     """Base account schema."""
 

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -435,7 +435,7 @@ async def get_opening_balance_readiness(db: AsyncSession, user_id: UUID) -> dict
         select(func.min(JournalEntry.entry_date)).where(
             JournalEntry.user_id == user_id,
             JournalEntry.status.in_(posted),
-            JournalEntry.id.not_in(opening_entry_ids),
+            JournalEntry.id.notin_(opening_entry_ids),
         )
     )
     earliest_opening = await db.scalar(

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -405,6 +405,59 @@ async def post_opening_balance_entry(
     return await post_journal_entry(db, entry.id, user_id)
 
 
+async def get_opening_balance_readiness(db: AsyncSession, user_id: UUID) -> dict:
+    """Detect whether a user's balance sheet may be silently incomplete (#949 / AC2.16.1).
+
+    The everyday-user persona who already owns assets/liabilities on day one will,
+    without recording opening balances, get a balance sheet that looks right but
+    omits the starting position. This returns ``needs_opening_balance=True`` when
+    the user has posted activity but no opening-balance entry on or before the
+    earliest such activity, so the UI can nudge them before they ship incomplete
+    numbers.
+    """
+    posted = (JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED)
+
+    # Opening-balance entries are exactly the journal entries with a line on the
+    # user's system-managed Opening Balance Equity account (code 3199).
+    opening_entry_ids = (
+        select(JournalLine.journal_entry_id)
+        .join(Account, Account.id == JournalLine.account_id)
+        .where(
+            Account.user_id == user_id,
+            Account.is_system.is_(True),
+            Account.code == "3199",
+        )
+    )
+
+    # Earliest "real" activity = earliest posted/reconciled entry that is not an
+    # opening-balance entry (statements, manual entries, FX, processing, ...).
+    earliest_activity = await db.scalar(
+        select(func.min(JournalEntry.entry_date)).where(
+            JournalEntry.user_id == user_id,
+            JournalEntry.status.in_(posted),
+            JournalEntry.id.not_in(opening_entry_ids),
+        )
+    )
+    earliest_opening = await db.scalar(
+        select(func.min(JournalEntry.entry_date)).where(
+            JournalEntry.user_id == user_id,
+            JournalEntry.status.in_(posted),
+            JournalEntry.id.in_(opening_entry_ids),
+        )
+    )
+
+    has_activity = earliest_activity is not None
+    has_opening_before = earliest_opening is not None and (
+        earliest_activity is None or earliest_opening <= earliest_activity
+    )
+    return {
+        "needs_opening_balance": has_activity and not has_opening_before,
+        "has_activity": has_activity,
+        "has_opening_entry": earliest_opening is not None,
+        "earliest_activity_date": earliest_activity,
+    }
+
+
 async def create_journal_entry(
     db: AsyncSession,
     user_id: UUID,

--- a/apps/backend/tests/accounting/test_opening_balance_readiness.py
+++ b/apps/backend/tests/accounting/test_opening_balance_readiness.py
@@ -1,0 +1,92 @@
+"""Opening-balance readiness nudge (#949, EPIC-002 AC2.16).
+
+Warns the everyday-user persona who has posted activity but never recorded a
+starting position, so they don't silently ship an incomplete balance sheet.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import Account, AccountType
+from src.services.accounting import get_opening_balance_readiness, post_opening_balance_entry
+
+from ._ledger_helpers import create_valid_posted_entry
+
+
+async def _asset(db: AsyncSession, user_id, name: str = "Bank") -> Account:
+    account = Account(user_id=user_id, name=name, type=AccountType.ASSET, currency="SGD")
+    db.add(account)
+    await db.flush()
+    return account
+
+
+async def test_AC2_16_1_no_activity_does_not_need_opening_balance(db: AsyncSession, test_user) -> None:
+    """AC2.16.1: a user with no posted activity is not nudged — there is nothing
+    to be incomplete about yet."""
+    readiness = await get_opening_balance_readiness(db, test_user.id)
+    assert readiness["needs_opening_balance"] is False
+    assert readiness["has_activity"] is False
+    assert readiness["earliest_activity_date"] is None
+
+
+async def test_AC2_16_1_activity_without_opening_entry_needs_opening_balance(db: AsyncSession, test_user) -> None:
+    """AC2.16.1: posted activity with no opening-balance entry flags the gap."""
+    await create_valid_posted_entry(db, test_user.id, entry_date=date(2026, 3, 1))
+
+    readiness = await get_opening_balance_readiness(db, test_user.id)
+    assert readiness["needs_opening_balance"] is True
+    assert readiness["has_activity"] is True
+    assert readiness["has_opening_entry"] is False
+    assert readiness["earliest_activity_date"] == date(2026, 3, 1)
+
+
+async def test_AC2_16_1_opening_entry_before_activity_clears_the_nudge(db: AsyncSession, test_user) -> None:
+    """AC2.16.1: an opening-balance entry on/before the earliest activity clears it."""
+    asset = await _asset(db, test_user.id)
+    await create_valid_posted_entry(db, test_user.id, entry_date=date(2026, 3, 1))
+    await post_opening_balance_entry(
+        db,
+        test_user.id,
+        entry_date=date(2026, 1, 1),
+        balances={asset.id: Decimal("1000.00")},
+        currency="SGD",
+        memo="Opening balances",
+    )
+    await db.commit()
+
+    readiness = await get_opening_balance_readiness(db, test_user.id)
+    assert readiness["needs_opening_balance"] is False
+    assert readiness["has_opening_entry"] is True
+
+
+async def test_AC2_16_1_opening_entry_after_activity_still_needs(db: AsyncSession, test_user) -> None:
+    """AC2.16.1: an opening entry dated *after* the earliest activity leaves the
+    early period uncovered, so the nudge stays on."""
+    asset = await _asset(db, test_user.id)
+    await create_valid_posted_entry(db, test_user.id, entry_date=date(2026, 1, 1))
+    await post_opening_balance_entry(
+        db,
+        test_user.id,
+        entry_date=date(2026, 2, 1),
+        balances={asset.id: Decimal("1000.00")},
+        currency="SGD",
+        memo="Opening balances",
+    )
+    await db.commit()
+
+    readiness = await get_opening_balance_readiness(db, test_user.id)
+    assert readiness["needs_opening_balance"] is True
+    assert readiness["has_opening_entry"] is True
+
+
+async def test_AC2_16_2_readiness_endpoint_returns_status(client: AsyncClient) -> None:
+    """AC2.16.2: the endpoint exposes the readiness signal to the UI."""
+    resp = await client.get("/accounts/opening-balance-readiness")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["needs_opening_balance"] is False
+    assert body["has_activity"] is False
+    assert body["has_opening_entry"] is False

--- a/apps/frontend/src/__tests__/accountsPage.test.tsx
+++ b/apps/frontend/src/__tests__/accountsPage.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -334,12 +334,13 @@ describe("AccountsPage", () => {
 
     render(<AccountsPage />, { wrapper: createWrapper() })
 
-    expect(await screen.findByText(/Your balance sheet may be incomplete/)).toBeInTheDocument()
+    const nudgeText = await screen.findByText(/Your balance sheet may be incomplete/)
     expect(screen.getByText(/since 2026-01-15/)).toBeInTheDocument()
 
-    // The nudge's CTA opens the guided opening-balance modal.
-    const nudgeButtons = screen.getAllByRole("button", { name: /Set opening balances/i })
-    fireEvent.click(nudgeButtons[0])
+    // Click the CTA inside the nudge alert (not the header button) — it opens the modal.
+    const nudge = nudgeText.closest('[role="status"]') as HTMLElement
+    expect(nudge).not.toBeNull()
+    fireEvent.click(within(nudge).getByRole("button", { name: /Set opening balances/i }))
     expect(screen.getByText("Opening Balance Modal")).toBeInTheDocument()
   })
 

--- a/apps/frontend/src/__tests__/accountsPage.test.tsx
+++ b/apps/frontend/src/__tests__/accountsPage.test.tsx
@@ -73,13 +73,16 @@ describe("AccountsPage", () => {
   })
 
   it("AC16.15.1 renders loading and error retry states", async () => {
+    const accountsCalls = () =>
+      mockedApiFetch.mock.calls.filter((c) => c[0] === "/api/accounts?include_balance=true").length
     mockedApiFetch.mockRejectedValue(new Error("accounts failed"))
 
     render(<AccountsPage />, { wrapper: createWrapper() })
 
     await waitFor(() => expect(screen.queryByText("Failed to load accounts")).not.toBeNull())
+    const before = accountsCalls()
     fireEvent.click(screen.getByRole("button", { name: "Retry loading accounts" }))
-    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(accountsCalls()).toBeGreaterThan(before))
   })
 
   it("AC16.15.2 renders grouped accounts and supports type filters", async () => {
@@ -126,12 +129,14 @@ describe("AccountsPage", () => {
   })
 
   it("AC16.15.4 delete error shows error toast", async () => {
-    mockedApiFetch
-      .mockResolvedValueOnce({
+    mockedApiFetch.mockImplementation((path: string, opts?: RequestInit) => {
+      if (path === "/api/accounts/opening-balance-readiness") return Promise.resolve({ needs_opening_balance: false })
+      if (opts?.method === "DELETE") return Promise.reject(new Error("Cannot delete account with transactions"))
+      return Promise.resolve({
         items: [{ id: "a1", name: "Cash", type: "ASSET", currency: "SGD", is_active: true, balance: "1000" }],
         total: 1,
       } satisfies AccountListResponse)
-      .mockRejectedValueOnce(new Error("Cannot delete account with transactions"))
+    })
     render(<AccountsPage />, { wrapper: createWrapper() })
     await waitFor(() => expect(screen.queryByText("Cash")).not.toBeNull())
     fireEvent.click(screen.getByTitle("Delete Account"))
@@ -158,10 +163,13 @@ describe("AccountsPage", () => {
   })
 
   it("AC16.15.6 cancel delete dialog closes without API call", async () => {
-    mockedApiFetch.mockResolvedValueOnce({
-      items: [{ id: "a1", name: "Cash", type: "ASSET", currency: "SGD", is_active: true, balance: "1000" }],
-      total: 1,
-    } satisfies AccountListResponse)
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/accounts/opening-balance-readiness") return Promise.resolve({ needs_opening_balance: false })
+      return Promise.resolve({
+        items: [{ id: "a1", name: "Cash", type: "ASSET", currency: "SGD", is_active: true, balance: "1000" }],
+        total: 1,
+      } satisfies AccountListResponse)
+    })
 
     render(<AccountsPage />, { wrapper: createWrapper() })
 
@@ -171,7 +179,8 @@ describe("AccountsPage", () => {
     fireEvent.click(screen.getByText("Cancel Delete"))
 
     await waitFor(() => expect(screen.queryByTestId("confirm-dialog")).toBeNull())
-    expect(mockedApiFetch).toHaveBeenCalledTimes(1)
+    // Cancelling never calls the delete endpoint.
+    expect(mockedApiFetch).not.toHaveBeenCalledWith("/api/accounts/a1", { method: "DELETE" })
   })
 
   it("AC16.15.7 edit button opens modal with account data", async () => {
@@ -214,18 +223,18 @@ describe("AccountsPage", () => {
   })
 
   it("AC16.15.9 modal onSuccess triggers account list refresh", async () => {
-    mockedApiFetch
-      .mockResolvedValueOnce({
-        items: [{ id: "a1", name: "Cash", type: "ASSET", currency: "SGD", is_active: true, balance: "1000" }],
-        total: 1,
-      } satisfies AccountListResponse)
-      .mockResolvedValueOnce({
-        items: [
-          { id: "a1", name: "Cash", type: "ASSET", currency: "SGD", is_active: true, balance: "1000" },
-          { id: "a2", name: "Savings", type: "ASSET", currency: "SGD", is_active: true, balance: "5000" },
-        ],
-        total: 2,
-      } satisfies AccountListResponse)
+    let accountsCall = 0
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/accounts/opening-balance-readiness") return Promise.resolve({ needs_opening_balance: false })
+      accountsCall += 1
+      const items: Account[] = [
+        { id: "a1", name: "Cash", type: "ASSET", currency: "SGD", is_active: true, balance: "1000" },
+      ]
+      if (accountsCall > 1) {
+        items.push({ id: "a2", name: "Savings", type: "ASSET", currency: "SGD", is_active: true, balance: "5000" })
+      }
+      return Promise.resolve({ items, total: items.length } satisfies AccountListResponse)
+    })
 
     render(<AccountsPage />, { wrapper: createWrapper() })
 
@@ -310,5 +319,44 @@ describe("AccountsPage", () => {
 
     fireEvent.click(screen.getByText("Mock Close Opening"))
     await waitFor(() => expect(screen.queryByText("Opening Balance Modal")).not.toBeInTheDocument())
+  })
+
+  it("AC2.16.3 shows a readiness nudge and opens the modal when opening balances are missing", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/accounts/opening-balance-readiness") {
+        return Promise.resolve({ needs_opening_balance: true, earliest_activity_date: "2026-01-15" })
+      }
+      return Promise.resolve({
+        items: [{ id: "a1", name: "Cash", type: "ASSET", currency: "SGD", is_active: true, balance: "1000" }],
+        total: 1,
+      } satisfies AccountListResponse)
+    })
+
+    render(<AccountsPage />, { wrapper: createWrapper() })
+
+    expect(await screen.findByText(/Your balance sheet may be incomplete/)).toBeInTheDocument()
+    expect(screen.getByText(/since 2026-01-15/)).toBeInTheDocument()
+
+    // The nudge's CTA opens the guided opening-balance modal.
+    const nudgeButtons = screen.getAllByRole("button", { name: /Set opening balances/i })
+    fireEvent.click(nudgeButtons[0])
+    expect(screen.getByText("Opening Balance Modal")).toBeInTheDocument()
+  })
+
+  it("AC2.16.3 hides the readiness nudge when opening balances are already recorded", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/accounts/opening-balance-readiness") {
+        return Promise.resolve({ needs_opening_balance: false, earliest_activity_date: null })
+      }
+      return Promise.resolve({
+        items: [{ id: "a1", name: "Cash", type: "ASSET", currency: "SGD", is_active: true, balance: "1000" }],
+        total: 1,
+      } satisfies AccountListResponse)
+    })
+
+    render(<AccountsPage />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByText("Cash")).toBeInTheDocument())
+    expect(screen.queryByText(/Your balance sheet may be incomplete/)).not.toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/app/(main)/accounts/page.tsx
+++ b/apps/frontend/src/app/(main)/accounts/page.tsx
@@ -32,6 +32,16 @@ export default function AccountsPage() {
         queryFn: () => apiFetch<AccountListResponse>("/api/accounts?include_balance=true"),
     });
 
+    // #949: nudge the user if they have activity but no recorded opening balances,
+    // so they don't silently ship an incomplete balance sheet.
+    const { data: readiness } = useQuery({
+        queryKey: ["opening-balance-readiness"],
+        queryFn: () =>
+            apiFetch<{ needs_opening_balance: boolean; earliest_activity_date: string | null }>(
+                "/api/accounts/opening-balance-readiness",
+            ),
+    });
+
     const deleteMutation = useMutation({
         mutationFn: (accountId: string) => apiFetch(`/api/accounts/${accountId}`, { method: "DELETE" }),
         onSuccess: () => {
@@ -98,6 +108,26 @@ export default function AccountsPage() {
                     </div>
                 )}
             />
+
+            {/* #949 readiness nudge: warn before shipping a silently-incomplete balance sheet. */}
+            {readiness?.needs_opening_balance && (
+                <Alert variant="warning" className="mb-4">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <span>
+                            Your balance sheet may be incomplete — you have activity
+                            {readiness.earliest_activity_date ? ` since ${readiness.earliest_activity_date}` : ""} but
+                            no opening balances recorded. Set your starting balances so reports tie out from day one.
+                        </span>
+                        <Button
+                            variant="secondary"
+                            onClick={() => setIsOpeningBalanceOpen(true)}
+                            className="shrink-0"
+                        >
+                            Set opening balances
+                        </Button>
+                    </div>
+                </Alert>
+            )}
 
             {/* Tabs */}
             <div className="mb-6 flex w-full flex-wrap gap-1 rounded-lg bg-[var(--background-muted)] p-1 sm:w-fit">
@@ -211,6 +241,7 @@ export default function AccountsPage() {
                 onSuccess={() => {
                     showToast("Opening balances recorded", "success");
                     queryClient.invalidateQueries({ queryKey: ["accounts"] });
+                    queryClient.invalidateQueries({ queryKey: ["opening-balance-readiness"] });
                 }}
                 accounts={accounts}
             />

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -253,6 +253,19 @@ A user with pre-existing assets/liabilities can establish year-start balances vi
 | AC2.15.7 | Opening balances may only target user-managed accounts; a system account (e.g. Processing) cannot be set via this endpoint even though the entry is SYSTEM-typed | `test_AC2_15_7_system_account_target_is_rejected` | `accounting/test_opening_balance.py` | P0 |
 | AC2.15.8 | The Accounts page offers a guided opening-balance flow: a non-accountant enters an as-of date and a starting balance per eligible (active, non-income/expense) account, and the UI posts the balances map to `POST /api/accounts/opening-balances` — never hand-written journal lines — validating positive two-decimal amounts and surfacing backend errors instead of silently closing | `AC2.15.8 lists only eligible accounts and hides income/expense and inactive ones`, `AC2.15.8 posts a balances map without requiring hand-written journal lines`, `AC2.15.8 blocks submission until at least one positive balance is entered`, `AC2.15.8 rejects non-positive or over-precise amounts before calling the API`, `AC2.15.8 surfaces a backend error instead of closing` | `apps/frontend/src/__tests__/openingBalanceModal.test.tsx` | P1 |
 
+### AC2.16: Opening-Balance Readiness Nudge ([#949](https://github.com/wangzitian0/finance_report/issues/949))
+
+The everyday-user persona who already owns assets/liabilities on day one can post
+real activity without ever recording a starting position, yielding a balance
+sheet that looks right but silently omits the opening balances. These ACs surface
+that gap before the numbers are trusted.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC2.16.1 | `get_opening_balance_readiness` reports `needs_opening_balance=True` only when the user has posted activity and no opening-balance entry on or before its earliest date (no activity, an opening entry before activity, or a mis-dated opening entry after activity are all distinguished) | `test_AC2_16_1_no_activity_does_not_need_opening_balance`, `test_AC2_16_1_activity_without_opening_entry_needs_opening_balance`, `test_AC2_16_1_opening_entry_before_activity_clears_the_nudge`, `test_AC2_16_1_opening_entry_after_activity_still_needs` | `apps/backend/tests/accounting/test_opening_balance_readiness.py` | P1 |
+| AC2.16.2 | `GET /api/accounts/opening-balance-readiness` exposes the readiness signal to the UI | `test_AC2_16_2_readiness_endpoint_returns_status` | `apps/backend/tests/accounting/test_opening_balance_readiness.py` | P1 |
+| AC2.16.3 | The Accounts page shows a warning nudge (with a CTA that opens the guided flow) when opening balances are missing, and hides it once they are recorded | `AC2.16.3 shows a readiness nudge and opens the modal when opening balances are missing`, `AC2.16.3 hides the readiness nudge when opening balances are already recorded` | `apps/frontend/src/__tests__/accountsPage.test.tsx` | P1 |
+
 ## 📏 Acceptance Criteria
 
 > ℹ️ **Non-contiguous AC numbering**: Gaps in `AC2.x.y` numbers reflect deprecated or merged ACs preserved through generated registry indexes plus explicit overrides. Do **not** renumber. New ACs append to the next available index in this EPIC.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,8 +5,8 @@
 
 - API title: `Finance Report API`
 - API version: `0.1.0`
-- Endpoint count: `129`
-- Schema count: `213`
+- Endpoint count: `130`
+- Schema count: `214`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 
@@ -14,7 +14,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 
 | Group | Endpoints |
 |---|---:|
-| `accounts` | 9 |
+| `accounts` | 10 |
 | `ai` | 1 |
 | `ai-feedback` | 2 |
 | `assets` | 11 |
@@ -46,6 +46,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `GET` | `/accounts` | yes | `account_type` (query), `is_active` (query), `include_balance` (query), `limit` (query), `offset` (query) | - | `200` `ListResponse_AccountResponse_` | List Accounts |
 | `POST` | `/accounts` | yes | - | `AccountCreate` | `201` `AccountResponse` | Create Account |
 | `GET` | `/accounts/coverage` | yes | `as_of` (query), `stale_after_days` (query) | - | `200` `AccountCoverageListResponse` | List Account Statement Coverage |
+| `GET` | `/accounts/opening-balance-readiness` | yes | - | - | `200` `OpeningBalanceReadinessResponse` | Get Opening Balance Readiness Status |
 | `POST` | `/accounts/opening-balances` | yes | - | `OpeningBalanceRequest` | `201` `JournalEntryResponse` | Post Opening Balances |
 | `GET` | `/accounts/processing/pending` | yes | - | - | `200` `ListResponse_ProcessingPendingItem_` | List Processing Pending |
 | `GET` | `/accounts/processing/summary` | yes | - | - | `200` `ProcessingSummaryResponse` | Get Processing Summary |


### PR DESCRIPTION
## Summary
Closes the **last open item on #949** — the "readiness nudge" scoped out of the guided-flow PR (#1022). The everyday-user persona can post real activity (statements, manual entries) without ever recording a starting position, leaving a balance sheet that *looks* right but silently omits the opening balances. This warns them before they trust the numbers.

## Changes
- **Backend** — `get_opening_balance_readiness()` (services/accounting.py): `needs_opening_balance=True` only when the user has posted activity **and** no opening-balance entry (a `SYSTEM` entry touching the code-`3199` Opening Balance Equity account) on or before the earliest such activity. Exposed via `GET /api/accounts/opening-balance-readiness` → `{needs_opening_balance, has_activity, has_opening_entry, earliest_activity_date}`.
- **Frontend** — a warning `Alert` banner on the Accounts page surfaces the gap with a **Set opening balances** CTA that opens the existing guided modal; the banner clears once balances are recorded (the readiness query is invalidated on success).

## Tests / gates
- Backend (`test_opening_balance_readiness.py`, AC2.16.1/.2): no-activity → no nudge; activity without opening entry → nudge; opening entry **before** activity → clears; mis-dated opening entry **after** activity → still nudges; endpoint returns the status. **12 accounting tests pass.**
- Frontend (`accountsPage.test.tsx`, AC2.16.3): banner shown when missing (CTA opens modal) / hidden when recorded. Existing accounts tests made path-aware for the new query. **15 pass.**
- API reference regenerated; AC registry + traceability gates, ruff, `tsc`, and ≥98% frontend coverage all green.

After this merges, #949 is fully delivered (backend #985 + guided UI #1022 + this nudge) and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)