### PR TITLE
[finance_report_infra] feat(frontend): surface missing OpenPanel client id in deployed envs (Infra-014 C5)

### DIFF
--- a/apps/frontend/src/__tests__/rootLayout.test.tsx
+++ b/apps/frontend/src/__tests__/rootLayout.test.tsx
@@ -34,6 +34,27 @@ describe("RootLayout", () => {
     expect(screen.getByText("Root Child")).toBeInTheDocument()
   })
 
+  it("Infra-014 C5: warns once per process when client id is missing in a deployed env", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const prevUrl = process.env.NEXT_PUBLIC_APP_URL
+    const prevId = process.env.OPENPANEL_CLIENT_ID
+    process.env.NEXT_PUBLIC_APP_URL = "https://report.zitian.party"
+    delete process.env.OPENPANEL_CLIENT_ID
+    try {
+      render(<RootLayout><div>a</div></RootLayout>)
+      render(<RootLayout><div>b</div></RootLayout>)
+      // force-dynamic runs per request, but the module-level guard logs only once.
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+      expect(String(errorSpy.mock.calls[0]?.[0])).toContain("OPENPANEL_CLIENT_ID is empty")
+    } finally {
+      errorSpy.mockRestore()
+      if (prevUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL
+      else process.env.NEXT_PUBLIC_APP_URL = prevUrl
+      if (prevId === undefined) delete process.env.OPENPANEL_CLIENT_ID
+      else process.env.OPENPANEL_CLIENT_ID = prevId
+    }
+  })
+
   it("Infra-014 C5: flags a missing OpenPanel client id only in deployed non-preview envs", () => {
     // Deployed (staging/production https hosts) without a client id -> surfaced.
     expect(analyticsClientIdMissingInDeployedEnv(undefined, "https://report.zitian.party")).toBe(true)

--- a/apps/frontend/src/__tests__/rootLayout.test.tsx
+++ b/apps/frontend/src/__tests__/rootLayout.test.tsx
@@ -2,7 +2,8 @@ import { render, screen } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 
-import RootLayout, { analyticsClientIdMissingInDeployedEnv, metadata, viewport } from "@/app/layout"
+import RootLayout, { metadata, viewport } from "@/app/layout"
+import { analyticsClientIdMissingInDeployedEnv } from "@/lib/analytics-env"
 
 vi.mock("next/font/google", () => ({
   Inter: () => ({ variable: "--font-inter" }),

--- a/apps/frontend/src/__tests__/rootLayout.test.tsx
+++ b/apps/frontend/src/__tests__/rootLayout.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 
-import RootLayout, { metadata, viewport } from "@/app/layout"
+import RootLayout, { analyticsClientIdMissingInDeployedEnv, metadata, viewport } from "@/app/layout"
 
 vi.mock("next/font/google", () => ({
   Inter: () => ({ variable: "--font-inter" }),
@@ -31,6 +31,18 @@ describe("RootLayout", () => {
     expect(screen.getByTestId("providers")).toBeInTheDocument()
     expect(screen.getByTestId("auth-guard")).toBeInTheDocument()
     expect(screen.getByText("Root Child")).toBeInTheDocument()
+  })
+
+  it("Infra-014 C5: flags a missing OpenPanel client id only in deployed non-preview envs", () => {
+    // Deployed (staging/production https hosts) without a client id -> surfaced.
+    expect(analyticsClientIdMissingInDeployedEnv(undefined, "https://report.zitian.party")).toBe(true)
+    expect(analyticsClientIdMissingInDeployedEnv("", "https://report-staging.zitian.party")).toBe(true)
+    // Preview and local are intentionally OpenPanel-less -> silent.
+    expect(analyticsClientIdMissingInDeployedEnv(undefined, "https://report-pr-7.zitian.party")).toBe(false)
+    expect(analyticsClientIdMissingInDeployedEnv(undefined, "http://localhost:3000")).toBe(false)
+    expect(analyticsClientIdMissingInDeployedEnv(undefined, undefined)).toBe(false)
+    // A configured client id is never flagged.
+    expect(analyticsClientIdMissingInDeployedEnv("abc-123", "https://report.zitian.party")).toBe(false)
   })
 
   it("AC16.25.4 root layout metadata keeps viewport-only theme color", () => {

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import type { Viewport } from "next";
 import { Analytics } from "@/components/Analytics";
 import { AuthGuard } from "@/components/AuthGuard";
+import { analyticsClientIdMissingInDeployedEnv } from "@/lib/analytics-env";
 import { Inter } from "next/font/google";
 import { Providers } from "./providers";
 import "./globals.css";
@@ -45,20 +46,6 @@ export const viewport: Viewport = {
 // read per request rather than captured at build (the finance app is auth-gated
 // and already effectively dynamic).
 export const dynamic = "force-dynamic";
-
-// C5 (Infra-014): page-view analytics MUST be configured in deployed, non-preview
-// environments (staging/production). A missing client id there means analytics is
-// silently off — a misconfiguration we surface (server log → SigNoz) instead of
-// failing silently, but never by throwing (that would break SSR). Preview
-// (report-pr-N) and local intentionally have no OpenPanel, so they stay silent.
-export function analyticsClientIdMissingInDeployedEnv(
-  clientId: string | undefined,
-  appUrl: string | undefined,
-): boolean {
-  if (clientId && clientId.trim()) return false;
-  const url = (appUrl ?? "").trim();
-  return url.startsWith("https://") && !url.includes("-pr-") && !url.includes("localhost");
-}
 
 export default function RootLayout({
   children,

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -46,6 +46,20 @@ export const viewport: Viewport = {
 // and already effectively dynamic).
 export const dynamic = "force-dynamic";
 
+// C5 (Infra-014): page-view analytics MUST be configured in deployed, non-preview
+// environments (staging/production). A missing client id there means analytics is
+// silently off — a misconfiguration we surface (server log → SigNoz) instead of
+// failing silently, but never by throwing (that would break SSR). Preview
+// (report-pr-N) and local intentionally have no OpenPanel, so they stay silent.
+export function analyticsClientIdMissingInDeployedEnv(
+  clientId: string | undefined,
+  appUrl: string | undefined,
+): boolean {
+  if (clientId && clientId.trim()) return false;
+  const url = (appUrl ?? "").trim();
+  return url.startsWith("https://") && !url.includes("-pr-") && !url.includes("localhost");
+}
+
 export default function RootLayout({
   children,
 }: {
@@ -54,6 +68,13 @@ export default function RootLayout({
   // Gate entirely on the client id: when unset, no <Analytics> (and no extra
   // client boundary / analytics bundle) is rendered at all — a complete no-op.
   const openpanelClientId = process.env.OPENPANEL_CLIENT_ID?.trim();
+
+  if (analyticsClientIdMissingInDeployedEnv(openpanelClientId, process.env.NEXT_PUBLIC_APP_URL)) {
+    console.error(
+      `[observability] OPENPANEL_CLIENT_ID is empty for ${process.env.NEXT_PUBLIC_APP_URL}; ` +
+        "page-view analytics is disabled. infra2 must issue the OpenPanel client id for this environment.",
+    );
+  }
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -47,6 +47,11 @@ export const viewport: Viewport = {
 // and already effectively dynamic).
 export const dynamic = "force-dynamic";
 
+// `force-dynamic` runs RootLayout per request, so log the misconfig at most once
+// per server process (mirrors the module-level guard in lib/api.ts) to avoid
+// flooding container logs / SigNoz on every request.
+let analyticsMisconfigWarned = false;
+
 export default function RootLayout({
   children,
 }: {
@@ -56,7 +61,11 @@ export default function RootLayout({
   // client boundary / analytics bundle) is rendered at all — a complete no-op.
   const openpanelClientId = process.env.OPENPANEL_CLIENT_ID?.trim();
 
-  if (analyticsClientIdMissingInDeployedEnv(openpanelClientId, process.env.NEXT_PUBLIC_APP_URL)) {
+  if (
+    !analyticsMisconfigWarned &&
+    analyticsClientIdMissingInDeployedEnv(openpanelClientId, process.env.NEXT_PUBLIC_APP_URL)
+  ) {
+    analyticsMisconfigWarned = true;
     console.error(
       `[observability] OPENPANEL_CLIENT_ID is empty for ${process.env.NEXT_PUBLIC_APP_URL}; ` +
         "page-view analytics is disabled. infra2 must issue the OpenPanel client id for this environment.",

--- a/apps/frontend/src/lib/analytics-env.ts
+++ b/apps/frontend/src/lib/analytics-env.ts
@@ -1,0 +1,18 @@
+/**
+ * C5 (Infra-014): page-view analytics must be configured in deployed, non-preview
+ * environments (staging/production). A missing client id there means analytics is
+ * silently off — a misconfiguration the app surfaces (server log → SigNoz) instead
+ * of failing silently, but never by throwing (that would break SSR). Preview
+ * (report-pr-N) and local intentionally have no OpenPanel, so they stay silent.
+ *
+ * Kept in a plain module (not layout.tsx) because Next.js forbids arbitrary
+ * exports from a Layout file.
+ */
+export function analyticsClientIdMissingInDeployedEnv(
+  clientId: string | undefined,
+  appUrl: string | undefined,
+): boolean {
+  if (clientId && clientId.trim()) return false;
+  const url = (appUrl ?? "").trim();
+  return url.startsWith("https://") && !url.includes("-pr-") && !url.includes("localhost");
+}


### PR DESCRIPTION
## What
Final slice of **Infra-014** (C5): frontend fast-fail *parity* for the analytics contract.

`RootLayout` (server component) now logs a **server-side `console.error`** (visible in container logs → SigNoz) when `OPENPANEL_CLIENT_ID` is empty **and** the app is a **deployed, non-preview** env (`NEXT_PUBLIC_APP_URL` is `https://`, not `report-pr-*`, not `localhost`). Previously a missing client id was a completely silent no-op everywhere — so a staging/prod misconfig went unnoticed.

- **Never throws** (would break SSR) — it's a visible log, not a crash.
- **Preview (`report-pr-N`) and local stay silent no-ops** by design (OpenPanel intentionally unconfigured there).
- Detection is a pure exported helper `analyticsClientIdMissingInDeployedEnv()`, unit-tested.

## Why
Matches the backend C4 contract guard: deployed envs must have the contract that infra2 issues; missing it is surfaced, not swallowed. "Full FE env generator" remains out-of-scope (per the EPIC).

## Verified locally
`vitest` (rootLayout — 3 passed incl. the new helper cases), `eslint` clean, `tsc --noEmit` clean.

This completes Infra-014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)