### PR TITLE
[finance_report_ui_1003] feat(corrections): type top_corrections as TopCorrection model (AC18.2.5)

### DIFF
--- a/apps/backend/src/routers/corrections.py
+++ b/apps/backend/src/routers/corrections.py
@@ -30,11 +30,23 @@ class CorrectionResponse(BaseModel):
     corrected_category: str
 
 
+class TopCorrection(BaseModel):
+    """A single aggregated correction pattern (original → corrected category).
+
+    Mirrors the dict shape emitted by ``get_correction_stats`` so the stats
+    response carries a typed schema instead of an opaque ``dict``.
+    """
+
+    count: int
+    original_category: str | None
+    corrected_category: str
+
+
 class CorrectionStatsResponse(BaseModel):
     """Correction statistics response."""
 
     total_corrections: int
-    top_corrections: list[dict]
+    top_corrections: list[TopCorrection]
     correction_rate_by_category: dict[str, float]
 
 

--- a/apps/backend/tests/api/test_corrections_router.py
+++ b/apps/backend/tests/api/test_corrections_router.py
@@ -44,7 +44,7 @@ def test_AC18_2_5_top_corrections_is_typed_pydantic_model():
 
     The stats response schema must declare ``top_corrections`` as a list of
     ``TopCorrection`` models (count: int, original_category: str | None,
-    corrected_category: str | None), not an untyped ``list[dict]``.
+    corrected_category: str), not an untyped ``list[dict]``.
     """
     # The model exists and carries the exact keys the service emits.
     item = corrections.TopCorrection(

--- a/apps/backend/tests/api/test_corrections_router.py
+++ b/apps/backend/tests/api/test_corrections_router.py
@@ -39,6 +39,39 @@ async def test_post_create_correction_and_stats(client: AsyncClient, db, test_us
     assert isinstance(sbody["top_corrections"], list)
 
 
+def test_AC18_2_5_top_corrections_is_typed_pydantic_model():
+    """AC18.2.5: top_corrections is typed as a TopCorrection Pydantic model.
+
+    The stats response schema must declare ``top_corrections`` as a list of
+    ``TopCorrection`` models (count: int, original_category: str | None,
+    corrected_category: str | None), not an untyped ``list[dict]``.
+    """
+    # The model exists and carries the exact keys the service emits.
+    item = corrections.TopCorrection(
+        count=3,
+        original_category=None,
+        corrected_category="Transport",
+    )
+    assert item.count == 3
+    assert item.original_category is None
+    assert item.corrected_category == "Transport"
+
+    # The response schema field is typed as list[TopCorrection], not list[dict].
+    field = corrections.CorrectionStatsResponse.model_fields["top_corrections"]
+    assert field.annotation == list[corrections.TopCorrection]
+
+    # Raw service-shaped dicts coerce into the typed model.
+    response = corrections.CorrectionStatsResponse(
+        total_corrections=3,
+        top_corrections=[
+            {"count": 3, "original_category": None, "corrected_category": "Transport"},
+        ],
+        correction_rate_by_category={"None": 100.0},
+    )
+    assert isinstance(response.top_corrections[0], corrections.TopCorrection)
+    assert response.top_corrections[0].corrected_category == "Transport"
+
+
 async def test_create_correction_returns_404_when_transaction_is_missing(monkeypatch):
     """AC18.2.2: Corrections API maps missing transactions to 404 responses."""
 

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -263,6 +263,7 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
 | AC18.2.2 | 2 | Corrections API records and retrieves correction stats |
 | AC18.2.3 | 2 | Few-shot examples from corrections injected into extraction prompt |
 | AC18.2.4 | 2 | Correction cache with 1-hour TTL |
+| AC18.2.5 | 2 | `top_corrections` typed as a `TopCorrection` Pydantic model in the corrections stats response |
 | AC18.3.1 | 3 | `ai_semantic_score()` returns similarity for transaction description pairs |
 | AC18.3.2 | 3 | Hybrid scoring: `0.7 * algorithmic + 0.3 * AI` for 60-84 range only |
 | AC18.3.3 | 3 | Feature flag `enable_ai_reconciliation` controls AI scoring |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -6,7 +6,7 @@
 - API title: `Finance Report API`
 - API version: `0.1.0`
 - Endpoint count: `130`
-- Schema count: `221`
+- Schema count: `222`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 


### PR DESCRIPTION
## Summary

PR #1060 already shipped the UI "Confidence Trend" surface for #1003. The one remaining acceptance criterion was that `top_corrections` in the corrections stats response was still **untyped** (`top_corrections: list[dict]` in `apps/backend/src/routers/corrections.py`).

This PR types it as a Pydantic model:

- New `TopCorrection` model with the exact keys `get_correction_stats` emits: `count: int`, `original_category: str | None`, `corrected_category: str`.
- `CorrectionStatsResponse.top_corrections` changed from `list[dict]` to `list[TopCorrection]`. Pydantic coerces the service's dict rows into the typed model, so the service return shape is unchanged and all existing tests stay green.

## AC

- Added **AC18.2.5** to `docs/project/EPIC-018.ai-driven-pipeline.md` (Phase 2 feedback loop): "`top_corrections` typed as a `TopCorrection` Pydantic model in the corrections stats response".

## Tests

- New CI-executed test `test_AC18_2_5_top_corrections_is_typed_pydantic_model` in `apps/backend/tests/api/test_corrections_router.py` asserting the model fields, the `list[TopCorrection]` annotation, and dict→model coercion. Written failing first (🔴), then made green (🟢).
- Existing corrections router + service tests remain green (14 passed).

## Docs / gates

- Regenerated `docs/reference/api.md` (schema count 221 → 222).
- AC traceability gate passes; diff-aware preflight gates all pass (ac-traceability, doc-consistency, api-reference, router-contract, backend-format with CI-pinned ruff 0.14.11).

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)