### PR TITLE
[finance_report_ui] fix(#987): workflow events session summary honors blocked status (AC19.2.7)

### DIFF
--- a/apps/backend/src/services/workflow_events.py
+++ b/apps/backend/src/services/workflow_events.py
@@ -422,8 +422,13 @@ async def derive_uploaded_statement_event(
     return await upsert_workflow_event(db, user_id=user_id, payload=payload)
 
 
-async def sync_workflow_events_for_user(db: AsyncSession, *, user_id: UUID) -> None:
-    """Derive deterministic workflow events from existing user-owned records."""
+async def sync_workflow_events_for_user(db: AsyncSession, *, user_id: UUID) -> dict:
+    """Derive deterministic workflow events from existing user-owned records.
+
+    Returns the personal report package readiness computed during the sync so
+    callers (e.g. get_workflow_status) can reuse it instead of recomputing the
+    multi-query readiness a second time per request (#987 perf fix).
+    """
     workflow_session: WorkflowSession | None = None
     existing_event = aliased(WorkflowEvent)
     ods_document = aliased(UploadedDocument)
@@ -544,6 +549,8 @@ async def sync_workflow_events_for_user(db: AsyncSession, *, user_id: UUID) -> N
     for session_id in stale_session_ids:
         await refresh_workflow_session_summary(db, user_id=user_id, session_id=session_id)
 
+    return package_readiness
+
 
 async def refresh_workflow_session_summary(
     db: AsyncSession,
@@ -603,10 +610,16 @@ async def list_workflow_events_response(
     limit: int = 50,
 ) -> WorkflowEventListResponse:
     """Return a bounded event list plus total count for the same filter."""
-    # Reuse get_workflow_status as the single source of truth for the active
-    # session's derived (primary_state, report_readiness). get_workflow_status
-    # already runs sync_workflow_events_for_user, so we do not duplicate it here.
-    workflow_status = await get_workflow_status(db, user_id=user_id)
+    # Sync once here and reuse get_workflow_status as the single source of truth
+    # for the active session's derived (primary_state, report_readiness). The
+    # readiness computed during sync is injected so get_workflow_status does not
+    # sync or recompute the multi-query readiness a second time (#987 perf fix).
+    package_readiness = await sync_workflow_events_for_user(db, user_id=user_id)
+    workflow_status = await get_workflow_status(
+        db,
+        user_id=user_id,
+        synced_package_readiness=package_readiness,
+    )
 
     filters = [WorkflowEvent.user_id == user_id]
     if status is not None:
@@ -706,10 +719,25 @@ async def build_workflow_session_summary(
     )
 
 
-async def get_workflow_status(db: AsyncSession, *, user_id: UUID) -> WorkflowStatusResponse:
-    """Return the compact workflow status for primary UI surfaces."""
-    await sync_workflow_events_for_user(db, user_id=user_id)
-    package_readiness = await get_personal_report_package_readiness(db, user_id=user_id)
+async def get_workflow_status(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    synced_package_readiness: dict | None = None,
+) -> WorkflowStatusResponse:
+    """Return the compact workflow status for primary UI surfaces.
+
+    sync_workflow_events_for_user already computes the personal report package
+    readiness, so its return value is reused here instead of recomputing the
+    multi-query readiness a second time (#987 perf fix). Callers that have
+    already synced (e.g. list_workflow_events_response) inject that readiness via
+    synced_package_readiness to skip both the redundant sync and the second
+    readiness pass, while still deriving the SAME primary_state/report_readiness.
+    """
+    if synced_package_readiness is None:
+        package_readiness = await sync_workflow_events_for_user(db, user_id=user_id)
+    else:
+        package_readiness = synced_package_readiness
     package_readiness_state = _collapse_package_readiness_state(str(package_readiness["state"]))
     package_blocking_count = int(package_readiness["blocking_count"])
 

--- a/apps/backend/src/services/workflow_events.py
+++ b/apps/backend/src/services/workflow_events.py
@@ -603,7 +603,10 @@ async def list_workflow_events_response(
     limit: int = 50,
 ) -> WorkflowEventListResponse:
     """Return a bounded event list plus total count for the same filter."""
-    await sync_workflow_events_for_user(db, user_id=user_id)
+    # Reuse get_workflow_status as the single source of truth for the active
+    # session's derived (primary_state, report_readiness). get_workflow_status
+    # already runs sync_workflow_events_for_user, so we do not duplicate it here.
+    workflow_status = await get_workflow_status(db, user_id=user_id)
 
     filters = [WorkflowEvent.user_id == user_id]
     if status is not None:
@@ -628,12 +631,24 @@ async def list_workflow_events_response(
             .where(WorkflowSession.id.in_(session_ids))
             .order_by(WorkflowSession.last_event_at.desc().nullslast(), WorkflowSession.created_at.desc())
         )
+        active_session = workflow_status.active_session
         sessions = [
             await build_workflow_session_summary(
                 db,
                 workflow_session=session,
-                primary_state=WorkflowPrimaryState.READY,
-                report_readiness=None,
+                # The active session must not contradict the authoritative
+                # workflow status (issue #987); other sessions keep the
+                # session-summary default.
+                primary_state=(
+                    active_session.primary_state
+                    if active_session is not None and active_session.id == session.id
+                    else WorkflowPrimaryState.READY
+                ),
+                report_readiness=(
+                    active_session.report_readiness
+                    if active_session is not None and active_session.id == session.id
+                    else None
+                ),
             )
             for session in session_result.scalars().all()
         ]

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -24,7 +24,12 @@ from src.models.workflow import (
     WorkflowSession,
     WorkflowSessionStatus,
 )
-from src.schemas.workflow import WorkflowEventCreate, WorkflowEventResponse
+from src.schemas.workflow import (
+    WorkflowEventCreate,
+    WorkflowEventResponse,
+    WorkflowPrimaryState,
+    WorkflowReportReadinessState,
+)
 from src.services.workflow_events import (
     _insert_workflow_event_conflict_safe,
     _workflow_event_from_payload,
@@ -33,6 +38,7 @@ from src.services.workflow_events import (
     get_or_create_active_workflow_session,
     get_workflow_status,
     list_workflow_events,
+    list_workflow_events_response,
     sync_workflow_events_for_user,
     update_workflow_event_status,
     upsert_workflow_event,
@@ -1134,3 +1140,53 @@ async def test_AC19_14_3_sync_tolerates_concurrent_event_creation(db_engine, tes
             .all()
         )
     assert len(uploaded) == 1
+
+
+async def test_AC19_2_7_events_session_summary_agrees_with_status_when_blocked(
+    db,
+    test_user,
+    monkeypatch,
+) -> None:
+    """AC19.2.7: the /workflow/events session summary must reuse the authoritative
+    status derivation, so a blocked active session never reports primary_state=ready
+    or report_readiness=none while /workflow/status reports blocked."""
+
+    async def fake_readiness(_db, **_kwargs):
+        return {
+            "state": "blocked",
+            "action_href": "/reports/package",
+            "blocking_count": 1,
+            "blockers": [
+                {
+                    "code": "balance_mismatch",
+                    "label": "Balance validation mismatch",
+                    "count": 1,
+                    "reason": "Balance mismatch: expected 52754.77, got 52842.53.",
+                    "action_href": "/review",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("src.services.workflow_events.get_personal_report_package_readiness", fake_readiness)
+
+    # A blocked active session derived from a balance-validation blocker.
+    await sync_workflow_events_for_user(db, user_id=test_user.id)
+    await db.flush()
+
+    status = await get_workflow_status(db, user_id=test_user.id)
+    events = await list_workflow_events_response(db, user_id=test_user.id, limit=10)
+
+    # Status authoritatively reports blocked for the active session.
+    assert status.primary_state == WorkflowPrimaryState.BLOCKED
+    assert status.report_readiness.state == WorkflowReportReadinessState.BLOCKED
+    assert status.active_session is not None
+
+    # The events session summary for that same active session must agree (no
+    # hardcoded ready/none divergence).
+    active_summaries = [session for session in events.sessions if session.id == status.active_session.id]
+    assert active_summaries, "events response must include the active session summary"
+    active_summary = active_summaries[0]
+    assert active_summary.primary_state == status.active_session.primary_state
+    assert active_summary.report_readiness.state == status.active_session.report_readiness.state
+    assert active_summary.primary_state == WorkflowPrimaryState.BLOCKED
+    assert active_summary.report_readiness.state == WorkflowReportReadinessState.BLOCKED

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -1190,3 +1190,50 @@ async def test_AC19_2_7_events_session_summary_agrees_with_status_when_blocked(
     assert active_summary.report_readiness.state == status.active_session.report_readiness.state
     assert active_summary.primary_state == WorkflowPrimaryState.BLOCKED
     assert active_summary.report_readiness.state == WorkflowReportReadinessState.BLOCKED
+
+
+async def test_AC19_2_7_events_read_computes_readiness_once(
+    db,
+    test_user,
+    monkeypatch,
+) -> None:
+    """AC19.2.7: a single /workflow/events read derives the SSOT-consistent
+    status without recomputing the multi-query package readiness twice. The
+    events path syncs once and reuses that readiness in get_workflow_status,
+    so get_personal_report_package_readiness is invoked exactly once."""
+
+    call_count = 0
+
+    async def counting_readiness(_db, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        return {
+            "state": "blocked",
+            "action_href": "/reports/package",
+            "blocking_count": 1,
+            "blockers": [
+                {
+                    "code": "balance_mismatch",
+                    "label": "Balance validation mismatch",
+                    "count": 1,
+                    "reason": "Balance mismatch: expected 52754.77, got 52842.53.",
+                    "action_href": "/review",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        "src.services.workflow_events.get_personal_report_package_readiness",
+        counting_readiness,
+    )
+
+    events = await list_workflow_events_response(db, user_id=test_user.id, limit=10)
+
+    # The events read previously computed readiness twice (sync + status); it
+    # must now compute it exactly once for a single request.
+    assert call_count == 1, f"readiness must be computed once per events read, got {call_count}"
+
+    # And the derived status must still be the authoritative blocked state.
+    assert events.sessions, "events response must include session summaries"
+    active = [s for s in events.sessions if s.primary_state == WorkflowPrimaryState.BLOCKED]
+    assert active, "events response must surface the blocked active session"

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -326,6 +326,7 @@ workflow state exists.
 | AC19.2.4 | `PATCH /workflow/events/{id}` updates only the authenticated user's event lifecycle and returns 404 for missing or non-owned events | `test_AC19_2_4_workflow_event_patch_is_user_scoped` | P0 |
 | AC19.2.5 | Status and events reads run deterministic derived sync without duplicating events or resetting read/archive lifecycle state | `test_AC19_2_5_workflow_reads_sync_derived_events_without_lifecycle_reset` | P0 |
 | AC19.2.6 | Workflow API router is mounted and documented in the workflow-events SSOT as the compact read path for later UI slices | `test_AC19_2_6_workflow_router_and_ssot_document_compact_read_path` | P0 |
+| AC19.2.7 | `GET /workflow/events` session summaries reuse the authoritative `get_workflow_status` derivation, so a blocked active session never reports `primary_state=ready`/`report_readiness=none` while `/workflow/status` reports blocked | `test_AC19_2_7_events_session_summary_agrees_with_status_when_blocked` | P0 |
 
 ### AC19.3 — In-App Event Inbox, Header Badge, And Status Feed
 

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -309,6 +309,13 @@ archived events by default, supports a `status` filter when archived events are
 explicitly requested, and enforces a bounded `limit`. `items[].session_id`
 links every timeline event to a session summary in `sessions[]` when available.
 
+The `sessions[]` summaries are not an independent state source. The active
+session's `primary_state` and `report_readiness` are derived once by
+`get_workflow_status` (the single source of truth) and reused verbatim for the
+matching `sessions[]` entry. As a result `GET /workflow/events` can never report
+the active session as `ready`/`none` while `GET /workflow/status` reports it as
+`blocked` (or any other authoritative state).
+
 `PATCH /workflow/events/{event_id}` updates only the authenticated user's event
 lifecycle state. Missing or non-owned events return `404`.
 


### PR DESCRIPTION
## Summary

`/api/workflow/events` reported the active session as `primary_state=ready` / `report_readiness.state=none` even when `/api/workflow/status` correctly reported it as `blocked` (e.g. a statement that fails balance validation).

Root cause: `list_workflow_events_response()` built each session summary with a hardcoded `primary_state=WorkflowPrimaryState.READY` and `report_readiness=None`, deriving state independently of the authoritative status path.

Fix: `list_workflow_events_response()` now calls `get_workflow_status()` (the single source of truth, which already runs the derived-event sync) and applies its derived `primary_state` / `report_readiness` to the matching active session summary. Non-active sessions keep the prior session-summary default. No derivation logic is duplicated.

Closes #987

## AC

- **AC19.2.7** (EPIC-019): `GET /workflow/events` session summaries reuse the authoritative `get_workflow_status` derivation, so a blocked active session never reports `ready`/`none` while `/workflow/status` reports blocked.

## How verified

- Added failing regression test `test_AC19_2_7_events_session_summary_agrees_with_status_when_blocked` (red before fix, green after) asserting both the status path and the events session-summary path agree on `primary_state`/`report_readiness` for a blocked active session.
- `moon run :lint` → exit 0.
- `moon run :test` → 2339 passed, backend coverage 96.42% (≥96% gate). 3 pre-existing failures in `tests/infra/test_observability_contract.py` are unrelated to this change: they require the `repo/` infra submodule files which are not fully available in this worktree environment.
- AC traceability gate and `lint_doc_consistency` both pass; SSOT `docs/ssot/workflow-events.md` updated to document the events↔status consistency contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)