### PR TITLE
[finance_report_audit] router contract-maturity audit kickoff (#1055 PR3, #1000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Detached Owner Shortcut Guard
         run: |
           uv run python tools/check_detached_owner_shortcuts.py
+      - name: Router Contract Maturity Guard
+        run: |
+          uv run python tools/audit_router_contracts.py --check
       - name: Install frontend dependencies
         run: npm ci
         working-directory: apps/frontend

--- a/common/ssot/audit_router_contracts.py
+++ b/common/ssot/audit_router_contracts.py
@@ -41,8 +41,25 @@ class UntypedEndpoint:
     handler: str
 
 
-def _route_decorators(node: ast.AST) -> Iterable[tuple[str, ast.Call]]:
-    """Yield (http_method, call) for each @router.<method>(...) decorator on a function."""
+def _router_names(tree: ast.AST) -> set[str]:
+    """Names bound to an ``APIRouter()`` in this module (plus the conventional ``app``).
+
+    A module may declare more than one router (e.g. ``router`` and ``conflicts_router``
+    in review.py); hardcoding ``{"router", "app"}`` would let endpoints on any other
+    router bypass the gate, so the set is derived from the actual assignments.
+    """
+    names = {"app"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            func = node.value.func
+            callee = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+            if callee == "APIRouter":
+                names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    return names
+
+
+def _route_decorators(node: ast.AST, router_names: set[str]) -> Iterable[tuple[str, ast.Call]]:
+    """Yield (http_method, call) for each @<router>.<method>(...) decorator on a function."""
     if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
         return
     for deco in node.decorator_list:
@@ -51,13 +68,21 @@ def _route_decorators(node: ast.AST) -> Iterable[tuple[str, ast.Call]]:
             and isinstance(deco.func, ast.Attribute)
             and deco.func.attr in _HTTP_METHODS
             and isinstance(deco.func.value, ast.Name)
-            and deco.func.value.id in {"router", "app"}
+            and deco.func.value.id in router_names
         ):
             yield deco.func.attr, deco
 
 
 def _has_response_model(call: ast.Call) -> bool:
-    return any(kw.arg == "response_model" for kw in call.keywords)
+    """True only if a *non-None* response_model is declared.
+
+    ``response_model=None`` is an untyped/undocumented contract — counting it as
+    typed would let the gate be silenced without actually adding a schema.
+    """
+    for kw in call.keywords:
+        if kw.arg == "response_model":
+            return not (isinstance(kw.value, ast.Constant) and kw.value.value is None)
+    return False
 
 
 def _route_literal(call: ast.Call) -> str:
@@ -73,9 +98,10 @@ def scan_file(path: Path, *, repo_root: Path) -> list[UntypedEndpoint]:
     except ValueError:
         rel = path.as_posix()
 
+    router_names = _router_names(tree)
     findings: list[UntypedEndpoint] = []
     for node in ast.walk(tree):
-        for method, call in _route_decorators(node):
+        for method, call in _route_decorators(node, router_names):
             if not _has_response_model(call):
                 # Status-only / 204 handlers are legitimately bodiless, but they should
                 # still be explicit; we surface them so the decision is recorded, not hidden.
@@ -105,14 +131,18 @@ def render_markdown(findings: Sequence[UntypedEndpoint]) -> str:
         "# Router Contract Maturity — Untyped Endpoints",
         "",
         "Kickoff of [#1000](https://github.com/wangzitian0/finance_report/issues/1000). "
-        "Endpoints below declare no `response_model`, so their response contract is "
-        "absent from the OpenAPI schema. Type them (or document why a status-only "
-        "handler is intentional) and lower the budget in `audit_router_contracts.py`.",
+        "Endpoints below declare no (non-`None`) `response_model`, so their response "
+        "contract is absent from the OpenAPI schema. Type them (or document why a "
+        "status-only handler is intentional) and lower the budget "
+        "(`DEFAULT_MAX_UNTYPED_ENDPOINTS` in `common/ssot/audit_router_contracts.py`).",
         "",
         f"**Untyped endpoints: {len(findings)}**",
         "",
-        "| Method | Route | Handler | File:line |",
-        "|--------|-------|---------|-----------|",
+        "The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=...)` "
+        "(e.g. `/accounts`), so combine it with the router's prefix to get the full path.",
+        "",
+        "| Method | Route (router-relative) | Handler | File:line |",
+        "|--------|-------------------------|---------|-----------|",
     ]
     for f in findings:
         lines.append(f"| `{f.method}` | `{f.route}` | `{f.handler}` | {f.relative_path}:{f.line} |")

--- a/common/ssot/audit_router_contracts.py
+++ b/common/ssot/audit_router_contracts.py
@@ -1,0 +1,158 @@
+"""Router contract-maturity audit: find HTTP endpoints with no typed response model.
+
+The kickoff slice of #1000 (end-to-end module maturity audit). An endpoint that
+declares no ``response_model`` returns an *untyped* body — the OpenAPI schema and
+the generated API reference cannot describe its contract, and clients have no
+typed shape to bind to. That is the clearest, most mechanical contract gap, so it
+is the first thing this audit pins.
+
+This is a **budget gate**, not a big-bang cleanup: the current count of untyped
+endpoints is a non-growth ceiling (like ``detached_owner_guard``). New untyped
+endpoints fail the gate; the ceiling only ratchets *down* as gaps are typed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_ROUTER_DIR = Path("apps/backend/src/routers")
+_HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options"}
+
+# Non-growth ceiling. Lower this as endpoints gain a response_model; never raise it.
+# Today's 12 are a mix of legitimately-bodiless handlers (204 DELETEs, file/stream
+# exports) and a few real gaps (e.g. list_report_snapshots, update_prices) — see the
+# generated findings doc. The gate stops the count growing; it ratchets down as gaps close.
+DEFAULT_MAX_UNTYPED_ENDPOINTS = 12
+
+
+@dataclass(frozen=True, order=True)
+class UntypedEndpoint:
+    """One HTTP endpoint declared without a response_model."""
+
+    relative_path: str
+    line: int
+    method: str
+    route: str
+    handler: str
+
+
+def _route_decorators(node: ast.AST) -> Iterable[tuple[str, ast.Call]]:
+    """Yield (http_method, call) for each @router.<method>(...) decorator on a function."""
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return
+    for deco in node.decorator_list:
+        if (
+            isinstance(deco, ast.Call)
+            and isinstance(deco.func, ast.Attribute)
+            and deco.func.attr in _HTTP_METHODS
+            and isinstance(deco.func.value, ast.Name)
+            and deco.func.value.id in {"router", "app"}
+        ):
+            yield deco.func.attr, deco
+
+
+def _has_response_model(call: ast.Call) -> bool:
+    return any(kw.arg == "response_model" for kw in call.keywords)
+
+
+def _route_literal(call: ast.Call) -> str:
+    if call.args and isinstance(call.args[0], ast.Constant) and isinstance(call.args[0].value, str):
+        return call.args[0].value
+    return "?"
+
+
+def scan_file(path: Path, *, repo_root: Path) -> list[UntypedEndpoint]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    try:
+        rel = path.relative_to(repo_root).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+
+    findings: list[UntypedEndpoint] = []
+    for node in ast.walk(tree):
+        for method, call in _route_decorators(node):
+            if not _has_response_model(call):
+                # Status-only / 204 handlers are legitimately bodiless, but they should
+                # still be explicit; we surface them so the decision is recorded, not hidden.
+                findings.append(
+                    UntypedEndpoint(
+                        relative_path=rel,
+                        line=node.lineno,
+                        method=method.upper(),
+                        route=_route_literal(call),
+                        handler=node.name,
+                    )
+                )
+    return findings
+
+
+def scan_dir(router_dir: Path, *, repo_root: Path) -> list[UntypedEndpoint]:
+    findings: list[UntypedEndpoint] = []
+    for path in sorted(router_dir.rglob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        findings.extend(scan_file(path, repo_root=repo_root))
+    return sorted(findings)
+
+
+def render_markdown(findings: Sequence[UntypedEndpoint]) -> str:
+    lines = [
+        "# Router Contract Maturity — Untyped Endpoints",
+        "",
+        "Kickoff of [#1000](https://github.com/wangzitian0/finance_report/issues/1000). "
+        "Endpoints below declare no `response_model`, so their response contract is "
+        "absent from the OpenAPI schema. Type them (or document why a status-only "
+        "handler is intentional) and lower the budget in `audit_router_contracts.py`.",
+        "",
+        f"**Untyped endpoints: {len(findings)}**",
+        "",
+        "| Method | Route | Handler | File:line |",
+        "|--------|-------|---------|-----------|",
+    ]
+    for f in findings:
+        lines.append(f"| `{f.method}` | `{f.route}` | `{f.handler}` | {f.relative_path}:{f.line} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit router endpoints for missing response_model contracts.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--router-dir", type=Path, default=None)
+    parser.add_argument("--max-allowed", type=int, default=DEFAULT_MAX_UNTYPED_ENDPOINTS)
+    parser.add_argument("--output", type=Path, default=None, help="Write the findings markdown here.")
+    parser.add_argument("--check", action="store_true", help="Exit nonzero if the budget is exceeded.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    router_dir = (args.router_dir or (repo_root / DEFAULT_ROUTER_DIR)).resolve()
+    findings = scan_dir(router_dir, repo_root=repo_root)
+
+    if args.output:
+        args.output.write_text(render_markdown(findings), encoding="utf-8")
+
+    count = len(findings)
+    if args.check and count > args.max_allowed:
+        print(
+            f"Untyped-endpoint count {count} exceeds budget {args.max_allowed}. "
+            f"Add a response_model or lower the budget.",
+            file=sys.stderr,
+        )
+        for f in findings:
+            print(f"  {f.relative_path}:{f.line}: {f.method} {f.route} ({f.handler})", file=sys.stderr)
+        return 1
+
+    print(f"Untyped endpoints: {count} (budget {args.max_allowed}).")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -114,6 +114,7 @@ explicit AC IDs for the behavior.
 | `apps/frontend/src/hooks/__tests__/useFocusTrap.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/lib/currency.test.ts` | `docs/ssot/frontend-patterns.md` |
 | `tests/tooling/test_agent_runtime_symlinks.py` | `docs/agents/orchestration.md` |
+| `tests/tooling/test_audit_router_contracts.py` | `docs/reference/router-contract-maturity.md` |
 | `tests/tooling/test_check_env_keys.py` | `docs/ssot/development.md` |
 | `tests/tooling/test_check_manifest.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_check_ssot_ownership.py` | `docs/ssot/MANIFEST.yaml` |

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -1,11 +1,13 @@
 # Router Contract Maturity — Untyped Endpoints
 
-Kickoff of [#1000](https://github.com/wangzitian0/finance_report/issues/1000). Endpoints below declare no `response_model`, so their response contract is absent from the OpenAPI schema. Type them (or document why a status-only handler is intentional) and lower the budget in `audit_router_contracts.py`.
+Kickoff of [#1000](https://github.com/wangzitian0/finance_report/issues/1000). Endpoints below declare no (non-`None`) `response_model`, so their response contract is absent from the OpenAPI schema. Type them (or document why a status-only handler is intentional) and lower the budget (`DEFAULT_MAX_UNTYPED_ENDPOINTS` in `common/ssot/audit_router_contracts.py`).
 
 **Untyped endpoints: 12**
 
-| Method | Route | Handler | File:line |
-|--------|-------|---------|-----------|
+The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=...)` (e.g. `/accounts`), so combine it with the router's prefix to get the full path.
+
+| Method | Route (router-relative) | Handler | File:line |
+|--------|-------------------------|---------|-----------|
 | `DELETE` | `/{account_id}` | `delete_account` | apps/backend/src/routers/accounts.py:240 |
 | `DELETE` | `/valuation-snapshots/{snapshot_id}` | `delete_valuation_snapshot` | apps/backend/src/routers/assets.py:186 |
 | `POST` | `` | `chat_message` | apps/backend/src/routers/chat.py:37 |

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -1,0 +1,20 @@
+# Router Contract Maturity — Untyped Endpoints
+
+Kickoff of [#1000](https://github.com/wangzitian0/finance_report/issues/1000). Endpoints below declare no `response_model`, so their response contract is absent from the OpenAPI schema. Type them (or document why a status-only handler is intentional) and lower the budget in `audit_router_contracts.py`.
+
+**Untyped endpoints: 12**
+
+| Method | Route | Handler | File:line |
+|--------|-------|---------|-----------|
+| `DELETE` | `/{account_id}` | `delete_account` | apps/backend/src/routers/accounts.py:240 |
+| `DELETE` | `/valuation-snapshots/{snapshot_id}` | `delete_valuation_snapshot` | apps/backend/src/routers/assets.py:186 |
+| `POST` | `` | `chat_message` | apps/backend/src/routers/chat.py:37 |
+| `DELETE` | `/session/{session_id}` | `delete_session` | apps/backend/src/routers/chat.py:211 |
+| `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:142 |
+| `POST` | `/prices/update` | `update_prices` | apps/backend/src/routers/portfolio.py:864 |
+| `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:1776 |
+| `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:2058 |
+| `GET` | `/{report_type}/snapshots` | `list_report_snapshots` | apps/backend/src/routers/reports.py:2217 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:536 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:800 |
+| `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:102 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - Overview: reference/api-overview.md
       - Generated API Reference: reference/api.md
       - Generated DB Schema Reference: reference/db-schema.md
+      - Router Contract Maturity: reference/router-contract-maturity.md
   - Technical Docs:
       - Architecture: ssot/README.md
       - Development Guide: ssot/development.md

--- a/tests/tooling/test_audit_router_contracts.py
+++ b/tests/tooling/test_audit_router_contracts.py
@@ -80,3 +80,38 @@ def test_findings_doc_is_in_sync() -> None:
     assert doc == expected, (
         "Run: python tools/audit_router_contracts.py --output docs/reference/router-contract-maturity.md"
     )
+
+
+def test_cli_writes_output_and_reports_within_budget(tmp_path: Path, capsys) -> None:
+    """--output writes the findings doc; a within-budget run prints and exits 0."""
+    routers = tmp_path / "routers"
+    routers.mkdir()
+    (routers / "demo.py").write_text(
+        'from fastapi import APIRouter\nrouter = APIRouter()\n\n\n@router.get("/ok", response_model=int)\nasync def ok() -> int:\n    return 1\n',
+        encoding="utf-8",
+    )
+    out = tmp_path / "findings.md"
+    code = audit.main(["--repo-root", str(tmp_path), "--router-dir", str(routers), "--output", str(out)])
+    assert code == 0
+    assert out.exists() and "Untyped Endpoints" in out.read_text(encoding="utf-8")
+    assert "Untyped endpoints: 0" in capsys.readouterr().out
+
+
+def test_route_literal_fallback_and_path_outside_repo(tmp_path: Path) -> None:
+    """A non-literal route falls back to '?'; a file outside repo_root keeps its posix path."""
+    router = tmp_path / "demo.py"
+    router.write_text(
+        "from fastapi import APIRouter\nrouter = APIRouter()\n_p = '/dyn'\n\n\n@router.get(_p)\nasync def dyn():\n    return {}\n",
+        encoding="utf-8",
+    )
+    findings = audit.scan_file(router, repo_root=Path("/some/other/root"))
+    assert len(findings) == 1
+    assert findings[0].route == "?"
+    assert findings[0].relative_path == router.as_posix()
+
+
+def test_tools_wrapper_delegates_to_common() -> None:
+    """The CLI wrapper delegates to the common implementation."""
+    from tools import audit_router_contracts as wrapper
+
+    assert wrapper.main is audit.main

--- a/tests/tooling/test_audit_router_contracts.py
+++ b/tests/tooling/test_audit_router_contracts.py
@@ -1,0 +1,82 @@
+"""Contracts for the router contract-maturity audit (#1000 kickoff, #1055 PR3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from common.ssot import audit_router_contracts as audit
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_detects_endpoint_without_response_model(tmp_path: Path) -> None:
+    """An @router endpoint with no response_model is flagged; a typed one is not."""
+    router = tmp_path / "apps" / "backend" / "src" / "routers" / "demo.py"
+    router.parent.mkdir(parents=True)
+    router.write_text(
+        """
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/typed", response_model=int)
+async def typed() -> int:
+    return 1
+
+
+@router.post("/untyped")
+async def untyped():
+    return {"x": 1}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = audit.scan_dir(tmp_path / "apps" / "backend" / "src" / "routers", repo_root=tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0].handler == "untyped"
+    assert findings[0].method == "POST"
+    assert findings[0].route == "/untyped"
+
+
+def test_budget_gate_fails_on_growth(tmp_path: Path) -> None:
+    """The CLI exits nonzero when untyped endpoints exceed the budget."""
+    router = tmp_path / "apps" / "backend" / "src" / "routers" / "demo.py"
+    router.parent.mkdir(parents=True)
+    router.write_text(
+        """
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.delete("/a")
+async def a():
+    return None
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    exit_code = audit.main(
+        ["--repo-root", str(tmp_path), "--router-dir", str(router.parent), "--max-allowed", "0", "--check"]
+    )
+    assert exit_code == 1
+
+
+def test_real_repo_within_budget() -> None:
+    """The current untyped-endpoint count is a non-growth ceiling."""
+    findings = audit.scan_dir(ROOT / "apps" / "backend" / "src" / "routers", repo_root=ROOT)
+    assert len(findings) <= audit.DEFAULT_MAX_UNTYPED_ENDPOINTS, [
+        f"{f.relative_path}:{f.line} {f.method} {f.route}" for f in findings
+    ]
+
+
+def test_findings_doc_is_in_sync() -> None:
+    """The committed findings doc matches the current scan (regenerate on change)."""
+    findings = audit.scan_dir(ROOT / "apps" / "backend" / "src" / "routers", repo_root=ROOT)
+    expected = audit.render_markdown(findings)
+    doc = (ROOT / "docs" / "reference" / "router-contract-maturity.md").read_text(encoding="utf-8")
+    assert doc == expected, (
+        "Run: python tools/audit_router_contracts.py --output docs/reference/router-contract-maturity.md"
+    )

--- a/tests/tooling/test_audit_router_contracts.py
+++ b/tests/tooling/test_audit_router_contracts.py
@@ -40,6 +40,35 @@ async def untyped():
     assert findings[0].route == "/untyped"
 
 
+def test_response_model_none_counts_as_untyped(tmp_path: Path) -> None:
+    """response_model=None is an untyped contract — it must not silence the gate."""
+    router = tmp_path / "demo.py"
+    router.write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n\n\n"
+        '@router.get("/none", response_model=None)\n'
+        "async def none_handler():\n    return {}\n",
+        encoding="utf-8",
+    )
+    findings = audit.scan_file(router, repo_root=tmp_path)
+    assert len(findings) == 1 and findings[0].handler == "none_handler"
+
+
+def test_detects_endpoints_on_any_apirouter_variable(tmp_path: Path) -> None:
+    """An untyped endpoint on a second APIRouter (not named 'router') is still caught."""
+    router = tmp_path / "demo.py"
+    router.write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n"
+        'conflicts_router = APIRouter(prefix="/review")\n\n\n'
+        '@conflicts_router.delete("/{conflict_id}")\n'
+        "async def drop_conflict():\n    return None\n",
+        encoding="utf-8",
+    )
+    findings = audit.scan_file(router, repo_root=tmp_path)
+    assert len(findings) == 1 and findings[0].handler == "drop_conflict"
+
+
 def test_budget_gate_fails_on_growth(tmp_path: Path) -> None:
     """The CLI exits nonzero when untyped endpoints exceed the budget."""
     router = tmp_path / "apps" / "backend" / "src" / "routers" / "demo.py"

--- a/tools/audit_router_contracts.py
+++ b/tools/audit_router_contracts.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Command wrapper for the router contract-maturity audit (untyped endpoints)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.ssot.audit_router_contracts import main  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

**PR 3 of #1055.** Turns the broad #1000 ("module maturity / contract gaps across all routers") into **actionable, gated data**, starting with the clearest mechanical gap: HTTP endpoints that declare **no `response_model`**. Such an endpoint returns an untyped body, so its contract is absent from the OpenAPI schema and clients have nothing typed to bind to.

## What's added

- **`common/ssot/audit_router_contracts.py`** — AST scan of `apps/backend/src/routers` for `@router.<method>` handlers lacking `response_model`, with a **non-growth budget gate** (like `detached_owner_guard`). Current ceiling **12**; ratchets only downward.
- **`tools/audit_router_contracts.py`** — CLI wrapper.
- **`docs/reference/router-contract-maturity.md`** — generated findings. The 12 untyped endpoints are a mix of **legitimately bodiless** (204 `DELETE`s, file/stream exports) and a **few real gaps** (`list_report_snapshots`, `update_prices`).
- **CI lint gate** — `audit_router_contracts.py --check` so no *new* untyped endpoint lands.
- **`tests/tooling/test_audit_router_contracts.py`** — detection, budget gate, repo ceiling, doc-in-sync (4 pass).

## Why a budget gate, not a cleanup

The 12 include several endpoints that are *correctly* untyped (a 204 has no body; an export streams a file). The honest move is to **record** them in the findings doc, **freeze** the count so it can't grow, and ratchet it down as the real gaps get typed — rather than force `response_model` onto handlers that shouldn't have one.

Next slices of #1000 (error-envelope consistency, pagination, auth coverage) can follow the same scanner + budget-gate pattern.

## Test plan
- ✅ 4 tooling tests pass; ruff clean; CI YAML parses; `--check` passes at budget 12

Part of #1055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)