### PR TITLE
[finance_report_infra] feat(preflight): add frontend, env-reference & tooling gates

### DIFF
--- a/.opencode/skills/domain/preflight/SKILL.md
+++ b/.opencode/skills/domain/preflight/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: preflight
-description: Run the project's gate checks that are relevant to the current diff BEFORE committing or pushing. Use this whenever you have edited files and are about to commit/push, or after editing EPIC/AC docs, SSOT docs, Pydantic schemas, Alembic migrations, .env files, backend services, or tooling — so CI-style failures surface locally instead of after a push.
+description: Run the project's gate checks that are relevant to the current diff BEFORE committing or pushing. Use this whenever you have edited files and are about to commit/push, or after editing EPIC/AC docs, SSOT docs, Pydantic schemas, Alembic migrations, .env files, backend services, the frontend, config.py, or tooling — so CI-style failures surface locally instead of after a push.
 ---
 
 # Preflight — diff-aware local gates
 
 This repo enforces strict gates in CI/pre-commit (EPIC→AC→test traceability, SSOT
 ownership, doc-nav consistency, schema contracts, migration risk, env-key
-consistency, ruff, the transaction-boundary meta-test). Forgetting which one a
-change needs is how failures slip through to CI. Preflight maps your **changed
-files** to the relevant gates and runs only those.
+consistency, ruff, the transaction-boundary meta-test, the env-reference drift
+check, the tooling contract tests, and the frontend lint/coverage/build gates).
+Forgetting which one a change needs is how failures slip through to CI. Preflight
+maps your **changed files** to the relevant gates and runs only those.
 
 ## Use it before every commit/push
 
@@ -33,7 +34,10 @@ Exit code is non-zero if any gate fails; the summary names which one.
 | `apps/backend/migrations/*` | `check_migration_risk.py` |
 | `.env*` | `check_env_keys.py` |
 | `apps/backend/*.py` | `ruff check` + `ruff format --check` |
+| `apps/backend/src/config.py` | `generate_env_reference.py --check` (.env.example / env-reference drift) |
 | `apps/backend/src/services/*.py` | `test_transaction_boundaries.py` |
+| `tools/*`, `common/*` | `pytest tests/tooling/` (tool-wrapper sys.path contract + dispatchers) |
+| `apps/frontend/*` | `npm run lint` + `npm run test:coverage` + `npm run build` |
 
 It includes **untracked** files, so new files are checked before they are
 committed. The mapping lives in `common/ssot/preflight.py` (`CHECKS`); add a new

--- a/common/ssot/preflight.py
+++ b/common/ssot/preflight.py
@@ -126,6 +126,29 @@ CHECKS: tuple[Check, ...] = (
         why="service changed: re-run the commit/transaction-boundary meta-test",
         cwd="apps/backend",
     ),
+    Check(
+        name="env-reference",
+        globs=("apps/backend/src/config.py",),
+        commands=((PY, "tools/generate_env_reference.py", "--check"),),
+        why="config.py changed: regenerate .env.example + env reference and assert no drift",
+    ),
+    Check(
+        name="tooling",
+        globs=("tools/*", "common/*"),
+        commands=((PY, "-m", "pytest", "tests/tooling/", "-q", "--no-cov"),),
+        why="tooling/common changed: run tests/tooling (tool-wrapper sys.path contract + dispatchers)",
+    ),
+    Check(
+        name="frontend",
+        globs=("apps/frontend/*",),
+        commands=(
+            ("npm", "run", "lint"),
+            ("npm", "run", "test:coverage"),
+            ("npm", "run", "build"),
+        ),
+        why="frontend changed: eslint + vitest coverage gate + next build (layout/route type rules)",
+        cwd="apps/frontend",
+    ),
 )
 
 

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -53,8 +53,28 @@ class TestSelectChecks:
         ]
         assert "schema-validate" in names
 
+    def test_frontend_edit_selects_frontend_gate(self):
+        names = [
+            c.name
+            for c in preflight.select_checks(["apps/frontend/src/app/layout.tsx"])
+        ]
+        assert names == ["frontend"]
+
+    def test_config_edit_selects_env_reference_and_backend_format(self):
+        names = [
+            c.name for c in preflight.select_checks(["apps/backend/src/config.py"])
+        ]
+        assert "env-reference" in names
+        assert "backend-format" in names
+
+    def test_tooling_edit_selects_tooling_gate(self):
+        names = [
+            c.name for c in preflight.select_checks(["tools/generate_env_reference.py"])
+        ]
+        assert "tooling" in names
+
     def test_unrelated_file_selects_nothing(self):
-        assert preflight.select_checks(["apps/frontend/src/app/page.tsx"]) == []
+        assert preflight.select_checks(["Makefile"]) == []
 
     def test_no_changes_selects_nothing(self):
         assert preflight.select_checks([]) == []
@@ -125,9 +145,7 @@ class TestRunAndMain:
         assert rc == 0
 
     def test_main_no_relevant_gates_is_clean(self):
-        rc = preflight.main(
-            ["--changed", "apps/frontend/src/app/page.tsx"], runner=lambda argv, cwd: 1
-        )
+        rc = preflight.main(["--changed", "Makefile"], runner=lambda argv, cwd: 1)
         assert rc == 0
 
     def test_main_list_does_not_run_anything(self):


### PR DESCRIPTION
## Why
This epic hit several CI failures that the local `preflight` dispatcher didn't cover, so they only surfaced after a push (multiple round-trips). Fixing the **enforcement mechanism** (not docs) so the same failures surface locally.

## What — three gates added to `common/ssot/preflight.py`
| Touched | Now runs | Caught what bit us |
|---|---|---|
| `apps/frontend/*` | `npm run lint` + `test:coverage` + `build` | vitest **98% coverage threshold**; Next's **layout/route export type rule** (only fails in `next build`) |
| `apps/backend/src/config.py` | `generate_env_reference.py --check` | `.env.example` / env-reference **drift** |
| `tools/*`, `common/*` | `pytest tests/tooling/` | tool-wrapper **sys.path contract (AC8.13.56)** + dispatcher regressions |

Also updated the **`preflight` skill** (trigger list + mapping table).

## Verified
- `tests/tooling/test_preflight.py` → **22 passed** (added select-checks cases for each new gate; fixed the two tests that used a frontend file as the "unrelated" example).
- `preflight --list` shows the new gates fire for the right diffs; dogfooded on this PR's own diff (selects `tooling`).
- ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)