### PR TITLE
[finance_report_test_and_doc] feat(maintenance): purge-test-accounts CLI + runbook (#997 item 4)

### DIFF
--- a/docs/contributing/staging-test-account-cleanup.md
+++ b/docs/contributing/staging-test-account-cleanup.md
@@ -57,10 +57,11 @@ Matched 4 test account(s); Would purge 3, blocked 1.
 ## Safety
 
 - **Dry run is the default.** You must pass `--apply` to delete anything.
-- **Environment guard.** `--apply` is refused unless `ENVIRONMENT` is one of
-  `development` / `dev` / `local` / `test` / `testing` / `ci` / `staging`. Running
-  against any other environment (including an unset one) requires an explicit
-  `--force`. **Never** point this at production.
+- **Environment guard.** `--apply` is refused unless `ENVIRONMENT` (or its alias
+  `ENV`) is one of `development` / `dev` / `local` / `test` / `testing` / `ci` /
+  `staging`. The guard reads the raw variable, so an **unset/empty** value is
+  treated as unsafe (not as the `development` default); running against any other
+  environment requires an explicit `--force`. **Never** point this at production.
 - **No force-delete of real ledger data.** The immutable-ledger guard is never
   bypassed; blocked accounts are surfaced, not destroyed.
 

--- a/docs/contributing/staging-test-account-cleanup.md
+++ b/docs/contributing/staging-test-account-cleanup.md
@@ -1,0 +1,71 @@
+# Staging Test-Account Cleanup
+
+QA and E2E runs leave behind disposable accounts (`qa.*@example.com`,
+`e2e-*@test.example.com`, `load-test-*@example.com`) on shared/staging
+databases. `tools/purge_test_accounts.py` reclaims them safely.
+
+This is the operator runbook. The deletion logic, safety model, and email
+predicate live in `apps/backend/src/services/test_account_purge.py` and are unit
+tested (EPIC-008 AC8.17).
+
+## What it does
+
+- Selects accounts whose email matches a **narrow** predicate (qa/e2e/load-test
+  prefixes on `example.com` / `test.example.com`). Plain `user@example.com`
+  fixtures are **not** matched.
+- Deletes each matched account and every row it owns, **one account per
+  transaction (savepoint)** — all-or-nothing, never half-deleted.
+- An account that still holds **immutable posted/reconciled ledger entries** is
+  reported as `blocked` and left fully intact (the same contract the API enforces
+  with a `409`, see [#988](https://github.com/wangzitian0/finance_report/issues/988)).
+  Void those entries first if the account genuinely must go.
+
+## Usage
+
+Run from the repository root.
+
+```bash
+# 1. Dry run (default): report what WOULD be purged / blocked. Changes nothing.
+python tools/purge_test_accounts.py
+
+# 2. Apply on a dev/staging database:
+python tools/purge_test_accounts.py --apply
+
+# 3. One-off custom predicate (e.g. a specific load-test batch):
+python tools/purge_test_accounts.py --pattern '^load-test-2026-.*@example\.com$' --apply
+```
+
+The target database and mode are echoed (with credentials redacted) before
+anything runs:
+
+```
+[purge-test-accounts] target=postgresql+asyncpg://***@staging-db:5432/finance_report environment='staging' mode=dry-run
+```
+
+### Output
+
+```
+Matched 4 test account(s); Would purge 3, blocked 1.
+  ~ qa.alice@example.com
+  ~ e2e-bob@test.example.com
+  ~ load-test-carol@example.com
+  ! qa.has-ledger@example.com — blocked: cannot delete immutable journal entry ... with status posted
+```
+
+(`~` = would purge in a dry run, `-` = purged with `--apply`, `!` = blocked.)
+
+## Safety
+
+- **Dry run is the default.** You must pass `--apply` to delete anything.
+- **Environment guard.** `--apply` is refused unless `ENVIRONMENT` is one of
+  `development` / `dev` / `local` / `test` / `testing` / `ci` / `staging`. Running
+  against any other environment (including an unset one) requires an explicit
+  `--force`. **Never** point this at production.
+- **No force-delete of real ledger data.** The immutable-ledger guard is never
+  bypassed; blocked accounts are surfaced, not destroyed.
+
+## Scheduling (optional)
+
+This tool is intentionally **operator-run**, not wired to a destructive cron.
+If a recurring sweep is wanted, schedule the **dry-run** form for visibility and
+keep `--apply` a manual, reviewed action.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - Red Lines: agents/red-lines.md
       - App/Infra Contract Boundary: agents/app-infra-contract-boundary.md
       - Branch Policy: contributing/branch-policy.md
+      - Staging Test-Account Cleanup: contributing/staging-test-account-cleanup.md
   - Development:
       - Project Overview: project/README.md
       - Design Decisions: project/DECISIONS.md

--- a/tools/purge_test_accounts.py
+++ b/tools/purge_test_accounts.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -34,9 +35,8 @@ for _path in (ROOT_DIR, BACKEND_DIR):
     if str(_path) not in sys.path:
         sys.path.insert(0, str(_path))
 
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine  # noqa: E402
-
 from src.config import settings  # noqa: E402
+from src.database import async_session_maker  # noqa: E402
 from src.services.test_account_purge import (  # noqa: E402
     DEFAULT_TEST_EMAIL_PATTERN,
     is_safe_purge_environment,
@@ -46,11 +46,13 @@ from src.services.test_account_purge import (  # noqa: E402
 
 def _redact(database_url: str) -> str:
     """Hide credentials when echoing the target DB back to the operator."""
-    if "@" in database_url:
+    if "://" in database_url and "@" in database_url:
         scheme, _, tail = database_url.partition("://")
         host = tail.split("@", 1)[1]
         return f"{scheme}://***@{host}"
-    return database_url
+    # No recognizable scheme://credentials@host shape — nothing safe to keep, so
+    # don't echo a possibly-credential-bearing string back verbatim.
+    return "***" if "@" in database_url else database_url
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -94,17 +96,22 @@ async def _run(args: argparse.Namespace) -> int:
         )
         return 2
 
-    engine = create_async_engine(settings.database_url)
-    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    # Validate the operator-supplied regex up front so a typo is a clean error,
+    # not a traceback after we have already touched the database.
     try:
-        async with session_maker() as session:
-            report = await purge_test_accounts(
-                session, pattern=args.pattern, apply=args.apply
-            )
-            if args.apply:
-                await session.commit()
-    finally:
-        await engine.dispose()
+        re.compile(args.pattern)
+    except re.error as exc:
+        print(f"Invalid --pattern regex: {exc}", file=sys.stderr)
+        return 2
+
+    # Reuse the application's configured session maker (pool_pre_ping + pool sizes
+    # from src/database.py) rather than spinning up a bare engine.
+    async with async_session_maker() as session:
+        report = await purge_test_accounts(
+            session, pattern=args.pattern, apply=args.apply
+        )
+        if args.apply:
+            await session.commit()
 
     print(report.summary())
     return 0

--- a/tools/purge_test_accounts.py
+++ b/tools/purge_test_accounts.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Purge throwaway test/QA accounts from a staging database (#997 item 4).
+
+Thin operator CLI around ``src.services.test_account_purge``. The deletion logic,
+its safety model, and the email predicate live in that library (and are unit
+tested); this wrapper only owns argument parsing, the environment guard, the DB
+session, and the final commit.
+
+Examples:
+    # Dry run (default) — report what would be purged, change nothing:
+    python tools/purge_test_accounts.py
+
+    # Actually delete, on a staging/dev database:
+    python tools/purge_test_accounts.py --apply
+
+    # One-off custom predicate:
+    python tools/purge_test_accounts.py --pattern '^load-test-.*@example\\.com$' --apply
+
+Accounts still holding immutable posted/reconciled ledger entries are reported as
+*blocked* and left untouched — void those entries first (see #988).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+BACKEND_DIR = ROOT_DIR / "apps" / "backend"
+for _path in (ROOT_DIR, BACKEND_DIR):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine  # noqa: E402
+
+from src.config import settings  # noqa: E402
+from src.services.test_account_purge import (  # noqa: E402
+    DEFAULT_TEST_EMAIL_PATTERN,
+    is_safe_purge_environment,
+    purge_test_accounts,
+)
+
+
+def _redact(database_url: str) -> str:
+    """Hide credentials when echoing the target DB back to the operator."""
+    if "@" in database_url:
+        scheme, _, tail = database_url.partition("://")
+        host = tail.split("@", 1)[1]
+        return f"{scheme}://***@{host}"
+    return database_url
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Purge disposable test/QA accounts from a database."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually delete. Without this flag the run is a dry run (default).",
+    )
+    parser.add_argument(
+        "--pattern",
+        default=DEFAULT_TEST_EMAIL_PATTERN,
+        help="Email regex selecting test accounts (default: qa/e2e/load-test prefixes on example.com).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Override the environment guard. Required to --apply outside a dev/staging environment.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    target = _redact(settings.database_url)
+    mode = "APPLY" if args.apply else "dry-run"
+    print(
+        f"[purge-test-accounts] target={target} environment={settings.environment!r} mode={mode}"
+    )
+
+    if (
+        args.apply
+        and not is_safe_purge_environment(settings.environment)
+        and not args.force
+    ):
+        print(
+            f"Refusing to --apply in environment {settings.environment!r}. "
+            "Re-run with --force only if you are certain this is not production.",
+            file=sys.stderr,
+        )
+        return 2
+
+    engine = create_async_engine(settings.database_url)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_maker() as session:
+            report = await purge_test_accounts(
+                session, pattern=args.pattern, apply=args.apply
+            )
+            if args.apply:
+                await session.commit()
+    finally:
+        await engine.dispose()
+
+    print(report.summary())
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(_run(_parse_args(argv)))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/purge_test_accounts.py
+++ b/tools/purge_test_accounts.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import sys
 from pathlib import Path
 
@@ -77,17 +78,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 async def _run(args: argparse.Namespace) -> int:
     target = _redact(settings.database_url)
     mode = "APPLY" if args.apply else "dry-run"
+    # Read the RAW environment variable rather than settings.environment, which
+    # defaults to "development" when ENVIRONMENT/ENV is unset — an unset variable
+    # in a production shell must read as unsafe, not as a safe default (AC8.17.5).
+    raw_environment = os.environ.get("ENVIRONMENT") or os.environ.get("ENV")
     print(
-        f"[purge-test-accounts] target={target} environment={settings.environment!r} mode={mode}"
+        f"[purge-test-accounts] target={target} environment={raw_environment!r} mode={mode}"
     )
 
-    if (
-        args.apply
-        and not is_safe_purge_environment(settings.environment)
-        and not args.force
-    ):
+    if args.apply and not is_safe_purge_environment(raw_environment) and not args.force:
         print(
-            f"Refusing to --apply in environment {settings.environment!r}. "
+            f"Refusing to --apply in environment {raw_environment!r}. "
             "Re-run with --force only if you are certain this is not production.",
             file=sys.stderr,
         )


### PR DESCRIPTION
## What

Operator half of **#997 item 4** — stacked on #1029 (the purge library). Adds the CLI entry point and runbook so QA/E2E leftovers can actually be reclaimed from a staging database.

> **Stacked PR.** Base is `feat/997-test-account-purge-lib` (#1029); review/merge that first. GitHub auto-retargets this to `main` when #1029 merges. The diff here is only the CLI + guard + runbook.

## Changes

- **`tools/purge_test_accounts.py`** — thin CLI around `src.services.test_account_purge`:
  - Dry-run by default; `--apply` to delete; `--pattern` for one-off predicates.
  - Echoes target DB + mode (credentials redacted) before acting.
  - Owns the DB session + final commit, so the service stays commit-free (EPIC-012 AC12.26.1).
- **Environment guard** (`is_safe_purge_environment`, **AC8.17.5**): `--apply` is refused outside `dev`/`staging`/`ci`/... unless `--force`, so a misconfigured `ENVIRONMENT` can never silently delete real accounts.
- **Runbook** — `docs/contributing/staging-test-account-cleanup.md` (added to mkdocs nav). Intentionally **operator-run, not wired to a destructive cron** — blocked (immutable-ledger) accounts are surfaced, never force-deleted.

## Verification

- `pytest tests/services/test_test_account_purge.py` → 8 passed (incl. AC8.17.5 guard) + commit-boundary guard passes.
- `ruff check` clean; `tools/lint_doc_consistency.py` → exit 0 (doc in nav); AC traceability gate PASSED (1503 ACs).
- `python tools/purge_test_accounts.py --help` works.

Part of #997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)