### PR TITLE
[finance_report_hacker] feat(#1001): dedicated Stage-2 review surface at /review

### DIFF
--- a/apps/frontend/src/__tests__/attention.test.ts
+++ b/apps/frontend/src/__tests__/attention.test.ts
@@ -61,7 +61,7 @@ describe("attention model (EPIC-022 AC22.6)", () => {
   it("AC22.6.1 every item deep-links to the surface where the user can act", () => {
     const byId = Object.fromEntries(buildAttentionItems(sources).map((i) => [i.id, i.href]));
     expect(byId["statement:bad"]).toBe("/statements/bad/review");
-    expect(byId["reconciliation:pending"]).toBe("/reconciliation/review-queue");
+    expect(byId["reconciliation:pending"]).toBe("/review");
     expect(byId["reconciliation:unmatched"]).toBe("/reconciliation/unmatched");
     expect(byId["processing:stalled"]).toBe("/processing");
   });

--- a/apps/frontend/src/__tests__/attentionQueue.test.tsx
+++ b/apps/frontend/src/__tests__/attentionQueue.test.tsx
@@ -52,7 +52,7 @@ describe("Attention queue (EPIC-022 AC22.6)", () => {
     // Unmatched (confidence 0) comes before the parsed statement (40) before pending review (80).
     expect(rows[0]).toHaveAttribute("href", "/reconciliation/unmatched?from=attention");
     expect(rows[1]).toHaveAttribute("href", "/statements/bad/review?from=attention");
-    expect(rows[2]).toHaveAttribute("href", "/reconciliation/review-queue?from=attention");
+    expect(rows[2]).toHaveAttribute("href", "/review?from=attention");
 
     expect(within(rows[1]).getByText("bad.pdf")).toBeInTheDocument();
     expect(within(rows[0]).getByText("0% confidence")).toBeInTheDocument();

--- a/apps/frontend/src/__tests__/reviewLandingPage.test.tsx
+++ b/apps/frontend/src/__tests__/reviewLandingPage.test.tsx
@@ -21,11 +21,13 @@ const queueData = {
     pending_matches: [
         {
             id: "m1",
-            match_score: 88,
+            // Decimal fields serialize as strings (the MoneyValue decimal-string
+            // contract / generated api-types), so the mock mirrors the wire shape.
+            match_score: "88",
             status: "pending_review",
             created_at: "2024-01-03T00:00:00Z",
             description: "Salary transfer",
-            amount: 20,
+            amount: "20",
             txn_date: "2024-01-03",
             confidence_tier: "HIGH",
         },

--- a/apps/frontend/src/__tests__/reviewLandingPage.test.tsx
+++ b/apps/frontend/src/__tests__/reviewLandingPage.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+
+import ReviewPage from "@/app/(main)/review/page";
+import { apiFetch } from "@/lib/api";
+
+import { renderReviewComponent } from "./helpers/renderReviewComponent";
+
+// #1001 / AC16.36: the dedicated /review surface is a first-class Stage-2 review
+// destination, independent of the reconciliation workbench it used to nest under.
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+vi.mock("next/navigation", () => ({
+    useRouter: vi.fn(() => ({ replace: vi.fn(), push: vi.fn() })),
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+    usePathname: vi.fn(() => "/review"),
+}));
+
+const mockedApi = vi.mocked(apiFetch);
+
+const queueData = {
+    pending_matches: [
+        {
+            id: "m1",
+            match_score: 88,
+            status: "pending_review",
+            created_at: "2024-01-03T00:00:00Z",
+            description: "Salary transfer",
+            amount: 20,
+            txn_date: "2024-01-03",
+            confidence_tier: "HIGH",
+        },
+    ],
+    consistency_checks: [],
+    has_unresolved_checks: false,
+};
+
+describe("dedicated /review surface (#1001)", () => {
+    beforeEach(() => {
+        mockedApi.mockReset();
+        mockedApi.mockImplementation((path: string) => {
+            if (path.startsWith("/api/statements/stage2/queue")) {
+                return Promise.resolve(queueData as never);
+            }
+            if (path === "/api/accounts/processing/summary") {
+                return Promise.resolve({
+                    pending_count: 0,
+                    pending_total: "0",
+                    currency: "SGD",
+                    oldest_pending_date: null,
+                } as never);
+            }
+            if (path.startsWith("/api/statements/consistency-checks/list")) {
+                return Promise.resolve({ items: [] } as never);
+            }
+            return Promise.reject(new Error(`Unexpected path ${path}`));
+        });
+    });
+
+    it("AC16.36.1 renders the Stage-2 review queue as a standalone page", async () => {
+        renderReviewComponent(<ReviewPage />);
+
+        expect(await screen.findByText("Review queue")).toBeInTheDocument();
+        // The description renders in both the desktop table and mobile card views.
+        await waitFor(() => expect(screen.getAllByText("Salary transfer").length).toBeGreaterThan(0));
+    });
+
+    it("AC16.36.2 loads the global queue (no run filter) on the dedicated route", async () => {
+        renderReviewComponent(<ReviewPage />);
+
+        await waitFor(() => {
+            // Pathname is /review (not /review/run/<id>), so the global, unfiltered
+            // queue endpoint is hit — review is no longer scoped to a single run.
+            const queueCall = mockedApi.mock.calls.find((call) =>
+                String(call[0]).startsWith("/api/statements/stage2/queue")
+            );
+            expect(queueCall).toBeDefined();
+            expect(String(queueCall?.[0])).not.toContain("run_id");
+        });
+    });
+});

--- a/apps/frontend/src/__tests__/reviewLandingPage.test.tsx
+++ b/apps/frontend/src/__tests__/reviewLandingPage.test.tsx
@@ -8,10 +8,16 @@ import { renderReviewComponent } from "./helpers/renderReviewComponent";
 
 // #1001 / AC16.36: the dedicated /review surface is a first-class Stage-2 review
 // destination, independent of the reconciliation workbench it used to nest under.
+//
+// Hoist stable router/searchParams instances so every hook call returns the same
+// references. Stage2ReviewQueue memoizes callbacks on `router`/`searchParams`;
+// fresh objects per render would retrigger effects and make the test flaky/slow.
+const router = { replace: vi.fn(), push: vi.fn() };
+const searchParams = new URLSearchParams();
 vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
 vi.mock("next/navigation", () => ({
-    useRouter: vi.fn(() => ({ replace: vi.fn(), push: vi.fn() })),
-    useSearchParams: vi.fn(() => new URLSearchParams()),
+    useRouter: vi.fn(() => router),
+    useSearchParams: vi.fn(() => searchParams),
     usePathname: vi.fn(() => "/review"),
 }));
 

--- a/apps/frontend/src/app/(main)/page.tsx
+++ b/apps/frontend/src/app/(main)/page.tsx
@@ -362,7 +362,7 @@ export default function HomePage() {
             <Link href="/reconciliation" className="flex justify-between p-3 rounded-md bg-[var(--success-muted)] text-sm hover:ring-1 hover:ring-[var(--success)] transition-all">
               <span>Auto accepted</span><span className="font-semibold">{stats?.auto_accepted ?? 0}</span>
             </Link>
-            <Link href="/reconciliation/review-queue" className="flex justify-between p-3 rounded-md bg-[var(--warning-muted)] text-sm hover:ring-1 hover:ring-[var(--warning)] transition-all">
+            <Link href="/review" className="flex justify-between p-3 rounded-md bg-[var(--warning-muted)] text-sm hover:ring-1 hover:ring-[var(--warning)] transition-all">
               <span>Pending review</span><span className="font-semibold">{stats?.pending_review ?? 0}</span>
             </Link>
             <Link href="/reconciliation/unmatched" className="flex justify-between p-3 rounded-md bg-[var(--error-muted)] text-sm hover:ring-1 hover:ring-[var(--error)] transition-all">

--- a/apps/frontend/src/app/(main)/review/page.tsx
+++ b/apps/frontend/src/app/(main)/review/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Stage2ReviewQueue } from "@/components/review/Stage2ReviewQueue";
+
+/**
+ * Dedicated Stage-2 review surface (#1001).
+ *
+ * Canonical, top-level home for the reconciliation review queue. Previously the
+ * only entry was `/reconciliation/review-queue`, which nested review under the
+ * reconciliation module ("parasitic on statements"). This route makes Stage-2
+ * review a first-class destination reached from the Attention center, decoupled
+ * from the reconciliation workbench. The run-scoped variant lives at
+ * `/review/run/[runId]`.
+ */
+export default function ReviewPage() {
+    return <Stage2ReviewQueue />;
+}

--- a/apps/frontend/src/lib/attention.ts
+++ b/apps/frontend/src/lib/attention.ts
@@ -94,7 +94,9 @@ export function buildAttentionItems(sources: AttentionSources): AttentionItem[] 
       detail: "Reconciliation review",
       reason: "Auto-matched to ledger entries but below the confidence bar to post without a human check — confirm or correct each match.",
       confidence: clampConfidence(stats.match_rate ?? 0),
-      href: "/reconciliation/review-queue",
+      // #1001: the dedicated Stage-2 review surface, decoupled from the
+      // reconciliation workbench.
+      href: "/review",
     });
   }
 

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -605,6 +605,20 @@ is a typed `Stage2PendingMatch`, not `list[dict]`.
 | AC16.35.1 | An empty batch approve returns the typed counters with no `success` field | `test_AC16_35_1_batch_approve_empty_returns_typed_response` | `api/test_typed_contract_sweep.py` | P1 |
 | AC16.35.2 | Unresolved consistency checks block batch approve with a 409 structured error | `test_AC16_35_2_batch_approve_blocked_returns_409` | `api/test_typed_contract_sweep.py` | P1 |
 
+### AC16.36: Dedicated Stage-2 Review Surface ([#1001](https://github.com/wangzitian0/finance_report/issues/1001))
+
+Tier 1 of #1000. Stage-2 review gets a first-class `/review` route instead of being
+reachable only via `/reconciliation/review-queue` (nested under the reconciliation
+workbench — "parasitic on statements"). The Attention center and the home Risk-radar
+deep-link to `/review`; the run-scoped variant stays at `/review/run/[runId]`. Per the
+EPIC-022 IA (AC22.2.4) review stays out of the sidebar — it is reached from the
+attention/notification flow, not a standalone nav peer.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC16.36.1 | The dedicated `/review` route renders the Stage-2 review queue standalone | `AC16.36.1 renders the Stage-2 review queue as a standalone page` | `__tests__/reviewLandingPage.test.tsx` | P1 |
+| AC16.36.2 | The dedicated route loads the global queue (no run filter) | `AC16.36.2 loads the global queue (no run filter) on the dedicated route` | `__tests__/reviewLandingPage.test.tsx` | P2 |
+
 ---
 
 ## Historical Implementation Notes


### PR DESCRIPTION
## What & why

PR B of the **#1074** root sweep — **stacked on PR A** (#1096). Targets the PR A branch; GitHub will retarget it to `main` automatically once #1096 merges.

Closes the last open #1001 acceptance: *"A dedicated Stage-2 review surface (not parasitic on statements)."* Today Stage-2 review is only reachable via `/reconciliation/review-queue` (nested under the reconciliation workbench) or `/review/run/[runId]`.

## Changes
- **New `/review` page** (`app/(main)/review/page.tsx`): a first-class, top-level Stage-2 review destination (global queue). Run-scoped review stays at `/review/run/[runId]`.
- **Repointed deep-links**: the Attention center (`lib/attention.ts`) and the home Risk-radar (`app/(main)/page.tsx`) now link to `/review` instead of the nested `/reconciliation/review-queue` (kept as a working alias).
- **IA-respecting**: per EPIC-022 (AC22.2.4) review is surfaced through the attention/notification flow, **not** a sidebar peer — no nav item added, so the IA contract test stays green.

## Tests / ACs
- New `reviewLandingPage.test.tsx`: the dedicated route renders the queue standalone and loads the global (no-run-filter) queue.
- Updated `attention.test.ts` / `attentionQueue.test.tsx` href assertions.
- **AC16.36** registered in EPIC-016. Traceability gate passes (100%). Full frontend suite (777) green.

## Note
Backend-sourced notification `action_href` values (unified inbox / chat) still point at `/reconciliation/review-queue`; repointing those is a backend concern, out of scope here. The alias keeps them working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)