### PR TITLE
[finance_report_hacker_prompt] fix(extraction): multi-section + per-currency completeness self-check (#1086)

### DIFF
--- a/apps/backend/src/prompts/statement.py
+++ b/apps/backend/src/prompts/statement.py
@@ -52,11 +52,14 @@ Important Rules:
 10. Include "balance_after" showing the running balance after the transaction (from the balance column if present)
 11. Auto-detect the institution name from the document header/logo and return it in the "institution" field
 12. For each transaction, suggest a category from: Food & Dining, Transport, Shopping, Utilities, Salary, Transfer, Investment, Insurance, Rent, Healthcare, Entertainment, Education, Subscriptions, Other. Set "suggested_category" and "category_confidence" (0.0-1.0). If unsure, use "Other" with low confidence.
+13. MULTI-SECTION STATEMENTS: a statement may contain more than one transaction section (e.g. "SAVINGS - TRANSACTION DETAILS" and "INVESTMENTS - TRANSACTION DETAILS"). Extract transactions from EVERY section, but record each cash movement EXACTLY ONCE. A transfer or fund purchase/redemption between the user's own accounts (e.g. "Buy - Mari Invest" / "Sell - Mari Invest") is shown as a cash movement in one section AND mirrored in another - include ONLY the single cash leg that moves THIS statement's balance (a purchase/"Buy" reduces cash -> OUT; a redemption/"Sell" adds cash -> IN), and do NOT also add the mirrored row from the other section as a second transaction. Do NOT skip transfers between the user's own accounts, and do NOT double-count them.
+14. COMPLETENESS SELF-CHECK (do this before returning): reconcile EACH currency separately. For every currency present, opening_balance + sum(IN) - sum(OUT) for that currency MUST equal that currency's closing balance within 0.10. Never add amounts across different currencies. The top-level opening_balance/closing_balance are for the statement's primary currency. If a currency does NOT balance, you have either missed, duplicated, or mis-signed a transaction: use the running balance ("balance_after" / the daily balance column) to locate the day where the balance jumps and correct it using ONLY what the document actually shows. NEVER invent, fabricate, or alter transactions or balances to force a match - if the document genuinely does not reconcile, return exactly what is shown.
+15. FOREIGN-EXCHANGE / CROSS-CURRENCY: if a line converts one currency to another (e.g. "Converted 1,000 SGD to 740 USD"), record the leg in the currency that actually moved on THIS statement and set its "currency" accordingly; preserve the other currency, the exchange rate, and any fee/spread in "raw_text" (and "reference" if shown). List a separately-shown fee as its own transaction.
 """
 
 VALIDATION_PROMPT = """Verify the extracted data:
 
-1. Balance check: opening_balance + sum(IN) - sum(OUT) ≈ closing_balance (tolerance: 0.10)
+1. Balance check: opening_balance + sum(IN) - sum(OUT) ≈ closing_balance (tolerance: 0.10), computed per currency - never sum amounts across different currencies. Only perform a per-currency balance check when the document actually provides that currency's opening and closing balance.
 2. Date check: All transaction dates should be within period_start and period_end
 3. Completeness: No missing required fields
 
@@ -146,9 +149,11 @@ GXS Bank Singapore statement:
     "MariBank": """
 MariBank Singapore statement:
 - Digital bank monthly statement
+- Sections: SAVINGS transaction details, INVESTMENTS transaction details, and a daily SAVINGS interest-details table
 - PayNow transfers to merchants
-- Interest entries
+- Interest: a single total "Interest" line appears in the savings transaction table. The daily interest-details table is informational - do NOT also add each day as a separate transaction.
 - Credit card repayments
+- Fund transfers with Mari Invest: "Buy - Mari Invest" (cash OUT of savings) and "Sell - Mari Invest" (cash IN to savings) - always include these savings-side cash legs
 """,
 }
 

--- a/apps/backend/tests/extraction/test_extraction.py
+++ b/apps/backend/tests/extraction/test_extraction.py
@@ -213,6 +213,16 @@ class TestPromptGeneration:
         assert "transactions" in prompt
         assert "suggested_category" in prompt
         assert "category_confidence" in prompt
+        # Multi-section extraction + per-currency completeness self-check (#1086/#1123)
+        assert "MULTI-SECTION" in prompt
+        assert "EVERY section" in prompt
+        assert "COMPLETENESS SELF-CHECK" in prompt
+        assert "reconcile EACH currency separately" in prompt
+        assert "Never add amounts across different currencies" in prompt
+        # Guardrails: no double-counting of mirrored legs, no fabrication (CR #1124)
+        assert "EXACTLY ONCE" in prompt
+        assert "do NOT double-count" in prompt
+        assert "NEVER invent, fabricate" in prompt
 
     def test_get_parsing_prompt_dbs(self):
         """AC13.4.2: Test DBS-specific prompt."""
@@ -258,6 +268,9 @@ class TestPromptGeneration:
 
         prompt = get_parsing_prompt("MariBank")
         assert "MariBank" in prompt
+        # MariBank hint must name the savings<->Mari Invest transfer legs (#1086)
+        assert "Buy - Mari Invest" in prompt
+        assert "Sell - Mari Invest" in prompt
 
 
 class TestMediaPayloadBuilder:


### PR DESCRIPTION
## Problem
Bank-statement extraction silently dropped one leg of an own-account transfer, breaking reconciliation and dead-ending the statement.

- Live repro on staging: `Mar2025_MariBank` extracted opening `98,416.10` and closing `53,335.15` correctly, but `expected 103,335.15` — exactly **+50,000.00** off → status `uploaded` (dead-end, #1085) and the staging AI/OCR gate failed (#1089).

## Root cause (verified, not guessed)
I read the actual PDF and pulled the model's extracted rows:
- The statement **reconciles perfectly**: starting `98,416.10` − outgoing `95,286.59` + incoming `50,205.64` = `53,335.15`.
- The model extracted every line **except** `03 MAR Buy - Mari Invest −50,000.00` (it kept the mirror leg `Sell - Mari Invest +50,094.57`). That single omission = the 50,000 gap.
- Why: this statement has multiple sections (`SAVINGS` + `INVESTMENTS` transaction tables) and the fund purchase appears **twice** (savings cash-out + investment buy). The parsing prompt had **no guidance** for multi-section statements / mirrored transfer legs and **no completeness self-check**.

So the balance check was correct (the extraction was genuinely incomplete) — the fix belongs in the **prompt**, not the validator or the state machine.

## Change (prompt-only; no schema/API/DB change)
`apps/backend/src/prompts/statement.py`:
- **Multi-section rule**: extract transactions from every section; always include the cash leg of own-account transfers (`Buy`=OUT, `Sell`=IN).
- **Per-currency completeness self-check**: before returning, reconcile **each currency** (`opening + ΣIN − ΣOUT = closing`) via the running balance; never sum across currencies. (Written per-currency on purpose — see the multi-currency design follow-up #1123.)
- **FX / cross-currency capture**: record the leg in the currency that moved; preserve the other currency, rate, and fee in `raw_text`/`reference`.
- **MariBank hint**: name the `Buy/Sell - Mari Invest` legs; treat the daily interest-details table as informational.

## Evidence (A/B on `z-ai/glm-4.6v`, same model as the staging gate)
| Statement | Before | After |
|---|---|---|
| MariBank Mar2025 (failing) | drops Buy, off by 50,000 ❌ | 7 txns, reconciles to `53,335.15` ✅ (Buy −50,000 captured) |
| GXS 2506 (previously clean) | balanced | 35 txns, still balanced ✅ (no regression) |

## Tests
Extended the existing prompt tests (no new AC IDs) to assert the multi-section rule, the per-currency self-check, and the MariBank transfer legs are present. `pytest -k get_parsing_prompt` → 7 passed; `ruff` clean.

## Scope / follow-ups
- Fixes the immediate dropped-leg class. Downstream handling of any still-unreconciled statement (the `uploaded` dead-end) remains #1085.
- The deeper multi-currency / FX-event / cross-account-transfer model is tracked as a separate design issue **#1123** (this PR's per-currency wording is the extraction-layer slice of that).

Closes #1086 · unblocks #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)
