### PR TITLE
[finance_report_ui_751] feat(#751): report shell primitives + dashboard hook layer (Slice 3, AC5.33-AC5.35)

### DIFF
--- a/apps/frontend/src/__tests__/reportFilters.test.tsx
+++ b/apps/frontend/src/__tests__/reportFilters.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CurrencyFilterControl, DateFilterControl } from "@/components/reports/ReportFilters";
+
+describe("Report filter controls", () => {
+  it("AC5.34.1 renders labelled date input and emits change", () => {
+    const onChange = vi.fn();
+    render(<DateFilterControl label="As of date" value="2026-06-30" onChange={onChange} />);
+
+    const input = screen.getByLabelText("As of date");
+    expect(input).toHaveValue("2026-06-30");
+
+    fireEvent.change(input, { target: { value: "2026-07-01" } });
+    expect(onChange).toHaveBeenCalledWith("2026-07-01");
+  });
+
+  it("AC5.34.2 renders currency options and emits change", () => {
+    const onChange = vi.fn();
+    render(
+      <CurrencyFilterControl
+        value="SGD"
+        currencies={["SGD", "USD", "EUR"]}
+        onChange={onChange}
+      />,
+    );
+
+    const select = screen.getByLabelText("Currency");
+    expect(select).toHaveValue("SGD");
+    expect(screen.getByRole("option", { name: "USD" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "EUR" })).toBeInTheDocument();
+
+    fireEvent.change(select, { target: { value: "USD" } });
+    expect(onChange).toHaveBeenCalledWith("USD");
+  });
+});

--- a/apps/frontend/src/__tests__/reportPageShell.test.tsx
+++ b/apps/frontend/src/__tests__/reportPageShell.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ReportPageShell } from "@/components/reports/ReportPageShell";
+
+describe("ReportPageShell", () => {
+  it("AC5.33.1 renders title, description, toolbar, and body content", () => {
+    render(
+      <ReportPageShell
+        title="Balance Sheet"
+        description="Assets = Liabilities + Equity"
+        toolbar={<button type="button">Export CSV</button>}
+        loadingLabel="Loading balance sheet"
+      >
+        <div>Report body</div>
+      </ReportPageShell>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Balance Sheet" })).toBeInTheDocument();
+    expect(screen.getByText("Assets = Liabilities + Equity")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export CSV" })).toBeInTheDocument();
+    expect(screen.getByText("Report body")).toBeInTheDocument();
+  });
+
+  it("AC5.33.2 shows loading skeleton while loading", () => {
+    render(
+      <ReportPageShell title="Cash Flow" loadingLabel="Loading cash flow" isLoading>
+        <div>Report body</div>
+      </ReportPageShell>,
+    );
+
+    expect(screen.getByRole("status", { name: "Loading cash flow" })).toBeInTheDocument();
+    expect(screen.queryByText("Report body")).not.toBeInTheDocument();
+  });
+
+  it("AC5.33.3 shows error message and retries on click", () => {
+    const onRetry = vi.fn();
+    render(
+      <ReportPageShell
+        title="Income Statement"
+        loadingLabel="Loading income statement"
+        isError
+        errorMessage="Boom"
+        onRetry={onRetry}
+      >
+        <div>Report body</div>
+      </ReportPageShell>,
+    );
+
+    expect(screen.getByText("Boom")).toBeInTheDocument();
+    expect(screen.queryByText("Report body")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/__tests__/reportToolbar.test.tsx
+++ b/apps/frontend/src/__tests__/reportToolbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -12,16 +12,19 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-vi.mock("@/lib/api", () => ({
-  apiDownload: vi.fn(),
-}));
-
 describe("ReportToolbar", () => {
-  it("AC5.33.4 renders AI prompt, home link, and CSV export", () => {
+  it("AC5.33.4 renders AI prompt, home link, and caller-provided export control", () => {
+    // The export control is caller-provided (#751: this primitive must not import
+    // API/transport code). The page wires the actual export behavior in.
+    const onExport = vi.fn();
     render(
       <ReportToolbar
         aiPrompt="Explain my balance sheet"
-        exportPath="/api/reports/export?report_type=balance-sheet&format=csv&currency=SGD"
+        exportControl={
+          <button type="button" onClick={onExport}>
+            Export CSV
+          </button>
+        }
       />,
     );
 
@@ -31,7 +34,11 @@ describe("ReportToolbar", () => {
       `/chat?prompt=${encodeURIComponent("Explain my balance sheet")}`,
     );
     expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
-    expect(screen.getByRole("button", { name: "Export CSV" })).toBeInTheDocument();
+
+    const exportButton = screen.getByRole("button", { name: "Export CSV" });
+    expect(exportButton).toBeInTheDocument();
+    fireEvent.click(exportButton);
+    expect(onExport).toHaveBeenCalledTimes(1);
   });
 
   it("AC5.33.5 links to chat with url-encoded prompt", () => {

--- a/apps/frontend/src/__tests__/reportToolbar.test.tsx
+++ b/apps/frontend/src/__tests__/reportToolbar.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AiPromptAction, ReportToolbar } from "@/components/reports/ReportToolbar";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/api", () => ({
+  apiDownload: vi.fn(),
+}));
+
+describe("ReportToolbar", () => {
+  it("AC5.33.4 renders AI prompt, home link, and CSV export", () => {
+    render(
+      <ReportToolbar
+        aiPrompt="Explain my balance sheet"
+        exportPath="/api/reports/export?report_type=balance-sheet&format=csv&currency=SGD"
+      />,
+    );
+
+    const aiLink = screen.getByRole("link", { name: "AI Interpretation" });
+    expect(aiLink).toHaveAttribute(
+      "href",
+      `/chat?prompt=${encodeURIComponent("Explain my balance sheet")}`,
+    );
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
+    expect(screen.getByRole("button", { name: "Export CSV" })).toBeInTheDocument();
+  });
+
+  it("AC5.33.5 links to chat with url-encoded prompt", () => {
+    render(<AiPromptAction prompt="Summarize income from 2026-01-01 to 2026-06-30" />);
+
+    expect(screen.getByRole("link", { name: "AI Interpretation" })).toHaveAttribute(
+      "href",
+      `/chat?prompt=${encodeURIComponent("Summarize income from 2026-01-01 to 2026-06-30")}`,
+    );
+  });
+});

--- a/apps/frontend/src/__tests__/useDashboardData.test.ts
+++ b/apps/frontend/src/__tests__/useDashboardData.test.ts
@@ -1,0 +1,147 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDashboardData } from "@/hooks/useDashboardData";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function routeResponder(map: Record<string, unknown>, fallback?: (path: string) => unknown) {
+  return (path: string) => {
+    const key = Object.keys(map).find((prefix) => path.startsWith(prefix));
+    if (key) return Promise.resolve(map[key]);
+    if (fallback) return Promise.resolve(fallback(path));
+    return Promise.resolve(undefined);
+  };
+}
+
+describe("useDashboardData", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("AC5.35.1 aggregates dashboard endpoints over apiFetch", async () => {
+    mockedApiFetch.mockImplementation((path: string) =>
+      routeResponder({
+        "/api/reports/balance-sheet": {
+          assets: [{ account_id: "a1", name: "Cash", amount: "5000" }],
+          liabilities: [],
+          equity: [],
+          total_assets: "5000",
+          total_liabilities: "1000",
+          total_equity: "4000",
+          equation_delta: "0",
+          currency: "USD",
+          as_of_date: "2026-02-01",
+          is_balanced: true,
+        },
+        "/api/reports/income-statement": {
+          currency: "USD",
+          trends: [],
+          income: [],
+          expenses: [],
+          total_income: "3500",
+          total_expenses: "1200",
+          net_income: "2300",
+        },
+        "/api/income/annualized": {
+          annualized_total: "42000",
+          currency: "USD",
+        },
+        "/api/chat/suggestions": { suggestions: [], structured_suggestions: [] },
+      })(path),
+    );
+
+    const { result } = renderHook(() => useDashboardData(false));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.balanceSheet?.total_assets).toBe("5000");
+    expect(result.current.incomeStatement?.total_income).toBe("3500");
+    expect(result.current.annualizedIncome?.annualized_total).toBe("42000");
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/reports/balance-sheet"),
+    );
+  });
+
+  it("AC5.35.2 normalizes missing report fields to defaults", async () => {
+    // Backend returns sparse payloads (only a few fields populated).
+    mockedApiFetch.mockImplementation((path: string) =>
+      routeResponder(
+        {
+          "/api/reports/balance-sheet": { currency: "SGD" },
+          "/api/reports/income-statement": { currency: "SGD" },
+          "/api/income/annualized": {},
+          "/api/chat/suggestions": { suggestions: [], structured_suggestions: [] },
+        },
+        () => null,
+      )(path),
+    );
+
+    const { result } = renderHook(() => useDashboardData(false));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.balanceSheet?.total_assets).toBe("0");
+    expect(result.current.balanceSheet?.assets).toEqual([]);
+    expect(result.current.incomeStatement?.net_income).toBe("0");
+    expect(result.current.annualizedIncome?.annualized_total).toBe("0");
+    expect(result.current.restrictedHoldings).toEqual([]);
+  });
+
+  it("AC5.35.3 surfaces error and retries on failure", async () => {
+    mockedApiFetch.mockReturnValue(Promise.reject(new Error("network down")));
+
+    const { result } = renderHook(() => useDashboardData(false));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe("network down");
+
+    // Recover on retry.
+    mockedApiFetch.mockImplementation((path: string) =>
+      routeResponder(
+        {
+          "/api/reports/balance-sheet": { currency: "SGD" },
+          "/api/reports/income-statement": { currency: "SGD" },
+          "/api/income/annualized": {},
+          "/api/chat/suggestions": { suggestions: [], structured_suggestions: [] },
+        },
+        () => null,
+      )(path),
+    );
+
+    await act(async () => {
+      result.current.retry();
+    });
+
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+
+  it("AC5.35.4 tolerates failing chat suggestions endpoint", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path.startsWith("/api/chat/suggestions")) {
+        return Promise.reject(new Error("suggestions unavailable"));
+      }
+      return routeResponder(
+        {
+          "/api/reports/balance-sheet": { currency: "SGD" },
+          "/api/reports/income-statement": { currency: "SGD" },
+          "/api/income/annualized": {},
+        },
+        () => null,
+      )(path);
+    });
+
+    const { result } = renderHook(() => useDashboardData(false));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.advisorSuggestions).toEqual([]);
+  });
+});

--- a/apps/frontend/src/__tests__/useReportFilters.test.ts
+++ b/apps/frontend/src/__tests__/useReportFilters.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useReportFilters } from "@/hooks/useReportFilters";
+
+describe("useReportFilters", () => {
+  it("AC5.34.3 builds query string from filter state", () => {
+    const { result } = renderHook(() =>
+      useReportFilters({
+        reportType: "income-statement",
+        initialStartDate: "2026-01-01",
+        initialEndDate: "2026-06-30",
+        initialCurrency: "USD",
+      }),
+    );
+
+    const params = new URLSearchParams(result.current.queryString);
+    expect(params.get("start_date")).toBe("2026-01-01");
+    expect(params.get("end_date")).toBe("2026-06-30");
+    expect(params.get("currency")).toBe("USD");
+  });
+
+  it("AC5.34.4 derives csv export path for report type", () => {
+    const { result } = renderHook(() =>
+      useReportFilters({
+        reportType: "balance-sheet",
+        initialAsOfDate: "2026-06-30",
+        initialCurrency: "SGD",
+      }),
+    );
+
+    expect(result.current.exportPath).toContain(
+      "/api/reports/export?report_type=balance-sheet&format=csv&",
+    );
+    expect(result.current.exportPath).toContain("as_of_date=2026-06-30");
+    expect(result.current.exportPath).toContain("currency=SGD");
+  });
+
+  it("AC5.34.5 updates query string when currency changes", () => {
+    const { result } = renderHook(() =>
+      useReportFilters({
+        reportType: "cash-flow",
+        initialStartDate: "2026-05-01",
+        initialEndDate: "2026-06-01",
+        initialCurrency: "SGD",
+      }),
+    );
+
+    expect(new URLSearchParams(result.current.queryString).get("currency")).toBe("SGD");
+
+    act(() => {
+      result.current.setCurrency("EUR");
+    });
+
+    expect(new URLSearchParams(result.current.queryString).get("currency")).toBe("EUR");
+  });
+});

--- a/apps/frontend/src/app/(main)/page.tsx
+++ b/apps/frontend/src/app/(main)/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Landmark, FileText, BookOpen } from "lucide-react";
 import ProcessingSummaryCard from "@/components/ProcessingSummaryCard";
 import { UploadToReportHomePanel } from "@/components/workflow/WorkflowNotifications";
@@ -9,213 +9,41 @@ import { AdvisorBrief } from "@/components/advisor/AdvisorBrief";
 import { TrustMeter } from "@/components/home/TrustMeter";
 import { InfoHint } from "@/components/ui/InfoHint";
 
-import { apiFetch } from "@/lib/api";
-import { formatDateInput, formatDateDisplay, formatMonthLabel } from "@/lib/date";
+import { formatDateDisplay, formatMonthLabel } from "@/lib/date";
 import { amountToChartNumber, compareAmounts, formatCurrencyLocale, subtractAmounts, toDecimal } from "@/lib/currency";
+import { useDashboardData } from "@/hooks/useDashboardData";
 import { BarChart } from "@/components/charts/BarChart";
 import { NetWorthTimeSeriesChart } from "@/components/charts/NetWorthTimeSeriesChart";
 import { PieChart } from "@/components/charts/PieChart";
 import { TrendChart } from "@/components/charts/TrendChart";
-import {
-  AccountListResponse,
-  AdvisorSuggestion,
-  BankStatementListResponse,
-  BalanceSheetResponse,
-  ChatSuggestionsResponse,
-  AnnualizedIncomeResponse,
-  IncomeStatementResponse,
-  JournalEntryListResponse,
-  ReconciliationStatsResponse,
-  RestrictedHolding,
-  TrendResponse,
-  UnmatchedTransactionsResponse
-} from "@/lib/types";
 
 const CHART_PALETTE = ["var(--chart-1)", "var(--chart-2)", "var(--chart-3)", "var(--chart-4)", "var(--chart-5)"];
 
-const EMPTY_BALANCE_SHEET: BalanceSheetResponse = {
-  as_of_date: "",
-  currency: "SGD",
-  assets: [],
-  liabilities: [],
-  equity: [],
-  total_assets: "0",
-  total_liabilities: "0",
-  total_equity: "0",
-  equation_delta: "0",
-  is_balanced: true,
-};
-
-const EMPTY_INCOME_STATEMENT: IncomeStatementResponse = {
-  start_date: "",
-  end_date: "",
-  currency: "SGD",
-  income: [],
-  expenses: [],
-  total_income: "0",
-  total_expenses: "0",
-  net_income: "0",
-  trends: [],
-};
-
-const EMPTY_ANNUALIZED_INCOME: AnnualizedIncomeResponse = {
-  annualized_salary: "0",
-  annualized_bonus: "0",
-  annualized_dividend: "0",
-  annualized_total: "0",
-  currency: "SGD",
-  as_of: "",
-};
-
-function normalizeBalanceSheet(data?: Partial<BalanceSheetResponse> | null): BalanceSheetResponse {
-  return {
-    ...EMPTY_BALANCE_SHEET,
-    ...data,
-    assets: data?.assets ?? [],
-    liabilities: data?.liabilities ?? [],
-    equity: data?.equity ?? [],
-    total_assets: data?.total_assets ?? "0",
-    total_liabilities: data?.total_liabilities ?? "0",
-    total_equity: data?.total_equity ?? "0",
-    equation_delta: data?.equation_delta ?? "0",
-    currency: data?.currency ?? "SGD",
-    as_of_date: data?.as_of_date ?? "",
-    is_balanced: data?.is_balanced ?? true,
-  };
-}
-
-function normalizeIncomeStatement(data?: Partial<IncomeStatementResponse> | null): IncomeStatementResponse {
-  return {
-    ...EMPTY_INCOME_STATEMENT,
-    ...data,
-    income: data?.income ?? [],
-    expenses: data?.expenses ?? [],
-    trends: data?.trends ?? [],
-    total_income: data?.total_income ?? "0",
-    total_expenses: data?.total_expenses ?? "0",
-    net_income: data?.net_income ?? "0",
-    currency: data?.currency ?? "SGD",
-  };
-}
-
-function normalizeAnnualizedIncome(data?: Partial<AnnualizedIncomeResponse> | null): AnnualizedIncomeResponse {
-  return {
-    ...EMPTY_ANNUALIZED_INCOME,
-    ...data,
-    annualized_salary: data?.annualized_salary ?? "0",
-    annualized_bonus: data?.annualized_bonus ?? "0",
-    annualized_dividend: data?.annualized_dividend ?? "0",
-    annualized_total: data?.annualized_total ?? "0",
-    currency: data?.currency ?? "SGD",
-    as_of: data?.as_of ?? "",
-  };
-}
-
-interface OnboardingStatus {
-  accountCount: number;
-  statementCount: number;
-  approvedStatementCount: number;
-  postedEntryCount: number;
-}
-
 export default function HomePage() {
-  const [balanceSheet, setBalanceSheet] = useState<BalanceSheetResponse | null>(null);
-  const [incomeStatement, setIncomeStatement] = useState<IncomeStatementResponse | null>(null);
-  const [trend, setTrend] = useState<TrendResponse | null>(null);
-  const [stats, setStats] = useState<ReconciliationStatsResponse | null>(null);
-  const [unmatched, setUnmatched] = useState<UnmatchedTransactionsResponse | null>(null);
-  const [recentEntries, setRecentEntries] = useState<JournalEntryListResponse | null>(null);
-  const [onboardingStatus, setOnboardingStatus] = useState<OnboardingStatus | null>(null);
-  const [advisorSuggestions, setAdvisorSuggestions] = useState<AdvisorSuggestion[]>([]);
-  const [annualizedIncome, setAnnualizedIncome] = useState<AnnualizedIncomeResponse | null>(null);
-  const [restrictedHoldings, setRestrictedHoldings] = useState<RestrictedHolding[]>([]);
   const [includeRestricted, setIncludeRestricted] = useState(false);
   // EPIC-022 PR4: Home defaults to a lean view; heavy charts are opt-in.
   const [showAnalytics, setShowAnalytics] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [trendAccountId, setTrendAccountId] = useState<string | null>(null);
-  const [trendAccountName, setTrendAccountName] = useState<string>("Top Asset");
 
-  const fetchData = useCallback(async () => {
-    const today = new Date();
-    const incomeStart = formatDateInput(new Date(today.getFullYear(), today.getMonth() - 11, 1));
-    const incomeEnd = formatDateInput(today);
-    setLoading(true);
-    try {
-      const [
-        balanceData,
-        incomeData,
-        annualizedData,
-        restrictedData,
-        statsData,
-        unmatchedData,
-        journalData,
-        accountData,
-        statementData,
-        postedJournalData,
-        chatSuggestionsData,
-      ] = await Promise.all([
-        apiFetch<BalanceSheetResponse>(`/api/reports/balance-sheet?include_restricted=${includeRestricted ? "true" : "false"}`),
-        apiFetch<IncomeStatementResponse>(`/api/reports/income-statement?start_date=${incomeStart}&end_date=${incomeEnd}`),
-        apiFetch<AnnualizedIncomeResponse>("/api/income/annualized"),
-        apiFetch<RestrictedHolding[]>("/api/assets/restricted"),
-        apiFetch<ReconciliationStatsResponse>("/api/reconciliation/stats"),
-        apiFetch<UnmatchedTransactionsResponse>("/api/reconciliation/unmatched?limit=5"),
-        apiFetch<JournalEntryListResponse>("/api/journal-entries?page=1&page_size=5"),
-        apiFetch<AccountListResponse>("/api/accounts?limit=1"),
-        apiFetch<BankStatementListResponse>("/api/statements"),
-        apiFetch<JournalEntryListResponse>("/api/journal-entries?status_filter=posted&limit=1"),
-        apiFetch<ChatSuggestionsResponse>("/api/chat/suggestions?language=en&include_structured=true").catch(() => ({
-          suggestions: [],
-          structured_suggestions: [],
-        })),
-      ]);
-      setBalanceSheet(normalizeBalanceSheet(balanceData));
-      setIncomeStatement(normalizeIncomeStatement(incomeData));
-      setAnnualizedIncome(normalizeAnnualizedIncome(annualizedData));
-      setRestrictedHoldings(Array.isArray(restrictedData) ? restrictedData : []);
-      setStats(statsData || { total_transactions: 0, matched_transactions: 0, unmatched_transactions: 0, pending_review: 0, auto_accepted: 0, match_rate: 0, score_distribution: {} });
-      setUnmatched(unmatchedData || { items: [], total: 0 });
-      setRecentEntries(journalData || { items: [], total: 0 });
-      setOnboardingStatus({
-        accountCount: accountData?.total ?? 0,
-        statementCount: statementData?.total ?? 0,
-        approvedStatementCount: statementData?.items?.filter((statement) => statement.status === "approved").length ?? 0,
-        postedEntryCount: postedJournalData?.total ?? 0,
-      });
-      setAdvisorSuggestions(chatSuggestionsData?.structured_suggestions ?? []);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load dashboard data.");
-    } finally {
-      setLoading(false);
-    }
-  }, [includeRestricted]);
-
-  const fetchTrend = useCallback(async () => {
-    if (!balanceSheet || !balanceSheet.assets) return;
-    const sortedAssets = [...balanceSheet.assets].sort((a, b) => compareAmounts(b.amount, a.amount));
-    const target = trendAccountId
-      ? sortedAssets.find((a) => a.account_id === trendAccountId) ?? sortedAssets[0]
-      : sortedAssets[0];
-    if (!target) return;
-    setTrendAccountName(target.name);
-    try {
-      const trendData = await apiFetch<TrendResponse>(`/api/reports/trend?account_id=${target.account_id}&period=monthly`);
-      setTrend(trendData);
-    } catch (err) {
-      console.error("Failed to fetch trend data:", err);
-      setTrend(null);
-    }
-  }, [balanceSheet, trendAccountId]);
-
-  useEffect(() => { fetchData(); }, [fetchData]);
-  useEffect(() => {
-    if (balanceSheet && balanceSheet.assets) {
-      fetchTrend();
-    }
-  }, [fetchTrend, balanceSheet]);
+  // Slice 3 of #751: dashboard aggregation + normalization live in the hook
+  // layer; the route composes the returned data.
+  const {
+    balanceSheet,
+    incomeStatement,
+    annualizedIncome,
+    restrictedHoldings,
+    stats,
+    unmatched,
+    recentEntries,
+    onboardingStatus,
+    advisorSuggestions,
+    trend,
+    trendAccountName,
+    trendAccountId,
+    setTrendAccountId,
+    loading,
+    error,
+    retry: fetchData,
+  } = useDashboardData(includeRestricted);
 
   const netAssets = useMemo(() => {
     return balanceSheet ? subtractAmounts(balanceSheet.total_assets ?? 0, balanceSheet.total_liabilities ?? 0) : toDecimal("0");

--- a/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
@@ -12,6 +12,7 @@ import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
 import { ReportPageShell } from "@/components/reports/ReportPageShell";
 import { ReportToolbar } from "@/components/reports/ReportToolbar";
+import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
 import { CurrencyFilterControl, DateFilterControl } from "@/components/reports/ReportFilters";
 import { ProvenanceBadge } from "@/components/ui/ProvenanceBadge";
 import { InfoHint } from "@/components/ui/InfoHint";
@@ -114,7 +115,12 @@ export default function BalanceSheetPage() {
       isError={reportQuery.isError}
       errorMessage={reportQuery.error?.message}
       onRetry={() => void reportQuery.refetch()}
-      toolbar={<ReportToolbar aiPrompt={aiPrompt} exportPath={exportPath} />}
+      toolbar={
+        <ReportToolbar
+          aiPrompt={aiPrompt}
+          exportControl={<ExportCsvButton path={exportPath} />}
+        />
+      }
     >
       <div className="flex flex-wrap gap-3 mb-6 text-sm">
         <DateFilterControl label="As of date" value={asOfDate} onChange={setAsOfDate} />

--- a/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
@@ -4,14 +4,15 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 
-import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
-import { formatDateInput } from "@/lib/date";
 import { formatCurrencyLocale } from "@/lib/currency";
 import { useCurrencies } from "@/hooks/useCurrencies";
 import { useApiQuery } from "@/hooks/useApiQuery";
+import { useReportFilters } from "@/hooks/useReportFilters";
 import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
-import { ReportPageSkeleton } from "@/components/reports/ReportPageSkeleton";
+import { ReportPageShell } from "@/components/reports/ReportPageShell";
+import { ReportToolbar } from "@/components/reports/ReportToolbar";
+import { CurrencyFilterControl, DateFilterControl } from "@/components/reports/ReportFilters";
 import { ProvenanceBadge } from "@/components/ui/ProvenanceBadge";
 import { InfoHint } from "@/components/ui/InfoHint";
 import type { BalanceSheetResponse, ReportLine } from "@/lib/types";
@@ -32,13 +33,16 @@ const buildTree = (lines: ReportLine[]): AccountNode[] => {
 };
 
 export default function BalanceSheetPage() {
-  const [asOfDate, setAsOfDate] = useState(() => formatDateInput(new Date()));
-  const [currency, setCurrency] = useState("SGD");
+  const { asOfDate, setAsOfDate, currency, setCurrency } = useReportFilters({
+    reportType: "balance-sheet",
+  });
   const [includeRestricted, setIncludeRestricted] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [drillTarget, setDrillTarget] = useState<AccountLineageTarget | null>(null);
   const { currencies } = useCurrencies();
 
+  // Balance sheet adds the restricted-holdings toggle on top of the shared
+  // date/currency filters, so it builds its own request query string here.
   const queryString = useMemo(() => {
     const params = new URLSearchParams({
       as_of_date: asOfDate,
@@ -68,7 +72,7 @@ export default function BalanceSheetPage() {
   const equityTree = useMemo(() => report ? buildTree(report.equity) : [], [report]);
 
   const exportPath = `/api/reports/export?report_type=balance-sheet&format=csv&${queryString}`;
-  const aiPrompt = useMemo(() => encodeURIComponent(`Explain my balance sheet as of ${asOfDate} in ${currency}. Highlight any risks.`), [asOfDate, currency]);
+  const aiPrompt = useMemo(() => `Explain my balance sheet as of ${asOfDate} in ${currency}. Highlight any risks.`, [asOfDate, currency]);
 
   const toggle = (id: string) => setExpanded((prev) => { const next = new Set(prev); next.has(id) ? next.delete(id) : next.add(id); return next; });
 
@@ -101,28 +105,20 @@ export default function BalanceSheetPage() {
     );
   };
 
-  if (reportQuery.isLoading) return <ReportPageSkeleton label="Loading balance sheet" />;
-  if (reportQuery.isError) return (
-    <div className="p-6"><div className="card p-8 text-center max-w-md mx-auto"><p className="text-muted mb-4">{reportQuery.error.message}</p><button onClick={() => void reportQuery.refetch()} className="btn-secondary">Retry</button></div></div>
-  );
-
   return (
-    <div className="p-6">
-      <div className="page-header flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
-        <div>
-          <h1 className="page-title">Balance Sheet</h1>
-          <p className="page-description">Assets = Liabilities + Equity</p>
-        </div>
-        <div className="flex gap-2">
-          <Link href={`/chat?prompt=${aiPrompt}`} className="btn-secondary text-sm">AI Interpretation</Link>
-          <Link href="/" className="btn-secondary text-sm">Home</Link>
-          <ExportCsvButton path={exportPath} />
-        </div>
-      </div>
-
+    <ReportPageShell
+      title="Balance Sheet"
+      description="Assets = Liabilities + Equity"
+      loadingLabel="Loading balance sheet"
+      isLoading={reportQuery.isLoading}
+      isError={reportQuery.isError}
+      errorMessage={reportQuery.error?.message}
+      onRetry={() => void reportQuery.refetch()}
+      toolbar={<ReportToolbar aiPrompt={aiPrompt} exportPath={exportPath} />}
+    >
       <div className="flex flex-wrap gap-3 mb-6 text-sm">
-        <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">As of date</span><input type="date" value={asOfDate} onChange={(e) => setAsOfDate(e.target.value)} className="input w-auto" /></label>
-        <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">Currency</span><select value={currency} onChange={(e) => setCurrency(e.target.value)} className="input w-auto">{currencies.map((c) => <option key={c} value={c}>{c}</option>)}</select></label>
+        <DateFilterControl label="As of date" value={asOfDate} onChange={setAsOfDate} />
+        <CurrencyFilterControl value={currency} currencies={currencies} onChange={setCurrency} />
         <label className="self-end flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2">
           <input type="checkbox" checked={includeRestricted} onChange={(e) => setIncludeRestricted(e.target.checked)} />
           <span>Include restricted holdings</span>
@@ -187,6 +183,6 @@ export default function BalanceSheetPage() {
       </div>
 
       <AccountLineageDrawer target={drillTarget} onClose={() => setDrillTarget(null)} />
-    </div>
+    </ReportPageShell>
   );
 }

--- a/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
@@ -1,31 +1,33 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import { SankeyChart } from "@/components/charts/SankeyChart";
-import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
 import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
-import { ReportPageSkeleton } from "@/components/reports/ReportPageSkeleton";
+import { ReportPageShell } from "@/components/reports/ReportPageShell";
+import { ReportToolbar } from "@/components/reports/ReportToolbar";
+import { CurrencyFilterControl, DateFilterControl } from "@/components/reports/ReportFilters";
 import { formatDateInput } from "@/lib/date";
 import { compareAmounts, formatCurrencyLocale, toDecimal } from "@/lib/currency";
 import { useCurrencies } from "@/hooks/useCurrencies";
 import { useApiQuery } from "@/hooks/useApiQuery";
+import { useReportFilters } from "@/hooks/useReportFilters";
 import type { CashFlowItem, CashFlowResponse } from "@/lib/types";
 
+const defaultStartDate = () => {
+  const d = new Date();
+  d.setMonth(d.getMonth() - 1);
+  return formatDateInput(d);
+};
+
 export default function CashFlowPage() {
-  const [startDate, setStartDate] = useState(() => { const d = new Date(); d.setMonth(d.getMonth() - 1); return formatDateInput(d); });
-  const [endDate, setEndDate] = useState(() => formatDateInput(new Date()));
-  const [currency, setCurrency] = useState("SGD");
+  const { startDate, setStartDate, endDate, setEndDate, currency, setCurrency, queryString, exportPath } =
+    useReportFilters({ reportType: "cash-flow", initialStartDate: defaultStartDate() });
   const [drillTarget, setDrillTarget] = useState<AccountLineageTarget | null>(null);
   const { currencies } = useCurrencies();
 
-  const queryString = useMemo(() => {
-    const params = new URLSearchParams({ start_date: startDate, end_date: endDate, currency });
-    return params.toString();
-  }, [currency, endDate, startDate]);
   const reportQuery = useApiQuery<CashFlowResponse>(
     ["report", "cash-flow", queryString],
     `/api/reports/cash-flow?${queryString}`,
@@ -34,8 +36,7 @@ export default function CashFlowPage() {
   const report = reportQuery.data ?? null;
 
   const summary = useMemo(() => report?.summary, [report]);
-  const exportPath = `/api/reports/export?report_type=cash-flow&format=csv&${queryString}`;
-  const aiPrompt = useMemo(() => encodeURIComponent(`Analyze my cash flow from ${startDate} to ${endDate} in ${currency}. What are the main sources and uses of cash?`), [currency, endDate, startDate]);
+  const aiPrompt = useMemo(() => `Analyze my cash flow from ${startDate} to ${endDate} in ${currency}. What are the main sources and uses of cash?`, [currency, endDate, startDate]);
 
   const renderSection = (title: string, items: CashFlowItem[], colorClass: string) => (
     <div className="card p-5">
@@ -75,27 +76,21 @@ export default function CashFlowPage() {
     </div>
   );
 
-  if (reportQuery.isLoading) return <ReportPageSkeleton label="Loading cash flow" />;
-  if (reportQuery.isError) return <div className="p-6"><div className="card p-8 text-center max-w-md mx-auto"><p className="text-muted mb-4">{reportQuery.error.message}</p><button onClick={() => void reportQuery.refetch()} className="btn-secondary">Retry</button></div></div>;
-
   return (
-    <div className="p-6">
-      <div className="page-header flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
-        <div>
-          <h1 className="page-title">Cash Flow Statement</h1>
-          <p className="page-description">Operating, Investing, and Financing activities</p>
-        </div>
-        <div className="flex gap-2">
-          <Link href={`/chat?prompt=${aiPrompt}`} className="btn-secondary text-sm">AI Interpretation</Link>
-          <Link href="/" className="btn-secondary text-sm">Home</Link>
-          <ExportCsvButton path={exportPath} />
-        </div>
-      </div>
-
+    <ReportPageShell
+      title="Cash Flow Statement"
+      description="Operating, Investing, and Financing activities"
+      loadingLabel="Loading cash flow"
+      isLoading={reportQuery.isLoading}
+      isError={reportQuery.isError}
+      errorMessage={reportQuery.error?.message}
+      onRetry={() => void reportQuery.refetch()}
+      toolbar={<ReportToolbar aiPrompt={aiPrompt} exportPath={exportPath} />}
+    >
       <div className="flex flex-wrap gap-3 mb-6 text-sm">
-        <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">Start date</span><input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className="input w-auto" /></label>
-        <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">End date</span><input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className="input w-auto" /></label>
-        <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">Currency</span><select value={currency} onChange={(e) => setCurrency(e.target.value)} className="input w-auto">{currencies.map((c) => <option key={c} value={c}>{c}</option>)}</select></label>
+        <DateFilterControl label="Start date" value={startDate} onChange={setStartDate} />
+        <DateFilterControl label="End date" value={endDate} onChange={setEndDate} />
+        <CurrencyFilterControl value={currency} currencies={currencies} onChange={setCurrency} />
       </div>
 
       <FxWarningBanner warnings={report?.fx_warnings} />
@@ -205,6 +200,6 @@ export default function CashFlowPage() {
       )}
 
       <AccountLineageDrawer target={drillTarget} onClose={() => setDrillTarget(null)} />
-    </div>
+    </ReportPageShell>
   );
 }

--- a/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/cash-flow/page.tsx
@@ -8,6 +8,7 @@ import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
 import { ReportPageShell } from "@/components/reports/ReportPageShell";
 import { ReportToolbar } from "@/components/reports/ReportToolbar";
+import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
 import { CurrencyFilterControl, DateFilterControl } from "@/components/reports/ReportFilters";
 import { formatDateInput } from "@/lib/date";
 import { compareAmounts, formatCurrencyLocale, toDecimal } from "@/lib/currency";
@@ -85,7 +86,12 @@ export default function CashFlowPage() {
       isError={reportQuery.isError}
       errorMessage={reportQuery.error?.message}
       onRetry={() => void reportQuery.refetch()}
-      toolbar={<ReportToolbar aiPrompt={aiPrompt} exportPath={exportPath} />}
+      toolbar={
+        <ReportToolbar
+          aiPrompt={aiPrompt}
+          exportControl={<ExportCsvButton path={exportPath} />}
+        />
+      }
     >
       <div className="flex flex-wrap gap-3 mb-6 text-sm">
         <DateFilterControl label="Start date" value={startDate} onChange={setStartDate} />

--- a/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
@@ -1,19 +1,20 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import { BarChart } from "@/components/charts/BarChart";
 import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
-import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
-import { ReportPageSkeleton } from "@/components/reports/ReportPageSkeleton";
+import { ReportPageShell } from "@/components/reports/ReportPageShell";
+import { ReportToolbar } from "@/components/reports/ReportToolbar";
+import { CurrencyFilterControl, DateFilterControl } from "@/components/reports/ReportFilters";
 import { ProvenanceBadge } from "@/components/ui/ProvenanceBadge";
 import { formatDateInput, formatMonthLabel } from "@/lib/date";
 import { amountToChartNumber, formatCurrencyLocale } from "@/lib/currency";
 import { useCurrencies } from "@/hooks/useCurrencies";
 import { useApiQuery } from "@/hooks/useApiQuery";
+import { useReportFilters } from "@/hooks/useReportFilters";
 import type { IncomeStatementResponse } from "@/lib/types";
 
 const ACCOUNT_TYPE_OPTIONS = [
@@ -33,10 +34,18 @@ const TAG_OPTIONS = [
   { value: "food", label: "Food & Dining" },
 ];
 
+const defaultStartDate = () => {
+  const d = new Date();
+  d.setMonth(d.getMonth() - 11);
+  d.setDate(1);
+  return formatDateInput(d);
+};
+
 export default function IncomeStatementPage() {
-  const [startDate, setStartDate] = useState(() => { const d = new Date(); d.setMonth(d.getMonth() - 11); d.setDate(1); return formatDateInput(d); });
-  const [endDate, setEndDate] = useState(() => formatDateInput(new Date()));
-  const [currency, setCurrency] = useState("SGD");
+  const { startDate, setStartDate, endDate, setEndDate, currency, setCurrency } = useReportFilters({
+    reportType: "income-statement",
+    initialStartDate: defaultStartDate(),
+  });
   const [accountTypeFilter, setAccountTypeFilter] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [drillTarget, setDrillTarget] = useState<AccountLineageTarget | null>(null);
@@ -70,29 +79,24 @@ export default function IncomeStatementPage() {
 
   const barItems = useMemo(() => report ? report.trends.slice(-6).map((t) => ({ label: formatMonthLabel(t.period_start), income: amountToChartNumber(t.total_income), expense: amountToChartNumber(t.total_expenses) })) : [], [report]);
   const exportPath = useMemo(() => `/api/reports/export?report_type=income-statement&format=csv&${queryString}`, [queryString]);
-  const aiPrompt = useMemo(() => encodeURIComponent(`Summarize my income statement from ${startDate} to ${endDate} in ${currency}. Highlight key trends.`), [currency, endDate, startDate]);
-
-  if (reportQuery.isLoading) return <ReportPageSkeleton label="Loading income statement" sections={2} />;
-  if (reportQuery.isError) return <div className="p-6"><div className="card p-8 text-center max-w-md mx-auto"><p className="text-muted mb-4">{reportQuery.error.message}</p><button onClick={() => void reportQuery.refetch()} className="btn-secondary">Retry</button></div></div>;
+  const aiPrompt = useMemo(() => `Summarize my income statement from ${startDate} to ${endDate} in ${currency}. Highlight key trends.`, [currency, endDate, startDate]);
 
   return (
-    <div className="p-6">
-      <div className="page-header flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
-        <div>
-          <h1 className="page-title">Income Statement</h1>
-          <p className="page-description">Net Income = Income - Expenses</p>
-        </div>
-        <div className="flex gap-2 flex-wrap">
-          <Link href={`/chat?prompt=${aiPrompt}`} className="btn-secondary text-sm">AI Interpretation</Link>
-          <Link href="/" className="btn-secondary text-sm">Home</Link>
-          <ExportCsvButton path={exportPath} />
-        </div>
-      </div>
-
+    <ReportPageShell
+      title="Income Statement"
+      description="Net Income = Income - Expenses"
+      loadingLabel="Loading income statement"
+      loadingSections={2}
+      isLoading={reportQuery.isLoading}
+      isError={reportQuery.isError}
+      errorMessage={reportQuery.error?.message}
+      onRetry={() => void reportQuery.refetch()}
+      toolbar={<ReportToolbar aiPrompt={aiPrompt} exportPath={exportPath} />}
+    >
       <div className="flex flex-wrap gap-3 mb-6 text-sm">
-        <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">Start date</span><input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className="input w-auto" /></label>
-        <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">End date</span><input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className="input w-auto" /></label>
-        <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">Currency</span><select value={currency} onChange={(e) => setCurrency(e.target.value)} className="input w-auto">{currencies.map((c) => <option key={c} value={c}>{c}</option>)}</select></label>
+        <DateFilterControl label="Start date" value={startDate} onChange={setStartDate} />
+        <DateFilterControl label="End date" value={endDate} onChange={setEndDate} />
+        <CurrencyFilterControl value={currency} currencies={currencies} onChange={setCurrency} />
         <label className="flex flex-col gap-1"><span className="text-xs text-muted uppercase">Account type</span><select value={accountTypeFilter} onChange={(e) => setAccountTypeFilter(e.target.value)} className="input w-auto">
           {ACCOUNT_TYPE_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
         </select></label>
@@ -213,6 +217,6 @@ export default function IncomeStatementPage() {
       </div>
 
       <AccountLineageDrawer target={drillTarget} onClose={() => setDrillTarget(null)} />
-    </div>
+    </ReportPageShell>
   );
 }

--- a/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/income-statement/page.tsx
@@ -8,6 +8,7 @@ import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
 import { ReportPageShell } from "@/components/reports/ReportPageShell";
 import { ReportToolbar } from "@/components/reports/ReportToolbar";
+import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
 import { CurrencyFilterControl, DateFilterControl } from "@/components/reports/ReportFilters";
 import { ProvenanceBadge } from "@/components/ui/ProvenanceBadge";
 import { formatDateInput, formatMonthLabel } from "@/lib/date";
@@ -91,7 +92,12 @@ export default function IncomeStatementPage() {
       isError={reportQuery.isError}
       errorMessage={reportQuery.error?.message}
       onRetry={() => void reportQuery.refetch()}
-      toolbar={<ReportToolbar aiPrompt={aiPrompt} exportPath={exportPath} />}
+      toolbar={
+        <ReportToolbar
+          aiPrompt={aiPrompt}
+          exportControl={<ExportCsvButton path={exportPath} />}
+        />
+      }
     >
       <div className="flex flex-wrap gap-3 mb-6 text-sm">
         <DateFilterControl label="Start date" value={startDate} onChange={setStartDate} />

--- a/apps/frontend/src/components/reports/ReportFilters.tsx
+++ b/apps/frontend/src/components/reports/ReportFilters.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useId } from "react";
+
+/**
+ * Reusable report filter controls (Slice 3 of #751).
+ *
+ * The labelled date input and currency `<select>` were duplicated across every
+ * report route. These primitives keep the exact markup/classes the routes used
+ * (`input w-auto`, uppercase muted label) while emitting plain string values so
+ * routes can wire them to `useReportFilters` state.
+ */
+
+interface DateFilterControlProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function DateFilterControl({ label, value, onChange }: DateFilterControlProps) {
+  const id = useId();
+  return (
+    <label htmlFor={id} className="flex flex-col gap-1">
+      <span className="text-xs text-muted uppercase">{label}</span>
+      <input
+        id={id}
+        type="date"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="input w-auto"
+      />
+    </label>
+  );
+}
+
+interface CurrencyFilterControlProps {
+  value: string;
+  currencies: string[];
+  onChange: (value: string) => void;
+  label?: string;
+}
+
+export function CurrencyFilterControl({
+  value,
+  currencies,
+  onChange,
+  label = "Currency",
+}: CurrencyFilterControlProps) {
+  const id = useId();
+  return (
+    <label htmlFor={id} className="flex flex-col gap-1">
+      <span className="text-xs text-muted uppercase">{label}</span>
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="input w-auto"
+      >
+        {currencies.map((currency) => (
+          <option key={currency} value={currency}>
+            {currency}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/frontend/src/components/reports/ReportPageShell.tsx
+++ b/apps/frontend/src/components/reports/ReportPageShell.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { ReportPageSkeleton } from "@/components/reports/ReportPageSkeleton";
+
+/**
+ * Report page shell (Slice 3 of #751).
+ *
+ * Owns the header (title + description + toolbar slot) and the loading / error
+ * lifecycle that every report route repeated by hand. Routes pass query state in
+ * (`isLoading`, `isError`, `errorMessage`, `onRetry`) and compose the report
+ * body + filters as children, so the route file stays thin.
+ */
+
+interface ReportPageShellProps {
+  title: string;
+  description?: string;
+  toolbar?: ReactNode;
+  loadingLabel: string;
+  /** Number of skeleton sections to show while loading. */
+  loadingSections?: number;
+  isLoading?: boolean;
+  isError?: boolean;
+  errorMessage?: string;
+  onRetry?: () => void;
+  children: ReactNode;
+}
+
+export function ReportPageShell({
+  title,
+  description,
+  toolbar,
+  loadingLabel,
+  loadingSections,
+  isLoading = false,
+  isError = false,
+  errorMessage,
+  onRetry,
+  children,
+}: ReportPageShellProps) {
+  if (isLoading) {
+    return <ReportPageSkeleton label={loadingLabel} sections={loadingSections} />;
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="card p-8 text-center max-w-md mx-auto">
+          <p className="text-muted mb-4">{errorMessage ?? "Failed to load report."}</p>
+          {onRetry && (
+            <button type="button" onClick={onRetry} className="btn-secondary">
+              Retry
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <div className="page-header flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
+        <div>
+          <h1 className="page-title">{title}</h1>
+          {description && <p className="page-description">{description}</p>}
+        </div>
+        {toolbar}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/reports/ReportToolbar.tsx
+++ b/apps/frontend/src/components/reports/ReportToolbar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
+
+/**
+ * Report toolbar primitives (Slice 3 of #751).
+ *
+ * The "AI Interpretation / Home / Export CSV" action cluster was duplicated
+ * verbatim across every report route. `ReportToolbar` composes it from props so
+ * routes only supply the prompt text and export path; `AiPromptAction` is the
+ * standalone AI link used inside it.
+ */
+
+interface AiPromptActionProps {
+  /** Natural-language prompt; URL-encoded into the chat route. */
+  prompt: string;
+  label?: string;
+}
+
+export function AiPromptAction({ prompt, label = "AI Interpretation" }: AiPromptActionProps) {
+  return (
+    <Link href={`/chat?prompt=${encodeURIComponent(prompt)}`} className="btn-secondary text-sm">
+      {label}
+    </Link>
+  );
+}
+
+interface ReportToolbarProps {
+  /** Natural-language prompt for the AI interpretation action. */
+  aiPrompt: string;
+  /** Authenticated CSV export path. */
+  exportPath: string;
+  /** Destination for the "Home" link. */
+  homeHref?: string;
+  /** Optional extra actions rendered before the standard cluster. */
+  children?: ReactNode;
+}
+
+export function ReportToolbar({
+  aiPrompt,
+  exportPath,
+  homeHref = "/",
+  children,
+}: ReportToolbarProps) {
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {children}
+      <AiPromptAction prompt={aiPrompt} />
+      <Link href={homeHref} className="btn-secondary text-sm">
+        Home
+      </Link>
+      <ExportCsvButton path={exportPath} />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/reports/ReportToolbar.tsx
+++ b/apps/frontend/src/components/reports/ReportToolbar.tsx
@@ -3,15 +3,18 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-import { ExportCsvButton } from "@/components/reports/ExportCsvButton";
-
 /**
  * Report toolbar primitives (Slice 3 of #751).
  *
  * The "AI Interpretation / Home / Export CSV" action cluster was duplicated
  * verbatim across every report route. `ReportToolbar` composes it from props so
- * routes only supply the prompt text and export path; `AiPromptAction` is the
- * standalone AI link used inside it.
+ * routes only supply the prompt text and the export control; `AiPromptAction` is
+ * the standalone AI link used inside it.
+ *
+ * As a pure UI primitive, `ReportToolbar` does NOT import any API/transport code
+ * (#751 dependency rule). The export control is caller-provided via the
+ * `exportControl` slot: the page (or a hook) wires `apiDownload` + the export
+ * path and passes the rendered control in.
  */
 
 interface AiPromptActionProps {
@@ -31,8 +34,11 @@ export function AiPromptAction({ prompt, label = "AI Interpretation" }: AiPrompt
 interface ReportToolbarProps {
   /** Natural-language prompt for the AI interpretation action. */
   aiPrompt: string;
-  /** Authenticated CSV export path. */
-  exportPath: string;
+  /**
+   * Caller-provided export control (e.g. `<ExportCsvButton />`). The page owns
+   * the API/transport wiring so this primitive stays free of `@/lib/api`.
+   */
+  exportControl?: ReactNode;
   /** Destination for the "Home" link. */
   homeHref?: string;
   /** Optional extra actions rendered before the standard cluster. */
@@ -41,7 +47,7 @@ interface ReportToolbarProps {
 
 export function ReportToolbar({
   aiPrompt,
-  exportPath,
+  exportControl,
   homeHref = "/",
   children,
 }: ReportToolbarProps) {
@@ -52,7 +58,7 @@ export function ReportToolbar({
       <Link href={homeHref} className="btn-secondary text-sm">
         Home
       </Link>
-      <ExportCsvButton path={exportPath} />
+      {exportControl}
     </div>
   );
 }

--- a/apps/frontend/src/hooks/useDashboardData.ts
+++ b/apps/frontend/src/hooks/useDashboardData.ts
@@ -1,0 +1,294 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { apiFetch } from "@/lib/api";
+import { compareAmounts } from "@/lib/currency";
+import { formatDateInput } from "@/lib/date";
+import type {
+  AccountListResponse,
+  AdvisorSuggestion,
+  AnnualizedIncomeResponse,
+  BalanceSheetResponse,
+  BankStatementListResponse,
+  ChatSuggestionsResponse,
+  IncomeStatementResponse,
+  JournalEntryListResponse,
+  ReconciliationStatsResponse,
+  RestrictedHolding,
+  TrendResponse,
+  UnmatchedTransactionsResponse,
+} from "@/lib/types";
+
+/**
+ * Dashboard data hook (Slice 3 of #751).
+ *
+ * Moves the home route's parallel API aggregation and report normalization out
+ * of the route page and behind the shared `apiFetch` transport. The route now
+ * composes the returned, normalized data instead of fetching and reshaping it
+ * inline. Monetary values stay decimal strings; no behavior change.
+ */
+
+const EMPTY_BALANCE_SHEET: BalanceSheetResponse = {
+  as_of_date: "",
+  currency: "SGD",
+  assets: [],
+  liabilities: [],
+  equity: [],
+  total_assets: "0",
+  total_liabilities: "0",
+  total_equity: "0",
+  equation_delta: "0",
+  is_balanced: true,
+};
+
+const EMPTY_INCOME_STATEMENT: IncomeStatementResponse = {
+  start_date: "",
+  end_date: "",
+  currency: "SGD",
+  income: [],
+  expenses: [],
+  total_income: "0",
+  total_expenses: "0",
+  net_income: "0",
+  trends: [],
+};
+
+const EMPTY_ANNUALIZED_INCOME: AnnualizedIncomeResponse = {
+  annualized_salary: "0",
+  annualized_bonus: "0",
+  annualized_dividend: "0",
+  annualized_total: "0",
+  currency: "SGD",
+  as_of: "",
+};
+
+const EMPTY_STATS: ReconciliationStatsResponse = {
+  total_transactions: 0,
+  matched_transactions: 0,
+  unmatched_transactions: 0,
+  pending_review: 0,
+  auto_accepted: 0,
+  match_rate: 0,
+  score_distribution: {},
+};
+
+function normalizeBalanceSheet(
+  data?: Partial<BalanceSheetResponse> | null,
+): BalanceSheetResponse {
+  return {
+    ...EMPTY_BALANCE_SHEET,
+    ...data,
+    assets: data?.assets ?? [],
+    liabilities: data?.liabilities ?? [],
+    equity: data?.equity ?? [],
+    total_assets: data?.total_assets ?? "0",
+    total_liabilities: data?.total_liabilities ?? "0",
+    total_equity: data?.total_equity ?? "0",
+    equation_delta: data?.equation_delta ?? "0",
+    currency: data?.currency ?? "SGD",
+    as_of_date: data?.as_of_date ?? "",
+    is_balanced: data?.is_balanced ?? true,
+  };
+}
+
+function normalizeIncomeStatement(
+  data?: Partial<IncomeStatementResponse> | null,
+): IncomeStatementResponse {
+  return {
+    ...EMPTY_INCOME_STATEMENT,
+    ...data,
+    income: data?.income ?? [],
+    expenses: data?.expenses ?? [],
+    trends: data?.trends ?? [],
+    total_income: data?.total_income ?? "0",
+    total_expenses: data?.total_expenses ?? "0",
+    net_income: data?.net_income ?? "0",
+    currency: data?.currency ?? "SGD",
+  };
+}
+
+function normalizeAnnualizedIncome(
+  data?: Partial<AnnualizedIncomeResponse> | null,
+): AnnualizedIncomeResponse {
+  return {
+    ...EMPTY_ANNUALIZED_INCOME,
+    ...data,
+    annualized_salary: data?.annualized_salary ?? "0",
+    annualized_bonus: data?.annualized_bonus ?? "0",
+    annualized_dividend: data?.annualized_dividend ?? "0",
+    annualized_total: data?.annualized_total ?? "0",
+    currency: data?.currency ?? "SGD",
+    as_of: data?.as_of ?? "",
+  };
+}
+
+export interface DashboardOnboardingStatus {
+  accountCount: number;
+  statementCount: number;
+  approvedStatementCount: number;
+  postedEntryCount: number;
+}
+
+export interface UseDashboardDataResult {
+  balanceSheet: BalanceSheetResponse | null;
+  incomeStatement: IncomeStatementResponse | null;
+  annualizedIncome: AnnualizedIncomeResponse | null;
+  restrictedHoldings: RestrictedHolding[];
+  stats: ReconciliationStatsResponse | null;
+  unmatched: UnmatchedTransactionsResponse | null;
+  recentEntries: JournalEntryListResponse | null;
+  onboardingStatus: DashboardOnboardingStatus | null;
+  advisorSuggestions: AdvisorSuggestion[];
+  trend: TrendResponse | null;
+  trendAccountName: string;
+  trendAccountId: string | null;
+  setTrendAccountId: (id: string | null) => void;
+  loading: boolean;
+  error: string | null;
+  retry: () => void;
+}
+
+export function useDashboardData(includeRestricted: boolean): UseDashboardDataResult {
+  const [balanceSheet, setBalanceSheet] = useState<BalanceSheetResponse | null>(null);
+  const [incomeStatement, setIncomeStatement] = useState<IncomeStatementResponse | null>(null);
+  const [annualizedIncome, setAnnualizedIncome] = useState<AnnualizedIncomeResponse | null>(null);
+  const [restrictedHoldings, setRestrictedHoldings] = useState<RestrictedHolding[]>([]);
+  const [stats, setStats] = useState<ReconciliationStatsResponse | null>(null);
+  const [unmatched, setUnmatched] = useState<UnmatchedTransactionsResponse | null>(null);
+  const [recentEntries, setRecentEntries] = useState<JournalEntryListResponse | null>(null);
+  const [onboardingStatus, setOnboardingStatus] = useState<DashboardOnboardingStatus | null>(null);
+  const [advisorSuggestions, setAdvisorSuggestions] = useState<AdvisorSuggestion[]>([]);
+  const [trend, setTrend] = useState<TrendResponse | null>(null);
+  const [trendAccountId, setTrendAccountId] = useState<string | null>(null);
+  const [trendAccountName, setTrendAccountName] = useState<string>("Top Asset");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    const today = new Date();
+    const incomeStart = formatDateInput(new Date(today.getFullYear(), today.getMonth() - 11, 1));
+    const incomeEnd = formatDateInput(today);
+    setLoading(true);
+    try {
+      const [
+        balanceData,
+        incomeData,
+        annualizedData,
+        restrictedData,
+        statsData,
+        unmatchedData,
+        journalData,
+        accountData,
+        statementData,
+        postedJournalData,
+        chatSuggestionsData,
+      ] = await Promise.all([
+        apiFetch<BalanceSheetResponse>(
+          `/api/reports/balance-sheet?include_restricted=${includeRestricted ? "true" : "false"}`,
+        ),
+        apiFetch<IncomeStatementResponse>(
+          `/api/reports/income-statement?start_date=${incomeStart}&end_date=${incomeEnd}`,
+        ),
+        apiFetch<AnnualizedIncomeResponse>("/api/income/annualized"),
+        apiFetch<RestrictedHolding[]>("/api/assets/restricted"),
+        apiFetch<ReconciliationStatsResponse>("/api/reconciliation/stats"),
+        apiFetch<UnmatchedTransactionsResponse>("/api/reconciliation/unmatched?limit=5"),
+        apiFetch<JournalEntryListResponse>("/api/journal-entries?page=1&page_size=5"),
+        apiFetch<AccountListResponse>("/api/accounts?limit=1"),
+        apiFetch<BankStatementListResponse>("/api/statements"),
+        apiFetch<JournalEntryListResponse>("/api/journal-entries?status_filter=posted&limit=1"),
+        apiFetch<ChatSuggestionsResponse>(
+          "/api/chat/suggestions?language=en&include_structured=true",
+        ).catch(() => ({ suggestions: [], structured_suggestions: [] })),
+      ]);
+      setBalanceSheet(normalizeBalanceSheet(balanceData));
+      setIncomeStatement(normalizeIncomeStatement(incomeData));
+      setAnnualizedIncome(normalizeAnnualizedIncome(annualizedData));
+      setRestrictedHoldings(Array.isArray(restrictedData) ? restrictedData : []);
+      setStats(statsData || EMPTY_STATS);
+      setUnmatched(unmatchedData || { items: [], total: 0 });
+      setRecentEntries(journalData || { items: [], total: 0 });
+      setOnboardingStatus({
+        accountCount: accountData?.total ?? 0,
+        statementCount: statementData?.total ?? 0,
+        approvedStatementCount:
+          statementData?.items?.filter((statement) => statement.status === "approved").length ?? 0,
+        postedEntryCount: postedJournalData?.total ?? 0,
+      });
+      setAdvisorSuggestions(chatSuggestionsData?.structured_suggestions ?? []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load dashboard data.");
+    } finally {
+      setLoading(false);
+    }
+  }, [includeRestricted]);
+
+  const fetchTrend = useCallback(async () => {
+    if (!balanceSheet || !balanceSheet.assets) return;
+    const sortedAssets = [...balanceSheet.assets].sort((a, b) => compareAmounts(b.amount, a.amount));
+    const target = trendAccountId
+      ? sortedAssets.find((a) => a.account_id === trendAccountId) ?? sortedAssets[0]
+      : sortedAssets[0];
+    if (!target) return;
+    setTrendAccountName(target.name);
+    try {
+      const trendData = await apiFetch<TrendResponse>(
+        `/api/reports/trend?account_id=${target.account_id}&period=monthly`,
+      );
+      setTrend(trendData);
+    } catch (err) {
+      console.error("Failed to fetch trend data:", err);
+      setTrend(null);
+    }
+  }, [balanceSheet, trendAccountId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  useEffect(() => {
+    if (balanceSheet && balanceSheet.assets) {
+      fetchTrend();
+    }
+  }, [fetchTrend, balanceSheet]);
+
+  return useMemo(
+    () => ({
+      balanceSheet,
+      incomeStatement,
+      annualizedIncome,
+      restrictedHoldings,
+      stats,
+      unmatched,
+      recentEntries,
+      onboardingStatus,
+      advisorSuggestions,
+      trend,
+      trendAccountName,
+      trendAccountId,
+      setTrendAccountId,
+      loading,
+      error,
+      retry: fetchData,
+    }),
+    [
+      advisorSuggestions,
+      annualizedIncome,
+      balanceSheet,
+      error,
+      fetchData,
+      incomeStatement,
+      loading,
+      onboardingStatus,
+      recentEntries,
+      restrictedHoldings,
+      stats,
+      trend,
+      trendAccountId,
+      trendAccountName,
+      unmatched,
+    ],
+  );
+}

--- a/apps/frontend/src/hooks/useReportFilters.ts
+++ b/apps/frontend/src/hooks/useReportFilters.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+
+import { formatDateInput } from "@/lib/date";
+
+/**
+ * Query-layer hook for report routes (Slice 3 of #751).
+ *
+ * Owns the shared date + currency filter state for a report page and derives the
+ * API query string, CSV export path, and AI-prompt text. This keeps report
+ * routes thin: they express page-level intent and read the derived values
+ * instead of re-implementing URLSearchParams / export-path / prompt boilerplate.
+ *
+ * Two filter shapes are supported, matching the existing report endpoints:
+ *  - point-in-time reports (balance sheet) use a single `as_of_date`;
+ *  - range reports (income statement, cash flow) use `start_date`/`end_date`.
+ */
+
+export type ReportType = "balance-sheet" | "income-statement" | "cash-flow";
+
+interface UseReportFiltersOptions {
+  reportType: ReportType;
+  initialAsOfDate?: string;
+  initialStartDate?: string;
+  initialEndDate?: string;
+  initialCurrency?: string;
+}
+
+export interface UseReportFiltersResult {
+  asOfDate: string;
+  startDate: string;
+  endDate: string;
+  currency: string;
+  setAsOfDate: (value: string) => void;
+  setStartDate: (value: string) => void;
+  setEndDate: (value: string) => void;
+  setCurrency: (value: string) => void;
+  /** Encoded API query string (without a leading `?`). */
+  queryString: string;
+  /** Authenticated CSV export path for this report + current filters. */
+  exportPath: string;
+}
+
+const today = () => formatDateInput(new Date());
+
+export function useReportFilters(
+  options: UseReportFiltersOptions,
+): UseReportFiltersResult {
+  const { reportType } = options;
+  const isPointInTime = reportType === "balance-sheet";
+
+  const [asOfDate, setAsOfDate] = useState(options.initialAsOfDate ?? today());
+  const [startDate, setStartDate] = useState(options.initialStartDate ?? today());
+  const [endDate, setEndDate] = useState(options.initialEndDate ?? today());
+  const [currency, setCurrency] = useState(options.initialCurrency ?? "SGD");
+
+  const queryString = useMemo(() => {
+    const params = new URLSearchParams();
+    if (isPointInTime) {
+      params.set("as_of_date", asOfDate);
+    } else {
+      params.set("start_date", startDate);
+      params.set("end_date", endDate);
+    }
+    params.set("currency", currency);
+    return params.toString();
+  }, [asOfDate, currency, endDate, isPointInTime, startDate]);
+
+  const exportPath = useMemo(
+    () => `/api/reports/export?report_type=${reportType}&format=csv&${queryString}`,
+    [queryString, reportType],
+  );
+
+  return {
+    asOfDate,
+    startDate,
+    endDate,
+    currency,
+    setAsOfDate: useCallback((value: string) => setAsOfDate(value), []),
+    setStartDate: useCallback((value: string) => setStartDate(value), []),
+    setEndDate: useCallback((value: string) => setEndDate(value), []),
+    setCurrency: useCallback((value: string) => setCurrency(value), []),
+    queryString,
+    exportPath,
+  };
+}

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -350,6 +350,51 @@ explicit FX-failure response model. Monetary values stay `Decimal`.
 | AC5.32.5 | Currency normalization is a single shared helper (`normalize_currency_code`), not duplicated `.strip().upper()` | `test_AC5_32_5_normalize_currency_code_is_shared_helper` | `reporting/test_income_typed_currency.py` | P2 |
 | AC5.32.6 | The endpoint normalizes a soft (lower-case) base-currency setting in its response | `test_AC5_32_6_endpoint_returns_normalized_currency_for_soft_base_config` | `reporting/test_income_typed_currency.py` | P2 |
 
+### AC5.33: Report Page Shell + Toolbar Primitives ([#751](https://github.com/wangzitian0/finance_report/issues/751))
+
+Slice 3 of the frontend reuse architecture (#751). Extract the repeated
+report-route boilerplate (header, AI-interpretation / home / CSV-export toolbar,
+loading skeleton, error+retry state) into shared composition primitives
+(`ReportPageShell`, `ReportToolbar`, `AiPromptAction`) so report routes stay thin
+and behavior is identical across balance-sheet, income-statement, and cash-flow.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.33.1 | `ReportPageShell` renders title, description, and toolbar slot, and shows the report body when not loading or errored | `AC5.33.1 renders title, description, toolbar, and body content` | `apps/frontend/src/__tests__/reportPageShell.test.tsx` | P1 |
+| AC5.33.2 | `ReportPageShell` renders the loading skeleton (and not the body) while `isLoading` | `AC5.33.2 shows loading skeleton while loading` | `apps/frontend/src/__tests__/reportPageShell.test.tsx` | P1 |
+| AC5.33.3 | `ReportPageShell` renders the error message with a working Retry action on `isError` | `AC5.33.3 shows error message and retries on click` | `apps/frontend/src/__tests__/reportPageShell.test.tsx` | P1 |
+| AC5.33.4 | `ReportToolbar` composes the AI-prompt action, Home link, and CSV export action from its props | `AC5.33.4 renders AI prompt, home link, and CSV export` | `apps/frontend/src/__tests__/reportToolbar.test.tsx` | P1 |
+| AC5.33.5 | `AiPromptAction` links to the chat route with a URL-encoded prompt | `AC5.33.5 links to chat with url-encoded prompt` | `apps/frontend/src/__tests__/reportToolbar.test.tsx` | P1 |
+
+### AC5.34: Report Filter Controls + Filter Hook ([#751](https://github.com/wangzitian0/finance_report/issues/751))
+
+Slice 3 of #751. Provide reusable date and currency filter controls plus a
+`useReportFilters` query-layer hook that owns the filter state and derives the
+query string, CSV export path, and AI-prompt text so route pages only express
+page-level intent.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.34.1 | `DateFilterControl` renders a labelled date input and emits changes | `AC5.34.1 renders labelled date input and emits change` | `apps/frontend/src/__tests__/reportFilters.test.tsx` | P1 |
+| AC5.34.2 | `CurrencyFilterControl` renders a labelled currency select with the provided options and emits changes | `AC5.34.2 renders currency options and emits change` | `apps/frontend/src/__tests__/reportFilters.test.tsx` | P1 |
+| AC5.34.3 | `useReportFilters` builds a query string from its date and currency state | `AC5.34.3 builds query string from filter state` | `apps/frontend/src/__tests__/useReportFilters.test.ts` | P1 |
+| AC5.34.4 | `useReportFilters` derives the CSV export path for the given report type | `AC5.34.4 derives csv export path for report type` | `apps/frontend/src/__tests__/useReportFilters.test.ts` | P1 |
+| AC5.34.5 | `useReportFilters` updates the query string when the currency changes | `AC5.34.5 updates query string when currency changes` | `apps/frontend/src/__tests__/useReportFilters.test.ts` | P1 |
+
+### AC5.35: Dashboard Aggregation Moved Into Hook Layer ([#751](https://github.com/wangzitian0/finance_report/issues/751))
+
+Slice 3 of #751. Move the dashboard's parallel API aggregation and report
+normalization out of the route page and into a `useDashboardData` hook (over the
+shared `apiFetch` transport), so the home route composes data instead of
+fetching and normalizing it inline. Monetary values stay decimal strings.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.35.1 | `useDashboardData` aggregates the dashboard endpoints over `apiFetch` and exposes a single loading flag | `AC5.35.1 aggregates dashboard endpoints over apiFetch` | `apps/frontend/src/__tests__/useDashboardData.test.ts` | P1 |
+| AC5.35.2 | `useDashboardData` normalizes missing balance-sheet / income / annualized fields to safe decimal-string defaults | `AC5.35.2 normalizes missing report fields to defaults` | `apps/frontend/src/__tests__/useDashboardData.test.ts` | P1 |
+| AC5.35.3 | `useDashboardData` surfaces an error message and a retry that refetches when aggregation fails | `AC5.35.3 surfaces error and retries on failure` | `apps/frontend/src/__tests__/useDashboardData.test.ts` | P1 |
+| AC5.35.4 | `useDashboardData` tolerates a failing chat-suggestions endpoint without failing the whole dashboard | `AC5.35.4 tolerates failing chat suggestions endpoint` | `apps/frontend/src/__tests__/useDashboardData.test.ts` | P1 |
+
 ## 📏 Acceptance Criteria
 
 ### 🟢 Must Have


### PR DESCRIPTION
Part of #751 (Slice 3 — reports & dashboard cleanup). Slices 1 (#749, shared foundation) and 2 (#750, statements/journal migration) are already merged; this builds on the existing shared foundation (`lib/api` transport, `useApiQuery` query helper, `components/ui`, `lib/currency` money boundary).

## What shipped

### Report page shell primitives (AC5.33, AC5.34)
- `ReportPageShell` — owns the header (title/description) + toolbar slot + loading skeleton + error/retry lifecycle that every report route re-implemented.
- `ReportToolbar` / `AiPromptAction` — the "AI Interpretation / Home / Export CSV" action cluster, composed from props.
- `DateFilterControl` / `CurrencyFilterControl` — reusable labelled date/currency filter controls.
- `useReportFilters` — query-layer hook owning date/currency filter state and deriving the API query string + CSV export path for each report type.

### Dashboard aggregation moved into the hook layer (AC5.35)
- `useDashboardData` — the home route's parallel `apiFetch` aggregation and report normalization moved out of the route page and behind the shared transport. The route now composes the returned, normalized data instead of fetching + reshaping inline. Monetary values stay decimal strings; **no behavior change**.

### Thin pages
`balance-sheet`, `income-statement`, `cash-flow`, and the dashboard route now compose these primitives/hooks. The dashboard route dropped from 582 → 410 lines.

## Dependency rules respected
- UI primitives (`ReportPageShell`/`ReportToolbar`/`ReportFilters`) import **no** React Query, API client, or business hooks.
- `useReportFilters` depends only on React + `lib/date`.
- `useDashboardData` uses the shared `apiFetch` transport — no raw `fetch()`.
- No `float` for money; all amounts stay decimal strings.

## Tests
- 14 new AC-referencing tests written red-first (AC5.33.1–5, AC5.34.1–5, AC5.35.1–4).
- Existing report/dashboard page tests stay green (behavior preserved).
- Local: `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run test` (787 passing) ✅ · coverage gate 98% ✅ · `npm run build` ✅.
- `preflight`: `ac-traceability` ✅ · `doc-consistency` ✅ · `frontend` ✅.

Frontend-only; no API/schema changes (no `api.md` regen needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)