### PR TITLE
[finance_report_ui] feat(preflight): api-reference + router-contract gates (local==CI parity)

### DIFF
--- a/common/ssot/preflight.py
+++ b/common/ssot/preflight.py
@@ -89,6 +89,32 @@ CHECKS: tuple[Check, ...] = (
         why="Pydantic schema changed: validate schema contracts",
     ),
     Check(
+        name="api-reference",
+        globs=(
+            "apps/backend/src/routers/*.py",
+            "apps/backend/src/schemas/*.py",
+            "apps/backend/src/main.py",
+        ),
+        commands=((PY, "../../tools/generate_api_reference.py", "--check"),),
+        why="router/schema changed: the generated OpenAPI reference (docs/reference/api.md) must be regenerated — mirrors the CI 'Generated API Reference Check' Lint gate",
+        cwd="apps/backend",
+    ),
+    Check(
+        name="router-contract",
+        globs=("apps/backend/src/routers/*.py",),
+        commands=(
+            (
+                PY,
+                "-m",
+                "pytest",
+                "tests/tooling/test_audit_router_contracts.py::test_findings_doc_is_in_sync",
+                "-q",
+                "--no-cov",
+            ),
+        ),
+        why="router changed: docs/reference/router-contract-maturity.md must be regenerated (tools/audit_router_contracts.py --output ...) — mirrors the CI Tooling/Common Coverage gate",
+    ),
+    Check(
         name="migration-risk",
         globs=("apps/backend/migrations/*",),
         commands=((PY, "tools/check_migration_risk.py"),),

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -126,7 +126,7 @@ file.
 | Ordinary backend source | `moon run :test -- --smart` or `moon run :test -- --fast tests/...` for a focused backend path | Escalate when the change crosses service boundaries or touches shared helpers |
 | accounting, posting, reconciliation, money, balance | Focused domain pytest suite plus changed-file tests | Always include invariant tests beyond the touched file |
 | schema, migrations | `cd apps/backend && uv run alembic upgrade head && uv run alembic check`, plus focused DB-backed tests | Required for any Alembic, SQLAlchemy model, enum, or persistence contract change |
-| API contract, OpenAPI | Backend API tests plus affected frontend API consumer tests | Required for route, schema, generated API reference, or response-shape changes |
+| API contract, OpenAPI | Backend API tests plus affected frontend API consumer tests; `tools/preflight.py` runs the `api-reference` and `router-contract` gates so `docs/reference/api.md` and `docs/reference/router-contract-maturity.md` are verified locally, matching the CI Lint and Tooling gates | Required for route, schema, generated API reference, or response-shape changes |
 | Frontend component or route | Focused Vitest/spec, then affected Playwright when browser behavior changes | Escalate for navigation, responsive layout, workflow, or API-bound behavior |
 | shared common/tooling | Focused tooling tests plus affected downstream contracts | Escalate when a common package feeds CI, coverage, SSOT, or command wrappers |
 | Docker, workflow, environment, deploy | Static/tooling contract checks locally; PR CI and deployed gates own runtime proof | Required image/deploy proof stays in PR CI, PR Preview, staging, or production |

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -53,6 +53,27 @@ class TestSelectChecks:
         ]
         assert "schema-validate" in names
 
+    def test_router_edit_selects_api_reference_and_router_contract(self):
+        # A router change shifts the OpenAPI surface AND the router-contract
+        # maturity scan; both generated docs are CI-gated, so preflight must
+        # flag them locally (parity with CI's api-reference + Tooling gates).
+        names = [
+            c.name
+            for c in preflight.select_checks(["apps/backend/src/routers/income.py"])
+        ]
+        assert "api-reference" in names
+        assert "router-contract" in names
+
+    def test_schema_edit_selects_api_reference(self):
+        # Schema changes also move the OpenAPI reference (but not the
+        # router-contract scan, which only reads routers/).
+        names = [
+            c.name
+            for c in preflight.select_checks(["apps/backend/src/schemas/income.py"])
+        ]
+        assert "api-reference" in names
+        assert "router-contract" not in names
+
     def test_frontend_edit_selects_frontend_gate(self):
         names = [
             c.name


### PR DESCRIPTION
## Why

The `preflight` dispatcher (`common/ssot/preflight.py`) mirrors a subset of CI gates so failures surface locally before a push. But it was missing the **two generated-doc gates CI enforces**, so a router/schema change passed preflight locally and then failed CI on a stale doc. Both bit real PRs this week:

- **`docs/reference/api.md`** stale → CI "Generated API Reference Check" (Lint job) failed on #1062 and #1069.
- **`docs/reference/router-contract-maturity.md`** stale → CI Tooling/Common Coverage `test_findings_doc_is_in_sync` failed on #1069.

Closing the gap means `preflight` == CI for these gates.

## What

Two new gates in the dispatcher:

| Gate | Triggers on | Runs | Mirrors CI |
|---|---|---|---|
| `api-reference` | `routers/*.py`, `schemas/*.py`, `main.py` | `generate_api_reference.py --check` | Lint → Generated API Reference Check |
| `router-contract` | `routers/*.py` | `test_audit_router_contracts.py::test_findings_doc_is_in_sync` | Tooling/Common Coverage |

## Tests / docs

- 2 selection tests added to `tests/tooling/test_preflight.py` (router edit → both gates; schema edit → api-reference only). Full preflight suite: **24 passed**.
- No AC registration: `test_preflight.py` is in `docs/analysis/traceability-exceptions.md` (mapped to `docs/ssot/ci-cd.md`), which is updated here.

## Verification

- `pytest tests/tooling/test_preflight.py` → 24 passed
- `ruff check` → clean
- Both gate commands confirmed exit-0 on clean `main` and fire on a router edit (`['api-reference', 'router-contract', 'backend-format']`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)