### PR TITLE
[finance_report_ui_1010] feat(#1010): editable AI settings + /auth/me session bootstrap (EPIC-022 AC22.15)

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -20,3 +20,10 @@ moon run :test
 | Environment contract | [environments.md](../../docs/ssot/environments.md), [.env.example](../../.env.example) |
 | Database model | [schema.md](../../docs/ssot/schema.md), [Generated DB schema reference](../../docs/reference/db-schema.md) |
 | Test policy | [tdd.md](../../docs/ssot/tdd.md), [coverage.md](../../docs/ssot/coverage.md) |
+
+## Router notes
+
+- `users` (`src/routers/users.py`) is intentionally self-scoped; a multi-user
+  admin panel is **deliberately deferred** (no multi-tenant need). See #1010 /
+  EPIC-022 AC22.15. Only `/users/me/settings` is consumed (the AI Settings editor).
+- `GET /auth/me` backs the frontend session bootstrap (`hooks/useSessionBootstrap.ts`).

--- a/apps/frontend/src/__tests__/aiSettingsPage.test.tsx
+++ b/apps/frontend/src/__tests__/aiSettingsPage.test.tsx
@@ -1,24 +1,35 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import AiSettingsPage from "@/app/(main)/settings/ai/page"
-import { apiFetch } from "@/lib/api"
+import { fetchUserSettings, patchUserSettings } from "@/lib/api"
 
 vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: ReactNode }) => <a href={href}>{children}</a>,
 }))
 
-vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }))
+vi.mock("@/lib/api", () => ({
+  fetchUserSettings: vi.fn(),
+  patchUserSettings: vi.fn(),
+}))
 
-const mockedApiFetch = vi.mocked(apiFetch)
+const showToast = vi.fn()
+vi.mock("@/components/ui/Toast", () => ({
+  useToast: () => ({ showToast }),
+}))
+
+const mockedFetch = vi.mocked(fetchUserSettings)
+const mockedPatch = vi.mocked(patchUserSettings)
 
 beforeEach(() => {
-  mockedApiFetch.mockReset()
-  mockedApiFetch.mockResolvedValue({ enable_ai_reconciliation: true, enable_ai_classification: true })
+  showToast.mockReset()
+  mockedFetch.mockReset()
+  mockedPatch.mockReset()
+  mockedFetch.mockResolvedValue({ enable_ai_reconciliation: true, enable_ai_classification: false })
 })
 
-describe("AiSettingsPage (EPIC-022 AC22.4.3)", () => {
+describe("AiSettingsPage (EPIC-022 AC22.4.3, AC22.15.2)", () => {
   it("AC22.4.3 links to the AI suggestion review surface so it is not orphaned", async () => {
     render(<AiSettingsPage />)
     await waitFor(() => expect(screen.getByText("AI Settings")).toBeInTheDocument())
@@ -26,5 +37,67 @@ describe("AiSettingsPage (EPIC-022 AC22.4.3)", () => {
       "href",
       "/review/ai-suggestions",
     )
+  })
+
+  it("AC22.15.2 renders the loaded flags and keeps Save disabled until edited", async () => {
+    render(<AiSettingsPage />)
+    await waitFor(() => expect(screen.getByText("AI Settings")).toBeInTheDocument())
+
+    expect(screen.getByLabelText("Enable AI reconciliation")).toBeChecked()
+    expect(screen.getByLabelText("Enable AI classification")).not.toBeChecked()
+    expect(screen.getByRole("button", { name: /Save changes/i })).toBeDisabled()
+  })
+
+  it("AC22.15.2 submits edited flags via patchUserSettings and shows success", async () => {
+    mockedPatch.mockResolvedValue({ enable_ai_reconciliation: true, enable_ai_classification: true })
+    render(<AiSettingsPage />)
+    await waitFor(() => expect(screen.getByText("AI Settings")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText("Enable AI classification"))
+    const save = screen.getByRole("button", { name: /Save changes/i })
+    expect(save).toBeEnabled()
+    fireEvent.click(save)
+
+    await waitFor(() =>
+      expect(mockedPatch).toHaveBeenCalledWith({
+        enable_ai_reconciliation: true,
+        enable_ai_classification: true,
+      }),
+    )
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith("AI settings saved", "success"))
+    // After a successful save the form is no longer dirty.
+    await waitFor(() => expect(screen.getByRole("button", { name: /Save changes/i })).toBeDisabled())
+  })
+
+  it("AC22.15.2 surfaces an error and keeps the draft when the PATCH fails", async () => {
+    mockedPatch.mockRejectedValue(new Error("Save failed"))
+    render(<AiSettingsPage />)
+    await waitFor(() => expect(screen.getByText("AI Settings")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText("Enable AI classification"))
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }))
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Save failed"))
+    // Edit is preserved so the user can retry.
+    expect(screen.getByLabelText("Enable AI classification")).toBeChecked()
+    expect(showToast).not.toHaveBeenCalled()
+  })
+
+  it("AC22.15.2 Reset reverts the draft to the last saved values", async () => {
+    render(<AiSettingsPage />)
+    await waitFor(() => expect(screen.getByText("AI Settings")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText("Enable AI classification"))
+    expect(screen.getByLabelText("Enable AI classification")).toBeChecked()
+
+    fireEvent.click(screen.getByRole("button", { name: /Reset/i }))
+    expect(screen.getByLabelText("Enable AI classification")).not.toBeChecked()
+    expect(screen.getByRole("button", { name: /Save changes/i })).toBeDisabled()
+  })
+
+  it("AC22.15.2 shows a load error when fetchUserSettings rejects", async () => {
+    mockedFetch.mockRejectedValue(new Error("Load failed"))
+    render(<AiSettingsPage />)
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Load failed"))
   })
 })

--- a/apps/frontend/src/__tests__/apiFunctions.test.ts
+++ b/apps/frontend/src/__tests__/apiFunctions.test.ts
@@ -395,6 +395,76 @@ describe('apiUpload', () => {
   });
 });
 
+describe('user settings & session bootstrap client (EPIC-022 AC22.15 / #1010)', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.unstubAllGlobals();
+    vi.stubGlobal('localStorage', localStorageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubGlobal('localStorage', localStorageMock);
+  });
+
+  it('AC22.15.1 fetchUserSettings GETs /api/users/me/settings via apiFetch', async () => {
+    const fetchMock = makeFetchMock(200, {
+      enable_ai_reconciliation: true,
+      enable_ai_classification: false,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchUserSettings } = await import('../lib/api');
+    const result = await fetchUserSettings();
+
+    expect(result).toEqual({ enable_ai_reconciliation: true, enable_ai_classification: false });
+    expect(fetchMock.mock.calls[0][0]).toMatch(/\/api\/users\/me\/settings/);
+    expect(fetchMock.mock.calls[0][1]?.method ?? 'GET').toBe('GET');
+  });
+
+  it('AC22.15.1 patchUserSettings PATCHes the edited flags via apiFetch', async () => {
+    const fetchMock = makeFetchMock(200, {
+      enable_ai_reconciliation: false,
+      enable_ai_classification: true,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { patchUserSettings } = await import('../lib/api');
+    const result = await patchUserSettings({ enable_ai_classification: true });
+
+    expect(result).toEqual({ enable_ai_reconciliation: false, enable_ai_classification: true });
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
+    expect(calledUrl).toMatch(/\/api\/users\/me\/settings/);
+    expect(calledInit.method).toBe('PATCH');
+    expect(JSON.parse(calledInit.body as string)).toEqual({ enable_ai_classification: true });
+  });
+
+  it('AC22.15.1 patchUserSettings surfaces backend error detail', async () => {
+    const fetchMock = makeFetchMock(400, { detail: 'Invalid setting' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { patchUserSettings } = await import('../lib/api');
+    await expect(patchUserSettings({ enable_ai_reconciliation: true })).rejects.toThrow('Invalid setting');
+  });
+
+  it('AC22.15.3 fetchCurrentUser GETs /api/auth/me via apiFetch', async () => {
+    const fetchMock = makeFetchMock(200, {
+      id: 'user-1',
+      email: 'a@example.com',
+      name: null,
+      created_at: '2026-01-01T00:00:00Z',
+      access_token: 'tok',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchCurrentUser } = await import('../lib/api');
+    const result = await fetchCurrentUser();
+
+    expect(result.email).toBe('a@example.com');
+    expect(fetchMock.mock.calls[0][0]).toMatch(/\/api\/auth\/me/);
+  });
+});
+
 describe('apiDownload', () => {
   beforeEach(() => {
     localStorageMock.clear();

--- a/apps/frontend/src/__tests__/apiFunctions.test.ts
+++ b/apps/frontend/src/__tests__/apiFunctions.test.ts
@@ -453,7 +453,6 @@ describe('user settings & session bootstrap client (EPIC-022 AC22.15 / #1010)', 
       email: 'a@example.com',
       name: null,
       created_at: '2026-01-01T00:00:00Z',
-      access_token: 'tok',
     });
     vi.stubGlobal('fetch', fetchMock);
 

--- a/apps/frontend/src/__tests__/appShellSessionBootstrap.test.tsx
+++ b/apps/frontend/src/__tests__/appShellSessionBootstrap.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useSessionBootstrap } from "@/hooks/useSessionBootstrap"
+import { fetchCurrentUser } from "@/lib/api"
+import { clearUser, getUserEmail, getUserId, setUser } from "@/lib/auth"
+
+vi.mock("@/lib/api", () => ({
+  fetchCurrentUser: vi.fn(),
+}))
+
+const mockedFetchCurrentUser = vi.mocked(fetchCurrentUser)
+
+beforeEach(() => {
+  localStorage.clear()
+  mockedFetchCurrentUser.mockReset()
+})
+
+describe("useSessionBootstrap (EPIC-022 AC22.15.3 / #1010)", () => {
+  it("AC22.15.3 does not call /auth/me when there is no local session", async () => {
+    renderHook(() => useSessionBootstrap())
+    expect(mockedFetchCurrentUser).not.toHaveBeenCalled()
+  })
+
+  it("AC22.15.3 consumes /auth/me on mount and refreshes the cached identity", async () => {
+    setUser("stale-id", "stale@example.com")
+    mockedFetchCurrentUser.mockResolvedValue({
+      id: "fresh-id",
+      email: "fresh@example.com",
+      name: null,
+      created_at: "2026-01-01T00:00:00Z",
+      access_token: "tok",
+    })
+
+    renderHook(() => useSessionBootstrap())
+
+    await waitFor(() => expect(mockedFetchCurrentUser).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(getUserId()).toBe("fresh-id"))
+    expect(getUserEmail()).toBe("fresh@example.com")
+  })
+
+  it("AC22.15.3 clears the stale local identity when /auth/me fails", async () => {
+    setUser("stale-id", "stale@example.com")
+    mockedFetchCurrentUser.mockRejectedValue(new Error("boom"))
+
+    renderHook(() => useSessionBootstrap())
+
+    await waitFor(() => expect(getUserId()).toBeNull())
+  })
+
+  it("AC22.15.3 is a no-op after the session was cleared", () => {
+    setUser("id", "e@example.com")
+    clearUser()
+    renderHook(() => useSessionBootstrap())
+    expect(mockedFetchCurrentUser).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/__tests__/appShellSessionBootstrap.test.tsx
+++ b/apps/frontend/src/__tests__/appShellSessionBootstrap.test.tsx
@@ -29,7 +29,6 @@ describe("useSessionBootstrap (EPIC-022 AC22.15.3 / #1010)", () => {
       email: "fresh@example.com",
       name: null,
       created_at: "2026-01-01T00:00:00Z",
-      access_token: "tok",
     })
 
     renderHook(() => useSessionBootstrap())

--- a/apps/frontend/src/__tests__/shellAndAuth.test.tsx
+++ b/apps/frontend/src/__tests__/shellAndAuth.test.tsx
@@ -18,6 +18,12 @@ vi.mock("@/lib/auth", () => ({
   isAuthenticated: () => isAuthenticatedMock(),
 }))
 
+// Session bootstrap (EPIC-022 AC22.15.3) has its own dedicated test; the shell
+// layout tests stub it so they stay focused on layout/auth-guard behavior.
+vi.mock("@/hooks/useSessionBootstrap", () => ({
+  useSessionBootstrap: vi.fn(),
+}))
+
 vi.mock("@/hooks/useWorkspace", () => ({
   WorkspaceProvider: ({ children }: { children: ReactNode }) => <div data-testid="workspace-provider">{children}</div>,
   useWorkspace: () => ({ isCollapsed: true }),

--- a/apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx
+++ b/apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx
@@ -5,10 +5,12 @@ import AiSuggestionsPage from "@/app/(main)/review/ai-suggestions/page";
 import AiSettingsPage from "@/app/(main)/settings/ai/page";
 import AuditTrailPanel from "@/components/AuditTrailPanel";
 import ConfidenceBadge from "@/components/ui/ConfidenceBadge";
-import { apiFetch } from "@/lib/api";
+import { apiFetch, fetchUserSettings, patchUserSettings } from "@/lib/api";
 
 vi.mock("@/lib/api", () => ({
   apiFetch: vi.fn(),
+  fetchUserSettings: vi.fn(),
+  patchUserSettings: vi.fn(),
 }));
 
 vi.mock("@/components/ui/Toast", () => ({
@@ -16,10 +18,14 @@ vi.mock("@/components/ui/Toast", () => ({
 }));
 
 const mockedApiFetch = vi.mocked(apiFetch);
+const mockedFetchUserSettings = vi.mocked(fetchUserSettings);
+const mockedPatchUserSettings = vi.mocked(patchUserSettings);
 
 describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
   beforeEach(() => {
     mockedApiFetch.mockReset();
+    mockedFetchUserSettings.mockReset();
+    mockedPatchUserSettings.mockReset();
   });
 
   it("AC18.5.1 — ConfidenceBadge renders confidence tier labels", () => {
@@ -182,9 +188,8 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
   });
 
   it("AC18.5.5 — Settings AI toggles persist", async () => {
-    mockedApiFetch
-      .mockResolvedValueOnce({ enable_ai_reconciliation: true, enable_ai_classification: false })
-      .mockResolvedValueOnce({ enable_ai_reconciliation: true, enable_ai_classification: true });
+    mockedFetchUserSettings.mockResolvedValue({ enable_ai_reconciliation: true, enable_ai_classification: false });
+    mockedPatchUserSettings.mockResolvedValue({ enable_ai_reconciliation: true, enable_ai_classification: true });
 
     render(<AiSettingsPage />);
 
@@ -194,11 +199,12 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
     expect(classificationToggle).not.toBeChecked();
 
     fireEvent.click(classificationToggle);
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
 
     await waitFor(() =>
-      expect(mockedApiFetch).toHaveBeenCalledWith("/api/users/me/settings", {
-        method: "PATCH",
-        body: JSON.stringify({ enable_ai_classification: true }),
+      expect(mockedPatchUserSettings).toHaveBeenCalledWith({
+        enable_ai_reconciliation: true,
+        enable_ai_classification: true,
       }),
     );
   });
@@ -225,7 +231,7 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
   });
 
   it("AC18.5.7 — AI settings mount reflects saved toggles", async () => {
-    mockedApiFetch.mockResolvedValueOnce({ enable_ai_reconciliation: false, enable_ai_classification: true });
+    mockedFetchUserSettings.mockResolvedValue({ enable_ai_reconciliation: false, enable_ai_classification: true });
 
     render(<AiSettingsPage />);
 
@@ -234,27 +240,26 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
   });
 
   it("test_AC8_13_48 — AI settings handles load and reconciliation update failures", async () => {
-    mockedApiFetch.mockRejectedValueOnce(new Error("settings unavailable"));
+    mockedFetchUserSettings.mockRejectedValueOnce(new Error("settings unavailable"));
 
     render(<AiSettingsPage />);
 
-    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledWith("/api/users/me/settings"));
-    expect(screen.getByText("Loading AI settings...")).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent("settings unavailable");
 
-    mockedApiFetch.mockReset();
-    mockedApiFetch
-      .mockResolvedValueOnce({ enable_ai_reconciliation: false, enable_ai_classification: true })
-      .mockRejectedValueOnce(new Error("update failed"));
+    mockedFetchUserSettings.mockReset();
+    mockedFetchUserSettings.mockResolvedValue({ enable_ai_reconciliation: false, enable_ai_classification: true });
+    mockedPatchUserSettings.mockRejectedValueOnce(new Error("update failed"));
 
     render(<AiSettingsPage />);
 
     const reconciliationToggle = await screen.findByLabelText("Enable AI reconciliation");
     fireEvent.click(reconciliationToggle);
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
 
     await waitFor(() =>
-      expect(mockedApiFetch).toHaveBeenCalledWith("/api/users/me/settings", {
-        method: "PATCH",
-        body: JSON.stringify({ enable_ai_reconciliation: true }),
+      expect(mockedPatchUserSettings).toHaveBeenCalledWith({
+        enable_ai_reconciliation: true,
+        enable_ai_classification: true,
       }),
     );
     expect(await screen.findByText("update failed")).toBeInTheDocument();

--- a/apps/frontend/src/app/(main)/settings/ai/page.tsx
+++ b/apps/frontend/src/app/(main)/settings/ai/page.tsx
@@ -1,25 +1,33 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { apiFetch } from "@/lib/api";
+import { useToast } from "@/components/ui/Toast";
+import { fetchUserSettings, patchUserSettings } from "@/lib/api";
+import type { UserAiSettings } from "@/lib/types";
 
-interface AiSettings {
-  enable_ai_reconciliation: boolean;
-  enable_ai_classification: boolean;
-}
+const DEFAULT_SETTINGS: UserAiSettings = {
+  enable_ai_reconciliation: false,
+  enable_ai_classification: false,
+};
 
 export default function AiSettingsPage() {
-  const [settings, setSettings] = useState<AiSettings | null>(null);
+  const { showToast } = useToast();
+  // `saved` is the last value persisted by the backend; `draft` is the
+  // in-progress edit. A dirty form is any divergence between the two.
+  const [saved, setSaved] = useState<UserAiSettings | null>(null);
+  const [draft, setDraft] = useState<UserAiSettings | null>(null);
   const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchSettings = useCallback(async () => {
+  const loadSettings = useCallback(async () => {
     setLoading(true);
     try {
-      const data = await apiFetch<AiSettings>("/api/users/me/settings");
-      setSettings(data);
+      const data = await fetchUserSettings();
+      setSaved(data);
+      setDraft(data);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load AI settings");
@@ -29,29 +37,57 @@ export default function AiSettingsPage() {
   }, []);
 
   useEffect(() => {
-    fetchSettings();
-  }, [fetchSettings]);
+    loadSettings();
+  }, [loadSettings]);
 
-  const updateSetting = async (key: keyof AiSettings, value: boolean) => {
-    const nextSettings = { ...(settings ?? { enable_ai_reconciliation: false, enable_ai_classification: false }), [key]: value };
-    setSettings(nextSettings);
+  const isDirty = useMemo(() => {
+    if (!saved || !draft) return false;
+    return (
+      saved.enable_ai_reconciliation !== draft.enable_ai_reconciliation ||
+      saved.enable_ai_classification !== draft.enable_ai_classification
+    );
+  }, [saved, draft]);
+
+  const setField = (key: keyof UserAiSettings, value: boolean) => {
+    setDraft((prev) => ({ ...(prev ?? DEFAULT_SETTINGS), [key]: value }));
+  };
+
+  const handleReset = () => {
+    if (saved) setDraft(saved);
+    setError(null);
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!draft || submitting) return;
+    setSubmitting(true);
+    setError(null);
     try {
-      const updated = await apiFetch<AiSettings>("/api/users/me/settings", {
-        method: "PATCH",
-        body: JSON.stringify({ [key]: value }),
-      });
-      setSettings(updated);
-      setError(null);
+      const updated = await patchUserSettings(draft);
+      setSaved(updated);
+      setDraft(updated);
+      showToast("AI settings saved", "success");
     } catch (err) {
-      setSettings(settings);
-      setError(err instanceof Error ? err.message : "Failed to update AI settings");
+      setError(err instanceof Error ? err.message : "Failed to save AI settings");
+    } finally {
+      setSubmitting(false);
     }
   };
 
-  if (loading || !settings) {
+  if (loading) {
     return (
       <div className="p-6">
         <div className="card p-8 text-center text-muted">Loading AI settings...</div>
+      </div>
+    );
+  }
+
+  if (!draft) {
+    return (
+      <div className="p-6 max-w-3xl">
+        <div role="alert" className="alert-error">
+          {error ?? "Failed to load AI settings"}
+        </div>
       </div>
     );
   }
@@ -69,36 +105,61 @@ export default function AiSettingsPage() {
         </Link>
       </div>
 
-      {error && <div className="mb-4 alert-error">{error}</div>}
+      {error && (
+        <div role="alert" className="mb-4 alert-error">
+          {error}
+        </div>
+      )}
 
-      <div className="card divide-y divide-[var(--border)]">
-        <label className="p-5 flex items-center justify-between gap-4 cursor-pointer">
-          <div>
-            <div className="font-medium">Enable AI reconciliation</div>
-            <p className="text-sm text-muted">Use semantic AI scoring for reconciliation candidates in the 60-84 review band.</p>
-          </div>
-          <input
-            aria-label="Enable AI reconciliation"
-            type="checkbox"
-            checked={settings.enable_ai_reconciliation}
-            onChange={(event) => updateSetting("enable_ai_reconciliation", event.target.checked)}
-            className="h-5 w-5 rounded"
-          />
-        </label>
-        <label className="p-5 flex items-center justify-between gap-4 cursor-pointer">
-          <div>
-            <div className="font-medium">Enable AI classification</div>
-            <p className="text-sm text-muted">Use AI-extracted category suggestions before manual classification review.</p>
-          </div>
-          <input
-            aria-label="Enable AI classification"
-            type="checkbox"
-            checked={settings.enable_ai_classification}
-            onChange={(event) => updateSetting("enable_ai_classification", event.target.checked)}
-            className="h-5 w-5 rounded"
-          />
-        </label>
-      </div>
+      <form onSubmit={handleSubmit}>
+        <div className="card divide-y divide-[var(--border)]">
+          <label className="p-5 flex items-center justify-between gap-4 cursor-pointer">
+            <div>
+              <div className="font-medium">Enable AI reconciliation</div>
+              <p className="text-sm text-muted">Use semantic AI scoring for reconciliation candidates in the 60-84 review band.</p>
+            </div>
+            <input
+              aria-label="Enable AI reconciliation"
+              type="checkbox"
+              checked={draft.enable_ai_reconciliation}
+              disabled={submitting}
+              onChange={(event) => setField("enable_ai_reconciliation", event.target.checked)}
+              className="h-5 w-5 rounded"
+            />
+          </label>
+          <label className="p-5 flex items-center justify-between gap-4 cursor-pointer">
+            <div>
+              <div className="font-medium">Enable AI classification</div>
+              <p className="text-sm text-muted">Use AI-extracted category suggestions before manual classification review.</p>
+            </div>
+            <input
+              aria-label="Enable AI classification"
+              type="checkbox"
+              checked={draft.enable_ai_classification}
+              disabled={submitting}
+              onChange={(event) => setField("enable_ai_classification", event.target.checked)}
+              className="h-5 w-5 rounded"
+            />
+          </label>
+        </div>
+
+        <div className="mt-4 flex items-center gap-3">
+          <button type="submit" className="btn-primary" disabled={!isDirty || submitting}>
+            {submitting ? "Saving..." : "Save changes"}
+          </button>
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={handleReset}
+            disabled={!isDirty || submitting}
+          >
+            Reset
+          </button>
+          {isDirty && !submitting && (
+            <span className="text-sm text-muted">Unsaved changes</span>
+          )}
+        </div>
+      </form>
     </div>
   );
 }

--- a/apps/frontend/src/components/AppShell.tsx
+++ b/apps/frontend/src/components/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode } from "react";
 import { WorkspaceProvider, useWorkspace } from "@/hooks/useWorkspace";
+import { useSessionBootstrap } from "@/hooks/useSessionBootstrap";
 import { Sidebar } from "@/components/Sidebar";
 import { MobileNav } from "@/components/MobileNav";
 import { WorkspaceTabs } from "@/components/WorkspaceTabs";
@@ -14,6 +15,8 @@ interface AppShellProps {
 
 function AppShellContent({ children }: AppShellProps) {
     const { isCollapsed } = useWorkspace();
+    // Confirm/refresh the authenticated session against /auth/me on mount.
+    useSessionBootstrap();
 
     return (
         <div className="min-h-screen">

--- a/apps/frontend/src/hooks/useSessionBootstrap.ts
+++ b/apps/frontend/src/hooks/useSessionBootstrap.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { fetchCurrentUser } from "@/lib/api";
+import { clearUser, getUserId, setUser } from "@/lib/auth";
+
+/**
+ * Session bootstrap (EPIC-022 AC22.15 / #1010).
+ *
+ * Consumes `GET /api/auth/me` once on mount to confirm the cookie-backed
+ * session is still valid and to keep the locally-cached user identity in sync
+ * with the authoritative backend. Without this, `/auth/me` was registered and
+ * backend-tested but never consumed by the frontend.
+ *
+ * - Only runs when a local session id is present (skips the login route, which
+ *   renders outside the authenticated shell).
+ * - On success, refreshes the cached id/email from the backend response.
+ * - The shared `apiFetch` client already redirects to `/login` on a 401; any
+ *   other failure clears the stale local identity defensively.
+ */
+export function useSessionBootstrap(): void {
+    useEffect(() => {
+        if (getUserId() === null) return;
+
+        let cancelled = false;
+        void (async () => {
+            try {
+                const user = await fetchCurrentUser();
+                if (!cancelled) {
+                    setUser(user.id, user.email);
+                }
+            } catch {
+                // 401 is handled by apiFetch (redirect to /login). For any other
+                // failure, drop the stale local identity rather than trusting it.
+                if (!cancelled) {
+                    clearUser();
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -2,6 +2,9 @@ import { getAccessToken, getUserId } from "./auth";
 import type {
   ConfidenceNorthStarResponse,
   CorrectionLoopReplayResponse,
+  CurrentUser,
+  UserAiSettings,
+  UserAiSettingsUpdate,
   WorkflowEventListResponse,
   WorkflowEventResponse,
   WorkflowEventStatus,
@@ -346,4 +349,28 @@ export async function fetchConfidenceNorthStar(): Promise<ConfidenceNorthStarRes
 /** The held-out replay of the correction loop — does it lower the proportion? */
 export async function fetchCorrectionLoopReplay(): Promise<CorrectionLoopReplayResponse> {
   return apiFetch<CorrectionLoopReplayResponse>("/api/metrics/correction-loop/replay");
+}
+
+// ── Current-user AI settings (EPIC-022 AC22.15 / #1010) ────────────────────
+
+/** The effective AI feature flags for the signed-in user. */
+export async function fetchUserSettings(): Promise<UserAiSettings> {
+  return apiFetch<UserAiSettings>("/api/users/me/settings");
+}
+
+/** Persist current-user AI setting overrides and return the effective flags. */
+export async function patchUserSettings(
+  update: UserAiSettingsUpdate
+): Promise<UserAiSettings> {
+  return apiFetch<UserAiSettings>("/api/users/me/settings", {
+    method: "PATCH",
+    body: JSON.stringify(update),
+  });
+}
+
+// ── Session bootstrap (EPIC-022 AC22.15 / #1010) ───────────────────────────
+
+/** The authenticated identity backing the current session cookie/token. */
+export async function fetchCurrentUser(): Promise<CurrentUser> {
+  return apiFetch<CurrentUser>("/api/auth/me");
 }

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1071,3 +1071,24 @@ export interface CorrectionLoopReplayResponse {
   /** Whether the correction loop measurably lowered the held-out proportion. */
   reduced: boolean;
 }
+
+// ── User AI settings & session identity (EPIC-022 AC22.15 / #1010) ──────────
+//
+// Mirrors backend `UserAiSettingsResponse` / `UserAiSettingsUpdate`
+// (apps/backend/src/schemas/user.py) and `AuthResponse`
+// (apps/backend/src/schemas/auth.py).
+
+export interface UserAiSettings {
+  enable_ai_reconciliation: boolean;
+  enable_ai_classification: boolean;
+}
+
+export type UserAiSettingsUpdate = Partial<UserAiSettings>;
+
+export interface CurrentUser {
+  id: string;
+  email: string;
+  name: string | null;
+  created_at: string;
+  access_token: string;
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1075,8 +1075,7 @@ export interface CorrectionLoopReplayResponse {
 // ── User AI settings & session identity (EPIC-022 AC22.15 / #1010) ──────────
 //
 // Mirrors backend `UserAiSettingsResponse` / `UserAiSettingsUpdate`
-// (apps/backend/src/schemas/user.py) and `AuthResponse`
-// (apps/backend/src/schemas/auth.py).
+// (apps/backend/src/schemas/user.py).
 
 export interface UserAiSettings {
   enable_ai_reconciliation: boolean;
@@ -1085,10 +1084,17 @@ export interface UserAiSettings {
 
 export type UserAiSettingsUpdate = Partial<UserAiSettings>;
 
+/**
+ * Identity returned by `GET /api/auth/me`, consumed by `useSessionBootstrap`.
+ *
+ * Deliberately excludes the bearer `access_token` that the backend
+ * `AuthResponse` carries: the frontend uses cookie-based auth and never
+ * persists a token from this endpoint, so exposing it on the typed shape would
+ * only invite misuse. This type is the non-secret identity subset only.
+ */
 export interface CurrentUser {
   id: string;
   email: string;
   name: string | null;
   created_at: string;
-  access_token: string;
 }

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -347,3 +347,21 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 | AC22.14.1 | `POST /api/chat` exposes structured grounding metadata for personal-data answers, including source citations with confidence tiers, without sending or returning raw account numbers or transaction-level PII | `test_chat_router.py`, `test_ai_advisor_service.py` | P1 |
 | AC22.14.2 | `ChatPanel` renders assistant-answer citations as safe internal links and shows pending-action chips without parsing LLM prose | `chatPanelComponent.test.tsx` | P1 |
 | AC22.14.3 | A grounded chat answer that has pending reconciliation review context exposes a `Review N` action deep-link to the review queue while preserving the assistant's read-only/no-write boundary | `test_ai_advisor_service.py`, `chatPanelComponent.test.tsx` | P1 |
+
+### AC22.15 — Settings Editor And Session Bootstrap (Surface Gaps)
+
+> #1010 follow-up slice (part of #1000 Tier 3). The `PATCH /users/me/settings`
+> capability existed on the backend but the AI Settings page only auto-toggled
+> per-checkbox via inline `apiFetch`, with no typed client function, no explicit
+> save action, and no submit/success/error affordance. The `/auth/me` endpoint
+> was registered and backend-tested but never consumed by the frontend. This
+> slice gives the user a real settings editor backed by a typed `lib/api.ts`
+> client function, and consumes `/auth/me` for session bootstrap so it is no
+> longer frontend-dead. The broader `users` CRUD endpoints stay deliberately
+> deferred (no user-admin panel) — recorded in the backend README.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC22.15.1 | A typed `patchUserSettings` client function in `lib/api.ts` issues `PATCH /api/users/me/settings` through the shared `apiFetch` client (no raw `fetch`) and returns the effective `UserAiSettings` response | `apiFunctions.test.ts` | P1 |
+| AC22.15.2 | The AI Settings page renders an editable form with explicit Save and Reset controls that submits the edited flags via `patchUserSettings`, surfacing loading, submitting, success, and error states using shared UI primitives | `aiSettingsPage.test.tsx` | P1 |
+| AC22.15.3 | A typed `fetchCurrentUser` client function consumes `GET /api/auth/me`, and the authenticated app shell calls it on mount to bootstrap/refresh the local session identity, clearing local session state when the endpoint reports the session is invalid | `apiFunctions.test.ts`, `appShellSessionBootstrap.test.tsx` | P1 |


### PR DESCRIPTION
Closes #1010

Part of #1000 (Tier 3). Closes the three settings/users surface gaps.

## What changed

### 1. Settings editor calls `PATCH /users/me/settings`
The AI Settings page (`app/(main)/settings/ai/page.tsx`) previously auto-saved
each checkbox inline via a raw `apiFetch` call with no explicit save action. It
is now a real editable form:
- Explicit **Save changes** / **Reset** controls with dirty-state tracking.
- Distinct loading / submitting / success (toast) / error (alert) states using
  the shared `Toast` + `alert-error` primitives.
- Submits via a new typed **`patchUserSettings`** client in `lib/api.ts`
  (plus `fetchUserSettings`), wrapping the shared `apiFetch` — no raw `fetch`.

### 2. Decision: user admin — DEFERRED
A full multi-user admin panel is **deliberately deferred**, not missing by
accident. The `users` router is intentionally self-scoped (`/users/{id}` 404s
for any id but your own; `POST /users` is disabled in favor of `/auth/register`)
and the product has no multi-tenant/admin need. Only `/users/me/settings` is
consumed. Recorded as a concise note in `apps/backend/README.md`.

### 3. Decision: `/auth/me` — CONSUMED (not removed)
`/auth/me` was registered and backend-tested but never called by the frontend.
Rather than delete a working, well-tested endpoint, it is now **consumed for
session bootstrap**: a new `useSessionBootstrap` hook (wired into the
authenticated `AppShell`) calls it once on mount via the typed `fetchCurrentUser`
client to validate and refresh the cached identity, clearing stale local session
state if the session is invalid. Wiring was cheap, so removal was unwarranted;
the backend API surface is unchanged (api.md needs no regen).

## AC / tests
Registers **EPIC-022 AC22.15.1–.3** (next free group; AC22.14 was the prior max):
- AC22.15.1 — typed `patchUserSettings`/`fetchUserSettings` via `apiFetch` — `apiFunctions.test.ts`
- AC22.15.2 — editable form: render, edit, Save success + toast, Save error keeps draft, Reset, load error — `aiSettingsPage.test.tsx`
- AC22.15.3 — `fetchCurrentUser` + `useSessionBootstrap` on shell mount — `apiFunctions.test.ts`, `appShellSessionBootstrap.test.tsx`

Existing EPIC-018 `AC18.5.5/.7` verification tests were updated to the new typed-client contract (no AC text changed). `shellAndAuth.test.tsx` stubs the new hook.

## Local results
- `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run test` ✅ 786 passed · coverage thresholds met (lines 98.01 / functions 98.51 / branches 86.35 / statements 99.42) · `npm run build` ✅
- AC traceability gate ✅ (100%, 0 missing) · doc-consistency ✅ · api-reference `--check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)