### PR TITLE
[finance_report_test_and_doc] refactor(backend): dedup + de-layer portfolio / reporting / statements

### DIFF
--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -9,15 +9,11 @@ from sqlalchemy import select
 
 from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
-from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition, PositionStatus
-from src.models.market_data import StockPrice
 from src.models.portfolio import (
     DividendIncome,
     InvestmentTransaction,
     InvestmentTransactionType,
-    MarketDataOverride,
-    PriceSource,
 )
 from src.schemas.portfolio import (
     BrokerageImportRequest,
@@ -26,9 +22,6 @@ from src.schemas.portfolio import (
     CostBasisMethodUpdateResponse,
     DividendEventResponse,
     HoldingResponse,
-    InvestmentPerformanceAllocationRow,
-    InvestmentPerformanceDataFreshness,
-    InvestmentPerformanceHoldingRow,
     InvestmentPerformanceReportScheduleResponse,
     PortfolioSummaryDashboardResponse,
     PriceUpdateBatchResponse,
@@ -37,9 +30,10 @@ from src.schemas.portfolio import (
 )
 from src.services import allocation, performance
 from src.services.brokerage_positions import BrokeragePositionImportService
-from src.services.fx import FxRateError, convert_amount
+from src.services.fx import FxRateError
 from src.services.performance import InsufficientDataError, PerformanceError
-from src.services.portfolio import AssetNotFoundError, PortfolioNotFoundError, PortfolioService
+from src.services.performance_report import build_investment_performance_report_schedule
+from src.services.portfolio import AssetNotFoundError, PortfolioNotFoundError, portfolio_service
 from src.utils.money import to_money
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
@@ -50,7 +44,7 @@ logger = get_logger(__name__)
 _DEFAULT_LIST_LIMIT = 100
 _MAX_LIST_LIMIT = 500
 
-_portfolio_service = PortfolioService()
+_portfolio_service = portfolio_service
 _brokerage_import_service = BrokeragePositionImportService()
 
 
@@ -82,72 +76,6 @@ class DividendCreateRequest(BaseModel):
     payment_date: date
     amount: Decimal = Field(decimal_places=2, gt=0)
     currency: str = Field(min_length=3, max_length=3)
-
-
-def _money(value: Decimal) -> Decimal:
-    # Canonical money rounding (banker's / HALF_EVEN). See docs/ssot/accounting.md#decimal-rule.
-    return to_money(Decimal(value))
-
-
-def _percent(value: Decimal | None) -> Decimal | None:
-    if value is None:
-        return None
-    return Decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
-
-
-def _source_document_links(source_documents: object) -> list[str]:
-    if isinstance(source_documents, list):
-        docs = source_documents
-    elif isinstance(source_documents, dict):
-        docs = source_documents.get("documents") or source_documents.get("source_documents") or [source_documents]
-    else:
-        docs = []
-
-    links: list[str] = []
-    for doc in docs:
-        if isinstance(doc, dict):
-            doc_type = doc.get("doc_type") or doc.get("type") or "source"
-            doc_id = doc.get("doc_id") or doc.get("id") or doc.get("source_id")
-            if doc_id:
-                links.append(f"{doc_type}:{doc_id}")
-    return links
-
-
-def _freshness_link(asset_identifier: str, source_kind: str, source_id: object, evidence_date: date) -> str:
-    return f"price_source:{source_kind}:{asset_identifier}:{source_id}:{evidence_date.isoformat()}"
-
-
-async def _report_preparation_holdings(
-    db: DbSession,
-    user_id: CurrentUserId,
-    as_of_date: date,
-) -> list[HoldingResponse]:
-    """Load current holdings only when post-period manual prices evidence report preparation."""
-    override_result = await db.execute(
-        select(MarketDataOverride)
-        .where(MarketDataOverride.user_id == user_id)
-        .where(MarketDataOverride.source == PriceSource.MANUAL)
-        .where(MarketDataOverride.price_date > as_of_date)
-        .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
-    )
-    override_assets = {override.asset_identifier for override in override_result.scalars().all()}
-    if not override_assets:
-        return []
-
-    try:
-        current_holdings = await _portfolio_service.get_holdings(
-            db=db,
-            user_id=user_id,
-            include_disposed=True,
-        )
-    except (PortfolioNotFoundError, AssetNotFoundError):
-        return []
-
-    return [
-        holding
-        for holding in current_holdings
-        if holding.asset_identifier in override_assets and holding.status == PositionStatus.ACTIVE
-    ]
 
 
 @router.post("/brokerage/import", response_model=BrokerageImportResponse, status_code=status.HTTP_200_OK)
@@ -232,52 +160,20 @@ async def get_portfolio_summary(
         )
 
     year_start = date(report_date.year, 1, 1)
-    realized_result = await db.execute(
-        select(InvestmentTransaction)
-        .where(InvestmentTransaction.user_id == user_id)
-        .where(InvestmentTransaction.transaction_type == InvestmentTransactionType.SELL)
-        .where(InvestmentTransaction.transaction_date >= year_start)
-        .where(InvestmentTransaction.transaction_date <= report_date)
-    )
     summary_currency = summary.currency.upper()
-    realized_pnl_ytd = Decimal("0.00")
-    for txn in realized_result.scalars().all():
-        realized_amount = txn.realized_pnl or Decimal("0.00")
-        try:
-            realized_pnl_ytd += await convert_amount(
-                db,
-                realized_amount,
-                txn.currency,
-                summary_currency,
-                txn.transaction_date,
-                lazy_load=True,
-            )
-        except FxRateError as exc:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
-
-    dividend_result = await db.execute(
-        select(DividendIncome)
-        .where(DividendIncome.user_id == user_id)
-        .where(DividendIncome.payment_date >= year_start)
-        .where(DividendIncome.payment_date <= report_date)
-    )
-    dividend_income_ytd = Decimal("0.00")
-    for dividend in dividend_result.scalars().all():
-        try:
-            dividend_income_ytd += await convert_amount(
-                db,
-                dividend.amount,
-                dividend.currency,
-                summary_currency,
-                dividend.payment_date,
-                lazy_load=True,
-            )
-        except FxRateError as exc:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    try:
+        realized_by_asset, _ = await _portfolio_service.get_realized_pnl_by_asset(
+            db, user_id, start_date=year_start, end_date=report_date, target_currency=summary_currency
+        )
+        dividend_by_asset = await _portfolio_service.get_dividend_income_by_asset(
+            db, user_id, start_date=year_start, end_date=report_date, target_currency=summary_currency
+        )
+    except FxRateError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
 
     data = summary.model_dump()
-    data["realized_pnl_ytd"] = to_money(Decimal(realized_pnl_ytd))
-    data["dividend_income_ytd"] = to_money(Decimal(dividend_income_ytd))
+    data["realized_pnl_ytd"] = to_money(sum(realized_by_asset.values(), Decimal("0.00")))
+    data["dividend_income_ytd"] = to_money(sum(dividend_by_asset.values(), Decimal("0.00")))
     return PortfolioSummaryDashboardResponse(**data)
 
 
@@ -489,7 +385,6 @@ async def get_investment_performance_report_schedule(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="period_start must be <= period_end"
         )
-
     if as_of_date < period_end:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="as_of_date must be >= period_end")
 
@@ -500,318 +395,17 @@ async def get_investment_performance_report_schedule(
             detail="Investment performance report schedule currently supports SGD presentation currency",
         )
 
-    notes: list[str] = [
-        "Cost basis uses the holding-level cost-basis method where available.",
-        (
-            "Market values use the latest available brokerage or market-data snapshot on or before the as-of date; "
-            "report-preparation overrides after the as-of date are disclosed when they evidence active holdings."
-        ),
-    ]
-
-    used_report_preparation_evidence = False
     try:
-        holdings = list(
-            await _portfolio_service.get_holdings(
-                db=db,
-                user_id=user_id,
-                as_of_date=as_of_date,
-                include_disposed=True,
-            )
-        )
-    except (PortfolioNotFoundError, AssetNotFoundError):
-        holdings = []
-
-    if not holdings:
-        holdings = await _report_preparation_holdings(db=db, user_id=user_id, as_of_date=as_of_date)
-        used_report_preparation_evidence = bool(holdings)
-        if used_report_preparation_evidence:
-            notes.append(
-                "No holdings snapshot existed on or before the as-of date; the schedule used active holdings "
-                "with post-period manual market-data overrides as report-preparation evidence."
-            )
-        else:
-            notes.append("No portfolio holdings were available for the requested as-of date.")
-
-    asset_identifiers = [holding.asset_identifier for holding in holdings]
-    position_by_asset: dict[str, ManagedPosition] = {}
-    if asset_identifiers:
-        position_result = await db.execute(
-            select(ManagedPosition)
-            .where(ManagedPosition.user_id == user_id)
-            .where(ManagedPosition.asset_identifier.in_(asset_identifiers))
-        )
-        position_by_asset = {position.asset_identifier: position for position in position_result.scalars().all()}
-
-    async def _schedule_amount(amount: Decimal, source_currency: str, rate_date: date) -> Decimal:
-        try:
-            return await convert_amount(
-                db,
-                amount,
-                source_currency,
-                currency,
-                rate_date,
-                lazy_load=True,
-            )
-        except FxRateError as exc:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
-
-    async def _metric_or_note(metric_name: str, calculation):
-        try:
-            return await calculation()
-        except InsufficientDataError as exc:
-            notes.append(f"{metric_name} unavailable: {exc}")
-            return None
-        except PerformanceError as exc:
-            notes.append(f"{metric_name} unavailable: {exc}")
-            return None
-
-    xirr = await _metric_or_note(
-        "XIRR", lambda: performance.calculate_xirr(db=db, user_id=user_id, as_of_date=as_of_date)
-    )
-    twr = await _metric_or_note(
-        "TWR",
-        lambda: performance.calculate_time_weighted_return(
-            db=db,
-            user_id=user_id,
+        return await build_investment_performance_report_schedule(
+            db,
+            user_id,
             period_start=period_start,
             period_end=period_end,
-        ),
-    )
-    mwr = await _metric_or_note(
-        "MWR",
-        lambda: performance.calculate_money_weighted_return(db=db, user_id=user_id, as_of_date=as_of_date),
-    )
-    dividend_yield = await _metric_or_note(
-        "Dividend yield",
-        lambda: performance.calculate_dividend_yield(db=db, user_id=user_id, as_of_date=as_of_date),
-    )
-
-    realized_result = await db.execute(
-        select(InvestmentTransaction)
-        .where(InvestmentTransaction.user_id == user_id)
-        .where(InvestmentTransaction.transaction_type == InvestmentTransactionType.SELL)
-        .where(InvestmentTransaction.transaction_date >= period_start)
-        .where(InvestmentTransaction.transaction_date <= period_end)
-    )
-    realized_by_asset: dict[str, Decimal] = {}
-    source_links: set[str] = {"report_section:investment_performance"}
-    for txn in realized_result.scalars().all():
-        realized_pnl = await _schedule_amount(
-            txn.realized_pnl or Decimal("0.00"),
-            txn.currency,
-            txn.transaction_date,
+            as_of_date=as_of_date,
+            currency=currency,
         )
-        realized_by_asset[txn.asset_identifier] = (
-            realized_by_asset.get(txn.asset_identifier, Decimal("0.00")) + realized_pnl
-        )
-        if txn.journal_entry_id:
-            source_links.add(f"journal_entry:{txn.journal_entry_id}")
-        if txn.source_id:
-            source_links.add(f"investment_transaction_source:{txn.source_id}")
-
-    dividend_result = await db.execute(
-        select(DividendIncome, ManagedPosition)
-        .join(ManagedPosition, DividendIncome.position_id == ManagedPosition.id)
-        .where(DividendIncome.user_id == user_id)
-        .where(ManagedPosition.user_id == user_id)
-        .where(DividendIncome.payment_date >= period_start)
-        .where(DividendIncome.payment_date <= period_end)
-    )
-    dividend_by_asset: dict[str, Decimal] = {}
-    for dividend, position in dividend_result.all():
-        dividend_amount = await _schedule_amount(dividend.amount, dividend.currency, dividend.payment_date)
-        dividend_by_asset[position.asset_identifier] = (
-            dividend_by_asset.get(
-                position.asset_identifier,
-                Decimal("0.00"),
-            )
-            + dividend_amount
-        )
-
-    holding_rows: list[InvestmentPerformanceHoldingRow] = []
-    for holding in holdings:
-        position = position_by_asset.get(holding.asset_identifier)
-        if position is None:
-            cost_basis = _money(await _schedule_amount(holding.cost_basis, holding.currency, holding.acquisition_date))
-        else:
-            cost_basis = _money(
-                await _schedule_amount(position.cost_basis, position.currency, position.acquisition_date)
-            )
-        market_value = _money(holding.market_value)
-        holding_rows.append(
-            InvestmentPerformanceHoldingRow(
-                asset_identifier=holding.asset_identifier,
-                quantity=holding.quantity,
-                cost_basis=cost_basis,
-                market_value=market_value,
-                unrealized_pnl=_money(market_value - cost_basis),
-                realized_pnl=_money(realized_by_asset.get(holding.asset_identifier, Decimal("0.00"))),
-                dividend_income=_money(dividend_by_asset.get(holding.asset_identifier, Decimal("0.00"))),
-                currency=holding.currency,
-            )
-        )
-
-    allocation_rows: list[InvestmentPerformanceAllocationRow] = []
-    for dimension, loader in [
-        ("sector", allocation.get_sector_allocation),
-        ("geography", allocation.get_geography_allocation),
-        ("asset_class", allocation.get_asset_class_allocation),
-    ]:
-        for row in await loader(db=db, user_id=user_id, as_of_date=as_of_date):
-            allocation_rows.append(
-                InvestmentPerformanceAllocationRow(
-                    dimension=dimension,
-                    category=row.category,
-                    value=_money(row.value),
-                    percentage=_money(row.percentage),
-                    count=row.count,
-                )
-            )
-    if used_report_preparation_evidence and not allocation_rows and holding_rows:
-        total_market_value = sum((row.market_value for row in holding_rows), Decimal("0.00"))
-        for dimension, attribute, fallback_category in [
-            ("sector", "sector", "Unclassified"),
-            ("geography", "geography", "Unclassified"),
-            ("asset_class", "asset_type", "Unclassified"),
-        ]:
-            grouped: dict[str, tuple[Decimal, int]] = {}
-            for holding, row in zip(holdings, holding_rows, strict=True):
-                category = getattr(holding, attribute) or fallback_category
-                current_value, current_count = grouped.get(category, (Decimal("0.00"), 0))
-                grouped[category] = (current_value + row.market_value, current_count + 1)
-            for category, (value, count) in grouped.items():
-                percentage = Decimal("0.00")
-                if total_market_value:
-                    percentage = (value / total_market_value * Decimal("100")).quantize(
-                        Decimal("0.01"), rounding=ROUND_HALF_UP
-                    )
-                allocation_rows.append(
-                    InvestmentPerformanceAllocationRow(
-                        dimension=dimension,
-                        category=category,
-                        value=_money(value),
-                        percentage=percentage,
-                        count=count,
-                    )
-                )
-        notes.append("Allocation rows use report-preparation holdings when as-of allocation snapshots are unavailable.")
-
-    latest_atomic_query = select(AtomicPosition).where(AtomicPosition.user_id == user_id)
-    if used_report_preparation_evidence and asset_identifiers:
-        latest_atomic_query = latest_atomic_query.where(AtomicPosition.asset_identifier.in_(asset_identifiers))
-    else:
-        latest_atomic_query = latest_atomic_query.where(AtomicPosition.snapshot_date <= as_of_date)
-    latest_atomic_result = await db.execute(
-        latest_atomic_query.order_by(AtomicPosition.snapshot_date.desc(), AtomicPosition.created_at.desc())
-    )
-    atomics = list(latest_atomic_result.scalars().all())
-    latest_atomic_by_asset: dict[str, AtomicPosition] = {}
-    for atomic in atomics:
-        latest_atomic_by_asset.setdefault(atomic.asset_identifier, atomic)
-        for link in _source_document_links(atomic.source_documents):
-            source_links.add(link)
-
-    latest_override_query = (
-        select(MarketDataOverride)
-        .where(MarketDataOverride.user_id == user_id)
-        .where(MarketDataOverride.price_date <= as_of_date)
-    )
-    latest_override_result = await db.execute(
-        latest_override_query.order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
-    )
-    overrides = list(latest_override_result.scalars().all())
-    if asset_identifiers:
-        report_preparation_override_result = await db.execute(
-            select(MarketDataOverride)
-            .where(MarketDataOverride.user_id == user_id)
-            .where(MarketDataOverride.asset_identifier.in_(asset_identifiers))
-            .where(MarketDataOverride.source == PriceSource.MANUAL)
-            .where(MarketDataOverride.price_date > as_of_date)
-            .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
-        )
-        overrides.extend(report_preparation_override_result.scalars().all())
-        overrides.sort(key=lambda override: override.price_date, reverse=True)
-    latest_override = overrides[0] if overrides else None
-    latest_override_by_asset: dict[str, MarketDataOverride] = {}
-    for override in overrides:
-        latest_override_by_asset.setdefault(override.asset_identifier, override)
-
-    stock_prices: list[StockPrice] = []
-    if asset_identifiers:
-        stock_price_result = await db.execute(
-            select(StockPrice)
-            .where(StockPrice.symbol.in_(asset_identifiers))
-            .where(StockPrice.price_date <= as_of_date)
-            .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc(), StockPrice.source.asc())
-        )
-        stock_prices = list(stock_price_result.scalars().all())
-    latest_stock_price_by_asset: dict[str, StockPrice] = {}
-    for stock_price in stock_prices:
-        latest_stock_price_by_asset.setdefault(stock_price.symbol, stock_price)
-
-    price_dates: list[date] = []
-    providers: set[str] = set()
-    stale_holdings: list[str] = []
-    for asset_identifier in asset_identifiers:
-        override = latest_override_by_asset.get(asset_identifier)
-        stock_price = latest_stock_price_by_asset.get(asset_identifier)
-        atomic = latest_atomic_by_asset.get(asset_identifier)
-
-        candidates: list[tuple[date, str, object, str | None]] = []
-        if override is not None:
-            candidates.append((override.price_date, "market_data_override", override.id, override.source.value))
-        if stock_price is not None:
-            candidates.append((stock_price.price_date, "stock_price", stock_price.id, stock_price.source))
-        if atomic is not None:
-            candidates.append((atomic.snapshot_date, "atomic_position", atomic.id, atomic.broker))
-
-        if not candidates:
-            stale_holdings.append(asset_identifier)
-            continue
-
-        evidence_date, source_kind, source_id, provider = max(candidates, key=lambda candidate: candidate[0])
-        price_dates.append(evidence_date)
-        source_links.add(_freshness_link(asset_identifier, source_kind, source_id, evidence_date))
-        if provider:
-            providers.add(provider)
-        if evidence_date < as_of_date:
-            stale_holdings.append(asset_identifier)
-
-    latest_price_date = max(price_dates) if price_dates else None
-    market_data_provider = ", ".join(sorted(providers)) if providers else None
-
-    data_freshness = InvestmentPerformanceDataFreshness(
-        latest_price_date=latest_price_date,
-        market_data_provider=market_data_provider,
-        stale=bool(stale_holdings),
-        stale_holdings=sorted(stale_holdings),
-        manual_override_basis=(
-            f"{latest_override.asset_identifier}:{latest_override.price_date.isoformat()}"
-            if latest_override is not None
-            else None
-        ),
-    )
-    if data_freshness.stale:
-        notes.append("One or more market values use stale data relative to the requested as-of date.")
-
-    return InvestmentPerformanceReportScheduleResponse(
-        period_start=period_start,
-        period_end=period_end,
-        as_of_date=as_of_date,
-        currency=currency,
-        xirr=_percent(xirr),
-        time_weighted_return=_percent(twr),
-        money_weighted_return=_percent(mwr),
-        realized_pnl=_money(sum(realized_by_asset.values(), Decimal("0.00"))),
-        unrealized_pnl=_money(sum((row.unrealized_pnl for row in holding_rows), Decimal("0.00"))),
-        dividend_income=_money(sum(dividend_by_asset.values(), Decimal("0.00"))),
-        dividend_yield=_percent(dividend_yield),
-        holdings=holding_rows,
-        allocation=allocation_rows,
-        data_freshness=data_freshness,
-        source_links=sorted(source_links),
-        notes=notes,
-    )
+    except FxRateError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
 
 
 @router.get("/allocation/sector", response_model=list[AllocationBreakdownResponse])

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -24,7 +24,6 @@ from src.models import (
     BankStatementStatus,
     UploadedDocument,
 )
-from src.models.layer2 import AtomicTransaction
 from src.models.statement_summary import StatementSummary
 from src.schemas import (
     AtomicTransactionResponse,
@@ -47,6 +46,11 @@ from src.schemas.review import (
 from src.services import StorageError, StorageService
 from src.services.ai_models import ModelCatalogError, get_model_info, model_matches_modality
 from src.services.brokerage_positions import BrokeragePositionImportService
+from src.services.brokerage_statement_payload import (
+    _brokerage_import_not_ready_reason,
+    _brokerage_payload_from_persisted_extraction,
+    _brokerage_payload_from_statement,
+)
 from src.services.statement_pipeline import submit_parse_pipeline
 from src.services.statement_posting import auto_create_posted_entries_for_statement, resolve_statement_posting_account
 from src.services.statement_validation import (
@@ -592,94 +596,6 @@ async def list_statement_transactions(
     return BankStatementTransactionListResponse(items=items, total=len(items))
 
 
-def _brokerage_payload_from_statement(
-    statement: StatementSummary,
-    transactions: list[AtomicTransaction],
-) -> dict:
-    """Build an import payload from a parsed brokerage statement."""
-    events = []
-    for txn in transactions:
-        direction = txn.direction.value if hasattr(txn.direction, "value") else txn.direction
-        signed_amount = txn.amount if direction == "IN" else -txn.amount
-        events.append(
-            {
-                "date": txn.txn_date.isoformat(),
-                "description": txn.description,
-                "amount": str(signed_amount),
-                "currency": txn.currency or statement.currency,
-                "raw_text": txn.description,
-            }
-        )
-
-    return {
-        "institution": statement.institution,
-        "statement": {
-            "institution": statement.institution,
-            "period_end": statement.period_end.isoformat() if statement.period_end else None,
-            "currency": statement.currency,
-        },
-        "transactions": events,
-        "events": events,
-    }
-
-
-def _extract_brokerage_payload_from_metadata(metadata: dict | None) -> dict | None:
-    """Return the structured extraction payload stored in Layer 1 metadata."""
-    if not isinstance(metadata, dict):
-        return None
-    for key in ("extraction_payload", "parsed_payload", "payload"):
-        payload = metadata.get(key)
-        if isinstance(payload, dict):
-            return payload
-    return metadata if any(key in metadata for key in ("positions", "holdings", "securities")) else None
-
-
-def _enrich_brokerage_payload_from_statement(payload: dict, statement: StatementSummary) -> dict:
-    """Backfill statement metadata into a recovered extraction payload."""
-    enriched = dict(payload)
-    enriched.setdefault("institution", statement.institution)
-    statement_payload = enriched.get("statement") if isinstance(enriched.get("statement"), dict) else {}
-    statement_payload = dict(statement_payload)
-    statement_payload.setdefault("institution", statement.institution)
-    statement_payload.setdefault("period_end", statement.period_end.isoformat() if statement.period_end else None)
-    statement_payload.setdefault("currency", statement.currency)
-    enriched["statement"] = statement_payload
-    return enriched
-
-
-async def _brokerage_payload_from_persisted_extraction(
-    db,
-    *,
-    statement: StatementSummary,
-    uploaded_document: UploadedDocument | None,
-    user_id: UUID,
-) -> dict | None:
-    """Load the persisted OCR extraction payload for statement-scoped imports."""
-    payload = _extract_brokerage_payload_from_metadata(statement.extraction_metadata)
-    if payload is not None:
-        return _enrich_brokerage_payload_from_statement(payload, statement)
-
-    if uploaded_document is None:
-        return None
-    payload = _extract_brokerage_payload_from_metadata(uploaded_document.extraction_metadata)
-    if payload is None:
-        return None
-    return _enrich_brokerage_payload_from_statement(payload, statement)
-
-
-def _brokerage_import_not_ready_reason(statement: StatementSummary, transaction_count: int) -> str:
-    """Explain why a brokerage statement cannot be imported yet."""
-    status_value = statement.status.value if hasattr(statement.status, "value") else str(statement.status)
-    validation_error = statement.validation_error
-
-    if status_value == BankStatementStatus.REJECTED.value:
-        return f"Provider parsing failed before brokerage import: {validation_error or 'statement rejected'}"
-    if status_value in {BankStatementStatus.UPLOADED.value, BankStatementStatus.PARSING.value}:
-        return "Provider parsing has not completed; statement must be parsed before brokerage import"
-
-    return f"Statement must be parsed before importing brokerage positions; current status={status_value}"
-
-
 # Synchronous 200: the import runs inline and returns the full BrokerageImportResponse
 # (counts + reconciliation results), so the operation is complete on response — not a
 # 202 background job (cf. #1099 AC12.29.1).
@@ -703,9 +619,7 @@ async def import_brokerage_statement_positions(
     uploaded_document = await _resolve_uploaded_document(db, statement, user_id)
     source_filename = uploaded_document.original_filename if uploaded_document else statement.file_hash
 
-    payload = await _brokerage_payload_from_persisted_extraction(
-        db, statement=statement, uploaded_document=uploaded_document, user_id=user_id
-    )
+    payload = _brokerage_payload_from_persisted_extraction(statement=statement, uploaded_document=uploaded_document)
     if payload is None:
         payload = _brokerage_payload_from_statement(statement, transactions)
     request_id = _current_request_id()

--- a/apps/backend/src/services/brokerage_statement_payload.py
+++ b/apps/backend/src/services/brokerage_statement_payload.py
@@ -1,0 +1,100 @@
+"""Brokerage-statement import payload assembly.
+
+Pure domain helpers that build or recover the import payload consumed by
+``BrokeragePositionImportService`` from a parsed brokerage statement, its
+transactions, and persisted OCR extraction metadata, plus the not-ready-reason
+message. Extracted from the statements router so the router stays a thin HTTP
+layer; behavior unchanged.
+"""
+
+from __future__ import annotations
+
+from src.models import BankStatementStatus, UploadedDocument
+from src.models.layer2 import AtomicTransaction
+from src.models.statement_summary import StatementSummary
+
+
+def _brokerage_payload_from_statement(
+    statement: StatementSummary,
+    transactions: list[AtomicTransaction],
+) -> dict:
+    """Build an import payload from a parsed brokerage statement."""
+    events = []
+    for txn in transactions:
+        direction = txn.direction.value if hasattr(txn.direction, "value") else txn.direction
+        signed_amount = txn.amount if direction == "IN" else -txn.amount
+        events.append(
+            {
+                "date": txn.txn_date.isoformat(),
+                "description": txn.description,
+                "amount": str(signed_amount),
+                "currency": txn.currency or statement.currency,
+                "raw_text": txn.description,
+            }
+        )
+
+    return {
+        "institution": statement.institution,
+        "statement": {
+            "institution": statement.institution,
+            "period_end": statement.period_end.isoformat() if statement.period_end else None,
+            "currency": statement.currency,
+        },
+        "transactions": events,
+        "events": events,
+    }
+
+
+def _extract_brokerage_payload_from_metadata(metadata: dict | None) -> dict | None:
+    """Return the structured extraction payload stored in Layer 1 metadata."""
+    if not isinstance(metadata, dict):
+        return None
+    for key in ("extraction_payload", "parsed_payload", "payload"):
+        payload = metadata.get(key)
+        if isinstance(payload, dict):
+            return payload
+    return metadata if any(key in metadata for key in ("positions", "holdings", "securities")) else None
+
+
+def _enrich_brokerage_payload_from_statement(payload: dict, statement: StatementSummary) -> dict:
+    """Backfill statement metadata into a recovered extraction payload."""
+    enriched = dict(payload)
+    enriched.setdefault("institution", statement.institution)
+    statement_payload = enriched.get("statement") if isinstance(enriched.get("statement"), dict) else {}
+    statement_payload = dict(statement_payload)
+    statement_payload.setdefault("institution", statement.institution)
+    statement_payload.setdefault("period_end", statement.period_end.isoformat() if statement.period_end else None)
+    statement_payload.setdefault("currency", statement.currency)
+    enriched["statement"] = statement_payload
+    return enriched
+
+
+def _brokerage_payload_from_persisted_extraction(
+    *,
+    statement: StatementSummary,
+    uploaded_document: UploadedDocument | None,
+) -> dict | None:
+    """Load the persisted OCR extraction payload for statement-scoped imports."""
+    payload = _extract_brokerage_payload_from_metadata(statement.extraction_metadata)
+    if payload is not None:
+        return _enrich_brokerage_payload_from_statement(payload, statement)
+
+    if uploaded_document is None:
+        return None
+    payload = _extract_brokerage_payload_from_metadata(uploaded_document.extraction_metadata)
+    if payload is None:
+        return None
+    return _enrich_brokerage_payload_from_statement(payload, statement)
+
+
+def _brokerage_import_not_ready_reason(statement: StatementSummary, transaction_count: int) -> str:
+    """Explain why a brokerage statement cannot be imported yet."""
+    status_value = statement.status.value if hasattr(statement.status, "value") else str(statement.status)
+    validation_error = statement.validation_error
+
+    if status_value == BankStatementStatus.REJECTED.value:
+        return f"Provider parsing failed before brokerage import: {validation_error or 'statement rejected'}"
+    if status_value in {BankStatementStatus.UPLOADED.value, BankStatementStatus.PARSING.value}:
+        return "Provider parsing has not completed; statement must be parsed before brokerage import"
+
+    return f"Statement must be parsed before importing brokerage positions; current status={status_value}"

--- a/apps/backend/src/services/performance_report.py
+++ b/apps/backend/src/services/performance_report.py
@@ -1,0 +1,382 @@
+"""Investment performance report-schedule assembly (EPIC-005).
+
+Builds the report-ready :class:`InvestmentPerformanceReportScheduleResponse` from
+holdings, realized P&L, dividends, allocations, and market-data freshness.
+Extracted from the portfolio router so the router stays a thin HTTP layer; the
+realized-P&L and dividend aggregation now live on ``PortfolioService`` and are
+shared with the portfolio summary endpoint. Raises ``FxRateError`` on conversion
+failure (the router maps it to HTTP 422). Behavior unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import ROUND_HALF_UP, Decimal
+
+from sqlalchemy import select
+
+from src.deps import CurrentUserId, DbSession
+from src.models.layer2 import AtomicPosition
+from src.models.layer3 import ManagedPosition, PositionStatus
+from src.models.market_data import StockPrice
+from src.models.portfolio import MarketDataOverride, PriceSource
+from src.schemas.portfolio import (
+    HoldingResponse,
+    InvestmentPerformanceAllocationRow,
+    InvestmentPerformanceDataFreshness,
+    InvestmentPerformanceHoldingRow,
+    InvestmentPerformanceReportScheduleResponse,
+)
+from src.services import allocation, performance
+from src.services.fx import convert_amount
+from src.services.performance import InsufficientDataError, PerformanceError
+from src.services.portfolio import AssetNotFoundError, PortfolioNotFoundError, portfolio_service
+from src.utils.money import to_money
+
+
+def _money(value: Decimal) -> Decimal:
+    # Canonical money rounding (banker's / HALF_EVEN). See docs/ssot/accounting.md#decimal-rule.
+    return to_money(Decimal(value))
+
+
+def _percent(value: Decimal | None) -> Decimal | None:
+    if value is None:
+        return None
+    return Decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _source_document_links(source_documents: object) -> list[str]:
+    if isinstance(source_documents, list):
+        docs = source_documents
+    elif isinstance(source_documents, dict):
+        docs = source_documents.get("documents") or source_documents.get("source_documents") or [source_documents]
+    else:
+        docs = []
+
+    links: list[str] = []
+    for doc in docs:
+        if isinstance(doc, dict):
+            doc_type = doc.get("doc_type") or doc.get("type") or "source"
+            doc_id = doc.get("doc_id") or doc.get("id") or doc.get("source_id")
+            if doc_id:
+                links.append(f"{doc_type}:{doc_id}")
+    return links
+
+
+def _freshness_link(asset_identifier: str, source_kind: str, source_id: object, evidence_date: date) -> str:
+    return f"price_source:{source_kind}:{asset_identifier}:{source_id}:{evidence_date.isoformat()}"
+
+
+async def _report_preparation_holdings(
+    db: DbSession,
+    user_id: CurrentUserId,
+    as_of_date: date,
+) -> list[HoldingResponse]:
+    """Load current holdings only when post-period manual prices evidence report preparation."""
+    override_result = await db.execute(
+        select(MarketDataOverride)
+        .where(MarketDataOverride.user_id == user_id)
+        .where(MarketDataOverride.source == PriceSource.MANUAL)
+        .where(MarketDataOverride.price_date > as_of_date)
+        .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+    )
+    override_assets = {override.asset_identifier for override in override_result.scalars().all()}
+    if not override_assets:
+        return []
+
+    try:
+        current_holdings = await portfolio_service.get_holdings(
+            db=db,
+            user_id=user_id,
+            include_disposed=True,
+        )
+    except (PortfolioNotFoundError, AssetNotFoundError):
+        return []
+
+    return [
+        holding
+        for holding in current_holdings
+        if holding.asset_identifier in override_assets and holding.status == PositionStatus.ACTIVE
+    ]
+
+
+async def build_investment_performance_report_schedule(
+    db: DbSession,
+    user_id: CurrentUserId,
+    *,
+    period_start: date,
+    period_end: date,
+    as_of_date: date,
+    currency: str,
+) -> InvestmentPerformanceReportScheduleResponse:
+    """Assemble the report-ready investment performance schedule (validated inputs)."""
+    notes: list[str] = [
+        "Cost basis uses the holding-level cost-basis method where available.",
+        (
+            "Market values use the latest available brokerage or market-data snapshot on or before the as-of date; "
+            "report-preparation overrides after the as-of date are disclosed when they evidence active holdings."
+        ),
+    ]
+
+    used_report_preparation_evidence = False
+    try:
+        holdings = list(
+            await portfolio_service.get_holdings(
+                db=db,
+                user_id=user_id,
+                as_of_date=as_of_date,
+                include_disposed=True,
+            )
+        )
+    except (PortfolioNotFoundError, AssetNotFoundError):
+        holdings = []
+
+    if not holdings:
+        holdings = await _report_preparation_holdings(db=db, user_id=user_id, as_of_date=as_of_date)
+        used_report_preparation_evidence = bool(holdings)
+        if used_report_preparation_evidence:
+            notes.append(
+                "No holdings snapshot existed on or before the as-of date; the schedule used active holdings "
+                "with post-period manual market-data overrides as report-preparation evidence."
+            )
+        else:
+            notes.append("No portfolio holdings were available for the requested as-of date.")
+
+    asset_identifiers = [holding.asset_identifier for holding in holdings]
+    position_by_asset: dict[str, ManagedPosition] = {}
+    if asset_identifiers:
+        position_result = await db.execute(
+            select(ManagedPosition)
+            .where(ManagedPosition.user_id == user_id)
+            .where(ManagedPosition.asset_identifier.in_(asset_identifiers))
+        )
+        position_by_asset = {position.asset_identifier: position for position in position_result.scalars().all()}
+
+    async def _schedule_amount(amount: Decimal, source_currency: str, rate_date: date) -> Decimal:
+        return await convert_amount(db, amount, source_currency, currency, rate_date, lazy_load=True)
+
+    async def _metric_or_note(metric_name: str, calculation):
+        try:
+            return await calculation()
+        except InsufficientDataError as exc:
+            notes.append(f"{metric_name} unavailable: {exc}")
+            return None
+        except PerformanceError as exc:
+            notes.append(f"{metric_name} unavailable: {exc}")
+            return None
+
+    xirr = await _metric_or_note(
+        "XIRR", lambda: performance.calculate_xirr(db=db, user_id=user_id, as_of_date=as_of_date)
+    )
+    twr = await _metric_or_note(
+        "TWR",
+        lambda: performance.calculate_time_weighted_return(
+            db=db,
+            user_id=user_id,
+            period_start=period_start,
+            period_end=period_end,
+        ),
+    )
+    mwr = await _metric_or_note(
+        "MWR",
+        lambda: performance.calculate_money_weighted_return(db=db, user_id=user_id, as_of_date=as_of_date),
+    )
+    dividend_yield = await _metric_or_note(
+        "Dividend yield",
+        lambda: performance.calculate_dividend_yield(db=db, user_id=user_id, as_of_date=as_of_date),
+    )
+
+    realized_by_asset, realized_source_refs = await portfolio_service.get_realized_pnl_by_asset(
+        db, user_id, start_date=period_start, end_date=period_end, target_currency=currency
+    )
+    source_links: set[str] = {"report_section:investment_performance"}
+    source_links.update(realized_source_refs)
+
+    dividend_by_asset = await portfolio_service.get_dividend_income_by_asset(
+        db, user_id, start_date=period_start, end_date=period_end, target_currency=currency
+    )
+
+    holding_rows: list[InvestmentPerformanceHoldingRow] = []
+    for holding in holdings:
+        position = position_by_asset.get(holding.asset_identifier)
+        if position is None:
+            cost_basis = _money(await _schedule_amount(holding.cost_basis, holding.currency, holding.acquisition_date))
+        else:
+            cost_basis = _money(
+                await _schedule_amount(position.cost_basis, position.currency, position.acquisition_date)
+            )
+        market_value = _money(holding.market_value)
+        holding_rows.append(
+            InvestmentPerformanceHoldingRow(
+                asset_identifier=holding.asset_identifier,
+                quantity=holding.quantity,
+                cost_basis=cost_basis,
+                market_value=market_value,
+                unrealized_pnl=_money(market_value - cost_basis),
+                realized_pnl=_money(realized_by_asset.get(holding.asset_identifier, Decimal("0.00"))),
+                dividend_income=_money(dividend_by_asset.get(holding.asset_identifier, Decimal("0.00"))),
+                currency=holding.currency,
+            )
+        )
+
+    allocation_rows: list[InvestmentPerformanceAllocationRow] = []
+    for dimension, loader in [
+        ("sector", allocation.get_sector_allocation),
+        ("geography", allocation.get_geography_allocation),
+        ("asset_class", allocation.get_asset_class_allocation),
+    ]:
+        for row in await loader(db=db, user_id=user_id, as_of_date=as_of_date):
+            allocation_rows.append(
+                InvestmentPerformanceAllocationRow(
+                    dimension=dimension,
+                    category=row.category,
+                    value=_money(row.value),
+                    percentage=_money(row.percentage),
+                    count=row.count,
+                )
+            )
+    if used_report_preparation_evidence and not allocation_rows and holding_rows:
+        total_market_value = sum((row.market_value for row in holding_rows), Decimal("0.00"))
+        for dimension, attribute, fallback_category in [
+            ("sector", "sector", "Unclassified"),
+            ("geography", "geography", "Unclassified"),
+            ("asset_class", "asset_type", "Unclassified"),
+        ]:
+            grouped: dict[str, tuple[Decimal, int]] = {}
+            for holding, row in zip(holdings, holding_rows, strict=True):
+                category = getattr(holding, attribute) or fallback_category
+                current_value, current_count = grouped.get(category, (Decimal("0.00"), 0))
+                grouped[category] = (current_value + row.market_value, current_count + 1)
+            for category, (value, count) in grouped.items():
+                percentage = Decimal("0.00")
+                if total_market_value:
+                    percentage = (value / total_market_value * Decimal("100")).quantize(
+                        Decimal("0.01"), rounding=ROUND_HALF_UP
+                    )
+                allocation_rows.append(
+                    InvestmentPerformanceAllocationRow(
+                        dimension=dimension,
+                        category=category,
+                        value=_money(value),
+                        percentage=percentage,
+                        count=count,
+                    )
+                )
+        notes.append("Allocation rows use report-preparation holdings when as-of allocation snapshots are unavailable.")
+
+    latest_atomic_query = select(AtomicPosition).where(AtomicPosition.user_id == user_id)
+    if used_report_preparation_evidence and asset_identifiers:
+        latest_atomic_query = latest_atomic_query.where(AtomicPosition.asset_identifier.in_(asset_identifiers))
+    else:
+        latest_atomic_query = latest_atomic_query.where(AtomicPosition.snapshot_date <= as_of_date)
+    latest_atomic_result = await db.execute(
+        latest_atomic_query.order_by(AtomicPosition.snapshot_date.desc(), AtomicPosition.created_at.desc())
+    )
+    atomics = list(latest_atomic_result.scalars().all())
+    latest_atomic_by_asset: dict[str, AtomicPosition] = {}
+    for atomic in atomics:
+        latest_atomic_by_asset.setdefault(atomic.asset_identifier, atomic)
+        for link in _source_document_links(atomic.source_documents):
+            source_links.add(link)
+
+    latest_override_query = (
+        select(MarketDataOverride)
+        .where(MarketDataOverride.user_id == user_id)
+        .where(MarketDataOverride.price_date <= as_of_date)
+    )
+    latest_override_result = await db.execute(
+        latest_override_query.order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+    )
+    overrides = list(latest_override_result.scalars().all())
+    if asset_identifiers:
+        report_preparation_override_result = await db.execute(
+            select(MarketDataOverride)
+            .where(MarketDataOverride.user_id == user_id)
+            .where(MarketDataOverride.asset_identifier.in_(asset_identifiers))
+            .where(MarketDataOverride.source == PriceSource.MANUAL)
+            .where(MarketDataOverride.price_date > as_of_date)
+            .order_by(MarketDataOverride.price_date.desc(), MarketDataOverride.created_at.desc())
+        )
+        overrides.extend(report_preparation_override_result.scalars().all())
+        overrides.sort(key=lambda override: override.price_date, reverse=True)
+    latest_override = overrides[0] if overrides else None
+    latest_override_by_asset: dict[str, MarketDataOverride] = {}
+    for override in overrides:
+        latest_override_by_asset.setdefault(override.asset_identifier, override)
+
+    stock_prices: list[StockPrice] = []
+    if asset_identifiers:
+        stock_price_result = await db.execute(
+            select(StockPrice)
+            .where(StockPrice.symbol.in_(asset_identifiers))
+            .where(StockPrice.price_date <= as_of_date)
+            .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc(), StockPrice.source.asc())
+        )
+        stock_prices = list(stock_price_result.scalars().all())
+    latest_stock_price_by_asset: dict[str, StockPrice] = {}
+    for stock_price in stock_prices:
+        latest_stock_price_by_asset.setdefault(stock_price.symbol, stock_price)
+
+    price_dates: list[date] = []
+    providers: set[str] = set()
+    stale_holdings: list[str] = []
+    for asset_identifier in asset_identifiers:
+        override = latest_override_by_asset.get(asset_identifier)
+        stock_price = latest_stock_price_by_asset.get(asset_identifier)
+        atomic = latest_atomic_by_asset.get(asset_identifier)
+
+        candidates: list[tuple[date, str, object, str | None]] = []
+        if override is not None:
+            candidates.append((override.price_date, "market_data_override", override.id, override.source.value))
+        if stock_price is not None:
+            candidates.append((stock_price.price_date, "stock_price", stock_price.id, stock_price.source))
+        if atomic is not None:
+            candidates.append((atomic.snapshot_date, "atomic_position", atomic.id, atomic.broker))
+
+        if not candidates:
+            stale_holdings.append(asset_identifier)
+            continue
+
+        evidence_date, source_kind, source_id, provider = max(candidates, key=lambda candidate: candidate[0])
+        price_dates.append(evidence_date)
+        source_links.add(_freshness_link(asset_identifier, source_kind, source_id, evidence_date))
+        if provider:
+            providers.add(provider)
+        if evidence_date < as_of_date:
+            stale_holdings.append(asset_identifier)
+
+    latest_price_date = max(price_dates) if price_dates else None
+    market_data_provider = ", ".join(sorted(providers)) if providers else None
+
+    data_freshness = InvestmentPerformanceDataFreshness(
+        latest_price_date=latest_price_date,
+        market_data_provider=market_data_provider,
+        stale=bool(stale_holdings),
+        stale_holdings=sorted(stale_holdings),
+        manual_override_basis=(
+            f"{latest_override.asset_identifier}:{latest_override.price_date.isoformat()}"
+            if latest_override is not None
+            else None
+        ),
+    )
+    if data_freshness.stale:
+        notes.append("One or more market values use stale data relative to the requested as-of date.")
+
+    return InvestmentPerformanceReportScheduleResponse(
+        period_start=period_start,
+        period_end=period_end,
+        as_of_date=as_of_date,
+        currency=currency,
+        xirr=_percent(xirr),
+        time_weighted_return=_percent(twr),
+        money_weighted_return=_percent(mwr),
+        realized_pnl=_money(sum(realized_by_asset.values(), Decimal("0.00"))),
+        unrealized_pnl=_money(sum((row.unrealized_pnl for row in holding_rows), Decimal("0.00"))),
+        dividend_income=_money(sum(dividend_by_asset.values(), Decimal("0.00"))),
+        dividend_yield=_percent(dividend_yield),
+        holdings=holding_rows,
+        allocation=allocation_rows,
+        data_freshness=data_freshness,
+        source_links=sorted(source_links),
+        notes=notes,
+    )

--- a/apps/backend/src/services/portfolio.py
+++ b/apps/backend/src/services/portfolio.py
@@ -14,7 +14,13 @@ from src.logger import get_logger
 from src.models import StockPrice
 from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition, PositionStatus
-from src.models.portfolio import MarketDataOverride, PriceSource
+from src.models.portfolio import (
+    DividendIncome,
+    InvestmentTransaction,
+    InvestmentTransactionType,
+    MarketDataOverride,
+    PriceSource,
+)
 from src.schemas.portfolio import (
     HoldingResponse,
     PortfolioSummaryResponse,
@@ -873,3 +879,85 @@ class PortfolioService:
         )
         result = await db.execute(query)
         return result.scalar_one_or_none()
+
+    async def get_realized_pnl_by_asset(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        *,
+        start_date: date,
+        end_date: date,
+        target_currency: str,
+    ) -> tuple[dict[str, Decimal], set[str]]:
+        """Per-asset realized P&L from SELL transactions in ``[start_date, end_date]``.
+
+        Each transaction's realized P&L is converted to ``target_currency`` at the
+        transaction date. Returns ``(by_asset, source_refs)`` where ``source_refs``
+        carries journal-entry / transaction-source links for traceability. Raises
+        ``fx.FxRateError`` when a required rate is unavailable.
+        """
+        result = await db.execute(
+            select(InvestmentTransaction)
+            .where(InvestmentTransaction.user_id == user_id)
+            .where(InvestmentTransaction.transaction_type == InvestmentTransactionType.SELL)
+            .where(InvestmentTransaction.transaction_date >= start_date)
+            .where(InvestmentTransaction.transaction_date <= end_date)
+        )
+        by_asset: dict[str, Decimal] = {}
+        source_refs: set[str] = set()
+        for txn in result.scalars().all():
+            amount = await fx.convert_amount(
+                db,
+                txn.realized_pnl or Decimal("0.00"),
+                txn.currency,
+                target_currency,
+                txn.transaction_date,
+                lazy_load=True,
+            )
+            by_asset[txn.asset_identifier] = by_asset.get(txn.asset_identifier, Decimal("0.00")) + amount
+            if txn.journal_entry_id:
+                source_refs.add(f"journal_entry:{txn.journal_entry_id}")
+            if txn.source_id:
+                source_refs.add(f"investment_transaction_source:{txn.source_id}")
+        return by_asset, source_refs
+
+    async def get_dividend_income_by_asset(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        *,
+        start_date: date,
+        end_date: date,
+        target_currency: str,
+    ) -> dict[str, Decimal]:
+        """Per-asset dividend income in ``[start_date, end_date]``.
+
+        Each dividend is converted to ``target_currency`` at the payment date and
+        grouped by the owning position's asset identifier. Raises ``fx.FxRateError``
+        when a required rate is unavailable.
+        """
+        result = await db.execute(
+            select(DividendIncome, ManagedPosition)
+            .join(ManagedPosition, DividendIncome.position_id == ManagedPosition.id)
+            .where(DividendIncome.user_id == user_id)
+            .where(ManagedPosition.user_id == user_id)
+            .where(DividendIncome.payment_date >= start_date)
+            .where(DividendIncome.payment_date <= end_date)
+        )
+        by_asset: dict[str, Decimal] = {}
+        for dividend, position in result.all():
+            amount = await fx.convert_amount(
+                db,
+                dividend.amount,
+                dividend.currency,
+                target_currency,
+                dividend.payment_date,
+                lazy_load=True,
+            )
+            by_asset[position.asset_identifier] = by_asset.get(position.asset_identifier, Decimal("0.00")) + amount
+        return by_asset
+
+
+# Shared singleton instance reused by the portfolio router and the
+# performance-report service so monkeypatching one reference affects both.
+portfolio_service = PortfolioService()

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -1862,6 +1862,54 @@ async def get_category_breakdown(
     }
 
 
+def _cash_flow_agg_stmt(user_id: UUID, *date_conditions):
+    """Per-(account, currency, direction) journal-line sums for the cash-flow
+    statement: report-eligible entries scoped by the given date conditions."""
+    stmt = (
+        select(
+            Account.id.label("account_id"),
+            JournalLine.currency,
+            JournalLine.direction,
+            func.sum(JournalLine.amount).label("total"),
+        )
+        .join(Account, JournalLine.account_id == Account.id)
+        .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
+        .where(Account.user_id == user_id)
+        .where(JournalEntry.status.in_(_REPORT_STATUSES))
+        .group_by(Account.id, JournalLine.currency, JournalLine.direction)
+    )
+    for condition in date_conditions:
+        stmt = stmt.where(condition)
+    return stmt
+
+
+def _accumulate_period_balances(
+    rows,
+    account_id_to_account: dict[UUID, Account],
+    fx_rates: PrefetchedFxRates,
+    *,
+    target_currency: str,
+    rate_date: date,
+) -> dict[UUID, Decimal]:
+    """Convert each aggregated row to ``target_currency`` at ``rate_date`` and
+    accumulate signed balances per account. Raises ReportError on a missing rate."""
+    balances: dict[UUID, Decimal] = {}
+    for row in rows:
+        rate = fx_rates.get_rate(row.currency, target_currency, rate_date)
+        if rate is None:
+            if row.currency.upper() == target_currency:
+                rate = Decimal("1")
+            else:
+                raise ReportError(f"No FX rate available for {row.currency}/{target_currency} on {rate_date}")
+        converted = Decimal(str(row.total)) * rate
+        account = account_id_to_account.get(row.account_id)
+        if account:
+            balances[row.account_id] = balances.get(row.account_id, Decimal("0")) + _signed_amount(
+                account.type, row.direction, converted
+            )
+    return balances
+
+
 async def generate_cash_flow(
     db: AsyncSession,
     user_id: UUID,
@@ -1888,68 +1936,21 @@ async def generate_cash_flow(
 
     account_id_to_account = {a.id: a for a in all_accounts}
 
-    agg_stmt_before = (
-        select(
-            Account.id.label("account_id"),
-            JournalLine.currency,
-            JournalLine.direction,
-            func.sum(JournalLine.amount).label("total"),
+    rows_before = (await db.execute(_cash_flow_agg_stmt(user_id, JournalEntry.entry_date < start_date))).all()
+    rows_during = (
+        await db.execute(
+            _cash_flow_agg_stmt(user_id, JournalEntry.entry_date >= start_date, JournalEntry.entry_date <= end_date)
         )
-        .join(Account, JournalLine.account_id == Account.id)
-        .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
-        .where(Account.user_id == user_id)
-        .where(JournalEntry.status.in_(_REPORT_STATUSES))
-        .where(JournalEntry.entry_date < start_date)
-        .group_by(Account.id, JournalLine.currency, JournalLine.direction)
-    )
-    result_before = await db.execute(agg_stmt_before)
-    rows_before = result_before.all()
-
-    agg_stmt_during = (
-        select(
-            Account.id.label("account_id"),
-            JournalLine.currency,
-            JournalLine.direction,
-            func.sum(JournalLine.amount).label("total"),
-        )
-        .join(Account, JournalLine.account_id == Account.id)
-        .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
-        .where(Account.user_id == user_id)
-        .where(JournalEntry.status.in_(_REPORT_STATUSES))
-        .where(JournalEntry.entry_date >= start_date)
-        .where(JournalEntry.entry_date <= end_date)
-        .group_by(Account.id, JournalLine.currency, JournalLine.direction)
-    )
-    result_during = await db.execute(agg_stmt_during)
-    rows_during = result_during.all()
-
-    agg_stmt_ending = (
-        select(
-            Account.id.label("account_id"),
-            JournalLine.currency,
-            JournalLine.direction,
-            func.sum(JournalLine.amount).label("total"),
-        )
-        .join(Account, JournalLine.account_id == Account.id)
-        .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
-        .where(Account.user_id == user_id)
-        .where(JournalEntry.status.in_(_REPORT_STATUSES))
-        .where(JournalEntry.entry_date <= end_date)
-        .group_by(Account.id, JournalLine.currency, JournalLine.direction)
-    )
-    result_ending = await db.execute(agg_stmt_ending)
-    rows_ending = result_ending.all()
+    ).all()
+    rows_ending = (await db.execute(_cash_flow_agg_stmt(user_id, JournalEntry.entry_date <= end_date))).all()
 
     fx_needs: list[tuple[str, str, date, date | None, date | None]] = []
-    for row in rows_before:
-        if row.currency.upper() != target_currency:
-            fx_needs.append((row.currency, target_currency, start_date, None, None))
-    for row in rows_during:
-        if row.currency.upper() != target_currency:
-            fx_needs.append((row.currency, target_currency, end_date, None, None))
-    for row in rows_ending:
-        if row.currency.upper() != target_currency:
-            fx_needs.append((row.currency, target_currency, end_date, None, None))
+    for rows, rate_date in ((rows_before, start_date), (rows_during, end_date), (rows_ending, end_date)):
+        fx_needs.extend(
+            (row.currency, target_currency, rate_date, None, None)
+            for row in rows
+            if row.currency.upper() != target_currency
+        )
 
     fx_rates = PrefetchedFxRates(lazy_load=True)
     if fx_needs:
@@ -1963,53 +1964,15 @@ async def generate_cash_flow(
             )
             raise ReportError(str(exc)) from exc
 
-    balances_before: dict[UUID, Decimal] = {}
-    for row in rows_before:
-        rate = fx_rates.get_rate(row.currency, target_currency, start_date)
-        if rate is None:
-            if row.currency.upper() == target_currency:
-                rate = Decimal("1")
-            else:
-                raise ReportError(f"No FX rate available for {row.currency}/{target_currency} on {start_date}")
-
-        converted = Decimal(str(row.total)) * rate
-        account = account_id_to_account.get(row.account_id)
-        if account:
-            if row.account_id not in balances_before:
-                balances_before[row.account_id] = Decimal("0")
-            balances_before[row.account_id] += _signed_amount(account.type, row.direction, converted)
-
-    activity_movements: dict[UUID, Decimal] = {}
-    for row in rows_during:
-        rate = fx_rates.get_rate(row.currency, target_currency, end_date)
-        if rate is None:
-            if row.currency.upper() == target_currency:
-                rate = Decimal("1")
-            else:
-                raise ReportError(f"No FX rate available for {row.currency}/{target_currency} on {end_date}")
-
-        converted = Decimal(str(row.total)) * rate
-        account = account_id_to_account.get(row.account_id)
-        if account:
-            if row.account_id not in activity_movements:
-                activity_movements[row.account_id] = Decimal("0")
-            activity_movements[row.account_id] += _signed_amount(account.type, row.direction, converted)
-
-    balances_ending: dict[UUID, Decimal] = {}
-    for row in rows_ending:
-        rate = fx_rates.get_rate(row.currency, target_currency, end_date)
-        if rate is None:
-            if row.currency.upper() == target_currency:
-                rate = Decimal("1")
-            else:
-                raise ReportError(f"No FX rate available for {row.currency}/{target_currency} on {end_date}")
-
-        converted = Decimal(str(row.total)) * rate
-        account = account_id_to_account.get(row.account_id)
-        if account:
-            if row.account_id not in balances_ending:
-                balances_ending[row.account_id] = Decimal("0")
-            balances_ending[row.account_id] += _signed_amount(account.type, row.direction, converted)
+    balances_before = _accumulate_period_balances(
+        rows_before, account_id_to_account, fx_rates, target_currency=target_currency, rate_date=start_date
+    )
+    activity_movements = _accumulate_period_balances(
+        rows_during, account_id_to_account, fx_rates, target_currency=target_currency, rate_date=end_date
+    )
+    balances_ending = _accumulate_period_balances(
+        rows_ending, account_id_to_account, fx_rates, target_currency=target_currency, rate_date=end_date
+    )
 
     beginning_cash = Decimal("0")
     ending_cash = Decimal("0")

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -15,7 +15,6 @@ from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AssetType, AtomicPosition, AtomicTransaction, TransactionDirection
 from src.models.layer3 import ManagedPosition
 from src.models.statement_summary import StatementSummary
-from src.routers.statements import _brokerage_payload_from_statement
 from src.schemas.portfolio import BrokerageImportRequest, BrokerageImportResponse
 from src.services.brokerage_positions import (
     BrokeragePositionImportService,
@@ -27,6 +26,7 @@ from src.services.brokerage_positions import (
     detect_broker,
     parse_brokerage_positions,
 )
+from src.services.brokerage_statement_payload import _brokerage_payload_from_statement
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 

--- a/apps/backend/tests/portfolio/test_financial_logic_audit.py
+++ b/apps/backend/tests/portfolio/test_financial_logic_audit.py
@@ -10,7 +10,7 @@ from src.models import Account, AccountType, FxRate
 from src.models.layer2 import AtomicPosition, AtomicTransaction, TransactionDirection
 from src.models.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
 from src.models.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType
-from src.routers.portfolio import _source_document_links
+from src.services.performance_report import _source_document_links
 from src.services.performance import calculate_money_weighted_return, calculate_time_weighted_return, calculate_xirr
 
 

--- a/apps/backend/tests/portfolio/test_financial_logic_audit.py
+++ b/apps/backend/tests/portfolio/test_financial_logic_audit.py
@@ -10,8 +10,8 @@ from src.models import Account, AccountType, FxRate
 from src.models.layer2 import AtomicPosition, AtomicTransaction, TransactionDirection
 from src.models.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
 from src.models.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType
-from src.services.performance_report import _source_document_links
 from src.services.performance import calculate_money_weighted_return, calculate_time_weighted_return, calculate_xirr
+from src.services.performance_report import _source_document_links
 
 
 async def _investment_position(db: AsyncSession, test_user, *, asset_identifier: str = "AUDIT") -> ManagedPosition:

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -15,6 +15,6 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:142 |
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:475 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:755 |
-| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:536 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:764 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:540 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:678 |
 | `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:102 |

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -2624,6 +2624,7 @@ def test_AC8_13_10_multi_brokerage_upload_to_portfolio_value_gate() -> None:
     workflow = read(".github/workflows/staging-deploy.yml")
     brokerage = read("tests/e2e/test_brokerage_upload_to_portfolio_value.py")
     statements_router = read("apps/backend/src/routers/statements.py")
+    brokerage_payload = read("apps/backend/src/services/brokerage_statement_payload.py")
     generator = read("tools/_lib/pdf_fixtures/generate_pdf_fixtures.py")
 
     assert "tools/staging_ai_ocr_gate_contract.py --shell" in workflow
@@ -2648,7 +2649,7 @@ def test_AC8_13_10_multi_brokerage_upload_to_portfolio_value_gate() -> None:
     assert "BrokeragePositionImportService" in statements_router
     assert (
         "Statement must be parsed before importing brokerage positions"
-        in statements_router
+        in brokerage_payload
     )
     assert '"futu"' in generator
 


### PR DESCRIPTION
Three targeted refactors from the arch+DRY audit — one commit each.

## 1. `routers/portfolio.py` (934 → 528) — DRY **and** layering
- **DRY**: realized-P&L and dividend aggregation ("filter SELL txns / dividends in a period, FX-convert, accumulate") was copy-pasted in `get_portfolio_summary` and the report-schedule handler. Extracted `PortfolioService.get_realized_pnl_by_asset` / `get_dividend_income_by_asset` (raising `FxRateError`; the router maps to 422). Both endpoints share them now — duplication and drift gone.
- **Layering**: `get_investment_performance_report_schedule` was a 341-line handler (36% of the router) inlining holdings/allocation/freshness/aggregation logic. Moved to `services/performance_report.build_investment_performance_report_schedule`; the route is now thin validation + delegation. A shared `portfolio_service` singleton lets monkeypatching one reference affect both modules.

## 2. `services/reporting.py` (2093 → 2056) — DRY
`generate_cash_flow` built three near-identical aggregation queries (before/during/ending — only the date predicate differs) and three identical convert-and-accumulate loops. Extracted `_cash_flow_agg_stmt` + `_accumulate_period_balances` and folded the FX-needs collection into one loop.

## 3. `routers/statements.py` (947 → 863) — layering
Moved the five brokerage import-payload helpers (build/recover payload from statement + transactions + persisted OCR metadata, plus the not-ready-reason) to `services/brokerage_statement_payload.py`.

## Honest scoping
- The `upload_statement` handler (191 lines, mixes validation/storage/DB/pipeline) is **intentionally deferred** to its own PR — extracting it touches storage side-effects, commits, and the parse pipeline, which is too risky to bundle with two other refactors.
- These are structural/DRY fixes: total LOC is roughly flat (the genuine duplication removed is ~real but small, ~70 lines; the rest is relocation). The win is layering + eliminating the P&L/dividend drift.

## Verification
- ruff `check src tests` + `format --check` clean; router-contract-maturity.md regenerated (statements line shift).
- **644 tests** green across portfolio / reporting / api / statements-supervisor; routes keep paths/signatures (reports.py snapshot path still calls the thin report-schedule route).
- Tests importing moved helpers repointed to their new modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)