### PR TITLE
[finance_report_test_and_doc] refactor(frontend): shrink oversized FE files (types.ts dedup + package page split)

### DIFF
--- a/apps/frontend/src/app/(main)/reports/package/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/package/page.tsx
@@ -1,281 +1,50 @@
 "use client";
 
-import { Download, FileJson, Network, Printer, Save, X } from "lucide-react";
-import Link from "next/link";
 import { useState } from "react";
 
-import { SkeletonBlock } from "@/components/ui";
-import { apiDownload, apiFetch } from "@/lib/api";
-import { formatCurrencyLocale } from "@/lib/currency";
-import { formatDateInput } from "@/lib/date";
 import {
-  anchorFromIdentifiers,
-  lineageUrl,
-  nodeLabel,
-  type LineageAnchor,
-} from "@/lib/lineage";
+  PackageCover,
+  PackageFrameworkSelection,
+  PackageLoadingSkeleton,
+  PackageSetupGuidance,
+  PackageTableOfContents,
+} from "@/components/reports/package/PackageChrome";
+import {
+  PackageFrameworkPolicySection,
+  PackageReadinessSection,
+  PackageSourceTrustSection,
+} from "@/components/reports/package/PackageReadinessSections";
+import {
+  PackageAnnualizedScheduleSection,
+  PackageExportContractSection,
+  PackageNotesSection,
+  PackageSectionCards,
+} from "@/components/reports/package/PackageScheduleSections";
+import { PackageSnapshotsCard } from "@/components/reports/package/PackageSnapshotsCard";
+import {
+  LineagePanelModal,
+  PackageTraceabilitySection,
+} from "@/components/reports/package/PackageTraceability";
+import {
+  FRAMEWORK_LABELS,
+  evidenceBundleReferences,
+  lineageAnchorForLine,
+  packageTocLinks,
+  type LineagePanelState,
+} from "@/components/reports/package/shared";
 import {
   generatePackageSnapshot,
   isValidReportDate,
-  reportPeriodStart,
   usePersonalReportPackage,
 } from "@/hooks/usePersonalReportPackage";
+import { apiDownload, apiFetch } from "@/lib/api";
+import { formatDateInput } from "@/lib/date";
+import { lineageUrl } from "@/lib/lineage";
 import type {
   EvidenceLineageResponse,
-  FrameworkPolicyResult,
-  MoneyValue,
-  PersonalReportPackageContractResponse,
   PersonalReportPackageSnapshotSummary,
   PersonalReportPackageTraceabilityLine,
 } from "@/lib/types";
-
-const FRAMEWORK_LABELS: Record<string, string> = {
-  personal_us_gaap_like: "US-like",
-  personal_hkfrs_like: "HK-like",
-};
-
-function formatScheduleCurrency(
-  value: MoneyValue,
-  currency: string,
-): string {
-  return formatCurrencyLocale(value, currency, "en-US", {
-    maximumFractionDigits: 0,
-  }).replace(/\u00a0/g, " ");
-}
-
-function renderCsv(values?: string[]): string {
-  return values && values.length ? values.join(", ") : "none";
-}
-
-function renderAnchorDetail(primary: string, identifiers?: string[]) {
-  return (
-    <>
-      <p className="mt-1 text-xs text-muted">{primary}</p>
-      {identifiers?.length ? (
-        <p className="mt-1 max-w-xs break-words font-mono text-[11px] text-muted">
-          {identifiers.join(", ")}
-        </p>
-      ) : null}
-    </>
-  );
-}
-
-function evidenceBundleReferences(
-  policyResult: FrameworkPolicyResult,
-): string[] {
-  const anchors = [
-    ...policyResult.decisions.flatMap((decision) => decision.evidence_anchors),
-    ...policyResult.gaps.flatMap((gap) => gap.evidence_anchors),
-  ];
-  return Array.from(
-    new Set(
-      anchors.map((anchor) => `${anchor.anchor_type}:${anchor.source_id}`),
-    ),
-  ).sort();
-}
-
-type LineagePanelState = {
-  line: PersonalReportPackageTraceabilityLine;
-  response: EvidenceLineageResponse | null;
-  isLoading: boolean;
-  error: string | null;
-};
-
-type PackageTocLink = {
-  id: string;
-  label: string;
-  status?: string;
-};
-
-function sectionAnchorId(sectionId: string): string {
-  return `package-section-${sectionId}`;
-}
-
-function packageTocLinks(
-  contract: PersonalReportPackageContractResponse,
-  includeOutputSections: boolean,
-): PackageTocLink[] {
-  const links: PackageTocLink[] = [
-    { id: "package-framework-selection", label: "Reporting Framework" },
-  ];
-  if (includeOutputSections) {
-    links.push(
-      { id: "package-readiness", label: "Report Readiness" },
-      { id: "package-source-trust", label: "Source Trust" },
-      { id: "package-framework-policy", label: "Framework Policy" },
-    );
-  }
-  links.push(
-    ...contract.sections.map((section) => ({
-      id: sectionAnchorId(section.section_id),
-      label: section.label,
-      status: section.status,
-    })),
-  );
-  if (includeOutputSections) {
-    links.push({ id: "package-export-contract", label: "Export Contract" });
-  }
-  return links;
-}
-
-function PackageCover({
-  contract,
-  reportDate,
-  selectedFrameworkLabel,
-}: {
-  contract: PersonalReportPackageContractResponse;
-  reportDate: string;
-  selectedFrameworkLabel: string | null;
-}) {
-  return (
-    <section aria-label="Report package cover" className="card p-6 mb-6">
-      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <p className="text-xs uppercase tracking-wide text-muted">
-            Personal financial-report package
-          </p>
-          <h2 className="mt-2 text-2xl font-semibold">Personal Report Package</h2>
-          <p className="mt-2 font-mono text-sm text-muted">
-            {contract.package_id}
-          </p>
-        </div>
-        <dl className="grid gap-3 text-sm sm:grid-cols-2 lg:min-w-[28rem]">
-          <div>
-            <dt className="text-xs text-muted">Framework</dt>
-            <dd className="mt-1 font-semibold">
-              {selectedFrameworkLabel ?? "Framework not selected"}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Report Date</dt>
-            <dd className="mt-1 font-mono text-xs">{reportDate}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Report Period</dt>
-            <dd className="mt-1 font-mono text-xs">
-              {reportPeriodStart(reportDate)} to {reportDate}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Package Version</dt>
-            <dd className="mt-1 font-mono text-xs">{contract.version}</dd>
-          </div>
-        </dl>
-      </div>
-    </section>
-  );
-}
-
-function PackageTableOfContents({ links }: { links: PackageTocLink[] }) {
-  return (
-    <nav
-      aria-label="Report package table of contents"
-      className="card p-5 mb-6"
-    >
-      <h2 className="font-semibold">Table of Contents</h2>
-      <ol className="mt-4 grid gap-2 text-sm md:grid-cols-2">
-        {links.map((link) => (
-          <li key={link.id}>
-            <a
-              href={`#${link.id}`}
-              aria-label={link.status ? `${link.label} ${link.status}` : link.label}
-              className="flex items-center justify-between gap-3 rounded-control border border-[var(--border)] px-3 py-2 text-[var(--foreground)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)]"
-            >
-              <span>{link.label}</span>
-              {link.status ? (
-                <span className="badge badge-muted">{link.status}</span>
-              ) : null}
-            </a>
-          </li>
-        ))}
-      </ol>
-    </nav>
-  );
-}
-
-function PackageSetupGuidance() {
-  return (
-    <section aria-label="Package setup guidance" className="card p-5 mb-6">
-      <h2 className="font-semibold">Package Setup</h2>
-      <div className="mt-4 grid gap-3 md:grid-cols-3">
-        {[
-          ["1", "Choose a framework", "Select US-like or HK-like before package output is loaded."],
-          ["2", "Confirm the date", "The report date pins period and point-in-time sections."],
-          ["3", "Review readiness", "Package blockers appear before statements and schedules."],
-        ].map(([step, title, description]) => (
-          <div key={step} className="rounded border border-[var(--border)] p-3">
-            <p className="font-mono text-xs text-muted">Step {step}</p>
-            <p className="mt-2 font-medium">{title}</p>
-            <p className="mt-1 text-sm text-muted">{description}</p>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function PackageLoadingSkeleton() {
-  return (
-    <section
-      role="status"
-      aria-label="Loading report package"
-      aria-busy="true"
-      aria-live="polite"
-      className="space-y-4"
-    >
-      <div className="grid gap-4 md:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, index) => (
-          <div key={index} className="card p-4">
-            <SkeletonBlock className="h-3 w-20" />
-            <SkeletonBlock className="mt-3 h-6 w-16" />
-          </div>
-        ))}
-      </div>
-      <div className="card p-5">
-        <SkeletonBlock className="h-5 w-48" />
-        <div className="mt-5 grid gap-3 lg:grid-cols-2">
-          {Array.from({ length: 6 }).map((_, index) => (
-            <div key={index} className="rounded border border-[var(--border)] p-3">
-              <SkeletonBlock className="h-4 w-3/5" />
-              <SkeletonBlock className="mt-3 h-3 w-full" />
-              <SkeletonBlock className="mt-2 h-3 w-4/5" />
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function formatSnapshotTimestamp(value?: string | null): string {
-  if (!value) return "Not recorded";
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-function snapshotDownloadLabel(
-  snapshot: PersonalReportPackageSnapshotSummary,
-  format: "JSON" | "CSV",
-): string {
-  const framework = FRAMEWORK_LABELS[snapshot.framework_id] ?? snapshot.framework_id;
-  return `Download ${format} snapshot ${snapshot.id} for ${framework} ${snapshot.start_date} to ${snapshot.end_date}`;
-}
-
-function lineageAnchorForLine(
-  line: PersonalReportPackageTraceabilityLine,
-): LineageAnchor | null {
-  return anchorFromIdentifiers([
-    ...(line.ledger_anchor.identifiers ?? []),
-    ...(line.source_anchor.identifiers ?? []),
-  ]);
-}
 
 export default function PersonalReportPackagePage() {
   const [selectedFrameworkId, setSelectedFrameworkId] = useState<string | null>(
@@ -302,10 +71,6 @@ export default function PersonalReportPackagePage() {
     isPackageLoading,
     error,
   } = usePersonalReportPackage(selectedFrameworkId, reportDate);
-
-  function handleReportDateChange(nextReportDate: string) {
-    setReportDate(nextReportDate);
-  }
 
   async function openLineagePanel(line: PersonalReportPackageTraceabilityLine) {
     setLineagePanel({ line, response: null, isLoading: true, error: null });
@@ -398,81 +163,22 @@ export default function PersonalReportPackagePage() {
     return <div className="p-6 text-muted">Loading package contract...</div>;
   }
 
-  const frameworkButtons = contract.supported_frameworks.map((frameworkId) => {
-    const isSelected = selectedFrameworkId === frameworkId;
-    return (
-      <button
-        key={frameworkId}
-        type="button"
-        className={`${isSelected ? "btn-primary" : "btn-secondary"} text-sm`}
-        aria-pressed={isSelected}
-        onClick={() => setSelectedFrameworkId(frameworkId)}
-      >
-        {FRAMEWORK_LABELS[frameworkId] ?? frameworkId}
-      </button>
-    );
-  });
-
   const selectedFrameworkLabel = selectedFrameworkId
     ? (FRAMEWORK_LABELS[selectedFrameworkId] ?? selectedFrameworkId)
     : null;
 
   const frameworkSelection = (
-    <section id="package-framework-selection" className="card p-5 mb-6">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <h2 className="font-semibold">Reporting Framework</h2>
-          <p className="mt-2 text-sm text-muted">
-            {selectedFrameworkId
-              ? `${selectedFrameworkLabel} selected for this package.`
-              : "Select a framework before package output is loaded."}
-          </p>
-        </div>
-        <div className="flex flex-wrap items-end gap-3">
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="text-xs text-muted uppercase">Report date</span>
-            <input
-              type="date"
-              value={reportDate}
-              onChange={(event) => handleReportDateChange(event.target.value)}
-              className="input w-auto"
-              aria-label="Package report date"
-            />
-          </label>
-          <div className="flex flex-wrap gap-2">{frameworkButtons}</div>
-        </div>
-      </div>
-      {selectedFrameworkId ? (
-        <dl className="mt-5 grid md:grid-cols-4 gap-3 text-sm">
-          <div>
-            <dt className="text-xs text-muted">Selected Framework</dt>
-            <dd className="mt-1 font-mono text-xs">{selectedFrameworkId}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Report Period</dt>
-            <dd className="mt-1 font-mono text-xs">
-              {reportPeriodStart(reportDate)} to {reportDate}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Policy Endpoint</dt>
-            <dd className="mt-1 font-mono text-xs">
-              {contract.framework_policy_endpoint}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Supported Frameworks</dt>
-            <dd className="mt-1 font-mono text-xs">
-              {contract.supported_frameworks.join(", ")}
-            </dd>
-          </div>
-        </dl>
-      ) : null}
-    </section>
+    <PackageFrameworkSelection
+      contract={contract}
+      selectedFrameworkId={selectedFrameworkId}
+      selectedFrameworkLabel={selectedFrameworkLabel}
+      reportDate={reportDate}
+      onSelectFramework={setSelectedFrameworkId}
+      onReportDateChange={setReportDate}
+    />
   );
 
   if (!selectedFrameworkId) {
-    const setupTocLinks = packageTocLinks(contract, false);
     return (
       <div className="p-6">
         <div className="page-header">
@@ -485,7 +191,7 @@ export default function PersonalReportPackagePage() {
           selectedFrameworkLabel={selectedFrameworkLabel}
         />
         {frameworkSelection}
-        <PackageTableOfContents links={setupTocLinks} />
+        <PackageTableOfContents links={packageTocLinks(contract, false)} />
         <PackageSetupGuidance />
       </div>
     );
@@ -541,757 +247,46 @@ export default function PersonalReportPackagePage() {
 
       <PackageTableOfContents links={outputTocLinks} />
 
-      <section className="card p-5 mb-6 print:hidden">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <h2 className="font-semibold">Saved Package Artifacts</h2>
-            <p className="mt-1 text-sm text-muted">
-              Generate an immutable package snapshot before downloading JSON or CSV.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              onClick={createPackageSnapshot}
-              disabled={!canGenerateSnapshot}
-              className="btn-primary inline-flex items-center gap-2 text-sm"
-            >
-              <Save className="h-4 w-4" aria-hidden="true" />
-              {generatingSnapshot ? "Generating..." : "Generate Snapshot"}
-            </button>
-            <button
-              type="button"
-              onClick={() => window.print()}
-              className="btn-secondary inline-flex items-center gap-2 text-sm"
-            >
-              <Printer className="h-4 w-4" aria-hidden="true" />
-              Print / Save as PDF
-            </button>
-          </div>
-        </div>
-        {snapshotError ? (
-          <p className="mt-3 text-sm text-[var(--error)]">{snapshotError}</p>
-        ) : null}
-        <div className="mt-5">
-          <h3 className="text-sm font-semibold">Recent Snapshots</h3>
-          {packageSnapshots.length ? (
-            <div className="mt-3 overflow-x-auto">
-              <table className="min-w-full text-left text-sm">
-                <thead className="text-xs uppercase text-muted">
-                  <tr>
-                    <th className="py-2 pr-4 font-medium">Status</th>
-                    <th className="py-2 pr-4 font-medium">Framework</th>
-                    <th className="py-2 pr-4 font-medium">Period</th>
-                    <th className="py-2 pr-4 font-medium">Created</th>
-                    <th className="py-2 font-medium">Downloads</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {packageSnapshots.map((snapshot) => (
-                    <tr key={snapshot.id} className="border-t border-[var(--border)]">
-                      <td className="py-3 pr-4">
-                        <span className="badge badge-muted">
-                          {snapshot.status === "trusted" ? "Trusted" : "Draft"}
-                        </span>
-                      </td>
-                      <td className="py-3 pr-4 font-mono text-xs">
-                        {snapshot.framework_id}
-                      </td>
-                      <td className="py-3 pr-4 font-mono text-xs">
-                        {snapshot.start_date} to {snapshot.end_date}
-                      </td>
-                      <td className="py-3 pr-4 text-muted">
-                        {formatSnapshotTimestamp(snapshot.created_at)}
-                      </td>
-                      <td className="py-3">
-                        <div className="flex flex-wrap gap-2">
-                          <button
-                            type="button"
-                            onClick={() => downloadPackageSnapshot(snapshot, "json")}
-                            disabled={downloadingSnapshot === `${snapshot.id}:json`}
-                            className="btn-secondary inline-flex items-center gap-2 text-xs"
-                            aria-label={snapshotDownloadLabel(snapshot, "JSON")}
-                          >
-                            <FileJson className="h-4 w-4" aria-hidden="true" />
-                            JSON
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => downloadPackageSnapshot(snapshot, "csv")}
-                            disabled={downloadingSnapshot === `${snapshot.id}:csv`}
-                            className="btn-secondary inline-flex items-center gap-2 text-xs"
-                            aria-label={snapshotDownloadLabel(snapshot, "CSV")}
-                          >
-                            <Download className="h-4 w-4" aria-hidden="true" />
-                            CSV
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <p className="mt-3 text-sm text-muted">No saved package snapshots yet.</p>
-          )}
-        </div>
-      </section>
+      <PackageSnapshotsCard
+        snapshots={packageSnapshots}
+        snapshotError={snapshotError}
+        canGenerate={canGenerateSnapshot}
+        generating={generatingSnapshot}
+        downloading={downloadingSnapshot}
+        onGenerate={createPackageSnapshot}
+        onDownload={downloadPackageSnapshot}
+      />
 
-      <section id="package-readiness" className="card p-5 mb-6">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <h2 className="font-semibold">Report Readiness</h2>
-            <p className="mt-2 text-sm text-muted">
-              {readiness.state === "blocked"
-                ? `${readiness.blocking_count} blocker${readiness.blocking_count === 1 ? "" : "s"} must be resolved before package output is trusted.`
-                : `Current package state is ${readiness.label.toLowerCase()}.`}
-            </p>
-          </div>
-          <Link className="badge badge-muted" href={readiness.action_href}>
-            {readiness.label}
-          </Link>
-        </div>
-        <dl className="mt-5 grid md:grid-cols-4 gap-3 text-sm">
-          <div>
-            <dt className="text-xs text-muted">Statements</dt>
-            <dd className="mt-1 font-semibold">
-              {readiness.source_summary.statements ?? 0}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Journal Entries</dt>
-            <dd className="mt-1 font-semibold">
-              {readiness.source_summary.posted_journal_entries ?? 0}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Manual Valuations</dt>
-            <dd className="mt-1 font-semibold">
-              {readiness.source_summary.manual_valuations ?? 0}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Blockers</dt>
-            <dd className="mt-1 font-semibold">{readiness.blocking_count}</dd>
-          </div>
-        </dl>
-        {readiness.blockers.length ? (
-          <div className="mt-5 grid lg:grid-cols-2 gap-4">
-            {readiness.blockers.map((blocker) => (
-              <article
-                key={blocker.code}
-                className="border border-[var(--border)] rounded p-3"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="font-medium">{blocker.label}</p>
-                    <p className="text-xs font-mono text-muted mt-1">
-                      {blocker.code}
-                    </p>
-                  </div>
-                  <Link
-                    className="badge badge-muted"
-                    href={blocker.action_href}
-                  >
-                    {blocker.count}
-                  </Link>
-                </div>
-                <p className="mt-3 text-sm text-muted">{blocker.reason}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
-      </section>
+      <PackageReadinessSection readiness={readiness} />
 
       {readiness.source_trust_summary ? (
-        <section id="package-source-trust" className="card p-5 mb-6" aria-label="Source trust summary">
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <h2 className="font-semibold">Source Trust</h2>
-            </div>
-            <span className="badge badge-muted">
-              {readiness.source_trust_summary.source_classes.length} classes
-            </span>
-          </div>
-          <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
-            <div>
-              <dt className="text-xs text-muted">Deterministic PR</dt>
-              <dd className="mt-1 font-mono text-xs">
-                {renderCsv(
-                  readiness.source_trust_summary
-                    .deterministic_pr_source_classes,
-                )}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-muted">Post-merge LLM/OCR</dt>
-              <dd className="mt-1 font-mono text-xs">
-                {renderCsv(
-                  readiness.source_trust_summary
-                    .post_merge_llm_ocr_source_classes,
-                )}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-muted">Manual Trusted</dt>
-              <dd className="mt-1 font-mono text-xs">
-                {renderCsv(
-                  readiness.source_trust_summary.manual_trusted_source_classes,
-                )}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-muted">Trust Gaps</dt>
-              <dd className="mt-1 font-mono text-xs">
-                {renderCsv(readiness.source_trust_summary.gap_source_classes)}
-              </dd>
-            </div>
-          </dl>
-          {readiness.source_trust_summary.blocker_codes.length ? (
-            <div className="mt-4">
-              <p className="text-xs text-muted">Blocker Codes</p>
-              <p className="mt-1 font-mono text-xs">
-                {readiness.source_trust_summary.blocker_codes.join(", ")}
-              </p>
-            </div>
-          ) : null}
-        </section>
+        <PackageSourceTrustSection summary={readiness.source_trust_summary} />
       ) : null}
 
-      <section id="package-framework-policy" className="card p-5 mb-6">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <h2 className="font-semibold">Framework Policy</h2>
-            <p className="mt-2 max-w-3xl break-words font-mono text-xs text-muted">
-              {frameworkPolicy.result_id}
-            </p>
-          </div>
-          <span className="badge badge-muted">
-            {frameworkPolicy.framework_id}
-          </span>
-        </div>
-        <dl className="mt-5 grid md:grid-cols-4 gap-3 text-sm">
-          <div>
-            <dt className="text-xs text-muted">Framework</dt>
-            <dd className="mt-1 font-mono text-xs">
-              {frameworkPolicy.framework_id}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Matrix Version</dt>
-            <dd className="mt-1 font-semibold">
-              {frameworkPolicy.matrix_version}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Decisions</dt>
-            <dd className="mt-1 font-semibold">
-              {frameworkPolicy.decisions.length}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Gaps</dt>
-            <dd className="mt-1 font-semibold">
-              {frameworkPolicy.gaps.length}
-            </dd>
-          </div>
-        </dl>
-        <div className="mt-5 grid lg:grid-cols-2 gap-4">
-          {frameworkPolicy.decisions.map((decision) => (
-            <article
-              key={`${decision.domain}:${decision.line_mappings.balance_sheet ?? decision.presentation}`}
-              className="border border-[var(--border)] rounded p-3"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="font-medium">{decision.domain}</p>
-                  <p className="mt-1 text-xs font-mono text-muted">
-                    {decision.review_state}
-                  </p>
-                </div>
-                <span className="badge badge-muted">
-                  {decision.confidence_tier}
-                </span>
-              </div>
-              <dl className="mt-3 space-y-1 text-xs">
-                {Object.entries(decision.line_mappings).map(
-                  ([section, line]) => (
-                    <div
-                      key={`${decision.domain}:${section}`}
-                      className="flex justify-between gap-3"
-                    >
-                      <dt className="text-muted">{section}</dt>
-                      <dd className="font-mono text-right">{line}</dd>
-                    </div>
-                  ),
-                )}
-              </dl>
-            </article>
-          ))}
-          {frameworkPolicy.gaps.map((gap) => (
-            <article
-              key={`${gap.code}:${gap.fact_id}`}
-              className="border border-[var(--border)] rounded p-3"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="font-medium">{gap.code}</p>
-                  <p className="mt-1 text-xs font-mono text-muted">
-                    {gap.fact_id}
-                  </p>
-                </div>
-                <span className="badge badge-muted">{gap.instrument_type}</span>
-              </div>
-              <p className="mt-3 text-sm text-muted">{gap.reason}</p>
-            </article>
-          ))}
-        </div>
-      </section>
+      <PackageFrameworkPolicySection policy={frameworkPolicy} />
 
-      <div className="grid lg:grid-cols-2 gap-4 mb-6">
-        {contract.sections.map((section) => (
-          <section
-            key={section.section_id}
-            id={sectionAnchorId(section.section_id)}
-            className="card p-5"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <h2 className="font-semibold">{section.label}</h2>
-              </div>
-              <span className="badge badge-muted">{section.status}</span>
-            </div>
-            <dl className="mt-4 space-y-2 text-sm">
-              <div className="flex justify-between gap-3">
-                <dt className="text-muted">Owner</dt>
-                <dd className="font-medium">{section.owner_epic}</dd>
-              </div>
-              <div className="flex justify-between gap-3">
-                <dt className="text-muted">Endpoint</dt>
-                <dd className="font-mono text-xs text-right">
-                  {section.source_endpoint}
-                </dd>
-              </div>
-              {section.blocking_issue ? (
-                <div className="flex justify-between gap-3">
-                  <dt className="text-muted">Follow-up</dt>
-                  <dd className="font-medium">{section.blocking_issue}</dd>
-                </div>
-              ) : null}
-            </dl>
-          </section>
-        ))}
-      </div>
+      <PackageSectionCards sections={contract.sections} />
 
-      <section id="package-annualized-income-detail" className="card p-5 mb-6">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h2 className="font-semibold">Annualized Income Schedule</h2>
-          </div>
-          <span className="badge badge-muted">
-            {annualizedSchedule.trailing_period_days} days
-          </span>
-        </div>
-        <div className="mt-4 grid md:grid-cols-4 gap-3">
-          <div>
-            <p className="text-xs text-muted">Total</p>
-            <p className="mt-1 font-semibold">
-              {formatScheduleCurrency(
-                annualizedSchedule.income.annualized_total,
-                annualizedSchedule.income.currency,
-              )}
-            </p>
-          </div>
-          <div>
-            <p className="text-xs text-muted">Salary</p>
-            <p className="mt-1 font-semibold">
-              {formatScheduleCurrency(
-                annualizedSchedule.income.annualized_salary,
-                annualizedSchedule.income.currency,
-              )}
-            </p>
-          </div>
-          <div>
-            <p className="text-xs text-muted">Bonus</p>
-            <p className="mt-1 font-semibold">
-              {formatScheduleCurrency(
-                annualizedSchedule.income.annualized_bonus,
-                annualizedSchedule.income.currency,
-              )}
-            </p>
-          </div>
-          <div>
-            <p className="text-xs text-muted">Dividend</p>
-            <p className="mt-1 font-semibold">
-              {formatScheduleCurrency(
-                annualizedSchedule.income.annualized_dividend,
-                annualizedSchedule.income.currency,
-              )}
-            </p>
-          </div>
-        </div>
-        <div className="mt-5 grid lg:grid-cols-2 gap-4">
-          <div>
-            <h3 className="text-sm font-semibold">Restricted Holdings</h3>
-            <div className="mt-3 space-y-2">
-              {annualizedSchedule.restricted_holdings.map((holding) => (
-                <div
-                  key={`${holding.compensation_type}:${holding.ticker}`}
-                  className="border border-[var(--border)] rounded p-3"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <p className="font-medium">{holding.ticker}</p>
-                      <p className="text-xs text-muted">
-                        {holding.compensation_type}
-                      </p>
-                    </div>
-                    <p className="font-semibold">
-                      {formatScheduleCurrency(
-                        holding.fair_value,
-                        holding.currency,
-                      )}
-                    </p>
-                  </div>
-                  <dl className="mt-3 space-y-1 text-xs">
-                    {holding.vesting_schedule ? (
-                      <div className="flex justify-between gap-3">
-                        <dt className="text-muted">Vesting</dt>
-                        <dd>{holding.vesting_schedule}</dd>
-                      </div>
-                    ) : null}
-                    {holding.unlock_date ? (
-                      <div className="flex justify-between gap-3">
-                        <dt className="text-muted">Unlock</dt>
-                        <dd>{holding.unlock_date}</dd>
-                      </div>
-                    ) : null}
-                  </dl>
-                </div>
-              ))}
-            </div>
-          </div>
-          <div>
-            <h3 className="text-sm font-semibold">Net Worth Treatment</h3>
-            <dl className="mt-3 space-y-2 text-sm">
-              <div className="flex justify-between gap-3">
-                <dt className="text-muted">Liquid Default</dt>
-                <dd className="font-mono text-xs text-right">
-                  {
-                    annualizedSchedule.net_worth_treatment
-                      .liquid_net_worth_default
-                  }
-                </dd>
-              </div>
-              <div className="flex justify-between gap-3">
-                <dt className="text-muted">Restricted Basis</dt>
-                <dd className="font-mono text-xs text-right">
-                  {
-                    annualizedSchedule.net_worth_treatment
-                      .restricted_wealth_basis
-                  }
-                </dd>
-              </div>
-            </dl>
-            <ul className="mt-4 space-y-1 text-sm text-muted">
-              {annualizedSchedule.notes.map((note) => (
-                <li key={note}>{note}</li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </section>
+      <PackageAnnualizedScheduleSection schedule={annualizedSchedule} />
 
-      <section id="package-notes-detail" className="card p-5 mb-6">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h2 className="font-semibold">{packageNotes.label}</h2>
-          </div>
-          <span className="badge badge-muted">{packageNotes.status}</span>
-        </div>
-        <p className="mt-4 text-sm text-muted">
-          {packageNotes.non_compliance_statement}
-        </p>
-        <div className="mt-5 grid lg:grid-cols-2 gap-4">
-          {packageNotes.notes.map((note) => (
-            <article
-              key={note.note_id}
-              className="border border-[var(--border)] rounded p-3"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="font-medium">{note.label}</p>
-                  <p className="text-xs font-mono text-muted mt-1">
-                    {note.note_id}
-                  </p>
-                </div>
-                <span className="badge badge-muted">{note.owner_epic}</span>
-              </div>
-              <p className="mt-3 text-sm text-muted">{note.disclosure}</p>
-              <dl className="mt-3 space-y-1 text-xs">
-                <div className="flex justify-between gap-3">
-                  <dt className="text-muted">Basis</dt>
-                  <dd className="font-mono text-right">{note.basis}</dd>
-                </div>
-                <div className="flex justify-between gap-3">
-                  <dt className="text-muted">Source</dt>
-                  <dd className="font-mono text-right">{note.source_state}</dd>
-                </div>
-              </dl>
-            </article>
-          ))}
-        </div>
-      </section>
+      <PackageNotesSection notes={packageNotes} />
 
-      <section id="package-traceability-detail" className="card p-5 mb-6">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h2 className="font-semibold">{traceabilityAppendix.label}</h2>
-          </div>
-          <span className="badge badge-muted">
-            {traceabilityAppendix.status}
-          </span>
-        </div>
-        <div className="mt-5 overflow-x-auto">
-          <table className="min-w-full text-sm">
-            <thead className="text-left text-xs text-muted">
-              <tr>
-                <th className="py-2 pr-4 font-medium">Line</th>
-                <th className="py-2 pr-4 font-medium">Source</th>
-                <th className="py-2 pr-4 font-medium">Ledger</th>
-                <th className="py-2 pr-4 font-medium">Review</th>
-                <th className="py-2 font-medium">Confidence</th>
-                <th className="py-2 pl-4 font-medium">Lineage</th>
-              </tr>
-            </thead>
-            <tbody>
-              {traceabilityAppendix.lines.map((line) => (
-                <tr
-                  key={line.line_id}
-                  className="border-t border-[var(--border)] align-top"
-                >
-                  <td className="py-3 pr-4">
-                    <p className="font-mono text-xs">{line.line_id}</p>
-                    <p className="mt-1 text-xs text-muted">{line.label}</p>
-                  </td>
-                  <td className="py-3 pr-4">
-                    <p className="font-mono text-xs">{line.source_state}</p>
-                    {renderAnchorDetail(
-                      (line.source_anchor.source_types ?? []).join(", ") ||
-                        line.source_anchor.state,
-                      line.source_anchor.identifiers,
-                    )}
-                  </td>
-                  <td className="py-3 pr-4">
-                    <p className="font-mono text-xs">
-                      {line.ledger_anchor.state}
-                    </p>
-                    {renderAnchorDetail(
-                      (line.ledger_anchor.entry_statuses ?? []).join(", ") ||
-                        line.ledger_anchor.unavailable_reason ||
-                        line.ledger_anchor.state,
-                      line.ledger_anchor.identifiers,
-                    )}
-                  </td>
-                  <td className="py-3 pr-4 font-mono text-xs">
-                    {line.review_state}
-                  </td>
-                  <td className="py-3">
-                    <div className="flex flex-col gap-2">
-                      <span className="badge badge-muted">
-                        {line.confidence_tier}
-                      </span>
-                      <span className="font-mono text-xs text-muted">
-                        {line.proof_level ?? "unclassified"}
-                      </span>
-                      <span className="font-mono text-xs text-muted">
-                        {line.anchor_count ?? 0} anchors
-                      </span>
-                      {line.blocker_codes?.length ? (
-                        <span className="font-mono text-xs text-muted">
-                          {line.blocker_codes.join(", ")}
-                        </span>
-                      ) : null}
-                    </div>
-                  </td>
-                  <td className="py-3 pl-4">
-                    <button
-                      type="button"
-                      className="btn-secondary inline-flex h-9 w-9 items-center justify-center p-0"
-                      aria-label={`Trace lineage for ${line.line_id}`}
-                      title="Trace lineage"
-                      onClick={() => void openLineagePanel(line)}
-                    >
-                      <Network aria-hidden="true" className="h-4 w-4" />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        <div className="mt-5 grid lg:grid-cols-2 gap-4">
-          {traceabilityAppendix.completeness_warnings.map((warning) => (
-            <article
-              key={warning.code}
-              className="border border-[var(--border)] rounded p-3"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="font-medium">{warning.label}</p>
-                  <p className="text-xs font-mono text-muted mt-1">
-                    {warning.code}
-                  </p>
-                </div>
-                <span className="badge badge-muted">{warning.state}</span>
-              </div>
-              {warning.remediation ? (
-                <p className="mt-3 text-sm text-muted">{warning.remediation}</p>
-              ) : null}
-            </article>
-          ))}
-        </div>
-      </section>
+      <PackageTraceabilitySection
+        appendix={traceabilityAppendix}
+        onTrace={(line) => void openLineagePanel(line)}
+      />
 
-      <section id="package-export-contract" className="card p-5">
-        <h2 className="font-semibold">Export Contract</h2>
-        <dl className="mt-4 space-y-2 text-sm">
-          <div className="flex justify-between gap-3">
-            <dt className="text-muted">Formats</dt>
-            <dd className="font-medium">
-              {contract.export_contract.formats.join(", ")}
-            </dd>
-          </div>
-          <div className="flex justify-between gap-3">
-            <dt className="text-muted">CSV Columns</dt>
-            <dd className="font-mono text-xs text-right">
-              {contract.export_contract.csv_columns.join(", ")}
-            </dd>
-          </div>
-          <div className="flex justify-between gap-3">
-            <dt className="text-muted">Decimal Serialization</dt>
-            <dd className="font-medium">
-              {contract.period_semantics.decimal_serialization}
-            </dd>
-          </div>
-          <div className="flex justify-between gap-3">
-            <dt className="text-muted">Framework Policy Result</dt>
-            <dd className="max-w-md break-words font-mono text-xs text-right">
-              {frameworkPolicy.result_id}
-            </dd>
-          </div>
-          <div className="flex justify-between gap-3">
-            <dt className="text-muted">Framework Policy Matrix Version</dt>
-            <dd className="font-medium">{frameworkPolicy.matrix_version}</dd>
-          </div>
-          <div className="flex justify-between gap-3">
-            <dt className="text-muted">Evidence Bundle References</dt>
-            <dd className="max-w-md break-words font-mono text-xs text-right">
-              {evidenceReferences.join(", ") || "none"}
-            </dd>
-          </div>
-        </dl>
-      </section>
+      <PackageExportContractSection
+        contract={contract}
+        policy={frameworkPolicy}
+        evidenceReferences={evidenceReferences}
+      />
+
       {lineagePanel ? (
-        <div className="fixed inset-0 z-50 flex items-start justify-end bg-black/30 p-4">
-          <section
-            role="dialog"
-            aria-modal="true"
-            aria-label="Evidence Lineage"
-            className="flex max-h-[calc(100vh-2rem)] w-full max-w-3xl flex-col overflow-hidden rounded border border-[var(--border)] bg-[var(--background)] shadow-xl"
-          >
-            <div className="flex items-start justify-between gap-3 border-b border-[var(--border)] p-4">
-              <div>
-                <p className="text-xs font-mono text-muted">
-                  {lineagePanel.line.line_id}
-                </p>
-                <h2 className="mt-1 font-semibold">Evidence Lineage</h2>
-              </div>
-              <button
-                type="button"
-                className="btn-secondary inline-flex h-9 w-9 items-center justify-center p-0"
-                aria-label="Close evidence lineage"
-                onClick={() => setLineagePanel(null)}
-              >
-                <X aria-hidden="true" className="h-4 w-4" />
-              </button>
-            </div>
-            <div className="overflow-y-auto p-4">
-              {lineagePanel.isLoading ? (
-                <p className="text-sm text-muted">Loading evidence lineage...</p>
-              ) : lineagePanel.error ? (
-                <p className="text-sm text-[var(--error)]">
-                  {lineagePanel.error}
-                </p>
-              ) : lineagePanel.response ? (
-                <div className="space-y-5">
-                  {lineagePanel.response.blockers.length ? (
-                    <div className="space-y-2">
-                      {lineagePanel.response.blockers.map((blocker) => (
-                        <div
-                          key={blocker.code}
-                          className="rounded border border-[var(--border)] p-3"
-                        >
-                          <p className="font-mono text-xs">{blocker.code}</p>
-                          <p className="mt-1 text-sm text-muted">
-                            {blocker.message}
-                          </p>
-                        </div>
-                      ))}
-                    </div>
-                  ) : null}
-                  <div>
-                    <h3 className="text-sm font-semibold">Nodes</h3>
-                    <div className="mt-3 grid gap-3 md:grid-cols-2">
-                      {lineagePanel.response.nodes.map((node) => (
-                        <article
-                          key={node.id}
-                          className="rounded border border-[var(--border)] p-3"
-                        >
-                          <div className="flex items-start justify-between gap-3">
-                            <p className="font-mono text-xs">
-                              {node.node_kind}
-                            </p>
-                            <span className="badge badge-muted">
-                              {node.entity_type}
-                            </span>
-                          </div>
-                          <p className="mt-2 break-words font-mono text-[11px] text-muted">
-                            {nodeLabel(node)}
-                          </p>
-                        </article>
-                      ))}
-                    </div>
-                  </div>
-                  <div>
-                    <h3 className="text-sm font-semibold">Edges</h3>
-                    <div className="mt-3 space-y-2">
-                      {lineagePanel.response.edges.map((edge) => (
-                        <article
-                          key={edge.id}
-                          className="rounded border border-[var(--border)] p-3"
-                        >
-                          <div className="flex flex-wrap items-center gap-2">
-                            <span className="font-mono text-xs">
-                              {edge.relation}
-                            </span>
-                            <span className="badge badge-muted">
-                              {edge.direction}
-                            </span>
-                            <span className="font-mono text-xs text-muted">
-                              depth {edge.depth}
-                            </span>
-                          </div>
-                        </article>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </section>
-        </div>
+        <LineagePanelModal
+          panel={lineagePanel}
+          onClose={() => setLineagePanel(null)}
+        />
       ) : null}
     </div>
   );

--- a/apps/frontend/src/components/reports/package/PackageChrome.tsx
+++ b/apps/frontend/src/components/reports/package/PackageChrome.tsx
@@ -1,0 +1,219 @@
+import { SkeletonBlock } from "@/components/ui";
+import { reportPeriodStart } from "@/hooks/usePersonalReportPackage";
+import type { PersonalReportPackageContractResponse } from "@/lib/types";
+
+import { FRAMEWORK_LABELS, type PackageTocLink } from "./shared";
+
+export function PackageCover({
+  contract,
+  reportDate,
+  selectedFrameworkLabel,
+}: {
+  contract: PersonalReportPackageContractResponse;
+  reportDate: string;
+  selectedFrameworkLabel: string | null;
+}) {
+  return (
+    <section aria-label="Report package cover" className="card p-6 mb-6">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted">
+            Personal financial-report package
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold">Personal Report Package</h2>
+          <p className="mt-2 font-mono text-sm text-muted">
+            {contract.package_id}
+          </p>
+        </div>
+        <dl className="grid gap-3 text-sm sm:grid-cols-2 lg:min-w-[28rem]">
+          <div>
+            <dt className="text-xs text-muted">Framework</dt>
+            <dd className="mt-1 font-semibold">
+              {selectedFrameworkLabel ?? "Framework not selected"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Report Date</dt>
+            <dd className="mt-1 font-mono text-xs">{reportDate}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Report Period</dt>
+            <dd className="mt-1 font-mono text-xs">
+              {reportPeriodStart(reportDate)} to {reportDate}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Package Version</dt>
+            <dd className="mt-1 font-mono text-xs">{contract.version}</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+export function PackageTableOfContents({ links }: { links: PackageTocLink[] }) {
+  return (
+    <nav
+      aria-label="Report package table of contents"
+      className="card p-5 mb-6"
+    >
+      <h2 className="font-semibold">Table of Contents</h2>
+      <ol className="mt-4 grid gap-2 text-sm md:grid-cols-2">
+        {links.map((link) => (
+          <li key={link.id}>
+            <a
+              href={`#${link.id}`}
+              aria-label={link.status ? `${link.label} ${link.status}` : link.label}
+              className="flex items-center justify-between gap-3 rounded-control border border-[var(--border)] px-3 py-2 text-[var(--foreground)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)]"
+            >
+              <span>{link.label}</span>
+              {link.status ? (
+                <span className="badge badge-muted">{link.status}</span>
+              ) : null}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+export function PackageSetupGuidance() {
+  return (
+    <section aria-label="Package setup guidance" className="card p-5 mb-6">
+      <h2 className="font-semibold">Package Setup</h2>
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        {[
+          ["1", "Choose a framework", "Select US-like or HK-like before package output is loaded."],
+          ["2", "Confirm the date", "The report date pins period and point-in-time sections."],
+          ["3", "Review readiness", "Package blockers appear before statements and schedules."],
+        ].map(([step, title, description]) => (
+          <div key={step} className="rounded border border-[var(--border)] p-3">
+            <p className="font-mono text-xs text-muted">Step {step}</p>
+            <p className="mt-2 font-medium">{title}</p>
+            <p className="mt-1 text-sm text-muted">{description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function PackageLoadingSkeleton() {
+  return (
+    <section
+      role="status"
+      aria-label="Loading report package"
+      aria-busy="true"
+      aria-live="polite"
+      className="space-y-4"
+    >
+      <div className="grid gap-4 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="card p-4">
+            <SkeletonBlock className="h-3 w-20" />
+            <SkeletonBlock className="mt-3 h-6 w-16" />
+          </div>
+        ))}
+      </div>
+      <div className="card p-5">
+        <SkeletonBlock className="h-5 w-48" />
+        <div className="mt-5 grid gap-3 lg:grid-cols-2">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="rounded border border-[var(--border)] p-3">
+              <SkeletonBlock className="h-4 w-3/5" />
+              <SkeletonBlock className="mt-3 h-3 w-full" />
+              <SkeletonBlock className="mt-2 h-3 w-4/5" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function PackageFrameworkSelection({
+  contract,
+  selectedFrameworkId,
+  selectedFrameworkLabel,
+  reportDate,
+  onSelectFramework,
+  onReportDateChange,
+}: {
+  contract: PersonalReportPackageContractResponse;
+  selectedFrameworkId: string | null;
+  selectedFrameworkLabel: string | null;
+  reportDate: string;
+  onSelectFramework: (frameworkId: string) => void;
+  onReportDateChange: (reportDate: string) => void;
+}) {
+  const frameworkButtons = contract.supported_frameworks.map((frameworkId) => {
+    const isSelected = selectedFrameworkId === frameworkId;
+    return (
+      <button
+        key={frameworkId}
+        type="button"
+        className={`${isSelected ? "btn-primary" : "btn-secondary"} text-sm`}
+        aria-pressed={isSelected}
+        onClick={() => onSelectFramework(frameworkId)}
+      >
+        {FRAMEWORK_LABELS[frameworkId] ?? frameworkId}
+      </button>
+    );
+  });
+
+  return (
+    <section id="package-framework-selection" className="card p-5 mb-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="font-semibold">Reporting Framework</h2>
+          <p className="mt-2 text-sm text-muted">
+            {selectedFrameworkId
+              ? `${selectedFrameworkLabel} selected for this package.`
+              : "Select a framework before package output is loaded."}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-xs text-muted uppercase">Report date</span>
+            <input
+              type="date"
+              value={reportDate}
+              onChange={(event) => onReportDateChange(event.target.value)}
+              className="input w-auto"
+              aria-label="Package report date"
+            />
+          </label>
+          <div className="flex flex-wrap gap-2">{frameworkButtons}</div>
+        </div>
+      </div>
+      {selectedFrameworkId ? (
+        <dl className="mt-5 grid md:grid-cols-4 gap-3 text-sm">
+          <div>
+            <dt className="text-xs text-muted">Selected Framework</dt>
+            <dd className="mt-1 font-mono text-xs">{selectedFrameworkId}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Report Period</dt>
+            <dd className="mt-1 font-mono text-xs">
+              {reportPeriodStart(reportDate)} to {reportDate}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Policy Endpoint</dt>
+            <dd className="mt-1 font-mono text-xs">
+              {contract.framework_policy_endpoint}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Supported Frameworks</dt>
+            <dd className="mt-1 font-mono text-xs">
+              {contract.supported_frameworks.join(", ")}
+            </dd>
+          </div>
+        </dl>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/frontend/src/components/reports/package/PackageReadinessSections.tsx
+++ b/apps/frontend/src/components/reports/package/PackageReadinessSections.tsx
@@ -1,0 +1,237 @@
+import Link from "next/link";
+
+import type {
+  FrameworkPolicyResult,
+  PersonalReportPackageReadinessResponse,
+} from "@/lib/types";
+
+import { renderCsv } from "./shared";
+
+type SourceTrustSummary = NonNullable<
+  PersonalReportPackageReadinessResponse["source_trust_summary"]
+>;
+
+export function PackageReadinessSection({
+  readiness,
+}: {
+  readiness: PersonalReportPackageReadinessResponse;
+}) {
+  return (
+    <section id="package-readiness" className="card p-5 mb-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="font-semibold">Report Readiness</h2>
+          <p className="mt-2 text-sm text-muted">
+            {readiness.state === "blocked"
+              ? `${readiness.blocking_count} blocker${readiness.blocking_count === 1 ? "" : "s"} must be resolved before package output is trusted.`
+              : `Current package state is ${readiness.label.toLowerCase()}.`}
+          </p>
+        </div>
+        <Link className="badge badge-muted" href={readiness.action_href}>
+          {readiness.label}
+        </Link>
+      </div>
+      <dl className="mt-5 grid md:grid-cols-4 gap-3 text-sm">
+        <div>
+          <dt className="text-xs text-muted">Statements</dt>
+          <dd className="mt-1 font-semibold">
+            {readiness.source_summary.statements ?? 0}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Journal Entries</dt>
+          <dd className="mt-1 font-semibold">
+            {readiness.source_summary.posted_journal_entries ?? 0}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Manual Valuations</dt>
+          <dd className="mt-1 font-semibold">
+            {readiness.source_summary.manual_valuations ?? 0}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Blockers</dt>
+          <dd className="mt-1 font-semibold">{readiness.blocking_count}</dd>
+        </div>
+      </dl>
+      {readiness.blockers.length ? (
+        <div className="mt-5 grid lg:grid-cols-2 gap-4">
+          {readiness.blockers.map((blocker) => (
+            <article
+              key={blocker.code}
+              className="border border-[var(--border)] rounded p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-medium">{blocker.label}</p>
+                  <p className="text-xs font-mono text-muted mt-1">
+                    {blocker.code}
+                  </p>
+                </div>
+                <Link
+                  className="badge badge-muted"
+                  href={blocker.action_href}
+                >
+                  {blocker.count}
+                </Link>
+              </div>
+              <p className="mt-3 text-sm text-muted">{blocker.reason}</p>
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export function PackageSourceTrustSection({
+  summary,
+}: {
+  summary: SourceTrustSummary;
+}) {
+  return (
+    <section id="package-source-trust" className="card p-5 mb-6" aria-label="Source trust summary">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="font-semibold">Source Trust</h2>
+        </div>
+        <span className="badge badge-muted">
+          {summary.source_classes.length} classes
+        </span>
+      </div>
+      <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
+        <div>
+          <dt className="text-xs text-muted">Deterministic PR</dt>
+          <dd className="mt-1 font-mono text-xs">
+            {renderCsv(summary.deterministic_pr_source_classes)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Post-merge LLM/OCR</dt>
+          <dd className="mt-1 font-mono text-xs">
+            {renderCsv(summary.post_merge_llm_ocr_source_classes)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Manual Trusted</dt>
+          <dd className="mt-1 font-mono text-xs">
+            {renderCsv(summary.manual_trusted_source_classes)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Trust Gaps</dt>
+          <dd className="mt-1 font-mono text-xs">
+            {renderCsv(summary.gap_source_classes)}
+          </dd>
+        </div>
+      </dl>
+      {summary.blocker_codes.length ? (
+        <div className="mt-4">
+          <p className="text-xs text-muted">Blocker Codes</p>
+          <p className="mt-1 font-mono text-xs">
+            {summary.blocker_codes.join(", ")}
+          </p>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export function PackageFrameworkPolicySection({
+  policy,
+}: {
+  policy: FrameworkPolicyResult;
+}) {
+  return (
+    <section id="package-framework-policy" className="card p-5 mb-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="font-semibold">Framework Policy</h2>
+          <p className="mt-2 max-w-3xl break-words font-mono text-xs text-muted">
+            {policy.result_id}
+          </p>
+        </div>
+        <span className="badge badge-muted">
+          {policy.framework_id}
+        </span>
+      </div>
+      <dl className="mt-5 grid md:grid-cols-4 gap-3 text-sm">
+        <div>
+          <dt className="text-xs text-muted">Framework</dt>
+          <dd className="mt-1 font-mono text-xs">
+            {policy.framework_id}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Matrix Version</dt>
+          <dd className="mt-1 font-semibold">
+            {policy.matrix_version}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Decisions</dt>
+          <dd className="mt-1 font-semibold">
+            {policy.decisions.length}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Gaps</dt>
+          <dd className="mt-1 font-semibold">
+            {policy.gaps.length}
+          </dd>
+        </div>
+      </dl>
+      <div className="mt-5 grid lg:grid-cols-2 gap-4">
+        {policy.decisions.map((decision) => (
+          <article
+            key={`${decision.domain}:${decision.line_mappings.balance_sheet ?? decision.presentation}`}
+            className="border border-[var(--border)] rounded p-3"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-medium">{decision.domain}</p>
+                <p className="mt-1 text-xs font-mono text-muted">
+                  {decision.review_state}
+                </p>
+              </div>
+              <span className="badge badge-muted">
+                {decision.confidence_tier}
+              </span>
+            </div>
+            <dl className="mt-3 space-y-1 text-xs">
+              {Object.entries(decision.line_mappings).map(
+                ([section, line]) => (
+                  <div
+                    key={`${decision.domain}:${section}`}
+                    className="flex justify-between gap-3"
+                  >
+                    <dt className="text-muted">{section}</dt>
+                    <dd className="font-mono text-right">{line}</dd>
+                  </div>
+                ),
+              )}
+            </dl>
+          </article>
+        ))}
+        {policy.gaps.map((gap) => (
+          <article
+            key={`${gap.code}:${gap.fact_id}`}
+            className="border border-[var(--border)] rounded p-3"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-medium">{gap.code}</p>
+                <p className="mt-1 text-xs font-mono text-muted">
+                  {gap.fact_id}
+                </p>
+              </div>
+              <span className="badge badge-muted">{gap.instrument_type}</span>
+            </div>
+            <p className="mt-3 text-sm text-muted">{gap.reason}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/reports/package/PackageScheduleSections.tsx
+++ b/apps/frontend/src/components/reports/package/PackageScheduleSections.tsx
@@ -1,0 +1,273 @@
+import type {
+  AnnualizedIncomeScheduleResponse,
+  FrameworkPolicyResult,
+  PersonalReportPackageContractResponse,
+  PersonalReportPackageNotesResponse,
+} from "@/lib/types";
+
+import { formatScheduleCurrency, sectionAnchorId } from "./shared";
+
+export function PackageSectionCards({
+  sections,
+}: {
+  sections: PersonalReportPackageContractResponse["sections"];
+}) {
+  return (
+    <div className="grid lg:grid-cols-2 gap-4 mb-6">
+      {sections.map((section) => (
+        <section
+          key={section.section_id}
+          id={sectionAnchorId(section.section_id)}
+          className="card p-5"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h2 className="font-semibold">{section.label}</h2>
+            </div>
+            <span className="badge badge-muted">{section.status}</span>
+          </div>
+          <dl className="mt-4 space-y-2 text-sm">
+            <div className="flex justify-between gap-3">
+              <dt className="text-muted">Owner</dt>
+              <dd className="font-medium">{section.owner_epic}</dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-muted">Endpoint</dt>
+              <dd className="font-mono text-xs text-right">
+                {section.source_endpoint}
+              </dd>
+            </div>
+            {section.blocking_issue ? (
+              <div className="flex justify-between gap-3">
+                <dt className="text-muted">Follow-up</dt>
+                <dd className="font-medium">{section.blocking_issue}</dd>
+              </div>
+            ) : null}
+          </dl>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export function PackageAnnualizedScheduleSection({
+  schedule,
+}: {
+  schedule: AnnualizedIncomeScheduleResponse;
+}) {
+  return (
+    <section id="package-annualized-income-detail" className="card p-5 mb-6">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="font-semibold">Annualized Income Schedule</h2>
+        </div>
+        <span className="badge badge-muted">
+          {schedule.trailing_period_days} days
+        </span>
+      </div>
+      <div className="mt-4 grid md:grid-cols-4 gap-3">
+        <div>
+          <p className="text-xs text-muted">Total</p>
+          <p className="mt-1 font-semibold">
+            {formatScheduleCurrency(
+              schedule.income.annualized_total,
+              schedule.income.currency,
+            )}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-muted">Salary</p>
+          <p className="mt-1 font-semibold">
+            {formatScheduleCurrency(
+              schedule.income.annualized_salary,
+              schedule.income.currency,
+            )}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-muted">Bonus</p>
+          <p className="mt-1 font-semibold">
+            {formatScheduleCurrency(
+              schedule.income.annualized_bonus,
+              schedule.income.currency,
+            )}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-muted">Dividend</p>
+          <p className="mt-1 font-semibold">
+            {formatScheduleCurrency(
+              schedule.income.annualized_dividend,
+              schedule.income.currency,
+            )}
+          </p>
+        </div>
+      </div>
+      <div className="mt-5 grid lg:grid-cols-2 gap-4">
+        <div>
+          <h3 className="text-sm font-semibold">Restricted Holdings</h3>
+          <div className="mt-3 space-y-2">
+            {schedule.restricted_holdings.map((holding) => (
+              <div
+                key={`${holding.compensation_type}:${holding.ticker}`}
+                className="border border-[var(--border)] rounded p-3"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-medium">{holding.ticker}</p>
+                    <p className="text-xs text-muted">
+                      {holding.compensation_type}
+                    </p>
+                  </div>
+                  <p className="font-semibold">
+                    {formatScheduleCurrency(
+                      holding.fair_value,
+                      holding.currency,
+                    )}
+                  </p>
+                </div>
+                <dl className="mt-3 space-y-1 text-xs">
+                  {holding.vesting_schedule ? (
+                    <div className="flex justify-between gap-3">
+                      <dt className="text-muted">Vesting</dt>
+                      <dd>{holding.vesting_schedule}</dd>
+                    </div>
+                  ) : null}
+                  {holding.unlock_date ? (
+                    <div className="flex justify-between gap-3">
+                      <dt className="text-muted">Unlock</dt>
+                      <dd>{holding.unlock_date}</dd>
+                    </div>
+                  ) : null}
+                </dl>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold">Net Worth Treatment</h3>
+          <dl className="mt-3 space-y-2 text-sm">
+            <div className="flex justify-between gap-3">
+              <dt className="text-muted">Liquid Default</dt>
+              <dd className="font-mono text-xs text-right">
+                {schedule.net_worth_treatment.liquid_net_worth_default}
+              </dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-muted">Restricted Basis</dt>
+              <dd className="font-mono text-xs text-right">
+                {schedule.net_worth_treatment.restricted_wealth_basis}
+              </dd>
+            </div>
+          </dl>
+          <ul className="mt-4 space-y-1 text-sm text-muted">
+            {schedule.notes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function PackageNotesSection({
+  notes,
+}: {
+  notes: PersonalReportPackageNotesResponse;
+}) {
+  return (
+    <section id="package-notes-detail" className="card p-5 mb-6">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="font-semibold">{notes.label}</h2>
+        </div>
+        <span className="badge badge-muted">{notes.status}</span>
+      </div>
+      <p className="mt-4 text-sm text-muted">
+        {notes.non_compliance_statement}
+      </p>
+      <div className="mt-5 grid lg:grid-cols-2 gap-4">
+        {notes.notes.map((note) => (
+          <article
+            key={note.note_id}
+            className="border border-[var(--border)] rounded p-3"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-medium">{note.label}</p>
+                <p className="text-xs font-mono text-muted mt-1">
+                  {note.note_id}
+                </p>
+              </div>
+              <span className="badge badge-muted">{note.owner_epic}</span>
+            </div>
+            <p className="mt-3 text-sm text-muted">{note.disclosure}</p>
+            <dl className="mt-3 space-y-1 text-xs">
+              <div className="flex justify-between gap-3">
+                <dt className="text-muted">Basis</dt>
+                <dd className="font-mono text-right">{note.basis}</dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="text-muted">Source</dt>
+                <dd className="font-mono text-right">{note.source_state}</dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function PackageExportContractSection({
+  contract,
+  policy,
+  evidenceReferences,
+}: {
+  contract: PersonalReportPackageContractResponse;
+  policy: FrameworkPolicyResult;
+  evidenceReferences: string[];
+}) {
+  return (
+    <section id="package-export-contract" className="card p-5">
+      <h2 className="font-semibold">Export Contract</h2>
+      <dl className="mt-4 space-y-2 text-sm">
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted">Formats</dt>
+          <dd className="font-medium">
+            {contract.export_contract.formats.join(", ")}
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted">CSV Columns</dt>
+          <dd className="font-mono text-xs text-right">
+            {contract.export_contract.csv_columns.join(", ")}
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted">Decimal Serialization</dt>
+          <dd className="font-medium">
+            {contract.period_semantics.decimal_serialization}
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted">Framework Policy Result</dt>
+          <dd className="max-w-md break-words font-mono text-xs text-right">
+            {policy.result_id}
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted">Framework Policy Matrix Version</dt>
+          <dd className="font-medium">{policy.matrix_version}</dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted">Evidence Bundle References</dt>
+          <dd className="max-w-md break-words font-mono text-xs text-right">
+            {evidenceReferences.join(", ") || "none"}
+          </dd>
+        </div>
+      </dl>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/reports/package/PackageSnapshotsCard.tsx
+++ b/apps/frontend/src/components/reports/package/PackageSnapshotsCard.tsx
@@ -1,0 +1,125 @@
+import { Download, FileJson, Printer, Save } from "lucide-react";
+
+import type { PersonalReportPackageSnapshotSummary } from "@/lib/types";
+
+import { formatSnapshotTimestamp, snapshotDownloadLabel } from "./shared";
+
+export function PackageSnapshotsCard({
+  snapshots,
+  snapshotError,
+  canGenerate,
+  generating,
+  downloading,
+  onGenerate,
+  onDownload,
+}: {
+  snapshots: PersonalReportPackageSnapshotSummary[];
+  snapshotError: string | null;
+  canGenerate: boolean;
+  generating: boolean;
+  downloading: string | null;
+  onGenerate: () => void;
+  onDownload: (
+    snapshot: PersonalReportPackageSnapshotSummary,
+    format: "json" | "csv",
+  ) => void;
+}) {
+  return (
+    <section className="card p-5 mb-6 print:hidden">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="font-semibold">Saved Package Artifacts</h2>
+          <p className="mt-1 text-sm text-muted">
+            Generate an immutable package snapshot before downloading JSON or CSV.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onGenerate}
+            disabled={!canGenerate}
+            className="btn-primary inline-flex items-center gap-2 text-sm"
+          >
+            <Save className="h-4 w-4" aria-hidden="true" />
+            {generating ? "Generating..." : "Generate Snapshot"}
+          </button>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="btn-secondary inline-flex items-center gap-2 text-sm"
+          >
+            <Printer className="h-4 w-4" aria-hidden="true" />
+            Print / Save as PDF
+          </button>
+        </div>
+      </div>
+      {snapshotError ? (
+        <p className="mt-3 text-sm text-[var(--error)]">{snapshotError}</p>
+      ) : null}
+      <div className="mt-5">
+        <h3 className="text-sm font-semibold">Recent Snapshots</h3>
+        {snapshots.length ? (
+          <div className="mt-3 overflow-x-auto">
+            <table className="min-w-full text-left text-sm">
+              <thead className="text-xs uppercase text-muted">
+                <tr>
+                  <th className="py-2 pr-4 font-medium">Status</th>
+                  <th className="py-2 pr-4 font-medium">Framework</th>
+                  <th className="py-2 pr-4 font-medium">Period</th>
+                  <th className="py-2 pr-4 font-medium">Created</th>
+                  <th className="py-2 font-medium">Downloads</th>
+                </tr>
+              </thead>
+              <tbody>
+                {snapshots.map((snapshot) => (
+                  <tr key={snapshot.id} className="border-t border-[var(--border)]">
+                    <td className="py-3 pr-4">
+                      <span className="badge badge-muted">
+                        {snapshot.status === "trusted" ? "Trusted" : "Draft"}
+                      </span>
+                    </td>
+                    <td className="py-3 pr-4 font-mono text-xs">
+                      {snapshot.framework_id}
+                    </td>
+                    <td className="py-3 pr-4 font-mono text-xs">
+                      {snapshot.start_date} to {snapshot.end_date}
+                    </td>
+                    <td className="py-3 pr-4 text-muted">
+                      {formatSnapshotTimestamp(snapshot.created_at)}
+                    </td>
+                    <td className="py-3">
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => onDownload(snapshot, "json")}
+                          disabled={downloading === `${snapshot.id}:json`}
+                          className="btn-secondary inline-flex items-center gap-2 text-xs"
+                          aria-label={snapshotDownloadLabel(snapshot, "JSON")}
+                        >
+                          <FileJson className="h-4 w-4" aria-hidden="true" />
+                          JSON
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onDownload(snapshot, "csv")}
+                          disabled={downloading === `${snapshot.id}:csv`}
+                          className="btn-secondary inline-flex items-center gap-2 text-xs"
+                          aria-label={snapshotDownloadLabel(snapshot, "CSV")}
+                        >
+                          <Download className="h-4 w-4" aria-hidden="true" />
+                          CSV
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="mt-3 text-sm text-muted">No saved package snapshots yet.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/reports/package/PackageTraceability.tsx
+++ b/apps/frontend/src/components/reports/package/PackageTraceability.tsx
@@ -1,0 +1,238 @@
+import { Network, X } from "lucide-react";
+
+import { nodeLabel } from "@/lib/lineage";
+import type {
+  PersonalReportPackageTraceabilityLine,
+  PersonalReportPackageTraceabilityResponse,
+} from "@/lib/types";
+
+import { renderAnchorDetail, type LineagePanelState } from "./shared";
+
+export function PackageTraceabilitySection({
+  appendix,
+  onTrace,
+}: {
+  appendix: PersonalReportPackageTraceabilityResponse;
+  onTrace: (line: PersonalReportPackageTraceabilityLine) => void;
+}) {
+  return (
+    <section id="package-traceability-detail" className="card p-5 mb-6">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="font-semibold">{appendix.label}</h2>
+        </div>
+        <span className="badge badge-muted">
+          {appendix.status}
+        </span>
+      </div>
+      <div className="mt-5 overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="text-left text-xs text-muted">
+            <tr>
+              <th className="py-2 pr-4 font-medium">Line</th>
+              <th className="py-2 pr-4 font-medium">Source</th>
+              <th className="py-2 pr-4 font-medium">Ledger</th>
+              <th className="py-2 pr-4 font-medium">Review</th>
+              <th className="py-2 font-medium">Confidence</th>
+              <th className="py-2 pl-4 font-medium">Lineage</th>
+            </tr>
+          </thead>
+          <tbody>
+            {appendix.lines.map((line) => (
+              <tr
+                key={line.line_id}
+                className="border-t border-[var(--border)] align-top"
+              >
+                <td className="py-3 pr-4">
+                  <p className="font-mono text-xs">{line.line_id}</p>
+                  <p className="mt-1 text-xs text-muted">{line.label}</p>
+                </td>
+                <td className="py-3 pr-4">
+                  <p className="font-mono text-xs">{line.source_state}</p>
+                  {renderAnchorDetail(
+                    (line.source_anchor.source_types ?? []).join(", ") ||
+                      line.source_anchor.state,
+                    line.source_anchor.identifiers,
+                  )}
+                </td>
+                <td className="py-3 pr-4">
+                  <p className="font-mono text-xs">
+                    {line.ledger_anchor.state}
+                  </p>
+                  {renderAnchorDetail(
+                    (line.ledger_anchor.entry_statuses ?? []).join(", ") ||
+                      line.ledger_anchor.unavailable_reason ||
+                      line.ledger_anchor.state,
+                    line.ledger_anchor.identifiers,
+                  )}
+                </td>
+                <td className="py-3 pr-4 font-mono text-xs">
+                  {line.review_state}
+                </td>
+                <td className="py-3">
+                  <div className="flex flex-col gap-2">
+                    <span className="badge badge-muted">
+                      {line.confidence_tier}
+                    </span>
+                    <span className="font-mono text-xs text-muted">
+                      {line.proof_level ?? "unclassified"}
+                    </span>
+                    <span className="font-mono text-xs text-muted">
+                      {line.anchor_count ?? 0} anchors
+                    </span>
+                    {line.blocker_codes?.length ? (
+                      <span className="font-mono text-xs text-muted">
+                        {line.blocker_codes.join(", ")}
+                      </span>
+                    ) : null}
+                  </div>
+                </td>
+                <td className="py-3 pl-4">
+                  <button
+                    type="button"
+                    className="btn-secondary inline-flex h-9 w-9 items-center justify-center p-0"
+                    aria-label={`Trace lineage for ${line.line_id}`}
+                    title="Trace lineage"
+                    onClick={() => onTrace(line)}
+                  >
+                    <Network aria-hidden="true" className="h-4 w-4" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-5 grid lg:grid-cols-2 gap-4">
+        {appendix.completeness_warnings.map((warning) => (
+          <article
+            key={warning.code}
+            className="border border-[var(--border)] rounded p-3"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-medium">{warning.label}</p>
+                <p className="text-xs font-mono text-muted mt-1">
+                  {warning.code}
+                </p>
+              </div>
+              <span className="badge badge-muted">{warning.state}</span>
+            </div>
+            {warning.remediation ? (
+              <p className="mt-3 text-sm text-muted">{warning.remediation}</p>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function LineagePanelModal({
+  panel,
+  onClose,
+}: {
+  panel: LineagePanelState;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-end bg-black/30 p-4">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label="Evidence Lineage"
+        className="flex max-h-[calc(100vh-2rem)] w-full max-w-3xl flex-col overflow-hidden rounded border border-[var(--border)] bg-[var(--background)] shadow-xl"
+      >
+        <div className="flex items-start justify-between gap-3 border-b border-[var(--border)] p-4">
+          <div>
+            <p className="text-xs font-mono text-muted">
+              {panel.line.line_id}
+            </p>
+            <h2 className="mt-1 font-semibold">Evidence Lineage</h2>
+          </div>
+          <button
+            type="button"
+            className="btn-secondary inline-flex h-9 w-9 items-center justify-center p-0"
+            aria-label="Close evidence lineage"
+            onClick={onClose}
+          >
+            <X aria-hidden="true" className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="overflow-y-auto p-4">
+          {panel.isLoading ? (
+            <p className="text-sm text-muted">Loading evidence lineage...</p>
+          ) : panel.error ? (
+            <p className="text-sm text-[var(--error)]">
+              {panel.error}
+            </p>
+          ) : panel.response ? (
+            <div className="space-y-5">
+              {panel.response.blockers.length ? (
+                <div className="space-y-2">
+                  {panel.response.blockers.map((blocker) => (
+                    <div
+                      key={blocker.code}
+                      className="rounded border border-[var(--border)] p-3"
+                    >
+                      <p className="font-mono text-xs">{blocker.code}</p>
+                      <p className="mt-1 text-sm text-muted">
+                        {blocker.message}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              <div>
+                <h3 className="text-sm font-semibold">Nodes</h3>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  {panel.response.nodes.map((node) => (
+                    <article
+                      key={node.id}
+                      className="rounded border border-[var(--border)] p-3"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <p className="font-mono text-xs">
+                          {node.node_kind}
+                        </p>
+                        <span className="badge badge-muted">
+                          {node.entity_type}
+                        </span>
+                      </div>
+                      <p className="mt-2 break-words font-mono text-[11px] text-muted">
+                        {nodeLabel(node)}
+                      </p>
+                    </article>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <h3 className="text-sm font-semibold">Edges</h3>
+                <div className="mt-3 space-y-2">
+                  {panel.response.edges.map((edge) => (
+                    <article
+                      key={edge.id}
+                      className="rounded border border-[var(--border)] p-3"
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-xs">
+                          {edge.relation}
+                        </span>
+                        <span className="badge badge-muted">
+                          {edge.direction}
+                        </span>
+                        <span className="font-mono text-xs text-muted">
+                          depth {edge.depth}
+                        </span>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/reports/package/shared.tsx
+++ b/apps/frontend/src/components/reports/package/shared.tsx
@@ -1,0 +1,130 @@
+import { formatCurrencyLocale } from "@/lib/currency";
+import { anchorFromIdentifiers, type LineageAnchor } from "@/lib/lineage";
+import type {
+  EvidenceLineageResponse,
+  FrameworkPolicyResult,
+  MoneyValue,
+  PersonalReportPackageContractResponse,
+  PersonalReportPackageSnapshotSummary,
+  PersonalReportPackageTraceabilityLine,
+} from "@/lib/types";
+
+export const FRAMEWORK_LABELS: Record<string, string> = {
+  personal_us_gaap_like: "US-like",
+  personal_hkfrs_like: "HK-like",
+};
+
+export type LineagePanelState = {
+  line: PersonalReportPackageTraceabilityLine;
+  response: EvidenceLineageResponse | null;
+  isLoading: boolean;
+  error: string | null;
+};
+
+export type PackageTocLink = {
+  id: string;
+  label: string;
+  status?: string;
+};
+
+export function sectionAnchorId(sectionId: string): string {
+  return `package-section-${sectionId}`;
+}
+
+export function packageTocLinks(
+  contract: PersonalReportPackageContractResponse,
+  includeOutputSections: boolean,
+): PackageTocLink[] {
+  const links: PackageTocLink[] = [
+    { id: "package-framework-selection", label: "Reporting Framework" },
+  ];
+  if (includeOutputSections) {
+    links.push(
+      { id: "package-readiness", label: "Report Readiness" },
+      { id: "package-source-trust", label: "Source Trust" },
+      { id: "package-framework-policy", label: "Framework Policy" },
+    );
+  }
+  links.push(
+    ...contract.sections.map((section) => ({
+      id: sectionAnchorId(section.section_id),
+      label: section.label,
+      status: section.status,
+    })),
+  );
+  if (includeOutputSections) {
+    links.push({ id: "package-export-contract", label: "Export Contract" });
+  }
+  return links;
+}
+
+export function formatScheduleCurrency(
+  value: MoneyValue,
+  currency: string,
+): string {
+  return formatCurrencyLocale(value, currency, "en-US", {
+    maximumFractionDigits: 0,
+  }).replace(/\u00a0/g, " ");
+}
+
+export function renderCsv(values?: string[]): string {
+  return values && values.length ? values.join(", ") : "none";
+}
+
+export function renderAnchorDetail(primary: string, identifiers?: string[]) {
+  return (
+    <>
+      <p className="mt-1 text-xs text-muted">{primary}</p>
+      {identifiers?.length ? (
+        <p className="mt-1 max-w-xs break-words font-mono text-[11px] text-muted">
+          {identifiers.join(", ")}
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+export function evidenceBundleReferences(
+  policyResult: FrameworkPolicyResult,
+): string[] {
+  const anchors = [
+    ...policyResult.decisions.flatMap((decision) => decision.evidence_anchors),
+    ...policyResult.gaps.flatMap((gap) => gap.evidence_anchors),
+  ];
+  return Array.from(
+    new Set(
+      anchors.map((anchor) => `${anchor.anchor_type}:${anchor.source_id}`),
+    ),
+  ).sort();
+}
+
+export function formatSnapshotTimestamp(value?: string | null): string {
+  if (!value) return "Not recorded";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function snapshotDownloadLabel(
+  snapshot: PersonalReportPackageSnapshotSummary,
+  format: "JSON" | "CSV",
+): string {
+  const framework =
+    FRAMEWORK_LABELS[snapshot.framework_id] ?? snapshot.framework_id;
+  return `Download ${format} snapshot ${snapshot.id} for ${framework} ${snapshot.start_date} to ${snapshot.end_date}`;
+}
+
+export function lineageAnchorForLine(
+  line: PersonalReportPackageTraceabilityLine,
+): LineageAnchor | null {
+  return anchorFromIdentifiers([
+    ...(line.ledger_anchor.identifiers ?? []),
+    ...(line.source_anchor.identifiers ?? []),
+  ]);
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2,6 +2,8 @@
  * Shared Type Definitions
  */
 
+import type { Schemas } from "./api-schema";
+
 export type DecimalValue = string;
 export type MoneyValue = DecimalValue;
 export type DataProvenance = "imported" | "manual" | "derived";
@@ -46,13 +48,7 @@ export interface JournalEntry {
   total_amount?: MoneyValue;
 }
 
-export interface JournalEntrySummary {
-  id: string;
-  entry_date: string;
-  memo?: string | null;
-  status: string;
-  total_amount: MoneyValue;
-}
+export type JournalEntrySummary = Schemas["JournalEntrySummary"];
 
 export interface JournalEntryListResponse {
   items: JournalEntry[];
@@ -118,36 +114,11 @@ export interface BankStatementListResponse {
   total: number;
 }
 
-export interface ReportLine {
-  account_id: string;
-  name: string;
-  type: string;
-  parent_id?: string | null;
-  amount: MoneyValue;
-  provenance?: DataProvenance | null;
-}
+export type ReportLine = Schemas["ReportLine"];
 
-export interface AccountLineageLine {
-  journal_line_id: string;
-  journal_entry_id: string;
-  entry_date: string;
-  memo: string;
-  direction: string;
-  original_amount: MoneyValue;
-  original_currency: string;
-  amount: MoneyValue;
-}
+export type AccountLineageLine = Schemas["AccountLineageLine"];
 
-export interface AccountLineageResponse {
-  account_id: string;
-  account_name: string;
-  account_type: string;
-  currency: string;
-  as_of_date: string;
-  start_date: string | null;
-  total: MoneyValue;
-  lines: AccountLineageLine[];
-}
+export type AccountLineageResponse = Schemas["AccountLineageResponse"];
 
 export interface FxWarning {
   type: string;
@@ -177,13 +148,7 @@ export interface BalanceSheetResponse {
   is_balanced: boolean;
 }
 
-export interface IncomeStatementTrend {
-  period_start: string;
-  period_end: string;
-  total_income: MoneyValue;
-  total_expenses: MoneyValue;
-  net_income: MoneyValue;
-}
+export type IncomeStatementTrend = Schemas["IncomeStatementTrend"];
 
 export interface IncomeStatementResponse {
   start_date: string;
@@ -202,23 +167,9 @@ export interface IncomeStatementResponse {
   };
 }
 
-export interface CashFlowItem {
-  category: string;
-  subcategory: string;
-  amount: MoneyValue;
-  description: string | null;
-  /** Account this line's movement belongs to, for report drill-down (#887). */
-  account_id?: string | null;
-}
+export type CashFlowItem = Schemas["CashFlowItem"];
 
-export interface CashFlowSummary {
-  operating_activities: MoneyValue;
-  investing_activities: MoneyValue;
-  financing_activities: MoneyValue;
-  net_cash_flow: MoneyValue;
-  beginning_cash: MoneyValue;
-  ending_cash: MoneyValue;
-}
+export type CashFlowSummary = Schemas["CashFlowSummary"];
 
 export interface CashFlowResponse {
   start_date: string;
@@ -231,17 +182,7 @@ export interface CashFlowResponse {
   fx_warnings?: FxWarning[];
 }
 
-export interface PersonalReportPackageSectionContract {
-  section_id: string;
-  label: string;
-  owner_epic: string;
-  period_type?: string;
-  source_endpoint: string;
-  status: string;
-  required?: boolean;
-  blocking_issue?: string | null;
-  decimal_total_fields?: string[];
-}
+export type PersonalReportPackageSectionContract = Schemas["PersonalReportPackageSectionContract"];
 
 export interface PersonalReportPackageContractResponse {
   package_id: string;
@@ -257,14 +198,7 @@ export interface PersonalReportPackageContractResponse {
   };
 }
 
-export interface PersonalReportPackageReadinessBlocker {
-  code: string;
-  label: string;
-  severity: string;
-  count: number;
-  reason: string;
-  action_href: string;
-}
+export type PersonalReportPackageReadinessBlocker = Schemas["PersonalReportPackageReadinessBlocker"];
 
 export interface PersonalReportPackageReadinessResponse {
   package_id: string;
@@ -301,23 +235,9 @@ export interface PersonalReportPackageSnapshotPayload {
   section_payloads: Record<string, unknown>;
 }
 
-export interface PersonalReportPackageSnapshotSummary {
-  id: string;
-  package_id: string;
-  status: "draft" | "trusted";
-  framework_id: string;
-  start_date: string;
-  end_date: string;
-  as_of_date: string;
-  currency: string;
-  readiness_state: string;
-  is_latest: boolean;
-  created_at?: string | null;
-}
+export type PersonalReportPackageSnapshotSummary = Schemas["PersonalReportPackageSnapshotSummary"];
 
-export interface PersonalReportPackageSnapshotResponse extends PersonalReportPackageSnapshotSummary {
-  payload: PersonalReportPackageSnapshotPayload;
-}
+export type PersonalReportPackageSnapshotResponse = Schemas["PersonalReportPackageSnapshotResponse"];
 
 export interface AdvisorSuggestion {
   basis: string;
@@ -352,97 +272,25 @@ export interface ChatSuggestionsResponse {
   structured_suggestions?: AdvisorSuggestion[];
 }
 
-export interface PersonalReportPackageNote {
-  note_id: string;
-  label: string;
-  owner_epic: string;
-  basis: string;
-  source_state: string;
-  applies_to_sections: string[];
-  disclosure: string;
-}
+export type PersonalReportPackageNote = Schemas["PersonalReportPackageNote"];
 
-export interface PersonalReportPackageNotesResponse {
-  section_id: string;
-  label: string;
-  status: string;
-  notes: PersonalReportPackageNote[];
-  non_compliance_statement: string;
-}
+export type PersonalReportPackageNotesResponse = Schemas["PersonalReportPackageNotesResponse"];
 
-export interface PersonalReportPackageTraceabilityAnchor {
-  state: string;
-  source_types?: string[];
-  entry_statuses?: string[];
-  identifier_fields?: string[];
-  identifiers?: string[];
-  unavailable_reason?: string | null;
-  details?: Array<Record<string, string | number | null>>;
-}
+export type PersonalReportPackageTraceabilityAnchor = Schemas["PersonalReportPackageTraceabilityAnchor"];
 
-export interface PersonalReportPackageTraceabilityLine {
-  line_id: string;
-  section_id: string;
-  label: string;
-  amount_field?: string | null;
-  currency_field?: string | null;
-  source_state: string;
-  source_anchor: PersonalReportPackageTraceabilityAnchor;
-  ledger_anchor: PersonalReportPackageTraceabilityAnchor;
-  review_state: string;
-  confidence_tier: string;
-  source_classes?: string[];
-  proof_level?: string;
-  anchor_count?: number;
-  blocker_codes?: string[];
-}
+export type PersonalReportPackageTraceabilityLine = Schemas["PersonalReportPackageTraceabilityLine"];
 
-export interface PersonalReportPackageCompletenessWarning {
-  code: string;
-  label: string;
-  applies_to_sections: string[];
-  state: string;
-  remediation?: string | null;
-}
+export type PersonalReportPackageCompletenessWarning = Schemas["PersonalReportPackageCompletenessWarning"];
 
-export interface PersonalReportPackageTraceabilityResponse {
-  section_id: string;
-  label: string;
-  status: string;
-  lines: PersonalReportPackageTraceabilityLine[];
-  completeness_warnings: PersonalReportPackageCompletenessWarning[];
-}
+export type PersonalReportPackageTraceabilityResponse = Schemas["PersonalReportPackageTraceabilityResponse"];
 
-export interface EvidenceLineageNode {
-  id: string;
-  node_kind: string;
-  entity_type: string;
-  entity_id: string;
-  properties: Record<string, string | number | boolean | null>;
-}
+export type EvidenceLineageNode = Schemas["EvidenceLineageNode"];
 
-export interface EvidenceLineageEdge {
-  id: string;
-  from_node_id: string;
-  to_node_id: string;
-  relation: string;
-  direction: "upstream" | "downstream";
-  depth: number;
-  properties: Record<string, string | number | boolean | null>;
-}
+export type EvidenceLineageEdge = Schemas["EvidenceLineageEdge"];
 
-export interface EvidenceLineageBlocker {
-  code: string;
-  message: string;
-}
+export type EvidenceLineageBlocker = Schemas["EvidenceLineageBlocker"];
 
-export interface EvidenceLineageResponse {
-  anchor: EvidenceLineageNode | null;
-  nodes: EvidenceLineageNode[];
-  edges: EvidenceLineageEdge[];
-  blockers: EvidenceLineageBlocker[];
-  max_depth: number;
-}
+export type EvidenceLineageResponse = Schemas["EvidenceLineageResponse"];
 
 export interface FrameworkPolicyEvidenceAnchor {
   anchor_id: string;
@@ -547,124 +395,29 @@ export type WorkflowReportImpact =
 
 export type WorkflowSessionStatus = "active" | "generated" | "archived";
 
-export interface WorkflowNextActionResponse {
-  type: WorkflowNextActionType;
-  count: number;
-  href: string;
-  label: string;
-  summary: string;
-}
+export type WorkflowNextActionResponse = Schemas["WorkflowNextActionResponse"];
 
-export interface WorkflowReportReadinessResponse {
-  state: WorkflowReportReadinessState;
-  blocking_count: number;
-  href: string;
-}
+export type WorkflowReportReadinessResponse = Schemas["WorkflowReportReadinessResponse"];
 
-export interface WorkflowEventCountsResponse {
-  unread: number;
-  action_required: number;
-  blocked: number;
-}
+export type WorkflowEventCountsResponse = Schemas["WorkflowEventCountsResponse"];
 
-export interface WorkflowSessionSummaryResponse {
-  id: string;
-  status: WorkflowSessionStatus;
-  title: string;
-  summary: string;
-  started_at: string;
-  last_event_at?: string | null;
-  source_count: number;
-  report_href?: string | null;
-  primary_state: WorkflowPrimaryState;
-  report_readiness: WorkflowReportReadinessResponse;
-  event_counts: WorkflowEventCountsResponse;
-}
+export type WorkflowSessionSummaryResponse = Schemas["WorkflowSessionSummaryResponse"];
 
-export interface WorkflowStatusResponse {
-  primary_state: WorkflowPrimaryState;
-  next_action: WorkflowNextActionResponse;
-  report_readiness: WorkflowReportReadinessResponse;
-  event_counts: WorkflowEventCountsResponse;
-  active_session?: WorkflowSessionSummaryResponse | null;
-}
+export type WorkflowStatusResponse = Schemas["WorkflowStatusResponse"];
 
-export interface WorkflowEventResponse {
-  id: string;
-  user_id: string;
-  session_id?: string | null;
-  occurred_at: string;
-  family: WorkflowEventFamily;
-  severity: WorkflowEventSeverity;
-  status: WorkflowEventStatus;
-  title: string;
-  summary: string;
-  source_type: string;
-  source_id: string;
-  action_href: string;
-  report_impact: WorkflowReportImpact;
-  dedupe_key: string;
-  created_at: string;
-  updated_at: string;
-}
+export type WorkflowEventResponse = Schemas["WorkflowEventResponse"];
 
-export interface WorkflowEventListResponse {
-  items: WorkflowEventResponse[];
-  total: number;
-  sessions: WorkflowSessionSummaryResponse[];
-}
+export type WorkflowEventListResponse = Schemas["WorkflowEventListResponse"];
 
-export interface AnnualizedIncomeScheduleIncome {
-  annualized_salary: MoneyValue;
-  annualized_bonus: MoneyValue;
-  annualized_dividend: MoneyValue;
-  annualized_total: MoneyValue;
-  currency: string;
-  calculation_basis: string;
-}
+export type AnnualizedIncomeScheduleIncome = Schemas["AnnualizedIncomeScheduleIncome"];
 
-export interface AnnualizedIncomeScheduleHolding {
-  ticker: string;
-  compensation_type: string;
-  fair_value: MoneyValue;
-  currency: string;
-  valuation_basis: string;
-  vesting_schedule?: string | null;
-  unlock_date?: string | null;
-  liquidity_class: string;
-  net_worth_treatment: string;
-}
+export type AnnualizedIncomeScheduleHolding = Schemas["AnnualizedIncomeScheduleHolding"];
 
-export interface AnnualizedIncomeScheduleNetWorthTreatment {
-  liquid_net_worth_default: string;
-  restricted_wealth_basis: string;
-  include_restricted_query: string;
-  exclude_restricted_query: string;
-}
+export type AnnualizedIncomeScheduleNetWorthTreatment = Schemas["AnnualizedIncomeScheduleNetWorthTreatment"];
 
-export interface AnnualizedIncomeScheduleResponse {
-  section_id: string;
-  label: string;
-  as_of_date: string;
-  trailing_period_start: string;
-  trailing_period_end: string;
-  trailing_period_days: number;
-  income: AnnualizedIncomeScheduleIncome;
-  restricted_holdings: AnnualizedIncomeScheduleHolding[];
-  restricted_fair_value_total: MoneyValue;
-  restricted_fair_value_total_currency: string;
-  net_worth_treatment: AnnualizedIncomeScheduleNetWorthTreatment;
-  notes: string[];
-}
+export type AnnualizedIncomeScheduleResponse = Schemas["AnnualizedIncomeScheduleResponse"];
 
-export interface AnnualizedIncomeResponse {
-  annualized_salary: MoneyValue;
-  annualized_bonus: MoneyValue;
-  annualized_dividend: MoneyValue;
-  annualized_total: MoneyValue;
-  currency: string;
-  as_of: string;
-}
+export type AnnualizedIncomeResponse = Schemas["AnnualizedIncomeResponse"];
 
 export interface RestrictedHolding {
   ticker: string;
@@ -675,22 +428,9 @@ export interface RestrictedHolding {
   currency: string;
 }
 
-export interface ValuationComponentsResponse {
-  items: unknown[];
-  total_assets: MoneyValue;
-  total_liabilities: MoneyValue;
-  net_worth_delta: MoneyValue;
-}
+export type ValuationComponentsResponse = Schemas["ValuationComponentsResponse"];
 
-export interface ReconciliationStatsResponse {
-  total_transactions: number;
-  matched_transactions: number;
-  unmatched_transactions: number;
-  pending_review: number;
-  auto_accepted: number;
-  match_rate: number;
-  score_distribution: Record<string, number>;
-}
+export type ReconciliationStatsResponse = Schemas["ReconciliationStatsResponse"];
 
 export interface UnmatchedTransactionsResponse {
   items: BankStatementTransactionSummary[];
@@ -712,27 +452,11 @@ export interface TrendResponse {
 
 export type NetWorthRange = "1M" | "3M" | "6M" | "1Y" | "All";
 
-export interface NetWorthTimeSeriesPoint {
-  date: string;
-  total_assets: MoneyValue;
-  total_liabilities: MoneyValue;
-  net_worth: MoneyValue;
-  currency: string;
-}
+export type NetWorthTimeSeriesPoint = Schemas["NetWorthTimeSeriesPoint"];
 
-export interface NetWorthTimeSeriesResponse {
-  currency: string;
-  granularity: "daily" | "monthly";
-  points: NetWorthTimeSeriesPoint[];
-}
+export type NetWorthTimeSeriesResponse = Schemas["NetWorthTimeSeriesResponse"];
 
-export interface NetWorthAllocationSourceLine {
-  source_type: string;
-  source_id: string | null;
-  label: string;
-  value: MoneyValue;
-  href: string | null;
-}
+export type NetWorthAllocationSourceLine = Schemas["NetWorthAllocationSourceLine"];
 
 export interface NetWorthAllocationRow {
   asset_class: string;
@@ -940,32 +664,11 @@ export interface PerformanceMetrics {
   money_weighted_return: string;
 }
 
-export interface InvestmentPerformanceHoldingRow {
-  asset_identifier: string;
-  quantity: string;
-  cost_basis: string;
-  market_value: string;
-  unrealized_pnl: string;
-  realized_pnl: string;
-  dividend_income: string;
-  currency: string;
-}
+export type InvestmentPerformanceHoldingRow = Schemas["InvestmentPerformanceHoldingRow"];
 
-export interface InvestmentPerformanceAllocationRow {
-  dimension: "sector" | "geography" | "asset_class" | string;
-  category: string;
-  value: string;
-  percentage: string;
-  count: number;
-}
+export type InvestmentPerformanceAllocationRow = Schemas["InvestmentPerformanceAllocationRow"];
 
-export interface InvestmentPerformanceDataFreshness {
-  latest_price_date: string | null;
-  market_data_provider: string | null;
-  stale: boolean;
-  stale_holdings: string[];
-  manual_override_basis?: string | null;
-}
+export type InvestmentPerformanceDataFreshness = Schemas["InvestmentPerformanceDataFreshness"];
 
 export interface InvestmentPerformanceReportSchedule {
   period_start: string;
@@ -1014,24 +717,9 @@ export interface PriceUpdateResponse {
   }>;
 }
 
-export interface ProcessingSummaryResponse {
-  pending_count: number;
-  pending_total: string;
-  current_balance: string;
-  currency: string;
-  oldest_pending_date: string | null;
-}
+export type ProcessingSummaryResponse = Schemas["ProcessingSummaryResponse"];
 
-export interface ProcessingPendingItem {
-  entry_id: string;
-  from_account: string;
-  to_account: string;
-  amount: string;
-  currency: string;
-  initiated_date: string;
-  days_outstanding: number;
-  description: string;
-}
+export type ProcessingPendingItem = Schemas["ProcessingPendingItem"];
 
 export interface ProcessingPendingListResponse {
   items: ProcessingPendingItem[];
@@ -1040,16 +728,7 @@ export interface ProcessingPendingListResponse {
 
 // ── Brokerage Import (EPIC-017 / statement import completion) ─────────────
 
-export interface BrokerageImportResponse {
-  broker: string;
-  parsed_positions: number;
-  created_atomic_positions: number;
-  existing_atomic_positions: number;
-  reconcile_created: number;
-  reconcile_updated: number;
-  reconcile_disposed: number;
-  skipped: number;
-}
+export type BrokerageImportResponse = Schemas["BrokerageImportResponse"];
 
 // ── North-Star confidence metric (EPIC-018 AC18.12 / #1003, #1055 PR4) ─────
 //
@@ -1057,32 +736,16 @@ export interface BrokerageImportResponse {
 // ledger facts that sit in the LOW confidence tier. Lower is better. Decimal
 // proportions arrive as strings (e.g. "0.12500") to preserve precision.
 
-export interface ConfidenceMetricPoint {
-  total_count: number;
-  low_confidence_count: number;
-  low_confidence_proportion: DecimalValue;
-  tier_breakdown: Record<string, number>;
-}
+export type ConfidenceMetricPoint = Schemas["ConfidenceMetricPoint"];
 
 export interface ConfidenceMetricSnapshot extends ConfidenceMetricPoint {
   id: string;
   captured_at: string;
 }
 
-export interface ConfidenceNorthStarResponse {
-  current: ConfidenceMetricPoint;
-  /** Recorded trend, newest-first. */
-  series: ConfidenceMetricSnapshot[];
-}
+export type ConfidenceNorthStarResponse = Schemas["ConfidenceNorthStarResponse"];
 
-export interface CorrectionLoopReplayResponse {
-  holdout_size: number;
-  grounded: number;
-  proportion_before: DecimalValue;
-  proportion_after: DecimalValue;
-  /** Whether the correction loop measurably lowered the held-out proportion. */
-  reduced: boolean;
-}
+export type CorrectionLoopReplayResponse = Schemas["CorrectionLoopReplayResponse"];
 
 // ── User AI settings & session identity (EPIC-022 AC22.15 / #1010) ──────────
 //
@@ -1094,7 +757,7 @@ export interface UserAiSettings {
   enable_ai_classification: boolean;
 }
 
-export type UserAiSettingsUpdate = Partial<UserAiSettings>;
+export type UserAiSettingsUpdate = Schemas["UserAiSettingsUpdate"];
 
 /**
  * Identity returned by `GET /api/auth/me`, consumed by `useSessionBootstrap`.


### PR DESCRIPTION
## Why
Two of the largest hand-written frontend files were oversized for architecture/DRY reasons. This PR shrinks both without behavior change.

| File | Before | After | Cut |
|------|-------:|------:|----:|
| `lib/types.ts` | 1112 | 775 | −337 |
| `reports/package/page.tsx` | 1298 | 293 | −1005 |

## Task 1 — dedup `types.ts` against the generated OpenAPI contract
- Replaced **48** hand-written response/DTO interfaces with `Schemas["..."]` aliases (`api-schema.ts`) — the incremental migration that file's header already prescribes. Eliminates FE↔BE drift for those shapes.
- Export names preserved, so all **74** importers are untouched.
- **15** types kept hand-written where the generated schema genuinely diverges (optionality/field drift surfaced by `tsc`): report responses, framework policy, readiness/contract, advisor, reconciliation match, net-worth allocation. These need a backend-contract reconciliation pass (follow-up) rather than forcing consumer null-guard churn here.

## Task 3 — split the report-package page into components
Extracted ~1000 lines of inline report-body JSX into co-located presentational components under `components/reports/package/`:
- `PackageChrome` (cover, TOC, setup, skeleton, framework selection)
- `PackageSnapshotsCard`
- `PackageReadinessSections` (readiness, source trust, framework policy)
- `PackageScheduleSections` (section cards, annualized, notes, export contract)
- `PackageTraceability` (traceability table + lineage modal)
- `shared.tsx` (constants, types, pure formatters)

`page.tsx` now holds only state, the data hook, action handlers, and orchestration. Rendered markup is **byte-identical**, so the existing 1585-line `personalReportPackagePage` test passes unchanged. Components live under `src/components` (not an `app/_components` dir) so Next's client-entry serializable-props rule doesn't false-positive on the callback props.

## Verification
- `tsc --noEmit` clean
- `next lint` clean
- **826/826** FE tests pass

Pure refactor — no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)