### PR TITLE
[finance_report_audit] fix(statements): resolve balance-mismatch lifecycle dead-end + sync CSV intake (#1141)

### DIFF
--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -253,9 +253,10 @@ async def upload_statement(
     omitted model uses the OCR-first default pipeline.
 
     Institution is optional for PDF/image uploads (AI auto-detects it from the
-    document). It is **required** for CSV uploads — CSVs have no detectable header,
-    so a missing institution is rejected synchronously with HTTP 400 rather than
-    accepted and rejected asynchronously by the parse worker (#1141 / #1087).
+    document). It is **required** for CSV uploads — the institution cannot be
+    auto-detected from CSV content, so a missing institution is rejected
+    synchronously with HTTP 400 rather than accepted and rejected asynchronously
+    by the parse worker (#1141 / #1087).
     """
     filename = Path(file.filename or "unknown").name or "unknown"
     extension = filename.rsplit(".", 1)[-1].lower() if "." in filename else "pdf"
@@ -278,7 +279,11 @@ async def upload_statement(
     # fail later inside the async parse worker ("Institution is required for CSV
     # parsing"), leaving an orphaned PARSING record. Reject it synchronously here
     # with an actionable 400 instead of accepting (202) then rejecting async.
-    if extension == "csv" and not (institution and institution.strip()):
+    # Normalize the institution up front: persist/pass the STRIPPED value so that
+    # leading/trailing whitespace can't break CSV institution routing downstream
+    # in ``ExtractionService._parse_csv_content()`` (#1141 / #1087).
+    institution = institution.strip() if institution else None
+    if extension == "csv" and not institution:
         raise_bad_request("Institution is required for CSV uploads. Please select an institution and retry.")
 
     if account_id is not None:

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -247,7 +247,11 @@ async def upload_statement(
 
     Supported file types: PDF, CSV, PNG, JPG. Model is optional for PDF/image uploads;
     omitted model uses the OCR-first default pipeline.
-    Institution is optional - AI will auto-detect from document if not provided.
+
+    Institution is optional for PDF/image uploads (AI auto-detects it from the
+    document). It is **required** for CSV uploads — CSVs have no detectable header,
+    so a missing institution is rejected synchronously with HTTP 400 rather than
+    accepted and rejected asynchronously by the parse worker (#1141 / #1087).
     """
     filename = Path(file.filename or "unknown").name or "unknown"
     extension = filename.rsplit(".", 1)[-1].lower() if "." in filename else "pdf"
@@ -264,6 +268,14 @@ async def upload_statement(
 
     if extension not in ("pdf", "csv", "png", "jpg", "jpeg"):
         raise_bad_request(f"Unsupported file type: {extension}")
+
+    # AC13.18.6 (#1141 / #1087): CSV parsing cannot auto-detect the institution the
+    # way PDF/image vision extraction can, so a CSV without an institution can only
+    # fail later inside the async parse worker ("Institution is required for CSV
+    # parsing"), leaving an orphaned PARSING record. Reject it synchronously here
+    # with an actionable 400 instead of accepting (202) then rejecting async.
+    if extension == "csv" and not (institution and institution.strip()):
+        raise_bad_request("Institution is required for CSV uploads. Please select an institution and retry.")
 
     if account_id is not None:
         account_result = await db.execute(

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -566,9 +566,12 @@ class ExtractionService:
                 # Routing differs by document class on purpose (#981): brokerage payloads
                 # reconcile via Layer-2 AtomicPosition snapshots, not a running-balance chain, so
                 # `balance_valid` is not their gating signal — they always go to `parsed`/review.
-                # Bank statements route by `route_by_threshold`, where an invalid balance chain
-                # sends them to `uploaded` (manual entry). Same "balance invalid" input, different
-                # destination by design.
+                # Bank statements route by `route_by_threshold`. As of #1141 an invalid balance
+                # chain also sends a bank statement to `parsed` (review with a validation_error),
+                # not `uploaded`: a parsed-but-unreconciled statement is reviewable, not a manual-
+                # entry dead-end. `uploaded` is now reserved for genuinely low-signal valid-balance
+                # parses (score < 60). Both classes therefore converge on `parsed`/review for the
+                # "balance invalid" outcome.
                 status = (
                     BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(confidence, is_valid)
                 )

--- a/apps/backend/src/services/validation.py
+++ b/apps/backend/src/services/validation.py
@@ -247,9 +247,25 @@ def _score_currency_consistency(transactions: list[dict[str, Any]], header_curre
 
 
 def route_by_threshold(score: int, balance_valid: bool) -> BankStatementStatus:
-    """Route statement by confidence threshold and validation result."""
+    """Route a parsed bank statement by confidence threshold and balance validity.
+
+    Resting states (#1141):
+
+    - **Balance invalid** -> ``PARSED`` (review) regardless of score. The statement
+      parsed but its running balance does not reconcile; it must enter review
+      carrying a ``validation_error`` — the same reviewable resting state as a
+      brokerage statement. It is never parked in ``uploaded``, which was a
+      dead-end the retry endpoint rejected and report readiness ignored (#1085).
+      It also never auto-approves: an unreconciled balance must be human-reviewed.
+    - **Balance valid, score >= 85** -> ``APPROVED`` (auto-accept).
+    - **Balance valid, score >= 60** -> ``PARSED`` (review).
+    - **Balance valid, score < 60** -> ``UPLOADED``: a genuinely low-signal parse
+      where there is not enough extracted structure to review meaningfully, so the
+      user is routed to manual entry. (Distinct from the balance-invalid case,
+      where there *is* a reviewable parse that merely fails reconciliation.)
+    """
     if not balance_valid:
-        return BankStatementStatus.UPLOADED
+        return BankStatementStatus.PARSED
     if score >= 85:
         return BankStatementStatus.APPROVED
     if score >= 60:

--- a/apps/backend/tests/accounting/test_validation.py
+++ b/apps/backend/tests/accounting/test_validation.py
@@ -60,7 +60,48 @@ def test_route_by_threshold():
     assert route_by_threshold(90, True) == BankStatementStatus.APPROVED
     assert route_by_threshold(70, True) == BankStatementStatus.PARSED
     assert route_by_threshold(50, True) == BankStatementStatus.UPLOADED
-    assert route_by_threshold(90, False) == BankStatementStatus.UPLOADED
+    # AC13.18.1 (#1141): a balance-invalid bank statement no longer dead-ends in
+    # `uploaded`; it enters review (`PARSED`), matching the brokerage path.
+    assert route_by_threshold(90, False) == BankStatementStatus.PARSED
+
+
+def test_AC13_18_1_balance_invalid_routes_to_parsed_review():
+    """AC13.18.1 (#1141): balance-invalid bank statements route to PARSED (review).
+
+    A parsed-but-unvalidated bank statement must never be parked in `uploaded`
+    (the retry-rejected, readiness-invisible dead-end). It must enter the same
+    reviewable resting state as a brokerage statement, regardless of score.
+    """
+    for score in (0, 50, 59, 60, 84, 85, 95, 100):
+        assert route_by_threshold(score, balance_valid=False) == BankStatementStatus.PARSED, (
+            f"balance-invalid score={score} must route to PARSED, never UPLOADED"
+        )
+    # Valid-balance routing semantics are preserved (low signal -> manual entry).
+    assert route_by_threshold(50, balance_valid=True) == BankStatementStatus.UPLOADED
+
+
+def test_AC13_18_4_readiness_counts_parsed_balance_invalid():
+    """AC13.18.4 (#1141): the balance-invalid resting state is readiness-visible.
+
+    A balance-invalid bank statement rests in `PARSED`; report readiness counts
+    `PARSED` + `APPROVED` summaries, so the statement is now an available report
+    input instead of an invisible `uploaded` orphan. This pins the resting status
+    against the set readiness actually counts.
+    """
+    import inspect
+
+    from src.services import report_readiness
+
+    resting_status = route_by_threshold(95, balance_valid=False)
+    assert resting_status == BankStatementStatus.PARSED
+
+    # The readiness query filters statements by status; PARSED + APPROVED are the
+    # counted (confirmed) classes. Assert the resting status is among them.
+    source = inspect.getsource(report_readiness.get_personal_report_package_readiness)
+    assert "BankStatementStatus.PARSED" in source
+    assert "BankStatementStatus.APPROVED" in source
+    counted = {BankStatementStatus.PARSED, BankStatementStatus.APPROVED}
+    assert resting_status in counted
 
 
 def test_validate_balance_tolerance():

--- a/apps/backend/tests/accounting/test_validation.py
+++ b/apps/backend/tests/accounting/test_validation.py
@@ -60,13 +60,13 @@ def test_route_by_threshold():
     assert route_by_threshold(90, True) == BankStatementStatus.APPROVED
     assert route_by_threshold(70, True) == BankStatementStatus.PARSED
     assert route_by_threshold(50, True) == BankStatementStatus.UPLOADED
-    # AC13.18.1 (#1141): a balance-invalid bank statement no longer dead-ends in
+    # AC13.21.1 (#1141): a balance-invalid bank statement no longer dead-ends in
     # `uploaded`; it enters review (`PARSED`), matching the brokerage path.
     assert route_by_threshold(90, False) == BankStatementStatus.PARSED
 
 
-def test_AC13_18_1_balance_invalid_routes_to_parsed_review():
-    """AC13.18.1 (#1141): balance-invalid bank statements route to PARSED (review).
+def test_AC13_21_1_balance_invalid_routes_to_parsed_review():
+    """AC13.21.1 (#1141): balance-invalid bank statements route to PARSED (review).
 
     A parsed-but-unvalidated bank statement must never be parked in `uploaded`
     (the retry-rejected, readiness-invisible dead-end). It must enter the same
@@ -80,8 +80,8 @@ def test_AC13_18_1_balance_invalid_routes_to_parsed_review():
     assert route_by_threshold(50, balance_valid=True) == BankStatementStatus.UPLOADED
 
 
-def test_AC13_18_4_readiness_counts_parsed_balance_invalid():
-    """AC13.18.4 (#1141): the balance-invalid resting state is readiness-visible.
+def test_AC13_21_4_readiness_counts_parsed_balance_invalid():
+    """AC13.21.4 (#1141): the balance-invalid resting state is readiness-visible.
 
     A balance-invalid bank statement rests in `PARSED`; report readiness counts
     `PARSED` + `APPROVED` summaries, so the statement is now an available report

--- a/apps/backend/tests/accounting/test_validation.py
+++ b/apps/backend/tests/accounting/test_validation.py
@@ -80,28 +80,42 @@ def test_AC13_21_1_balance_invalid_routes_to_parsed_review():
     assert route_by_threshold(50, balance_valid=True) == BankStatementStatus.UPLOADED
 
 
-def test_AC13_21_4_readiness_counts_parsed_balance_invalid():
+async def test_AC13_21_4_readiness_counts_parsed_balance_invalid(db, test_user):
     """AC13.21.4 (#1141): the balance-invalid resting state is readiness-visible.
 
-    A balance-invalid bank statement rests in `PARSED`; report readiness counts
-    `PARSED` + `APPROVED` summaries, so the statement is now an available report
-    input instead of an invisible `uploaded` orphan. This pins the resting status
-    against the set readiness actually counts.
+    A balance-invalid bank statement rests in `PARSED` (see routing below); report
+    readiness counts `PARSED` + `APPROVED` summaries, so the statement is an
+    available report input instead of an invisible `uploaded` orphan. This drives
+    the real readiness query against a seeded DB row rather than inspecting source
+    text, so a regression in the status filter would actually fail the test.
     """
-    import inspect
+    from src.models import StatementSummary
+    from src.services.report_readiness import get_personal_report_package_readiness
 
-    from src.services import report_readiness
-
+    # The balance-invalid bank statement rests in PARSED, not UPLOADED.
     resting_status = route_by_threshold(95, balance_valid=False)
     assert resting_status == BankStatementStatus.PARSED
 
-    # The readiness query filters statements by status; PARSED + APPROVED are the
-    # counted (confirmed) classes. Assert the resting status is among them.
-    source = inspect.getsource(report_readiness.get_personal_report_package_readiness)
-    assert "BankStatementStatus.PARSED" in source
-    assert "BankStatementStatus.APPROVED" in source
-    counted = {BankStatementStatus.PARSED, BankStatementStatus.APPROVED}
-    assert resting_status in counted
+    # Baseline: no statements seeded -> readiness counts zero.
+    baseline = await get_personal_report_package_readiness(db, test_user.id)
+    assert baseline["source_summary"]["statements"] == 0
+
+    # Seed a PARSED, balance-invalid statement (the exact resting state under test).
+    statement = StatementSummary(
+        user_id=test_user.id,
+        account_id=None,
+        file_hash="readiness-parsed-balance-invalid",
+        institution="DBS",
+        currency="SGD",
+        status=resting_status,
+        balance_validated=False,
+    )
+    db.add(statement)
+    await db.flush()
+
+    # The real readiness query must count the PARSED balance-invalid statement.
+    readiness = await get_personal_report_package_readiness(db, test_user.id)
+    assert readiness["source_summary"]["statements"] == 1
 
 
 def test_validate_balance_tolerance():

--- a/apps/backend/tests/ai/test_models_repr.py
+++ b/apps/backend/tests/ai/test_models_repr.py
@@ -91,7 +91,8 @@ def test_validation_route_by_threshold():
 
     assert route_by_threshold(85, True) == BankStatementStatus.APPROVED
     assert route_by_threshold(60, True) == BankStatementStatus.PARSED
-    assert route_by_threshold(50, False) == BankStatementStatus.UPLOADED
+    # #1141: balance-invalid bank statements route to PARSED (review), not UPLOADED.
+    assert route_by_threshold(50, False) == BankStatementStatus.PARSED
     assert route_by_threshold(50, True) == BankStatementStatus.UPLOADED
 
 

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -1040,8 +1040,8 @@ async def test_retry_statement_parsing_allowed(db, monkeypatch, storage_stub, te
         assert resp.status == BankStatementStatus.PARSING
 
 
-async def test_AC13_18_3_retry_accepts_parsed_resting_state(db, storage_stub, test_user):
-    """AC13.18.3 (#1141): retry accepts a balance-invalid statement at its PARSED rest.
+async def test_AC13_21_3_retry_accepts_parsed_resting_state(db, storage_stub, test_user):
+    """AC13.21.3 (#1141): retry accepts a balance-invalid statement at its PARSED rest.
 
     A balance-invalid bank statement now rests in PARSED (review) instead of the
     UPLOADED dead-end that the retry endpoint rejected. PARSED is already an
@@ -1082,8 +1082,8 @@ async def test_AC13_18_3_retry_accepts_parsed_resting_state(db, storage_stub, te
         assert resp.id == sid
 
 
-async def test_AC13_18_6_csv_missing_institution_rejected_sync(db, storage_stub, test_user):
-    """AC13.18.6 (#1141): CSV upload without an institution fails synchronously (400).
+async def test_AC13_21_6_csv_missing_institution_rejected_sync(db, storage_stub, test_user):
+    """AC13.21.6 (#1141): CSV upload without an institution fails synchronously (400).
 
     Previously a CSV with no institution was accepted (202) and only rejected
     asynchronously inside the parse worker ("Institution is required for CSV

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -1040,6 +1040,72 @@ async def test_retry_statement_parsing_allowed(db, monkeypatch, storage_stub, te
         assert resp.status == BankStatementStatus.PARSING
 
 
+async def test_AC13_18_3_retry_accepts_parsed_resting_state(db, storage_stub, test_user):
+    """AC13.18.3 (#1141): retry accepts a balance-invalid statement at its PARSED rest.
+
+    A balance-invalid bank statement now rests in PARSED (review) instead of the
+    UPLOADED dead-end that the retry endpoint rejected. PARSED is already an
+    allowed retry state, so retry must NOT raise a 400 for it.
+    """
+    from unittest.mock import patch
+    from uuid import uuid4
+
+    from src.schemas import RetryParsingRequest
+
+    sid = uuid4()
+    statement = StatementSummary(
+        id=sid,
+        user_id=test_user.id,
+        status=BankStatementStatus.PARSED,
+        stage1_status=Stage1Status.PENDING_REVIEW,
+        balance_validated=False,
+        validation_error="Balance mismatch: expected 1500.00, got 9999.99",
+        file_hash="h_parsed_balance_invalid",
+        institution="DBS",
+    )
+    db.add(statement)
+    await db.flush()
+    await seed_uploaded_document(db, statement, file_path="p", original_filename="f.pdf")
+    await db.commit()
+
+    with patch("src.routers.statements.StorageService") as mock_storage_cls:
+        mock_storage = mock_storage_cls.return_value
+        mock_storage.get_object.return_value = b"content"
+
+        # Must not raise HTTP 400: PARSED is an accepted retry resting state.
+        resp = await statements_router.retry_statement_parsing(
+            statement_id=sid,
+            request=RetryParsingRequest(model=None),
+            db=db,
+            user_id=test_user.id,
+        )
+        assert resp.id == sid
+
+
+async def test_AC13_18_6_csv_missing_institution_rejected_sync(db, storage_stub, test_user):
+    """AC13.18.6 (#1141): CSV upload without an institution fails synchronously (400).
+
+    Previously a CSV with no institution was accepted (202) and only rejected
+    asynchronously inside the parse worker ("Institution is required for CSV
+    parsing"), leaving an orphaned PARSING record. The upload route must reject it
+    up-front with HTTP 400 and an actionable message.
+    """
+    upload_file = make_upload_file("statement.csv", b"date,amount\n2025-01-01,10.00\n")
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.upload_statement(
+            file=upload_file,
+            institution=None,
+            account_id=None,
+            model=None,
+            db=db,
+            user_id=test_user.id,
+        )
+    await upload_file.close()
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "institution" in exc.value.detail.lower()
+
+
 async def test_retry_statement_success(db, monkeypatch, storage_stub, model_catalog_stub, test_user):
     """AC3.5.19: Retry parsing with stronger model succeeds."""
     from src.schemas import RetryParsingRequest

--- a/apps/backend/tests/e2e/test_core_journeys.py
+++ b/apps/backend/tests/e2e/test_core_journeys.py
@@ -801,13 +801,16 @@ async def test_statement_upload_csv(client, test_user):
     EPIC-003 EPIC-013 / AC8.4.1: Upload bank statement (CSV format)
     AC8.10.4: Traceability — statement upload works
     GIVEN a user is authenticated
-    WHEN uploading a CSV bank statement
+    WHEN uploading a CSV bank statement with an institution (required for CSV — #1087)
     THEN it should return 202 Accepted with statement metadata
     """
     csv_content = "Date,Description,Amount\n2026-01-15,Coffee Shop,-5.00\n2026-01-16,Salary,5000.00\n"
+    # CSV parsing has no AI institution auto-detect, so institution is required and
+    # validated synchronously (AC13.21.6 / #1087). Provide it to exercise the happy path.
     response = await client.post(
         "/statements/upload",
         files={"file": ("test_statement.csv", csv_content.encode(), "text/csv")},
+        data={"institution": "DBS"},
     )
     assert response.status_code == 202
     data = response.json()

--- a/apps/backend/tests/e2e/test_core_journeys.py
+++ b/apps/backend/tests/e2e/test_core_journeys.py
@@ -828,9 +828,11 @@ async def test_statement_list_and_get(client, test_user):
     """
     # Upload first
     csv_content = "Date,Description,Amount\n2026-02-01,Groceries,-50.00\n"
+    # institution is required for CSV (no AI auto-detect) — #1087 / AC13.21.6
     upload_resp = await client.post(
         "/statements/upload",
         files={"file": ("list_test.csv", csv_content.encode(), "text/csv")},
+        data={"institution": "DBS"},
     )
     assert upload_resp.status_code == 202
     stmt_id = upload_resp.json()["id"]
@@ -857,9 +859,11 @@ async def test_statement_full_flow(client, test_user):
     """
     # Upload
     csv_content = "Date,Description,Amount\n2026-03-01,Rent,-1500.00\n"
+    # institution is required for CSV (no AI auto-detect) — #1087 / AC13.21.6
     upload_resp = await client.post(
         "/statements/upload",
         files={"file": ("flow_test.csv", csv_content.encode(), "text/csv")},
+        data={"institution": "DBS"},
     )
     assert upload_resp.status_code == 202
     stmt_id = upload_resp.json()["id"]

--- a/apps/backend/tests/extraction/test_extraction_determinism.py
+++ b/apps/backend/tests/extraction/test_extraction_determinism.py
@@ -70,7 +70,8 @@ _BANK_VALID = {
 }
 
 # Same bank statement but the closing balance does not reconcile (balance invalid)
-# -> must route to UPLOADED (manual review) on every parse.
+# -> must route to PARSED (review) on every parse (#1141: no longer a UPLOADED
+# dead-end; it enters review with a validation_error like the brokerage path).
 _BANK_BALANCE_INVALID = {
     **_BANK_VALID,
     "closing_balance": "9999.99",
@@ -195,13 +196,18 @@ class TestRepeatedParseDeterminism:
     @pytest.mark.parametrize(
         "payload,expected_status",
         [
-            (_BANK_BALANCE_INVALID, BankStatementStatus.UPLOADED),
+            (_BANK_BALANCE_INVALID, BankStatementStatus.PARSED),
             (_BROKERAGE, BankStatementStatus.PARSED),
         ],
-        ids=["bank_balance_invalid->uploaded", "brokerage->parsed"],
+        ids=["bank_balance_invalid->parsed", "brokerage->parsed"],
     )
     async def test_routing_is_consistent_per_payload_class(self, db, test_user, payload, expected_status):
-        """AC13.13.3: each payload class routes to one stable status across N parses."""
+        """AC13.13.3 / AC13.18.5: each payload class routes to one stable status across N parses.
+
+        Post-#1141 a balance-invalid bank statement rests in PARSED (review), the
+        same deterministic resting state as a brokerage statement — never the
+        UPLOADED dead-end.
+        """
         statuses = []
         for i in range(RUNS):
             statement, _ = await self._parse_once(db, test_user.id, payload, f"route-{expected_status.value}-{i}")
@@ -210,3 +216,22 @@ class TestRepeatedParseDeterminism:
         assert set(statuses) == {expected_status}, (
             f"Routing drifted across {RUNS} parses: {set(statuses)} (expected always {expected_status})"
         )
+
+    async def test_AC13_18_2_balance_invalid_parse_is_pending_review(self, db, test_user):
+        """AC13.18.2 (#1141): a balance-invalid bank parse lands in PARSED review.
+
+        The statement must carry the reviewable resting state (`PARSED` +
+        `stage1_status=PENDING_REVIEW`) and a `validation_error` describing the
+        mismatch — not the `uploaded` dead-end that the retry endpoint rejects and
+        report readiness ignores.
+        """
+        from src.models.statement_enums import Stage1Status
+
+        statement, _ = await self._parse_once(db, test_user.id, _BANK_BALANCE_INVALID, "ac13-18-2")
+
+        assert statement.status == BankStatementStatus.PARSED
+        assert statement.status != BankStatementStatus.UPLOADED
+        assert statement.stage1_status == Stage1Status.PENDING_REVIEW
+        assert statement.balance_validated is False
+        assert statement.validation_error
+        assert "mismatch" in statement.validation_error.lower()

--- a/apps/backend/tests/extraction/test_extraction_determinism.py
+++ b/apps/backend/tests/extraction/test_extraction_determinism.py
@@ -202,7 +202,7 @@ class TestRepeatedParseDeterminism:
         ids=["bank_balance_invalid->parsed", "brokerage->parsed"],
     )
     async def test_routing_is_consistent_per_payload_class(self, db, test_user, payload, expected_status):
-        """AC13.13.3 / AC13.18.5: each payload class routes to one stable status across N parses.
+        """AC13.13.3 / AC13.21.5: each payload class routes to one stable status across N parses.
 
         Post-#1141 a balance-invalid bank statement rests in PARSED (review), the
         same deterministic resting state as a brokerage statement — never the
@@ -217,8 +217,8 @@ class TestRepeatedParseDeterminism:
             f"Routing drifted across {RUNS} parses: {set(statuses)} (expected always {expected_status})"
         )
 
-    async def test_AC13_18_2_balance_invalid_parse_is_pending_review(self, db, test_user):
-        """AC13.18.2 (#1141): a balance-invalid bank parse lands in PARSED review.
+    async def test_AC13_21_2_balance_invalid_parse_is_pending_review(self, db, test_user):
+        """AC13.21.2 (#1141): a balance-invalid bank parse lands in PARSED review.
 
         The statement must carry the reviewable resting state (`PARSED` +
         `stage1_status=PENDING_REVIEW`) and a `validation_error` describing the

--- a/apps/backend/tests/extraction/test_pdf_parsing.py
+++ b/apps/backend/tests/extraction/test_pdf_parsing.py
@@ -413,9 +413,14 @@ class TestConfidenceRouting:
         assert status == BankStatementStatus.UPLOADED  # Not auto-parsed
 
     def test_invalid_balance_never_auto_accept(self):
-        """Invalid balance should never auto-accept regardless of score."""
+        """Invalid balance should never auto-accept regardless of score.
+
+        #1141: balance-invalid statements route to PARSED (review) rather than the
+        UPLOADED dead-end, but still never auto-approve.
+        """
         status = route_by_threshold(95, balance_valid=False)
-        assert status == BankStatementStatus.UPLOADED
+        assert status == BankStatementStatus.PARSED
+        assert status != BankStatementStatus.APPROVED
 
 
 class TestStatementCompleteness:

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -316,26 +316,26 @@ this gate.
 | AC13.13.2 | Re-parsing identical model output yields identical confidence/status/validation_error across N parses. | `test_repeated_parse_yields_identical_confidence_status_validation` | `extraction/test_extraction_determinism.py` | P0 |
 | AC13.13.3 | Each payload class (bank-valid, bank-balance-invalid, brokerage) routes consistently across N parses. | `test_routing_is_consistent_per_payload_class` | `extraction/test_extraction_determinism.py` | P0 |
 
-### AC13.18: Balance-Mismatch Statement Lifecycle (#1141, folds #1085 + #1087)
+### AC13.21: Balance-Mismatch Statement Lifecycle (#1141, folds #1085 + #1087)
 
 A bank statement that parses cleanly but whose running balance does not reconcile
 must **not** be parked in `uploaded` (a dead-end that the retry endpoint rejects
 and the report-readiness query ignores). It must enter the same reviewable resting
 state as a brokerage statement: `PARSED` with `stage1_status=PENDING_REVIEW` and a
 `validation_error` describing the mismatch. This makes balance-invalid bank
-statements retriable (AC13.18.3), visible to readiness (AC13.18.4), and
-deterministic (AC13.18.5). CSV intake with a missing institution must fail
+statements retriable (AC13.21.3), visible to readiness (AC13.21.4), and
+deterministic (AC13.21.5). CSV intake with a missing institution must fail
 synchronously at upload with HTTP 400 instead of accepting (202) and then
-rejecting asynchronously (AC13.18.6).
+rejecting asynchronously (AC13.21.6).
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC13.18.1 | `route_by_threshold` routes a balance-invalid bank statement to `PARSED` (review), never `uploaded`, regardless of score. | `test_AC13_18_1_balance_invalid_routes_to_parsed_review` | `accounting/test_validation.py` | P0 |
-| AC13.18.2 | A parsed bank statement that fails balance reconciliation lands in `PARSED` with `stage1_status=PENDING_REVIEW` and a `validation_error`. | `test_AC13_18_2_balance_invalid_parse_is_pending_review` | `extraction/test_extraction_determinism.py` | P0 |
-| AC13.18.3 | The retry endpoint accepts a balance-invalid statement at its `PARSED` resting state. | `test_AC13_18_3_retry_accepts_parsed_resting_state` | `api/test_statements_router.py` | P0 |
-| AC13.18.4 | Report readiness counts the balance-invalid `PARSED` statement as an available input. | `test_AC13_18_4_readiness_counts_parsed_balance_invalid` | `accounting/test_validation.py` | P1 |
-| AC13.18.5 | The same balance-mismatch payload routes to the same `PARSED` status deterministically across N parses. | `test_routing_is_consistent_per_payload_class` | `extraction/test_extraction_determinism.py` | P0 |
-| AC13.18.6 | CSV upload with a missing institution fails synchronously with HTTP 400 and an actionable message. | `test_AC13_18_6_csv_missing_institution_rejected_sync` | `api/test_statements_router.py` | P0 |
+| AC13.21.1 | `route_by_threshold` routes a balance-invalid bank statement to `PARSED` (review), never `uploaded`, regardless of score. | `test_AC13_21_1_balance_invalid_routes_to_parsed_review` | `accounting/test_validation.py` | P0 |
+| AC13.21.2 | A parsed bank statement that fails balance reconciliation lands in `PARSED` with `stage1_status=PENDING_REVIEW` and a `validation_error`. | `test_AC13_21_2_balance_invalid_parse_is_pending_review` | `extraction/test_extraction_determinism.py` | P0 |
+| AC13.21.3 | The retry endpoint accepts a balance-invalid statement at its `PARSED` resting state. | `test_AC13_21_3_retry_accepts_parsed_resting_state` | `api/test_statements_router.py` | P0 |
+| AC13.21.4 | Report readiness counts the balance-invalid `PARSED` statement as an available input. | `test_AC13_21_4_readiness_counts_parsed_balance_invalid` | `accounting/test_validation.py` | P1 |
+| AC13.21.5 | The same balance-mismatch payload routes to the same `PARSED` status deterministically across N parses. | `test_routing_is_consistent_per_payload_class` | `extraction/test_extraction_determinism.py` | P0 |
+| AC13.21.6 | CSV upload with a missing institution fails synchronously with HTTP 400 and an actionable message. | `test_AC13_21_6_csv_missing_institution_rejected_sync` | `api/test_statements_router.py` | P0 |
 
 ### AC13.16: Deterministic Decoding — Request Seed (issue #989)
 

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -316,6 +316,27 @@ this gate.
 | AC13.13.2 | Re-parsing identical model output yields identical confidence/status/validation_error across N parses. | `test_repeated_parse_yields_identical_confidence_status_validation` | `extraction/test_extraction_determinism.py` | P0 |
 | AC13.13.3 | Each payload class (bank-valid, bank-balance-invalid, brokerage) routes consistently across N parses. | `test_routing_is_consistent_per_payload_class` | `extraction/test_extraction_determinism.py` | P0 |
 
+### AC13.18: Balance-Mismatch Statement Lifecycle (#1141, folds #1085 + #1087)
+
+A bank statement that parses cleanly but whose running balance does not reconcile
+must **not** be parked in `uploaded` (a dead-end that the retry endpoint rejects
+and the report-readiness query ignores). It must enter the same reviewable resting
+state as a brokerage statement: `PARSED` with `stage1_status=PENDING_REVIEW` and a
+`validation_error` describing the mismatch. This makes balance-invalid bank
+statements retriable (AC13.18.3), visible to readiness (AC13.18.4), and
+deterministic (AC13.18.5). CSV intake with a missing institution must fail
+synchronously at upload with HTTP 400 instead of accepting (202) and then
+rejecting asynchronously (AC13.18.6).
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC13.18.1 | `route_by_threshold` routes a balance-invalid bank statement to `PARSED` (review), never `uploaded`, regardless of score. | `test_AC13_18_1_balance_invalid_routes_to_parsed_review` | `accounting/test_validation.py` | P0 |
+| AC13.18.2 | A parsed bank statement that fails balance reconciliation lands in `PARSED` with `stage1_status=PENDING_REVIEW` and a `validation_error`. | `test_AC13_18_2_balance_invalid_parse_is_pending_review` | `extraction/test_extraction_determinism.py` | P0 |
+| AC13.18.3 | The retry endpoint accepts a balance-invalid statement at its `PARSED` resting state. | `test_AC13_18_3_retry_accepts_parsed_resting_state` | `api/test_statements_router.py` | P0 |
+| AC13.18.4 | Report readiness counts the balance-invalid `PARSED` statement as an available input. | `test_AC13_18_4_readiness_counts_parsed_balance_invalid` | `accounting/test_validation.py` | P1 |
+| AC13.18.5 | The same balance-mismatch payload routes to the same `PARSED` status deterministically across N parses. | `test_routing_is_consistent_per_payload_class` | `extraction/test_extraction_determinism.py` | P0 |
+| AC13.18.6 | CSV upload with a missing institution fails synchronously with HTTP 400 and an actionable message. | `test_AC13_18_6_csv_missing_institution_rejected_sync` | `api/test_statements_router.py` | P0 |
+
 ### AC13.16: Deterministic Decoding — Request Seed (issue #989)
 
 Complements AC13.13 (downstream determinism). AC13.13 pins everything *after* the

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -15,6 +15,6 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:142 |
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:475 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:755 |
-| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:552 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:690 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:557 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:695 |
 | `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:102 |

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -15,6 +15,6 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:142 |
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:475 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:755 |
-| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:536 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:764 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:548 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:776 |
 | `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:102 |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -188,19 +188,40 @@ Brokerage extraction feeds Layer 2 `AtomicPosition` through `apps/backend/src/se
 
 Routing after parsing depends on the document class, on purpose (#981):
 
-- **Bank statements** route via `route_by_threshold(confidence, balance_valid)`: an invalid
-  running-balance chain sends them to `uploaded` (manual entry), and high confidence + valid
-  balance can auto-approve. **Exception:** CSV exports without source statement balances take the
-  inferred-balance path (`has_inferred_csv_balances`), which forces `parsed`/review with
-  `balance_valid = False` rather than routing to `uploaded` — so they remain reviewable instead of
-  demanding manual entry.
+- **Bank statements** route via `route_by_threshold(confidence, balance_valid)`:
+  - **Balance invalid** → `parsed` (review) regardless of confidence (#1141). The statement
+    parsed but its running balance does not reconcile, so it enters review carrying a
+    `validation_error` and `stage1_status = pending_review`. It never auto-approves and is
+    **never** parked in `uploaded`.
+  - **Balance valid + confidence ≥ 85** → can auto-approve (`approved`).
+  - **Balance valid + confidence ≥ 60** → `parsed` (review).
+  - **Balance valid + confidence < 60** → `uploaded` (genuinely low-signal parse → manual entry).
+  - CSV exports without source statement balances take the inferred-balance path
+    (`has_inferred_csv_balances`), which forces `parsed`/review with `balance_valid = False`.
 - **Brokerage statements** always route to `parsed` (review) regardless of `balance_valid`,
   because they reconcile via `AtomicPosition` position snapshots rather than a running-balance
   chain — `balance_valid` is not a meaningful gating signal for them.
 
-So the same "balance invalid" outcome lands a (non-CSV) bank statement in `uploaded` but a
-brokerage statement in `parsed`. This is by design, not a routing bug. Owner: `ExtractionService`
-status selection (`BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(...)`).
+So the "balance invalid" outcome now lands **both** a (non-CSV) bank statement and a brokerage
+statement in `parsed`/review — a single deterministic, reviewable terminal state (#1141, folding
+#1085). `uploaded` is reserved for genuinely low-signal valid-balance parses, not for
+parsed-but-unreconciled statements. Owner: `ExtractionService` status selection
+(`BankStatementStatus.PARSED if is_brokerage_payload else route_by_threshold(...)`).
+
+### Balance-mismatch lifecycle invariants (#1141)
+
+The single balance-mismatch terminal state (`parsed`, `stage1_status = pending_review`,
+`validation_error` set) is consistent across the lifecycle:
+
+- **Retry**: the retry endpoint (`POST /statements/{id}/retry`) accepts `parsed` (alongside
+  `rejected`/`parsing`), so a balance-mismatch statement is retriable. `uploaded` remains
+  non-retriable, which is now safe because balance-mismatch statements no longer rest there.
+- **Readiness**: `get_personal_report_package_readiness` counts `parsed` + `approved` summaries,
+  so a balance-mismatch statement is a visible report input rather than an invisible orphan.
+- **CSV intake** (#1087): CSV parsing cannot auto-detect the institution, so the upload route
+  rejects a CSV with a missing institution **synchronously** with HTTP 400 (actionable message)
+  instead of accepting (202) and rejecting asynchronously inside the parse worker. PDF/image
+  uploads keep institution optional (vision auto-detect).
 
 Parsing priority:
 1. Prefer structured `positions`, `holdings`, or `securities` arrays from OCR/LLM output.


### PR DESCRIPTION
## Summary

Fixes the balance-mismatch statement lifecycle dead-end (root **#1141**, folding **#1085** and **#1087**).

A bank statement that parsed cleanly but whose running balance did not reconcile was parked in `uploaded` — a dead-end the retry endpoint rejected and report readiness ignored. It now enters the same reviewable resting state as a brokerage statement: `parsed` + `stage1_status=pending_review` + a `validation_error`. `uploaded` is reserved for genuinely low-signal **valid-balance** parses (score < 60).

CSV uploads with a missing institution were accepted (202) then rejected asynchronously inside the parse worker; they now fail **synchronously** with HTTP 400 and an actionable message.

## Acceptance Criteria (EPIC-013 AC13.18)

- [x] **AC-A1/AC13.18.1** — `route_by_threshold(score, balance_valid=False)` returns `PARSED` (review) regardless of score; never `uploaded`, never auto-`approved`.
- [x] **AC-A2/AC13.18.2** — a balance-invalid bank parse lands in `PARSED` with `stage1_status=PENDING_REVIEW` and a `validation_error` (handled by the existing extraction.py call site, now reached via the corrected routing).
- [x] **AC-A3/AC13.18.3** — retry endpoint accepts the `parsed` resting state (it already allows PARSED/REJECTED/PARSING; confirmed via test).
- [x] **AC-A4/AC13.18.4** — report readiness counts `parsed` + `approved`, so the statement is now a visible report input (confirmed via test).
- [x] **AC-A5/AC13.18.5** — same balance-mismatch payload routes to the same `PARSED` status deterministically across N parses (updated determinism test).
- [x] **AC-A6/AC13.18.6** — CSV upload with missing institution fails synchronously with HTTP 400 + actionable message; upload-route docstring updated.
- [x] **AC-A7** — SSOT `docs/ssot/extraction.md` updated with the single balance-mismatch terminal state + retry/readiness/intake semantics.

## Folded issues

- **#1085** (balance-mismatch parked in `uploaded`) — folded in.
- **#1087** (CSV intake institution-required async reject) — folded in (now synchronous 400; the extraction-layer guard is kept as defense-in-depth).

## Tests / lint run

- `uv run pytest tests/extraction/ tests/api/test_statements_router.py tests/accounting/test_validation.py tests/ai/test_models_repr.py --no-cov` → all green (620+ passed).
- `uv run ruff check` + `ruff format --check` on all changed files → clean.
- AC index/traceability gate (`tools/check_ac_index.py`) → PASSED (1667 ACs, +6).

Note: the full suite was not run end-to-end (needs DB/services); targeted affected tests + lint + AC gate were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)