### PR TITLE
[finance_report_vision] test(extraction): cover JSON-repair edge branches (#982)

### DIFF
--- a/apps/backend/tests/extraction/test_json_repair.py
+++ b/apps/backend/tests/extraction/test_json_repair.py
@@ -55,6 +55,21 @@ class TestRepairJsonObject:
         assert repaired is not None
         assert json.loads(repaired) == {"note": "balance {pending}", "ok": True}
 
+    def test_unbalanced_open_brace_returns_none(self):
+        """AC13.14.4c: An opening brace with no matching close (truncated response)
+        is unrecoverable rather than returning a partial object."""
+        assert ExtractionService._repair_json_object('{"a": 1, "b": 2') is None
+        # A brace inside a string must not count as the close that balances it.
+        assert ExtractionService._repair_json_object('{"note": "a } b"') is None
+
+    def test_escaped_quote_in_string_does_not_end_object_early(self):
+        """AC13.14.4d: A backslash-escaped quote inside a string value does not end
+        the string early, so the full object is recovered."""
+        content = '{"path": "C:\\\\Users\\\\x", "quote": "she said \\"hi\\"", "ok": true}'
+        repaired = ExtractionService._repair_json_object(content)
+        assert repaired is not None
+        assert json.loads(repaired) == {"path": "C:\\Users\\x", "quote": 'she said "hi"', "ok": True}
+
 
 class TestExtractionSalvagesFencedResponse:
     async def test_fenced_response_is_salvaged(self):


### PR DESCRIPTION
## Summary
Closes the two test-coverage gaps I flagged in the merged `#982` JSON-repair helper. Test-only; **no behavior change**.

`_repair_json_object` already handles these defensively, but they were unasserted:
- **Unbalanced open brace** (truncated model response, e.g. `{"a": 1, "b": 2`) → returns `None` (no partial object); a `}` inside a string does not count as the close.
- **Backslash-escaped quote** inside a string value → does not end the string early, so the full object is recovered.

## Tests
`AC13.14.4c` (`test_unbalanced_open_brace_returns_none`) and `AC13.14.4d` (`test_escaped_quote_in_string_does_not_end_object_early`) in `extraction/test_json_repair.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)