### PR TITLE
[finance_report_infra] feat(config): fast-fail on broken telemetry contract in deployed envs (Infra-014 C4)

### DIFF
--- a/apps/backend/src/boot.py
+++ b/apps/backend/src/boot.py
@@ -18,7 +18,7 @@ from enum import Enum
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from src.config import settings
+from src.config import PROTECTED_ENVIRONMENTS, settings
 from src.logger import get_logger
 
 logger = get_logger(__name__)
@@ -28,7 +28,7 @@ VAULT_SECRETS_STALENESS_THRESHOLD_SECONDS = 3600
 DEVELOPMENT_SECRET_KEY = "dev_secret_key_change_in_prod"
 DEVELOPMENT_DATABASE_URL = "postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/finance_report"
 DEVELOPMENT_S3_SECRET_KEY = "minio_local_secret"
-PROTECTED_ENVIRONMENTS = frozenset({"staging", "production"})
+# PROTECTED_ENVIRONMENTS is the single source of truth in src.config (imported above).
 LOCAL_ENVIRONMENTS = frozenset({"development", "test", "ci"})
 
 

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -8,8 +8,12 @@ Environment Variable Strategy:
 
 from functools import cached_property
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Environments that are real deployments (infra2 issues the telemetry contract
+# here). Local/CI/preview are exempt from the deployed-env fast-fail below.
+_DEPLOYED_ENVIRONMENTS = frozenset({"staging", "production"})
 
 
 def parse_comma_list(value: str | list[str] | None, default: list[str]) -> list[str]:
@@ -399,6 +403,31 @@ class Settings(BaseSettings):
         if isinstance(value, str) and not value.strip():
             return None
         return value
+
+    @model_validator(mode="after")
+    def _require_telemetry_contract_in_deployed_envs(self) -> "Settings":
+        """Fast-fail when a deployed env ships telemetry without the contract.
+
+        In staging/production, if OTEL export is enabled, the resource MUST carry a
+        ``deployment.environment`` tag (issued by infra2 at deploy — see
+        repo/docs/ssot/core.environments.md#telemetry-identity). This catches the
+        "untagged production telemetry" class before it reaches SigNoz. Non-deployed
+        environments (local/CI/preview) and telemetry-off deploys are exempt, so
+        this never trips local, tests, or a SigNoz-less deploy.
+        """
+        if self.environment.strip().lower() not in _DEPLOYED_ENVIRONMENTS:
+            return self
+        if not self.otel_exporter_otlp_endpoint:
+            return self
+        attrs = parse_key_value_pairs(self.otel_resource_attributes)
+        if "deployment.environment" not in attrs:
+            raise ValueError(
+                "Telemetry contract violation: OTEL export is enabled in a deployed "
+                "environment but OTEL_RESOURCE_ATTRIBUTES has no "
+                "deployment.environment tag. infra2 must issue it; see "
+                "repo/docs/ssot/core.environments.md#telemetry-identity."
+            )
+        return self
 
     # S3 optional settings
     s3_region: str = Field(

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -13,7 +13,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Environments that are real deployments (infra2 issues the telemetry contract
 # here). Local/CI/preview are exempt from the deployed-env fast-fail below.
-_DEPLOYED_ENVIRONMENTS = frozenset({"staging", "production"})
+# Single source of truth — boot.py imports this (config is the lower-level module).
+PROTECTED_ENVIRONMENTS = frozenset({"staging", "production"})
 
 
 def parse_comma_list(value: str | list[str] | None, default: list[str]) -> list[str]:
@@ -415,7 +416,7 @@ class Settings(BaseSettings):
         environments (local/CI/preview) and telemetry-off deploys are exempt, so
         this never trips local, tests, or a SigNoz-less deploy.
         """
-        if self.environment.strip().lower() not in _DEPLOYED_ENVIRONMENTS:
+        if self.environment.strip().lower() not in PROTECTED_ENVIRONMENTS:
             return self
         if not self.otel_exporter_otlp_endpoint:
             return self

--- a/apps/backend/tests/infra/test_observability_contract.py
+++ b/apps/backend/tests/infra/test_observability_contract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from pydantic import ValidationError
 
 from src import logger as logger_module, observability as observability_module
 from src.config import Settings
@@ -40,6 +41,31 @@ def test_otel_settings_are_explicit_and_environment_backed(monkeypatch) -> None:
     assert settings.otel_exporter_otlp_endpoint == "http://collector:4318"
     assert settings.otel_service_name == "finance-report-worker"
     assert settings.otel_resource_attributes == "deployment.environment=staging"
+
+
+def test_telemetry_contract_fast_fails_in_deployed_env_without_tag(monkeypatch) -> None:
+    """Infra-014 C4: a deployed env exporting OTEL without a deployment.environment
+    tag fails fast at config load; local/CI/preview and telemetry-off are exempt."""
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "service.version=abc123")
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None)
+
+    # Tag present -> loads.
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=production")
+    assert Settings(_env_file=None).environment == "production"
+
+    # Telemetry off in a deployed env is allowed (no endpoint).
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+    assert Settings(_env_file=None).environment == "production"
+
+    # Non-deployed env is exempt even with endpoint set and no tag.
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+    assert Settings(_env_file=None).environment == "development"
 
 
 def test_observability_ssot_and_env_docs_are_linked() -> None:


### PR DESCRIPTION
## What
Closes the **App-side telemetry contract** (Infra-014). You asked for both actions in one PR — but the live check showed **(a) `service.version` is already done**, so this PR is the **(b) fast-fail** half.

**(a) `service.version` — already implemented + verified live (no change):** `apps/backend/src/logger.py:_build_otel_resource` already adds `service.version`/`git.commit = git_commit_sha` to the OTEL resource (guarded by `test_AC10_4_4`). Confirmed in SigNoz/ClickHouse: prod resources carry `service.version=v0.1.7`, staging carry the per-deploy commit — alongside `deployment.environment`.

**(b) C4 fast-fail (this change):** a `model_validator` in `config.py` — in **staging/production**, if OTEL export is enabled, the resource **must** carry a `deployment.environment` tag (issued by infra2). Missing → fail fast at config load. Local/CI/preview and telemetry-off deploys are exempt, so it never trips local, tests, or a SigNoz-less deploy. Catches the "untagged production telemetry" regression class structurally. Test in `test_observability_contract.py`.

## Safety
Gated on `environment ∈ {staging, production}` **and** `otel_exporter_otlp_endpoint` set. Prod/staging currently satisfy the contract (verified live), so this does not affect the running deploys — it only guards against regression.

## Verified locally
`tests/infra` → 198 passed; env-reference `--check`, `check_env_keys`, AC traceability all green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)