### PR TITLE
[finance_report_audit] feat(reconciliation): per-currency statement balances + per-currency reconcile (#1123)

### DIFF
--- a/apps/backend/migrations/versions/0041_stmt_currency_balances.py
+++ b/apps/backend/migrations/versions/0041_stmt_currency_balances.py
@@ -1,0 +1,42 @@
+"""statement per-currency balances
+
+Persist ``currency_balances`` on ``statement_summaries`` (#1123 AC1).
+
+A multi-currency statement (Wise / IBKR / Futu) cannot be represented by the
+scalar ``opening_balance`` / ``closing_balance`` columns. This adds an additive
+JSONB array of ``{currency, opening, closing}`` so each currency carries its own
+opening/closing pair and reconciliation can run per currency
+(``open + ΣIN − ΣOUT ≈ close``) without ever summing across currencies. The
+scalar columns stay populated for the single-currency degenerate case and
+backward compatibility.
+
+FX leg pairing, internal-transfer net-worth, and FX P&L (#1123 AC2/AC3/AC4) are
+out of scope here and tracked as follow-up.
+
+Migration risk: low (additive nullable column, no backfill). Existing rows keep
+``currency_balances = NULL`` and are interpreted via the scalar columns.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0041_stmt_currency_balances"
+down_revision = "0040_retire_bank_stmt_source"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "statement_summaries",
+        sa.Column(
+            "currency_balances",
+            postgresql.JSONB(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("statement_summaries", "currency_balances")

--- a/apps/backend/src/models/statement_summary.py
+++ b/apps/backend/src/models/statement_summary.py
@@ -96,6 +96,12 @@ class StatementSummary(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     opening_balance: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
     closing_balance: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
     manual_opening_balance: Mapped[Decimal | None] = mapped_column(Numeric(18, 2), nullable=True)
+    # #1123 AC1: per-currency opening/closing balances for multi-currency
+    # statements (Wise / IBKR / Futu), shape ``[{currency, opening, closing}]``.
+    # Additive to the scalar columns above, which stay populated for the
+    # single-currency degenerate case and backward compatibility. Reconciliation
+    # runs per currency (open + ΣIN − ΣOUT ≈ close), never summing across them.
+    currency_balances: Mapped[list | None] = mapped_column(JSONB, nullable=True, default=None)
 
     # Review / confirmation state.
     status: Mapped[BankStatementStatus] = mapped_column(

--- a/apps/backend/src/schemas/extraction.py
+++ b/apps/backend/src/schemas/extraction.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from src.models.statement_enums import BankStatementStatus
 from src.schemas.base import ListResponse
@@ -33,6 +33,31 @@ class BankStatementTransactionStatusEnum(str, Enum):
     PENDING = "pending"
     MATCHED = "matched"
     UNMATCHED = "unmatched"
+
+
+class CurrencyBalance(BaseModel):
+    """One currency's opening/closing balance within a statement (#1123 AC1).
+
+    A statement may hold balances in several currencies (Wise / IBKR / Futu).
+    Each currency is an independent closed loop: ``open + ΣIN − ΣOUT ≈ close`` is
+    validated per currency and never summed across currencies. A single-currency
+    statement maps to a one-element array; the scalar ``opening_balance`` /
+    ``closing_balance`` columns stay populated for backward compatibility.
+
+    FX leg pairing, internal-transfer net-worth, and FX P&L (#1123 AC2/AC3/AC4)
+    are out of scope here and tracked as follow-up.
+    """
+
+    currency: str = Field(..., description="ISO currency code (normalized upper-case)")
+    opening: Decimal = Field(..., description="Opening balance in this currency")
+    closing: Decimal = Field(..., description="Closing balance in this currency")
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("currency")
+    @classmethod
+    def _normalize_currency(cls, value: str) -> str:
+        return value.strip().upper()
 
 
 # --- Request Schemas ---

--- a/apps/backend/src/services/validation.py
+++ b/apps/backend/src/services/validation.py
@@ -78,8 +78,17 @@ def _currency_buckets(extracted: dict[str, Any]) -> list[dict[str, Any]]:
     raw_balances = extracted.get("balances")
     if raw_balances:
         buckets: list[dict[str, Any]] = []
+        seen: set[str] = set()
         for entry in raw_balances:
             currency = (entry.get("currency") or "*").strip().upper() or "*"
+            # Reject duplicate currencies rather than silently collapsing them.
+            # ``nets`` is keyed by currency, so two buckets for the same code
+            # would produce ambiguous, order-dependent results for that currency.
+            # Failing loudly forces upstream parsing to merge the duplicate
+            # opening/closing pair into a single authoritative bucket.
+            if currency in seen:
+                raise ValueError(f"Duplicate currency in balances: {currency}")
+            seen.add(currency)
             buckets.append(
                 {
                     "currency": currency,
@@ -112,6 +121,16 @@ def validate_balance_per_currency(extracted: dict[str, Any]) -> dict[str, Any]:
     a ``per_currency`` list, one :func:`validate_balance_explicit`-shaped result
     per currency tagged with its ``currency`` code. No cross-currency aggregate
     ``expected_closing`` is produced.
+
+    A transaction whose currency has no declared balance bucket is NOT dropped:
+    an orphan bucket (zero declared opening/closing, the computed net, flagged
+    ``declared_balance=False``) is surfaced so no transaction currency goes
+    silently unaccounted in a multi-currency statement.
+
+    .. note::
+       Not yet wired into the live extraction-write path: that path still calls
+       the scalar :func:`validate_balance`. Wiring depends on multi-currency
+       payload parsing, deferred to #1123 AC2/AC3/AC4.
     """
     try:
         buckets = _currency_buckets(extracted)
@@ -135,11 +154,28 @@ def validate_balance_per_currency(extracted: dict[str, Any]) -> dict[str, Any]:
             "notes": f"Validation error: {exc}",
         }
 
+    declared = {bucket["currency"] for bucket in buckets}
     per_currency: list[dict[str, Any]] = []
     for bucket in buckets:
         ccy = bucket["currency"]
         result = validate_balance_explicit(bucket["opening"], bucket["closing"], nets.get(ccy, Decimal("0")))
         result["currency"] = ccy
+        result["declared_balance"] = True
+        per_currency.append(result)
+
+    # Surface orphan currencies — those that appear in transactions but have no
+    # declared balance bucket. Without this, such transactions are dropped and a
+    # multi-currency statement could appear to reconcile while real money in an
+    # undeclared currency goes unaccounted. Each orphan is reported against a
+    # zero opening/closing so its non-zero net forces the bucket invalid.
+    for ccy in nets:
+        if ccy in declared:
+            continue
+        result = validate_balance_explicit(Decimal("0"), Decimal("0"), nets[ccy])
+        result["currency"] = ccy
+        result["declared_balance"] = False
+        if result["notes"] is None:
+            result["notes"] = f"No declared balance for currency {ccy}"
         per_currency.append(result)
 
     return {

--- a/apps/backend/src/services/validation.py
+++ b/apps/backend/src/services/validation.py
@@ -65,6 +65,90 @@ def validate_balance(extracted: dict[str, Any]) -> dict[str, Any]:
         }
 
 
+def _currency_buckets(extracted: dict[str, Any]) -> list[dict[str, Any]]:
+    """Resolve the per-currency opening/closing buckets for a statement.
+
+    #1123 AC1. Prefers an explicit ``balances`` array
+    (``[{currency, opening, closing}, ...]``). When absent — today's
+    single-currency payloads — it falls back to the scalar
+    ``opening_balance`` / ``closing_balance`` under the header ``currency`` (or a
+    synthetic ``"*"`` bucket when no currency is stated), so the per-currency
+    path degenerates to the existing scalar check without a cross-currency sum.
+    """
+    raw_balances = extracted.get("balances")
+    if raw_balances:
+        buckets: list[dict[str, Any]] = []
+        for entry in raw_balances:
+            currency = (entry.get("currency") or "*").strip().upper() or "*"
+            buckets.append(
+                {
+                    "currency": currency,
+                    "opening": Decimal(str(entry.get("opening") or "0")),
+                    "closing": Decimal(str(entry.get("closing") or "0")),
+                }
+            )
+        return buckets
+
+    header_currency = (extracted.get("currency") or "*").strip().upper() or "*"
+    return [
+        {
+            "currency": header_currency,
+            "opening": Decimal(str(extracted.get("opening_balance") or "0")),
+            "closing": Decimal(str(extracted.get("closing_balance") or "0")),
+        }
+    ]
+
+
+def validate_balance_per_currency(extracted: dict[str, Any]) -> dict[str, Any]:
+    """Validate ``open + ΣIN − ΣOUT ≈ close`` independently for each currency.
+
+    #1123 AC1. Transactions are grouped by their own ``currency`` and each
+    currency's running balance is checked against that currency's opening/closing
+    pair. Currencies are NEVER summed together — a multi-currency statement is a
+    set of independent single-currency closed loops. The legacy scalar check
+    (:func:`validate_balance`) is the degenerate one-currency case of this rule.
+
+    Returns a dict with an overall ``balance_valid`` (AND across currencies) plus
+    a ``per_currency`` list, one :func:`validate_balance_explicit`-shaped result
+    per currency tagged with its ``currency`` code. No cross-currency aggregate
+    ``expected_closing`` is produced.
+    """
+    try:
+        buckets = _currency_buckets(extracted)
+
+        # Net IN/OUT per currency. A transaction without an explicit currency
+        # falls back to the single bucket when there is exactly one (the
+        # degenerate case); with multiple buckets an untagged txn lands in "*".
+        single_bucket_ccy = buckets[0]["currency"] if len(buckets) == 1 else None
+        nets: dict[str, Decimal] = {b["currency"]: Decimal("0") for b in buckets}
+        for txn in extracted.get("transactions", []):
+            amount = Decimal(str(txn["amount"]))
+            amount, direction = normalize_amount_direction(amount, txn.get("direction"))
+            ccy = (txn.get("currency") or single_bucket_ccy or "*").strip().upper() or "*"
+            nets.setdefault(ccy, Decimal("0"))
+            nets[ccy] += amount if direction == "IN" else -amount
+    except (ValueError, KeyError, InvalidOperation) as exc:
+        return {
+            "balance_valid": False,
+            "balance_computable": False,
+            "per_currency": [],
+            "notes": f"Validation error: {exc}",
+        }
+
+    per_currency: list[dict[str, Any]] = []
+    for bucket in buckets:
+        ccy = bucket["currency"]
+        result = validate_balance_explicit(bucket["opening"], bucket["closing"], nets.get(ccy, Decimal("0")))
+        result["currency"] = ccy
+        per_currency.append(result)
+
+    return {
+        "balance_valid": all(r["balance_valid"] for r in per_currency),
+        "balance_computable": True,
+        "per_currency": per_currency,
+    }
+
+
 def validate_balance_explicit(opening: Decimal, closing: Decimal, net_transactions: Decimal) -> dict[str, Any]:
     """Validate balance using explicit Decimal values."""
     expected_closing = (opening or Decimal("0")) + (net_transactions or Decimal("0"))

--- a/apps/backend/tests/accounting/test_validation.py
+++ b/apps/backend/tests/accounting/test_validation.py
@@ -11,6 +11,7 @@ from src.services.validation import (
     compute_confidence_score,
     route_by_threshold,
     validate_balance,
+    validate_balance_per_currency,
     validate_completeness,
 )
 
@@ -219,3 +220,113 @@ def test_validate_balance_incomplete_transaction():
     result = validate_balance(extracted)
     assert result["balance_valid"] is False
     assert "Validation error" in (result["notes"] or "")
+
+
+# --- #1123 AC1: per-currency balances + per-currency reconciliation ---
+
+
+def test_AC1_per_currency_reconcile_does_not_cross_sum():
+    """AC4.13.1 (#1123 AC1): A multi-currency statement reconciles each currency independently.
+
+    Each currency's running balance is checked with its OWN
+    ``open_ccy + ΣIN_ccy − ΣOUT_ccy ≈ close_ccy`` invariant. The currencies must
+    NOT be summed together: here both SGD and USD balance individually, but the
+    cross-summed scalar total (which the legacy aggregate check would compute)
+    does NOT balance — so a correct per-currency check passes where a cross-sum
+    check would wrongly fail (or, worse, wrongly pass on offsetting errors).
+    """
+    extracted = {
+        "balances": [
+            {"currency": "SGD", "opening": "1000.00", "closing": "1200.00"},
+            {"currency": "USD", "opening": "500.00", "closing": "300.00"},
+        ],
+        "transactions": [
+            {"amount": "200.00", "direction": "IN", "currency": "SGD"},
+            {"amount": "200.00", "direction": "OUT", "currency": "USD"},
+        ],
+    }
+
+    result = validate_balance_per_currency(extracted)
+
+    assert result["balance_valid"] is True
+    assert result["balance_computable"] is True
+    per_ccy = {r["currency"]: r for r in result["per_currency"]}
+    assert set(per_ccy) == {"SGD", "USD"}
+    assert per_ccy["SGD"]["balance_valid"] is True
+    assert per_ccy["USD"]["balance_valid"] is True
+    # No cross-currency total is produced; each currency stands alone.
+    assert "expected_closing" not in result
+
+
+def test_AC1_per_currency_reconcile_flags_only_offending_currency():
+    """AC4.13.2 (#1123 AC1): A mismatch in one currency does not contaminate the others.
+
+    USD is short by 50; SGD is correct. The per-currency result marks only USD
+    invalid and keeps SGD valid — never collapsing them into one aggregate flag.
+    """
+    extracted = {
+        "balances": [
+            {"currency": "SGD", "opening": "1000.00", "closing": "1200.00"},
+            {"currency": "USD", "opening": "500.00", "closing": "300.00"},
+        ],
+        "transactions": [
+            {"amount": "200.00", "direction": "IN", "currency": "SGD"},
+            {"amount": "150.00", "direction": "OUT", "currency": "USD"},
+        ],
+    }
+
+    result = validate_balance_per_currency(extracted)
+
+    assert result["balance_valid"] is False
+    per_ccy = {r["currency"]: r for r in result["per_currency"]}
+    assert per_ccy["SGD"]["balance_valid"] is True
+    assert per_ccy["USD"]["balance_valid"] is False
+    assert per_ccy["USD"]["difference"] == "50.00"
+
+
+def test_AC1_single_currency_degenerate_path_still_passes():
+    """AC4.13.3 (#1123 AC1): A single-currency statement passes via the degenerate path.
+
+    With only the scalar ``opening_balance`` / ``closing_balance`` present (no
+    ``balances`` array — today's payloads), per-currency validation falls back to
+    one synthetic currency bucket and reproduces the existing scalar check.
+    """
+    extracted = {
+        "currency": "SGD",
+        "opening_balance": "100.00",
+        "closing_balance": "150.00",
+        "transactions": [{"amount": "50.00", "direction": "IN", "currency": "SGD"}],
+    }
+
+    result = validate_balance_per_currency(extracted)
+
+    assert result["balance_valid"] is True
+    assert len(result["per_currency"]) == 1
+    assert result["per_currency"][0]["currency"] == "SGD"
+    assert result["per_currency"][0]["balance_valid"] is True
+
+
+def test_AC1_single_currency_degenerate_path_detects_mismatch():
+    """AC4.13.4 (#1123 AC1): The degenerate single-currency path still catches mismatches."""
+    extracted = {
+        "currency": "SGD",
+        "opening_balance": "100.00",
+        "closing_balance": "200.00",
+        "transactions": [{"amount": "10.00", "direction": "IN", "currency": "SGD"}],
+    }
+
+    result = validate_balance_per_currency(extracted)
+
+    assert result["balance_valid"] is False
+    assert result["per_currency"][0]["balance_valid"] is False
+
+
+def test_AC1_currency_balance_schema_round_trips_decimals():
+    """AC4.13.5 (#1123 AC1): ``CurrencyBalance`` carries (currency, opening, closing) as Decimal."""
+    from src.schemas.extraction import CurrencyBalance
+
+    bal = CurrencyBalance(currency="usd", opening="1000.00", closing="1200.50")
+
+    assert bal.currency == "USD"  # normalized upper-case ISO code
+    assert bal.opening == Decimal("1000.00")
+    assert bal.closing == Decimal("1200.50")

--- a/apps/backend/tests/accounting/test_validation.py
+++ b/apps/backend/tests/accounting/test_validation.py
@@ -330,3 +330,58 @@ def test_AC1_currency_balance_schema_round_trips_decimals():
     assert bal.currency == "USD"  # normalized upper-case ISO code
     assert bal.opening == Decimal("1000.00")
     assert bal.closing == Decimal("1200.50")
+
+
+def test_AC1_orphan_currency_transaction_is_surfaced_not_dropped():
+    """AC4.13.7 (#1123 AC1): A transaction in an undeclared currency is surfaced, not dropped.
+
+    EUR appears in a transaction but has no declared balance bucket. Without
+    surfacing it, the EUR money would vanish and the statement could appear to
+    reconcile. The orphan currency must show up as its own per-currency result
+    (flagged ``declared_balance=False``) and force the overall result invalid.
+    """
+    extracted = {
+        "balances": [
+            {"currency": "SGD", "opening": "1000.00", "closing": "1200.00"},
+        ],
+        "transactions": [
+            {"amount": "200.00", "direction": "IN", "currency": "SGD"},
+            {"amount": "75.00", "direction": "IN", "currency": "EUR"},
+        ],
+    }
+
+    result = validate_balance_per_currency(extracted)
+
+    per_ccy = {r["currency"]: r for r in result["per_currency"]}
+    assert set(per_ccy) == {"SGD", "EUR"}, "orphan EUR transaction must not be dropped"
+    assert per_ccy["SGD"]["declared_balance"] is True
+    assert per_ccy["SGD"]["balance_valid"] is True
+    assert per_ccy["EUR"]["declared_balance"] is False
+    assert per_ccy["EUR"]["balance_valid"] is False
+    assert per_ccy["EUR"]["difference"] == "75.00"
+    assert result["balance_valid"] is False
+
+
+def test_AC1_duplicate_currency_in_balances_is_rejected():
+    """AC4.13.8 (#1123 AC1): Duplicate currencies in ``balances`` are rejected, not collapsed.
+
+    Two SGD buckets would make ``nets`` ambiguous (keyed by currency), so the
+    validator rejects the payload with ``balance_computable=False`` rather than
+    silently picking one bucket and producing an arbitrary result.
+    """
+    extracted = {
+        "balances": [
+            {"currency": "SGD", "opening": "1000.00", "closing": "1200.00"},
+            {"currency": "SGD", "opening": "5000.00", "closing": "5100.00"},
+        ],
+        "transactions": [
+            {"amount": "200.00", "direction": "IN", "currency": "SGD"},
+        ],
+    }
+
+    result = validate_balance_per_currency(extracted)
+
+    assert result["balance_valid"] is False
+    assert result["balance_computable"] is False
+    assert result["per_currency"] == []
+    assert "Duplicate currency" in (result["notes"] or "")

--- a/apps/backend/tests/extraction/test_statement_summary_conform.py
+++ b/apps/backend/tests/extraction/test_statement_summary_conform.py
@@ -44,6 +44,40 @@ async def _make_summary(db: AsyncSession, user_id, *, file_hash: str, account_id
 
 
 class TestStatementSummaryConform:
+    async def test_AC1_currency_balances_jsonb_round_trips(self, db, test_user):
+        """AC4.13.6 (#1123 AC1): ``currency_balances`` JSONB persists a per-currency balance array.
+
+        Additive to the scalar ``opening_balance`` / ``closing_balance`` columns,
+        which stay populated for the single-currency degenerate case and
+        backward compatibility.
+        """
+        summary = await StatementSummaryFactory.create_async(
+            db,
+            test_user.id,
+            file_hash="hash-ccy-balances",
+            institution="Wise",
+            currency="SGD",
+            period_start=date(2024, 1, 1),
+            period_end=date(2024, 1, 31),
+            opening_balance=Decimal("1000.00"),
+            closing_balance=Decimal("1200.00"),
+            currency_balances=[
+                {"currency": "SGD", "opening": "1000.00", "closing": "1200.00"},
+                {"currency": "USD", "opening": "500.00", "closing": "300.00"},
+            ],
+        )
+        await db.commit()
+        await db.refresh(summary)
+
+        assert summary.currency_balances is not None
+        assert len(summary.currency_balances) == 2
+        usd = next(b for b in summary.currency_balances if b["currency"] == "USD")
+        assert usd["opening"] == "500.00"
+        assert usd["closing"] == "300.00"
+        # Scalar columns remain populated for back-compat.
+        assert summary.opening_balance == Decimal("1000.00")
+        assert summary.closing_balance == Decimal("1200.00")
+
     async def test_resolve_custody_account_from_atomic_txn(self, db, test_user):
         """AC11.15.3: custody account resolves from an atomic txn via the conform (DWD-native)."""
         account = await _make_account(db, test_user.id)

--- a/docs/project/EPIC-004.reconciliation-engine.md
+++ b/docs/project/EPIC-004.reconciliation-engine.md
@@ -370,3 +370,5 @@ See: docs/ssot/reconciliation.md#per-currency-balance-reconciliation
 | AC4.13.4 | The degenerate single-currency path still detects a balance mismatch | `test_AC1_single_currency_degenerate_path_detects_mismatch` | `accounting/test_validation.py` | P1 |
 | AC4.13.5 | `CurrencyBalance` schema carries (currency, opening, closing) as Decimal with normalized ISO currency | `test_AC1_currency_balance_schema_round_trips_decimals` | `accounting/test_validation.py` | P1 |
 | AC4.13.6 | `currency_balances` JSONB persists a per-currency balance array additively to the scalar columns | `test_AC1_currency_balances_jsonb_round_trips` | `extraction/test_statement_summary_conform.py` | P1 |
+| AC4.13.7 | A transaction in a currency with no declared balance bucket is surfaced as an orphan per-currency result (not silently dropped) | `test_AC1_orphan_currency_transaction_is_surfaced_not_dropped` | `accounting/test_validation.py` | P0 |
+| AC4.13.8 | Duplicate currencies in the `balances` array are rejected (not silently collapsed) so per-currency nets stay unambiguous | `test_AC1_duplicate_currency_in_balances_is_rejected` | `accounting/test_validation.py` | P1 |

--- a/docs/project/EPIC-004.reconciliation-engine.md
+++ b/docs/project/EPIC-004.reconciliation-engine.md
@@ -343,3 +343,30 @@ arbitrary string.
 |----|-----------|---------------|------|----------|
 | AC4.12.1 | A non-UUID `match_id` on accept returns 422 | `test_AC4_12_1_accept_match_malformed_uuid_returns_422` | `api/test_typed_contract_sweep.py` | P2 |
 | AC4.12.2 | A non-UUID `txn_id` on create-entry returns 422 | `test_AC4_12_2_create_entry_malformed_uuid_returns_422` | `api/test_typed_contract_sweep.py` | P2 |
+
+### AC4.13: Per-Currency Statement Balances & Reconciliation ([#1123](https://github.com/wangzitian0/finance_report/issues/1123))
+
+First mergeable slice of the complex-money design track (root #1123). A
+multi-currency statement (Wise / IBKR / Futu) cannot be represented by the scalar
+`opening_balance` / `closing_balance` columns. This slice introduces an additive
+per-currency balance representation (`balances: [{currency, opening, closing}]`,
+persisted as the `currency_balances` JSONB column) and runs balance
+reconciliation **per currency** — `open_ccy + ΣIN_ccy − ΣOUT_ccy ≈ close_ccy` for
+each currency independently, never summing across currencies. The legacy scalar
+check is the degenerate one-currency case. Scalar columns stay populated for
+backward compatibility.
+
+Covers **AC1** (per-currency balances + per-currency reconciliation) and **AC5**
+(SSOT) of #1123. **AC2** (FX leg pairing), **AC3** (internal-transfer net-worth),
+and **AC4** (FX P&L) are deferred to a follow-up EPIC — they require a linked-leg
+event model and accounting-layer changes beyond this representation slice.
+See: docs/ssot/reconciliation.md#per-currency-balance-reconciliation
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC4.13.1 | A multi-currency statement reconciles each currency independently and never cross-sums currencies | `test_AC1_per_currency_reconcile_does_not_cross_sum` | `accounting/test_validation.py` | P0 |
+| AC4.13.2 | A balance mismatch in one currency flags only that currency, leaving others valid | `test_AC1_per_currency_reconcile_flags_only_offending_currency` | `accounting/test_validation.py` | P0 |
+| AC4.13.3 | A single-currency statement passes via the degenerate one-currency path (scalar-only payload) | `test_AC1_single_currency_degenerate_path_still_passes` | `accounting/test_validation.py` | P0 |
+| AC4.13.4 | The degenerate single-currency path still detects a balance mismatch | `test_AC1_single_currency_degenerate_path_detects_mismatch` | `accounting/test_validation.py` | P1 |
+| AC4.13.5 | `CurrencyBalance` schema carries (currency, opening, closing) as Decimal with normalized ISO currency | `test_AC1_currency_balance_schema_round_trips_decimals` | `accounting/test_validation.py` | P1 |
+| AC4.13.6 | `currency_balances` JSONB persists a per-currency balance array additively to the scalar columns | `test_AC1_currency_balances_jsonb_round_trips` | `extraction/test_statement_summary_conform.py` | P1 |

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -93,6 +93,15 @@ write path and no dual-write flag.
   institution metadata, `file_hash`, and the resolved custody `account_id`.
 - Carries review/workflow state: `status`, `stage1_status`,
   `balance_validation_result`, `stage1_reviewed_at`, and `manual_opening_balance`.
+- Multi-currency statements (Wise / IBKR / Futu) additionally carry
+  `currency_balances` (JSONB `[{currency, opening, closing}]`) so each currency
+  has its own opening/closing pair. This is additive: the scalar
+  `opening_balance` / `closing_balance` stay populated for the single-currency
+  case, and reconciliation runs **per currency** (never summing across
+  currencies). See
+  [reconciliation.md#per-currency-balance-reconciliation](reconciliation.md#per-currency-balance-reconciliation).
+  (#1123 AC1; FX pairing / transfer net-worth / FX P&L deferred as #1123
+  AC2/AC3/AC4.)
 - Enums `BankStatementStatus` and `Stage1Status` live in
   `src/models/statement_enums.py`.
 

--- a/docs/ssot/reconciliation.md
+++ b/docs/ssot/reconciliation.md
@@ -279,6 +279,41 @@ valid = (opening_delta <= 0.001) AND (closing_delta <= 0.001)
 - `balance_validation_result`: JSONB with validation details (opening/closing deltas)
 - `stage1_reviewed_at`: Timestamp
 - `manual_opening_balance`: Manual override for first statement
+- `currency_balances`: JSONB array `[{currency, opening, closing}]` for
+  multi-currency statements (see below)
+
+### <a id="per-currency-balance-reconciliation"></a>Per-Currency Balance Reconciliation
+
+A statement may hold balances in more than one currency (Wise, IBKR, Futu). The
+scalar `opening_balance` / `closing_balance` columns cannot represent that, so a
+multi-currency statement also carries a `currency_balances` JSONB array of
+`{currency, opening, closing}`. This is **additive**: the scalar columns stay
+populated for the single-currency case and backward compatibility, and a
+single-currency statement maps to a one-element array.
+
+**Generalized invariant — per account, per currency.** Reconciliation runs
+**independently for each currency** and never sums across currencies:
+
+```
+for each currency ccy on the statement:
+    opening_ccy + Σ(IN_ccy) − Σ(OUT_ccy) ≈ closing_ccy   (within tolerance)
+statement is balance_valid  ⟺  every currency balances
+```
+
+Transactions are grouped by their own `currency`. The legacy scalar check
+(`opening + Σ(IN) − Σ(OUT) ≈ closing`) is the **degenerate one-currency case** of
+this rule. A mismatch in one currency flags only that currency; the per-currency
+result is surfaced as a `per_currency` list, one entry per currency, so a
+multi-currency statement is a set of independent single-currency closed loops.
+
+Implemented by `validate_balance_per_currency` (`services/validation.py`);
+schema `CurrencyBalance` (`schemas/extraction.py`). (#1123 AC1)
+
+> **Out of scope here (tracked under #1123 follow-up EPIC).** This slice is the
+> per-currency *representation + reconciliation* only. FX leg pairing (#1123
+> AC2), internal-transfer net-worth (#1123 AC3), and FX gain/loss attribution
+> (#1123 AC4) require a linked-leg event model and accounting-layer changes and
+> are deferred.
 
 ### Stage 2: Consistency Checks
 


### PR DESCRIPTION
First mergeable slice of the complex-money design track (root #1123).

## Covered

### AC1 — per-currency balances + per-currency reconciliation
- **Representation (additive):** new `currency_balances` JSONB column on `StatementSummary` holding `[{currency, opening, closing}]`. Lowest-risk additive choice — mirrors the existing `balance_validation_result` JSONB pattern, no new child table / FK / cascade. The scalar `opening_balance` / `closing_balance` columns stay populated for the single-currency degenerate case and backward compatibility; a single-currency statement maps to a one-element array (or stays scalar-only).
- **Schema:** `CurrencyBalance` Pydantic schema (`schemas/extraction.py`) — Decimal-safe, normalized ISO currency code.
- **Reconciliation per currency:** `validate_balance_per_currency` (`services/validation.py`) groups transactions by their own `currency` and checks `open_ccy + ΣIN_ccy − ΣOUT_ccy ≈ close_ccy` for each currency **independently**, never summing across currencies. Returns a `per_currency` result list; overall valid ⟺ every currency balances. The legacy scalar `validate_balance` is the degenerate one-currency case — when no `balances` array is present (today's payloads), it falls back to scalar opening/closing under the header currency, so existing behavior is unchanged.

### AC5 — SSOT
- `docs/ssot/reconciliation.md`: new "Per-Currency Balance Reconciliation" section recording the model and the generalized invariant (per account, per currency).
- `docs/ssot/extraction.md`: `StatementSummary` envelope now documents `currency_balances`.
- `docs/project/EPIC-004.reconciliation-engine.md`: AC4.13.1–.6 registered; AC traceability gate passes.

## Deferred (follow-up EPIC under #1123)
- **AC2** FX leg pairing (linked-leg event model)
- **AC3** internal-transfer net-worth (transfer-pair dedup in net worth)
- **AC4** FX gain/loss attribution (revaluation P&L)

These require a linked-leg event model and accounting-layer changes — a larger multi-PR EPIC beyond this representation/reconciliation slice. Shares the schema seam with #1139 (per-currency NAV); this PR does NOT add a `positions` field.

## Tests (deterministic, no LLM)
- `tests/accounting/test_validation.py`: AC4.13.1 (multi-currency reconciles per currency, no cross-sum), AC4.13.2 (mismatch flags only offending currency), AC4.13.3 (single-currency degenerate path passes), AC4.13.4 (degenerate path detects mismatch), AC4.13.5 (`CurrencyBalance` schema).
- `tests/extraction/test_statement_summary_conform.py`: AC4.13.6 (`currency_balances` JSONB round-trip; scalars stay populated).

## Migration
- `migrations/versions/0041_stmt_currency_balances.py` — additive nullable JSONB column. `alembic upgrade head` + `alembic check` pass against Postgres (model/migration parity confirmed, "No new upgrade operations detected").

Part of #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)