### PR TITLE
[finance_report_test_and_doc] docs(#821): define FR + infra2 SSOT HLS family model

### DIFF
--- a/docs/project/EPIC-014.ttd-transformation.md
+++ b/docs/project/EPIC-014.ttd-transformation.md
@@ -95,9 +95,11 @@ As-is:
 
 To-be:
 
-- [ ] Define the FR SSOT HLS model with 6-8 families, concept boundaries, and
+- [x] Define the FR SSOT HLS model with 6-8 families, concept boundaries, and
   child binding rules in
-  [#821](https://github.com/wangzitian0/finance_report/issues/821).
+  [#821](https://github.com/wangzitian0/finance_report/issues/821) (see
+  [SSOT HLS Family Model](#ssot-hls-family-model) below; documentation only —
+  no concept is moved or re-owned in this step).
 - [x] Add report-only design metrics for family coverage, orphan files,
   duplicate owners, clause binding, proof/checker coverage, and high-risk
   owner coverage in
@@ -108,6 +110,48 @@ To-be:
 - [ ] Run threshold-based SSOT cleanup only after the metrics show enough
   evidence for targeted consolidation in
   [#824](https://github.com/wangzitian0/finance_report/issues/824).
+
+## SSOT HLS Family Model
+
+This is the FR high-level structure (HLS) family model defined by
+[#821](https://github.com/wangzitian0/finance_report/issues/821). It is the
+**foundation for the [#824](https://github.com/wangzitian0/finance_report/issues/824)
+threshold cleanup**: it groups the existing FR SSOT concepts in
+[`docs/ssot/MANIFEST.yaml`](../ssot/MANIFEST.yaml) into 6-8 reader-facing
+families so cleanup PRs can backfill `family` / `kind` and bind child artifacts
+deterministically.
+
+This step is **documentation only**. It does not move, rename, merge, or
+re-own any concept; `MANIFEST.yaml` remains the single owner registry. The
+family column maps to the `family` field a manifest entry should carry; the
+member column lists the current inferred manifest groupings (the
+`inferred_family_distribution` keys in
+`python tools/report_ssot_governance.py`) that belong to each family.
+
+### Concept vs clause boundary
+
+- A **concept** is an independently governed SSOT base element with its own
+  owner file (an entry whose `kind` is `concept`, or unset and treated as the
+  default). It is the unit that a family groups.
+- A **clause** is a child parameter, machine table, baseline, registry, or
+  matrix that only exists to parameterize a parent concept (`kind` of `clause`,
+  `matrix`, `registry`, or `baseline`). A clause MUST `parent` its concept and
+  inherit the parent's family; it is never reviewed as a standalone concept.
+- A **family** is a reader-facing grouping of related concepts. Families do not
+  own facts; they route a reader to the owning concept before the individual
+  entry. Ownership stays in `MANIFEST.yaml`.
+
+### FR family map (6-8 families)
+
+| Family | Scope | Member manifest groups (inferred) |
+|---|---|---|
+| `accounting` | Double-entry ledger, in-transit funds, reconciliation, and trust hierarchy | `accounting`, `reconciliation`, `confirmation`, `processing`, `source` |
+| `reporting` | Reports, frameworks, market data, assets, and evidence/workflow read models | `reporting`, `framework`, `market`, `assets`, `evidence`, `workflow` |
+| `extraction` | Statement parsing, AI advisor, and PDF fixtures | `extraction`, `ai`, `pdf` |
+| `schema` | Database schema, data layering, enum naming, and migration risk | `schema`, `migration` |
+| `platform` | Dev workflow, environments, CI/CD, coverage, deployment, and observability | `development`, `environments`, `ci`, `test`, `delivery`, `coverage`, `deployment`, `observability`, `runtime`, `env` |
+| `identity` | Auth identity and frontend integration contract | `auth`, `frontend` |
+| `governance` | TDD workflow, critical-proof matrix, agent governance, and branch policy | `tdd`, `critical`, `agents`, `contributing` |
 
 ## Simplification Acceleration Track
 
@@ -233,3 +277,4 @@ Historical work-progress reports and test-organization audits were removed from 
 | AC14.1.15 | Threshold cleanup for #824 migrates representative machine-owned FR SSOT entries to explicit `family`, `kind`, `proofs`, and inbound SSOT Markdown links so `finance_report.machine_owner_entries_missing_proof` stays zero | `test_AC14_1_15_machine_owned_ssot_entries_have_explicit_shape_and_proof` | `tests/tooling/test_ssot_governance_report.py` | P1 |
 | AC14.1.16 | SSOT governance gates keep protected per-system governance ratios non-decreasing and protected debt counts non-increasing against the base ref | `test_AC14_1_16_ssot_governance_ratios_cannot_regress` | `tests/tooling/test_ssot_governance_report.py` | P1 |
 | AC14.1.17 | DB schema inventory is generated from SQLAlchemy metadata, published by the MkDocs build, CI-checked for deterministic generation, gitignored as generated output, and linked from macro SSOT/domain docs instead of hand-maintained table/column/API catalogs | `test_AC14_1_17_render_db_schema_reference_uses_sqlalchemy_metadata`, `test_AC14_1_17_generated_db_schema_reference_is_ci_checked` | `tests/tooling/test_generate_db_schema_reference.py`, `tests/tooling/test_post_merge_e2e_gates.py` | P1 |
+| AC14.1.18 | FR (EPIC-014) and infra2 (Infra-006) each document a 6-8 family SSOT HLS model with explicit concept/clause boundaries, the family map covers every MANIFEST.yaml-inferred family, the HLS checklist links #821/#822/#823/#824, and the definition does not move or re-own any SSOT concept | `test_AC14_1_18_fr_hls_family_model_is_documented_and_consistent`, `test_AC14_1_18_infra2_hls_family_model_is_documented_and_consistent`, `test_AC14_1_18_hls_checklist_links_governance_loop_issues`, `test_AC14_1_18_documentation_only_does_not_re_own_concepts` | `tests/tooling/test_ssot_hls_family_model.py` | P1 |

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -40,6 +40,26 @@ The migration of code-owned SSOT facts into common packages or generated
 contracts is tracked in
 [issue #453](https://github.com/wangzitian0/finance_report/issues/453).
 
+## SSOT HLS Family Model
+
+The high-level structure (HLS) family model groups the concepts in
+[MANIFEST.yaml](./MANIFEST.yaml) into 6-8 reader-facing families so a domain
+reader starts from a family entry point instead of a flat concept list. The
+family model is a **definition layer only** — it routes readers and feeds the
+`family` field; it does not own or re-own any concept (ownership stays in
+MANIFEST.yaml).
+
+- FR family map, concept/clause boundary, and governance loop:
+  [EPIC-014 — SSOT HLS Family Model](../project/EPIC-014.ttd-transformation.md#ssot-hls-family-model).
+- infra2 family map and boundary:
+  [Infra-006 — SSOT HLS Family Model](../../repo/docs/project/Infra-006.documentation_engineering.md#ssot-hls-family-model).
+
+Family/kind coverage is reported by `python tools/report_ssot_governance.py`
+([#822](https://github.com/wangzitian0/finance_report/issues/822)). This model
+is the foundation for the
+[#824](https://github.com/wangzitian0/finance_report/issues/824) threshold
+cleanup that backfills `family` / `kind` and binds child clauses.
+
 ## Core System Documents
 
 | Document | Key | Current owner role |

--- a/tests/tooling/test_ssot_hls_family_model.py
+++ b/tests/tooling/test_ssot_hls_family_model.py
@@ -42,6 +42,12 @@ FAMILY_ROW = re.compile(r"^\|\s*`(?P<family>[a-z0-9_]+)`\s*\|")
 
 
 def _read(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Required SSOT file not found: {path}. If this is an infra2 path "
+            f"under the 'repo/' submodule, the submodule is likely not "
+            f"initialized — run `git submodule update --init --recursive`."
+        )
     return path.read_text(encoding="utf-8")
 
 
@@ -63,7 +69,7 @@ def _declared_families(text: str) -> list[str]:
 
 
 def _manifest_inferred_families(manifest_path: Path, entry_key: str) -> set[str]:
-    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    data = yaml.safe_load(_read(manifest_path)) or {}
     raw_entries = data.get(entry_key) or {}
     families: set[str] = set()
     for key, raw in raw_entries.items():
@@ -86,15 +92,34 @@ def _backticked_tokens(text: str) -> set[str]:
     return set(re.findall(r"`([a-z0-9_]+)`", text))
 
 
-def _family_map_coverage(section: str, inferred: set[str]) -> set[str]:
-    """Inferred manifest families not listed as a member in the family map.
+def _family_member_counts(section: str) -> dict[str, int]:
+    """Count occurrences of each backticked member token in the family-map table.
 
-    Every inferred family must appear somewhere in the HLS family-model section
-    as a backticked member token, so each manifest grouping is explicitly bound
-    to exactly one declared family (no orphan grouping).
+    Only the *member* column (the last cell of each `| `family` | … |` table
+    row) is parsed, so prose and the scope column cannot create false positives.
+    A token bound under multiple declared families is counted more than once.
     """
-    listed = _backticked_tokens(section)
-    return {fam for fam in inferred if fam not in listed}
+    counts: dict[str, int] = {}
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not FAMILY_ROW.match(stripped):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        member_cell = cells[-1]
+        for token in re.findall(r"`([a-z0-9_]+)`", member_cell):
+            counts[token] = counts.get(token, 0) + 1
+    return counts
+
+
+def _family_map_coverage(section: str, inferred: set[str]) -> set[str]:
+    """Inferred manifest families not bound to exactly one declared family.
+
+    Every inferred family must appear as a member token in exactly one
+    family-map row's member column, so each manifest grouping is bound to
+    exactly one declared family (no orphan grouping and no duplicate binding).
+    """
+    counts = _family_member_counts(section)
+    return {fam for fam in inferred if counts.get(fam, 0) != 1}
 
 
 def test_AC14_1_18_fr_hls_family_model_is_documented_and_consistent() -> None:
@@ -116,7 +141,8 @@ def test_AC14_1_18_fr_hls_family_model_is_documented_and_consistent() -> None:
     inferred = _manifest_inferred_families(FR_MANIFEST, "concepts")
     uncovered = _family_map_coverage(section, inferred)
     assert not uncovered, (
-        f"FR family map does not cover manifest-inferred families: {sorted(uncovered)}"
+        "FR family map must bind each manifest-inferred family to exactly one "
+        f"declared family; offending (missing or duplicated): {sorted(uncovered)}"
     )
 
 
@@ -139,7 +165,8 @@ def test_AC14_1_18_infra2_hls_family_model_is_documented_and_consistent() -> Non
     inferred = _manifest_inferred_families(INFRA_MANIFEST, "entries")
     uncovered = _family_map_coverage(section, inferred)
     assert not uncovered, (
-        f"infra2 family map does not cover manifest-inferred families: "
+        "infra2 family map must bind each manifest-inferred family to exactly "
+        f"one declared family; offending (missing or duplicated): "
         f"{sorted(uncovered)}"
     )
 

--- a/tests/tooling/test_ssot_hls_family_model.py
+++ b/tests/tooling/test_ssot_hls_family_model.py
@@ -1,0 +1,165 @@
+"""AC14.1.18: FR + infra2 SSOT HLS family model is documented and consistent.
+
+This is a documentation-governance test for issue #821. It does NOT move or
+re-own any SSOT concept; it only asserts that:
+
+1. EPIC-014 (FR) and Infra-006 (infra2) each declare an SSOT HLS family model
+   with 6-8 families plus explicit concept/clause boundary rules.
+2. The declared family map is machine-parseable from the doc and is consistent
+   with the existing MANIFEST.yaml groupings (every manifest entry's inferred
+   family is covered by exactly one declared family).
+3. The HLS governance checklist links #821 and the follow-up
+   metric/gate/cleanup issues (#822, #823, #824).
+
+The first step of #821 is documentation only; ownership stays in MANIFEST.yaml.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from common.ssot import governance_report
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FR_EPIC = ROOT / "docs/project/EPIC-014.ttd-transformation.md"
+INFRA_EPIC = ROOT / "repo/docs/project/Infra-006.documentation_engineering.md"
+FR_MANIFEST = ROOT / "docs/ssot/MANIFEST.yaml"
+INFRA_MANIFEST = ROOT / "repo/docs/ssot/MANIFEST.yaml"
+
+ISSUE_LINKS = (
+    "/issues/821",
+    "/issues/822",
+    "/issues/823",
+    "/issues/824",
+)
+
+FAMILY_SECTION_HEADING = "## SSOT HLS Family Model"
+FAMILY_ROW = re.compile(r"^\|\s*`(?P<family>[a-z0-9_]+)`\s*\|")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _family_section(text: str) -> str:
+    assert FAMILY_SECTION_HEADING in text, f"missing '{FAMILY_SECTION_HEADING}' section"
+    after = text.split(FAMILY_SECTION_HEADING, 1)[1]
+    # Stop at the next level-2 heading.
+    return after.split("\n## ", 1)[0]
+
+
+def _declared_families(text: str) -> list[str]:
+    section = _family_section(text)
+    families: list[str] = []
+    for line in section.splitlines():
+        match = FAMILY_ROW.match(line.strip())
+        if match:
+            families.append(match.group("family"))
+    return families
+
+
+def _manifest_inferred_families(manifest_path: Path, entry_key: str) -> set[str]:
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    raw_entries = data.get(entry_key) or {}
+    families: set[str] = set()
+    for key, raw in raw_entries.items():
+        entry = governance_report.GovernanceEntry(
+            key=str(key),
+            owner=str(raw.get("owner") or ""),
+            description=str(raw.get("description") or ""),
+            cross_refs=(),
+            proofs=(),
+            family=(str(raw["family"]) if raw.get("family") else None),
+            kind=str(raw["kind"]) if raw.get("kind") else None,
+            parent=None,
+            authority=None,
+        )
+        families.add(governance_report._infer_family(entry))
+    return families
+
+
+def _backticked_tokens(text: str) -> set[str]:
+    return set(re.findall(r"`([a-z0-9_]+)`", text))
+
+
+def _family_map_coverage(section: str, inferred: set[str]) -> set[str]:
+    """Inferred manifest families not listed as a member in the family map.
+
+    Every inferred family must appear somewhere in the HLS family-model section
+    as a backticked member token, so each manifest grouping is explicitly bound
+    to exactly one declared family (no orphan grouping).
+    """
+    listed = _backticked_tokens(section)
+    return {fam for fam in inferred if fam not in listed}
+
+
+def test_AC14_1_18_fr_hls_family_model_is_documented_and_consistent() -> None:
+    """AC14.1.18: EPIC-014 declares 6-8 FR families consistent with MANIFEST."""
+
+    text = _read(FR_EPIC)
+    families = _declared_families(text)
+
+    assert 6 <= len(families) <= 8, (
+        f"FR HLS model must declare 6-8 families, found {len(families)}: {families}"
+    )
+    assert len(families) == len(set(families)), "FR families must be unique"
+
+    section = _family_section(text)
+    assert "concept" in section.lower(), "family model must state concept boundary"
+    assert "clause" in section.lower(), "family model must state clause boundary"
+    assert "MANIFEST.yaml" in section, "family model must reference MANIFEST.yaml"
+
+    inferred = _manifest_inferred_families(FR_MANIFEST, "concepts")
+    uncovered = _family_map_coverage(section, inferred)
+    assert not uncovered, (
+        f"FR family map does not cover manifest-inferred families: {sorted(uncovered)}"
+    )
+
+
+def test_AC14_1_18_infra2_hls_family_model_is_documented_and_consistent() -> None:
+    """AC14.1.18: Infra-006 declares 6-8 infra2 families consistent with MANIFEST."""
+
+    text = _read(INFRA_EPIC)
+    families = _declared_families(text)
+
+    assert 6 <= len(families) <= 8, (
+        f"infra2 HLS model must declare 6-8 families, found {len(families)}: {families}"
+    )
+    assert len(families) == len(set(families)), "infra2 families must be unique"
+
+    section = _family_section(text)
+    assert "concept" in section.lower(), "family model must state concept boundary"
+    assert "clause" in section.lower(), "family model must state clause boundary"
+    assert "MANIFEST.yaml" in section, "family model must reference MANIFEST.yaml"
+
+    inferred = _manifest_inferred_families(INFRA_MANIFEST, "entries")
+    uncovered = _family_map_coverage(section, inferred)
+    assert not uncovered, (
+        f"infra2 family map does not cover manifest-inferred families: "
+        f"{sorted(uncovered)}"
+    )
+
+
+def test_AC14_1_18_hls_checklist_links_governance_loop_issues() -> None:
+    """AC14.1.18: Both HLS checklists link #821 and follow-up #822/#823/#824."""
+
+    for path in (FR_EPIC, INFRA_EPIC):
+        text = _read(path)
+        for link in ISSUE_LINKS:
+            assert link in text, f"{path.name} must link {link}"
+
+
+def test_AC14_1_18_documentation_only_does_not_re_own_concepts() -> None:
+    """AC14.1.18: Defining the HLS model does not change manifest ownership.
+
+    The family model is a definition layer. MANIFEST.yaml stays the single
+    owner registry and must still parse with zero report errors after the docs
+    land.
+    """
+
+    report = governance_report.build_report(ROOT, include_infra2=True)
+    assert report["overall"]["errors"] == []


### PR DESCRIPTION
## Summary

Defines the high-level SSOT (HLS) governance **family model** for both systems as the first, documentation-only step of the SSOT HLS governance loop. Each system now declares 6-8 reader-facing SSOT families with explicit **concept vs clause** boundary rules:

- **FR (EPIC-014)** — 7 families: `accounting`, `reporting`, `extraction`, `schema`, `platform`, `identity`, `governance`. Each family maps to the inferred manifest groupings (`inferred_family_distribution` keys) so cleanup PRs can backfill `family` / `kind`.
- **infra2 (Infra-006)** — 7 families: `core`, `bootstrap`, `platform`, `db`, `vault`, `ops`, `watchdog`.
- `docs/ssot/README.md` routes readers to the family model as a **definition layer** (not an ownership change).

**No existing SSOT concept is moved or re-owned** in this step. `docs/ssot/MANIFEST.yaml` (FR) and `repo/docs/ssot/MANIFEST.yaml` (infra2) remain the single owner registries. The model is the **foundation for the #824 threshold cleanup**.

The infra2-side doc change lands in the `wangzitian0/infra2` submodule branch `issue-821-ssot-hls-model` (commit bumped via the submodule pointer); a matching infra2 PR is required before merge so CI can check out the pinned SHA.

## Acceptance criteria

- **AC14.1.18** (infra, EPIC-014 / `docs/infra_registry.yaml`): FR and infra2 each document a 6-8 family SSOT HLS model with explicit concept/clause boundaries, the family map covers every `MANIFEST.yaml`-inferred family, the HLS checklist links #821/#822/#823/#824, and the definition does not move or re-own any SSOT concept.
  - Tests: `tests/tooling/test_ssot_hls_family_model.py` (4 test functions).

## Files changed

- `docs/project/EPIC-014.ttd-transformation.md` — FR HLS family map + concept/clause boundary; AC14.1.18 row; #821 box checked.
- `repo/docs/project/Infra-006.documentation_engineering.md` (infra2 submodule) — infra2 HLS family map + boundary; checklist boxes + change log.
- `docs/ssot/README.md` — SSOT HLS Family Model definition/routing section.
- `tests/tooling/test_ssot_hls_family_model.py` — new governance test (red→green).
- `repo` — submodule pointer bump to the matching infra2 commit.

## Local gate results

- `tools/preflight.py` (ac-traceability, ssot-ownership, doc-consistency): **PASS**
- `tools/check_ac_traceability.py`: **PASS** (1582/1582 mandatory ACs covered, 0 missing; AC14.1.18 recognized)
- `tools/check_manifest.py`: **PASS**
- `tools/check_ssot_ownership.py`: **PASS**
- `tools/report_ssot_governance.py` incremental gate over changed files: **PASS**
- `tests/tooling/test_ssot_hls_family_model.py`: **PASS** (4/4)
- `tests/tooling/test_ssot_governance_report.py` + `test_check_manifest.py` + `test_lint_doc_consistency.py`: **PASS** (no regression)
- `ruff check` / `ruff format --check` on new test: **PASS**
- `moon run :lint`: Python lint + format + detached-owner check **PASS**; frontend `next lint` fails with `next: command not found` (frontend deps not installed in this worktree; unrelated to this docs/test change).

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)