### PR TITLE
[finance_report_ui] fix(#575): verify effective prod app env before health wait, fail-fast on stale deploy (Infra-009)

### DIFF
--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -253,6 +253,21 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 | AC7.13.4 | On deploy/rollout failure the lifecycle rolls back to last-known-good source/env or marks the record safe-to-reconcile, recording which mutation step (source/env/deploy/rollout) it was left at — never a silent half-update | `test_AC7_13_4_mutate_then_fail_marks_state_and_records_step` | `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
 | AC7.13.5 | The CI/CD SSOT documents both the no-new-deployment fail-fast mode and the half-update rollback / safe-to-reconcile recovery path | `test_AC7_13_5_ci_cd_docs_describe_failure_modes` | `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
 
+### AC7.14: Effective Production App Env Verification (#575)
+
+> The production deploy must verify the effective remote app env (`IMAGE_TAG`,
+> `GIT_COMMIT_SHA`, `IAC_CONFIG_HASH`) before the long health wait and fail fast
+> on a stale Dokploy env, with a guarded automated reconcile path (#575).
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC7.14.1 | The production deploy verifies the effective remote app state (`IMAGE_TAG`, `GIT_COMMIT_SHA`, `IAC_CONFIG_HASH`) before the long health wait; a matching effective env proceeds | `test_AC7_14_1_verify_passes_when_effective_env_matches` | `tests/tooling/test_issue_575_effective_env_verify.py` | P0 |
+| AC7.14.2 | If Dokploy reports success but the effective app env / compose config is stale, the deploy fails fast with diagnostics that name the stale values (never secrets) | `test_AC7_14_2_verify_fails_fast_and_names_stale_values` | `tests/tooling/test_issue_575_effective_env_verify.py` | P0 |
+| AC7.14.3 | A safe automated reconcile / force-recreate path for the stateless app containers exists, is guarded by an explicit opt-in, and handles the fixed `container_name` conflict | `test_AC7_14_3_force_recreate_path_exists_and_is_guarded` | `tests/tooling/test_issue_575_effective_env_verify.py` | P0 |
+| AC7.14.4 | `tools/_lib/shell/dokploy_deploy.sh` has contract coverage for stale remote env detection and forced release-token refresh | `test_AC7_14_2_verify_fails_fast_and_names_stale_values`, `test_AC7_14_3_force_recreate_path_exists_and_is_guarded` | `tests/tooling/test_issue_575_effective_env_verify.py` | P0 |
+| AC7.14.5 | Production deployment docs describe the stale-env failure mode and the automated recovery path | `test_AC7_14_5_deployment_doc_describes_stale_env_failure_and_recovery` | `tests/tooling/test_issue_575_effective_env_verify.py` | P0 |
+| AC7.14.6 | The post-reconcile rollout-wait baseline (`previous_deployment_ids` / `previous_deployment_signatures`) is snapshotted from the pre-reconcile compose state, *before* `force_recreate_stateless_app` triggers `compose.redeploy`, so a fast redeploy's freshly-created deployment is still detected as new (no spurious "did not create a new deployment" timeout) | `test_AC7_14_6_rollout_baseline_snapshotted_before_force_recreate`, `test_AC7_14_6_fast_redeploy_detected_as_new_with_pre_reconcile_baseline` | `tests/tooling/test_issue_575_effective_env_verify.py` | P0 |
+
 
 ## 📏 Acceptance Criteria
 

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -172,6 +172,37 @@ deploy helper reports only endpoint, HTTP status, safe message fields, and an
 allowlisted effective environment diff for `IMAGE_TAG`, `GIT_COMMIT_SHA`,
 `IAC_CONFIG_HASH`, `ENV_SUFFIX`, and `COMPOSE_PROFILES`.
 
+### Stale effective app env failure mode (issue #575)
+
+A Dokploy deploy can report success while the **effective** remote app env /
+compose config stays on the previous release: the generated app `.env` keeps the
+old `IMAGE_TAG`, `GIT_COMMIT_SHA`, and `IAC_CONFIG_HASH`, so the health gate
+reads the stale version for its whole window. Triggering the deploy and seeing
+the rollout reach `done` is therefore **not** proof that the requested release is
+effective.
+
+To close this gap, after the rollout reaches `done` but **before** the long
+health wait, `tools/dokploy_deploy.sh` re-fetches `compose.one` and verifies the
+**effective** remote app env against the requested release via
+`verify_effective_remote_app_env` (allowlisted `IMAGE_TAG`, `GIT_COMMIT_SHA`,
+`IAC_CONFIG_HASH`; secret env values are never echoed):
+
+- **Match** → proceed to the health wait.
+- **Stale** → fail fast with diagnostics that name each stale value
+  (`expected=… actual=…`), and attempt one **guarded automated recovery** path
+  before failing the deploy.
+
+The automated recovery is `force_recreate_stateless_app`, gated behind the
+explicit `DOKPLOY_ALLOW_FORCE_RECREATE=true` opt-in. It refreshes the release
+token with a fresh `IAC_CONFIG_HASH` (forcing Dokploy to recreate the stateless
+app containers even for an unchanged image tag), re-pushes the corrected env, and
+forces a `compose.redeploy`. The recreate also resolves the fixed
+`container_name` (`finance_report-{backend,frontend}${ENV_SUFFIX}`) conflict by
+replacing the stale stateless containers; postgres/redis are never touched. The
+deploy then re-verifies the effective env and fails the release if it is still
+stale. This replaces the previous manual SSH + stateless container recreate
+recovery.
+
 Dokploy API and CLI usage should stay minimal and state-oriented. Use whichever
 surface exposes the required operation, then prove correctness by comparing the
 effective runtime state against the requested allowlist; do not log full API

--- a/tests/tooling/test_issue_575_effective_env_verify.py
+++ b/tests/tooling/test_issue_575_effective_env_verify.py
@@ -61,7 +61,7 @@ def _run(snippet: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
 
 
 def test_AC7_14_1_verify_passes_when_effective_env_matches() -> None:
-    """AC7.13.1 AC7.13.2: matching effective remote env proceeds (exit 0)."""
+    """AC7.14.1 AC7.14.2: matching effective remote env proceeds (exit 0)."""
     block = _function_block(
         "verify_effective_remote_app_env()", "force_recreate_stateless_app()"
     )
@@ -83,7 +83,7 @@ def test_AC7_14_1_verify_passes_when_effective_env_matches() -> None:
 
 
 def test_AC7_14_2_verify_fails_fast_and_names_stale_values() -> None:
-    """AC7.13.2 AC7.13.4: stale effective env fails fast naming the stale keys."""
+    """AC7.14.2 AC7.14.4: stale effective env fails fast naming the stale keys."""
     block = _function_block(
         "verify_effective_remote_app_env()", "force_recreate_stateless_app()"
     )
@@ -109,7 +109,7 @@ def test_AC7_14_2_verify_fails_fast_and_names_stale_values() -> None:
 
 
 def test_AC7_14_3_force_recreate_path_exists_and_is_guarded() -> None:
-    """AC7.13.3 AC7.13.4: a guarded force-recreate reconcile path exists.
+    """AC7.14.3 AC7.14.4: a guarded force-recreate reconcile path exists.
 
     The reconcile path must (a) be guarded by an explicit opt-in env flag,
     (b) refresh the release token (new IAC_CONFIG_HASH), and (c) handle the
@@ -133,7 +133,7 @@ def test_AC7_14_3_force_recreate_path_exists_and_is_guarded() -> None:
 
 
 def test_AC7_14_6_rollout_baseline_snapshotted_before_force_recreate() -> None:
-    """AC7.13.6: the rollout-wait baseline is the PRE-reconcile snapshot.
+    """AC7.14.6: the rollout-wait baseline is the PRE-reconcile snapshot.
 
     Regression guard for the Copilot ordering bug: ``previous_deployment_ids`` /
     ``previous_deployment_signatures`` (the baseline passed to
@@ -168,7 +168,7 @@ def test_AC7_14_6_rollout_baseline_snapshotted_before_force_recreate() -> None:
 
 
 def test_AC7_14_6_fast_redeploy_detected_as_new_with_pre_reconcile_baseline() -> None:
-    """AC7.13.6: a fast redeploy is still recognized as a new deployment.
+    """AC7.14.6: a fast redeploy is still recognized as a new deployment.
 
     Behavioral regression test exercising the real
     ``wait_for_dokploy_deployment_rollout`` with the pre-reconcile baseline.
@@ -246,7 +246,7 @@ echo "RECONCILE_ROLLOUT_OK"
 
 
 def test_AC7_14_5_deployment_doc_describes_stale_env_failure_and_recovery() -> None:
-    """AC7.13.5: deployment SSOT documents the stale-env failure mode + recovery."""
+    """AC7.14.5: deployment SSOT documents the stale-env failure mode + recovery."""
     doc = (ROOT / "docs" / "ssot" / "deployment.md").read_text(encoding="utf-8")
     lowered = doc.lower()
     assert "stale" in lowered

--- a/tests/tooling/test_issue_575_effective_env_verify.py
+++ b/tests/tooling/test_issue_575_effective_env_verify.py
@@ -60,7 +60,7 @@ def _run(snippet: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_AC7_13_1_verify_passes_when_effective_env_matches() -> None:
+def test_AC7_14_1_verify_passes_when_effective_env_matches() -> None:
     """AC7.13.1 AC7.13.2: matching effective remote env proceeds (exit 0)."""
     block = _function_block(
         "verify_effective_remote_app_env()", "force_recreate_stateless_app()"
@@ -82,7 +82,7 @@ def test_AC7_13_1_verify_passes_when_effective_env_matches() -> None:
     assert "hvs.secret" not in out
 
 
-def test_AC7_13_2_verify_fails_fast_and_names_stale_values() -> None:
+def test_AC7_14_2_verify_fails_fast_and_names_stale_values() -> None:
     """AC7.13.2 AC7.13.4: stale effective env fails fast naming the stale keys."""
     block = _function_block(
         "verify_effective_remote_app_env()", "force_recreate_stateless_app()"
@@ -108,7 +108,7 @@ def test_AC7_13_2_verify_fails_fast_and_names_stale_values() -> None:
     assert "hvs.secret" not in out
 
 
-def test_AC7_13_3_force_recreate_path_exists_and_is_guarded() -> None:
+def test_AC7_14_3_force_recreate_path_exists_and_is_guarded() -> None:
     """AC7.13.3 AC7.13.4: a guarded force-recreate reconcile path exists.
 
     The reconcile path must (a) be guarded by an explicit opt-in env flag,
@@ -132,7 +132,7 @@ def test_AC7_13_3_force_recreate_path_exists_and_is_guarded() -> None:
     assert "force_recreate_stateless_app" in script
 
 
-def test_AC7_13_6_rollout_baseline_snapshotted_before_force_recreate() -> None:
+def test_AC7_14_6_rollout_baseline_snapshotted_before_force_recreate() -> None:
     """AC7.13.6: the rollout-wait baseline is the PRE-reconcile snapshot.
 
     Regression guard for the Copilot ordering bug: ``previous_deployment_ids`` /
@@ -167,7 +167,7 @@ def test_AC7_13_6_rollout_baseline_snapshotted_before_force_recreate() -> None:
     ), "post-reconcile snapshot must not be used as the rollout baseline"
 
 
-def test_AC7_13_6_fast_redeploy_detected_as_new_with_pre_reconcile_baseline() -> None:
+def test_AC7_14_6_fast_redeploy_detected_as_new_with_pre_reconcile_baseline() -> None:
     """AC7.13.6: a fast redeploy is still recognized as a new deployment.
 
     Behavioral regression test exercising the real
@@ -245,7 +245,7 @@ echo "RECONCILE_ROLLOUT_OK"
     assert "did not create a new deployment" not in out, out
 
 
-def test_AC7_13_5_deployment_doc_describes_stale_env_failure_and_recovery() -> None:
+def test_AC7_14_5_deployment_doc_describes_stale_env_failure_and_recovery() -> None:
     """AC7.13.5: deployment SSOT documents the stale-env failure mode + recovery."""
     doc = (ROOT / "docs" / "ssot" / "deployment.md").read_text(encoding="utf-8")
     lowered = doc.lower()

--- a/tests/tooling/test_issue_575_effective_env_verify.py
+++ b/tests/tooling/test_issue_575_effective_env_verify.py
@@ -1,0 +1,143 @@
+"""Issue #575: production deploy must verify effective remote app env.
+
+A Dokploy deploy can report success while the effective production app
+configuration remains on the previous release (stale ``IMAGE_TAG`` /
+``GIT_COMMIT_SHA`` / ``IAC_CONFIG_HASH``). The deploy script must read back the
+effective remote app env *before* the long health wait, fail fast with
+diagnostics that name the stale values (never secrets), and expose a guarded
+force-recreate / reconcile path for stateless app containers.
+
+These are behavioral contract tests: they source the relevant function block
+out of ``tools/_lib/shell/dokploy_deploy.sh`` and run it under bash with the
+Dokploy API calls stubbed, mirroring
+``test_post_merge_e2e_gates.py::test_AC8_13_72_staging_dokploy_rollout_parsing_is_typed_and_fail_fast``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_SCRIPT = ROOT / "tools" / "_lib" / "shell" / "dokploy_deploy.sh"
+
+
+def _function_block(start: str, end: str) -> str:
+    """Extract the source text from ``start`` (inclusive) up to ``end``."""
+    text = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    assert start in text, f"{start} missing from deploy script"
+    assert end in text, f"{end} missing from deploy script"
+    return start + text.split(start, 1)[1].split(end, 1)[0]
+
+
+# A minimal harness: the verification function plus stubs for the common-shell
+# helpers it relies on (env_value / render_allowlisted_env_diff style readback).
+_HARNESS_HELPERS = r"""
+env_value() {
+  printf "%s\n" "$1" | awk -F= -v key="$2" '$1 == key { sub(/^[^=]*=/, ""); print }'
+}
+# Stub dokploy_api_call: write the queued response body to the output file.
+dokploy_api_call() {
+  local method="$1" endpoint="$2" data="$3" output_file="$4"
+  printf "%s" "$STUB_EFFECTIVE_RESPONSE" > "$output_file"
+  return 0
+}
+safe_jq() {
+  local filter="$1" json="$2"
+  printf "%s" "$json" | jq -r "$filter"
+}
+"""
+
+
+def _run(snippet: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", snippet],
+        cwd=ROOT,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin", **env},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_AC7_13_1_verify_passes_when_effective_env_matches() -> None:
+    """AC7.13.1 AC7.13.2: matching effective remote env proceeds (exit 0)."""
+    block = _function_block(
+        "verify_effective_remote_app_env()", "force_recreate_stateless_app()"
+    )
+    response = (
+        '{"env":"IMAGE_TAG=v0.1.5\\nGIT_COMMIT_SHA=v0.1.5\\n'
+        'IAC_CONFIG_HASH=deploy-v0.1.5-123\\nVAULT_APP_TOKEN=hvs.secret"}'
+    )
+    snippet = (
+        _HARNESS_HELPERS
+        + block
+        + '\nverify_effective_remote_app_env "cid" "v0.1.5" "deploy-v0.1.5-123"\n'
+    )
+    result = _run(snippet, {"STUB_EFFECTIVE_RESPONSE": response})
+    assert result.returncode == 0, result.stdout + result.stderr
+    out = result.stdout + result.stderr
+    assert "effective_env_verification: match" in out
+    # Never echo secret env values.
+    assert "hvs.secret" not in out
+
+
+def test_AC7_13_2_verify_fails_fast_and_names_stale_values() -> None:
+    """AC7.13.2 AC7.13.4: stale effective env fails fast naming the stale keys."""
+    block = _function_block(
+        "verify_effective_remote_app_env()", "force_recreate_stateless_app()"
+    )
+    # Dokploy reported success but the effective env is still on v0.1.4.
+    response = (
+        '{"env":"IMAGE_TAG=v0.1.4\\nGIT_COMMIT_SHA=v0.1.4\\n'
+        'IAC_CONFIG_HASH=deploy-v0.1.4-000\\nVAULT_APP_TOKEN=hvs.secret"}'
+    )
+    snippet = (
+        _HARNESS_HELPERS
+        + block
+        + '\nverify_effective_remote_app_env "cid" "v0.1.5" "deploy-v0.1.5-123"\n'
+    )
+    result = _run(snippet, {"STUB_EFFECTIVE_RESPONSE": response})
+    out = result.stdout + result.stderr
+    assert result.returncode != 0, out
+    assert "effective_env_verification: stale" in out
+    # Diagnostics must name each stale value (expected vs actual), no secrets.
+    assert "IMAGE_TAG: expected=v0.1.5 actual=v0.1.4" in out
+    assert "GIT_COMMIT_SHA: expected=v0.1.5 actual=v0.1.4" in out
+    assert "IAC_CONFIG_HASH: expected=deploy-v0.1.5-123 actual=deploy-v0.1.4-000" in out
+    assert "hvs.secret" not in out
+
+
+def test_AC7_13_3_force_recreate_path_exists_and_is_guarded() -> None:
+    """AC7.13.3 AC7.13.4: a guarded force-recreate reconcile path exists.
+
+    The reconcile path must (a) be guarded by an explicit opt-in env flag,
+    (b) refresh the release token (new IAC_CONFIG_HASH), and (c) handle the
+    fixed ``container_name`` conflict for stateless app containers.
+    """
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    assert "force_recreate_stateless_app()" in script
+    assert "verify_effective_remote_app_env" in script
+    # Verification happens before the long health wait: the call site precedes
+    # the script returning success.
+    assert script.index('verify_effective_remote_app_env "$COMPOSE_ID"') < script.index(
+        'echo "Deployment triggered successfully"'
+    )
+    # Guarded reconcile: explicit opt-in flag, forced token refresh, and
+    # container_name conflict handling.
+    assert "DOKPLOY_ALLOW_FORCE_RECREATE" in script
+    assert "IAC_CONFIG_HASH" in script
+    assert "container_name" in script.lower()
+    # Force-recreate is only attempted on a detected stale-env mismatch.
+    assert "force_recreate_stateless_app" in script
+
+
+def test_AC7_13_5_deployment_doc_describes_stale_env_failure_and_recovery() -> None:
+    """AC7.13.5: deployment SSOT documents the stale-env failure mode + recovery."""
+    doc = (ROOT / "docs" / "ssot" / "deployment.md").read_text(encoding="utf-8")
+    lowered = doc.lower()
+    assert "stale" in lowered
+    assert "effective" in lowered and "verif" in lowered
+    assert "force" in lowered and "recreate" in lowered
+    assert "iac_config_hash" in lowered
+    assert "dokploy_allow_force_recreate" in lowered

--- a/tests/tooling/test_issue_575_effective_env_verify.py
+++ b/tests/tooling/test_issue_575_effective_env_verify.py
@@ -132,6 +132,119 @@ def test_AC7_13_3_force_recreate_path_exists_and_is_guarded() -> None:
     assert "force_recreate_stateless_app" in script
 
 
+def test_AC7_13_6_rollout_baseline_snapshotted_before_force_recreate() -> None:
+    """AC7.13.6: the rollout-wait baseline is the PRE-reconcile snapshot.
+
+    Regression guard for the Copilot ordering bug: ``previous_deployment_ids`` /
+    ``previous_deployment_signatures`` (the baseline passed to
+    ``wait_for_dokploy_deployment_rollout``) must be captured from the
+    pre-reconcile ``compose.one`` snapshot, *before*
+    ``force_recreate_stateless_app`` triggers ``compose.redeploy``. Capturing
+    them after the redeploy lets a fast redeploy's freshly-created deployment
+    record leak into the baseline, so the waiter sees no "new" deployment and
+    spuriously times out with "did not create a new deployment".
+    """
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    # The baseline capture from the pre-reconcile snapshot must precede the
+    # force-recreate call that triggers compose.redeploy.
+    baseline_capture = 'previous_deployment_ids=$(deployment_ids_from_response "$reconcile_response")'
+    force_recreate_call = 'force_recreate_stateless_app "$COMPOSE_ID" "$IMAGE_TAG"'
+    assert baseline_capture in script, "pre-reconcile baseline capture missing"
+    assert force_recreate_call in script, "force-recreate call missing"
+    assert script.index(baseline_capture) < script.index(force_recreate_call), (
+        "rollout baseline must be snapshotted BEFORE force_recreate triggers redeploy"
+    )
+
+    # The pre-reconcile snapshot must feed the rollout wait, and a stale
+    # post-reconcile snapshot must NOT be used as the rollout baseline.
+    assert (
+        'previous_deployment_signatures=$(deployment_signature_map_from_response "$reconcile_response")'
+        in script
+    ), "pre-reconcile signature baseline missing"
+    assert (
+        "Post-reconcile deployment snapshot" not in script
+    ), "post-reconcile snapshot must not be used as the rollout baseline"
+
+
+def test_AC7_13_6_fast_redeploy_detected_as_new_with_pre_reconcile_baseline() -> None:
+    """AC7.13.6: a fast redeploy is still recognized as a new deployment.
+
+    Behavioral regression test exercising the real
+    ``wait_for_dokploy_deployment_rollout`` with the pre-reconcile baseline.
+    The pre-reconcile snapshot has a single deployment ``d1``. By the time the
+    rollout waiter probes, the fast redeploy has already created ``d2``
+    (status ``done``). Using the pre-reconcile baseline ({d1}) the waiter sees
+    ``d2`` as new and succeeds. If the (buggy) post-reconcile baseline
+    ({d1,d2}) were used, ``d2`` would not be "new" and the waiter would time
+    out -- so this asserts the correct ordering end-to-end.
+    """
+    helpers = _function_block(
+        "deployment_ids_from_response()", "redact_dokploy_diagnostic_value()"
+    )
+    waiter = _function_block(
+        "wait_for_dokploy_deployment_rollout()", "deploy_compose()"
+    )
+
+    # Pre-reconcile snapshot: only d1 exists.
+    pre_snapshot = '{"deployments":[{"deploymentId":"d1","status":"done","createdAt":"1"}]}'
+    # Rollout probe response: fast redeploy already created d2 (done).
+    rollout_resp = (
+        '{"composeStatus":"done","deployments":['
+        '{"deploymentId":"d1","status":"done","createdAt":"1"},'
+        '{"deploymentId":"d2","status":"done","createdAt":"2"}]}'
+    )
+
+    harness = r"""
+response_file=$(mktemp)
+safe_jq() { printf "%s" "$2" | jq -r "$1"; }
+render_dokploy_rollout_summary() { :; }
+# Sequenced stub: first call returns the pre-reconcile snapshot, every
+# subsequent (rollout probe) call returns the post-redeploy rollout response.
+__CALLS=0
+dokploy_api_call() {
+  local output_file="$4"
+  __CALLS=$((__CALLS + 1))
+  if [[ "$__CALLS" -eq 1 ]]; then
+    printf "%s" "$PRE_SNAPSHOT" > "$output_file"
+  else
+    printf "%s" "$ROLLOUT_RESP" > "$output_file"
+  fi
+  return 0
+}
+"""
+
+    # Reconstruct the fixed reconcile ordering: capture baseline from the
+    # pre-reconcile snapshot BEFORE the (stubbed) redeploy, then wait.
+    driver = r"""
+dokploy_api_call "GET" "compose.one?composeId=cid" "" "$response_file" "Pre-reconcile env snapshot"
+reconcile_response=$(cat "$response_file")
+previous_deployment_ids=$(deployment_ids_from_response "$reconcile_response")
+previous_deployment_signatures=$(deployment_signature_map_from_response "$reconcile_response")
+# (force_recreate -> compose.redeploy happens here; the fast redeploy created d2)
+wait_for_dokploy_deployment_rollout "cid" "$previous_deployment_ids" "$previous_deployment_signatures"
+echo "RECONCILE_ROLLOUT_OK"
+"""
+
+    snippet = helpers + waiter + harness + driver
+    result = _run(
+        snippet,
+        {
+            "PRE_SNAPSHOT": pre_snapshot,
+            "ROLLOUT_RESP": rollout_resp,
+            "DOKPLOY_ROLLOUT_INTERVAL_SECONDS": "0",
+            "DOKPLOY_ROLLOUT_TIMEOUT_SECONDS": "5",
+            "DOKPLOY_NEW_DEPLOYMENT_TIMEOUT_SECONDS": "5",
+        },
+    )
+    out = result.stdout + result.stderr
+    assert result.returncode == 0, out
+    # The new deployment d2 must be detected as new (not hidden by the baseline).
+    assert "new_deployment_ids=d2" in out, out
+    assert "RECONCILE_ROLLOUT_OK" in out, out
+    assert "did not create a new deployment" not in out, out
+
+
 def test_AC7_13_5_deployment_doc_describes_stale_env_failure_and_recovery() -> None:
     """AC7.13.5: deployment SSOT documents the stale-env failure mode + recovery."""
     doc = (ROOT / "docs" / "ssot" / "deployment.md").read_text(encoding="utf-8")

--- a/tools/_lib/shell/dokploy_deploy.sh
+++ b/tools/_lib/shell/dokploy_deploy.sh
@@ -527,15 +527,21 @@ if ! verify_effective_remote_app_env "$COMPOSE_ID" "$IMAGE_TAG" "$IAC_CONFIG_HAS
   reconcile_response=$(cat "$response_file")
   reconcile_env=$(safe_jq '.env // empty' "$reconcile_response" "pre-reconcile env fetch") || exit 1
 
+  # Capture the rollout-wait baseline from the PRE-reconcile snapshot, BEFORE
+  # force_recreate_stateless_app triggers compose.redeploy. A post-redeploy
+  # snapshot can already include the newly-created deployment record (a fast
+  # redeploy completes before we re-fetch), which would hide the new deployment
+  # from wait_for_dokploy_deployment_rollout and cause a spurious "did not
+  # create a new deployment" timeout. Using the pre-reconcile baseline
+  # guarantees the freshly-created deployment is detected as new.
+  previous_deployment_ids=$(deployment_ids_from_response "$reconcile_response") || exit 1
+  previous_deployment_signatures=$(deployment_signature_map_from_response "$reconcile_response") || exit 1
+
   if ! force_recreate_stateless_app "$COMPOSE_ID" "$IMAGE_TAG" "$reconcile_env"; then
     echo "ERROR: Effective remote app env is stale and automated reconcile was not performed (issue #575)" >&2
     exit 1
   fi
 
-  dokploy_api_call "GET" "compose.one?composeId=$COMPOSE_ID" "" "$response_file" "Post-reconcile deployment snapshot"
-  reconcile_snapshot=$(cat "$response_file")
-  previous_deployment_ids=$(deployment_ids_from_response "$reconcile_snapshot") || exit 1
-  previous_deployment_signatures=$(deployment_signature_map_from_response "$reconcile_snapshot") || exit 1
   set +e
   wait_for_dokploy_deployment_rollout "$COMPOSE_ID" "$previous_deployment_ids" "$previous_deployment_signatures"
   rollout_status=$?

--- a/tools/_lib/shell/dokploy_deploy.sh
+++ b/tools/_lib/shell/dokploy_deploy.sh
@@ -281,7 +281,7 @@ if [[ ${#missing_args[@]} -gt 0 ]] || [[ ${#missing_envs[@]} -gt 0 ]]; then
   echo "========================================="
   echo "ERROR: Missing Required Dependencies"
   echo "========================================="
-  
+
   if [[ ${#missing_args[@]} -gt 0 ]]; then
     echo ""
     echo "Missing Arguments:"
@@ -289,7 +289,7 @@ if [[ ${#missing_args[@]} -gt 0 ]] || [[ ${#missing_envs[@]} -gt 0 ]]; then
     echo ""
     echo "Usage: $0 <compose_id> <image_tag> <app_url>"
   fi
-  
+
   if [[ ${#missing_envs[@]} -gt 0 ]]; then
     echo ""
     echo "Missing Environment Variables:"
@@ -297,7 +297,7 @@ if [[ ${#missing_args[@]} -gt 0 ]] || [[ ${#missing_envs[@]} -gt 0 ]]; then
     echo ""
     echo "Required in workflow step 'env:' section"
   fi
-  
+
   echo "========================================="
   exit 1
 fi
@@ -409,6 +409,147 @@ if [[ "$rollout_status" -eq 2 || "$rollout_status" -eq 3 ]]; then
   fi
 elif [[ "$rollout_status" -ne 0 ]]; then
   exit "$rollout_status"
+fi
+
+# Read back the EFFECTIVE remote app env after Dokploy reports a rollout as done
+# but BEFORE the long health wait, and compare the release-defining values
+# (IMAGE_TAG, GIT_COMMIT_SHA, IAC_CONFIG_HASH) against what this deploy
+# requested. Issue #575: Dokploy can report success while the generated app env
+# / effective compose config remains on the previous release, which makes the
+# health gate wait out its entire window reading the old version. On mismatch
+# this fails fast with diagnostics that NAME the stale values (never secrets).
+#
+# Usage: verify_effective_remote_app_env <compose_id> <expected_image_tag> <expected_iac_config_hash>
+# Returns: 0 when the effective env matches; 1 when it is stale.
+verify_effective_remote_app_env() {
+  local compose_id="$1"
+  local expected_image_tag="$2"
+  local expected_iac_config_hash="$3"
+  local verify_response_file
+  local verify_response
+  local effective
+  local key expected actual
+  local stale=0
+
+  verify_response_file=$(mktemp)
+  register_cleanup "$verify_response_file" 2>/dev/null || true
+
+  dokploy_api_call "GET" "compose.one?composeId=$compose_id" "" "$verify_response_file" "Effective remote app env verification"
+  verify_response=$(cat "$verify_response_file")
+  effective=$(safe_jq '.env // empty' "$verify_response" "post-rollout effective env fetch") || return 1
+
+  echo "Verifying effective remote app env before health wait (compose_id=$compose_id)"
+  # Only the allowlisted release-defining values are read; secret env values are
+  # never echoed.
+  for key in IMAGE_TAG GIT_COMMIT_SHA IAC_CONFIG_HASH; do
+    case "$key" in
+      IMAGE_TAG) expected="$expected_image_tag" ;;
+      GIT_COMMIT_SHA) expected="$expected_image_tag" ;;
+      IAC_CONFIG_HASH) expected="$expected_iac_config_hash" ;;
+    esac
+    actual="$(env_value "$effective" "$key")"
+    if [[ "$expected" == "$actual" ]]; then
+      echo "$key: match"
+    else
+      echo "$key: expected=$expected actual=$actual"
+      stale=1
+    fi
+  done
+
+  if [[ "$stale" -eq 0 ]]; then
+    echo "effective_env_verification: match"
+    return 0
+  fi
+
+  echo "effective_env_verification: stale" >&2
+  echo "ERROR: Dokploy reported success but the effective remote app env is stale (issue #575)" >&2
+  return 1
+}
+
+# Safe, GUARDED reconcile / force-recreate path for the stateless app containers
+# when the effective remote env is stale after a "successful" Dokploy deploy.
+# Issue #575: recovery previously required manual SSH + a stateless container
+# recreate. This reconcile refreshes the release token (a fresh IAC_CONFIG_HASH
+# so Dokploy is forced to recreate even for the same image tag), pushes the
+# corrected env, and forces a compose.redeploy. It is gated behind the explicit
+# DOKPLOY_ALLOW_FORCE_RECREATE opt-in because force-recreate can briefly drop the
+# fixed-container_name stateless app containers; postgres/redis are never touched.
+#
+# Usage: force_recreate_stateless_app <compose_id> <image_tag> <current_env>
+# Returns: 0 on a triggered reconcile; 1 when not permitted or on failure.
+force_recreate_stateless_app() {
+  local compose_id="$1"
+  local image_tag="$2"
+  local current_env="$3"
+  local reconciled_env
+  local refreshed_hash
+  local reconcile_payload
+  local reconcile_update_file
+
+  if [[ "${DOKPLOY_ALLOW_FORCE_RECREATE:-false}" != "true" ]]; then
+    echo "Stale effective env detected but DOKPLOY_ALLOW_FORCE_RECREATE is not 'true'; refusing automated force-recreate." >&2
+    echo "Set DOKPLOY_ALLOW_FORCE_RECREATE=true to allow the guarded stateless app reconcile." >&2
+    return 1
+  fi
+
+  echo "Reconciling stale stateless app deployment via guarded force-recreate (compose_id=$compose_id)"
+  # Force a fresh release token so Dokploy recreates the stateless app
+  # containers even when the requested image tag is unchanged. The fixed
+  # container_name (finance_report-{backend,frontend}${ENV_SUFFIX}) can otherwise
+  # collide with the still-running stale container; a recreate resolves the
+  # container_name conflict by replacing it.
+  refreshed_hash="reconcile-${image_tag}-$(date +%s)"
+  reconciled_env="$current_env"
+  reconciled_env=$(update_env_var "$reconciled_env" "IMAGE_TAG" "$image_tag")
+  reconciled_env=$(update_env_var "$reconciled_env" "GIT_COMMIT_SHA" "$image_tag")
+  reconciled_env=$(update_env_var "$reconciled_env" "IAC_CONFIG_HASH" "$refreshed_hash")
+  RECONCILE_IAC_CONFIG_HASH="$refreshed_hash"
+
+  reconcile_update_file=$(mktemp)
+  register_cleanup "$reconcile_update_file" 2>/dev/null || true
+  reconcile_payload=$(safe_jq_build --arg id "$compose_id" --arg env "$reconciled_env" '{composeId: $id, env: $env}') || return 1
+  dokploy_api_call "POST" "compose.update" "$reconcile_payload" "$reconcile_update_file" "Stale-env reconcile update" || return 1
+
+  # compose.redeploy forces a recreate of the (stateless) app containers,
+  # resolving the fixed container_name conflict by replacing the stale ones.
+  deploy_compose "compose.redeploy" "Stale-env force-recreate redeploy" || return 1
+  echo "Stale-env force-recreate redeploy triggered with refreshed IAC_CONFIG_HASH"
+  return 0
+}
+
+# Issue #575: Dokploy can report the rollout as done while the effective remote
+# app env / compose config is still on the previous release. Verify the
+# effective remote app state (IMAGE_TAG / GIT_COMMIT_SHA / IAC_CONFIG_HASH)
+# BEFORE the caller starts the long health wait. On a stale mismatch, attempt a
+# single guarded force-recreate reconcile and re-verify; otherwise fail fast.
+if ! verify_effective_remote_app_env "$COMPOSE_ID" "$IMAGE_TAG" "$IAC_CONFIG_HASH_VALUE"; then
+  dokploy_api_call "GET" "compose.one?composeId=$COMPOSE_ID" "" "$response_file" "Pre-reconcile env snapshot"
+  reconcile_response=$(cat "$response_file")
+  reconcile_env=$(safe_jq '.env // empty' "$reconcile_response" "pre-reconcile env fetch") || exit 1
+
+  if ! force_recreate_stateless_app "$COMPOSE_ID" "$IMAGE_TAG" "$reconcile_env"; then
+    echo "ERROR: Effective remote app env is stale and automated reconcile was not performed (issue #575)" >&2
+    exit 1
+  fi
+
+  dokploy_api_call "GET" "compose.one?composeId=$COMPOSE_ID" "" "$response_file" "Post-reconcile deployment snapshot"
+  reconcile_snapshot=$(cat "$response_file")
+  previous_deployment_ids=$(deployment_ids_from_response "$reconcile_snapshot") || exit 1
+  previous_deployment_signatures=$(deployment_signature_map_from_response "$reconcile_snapshot") || exit 1
+  set +e
+  wait_for_dokploy_deployment_rollout "$COMPOSE_ID" "$previous_deployment_ids" "$previous_deployment_signatures"
+  rollout_status=$?
+  set -e
+  if [[ "$rollout_status" -ne 0 ]]; then
+    echo "ERROR: Stale-env reconcile redeploy did not reach done (issue #575)" >&2
+    exit "$rollout_status"
+  fi
+
+  if ! verify_effective_remote_app_env "$COMPOSE_ID" "$IMAGE_TAG" "${RECONCILE_IAC_CONFIG_HASH:-$IAC_CONFIG_HASH_VALUE}"; then
+    echo "ERROR: Effective remote app env is still stale after force-recreate reconcile (issue #575)" >&2
+    exit 1
+  fi
+  echo "Stale effective remote app env reconciled successfully"
 fi
 
 echo "Deployment triggered successfully"


### PR DESCRIPTION
## Summary

A `v0.1.5` production deploy reported success while the effective production app `.env` still carried `IMAGE_TAG=v0.1.4`, `GIT_COMMIT_SHA=v0.1.4`, and the old `IAC_CONFIG_HASH`; the health gate read v0.1.4 for its entire window and recovery required manual SSH + a stateless container recreate.

`tools/_lib/shell/dokploy_deploy.sh` now closes that gap. After the Dokploy rollout reaches `done` but **before** the long health wait, it re-fetches `compose.one` and verifies the **effective** remote app env against the requested release:

- **`verify_effective_remote_app_env`** compares the allowlisted release-defining values (`IMAGE_TAG`, `GIT_COMMIT_SHA`, `IAC_CONFIG_HASH`) and never echoes secret env values. On match it proceeds; on a stale mismatch it fails fast with diagnostics that name each stale value (`expected=… actual=…`).
- **`force_recreate_stateless_app`** is the guarded automated recovery, gated behind the explicit `DOKPLOY_ALLOW_FORCE_RECREATE=true` opt-in. It refreshes the release token with a fresh `IAC_CONFIG_HASH` (forcing Dokploy to recreate even for an unchanged tag), re-pushes the corrected env, and forces a `compose.redeploy` that resolves the fixed `container_name` (`finance_report-{backend,frontend}${ENV_SUFFIX}`) conflict by replacing the stale stateless containers. The deploy then re-verifies and fails the release if still stale. Postgres/Redis are never touched.

Production deployment SSOT (`docs/ssot/deployment.md`) documents the stale-env failure mode and the automated recovery path.

Closes #575

## Acceptance Criteria (EPIC-007 / Infra-009)

- **AC7.13.1** — production deploy verifies effective remote app state (`IMAGE_TAG`/`GIT_COMMIT_SHA`/`IAC_CONFIG_HASH`) before the long health wait; matching env proceeds.
- **AC7.13.2** — Dokploy-success-but-stale fails fast with diagnostics naming the stale values (no secrets).
- **AC7.13.3** — guarded automated reconcile / force-recreate path for stateless app containers, with `container_name` conflict handling.
- **AC7.13.4** — `dokploy_deploy.sh` has contract coverage for stale remote env detection and forced release-token refresh.
- **AC7.13.5** — production deployment docs describe the stale-env failure mode + automated recovery.

## Verification

- **Test mechanism**: behavioral contract tests in `tests/tooling/test_issue_575_effective_env_verify.py`. The match/stale cases source the `verify_effective_remote_app_env` function block out of the script and run it under `bash` with `dokploy_api_call`/responses stubbed (mirrors the existing `test_post_merge_e2e_gates.py::test_AC8_13_72_staging_dokploy_rollout_parsing_is_typed_and_fail_fast` harness). Real behavioral assertions for the verify pass/fail-fast path; structural assertions for the guarded reconcile wiring and the doc.
- `moon run :lint` — **pass (exit 0)**.
- `moon run :test` — **pass (exit 0), 2341 passed** (with the `repo/` submodule checked out). On a fresh worktree without the submodule, 3 unrelated `tests/infra/test_observability_contract.py` cases fail with `FileNotFoundError` for `repo/finance_report/finance_report/10.app/*`; those pass once `git submodule update --init repo` is run and are unrelated to this change.
- `shellcheck -x` on the modified script: clean (only pre-existing info-level SC2016 on `safe_jq_build` jq filters, matching the established convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second commit: pre-existing AC-ID collision fix

While rebasing onto current `main`, the AC-ID uniqueness gate (`generate_ac_registry.py --check`) failed on a **pre-existing** collision unrelated to #575: PRs #1039 (vision fallback) and #1036 (#989 self-consistency) merged in parallel and both claimed the `AC13.17` group in EPIC-013. A separate commit renumbers the later self-consistency group to `AC13.18` (vision-fallback keeps `AC13.17`) and updates the matching `test_self_consistency.py` docstrings. Doc/docstring text only; behavior unchanged. This unblocks the shared gate for this and every other branch off main.
