### PR TITLE
[finance_report_audit] chore(#896): retire legacy bank_statement source_type

### DIFF
--- a/apps/backend/migrations/versions/0040_retire_bank_stmt_source.py
+++ b/apps/backend/migrations/versions/0040_retire_bank_stmt_source.py
@@ -1,0 +1,78 @@
+"""Retire the legacy ``bank_statement`` journal source_type value (#896).
+
+The historical data migration already happened in
+``0018_source_type_priority`` (``UPDATE journal_entries SET source_type =
+'auto_parsed' WHERE source_type::text = 'bank_statement'``). New code never
+writes the value: every write path runs ``normalize_source_type`` first, which
+maps ``bank_statement`` -> ``auto_parsed``. The value is therefore dead in both
+data and code, and this revision drops it from the enum type.
+
+Drift tolerance (AC13.10.4): this migration does NOT assume a particular enum
+state. It re-runs the defensive ``UPDATE`` first so the type rebuild can never
+fail on a stray row, and it only rebuilds the type when the ``bank_statement``
+label is actually present. Postgres has no ``DROP VALUE``, so we rename-create-
+rebind-drop. The raw string ``'bank_statement'`` is still tolerated at the
+application layer (``normalize_source_type`` and the immutability trigger keep a
+text-level guard) so historical raw values remain harmless.
+"""
+
+from alembic import op
+
+revision = "0040_retire_bank_stmt_source"
+down_revision = "0039_stmt_conflicts_resolved"
+branch_labels = None
+depends_on = None
+
+
+_REMAINING_VALUES = (
+    "manual",
+    "user_confirmed",
+    "auto_matched",
+    "auto_parsed",
+    "system",
+    "fx_revaluation",
+)
+
+
+def upgrade() -> None:
+    # 1. Defensive, idempotent: collapse any residual legacy rows before the
+    #    type is rebuilt. Text-cast comparison tolerates either enum state.
+    op.execute(
+        "UPDATE journal_entries SET source_type = 'auto_parsed' "
+        "WHERE source_type::text = 'bank_statement'"
+    )
+
+    # 2. Rebuild the enum without 'bank_statement'. Guarded so the migration is
+    #    a no-op on databases where the label was never present.
+    new_values = ", ".join(f"'{value}'" for value in _REMAINING_VALUES)
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM pg_enum e
+                JOIN pg_type t ON t.oid = e.enumtypid
+                WHERE t.typname = 'journal_source_type_enum'
+                  AND e.enumlabel = 'bank_statement'
+            ) THEN
+                ALTER TYPE journal_source_type_enum RENAME TO journal_source_type_enum_old;
+                CREATE TYPE journal_source_type_enum AS ENUM ({new_values});
+                ALTER TABLE journal_entries
+                    ALTER COLUMN source_type DROP DEFAULT,
+                    ALTER COLUMN source_type TYPE journal_source_type_enum
+                        USING source_type::text::journal_source_type_enum;
+                DROP TYPE journal_source_type_enum_old;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Re-add the label so the migration is reversible. Idempotent and tolerant
+    # of an already-present label (mirrors 0018's defensive ADD VALUE).
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TYPE journal_source_type_enum ADD VALUE IF NOT EXISTS 'bank_statement'"
+        )

--- a/apps/backend/src/models/journal.py
+++ b/apps/backend/src/models/journal.py
@@ -35,9 +35,10 @@ class JournalEntrySourceType(str, enum.Enum):
     USER_CONFIRMED = "user_confirmed"
     AUTO_MATCHED = "auto_matched"
     AUTO_PARSED = "auto_parsed"
-    # Deprecated legacy value. New statement-derived entries should use
-    # AUTO_PARSED, USER_CONFIRMED, or AUTO_MATCHED.
-    BANK_STATEMENT = "bank_statement"
+    # NOTE: the legacy ``bank_statement`` value was retired in migration 0040
+    # (#896). Data was migrated to ``auto_parsed`` in 0018 and no write path
+    # emits it. The raw string is still tolerated defensively by
+    # ``normalize_source_type`` and the immutability trigger's text guards.
     SYSTEM = "system"
     FX_REVALUATION = "fx_revaluation"
 

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -736,7 +736,7 @@ def _review_state_for_source_type(source_type: JournalEntrySourceType) -> str:
         return "reviewed_source"
     if source_type == JournalEntrySourceType.AUTO_MATCHED:
         return "auto_matched"
-    if source_type in {JournalEntrySourceType.AUTO_PARSED, JournalEntrySourceType.BANK_STATEMENT}:
+    if source_type == JournalEntrySourceType.AUTO_PARSED:
         return "unreviewed_auto_parse"
     return "system_generated"
 

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -46,6 +46,7 @@ from src.services.fx import (
 )
 from src.services.fx_revaluation import RevaluationError, calculate_unrealized_fx_gains
 from src.services.portfolio import AssetNotFoundError, PortfolioService
+from src.services.source_type_priority import normalize_source_type
 from src.utils.money import to_money
 
 logger = get_logger(__name__)
@@ -55,7 +56,6 @@ _IMPORTED_SOURCE_TYPES = {
     JournalEntrySourceType.AUTO_PARSED,
     JournalEntrySourceType.AUTO_MATCHED,
     JournalEntrySourceType.USER_CONFIRMED,
-    JournalEntrySourceType.BANK_STATEMENT,
 }
 _MANUAL_SOURCE_TYPES = {JournalEntrySourceType.MANUAL}
 _DERIVED_SOURCE_TYPES = {JournalEntrySourceType.SYSTEM, JournalEntrySourceType.FX_REVALUATION}
@@ -155,9 +155,9 @@ def _provenance_from_source_type(source_type: JournalEntrySourceType | str | Non
     if source_type is None:
         return None
     try:
-        normalized = (
-            source_type if isinstance(source_type, JournalEntrySourceType) else JournalEntrySourceType(source_type)
-        )
+        # normalize_source_type folds retired legacy values (e.g. the
+        # bank_statement text retired in 0040) back into the live hierarchy.
+        normalized = normalize_source_type(source_type)
     except ValueError:
         return None
     if normalized in _MANUAL_SOURCE_TYPES:

--- a/apps/backend/src/services/source_type_priority.py
+++ b/apps/backend/src/services/source_type_priority.py
@@ -12,9 +12,13 @@ class SourceTypeDowngradeError(ValueError):
     """Raised when a source_type transition would reduce trust."""
 
 
+# Raw text of the retired ``bank_statement`` source_type (migration 0040, #896).
+# Kept as a string so historical values are still normalized away even though
+# the enum no longer defines the member.
+_LEGACY_BANK_STATEMENT_VALUE = "bank_statement"
+
 TRUST_RANK: dict[JournalEntrySourceType, int] = {
     JournalEntrySourceType.AUTO_PARSED: 1,
-    JournalEntrySourceType.BANK_STATEMENT: 1,
     JournalEntrySourceType.AUTO_MATCHED: 2,
     JournalEntrySourceType.USER_CONFIRMED: 3,
     JournalEntrySourceType.MANUAL: 4,
@@ -22,14 +26,12 @@ TRUST_RANK: dict[JournalEntrySourceType, int] = {
 
 STATEMENT_SOURCE_TYPES: tuple[JournalEntrySourceType, ...] = (
     JournalEntrySourceType.AUTO_PARSED,
-    JournalEntrySourceType.BANK_STATEMENT,
     JournalEntrySourceType.AUTO_MATCHED,
     JournalEntrySourceType.USER_CONFIRMED,
 )
 
 USER_DATA_SOURCE_TYPES: tuple[JournalEntrySourceType, ...] = (
     JournalEntrySourceType.AUTO_PARSED,
-    JournalEntrySourceType.BANK_STATEMENT,
     JournalEntrySourceType.AUTO_MATCHED,
     JournalEntrySourceType.USER_CONFIRMED,
     JournalEntrySourceType.MANUAL,
@@ -41,7 +43,7 @@ def normalize_source_type(source_type: JournalEntrySourceType | str | None) -> J
     if source_type is None:
         return JournalEntrySourceType.MANUAL
     value = source_type.value if isinstance(source_type, JournalEntrySourceType) else str(source_type)
-    if value == JournalEntrySourceType.BANK_STATEMENT.value:
+    if value == _LEGACY_BANK_STATEMENT_VALUE:
         return JournalEntrySourceType.AUTO_PARSED
     return JournalEntrySourceType(value)
 

--- a/apps/backend/tests/accounting/test_accounting_integration.py
+++ b/apps/backend/tests/accounting/test_accounting_integration.py
@@ -681,7 +681,9 @@ async def test_create_journal_entry_custom_source_type(db: AsyncSession, bank_ac
         entry_date=date.today(),
         memo="Bank statement entry",
         lines_data=lines_data,
-        source_type=JournalEntrySourceType.BANK_STATEMENT,
+        # Legacy raw 'bank_statement' (retired from the enum in 0040, #896) is
+        # still accepted on write and normalized to auto_parsed.
+        source_type="bank_statement",
         source_id=source_id,
     )
 

--- a/apps/backend/tests/accounting/test_core_unit_coverage.py
+++ b/apps/backend/tests/accounting/test_core_unit_coverage.py
@@ -47,7 +47,9 @@ class TestReportingHelpers:
         ("source_type", "expected"),
         [
             (JournalEntrySourceType.MANUAL, "manual"),
-            (JournalEntrySourceType.BANK_STATEMENT, "imported"),
+            # bank_statement was retired from the enum in 0040 (#896); the raw
+            # string still classifies as imported via normalize_source_type.
+            ("bank_statement", "imported"),
             (JournalEntrySourceType.SYSTEM, "derived"),
             (JournalEntrySourceType.FX_REVALUATION, "derived"),
             ("manual", "manual"),

--- a/apps/backend/tests/api/test_audit_router.py
+++ b/apps/backend/tests/api/test_audit_router.py
@@ -37,7 +37,7 @@ async def audited_entry(db: AsyncSession, test_user: User) -> JournalEntry:
         user_id=test_user.id,
         entry_date=date(2026, 4, 1),
         memo="Audited transaction",
-        source_type=JournalEntrySourceType.BANK_STATEMENT,
+        source_type=JournalEntrySourceType.AUTO_PARSED,
         status=JournalEntryStatus.DRAFT,
     )
     db.add_all([account, entry])

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -1562,7 +1562,7 @@ def test_AC19_10_1_anchor_detail_helpers_keep_auditable_deduped_payloads():
         user_id=user_id,
         entry_date=date(2026, 5, 31),
         memo="Ledger detail",
-        source_type=JournalEntrySourceType.BANK_STATEMENT,
+        source_type=JournalEntrySourceType.AUTO_PARSED,
         status=JournalEntryStatus.POSTED,
     )
     line = JournalLine(

--- a/apps/backend/tests/infra/test_migrations.py
+++ b/apps/backend/tests/infra/test_migrations.py
@@ -76,3 +76,26 @@ def test_AC13_10_4_source_type_migration_handles_missing_legacy_enum_label():
     assert "ADD VALUE IF NOT EXISTS 'bank_statement'" in source
     assert "source_type::text = 'bank_statement'" in source
     assert "WHERE source_type = 'bank_statement'" not in source
+
+
+def test_AC13_10_4_retire_bank_statement_value_is_drift_tolerant():
+    """AC13.10.4: dropping the legacy bank_statement enum value must tolerate drift.
+
+    0040 (#896) removes 'bank_statement' from journal_source_type_enum. It must
+    (a) re-run the defensive data collapse first so the type rebuild cannot fail
+    on a stray row, (b) only rebuild when the label is actually present, and
+    (c) never compare with a raw enum literal that would error if the label is
+    absent.
+    """
+    migration = SCRIPT_LOCATION / "versions" / "0040_retire_bank_stmt_source.py"
+    source = migration.read_text()
+
+    # Defensive, text-cast data collapse before any type surgery.
+    assert "UPDATE journal_entries SET source_type = 'auto_parsed'" in source
+    assert "WHERE source_type::text = 'bank_statement'" in source
+    # Rebuild is guarded on the label actually existing (no-op otherwise).
+    assert "e.enumlabel = 'bank_statement'" in source
+    # Reversible: the label can be re-added without assuming its absence.
+    assert "ADD VALUE IF NOT EXISTS 'bank_statement'" in source
+    # Never a naive enum-literal comparison that errors when the label is gone.
+    assert "WHERE source_type = 'bank_statement'" not in source

--- a/apps/backend/tests/services/test_confidence_tier.py
+++ b/apps/backend/tests/services/test_confidence_tier.py
@@ -11,7 +11,8 @@ from src.services.confidence_tier import derive_confidence_tier, derive_reconcil
         (JournalEntrySourceType.USER_CONFIRMED, "HIGH"),
         (JournalEntrySourceType.AUTO_MATCHED, "MEDIUM"),
         (JournalEntrySourceType.AUTO_PARSED, "LOW"),
-        (JournalEntrySourceType.BANK_STATEMENT, "LOW"),
+        # bank_statement was retired from the enum in 0040 (#896); the raw-string
+        # case is still covered by the string-parametrized test below.
         (JournalEntrySourceType.SYSTEM, "LOW"),
         (JournalEntrySourceType.FX_REVALUATION, "LOW"),
     ],

--- a/apps/backend/tests/unit/services/test_source_type_priority.py
+++ b/apps/backend/tests/unit/services/test_source_type_priority.py
@@ -18,10 +18,11 @@ from src.services.source_type_priority import (
 
 
 def test_normalize_source_type_defaults_and_legacy_values() -> None:
-    """Legacy bank_statement values normalize to auto_parsed."""
+    """The retired bank_statement raw value still normalizes to auto_parsed."""
     assert normalize_source_type(None) == JournalEntrySourceType.MANUAL
+    # 'bank_statement' was retired from the enum in 0040 (#896); the raw string
+    # must still be tolerated and folded into auto_parsed.
     assert normalize_source_type("bank_statement") == JournalEntrySourceType.AUTO_PARSED
-    assert normalize_source_type(JournalEntrySourceType.BANK_STATEMENT) == JournalEntrySourceType.AUTO_PARSED
 
 
 def test_invalid_and_non_user_source_types_are_not_ranked() -> None:
@@ -31,7 +32,6 @@ def test_invalid_and_non_user_source_types_are_not_ranked() -> None:
     assert not is_user_data_source_type(JournalEntrySourceType.SYSTEM)
     assert statement_source_values() == [
         "auto_parsed",
-        "bank_statement",
         "auto_matched",
         "user_confirmed",
     ]
@@ -48,8 +48,8 @@ def test_promote_entry_source_type_preserves_higher_trust_values() -> None:
 
 
 def test_promote_entry_source_type_normalizes_legacy_value_when_preserving() -> None:
-    """Legacy bank_statement is normalized even when no rank promotion occurs."""
-    entry = JournalEntry(source_type=JournalEntrySourceType.BANK_STATEMENT)
+    """A retired bank_statement raw value is normalized even without rank promotion."""
+    entry = JournalEntry(source_type="bank_statement")
 
     changed = promote_entry_source_type(entry, JournalEntrySourceType.AUTO_PARSED)
 

--- a/docs/ssot/migration-risk.yaml
+++ b/docs/ssot/migration-risk.yaml
@@ -95,3 +95,11 @@ migrations:
     file: c955c65dcc1f_add_is_system_to_accounts.py
     risk: medium
     proof: Adds non-null account flag with server default; staging should exercise account reads and writes.
+  0040_retire_bank_stmt_source:
+    file: 0040_retire_bank_stmt_source.py
+    risk: high
+    issue: "#896"
+    proof: Retires the dead legacy bank_statement value from journal_source_type_enum. Data was already collapsed to auto_parsed in 0018 and no write path emits it (every write runs normalize_source_type first); the upgrade re-runs the defensive text-cast UPDATE before rebuilding the enum, so the data mutation is idempotent and a no-op on already-clean data.
+    staging_validation: Deploy to staging and exercise upload -> parse -> reconcile -> report; confirm journal entries persist and read back with the rebuilt enum and that no path attempts to write bank_statement.
+    production_preflight: None required - the defensive UPDATE collapses any residual bank_statement rows before the enum rebuild, so the type recreate cannot fail on a stray value regardless of production row count. Optionally count rows with source_type::text = 'bank_statement' to confirm zero.
+    rollback_strategy: downgrade() re-adds the bank_statement label idempotently (ADD VALUE IF NOT EXISTS); restore from pre-migration snapshot only if the type rebuild is interrupted. The raw string stays tolerated by normalize_source_type so reverted code keeps working.


### PR DESCRIPTION
## What & why

Retires the deprecated `bank_statement` value from `journal_source_type_enum` (#896, Tier C).

The valuable part of this cleanup was **already done**: migration `0018` migrated historical rows to `auto_parsed`, and no write path emits `bank_statement` (every write runs `normalize_source_type` first, which folds it into `auto_parsed`). The value is dead in both **data** and **code**, so this drops it from the enum.

## Drift tolerance (AC13.10.4)

Removing a Postgres enum value has no `DROP VALUE`, so `0040` rename-creates-rebinds-drops. It is written to **not assume any enum state**:

- re-runs the defensive `UPDATE ... SET 'auto_parsed' WHERE source_type::text = 'bank_statement'` **before** any type surgery, so the rebuild can never fail on a stray row (prod row count is irrelevant);
- only rebuilds when the `bank_statement` label is actually present (no-op otherwise);
- the raw string `'bank_statement'` is still tolerated at the app layer — `normalize_source_type` keeps a string-level guard, and the immutability trigger keeps its `::text IN (...)` guard — so any historical raw value stays harmless;
- `downgrade()` re-adds the label idempotently.

## Changes

- **migration `0040_retire_bank_stmt_source`** — rebuild `journal_source_type_enum` without `bank_statement`
- **models/services** — drop the enum member; `source_type_priority` keeps string-level legacy normalization; `reporting._provenance_from_source_type` now routes through `normalize_source_type`
- **tests** — assert the legacy raw string still normalizes; new `0040` drift-tolerance assertion in `test_migrations`

> Note: the many other `"bank_statement"` strings in the codebase (report `source_classes`, `WorkflowEvent.source_type`, `DocumentType.BANK_STATEMENT`, confidence-tier keys) are **different namespaces** and are intentionally untouched.

## Verification

- ✅ 53 targeted unit tests pass (`source_type_priority.py` 100%)
- ✅ `ruff check` clean on all changed files
- ⚠️ DB-integration tests + `alembic upgrade head` / `alembic check` were **not runnable locally** (no Postgres/docker in the dev sandbox) — these are owned by the CI `schema-migrations` + backend jobs, which is the binding proof that `0040` applies and stays in parity with the model (`test_schema_drift.py` enforces this contract).

Closes part of #896 (the `normalize_source_type()` + `bank_statement` enum Tier-C item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)