### PR TITLE
[finance_report_hacker] fix(#1086 follow-up): make the LLM the primary date normalizer

### DIFF
--- a/apps/backend/src/prompts/statement.py
+++ b/apps/backend/src/prompts/statement.py
@@ -42,7 +42,10 @@ Output format (JSON object - NOT an array):
 Important Rules:
 1. Output MUST be a single JSON object starting with `{`, NOT an array `[`, and no markdown
 2. All amounts as non-negative strings with 2 decimal places, no commas (e.g., "10000.00")
-3. Dates in YYYY-MM-DD format
+3. Normalize EVERY date to ISO YYYY-MM-DD, converting from whatever format the
+   source uses — e.g. 2025年01月15日 -> 2025-01-15, 15/01/2025 -> 2025-01-15,
+   2025/1/5 -> 2025-01-05, 15 Jan 2025 -> 2025-01-15. Do the conversion yourself;
+   never echo a non-ISO source format.
 4. direction: "IN" for credits/deposits, "OUT" for debits/withdrawals
 5. Include ALL transactions visible in the document
 6. Preserve raw_text exactly as shown (for audit trail)

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -62,11 +62,15 @@ _DATE_FORMATS: tuple[str, ...] = (
 
 
 def _tolerant_parse_date(value: str | None) -> date | None:
-    """Parse a date from common bank/brokerage formats, not just strict ISO (#1086).
+    """Defensive fallback parser for dates the model didn't normalize to ISO (#1086).
 
-    Returns ``None`` for empty/unparseable input so callers decide whether a missing
-    date is fatal (a required statement period) or skippable (one bad transaction
-    row), instead of a strict ``date.fromisoformat`` aborting the whole document.
+    Primary date normalization is the extraction model's responsibility — the parsing
+    prompt instructs it to emit ISO ``YYYY-MM-DD`` for every source format. This
+    handles the residual cases where the model still echoes a common non-ISO form
+    (Chinese ``YYYY年MM月DD日``, ``DD/MM/YYYY``, ``YYYY.MM.DD``, ``DD Mon YYYY``, ISO
+    datetimes). It returns ``None`` for empty/unparseable input so callers decide
+    whether a missing date is fatal (a required statement period) or skippable (one
+    bad row), instead of a strict ``date.fromisoformat`` aborting the whole document.
     """
     if value is None:
         return None
@@ -444,15 +448,22 @@ class ExtractionService:
                     )
                     continue
 
+                # Primary date normalization is the model's job (see the parsing
+                # prompt's ISO rule). `_tolerant_parse_date` is only a defensive net
+                # for the few rows the model still emits in a non-ISO/empty form.
                 parsed_date = _tolerant_parse_date(txn_date_val)
                 if parsed_date is None:
                     # #1086: one unparseable row date is non-fatal — skip and flag the
                     # row instead of rejecting the whole (often multi-month) statement.
+                    # Carry description/amount so the skipped row is identifiable from
+                    # logs without reproducing locally.
                     logger.warning(
                         "Skipping transaction row with unparseable date",
                         raw_date=txn_date_val,
+                        description=txn.get("description", "N/A"),
+                        amount=txn.get("amount"),
                         is_brokerage=is_brokerage_payload,
-                        filename=original_filename or (file_path.name if file_path else "unknown"),
+                        statement_file=original_filename or (file_path.name if file_path else "unknown"),
                     )
                     continue
 

--- a/apps/backend/tests/extraction/test_tolerant_date_parsing.py
+++ b/apps/backend/tests/extraction/test_tolerant_date_parsing.py
@@ -10,7 +10,22 @@ from pathlib import Path
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
+from src.prompts import get_parsing_prompt
 from src.services.extraction import ExtractionService, _tolerant_parse_date
+
+
+def test_AC13_19_4_parsing_prompt_instructs_iso_date_normalization():
+    """AC13.19.4: the extraction prompt makes the model the primary date normalizer.
+
+    Asserts the specific rule text and a concrete conversion example so the test fails
+    if the prompt drops or weakens the ISO-normalization requirement (the tolerant
+    parser is only a defensive fallback)."""
+    prompt = get_parsing_prompt("DBS")
+    # The explicit instruction to convert every source format to ISO.
+    assert "Normalize EVERY date to ISO YYYY-MM-DD" in prompt
+    assert "never echo a non-ISO source format" in prompt
+    # At least one concrete conversion example, incl. the Chinese format that broke #1086.
+    assert "2025年01月15日 -> 2025-01-15" in prompt
 
 
 def test_AC13_19_1_tolerant_parse_date_accepts_non_iso_formats():

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -223,6 +223,7 @@ of fatal.
 | AC13.19.1 | Common non-ISO date formats parse; empty/garbage return None | `test_AC13_19_1_tolerant_parse_date_accepts_non_iso_formats` | `extraction/test_tolerant_date_parsing.py` | P1 |
 | AC13.19.2 | A Chinese-format statement parses instead of being rejected | `test_AC13_19_2_chinese_format_statement_parses_instead_of_aborting` | `extraction/test_tolerant_date_parsing.py` | P1 |
 | AC13.19.3 | One unparseable row date is non-fatal — the row is skipped, the rest parse | `test_AC13_19_3_one_bad_row_date_is_non_fatal` | `extraction/test_tolerant_date_parsing.py` | P1 |
+| AC13.19.4 | The model is the primary date normalizer: the prompt instructs converting any source format to ISO YYYY-MM-DD (parser is only a fallback) | `test_AC13_19_4_parsing_prompt_instructs_iso_date_normalization` | `extraction/test_tolerant_date_parsing.py` | P1 |
 
 ### AC13.14: JSON-Repair Retry (issue #982)
 


### PR DESCRIPTION
## What & why

Follow-up to the merged #1113 (#1086), addressing review feedback:

> *"修复方式很奇怪…你是硬编码的修复么？不应该是 LLM 自动解析么？你可以强约束常见的，但整体应该让 LLM 来干这个。"*

Correct. #1113 leaned on a hardcoded format list as the parser. Date normalization should **primarily be the model's job**; the hardcoded parser should be a *constrained defensive fallback*, not the main mechanism.

## Changes
- **Prompt (primary fix)**: the parsing prompt now instructs the model to convert **every** source date format to ISO `YYYY-MM-DD` — with concrete examples (`2025年01月15日` → `2025-01-15`, `15/01/2025` → `2025-01-15`, …) — and to never echo a non-ISO source format.
- **`_tolerant_parse_date` reframed** (docstring) as a *defensive fallback* for the residual rows the model still emits non-ISO/empty, not the primary parser. (Behavior unchanged — still a safety net.)
- **CR fix (from #1113)**: the skip-and-flag warning now carries `description`/`amount`, so a dropped row is identifiable from logs without local repro.
- **AC13.19.4** + test asserting the prompt instructs ISO normalization.

## Verified
- Full extraction suite (499) + tx-boundary meta-test green; ruff clean; traceability 100%; vision-proof matrix regenerated.

## Closes the #1113 review comment
This resolves the open CR thread on #1113 (skip-warning context) and the design concern. `Relates to #1086`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)