### PR TITLE
[finance_report_infra] docs(ssot): demote App env/observability SSOT to pointers + guard (Infra-014 C1-app/D1)

### DIFF
--- a/docs/agents/app-infra-contract-boundary.md
+++ b/docs/agents/app-infra-contract-boundary.md
@@ -1,0 +1,48 @@
+# App / Infra Contract Boundary (Infra-014)
+
+> **Scope**: governs how this repo (the **App** / software) relates to **infra2**
+> (the **runtime**) for environment and observability configuration.
+
+## The rule
+
+**infra2 = runtime; this repo = software.** infra2 **owns and issues** the
+env/observability **contract**; the App **consumes** it and **fast-fails** when a
+required value is missing. The App must **NOT re-define environments or the
+observability contract**.
+
+## infra2 owns + issues (do not restate or hardcode here)
+
+- the environment **taxonomy** (names, suffixes, domains);
+- the single **no-suffix OTLP collector** endpoint (SigNoz is a single global
+  `prod_only` instance — there is no per-env collector);
+- the layered **telemetry identity** — underlying short-commit-SHA
+  `service.version` + surface `deployment.environment` alias (`production` /
+  `staging` / `pr-<N>` / `commit-<sha>` / `tag-<x>` / `main`) and its allowed
+  values;
+- OpenPanel per-environment **client ids**.
+
+## The App consumes (and only consumes)
+
+- `apps/backend/src/config.py` reads `OTEL_*` and analytics env vars by
+  `validation_alias` and **fast-fails** in deployed environments when a required
+  value is missing.
+- The App must **not** enumerate per-environment collector endpoints or
+  `deployment.environment` values, and must **not** maintain an
+  `openpanel_clients` map in `config.py` (that map lives in infra2's deploy
+  tooling).
+
+## Canonical contract (infra2, vendored at `repo/`)
+
+- [`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)
+- [`repo/docs/ssot/core.environments.md`](../../repo/docs/ssot/core.environments.md) — see the *Telemetry identity* section.
+
+## App-side consumption docs (pointers only, not the contract)
+
+- [`docs/ssot/observability.md`](../ssot/observability.md)
+- [`docs/ssot/environments.md`](../ssot/environments.md)
+
+## Anti-regression guard
+
+`tests/tooling/test_env_contract_boundary.py` fails if this repo re-grows the
+contract (missing pointers, drift patterns, or a hardcoded `openpanel_clients`
+map in `config.py`).

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -120,6 +120,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_coverage_analyzer.py` | `docs/ssot/coverage.md` |
 | `tests/tooling/test_delivery_gates_contract.py` | `docs/ssot/delivery-gates.yaml` |
 | `tests/tooling/test_dokploy_failure_snapshot.py` | `docs/ssot/ci-cd.md` |
+| `tests/tooling/test_env_contract_boundary.py` | `docs/ssot/observability.md` |
 | `tests/tooling/test_generate_fixtures.py` | `docs/ssot/extraction.md` |
 | `tests/tooling/test_github_workflow_timing_summary.py` | `docs/ssot/ci-cd.md` |
 | `tests/tooling/test_merge_lcov.py` | `docs/ssot/coverage.md` |

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -120,7 +120,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_coverage_analyzer.py` | `docs/ssot/coverage.md` |
 | `tests/tooling/test_delivery_gates_contract.py` | `docs/ssot/delivery-gates.yaml` |
 | `tests/tooling/test_dokploy_failure_snapshot.py` | `docs/ssot/ci-cd.md` |
-| `tests/tooling/test_env_contract_boundary.py` | `docs/ssot/observability.md` |
+| `tests/tooling/test_env_contract_boundary.py` | `docs/ssot/observability.md`, `docs/ssot/environments.md` |
 | `tests/tooling/test_generate_fixtures.py` | `docs/ssot/extraction.md` |
 | `tests/tooling/test_github_workflow_timing_summary.py` | `docs/ssot/ci-cd.md` |
 | `tests/tooling/test_merge_lcov.py` | `docs/ssot/coverage.md` |

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -13,7 +13,7 @@
     telemetry identity) are **owned and issued by infra2** (runtime), not by this
     App doc (software):
 
-    - [`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md)
+    - [`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md#telemetry-identity)
       — environment taxonomy + telemetry identity.
     - [`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)
       — single no-suffix OTLP collector and OTLP env vars.
@@ -192,7 +192,7 @@ separated (the `deployment.environment` surface alias and its allowed values) is
 part of the **infra2-owned** observability contract —
 [`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)
 and
-[`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md).
+[`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md#telemetry-identity).
 This App doc does not enumerate those values.
 
 **Note**: PR Previews have **dedicated MinIO/DB/Redis** to allow destructive testing, but send logs to shared SigNoz.

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -1,9 +1,30 @@
 # Six Environments SSOT
 
 > **SSOT Key**: `environments`
-> **Source of Truth** for all deployment environments, naming conventions, and isolation mechanisms.
+> **App-side view** of how this software *consumes* deployment environments —
+> naming conventions and isolation mechanisms the backend relies on.
 
 *Extracted from [development.md](./development.md) — see that file for Moon commands and local setup.*
+
+!!! warning "Environment taxonomy & telemetry identity are owned by infra2"
+    The canonical **environment taxonomy** and the **observability contract**
+    (OTLP collector endpoint, `deployment.environment` surface alias and its
+    allowed values, and the underlying short-commit-SHA `service.version`
+    telemetry identity) are **owned and issued by infra2** (runtime), not by this
+    App doc (software):
+
+    - [`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md)
+      — environment taxonomy + telemetry identity.
+    - [`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)
+      — single no-suffix OTLP collector and OTLP env vars.
+
+    This App doc describes only how the App **consumes** those environments
+    (which image/data runs where, container/DB/bucket naming the backend connects
+    to). The **App must NOT re-define environments or the observability
+    contract**; it consumes the infra2-issued values via `config.py` and
+    fast-fails on missing required values. Do not restate per-environment
+    collector endpoints or `deployment.environment` values here — see Infra-014 /
+    `AGENTS.md` for the boundary.
 
 ---
 
@@ -161,10 +182,18 @@ The production Platform layer (SigNoz, MinIO, Traefik) runs as **Singleton** ser
 
 | Service | Scope | Isolation Method | Example |
 |---------|-------|------------------|---------|
-| **SigNoz** | Singleton | `deployment.environment` tag | `staging`, `production`, `pr-47` |
+| **SigNoz** | Singleton | infra2-owned telemetry identity (see below) | — |
 | **MinIO** (Prod) | Singleton | Separate buckets | `finance-report-staging`, `finance-report-production` |
 | **Postgres** | Dedicated | Separate containers/instances | One per environment |
 | **Redis** | Dedicated | Separate containers/instances | One per environment |
+
+SigNoz is a single global instance shared across environments; how App logs are
+separated (the `deployment.environment` surface alias and its allowed values) is
+part of the **infra2-owned** observability contract —
+[`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)
+and
+[`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md).
+This App doc does not enumerate those values.
 
 **Note**: PR Previews have **dedicated MinIO/DB/Redis** to allow destructive testing, but send logs to shared SigNoz.
 

--- a/docs/ssot/observability.md
+++ b/docs/ssot/observability.md
@@ -19,7 +19,7 @@
 
     - [`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)
       — OTLP single no-suffix collector, signal types, OTLP env vars.
-    - [`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md)
+    - [`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md#telemetry-identity)
       — telemetry identity (`service.version` / `deployment.environment`) and
       environment taxonomy.
 
@@ -73,7 +73,7 @@ filtering**, and the allowed `deployment.environment` values are part of the
   [`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md).
 - Environment taxonomy + telemetry identity (`deployment.environment` values,
   `service.version`) →
-  [`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md).
+  [`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md#telemetry-identity).
 
 Credentials for the SigNoz UI are stored in 1Password (`Infra2` vault), item
 `platform/signoz/admin`. To view App logs, filter the SigNoz UI by the
@@ -145,7 +145,7 @@ concrete endpoint, `service.version`, and `deployment.environment` values, plus
 the `invoke env.set` procedure, live in the infra2 contract — see
 [`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)
 and
-[`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md).
+[`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md#telemetry-identity).
 The App must not hardcode or restate these per-environment values; it consumes
 whatever infra2 injects and fast-fails if a required value is absent.
 

--- a/docs/ssot/observability.md
+++ b/docs/ssot/observability.md
@@ -1,7 +1,33 @@
 # Observability SSOT
 
 > **SSOT Key**: `observability`
-> **Core Definition**: How application logs are structured and shipped to SigNoz via OTLP, with safe local fallbacks.
+> **Core Definition**: How the **App-side backend** *consumes* the observability
+> contract — which `OTEL_*` env vars `config.py` reads, the redacted
+> `/health.observability` runtime snapshot, and fast-fail behavior.
+
+!!! warning "Contract is owned by infra2 — this App doc covers consumption only"
+    The canonical **env/observability contract** is **owned and issued by
+    infra2** (runtime), not by this App doc (software). infra2 owns:
+
+    - the single no-suffix **OTLP collector** endpoint,
+    - the `deployment.environment` surface alias and its allowed values,
+    - the layered **telemetry identity** (underlying short-commit-SHA
+      `service.version` + surface `deployment.environment`),
+    - the environment **taxonomy**.
+
+    Canonical sources (infra2, vendored at `repo/`):
+
+    - [`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)
+      — OTLP single no-suffix collector, signal types, OTLP env vars.
+    - [`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md)
+      — telemetry identity (`service.version` / `deployment.environment`) and
+      environment taxonomy.
+
+    **The App must NOT re-define environments or the observability contract.**
+    It only *consumes* the contract via `config.py` and **fast-fails** if a
+    required value is missing. Per-environment collector endpoints and
+    `deployment.environment` value enumerations live in infra2 — see the
+    boundary in Infra-014 / `AGENTS.md`. Do not restate them here.
 
 ---
 
@@ -37,41 +63,21 @@ flowchart LR
 
 ---
 
-## 3. SigNoz Access
+## 3. SigNoz Access (infra2-owned)
 
-### 3.1 Web UI
+SigNoz access, the single global instance model, environment **attribute-based
+filtering**, and the allowed `deployment.environment` values are part of the
+**infra2-owned contract**. Do not restate the endpoints or per-env values here.
 
-| Environment | URL |
-|-------------|-----|
-| All (Production, Staging, PR) | https://signoz.zitian.party |
+- Platform, collector, single-instance model, OTLP env vars →
+  [`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md).
+- Environment taxonomy + telemetry identity (`deployment.environment` values,
+  `service.version`) →
+  [`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md).
 
-!!! info "Single Instance, Multi-Environment"
-    SigNoz runs as a **single global instance**. All environments share the same SigNoz deployment. Use `deployment.environment` attribute filter in the UI to view specific environment logs (e.g., `deployment.environment=production`).
-    
-    See [Six Environments (SSOT)](development.md#six-environments) for complete environment details.
-
-### 3.2 Credentials
-
-Stored in 1Password (`Infra2` vault):
-- **Item**: `platform/signoz/admin`
-- **Email**: `admin@zitian.party`
-
-### 3.3 Environment Separation
-
-SigNoz uses **attribute-based filtering** to separate environments:
-
-```bash
-# Production backend
-OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production"
-
-# Staging backend  
-OTEL_RESOURCE_ATTRIBUTES="deployment.environment=staging"
-
-# PR environment
-OTEL_RESOURCE_ATTRIBUTES="deployment.environment=pr-47"
-```
-
-In SigNoz UI, filter by `deployment.environment` to view specific environments.
+Credentials for the SigNoz UI are stored in 1Password (`Infra2` vault), item
+`platform/signoz/admin`. To view App logs, filter the SigNoz UI by the
+`deployment.environment` value that infra2 assigned to the target environment.
 
 ---
 
@@ -92,35 +98,26 @@ In SigNoz UI, filter by `deployment.environment` to view specific environments.
 
 ---
 
-## 5. Configuration Playbook
+## 5. App-Side Consumption (what `config.py` reads)
 
-### 5.1 Local Development (No SigNoz)
-Set nothing; logs render to stdout:
-```bash
-DEBUG=true
-```
+The App does **not** define collector endpoints or per-environment
+`deployment.environment` values — those are **issued by infra2** (see the banner
+at the top of this doc and
+[`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)).
+The App only *reads* the values infra2 injects.
 
-### 5.2 Production (SigNoz Enabled)
-Set OTEL variables via Vault/environment:
-```bash
-OTEL_EXPORTER_OTLP_ENDPOINT=http://platform-signoz-otel-collector:4318
-OTEL_SERVICE_NAME=finance-report-backend
-OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production
-```
+`apps/backend/src/config.py` reads these `OTEL_*` env vars (via pydantic
+`validation_alias`):
 
-### 5.3 Staging
-```bash
-OTEL_EXPORTER_OTLP_ENDPOINT=http://platform-signoz-otel-collector:4318
-OTEL_SERVICE_NAME=finance-report-backend
-OTEL_RESOURCE_ATTRIBUTES=deployment.environment=staging
-```
+| Env var | `config.py` field | App-side behavior |
+|---------|-------------------|-------------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `otel_exporter_otlp_endpoint` | When set, the backend exports logs/traces to the infra2-issued collector; when unset, the App degrades safely to stdout (local dev). |
+| `OTEL_SERVICE_NAME` | `otel_service_name` | App service identity used by the shared alert rule. |
+| `OTEL_RESOURCE_ATTRIBUTES` | `otel_resource_attributes` | Carries the infra2-issued `deployment.environment` (surface alias) and `service.version` (underlying short-commit-SHA). The App parses, never enumerates, these values. |
 
-### 5.4 PR Environments
-```bash
-OTEL_EXPORTER_OTLP_ENDPOINT=http://platform-signoz-otel-collector:4318
-OTEL_SERVICE_NAME=finance-report-backend
-OTEL_RESOURCE_ATTRIBUTES=deployment.environment=pr-${PR_NUMBER}
-```
+Local development needs nothing set; logs render to stdout (e.g. `DEBUG=true`).
+The concrete endpoint string and the allowed `deployment.environment` values are
+infra2's to define — find them in the infra2 contract, not here.
 
 ---
 
@@ -141,30 +138,16 @@ opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-http
 ```
 
-### 6.2 Vault Configuration
+### 6.2 Vault Configuration (infra2-owned)
 
-Set OTEL variables in Vault for each environment:
-
-```bash
-# Using infra2 env tool
-cd repo  # infra2 directory
-
-# Production
-uv run invoke env.set OTEL_EXPORTER_OTLP_ENDPOINT=http://platform-signoz-otel-collector:4318 \
-  --project=finance_report --env=production --service=app
-uv run invoke env.set OTEL_SERVICE_NAME=finance-report-backend \
-  --project=finance_report --env=production --service=app
-uv run invoke env.set OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production \
-  --project=finance_report --env=production --service=app
-
-# Staging
-uv run invoke env.set OTEL_EXPORTER_OTLP_ENDPOINT=http://platform-signoz-otel-collector:4318 \
-  --project=finance_report --env=staging --service=app
-uv run invoke env.set OTEL_SERVICE_NAME=finance-report-backend \
-  --project=finance_report --env=staging --service=app
-uv run invoke env.set OTEL_RESOURCE_ATTRIBUTES=deployment.environment=staging \
-  --project=finance_report --env=staging --service=app
-```
+The `OTEL_*` values are **issued by infra2** into Vault per environment. The
+concrete endpoint, `service.version`, and `deployment.environment` values, plus
+the `invoke env.set` procedure, live in the infra2 contract — see
+[`repo/docs/ssot/ops.observability.md`](../../repo/docs/ssot/ops.observability.md)
+and
+[`repo/docs/ssot/core.environments.md#telemetry-identity`](../../repo/docs/ssot/core.environments.md).
+The App must not hardcode or restate these per-environment values; it consumes
+whatever infra2 injects and fast-fails if a required value is absent.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
   - Governance:
       - Agent Orchestration: agents/orchestration.md
       - Red Lines: agents/red-lines.md
+      - App/Infra Contract Boundary: agents/app-infra-contract-boundary.md
       - Branch Policy: contributing/branch-policy.md
   - Development:
       - Project Overview: project/README.md

--- a/tests/tooling/test_env_contract_boundary.py
+++ b/tests/tooling/test_env_contract_boundary.py
@@ -1,0 +1,87 @@
+"""Anti-regression guard for the App/Infra env/observability contract boundary.
+
+EPIC Infra-014, slice D1.
+
+Principle: infra2 (runtime) owns + issues the env/observability contract; the
+App (software) consumes it via ``config.py`` and fast-fails. The App must NOT
+re-grow a parallel contract. These string-based assertions fail if the App's
+SSOT docs lose their pointer to the infra2 owner, re-introduce a drift pattern,
+or if ``config.py`` starts hardcoding a per-env OpenPanel client-id map.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+OBSERVABILITY_DOC = ROOT / "docs" / "ssot" / "observability.md"
+ENVIRONMENTS_DOC = ROOT / "docs" / "ssot" / "environments.md"
+CONFIG_PY = ROOT / "apps" / "backend" / "src" / "config.py"
+
+# Pointers each App doc MUST keep to the infra2-owned contract.
+OPS_OBSERVABILITY_POINTER = "repo/docs/ssot/ops.observability.md"
+CORE_ENVIRONMENTS_POINTER = "repo/docs/ssot/core.environments.md"
+
+# Drift patterns the App docs MUST NOT contain.
+#
+# The old wrong value is exactly ``deployment.environment=prod``. We must NOT
+# flag the legitimate ``deployment.environment=production`` used in App-side
+# verification text, so match ``...=prod`` only when it is not the prefix of a
+# longer word (i.e. followed by a non-word char or end of string).
+WRONG_DEPLOYMENT_ENV_RE = re.compile(r"deployment\.environment=prod(?![A-Za-z0-9_])")
+PER_ENV_COLLECTOR_FORM = "platform-signoz-otel-collector${ENV_SUFFIX}"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"expected file to exist: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_observability_doc_points_to_infra2_contract() -> None:
+    text = _read(OBSERVABILITY_DOC)
+    assert OPS_OBSERVABILITY_POINTER in text, (
+        "docs/ssot/observability.md must point at the infra2-owned contract "
+        f"({OPS_OBSERVABILITY_POINTER})"
+    )
+    assert CORE_ENVIRONMENTS_POINTER in text, (
+        "docs/ssot/observability.md must point at the infra2-owned contract "
+        f"({CORE_ENVIRONMENTS_POINTER})"
+    )
+
+
+def test_environments_doc_points_to_infra2_contract() -> None:
+    text = _read(ENVIRONMENTS_DOC)
+    assert OPS_OBSERVABILITY_POINTER in text, (
+        "docs/ssot/environments.md must point at the infra2-owned contract "
+        f"({OPS_OBSERVABILITY_POINTER})"
+    )
+    assert CORE_ENVIRONMENTS_POINTER in text, (
+        "docs/ssot/environments.md must point at the infra2-owned contract "
+        f"({CORE_ENVIRONMENTS_POINTER})"
+    )
+
+
+def test_app_docs_do_not_re_grow_contract_drift() -> None:
+    for doc in (OBSERVABILITY_DOC, ENVIRONMENTS_DOC):
+        text = _read(doc)
+        assert WRONG_DEPLOYMENT_ENV_RE.search(text) is None, (
+            f"{doc.relative_to(ROOT)} re-introduced the wrong contract value "
+            "'deployment.environment=prod'; the App must not restate "
+            "deployment.environment values (infra2 owns them)."
+        )
+        assert PER_ENV_COLLECTOR_FORM not in text, (
+            f"{doc.relative_to(ROOT)} re-introduced a per-env collector "
+            f"endpoint '{PER_ENV_COLLECTOR_FORM}'; the App must not restate "
+            "collector endpoints (infra2 owns the single no-suffix collector)."
+        )
+
+
+def test_config_py_does_not_hardcode_openpanel_client_map() -> None:
+    text = _read(CONFIG_PY)
+    assert "openpanel_clients" not in text, (
+        "apps/backend/src/config.py must not hardcode a per-env "
+        "'openpanel_clients' map; per-env OpenPanel client ids are issued by "
+        "infra2 (they live in infra2 deploy tooling, not the App config)."
+    )


### PR DESCRIPTION
## What
Completes the App side of **C1** (Infra-014): now that infra2 owns the env/observability contract (infra2#339, merged), the App's parallel SSOT is demoted to **App-side consumption + pointers**.

- `docs/ssot/observability.md` / `environments.md`: narrowed to "what `config.py` consumes" + a banner pointing at the canonical infra2 contract (`repo/docs/ssot/ops.observability.md`, `core.environments.md#telemetry-identity`). Removed the drifting restatements (per-env collector endpoints, `deployment.environment` value enumerations). **MANIFEST-owned anchors preserved.**
- **D1** `tests/tooling/test_env_contract_boundary.py`: guards against re-growing the contract (pointers present; no `deployment.environment=prod`; no `platform-signoz-otel-collector${ENV_SUFFIX}`; no `openpanel_clients` map in `config.py`).

## Not included
- **D2** (App/Infra boundary in `AGENTS.md`): omitted — `AGENTS.md`/`CLAUDE.md` is authorization-gated ("AI may NOT modify without explicit authorization"). Needs owner sign-off.
- **C2/C4/C5** (runtime issuance + fast-fail): next batch — ordered (C2 first), since fast-fail must not precede issuance.

## Verified locally
`check_manifest`, SSOT governance gate (`--fail-on-gate`), `lint_doc_consistency`, and the D1 test all pass. No runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)