### PR TITLE
[finance_report_hacker] fix(#1086): tolerant statement date parsing + non-fatal bad rows

### DIFF
--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -4,7 +4,7 @@ import hashlib
 import ipaddress
 import json
 import re
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 from io import BytesIO
 from pathlib import Path
@@ -44,6 +44,49 @@ CSV_INFERRED_BALANCE_REVIEW_NOTE = (
 )
 
 
+# Date formats seen across real bank/brokerage statements, beyond strict ISO.
+# Ordered so day-first forms win before the ambiguous US month-first form; this
+# preserves the prior CSV parser's resolution while adding non-ISO support (#1086).
+_DATE_FORMATS: tuple[str, ...] = (
+    "%Y-%m-%d",
+    "%Y/%m/%d",
+    "%Y.%m.%d",
+    "%Y年%m月%d日",  # Chinese bank statements, e.g. 2025年01月15日
+    "%d/%m/%Y",
+    "%d-%m-%Y",
+    "%d.%m.%Y",
+    "%m/%d/%Y",
+    "%d %b %Y",
+    "%d %B %Y",
+)
+
+
+def _tolerant_parse_date(value: str | None) -> date | None:
+    """Parse a date from common bank/brokerage formats, not just strict ISO (#1086).
+
+    Returns ``None`` for empty/unparseable input so callers decide whether a missing
+    date is fatal (a required statement period) or skippable (one bad transaction
+    row), instead of a strict ``date.fromisoformat`` aborting the whole document.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in {"none", "null", "n/a", "-"}:
+        return None
+    # Fast path: ISO date, or an ISO datetime whose leading 10 chars are the date.
+    iso_candidate = text[:10] if ("T" in text or " " in text) else text
+    try:
+        return date.fromisoformat(iso_candidate)
+    except ValueError:
+        pass
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
 class ExtractionError(Exception):
     """Raised when extraction fails."""
 
@@ -67,19 +110,15 @@ class ExtractionService:
         self.deduplication_service = DeduplicationService()
 
     def _safe_date(self, value: str | None) -> date:
-        """Safely parse date from string."""
+        """Safely parse a required date, accepting common non-ISO formats (#1086)."""
         if not value:
             logger.error("Date is required but was None or empty", value=value)
             raise ValueError("Date is required")
-        try:
-            return date.fromisoformat(str(value))
-        except (ValueError, TypeError) as exc:
-            logger.error(
-                "Failed to parse date",
-                value=value,
-                error_type=type(exc).__name__,
-            )
-            raise ValueError(f"Invalid date format: {value}") from exc
+        parsed = _tolerant_parse_date(value)
+        if parsed is None:
+            logger.error("Failed to parse date", value=value)
+            raise ValueError(f"Invalid date format: {value}")
+        return parsed
 
     def _safe_optional_date(self, value: str | None) -> date | None:
         """Safely parse an optional date from extraction output."""
@@ -405,16 +444,17 @@ class ExtractionService:
                     )
                     continue
 
-                try:
-                    parsed_date = date.fromisoformat(txn_date_val)
-                except ValueError as exc:
-                    if is_brokerage_payload:
-                        logger.info(
-                            "Skipping brokerage transaction row with non-bank date",
-                            filename=original_filename or (file_path.name if file_path else "unknown"),
-                        )
-                        continue
-                    raise ExtractionError(f"Invalid transaction date format: {txn_date_val}") from exc
+                parsed_date = _tolerant_parse_date(txn_date_val)
+                if parsed_date is None:
+                    # #1086: one unparseable row date is non-fatal — skip and flag the
+                    # row instead of rejecting the whole (often multi-month) statement.
+                    logger.warning(
+                        "Skipping transaction row with unparseable date",
+                        raw_date=txn_date_val,
+                        is_brokerage=is_brokerage_payload,
+                        filename=original_filename or (file_path.name if file_path else "unknown"),
+                    )
+                    continue
 
                 try:
                     amount = Decimal(str(txn["amount"]))
@@ -1165,7 +1205,6 @@ class ExtractionService:
         """
         import csv
         import io
-        from datetime import datetime
 
         if isinstance(file_content, bytes):
             text = file_content.decode(encoding="utf-8-sig", errors="ignore")
@@ -1196,23 +1235,8 @@ class ExtractionService:
         period_end: date | None = None
 
         def parse_date(value: str) -> date | None:
-            """Try multiple date formats."""
-            formats = [
-                "%d %b %Y",
-                "%d/%m/%Y",
-                "%Y-%m-%d",
-                "%d-%m-%Y",
-                "%m/%d/%Y",
-                "%Y/%m/%d",
-                "%d %B %Y",
-            ]
-            value = value.strip()
-            for fmt in formats:
-                try:
-                    return datetime.strptime(value, fmt).date()
-                except ValueError:
-                    continue
-            return None
+            """Parse a CSV date via the shared tolerant parser (#1086)."""
+            return _tolerant_parse_date(value)
 
         def parse_amount(value: str) -> Decimal | None:
             """Parse amount string to Decimal."""

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -603,10 +603,14 @@ async def test_parse_document_with_invalid_date_formats():
         }
     )
 
-    with pytest.raises(ExtractionError, match="Invalid transaction date format"):
-        await service.parse_document(
-            file_path=Path("test.pdf"), institution="DBS", user_id=uuid4(), file_content=b"content"
-        )
+    # #1086: an unparseable transaction-row date is non-fatal — the row is skipped
+    # and the rest of the document still parses, instead of rejecting the whole
+    # (often multi-month) statement.
+    statement, transactions = await service.parse_document(
+        file_path=Path("test.pdf"), institution="DBS", user_id=uuid4(), file_content=b"content"
+    )
+    assert statement is not None
+    assert len(transactions) == 0
 
 
 async def test_parse_document_unexpected_exception():
@@ -895,11 +899,13 @@ async def test_parse_document_non_string_date():
             ],
         }
     )
-    # str(True) -> 'True' which is not ISO format -> should raise
-    with pytest.raises(ExtractionError, match="Invalid transaction date format"):
-        await service.parse_document(
-            file_path=Path("test.pdf"), institution="DBS", user_id=uuid4(), file_content=b"content"
-        )
+    # str(True) -> 'True' is not a parseable date. #1086: the row is skipped
+    # (non-fatal) rather than aborting the document.
+    statement, transactions = await service.parse_document(
+        file_path=Path("test.pdf"), institution="DBS", user_id=uuid4(), file_content=b"content"
+    )
+    assert statement is not None
+    assert len(transactions) == 0
 
 
 async def test_parse_document_skips_none_date_string():

--- a/apps/backend/tests/extraction/test_tolerant_date_parsing.py
+++ b/apps/backend/tests/extraction/test_tolerant_date_parsing.py
@@ -1,0 +1,80 @@
+"""Tolerant statement date parsing — non-ISO formats + non-fatal bad rows (#1086).
+
+Before this, a single empty/non-ISO date aborted the entire document parse, making
+Chinese-format statements (e.g. ``2025年01月15日``) unparseable and discarding an
+otherwise-good multi-month statement on one bad row.
+"""
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from src.services.extraction import ExtractionService, _tolerant_parse_date
+
+
+def test_AC13_19_1_tolerant_parse_date_accepts_non_iso_formats():
+    """AC13.19.1: common non-ISO formats parse; empty/garbage return None."""
+    assert _tolerant_parse_date("2025-01-15") == date(2025, 1, 15)
+    assert _tolerant_parse_date("2025/01/15") == date(2025, 1, 15)
+    assert _tolerant_parse_date("2025.01.15") == date(2025, 1, 15)
+    assert _tolerant_parse_date("2025年01月15日") == date(2025, 1, 15)
+    assert _tolerant_parse_date("15/01/2025") == date(2025, 1, 15)
+    assert _tolerant_parse_date("15 Jan 2025") == date(2025, 1, 15)
+    assert _tolerant_parse_date("2025-01-15T00:00:00") == date(2025, 1, 15)
+    # Non-fatal sentinels and junk yield None so callers can skip/flag.
+    for bad in (None, "", "   ", "None", "null", "n/a", "-", "not-a-date"):
+        assert _tolerant_parse_date(bad) is None
+
+
+async def test_AC13_19_2_chinese_format_statement_parses_instead_of_aborting():
+    """AC13.19.2: a statement whose dates are in Chinese format parses successfully
+    rather than being rejected with "Date is required"/"Invalid date format"."""
+    service = ExtractionService()
+    service.extract_financial_data = AsyncMock(
+        return_value={
+            "period_start": "2025年01月01日",
+            "period_end": "2025年01月31日",
+            "opening_balance": "100.00",
+            "closing_balance": "150.00",
+            "transactions": [
+                {"date": "2025年01月15日", "amount": "50.00", "direction": "IN", "description": "工资"},
+            ],
+        }
+    )
+
+    statement, transactions = await service.parse_document(
+        file_path=Path("zh.pdf"), institution="CMB", user_id=uuid4(), file_content=b"content"
+    )
+
+    assert statement.period_start == date(2025, 1, 1)
+    assert statement.period_end == date(2025, 1, 31)
+    assert len(transactions) == 1
+    assert transactions[0].txn_date == date(2025, 1, 15)
+
+
+async def test_AC13_19_3_one_bad_row_date_is_non_fatal():
+    """AC13.19.3: one unparseable row date is skipped; the good rows still parse and
+    the document is not rejected as a whole."""
+    service = ExtractionService()
+    service.extract_financial_data = AsyncMock(
+        return_value={
+            "period_start": "2025-01-01",
+            "period_end": "2025-01-31",
+            "opening_balance": "100.00",
+            "closing_balance": "150.00",
+            "transactions": [
+                {"date": "garbage-date", "amount": "10.00", "direction": "IN", "description": "Bad"},
+                {"date": "2025/01/20", "amount": "50.00", "direction": "IN", "description": "Good"},
+            ],
+        }
+    )
+
+    statement, transactions = await service.parse_document(
+        file_path=Path("mixed.pdf"), institution="DBS", user_id=uuid4(), file_content=b"content"
+    )
+
+    assert statement is not None
+    assert len(transactions) == 1
+    assert transactions[0].description == "Good"
+    assert transactions[0].txn_date == date(2025, 1, 20)

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -210,6 +210,20 @@ Expected routing behavior remains threshold-based (See: `docs/ssot/reconciliatio
 | AC13.18.1 | The vision model list appends `VISION_FALLBACK_MODELS` after the primary OCR/vision model, deduplicated and order-preserving, so more than one model is attempted on the vision path | `test_ocr_model_selection_helpers_deduplicate_vision_models()`, `test_vision_extraction_models_dedupes_fallback_against_primary()`, `test_vision_extraction_models_without_fallbacks_returns_primary_only()`, `test_extract_financial_data_shared_ocr_vision_skips_layout_parser()`, `test_extract_financial_data_dedicated_ocr_failure_falls_back_to_vision()` | `extraction/test_extraction_error_paths.py` | P1 |
 | AC13.18.2 | When the primary vision model raises a non-retryable provider error (e.g. a 400), the vision path attempts the configured vision fallback model and succeeds instead of failing the upload | `test_vision_path_falls_back_to_secondary_model_on_non_retryable_error()` | `extraction/test_extraction_error_paths.py` | P1 |
 
+### AC13.19: Tolerant Statement Date Parsing ([#1086](https://github.com/wangzitian0/finance_report/issues/1086))
+
+A single empty/non-ISO date previously aborted the entire document parse, making
+Chinese-format statements (`2025年01月15日`) unparseable and discarding an otherwise-good
+multi-month statement on one bad row. A shared `_tolerant_parse_date` accepts common
+non-ISO formats, and an unparseable transaction-row date is skip-and-flagged instead
+of fatal.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC13.19.1 | Common non-ISO date formats parse; empty/garbage return None | `test_AC13_19_1_tolerant_parse_date_accepts_non_iso_formats` | `extraction/test_tolerant_date_parsing.py` | P1 |
+| AC13.19.2 | A Chinese-format statement parses instead of being rejected | `test_AC13_19_2_chinese_format_statement_parses_instead_of_aborting` | `extraction/test_tolerant_date_parsing.py` | P1 |
+| AC13.19.3 | One unparseable row date is non-fatal — the row is skipped, the rest parse | `test_AC13_19_3_one_bad_row_date_is_non_fatal` | `extraction/test_tolerant_date_parsing.py` | P1 |
+
 ### AC13.14: JSON-Repair Retry (issue #982)
 
 | ID | Test Case | Test Function | File | Priority |


### PR DESCRIPTION
## What & why

One of the two **blocking** issues. A single empty/non-ISO date aborted the **entire** document parse:
- Chinese-format statements (`2025年01月15日`, `2025/01/15`) were effectively unparseable.
- One bad date in a multi-month statement rejected the whole thing.
- **Strongly suspected root cause of the red staging AI/OCR gate (#1089)** — the China-Merchants-Bank repro failed with `"Date is required"` / `Invalid date format`.

## Fix
- **Shared `_tolerant_parse_date`** accepts common non-ISO formats (`YYYY/MM/DD`, `YYYY.MM.DD`, `YYYY年MM月DD日`, `DD/MM/YYYY`, `DD-MM-YYYY`, `DD Mon YYYY`, ISO datetimes) and returns `None` for empty/garbage so callers choose fatal-vs-skip.
- **`_safe_date`** (required statement period dates) now accepts those formats.
- **A bank transaction row with an unparseable date is skip-and-flagged** (logged warning) instead of raising `ExtractionError` and rejecting the whole statement.
- **CSV `parse_date`** delegates to the shared parser, gaining Chinese-date support and removing a duplicate format list.

## Tests
- New `extraction/test_tolerant_date_parsing.py` — AC13.19.1–3 (non-ISO formats; Chinese statement parses; one bad row is non-fatal).
- Updated two `test_extraction_error_paths.py` tests that encoded the old strict-abort contract.
- Full extraction suite green; ruff + traceability gate pass.

## Relation to #1089
This is the parse-robustness root fix. The companion PR (#1089) hardens the staging AI/OCR gate's failure reporting. Final green of the gate is confirmed by the next staging-deploy run.

`Closes #1086`

🤖 Generated with [Claude Code](https://claude.com/claude-code)