### PR TITLE
[finance_report_audit] surface the confidence loop in the UI (#1055 PR4, #1003)

### DIFF
--- a/apps/frontend/src/__tests__/confidence.test.ts
+++ b/apps/frontend/src/__tests__/confidence.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatProportionPercent,
   hasNoSnapshots,
+  parseProportion,
   summarizeReplay,
   toSparklinePoints,
   trendDelta,
@@ -25,6 +26,17 @@ function snapshot(
 }
 
 describe("confidence helpers (#1003 / #1055 PR4)", () => {
+  describe("parseProportion", () => {
+    it("returns null for null/undefined/blank/non-numeric and parses real values", () => {
+      expect(parseProportion(null)).toBeNull();
+      expect(parseProportion(undefined)).toBeNull();
+      expect(parseProportion("  ")).toBeNull();
+      expect(parseProportion("abc")).toBeNull();
+      expect(parseProportion("0.25")).toBe(0.25);
+      expect(parseProportion(0.5)).toBe(0.5);
+    });
+  });
+
   describe("formatProportionPercent", () => {
     it("formats a Decimal-string proportion as a percentage", () => {
       expect(formatProportionPercent("0.12500")).toBe("12.5%");

--- a/apps/frontend/src/__tests__/confidence.test.ts
+++ b/apps/frontend/src/__tests__/confidence.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatProportionPercent,
+  hasNoSnapshots,
+  summarizeReplay,
+  toSparklinePoints,
+  trendDelta,
+} from "@/lib/confidence";
+import type { ConfidenceMetricSnapshot } from "@/lib/types";
+
+function snapshot(
+  id: string,
+  proportion: string,
+  capturedAt = "2026-06-01T00:00:00Z",
+): ConfidenceMetricSnapshot {
+  return {
+    id,
+    captured_at: capturedAt,
+    total_count: 100,
+    low_confidence_count: 10,
+    low_confidence_proportion: proportion,
+    tier_breakdown: {},
+  };
+}
+
+describe("confidence helpers (#1003 / #1055 PR4)", () => {
+  describe("formatProportionPercent", () => {
+    it("formats a Decimal-string proportion as a percentage", () => {
+      expect(formatProportionPercent("0.12500")).toBe("12.5%");
+      expect(formatProportionPercent("0")).toBe("0.0%");
+      expect(formatProportionPercent("1")).toBe("100.0%");
+    });
+
+    it("renders an em dash for non-finite/missing values rather than NaN%", () => {
+      expect(formatProportionPercent("")).toBe("—");
+      expect(formatProportionPercent("not-a-number")).toBe("—");
+    });
+  });
+
+  describe("trendDelta", () => {
+    it("reports 'down' when the newest proportion is lower than the previous", () => {
+      const result = trendDelta([snapshot("b", "0.10"), snapshot("a", "0.20")]);
+      expect(result.direction).toBe("down");
+      expect(result.delta).toBeCloseTo(-0.1);
+    });
+
+    it("reports 'up' when the newest proportion is higher", () => {
+      expect(trendDelta([snapshot("b", "0.30"), snapshot("a", "0.20")]).direction).toBe("up");
+    });
+
+    it("is flat with fewer than two points or no change", () => {
+      expect(trendDelta([]).direction).toBe("flat");
+      expect(trendDelta([snapshot("a", "0.20")]).direction).toBe("flat");
+      expect(trendDelta([snapshot("b", "0.20"), snapshot("a", "0.20")]).direction).toBe("flat");
+    });
+  });
+
+  describe("toSparklinePoints", () => {
+    it("reverses newest-first into oldest-first percentage points", () => {
+      const points = toSparklinePoints(
+        [snapshot("new", "0.10"), snapshot("old", "0.20")],
+        (s) => s.id,
+      );
+      expect(points.map((p) => p.label)).toEqual(["old", "new"]);
+      expect(points.map((p) => p.value)).toEqual([20, 10]);
+    });
+  });
+
+  describe("summarizeReplay", () => {
+    it("summarises the before/after percentages and reduction verdict", () => {
+      const summary = summarizeReplay({
+        holdout_size: 8,
+        grounded: 3,
+        proportion_before: "0.30000",
+        proportion_after: "0.18000",
+        reduced: true,
+      });
+      expect(summary).toEqual({ reduced: true, before: "30.0%", after: "18.0%", hasHoldout: true });
+    });
+
+    it("flags an empty held-out split as no conclusion yet", () => {
+      const summary = summarizeReplay({
+        holdout_size: 0,
+        grounded: 0,
+        proportion_before: "0",
+        proportion_after: "0",
+        reduced: false,
+      });
+      expect(summary.hasHoldout).toBe(false);
+    });
+  });
+
+  describe("hasNoSnapshots", () => {
+    it("is true only when the series is empty", () => {
+      expect(hasNoSnapshots({ current: snapshot("c", "0.1"), series: [] })).toBe(true);
+      expect(
+        hasNoSnapshots({ current: snapshot("c", "0.1"), series: [snapshot("a", "0.1")] }),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/frontend/src/__tests__/confidence.test.ts
+++ b/apps/frontend/src/__tests__/confidence.test.ts
@@ -65,6 +65,22 @@ describe("confidence helpers (#1003 / #1055 PR4)", () => {
       expect(points.map((p) => p.label)).toEqual(["old", "new"]);
       expect(points.map((p) => p.value)).toEqual([20, 10]);
     });
+
+    it("drops blank-proportion snapshots instead of charting a bogus 0%", () => {
+      const points = toSparklinePoints(
+        [snapshot("new", "0.10"), snapshot("blank", "  "), snapshot("old", "0.20")],
+        (s) => s.id,
+      );
+      expect(points.map((p) => p.label)).toEqual(["old", "new"]);
+      expect(points.map((p) => p.value)).toEqual([20, 10]);
+    });
+  });
+
+  describe("blank/missing-proportion guards", () => {
+    it("trendDelta stays flat when an endpoint proportion is blank (no false 'down')", () => {
+      expect(trendDelta([snapshot("new", "  "), snapshot("old", "0.20")]).direction).toBe("flat");
+      expect(trendDelta([snapshot("new", "0.10"), snapshot("old", "")]).direction).toBe("flat");
+    });
   });
 
   describe("summarizeReplay", () => {

--- a/apps/frontend/src/__tests__/confidenceTrendPage.test.tsx
+++ b/apps/frontend/src/__tests__/confidenceTrendPage.test.tsx
@@ -86,6 +86,24 @@ describe("Confidence Trend page (#1003 / #1055 PR4)", () => {
     expect(screen.getByText(/Reduces low confidence/i)).toBeInTheDocument();
   });
 
+  it("shows the empty-trend state when every snapshot proportion is blank (no chartable points)", async () => {
+    // Series is non-empty but all proportions are blank, so toSparklinePoints drops
+    // them all — the chart must not be rendered with an empty (invalid-SVG) series.
+    mockedNorthStar.mockResolvedValue(
+      northStar({
+        series: [
+          { id: "b2", captured_at: "2026-06-10T00:00:00Z", total_count: 0, low_confidence_count: 0, low_confidence_proportion: "", tier_breakdown: {} },
+          { id: "b1", captured_at: "2026-06-01T00:00:00Z", total_count: 0, low_confidence_count: 0, low_confidence_proportion: "  ", tier_breakdown: {} },
+        ],
+      }),
+    );
+    mockedReplay.mockResolvedValue(replay({ holdout_size: 0, reduced: false }));
+
+    render(<ConfidenceTrendPage />);
+
+    await waitFor(() => expect(screen.getByText("No trend recorded yet")).toBeInTheDocument());
+  });
+
   it("shows an empty-trend state when no snapshots have been recorded yet", async () => {
     mockedNorthStar.mockResolvedValue(northStar({ series: [] }));
     mockedReplay.mockResolvedValue(replay({ holdout_size: 0, reduced: false }));

--- a/apps/frontend/src/__tests__/confidenceTrendPage.test.tsx
+++ b/apps/frontend/src/__tests__/confidenceTrendPage.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ConfidenceTrendPage from "@/app/(main)/confidence/page";
+import { fetchConfidenceNorthStar, fetchCorrectionLoopReplay } from "@/lib/api";
+import type {
+  ConfidenceNorthStarResponse,
+  CorrectionLoopReplayResponse,
+} from "@/lib/types";
+
+vi.mock("@/lib/api", () => ({
+  fetchConfidenceNorthStar: vi.fn(),
+  fetchCorrectionLoopReplay: vi.fn(),
+}));
+
+const mockedNorthStar = vi.mocked(fetchConfidenceNorthStar);
+const mockedReplay = vi.mocked(fetchCorrectionLoopReplay);
+
+function northStar(
+  overrides: Partial<ConfidenceNorthStarResponse> = {},
+): ConfidenceNorthStarResponse {
+  return {
+    current: {
+      total_count: 200,
+      low_confidence_count: 25,
+      low_confidence_proportion: "0.12500",
+      tier_breakdown: { LOW: 25, MEDIUM: 50, HIGH: 75, TRUSTED: 50 },
+    },
+    series: [
+      {
+        id: "s2",
+        captured_at: "2026-06-10T00:00:00Z",
+        total_count: 200,
+        low_confidence_count: 25,
+        low_confidence_proportion: "0.12500",
+        tier_breakdown: {},
+      },
+      {
+        id: "s1",
+        captured_at: "2026-06-01T00:00:00Z",
+        total_count: 180,
+        low_confidence_count: 36,
+        low_confidence_proportion: "0.20000",
+        tier_breakdown: {},
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function replay(
+  overrides: Partial<CorrectionLoopReplayResponse> = {},
+): CorrectionLoopReplayResponse {
+  return {
+    holdout_size: 10,
+    grounded: 4,
+    proportion_before: "0.30000",
+    proportion_after: "0.18000",
+    reduced: true,
+    ...overrides,
+  };
+}
+
+describe("Confidence Trend page (#1003 / #1055 PR4)", () => {
+  beforeEach(() => {
+    mockedNorthStar.mockReset();
+    mockedReplay.mockReset();
+  });
+
+  it("renders the current proportion, the trend direction, and the replay effect", async () => {
+    mockedNorthStar.mockResolvedValue(northStar());
+    mockedReplay.mockResolvedValue(replay());
+
+    render(<ConfidenceTrendPage />);
+
+    // Decimal-string proportion "0.12500" formats as a percentage, shown prominently.
+    expect(await screen.findByText("12.5%")).toBeInTheDocument();
+    expect(screen.getByText(/25 of 200 posted facts/i)).toBeInTheDocument();
+
+    // Newest (12.5%) is lower than previous (20%) — the good "trending down" news.
+    expect(screen.getByText(/Trending down/i)).toBeInTheDocument();
+
+    // Replay before -> after and the "reduces" verdict.
+    expect(screen.getByText("30.0%")).toBeInTheDocument();
+    expect(screen.getByText("18.0%")).toBeInTheDocument();
+    expect(screen.getByText(/Reduces low confidence/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty-trend state when no snapshots have been recorded yet", async () => {
+    mockedNorthStar.mockResolvedValue(northStar({ series: [] }));
+    mockedReplay.mockResolvedValue(replay({ holdout_size: 0, reduced: false }));
+
+    render(<ConfidenceTrendPage />);
+
+    await waitFor(() => expect(screen.getByText("No trend recorded yet")).toBeInTheDocument());
+    // Current proportion is still shown even with no series.
+    expect(screen.getByText("12.5%")).toBeInTheDocument();
+    // No held-out split -> the replay can't draw a conclusion yet.
+    expect(screen.getByText("Not enough correction history yet")).toBeInTheDocument();
+  });
+
+  it("surfaces a retryable error state when the metrics fail to load", async () => {
+    mockedNorthStar.mockRejectedValue(new Error("offline"));
+    mockedReplay.mockResolvedValue(replay());
+
+    render(<ConfidenceTrendPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Couldn't load the confidence trend")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("offline")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/__tests__/navigation.test.ts
+++ b/apps/frontend/src/__tests__/navigation.test.ts
@@ -34,6 +34,7 @@ describe("navigation metadata", () => {
       "Journal",
       "Reconciliation",
       "Processing",
+      "Confidence Trend",
       "AI Settings",
     ]);
     expect(advancedNavItems.find((item) => item.label === "AI Settings")?.href).toBe("/settings/ai");

--- a/apps/frontend/src/app/(main)/confidence/page.tsx
+++ b/apps/frontend/src/app/(main)/confidence/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+// #1003 / #1055 PR4: surface Axiom B's confidence loop in the UI.
+//
+// The backend already measures the loop — the North-Star low-confidence
+// proportion and the held-out correction-loop replay — but until now those
+// numbers were invisible to users. This page makes them legible: the current
+// proportion prominently (lower is better), the recorded trend over time, and
+// whether the correction loop measurably lowers the proportion.
+
+import { useCallback, useEffect, useState } from "react";
+import { TrendingDown, TrendingUp, Minus, ShieldCheck } from "lucide-react";
+
+import { fetchConfidenceNorthStar, fetchCorrectionLoopReplay } from "@/lib/api";
+import {
+  formatProportionPercent,
+  hasNoSnapshots,
+  summarizeReplay,
+  toSparklinePoints,
+  trendDelta,
+  type TrendDirection,
+} from "@/lib/confidence";
+import { formatDateTimeDisplay } from "@/lib/date";
+import type {
+  ConfidenceNorthStarResponse,
+  CorrectionLoopReplayResponse,
+} from "@/lib/types";
+import { TrendChart } from "@/components/charts/TrendChart";
+import { Badge, EmptyState, LoadingState, PageHeader } from "@/components/ui";
+
+interface ConfidenceData {
+  northStar: ConfidenceNorthStarResponse;
+  replay: CorrectionLoopReplayResponse;
+}
+
+const DIRECTION_ICON: Record<TrendDirection, typeof TrendingDown> = {
+  down: TrendingDown,
+  up: TrendingUp,
+  flat: Minus,
+};
+
+// Lower low-confidence proportion is better, so a "down" trend is the good news.
+const DIRECTION_LABEL: Record<TrendDirection, string> = {
+  down: "Trending down — fewer low-confidence facts",
+  up: "Trending up — more low-confidence facts",
+  flat: "Holding steady",
+};
+
+const DIRECTION_COLOR: Record<TrendDirection, string> = {
+  down: "var(--success)",
+  up: "var(--error)",
+  flat: "var(--foreground-muted)",
+};
+
+export default function ConfidenceTrendPage() {
+  const [data, setData] = useState<ConfidenceData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    // Reset to the loading state so a refresh/retry never shows stale numbers.
+    setData(null);
+    setError(null);
+    try {
+      const [northStar, replay] = await Promise.all([
+        fetchConfidenceNorthStar(),
+        fetchCorrectionLoopReplay(),
+      ]);
+      setData({ northStar, replay });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load the confidence trend");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="p-6">
+      <PageHeader
+        title="Confidence Trend"
+        description="The share of your posted data the system is least sure about — the low-confidence tail Axiom B works to shrink. Lower is better."
+      />
+
+      {data === null && !error && <LoadingState label="Loading the confidence trend" />}
+
+      {error && (
+        <EmptyState
+          role="alert"
+          title="Couldn't load the confidence trend"
+          description={error}
+          action={
+            <button onClick={load} className="btn-secondary text-sm">
+              Retry
+            </button>
+          }
+        />
+      )}
+
+      {data !== null && !error && (
+        <div className="space-y-6">
+          <NorthStarCard data={data.northStar} />
+          <ReplayCard replay={data.replay} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NorthStarCard({ data }: { data: ConfidenceNorthStarResponse }) {
+  const { current, series } = data;
+  const { direction } = trendDelta(series);
+  const DirectionIcon = DIRECTION_ICON[direction];
+  const points = toSparklinePoints(series, (snapshot) =>
+    formatDateTimeDisplay(snapshot.captured_at),
+  );
+
+  return (
+    <section className="card p-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="inline-flex items-center gap-2 font-semibold">
+            <ShieldCheck className="h-4 w-4 text-[var(--accent)]" aria-hidden="true" />
+            Low-confidence proportion
+          </h2>
+          <p className="mt-1 text-sm text-muted">
+            {current.low_confidence_count} of {current.total_count} posted facts are low confidence.
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-4xl font-semibold tabular-nums">
+            {formatProportionPercent(current.low_confidence_proportion)}
+          </p>
+          {series.length >= 2 && (
+            <p
+              className="mt-1 inline-flex items-center justify-end gap-1 text-xs"
+              style={{ color: DIRECTION_COLOR[direction] }}
+            >
+              <DirectionIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              {DIRECTION_LABEL[direction]}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {hasNoSnapshots(data) ? (
+        <EmptyState
+          framed={false}
+          className="mt-4"
+          title="No trend recorded yet"
+          description="The current proportion is shown above. A trend line appears here once snapshots accumulate."
+        />
+      ) : (
+        <div className="mt-5">
+          <TrendChart points={points} height={180} />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ReplayCard({ replay }: { replay: CorrectionLoopReplayResponse }) {
+  const summary = summarizeReplay(replay);
+
+  return (
+    <section className="card p-5">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-semibold">Correction-loop effect</h2>
+        {summary.hasHoldout && (
+          <Badge variant={summary.reduced ? "success" : "muted"}>
+            {summary.reduced ? "Reduces low confidence" : "No measurable reduction"}
+          </Badge>
+        )}
+      </div>
+      <p className="mt-1 text-sm text-muted">
+        A held-out replay of your past corrections — does the loop measurably shrink the
+        low-confidence proportion?
+      </p>
+
+      {summary.hasHoldout ? (
+        <div className="mt-4 grid grid-cols-2 gap-3 text-center">
+          <div className="rounded-md bg-[var(--background-muted)] p-3">
+            <p className="text-2xl font-semibold tabular-nums">{summary.before}</p>
+            <p className="mt-1 text-xs text-muted">Before the loop</p>
+          </div>
+          <div className="rounded-md bg-[var(--background-muted)] p-3">
+            <p
+              className="text-2xl font-semibold tabular-nums"
+              style={{ color: summary.reduced ? "var(--success)" : undefined }}
+            >
+              {summary.after}
+            </p>
+            <p className="mt-1 text-xs text-muted">After the loop</p>
+          </div>
+        </div>
+      ) : (
+        <EmptyState
+          framed={false}
+          className="mt-4"
+          title="Not enough correction history yet"
+          description="Once you've corrected enough recurring items, the replay can hold some out and measure the loop's effect."
+        />
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/src/app/(main)/confidence/page.tsx
+++ b/apps/frontend/src/app/(main)/confidence/page.tsx
@@ -143,7 +143,7 @@ function NorthStarCard({ data }: { data: ConfidenceNorthStarResponse }) {
         </div>
       </div>
 
-      {hasNoSnapshots(data) ? (
+      {hasNoSnapshots(data) || points.length === 0 ? (
         <EmptyState
           framed={false}
           className="mt-4"

--- a/apps/frontend/src/components/navigation.ts
+++ b/apps/frontend/src/components/navigation.ts
@@ -10,6 +10,7 @@ import {
     MessageSquare,
     ShieldCheck,
     SlidersHorizontal,
+    TrendingDown,
     UploadCloud,
     Wallet,
     Zap,
@@ -42,6 +43,7 @@ export const advancedNavItems: NavItem[] = [
     { icon: BookOpen, label: "Journal", href: "/journal", protected: true },
     { icon: Link2, label: "Reconciliation", href: "/reconciliation", protected: true },
     { icon: Clock, label: "Processing", href: "/processing", protected: true },
+    { icon: TrendingDown, label: "Confidence Trend", href: "/confidence", protected: true },
     { icon: SlidersHorizontal, label: "AI Settings", href: "/settings/ai", protected: true },
 ];
 
@@ -71,6 +73,7 @@ export const ROUTE_CONFIG: Record<string, RouteConfig> = {
     "/reconciliation/unmatched": { label: "Unmatched", Icon: Link2 },
     "/reconciliation/review-queue": { label: "Review Queue", Icon: Link2 },
     "/processing": { label: "Processing", Icon: Clock },
+    "/confidence": { label: "Confidence Trend", Icon: TrendingDown },
     "/chat": { label: "Chat", Icon: MessageSquare },
     "/settings/ai": { label: "AI Settings", Icon: SlidersHorizontal },
     "/ping-pong": { label: "Ping-Pong", Icon: Zap },

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,5 +1,7 @@
 import { getAccessToken, getUserId } from "./auth";
 import type {
+  ConfidenceNorthStarResponse,
+  CorrectionLoopReplayResponse,
   WorkflowEventListResponse,
   WorkflowEventResponse,
   WorkflowEventStatus,
@@ -332,4 +334,16 @@ export async function updateWorkflowEventStatus(
     method: "PATCH",
     body: JSON.stringify({ status }),
   });
+}
+
+// ── North-Star confidence metric (EPIC-018 AC18.12 / #1003, #1055 PR4) ─────
+
+/** The live low-confidence proportion plus its recorded trend (newest first). */
+export async function fetchConfidenceNorthStar(): Promise<ConfidenceNorthStarResponse> {
+  return apiFetch<ConfidenceNorthStarResponse>("/api/metrics/confidence-north-star");
+}
+
+/** The held-out replay of the correction loop — does it lower the proportion? */
+export async function fetchCorrectionLoopReplay(): Promise<CorrectionLoopReplayResponse> {
+  return apiFetch<CorrectionLoopReplayResponse>("/api/metrics/correction-loop/replay");
 }

--- a/apps/frontend/src/lib/confidence.ts
+++ b/apps/frontend/src/lib/confidence.ts
@@ -14,12 +14,6 @@ import type {
 } from "@/lib/types";
 
 /**
- * Format a Decimal proportion string (e.g. "0.12500") as a percentage label
- * (e.g. "12.5%"). Proportions arrive as strings to preserve precision, so we
- * parse with Number only at the display boundary. A non-finite or missing
- * value renders as an em dash rather than "NaN%".
- */
-/**
  * Parse a proportion to a finite number, or `null` for a missing/blank/non-finite
  * value. `Number("")` and `Number("  ")` coerce to 0, so blank strings must be
  * rejected explicitly rather than silently treated as 0.
@@ -31,6 +25,12 @@ export function parseProportion(value: string | number | null | undefined): numb
   return Number.isFinite(proportion) ? proportion : null;
 }
 
+/**
+ * Format a Decimal proportion string (e.g. "0.12500") as a percentage label
+ * (e.g. "12.5%"). Proportions arrive as strings to preserve precision, so we
+ * parse with Number only at the display boundary. A non-finite or missing
+ * value renders as an em dash rather than "NaN%".
+ */
 export function formatProportionPercent(value: string | number, decimals = 1): string {
   const proportion = parseProportion(value);
   if (proportion === null) return "—";

--- a/apps/frontend/src/lib/confidence.ts
+++ b/apps/frontend/src/lib/confidence.ts
@@ -19,12 +19,21 @@ import type {
  * parse with Number only at the display boundary. A non-finite or missing
  * value renders as an em dash rather than "NaN%".
  */
-export function formatProportionPercent(value: string | number, decimals = 1): string {
-  // `Number("")` and `Number("  ")` coerce to 0, which would render a misleading
-  // "0.0%" for a missing value — guard the empty/blank string explicitly.
-  if (typeof value === "string" && value.trim() === "") return "—";
+/**
+ * Parse a proportion to a finite number, or `null` for a missing/blank/non-finite
+ * value. `Number("")` and `Number("  ")` coerce to 0, so blank strings must be
+ * rejected explicitly rather than silently treated as 0.
+ */
+export function parseProportion(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const proportion = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(proportion)) return "—";
+  return Number.isFinite(proportion) ? proportion : null;
+}
+
+export function formatProportionPercent(value: string | number, decimals = 1): string {
+  const proportion = parseProportion(value);
+  if (proportion === null) return "—";
   return `${(proportion * 100).toFixed(decimals)}%`;
 }
 
@@ -44,10 +53,12 @@ export interface TrendDelta {
  */
 export function trendDelta(series: ConfidenceMetricSnapshot[]): TrendDelta {
   if (series.length < 2) return { direction: "flat", delta: 0 };
-  const newest = Number(series[0]?.low_confidence_proportion ?? 0);
-  const previous = Number(series[1]?.low_confidence_proportion ?? 0);
+  const newest = parseProportion(series[0]?.low_confidence_proportion);
+  const previous = parseProportion(series[1]?.low_confidence_proportion);
+  // A blank/missing endpoint means there is nothing trustworthy to compare.
+  if (newest === null || previous === null) return { direction: "flat", delta: 0 };
   const delta = newest - previous;
-  if (!Number.isFinite(delta) || delta === 0) return { direction: "flat", delta: 0 };
+  if (delta === 0) return { direction: "flat", delta: 0 };
   return { direction: delta < 0 ? "down" : "up", delta };
 }
 
@@ -69,9 +80,11 @@ export function toSparklinePoints(
     .reverse()
     .map((snapshot) => ({
       label: labelFor(snapshot),
-      value: Number(snapshot.low_confidence_proportion) * 100,
+      proportion: parseProportion(snapshot.low_confidence_proportion),
     }))
-    .filter((point) => Number.isFinite(point.value));
+    // Drop blank/non-finite points so a missing value can't inject a bogus 0% datapoint.
+    .filter((point): point is { label: string; proportion: number } => point.proportion !== null)
+    .map((point) => ({ label: point.label, value: point.proportion * 100 }));
 }
 
 export interface ReplaySummary {

--- a/apps/frontend/src/lib/confidence.ts
+++ b/apps/frontend/src/lib/confidence.ts
@@ -1,0 +1,102 @@
+// #1003 / #1055 PR4: make Axiom B's confidence loop visible to users.
+//
+// The backend already measures the loop — the North-Star low-confidence
+// proportion (EPIC-018 AC18.12) and the correction-loop replay (AC18.14) — but
+// those numbers live only in API responses. This module holds the pure, testable
+// glue the Confidence Trend view uses to turn the raw Decimal-string proportions
+// into something legible: a percentage, a direction, and the trend's framing
+// that "lower is better".
+
+import type {
+  ConfidenceMetricSnapshot,
+  ConfidenceNorthStarResponse,
+  CorrectionLoopReplayResponse,
+} from "@/lib/types";
+
+/**
+ * Format a Decimal proportion string (e.g. "0.12500") as a percentage label
+ * (e.g. "12.5%"). Proportions arrive as strings to preserve precision, so we
+ * parse with Number only at the display boundary. A non-finite or missing
+ * value renders as an em dash rather than "NaN%".
+ */
+export function formatProportionPercent(value: string | number, decimals = 1): string {
+  // `Number("")` and `Number("  ")` coerce to 0, which would render a misleading
+  // "0.0%" for a missing value — guard the empty/blank string explicitly.
+  if (typeof value === "string" && value.trim() === "") return "—";
+  const proportion = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(proportion)) return "—";
+  return `${(proportion * 100).toFixed(decimals)}%`;
+}
+
+export type TrendDirection = "down" | "up" | "flat";
+
+export interface TrendDelta {
+  /** Movement of the most recent point relative to the previous one. */
+  direction: TrendDirection;
+  /** Absolute change in proportion (newest minus previous), as a fraction. */
+  delta: number;
+}
+
+/**
+ * Compare the two newest points in a newest-first series. Lower proportion is
+ * better, so a "down" direction is the good news the view should celebrate.
+ * Fewer than two points means there is nothing to compare yet ("flat", 0).
+ */
+export function trendDelta(series: ConfidenceMetricSnapshot[]): TrendDelta {
+  if (series.length < 2) return { direction: "flat", delta: 0 };
+  const newest = Number(series[0]?.low_confidence_proportion ?? 0);
+  const previous = Number(series[1]?.low_confidence_proportion ?? 0);
+  const delta = newest - previous;
+  if (!Number.isFinite(delta) || delta === 0) return { direction: "flat", delta: 0 };
+  return { direction: delta < 0 ? "down" : "up", delta };
+}
+
+export interface SparklinePoint {
+  label: string;
+  /** Proportion as a percentage number (0–100) for charting. */
+  value: number;
+}
+
+/**
+ * Turn the newest-first series into oldest-first points for a left-to-right
+ * sparkline/trend, mapping each Decimal-string proportion to a 0–100 percentage.
+ */
+export function toSparklinePoints(
+  series: ConfidenceMetricSnapshot[],
+  labelFor: (snapshot: ConfidenceMetricSnapshot) => string,
+): SparklinePoint[] {
+  return [...series]
+    .reverse()
+    .map((snapshot) => ({
+      label: labelFor(snapshot),
+      value: Number(snapshot.low_confidence_proportion) * 100,
+    }))
+    .filter((point) => Number.isFinite(point.value));
+}
+
+export interface ReplaySummary {
+  reduced: boolean;
+  before: string;
+  after: string;
+  /** True once the corpus is large enough to have a held-out split to replay. */
+  hasHoldout: boolean;
+}
+
+/**
+ * Summarise the replay for display: whether the loop measurably reduced the
+ * proportion, and the before→after percentages. An empty held-out split means
+ * there isn't enough correction history to draw a conclusion yet.
+ */
+export function summarizeReplay(replay: CorrectionLoopReplayResponse): ReplaySummary {
+  return {
+    reduced: replay.reduced,
+    before: formatProportionPercent(replay.proportion_before),
+    after: formatProportionPercent(replay.proportion_after),
+    hasHoldout: replay.holdout_size > 0,
+  };
+}
+
+/** True when the North-Star has no recorded snapshots yet (empty trend). */
+export function hasNoSnapshots(data: ConfidenceNorthStarResponse): boolean {
+  return data.series.length === 0;
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1038,3 +1038,36 @@ export interface BrokerageImportResponse {
   reconcile_disposed: number;
   skipped: number;
 }
+
+// ── North-Star confidence metric (EPIC-018 AC18.12 / #1003, #1055 PR4) ─────
+//
+// The single measurable expression of Axiom B's loop: the share of posted
+// ledger facts that sit in the LOW confidence tier. Lower is better. Decimal
+// proportions arrive as strings (e.g. "0.12500") to preserve precision.
+
+export interface ConfidenceMetricPoint {
+  total_count: number;
+  low_confidence_count: number;
+  low_confidence_proportion: string;
+  tier_breakdown: Record<string, number>;
+}
+
+export interface ConfidenceMetricSnapshot extends ConfidenceMetricPoint {
+  id: string;
+  captured_at: string;
+}
+
+export interface ConfidenceNorthStarResponse {
+  current: ConfidenceMetricPoint;
+  /** Recorded trend, newest-first. */
+  series: ConfidenceMetricSnapshot[];
+}
+
+export interface CorrectionLoopReplayResponse {
+  holdout_size: number;
+  grounded: number;
+  proportion_before: string;
+  proportion_after: string;
+  /** Whether the correction loop measurably lowered the held-out proportion. */
+  reduced: boolean;
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1048,7 +1048,7 @@ export interface BrokerageImportResponse {
 export interface ConfidenceMetricPoint {
   total_count: number;
   low_confidence_count: number;
-  low_confidence_proportion: string;
+  low_confidence_proportion: DecimalValue;
   tier_breakdown: Record<string, number>;
 }
 
@@ -1066,8 +1066,8 @@ export interface ConfidenceNorthStarResponse {
 export interface CorrectionLoopReplayResponse {
   holdout_size: number;
   grounded: number;
-  proportion_before: string;
-  proportion_after: string;
+  proportion_before: DecimalValue;
+  proportion_after: DecimalValue;
   /** Whether the correction loop measurably lowered the held-out proportion. */
   reduced: boolean;
 }

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -90,6 +90,8 @@ explicit AC IDs for the behavior.
 | `apps/backend/tests/unit/utils/test_exceptions.py` | `docs/ssot/development.md` |
 | `apps/backend/tests/test_factories.py` | `apps/backend/tests/factories.py` |
 | `apps/frontend/src/__tests__/analytics.test.tsx` | Frontend analytics tracking (OpenPanel PV) — non-blocking infra, not product behavior |
+| `apps/frontend/src/__tests__/confidence.test.ts` | `docs/ssot/frontend-patterns.md` |
+| `apps/frontend/src/__tests__/confidenceTrendPage.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/__tests__/ConflictResolutionDialog.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/__tests__/ThemeToggle.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/__tests__/TransactionTable.test.tsx` | `docs/ssot/frontend-patterns.md` |


### PR DESCRIPTION
## What & why

Axiom B's confidence loop was measurable on the backend but **invisible in the UI**. This PR (part of #1055 PR4; advances #1003 (the UI surface)) adds a **Confidence Trend** view that makes the loop legible to everyday users.

It lives under **Advanced → Confidence Trend** (`/confidence`), following the existing IA (it's an analytical/internal surface, like the attention queue).

## What I built

A frontend-only "Confidence Trend" page that surfaces two **existing** read-only metrics endpoints:

1. **North-Star low-confidence proportion** (`GET /metrics/confidence-north-star`)
   - Current proportion shown prominently (large %), with the count context (`25 of 200 posted facts`).
   - **Lower is better** is made legible: a trend direction badge (down = green/good, up = red) comparing the two newest points.
   - The recorded series rendered as a trend line via the shared `TrendChart`.
2. **Correction-loop replay effect** (`GET /metrics/correction-loop/replay`)
   - A `Reduces low confidence` / `No measurable reduction` verdict from `reduced`.
   - Before → after percentages side by side.

## How it matches the design system

- All data fetching goes through the typed `lib/api.ts` client (new `fetchConfidenceNorthStar` / `fetchCorrectionLoopReplay` mirroring the existing `fetchWorkflow*` pattern) — **no raw `fetch()`**.
- Reuses existing primitives: `PageHeader`, `EmptyState`, `LoadingState`, `Badge`, `TrendChart`, Tailwind CSS-variable tokens (`--success`, `--error`, `--background-muted`, …).
- Mirrors the attention page's load/error/retry structure.
- Decimal proportions arrive as strings (e.g. `"0.12500"`); a pure, tested `lib/confidence.ts` formats them as percentages and derives the trend direction.

## States handled

- **Loading** — spinner via `LoadingState`.
- **Empty** — "No trend recorded yet" when the series is empty (still shows the current proportion); "Not enough correction history yet" when the replay has no held-out split.
- **Error** — retryable error card.

## Endpoints consumed (read-only, no backend changes)

- `GET /metrics/confidence-north-star`
- `GET /metrics/correction-loop/replay`

## Test plan

- `src/__tests__/confidence.test.ts` — unit tests for the pure helpers (percentage formatting incl. the em-dash for missing values, trend direction, sparkline mapping, replay summary).
- `src/__tests__/confidenceTrendPage.test.tsx` — render tests for the three key states (data + trend + replay verdict, empty-trend, retryable error).
- `src/__tests__/navigation.test.ts` — updated the advanced-nav expectation to include the new entry.

### Local results (in `apps/frontend`)
- `npm run lint` — ✅ no warnings or errors
- `npm run typecheck` — ✅ clean
- `npm run test` — ✅ 767 passed / 111 files
- `npm run build` — ✅ `/confidence` route compiled (5.68 kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)