### PR TITLE
[finance_report_hacker] feat(#1004): consume generated OpenAPI types at high-traffic call sites

### DIFF
--- a/apps/frontend/src/__tests__/apiTypedClient.test.ts
+++ b/apps/frontend/src/__tests__/apiTypedClient.test.ts
@@ -8,7 +8,7 @@ import type { Schemas } from "@/lib/api-schema";
 // against the generated `Schemas[...]` aliases, so a backend contract change that
 // isn't regenerated would fail the type-check.
 describe("generated typed client (#1004)", () => {
-    it("AC12.28.3 types Stage-2 batch responses against the generated schema", () => {
+    it("test_AC12_28_3_types_stage2_batch_responses_against_generated_schema", () => {
         const approve: Schemas["BatchApproveResponse"] = {
             approved_count: 2,
             journal_entries_created: 1,

--- a/apps/frontend/src/__tests__/apiTypedClient.test.ts
+++ b/apps/frontend/src/__tests__/apiTypedClient.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+
+import type { Schemas } from "@/lib/api-schema";
+
+// AC12.28.3: high-traffic call sites are typed against the generated OpenAPI
+// schema (#1004), so FE↔BE response-shape drift is caught at compile time
+// (`npm run build` / tsc) rather than at runtime. These values are checked
+// against the generated `Schemas[...]` aliases, so a backend contract change that
+// isn't regenerated would fail the type-check.
+describe("generated typed client (#1004)", () => {
+    it("AC12.28.3 types Stage-2 batch responses against the generated schema", () => {
+        const approve: Schemas["BatchApproveResponse"] = {
+            approved_count: 2,
+            journal_entries_created: 1,
+            journal_entries_reconciled: 1,
+        };
+        const reject: Schemas["BatchRejectResponse"] = { rejected_count: 3 };
+
+        expect(approve.approved_count).toBe(2);
+        expect(approve.journal_entries_created + approve.journal_entries_reconciled).toBe(2);
+        expect(reject.rejected_count).toBe(3);
+    });
+});

--- a/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
+++ b/apps/frontend/src/components/review/Stage2ReviewQueue.tsx
@@ -14,6 +14,7 @@ import { formatDateDisplay, formatDateTimeDisplay } from "@/lib/date";
 import { formatAmount } from "@/lib/currency";
 import { ATTENTION_SOURCE_PARAM, ATTENTION_SOURCE_VALUE, isAttentionOrigin } from "@/lib/attentionNavigation";
 import type { MoneyValue } from "@/lib/types";
+import type { Schemas } from "@/lib/api-schema";
 
 interface ConsistencyCheck {
     id: string;
@@ -210,7 +211,7 @@ export function Stage2ReviewQueue() {
 
         setActionLoading(true);
         try {
-            const result = await apiFetch<{ approved_count: number }>(
+            const result = await apiFetch<Schemas["BatchApproveResponse"]>(
                 "/api/statements/batch-approve-matches",
                 {
                     method: "POST",
@@ -235,7 +236,7 @@ export function Stage2ReviewQueue() {
 
         setActionLoading(true);
         try {
-            const result = await apiFetch<{ rejected_count: number }>(
+            const result = await apiFetch<Schemas["BatchRejectResponse"]>(
                 "/api/statements/batch-reject-matches",
                 {
                     method: "POST",
@@ -274,7 +275,7 @@ export function Stage2ReviewQueue() {
 
         setActionLoading(true);
         try {
-            const result = await apiFetch<{ approved_count: number }>(
+            const result = await apiFetch<Schemas["BatchApproveResponse"]>(
                 "/api/statements/batch-approve-matches",
                 {
                     method: "POST",

--- a/apps/frontend/src/lib/api-schema.ts
+++ b/apps/frontend/src/lib/api-schema.ts
@@ -1,0 +1,20 @@
+/**
+ * Typed access to the backend contract (#1004).
+ *
+ * `api-types.ts` is generated from the backend OpenAPI schema
+ * (`apps/frontend/openapi.json`, staleness-gated by
+ * `tools/generate_openapi_spec.py --check`). This module re-exports its schema
+ * objects under ergonomic aliases so call sites can type requests/responses
+ * against the generated contract — e.g. `apiFetch<Schemas["BatchApproveResponse"]>(...)`
+ * — giving compile-time FE↔BE drift detection instead of hand-written shapes.
+ *
+ * Migrate high-traffic modules to these aliases incrementally; do not edit
+ * `api-types.ts` by hand (run `npm run gen:api-types`).
+ */
+import type { components, paths } from "./api-types";
+
+/** All generated request/response models, keyed by their backend schema name. */
+export type Schemas = components["schemas"];
+
+/** All generated API paths/operations, for path-level typing when needed. */
+export type Paths = paths;

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -409,14 +409,17 @@ callers branch on a machine-readable code instead of matching `detail` text.
 ### AC12.28: Generated Frontend API Types from OpenAPI ([#1004](https://github.com/wangzitian0/finance_report/issues/1004))
 
 Tier 2 of #1000. The backend OpenAPI schema generates a checked-in TypeScript
-types module, and a staleness gate (`tools/generate_openapi_spec.py --check`)
-fails when the generated types drift from the live schema — enforcing the FE↔BE
-contract at the boundary.
+types module, a staleness gate (`tools/generate_openapi_spec.py --check`) fails
+when the generated types drift from the live schema, and high-traffic call sites
+consume the generated `Schemas[...]` aliases (via `lib/api-schema.ts`) so FE↔BE
+response-shape drift is caught at compile time — enforcing the contract at the
+boundary instead of leaving the generated client as dead code.
 
 | AC ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC12.28.1 | The generator emits the spec from the live OpenAPI schema | `test_AC12_28_1_generator_emits_types_from_openapi` | `tests/tooling/test_generate_openapi_spec.py` | P2 |
 | AC12.28.2 | The `--check` staleness gate fails when the committed spec is stale | `test_AC12_28_2_staleness_gate_detects_drift` | `tests/tooling/test_generate_openapi_spec.py` | P2 |
+| AC12.28.3 | High-traffic call sites type responses against the generated schema | `AC12.28.3 types Stage-2 batch responses against the generated schema` | `__tests__/apiTypedClient.test.ts` | P2 |
 
 ---
 

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -408,18 +408,20 @@ callers branch on a machine-readable code instead of matching `detail` text.
 
 ### AC12.28: Generated Frontend API Types from OpenAPI ([#1004](https://github.com/wangzitian0/finance_report/issues/1004))
 
-Tier 2 of #1000. The backend OpenAPI schema generates a checked-in TypeScript
-types module, a staleness gate (`tools/generate_openapi_spec.py --check`) fails
-when the generated types drift from the live schema, and high-traffic call sites
-consume the generated `Schemas[...]` aliases (via `lib/api-schema.ts`) so FE↔BE
-response-shape drift is caught at compile time — enforcing the contract at the
-boundary instead of leaving the generated client as dead code.
+Tier 2 of #1000. The backend OpenAPI schema is serialized to a checked-in spec
+(`apps/frontend/openapi.json`), and a staleness gate
+(`tools/generate_openapi_spec.py --check`) fails when that committed spec drifts
+from the live FastAPI schema. `api-types.ts` is regenerated from the spec
+(`npm run gen:api-types`), and high-traffic call sites consume the generated
+`Schemas[...]` aliases (via `lib/api-schema.ts`) so a backend response-shape
+change that isn't regenerated is caught at compile time (`npm run build`) —
+enforcing the FE↔BE contract instead of leaving the generated client as dead code.
 
 | AC ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC12.28.1 | The generator emits the spec from the live OpenAPI schema | `test_AC12_28_1_generator_emits_types_from_openapi` | `tests/tooling/test_generate_openapi_spec.py` | P2 |
 | AC12.28.2 | The `--check` staleness gate fails when the committed spec is stale | `test_AC12_28_2_staleness_gate_detects_drift` | `tests/tooling/test_generate_openapi_spec.py` | P2 |
-| AC12.28.3 | High-traffic call sites type responses against the generated schema | `AC12.28.3 types Stage-2 batch responses against the generated schema` | `__tests__/apiTypedClient.test.ts` | P2 |
+| AC12.28.3 | High-traffic call sites type responses against the generated schema | `test_AC12_28_3_types_stage2_batch_responses_against_generated_schema` | `__tests__/apiTypedClient.test.ts` | P2 |
 
 ---
 


### PR DESCRIPTION
## What & why

Completes the **last open child of #1000** — #1004's final acceptance: *"Replace inline-string `apiFetch` calls with the typed client (incrementally is fine; pick high-traffic modules first)."*

The earlier #1074 sweep (PR #1096) generated the OpenAPI spec + `api-types.ts` + the staleness gate, but **no call site consumed the generated types** — the client was dead code. This PR wires it in at a high-traffic module.

## Changes
- **`lib/api-schema.ts`**: ergonomic `Schemas` / `Paths` aliases over the generated `api-types.ts`.
- **`Stage2ReviewQueue.tsx`**: the three high-traffic Stage-2 batch calls now type their responses as `Schemas["BatchApproveResponse"]` / `Schemas["BatchRejectResponse"]` instead of hand-written inline shapes. A backend response-shape change that isn't regenerated now fails the FE type-check (`npm run build`).
- **AC12.28.3** + `apiTypedClient.test.ts`.

Further modules can adopt `Schemas[...]` incrementally.

## Verified
- `tsc --noEmit` clean (validates the generated-type consumption); full FE suite **826** green; traceability gate 100%; eslint clean.

## Closes
`Closes #1004` — which is the **last open child of #1000**. Once merged, #1000's children are all closed and the meta issue can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)