### PR TITLE
[finance_report_audit] activate the dormant AC behavioral-score ratchet (#1055 PR2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -969,8 +969,47 @@ jobs:
             ${{ runner.temp }}/reconciliation-audit/reconciliation-audit.md
           retention-days: 14
 
+  ac-behavioral-ratchet:
+    name: AC Behavioral Score Ratchet
+    needs: [changes, backend, backend-integration, backend-e2e-tier1]
+    if: needs.changes.outputs.pr_required == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Download all test junit artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: junit-artifacts
+
+      - name: Aggregate AC behavioral evidence and ratchet against baseline
+        run: |
+          # Collect every junit-xml emitted by the test stages (shards, integration, tier-1).
+          junit_files=$(find junit-artifacts -name '*.xml' -print)
+          if [ -z "$junit_files" ]; then
+            echo "No junit-xml artifacts found — cannot evaluate AC behavioral evidence." >&2
+            exit 1
+          fi
+          # shellcheck disable=SC2086
+          uv run --with pyyaml python tools/aggregate_ac_evidence.py $junit_files --output ac-evidence-current.json
+          # L2 (pass-required) + L3 (score ratchet) against the checked-in baseline.
+          uv run --with pyyaml python tools/check_ac_score_baseline.py ac-evidence-current.json
+
   finish:
-    needs: [changes, schema-migrations, backend, backend-integration, backend-e2e-tier1, frontend, container-images, lint, tooling-coverage, unified-coverage, ac-traceability]
+    needs: [changes, schema-migrations, backend, backend-integration, backend-e2e-tier1, frontend, container-images, lint, tooling-coverage, unified-coverage, ac-traceability, ac-behavioral-ratchet]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,7 +971,9 @@ jobs:
 
   ac-behavioral-ratchet:
     name: AC Behavioral Score Ratchet
-    needs: [changes, backend, backend-integration, backend-e2e-tier1]
+    # Wait for every test stage that emits junit (incl. frontend) so the aggregate is
+    # complete and cannot race an in-flight upload.
+    needs: [changes, backend, backend-integration, backend-e2e-tier1, frontend]
     if: needs.changes.outputs.pr_required == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -1068,6 +1070,7 @@ jobs:
         echo "Unified Coverage: ${{ needs.unified-coverage.result }}"
         echo "Lint: ${{ needs.lint.result }}"
         echo "AC Traceability: ${{ needs.ac-traceability.result }}"
+        echo "AC Behavioral Ratchet: ${{ needs.ac-behavioral-ratchet.result }}"
         if [[ "${{ needs.changes.result }}" != "success" ]]; then
           echo "::error::Change classification failed"
           exit 1
@@ -1107,6 +1110,10 @@ jobs:
           fi
           if [[ "${{ needs.unified-coverage.result }}" != "success" ]]; then
             echo "::error::Unified coverage check failed"
+            exit 1
+          fi
+          if [[ "${{ needs.ac-behavioral-ratchet.result }}" != "success" ]]; then
+            echo "::error::AC behavioral-score ratchet failed"
             exit 1
           fi
           if [[ "${{ needs.container-images.result }}" != "success" ]]; then

--- a/apps/backend/tests/integration/test_augmentation_seam_e2e.py
+++ b/apps/backend/tests/integration/test_augmentation_seam_e2e.py
@@ -70,7 +70,7 @@ async def _posted(
 
 
 async def test_AC8_16_1_augmentation_seam_excludes_superseded_and_surfaces_confidence(
-    db: AsyncSession, test_user: User
+    db: AsyncSession, test_user: User, ac_evidence
 ) -> None:
     """AC8.16.1: low-confidence extracted inputs and a corrected valuation reach the
     report without leaking a superseded row or laundering a low-confidence input."""
@@ -140,3 +140,13 @@ async def test_AC8_16_1_augmentation_seam_excludes_superseded_and_surfaces_confi
     # (3) the superseded valuation is also excluded from net-worth components (#968 class)
     components = await service.get_latest_valuation_components(db, user_id, as_of_date=as_of)
     assert components.total_assets == Decimal("1100000.00")
+
+    # Behavioral evidence: the corrected-only net-worth total (1.1M, not 2.1M) is the
+    # deterministic proof that the seam excludes the superseded row.
+    ac_evidence(
+        ac_id="AC8.16.1",
+        score=1.0,
+        metric="superseded_excluded_corrected_total_match",
+        comment="net-worth components == 1,100,000 (corrected only); a superseded leak would be 2,100,000",
+        provenance="deterministic",
+    )

--- a/docs/ssot/ac-score-baseline.json
+++ b/docs/ssot/ac-score-baseline.json
@@ -4,6 +4,11 @@
       "metric": "description_similarity_pct",
       "provenance": "deterministic",
       "score": 1.0
+    },
+    "AC8.16.1": {
+      "metric": "superseded_excluded_corrected_total_match",
+      "provenance": "deterministic",
+      "score": 1.0
     }
   },
   "version": 1

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -1075,7 +1075,7 @@ def test_AC8_13_16_ci_change_classification_and_frontend_cache() -> None:
     assert "needs.setup.outputs.pr_preview_required == 'true'" in pr_workflow
     assert "name: AC Traceability Check" in workflow
     assert (
-        "needs: [changes, schema-migrations, backend, backend-integration, backend-e2e-tier1, frontend, container-images, lint, tooling-coverage, unified-coverage, ac-traceability]"
+        "needs: [changes, schema-migrations, backend, backend-integration, backend-e2e-tier1, frontend, container-images, lint, tooling-coverage, unified-coverage, ac-traceability, ac-behavioral-ratchet]"
         in workflow
     )
     assert "finish remains the authoritative aggregate gate" in ci_cd
@@ -1804,7 +1804,7 @@ def test_AC8_13_25_full_ci_aggregates_static_traceability_and_test_gates() -> No
     assert "needs:" not in traceability_block.split("steps:", 1)[0]
     assert (
         "needs: [changes, schema-migrations, backend, backend-integration, backend-e2e-tier1, frontend, "
-        "container-images, lint, tooling-coverage, unified-coverage, ac-traceability]"
+        "container-images, lint, tooling-coverage, unified-coverage, ac-traceability, ac-behavioral-ratchet]"
         in finish_block
     )
     assert "Standalone lint and AC traceability start immediately" in ci_cd


### PR DESCRIPTION
## Summary

**PR 2 of #1055.** Verify-first finding: the "behavioral-anchoring metric + non-growth gate" #1055 asked for **already exists** — `common/ssot/check_ac_score_baseline.py` is a ratchet (L2 pass-required + L3 score non-regression), fed by `ac_evidence` junit properties via `ac_evidence_aggregate.py`, with the baseline in `docs/ssot/ac-score-baseline.json`. But it was wired into **no CI gate**, and only **one AC (AC4.1.4)** had ever emitted evidence. A sophisticated proof-strength mechanism, sitting dormant. So this **activates** it rather than rebuilding it.

## Changes

- **New CI job `ac-behavioral-ratchet`** — downloads every test stage's junit-xml, aggregates AC behavioral evidence, and ratchets it against the checked-in baseline. Added to `finish` needs so it actually gates.
- **Emit behavioral evidence from the AC8.16.1 seam test** — the corrected-only net-worth total (1.1M, not 2.1M) is the deterministic proof the seam excludes the superseded row.
- **Adopt AC8.16.1 into the baseline** (now AC4.1.4 + AC8.16.1) via the `--update` flow.

## Why this is the right lever

The systemic proof-strength gap (most ACs are string-presence coverage, not behavioral anchoring) isn't a missing tool — it's a dormant one with one user. With the gate now active, every test that calls `ac_evidence(...)` adds to the protected set, and the ratchet stops it regressing. Adoption can now grow AC-by-AC without a big-bang migration (new ACs are informational until `--update`).

## Test plan

- ✅ Full chain verified locally: emit → junit → `aggregate_ac_evidence` → `check_ac_score_baseline` **passes** (Missing 0 / Non-passing 0 / exit 0).
- ✅ CI YAML parses; ruff clean.
- The new `ac-behavioral-ratchet` CI job validates the wiring end-to-end against real artifacts.

Part of #1055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)