### PR TITLE
[finance_report_audit] docs(#896): sync SSOT for retired bank_statement source_type

### DIFF
--- a/docs/ssot/accounting.md
+++ b/docs/ssot/accounting.md
@@ -70,9 +70,12 @@ Ledger immutability protects accounting facts: entry ownership/date/memo/source
 identity, status correction path, and all journal-line amounts, directions,
 accounts, currencies, and FX rates. The only non-fact metadata update allowed on
 a posted/reconciled entry is the source-type-priority promotion from
-`auto_parsed`, `bank_statement`, or `auto_matched` to `user_confirmed`, with
-`source_id` and every accounting fact unchanged. The same promotion is allowed
-when the entry moves from `posted` to `reconciled`.
+`auto_parsed` or `auto_matched` to `user_confirmed`, with `source_id` and every
+accounting fact unchanged. The same promotion is allowed when the entry moves
+from `posted` to `reconciled`. (The immutability trigger's text guard also
+retains the retired legacy value `bank_statement` — see migration 0040 / #896 —
+so any historical row in that state can still be promoted, though no write path
+produces it anymore.)
 
 ---
 

--- a/docs/ssot/source-type-priority.md
+++ b/docs/ssot/source-type-priority.md
@@ -17,7 +17,10 @@
 > **Implementation Status**: The four-value user-data trust hierarchy is implemented:
 > `manual`, `user_confirmed`, `auto_matched`, `auto_parsed`.
 > Internal/system source types remain available as `system` and `fx_revaluation`.
-> `bank_statement` is a deprecated legacy value accepted for compatibility and normalized to `auto_parsed` for new API/service writes.
+> `bank_statement` was a legacy value, **retired from the enum in migration 0040 (#896)**. Its historical
+> rows were migrated to `auto_parsed` in 0018 and no write path emits it. The raw string is still tolerated
+> defensively — `normalize_source_type` folds it into `auto_parsed` — so legacy inputs and the immutability
+> trigger's text guard stay harmless.
 ---
 
 ## 2. Trust Hierarchy


### PR DESCRIPTION
Follow-up to #1137, which retired `bank_statement` from `JournalEntrySourceType` (migration 0040). That PR missed the SSOT prose sync (work-order step 5). This catches up the two docs that still described it as a live enum value.

## Changes
- **`docs/ssot/source-type-priority.md`** — `bank_statement` is no longer an enum value; clarify it was retired in 0040, data migrated to `auto_parsed` in 0018, and the raw string is still tolerated/normalized defensively.
- **`docs/ssot/accounting.md`** — drop `bank_statement` from the live source-type promotion list; note the immutability trigger keeps a legacy **text** guard for historical rows (no write path produces it anymore).

## Staleness sweep (what was checked)
- ✅ `docs/reference/db-schema.md` — **generated & untracked**, regenerated fresh in CI; no manual change needed (the local stale copy was regenerated).
- ✅ Frontend — only the unrelated `BankStatement` *document* types; no journal `source_type` enum.
- ✅ Tests — no assertion of `bank_statement` as a valid enum value or a fixed enum-count; fully handled in #1137.
- ✅ Other doc hits (`assets.md`, `source-coverage-matrix.yaml`, `workflow-events.md`, `processing_account.md`, `schema.md`, EPIC-013) are different namespaces (document/source-class taxonomy, `WorkflowEvent.source_type`, dropped ODS tables) — intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)