### PR TITLE
[finance_report_vision] fix(extraction): default AI_JSON_SEED off — glm-4.6v rejects seed (#989)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,8 @@ AI_EXTRACT_MAX_ATTEMPTS=2
 AI_JSON_DISABLE_THINKING=true
 # Max tokens for AI JSON completion calls.
 AI_JSON_MAX_TOKENS=8192
-# Fixed decoding seed for reproducible AI extraction (empty to omit).
-AI_JSON_SEED=42
+# Fixed decoding seed for reproducible extraction; off by default (only set for seed-supporting models).
+AI_JSON_SEED=
 # Timeout (seconds) for AI JSON completion calls.
 AI_JSON_TIMEOUT_SECONDS=360
 # Layout-parsing path appended to the AI base URL.

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -396,18 +396,25 @@ class Settings(BaseSettings):
     # provider decode reproducibly so the same statement does not sometimes
     # reconcile and sometimes not. Set AI_JSON_SEED= (empty) to omit it for
     # providers that reject the field.
+    # Off by default: Z.AI/GLM validates request params strictly and `seed` is
+    # NOT accepted by all models (e.g. glm-4.6v, the default vision/OCR model,
+    # returns HTTP 400 for it) — sending it unconditionally would break vision
+    # extraction. Opt in only for seed-supporting models (e.g. GLM-5.1).
+    # Determinism otherwise rests on temperature=0 / do_sample=false plus the
+    # balance-aware self-consistency retry (#989).
     ai_json_seed: int | None = Field(
-        default=42,
+        default=None,
         validation_alias="AI_JSON_SEED",
-        description="Fixed decoding seed for reproducible AI extraction (empty to omit).",
+        description="Fixed decoding seed for reproducible extraction; off by default (only set for seed-supporting models).",
         json_schema_extra={"group": "AI Provider"},
     )
 
     # Balance-aware self-consistency (#989 Step B): when a bank statement's
     # running-balance chain fails to reconcile, re-extract up to this many times
-    # (each attempt with a varied seed) and keep the first reconciling result
-    # before routing to `uploaded`. 1 disables retry (single-shot). Only failing
-    # parses retry, so the average cost increase is bounded.
+    # and keep the first reconciling result before routing to `uploaded`. When a
+    # seed is configured (off by default) each attempt varies it; otherwise
+    # retries rely on provider-side variance. 1 disables retry (single-shot).
+    # Only failing parses retry, so the average cost increase is bounded.
     ai_extract_max_attempts: int = Field(
         default=2,
         ge=1,

--- a/apps/backend/tests/extraction/test_seed_determinism.py
+++ b/apps/backend/tests/extraction/test_seed_determinism.py
@@ -74,3 +74,14 @@ def test_empty_seed_env_is_treated_as_none():
     assert Settings(AI_JSON_SEED="").ai_json_seed is None
     assert Settings(AI_JSON_SEED="   ").ai_json_seed is None
     assert Settings(AI_JSON_SEED="7").ai_json_seed == 7
+
+
+def test_seed_is_off_by_default(monkeypatch):
+    """AC13.16.5: the seed is off (None) by default, so it is never sent to
+    providers that reject unknown params (e.g. glm-4.6v returns HTTP 400) unless
+    explicitly opted in for a seed-supporting model (#989)."""
+    from src.config import Settings
+
+    # Ignore any AI_JSON_SEED in the developer's real environment / .env.
+    monkeypatch.delenv("AI_JSON_SEED", raising=False)
+    assert Settings(_env_file=None).ai_json_seed is None

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -305,8 +305,10 @@ this gate.
 
 Complements AC13.13 (downstream determinism). AC13.13 pins everything *after* the
 model response; this AC pins the *request* so the model itself decodes
-reproducibly: temperature 0 / `do_sample` false plus a fixed `seed`
-(`AI_JSON_SEED`, default 42) forwarded to the provider.
+reproducibly: temperature 0 / `do_sample` false, plus an optional fixed `seed`
+(`AI_JSON_SEED`) forwarded to the provider. The seed is **off by default**
+because Z.AI/GLM validates params strictly and some models (e.g. the default
+`glm-4.6v`) reject `seed` with HTTP 400; it is opt-in for seed-supporting models.
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
@@ -314,6 +316,7 @@ reproducibly: temperature 0 / `do_sample` false plus a fixed `seed`
 | AC13.16.2 | Extraction forwards the configured `ai_json_seed` to the model call | `test_extraction_forwards_configured_seed()` | `extraction/test_seed_determinism.py` | P1 |
 | AC13.16.3 | Extraction pins `temperature=0` / `do_sample=False` alongside the seed | `test_extraction_decoding_is_deterministic_by_default()` | `extraction/test_seed_determinism.py` | P1 |
 | AC13.16.4 | Empty `AI_JSON_SEED` parses as None (omitted) instead of raising | `test_empty_seed_env_is_treated_as_none()` | `extraction/test_seed_determinism.py` | P1 |
+| AC13.16.5 | The seed is off (None) by default so it is never sent to providers that reject it (e.g. glm-4.6v) | `test_seed_is_off_by_default()` | `extraction/test_seed_determinism.py` | P1 |
 
 ### AC13.17: Balance-Aware Self-Consistency Re-extract (issue #989 Step B)
 

--- a/docs/ssot/env-reference.generated.md
+++ b/docs/ssot/env-reference.generated.md
@@ -27,7 +27,7 @@ Where a field's `.env.example` value intentionally differs from its code default
 | `AI_EXTRACT_MAX_ATTEMPTS` | `2` |  |  | AI Provider | Max balance-aware re-extract attempts for bank statements (1 disables retry). |
 | `AI_JSON_DISABLE_THINKING` | `true` |  |  | AI Provider | Disable provider 'thinking' mode for AI JSON completion calls. |
 | `AI_JSON_MAX_TOKENS` | `8192` |  |  | AI Provider | Max tokens for AI JSON completion calls. |
-| `AI_JSON_SEED` | `42` |  |  | AI Provider | Fixed decoding seed for reproducible AI extraction (empty to omit). |
+| `AI_JSON_SEED` |  |  |  | AI Provider | Fixed decoding seed for reproducible extraction; off by default (only set for seed-supporting models). |
 | `AI_JSON_TIMEOUT_SECONDS` | `360` |  |  | AI Provider | Timeout (seconds) for AI JSON completion calls. |
 | `AI_LAYOUT_PARSING_PATH` | `/layout_parsing` |  |  | AI Provider | Layout-parsing path appended to the AI base URL. |
 | `AI_MODEL_CATALOG_SOURCE` | `configured` |  |  | AI Provider | Source of the AI model catalog. |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -239,7 +239,9 @@ VISION_FALLBACK_MODELS=glm-4.5v
 AI_JSON_TIMEOUT_SECONDS=360
 AI_JSON_MAX_TOKENS=8192
 AI_JSON_DISABLE_THINKING=true
-AI_JSON_SEED=42
+# Optional; off by default. Only set for seed-supporting models (e.g. GLM-5.1) —
+# glm-4.6v rejects `seed` with HTTP 400.
+AI_JSON_SEED=
 AI_DAILY_LIMIT_USD=2
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minio
@@ -254,11 +256,13 @@ S3_PRESIGN_EXPIRY_SECONDS=300
 ## Parsing Resilience
 
 - **Deterministic decoding**: JSON extraction pins `temperature=0` and
-  `do_sample=false`, and forwards a fixed request `seed` (`AI_JSON_SEED`,
-  default `42`) so the same statement decodes reproducibly. This keeps
+  `do_sample=false` so the same statement decodes reproducibly, keeping
   `balance_validated`, `confidence_score`, and Stage-1 routing from flipping
-  between uploads of the same source (#989). Set `AI_JSON_SEED=` (empty) to omit
-  the seed for providers that reject it.
+  between uploads of the same source (#989). An optional fixed request `seed`
+  (`AI_JSON_SEED`) can further pin decoding, but it is **off by default**: Z.AI/GLM
+  validates request params strictly and `seed` is rejected by some models
+  (notably `glm-4.6v`, the default vision/OCR model, returns HTTP 400), so it is
+  only safe to set for seed-supporting models such as GLM-5.1.
 - **Balance-aware self-consistency re-extract**: when a bank statement's
   running-balance chain fails to reconcile, `_extract_with_balance_retry`
   re-extracts up to `AI_EXTRACT_MAX_ATTEMPTS` times (each with a varied seed —


### PR DESCRIPTION
## Summary
Follow-up to the **#996** vision lane. Research of the **Z.AI/GLM API** surfaced a likely production-breaking default introduced by #1019.

### The problem
- Z.AI's official chat-completions API does **not** list `seed` as a parameter, **validates params strictly**, and returns **HTTP 400** (error `1210`/`1214`) on unsupported params — it does **not** silently ignore them. (Z.AI error-code docs + multiple GitHub reports.)
- `seed` is supported on **GLM-5.1** but **not on GLM-4.6**.
- This repo's default `VISION_MODEL` and `OCR_MODEL` are both `glm-4.6v`; since they're equal, the shared vision path sends the extraction request to `glm-4.6v` **with `seed=42`** (the previous default). That would **400 and break vision extraction on a default deployment** — and the self-consistency retry can't help because every attempt sends the seed.

### The fix
Make `AI_JSON_SEED` **off by default** (`None`). It stays **opt-in** for seed-supporting models (e.g. GLM-5.1). Determinism still rests on `temperature=0` / `do_sample=false` + the balance-aware self-consistency retry (#989 Step B), which is the actual reproducibility mechanism.

- `config.py`: default `None` with an explanatory comment.
- SSOT `extraction.md` + `EPIC-013` AC13.16: document the model-dependency and 400 risk.
- `.env.example` / env-reference regenerated (`AI_JSON_SEED=` empty).

## Tests
- `AC13.16.5` `test_seed_is_off_by_default()` — default `Settings().ai_json_seed is None`.
- Existing seed tests (forwarded-when-set, empty→None, payload omission) still pass (24).

## Sources
- Z.AI Chat Completion API reference (param list has no `seed`); Z.AI error-code docs (1210/1214 on bad params); AIMLAPI GLM-5.1 (seed supported) vs GLM-4.6 (not).

Relates to #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)