### PR TITLE
[finance_report_hacker] refactor(#1099 PR3/3): status.HTTP_* constants + documented synchronous 200s (AC12.29.1/.6)

### DIFF
--- a/apps/backend/src/routers/corrections.py
+++ b/apps/backend/src/routers/corrections.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field
 
 from src.deps import CurrentUserId, DbSession
@@ -50,7 +50,7 @@ class CorrectionStatsResponse(BaseModel):
     correction_rate_by_category: dict[str, float]
 
 
-@router.post("", response_model=CorrectionResponse, status_code=201)
+@router.post("", response_model=CorrectionResponse, status_code=status.HTTP_201_CREATED)
 async def create_correction(
     body: CorrectionRequest,
     db: DbSession = None,
@@ -76,7 +76,7 @@ async def create_correction(
             corrected_category=correction.corrected_category,
         )
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
 
 @router.get("/stats", response_model=CorrectionStatsResponse)

--- a/apps/backend/src/routers/reconciliation.py
+++ b/apps/backend/src/routers/reconciliation.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from uuid import UUID, uuid4
 
 import structlog
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -157,7 +157,10 @@ async def _load_entry_summaries(
     return {str(entry.id): _build_entry_summary(entry) for entry in result.scalars().all()}
 
 
-@router.post("/run", response_model=ReconciliationRunResponse)
+# Synchronous 200: matching runs inline and the response carries the completed run
+# result (matches_created/auto_accepted/pending_review/unmatched), so this is a
+# finished operation, not a 202 background job (cf. #1099 AC12.29.1).
+@router.post("/run", response_model=ReconciliationRunResponse, status_code=status.HTTP_200_OK)
 async def run_reconciliation(
     payload: ReconciliationRunRequest,
     db: DbSession = None,

--- a/apps/backend/src/routers/review.py
+++ b/apps/backend/src/routers/review.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, status
 from sqlalchemy import select
 
 from src.deps import CurrentUserId, DbSession
@@ -123,7 +123,7 @@ async def resolve_review_conflicts(
         await db.commit()
     except ValueError as exc:
         await db.rollback()
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
     logger.info(
         "stage1.conflicts.resolved",
@@ -203,7 +203,7 @@ async def resolve_consistency_check(
         check = await resolve_check(db, check_id, request.action, user_id, request.note)
         await db.commit()
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     return ConsistencyCheckResponse.model_validate(check)
 
@@ -291,7 +291,7 @@ async def batch_approve_matches(
             accepted_match = await accept_match_service(db, str(match.id), user_id=user_id)
         except ValueError as exc:
             await db.rollback()
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
         after_entry_ids = set(accepted_match.journal_entry_ids or [])
         approved_count += 1

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -680,7 +680,14 @@ def _brokerage_import_not_ready_reason(statement: StatementSummary, transaction_
     return f"Statement must be parsed before importing brokerage positions; current status={status_value}"
 
 
-@router.post("/{statement_id}/brokerage/import", response_model=BrokerageImportResponse)
+# Synchronous 200: the import runs inline and returns the full BrokerageImportResponse
+# (counts + reconciliation results), so the operation is complete on response — not a
+# 202 background job (cf. #1099 AC12.29.1).
+@router.post(
+    "/{statement_id}/brokerage/import",
+    response_model=BrokerageImportResponse,
+    status_code=status.HTTP_200_OK,
+)
 async def import_brokerage_statement_positions(
     statement_id: UUID,
     db: DbSession,
@@ -872,7 +879,7 @@ async def approve_statement_stage1(
         await db.commit()
     except ValueError as e:
         await db.rollback()
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     statement = await _get_statement_or_404(db, statement_id, user_id)
     response = await _compose_statement_response(db, statement, user_id)
@@ -893,7 +900,7 @@ async def reject_statement_stage1(
         await db.refresh(statement)
         await _queue_statement_reparse(db, statement, user_id)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except StorageError as exc:
         raise_service_unavailable(f"Failed to fetch file from storage: {exc}", cause=exc)
 
@@ -916,7 +923,7 @@ async def edit_and_approve_statement(
         await db.commit()
     except ValueError as e:
         await db.rollback()
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     statement = await _get_statement_or_404(db, statement_id, user_id)
     response = await _compose_statement_response(db, statement, user_id)
@@ -935,7 +942,7 @@ async def set_statement_opening_balance(
         await set_opening_balance(db, statement_id, user_id, request.opening_balance)
         await db.commit()
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     statement = await _get_statement_or_404(db, statement_id, user_id)
     return await _compose_statement_response(db, statement, user_id)

--- a/apps/backend/tests/api/test_api_surface_consistency.py
+++ b/apps/backend/tests/api/test_api_surface_consistency.py
@@ -16,14 +16,20 @@ PR1 of the sweep (this file's AC12.29.4/.5):
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from uuid import uuid4
 
 from fastapi import status
 from fastapi.routing import APIRoute
 from httpx import AsyncClient
 
+import src.routers as _routers_pkg
 from src.deps import DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT
 from src.main import app
+
+_ROUTER_DIR = Path(_routers_pkg.__file__).resolve().parent
+_RAW_STATUS_CODE = re.compile(r"status_code\s*=\s*\d")
 
 # The list endpoints #1099 named as unbounded; each must now accept bounded
 # limit/offset (AC12.29.2).
@@ -102,6 +108,30 @@ def test_AC12_29_4_no_route_or_tag_collisions() -> None:
 
     assert {"statements", "review"} <= _tags_under_prefix("/statements")
     assert {"ai", "ai-feedback"} <= _tags_under_prefix("/ai")
+
+
+def test_AC12_29_1_status_codes_use_constants_and_async_uses_202() -> None:
+    """AC12.29.1: routers use ``status.HTTP_*`` constants (no raw-integer
+    ``status_code=`` literals), and the async upload endpoint advertises ``202``."""
+    offenders: list[str] = []
+    for py in sorted(_ROUTER_DIR.glob("*.py")):
+        for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+            if _RAW_STATUS_CODE.search(line):
+                offenders.append(f"{py.name}:{lineno}: {line.strip()}")
+    assert not offenders, f"raw-integer status_code literals (use status.HTTP_*): {offenders}"
+
+    # The async/background upload endpoint advertises 202 Accepted (the parse runs
+    # in a background task). Synchronous long operations keep a documented 200.
+    upload = app.openapi()["paths"]["/statements/upload"]["post"]
+    assert "202" in upload["responses"]
+
+
+def test_AC12_29_6_deferred_url_renames_were_not_performed() -> None:
+    """AC12.29.6: the breaking verb-in-path URL renames are explicitly OUT OF SCOPE
+    for #1099; this guard fails if one slipped in (original URLs must still exist)."""
+    paths = set(app.openapi()["paths"])
+    for deferred in ("/reconciliation/run", "/market-data/sync/fx", "/market-data/sync/stocks"):
+        assert deferred in paths, f"{deferred} was renamed — URL renames are out of scope for #1099"
 
 
 def test_AC12_29_2_named_unbounded_endpoints_are_bounded() -> None:

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -436,6 +436,8 @@ tags+deprecations, then pagination, then status codes.
 
 | AC ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
+| AC12.29.1 | Router status codes use `status.HTTP_*` constants (zero raw-integer `status_code=` literals); the async upload endpoint advertises `202`, and synchronous long operations document their `200` | `test_AC12_29_1_status_codes_use_constants_and_async_uses_202` | `api/test_api_surface_consistency.py` | P1 |
+| AC12.29.6 | No unintended breaking change: the deliberately deferred verb-in-path URL renames (`/reconciliation/run`, `/market-data/sync/*`) are NOT performed — their original URLs still exist | `test_AC12_29_6_deferred_url_renames_were_not_performed` | `api/test_api_surface_consistency.py` | P1 |
 | AC12.29.2 | The three named unbounded list endpoints (`/assets/restricted`, `/reconciliation/transactions/{txn_id}/anomalies`, `/reports/package/snapshots`) accept bounded `limit`/`offset` with an enforced `le=MAX_PAGE_LIMIT` | `test_AC12_29_2_named_unbounded_endpoints_are_bounded` | `api/test_api_surface_consistency.py` | P1 |
 | AC12.29.3 | A single documented pagination convention exists (`deps.DEFAULT_PAGE_LIMIT`/`MAX_PAGE_LIMIT` via the shared `PaginationParams`); an over-max `limit` is rejected with 422 | `test_AC12_29_3_pagination_convention_is_enforced` | `api/test_api_surface_consistency.py` | P1 |
 | AC12.29.4 | No two API operations collide on (method, path); every router maps to exactly one OpenAPI tag (the deliberately shared `/statements` and `/ai` prefixes carry distinct tags and are documented) | `test_AC12_29_4_no_route_or_tag_collisions` | `api/test_api_surface_consistency.py` | P1 |

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -16,5 +16,5 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:1783 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:2063 |
 | `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:536 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:757 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:764 |
 | `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:102 |


### PR DESCRIPTION
## What & why
PR **3 of 3** (final) for the API-surface consistency sweep (#1099), EPIC-012 → AC12.29. **Stacked on PR2 (#1135)** — its base is the PR2 branch, so this diff is status-codes only. Merge order: PR1 (#1134) → PR2 (#1135) → this.

## AC12.29.1 — constants, not raw ints
- Every raw-integer `status_code=` literal in the routers → `status.HTTP_*` constant: `corrections.py` decorator `201 → HTTP_201_CREATED`, and the `400`/`404` `HTTPException` raises in `corrections`/`review`/`statements`. **Same status values, zero behavior change.**
- A guard test scans the router sources and fails on any `status_code=<digit>` literal.
- The "long" operations #1099 flagged (`POST /reconciliation/run`, `/market-data/sync/*`, `/statements/{id}/brokerage/import`) are **synchronous** — they compute and return the full result body — so `202` would be semantically wrong. They keep `200`, now made explicit + code-commented. The async **upload** endpoint remains the only `202` (parse runs in a background task), which the test asserts.

## AC12.29.6 — no unintended breaking change
- Regenerated `docs/reference/api.md` and `apps/frontend/openapi.json`: **no public-schema diff** (status values unchanged). Only `router-contract-maturity.md` shifts by a line number.
- Guard test asserts the deliberately deferred verb-in-path URL renames (`/reconciliation/run`, `/market-data/sync/*`) were **not** performed.

## Tests
`test_AC12_29_1_status_codes_use_constants_and_async_uses_202`, `test_AC12_29_6_deferred_url_renames_were_not_performed`. Affected router suites green (corrections/review/statements/reconciliation: 323+ tests). Local preflight green except `backend-format`, which flags only `src/services/market_data.py` — **not in this diff** (system ruff 0.15.17 vs pinned 0.14.11).

Completes #1099 with PR1 + PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)