### PR TITLE
[finance_report_hacker] fix(extraction): vision path falls back to secondary models (#1034)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,8 @@ OCR_MODEL=glm-4.6v
 PREFECT_API_URL=
 # Primary AI model id.
 PRIMARY_MODEL=glm-5.1
+# Comma-separated fallback AI model ids for the vision/OCR path. These must be vision-capable because the vision request carries image content; the text-only FALLBACK_MODELS are not reused here (#1034).
+VISION_FALLBACK_MODELS=glm-4.5v
 # Vision AI model id.
 VISION_MODEL=glm-4.6v
 # AI provider API key (empty key = AI features disabled). ZAI_API_KEY is preferred for the default Z.AI provider; AI_API_KEY is a provider-neutral alias. [VAULT]

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -339,6 +339,16 @@ class Settings(BaseSettings):
         description="Comma-separated fallback AI model ids.",
         json_schema_extra={"group": "AI Provider", "example": "glm-5-turbo,glm-5"},
     )
+    vision_fallback_models_str: str | None = Field(
+        default=None,
+        validation_alias="VISION_FALLBACK_MODELS",
+        description=(
+            "Comma-separated fallback AI model ids for the vision/OCR path. These "
+            "must be vision-capable because the vision request carries image "
+            "content; the text-only FALLBACK_MODELS are not reused here (#1034)."
+        ),
+        json_schema_extra={"group": "AI Provider", "example": "glm-4.5v"},
+    )
     # EPIC-019: when set, upload→report parsing is submitted as a durable Prefect
     # flow run instead of an in-process asyncio task. Unset (CI/local/preview) →
     # in-process fallback, no Prefect dependency. See services/statement_pipeline.py.
@@ -541,6 +551,23 @@ class Settings(BaseSettings):
             [
                 "glm-5-turbo",
                 "glm-5",
+            ],
+        )
+
+    @cached_property
+    def vision_fallback_models(self) -> list[str]:
+        """Parse vision-path fallback models from env string or use defaults.
+
+        The vision/OCR path sends image content, so its fallbacks must be
+        vision-capable; the text-only ``FALLBACK_MODELS`` are intentionally not
+        reused here (#1034). The default keeps a single secondary vision model so
+        a non-retryable failure of the primary vision model does not fail the
+        whole upload.
+        """
+        return parse_comma_list(
+            self.vision_fallback_models_str,
+            [
+                "glm-4.5v",
             ],
         )
 

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -62,6 +62,7 @@ class ExtractionService:
         self.vision_model = settings.vision_model
         self.ocr_model = settings.ocr_model
         self.fallback_models = settings.fallback_models
+        self.vision_fallback_models = settings.vision_fallback_models
         self.deduplication_service = DeduplicationService()
 
     def _safe_date(self, value: str | None) -> date:
@@ -603,9 +604,17 @@ class ExtractionService:
         return bool(self.ocr_model and self.ocr_model != self.vision_model)
 
     def _vision_extraction_models(self) -> list[str]:
-        """Return ordered vision/OCR models without duplicate provider calls."""
+        """Return ordered vision/OCR models without duplicate provider calls.
+
+        The primary OCR/vision models are followed by the configured
+        ``VISION_FALLBACK_MODELS`` so a non-retryable failure of the primary
+        vision model (e.g. a provider 400) falls through to a secondary
+        vision-capable model before the upload is rejected (#1034). The list is
+        deduplicated and order-preserving. Text-only ``FALLBACK_MODELS`` are not
+        reused here because the vision request carries image content.
+        """
         models: list[str] = []
-        for model in (self.ocr_model, self.vision_model):
+        for model in (self.ocr_model, self.vision_model, *self.vision_fallback_models):
             if model and model not in models:
                 models.append(model)
         return models

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -221,11 +221,16 @@ async def test_extract_financial_data_uses_ocr_first_pipeline():
 
 
 async def test_extract_financial_data_shared_ocr_vision_skips_layout_parser():
-    """AC8.12.6: Shared OCR/vision model uses one vision call and skips layout parsing."""
+    """AC8.12.6: Shared OCR/vision model uses one vision call and skips layout parsing.
+
+    AC13.17.1: the configured vision fallback model is appended after the primary
+    so more than one model is attempted on the vision path (#1034).
+    """
     service = ExtractionService()
     service.api_key = "test-key"
     service.ocr_model = "glm-4.6v"
     service.vision_model = "glm-4.6v"
+    service.vision_fallback_models = ["glm-4.5v"]
 
     mock_ocr = AsyncMock()
     mock_extract = AsyncMock(return_value={"transactions": []})
@@ -242,27 +247,99 @@ async def test_extract_financial_data_shared_ocr_vision_skips_layout_parser():
     assert result == {"transactions": []}
     mock_ocr.assert_not_awaited()
     call = mock_extract.await_args.kwargs
-    assert call["models"] == ["glm-4.6v"]
+    assert call["models"] == ["glm-4.6v", "glm-4.5v"]
     assert call["messages"][0]["content"][1] == image_payload
 
 
-def test_ocr_model_selection_helpers_deduplicate_vision_models():
-    """AC8.12.6: OCR/vision helper rules avoid duplicate provider calls."""
+async def test_vision_path_falls_back_to_secondary_model_on_non_retryable_error():
+    """AC13.17.2: when the primary vision model raises a non-retryable provider
+    error (e.g. a 400), the vision path attempts the configured vision fallback
+    model and succeeds instead of failing the upload (#1034)."""
+    from src.services.ai_streaming import AIStreamError
+
     service = ExtractionService()
+    service.api_key = "test-key"
+    service.ocr_model = "glm-4.6v"
+    service.vision_model = "glm-4.6v"
+    service.vision_fallback_models = ["glm-4.5v"]
+
+    attempted_models: list[str] = []
+
+    def fake_stream_ai_json(*, model, **kwargs):
+        attempted_models.append(model)
+        if model == "glm-4.6v":
+            raise AIStreamError(
+                'provider=zai model=glm-4.6v status_code=400 {"code":"1210","message":"Invalid API parameter"}',
+                retryable=False,
+            )
+        return f"stream:{model}"
+
+    async def fake_accumulate_stream(stream):
+        assert stream == "stream:glm-4.5v"
+        return '{"transactions": []}'
+
+    image_payload = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+    }
+
+    with (
+        patch.object(service, "_build_vision_media_payloads", return_value=[image_payload]),
+        patch("src.services.extraction.stream_ai_json", side_effect=fake_stream_ai_json),
+        patch("src.services.extraction.accumulate_stream", side_effect=fake_accumulate_stream),
+    ):
+        result = await service.extract_financial_data(b"content", "DBS", "pdf")
+
+    assert result == {"transactions": []}
+    # The primary vision model is attempted first, then the configured fallback.
+    assert attempted_models == ["glm-4.6v", "glm-4.5v"]
+
+
+def test_ocr_model_selection_helpers_deduplicate_vision_models():
+    """AC8.12.6: OCR/vision helper rules avoid duplicate provider calls.
+
+    AC13.17.1: configured vision fallbacks are appended to the vision model list,
+    deduplicated and order-preserving, so more than one model is attempted on the
+    vision path (#1034).
+    """
+    service = ExtractionService()
+    service.vision_fallback_models = ["glm-4.5v"]
 
     service.ocr_model = "glm-4.6v"
     service.vision_model = "glm-4.6v"
     assert service._uses_dedicated_layout_ocr() is False
-    assert service._vision_extraction_models() == ["glm-4.6v"]
+    assert service._vision_extraction_models() == ["glm-4.6v", "glm-4.5v"]
 
     service.ocr_model = "layout-ocr-model"
     service.vision_model = "glm-4.6v"
     assert service._uses_dedicated_layout_ocr() is True
-    assert service._vision_extraction_models() == ["layout-ocr-model", "glm-4.6v"]
+    assert service._vision_extraction_models() == ["layout-ocr-model", "glm-4.6v", "glm-4.5v"]
 
     service.ocr_model = ""
     service.vision_model = "glm-4.6v"
     assert service._uses_dedicated_layout_ocr() is False
+    assert service._vision_extraction_models() == ["glm-4.6v", "glm-4.5v"]
+
+
+def test_vision_extraction_models_dedupes_fallback_against_primary():
+    """AC13.17.1: a vision fallback equal to the primary vision/OCR model is not
+    attempted twice; ordering of the remaining fallbacks is preserved (#1034)."""
+    service = ExtractionService()
+    service.ocr_model = "glm-4.6v"
+    service.vision_model = "glm-4.6v"
+    service.vision_fallback_models = ["glm-4.6v", "glm-4.5v", "glm-4.5v"]
+
+    assert service._vision_extraction_models() == ["glm-4.6v", "glm-4.5v"]
+
+
+def test_vision_extraction_models_without_fallbacks_returns_primary_only():
+    """AC13.17.1: with no configured vision fallbacks the list is unchanged, so
+    deployments that opt out keep the prior single-model behavior (#1034)."""
+    service = ExtractionService()
+    service.ocr_model = "glm-4.6v"
+    service.vision_model = "glm-4.6v"
+    service.vision_fallback_models = []
+
     assert service._vision_extraction_models() == ["glm-4.6v"]
 
 
@@ -391,6 +468,7 @@ async def test_extract_financial_data_dedicated_ocr_failure_falls_back_to_vision
     service.api_key = "test-key"
     service.ocr_model = "layout-ocr-model"
     service.vision_model = "glm-4.6v"
+    service.vision_fallback_models = ["glm-4.5v"]
 
     mock_ocr = AsyncMock(side_effect=ExtractionError("layout parser unavailable"))
     mock_extract = AsyncMock(return_value={"transactions": []})
@@ -407,7 +485,8 @@ async def test_extract_financial_data_dedicated_ocr_failure_falls_back_to_vision
     assert result == {"transactions": []}
     mock_ocr.assert_awaited_once_with(b"content", None, "pdf", "application/pdf")
     call = mock_extract.await_args.kwargs
-    assert call["models"] == ["layout-ocr-model", "glm-4.6v"]
+    # AC13.17.1: the vision fallback model is appended after the primary vision model.
+    assert call["models"] == ["layout-ocr-model", "glm-4.6v", "glm-4.5v"]
     assert call["messages"][0]["content"][1] == image_payload
 
 
@@ -454,6 +533,7 @@ async def test_extract_financial_data_invalid_json_all_attempts():
     service = ExtractionService()
     service.api_key = "test-key"
     service.ocr_model = None
+    service.vision_fallback_models = []  # isolate single-model JSON-parse behavior
 
     # Invalid JSON - should fail with JSON parse error immediately
     content = "Invalid JSON without markdown that is clearly not empty"
@@ -957,6 +1037,7 @@ async def test_extract_empty_model_in_list_skipped():
     service.primary_model = ""  # Empty string model
     service.ocr_model = ""
     service.vision_model = ""
+    service.vision_fallback_models = []  # no fallbacks -> empty model list
 
     # With empty primary_model, the only model is "", which should be skipped
     # Then we fall to line 604: raise last_error or ExtractionError(...)
@@ -973,6 +1054,7 @@ async def test_extract_empty_ai_response():
     service = ExtractionService()
     service.api_key = "test-key"
     service.ocr_model = None
+    service.vision_fallback_models = []  # isolate single-model empty-response behavior
 
     with (
         patch("src.services.extraction.stream_ai_json"),
@@ -1039,6 +1121,7 @@ async def test_extract_no_models_tried_fallback_error():
     service.primary_model = ""
     service.ocr_model = ""
     service.vision_model = ""
+    service.vision_fallback_models = []  # no fallbacks -> empty model list
 
     with pytest.raises(ExtractionError, match="Extraction failed after all retries"):
         await service.extract_financial_data(

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -203,6 +203,13 @@ Expected routing behavior remains threshold-based (See: `docs/ssot/reconciliatio
 | AC13.15.4 | `is_brokerage` defaults to False so existing callers are unaffected | `test_default_is_not_brokerage()` | `extraction/test_extraction.py` | P1 |
 | AC13.15.5 | The cap uses the persisted transaction count (after skipped rows), not the raw extracted count | `test_effective_count_uses_persisted_not_extracted()` | `extraction/test_extraction.py` | P1 |
 
+### AC13.17: Vision Extraction Falls Back to Secondary Models (issue #1034)
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC13.17.1 | The vision model list appends `VISION_FALLBACK_MODELS` after the primary OCR/vision model, deduplicated and order-preserving, so more than one model is attempted on the vision path | `test_ocr_model_selection_helpers_deduplicate_vision_models()`, `test_vision_extraction_models_dedupes_fallback_against_primary()`, `test_vision_extraction_models_without_fallbacks_returns_primary_only()`, `test_extract_financial_data_shared_ocr_vision_skips_layout_parser()`, `test_extract_financial_data_dedicated_ocr_failure_falls_back_to_vision()` | `extraction/test_extraction_error_paths.py` | P1 |
+| AC13.17.2 | When the primary vision model raises a non-retryable provider error (e.g. a 400), the vision path attempts the configured vision fallback model and succeeds instead of failing the upload | `test_vision_path_falls_back_to_secondary_model_on_non_retryable_error()` | `extraction/test_extraction_error_paths.py` | P1 |
+
 ### AC13.14: JSON-Repair Retry (issue #982)
 
 | ID | Test Case | Test Function | File | Priority |

--- a/docs/ssot/env-reference.generated.md
+++ b/docs/ssot/env-reference.generated.md
@@ -35,6 +35,7 @@ Where a field's `.env.example` value intentionally differs from its code default
 | `OCR_MODEL` | `glm-4.6v` |  |  | AI Provider | OCR AI model id. |
 | `PREFECT_API_URL` |  |  |  | AI Provider | EPIC-019: set to the Prefect API URL to run upload->report parsing as durable Prefect flow runs (staging/prod and per-PR ephemeral Prefect). Leave unset for CI/local/preview -> in-process asyncio fallback (no Prefect needed). |
 | `PRIMARY_MODEL` | `glm-5.1` |  |  | AI Provider | Primary AI model id. |
+| `VISION_FALLBACK_MODELS` |  | `glm-4.5v` |  | AI Provider | Comma-separated fallback AI model ids for the vision/OCR path. These must be vision-capable because the vision request carries image content; the text-only FALLBACK_MODELS are not reused here (#1034). |
 | `VISION_MODEL` | `glm-4.6v` |  |  | AI Provider | Vision AI model id. |
 | `ZAI_API_KEY` |  |  | yes | AI Provider | AI provider API key (empty key = AI features disabled). ZAI_API_KEY is preferred for the default Z.AI provider; AI_API_KEY is a provider-neutral alias. |
 | `AI_API_KEY` |  |  | yes | AI Provider | Alias of `ZAI_API_KEY`. |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -235,6 +235,7 @@ PRIMARY_MODEL=glm-5.1
 OCR_MODEL=glm-4.6v
 VISION_MODEL=glm-4.6v
 FALLBACK_MODELS=glm-5-turbo,glm-5
+VISION_FALLBACK_MODELS=glm-4.5v
 AI_JSON_TIMEOUT_SECONDS=360
 AI_JSON_MAX_TOKENS=8192
 AI_JSON_DISABLE_THINKING=true
@@ -305,7 +306,8 @@ slice is registered.
 - **Manual override**: a selected image-capable model bypasses the default OCR path and is used directly as a vision chat model. Selecting the shared `OCR_MODEL` uses the same vision OCR model.
 - **Retry**: `/api/statements/{id}/retry` accepts a model override; omitted uses OCR-first mode.
 - **Catalog**: `/api/ai/models` returns the configured provider catalog for UI dropdowns (filterable by modality).
-- **Fallback models**: `FALLBACK_MODELS` are used after OCR text extraction when `PRIMARY_MODEL` fails.
+- **Fallback models (text path)**: `FALLBACK_MODELS` (default `glm-5-turbo,glm-5`) are attempted after OCR text extraction when `PRIMARY_MODEL` fails. These structure OCR Markdown and are text-only.
+- **Fallback models (vision path)**: `VISION_FALLBACK_MODELS` (default `glm-4.5v`) are appended after the primary OCR/vision model on the vision/image path, deduplicated and order-preserving. Because the vision request carries image content, these fallbacks must be vision-capable; the text-only `FALLBACK_MODELS` are intentionally **not** reused here. A non-retryable failure of the primary vision model (e.g. a provider `400`) therefore falls through to a secondary vision model before the upload is rejected with `ERR_EXT_003` (#1034). Set `VISION_FALLBACK_MODELS` empty to keep the prior single-model behavior.
 
 ## Data Integrity & Typing
 


### PR DESCRIPTION
## Root cause
The AI statement-extraction **vision/OCR path** attempted only one model. `_vision_extraction_models()` returned `[ocr_model, vision_model]` — both default `glm-4.6v`, deduped to a single entry — so a single non-retryable provider error failed the whole upload with `All 1 models failed` (`ERR_EXT_003`).

Staging evidence (2026-06-14):
```
provider=zai model=glm-4.6v status_code=400 {"code":"1210","message":"Invalid API parameter"}
-> AIStreamError (ERR_OR_002) -> "All 1 models failed" (ERR_EXT_003) -> statement.parse.failed
```

The OCR/text path already chains `FALLBACK_MODELS` (`models=[self.primary_model, *self.fallback_models]`); the vision path did not. PR #1026 (#982) shipped failed-parse lineage but not the fallback half.

## Fix
`_vision_extraction_models()` now appends a new, dedicated `VISION_FALLBACK_MODELS` config after the primary OCR/vision model, **deduplicated and order-preserving**, so a non-retryable failure of the primary vision model falls through to a secondary model before the upload is rejected.

**Config choice — new `VISION_FALLBACK_MODELS` (default `glm-4.5v`) rather than reusing `FALLBACK_MODELS`.** The vision request carries image content (base64 / image_url), and the existing text-path `FALLBACK_MODELS` (`glm-5-turbo`, `glm-5`) are not guaranteed vision-capable; reusing them would just trade one failure for another. The new config is parsed exactly like `FALLBACK_MODELS` (`parse_comma_list`). Set it empty to keep the prior single-model behavior.

## Tests (`apps/backend/tests/extraction/test_extraction_error_paths.py`)
- Updated `test_ocr_model_selection_helpers_deduplicate_vision_models` — it previously asserted the vision path returned **only** `[ocr, vision]` (it encoded the bug); now asserts the fallback is appended.
- Added `test_vision_extraction_models_dedupes_fallback_against_primary` and `test_vision_extraction_models_without_fallbacks_returns_primary_only` (dedup/ordering/opt-out).
- Added `test_vision_path_falls_back_to_secondary_model_on_non_retryable_error` — end-to-end: the primary vision model raises a non-retryable `400`, the configured fallback succeeds, both models attempted in order.
- Updated `test_extract_financial_data_shared_ocr_vision_skips_layout_parser` and `test_extract_financial_data_dedicated_ocr_failure_falls_back_to_vision` for the new list; pinned pre-existing single-model failure tests to `vision_fallback_models = []` to preserve their intent.

EPIC-013 AC13.17.1-2 added; SSOT `docs/ssot/extraction.md` documents the config + behavior.

`apps/backend` ruff lint + format clean; `tests/extraction/` 474 passed (full suite locally).

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)