### PR TITLE
[finance_report_vision] feat(extraction): balance-aware self-consistency re-extract (#989 Step B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ AI_BASE_URL=https://api.z.ai/api/coding/paas/v4
 AI_CHAT_COMPLETIONS_PATH=/chat/completions
 # Daily AI spend limit in USD (None to disable).
 AI_DAILY_LIMIT_USD=2
+# Max balance-aware re-extract attempts for bank statements (1 disables retry).
+AI_EXTRACT_MAX_ATTEMPTS=2
 # Disable provider 'thinking' mode for AI JSON completion calls.
 AI_JSON_DISABLE_THINKING=true
 # Max tokens for AI JSON completion calls.

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -388,6 +388,20 @@ class Settings(BaseSettings):
         json_schema_extra={"group": "AI Provider"},
     )
 
+    # Balance-aware self-consistency (#989 Step B): when a bank statement's
+    # running-balance chain fails to reconcile, re-extract up to this many times
+    # (each attempt with a varied seed) and keep the first reconciling result
+    # before routing to `uploaded`. 1 disables retry (single-shot). Only failing
+    # parses retry, so the average cost increase is bounded.
+    ai_extract_max_attempts: int = Field(
+        default=2,
+        ge=1,
+        le=5,
+        validation_alias="AI_EXTRACT_MAX_ATTEMPTS",
+        description="Max balance-aware re-extract attempts for bank statements (1 disables retry).",
+        json_schema_extra={"group": "AI Provider"},
+    )
+
     @field_validator("ai_json_seed", mode="before")
     @classmethod
     def _empty_seed_is_none(cls, value: object) -> object:

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -34,6 +34,7 @@ from src.services.validation import (
     compute_confidence_score,
     normalize_amount_direction,
     route_by_threshold,
+    validate_balance,
     validate_balance_explicit,
 )
 
@@ -321,12 +322,13 @@ class ExtractionService:
                     raise ExtractionError("Institution is required for CSV parsing")
                 extracted = await self._parse_csv_content(file_content, institution)
             elif file_type in ("pdf", "png", "jpg", "jpeg"):
-                extracted = await self.extract_financial_data(
+                extracted = await self._extract_with_balance_retry(
                     file_content=file_content,
                     institution=institution,
                     file_type=file_type,
                     file_url=file_url,
                     force_model=force_model,
+                    filename=original_filename or (file_path.name if file_path else None),
                 )
             else:
                 raise ExtractionError(f"Unsupported file type: {file_type}")
@@ -668,6 +670,78 @@ class ExtractionService:
         )
         return markdown
 
+    async def _extract_with_balance_retry(
+        self,
+        *,
+        file_content: bytes | None,
+        institution: str | None,
+        file_type: str,
+        file_url: str | None,
+        force_model: str | None,
+        filename: str | None,
+    ) -> dict[str, Any]:
+        """Re-extract until the running-balance chain reconciles (#989 Step B).
+
+        A non-deterministic model can drop/misread a transaction so the same PDF
+        sometimes reconciles and sometimes does not. When a bank statement fails
+        balance validation, re-extract up to ``ai_extract_max_attempts`` times,
+        each with a *different but reproducible* seed, and keep the first parse
+        that reconciles. Brokerage payloads do not reconcile like bank statements
+        (they import via Layer-2 positions), so they are never retried. If no
+        attempt reconciles, the smallest-difference result is returned so routing
+        to ``uploaded`` is unchanged.
+        """
+        max_attempts = max(1, settings.ai_extract_max_attempts)
+        base_seed = settings.ai_json_seed
+        best: dict[str, Any] | None = None
+        best_diff: Decimal | None = None
+
+        for attempt in range(max_attempts):
+            # Attempt 0 uses the configured seed; retries vary it so each is a
+            # distinct deterministic sample (None base => provider-side variance).
+            seed_override = base_seed + attempt if base_seed is not None and attempt > 0 else None
+            extracted = await self.extract_financial_data(
+                file_content=file_content,
+                institution=institution,
+                file_type=file_type,
+                file_url=file_url,
+                force_model=force_model,
+                seed_override=seed_override,
+            )
+
+            if looks_like_brokerage_payload(
+                extracted,
+                filename=filename,
+                institution=institution or extracted.get("institution"),
+            ):
+                return extracted
+
+            result = validate_balance(extracted)
+            if result.get("balance_valid"):
+                if attempt > 0:
+                    logger.info(
+                        "Balance reconciled on re-extract",
+                        attempt=attempt + 1,
+                        max_attempts=max_attempts,
+                        institution=institution or extracted.get("institution"),
+                    )
+                return extracted
+
+            try:
+                diff = Decimal(str(result.get("difference", "0") or "0"))
+            except (ValueError, TypeError, InvalidOperation):
+                diff = Decimal("0")
+            if best is None or diff < best_diff:
+                best, best_diff = extracted, diff
+
+        if max_attempts > 1:
+            logger.info(
+                "Balance did not reconcile after re-extract; keeping best parse",
+                attempts=max_attempts,
+                best_difference=str(best_diff),
+            )
+        return best if best is not None else extracted
+
     @staticmethod
     def _repair_json_object(content: str) -> str | None:
         """Best-effort recovery of a JSON object from a malformed model response.
@@ -722,6 +796,7 @@ class ExtractionService:
         return_raw: bool,
         has_content: bool,
         has_url: bool,
+        seed_override: int | None = None,
     ) -> dict[str, Any]:
         """Stream JSON extraction through the configured chat models."""
         last_error: ExtractionError | None = None
@@ -748,7 +823,7 @@ class ExtractionService:
                     max_tokens=settings.ai_json_max_tokens,
                     temperature=0.0,
                     do_sample=False,
-                    seed=settings.ai_json_seed,
+                    seed=seed_override if seed_override is not None else settings.ai_json_seed,
                     thinking={"type": "disabled"} if settings.ai_json_disable_thinking else None,
                 )
 
@@ -901,6 +976,7 @@ class ExtractionService:
         return_raw: bool = False,
         file_url: str | None = None,
         force_model: str | None = None,
+        seed_override: int | None = None,
     ) -> dict[str, Any]:
         """Extract structured statement data using OCR + chat models."""
         if file_content is None and not file_url:
@@ -957,6 +1033,7 @@ class ExtractionService:
                 return_raw=return_raw,
                 has_content=bool(file_content),
                 has_url=bool(file_url),
+                seed_override=seed_override,
             )
 
         if self._uses_dedicated_layout_ocr():
@@ -977,6 +1054,7 @@ class ExtractionService:
                     return_raw=return_raw,
                     has_content=bool(file_content),
                     has_url=bool(file_url),
+                    seed_override=seed_override,
                 )
             except ExtractionError as ocr_error:
                 logger.warning(
@@ -1021,6 +1099,7 @@ class ExtractionService:
             return_raw=return_raw,
             has_content=bool(file_content),
             has_url=bool(file_url),
+            seed_override=seed_override,
         )
 
     async def _parse_csv_content(self, file_content: bytes | str, institution: str) -> dict[str, Any]:

--- a/apps/backend/tests/extraction/test_self_consistency.py
+++ b/apps/backend/tests/extraction/test_self_consistency.py
@@ -1,0 +1,112 @@
+"""AC13.17: Balance-aware self-consistency re-extract (#989 Step B).
+
+When the extracted running-balance chain fails to reconcile, re-extract a bounded
+number of times before accepting the result (which would route the statement to
+`uploaded`). Each attempt varies the decoding seed so retries are *different but
+reproducible* samples; the first attempt that reconciles wins, otherwise the
+best-by-difference result is kept so routing is unchanged.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from src.config import settings
+from src.services.extraction import ExtractionService
+
+
+def _bank(diff: str = "0"):
+    """A bank payload whose closing balance is off by ``diff`` (0 => reconciles)."""
+    closing = "100.00" if diff == "0" else f"{100 - float(diff):.2f}"
+    return {
+        "institution": "DBS",
+        "period_start": "2025-01-01",
+        "period_end": "2025-01-31",
+        "opening_balance": "0.00",
+        "closing_balance": "100.00",
+        "currency": "SGD",
+        # one IN txn of `closing`; if closing != 100 the chain is off by `diff`
+        "transactions": [{"date": "2025-01-10", "amount": closing, "direction": "IN", "currency": "SGD"}],
+    }
+
+
+def _brokerage():
+    return {
+        "institution": "Futu",
+        "period_start": "2025-06-01",
+        "period_end": "2025-06-30",
+        "opening_balance": "0.00",
+        "closing_balance": "5000.00",
+        "currency": "HKD",
+        "positions": [{"symbol": "AAPL", "quantity": "10", "market_value": "5000.00"}],
+        "transactions": [],
+    }
+
+
+async def _run(service, attempts_returns, *, max_attempts=3, seed=42):
+    mock = AsyncMock(side_effect=attempts_returns)
+    with (
+        patch.object(settings, "ai_extract_max_attempts", max_attempts),
+        patch.object(settings, "ai_json_seed", seed),
+        patch.object(service, "extract_financial_data", mock),
+    ):
+        result = await service._extract_with_balance_retry(
+            file_content=b"x",
+            institution="DBS",
+            file_type="pdf",
+            file_url=None,
+            force_model=None,
+            filename="statement.pdf",
+        )
+    return result, mock
+
+
+async def test_reconciles_first_attempt_single_call():
+    """AC13.17.1: a reconciling first parse is returned without retry."""
+    service = ExtractionService()
+    result, mock = await _run(service, [_bank("0")])
+    assert result["closing_balance"] == "100.00"
+    assert mock.await_count == 1
+
+
+async def test_retries_until_reconciles():
+    """AC13.17.2: a failing parse is retried and the reconciling result wins."""
+    service = ExtractionService()
+    good = _bank("0")
+    result, mock = await _run(service, [_bank("12.50"), good])
+    assert result is good
+    assert mock.await_count == 2
+
+
+async def test_keeps_best_when_none_reconcile():
+    """AC13.17.3: when no attempt reconciles, the smallest-difference result is kept
+    (so routing to `uploaded` is unchanged) and all attempts are used."""
+    service = ExtractionService()
+    worst, best = _bank("40.00"), _bank("3.00")
+    result, mock = await _run(service, [worst, best, _bank("20.00")], max_attempts=3)
+    assert result is best
+    assert mock.await_count == 3
+
+
+async def test_brokerage_is_not_retried():
+    """AC13.17.4: brokerage payloads do not reconcile like bank statements and must
+    not burn retries."""
+    service = ExtractionService()
+    result, mock = await _run(service, [_brokerage(), _bank("0")])
+    assert "positions" in result
+    assert mock.await_count == 1
+
+
+async def test_seed_varies_per_attempt():
+    """AC13.17.5: attempt 0 uses the configured seed; retries use seed+1, seed+2 ..."""
+    service = ExtractionService()
+    _, mock = await _run(service, [_bank("5.00"), _bank("5.00"), _bank("5.00")], max_attempts=3, seed=42)
+    seeds = [c.kwargs.get("seed_override") for c in mock.await_args_list]
+    # attempt 0 -> None (falls back to settings seed); retries -> 43, 44
+    assert seeds == [None, 43, 44]
+
+
+async def test_max_attempts_one_disables_retry():
+    """AC13.17.6: max_attempts=1 keeps current single-shot behavior."""
+    service = ExtractionService()
+    result, mock = await _run(service, [_bank("9.00")], max_attempts=1)
+    assert result["closing_balance"] == "100.00"
+    assert mock.await_count == 1

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -304,3 +304,24 @@ reproducibly: temperature 0 / `do_sample` false plus a fixed `seed`
 | AC13.16.2 | Extraction forwards the configured `ai_json_seed` to the model call | `test_extraction_forwards_configured_seed()` | `extraction/test_seed_determinism.py` | P1 |
 | AC13.16.3 | Extraction pins `temperature=0` / `do_sample=False` alongside the seed | `test_extraction_decoding_is_deterministic_by_default()` | `extraction/test_seed_determinism.py` | P1 |
 | AC13.16.4 | Empty `AI_JSON_SEED` parses as None (omitted) instead of raising | `test_empty_seed_env_is_treated_as_none()` | `extraction/test_seed_determinism.py` | P1 |
+
+### AC13.17: Balance-Aware Self-Consistency Re-extract (issue #989 Step B)
+
+Step A (AC13.16) makes a single decode reproducible; this AC adds the
+**self-consistency** half. When a bank statement's running-balance chain fails to
+reconcile, `_extract_with_balance_retry` re-extracts up to
+`AI_EXTRACT_MAX_ATTEMPTS` times — each attempt with a *varied* seed (configured
+seed, then +1, +2 …) so retries are different-but-reproducible samples — and keeps
+the first parse that reconciles before the statement would route to `uploaded`.
+Brokerage payloads are never retried (they reconcile via Layer-2 positions, not a
+running-balance chain); if no attempt reconciles, the smallest-difference result is
+kept so routing is unchanged. Only failing parses retry, so average cost is bounded.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC13.17.1 | A reconciling first parse is returned without retry | `test_reconciles_first_attempt_single_call()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.17.2 | A failing parse is retried and the reconciling result wins | `test_retries_until_reconciles()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.17.3 | When no attempt reconciles, the smallest-difference result is kept | `test_keeps_best_when_none_reconcile()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.17.4 | Brokerage payloads are not retried | `test_brokerage_is_not_retried()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.17.5 | Attempt 0 uses the configured seed; retries vary it (seed+1, seed+2 …) | `test_seed_varies_per_attempt()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.17.6 | `AI_EXTRACT_MAX_ATTEMPTS=1` keeps single-shot behavior | `test_max_attempts_one_disables_retry()` | `extraction/test_self_consistency.py` | P1 |

--- a/docs/ssot/env-reference.generated.md
+++ b/docs/ssot/env-reference.generated.md
@@ -24,6 +24,7 @@ Where a field's `.env.example` value intentionally differs from its code default
 | `AI_BASE_URL` | `https://api.z.ai/api/coding/paas/v4` |  |  | AI Provider | AI provider base URL (provider-neutral; default targets Z.AI/GLM). |
 | `AI_CHAT_COMPLETIONS_PATH` | `/chat/completions` |  |  | AI Provider | Chat completions path appended to the AI base URL. |
 | `AI_DAILY_LIMIT_USD` | `2` |  |  | AI Provider | Daily AI spend limit in USD (None to disable). |
+| `AI_EXTRACT_MAX_ATTEMPTS` | `2` |  |  | AI Provider | Max balance-aware re-extract attempts for bank statements (1 disables retry). |
 | `AI_JSON_DISABLE_THINKING` | `true` |  |  | AI Provider | Disable provider 'thinking' mode for AI JSON completion calls. |
 | `AI_JSON_MAX_TOKENS` | `8192` |  |  | AI Provider | Max tokens for AI JSON completion calls. |
 | `AI_JSON_SEED` | `42` |  |  | AI Provider | Fixed decoding seed for reproducible AI extraction (empty to omit). |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -258,6 +258,14 @@ S3_PRESIGN_EXPIRY_SECONDS=300
   `balance_validated`, `confidence_score`, and Stage-1 routing from flipping
   between uploads of the same source (#989). Set `AI_JSON_SEED=` (empty) to omit
   the seed for providers that reject it.
+- **Balance-aware self-consistency re-extract**: when a bank statement's
+  running-balance chain fails to reconcile, `_extract_with_balance_retry`
+  re-extracts up to `AI_EXTRACT_MAX_ATTEMPTS` times (each with a varied seed —
+  configured seed, then +1, +2 …) and keeps the first parse that reconciles before
+  routing to `uploaded` (#989 Step B). Brokerage payloads are never retried; if no
+  attempt reconciles, the smallest-difference result is kept so routing is
+  unchanged. Only failing parses retry, so average cost is bounded; set
+  `AI_EXTRACT_MAX_ATTEMPTS=1` to disable.
 - **Bucket auto-create**: storage ensures the bucket exists before upload.
 - **Orphan cleanup**: if DB persistence fails after upload, the uploaded object is deleted.
 - **Periodic orphan sweep**: old statement storage objects without matching DB records are deleted by


### PR DESCRIPTION
## Summary
Completes **#989** (the last substantive piece of the **#996** vision lane). Step A (seed, merged in #1019) makes a single decode reproducible; **Step B** adds the self-consistency half that actually addresses the root symptom — *the same PDF sometimes reconciles and sometimes routes to `uploaded`* because a non-deterministic model dropped/misread one transaction.

## How it works
- New `ExtractionService._extract_with_balance_retry`, used by `parse_document`'s PDF/image path. When a bank statement's running-balance chain **fails to reconcile**, it re-extracts up to `AI_EXTRACT_MAX_ATTEMPTS` (default **2**) times and returns the first parse that reconciles.
- **Varied seed per attempt** (attempt 0 = configured seed, retries = seed+1, seed+2 …). This is the key interaction with Step A: a *fixed* seed would make every retry identical, so retries vary the seed → different-but-reproducible samples. Same PDF → same seed sequence → same final result (still deterministic end-to-end).
- **Brokerage payloads are never retried** — they reconcile via Layer-2 `AtomicPosition`, not a running-balance chain (they route to `parsed`/review regardless).
- If **no** attempt reconciles, the **smallest-difference** result is kept, so routing to `uploaded` is unchanged from today.
- **Bounded cost:** only balance-failing parses retry; reconciling/brokerage parses cost exactly one call as before. `AI_EXTRACT_MAX_ATTEMPTS=1` disables the feature entirely.

## Tests
`AC13.17.1-6` in `extraction/test_self_consistency.py`: reconcile-first (1 call), retry-until-reconcile (stops early), keep-best-when-none-reconcile, brokerage-not-retried, **seed varies per attempt** (`[None, 43, 44]`), and `max_attempts=1` single-shot. Full extraction + AI suite passes locally (619 passed; the 1 failure is the pre-existing env-driven `test_fallback_models_format`, which passes under CI's `glm-*` env).

## SSOT / config
- `AI_EXTRACT_MAX_ATTEMPTS` added to `config.py` (and auto-generated into `.env.example` + env-reference).
- `docs/ssot/extraction.md` Parsing Resilience + `EPIC-013` AC13.17 updated.

## Deploy note
This makes balance-failing bank uploads cost up to 2× model calls (default). Tune via `AI_EXTRACT_MAX_ATTEMPTS` (1–5). Pairs with the Step-A deploy check that the provider accepts the `seed` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)