### PR TITLE
[finance_report_hacker] fix(docs): renumber duplicate AC13.17 vision-fallback to AC13.18

### DIFF
--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -223,7 +223,7 @@ async def test_extract_financial_data_uses_ocr_first_pipeline():
 async def test_extract_financial_data_shared_ocr_vision_skips_layout_parser():
     """AC8.12.6: Shared OCR/vision model uses one vision call and skips layout parsing.
 
-    AC13.17.1: the configured vision fallback model is appended after the primary
+    AC13.18.1: the configured vision fallback model is appended after the primary
     so more than one model is attempted on the vision path (#1034).
     """
     service = ExtractionService()
@@ -252,7 +252,7 @@ async def test_extract_financial_data_shared_ocr_vision_skips_layout_parser():
 
 
 async def test_vision_path_falls_back_to_secondary_model_on_non_retryable_error():
-    """AC13.17.2: when the primary vision model raises a non-retryable provider
+    """AC13.18.2: when the primary vision model raises a non-retryable provider
     error (e.g. a 400), the vision path attempts the configured vision fallback
     model and succeeds instead of failing the upload (#1034)."""
     from src.services.ai_streaming import AIStreamError
@@ -298,7 +298,7 @@ async def test_vision_path_falls_back_to_secondary_model_on_non_retryable_error(
 def test_ocr_model_selection_helpers_deduplicate_vision_models():
     """AC8.12.6: OCR/vision helper rules avoid duplicate provider calls.
 
-    AC13.17.1: configured vision fallbacks are appended to the vision model list,
+    AC13.18.1: configured vision fallbacks are appended to the vision model list,
     deduplicated and order-preserving, so more than one model is attempted on the
     vision path (#1034).
     """
@@ -322,7 +322,7 @@ def test_ocr_model_selection_helpers_deduplicate_vision_models():
 
 
 def test_vision_extraction_models_dedupes_fallback_against_primary():
-    """AC13.17.1: a vision fallback equal to the primary vision/OCR model is not
+    """AC13.18.1: a vision fallback equal to the primary vision/OCR model is not
     attempted twice; ordering of the remaining fallbacks is preserved (#1034)."""
     service = ExtractionService()
     service.ocr_model = "glm-4.6v"
@@ -333,7 +333,7 @@ def test_vision_extraction_models_dedupes_fallback_against_primary():
 
 
 def test_vision_extraction_models_without_fallbacks_returns_primary_only():
-    """AC13.17.1: with no configured vision fallbacks the list is unchanged, so
+    """AC13.18.1: with no configured vision fallbacks the list is unchanged, so
     deployments that opt out keep the prior single-model behavior (#1034)."""
     service = ExtractionService()
     service.ocr_model = "glm-4.6v"
@@ -485,7 +485,7 @@ async def test_extract_financial_data_dedicated_ocr_failure_falls_back_to_vision
     assert result == {"transactions": []}
     mock_ocr.assert_awaited_once_with(b"content", None, "pdf", "application/pdf")
     call = mock_extract.await_args.kwargs
-    # AC13.17.1: the vision fallback model is appended after the primary vision model.
+    # AC13.18.1: the vision fallback model is appended after the primary vision model.
     assert call["models"] == ["layout-ocr-model", "glm-4.6v", "glm-4.5v"]
     assert call["messages"][0]["content"][1] == image_payload
 

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -203,12 +203,12 @@ Expected routing behavior remains threshold-based (See: `docs/ssot/reconciliatio
 | AC13.15.4 | `is_brokerage` defaults to False so existing callers are unaffected | `test_default_is_not_brokerage()` | `extraction/test_extraction.py` | P1 |
 | AC13.15.5 | The cap uses the persisted transaction count (after skipped rows), not the raw extracted count | `test_effective_count_uses_persisted_not_extracted()` | `extraction/test_extraction.py` | P1 |
 
-### AC13.17: Vision Extraction Falls Back to Secondary Models (issue #1034)
+### AC13.18: Vision Extraction Falls Back to Secondary Models (issue #1034)
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC13.17.1 | The vision model list appends `VISION_FALLBACK_MODELS` after the primary OCR/vision model, deduplicated and order-preserving, so more than one model is attempted on the vision path | `test_ocr_model_selection_helpers_deduplicate_vision_models()`, `test_vision_extraction_models_dedupes_fallback_against_primary()`, `test_vision_extraction_models_without_fallbacks_returns_primary_only()`, `test_extract_financial_data_shared_ocr_vision_skips_layout_parser()`, `test_extract_financial_data_dedicated_ocr_failure_falls_back_to_vision()` | `extraction/test_extraction_error_paths.py` | P1 |
-| AC13.17.2 | When the primary vision model raises a non-retryable provider error (e.g. a 400), the vision path attempts the configured vision fallback model and succeeds instead of failing the upload | `test_vision_path_falls_back_to_secondary_model_on_non_retryable_error()` | `extraction/test_extraction_error_paths.py` | P1 |
+| AC13.18.1 | The vision model list appends `VISION_FALLBACK_MODELS` after the primary OCR/vision model, deduplicated and order-preserving, so more than one model is attempted on the vision path | `test_ocr_model_selection_helpers_deduplicate_vision_models()`, `test_vision_extraction_models_dedupes_fallback_against_primary()`, `test_vision_extraction_models_without_fallbacks_returns_primary_only()`, `test_extract_financial_data_shared_ocr_vision_skips_layout_parser()`, `test_extract_financial_data_dedicated_ocr_failure_falls_back_to_vision()` | `extraction/test_extraction_error_paths.py` | P1 |
+| AC13.18.2 | When the primary vision model raises a non-retryable provider error (e.g. a 400), the vision path attempts the configured vision fallback model and succeeds instead of failing the upload | `test_vision_path_falls_back_to_secondary_model_on_non_retryable_error()` | `extraction/test_extraction_error_paths.py` | P1 |
 
 ### AC13.14: JSON-Repair Retry (issue #982)
 


### PR DESCRIPTION
## Problem
Post-merge `main` CI is **red** on the **AC Traceability Check**:

```
ERROR: AC IDs are defined more than once ... AC13.17.1 ... AC13.17.2 (EPIC-013)
ERROR: duplicate AC group headings ... AC13.17 in EPIC-013.statement-parsing-v2.md
```

PR #1039 (vision extraction fallback, #1034) and the concurrently-merged PR #1036 (balance-aware self-consistency, #989 Step B) **both** added an `AC13.17` section to `EPIC-013`. The new AC-ID uniqueness gate from #1040 (merged just before) correctly flags this — and the registry was silently dropping the second definition.

## Fix
#1036 merged first, so it keeps `AC13.17`. This renumbers the **vision-fallback** section (and its test docstrings) to the next free id **`AC13.18`**:
- `docs/project/EPIC-013.statement-parsing-v2.md`: `AC13.17` → `AC13.18` (heading + `.1`/`.2`)
- `apps/backend/tests/extraction/test_extraction_error_paths.py`: docstring refs `AC13.17.x` → `AC13.18.x`

Docs/docstrings only — no code or behavior change. Verified locally: `generate_ac_registry.py --check` and `check_ac_traceability.py` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)