### PR TITLE
[finance_report_audit] test(#audit): behavioral-anchor double-entry, FX & report outputs incl #990 input selection

### DIFF
--- a/apps/backend/tests/accounting/test_multicurrency_integrity.py
+++ b/apps/backend/tests/accounting/test_multicurrency_integrity.py
@@ -11,7 +11,7 @@ from src.models import Account, AccountType, Direction, JournalEntry, JournalEnt
 from src.services.accounting import ValidationError, validate_journal_balance, verify_accounting_equation
 
 
-def test_AC2_12_1_multicurrency_entry_balances_in_base_currency():
+def test_AC2_12_1_multicurrency_entry_balances_in_base_currency(ac_evidence):
     """AC2.12.1: Multi-currency journal validation balances converted base amounts."""
     bank_usd = JournalLine(
         account_id=uuid4(),
@@ -27,6 +27,9 @@ def test_AC2_12_1_multicurrency_entry_balances_in_base_currency():
         currency="SGD",
     )
 
+    # 100.00 USD @ 1.35 == 135.00 SGD: the converted debit must equal the SGD credit.
+    converted_debit = bank_usd.amount * bank_usd.fx_rate
+    assert converted_debit == equity_sgd.amount == Decimal("135.00")
     validate_journal_balance([bank_usd, equity_sgd])
 
     understated_credit = JournalLine(
@@ -37,6 +40,16 @@ def test_AC2_12_1_multicurrency_entry_balances_in_base_currency():
     )
     with pytest.raises(ValidationError):
         validate_journal_balance([bank_usd, understated_credit])
+
+    # Behavioral evidence: the converted base amount equals the golden 135.00 SGD;
+    # a wrong fx multiply or a missing conversion would not land on this number.
+    ac_evidence(
+        ac_id="AC2.12.1",
+        score=1.0,
+        metric="usd_to_sgd_converted_base_amount_match",
+        comment="100.00 USD @ 1.35 == 135.00 SGD converted base amount (deterministic)",
+        provenance="deterministic",
+    )
 
 
 async def test_AC2_12_2_accounting_equation_uses_base_currency_balances(db: AsyncSession, test_user):

--- a/apps/backend/tests/accounting/test_opening_balance.py
+++ b/apps/backend/tests/accounting/test_opening_balance.py
@@ -18,7 +18,9 @@ async def _account(client: AsyncClient, name: str, account_type: str) -> str:
     return resp.json()["id"]
 
 
-async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet(client: AsyncClient) -> None:
+async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet(
+    client: AsyncClient, ac_evidence
+) -> None:
     """AC2.15.1: a guided opening-balance request posts a balanced entry and the
     as-of balance sheet reflects the starting position with the equation intact."""
     bank = await _account(client, "Bank", "ASSET")
@@ -43,8 +45,18 @@ async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sh
     # Net worth (assets - liabilities) is captured as Opening Balance Equity.
     assert Decimal(bs["total_equity"]) == Decimal("5000.00")
 
+    # Behavioral evidence: 10000 asset offset by 5000 liability nets 5000 into equity,
+    # the entry balances at 10000.00, and the equation delta is exactly 0.00.
+    ac_evidence(
+        ac_id="AC2.15.1",
+        score=1.0,
+        metric="opening_balance_golden_totals_match",
+        comment="balanced 10000.00; total_assets 10000.00, total_equity 5000.00, equation_delta 0.00",
+        provenance="deterministic",
+    )
 
-async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client: AsyncClient) -> None:
+
+async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client: AsyncClient, ac_evidence) -> None:
     """AC2.15.2: a single asset opening balance is offset entirely into Opening
     Balance Equity, keeping the entry balanced."""
     savings = await _account(client, "Savings", "ASSET")
@@ -58,6 +70,16 @@ async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client:
     assert bs["is_balanced"] is True
     assert Decimal(bs["total_assets"]) == Decimal("8000.00")
     assert Decimal(bs["total_equity"]) == Decimal("8000.00")
+
+    # Behavioral evidence: a single 8000 asset is offset entirely into equity, so
+    # total_assets == total_equity == 8000.00 with the equation kept intact.
+    ac_evidence(
+        ac_id="AC2.15.2",
+        score=1.0,
+        metric="single_asset_opening_offsets_into_equity",
+        comment="total_assets 8000.00 == total_equity 8000.00 (single asset offset to equity)",
+        provenance="deterministic",
+    )
 
 
 async def test_AC2_15_3_unknown_account_is_rejected(client: AsyncClient) -> None:

--- a/apps/backend/tests/assets/test_manual_valuation_snapshots.py
+++ b/apps/backend/tests/assets/test_manual_valuation_snapshots.py
@@ -327,7 +327,7 @@ async def test_AC11_19_1_manual_valuation_correction_appends_version_and_preserv
 
 
 @pytest.mark.asyncio
-async def test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth(db, test_user):
+async def test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth(db, test_user, ac_evidence):
     """AC11.19.2: Heads-only reads use the current version, so a correction never double-counts."""
     service = AssetService()
     key = dict(
@@ -347,6 +347,17 @@ async def test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth(
     snapshots, total = await service.list_valuation_snapshots(db, test_user.id)
     assert total == 1, "list returns only current heads"
     assert snapshots[0].value == Decimal("1100000.00")
+
+    # Behavioral evidence (#990 version/supersession selection): heads-only read returns
+    # the corrected 1,100,000 only; a superseded leak (superseded_by_id IS NULL filter
+    # broken) would double-count to 2,100,000.
+    ac_evidence(
+        ac_id="AC11.19.2",
+        score=1.0,
+        metric="superseded_version_excluded_head_total_match",
+        comment="net-worth components total_assets == 1,100,000 (head only), not 2,100,000",
+        provenance="deterministic",
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/integration/test_cross_user_report_isolation_e2e.py
+++ b/apps/backend/tests/integration/test_cross_user_report_isolation_e2e.py
@@ -49,7 +49,7 @@ async def _post(db: AsyncSession, user_id: UUID, *, debit: Account, credit: Acco
     await post_journal_entry(db, entry.id, user_id)
 
 
-async def test_AC8_16_2_reports_exclude_other_users_entries(db: AsyncSession, test_user: User) -> None:
+async def test_AC8_16_2_reports_exclude_other_users_entries(db: AsyncSession, test_user: User, ac_evidence) -> None:
     """AC8.16.2: user A's report totals reflect only A's facts; B's data never leaks in."""
     user_a = test_user.id
     user_b = (await UserFactory.create_async(db)).id
@@ -115,3 +115,14 @@ async def test_AC8_16_2_reports_exclude_other_users_entries(db: AsyncSession, te
     b_nw = await service.get_latest_valuation_components(db, user_b, as_of_date=period_end)
     assert a_nw.total_assets == Decimal("200000.00")  # A's appraisal only, not 200000 + 800000
     assert b_nw.total_assets == Decimal("800000.00")  # B's own, not A's
+
+    # Behavioral evidence (#990 cross-user input selection): A's assets total is its
+    # own 1500.00, never 1500 + B's 17776; A's net-worth valuation is 200000.00, never
+    # 200000 + B's 800000. A cross-user leak would move both off these golden numbers.
+    ac_evidence(
+        ac_id="AC8.16.2",
+        score=1.0,
+        metric="cross_user_excluded_own_totals_match",
+        comment="A assets 1500.00 (not 1500+17776) and A net-worth 200000.00 (not +800000); B never leaks in",
+        provenance="deterministic",
+    )

--- a/apps/backend/tests/reporting/test_reporting.py
+++ b/apps/backend/tests/reporting/test_reporting.py
@@ -316,7 +316,7 @@ async def test_income_statement_calculation(db: AsyncSession, chart_of_accounts,
     assert report["net_income"] == Decimal("4800.00")
 
 
-async def test_reporting_dashboard_fixture_exact_totals(db: AsyncSession, chart_of_accounts, test_user_id):
+async def test_reporting_dashboard_fixture_exact_totals(db: AsyncSession, chart_of_accounts, test_user_id, ac_evidence):
     """[AC5.1.1][AC5.2.1][AC5.3.1][AC5.6.5] Deterministic fixture yields exact report totals."""
     cash, liability, equity, income, expense = chart_of_accounts
 
@@ -527,6 +527,31 @@ async def test_reporting_dashboard_fixture_exact_totals(db: AsyncSession, chart_
         "beginning_cash": Decimal("0.00"),
         "ending_cash": Decimal("1600.00"),
     }
+
+    # Behavioral evidence: each statement's headline total matches the golden value
+    # computed from the deterministic fixture above; any drift in the report math
+    # (sign rules, status/date filtering, FX) would move these numbers off the golden.
+    ac_evidence(
+        ac_id="AC5.1.1",
+        score=1.0,
+        metric="balance_sheet_totals_match_golden",
+        comment="assets 1600.00, liabilities 300.00, equity 1000.00; equation balanced (delta 0.00)",
+        provenance="deterministic",
+    )
+    ac_evidence(
+        ac_id="AC5.2.1",
+        score=1.0,
+        metric="income_statement_net_income_match_golden",
+        comment="income 500.00 - expenses 200.00 == net_income 300.00",
+        provenance="deterministic",
+    )
+    ac_evidence(
+        ac_id="AC5.3.1",
+        score=1.0,
+        metric="cash_flow_net_match_golden",
+        comment="operating 300.00 + financing 1300.00 == net_cash_flow 1600.00; ending_cash 1600.00",
+        provenance="deterministic",
+    )
 
 
 async def test_balance_sheet_fx_error(db: AsyncSession, chart_of_accounts, test_user_id):


### PR DESCRIPTION
## PR-B: Behavioral anchoring — double-entry, FX & report outputs (incl. #990 input selection)

Part of the 3-PR behavioral-test-anchoring effort. Raises **L2** (critical proof matrix) and **L3** (deterministic score ratchet) anchoring for the material *money-in / money-out* ACs. Append-only edits to `critical-proof-matrix.yaml` and `ac-score-baseline.json` (kept trivially mergeable with sibling PRs); markers/CI ratchet wiring untouched (owned by PR-A).

**Honesty:** every anchored test genuinely asserts its AC's behaviour. L3 scores are measured against golden amounts/balances already asserted in-test (`provenance=deterministic`); none are hand-set. Monetary values are `Decimal` throughout. No new tests were needed — the #990 input-selection invariants already had real behavioural tests, so this PR anchors and scores them rather than inventing coverage.

### Anchoring table

| AC id | domain | newly L2? | newly L3 (metric)? | notes |
|---|---|---|---|---|
| AC2.2.1 | double-entry | yes | — | balanced entry passes |
| AC2.2.2 | double-entry | yes | — | unbalanced rejected |
| AC2.2.3 | double-entry | yes | — | single-line rejected |
| AC2.14.1 | double-entry | yes | — | DB: posted needs ≥2 lines |
| AC2.14.2 | double-entry | yes | — | DB: posted balances in base ccy |
| AC2.14.3 | double-entry/FX | yes | — | DB: non-base line needs +fx_rate |
| AC2.14.4 | double-entry | yes | — | DB: posted immutable, drafts editable |
| AC2.14.5 | double-entry | yes | — | DB: void requires reversal rel |
| AC2.13.1 | double-entry | yes | — | rejects cross-user account |
| AC2.13.2 | double-entry | yes | — | DB-boundary cross-user reject |
| AC2.13.3 | double-entry | yes | — | balance queries ignore cross-user |
| AC2.12.1 | FX | yes | yes (`usd_to_sgd_converted_base_amount_match`) | 100 USD @1.35 == 135 SGD |
| AC2.12.2 | FX | yes | — | equation uses base-ccy balances |
| AC2.15.1 | double-entry/report | yes | yes (`opening_balance_golden_totals_match`) | bal 10000; assets 10000, equity 5000 |
| AC2.15.2 | double-entry/report | yes | yes (`single_asset_opening_offsets_into_equity`) | assets==equity==8000 |
| AC2.15.7 | double-entry | yes | — | system-account target rejected |
| AC5.1.1 | report output | yes | yes (`balance_sheet_totals_match_golden`) | BS golden totals |
| AC5.2.1 | report output | yes | yes (`income_statement_net_income_match_golden`) | IS net income golden |
| AC5.3.1 | report output | yes | yes (`cash_flow_net_match_golden`) | CF net golden |
| AC8.16.2 | report input (#990) | yes | yes (`cross_user_excluded_own_totals_match`) | cross-user isolation at report-number level |
| AC11.19.1 | report input (#990) | yes | — | supersession append-only chain |
| AC11.19.2 | report input (#990) | yes | yes (`superseded_version_excluded_head_total_match`) | superseded version excluded (heads-only) |

### Deliberately left at L1 (not anchored here)
- **Report INPUT statement/version selection for income statement & cash flow** — these read immutable journal entries with **no statement-level versioning layer in the model yet** (only `ManualValuationSnapshot` carries `superseded_by_id`). The supersession invariant is anchored where it actually exists today (valuation snapshots: AC11.19.1/2) and at the augmentation seam (AC8.16.1, already baselined). Writing a "superseded statement version ignored by IS/CF" test would require modelling a feature that does not exist, so it is parked rather than faked.
- **Void numeric-reversal-balance L3** — `test_void_journal_entry_creates_reversal` asserts a reversal is created but does not compare reversal amounts to the originals against a golden; left at L1 (the DB void-reversal invariant AC2.14.5 is anchored at L2 instead).

### Local gates (all green)
`check_critical_proof_matrix.py` (28 proofs, 6 outcomes), `check_ac_score_baseline.py` (10 ACs, 0 regressions/missing), `check_ac_traceability.py`, `check_e2e_epic_traceability.py`, `build_ac_traceability.py`, `lint_doc_consistency.py`, `generate_ac_registry.py --check`; all 20 anchored tests pass; ruff clean. Evidence verified end-to-end via `aggregate_ac_evidence.py` → `check_ac_score_baseline.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
