### PR TITLE
[finance_report_ui] fix(test): uppercase AccountType literal in dashboard tests (unblocks FE typecheck)

### DIFF
--- a/apps/frontend/src/__tests__/useAssetTrend.test.ts
+++ b/apps/frontend/src/__tests__/useAssetTrend.test.ts
@@ -34,8 +34,8 @@ describe("useAssetTrend (EPIC-022 AC22.16.3)", () => {
   it("AC22.16.3 is usable on its own and fetches the trend for the top asset", async () => {
     mockedApiFetch.mockResolvedValue({ points: [{ period_start: "2026-01-01", amount: "5000" }] });
     const balance = balanceWith([
-      { account_id: "a1", name: "Cash", type: "asset", amount: "5000" },
-      { account_id: "a2", name: "Brokerage", type: "asset", amount: "9000" },
+      { account_id: "a1", name: "Cash", type: "ASSET", amount: "5000" },
+      { account_id: "a2", name: "Brokerage", type: "ASSET", amount: "9000" },
     ]);
 
     const { result } = renderHook(() => useAssetTrend(balance));
@@ -51,8 +51,8 @@ describe("useAssetTrend (EPIC-022 AC22.16.3)", () => {
   it("AC22.16.3 refetches the trend when the selected account changes", async () => {
     mockedApiFetch.mockResolvedValue({ points: [] });
     const balance = balanceWith([
-      { account_id: "a1", name: "Cash", type: "asset", amount: "5000" },
-      { account_id: "a2", name: "Brokerage", type: "asset", amount: "9000" },
+      { account_id: "a1", name: "Cash", type: "ASSET", amount: "5000" },
+      { account_id: "a2", name: "Brokerage", type: "ASSET", amount: "9000" },
     ]);
 
     const { result } = renderHook(() => useAssetTrend(balance));
@@ -77,7 +77,7 @@ describe("useAssetTrend (EPIC-022 AC22.16.3)", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     mockedApiFetch.mockRejectedValue(new Error("trend down"));
     const { result } = renderHook(() =>
-      useAssetTrend(balanceWith([{ account_id: "a1", name: "Cash", type: "asset", amount: "5000" }])),
+      useAssetTrend(balanceWith([{ account_id: "a1", name: "Cash", type: "ASSET", amount: "5000" }])),
     );
 
     await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
@@ -87,8 +87,8 @@ describe("useAssetTrend (EPIC-022 AC22.16.3)", () => {
   it("AC22.16.3 clears a stale selection when the chosen account leaves the balance sheet", async () => {
     mockedApiFetch.mockResolvedValue({ points: [] });
     const initial = balanceWith([
-      { account_id: "a1", name: "Cash", type: "asset", amount: "5000" },
-      { account_id: "a2", name: "Brokerage", type: "asset", amount: "9000" },
+      { account_id: "a1", name: "Cash", type: "ASSET", amount: "5000" },
+      { account_id: "a2", name: "Brokerage", type: "ASSET", amount: "9000" },
     ]);
     const { result, rerender } = renderHook(({ bs }) => useAssetTrend(bs), {
       initialProps: { bs: initial },
@@ -101,7 +101,7 @@ describe("useAssetTrend (EPIC-022 AC22.16.3)", () => {
     // Refreshed balance sheet no longer contains a2 (e.g. restricted toggled
     // off): the stale selection is dropped so the <select> can't show a missing
     // value, and the trend falls back to the top remaining asset.
-    const refreshed = balanceWith([{ account_id: "a1", name: "Cash", type: "asset", amount: "5000" }]);
+    const refreshed = balanceWith([{ account_id: "a1", name: "Cash", type: "ASSET", amount: "5000" }]);
     rerender({ bs: refreshed });
 
     await waitFor(() => expect(result.current.trendAccountId).toBeNull());

--- a/apps/frontend/src/__tests__/useDashboardData.test.ts
+++ b/apps/frontend/src/__tests__/useDashboardData.test.ts
@@ -127,7 +127,7 @@ describe("useDashboardData", () => {
       routeResponder(
         {
           "/api/reports/balance-sheet": {
-            assets: [{ account_id: "a1", name: "Cash", type: "asset", amount: "5000" }],
+            assets: [{ account_id: "a1", name: "Cash", type: "ASSET", amount: "5000" }],
             liabilities: [],
             equity: [],
             total_assets: "5000",


### PR DESCRIPTION
## Problem
`tsc --noEmit` fails on `main` (TS2820) in two dashboard test files:

```
src/__tests__/useAssetTrend.test.ts: Type '"asset"' is not assignable to type
'"ASSET" | "INCOME" | "LIABILITY" | "EQUITY" | "EXPENSE"'. Did you mean '"ASSET"'?
```

`BalanceSheetResponse["assets"][].type` resolves to the uppercase `AccountType` enum, but the fixtures use lowercase `type: "asset"`.

## Why it was latent on main
The CI **Frontend Build & Test** job is gated on changed paths (`needs.changes`), so it's **skipped** on backend-only / docs merges. The casing mismatch (introduced by #1130) therefore never tripped a red check on `main`. It surfaces on any PR that touches a frontend path (e.g. `apps/frontend/openapi.json` regeneration in the #1099 pagination PR), which triggers the dormant typecheck job.

## Fix
`type: "asset"` → `type: "ASSET"` in `useAssetTrend.test.ts` (8) and `useDashboardData.test.ts` (1). Pure test-fixture casing; no runtime/source change.

## Verification
- `npx tsc --noEmit` → exit 0
- `vitest run` on both files → 9 passed

Unblocks the FE typecheck for the stacked #1099 PRs (#1135 / #1136), which currently inherit this failure from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)