### PR TITLE
[finance_report_vision] fix(extraction): self-consistency retry resilience + JSON-repair object pick (#996)

### DIFF
--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -704,19 +704,31 @@ class ExtractionService:
         base_seed = settings.ai_json_seed
         best: dict[str, Any] | None = None
         best_diff: Decimal | None = None
+        last_parse: dict[str, Any] | None = None
+        last_error: ExtractionError | None = None
 
         for attempt in range(max_attempts):
             # Attempt 0 uses the configured seed; retries vary it so each is a
             # distinct deterministic sample (None base => provider-side variance).
             seed_override = base_seed + attempt if base_seed is not None and attempt > 0 else None
-            extracted = await self.extract_financial_data(
-                file_content=file_content,
-                institution=institution,
-                file_type=file_type,
-                file_url=file_url,
-                force_model=force_model,
-                seed_override=seed_override,
-            )
+            try:
+                extracted = await self.extract_financial_data(
+                    file_content=file_content,
+                    institution=institution,
+                    file_type=file_type,
+                    file_url=file_url,
+                    force_model=force_model,
+                    seed_override=seed_override,
+                )
+            except ExtractionError as exc:
+                # A transient error on one attempt must not fail an upload that
+                # another attempt can satisfy. Skip it and keep trying remaining
+                # attempts (a later one may still reconcile); any earlier parse is
+                # retained as best/last_parse, and only the all-attempts-failed
+                # case re-raises below.
+                last_error = exc
+                continue
+            last_parse = extracted
 
             if looks_like_brokerage_payload(
                 extracted,
@@ -749,13 +761,21 @@ class ExtractionService:
                 if diff is not None and (best is None or diff < best_diff):
                     best, best_diff = extracted, diff
 
-        if max_attempts > 1:
-            logger.info(
-                "Balance did not reconcile after re-extract; keeping best parse",
-                attempts=max_attempts,
-                best_difference=str(best_diff),
-            )
-        return best if best is not None else extracted
+        if best is not None:
+            if max_attempts > 1:
+                logger.info(
+                    "Balance did not reconcile after re-extract; keeping best parse",
+                    attempts=max_attempts,
+                    best_difference=str(best_diff),
+                )
+            return best
+        if last_parse is not None:
+            # No balance-computable parse, but at least one attempt produced a
+            # (structurally-broken) result; return it so parse_document reports the
+            # failure exactly as the single-call path did.
+            return last_parse
+        # Every attempt raised — propagate so the upload fails as before.
+        raise last_error or ExtractionError("Extraction failed after all retries")
 
     @staticmethod
     def _repair_json_object(content: str) -> str | None:
@@ -763,43 +783,64 @@ class ExtractionService:
 
         Models occasionally wrap an otherwise-valid object in a markdown code
         fence or pad it with prose. Rather than rejecting the upload (#982),
-        extract the outermost balanced ``{...}`` object — tracking string
-        literals so braces inside values do not truncate it. Scanning from the
-        first ``{`` to its matching ``}`` naturally ignores any surrounding fence
-        (including single-line ``` ```json {...}``` ``` blocks) or prose. The
-        repair is deterministic and does not invent data; it returns ``None``
-        when no object can be recovered, leaving the original failure path intact.
+        scan every top-level balanced ``{...}`` object — tracking string literals
+        so braces inside values do not truncate one — and return the **largest**.
+        Returning the largest (rather than the first) avoids picking a small
+        inline *example* object that precedes the real, much larger extraction.
+        Any surrounding fence (including single-line ``` ```json {...}``` ``` blocks)
+        or prose is naturally ignored. The repair is deterministic and does not
+        invent data; it returns ``None`` when no balanced object can be recovered,
+        leaving the original failure path intact.
         """
         if not content:
             return None
 
         text = content.strip()
-        start = text.find("{")
-        if start == -1:
-            return None
-
-        depth = 0
-        in_string = False
-        escaped = False
-        for i in range(start, len(text)):
-            char = text[i]
-            if in_string:
-                if escaped:
-                    escaped = False
-                elif char == "\\":
-                    escaped = True
-                elif char == '"':
-                    in_string = False
+        objects: list[str] = []
+        i = 0
+        n = len(text)
+        while i < n:
+            if text[i] != "{":
+                i += 1
                 continue
-            if char == '"':
-                in_string = True
-            elif char == "{":
-                depth += 1
-            elif char == "}":
-                depth -= 1
-                if depth == 0:
-                    return text[start : i + 1]
-        return None
+            # Scan one balanced top-level object starting at i.
+            depth = 0
+            in_string = False
+            escaped = False
+            end = None
+            for j in range(i, n):
+                char = text[j]
+                if in_string:
+                    if escaped:
+                        escaped = False
+                    elif char == "\\":
+                        escaped = True
+                    elif char == '"':
+                        in_string = False
+                    continue
+                if char == '"':
+                    in_string = True
+                elif char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        end = j
+                        break
+            if end is None:
+                # This ``{`` never balances (leading junk like ``note: {oops`` or a
+                # truncated tail). Skip just this brace and keep scanning, so a
+                # complete object appearing later is still recovered. A salvaged
+                # fragment that is not a real statement is caught downstream by
+                # completeness/period validation.
+                i += 1
+                continue
+            objects.append(text[i : end + 1])
+            i = end + 1
+
+        if not objects:
+            return None
+        return max(objects, key=len)
 
     async def _extract_json_with_models(
         self,

--- a/apps/backend/tests/extraction/test_json_repair.py
+++ b/apps/backend/tests/extraction/test_json_repair.py
@@ -70,6 +70,37 @@ class TestRepairJsonObject:
         assert repaired is not None
         assert json.loads(repaired) == {"path": "C:\\Users\\x", "quote": 'she said "hi"', "ok": True}
 
+    def test_prefers_largest_object_when_example_precedes_real(self):
+        """AC13.14.7: when a small example object precedes the real (larger)
+        extraction, the real one is recovered — not the leading example."""
+        content = (
+            'Here is the format I will use: {"institution": "Example", "transactions": []}\n'
+            "Now the actual data:\n"
+            '{"institution": "DBS", "opening_balance": "1000.00", "closing_balance": "1100.00", '
+            '"transactions": [{"amount": "100.00", "direction": "IN"}]}'
+        )
+        repaired = ExtractionService._repair_json_object(content)
+        assert repaired is not None
+        obj = json.loads(repaired)
+        assert obj["institution"] == "DBS"
+        assert obj["transactions"] == [{"amount": "100.00", "direction": "IN"}]
+
+    def test_complete_object_then_trailing_unbalanced_brace(self):
+        """AC13.14.8: a complete object followed by trailing junk that opens an
+        unbalanced brace still recovers the complete object."""
+        content = '{"institution": "DBS", "transactions": []}\nnote: {oops'
+        repaired = ExtractionService._repair_json_object(content)
+        assert repaired is not None
+        assert json.loads(repaired) == {"institution": "DBS", "transactions": []}
+
+    def test_leading_unbalanced_brace_then_real_object(self):
+        """AC13.14.9: a leading unmatched brace (junk) before the real object does
+        not stop the scan — the real object is still recovered."""
+        content = 'note: {oops\n{"institution": "DBS", "transactions": []}'
+        repaired = ExtractionService._repair_json_object(content)
+        assert repaired is not None
+        assert json.loads(repaired) == {"institution": "DBS", "transactions": []}
+
 
 class TestExtractionSalvagesFencedResponse:
     async def test_fenced_response_is_salvaged(self):

--- a/apps/backend/tests/extraction/test_self_consistency.py
+++ b/apps/backend/tests/extraction/test_self_consistency.py
@@ -10,8 +10,10 @@ best-by-difference result is kept so routing is unchanged.
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from src.config import settings
-from src.services.extraction import ExtractionService
+from src.services.extraction import ExtractionError, ExtractionService
 
 
 def _bank(diff: str = "0"):
@@ -139,3 +141,43 @@ async def test_all_invalid_returns_last_parse():
     last = _structurally_invalid()
     result, _ = await _run(service, [_structurally_invalid(), last], max_attempts=2)
     assert result is last
+
+
+async def test_transient_retry_error_keeps_earlier_usable_parse():
+    """AC13.17.9: a transient extraction error on a *retry* attempt must not fail an
+    upload that an earlier attempt already produced a routable (balance-failing)
+    parse for — the earlier parse is kept (regression guard vs single-call behavior)."""
+    service = ExtractionService()
+    usable = _bank("5.00")  # balance-failing but routable to `uploaded`
+    result, mock = await _run(service, [usable, ExtractionError("429 rate limited")], max_attempts=2)
+    assert result is usable
+    assert mock.await_count == 2
+
+
+async def test_all_attempts_error_reraises():
+    """AC13.17.10: if every attempt raises (no usable parse ever produced), the error
+    propagates so the upload fails exactly as the old single-call path did."""
+    service = ExtractionService()
+    with pytest.raises(ExtractionError):
+        await _run(service, [ExtractionError("boom"), ExtractionError("boom2")], max_attempts=2)
+
+
+async def test_first_attempt_error_then_success_recovers():
+    """AC13.17.11: a transient error on the FIRST attempt does not abort; a later
+    attempt that reconciles is returned (more resilient than the old single call)."""
+    service = ExtractionService()
+    good = _bank("0")
+    result, mock = await _run(service, [ExtractionError("timeout"), good], max_attempts=2)
+    assert result is good
+    assert mock.await_count == 2
+
+
+async def test_error_mid_run_does_not_skip_remaining_attempts():
+    """AC13.17.12: an error after an earlier usable parse keeps trying the remaining
+    attempts; a later reconciling parse still wins (the retry count stays effective)."""
+    service = ExtractionService()
+    reconciled = _bank("0")
+    # attempt0: balance-failing (usable), attempt1: transient error, attempt2: reconciles
+    result, mock = await _run(service, [_bank("8.00"), ExtractionError("429"), reconciled], max_attempts=3)
+    assert result is reconciled
+    assert mock.await_count == 3

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -220,6 +220,9 @@ Expected routing behavior remains threshold-based (See: `docs/ssot/reconciliatio
 | AC13.14.4 | Content with no recoverable JSON object returns None; braces inside strings do not truncate | `test_unrecoverable_returns_none()`, `test_does_not_misread_braces_in_strings()` | `extraction/test_json_repair.py` | P1 |
 | AC13.14.5 | The extraction loop salvages a fenced response instead of rejecting the upload | `test_fenced_response_is_salvaged()`, `test_extract_financial_data_markdown_json()`, `test_extract_financial_data_json_markdown_fallback()` | `extraction/test_json_repair.py`, `extraction/test_extraction_flow.py`, `extraction/test_extraction_error_paths.py` | P1 |
 | AC13.14.6 | A response with no recoverable JSON still fails through the model-chain path | `test_unrecoverable_response_still_fails()` | `extraction/test_json_repair.py` | P1 |
+| AC13.14.7 | When a small example object precedes the real (larger) extraction, the largest object is recovered (not the example) | `test_prefers_largest_object_when_example_precedes_real()` | `extraction/test_json_repair.py` | P1 |
+| AC13.14.8 | A complete object followed by trailing unbalanced-brace junk still recovers the complete object | `test_complete_object_then_trailing_unbalanced_brace()` | `extraction/test_json_repair.py` | P1 |
+| AC13.14.9 | A leading unmatched brace (junk) before the real object does not stop the scan — the real object is recovered | `test_leading_unbalanced_brace_then_real_object()` | `extraction/test_json_repair.py` | P1 |
 
 ### AC13.10: Source Type Priority & Conflict Resolution
 
@@ -334,3 +337,7 @@ kept so routing is unchanged. Only failing parses retry, so average cost is boun
 | AC13.17.6 | `AI_EXTRACT_MAX_ATTEMPTS=1` keeps single-shot behavior | `test_max_attempts_one_disables_retry()` | `extraction/test_self_consistency.py` | P1 |
 | AC13.17.7 | A structurally-invalid parse (balance uncomputable, difference 0) does not win "best" over a numerically-close parse | `test_structurally_invalid_parse_does_not_win_as_best()` | `extraction/test_self_consistency.py` | P1 |
 | AC13.17.8 | If every attempt is structurally invalid, the last parse is returned so `parse_document` reports the failure | `test_all_invalid_returns_last_parse()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.17.9 | A transient extraction error on a retry attempt keeps the earlier usable parse (no upload regression) | `test_transient_retry_error_keeps_earlier_usable_parse()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.17.10 | If every attempt raises, the error propagates so the upload fails as in the single-call path | `test_all_attempts_error_reraises()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.17.11 | A transient error on the first attempt does not abort; a later reconciling attempt is returned | `test_first_attempt_error_then_success_recovers()` | `extraction/test_self_consistency.py` | P1 |
+| AC13.17.12 | An error after an earlier usable parse keeps trying remaining attempts; a later reconciling parse still wins | `test_error_mid_run_does_not_skip_remaining_attempts()` | `extraction/test_self_consistency.py` | P1 |


### PR DESCRIPTION
## Summary
Follow-up to the **#996** vision lane, from an end-to-end review of the six merged PRs (#1015, #1018, #1019, #1036, #1041, #1052). The review found **two real correctness bugs** (validation/config/seed code reviewed clean). Both are in `extraction.py`.

### Bug 1 (HIGH) — retry error fails an otherwise-routable upload (#989 Step B)
`_extract_with_balance_retry` had **no error handling** around the per-attempt `extract_financial_data` call. So if a *retry* attempt hit a transient error (429 / empty response / timeout), the **whole upload failed** — even though an earlier attempt had already produced a usable (balance-failing) parse that would have routed to `uploaded`. That's a regression vs. the old single-call path.

**Fix:** each attempt is wrapped; an earlier usable parse is kept, a first-attempt error no longer aborts a recoverable retry, and only the *all-attempts-failed* case re-raises (preserving the old failure semantics).

### Bug 2 (MED) — JSON-repair could accept the wrong object (#982)
`_repair_json_object` returned the **first** balanced `{...}`. If a model emitted a small inline *example* object before the real extraction, the example was silently accepted (wrong institution, zero transactions) — a data-integrity risk for a financial tool.

**Fix:** scan **every** top-level object and return the **largest** (the real statement JSON dwarfs an inline example). This also recovers a complete object followed by trailing unbalanced-brace junk.

## Tests
- `AC13.17.9-11` — retry keeps earlier usable parse; all-attempts-error re-raises; first-attempt error then success recovers.
- `AC13.14.7-8` — largest object preferred when an example precedes the real one; complete-object-then-trailing-junk recovered.
- Full extraction + ai suite: 631 passed (the 1 local failure is the pre-existing env-driven `test_fallback_models_format`, green under CI's `glm-*` env). AC-traceability gate passes.

## Review result
No unresolved CR comments on any of the six merged PRs; `validation.py` (under-extraction cap, `balance_computable`), `config.py` (seed/attempts settings), and seed threading all reviewed **clean**. These two were the only bugs found.

Relates to #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)