### PR TITLE
[finance_report_test_and_doc] fix(epic-013): resolve duplicate AC13.17 (renumber #989 Step B → AC13.18)

### DIFF
--- a/apps/backend/tests/extraction/test_self_consistency.py
+++ b/apps/backend/tests/extraction/test_self_consistency.py
@@ -1,4 +1,4 @@
-"""AC13.17: Balance-aware self-consistency re-extract (#989 Step B).
+"""AC13.18: Balance-aware self-consistency re-extract (#989 Step B).
 
 When the extracted running-balance chain fails to reconcile, re-extract a bounded
 number of times before accepting the result (which would route the statement to
@@ -60,7 +60,7 @@ async def _run(service, attempts_returns, *, max_attempts=3, seed=42):
 
 
 async def test_reconciles_first_attempt_single_call():
-    """AC13.17.1: a reconciling first parse is returned without retry."""
+    """AC13.18.1: a reconciling first parse is returned without retry."""
     service = ExtractionService()
     result, mock = await _run(service, [_bank("0")])
     assert result["closing_balance"] == "100.00"
@@ -68,7 +68,7 @@ async def test_reconciles_first_attempt_single_call():
 
 
 async def test_retries_until_reconciles():
-    """AC13.17.2: a failing parse is retried and the reconciling result wins."""
+    """AC13.18.2: a failing parse is retried and the reconciling result wins."""
     service = ExtractionService()
     good = _bank("0")
     result, mock = await _run(service, [_bank("12.50"), good])
@@ -77,7 +77,7 @@ async def test_retries_until_reconciles():
 
 
 async def test_keeps_best_when_none_reconcile():
-    """AC13.17.3: when no attempt reconciles, the smallest-difference result is kept
+    """AC13.18.3: when no attempt reconciles, the smallest-difference result is kept
     (so routing to `uploaded` is unchanged) and all attempts are used."""
     service = ExtractionService()
     worst, best = _bank("40.00"), _bank("3.00")
@@ -87,7 +87,7 @@ async def test_keeps_best_when_none_reconcile():
 
 
 async def test_brokerage_is_not_retried():
-    """AC13.17.4: brokerage payloads do not reconcile like bank statements and must
+    """AC13.18.4: brokerage payloads do not reconcile like bank statements and must
     not burn retries."""
     service = ExtractionService()
     result, mock = await _run(service, [_brokerage(), _bank("0")])
@@ -96,7 +96,7 @@ async def test_brokerage_is_not_retried():
 
 
 async def test_seed_varies_per_attempt():
-    """AC13.17.5: attempt 0 uses the configured seed; retries use seed+1, seed+2 ..."""
+    """AC13.18.5: attempt 0 uses the configured seed; retries use seed+1, seed+2 ..."""
     service = ExtractionService()
     _, mock = await _run(service, [_bank("5.00"), _bank("5.00"), _bank("5.00")], max_attempts=3, seed=42)
     seeds = [c.kwargs.get("seed_override") for c in mock.await_args_list]
@@ -105,7 +105,7 @@ async def test_seed_varies_per_attempt():
 
 
 async def test_max_attempts_one_disables_retry():
-    """AC13.17.6: max_attempts=1 keeps current single-shot behavior."""
+    """AC13.18.6: max_attempts=1 keeps current single-shot behavior."""
     service = ExtractionService()
     result, mock = await _run(service, [_bank("9.00")], max_attempts=1)
     assert result["closing_balance"] == "100.00"

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -312,7 +312,7 @@ reproducibly: temperature 0 / `do_sample` false plus a fixed `seed`
 | AC13.16.3 | Extraction pins `temperature=0` / `do_sample=False` alongside the seed | `test_extraction_decoding_is_deterministic_by_default()` | `extraction/test_seed_determinism.py` | P1 |
 | AC13.16.4 | Empty `AI_JSON_SEED` parses as None (omitted) instead of raising | `test_empty_seed_env_is_treated_as_none()` | `extraction/test_seed_determinism.py` | P1 |
 
-### AC13.17: Balance-Aware Self-Consistency Re-extract (issue #989 Step B)
+### AC13.18: Balance-Aware Self-Consistency Re-extract (issue #989 Step B)
 
 Step A (AC13.16) makes a single decode reproducible; this AC adds the
 **self-consistency** half. When a bank statement's running-balance chain fails to
@@ -326,9 +326,9 @@ kept so routing is unchanged. Only failing parses retry, so average cost is boun
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC13.17.1 | A reconciling first parse is returned without retry | `test_reconciles_first_attempt_single_call()` | `extraction/test_self_consistency.py` | P1 |
-| AC13.17.2 | A failing parse is retried and the reconciling result wins | `test_retries_until_reconciles()` | `extraction/test_self_consistency.py` | P1 |
-| AC13.17.3 | When no attempt reconciles, the smallest-difference result is kept | `test_keeps_best_when_none_reconcile()` | `extraction/test_self_consistency.py` | P1 |
-| AC13.17.4 | Brokerage payloads are not retried | `test_brokerage_is_not_retried()` | `extraction/test_self_consistency.py` | P1 |
-| AC13.17.5 | Attempt 0 uses the configured seed; retries vary it (seed+1, seed+2 …) | `test_seed_varies_per_attempt()` | `extraction/test_self_consistency.py` | P1 |
-| AC13.17.6 | `AI_EXTRACT_MAX_ATTEMPTS=1` keeps single-shot behavior | `test_max_attempts_one_disables_retry()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.18.1 | A reconciling first parse is returned without retry | `test_reconciles_first_attempt_single_call()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.18.2 | A failing parse is retried and the reconciling result wins | `test_retries_until_reconciles()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.18.3 | When no attempt reconciles, the smallest-difference result is kept | `test_keeps_best_when_none_reconcile()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.18.4 | Brokerage payloads are not retried | `test_brokerage_is_not_retried()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.18.5 | Attempt 0 uses the configured seed; retries vary it (seed+1, seed+2 …) | `test_seed_varies_per_attempt()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.18.6 | `AI_EXTRACT_MAX_ATTEMPTS=1` keeps single-shot behavior | `test_max_attempts_one_disables_retry()` | `extraction/test_self_consistency.py` | P1 |


### PR DESCRIPTION
## Why (this is currently red on `main` and blocks every PR)

Two merged PRs both registered **AC13.17** in `EPIC-013`:
- #1034 — *Vision Extraction Falls Back to Secondary Models*
- #989 Step B — *Balance-Aware Self-Consistency Re-extract*

The AC registry keeps the first definition and **silently drops** the rest, so:
1. the **AC Traceability gate errors** (`AC IDs defined more than once`, `duplicate AC group AC13.17`) — failing CI on every open PR merged against main; and
2. the self-consistency block's ACs were never actually traceability-checked (they were the dropped duplicate).

## Fix

Renumber the **self-consistency** block to **AC13.18** (it directly follows AC13.16 "Step A"), and update the matching `AC13.17.x → AC13.18.x` references in `test_self_consistency.py` docstrings. The vision-fallback block keeps AC13.17.

- No test logic changed — `test_self_consistency.py` still 6/6 green.
- `check_ac_traceability.py` → **PASSED**, 0 missing, no duplicate.
- `lint_doc_consistency.py` → clean.

(Found while CI-debugging an unrelated PR; surfaced by the new `ac-workflow` skill's "AC-number collision" gotcha.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)