### PR TITLE
[finance_report_test_and_doc] refactor(services): DRY + module splits (workflow_events, assets, reconciliation)

### DIFF
--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import Literal
 from uuid import UUID, uuid4
 
-from sqlalchemy import func, select
+from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -105,7 +105,7 @@ def _valuation_key_query(
     component_type: ManualValuationComponentType,
     source: str,
     as_of_date: date,
-):
+) -> Select[tuple[ManualValuationSnapshot]]:
     """Base select for a manual-valuation version-chain key.
 
     Matches the partial unique index identity (user_id, component_type, source,

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -99,6 +99,27 @@ _DEFAULT_LIQUIDITY_CLASS: dict[ManualValuationComponentType, ManualValuationLiqu
 }
 
 
+def _valuation_key_query(
+    user_id: UUID,
+    *,
+    component_type: ManualValuationComponentType,
+    source: str,
+    as_of_date: date,
+):
+    """Base select for a manual-valuation version-chain key.
+
+    Matches the partial unique index identity (user_id, component_type, source,
+    as_of_date); callers append head/order/lock clauses.
+    """
+    return (
+        select(ManualValuationSnapshot)
+        .where(ManualValuationSnapshot.user_id == user_id)
+        .where(ManualValuationSnapshot.component_type == component_type)
+        .where(ManualValuationSnapshot.source == source)
+        .where(ManualValuationSnapshot.as_of_date == as_of_date)
+    )
+
+
 class AssetService:
     """Service for managing asset positions."""
 
@@ -183,11 +204,7 @@ class AssetService:
         attribute of the fact, not part of its version-chain identity.
         """
         result = await db.execute(
-            select(ManualValuationSnapshot)
-            .where(ManualValuationSnapshot.user_id == user_id)
-            .where(ManualValuationSnapshot.component_type == component_type)
-            .where(ManualValuationSnapshot.source == source)
-            .where(ManualValuationSnapshot.as_of_date == as_of_date)
+            _valuation_key_query(user_id, component_type=component_type, source=source, as_of_date=as_of_date)
             .where(ManualValuationSnapshot.superseded_by_id.is_(None))
             .with_for_update()
         )
@@ -209,12 +226,9 @@ class AssetService:
         changes currency is still part of one history chain.
         """
         result = await db.execute(
-            select(ManualValuationSnapshot)
-            .where(ManualValuationSnapshot.user_id == user_id)
-            .where(ManualValuationSnapshot.component_type == component_type)
-            .where(ManualValuationSnapshot.source == source)
-            .where(ManualValuationSnapshot.as_of_date == as_of_date)
-            .order_by(ManualValuationSnapshot.version.desc())
+            _valuation_key_query(user_id, component_type=component_type, source=source, as_of_date=as_of_date).order_by(
+                ManualValuationSnapshot.version.desc()
+            )
         )
         return result.scalars().all()
 

--- a/apps/backend/src/services/reconciliation.py
+++ b/apps/backend/src/services/reconciliation.py
@@ -2,27 +2,20 @@
 
 from __future__ import annotations
 
-import os
-import re
 from collections.abc import Iterable
-from dataclasses import dataclass, replace
 from datetime import date, timedelta
 from decimal import Decimal
-from difflib import SequenceMatcher
 from itertools import combinations
-from pathlib import Path
 from uuid import UUID
 
-from sqlalchemy import delete, distinct, func, select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.config import settings
 from src.logger import get_logger
 from src.models import (
-    AccountType,
     AtomicTransaction,
-    Direction,
     JournalEntry,
     JournalEntrySourceType,
     JournalEntryStatus,
@@ -31,555 +24,41 @@ from src.models import (
     ReconciliationMatchJournalEntry,
     ReconciliationStatus,
 )
-from src.services.accounting import ValidationError, validate_journal_balance
 from src.services.processing_account import (
     create_transfer_in_entry,
     create_transfer_out_entry,
     detect_transfer_pattern,
     find_transfer_pairs,
 )
-from src.services.promotion_gate import RECONCILIATION_AUTO_ACCEPT_SCORE, RECONCILIATION_REVIEW_SCORE
-from src.services.source_type_priority import promote_entry_source_type, source_type_rank
+from src.services.reconciliation_config import (  # noqa: F401
+    DEFAULT_CONFIG,
+    MAX_COMBINATION_CANDIDATES,
+    MatchCandidate,
+    ReconciliationConfig,
+    _candidate_is_better,
+    _candidate_source_rank,
+    entry_bank_side_amount,
+    entry_total_amount,
+    is_entry_balanced,
+    load_reconciliation_config,
+)
+from src.services.reconciliation_scoring import (  # noqa: F401
+    ai_semantic_score,
+    extract_merchant_tokens,
+    is_cross_period,
+    normalize_text,
+    score_amount,
+    score_business_logic,
+    score_date,
+    score_description,
+    score_pattern,
+    weighted_total,
+)
+from src.services.reconciliation_stats import ReconciliationStats, get_reconciliation_stats  # noqa: F401
+from src.services.source_type_priority import promote_entry_source_type
 from src.services.statement_summary import resolve_custody_account_id
 
 logger = get_logger(__name__)
-
-
-@dataclass(frozen=True)
-class ReconciliationStats:
-    """Reconciliation statistics dataclass."""
-
-    total_transactions: int
-    matched_transactions: int
-    unmatched_transactions: int
-    pending_review: int
-    auto_accepted: int
-    match_rate: float
-    score_distribution: dict[str, int] | None = None
-
-
-async def get_reconciliation_stats(
-    db: AsyncSession,
-    user_id: UUID,
-    *,
-    include_distribution: bool = False,
-) -> ReconciliationStats:
-    """Get reconciliation statistics for a user.
-
-    Counts Layer-2 atomic transactions and their reconciliation matches.
-    A transaction is "matched" when it has an active (non-superseded)
-    accepted/auto-accepted match; "unmatched" otherwise.
-    """
-    # Total atomic transactions for the user
-    total_result = await db.execute(
-        select(func.count(AtomicTransaction.id)).where(AtomicTransaction.user_id == user_id)
-    )
-    total = total_result.scalar_one()
-
-    # Match status counts via ReconciliationMatch joined on atomic_txn_id
-    match_base = (
-        select(func.count(ReconciliationMatch.id))
-        .join(AtomicTransaction, ReconciliationMatch.atomic_txn_id == AtomicTransaction.id)
-        .where(AtomicTransaction.user_id == user_id)
-        .where(ReconciliationMatch.status != ReconciliationStatus.SUPERSEDED)
-    )
-
-    # Count DISTINCT atomic transactions that have an accepted/auto-accepted
-    # match. A single atomic transaction can carry multiple active accepted
-    # matches; counting rows would inflate `matched` and let match_rate exceed
-    # 100%.
-    matched_result = await db.execute(
-        select(func.count(distinct(ReconciliationMatch.atomic_txn_id)))
-        .join(AtomicTransaction, ReconciliationMatch.atomic_txn_id == AtomicTransaction.id)
-        .where(AtomicTransaction.user_id == user_id)
-        .where(ReconciliationMatch.status != ReconciliationStatus.SUPERSEDED)
-        .where(
-            ReconciliationMatch.status.in_(
-                [
-                    ReconciliationStatus.ACCEPTED,
-                    ReconciliationStatus.AUTO_ACCEPTED,
-                ]
-            )
-        )
-    )
-    pending_result = await db.execute(
-        match_base.where(ReconciliationMatch.status == ReconciliationStatus.PENDING_REVIEW)
-    )
-    auto_result = await db.execute(match_base.where(ReconciliationMatch.status == ReconciliationStatus.AUTO_ACCEPTED))
-
-    matched = matched_result.scalar_one()
-    pending = pending_result.scalar_one()
-    auto = auto_result.scalar_one()
-    unmatched = max(total - matched, 0)
-
-    # Score distribution (optional)
-    score_distribution: dict[str, int] | None = None
-    if include_distribution:
-        score_result = await db.execute(
-            select(ReconciliationMatch.match_score)
-            .join(AtomicTransaction, ReconciliationMatch.atomic_txn_id == AtomicTransaction.id)
-            .where(AtomicTransaction.user_id == user_id)
-        )
-        scores = score_result.scalars().all()
-        buckets = {"0-59": 0, "60-79": 0, "80-89": 0, "90-100": 0}
-        for score in scores:
-            if score < 60:
-                buckets["0-59"] += 1
-            elif score < 80:
-                buckets["60-79"] += 1
-            elif score < 90:
-                buckets["80-89"] += 1
-            else:
-                buckets["90-100"] += 1
-        score_distribution = buckets
-
-    # Compute match rate with zero-division guard
-    match_rate = float(round((matched / total) * 100, 2)) if total else 0.0
-
-    return ReconciliationStats(
-        total_transactions=total,
-        matched_transactions=matched,
-        unmatched_transactions=unmatched,
-        pending_review=pending,
-        auto_accepted=auto,
-        match_rate=match_rate,
-        score_distribution=score_distribution,
-    )
-
-
-@dataclass(frozen=True)
-class ReconciliationConfig:
-    """Runtime configuration for reconciliation scoring."""
-
-    weight_amount: Decimal
-    weight_date: Decimal
-    weight_description: Decimal
-    weight_business: Decimal
-    weight_history: Decimal
-    auto_accept: int
-    pending_review: int
-    amount_percent: Decimal
-    amount_absolute: Decimal
-    date_days: int
-
-
-@dataclass
-class MatchCandidate:
-    """Candidate match result."""
-
-    journal_entry_ids: list[str]
-    score: int
-    # Score components are 0-100 percentages, not monetary values.
-    # Float is acceptable per AGENTS.md which requires Decimal only for money.
-    breakdown: dict[str, float]
-
-
-def _candidate_source_rank(candidate: MatchCandidate, entries_by_id: dict[str, JournalEntry]) -> int:
-    """Return the highest source_type trust rank among a candidate's entries."""
-    return max(
-        (source_type_rank(entries_by_id[entry_id].source_type) for entry_id in candidate.journal_entry_ids), default=0
-    )
-
-
-def _candidate_is_better(
-    candidate: MatchCandidate,
-    best: MatchCandidate | None,
-    entries_by_id: dict[str, JournalEntry],
-) -> bool:
-    """Prefer higher score, then higher source_type trust for deterministic conflict resolution."""
-    if best is None:
-        return True
-    if candidate.score != best.score:
-        return candidate.score > best.score
-
-    candidate_rank = _candidate_source_rank(candidate, entries_by_id)
-    best_rank = _candidate_source_rank(best, entries_by_id)
-    if candidate_rank > best_rank:
-        candidate.breakdown["source_type_winner_rank"] = float(candidate_rank)
-        candidate.breakdown["source_type_loser_rank"] = float(best_rank)
-        return True
-    if candidate_rank < best_rank:
-        best.breakdown["source_type_winner_rank"] = float(best_rank)
-        best.breakdown["source_type_loser_rank"] = float(candidate_rank)
-    return False
-
-
-def entry_total_amount(entry: JournalEntry) -> Decimal:
-    """Return total debit amount for matching."""
-    return sum(line.amount for line in entry.lines if line.direction == Direction.DEBIT)
-
-
-def entry_bank_side_amount(entry: JournalEntry, transaction_direction: str | None) -> Decimal:
-    """Return the bank/cash-side amount that should match a statement transaction."""
-    if not transaction_direction:
-        return entry_total_amount(entry)
-    direction = transaction_direction.upper()
-    bank_line_direction = Direction.DEBIT if direction == "IN" else Direction.CREDIT
-    bank_lines = [
-        line.amount
-        for line in entry.lines
-        if line.direction == bank_line_direction and line.account and line.account.type == AccountType.ASSET
-    ]
-    if bank_lines:
-        return sum(bank_lines, Decimal("0.00"))
-    return entry_total_amount(entry)
-
-
-def is_entry_balanced(entry: JournalEntry) -> bool:
-    """Return True if entry is balanced."""
-    try:
-        validate_journal_balance(entry.lines)
-    except ValidationError:
-        return False
-    return True
-
-
-DEFAULT_CONFIG = ReconciliationConfig(
-    weight_amount=Decimal("0.40"),
-    weight_date=Decimal("0.25"),
-    weight_description=Decimal("0.20"),
-    weight_business=Decimal("0.10"),
-    weight_history=Decimal("0.05"),
-    auto_accept=RECONCILIATION_AUTO_ACCEPT_SCORE,
-    pending_review=RECONCILIATION_REVIEW_SCORE,
-    amount_percent=Decimal("0.005"),
-    amount_absolute=Decimal("0.10"),
-    date_days=7,
-)
-
-MAX_COMBINATION_CANDIDATES = 30
-
-_config_cache: ReconciliationConfig | None = None
-
-
-def load_reconciliation_config(force_reload: bool = False) -> ReconciliationConfig:
-    """Load reconciliation configuration from YAML if available.
-
-    Caches the result to avoid repeated disk I/O.
-    """
-    global _config_cache
-    if _config_cache is not None and not force_reload:
-        return _config_cache
-
-    config = DEFAULT_CONFIG
-    config_path = Path(__file__).resolve().parents[2] / "config" / "reconciliation.yaml"
-
-    if config_path.exists():
-        try:
-            import yaml
-        except ImportError:
-            yaml = None
-
-        if yaml:
-            try:
-                raw = yaml.safe_load(config_path.read_text()) or {}
-                scoring = raw.get("scoring", {})
-                weights = scoring.get("weights", {})
-                thresholds = scoring.get("thresholds", {})
-                tolerances = scoring.get("tolerances", {})
-
-                config = ReconciliationConfig(
-                    weight_amount=Decimal(str(weights.get("amount", config.weight_amount))),
-                    weight_date=Decimal(str(weights.get("date", config.weight_date))),
-                    weight_description=Decimal(str(weights.get("description", config.weight_description))),
-                    weight_business=Decimal(str(weights.get("business", config.weight_business))),
-                    weight_history=Decimal(str(weights.get("history", config.weight_history))),
-                    auto_accept=int(thresholds.get("auto_accept", config.auto_accept)),
-                    pending_review=int(thresholds.get("pending_review", config.pending_review)),
-                    amount_percent=Decimal(str(tolerances.get("amount_percent", config.amount_percent))),
-                    amount_absolute=Decimal(str(tolerances.get("amount_absolute", config.amount_absolute))),
-                    date_days=int(tolerances.get("date_days", config.date_days)),
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to load reconciliation config - using defaults",
-                    config_path=str(config_path),
-                    error=str(e),
-                    error_type=type(e).__name__,
-                )
-
-    auto_accept_env = os.getenv("RECONCILIATION_AUTO_ACCEPT_THRESHOLD")
-    pending_review_env = os.getenv("RECONCILIATION_REVIEW_THRESHOLD")
-    if auto_accept_env:
-        config = replace(config, auto_accept=int(auto_accept_env))
-    if pending_review_env:
-        config = replace(config, pending_review=int(pending_review_env))
-
-    _config_cache = config
-    return config
-
-
-def normalize_text(value: str) -> str:
-    """Normalize text for similarity comparison."""
-    cleaned = re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
-    return re.sub(r"\s+", " ", cleaned)
-
-
-def score_description(a: str | None, b: str | None) -> float:
-    """Score description similarity (0-100)."""
-    if not a or not b:
-        return 0.0
-    norm_a = normalize_text(a)
-    norm_b = normalize_text(b)
-    if not norm_a or not norm_b:
-        return 0.0
-    ratio = SequenceMatcher(None, norm_a, norm_b).ratio()
-    tokens_a = set(norm_a.split())
-    tokens_b = set(norm_b.split())
-    token_score = len(tokens_a & tokens_b) / len(tokens_a | tokens_b) if tokens_a | tokens_b else 0
-    return round(100 * (0.6 * ratio + 0.4 * token_score), 2)
-
-
-def score_amount(
-    txn_amount: Decimal,
-    entry_amount: Decimal,
-    config: ReconciliationConfig,
-    is_multi: bool = False,
-) -> float:
-    """Score amount match (0-100)."""
-    diff = abs(txn_amount - entry_amount)
-    if diff <= Decimal("0.01"):
-        return 100.0
-
-    tolerance = max(txn_amount * config.amount_percent, config.amount_absolute)
-    if diff <= tolerance:
-        return 90.0
-    if diff <= Decimal("5.00"):
-        return 70.0
-    if is_multi and diff <= tolerance * 2:
-        return 70.0
-    if txn_amount == Decimal("0"):
-        return 0.0
-
-    ratio = max(Decimal("0"), Decimal("100") - (diff / txn_amount) * Decimal("100"))
-    return float(round(ratio, 2))
-
-
-def is_cross_period(txn_date: date, entry_date: date, max_days: int) -> bool:
-    """Detect cross-period matching scenarios."""
-    if txn_date.month == entry_date.month:
-        return False
-    return abs((txn_date - entry_date).days) <= max_days
-
-
-def score_date(txn_date: date, entry_date: date, config: ReconciliationConfig) -> float:
-    """Score date proximity (0-100)."""
-    # Scoring tiers:
-    # - Same day: 100
-    # - Within 3 days: 90
-    # - Cross-month but within config.date_days: 75 (bonus for cross-period matching)
-    # - Same month within config.date_days: 70
-    # - Beyond config.date_days: decreasing score
-    #
-    diff_days = abs((txn_date - entry_date).days)
-    if diff_days == 0:
-        return 100.0
-    if diff_days <= 3:
-        return 90.0
-
-    # Check if within acceptable date window
-    if diff_days <= config.date_days:
-        # Cross-period matching gets a slight bonus (e.g., Friday txn -> Monday entry)
-        if is_cross_period(txn_date, entry_date, max_days=config.date_days):
-            return 75.0
-        return 70.0
-
-    # Beyond acceptable window - rapidly decreasing score
-    return float(max(0, 100 - diff_days * 10))
-
-
-def score_business_logic(transaction: AtomicTransaction, entry: JournalEntry) -> float:
-    """Score business logic fit based on account types."""
-    account_types = {line.account.type for line in entry.lines if line.account}
-    has_asset = AccountType.ASSET in account_types
-    has_income = AccountType.INCOME in account_types
-    has_expense = AccountType.EXPENSE in account_types
-    has_liability = AccountType.LIABILITY in account_types
-    has_equity = AccountType.EQUITY in account_types
-
-    if transaction.direction == "IN":
-        if has_asset and has_income:
-            return 100.0
-        if has_asset and has_liability:
-            return 85.0
-        if has_asset and has_equity:
-            return 75.0
-        if has_asset and account_types == {AccountType.ASSET}:
-            return 70.0
-        return 40.0
-
-    if transaction.direction == "OUT":
-        if has_asset and has_expense:
-            return 100.0
-        if has_asset and has_liability:
-            return 90.0
-        if has_asset and account_types == {AccountType.ASSET}:
-            return 70.0
-        return 40.0
-
-    return 50.0
-
-
-def extract_merchant_tokens(description: str) -> list[str]:
-    """Extract meaningful merchant tokens from transaction description.
-
-    Improved extraction that takes up to 3 significant words, skipping
-    common prefixes like transaction codes, dates, and generic terms.
-    """
-    skip_patterns = {
-        "ref",
-        "txn",
-        "trn",
-        "pos",
-        "atm",
-        "eft",
-        "ibk",
-        "ibt",
-        "payment",
-        "transfer",
-        "debit",
-        "credit",
-        "card",
-        "visa",
-        "mastercard",
-    }
-    words = normalize_text(description).split()
-    tokens = []
-    for word in words:
-        # Skip very short words, numbers, and common prefixes
-        if len(word) < 3:
-            continue
-        if word.isdigit():
-            continue
-        if word.lower() in skip_patterns:
-            continue
-        tokens.append(word)
-        if len(tokens) >= 3:
-            break
-    return tokens
-
-
-async def score_pattern(
-    db: AsyncSession,
-    transaction: AtomicTransaction,
-    config: ReconciliationConfig,
-    user_id: UUID,
-) -> float:
-    """Score based on historical matching patterns.
-
-    Uses improved merchant extraction that considers multiple significant words.
-    """
-    merchant_tokens = extract_merchant_tokens(transaction.description)
-    if not merchant_tokens:
-        return 0.0
-
-    # Use first meaningful token for pattern matching
-    token = merchant_tokens[0]
-    safe_token = token.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    pattern = f"%{safe_token}%"
-
-    result = await db.execute(
-        select(AtomicTransaction)
-        .join(
-            ReconciliationMatch,
-            ReconciliationMatch.atomic_txn_id == AtomicTransaction.id,
-        )
-        .where(AtomicTransaction.user_id == user_id)
-        .where(ReconciliationMatch.status.in_([ReconciliationStatus.AUTO_ACCEPTED, ReconciliationStatus.ACCEPTED]))
-        .where(AtomicTransaction.description.ilike(pattern, escape="\\"))
-        .order_by(AtomicTransaction.txn_date.desc())
-        .limit(10)
-    )
-    history = result.scalars().all()
-    if not history:
-        return 0.0
-
-    tolerance = max(transaction.amount * config.amount_percent, config.amount_absolute)
-    for past in history:
-        if abs(past.amount - transaction.amount) <= tolerance:
-            return 80.0
-    return 40.0
-
-
-def weighted_total(scores: dict[str, float], config: ReconciliationConfig) -> int:
-    """Compute weighted total score."""
-    total = (
-        Decimal(str(scores["amount"])) * config.weight_amount
-        + Decimal(str(scores["date"])) * config.weight_date
-        + Decimal(str(scores["description"])) * config.weight_description
-        + Decimal(str(scores["business"])) * config.weight_business
-        + Decimal(str(scores["history"])) * config.weight_history
-    )
-    return int(round(total, 0))
-
-
-async def ai_semantic_score(
-    txn_description: str,
-    entry_memo: str,
-    date_diff_days: int,
-    amount_match_pct: float,
-) -> int:
-    """EPIC-018 Phase 3: Compute AI semantic similarity score.
-
-    Calls the configured AI provider to assess semantic similarity between a bank transaction
-    description and a journal entry memo. Returns 0-100 score.
-
-    Falls back gracefully to 50 (neutral) on any error.
-    """
-    import json
-
-    from src.prompts.reconciliation import build_reconciliation_prompt
-    from src.services.ai_streaming import (
-        AIStreamError,
-        accumulate_stream,
-        stream_ai_json,
-    )
-
-    if not settings.ai_api_key:
-        logger.debug("AI reconciliation skipped: no API key configured")
-        return 50
-
-    prompt = build_reconciliation_prompt(
-        txn_description=txn_description,
-        entry_memo=entry_memo,
-        date_diff_days=date_diff_days,
-        amount_match_pct=amount_match_pct,
-    )
-
-    messages = [{"role": "user", "content": prompt}]
-
-    try:
-        stream = stream_ai_json(
-            messages=messages,
-            model=settings.primary_model,
-            api_key=settings.ai_api_key,
-            base_url=settings.ai_base_url,
-            timeout=30.0,
-        )
-        content = await accumulate_stream(stream)
-
-        if not content or not content.strip():
-            logger.warning("AI semantic score returned empty response")
-            return 50
-
-        parsed = json.loads(content)
-        score = int(parsed.get("similarity_score", 50))
-
-        logger.debug(
-            "AI semantic score computed",
-            score=score,
-            model=settings.primary_model,
-        )
-
-        return max(0, min(100, score))
-
-    except (AIStreamError, json.JSONDecodeError, ValueError, TypeError, KeyError) as e:
-        logger.warning(
-            "AI semantic score failed, using fallback",
-            error=str(e),
-            error_type=type(e).__name__,
-        )
-        return 50
 
 
 def prune_candidates(

--- a/apps/backend/src/services/reconciliation_config.py
+++ b/apps/backend/src/services/reconciliation_config.py
@@ -1,0 +1,182 @@
+"""Reconciliation config, match-candidate types, and entry helpers (split from reconciliation.py)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, replace
+from decimal import Decimal
+from pathlib import Path
+
+from src.logger import get_logger
+from src.models import (
+    AccountType,
+    Direction,
+    JournalEntry,
+)
+from src.services.accounting import ValidationError, validate_journal_balance
+from src.services.promotion_gate import RECONCILIATION_AUTO_ACCEPT_SCORE, RECONCILIATION_REVIEW_SCORE
+from src.services.source_type_priority import source_type_rank
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ReconciliationConfig:
+    """Runtime configuration for reconciliation scoring."""
+
+    weight_amount: Decimal
+    weight_date: Decimal
+    weight_description: Decimal
+    weight_business: Decimal
+    weight_history: Decimal
+    auto_accept: int
+    pending_review: int
+    amount_percent: Decimal
+    amount_absolute: Decimal
+    date_days: int
+
+
+@dataclass
+class MatchCandidate:
+    """Candidate match result."""
+
+    journal_entry_ids: list[str]
+    score: int
+    # Score components are 0-100 percentages, not monetary values.
+    # Float is acceptable per AGENTS.md which requires Decimal only for money.
+    breakdown: dict[str, float]
+
+
+def _candidate_source_rank(candidate: MatchCandidate, entries_by_id: dict[str, JournalEntry]) -> int:
+    """Return the highest source_type trust rank among a candidate's entries."""
+    return max(
+        (source_type_rank(entries_by_id[entry_id].source_type) for entry_id in candidate.journal_entry_ids), default=0
+    )
+
+
+def _candidate_is_better(
+    candidate: MatchCandidate,
+    best: MatchCandidate | None,
+    entries_by_id: dict[str, JournalEntry],
+) -> bool:
+    """Prefer higher score, then higher source_type trust for deterministic conflict resolution."""
+    if best is None:
+        return True
+    if candidate.score != best.score:
+        return candidate.score > best.score
+
+    candidate_rank = _candidate_source_rank(candidate, entries_by_id)
+    best_rank = _candidate_source_rank(best, entries_by_id)
+    if candidate_rank > best_rank:
+        candidate.breakdown["source_type_winner_rank"] = float(candidate_rank)
+        candidate.breakdown["source_type_loser_rank"] = float(best_rank)
+        return True
+    if candidate_rank < best_rank:
+        best.breakdown["source_type_winner_rank"] = float(best_rank)
+        best.breakdown["source_type_loser_rank"] = float(candidate_rank)
+    return False
+
+
+def entry_total_amount(entry: JournalEntry) -> Decimal:
+    """Return total debit amount for matching."""
+    return sum(line.amount for line in entry.lines if line.direction == Direction.DEBIT)
+
+
+def entry_bank_side_amount(entry: JournalEntry, transaction_direction: str | None) -> Decimal:
+    """Return the bank/cash-side amount that should match a statement transaction."""
+    if not transaction_direction:
+        return entry_total_amount(entry)
+    direction = transaction_direction.upper()
+    bank_line_direction = Direction.DEBIT if direction == "IN" else Direction.CREDIT
+    bank_lines = [
+        line.amount
+        for line in entry.lines
+        if line.direction == bank_line_direction and line.account and line.account.type == AccountType.ASSET
+    ]
+    if bank_lines:
+        return sum(bank_lines, Decimal("0.00"))
+    return entry_total_amount(entry)
+
+
+def is_entry_balanced(entry: JournalEntry) -> bool:
+    """Return True if entry is balanced."""
+    try:
+        validate_journal_balance(entry.lines)
+    except ValidationError:
+        return False
+    return True
+
+
+DEFAULT_CONFIG = ReconciliationConfig(
+    weight_amount=Decimal("0.40"),
+    weight_date=Decimal("0.25"),
+    weight_description=Decimal("0.20"),
+    weight_business=Decimal("0.10"),
+    weight_history=Decimal("0.05"),
+    auto_accept=RECONCILIATION_AUTO_ACCEPT_SCORE,
+    pending_review=RECONCILIATION_REVIEW_SCORE,
+    amount_percent=Decimal("0.005"),
+    amount_absolute=Decimal("0.10"),
+    date_days=7,
+)
+
+MAX_COMBINATION_CANDIDATES = 30
+
+_config_cache: ReconciliationConfig | None = None
+
+
+def load_reconciliation_config(force_reload: bool = False) -> ReconciliationConfig:
+    """Load reconciliation configuration from YAML if available.
+
+    Caches the result to avoid repeated disk I/O.
+    """
+    global _config_cache
+    if _config_cache is not None and not force_reload:
+        return _config_cache
+
+    config = DEFAULT_CONFIG
+    config_path = Path(__file__).resolve().parents[2] / "config" / "reconciliation.yaml"
+
+    if config_path.exists():
+        try:
+            import yaml
+        except ImportError:
+            yaml = None
+
+        if yaml:
+            try:
+                raw = yaml.safe_load(config_path.read_text()) or {}
+                scoring = raw.get("scoring", {})
+                weights = scoring.get("weights", {})
+                thresholds = scoring.get("thresholds", {})
+                tolerances = scoring.get("tolerances", {})
+
+                config = ReconciliationConfig(
+                    weight_amount=Decimal(str(weights.get("amount", config.weight_amount))),
+                    weight_date=Decimal(str(weights.get("date", config.weight_date))),
+                    weight_description=Decimal(str(weights.get("description", config.weight_description))),
+                    weight_business=Decimal(str(weights.get("business", config.weight_business))),
+                    weight_history=Decimal(str(weights.get("history", config.weight_history))),
+                    auto_accept=int(thresholds.get("auto_accept", config.auto_accept)),
+                    pending_review=int(thresholds.get("pending_review", config.pending_review)),
+                    amount_percent=Decimal(str(tolerances.get("amount_percent", config.amount_percent))),
+                    amount_absolute=Decimal(str(tolerances.get("amount_absolute", config.amount_absolute))),
+                    date_days=int(tolerances.get("date_days", config.date_days)),
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to load reconciliation config - using defaults",
+                    config_path=str(config_path),
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+
+    auto_accept_env = os.getenv("RECONCILIATION_AUTO_ACCEPT_THRESHOLD")
+    pending_review_env = os.getenv("RECONCILIATION_REVIEW_THRESHOLD")
+    if auto_accept_env:
+        config = replace(config, auto_accept=int(auto_accept_env))
+    if pending_review_env:
+        config = replace(config, pending_review=int(pending_review_env))
+
+    _config_cache = config
+    return config

--- a/apps/backend/src/services/reconciliation_scoring.py
+++ b/apps/backend/src/services/reconciliation_scoring.py
@@ -1,0 +1,298 @@
+"""Reconciliation scoring functions (split from reconciliation.py)."""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from decimal import Decimal
+from difflib import SequenceMatcher
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.logger import get_logger
+from src.models import (
+    AccountType,
+    AtomicTransaction,
+    JournalEntry,
+    ReconciliationMatch,
+    ReconciliationStatus,
+)
+from src.services.reconciliation_config import ReconciliationConfig
+
+logger = get_logger(__name__)
+
+
+def normalize_text(value: str) -> str:
+    """Normalize text for similarity comparison."""
+    cleaned = re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+    return re.sub(r"\s+", " ", cleaned)
+
+
+def score_description(a: str | None, b: str | None) -> float:
+    """Score description similarity (0-100)."""
+    if not a or not b:
+        return 0.0
+    norm_a = normalize_text(a)
+    norm_b = normalize_text(b)
+    if not norm_a or not norm_b:
+        return 0.0
+    ratio = SequenceMatcher(None, norm_a, norm_b).ratio()
+    tokens_a = set(norm_a.split())
+    tokens_b = set(norm_b.split())
+    token_score = len(tokens_a & tokens_b) / len(tokens_a | tokens_b) if tokens_a | tokens_b else 0
+    return round(100 * (0.6 * ratio + 0.4 * token_score), 2)
+
+
+def score_amount(
+    txn_amount: Decimal,
+    entry_amount: Decimal,
+    config: ReconciliationConfig,
+    is_multi: bool = False,
+) -> float:
+    """Score amount match (0-100)."""
+    diff = abs(txn_amount - entry_amount)
+    if diff <= Decimal("0.01"):
+        return 100.0
+
+    tolerance = max(txn_amount * config.amount_percent, config.amount_absolute)
+    if diff <= tolerance:
+        return 90.0
+    if diff <= Decimal("5.00"):
+        return 70.0
+    if is_multi and diff <= tolerance * 2:
+        return 70.0
+    if txn_amount == Decimal("0"):
+        return 0.0
+
+    ratio = max(Decimal("0"), Decimal("100") - (diff / txn_amount) * Decimal("100"))
+    return float(round(ratio, 2))
+
+
+def is_cross_period(txn_date: date, entry_date: date, max_days: int) -> bool:
+    """Detect cross-period matching scenarios."""
+    if txn_date.month == entry_date.month:
+        return False
+    return abs((txn_date - entry_date).days) <= max_days
+
+
+def score_date(txn_date: date, entry_date: date, config: ReconciliationConfig) -> float:
+    """Score date proximity (0-100)."""
+    # Scoring tiers:
+    # - Same day: 100
+    # - Within 3 days: 90
+    # - Cross-month but within config.date_days: 75 (bonus for cross-period matching)
+    # - Same month within config.date_days: 70
+    # - Beyond config.date_days: decreasing score
+    #
+    diff_days = abs((txn_date - entry_date).days)
+    if diff_days == 0:
+        return 100.0
+    if diff_days <= 3:
+        return 90.0
+
+    # Check if within acceptable date window
+    if diff_days <= config.date_days:
+        # Cross-period matching gets a slight bonus (e.g., Friday txn -> Monday entry)
+        if is_cross_period(txn_date, entry_date, max_days=config.date_days):
+            return 75.0
+        return 70.0
+
+    # Beyond acceptable window - rapidly decreasing score
+    return float(max(0, 100 - diff_days * 10))
+
+
+def score_business_logic(transaction: AtomicTransaction, entry: JournalEntry) -> float:
+    """Score business logic fit based on account types."""
+    account_types = {line.account.type for line in entry.lines if line.account}
+    has_asset = AccountType.ASSET in account_types
+    has_income = AccountType.INCOME in account_types
+    has_expense = AccountType.EXPENSE in account_types
+    has_liability = AccountType.LIABILITY in account_types
+    has_equity = AccountType.EQUITY in account_types
+
+    if transaction.direction == "IN":
+        if has_asset and has_income:
+            return 100.0
+        if has_asset and has_liability:
+            return 85.0
+        if has_asset and has_equity:
+            return 75.0
+        if has_asset and account_types == {AccountType.ASSET}:
+            return 70.0
+        return 40.0
+
+    if transaction.direction == "OUT":
+        if has_asset and has_expense:
+            return 100.0
+        if has_asset and has_liability:
+            return 90.0
+        if has_asset and account_types == {AccountType.ASSET}:
+            return 70.0
+        return 40.0
+
+    return 50.0
+
+
+def extract_merchant_tokens(description: str) -> list[str]:
+    """Extract meaningful merchant tokens from transaction description.
+
+    Improved extraction that takes up to 3 significant words, skipping
+    common prefixes like transaction codes, dates, and generic terms.
+    """
+    skip_patterns = {
+        "ref",
+        "txn",
+        "trn",
+        "pos",
+        "atm",
+        "eft",
+        "ibk",
+        "ibt",
+        "payment",
+        "transfer",
+        "debit",
+        "credit",
+        "card",
+        "visa",
+        "mastercard",
+    }
+    words = normalize_text(description).split()
+    tokens = []
+    for word in words:
+        # Skip very short words, numbers, and common prefixes
+        if len(word) < 3:
+            continue
+        if word.isdigit():
+            continue
+        if word.lower() in skip_patterns:
+            continue
+        tokens.append(word)
+        if len(tokens) >= 3:
+            break
+    return tokens
+
+
+async def score_pattern(
+    db: AsyncSession,
+    transaction: AtomicTransaction,
+    config: ReconciliationConfig,
+    user_id: UUID,
+) -> float:
+    """Score based on historical matching patterns.
+
+    Uses improved merchant extraction that considers multiple significant words.
+    """
+    merchant_tokens = extract_merchant_tokens(transaction.description)
+    if not merchant_tokens:
+        return 0.0
+
+    # Use first meaningful token for pattern matching
+    token = merchant_tokens[0]
+    safe_token = token.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{safe_token}%"
+
+    result = await db.execute(
+        select(AtomicTransaction)
+        .join(
+            ReconciliationMatch,
+            ReconciliationMatch.atomic_txn_id == AtomicTransaction.id,
+        )
+        .where(AtomicTransaction.user_id == user_id)
+        .where(ReconciliationMatch.status.in_([ReconciliationStatus.AUTO_ACCEPTED, ReconciliationStatus.ACCEPTED]))
+        .where(AtomicTransaction.description.ilike(pattern, escape="\\"))
+        .order_by(AtomicTransaction.txn_date.desc())
+        .limit(10)
+    )
+    history = result.scalars().all()
+    if not history:
+        return 0.0
+
+    tolerance = max(transaction.amount * config.amount_percent, config.amount_absolute)
+    for past in history:
+        if abs(past.amount - transaction.amount) <= tolerance:
+            return 80.0
+    return 40.0
+
+
+def weighted_total(scores: dict[str, float], config: ReconciliationConfig) -> int:
+    """Compute weighted total score."""
+    total = (
+        Decimal(str(scores["amount"])) * config.weight_amount
+        + Decimal(str(scores["date"])) * config.weight_date
+        + Decimal(str(scores["description"])) * config.weight_description
+        + Decimal(str(scores["business"])) * config.weight_business
+        + Decimal(str(scores["history"])) * config.weight_history
+    )
+    return int(round(total, 0))
+
+
+async def ai_semantic_score(
+    txn_description: str,
+    entry_memo: str,
+    date_diff_days: int,
+    amount_match_pct: float,
+) -> int:
+    """EPIC-018 Phase 3: Compute AI semantic similarity score.
+
+    Calls the configured AI provider to assess semantic similarity between a bank transaction
+    description and a journal entry memo. Returns 0-100 score.
+
+    Falls back gracefully to 50 (neutral) on any error.
+    """
+    import json
+
+    from src.prompts.reconciliation import build_reconciliation_prompt
+    from src.services.ai_streaming import (
+        AIStreamError,
+        accumulate_stream,
+        stream_ai_json,
+    )
+
+    if not settings.ai_api_key:
+        logger.debug("AI reconciliation skipped: no API key configured")
+        return 50
+
+    prompt = build_reconciliation_prompt(
+        txn_description=txn_description,
+        entry_memo=entry_memo,
+        date_diff_days=date_diff_days,
+        amount_match_pct=amount_match_pct,
+    )
+
+    messages = [{"role": "user", "content": prompt}]
+
+    try:
+        stream = stream_ai_json(
+            messages=messages,
+            model=settings.primary_model,
+            api_key=settings.ai_api_key,
+            base_url=settings.ai_base_url,
+            timeout=30.0,
+        )
+        content = await accumulate_stream(stream)
+
+        if not content or not content.strip():
+            logger.warning("AI semantic score returned empty response")
+            return 50
+
+        parsed = json.loads(content)
+        score = int(parsed.get("similarity_score", 50))
+
+        logger.debug(
+            "AI semantic score computed",
+            score=score,
+            model=settings.primary_model,
+        )
+
+        return max(0, min(100, score))
+
+    except (AIStreamError, json.JSONDecodeError, ValueError, TypeError, KeyError) as e:
+        logger.warning(
+            "AI semantic score failed, using fallback",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return 50

--- a/apps/backend/src/services/reconciliation_stats.py
+++ b/apps/backend/src/services/reconciliation_stats.py
@@ -1,0 +1,120 @@
+"""Reconciliation statistics aggregation (split from reconciliation.py)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import distinct, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logger import get_logger
+from src.models import (
+    AtomicTransaction,
+    ReconciliationMatch,
+    ReconciliationStatus,
+)
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ReconciliationStats:
+    """Reconciliation statistics dataclass."""
+
+    total_transactions: int
+    matched_transactions: int
+    unmatched_transactions: int
+    pending_review: int
+    auto_accepted: int
+    match_rate: float
+    score_distribution: dict[str, int] | None = None
+
+
+async def get_reconciliation_stats(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    include_distribution: bool = False,
+) -> ReconciliationStats:
+    """Get reconciliation statistics for a user.
+
+    Counts Layer-2 atomic transactions and their reconciliation matches.
+    A transaction is "matched" when it has an active (non-superseded)
+    accepted/auto-accepted match; "unmatched" otherwise.
+    """
+    # Total atomic transactions for the user
+    total_result = await db.execute(
+        select(func.count(AtomicTransaction.id)).where(AtomicTransaction.user_id == user_id)
+    )
+    total = total_result.scalar_one()
+
+    # Match status counts via ReconciliationMatch joined on atomic_txn_id
+    match_base = (
+        select(func.count(ReconciliationMatch.id))
+        .join(AtomicTransaction, ReconciliationMatch.atomic_txn_id == AtomicTransaction.id)
+        .where(AtomicTransaction.user_id == user_id)
+        .where(ReconciliationMatch.status != ReconciliationStatus.SUPERSEDED)
+    )
+
+    # Count DISTINCT atomic transactions that have an accepted/auto-accepted
+    # match. A single atomic transaction can carry multiple active accepted
+    # matches; counting rows would inflate `matched` and let match_rate exceed
+    # 100%.
+    matched_result = await db.execute(
+        select(func.count(distinct(ReconciliationMatch.atomic_txn_id)))
+        .join(AtomicTransaction, ReconciliationMatch.atomic_txn_id == AtomicTransaction.id)
+        .where(AtomicTransaction.user_id == user_id)
+        .where(ReconciliationMatch.status != ReconciliationStatus.SUPERSEDED)
+        .where(
+            ReconciliationMatch.status.in_(
+                [
+                    ReconciliationStatus.ACCEPTED,
+                    ReconciliationStatus.AUTO_ACCEPTED,
+                ]
+            )
+        )
+    )
+    pending_result = await db.execute(
+        match_base.where(ReconciliationMatch.status == ReconciliationStatus.PENDING_REVIEW)
+    )
+    auto_result = await db.execute(match_base.where(ReconciliationMatch.status == ReconciliationStatus.AUTO_ACCEPTED))
+
+    matched = matched_result.scalar_one()
+    pending = pending_result.scalar_one()
+    auto = auto_result.scalar_one()
+    unmatched = max(total - matched, 0)
+
+    # Score distribution (optional)
+    score_distribution: dict[str, int] | None = None
+    if include_distribution:
+        score_result = await db.execute(
+            select(ReconciliationMatch.match_score)
+            .join(AtomicTransaction, ReconciliationMatch.atomic_txn_id == AtomicTransaction.id)
+            .where(AtomicTransaction.user_id == user_id)
+        )
+        scores = score_result.scalars().all()
+        buckets = {"0-59": 0, "60-79": 0, "80-89": 0, "90-100": 0}
+        for score in scores:
+            if score < 60:
+                buckets["0-59"] += 1
+            elif score < 80:
+                buckets["60-79"] += 1
+            elif score < 90:
+                buckets["80-89"] += 1
+            else:
+                buckets["90-100"] += 1
+        score_distribution = buckets
+
+    # Compute match rate with zero-division guard
+    match_rate = float(round((matched / total) * 100, 2)) if total else 0.0
+
+    return ReconciliationStats(
+        total_transactions=total,
+        matched_transactions=matched,
+        unmatched_transactions=unmatched,
+        pending_review=pending,
+        auto_accepted=auto,
+        match_rate=match_rate,
+        score_distribution=score_distribution,
+    )

--- a/apps/backend/src/services/workflow_event_builders.py
+++ b/apps/backend/src/services/workflow_event_builders.py
@@ -1,0 +1,163 @@
+"""Workflow event payload builders (split from workflow_events.py).
+
+Pure constructors that turn statements / readiness blockers / package readiness
+into WorkflowEventCreate payloads. No DB or session logic.
+"""
+
+from datetime import UTC, datetime
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from src.models import StatementSummary
+from src.models.workflow import WorkflowEventFamily, WorkflowEventSeverity, WorkflowReportImpact
+from src.schemas.workflow import WorkflowEventCreate
+
+PACKAGE_WORKFLOW_SOURCE_ID = uuid5(NAMESPACE_URL, "finance-report:personal-financial-report-package")
+
+
+def build_workflow_dedupe_key(*, family: WorkflowEventFamily, source_type: str, source_id: UUID) -> str:
+    """Build the stable per-user dedupe key for a source-derived workflow event."""
+    return f"{source_type}:{source_id}:{family.value}"
+
+
+def _build_statement_event_payload(
+    statement: StatementSummary,
+    *,
+    family: WorkflowEventFamily,
+    occurred_at: datetime,
+    severity: WorkflowEventSeverity,
+    title: str,
+    summary: str,
+    action_href: str,
+    report_impact: WorkflowReportImpact,
+) -> WorkflowEventCreate:
+    """Shared builder for the per-statement workflow events (uploaded / parse-failed
+    / review-required / review-completed), which differ only in their family,
+    timestamp, severity, copy, deep link, and report impact."""
+    return WorkflowEventCreate(
+        occurred_at=occurred_at,
+        family=family,
+        severity=severity,
+        title=title,
+        summary=summary,
+        source_type="bank_statement",
+        source_id=statement.id,
+        action_href=action_href,
+        report_impact=report_impact,
+        dedupe_key=build_workflow_dedupe_key(
+            family=family,
+            source_type="bank_statement",
+            source_id=statement.id,
+        ),
+    )
+
+
+def build_uploaded_statement_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
+    """Build the deterministic uploaded-statement workflow event payload."""
+    return _build_statement_event_payload(
+        statement,
+        family=WorkflowEventFamily.SOURCE_UPLOADED,
+        occurred_at=statement.created_at,
+        severity=WorkflowEventSeverity.INFO,
+        title="Statement uploaded",
+        summary=f"{filename} was uploaded and is ready for processing.",
+        action_href=f"/statements/{statement.id}",
+        report_impact=WorkflowReportImpact.PROCESSING,
+    )
+
+
+def build_statement_parsing_failed_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
+    """Build the user-action event for a failed statement parse."""
+    return _build_statement_event_payload(
+        statement,
+        family=WorkflowEventFamily.SOURCE_PARSING_FAILED,
+        occurred_at=statement.updated_at or statement.created_at,
+        severity=WorkflowEventSeverity.ACTION_REQUIRED,
+        title="Statement parsing failed",
+        summary=f"{filename} could not be parsed and needs attention.",
+        action_href=f"/statements/{statement.id}",
+        report_impact=WorkflowReportImpact.BLOCKED,
+    )
+
+
+def build_review_required_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
+    """Build the user-action event for pending Stage 1 review."""
+    return _build_statement_event_payload(
+        statement,
+        family=WorkflowEventFamily.REVIEW_REQUIRED,
+        occurred_at=statement.updated_at or statement.created_at,
+        severity=WorkflowEventSeverity.ACTION_REQUIRED,
+        title="Source review required",
+        summary=f"{filename} needs source review before report readiness can advance.",
+        # Deep-link straight to this statement's review surface (EPIC-022 PR2):
+        # the standalone Review Queue page is gone; the notification card is the
+        # entry point, so it must point at the specific item to review.
+        action_href=f"/statements/{statement.id}/review",
+        report_impact=WorkflowReportImpact.BLOCKED,
+    )
+
+
+def build_review_completed_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
+    """Build the routine success event for completed Stage 1 review."""
+    return _build_statement_event_payload(
+        statement,
+        family=WorkflowEventFamily.REVIEW_COMPLETED,
+        occurred_at=statement.stage1_reviewed_at or statement.updated_at or statement.created_at,
+        severity=WorkflowEventSeverity.SUCCESS,
+        title="Source review completed",
+        summary=f"{filename} source review is complete.",
+        action_href=f"/statements/{statement.id}",
+        report_impact=WorkflowReportImpact.NONE,
+    )
+
+
+def _readiness_blocker_source_id(code: str) -> UUID:
+    return uuid5(NAMESPACE_URL, f"finance-report:readiness-blocker:{code}")
+
+
+def build_readiness_blocker_event_payload(blocker: dict[str, str | int]) -> WorkflowEventCreate:
+    """Build a lightweight user-facing event from a report-readiness blocker."""
+    code = str(blocker["code"])
+    family = (
+        WorkflowEventFamily.RECONCILIATION_BLOCKED
+        if code == "reconciliation_blocked"
+        else WorkflowEventFamily.REPORT_BLOCKED
+    )
+    count = int(blocker.get("count", 1))
+    return WorkflowEventCreate(
+        occurred_at=datetime.now(UTC),
+        family=family,
+        severity=WorkflowEventSeverity.BLOCKED,
+        title=str(blocker["label"]),
+        summary=f"{blocker['reason']} ({count} item{'s' if count != 1 else ''}).",
+        source_type="readiness_blocker",
+        source_id=_readiness_blocker_source_id(code),
+        action_href=str(blocker["action_href"]),
+        report_impact=WorkflowReportImpact.BLOCKED,
+        dedupe_key=f"readiness-blocker:{code}:{family.value}",
+    )
+
+
+def build_report_state_event_payload(package_readiness: dict) -> WorkflowEventCreate | None:
+    """Build report ready/generated events from package readiness."""
+    state = str(package_readiness["state"])
+    if state not in {"ready", "generated"}:
+        return None
+    family = WorkflowEventFamily.REPORT_GENERATED if state == "generated" else WorkflowEventFamily.REPORT_READY
+    title = "Report package generated" if state == "generated" else "Report package ready"
+    summary = (
+        "The personal report package has been generated."
+        if state == "generated"
+        else "The personal report package is ready to review."
+    )
+    return WorkflowEventCreate(
+        occurred_at=datetime.now(UTC),
+        family=family,
+        severity=WorkflowEventSeverity.SUCCESS,
+        title=title,
+        summary=summary,
+        source_type="report_package",
+        source_id=PACKAGE_WORKFLOW_SOURCE_ID,
+        action_href=str(package_readiness["action_href"]),
+        report_impact=WorkflowReportImpact.READY,
+        dedupe_key=f"report-package:{family.value}",
+    )

--- a/apps/backend/src/services/workflow_events.py
+++ b/apps/backend/src/services/workflow_events.py
@@ -1,7 +1,6 @@
 """Deterministic user-facing workflow event derivation."""
 
-from datetime import UTC, datetime
-from uuid import NAMESPACE_URL, UUID, uuid5
+from uuid import UUID
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
@@ -34,9 +33,18 @@ from src.schemas.workflow import (
     WorkflowStatusResponse,
 )
 from src.services.report_readiness import get_personal_report_package_readiness
+from src.services.workflow_event_builders import (  # noqa: F401
+    PACKAGE_WORKFLOW_SOURCE_ID,
+    build_readiness_blocker_event_payload,
+    build_report_state_event_payload,
+    build_review_completed_event_payload,
+    build_review_required_event_payload,
+    build_statement_parsing_failed_event_payload,
+    build_uploaded_statement_event_payload,
+    build_workflow_dedupe_key,
+)
 
 ACTIVE_WORKFLOW_SESSION_DEDUPE_KEY = "active-upload-to-report"
-PACKAGE_WORKFLOW_SOURCE_ID = uuid5(NAMESPACE_URL, "finance-report:personal-financial-report-package")
 MUTABLE_DERIVED_EVENT_SOURCE_TYPES = {"bank_statement", "readiness_blocker", "report_package"}
 MUTABLE_DERIVED_EVENT_FAMILIES = {
     WorkflowEventFamily.SOURCE_PARSING_FAILED,
@@ -98,11 +106,6 @@ def _next_action(
         ),
     }[action_type]
     return WorkflowNextActionResponse(type=action_type, count=count, href=href, label=copy[0], summary=copy[1])
-
-
-def build_workflow_dedupe_key(*, family: WorkflowEventFamily, source_type: str, source_id: UUID) -> str:
-    """Build the stable per-user dedupe key for a source-derived workflow event."""
-    return f"{source_type}:{source_id}:{family.value}"
 
 
 async def _get_active_workflow_session(db: AsyncSession, *, user_id: UUID) -> WorkflowSession | None:
@@ -221,150 +224,6 @@ async def _insert_workflow_event_conflict_safe(
             existing.session_id = session_id
         return existing
     return event
-
-
-def _build_statement_event_payload(
-    statement: StatementSummary,
-    *,
-    family: WorkflowEventFamily,
-    occurred_at: datetime,
-    severity: WorkflowEventSeverity,
-    title: str,
-    summary: str,
-    action_href: str,
-    report_impact: WorkflowReportImpact,
-) -> WorkflowEventCreate:
-    """Shared builder for the per-statement workflow events (uploaded / parse-failed
-    / review-required / review-completed), which differ only in their family,
-    timestamp, severity, copy, deep link, and report impact."""
-    return WorkflowEventCreate(
-        occurred_at=occurred_at,
-        family=family,
-        severity=severity,
-        title=title,
-        summary=summary,
-        source_type="bank_statement",
-        source_id=statement.id,
-        action_href=action_href,
-        report_impact=report_impact,
-        dedupe_key=build_workflow_dedupe_key(
-            family=family,
-            source_type="bank_statement",
-            source_id=statement.id,
-        ),
-    )
-
-
-def build_uploaded_statement_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
-    """Build the deterministic uploaded-statement workflow event payload."""
-    return _build_statement_event_payload(
-        statement,
-        family=WorkflowEventFamily.SOURCE_UPLOADED,
-        occurred_at=statement.created_at,
-        severity=WorkflowEventSeverity.INFO,
-        title="Statement uploaded",
-        summary=f"{filename} was uploaded and is ready for processing.",
-        action_href=f"/statements/{statement.id}",
-        report_impact=WorkflowReportImpact.PROCESSING,
-    )
-
-
-def build_statement_parsing_failed_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
-    """Build the user-action event for a failed statement parse."""
-    return _build_statement_event_payload(
-        statement,
-        family=WorkflowEventFamily.SOURCE_PARSING_FAILED,
-        occurred_at=statement.updated_at or statement.created_at,
-        severity=WorkflowEventSeverity.ACTION_REQUIRED,
-        title="Statement parsing failed",
-        summary=f"{filename} could not be parsed and needs attention.",
-        action_href=f"/statements/{statement.id}",
-        report_impact=WorkflowReportImpact.BLOCKED,
-    )
-
-
-def build_review_required_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
-    """Build the user-action event for pending Stage 1 review."""
-    return _build_statement_event_payload(
-        statement,
-        family=WorkflowEventFamily.REVIEW_REQUIRED,
-        occurred_at=statement.updated_at or statement.created_at,
-        severity=WorkflowEventSeverity.ACTION_REQUIRED,
-        title="Source review required",
-        summary=f"{filename} needs source review before report readiness can advance.",
-        # Deep-link straight to this statement's review surface (EPIC-022 PR2):
-        # the standalone Review Queue page is gone; the notification card is the
-        # entry point, so it must point at the specific item to review.
-        action_href=f"/statements/{statement.id}/review",
-        report_impact=WorkflowReportImpact.BLOCKED,
-    )
-
-
-def build_review_completed_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
-    """Build the routine success event for completed Stage 1 review."""
-    return _build_statement_event_payload(
-        statement,
-        family=WorkflowEventFamily.REVIEW_COMPLETED,
-        occurred_at=statement.stage1_reviewed_at or statement.updated_at or statement.created_at,
-        severity=WorkflowEventSeverity.SUCCESS,
-        title="Source review completed",
-        summary=f"{filename} source review is complete.",
-        action_href=f"/statements/{statement.id}",
-        report_impact=WorkflowReportImpact.NONE,
-    )
-
-
-def _readiness_blocker_source_id(code: str) -> UUID:
-    return uuid5(NAMESPACE_URL, f"finance-report:readiness-blocker:{code}")
-
-
-def build_readiness_blocker_event_payload(blocker: dict[str, str | int]) -> WorkflowEventCreate:
-    """Build a lightweight user-facing event from a report-readiness blocker."""
-    code = str(blocker["code"])
-    family = (
-        WorkflowEventFamily.RECONCILIATION_BLOCKED
-        if code == "reconciliation_blocked"
-        else WorkflowEventFamily.REPORT_BLOCKED
-    )
-    count = int(blocker.get("count", 1))
-    return WorkflowEventCreate(
-        occurred_at=datetime.now(UTC),
-        family=family,
-        severity=WorkflowEventSeverity.BLOCKED,
-        title=str(blocker["label"]),
-        summary=f"{blocker['reason']} ({count} item{'s' if count != 1 else ''}).",
-        source_type="readiness_blocker",
-        source_id=_readiness_blocker_source_id(code),
-        action_href=str(blocker["action_href"]),
-        report_impact=WorkflowReportImpact.BLOCKED,
-        dedupe_key=f"readiness-blocker:{code}:{family.value}",
-    )
-
-
-def build_report_state_event_payload(package_readiness: dict) -> WorkflowEventCreate | None:
-    """Build report ready/generated events from package readiness."""
-    state = str(package_readiness["state"])
-    if state not in {"ready", "generated"}:
-        return None
-    family = WorkflowEventFamily.REPORT_GENERATED if state == "generated" else WorkflowEventFamily.REPORT_READY
-    title = "Report package generated" if state == "generated" else "Report package ready"
-    summary = (
-        "The personal report package has been generated."
-        if state == "generated"
-        else "The personal report package is ready to review."
-    )
-    return WorkflowEventCreate(
-        occurred_at=datetime.now(UTC),
-        family=family,
-        severity=WorkflowEventSeverity.SUCCESS,
-        title=title,
-        summary=summary,
-        source_type="report_package",
-        source_id=PACKAGE_WORKFLOW_SOURCE_ID,
-        action_href=str(package_readiness["action_href"]),
-        report_impact=WorkflowReportImpact.READY,
-        dedupe_key=f"report-package:{family.value}",
-    )
 
 
 async def upsert_workflow_event(

--- a/apps/backend/src/services/workflow_events.py
+++ b/apps/backend/src/services/workflow_events.py
@@ -223,91 +223,94 @@ async def _insert_workflow_event_conflict_safe(
     return event
 
 
-def build_uploaded_statement_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
-    """Build the deterministic uploaded-statement workflow event payload."""
-    family = WorkflowEventFamily.SOURCE_UPLOADED
+def _build_statement_event_payload(
+    statement: StatementSummary,
+    *,
+    family: WorkflowEventFamily,
+    occurred_at: datetime,
+    severity: WorkflowEventSeverity,
+    title: str,
+    summary: str,
+    action_href: str,
+    report_impact: WorkflowReportImpact,
+) -> WorkflowEventCreate:
+    """Shared builder for the per-statement workflow events (uploaded / parse-failed
+    / review-required / review-completed), which differ only in their family,
+    timestamp, severity, copy, deep link, and report impact."""
     return WorkflowEventCreate(
-        occurred_at=statement.created_at,
+        occurred_at=occurred_at,
         family=family,
-        severity=WorkflowEventSeverity.INFO,
-        title="Statement uploaded",
-        summary=f"{filename} was uploaded and is ready for processing.",
+        severity=severity,
+        title=title,
+        summary=summary,
         source_type="bank_statement",
         source_id=statement.id,
-        action_href=f"/statements/{statement.id}",
-        report_impact=WorkflowReportImpact.PROCESSING,
+        action_href=action_href,
+        report_impact=report_impact,
         dedupe_key=build_workflow_dedupe_key(
             family=family,
             source_type="bank_statement",
             source_id=statement.id,
         ),
+    )
+
+
+def build_uploaded_statement_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
+    """Build the deterministic uploaded-statement workflow event payload."""
+    return _build_statement_event_payload(
+        statement,
+        family=WorkflowEventFamily.SOURCE_UPLOADED,
+        occurred_at=statement.created_at,
+        severity=WorkflowEventSeverity.INFO,
+        title="Statement uploaded",
+        summary=f"{filename} was uploaded and is ready for processing.",
+        action_href=f"/statements/{statement.id}",
+        report_impact=WorkflowReportImpact.PROCESSING,
     )
 
 
 def build_statement_parsing_failed_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
     """Build the user-action event for a failed statement parse."""
-    family = WorkflowEventFamily.SOURCE_PARSING_FAILED
-    return WorkflowEventCreate(
+    return _build_statement_event_payload(
+        statement,
+        family=WorkflowEventFamily.SOURCE_PARSING_FAILED,
         occurred_at=statement.updated_at or statement.created_at,
-        family=family,
         severity=WorkflowEventSeverity.ACTION_REQUIRED,
         title="Statement parsing failed",
         summary=f"{filename} could not be parsed and needs attention.",
-        source_type="bank_statement",
-        source_id=statement.id,
         action_href=f"/statements/{statement.id}",
         report_impact=WorkflowReportImpact.BLOCKED,
-        dedupe_key=build_workflow_dedupe_key(
-            family=family,
-            source_type="bank_statement",
-            source_id=statement.id,
-        ),
     )
 
 
 def build_review_required_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
     """Build the user-action event for pending Stage 1 review."""
-    family = WorkflowEventFamily.REVIEW_REQUIRED
-    return WorkflowEventCreate(
+    return _build_statement_event_payload(
+        statement,
+        family=WorkflowEventFamily.REVIEW_REQUIRED,
         occurred_at=statement.updated_at or statement.created_at,
-        family=family,
         severity=WorkflowEventSeverity.ACTION_REQUIRED,
         title="Source review required",
         summary=f"{filename} needs source review before report readiness can advance.",
-        source_type="bank_statement",
-        source_id=statement.id,
         # Deep-link straight to this statement's review surface (EPIC-022 PR2):
         # the standalone Review Queue page is gone; the notification card is the
         # entry point, so it must point at the specific item to review.
         action_href=f"/statements/{statement.id}/review",
         report_impact=WorkflowReportImpact.BLOCKED,
-        dedupe_key=build_workflow_dedupe_key(
-            family=family,
-            source_type="bank_statement",
-            source_id=statement.id,
-        ),
     )
 
 
 def build_review_completed_event_payload(statement: StatementSummary, filename: str) -> WorkflowEventCreate:
     """Build the routine success event for completed Stage 1 review."""
-    family = WorkflowEventFamily.REVIEW_COMPLETED
-    reviewed_at = statement.stage1_reviewed_at or statement.updated_at or statement.created_at
-    return WorkflowEventCreate(
-        occurred_at=reviewed_at,
-        family=family,
+    return _build_statement_event_payload(
+        statement,
+        family=WorkflowEventFamily.REVIEW_COMPLETED,
+        occurred_at=statement.stage1_reviewed_at or statement.updated_at or statement.created_at,
         severity=WorkflowEventSeverity.SUCCESS,
         title="Source review completed",
         summary=f"{filename} source review is complete.",
-        source_type="bank_statement",
-        source_id=statement.id,
         action_href=f"/statements/{statement.id}",
         report_impact=WorkflowReportImpact.NONE,
-        dedupe_key=build_workflow_dedupe_key(
-            family=family,
-            source_type="bank_statement",
-            source_id=statement.id,
-        ),
     )
 
 

--- a/apps/backend/tests/reconciliation/test_ai_reconciliation.py
+++ b/apps/backend/tests/reconciliation/test_ai_reconciliation.py
@@ -37,7 +37,7 @@ async def test_ai_semantic_score_returns_score():
     mock_stream = MagicMock()
 
     with (
-        patch("src.services.reconciliation.settings") as mock_settings,
+        patch("src.services.reconciliation_scoring.settings") as mock_settings,
         patch(
             "src.services.ai_streaming.stream_ai_json",
             return_value=mock_stream,
@@ -68,7 +68,7 @@ async def test_ai_semantic_score_returns_low_for_unrelated():
     mock_stream = MagicMock()
 
     with (
-        patch("src.services.reconciliation.settings") as mock_settings,
+        patch("src.services.reconciliation_scoring.settings") as mock_settings,
         patch(
             "src.services.ai_streaming.stream_ai_json",
             return_value=mock_stream,
@@ -98,7 +98,7 @@ async def test_ai_semantic_score_fallback_on_error():
     mock_stream = MagicMock(side_effect=AIStreamError("API error"))
 
     with (
-        patch("src.services.reconciliation.settings") as mock_settings,
+        patch("src.services.reconciliation_scoring.settings") as mock_settings,
         patch(
             "src.services.ai_streaming.stream_ai_json",
             mock_stream,
@@ -119,7 +119,7 @@ async def test_ai_semantic_score_fallback_on_error():
 
 async def test_ai_semantic_score_no_api_key_returns_50():
     """When no API key is configured, fall back to neutral score."""
-    with patch("src.services.reconciliation.settings") as mock_settings:
+    with patch("src.services.reconciliation_scoring.settings") as mock_settings:
         mock_settings.ai_api_key = ""
 
         score = await ai_semantic_score(
@@ -137,7 +137,7 @@ async def test_ai_semantic_score_empty_response_returns_50():
     mock_stream = MagicMock()
 
     with (
-        patch("src.services.reconciliation.settings") as mock_settings,
+        patch("src.services.reconciliation_scoring.settings") as mock_settings,
         patch(
             "src.services.ai_streaming.stream_ai_json",
             return_value=mock_stream,
@@ -168,7 +168,7 @@ async def test_ai_semantic_score_clamps_to_range():
     mock_stream = MagicMock()
 
     with (
-        patch("src.services.reconciliation.settings") as mock_settings,
+        patch("src.services.reconciliation_scoring.settings") as mock_settings,
         patch(
             "src.services.ai_streaming.stream_ai_json",
             return_value=mock_stream,

--- a/apps/backend/tests/reconciliation/test_reconciliation_scoring.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_scoring.py
@@ -103,7 +103,7 @@ def test_load_reconciliation_config_reads_yaml_and_env(monkeypatch: pytest.Monke
 
 def test_load_reconciliation_config_malformed_yaml(monkeypatch):
     """Test that malformed YAML falls back to defaults."""
-    from src.services import reconciliation
+    from src.services import reconciliation, reconciliation_config
 
     class MockPath:
         def exists(self):
@@ -122,7 +122,7 @@ def test_load_reconciliation_config_malformed_yaml(monkeypatch):
         def __truediv__(self, other):
             return self
 
-    monkeypatch.setattr(reconciliation, "Path", lambda *args: MockPath())
+    monkeypatch.setattr(reconciliation_config, "Path", lambda *args: MockPath())
     # Force reload to bypass cache
     config = reconciliation.load_reconciliation_config(force_reload=True)
     assert config.auto_accept == 85  # Default
@@ -132,7 +132,7 @@ def test_load_reconciliation_config_no_yaml_module(monkeypatch):
     """Test that missing yaml module falls back to defaults."""
     import sys
 
-    from src.services import reconciliation
+    from src.services import reconciliation, reconciliation_config
 
     # Mock Path to say file exists
     class MockPath:
@@ -149,7 +149,7 @@ def test_load_reconciliation_config_no_yaml_module(monkeypatch):
         def __truediv__(self, other):
             return self
 
-    monkeypatch.setattr(reconciliation, "Path", lambda *args: MockPath())
+    monkeypatch.setattr(reconciliation_config, "Path", lambda *args: MockPath())
 
     # Effectively hide yaml module from being used in the function's local scope
     # The function does 'import yaml' inside a try-except block

--- a/tests/tooling/test_reconciliation_thresholds_unit.py
+++ b/tests/tooling/test_reconciliation_thresholds_unit.py
@@ -21,6 +21,10 @@ sys.path.insert(0, str(REPO_ROOT / "apps" / "backend"))
 
 from src.models import ReconciliationMatch, ReconciliationStatus  # noqa: E402
 
+# Pre-cache real submodule deps so the isolated reconciliation load (which stubs
+# src.services) can still resolve them after the split into reconciliation_config etc.
+from src.services import promotion_gate as _promotion_gate  # noqa: E402, F401
+
 
 def _load_reconciliation_module():
     """Load reconciliation without importing src.services package exports."""
@@ -56,10 +60,24 @@ def _load_reconciliation_module():
     sys.modules["src.services.source_type_priority"] = source_type_priority_module
     sys.modules["src.services.statement_summary"] = statement_summary_module
 
+    # reconciliation.py was split into focused submodules; load them (in dependency
+    # order: config -> scoring -> stats) under their real names so reconciliation's
+    # re-export imports resolve inside this isolated environment.
+    split_submodules = ("reconciliation_config", "reconciliation_scoring", "reconciliation_stats")
+    services_dir = REPO_ROOT / "apps" / "backend" / "src" / "services"
     try:
+        for submodule_name in split_submodules:
+            sub_spec = importlib.util.spec_from_file_location(
+                f"src.services.{submodule_name}", services_dir / f"{submodule_name}.py"
+            )
+            assert sub_spec is not None and sub_spec.loader is not None
+            sub_module = importlib.util.module_from_spec(sub_spec)
+            sys.modules[f"src.services.{submodule_name}"] = sub_module
+            sub_spec.loader.exec_module(sub_module)
+
         spec = importlib.util.spec_from_file_location(
             "_reconciliation_under_test",
-            REPO_ROOT / "apps" / "backend" / "src" / "services" / "reconciliation.py",
+            services_dir / "reconciliation.py",
         )
         assert spec is not None
         assert spec.loader is not None
@@ -68,6 +86,8 @@ def _load_reconciliation_module():
         spec.loader.exec_module(module)
         return module
     finally:
+        for submodule_name in split_submodules:
+            sys.modules.pop(f"src.services.{submodule_name}", None)
         if previous_services is None:
             sys.modules.pop("src.services", None)
         else:

--- a/tests/tooling/test_reconciliation_thresholds_unit.py
+++ b/tests/tooling/test_reconciliation_thresholds_unit.py
@@ -65,6 +65,9 @@ def _load_reconciliation_module():
     # re-export imports resolve inside this isolated environment.
     split_submodules = ("reconciliation_config", "reconciliation_scoring", "reconciliation_stats")
     services_dir = REPO_ROOT / "apps" / "backend" / "src" / "services"
+    previous_submodules = {
+        name: sys.modules.get(f"src.services.{name}") for name in split_submodules
+    }
     try:
         for submodule_name in split_submodules:
             sub_spec = importlib.util.spec_from_file_location(
@@ -87,7 +90,11 @@ def _load_reconciliation_module():
         return module
     finally:
         for submodule_name in split_submodules:
-            sys.modules.pop(f"src.services.{submodule_name}", None)
+            previous = previous_submodules[submodule_name]
+            if previous is None:
+                sys.modules.pop(f"src.services.{submodule_name}", None)
+            else:
+                sys.modules[f"src.services.{submodule_name}"] = previous
         if previous_services is None:
             sys.modules.pop("src.services", None)
         else:


### PR DESCRIPTION
Backend DRY + module-division refactors from the arch audit. Behavior-preserving; total LOC ~flat (structural) except the DRY single-source-of-truth wins.

## Commits
1. **DRY** — `workflow_events.py` extract `_build_statement_event_payload` factory (the 4 per-statement builders shared no source of truth for `dedupe_key`/source — drift risk gone); `assets.py` extract `_valuation_key_query` for the duplicated version-chain WHERE clause.
2. **reconciliation split** — `reconciliation.py` (1438) → `reconciliation_config` / `reconciliation_scoring` / `reconciliation_stats` + matching engine; config/scoring/matching layering avoids a circular import. Re-exports keep `from src.services.reconciliation import …` unchanged (18 importers untouched). Matching is now 917 lines.
3. **workflow_events split** — payload builders → `workflow_event_builders.py` (pure constructors, no DB/session). `workflow_events.py` 902 → 764; re-exported.
4. **gate fix** — `test_reconciliation_thresholds_unit`'s isolated module loader now loads the new sibling submodules + pre-caches `promotion_gate`.

## Verification
- `ruff check src tests` + format clean.
- Test suites green: reconciliation (219), workflow (28), assets (73), workflow_events (28); full `tests/tooling/` green except the pre-existing `test_ssot_hls_family_model` (reads the `repo` submodule, fails only on a dirty local submodule — passes in CI).
- No router files changed → router-contract doc unaffected.

## Deliberately NOT in this PR (see PR discussion)
- `reporting.py` family split and `statements.upload_statement` extraction — flagged for separate dedicated PRs; reasoning in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)