### PR TITLE
[finance_report_hacker] fix(workflow): make workflow-event dedupe insert transaction-safe (#1033)

### DIFF
--- a/apps/backend/src/services/workflow_events.py
+++ b/apps/backend/src/services/workflow_events.py
@@ -5,6 +5,7 @@ from uuid import NAMESPACE_URL, UUID, uuid5
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
@@ -182,6 +183,46 @@ def _workflow_event_from_payload(
     return event
 
 
+async def _get_workflow_event_by_dedupe_key(
+    db: AsyncSession, *, user_id: UUID, dedupe_key: str
+) -> WorkflowEvent | None:
+    result = await db.execute(
+        select(WorkflowEvent).where(WorkflowEvent.user_id == user_id).where(WorkflowEvent.dedupe_key == dedupe_key)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _insert_workflow_event_conflict_safe(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    payload: WorkflowEventCreate,
+    session_id: UUID | None,
+) -> WorkflowEvent:
+    """Insert a new workflow event without letting a dedupe-key race poison the outer transaction.
+
+    Concurrent requests/background tasks for the same ``(user_id, dedupe_key)`` can both miss the
+    pre-insert SELECT and both attempt the insert; the loser raises a ``UniqueViolationError`` on
+    ``uq_workflow_events_user_dedupe_key``. Running the insert + flush inside a SAVEPOINT means that
+    on conflict only the nested transaction rolls back (the outer request transaction stays usable),
+    after which we re-fetch and update the now-existing row — mirroring the session guard above.
+    """
+    event = _workflow_event_from_payload(user_id=user_id, payload=payload, session_id=session_id)
+    try:
+        async with db.begin_nested():
+            db.add(event)
+            await db.flush()
+    except IntegrityError:
+        existing = await _get_workflow_event_by_dedupe_key(db, user_id=user_id, dedupe_key=payload.dedupe_key)
+        if existing is None:
+            raise
+        _apply_workflow_event_payload(existing, payload)
+        if existing.session_id is None:
+            existing.session_id = session_id
+        return existing
+    return event
+
+
 def build_uploaded_statement_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
     """Build the deterministic uploaded-statement workflow event payload."""
     family = WorkflowEventFamily.SOURCE_UPLOADED
@@ -336,15 +377,9 @@ async def upsert_workflow_event(
         workflow_session = await get_or_create_active_workflow_session(db, user_id=user_id)
         session_id = workflow_session.id
 
-    result = await db.execute(
-        select(WorkflowEvent)
-        .where(WorkflowEvent.user_id == user_id)
-        .where(WorkflowEvent.dedupe_key == payload.dedupe_key)
-    )
-    event = result.scalar_one_or_none()
+    event = await _get_workflow_event_by_dedupe_key(db, user_id=user_id, dedupe_key=payload.dedupe_key)
     if event is None:
-        event = _workflow_event_from_payload(user_id=user_id, payload=payload, session_id=session_id)
-        db.add(event)
+        event = await _insert_workflow_event_conflict_safe(db, user_id=user_id, payload=payload, session_id=session_id)
     else:
         _apply_workflow_event_payload(event, payload)
         if event.session_id is None:
@@ -414,7 +449,9 @@ async def sync_workflow_events_for_user(db: AsyncSession, *, user_id: UUID) -> N
         filename = ods_filename or statement.file_hash
         payload = build_uploaded_statement_event_payload(statement, filename)
         if event is None:
-            db.add(_workflow_event_from_payload(user_id=user_id, payload=payload, session_id=workflow_session.id))
+            await _insert_workflow_event_conflict_safe(
+                db, user_id=user_id, payload=payload, session_id=workflow_session.id
+            )
         else:
             _apply_workflow_event_payload(event, payload)
             if event.session_id is None:
@@ -468,7 +505,9 @@ async def sync_workflow_events_for_user(db: AsyncSession, *, user_id: UUID) -> N
         for payload in derived_payloads:
             event = event_by_dedupe_key.get(payload.dedupe_key)
             if event is None:
-                db.add(_workflow_event_from_payload(user_id=user_id, payload=payload, session_id=workflow_session.id))
+                await _insert_workflow_event_conflict_safe(
+                    db, user_id=user_id, payload=payload, session_id=workflow_session.id
+                )
             else:
                 _apply_workflow_event_payload(event, payload)
                 if event.session_id is None:

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -26,6 +26,9 @@ from src.models.workflow import (
 )
 from src.schemas.workflow import WorkflowEventCreate, WorkflowEventResponse
 from src.services.workflow_events import (
+    _insert_workflow_event_conflict_safe,
+    _workflow_event_from_payload,
+    build_uploaded_statement_event_payload,
     derive_uploaded_statement_event,
     get_or_create_active_workflow_session,
     get_workflow_status,
@@ -1020,3 +1023,114 @@ async def test_AC22_4_1_pending_stage2_match_surfaces_reconciliation_review_even
     recon_again = [e for e in events_again if e.family == WorkflowEventFamily.RECONCILIATION_BLOCKED]
     assert len(recon_again) == 1
     assert recon_again[0].id == original_event_id
+
+
+async def test_AC19_14_1_concurrent_upsert_same_dedupe_key_does_not_500(db_engine, test_user) -> None:
+    """AC19.14.1: Two concurrent upserts of the same (user_id, dedupe_key) workflow event both
+    succeed without a duplicate-key 500; exactly one row exists and both calls return it."""
+    sessionmaker = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+
+    source_id = uuid4()
+    payload = build_uploaded_statement_event_payload(
+        SimpleNamespace(id=source_id, created_at=datetime.now(UTC)),
+        "concurrent.pdf",
+    )
+
+    async with sessionmaker() as first_session, sessionmaker() as second_session:
+        first = await upsert_workflow_event(first_session, user_id=test_user.id, payload=payload)
+
+        second_task = asyncio.create_task(upsert_workflow_event(second_session, user_id=test_user.id, payload=payload))
+        await asyncio.sleep(0.2)
+        await first_session.commit()
+
+        second = await asyncio.wait_for(second_task, timeout=5)
+        await second_session.commit()
+
+    async with sessionmaker() as verify_session:
+        events = (
+            (
+                await verify_session.execute(
+                    select(WorkflowEvent)
+                    .where(WorkflowEvent.user_id == test_user.id)
+                    .where(WorkflowEvent.dedupe_key == payload.dedupe_key)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(events) == 1
+    assert first.dedupe_key == payload.dedupe_key
+    assert second.dedupe_key == payload.dedupe_key
+
+
+async def test_AC19_14_2_duplicate_insert_does_not_poison_outer_transaction(db, test_user) -> None:
+    """AC19.14.2: When the same (user_id, dedupe_key) is inserted twice within one session, the
+    second insert recovers via savepoint, returns the existing row, and the outer transaction stays
+    usable for subsequent reads/flushes (no 'transaction has been rolled back')."""
+    source_id = uuid4()
+    payload = build_uploaded_statement_event_payload(
+        SimpleNamespace(id=source_id, created_at=datetime.now(UTC)),
+        "duplicate.pdf",
+    )
+
+    workflow_session = await get_or_create_active_workflow_session(db, user_id=test_user.id)
+
+    # Pre-existing row with the same dedupe key, committed so it is visible to the next insert.
+    existing = _workflow_event_from_payload(user_id=test_user.id, payload=payload, session_id=workflow_session.id)
+    db.add(existing)
+    await db.commit()
+
+    # Force the racing path: a fresh ORM object inserted directly via the conflict-safe helper.
+    recovered = await _insert_workflow_event_conflict_safe(
+        db, user_id=test_user.id, payload=payload, session_id=workflow_session.id
+    )
+    assert recovered.id == existing.id
+
+    # The outer transaction must still be alive: this flush/read would raise if it were poisoned.
+    await db.flush()
+    count = await db.scalar(
+        select(func.count(WorkflowEvent.id))
+        .where(WorkflowEvent.user_id == test_user.id)
+        .where(WorkflowEvent.dedupe_key == payload.dedupe_key)
+    )
+    assert count == 1
+
+
+async def test_AC19_14_3_sync_tolerates_concurrent_event_creation(db_engine, test_user) -> None:
+    """AC19.14.3: Concurrent sync_workflow_events_for_user runs over the same source state do not
+    500 on the workflow-event dedupe key; the derived uploaded event is created exactly once."""
+    sessionmaker = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+
+    file_hash = uuid4().hex
+    async with sessionmaker() as setup_session:
+        await _make_statement(
+            setup_session,
+            test_user.id,
+            original_filename="race.pdf",
+            file_hash=file_hash,
+            status=BankStatementStatus.UPLOADED,
+        )
+        await setup_session.commit()
+
+    async with sessionmaker() as first_session, sessionmaker() as second_session:
+        await sync_workflow_events_for_user(first_session, user_id=test_user.id)
+        second_task = asyncio.create_task(sync_workflow_events_for_user(second_session, user_id=test_user.id))
+        await asyncio.sleep(0.2)
+        await first_session.commit()
+        await asyncio.wait_for(second_task, timeout=5)
+        await second_session.commit()
+
+    async with sessionmaker() as verify_session:
+        uploaded = (
+            (
+                await verify_session.execute(
+                    select(WorkflowEvent)
+                    .where(WorkflowEvent.user_id == test_user.id)
+                    .where(WorkflowEvent.family == WorkflowEventFamily.SOURCE_UPLOADED)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(uploaded) == 1

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -439,6 +439,21 @@ dependency (delivery speed unaffected).
 | AC19.13.1 | Statement parse dispatch is config-gated: with `PREFECT_API_URL` unset, `submit_parse_pipeline` runs the existing in-process `asyncio.create_task` fallback (no Prefect import) and returns the task to track | `test_AC19_13_1_dispatch_falls_back_to_asyncio_when_prefect_unset` | P0 |
 | AC19.13.2 | With `PREFECT_API_URL` set, `submit_parse_pipeline` submits a Prefect flow run with serializable params only (no raw bytes, no session maker — the worker re-fetches content and builds its own session) and returns None | `test_AC19_13_2_dispatch_submits_serializable_params_to_prefect` | P0 |
 
+### AC19.14 — Workflow-event dedupe is transaction-safe (issue #1033)
+
+Concurrent requests/background tasks for the same `(user_id, dedupe_key)` both miss the
+pre-insert SELECT and both insert; the loser raised a `UniqueViolationError` on
+`uq_workflow_events_user_dedupe_key` during autoflush, poisoning the outer request transaction so
+`/chat/suggestions`, `/workflow/events`, and advisor panels cascaded into 500s. Every workflow-event
+insert now runs inside a SAVEPOINT and recovers the existing row on conflict, mirroring the existing
+`uq_workflow_sessions_user_dedupe_key` guard.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC19.14.1 | Two concurrent `upsert_workflow_event` calls for the same `(user_id, dedupe_key)` both succeed without a duplicate-key 500; exactly one row exists and both calls return it | `test_AC19_14_1_concurrent_upsert_same_dedupe_key_does_not_500` | P0 |
+| AC19.14.2 | A duplicate `(user_id, dedupe_key)` insert recovers via savepoint, returns the existing row, and leaves the outer transaction usable for subsequent reads/flushes | `test_AC19_14_2_duplicate_insert_does_not_poison_outer_transaction` | P0 |
+| AC19.14.3 | Concurrent `sync_workflow_events_for_user` runs over the same source state do not 500 on the workflow-event dedupe key and create the derived uploaded event exactly once | `test_AC19_14_3_sync_tolerates_concurrent_event_creation` | P0 |
+
 ## How To Build It
 
 ### Backend

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -224,6 +224,17 @@ bank_statement:4ab1...:review.required
 Rerunning derivation updates mutable display fields, but it must not create
 duplicates or reset lifecycle status.
 
+The `UNIQUE(user_id, dedupe_key)` constraint is the authoritative dedupe guard.
+Because the same user-visible event can be derived concurrently (overlapping
+requests and background parse tasks), the `select`-then-`insert` upsert is
+inherently racy: both callers can miss the pre-insert read and both insert.
+Every workflow-event insert therefore runs inside a SAVEPOINT
+(`db.begin_nested()`); on the resulting `IntegrityError`, only the nested
+transaction rolls back (the outer request transaction stays usable) and the
+caller re-fetches and updates the now-existing row. This mirrors the
+`uq_workflow_sessions_user_dedupe_key` guard and prevents a duplicate insert
+from poisoning the outer transaction and cascading 500s.
+
 ---
 
 ## 8. Action Links


### PR DESCRIPTION
## Root cause

`apps/backend/src/services/workflow_events.py` created workflow events with **SELECT → `db.add()` → `await db.flush()`** and no DB-level conflict guard. Concurrent requests/background tasks for the same `(user_id, dedupe_key)` (e.g. `bank_statement:<id>:source.uploaded`) both missed the SELECT and both inserted. The loser then raised an asyncpg `UniqueViolationError` on `uq_workflow_events_user_dedupe_key` during **autoflush**, which **poisoned the entire outer request transaction**. Every endpoint that subsequently touched the session failed with `This Session's transaction has been rolled back due to a previous exception during flush` — cascading 500s across `/chat/suggestions`, `/workflow/events`, and advisor panels (workflow status, portfolio summary, market data status).

The **sessions** table was already protected (`.on_conflict_do_nothing(constraint="uq_workflow_sessions_user_dedupe_key")` at ~L135), but the three **event** insert sites never got equivalent protection.

## Fix

Factor a small helper `_insert_workflow_event_conflict_safe(...)` that runs the insert + flush inside a **SAVEPOINT** (`async with db.begin_nested():`). On `IntegrityError`, only the nested transaction rolls back — the outer request transaction stays alive — and the helper re-SELECTs the now-existing row, applies the payload, and returns it. This mirrors the existing session guard.

Applied consistently to all three insert sites:
- `upsert_workflow_event` (~L346)
- `sync_workflow_events_for_user` uploaded-event branch (~L417)
- `sync_workflow_events_for_user` derived-payload branch (~L471)

The non-conflict path is unchanged: it still returns the freshly created/updated event.

## Tests (EPIC-019, AC19.14)

New AC section `### AC19.14 — Workflow-event dedupe is transaction-safe (issue #1033)` in `docs/project/EPIC-019.event-driven-upload-to-report-ux.md`. Tests in `apps/backend/tests/workflow/test_workflow_events.py` exercise the **real** Postgres unique constraint via the existing conftest fixtures:

- `test_AC19_14_1_concurrent_upsert_same_dedupe_key_does_not_500` — two concurrent `upsert_workflow_event` calls (separate sessions) race the same dedupe key; both succeed, exactly one row exists.
- `test_AC19_14_2_duplicate_insert_does_not_poison_outer_transaction` — a duplicate insert recovers via savepoint, returns the existing row, and a subsequent flush/SELECT still succeeds (outer transaction not poisoned).
- `test_AC19_14_3_sync_tolerates_concurrent_event_creation` — concurrent `sync_workflow_events_for_user` runs do not 500 and create the derived uploaded event exactly once.

SSOT `docs/ssot/workflow-events.md` Dedupe Rules section documents the savepoint guard.

## Validation

- `ruff check` + `ruff format --check`: pass
- Targeted: `pytest tests/workflow/test_workflow_events.py` — 26 passed (23 existing + 3 new), against the real Postgres test DB
- AC traceability tooling tests (`tests/tooling/`): pass

Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)