### PR TITLE
[finance_report_ui] fix(#756,#758): fail-fast on no-new-deployment + rollback half-updated preview compose (Infra-AC7.13)

### DIFF
--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -239,6 +239,20 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 | AC7.12.6 | SSOT (`environments.md`) defines the data axis (empty / staging / anonymized prod snapshot) and the four data red lines (RL-DATA-1..4): a PR sha never runs on prod data; prod data is anonymized before leaving prod; non-prod object storage holds no real uploads; a backup is not an anonymized snapshot | `test_AC7_12_6_environments_define_data_axis_and_red_lines` | `tests/tooling/test_data_red_lines_contract.py` | P1 |
 | AC7.12.8 | The published `:<sha>` front-end image is environment-independent (same-origin `/api`, no environment domain baked in); a contract test fails if a concrete environment domain appears in the published image | `test_AC7_12_8_published_frontend_image_has_no_baked_env_domain` | `tests/tooling/test_frontend_same_origin_contract.py` | P0 |
 
+### AC7.13: Preview rollout proof & half-update safety (#756, #758)
+
+> The PR preview lifecycle (`tools/_lib/dev/pr_preview_lifecycle.py`) must fail
+> fast when Dokploy never creates a new deployment record (#756) and must never
+> leave a silently half-updated compose on a deploy/rollout failure (#758).
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC7.13.1 | A `composeStatus=done` rollout with no new deployment record for the requested SHA fails fast with the classified `DokployNoNewDeploymentRecord` error (`platform_failure_domain=dokploy-worker-or-deployment-record`) instead of proceeding to commit-scoped readiness against stale records | `test_AC7_13_1_no_new_deployment_record_raises_classified_subclass` | `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
+| AC7.13.2 | Rollout diagnostics distinguish "no new deployment created" from "new deployment created but route not ready", and effective-env reconciliation flags stale non-allowlisted keys by name without leaking secret values | `test_AC7_13_2_env_reconciliation_rejects_stale_non_allowlisted_keys` | `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
+| AC7.13.3 | `update_compose_env` reconciles the whole requested env against the effective remote env and fails fast when a stale non-allowlisted key diverges | `test_AC7_13_3_update_compose_env_fails_fast_on_stale_keys` | `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
+| AC7.13.4 | On deploy/rollout failure the lifecycle rolls back to last-known-good source/env or marks the record safe-to-reconcile, recording which mutation step (source/env/deploy/rollout) it was left at — never a silent half-update | `test_AC7_13_4_mutate_then_fail_marks_state_and_records_step` | `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
+| AC7.13.5 | The CI/CD SSOT documents both the no-new-deployment fail-fast mode and the half-update rollback / safe-to-reconcile recovery path | `test_AC7_13_5_ci_cd_docs_describe_failure_modes` | `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
+
 
 ## 📏 Acceptance Criteria
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -411,6 +411,33 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
   Dokploy `compose.delete`) by PR number/compose name rather than broad volume
   pruning. The deploy path is get-or-create + redeploy, so it updates the
   preview in place across commits without a pre-deploy delete.
+- PR preview rollout proof fails fast on a missing deployment record. When
+  Dokploy reports `composeStatus=done` but never exposes a **new** deployment
+  record for the requested SHA within the new-record window,
+  `wait_for_dokploy_deployment_rollout` raises the classified
+  `DokployNoNewDeploymentRecord` error
+  (`platform_failure_domain=dokploy-worker-or-deployment-record`) instead of
+  proceeding to commit-scoped readiness. This stops the lifecycle from
+  false-greening against stale records and then wasting the full readiness
+  window probing a route for a SHA that never rolled out. The diagnostics
+  distinguish "no new deployment created" (control-plane / worker failure) from
+  "new deployment created but route not ready" (a readiness/Traefik 404 window),
+  so a 404 is no longer the only signal. The retry ladder still recovers via
+  `compose.redeploy` and compose recreation because the classified error
+  subclasses `DokployDeploymentDidNotStart`.
+- PR preview deploy never leaves a silent half-update. The deploy mutates the
+  Dokploy compose (source then env) before triggering the rollout, so the
+  failure path captures the last-known-good source/env of an existing compose
+  before mutating. On a deploy/rollout failure it either rolls the compose back
+  to that last-known-good state (`recovery_state=rolled-back`) or, when no good
+  snapshot exists (a freshly created or recreated compose), explicitly marks the
+  record safe-to-reconcile (`recovery_state=marked-safe-to-reconcile`). The
+  failure context records which mutation step (`source`, `env`, `deploy`, or
+  `rollout`) the compose was left at. `update_compose_env` additionally
+  reconciles the **whole** requested env against the effective remote env so a
+  stale non-allowlisted key from a prior deploy cannot diverge unnoticed;
+  divergence fails fast with key-name-only diagnostics that never print env
+  values.
 - PR preview E2E explicitly excludes tests marked `llm`. The post-merge `Staging AI/OCR Gate` workflow is the single automated CI entry point that may spend provider quota.
 - PR preview non-LLM E2E is a strict preview-relevant subset: `STRICT_E2E_GATES=true`, marker `(smoke or e2e) and not llm`, `-n 4` parallelism, and explicit paths limited to `tests/e2e/test_core_journeys.py` plus `tests/e2e/test_e2e_flows.py::test_full_navigation`. Broader business regression paths, provider-sensitive paths, and state-sensitive registration or statement workflows remain staging/post-merge responsibilities.
 - The shared `.github/actions/setup-e2e-tests` action owns E2E Python import setup. It must export the repository root through `PYTHONPATH` via `$GITHUB_ENV` before preview, staging, AI/OCR, or production E2E pytest commands run, because `tests/e2e/conftest.py` imports shared helpers through the `tests.e2e.*` package path while pytest may choose `tests/e2e` as its root directory.

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -1105,7 +1105,13 @@ def test_AC8_13_72_deploy_action_reads_effective_env_before_deploy(
             return subprocess.CompletedProcess(
                 cmd,
                 0,
-                stdout=json.dumps({"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "running"}),
+                stdout=json.dumps(
+                    {
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
+                        "composeStatus": "running",
+                    }
+                ),
                 stderr="",
             )
         return subprocess.CompletedProcess(cmd, 0, stdout='{"ok":true}', stderr="")
@@ -1189,7 +1195,12 @@ def test_AC8_13_102_new_preview_redeploys_when_initial_deploy_record_is_missing(
                 cmd,
                 0,
                 stdout=json.dumps(
-                    {"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "idle", "deployments": []}
+                    {
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
+                        "composeStatus": "idle",
+                        "deployments": [],
+                    }
                 ),
                 stderr="",
             )
@@ -1280,7 +1291,12 @@ def test_AC8_13_102_existing_preview_without_deployments_is_recreated(
                 cmd,
                 0,
                 stdout=json.dumps(
-                    {"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "idle", "deployments": []}
+                    {
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
+                        "composeStatus": "idle",
+                        "deployments": [],
+                    }
                 ),
                 stderr="",
             )
@@ -1362,7 +1378,8 @@ def test_AC8_13_102_existing_preview_rollout_tracks_new_deployment_ids(
                 0,
                 stdout=json.dumps(
                     {
-                        "appName": "compose-pr-591-app", "env": effective_env,
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
                         "composeStatus": "running",
                         "deployments": [{"deploymentId": "old-dep-591"}],
                     }
@@ -1455,7 +1472,8 @@ def test_AC8_13_102_existing_preview_missing_deploy_record_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "appName": "compose-pr-591-app", "env": effective_env,
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
                         "composeStatus": "idle",
                         "deployments": [],
                     }
@@ -1468,7 +1486,8 @@ def test_AC8_13_102_existing_preview_missing_deploy_record_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "appName": "compose-pr-591-app", "env": effective_env,
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
                         "composeStatus": "idle",
                         "deployments": [{"deploymentId": "old-dep-591"}],
                     }
@@ -1567,7 +1586,8 @@ def test_AC8_13_102_recreated_preview_missing_record_fails_before_readiness(
             0,
             stdout=json.dumps(
                 {
-                    "appName": "compose-pr-591-app", "env": effective_env,
+                    "appName": "compose-pr-591-app",
+                    "env": effective_env,
                     "composeStatus": "idle",
                     "deployments": [],
                 }
@@ -1668,7 +1688,8 @@ def test_AC8_13_102_existing_preview_rollout_error_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "appName": "compose-pr-591-app", "env": effective_env,
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
                         "composeStatus": "idle",
                         "deployments": [],
                     }
@@ -1681,7 +1702,8 @@ def test_AC8_13_102_existing_preview_rollout_error_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "appName": "compose-pr-591-app", "env": effective_env,
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
                         "composeStatus": "error",
                         "deployments": [{"deploymentId": "dep-591", "status": "error"}],
                     }
@@ -1778,7 +1800,8 @@ def test_AC8_13_102_new_preview_missing_after_redeploy_recreates_once(
                 0,
                 stdout=json.dumps(
                     {
-                        "appName": "compose-pr-591-app", "env": effective_env,
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
                         "composeStatus": "idle",
                         "deployments": [],
                     }
@@ -1874,7 +1897,13 @@ def test_AC8_13_102_new_preview_rollout_error_still_fails(
             return subprocess.CompletedProcess(
                 cmd,
                 0,
-                stdout=json.dumps({"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "error"}),
+                stdout=json.dumps(
+                    {
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
+                        "composeStatus": "error",
+                    }
+                ),
                 stderr="",
             )
         return subprocess.CompletedProcess(cmd, 0, stdout='{"ok":true}', stderr="")
@@ -1954,7 +1983,13 @@ def test_AC8_13_98_existing_preview_compose_is_redeployed_without_pre_stop(
             return subprocess.CompletedProcess(
                 cmd,
                 0,
-                stdout=json.dumps({"appName": "compose-pr-591-app", "env": effective_env, "composeStatus": "running"}),
+                stdout=json.dumps(
+                    {
+                        "appName": "compose-pr-591-app",
+                        "env": effective_env,
+                        "composeStatus": "running",
+                    }
+                ),
                 stderr="",
             )
         return subprocess.CompletedProcess(cmd, 0, stdout='{"ok":true}', stderr="")
@@ -2749,3 +2784,313 @@ def test_AC8_13_125_pr_preview_runner_lifecycle_has_hard_timeout() -> None:
     assert "for i in $(seq 1 60)" in e2e_block
     assert "stack did not become healthy within 300s" in e2e_block
     assert "docker compose down --volumes --remove-orphans --timeout 30" in e2e_block
+
+
+# ---------------------------------------------------------------------------
+# Issue #756 — fail-fast on no-new-deployment record (classified error)
+# Issue #758 — rollback / safe-to-reconcile on mutate-then-fail
+# ---------------------------------------------------------------------------
+
+
+def _deploy_args() -> SimpleNamespace:
+    return SimpleNamespace(
+        action="deploy",
+        pr_number=591,
+        compose_name="pr-591",
+        compose_id="",
+        environment_id="env-test",
+        api_url="https://cloud.example/api",
+        api_key="secret-key",
+        github_integration_id="ghid",
+        branch="feature",
+        commit_sha="abc123",
+        registry="ghcr.io",
+        image_prefix="owner/finance_report",
+        internal_domain="zitian.party",
+        dry_run=False,
+    )
+
+
+def test_AC7_13_1_no_new_deployment_record_raises_classified_subclass(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AC7.13.1: A done compose with no new deployment record fails fast with the
+    dedicated DokployNoNewDeploymentRecord classified error (subclass of
+    DokployDeploymentDidNotStart so the existing retry flow still catches it)."""
+    lifecycle = lifecycle_module()
+
+    assert issubclass(
+        lifecycle.DokployNoNewDeploymentRecord,
+        lifecycle.DokployDeploymentDidNotStart,
+    )
+
+    monkeypatch.setattr(
+        lifecycle,
+        "get_compose_data",
+        lambda *args, **kwargs: {
+            "composeStatus": "done",
+            "deployments": [{"deploymentId": "old-dep"}],
+        },
+    )
+    monkeypatch.setattr(lifecycle.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(lifecycle.DokployNoNewDeploymentRecord) as excinfo:
+        lifecycle.wait_for_dokploy_deployment_rollout(
+            lifecycle.DokployConfig("https://cloud.example/api", "secret"),
+            compose_id="cmp-1",
+            previous_deployment_ids={"old-dep"},
+            timeout_seconds=1,
+            new_deployment_timeout_seconds=0,
+        )
+
+    assert "dokploy-worker-or-deployment-record" in str(excinfo.value)
+    out = capsys.readouterr().out
+    assert "proceeding to commit-scoped readiness" not in out
+    # AC7.13.2: diagnostics distinguish "no new deployment created" from a
+    # "route not ready" 404 window.
+    assert "did not create a new deployment record" in out
+
+
+def test_AC7_13_2_env_reconciliation_rejects_stale_non_allowlisted_keys() -> None:
+    """AC7.13.2: Non-allowlisted stale keys lingering in the effective env are
+    detected and the diagnostic names keys only (no secret values)."""
+    lifecycle = lifecycle_module()
+
+    requested = {"IMAGE_TAG": "pr-1-sha", "ZAI_API_KEY": "wanted"}
+    effective = "\n".join(
+        [
+            "IMAGE_TAG=pr-1-sha",
+            "ZAI_API_KEY=wanted",
+            # leftover from a previous deploy, not in the requested env at all
+            "STALE_TOKEN=leaked-secret-value",
+        ]
+    )
+
+    divergent = lifecycle.env_reconciliation_divergence(requested, effective)
+    assert "STALE_TOKEN" in divergent
+
+    diff = lifecycle.render_env_reconciliation_diff(requested, effective)
+    assert "STALE_TOKEN" in diff
+    assert "leaked-secret-value" not in diff
+    assert "raw_env_printed: false" in diff
+
+    # A fully-matching env reconciles cleanly.
+    clean = "\n".join(["IMAGE_TAG=pr-1-sha", "ZAI_API_KEY=wanted"])
+    assert lifecycle.env_reconciliation_divergence(requested, clean) == []
+
+
+def test_AC7_13_3_update_compose_env_fails_fast_on_stale_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC7.13.3: update_compose_env fails fast when the effective remote env keeps
+    a stale non-allowlisted key that diverges from the requested env."""
+    lifecycle = lifecycle_module()
+
+    requested = lifecycle.build_preview_env(
+        pr_number=591,
+        commit_sha="abc123",
+        registry="ghcr.io",
+        image_prefix="owner/finance_report",
+        internal_domain="zitian.party",
+    )
+    # Effective env echoes everything requested plus an orphan key.
+    effective = lifecycle.render_env(requested) + "ORPHAN_LEFTOVER=stale\n"
+
+    monkeypatch.setattr(lifecycle, "dokploy_api_call", lambda *a, **k: "{}")
+    monkeypatch.setattr(lifecycle, "get_compose_env", lambda *a, **k: effective)
+
+    with pytest.raises(RuntimeError, match="did not match requested deploy env"):
+        lifecycle.update_compose_env(
+            lifecycle.DokployConfig("https://cloud.example/api", "secret"),
+            compose_id="cmp-1",
+            env=requested,
+        )
+
+
+def test_AC7_13_4_mutate_then_fail_marks_state_and_records_step(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """AC7.13.4: When rollout fails after the compose was mutated, deploy_action
+    leaves an explicitly-marked safe-to-reconcile state, records which mutation
+    step it was left at, and does not silently report success."""
+    lifecycle = lifecycle_module()
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    context_path = tmp_path / "context.json"
+    monkeypatch.setenv(lifecycle.PR_PREVIEW_CONTEXT_ENV, str(context_path))
+
+    good_env = lifecycle.render_env(
+        lifecycle.build_preview_env(
+            pr_number=591,
+            commit_sha="prevsha",
+            registry="ghcr.io",
+            image_prefix="owner/finance_report",
+            internal_domain="zitian.party",
+        )
+    )
+
+    def fake_run_command(
+        cmd: list[str],
+        *,
+        input_text: str | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        rendered = " ".join(cmd)
+        if "environment.one" in rendered:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout='{"compose":[{"name":"pr-591","composeId":"cmp-591"}]}',
+                stderr="",
+            )
+        if "compose.create" in rendered:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout='{"composeId":"cmp-591-recreated"}', stderr=""
+            )
+        if "compose.one" in rendered:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=json.dumps(
+                    {
+                        "appName": "compose-pr-591-app",
+                        "env": good_env,
+                        "composeStatus": "done",
+                        "deployments": [{"deploymentId": "old-dep-591"}],
+                    }
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout='{"ok":true}', stderr="")
+
+    # Make the mutation steps no-ops so we exercise the rollout-failure path.
+    monkeypatch.setattr(lifecycle, "update_compose_env", lambda *a, **k: None)
+    monkeypatch.setattr(lifecycle, "update_compose_source", lambda *a, **k: None)
+    monkeypatch.setattr(lifecycle, "run_command", fake_run_command)
+
+    def fake_wait(*args: object, **kwargs: object) -> None:
+        raise lifecycle.DokployDeploymentFailed("rollout never went healthy")
+
+    monkeypatch.setattr(lifecycle, "wait_for_dokploy_deployment_rollout", fake_wait)
+
+    assert lifecycle.main_from_args(_deploy_args()) == 1
+
+    context = json.loads(context_path.read_text())
+    assert context["phase"] == "failed"
+    # AC7.13.4: the mutation step the environment was left at is recorded.
+    assert context.get("mutation_step") in {"deploy", "env", "source", "rollout"}
+    # AC7.13.1/758: an explicitly-marked safe-to-reconcile or rolled-back state,
+    # not a silent half-update.
+    assert context.get("recovery_state") in {
+        "rolled-back",
+        "marked-safe-to-reconcile",
+    }
+    out = capsys.readouterr().out
+    assert "PR preview deploy failed" in out
+
+
+def test_AC7_13_4_existing_compose_rolls_back_to_last_known_good_on_env_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """AC7.13.4: An existing compose whose env update fails reconciliation is
+    rolled back to its captured last-known-good source/env (not left half
+    updated), recording the env mutation step it failed at."""
+    lifecycle = lifecycle_module()
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    context_path = tmp_path / "context.json"
+    monkeypatch.setenv(lifecycle.PR_PREVIEW_CONTEXT_ENV, str(context_path))
+
+    last_known_good_env = "IMAGE_TAG=pr-591-prevsha\nGOOD_MARKER=keep\n"
+    last_known_good_command = (
+        "compose -p compose-pr-591-app -f docker-compose.pr-preview.yml up -d"
+    )
+    update_calls: list[dict[str, object]] = []
+
+    def fake_run_command(
+        cmd: list[str],
+        *,
+        input_text: str | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        rendered = " ".join(cmd)
+        if "environment.one" in rendered:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout='{"compose":[{"name":"pr-591","composeId":"cmp-591"}]}',
+                stderr="",
+            )
+        if "compose.one" in rendered:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=json.dumps(
+                    {
+                        "appName": "compose-pr-591-app",
+                        "command": last_known_good_command,
+                        "env": last_known_good_env,
+                        "composeStatus": "done",
+                        "deployments": [{"deploymentId": "old-dep-591"}],
+                    }
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout='{"ok":true}', stderr="")
+
+    monkeypatch.setattr(lifecycle, "run_command", fake_run_command)
+    monkeypatch.setattr(lifecycle, "update_compose_source", lambda *a, **k: None)
+
+    # Capture the rollback compose.update payload directly.
+    original_api_call = lifecycle.dokploy_api_call
+
+    def spy_api_call(config, method, endpoint, *, payload=None, expected_status=200):
+        if endpoint == "compose.update" and payload is not None:
+            update_calls.append(dict(payload))
+            return "{}"
+        return original_api_call(
+            config, method, endpoint, payload=payload, expected_status=expected_status
+        )
+
+    monkeypatch.setattr(lifecycle, "dokploy_api_call", spy_api_call)
+
+    # Effective env keeps a stale non-allowlisted key, so update_compose_env
+    # raises the reconciliation RuntimeError after the snapshot was captured.
+    def fake_get_compose_env(config, *, compose_id):
+        requested = lifecycle.build_preview_env(
+            pr_number=591,
+            commit_sha="abc123",
+            registry="ghcr.io",
+            image_prefix="owner/finance_report",
+            internal_domain="zitian.party",
+        )
+        return lifecycle.render_env(requested) + "STALE_LEFTOVER=old\n"
+
+    monkeypatch.setattr(lifecycle, "get_compose_env", fake_get_compose_env)
+
+    assert lifecycle.main_from_args(_deploy_args()) == 1
+
+    context = json.loads(context_path.read_text())
+    assert context["phase"] == "failed"
+    assert context.get("mutation_step") == "env"
+    assert context.get("recovery_state") == "rolled-back"
+    # The rollback restored the captured last-known-good env/command.
+    rollback = update_calls[-1]
+    assert rollback.get("env") == last_known_good_env
+    assert rollback.get("command") == last_known_good_command
+    out = capsys.readouterr().out
+    assert "Rolled compose back to last-known-good" in out
+
+
+def test_AC7_13_5_ci_cd_docs_describe_failure_modes() -> None:
+    """AC7.13.5: ci-cd SSOT documents both the no-new-deployment fail-fast mode
+    and the half-update rollback / safe-to-reconcile recovery path."""
+    ci_cd = (ROOT / "docs/ssot/ci-cd.md").read_text()
+    assert "dokploy-worker-or-deployment-record" in ci_cd
+    assert "safe-to-reconcile" in ci_cd
+    lowered = ci_cd.lower()
+    assert "no new deployment" in lowered
+    assert "rollback" in lowered or "roll back" in lowered

--- a/tools/_lib/dev/pr_preview_lifecycle.py
+++ b/tools/_lib/dev/pr_preview_lifecycle.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import quote
@@ -33,6 +34,26 @@ ALLOWLIST_ENV_KEYS = (
     "S3_HOST",
     "COMPOSE_PROFILES",
 )
+
+# Keys that the platform (Dokploy / Vault-agent) injects or owns in the
+# effective compose env. They legitimately appear in the effective env without
+# being part of the deterministic requested preview env, so reconciliation must
+# not treat them as stale drift (issue #758).
+PLATFORM_MANAGED_ENV_KEYS = (
+    "COMPOSE_PROJECT_NAME",
+    "VAULT_APP_TOKEN",
+)
+PLATFORM_MANAGED_ENV_PREFIXES = (
+    "VAULT_",
+    "DOKPLOY_",
+)
+
+
+def is_platform_managed_env_key(key: str) -> bool:
+    return key in PLATFORM_MANAGED_ENV_KEYS or key.startswith(
+        PLATFORM_MANAGED_ENV_PREFIXES
+    )
+
 
 COMPOSE_SUMMARY_KEYS = (
     "composeId",
@@ -89,6 +110,18 @@ class DokployConfig:
 
 class DokployDeploymentDidNotStart(RuntimeError):
     """Dokploy accepted a deploy request but did not create a new deployment."""
+
+
+class DokployNoNewDeploymentRecord(DokployDeploymentDidNotStart):
+    """Dokploy never created a new deployment record for the requested rollout.
+
+    Distinct from a generic "did not start": the compose can report
+    ``composeStatus=done`` against *stale* deployment records, which previously
+    let the waiter false-green and waste the readiness window probing a route
+    for a SHA that never rolled out (issue #756). This subclass classifies that
+    failure domain (``dokploy-worker-or-deployment-record``) while still being
+    caught by the existing ``DokployDeploymentDidNotStart`` retry handlers.
+    """
 
 
 class DokployDeploymentFailed(RuntimeError):
@@ -171,6 +204,57 @@ def render_allowlisted_env_diff(expected: dict[str, str], actual_env_text: str) 
     lines.append(
         f"result: {'match' if allowlisted_env_matches(expected, actual_env_text) else 'mismatch'}"
     )
+    lines.append("raw_env_printed: false")
+    return "\n".join(lines)
+
+
+def env_reconciliation_divergence(
+    requested: dict[str, str], actual_env_text: str
+) -> list[str]:
+    """Return env keys whose effective remote value diverges from the request.
+
+    Covers the whole requested env (not just the allowlist) plus stale keys that
+    linger in the effective env but were never requested — the non-allowlisted
+    drift class from issue #758. Only key *names* are returned so callers can
+    surface them without leaking secret values.
+    """
+
+    actual = parse_env(actual_env_text)
+    divergent: set[str] = set()
+    # A requested key that the effective env *does* expose must match. We do not
+    # flag requested keys the effective payload omits: Dokploy can return a
+    # partial view, and "incomplete echo" is a separate concern from the stale
+    # non-allowlisted drift this guards against.
+    for key, value in requested.items():
+        if key in actual and actual[key] != value:
+            divergent.add(key)
+    # A key present in the effective env that we never requested and that the
+    # platform does not own is a stale leftover from a prior deploy.
+    for key in actual:
+        if key not in requested and not is_platform_managed_env_key(key):
+            divergent.add(key)
+    return sorted(divergent)
+
+
+def render_env_reconciliation_diff(
+    requested: dict[str, str], actual_env_text: str
+) -> str:
+    """Render a secret-safe reconciliation diagnostic (key names only)."""
+
+    divergent = env_reconciliation_divergence(requested, actual_env_text)
+    actual = parse_env(actual_env_text)
+    lines = ["Effective deploy env reconciliation"]
+    lines.append(f"requested_key_count: {len(requested)}")
+    lines.append(f"effective_key_count: {len(actual)}")
+    for key in divergent:
+        if key not in requested:
+            reason = "stale-unrequested-key"
+        elif key not in actual:
+            reason = "missing-from-effective"
+        else:
+            reason = "value-mismatch"
+        lines.append(f"divergent_key: {key} ({reason})")
+    lines.append(f"result: {'match' if not divergent else 'mismatch'}")
     lines.append("raw_env_printed: false")
     return "\n".join(lines)
 
@@ -389,6 +473,8 @@ def build_preview_context(
     phase: str,
     compose_id: str = "",
     error: str = "",
+    mutation_step: str = "",
+    recovery_state: str = "",
 ) -> dict[str, str]:
     app_url = preview_app_url(args.pr_number, args.commit_sha, args.internal_domain)
     context = {
@@ -417,6 +503,10 @@ def build_preview_context(
     }
     if error:
         context["error"] = redact_diagnostic_value(error)
+    if mutation_step:
+        context["mutation_step"] = mutation_step
+    if recovery_state:
+        context["recovery_state"] = recovery_state
     return context
 
 
@@ -787,11 +877,48 @@ def update_compose_env(
     )
     effective_env = get_compose_env(config, compose_id=compose_id)
     print(render_allowlisted_env_diff(expected, effective_env))
+    # Reconcile the *whole* requested env against the effective remote env so a
+    # stale non-allowlisted key from a prior deploy cannot silently diverge
+    # (issue #758). Diagnostics name keys only and never print values.
+    print(render_env_reconciliation_diff(env, effective_env))
     if not allowlisted_env_matches(expected, effective_env):
         raise RuntimeError(
             "Dokploy effective environment did not match requested deploy env"
         )
+    if env_reconciliation_divergence(env, effective_env):
+        raise RuntimeError(
+            "Dokploy effective environment did not match requested deploy env "
+            "after full reconciliation (stale or divergent non-allowlisted keys)"
+        )
     print(f"Environment variables configured for compose: {compose_id}")
+
+
+def capture_compose_state(config: DokployConfig, *, compose_id: str) -> dict[str, str]:
+    """Snapshot the last-known-good compose source command and env.
+
+    Captured *before* a deploy mutates the compose so the failure path can roll
+    the record back instead of leaving a half-updated compose pointing at a SHA
+    that never rolled out (issue #758).
+    """
+
+    data = get_compose_data(config, compose_id=compose_id)
+    return {
+        "command": str(data.get("command") or ""),
+        "env": str(data.get("env") or ""),
+    }
+
+
+def restore_compose_state(
+    config: DokployConfig, *, compose_id: str, state: dict[str, str]
+) -> None:
+    """Roll the compose source command and env back to a captured snapshot."""
+
+    payload: dict[str, object] = {"composeId": compose_id}
+    if state.get("command"):
+        payload["command"] = state["command"]
+    payload["env"] = state.get("env", "")
+    dokploy_api_call(config, "POST", "compose.update", payload=payload)
+    print(f"Rolled compose back to last-known-good source/env: {compose_id}")
 
 
 def configure_preview_compose(
@@ -800,7 +927,12 @@ def configure_preview_compose(
     compose_id: str,
     args: argparse.Namespace,
     preview_env: dict[str, str],
+    on_step: Callable[[str], None] | None = None,
 ) -> None:
+    # ``on_step`` lets the caller mark which mutation the compose was left at
+    # (source vs env) so a failure can report and recover precisely (issue #758).
+    if on_step is not None:
+        on_step("source")
     update_compose_source(
         config,
         compose_id=compose_id,
@@ -808,6 +940,8 @@ def configure_preview_compose(
         github_integration_id=args.github_integration_id,
     )
     print_compose_summary(config, compose_id=compose_id, label="after-source-update")
+    if on_step is not None:
+        on_step("env")
     update_compose_env(
         config,
         compose_id=compose_id,
@@ -1027,12 +1161,13 @@ def wait_for_dokploy_deployment_rollout(
             and now >= new_deployment_deadline
         ):
             print(
-                "Dokploy did not expose a new deployment record, but compose "
+                "Dokploy did not create a new deployment record, but compose "
                 "is done with existing deployment records; failing before "
-                "application readiness. platform_failure_domain="
+                "application readiness instead of probing the route for a SHA "
+                "that never rolled out. platform_failure_domain="
                 "dokploy-worker-or-deployment-record"
             )
-            raise DokployDeploymentDidNotStart(
+            raise DokployNoNewDeploymentRecord(
                 "Dokploy compose is done with existing deployment records but "
                 "did not create a new deployment record for this rollout before "
                 f"readiness polling: compose_id={compose_id} "
@@ -1057,7 +1192,7 @@ def wait_for_dokploy_deployment_rollout(
                 )
                 new_deployment_deadline = min(now + 60.0, deadline)
                 continue
-            raise DokployDeploymentDidNotStart(
+            raise DokployNoNewDeploymentRecord(
                 "Dokploy deployment did not create a new deployment before "
                 f"readiness polling: compose_id={compose_id} "
                 f"composeStatus={compose_status or 'unknown'} "
@@ -1089,8 +1224,19 @@ def deploy_action(args: argparse.Namespace) -> int:
     config = DokployConfig(api_url=args.api_url, api_key=args.api_key)
     context_path = os.environ.get(PR_PREVIEW_CONTEXT_ENV, "")
     compose_id = ""
+    # Tracks which mutation the compose was left at and the last-known-good
+    # snapshot to roll back to on failure (issue #758). "step" advances as the
+    # deploy mutates source -> env -> deploy -> rollout. "good" is None until we
+    # have a snapshot worth restoring (only existing composes have one).
+    mutation: dict[str, object] = {"step": "preflight", "good": None}
 
-    def record_context(phase: str, *, error: str = "") -> None:
+    def record_context(
+        phase: str,
+        *,
+        error: str = "",
+        mutation_step: str = "",
+        recovery_state: str = "",
+    ) -> None:
         write_preview_context(
             context_path,
             build_preview_context(
@@ -1098,6 +1244,8 @@ def deploy_action(args: argparse.Namespace) -> int:
                 phase=phase,
                 compose_id=compose_id,
                 error=error,
+                mutation_step=mutation_step,
+                recovery_state=recovery_state,
             ),
         )
 
@@ -1145,11 +1293,23 @@ def deploy_action(args: argparse.Namespace) -> int:
         )
 
         def configure_current_compose() -> None:
+            # Snapshot the last-known-good source/env of an *existing* compose
+            # before mutating it, so a later rollout failure can roll back rather
+            # than leave a half-updated compose (issue #758). A freshly-created
+            # compose has no good state to restore, so leave the snapshot unset
+            # and fall back to the marked safe-to-reconcile path.
+            if existing_compose and mutation["good"] is None:
+                mutation["good"] = capture_compose_state(config, compose_id=compose_id)
+
+            def mark_step(step: str) -> None:
+                mutation["step"] = step
+
             configure_preview_compose(
                 config,
                 compose_id=compose_id,
                 args=args,
                 preview_env=preview_env,
+                on_step=mark_step,
             )
 
         def trigger_and_wait(*, force_redeploy: bool) -> None:
@@ -1158,6 +1318,7 @@ def deploy_action(args: argparse.Namespace) -> int:
             previous_deployment_signatures = deployment_signatures(
                 compose_data.get("deployments")
             )
+            mutation["step"] = "deploy"
             deploy_compose(config, compose_id=compose_id, force_redeploy=force_redeploy)
             print_compose_summary(
                 config,
@@ -1169,6 +1330,7 @@ def deploy_action(args: argparse.Namespace) -> int:
             record_context(
                 "redeploy-triggered" if force_redeploy else "deploy-triggered"
             )
+            mutation["step"] = "rollout"
             wait_for_dokploy_deployment_rollout(
                 config,
                 compose_id=compose_id,
@@ -1182,6 +1344,9 @@ def deploy_action(args: argparse.Namespace) -> int:
 
         def recreate_compose_before_retry() -> None:
             nonlocal compose_id, existing_compose
+            # The compose is being torn down and recreated fresh; there is no
+            # prior good state to roll back to anymore.
+            mutation["good"] = None
             delete_compose(config, compose_id=compose_id)
             compose_id = create_compose(
                 config,
@@ -1263,7 +1428,37 @@ def deploy_action(args: argparse.Namespace) -> int:
             )
         return 0
     except Exception as exc:
-        record_context("failed", error=f"{type(exc).__name__}: {exc}")
+        # Issue #758: never leave a silent half-update. If we mutated an existing
+        # compose, roll it back to the captured last-known-good source/env;
+        # otherwise (a freshly-created or already-recreated compose) explicitly
+        # mark the record safe-to-reconcile so a retry/reconcile knows the
+        # compose is not a trustworthy running state. Always record which
+        # mutation step the compose was left at.
+        mutation_step = str(mutation.get("step") or "preflight")
+        recovery_state = "marked-safe-to-reconcile"
+        good_state = mutation.get("good")
+        if isinstance(good_state, dict) and compose_id:
+            try:
+                restore_compose_state(config, compose_id=compose_id, state=good_state)
+                recovery_state = "rolled-back"
+            except Exception as rollback_exc:  # pragma: no cover - defensive
+                print(
+                    "WARNING: failed to roll preview compose back to "
+                    f"last-known-good; left safe-to-reconcile: "
+                    f"{type(rollback_exc).__name__}: "
+                    f"{redact_diagnostic_value(rollback_exc)}"
+                )
+        print(
+            "PR preview deploy left compose in a recovery state: "
+            f"compose_id={compose_id or 'none'} "
+            f"mutation_step={mutation_step} recovery_state={recovery_state}"
+        )
+        record_context(
+            "failed",
+            error=f"{type(exc).__name__}: {exc}",
+            mutation_step=mutation_step,
+            recovery_state=recovery_state,
+        )
         print(
             "PR preview deploy failed: "
             f"{type(exc).__name__}: {redact_diagnostic_value(exc)}"

--- a/tools/_lib/dev/pr_preview_lifecycle.py
+++ b/tools/_lib/dev/pr_preview_lifecycle.py
@@ -247,12 +247,11 @@ def render_env_reconciliation_diff(
     lines.append(f"requested_key_count: {len(requested)}")
     lines.append(f"effective_key_count: {len(actual)}")
     for key in divergent:
-        if key not in requested:
-            reason = "stale-unrequested-key"
-        elif key not in actual:
-            reason = "missing-from-effective"
-        else:
-            reason = "value-mismatch"
+        # env_reconciliation_divergence only reports keys that are present in the
+        # effective env: either a stale key we never requested, or a requested
+        # key whose effective value differs. It deliberately does not flag keys
+        # absent from the effective env, so those two are the only reasons here.
+        reason = "stale-unrequested-key" if key not in requested else "value-mismatch"
         lines.append(f"divergent_key: {key} ({reason})")
     lines.append(f"result: {'match' if not divergent else 'mismatch'}")
     lines.append("raw_env_printed: false")


### PR DESCRIPTION
## Summary

Two coupled PR-preview lifecycle hardening fixes in
`tools/_lib/dev/pr_preview_lifecycle.py`.

**#756 — false-green rollout fallback.** When Dokploy reports
`composeStatus=done` but never exposes a *new* deployment record for the
requested SHA, `wait_for_dokploy_deployment_rollout` now raises the dedicated
**`DokployNoNewDeploymentRecord`** classified error
(`platform_failure_domain=dokploy-worker-or-deployment-record`) instead of
proceeding to commit-scoped readiness against stale records (which wasted the
full readiness window on a misleading `traefik-public-route` 404). The error
subclasses `DokployDeploymentDidNotStart`, so the existing redeploy / recreate
retry ladder is unchanged. Diagnostics now distinguish "no new deployment
created" from "new deployment created but route not ready".

**#758 — mutate-then-fail leaves half-updated compose.** `deploy_action` now
captures the last-known-good compose source/env before mutating an existing
compose, tracks which mutation step it is at (`source` / `env` / `deploy` /
`rollout`), and on any deploy/rollout failure either:
- rolls the compose back to last-known-good (`recovery_state=rolled-back`), or
- explicitly marks it `safe-to-reconcile` when no good snapshot exists
  (a freshly created / recreated compose) — never a silent half-update.

`update_compose_env` additionally reconciles the **whole** requested env against
the effective remote env, so a stale non-allowlisted key from a prior deploy
fails fast with **key-name-only, secret-safe** diagnostics. Platform-managed
keys (Vault / Dokploy, e.g. `VAULT_APP_TOKEN`, `COMPOSE_PROJECT_NAME`) are
excluded from drift detection.

Closes #756
Closes #758

## ACs (EPIC-007)

- **AC7.13.1** — no-new-deployment-record rollout fails fast with classified `DokployNoNewDeploymentRecord`
- **AC7.13.2** — diagnostics distinguish "no new deployment" vs "route not ready"; env reconciliation names stale keys without leaking values
- **AC7.13.3** — `update_compose_env` fails fast on stale non-allowlisted keys
- **AC7.13.4** — deploy/rollout failure rolls back or marks safe-to-reconcile and records the mutation step
- **AC7.13.5** — CI/CD SSOT documents both failure modes

## Verification

- `moon run :lint` — **PASS** (exit 0)
- `moon run :test` — **PASS** (exit 0; backend 2341 passed, 96.42% coverage)
- `tests/tooling/test_pr_preview_lifecycle.py` — **75 passed** (6 new AC7.13 tests, TDD red→green)
- Full `tests/tooling/` suite — 1419 passed, 2 skipped
- AC traceability gate — PASS (100% mandatory ACs covered)
- AC registry / format / build-traceability governance — 130 passed
- doc-consistency / manifest / critical-proof-matrix gates — 161 passed

## Notes

- `repo/` infra2 submodule is left at the base-`main` pointer (the
  submodule-currency pre-commit hook is behind upstream on `main` itself); this
  UI-scope change does not touch infra2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)