### PR TITLE
[finance_report_audit] chore(#896): retire dead statement_id compat param (audit close-out, #1077)

### DIFF
--- a/apps/backend/src/routers/reconciliation.py
+++ b/apps/backend/src/routers/reconciliation.py
@@ -190,7 +190,6 @@ async def run_reconciliation(
     try:
         matches = await execute_matching(
             db,
-            statement_id=payload.statement_id,
             limit=payload.limit,
             user_id=user_id,
         )

--- a/apps/backend/src/services/reconciliation.py
+++ b/apps/backend/src/services/reconciliation.py
@@ -984,14 +984,12 @@ async def execute_matching(
     db: AsyncSession,
     *,
     user_id: UUID,
-    statement_id: UUID | str | None = None,
     limit: int | None = None,
 ) -> list[ReconciliationMatch]:
     """Execute reconciliation matching for pending transactions."""
     config = load_reconciliation_config()
 
-    # Read pending transactions from Layer 2 (atomic_transactions). ``statement_id``
-    # has no meaning on the atomic stream and is accepted only for caller compatibility.
+    # Read pending transactions from Layer 2 (atomic_transactions).
     transactions = await _get_pending_layer2_transactions(db, user_id, limit)
 
     if not transactions:
@@ -1360,7 +1358,6 @@ async def execute_matching(
         logger.error(
             "Reconciliation flush failed",
             user_id=str(user_id),
-            statement_id=str(statement_id) if statement_id else None,
             matches_attempted=len(matches),
             error=str(e),
             error_type=type(e).__name__,

--- a/tests/tooling/test_reconciliation_thresholds_unit.py
+++ b/tests/tooling/test_reconciliation_thresholds_unit.py
@@ -202,9 +202,7 @@ async def test_execute_matching_score_thresholds(
             new=AsyncMock(return_value=None),
         ),
     ):
-        matches = await execute_matching(
-            db, user_id=uuid4(), statement_id=txn.statement_id
-        )
+        matches = await execute_matching(db, user_id=uuid4())
 
     assert len(matches) == expected_match_count
     # bank-txn.status is no longer mutated under the Layer-2 read path (Stage 3 removes it)
@@ -263,9 +261,7 @@ async def test_execute_matching_rerun_is_idempotent_for_same_match() -> None:
             new=AsyncMock(return_value=existing_match),
         ),
     ):
-        matches = await execute_matching(
-            db, user_id=uuid4(), statement_id=txn.statement_id
-        )
+        matches = await execute_matching(db, user_id=uuid4())
 
     assert matches == []
     assert existing_match.status == ReconciliationStatus.AUTO_ACCEPTED


### PR DESCRIPTION
## What

Removes the dead `statement_id` compatibility parameter from
`execute_matching()`. It had no meaning on the Layer-2 atomic stream — the
docstring said it was "accepted only for caller compatibility" — and was never
used to filter anything.

Changes:
- `services/reconciliation.py` — drop the param from the signature and the
  `Reconciliation flush failed` structured-log field; tidy the now-stale comment.
- `routers/reconciliation.py` — stop forwarding `payload.statement_id` (the
  request schema field is kept; this is not an API-contract change).
- `tests/tooling/test_reconciliation_thresholds_unit.py` — drop the `statement_id=`
  kwarg from the two `execute_matching` calls.

## Why

Part of **#1077** (audit close-out & governance sunset) — the safe-now subset of
**#896**. Verified there are no other callers passing `statement_id`; the
unit test named `test_execute_matching_with_statement_id_filter` already calls
without it and documents that the stream scans all pending transactions.

### Explicitly deferred (still tracked in #896)
The other #896 items are **not** safe to delete now and stay out of this PR:
- **Frontend localStorage token** (`auth.ts`) — load-bearing: read by `lib/api.ts`
  and asserted by **AC16.10.14** (`Bearer` header). Needs the cookie-auth migration first.
- **CI legacy scalars / `staging_required`** — woven through `staging-deploy.yml`
  (~25 refs); a CI-contract rewrite to do alone, not in a close-out PR.

## Test
- `ruff check` + `ruff format --check` clean on all changed files.
- 99 passed across `test_reconciliation_matching_unit.py`,
  `test_reconciliation_engine.py`, `test_reconciliation_router_additional.py`.
- Preflight gates `api-reference`, `router-contract`, `transaction-boundary` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)