### PR TITLE
[finance_report_vision] feat(llm): EPIC-023 PR1 — frozen LLM contract + secret cipher (AC23.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,8 @@ AI_MODEL_CATALOG_SOURCE=configured
 AI_PROVIDER=zai
 # Comma-separated fallback AI model ids.
 FALLBACK_MODELS=glm-5-turbo,glm-5
+# Comma-separated Fernet keys (urlsafe base64, 32 bytes) for encrypting LLM provider API keys at rest; newest first. Empty disables DB-backed provider storage. Rotate by prepending a new key and re-encrypting all secrets. [VAULT]
+LLM_ENCRYPTION_KEYS=
 # OCR AI model id.
 OCR_MODEL=glm-4.6v
 # EPIC-019: set to the Prefect API URL to run upload->report parsing as durable Prefect flow runs (staging/prod and per-PR ephemeral Prefect). Leave unset for CI/local/preview -> in-process asyncio fallback (no Prefect needed).

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ registries, and generated reports rather than duplicated here.
 | [EPIC-020](docs/project/EPIC-020.framework-aware-personal-reporting.md) | Framework-aware personal financial reporting |
 | [EPIC-021](docs/project/EPIC-021.application-ai-advisor.md) | Application-layer AI Advisor |
 | [EPIC-022](docs/project/EPIC-022.everyday-user-ia.md) | Everyday-user information architecture |
+| [EPIC-023](docs/project/EPIC-023.llm-provider-abstraction.md) | LLM provider abstraction (litellm) |
 
 ## EPIC Status (Generated)
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "bcrypt==4.0.1",
     "httpx-sse>=0.4.3",
     "pymupdf>=1.24.0",
+    "cryptography>=42.0.0",
 ]
 
 [project.optional-dependencies]

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -424,6 +424,23 @@ class Settings(BaseSettings):
         json_schema_extra={"group": "AI Provider"},
     )
 
+    # LLM provider secret encryption (EPIC-023): project-level symmetric key(s)
+    # used to encrypt provider API keys at rest in the database (DB-backed
+    # provider config). Comma-separated Fernet keys, newest first; decryption
+    # tries all (MultiFernet) so rotation is a single pass — prepend a new key,
+    # re-encrypt every stored secret, then drop the old key. Empty disables
+    # DB-backed provider storage (env/Vault provider config still works).
+    llm_encryption_keys: str = Field(
+        default="",
+        validation_alias=AliasChoices("LLM_ENCRYPTION_KEYS", "LLM_ENCRYPTION_KEY"),
+        description=(
+            "Comma-separated Fernet keys (urlsafe base64, 32 bytes) for encrypting LLM "
+            "provider API keys at rest; newest first. Empty disables DB-backed provider "
+            "storage. Rotate by prepending a new key and re-encrypting all secrets."
+        ),
+        json_schema_extra={"group": "AI Provider", "vault": True},
+    )
+
     @field_validator("ai_json_seed", mode="before")
     @classmethod
     def _empty_seed_is_none(cls, value: object) -> object:
@@ -639,6 +656,15 @@ class Settings(BaseSettings):
                 "glm-4.5v",
             ],
         )
+
+    @cached_property
+    def llm_encryption_key_list(self) -> list[str]:
+        """Parsed Fernet keys for provider-secret encryption (newest first).
+
+        Empty when ``LLM_ENCRYPTION_KEYS`` is unset, which means DB-backed
+        provider secrets cannot be stored (see ``src/llm/common/secrets.py``).
+        """
+        return parse_comma_list(self.llm_encryption_keys, [])
 
 
 settings = Settings()

--- a/apps/backend/src/llm/__init__.py
+++ b/apps/backend/src/llm/__init__.py
@@ -1,0 +1,20 @@
+"""LLM provider abstraction (EPIC-023).
+
+``src/llm`` is the single entry point for talking to language models. It is built
+around three orthogonal axes (see ``docs/ssot/llm.md``):
+
+- **Protocol family** — ``openai-compatible`` / ``anthropic-compatible`` /
+  ``openrouter-compatible``. Every concrete vendor (Z.AI/GLM, DeepSeek, a local
+  vLLM, …) slots into one of these three; they are *not* enumerated as special
+  cases.
+- **Model** — a dynamic catalogue that may be far larger than the bound set,
+  each entry carrying capabilities (modalities, free-tier, pricing).
+- **Scene** — the fixed, code-defined set of call sites (``extraction.ocr``,
+  ``advisor.chat``, …). The binding ``scene -> model`` is the configurable
+  surface.
+
+``src/llm/common`` holds the frozen contract (types + protocols + the secret
+cipher) that the litellm client implementation (EPIC A) and the DB-backed
+configuration layer (EPIC B) both build against. Importing from ``common`` keeps
+the two halves decoupled so they can evolve in parallel.
+"""

--- a/apps/backend/src/llm/common/__init__.py
+++ b/apps/backend/src/llm/common/__init__.py
@@ -1,0 +1,62 @@
+"""Frozen contract for the LLM abstraction (EPIC-023).
+
+This package is the agreed boundary between the litellm client implementation
+(EPIC A) and the DB-backed configuration layer (EPIC B). It contains only value
+types, protocols, and the secret cipher — no provider SDK, no storage, no I/O
+beyond encryption — so importing it never pulls in either half.
+"""
+
+from __future__ import annotations
+
+from src.llm.common.config_source import ConfigSource
+from src.llm.common.errors import (
+    LLMBudgetExceeded,
+    LLMConfigError,
+    LLMError,
+    ModelCatalogError,
+)
+from src.llm.common.protocols import CatalogProvider, CostMeter, LLMClient
+from src.llm.common.secrets import FernetCipher, SecretCipher, build_cipher
+from src.llm.common.types import (
+    ChatResult,
+    Encrypted,
+    Message,
+    Modality,
+    ModelSpec,
+    ProtocolFamily,
+    ProviderRef,
+    ReasoningEffort,
+    Scene,
+    SceneBinding,
+    Usage,
+)
+
+__all__ = [
+    # config seam
+    "ConfigSource",
+    # errors
+    "LLMError",
+    "LLMConfigError",
+    "LLMBudgetExceeded",
+    "ModelCatalogError",
+    # service protocols
+    "LLMClient",
+    "CatalogProvider",
+    "CostMeter",
+    # secrets
+    "SecretCipher",
+    "FernetCipher",
+    "build_cipher",
+    # value types
+    "ProtocolFamily",
+    "Scene",
+    "Modality",
+    "ReasoningEffort",
+    "Encrypted",
+    "ProviderRef",
+    "ModelSpec",
+    "SceneBinding",
+    "Usage",
+    "ChatResult",
+    "Message",
+]

--- a/apps/backend/src/llm/common/config_source.py
+++ b/apps/backend/src/llm/common/config_source.py
@@ -1,0 +1,39 @@
+"""The configuration seam between the client (EPIC A) and storage (EPIC B).
+
+The litellm client resolves a :class:`~src.llm.common.types.Scene` to a provider
+and model purely through this protocol. EPIC A ships an env-backed implementation
+as a stopgap; EPIC B swaps in a ``DbConfigSource`` reading the
+``llm_provider`` / ``llm_scene_binding`` tables — without the client changing.
+Freezing this protocol is what lets the two halves proceed in parallel.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from src.llm.common.types import ProviderRef, Scene, SceneBinding
+
+
+@runtime_checkable
+class ConfigSource(Protocol):
+    """Read-only resolver for provider instances and scene bindings."""
+
+    async def list_providers(self) -> list[ProviderRef]:
+        """All configured providers (API keys already decrypted)."""
+        ...
+
+    async def get_provider(self, provider_id: str) -> ProviderRef | None:
+        """A single provider by id, or ``None`` if unknown."""
+        ...
+
+    async def get_binding(self, scene: Scene) -> SceneBinding | None:
+        """The model binding for a scene, or ``None`` if unbound."""
+        ...
+
+    async def is_configured(self) -> bool:
+        """Whether at least one provider exists.
+
+        Drives the frontend first-run modal: ``False`` means "ask the user to add
+        a provider before any AI feature can run".
+        """
+        ...

--- a/apps/backend/src/llm/common/errors.py
+++ b/apps/backend/src/llm/common/errors.py
@@ -1,0 +1,41 @@
+"""Exception hierarchy for the LLM abstraction (EPIC-023)."""
+
+from __future__ import annotations
+
+
+class LLMError(Exception):
+    """Base class for all LLM-layer failures.
+
+    ``retryable`` flags transient conditions (HTTP 429/5xx, mid-stream server
+    errors) so callers can decide whether to fall back or retry. It mirrors the
+    semantics of the legacy ``AIStreamError`` so existing call sites keep working
+    when they delegate into this layer.
+    """
+
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
+class LLMConfigError(LLMError):
+    """Configuration is missing or invalid (no provider, bad/absent encryption key).
+
+    Never retryable.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, retryable=False)
+
+
+class LLMBudgetExceeded(LLMError):
+    """A spend guard tripped before or after a call (replaces the daily-limit check).
+
+    Never retryable: retrying would only spend more.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, retryable=False)
+
+
+class ModelCatalogError(LLMError):
+    """The model catalogue could not be fetched or parsed."""

--- a/apps/backend/src/llm/common/protocols.py
+++ b/apps/backend/src/llm/common/protocols.py
@@ -1,0 +1,80 @@
+"""Service-facing protocols implemented by the litellm layer (EPIC A).
+
+Scenes call these; they never see a provider id or model string directly — the
+:class:`~src.llm.common.config_source.ConfigSource` resolves a
+:class:`~src.llm.common.types.Scene` to a concrete model behind the protocol.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from typing import Protocol, runtime_checkable
+
+from src.llm.common.types import ChatResult, Message, Modality, ModelSpec, ReasoningEffort, Scene, Usage
+
+
+@runtime_checkable
+class LLMClient(Protocol):
+    """Chat/extraction entry point, keyed by scene."""
+
+    def stream(
+        self,
+        scene: Scene,
+        messages: Sequence[Message],
+        *,
+        reasoning: ReasoningEffort | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream plain-text delta chunks for ``scene``."""
+        ...
+
+    def stream_json(
+        self,
+        scene: Scene,
+        messages: Sequence[Message],
+        *,
+        reasoning: ReasoningEffort | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream raw delta chunks of a JSON response for ``scene``.
+
+        JSON mode is prompt-driven (no ``response_format``) for the same reason as
+        the legacy path: several providers reject it with multimodal inputs.
+        """
+        ...
+
+    async def complete(
+        self,
+        scene: Scene,
+        messages: Sequence[Message],
+        *,
+        reasoning: ReasoningEffort | None = None,
+    ) -> ChatResult:
+        """Non-streaming completion with token + cost telemetry."""
+        ...
+
+
+@runtime_checkable
+class CatalogProvider(Protocol):
+    """Dynamic model catalogue (axis 2)."""
+
+    async def list_models(
+        self,
+        *,
+        provider_id: str | None = None,
+        modality: Modality | None = None,
+        free_only: bool = False,
+    ) -> list[ModelSpec]:
+        """Available models, optionally filtered by provider/modality/free-tier."""
+        ...
+
+
+@runtime_checkable
+class CostMeter(Protocol):
+    """Spend tracking + budget enforcement (replaces the daily-limit check)."""
+
+    async def check_budget(self) -> None:
+        """Raise :class:`~src.llm.common.errors.LLMBudgetExceeded` if over budget."""
+        ...
+
+    async def record(self, scene: Scene, model_id: str, usage: Usage, cost_usd: object | None) -> None:
+        """Record spend for a completed call."""
+        ...

--- a/apps/backend/src/llm/common/protocols.py
+++ b/apps/backend/src/llm/common/protocols.py
@@ -8,6 +8,7 @@ Scenes call these; they never see a provider id or model string directly — the
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
+from decimal import Decimal
 from typing import Protocol, runtime_checkable
 
 from src.llm.common.types import ChatResult, Message, Modality, ModelSpec, ReasoningEffort, Scene, Usage
@@ -75,6 +76,6 @@ class CostMeter(Protocol):
         """Raise :class:`~src.llm.common.errors.LLMBudgetExceeded` if over budget."""
         ...
 
-    async def record(self, scene: Scene, model_id: str, usage: Usage, cost_usd: object | None) -> None:
+    async def record(self, scene: Scene, model_id: str, usage: Usage, cost_usd: Decimal | None) -> None:
         """Record spend for a completed call."""
         ...

--- a/apps/backend/src/llm/common/secrets.py
+++ b/apps/backend/src/llm/common/secrets.py
@@ -16,6 +16,7 @@ DB layer that owns the secrets.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
@@ -48,8 +49,12 @@ class FernetCipher:
     """``MultiFernet``-backed :class:`SecretCipher`.
 
     Keys are ordered newest-first: index 0 encrypts, all keys are tried on
-    decrypt. ``current_version`` is the key count, so prepending a rotation key
-    bumps it and lets callers detect not-yet-rotated rows.
+    decrypt. ``current_version`` is a *stable fingerprint of the encrypting key*
+    (not the key count): rotating to a new key changes the stamp, while dropping
+    a retired key never changes a surviving key's stamp. So a row needs
+    re-stamping iff ``row.key_version != cipher.current_version`` — a check that
+    stays correct across the whole rotation lifecycle (the key-count approach
+    was non-monotonic: dropping the old key lowered the version again).
     """
 
     def __init__(self, keys: Sequence[str]) -> None:
@@ -60,7 +65,7 @@ class FernetCipher:
         except (ValueError, TypeError) as exc:
             raise LLMConfigError("Invalid Fernet key in LLM_ENCRYPTION_KEYS (need urlsafe base64, 32 bytes)") from exc
         self._multi = MultiFernet(fernets)
-        self._version = len(fernets)
+        self._version = _key_fingerprint(keys[0])
 
     @property
     def current_version(self) -> int:
@@ -86,6 +91,17 @@ class FernetCipher:
         except InvalidToken as exc:
             raise LLMConfigError("Could not rotate provider secret — encrypting key missing or value corrupt.") from exc
         return Encrypted(ciphertext=token.decode("ascii"), key_version=self._version)
+
+
+def _key_fingerprint(key: str) -> int:
+    """A stable, non-reversible 32-bit id for a Fernet key.
+
+    The first 4 bytes of SHA-256 over the key. It identifies *which* key sealed a
+    value without revealing the key, and is independent of how many keys are
+    configured, so it survives dropping retired keys after a rotation pass.
+    """
+    digest = hashlib.sha256(key.encode("ascii")).digest()
+    return int.from_bytes(digest[:4], "big")
 
 
 def build_cipher() -> FernetCipher:

--- a/apps/backend/src/llm/common/secrets.py
+++ b/apps/backend/src/llm/common/secrets.py
@@ -1,0 +1,103 @@
+"""Symmetric encryption for provider API keys at rest (EPIC-023).
+
+Provider secrets live in the database (EPIC B), so they must be encrypted with a
+project-level key supplied out-of-band via ``LLM_ENCRYPTION_KEYS`` (env/Vault).
+We use Fernet (authenticated AES-128-CBC + HMAC) wrapped in ``MultiFernet`` so
+key rotation is a single pass:
+
+    1. Generate a new key, prepend it to ``LLM_ENCRYPTION_KEYS`` (newest first).
+    2. Re-encrypt every stored secret with :meth:`FernetCipher.rotate` — decrypt
+       succeeds with any held key, re-encrypt always uses the newest.
+    3. Once every row carries the new ``key_version``, drop the old key.
+
+The cipher knows nothing about storage; the row-by-row rotation loop lives in the
+DB layer that owns the secrets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+
+from src.config import settings
+from src.llm.common.errors import LLMConfigError
+from src.llm.common.types import Encrypted
+
+
+@runtime_checkable
+class SecretCipher(Protocol):
+    """Contract for encrypting/decrypting provider secrets."""
+
+    @property
+    def current_version(self) -> int:
+        """Version stamped onto freshly-encrypted values (bumps on rotation)."""
+        ...
+
+    def encrypt(self, plaintext: str) -> Encrypted: ...
+
+    def decrypt(self, value: Encrypted) -> str: ...
+
+    def rotate(self, value: Encrypted) -> Encrypted:
+        """Re-encrypt an existing value with the newest key."""
+        ...
+
+
+class FernetCipher:
+    """``MultiFernet``-backed :class:`SecretCipher`.
+
+    Keys are ordered newest-first: index 0 encrypts, all keys are tried on
+    decrypt. ``current_version`` is the key count, so prepending a rotation key
+    bumps it and lets callers detect not-yet-rotated rows.
+    """
+
+    def __init__(self, keys: Sequence[str]) -> None:
+        if not keys:
+            raise LLMConfigError("FernetCipher requires at least one key")
+        try:
+            fernets = [Fernet(key.encode("ascii")) for key in keys]
+        except (ValueError, TypeError) as exc:
+            raise LLMConfigError("Invalid Fernet key in LLM_ENCRYPTION_KEYS (need urlsafe base64, 32 bytes)") from exc
+        self._multi = MultiFernet(fernets)
+        self._version = len(fernets)
+
+    @property
+    def current_version(self) -> int:
+        return self._version
+
+    def encrypt(self, plaintext: str) -> Encrypted:
+        token = self._multi.encrypt(plaintext.encode("utf-8"))
+        return Encrypted(ciphertext=token.decode("ascii"), key_version=self._version)
+
+    def decrypt(self, value: Encrypted) -> str:
+        try:
+            return self._multi.decrypt(value.ciphertext.encode("ascii")).decode("utf-8")
+        except InvalidToken as exc:
+            raise LLMConfigError(
+                "Could not decrypt provider secret — the encrypting key is no longer in "
+                "LLM_ENCRYPTION_KEYS (rotated out) or the value is corrupt."
+            ) from exc
+
+    def rotate(self, value: Encrypted) -> Encrypted:
+        """Re-encrypt ``value`` under the newest key (single-pass rotation step)."""
+        try:
+            token = self._multi.rotate(value.ciphertext.encode("ascii"))
+        except InvalidToken as exc:
+            raise LLMConfigError("Could not rotate provider secret — encrypting key missing or value corrupt.") from exc
+        return Encrypted(ciphertext=token.decode("ascii"), key_version=self._version)
+
+
+def build_cipher() -> FernetCipher:
+    """Construct the project cipher from ``LLM_ENCRYPTION_KEYS``.
+
+    Raises :class:`LLMConfigError` when no key is configured — callers that store
+    provider secrets must surface this as "DB-backed provider config unavailable".
+    """
+    keys = settings.llm_encryption_key_list
+    if not keys:
+        raise LLMConfigError(
+            "LLM_ENCRYPTION_KEYS is not set; DB-backed provider secrets cannot be encrypted. "
+            "Set a Fernet key (urlsafe base64, 32 bytes) via env/Vault."
+        )
+    return FernetCipher(keys)

--- a/apps/backend/src/llm/common/types.py
+++ b/apps/backend/src/llm/common/types.py
@@ -90,7 +90,8 @@ class ProviderRef:
     id: str
     label: str
     protocol: ProtocolFamily
-    api_key: str
+    # repr=False so the decrypted key never lands in logs/exceptions/debug output.
+    api_key: str = field(repr=False)
     api_base: str | None = None
 
 

--- a/apps/backend/src/llm/common/types.py
+++ b/apps/backend/src/llm/common/types.py
@@ -1,0 +1,145 @@
+"""Value objects for the LLM abstraction's three orthogonal axes (EPIC-023).
+
+Everything here is an immutable, dependency-free value type so both the litellm
+client (EPIC A) and the DB configuration layer (EPIC B) can share it without a
+cycle. Monetary values use :class:`~decimal.Decimal` per the project money rule;
+``float`` must never appear here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import StrEnum
+from typing import Any
+
+# An OpenAI-style chat message. Content may be a plain string or a list of
+# multimodal content parts (text / image_url / file), so we keep it permissive.
+Message = dict[str, Any]
+
+
+class ProtocolFamily(StrEnum):
+    """Axis 1 — the wire protocol a provider speaks.
+
+    Concrete vendors map onto exactly one family; e.g. Z.AI/GLM and DeepSeek are
+    ``OPENAI_COMPATIBLE`` (custom ``api_base``), Claude is ``ANTHROPIC_COMPATIBLE``.
+    """
+
+    OPENAI_COMPATIBLE = "openai-compatible"
+    ANTHROPIC_COMPATIBLE = "anthropic-compatible"
+    OPENROUTER_COMPATIBLE = "openrouter-compatible"
+
+
+class Scene(StrEnum):
+    """Axis 3 — a code-defined call site. Adding one is a contract change.
+
+    The value is the stable identifier persisted in bindings; keep it in sync
+    with ``docs/ssot/llm.md``.
+    """
+
+    EXTRACTION_OCR = "extraction.ocr"
+    EXTRACTION_VISION = "extraction.vision"
+    EXTRACTION_JSON = "extraction.json"
+    ADVISOR_CHAT = "advisor.chat"
+    STATEMENT_SUMMARY = "statement.summary"
+
+
+class Modality(StrEnum):
+    """Input modalities a model accepts."""
+
+    TEXT = "text"
+    IMAGE = "image"
+    PDF = "pdf"
+    FILE = "file"
+
+
+class ReasoningEffort(StrEnum):
+    """Per-scene reasoning depth, mapped onto each provider by the client.
+
+    ``NONE`` means "do not request extended reasoning"; the others map to the
+    litellm ``reasoning_effort`` parameter (which in turn maps to Anthropic
+    thinking budgets / OpenAI reasoning levels).
+    """
+
+    NONE = "none"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@dataclass(frozen=True, slots=True)
+class Encrypted:
+    """A provider secret at rest: ciphertext plus the key version that sealed it.
+
+    ``key_version`` lets the DB layer (EPIC B) tell, during a key rotation pass,
+    which rows still hold the old key. See :mod:`src.llm.common.secrets`.
+    """
+
+    ciphertext: str
+    key_version: int
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRef:
+    """A configured provider instance with its API key already decrypted.
+
+    This is the projection a :class:`~src.llm.common.config_source.ConfigSource`
+    hands to the client; persistence and encryption live below the contract.
+    """
+
+    id: str
+    label: str
+    protocol: ProtocolFamily
+    api_key: str
+    api_base: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ModelSpec:
+    """Axis 2 — one entry of the dynamic model catalogue."""
+
+    id: str
+    provider_id: str
+    modalities: frozenset[Modality] = field(default_factory=frozenset)
+    is_free: bool = False
+    input_price_per_mtok: Decimal | None = None
+    output_price_per_mtok: Decimal | None = None
+    supports_reasoning: bool = False
+
+    def accepts(self, modality: Modality) -> bool:
+        """Whether this model can take the given input modality."""
+        return modality in self.modalities
+
+
+@dataclass(frozen=True, slots=True)
+class SceneBinding:
+    """Axis 2 x Axis 3 — which model (and how) a scene resolves to."""
+
+    scene: Scene
+    model_id: str
+    reasoning: ReasoningEffort = ReasoningEffort.NONE
+    prefer_free: bool = False
+    fallback_model_ids: tuple[str, ...] = ()
+    max_tokens: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Usage:
+    """Token accounting for a single completion."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+@dataclass(frozen=True, slots=True)
+class ChatResult:
+    """A non-streaming completion result with cost telemetry."""
+
+    text: str
+    model_id: str
+    usage: Usage = field(default_factory=Usage)
+    cost_usd: Decimal | None = None

--- a/apps/backend/tests/unit/llm/test_contract.py
+++ b/apps/backend/tests/unit/llm/test_contract.py
@@ -1,0 +1,106 @@
+"""The seam protocols are runtime-checkable and swappable (EPIC-023 AC23.1.5).
+
+These tests pin the contract that lets EPIC A (litellm client) and EPIC B
+(DB config) implement opposite sides independently: a conforming object must
+satisfy ``isinstance`` against the protocol, and a non-conforming one must not.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+
+from src.llm.common import (
+    CatalogProvider,
+    ChatResult,
+    ConfigSource,
+    CostMeter,
+    FernetCipher,
+    LLMClient,
+    Message,
+    Modality,
+    ModelSpec,
+    ProviderRef,
+    ReasoningEffort,
+    Scene,
+    SceneBinding,
+    SecretCipher,
+    Usage,
+)
+
+
+class _FakeConfigSource:
+    async def list_providers(self) -> list[ProviderRef]:
+        return []
+
+    async def get_provider(self, provider_id: str) -> ProviderRef | None:
+        return None
+
+    async def get_binding(self, scene: Scene) -> SceneBinding | None:
+        return None
+
+    async def is_configured(self) -> bool:
+        return False
+
+
+class _FakeClient:
+    def stream(self, scene, messages, *, reasoning=None) -> AsyncIterator[str]:  # noqa: ANN001
+        raise NotImplementedError
+
+    def stream_json(self, scene, messages, *, reasoning=None) -> AsyncIterator[str]:  # noqa: ANN001
+        raise NotImplementedError
+
+    async def complete(
+        self,
+        scene: Scene,
+        messages: Sequence[Message],
+        *,
+        reasoning: ReasoningEffort | None = None,
+    ) -> ChatResult:
+        return ChatResult(text="", model_id="x", usage=Usage())
+
+
+class _FakeCatalog:
+    async def list_models(self, *, provider_id=None, modality=None, free_only=False) -> list[ModelSpec]:  # noqa: ANN001
+        return []
+
+
+class _FakeCostMeter:
+    async def check_budget(self) -> None:
+        return None
+
+    async def record(self, scene, model_id, usage, cost_usd) -> None:  # noqa: ANN001
+        return None
+
+
+class _NotAConfigSource:
+    async def list_providers(self) -> list[ProviderRef]:
+        return []
+
+    # missing get_provider / get_binding / is_configured
+
+
+def test_AC23_1_5_conforming_implementations_satisfy_the_protocols():
+    """AC23.1.5: a conforming object passes isinstance for each seam protocol."""
+    assert isinstance(_FakeConfigSource(), ConfigSource)
+    assert isinstance(_FakeClient(), LLMClient)
+    assert isinstance(_FakeCatalog(), CatalogProvider)
+    assert isinstance(_FakeCostMeter(), CostMeter)
+
+
+def test_AC23_1_5_fernet_cipher_is_a_secret_cipher():
+    """AC23.1.5: the shipped FernetCipher satisfies the SecretCipher protocol."""
+    from cryptography.fernet import Fernet
+
+    cipher = FernetCipher([Fernet.generate_key().decode("ascii")])
+    assert isinstance(cipher, SecretCipher)
+
+
+def test_AC23_1_5_non_conforming_object_is_rejected():
+    """AC23.1.5: a class missing protocol methods is not an instance — the contract bites."""
+    assert not isinstance(_NotAConfigSource(), ConfigSource)
+
+
+def test_AC23_1_5_modality_round_trips_via_model_spec():
+    """AC23.1.5: ModelSpec uses the Modality enum the catalogue/binding share."""
+    spec = ModelSpec(id="p/m", provider_id="p", modalities=frozenset({Modality.TEXT}))
+    assert spec.accepts(Modality.TEXT)

--- a/apps/backend/tests/unit/llm/test_contract.py
+++ b/apps/backend/tests/unit/llm/test_contract.py
@@ -104,3 +104,18 @@ def test_AC23_1_5_modality_round_trips_via_model_spec():
     """AC23.1.5: ModelSpec uses the Modality enum the catalogue/binding share."""
     spec = ModelSpec(id="p/m", provider_id="p", modalities=frozenset({Modality.TEXT}))
     assert spec.accepts(Modality.TEXT)
+
+
+def test_AC23_1_5_error_hierarchy_carries_retryable_semantics():
+    """AC23.1.5: the error contract — config/budget never retry; all derive from LLMError."""
+    from src.llm.common import LLMBudgetExceeded, LLMConfigError, LLMError, ModelCatalogError
+
+    budget = LLMBudgetExceeded("over daily budget")
+    assert isinstance(budget, LLMError)
+    assert budget.retryable is False
+
+    catalog = ModelCatalogError("catalogue unavailable", retryable=True)
+    assert isinstance(catalog, LLMError)
+    assert catalog.retryable is True
+
+    assert issubclass(LLMConfigError, LLMError)

--- a/apps/backend/tests/unit/llm/test_secrets.py
+++ b/apps/backend/tests/unit/llm/test_secrets.py
@@ -54,6 +54,15 @@ def test_AC23_1_3_rotation_is_single_pass_old_ciphertext_still_decrypts():
         new_only.decrypt(sealed)
 
 
+def test_AC23_1_3_rotate_fails_closed_on_a_corrupt_value():
+    """AC23.1.3: rotating a value no key can decrypt fails closed, not silently."""
+    from src.llm.common import Encrypted
+
+    cipher = FernetCipher([_key()])
+    with pytest.raises(LLMConfigError):
+        cipher.rotate(Encrypted(ciphertext="not-a-valid-token", key_version=1))
+
+
 def test_AC23_1_4_build_cipher_fails_closed_without_a_key(monkeypatch):
     """AC23.1.4: no LLM_ENCRYPTION_KEYS -> build_cipher raises (DB secrets fail closed)."""
     monkeypatch.setattr(settings, "llm_encryption_key_list", [], raising=False)

--- a/apps/backend/tests/unit/llm/test_secrets.py
+++ b/apps/backend/tests/unit/llm/test_secrets.py
@@ -23,31 +23,39 @@ def test_AC23_1_2_round_trips_a_provider_secret_without_storing_plaintext():
 
     assert sealed.ciphertext != secret
     assert secret not in sealed.ciphertext
-    assert sealed.key_version == 1
+    assert sealed.key_version == cipher.current_version
     assert cipher.decrypt(sealed) == secret
 
 
 def test_AC23_1_3_rotation_is_single_pass_old_ciphertext_still_decrypts():
-    """AC23.1.3: after prepending a new key, an old secret still decrypts and re-stamps."""
+    """AC23.1.3: after prepending a new key, an old secret still decrypts and re-stamps.
+
+    The version stamp is a stable fingerprint of the encrypting key, so "needs
+    re-stamping" is `row.key_version != cipher.current_version` and stays correct
+    even after the retired key is dropped.
+    """
     old_key, new_key = _key(), _key()
 
     old_cipher = FernetCipher([old_key])
     sealed = old_cipher.encrypt("provider-key")
-    assert sealed.key_version == 1
+    assert sealed.key_version == old_cipher.current_version
 
     # Rotation step 1: prepend the new key (newest first); both keys held.
     rotating = FernetCipher([new_key, old_key])
-    assert rotating.current_version == 2
-    # Old ciphertext keeps decrypting while both keys are present.
+    assert rotating.current_version != old_cipher.current_version  # new encrypting key -> new stamp
     assert rotating.decrypt(sealed) == "provider-key"
+    # A not-yet-rotated row is detectable: its stamp != the current encrypting key.
+    assert sealed.key_version != rotating.current_version
 
     # Rotation step 2: re-encrypt under the newest key and re-stamp the version.
     rotated = rotating.rotate(sealed)
-    assert rotated.key_version == 2
+    assert rotated.key_version == rotating.current_version
     assert rotating.decrypt(rotated) == "provider-key"
 
-    # Rotation step 3: once every row is re-stamped, the old key can be dropped.
+    # Rotation step 3: dropping the retired key does NOT change the surviving
+    # key's fingerprint, so already-rotated rows stay marked done.
     new_only = FernetCipher([new_key])
+    assert new_only.current_version == rotating.current_version
     assert new_only.decrypt(rotated) == "provider-key"
     # ...and the not-yet-rotated ciphertext fails closed under the new key alone.
     with pytest.raises(LLMConfigError):

--- a/apps/backend/tests/unit/llm/test_secrets.py
+++ b/apps/backend/tests/unit/llm/test_secrets.py
@@ -1,0 +1,76 @@
+"""Unit tests for provider-secret encryption + rotation (EPIC-023 AC23.1.2-.4)."""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+
+from src.config import settings
+from src.llm.common import FernetCipher, LLMConfigError, build_cipher
+
+
+def _key() -> str:
+    """A fresh Fernet key as the str form FernetCipher expects."""
+    return Fernet.generate_key().decode("ascii")
+
+
+def test_AC23_1_2_round_trips_a_provider_secret_without_storing_plaintext():
+    """AC23.1.2: encrypt -> decrypt recovers the secret; ciphertext is not the plaintext."""
+    cipher = FernetCipher([_key()])
+    secret = "sk-super-secret-provider-key"
+
+    sealed = cipher.encrypt(secret)
+
+    assert sealed.ciphertext != secret
+    assert secret not in sealed.ciphertext
+    assert sealed.key_version == 1
+    assert cipher.decrypt(sealed) == secret
+
+
+def test_AC23_1_3_rotation_is_single_pass_old_ciphertext_still_decrypts():
+    """AC23.1.3: after prepending a new key, an old secret still decrypts and re-stamps."""
+    old_key, new_key = _key(), _key()
+
+    old_cipher = FernetCipher([old_key])
+    sealed = old_cipher.encrypt("provider-key")
+    assert sealed.key_version == 1
+
+    # Rotation step 1: prepend the new key (newest first); both keys held.
+    rotating = FernetCipher([new_key, old_key])
+    assert rotating.current_version == 2
+    # Old ciphertext keeps decrypting while both keys are present.
+    assert rotating.decrypt(sealed) == "provider-key"
+
+    # Rotation step 2: re-encrypt under the newest key and re-stamp the version.
+    rotated = rotating.rotate(sealed)
+    assert rotated.key_version == 2
+    assert rotating.decrypt(rotated) == "provider-key"
+
+    # Rotation step 3: once every row is re-stamped, the old key can be dropped.
+    new_only = FernetCipher([new_key])
+    assert new_only.decrypt(rotated) == "provider-key"
+    # ...and the not-yet-rotated ciphertext fails closed under the new key alone.
+    with pytest.raises(LLMConfigError):
+        new_only.decrypt(sealed)
+
+
+def test_AC23_1_4_build_cipher_fails_closed_without_a_key(monkeypatch):
+    """AC23.1.4: no LLM_ENCRYPTION_KEYS -> build_cipher raises (DB secrets fail closed)."""
+    monkeypatch.setattr(settings, "llm_encryption_key_list", [], raising=False)
+    with pytest.raises(LLMConfigError):
+        build_cipher()
+
+
+def test_AC23_1_4_build_cipher_uses_configured_keys(monkeypatch):
+    """AC23.1.4: build_cipher constructs a working cipher from configured keys."""
+    monkeypatch.setattr(settings, "llm_encryption_key_list", [_key()], raising=False)
+    cipher = build_cipher()
+    assert cipher.decrypt(cipher.encrypt("x")) == "x"
+
+
+def test_AC23_1_4_fernet_cipher_rejects_empty_and_malformed_keys():
+    """AC23.1.4: an empty key list or a non-Fernet key is a config error, not a crash."""
+    with pytest.raises(LLMConfigError):
+        FernetCipher([])
+    with pytest.raises(LLMConfigError):
+        FernetCipher(["this-is-not-a-valid-fernet-key"])

--- a/apps/backend/tests/unit/llm/test_types.py
+++ b/apps/backend/tests/unit/llm/test_types.py
@@ -8,6 +8,7 @@ from src.llm.common import (
     Modality,
     ModelSpec,
     ProtocolFamily,
+    ProviderRef,
     ReasoningEffort,
     Scene,
     SceneBinding,
@@ -60,6 +61,15 @@ def test_AC23_1_1_scene_binding_defaults_are_conservative():
     assert binding.prefer_free is False
     assert binding.fallback_model_ids == ()
     assert binding.max_tokens is None
+
+
+def test_AC23_1_1_provider_ref_never_reprs_its_api_key():
+    """AC23.1.1: the decrypted api_key is excluded from repr/str (no secret in logs)."""
+    ref = ProviderRef(id="env", label="zai", protocol=ProtocolFamily.OPENAI_COMPATIBLE, api_key="sk-secret-123")
+    assert "sk-secret-123" not in repr(ref)
+    assert "sk-secret-123" not in str(ref)
+    # The key is still accessible programmatically.
+    assert ref.api_key == "sk-secret-123"
 
 
 def test_AC23_1_1_usage_totals_tokens():

--- a/apps/backend/tests/unit/llm/test_types.py
+++ b/apps/backend/tests/unit/llm/test_types.py
@@ -1,0 +1,68 @@
+"""Unit tests for the LLM contract value types (EPIC-023 AC23.1.1)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from src.llm.common import (
+    Modality,
+    ModelSpec,
+    ProtocolFamily,
+    ReasoningEffort,
+    Scene,
+    SceneBinding,
+    Usage,
+)
+
+
+def test_AC23_1_1_protocol_family_enumerates_exactly_three_universal_families():
+    """AC23.1.1: axis 1 is exactly the three universally-compatible protocol families."""
+    assert {f.value for f in ProtocolFamily} == {
+        "openai-compatible",
+        "anthropic-compatible",
+        "openrouter-compatible",
+    }
+
+
+def test_AC23_1_1_scene_enumerates_the_fixed_call_sites():
+    """AC23.1.1: axis 3 is the fixed, code-defined set of scenes (the binding keys)."""
+    assert {s.value for s in Scene} == {
+        "extraction.ocr",
+        "extraction.vision",
+        "extraction.json",
+        "advisor.chat",
+        "statement.summary",
+    }
+
+
+def test_AC23_1_1_model_spec_carries_capabilities_so_selection_is_data():
+    """AC23.1.1: a model's modalities/free/pricing are data on ModelSpec, not code branches."""
+    spec = ModelSpec(
+        id="zai/glm-4.6v",
+        provider_id="zai",
+        modalities=frozenset({Modality.IMAGE, Modality.PDF}),
+        is_free=False,
+        input_price_per_mtok=Decimal("0.60"),
+        output_price_per_mtok=Decimal("2.20"),
+        supports_reasoning=False,
+    )
+    assert spec.accepts(Modality.IMAGE)
+    assert spec.accepts(Modality.PDF)
+    assert not spec.accepts(Modality.TEXT)
+    # Money is Decimal, never float (project red line).
+    assert isinstance(spec.input_price_per_mtok, Decimal)
+
+
+def test_AC23_1_1_scene_binding_defaults_are_conservative():
+    """AC23.1.1: a binding maps scene x model with safe defaults (no reasoning, no free pref)."""
+    binding = SceneBinding(scene=Scene.EXTRACTION_VISION, model_id="zai/glm-4.6v")
+    assert binding.reasoning is ReasoningEffort.NONE
+    assert binding.prefer_free is False
+    assert binding.fallback_model_ids == ()
+    assert binding.max_tokens is None
+
+
+def test_AC23_1_1_usage_totals_tokens():
+    """AC23.1.1: Usage exposes total tokens for cost accounting."""
+    usage = Usage(prompt_tokens=1200, completion_tokens=300)
+    assert usage.total_tokens == 1500

--- a/common/ssot/generate_ac_registry.py
+++ b/common/ssot/generate_ac_registry.py
@@ -25,7 +25,7 @@ OUTPUT_INFRA = "docs/infra_registry.yaml"
 OVERRIDES = "docs/ac_registry_overrides.yaml"
 
 # EPIC classification: which EPICs are feature vs infra
-FEATURE_EPICS = {1, 2, 3, 4, 5, 6, 8, 11, 13, 15, 16, 17, 18, 19, 20, 21, 22}
+FEATURE_EPICS = {1, 2, 3, 4, 5, 6, 8, 11, 13, 15, 16, 17, 18, 19, 20, 21, 22, 23}
 INFRA_EPICS = {7, 9, 10, 12, 14}
 
 # EPIC-016 sub-classification: these AC16.XX.x groups route to infra
@@ -54,6 +54,7 @@ EPIC_NAMES: dict[int, str] = {
     20: "framework-aware-personal-reporting",
     21: "application-ai-advisor",
     22: "everyday-user-ia",
+    23: "llm-provider-abstraction",
 }
 
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -552,6 +552,7 @@ Product E2E ownership index:
 | `tests/e2e/test_core_journeys.py` | Deployed core journey E2E; AC references live in the test file |
 | `tests/e2e/test_e2e_flows.py` | Deployed extended flow E2E; AC references live in the test file |
 | `tests/e2e/test_four_asset_net_worth_golden_path.py` | Critical proof: AC8.13.42, AC8.13.10, AC5.7.3, AC11.9.1-AC11.9.3, AC17.5.4 |
+| `tests/e2e/test_llm_provider_abstraction_epic023.py` | LLM provider abstraction product owner E2E; EPIC-023 / AC23.1 references live in the test file |
 | `tests/e2e/test_market_data_price_paths.py` | Critical proof: AC11.10.7, AC11.10.11 |
 | `tests/e2e/test_personal_financial_report_package.py` | Critical proof: AC5.1.1, AC5.1.4, AC5.2.3, AC5.3.1, AC5.8.1, AC5.12.4, AC5.13.4-AC5.13.5, AC11.8.3, AC11.9.1-AC11.9.3, AC11.11.1-AC11.11.2, AC17.10.1-AC17.10.2, AC17.12.1-AC17.12.3, AC8.13.83-AC8.13.85, AC8.13.87-AC8.13.88 |
 | `tests/e2e/test_production_readonly_smoke.py` | Production-readonly smoke E2E; AC references live in the test file |

--- a/docs/project/EPIC-014.ttd-transformation.md
+++ b/docs/project/EPIC-014.ttd-transformation.md
@@ -157,7 +157,7 @@ member column lists the current inferred manifest groupings (the
 |---|---|---|
 | `accounting` | Double-entry ledger, in-transit funds, reconciliation, and trust hierarchy | `accounting`, `reconciliation`, `confirmation`, `processing`, `source` |
 | `reporting` | Reports, frameworks, market data, assets, and evidence/workflow read models | `reporting`, `framework`, `market`, `assets`, `evidence`, `workflow` |
-| `extraction` | Statement parsing, AI advisor, and PDF fixtures | `extraction`, `ai`, `pdf` |
+| `extraction` | Statement parsing, AI advisor, LLM provider abstraction, and PDF fixtures | `extraction`, `ai`, `llm`, `pdf` |
 | `schema` | Database schema, data layering, enum naming, and migration risk | `schema`, `migration` |
 | `platform` | Dev workflow, environments, CI/CD, coverage, deployment, and observability | `platform`, `development`, `environments`, `ci`, `test`, `delivery`, `coverage`, `deployment`, `observability`, `runtime`, `env` |
 | `identity` | Auth identity and frontend integration contract | `auth`, `frontend` |

--- a/docs/project/EPIC-023.llm-provider-abstraction.md
+++ b/docs/project/EPIC-023.llm-provider-abstraction.md
@@ -1,0 +1,78 @@
+# EPIC-023: LLM Provider Abstraction (litellm)
+
+> **Status**: In progress — PR1 lands the frozen contract (`src/llm/common`) and
+> the secret cipher; PR2 (EPIC A) implements the litellm client/catalogue/cost
+> and rewires existing call sites; PR3 (EPIC B) adds DB-backed provider config,
+> the scene×model matrix, and the first-run modal.
+> **Vision Anchor**: `decision-4-two-stage-review` — extraction quality depends on
+> being able to pick and swap the right model per scene without code surgery.
+> **Phase**: Platform / AI plumbing
+> **Priority**: P1 — the AI plumbing is currently raw `httpx` against a single
+> hard-coded provider; switching providers, optimising spend, or onboarding a new
+> model means editing code in several places.
+> **Dependencies**: EPIC-018 (AI feature flags)
+
+---
+
+## Objective
+
+Replace the bespoke `httpx` AI plumbing (`services/ai_streaming.py`,
+`services/ai_models.py`, the provider calls inside `services/extraction.py`) with
+**litellm behind a single in-repo package, `src/llm`**, structured around three
+orthogonal axes:
+
+```text
+Axis 1  Protocol family   openai-compatible | anthropic-compatible | openrouter-compatible
+Axis 2  Model             a dynamic catalogue (may be far larger than what is bound)
+Axis 3  Scene             a fixed, code-defined set of call sites
+Binding Scene × Model     the configurable surface (model + reasoning + fallbacks)
+```
+
+Concrete vendors are **not** special-cased: Z.AI/GLM, DeepSeek, a local vLLM, …
+all slot into `openai-compatible` via a custom `api_base`. Model selection is
+configuration, not code, and is intended to live in the database (EPIC B) so it
+can be edited at runtime — when nothing is configured, the app prompts the user.
+
+## Why This EPIC Exists
+
+Today the provider is reachable only by editing Python, the daily-spend guard and
+fallback list are hand-rolled, provider quirks are scattered `if provider == …`
+branches (OpenRouter headers, Z.AI rejecting `seed`/`response_format`), and there
+is no central place that says "which model does each feature use, and what does it
+cost". litellm gives us provider routing, `drop_params` (auto-dropping unsupported
+fields), `reasoning_effort`, fallback/budget routing, and cost accounting for
+free; this EPIC wraps it in a contract the rest of the app can depend on.
+
+## Non-Goals
+
+- Replacing the Z.AI `layout_parsing` private endpoint or the PyMuPDF PDF→image
+  pre-processing in `extraction.py` — these stay; litellm only handles the
+  OpenAI/Anthropic-shaped calls.
+- A model-marketplace / multi-tenant billing system. Spend tracking stays a
+  single per-deployment guard (now centralised).
+- Reusing the package outside the backend (no standalone published package yet).
+
+## Scope Slices
+
+| Slice | PR | Owns |
+|-------|----|------|
+| **common** | PR1 | `src/llm/common`: value types, `ConfigSource`/`LLMClient`/`CatalogProvider`/`CostMeter` protocols, `SecretCipher`+`FernetCipher`, `docs/ssot/llm.md`. The frozen contract A and B build against. |
+| **EPIC A** | PR2 | litellm `client`/`catalog`/`cost` implementations + `EnvConfigSource`; rewire `ai_streaming`/`ai_models`/`extraction` to delegate. |
+| **EPIC B** | PR3 | `llm_provider` + `llm_scene_binding` tables, `DbConfigSource`, `/llm/*` API, first-run modal + scene×model settings page. |
+
+A and B depend only on **common**, not on each other, so they proceed in
+parallel once PR1 merges.
+
+## Acceptance Criteria
+
+### AC23.1 — Frozen contract & secret encryption
+> PR1 slice. The shared types/protocols and the at-rest secret cipher that EPIC A
+> and EPIC B both build against.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC23.1.1 | The three axes are typed: `ProtocolFamily` enumerates exactly the three universal protocol families, `Scene` the fixed call sites, and `ModelSpec`/`SceneBinding` carry modality/free/reasoning so model selection is data, not code | `apps/backend/tests/unit/llm/test_types.py` | P1 |
+| AC23.1.2 | `FernetCipher` round-trips a provider secret (`encrypt` → `decrypt`) and never persists plaintext | `apps/backend/tests/unit/llm/test_secrets.py` | P1 |
+| AC23.1.3 | Key rotation is single-pass: a secret sealed by an older key still decrypts after a newer key is prepended, and `rotate()` re-stamps it to the newest `key_version` | `apps/backend/tests/unit/llm/test_secrets.py` | P1 |
+| AC23.1.4 | `build_cipher()` raises `LLMConfigError` when `LLM_ENCRYPTION_KEYS` is unset, and `FernetCipher` rejects malformed keys — DB-backed secrets fail closed | `apps/backend/tests/unit/llm/test_secrets.py` | P1 |
+| AC23.1.5 | The seam protocols (`ConfigSource`, `LLMClient`, `CatalogProvider`, `CostMeter`, `SecretCipher`) are runtime-checkable and a conforming implementation satisfies `isinstance`, so EPIC A/B can swap implementations behind the contract | `apps/backend/tests/unit/llm/test_contract.py` | P1 |

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -642,3 +642,16 @@ concepts:
       - docs/ssot/development.md
     proofs:
       - tests/tooling/test_runtime_incident_response_ssot.py
+
+  # ── LLM provider abstraction (EPIC-023) ───────────────────────────────
+  llm_provider_abstraction:
+    owner: docs/ssot/llm.md#axes
+    description: LLM layer's three orthogonal axes (protocol family x model x scene), scene->model binding, and at-rest provider-secret encryption.
+    cross_refs:
+      - docs/ssot/extraction.md
+      - docs/project/EPIC-023.llm-provider-abstraction.md
+      - apps/backend/src/llm/common/types.py
+      - apps/backend/src/llm/common/secrets.py
+    proofs:
+      - apps/backend/tests/unit/llm/test_secrets.py
+      - apps/backend/tests/unit/llm/test_types.py

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -646,6 +646,8 @@ concepts:
   # ── LLM provider abstraction (EPIC-023) ───────────────────────────────
   llm_provider_abstraction:
     owner: docs/ssot/llm.md#axes
+    family: llm
+    kind: concept
     description: LLM layer's three orthogonal axes (protocol family x model x scene), scene->model binding, and at-rest provider-secret encryption.
     cross_refs:
       - docs/ssot/extraction.md

--- a/docs/ssot/env-reference.generated.md
+++ b/docs/ssot/env-reference.generated.md
@@ -33,6 +33,7 @@ Where a field's `.env.example` value intentionally differs from its code default
 | `AI_MODEL_CATALOG_SOURCE` | `configured` |  |  | AI Provider | Source of the AI model catalog. |
 | `AI_PROVIDER` | `zai` |  | yes | AI Provider | AI provider id. Required for document extraction and the AI advisor (Z.AI/GLM defaults). |
 | `FALLBACK_MODELS` |  | `glm-5-turbo,glm-5` |  | AI Provider | Comma-separated fallback AI model ids. |
+| `LLM_ENCRYPTION_KEYS` |  |  | yes | AI Provider | Comma-separated Fernet keys (urlsafe base64, 32 bytes) for encrypting LLM provider API keys at rest; newest first. Empty disables DB-backed provider storage. Rotate by prepending a new key and re-encrypting all secrets. |
 | `OCR_MODEL` | `glm-4.6v` |  |  | AI Provider | OCR AI model id. |
 | `PREFECT_API_URL` |  |  |  | AI Provider | EPIC-019: set to the Prefect API URL to run upload->report parsing as durable Prefect flow runs (staging/prod and per-PR ephemeral Prefect). Leave unset for CI/local/preview -> in-process asyncio fallback (no Prefect needed). |
 | `PRIMARY_MODEL` | `glm-5.1` |  |  | AI Provider | Primary AI model id. |

--- a/docs/ssot/llm.md
+++ b/docs/ssot/llm.md
@@ -1,0 +1,101 @@
+# LLM Provider Abstraction SSOT
+
+> **SSOT Key**: `llm_provider_abstraction`
+> **Core Definition**: How the backend talks to language models — the three
+> orthogonal axes (protocol family × model × scene), the scene→model binding, and
+> the at-rest encryption of provider secrets.
+
+This document owns the *vocabulary and contracts* of the LLM layer. It does **not**
+own the concrete values (which provider, which key, which model per scene) — those
+are operational data that live in the database (EPIC-023 EPIC B) and are edited at
+runtime. The code-level contract is `apps/backend/src/llm/common`.
+
+---
+
+## 1. Source of Truth
+
+| Dimension | Physical Location (SSOT) | Description |
+|-----------|--------------------------|-------------|
+| **Contract (types/protocols)** | `apps/backend/src/llm/common/` | Frozen value types + protocols both halves build against |
+| **Secret cipher** | `apps/backend/src/llm/common/secrets.py` | Fernet/MultiFernet encryption of provider API keys at rest |
+| **Encryption key** | `LLM_ENCRYPTION_KEYS` (env/Vault) | Project-level symmetric key(s), newest first |
+| **Provider instances + scene bindings** | DB tables `llm_provider`, `llm_scene_binding` (EPIC B) | Runtime-editable configuration values |
+| **Client / catalogue / cost impl** | `apps/backend/src/llm/` (EPIC A) | litellm-backed implementations of the protocols |
+
+---
+
+## 2. <a id="axes"></a>The Three Orthogonal Axes
+
+Model usage is described by three axes that never collapse into one another.
+Adding a model touches only axis 2; re-pointing a feature touches only the
+binding; onboarding a vendor touches only axis 1.
+
+### Axis 1 — Protocol family
+
+Exactly three families, because these three are the universally-compatible wire
+protocols. Every concrete vendor maps onto one of them:
+
+| Family | Spoken by (examples) |
+|--------|----------------------|
+| `openai-compatible` | OpenAI, Z.AI/GLM, DeepSeek, a local vLLM (custom `api_base`) |
+| `anthropic-compatible` | Claude (native Messages API) |
+| `openrouter-compatible` | OpenRouter (adds `:free` tier, provider routing, extra headers) |
+
+A *provider instance* is `(protocol_family, api_base?, api_key, label)`. The
+litellm client turns it into a `provider/model` call string.
+
+### Axis 2 — Model
+
+A **dynamic catalogue** that can be much larger than the bound set. Each entry
+(`ModelSpec`) carries its `provider_id`, `modalities` (text/image/pdf/file),
+`is_free`, and pricing. Catalogue loading and free-tier flagging belong to the
+`CatalogProvider` (EPIC A).
+
+### Axis 3 — Scene
+
+The fixed, code-defined set of call sites. Adding or renaming a scene is a
+contract change (update this list and `src/llm/common/types.py:Scene`):
+
+| Scene | Where |
+|-------|-------|
+| `extraction.ocr` | Dedicated OCR / layout parsing |
+| `extraction.vision` | Vision-model fallback for image/PDF statements |
+| `extraction.json` | Structured-JSON extraction pass |
+| `advisor.chat` | AI advisor conversational replies |
+| `statement.summary` | Statement summary generation |
+
+### Binding — Scene × Model
+
+`SceneBinding` resolves a scene to `model_id` plus per-scene parameters:
+`reasoning` (depth), `prefer_free`, `fallback_model_ids`, `max_tokens`. This is
+the configurable surface — swapping the model for `extraction.vision` is one
+binding edit, independent of every other scene.
+
+---
+
+## 3. <a id="secrets"></a>Secret Encryption & Rotation
+
+Provider API keys are stored in the database, so they are encrypted at rest with
+a project-level key supplied via `LLM_ENCRYPTION_KEYS` (env/Vault), using Fernet
+wrapped in `MultiFernet`:
+
+- Keys are comma-separated, **newest first**. Index 0 encrypts; all keys are
+  tried on decrypt, so an old ciphertext keeps decrypting after a new key lands.
+- Each stored secret records the `key_version` that sealed it.
+- **Rotation is one pass**: prepend a new key, re-encrypt every stored secret via
+  `SecretCipher.rotate()` (the row loop lives in the DB layer), then drop the old
+  key once every row carries the new `key_version`.
+
+When `LLM_ENCRYPTION_KEYS` is empty, DB-backed provider secrets fail closed
+(`build_cipher()` raises `LLMConfigError`); env/Vault-only provider configuration
+still works.
+
+---
+
+## 4. <a id="config-flow"></a>Configuration Flow & First-Run
+
+The client resolves a scene through a `ConfigSource`. EPIC A ships an env-backed
+source; EPIC B swaps in a DB-backed one without the client changing. When
+`ConfigSource.is_configured()` is `False` (no provider exists), the frontend
+shows a first-run modal asking the user to add a provider before any AI feature
+runs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - Market Data: ssot/market_data.md
       - Source Type Priority: ssot/source-type-priority.md
       - Workflow Events: ssot/workflow-events.md
+      - LLM Provider Abstraction: ssot/llm.md
       - Evidence Lineage: ssot/evidence-lineage.md
       - Database Schema: ssot/schema.md
       - Observability: ssot/observability.md
@@ -148,6 +149,7 @@ nav:
           - "EPIC-020: Framework-Aware Personal Reporting": project/EPIC-020.framework-aware-personal-reporting.md
           - "EPIC-021: Application-Layer AI Advisor": project/EPIC-021.application-ai-advisor.md
           - "EPIC-022: Everyday-User IA": project/EPIC-022.everyday-user-ia.md
+          - "EPIC-023: LLM Provider Abstraction": project/EPIC-023.llm-provider-abstraction.md
 
 extra:
   social:

--- a/tests/e2e/test_llm_provider_abstraction_epic023.py
+++ b/tests/e2e/test_llm_provider_abstraction_epic023.py
@@ -32,7 +32,11 @@ def test_llm_provider_abstraction_epic023_product_owner_contract() -> None:
     secrets_src = read("apps/backend/src/llm/common/secrets.py")
 
     # Axis 1 — exactly the three universally-compatible protocol families.
-    for family in ("openai-compatible", "anthropic-compatible", "openrouter-compatible"):
+    for family in (
+        "openai-compatible",
+        "anthropic-compatible",
+        "openrouter-compatible",
+    ):
         assert family in ssot
         assert family in types_src
 

--- a/tests/e2e/test_llm_provider_abstraction_epic023.py
+++ b/tests/e2e/test_llm_provider_abstraction_epic023.py
@@ -1,0 +1,53 @@
+"""Product E2E owner for EPIC-023 (LLM provider abstraction).
+
+Mirrors the EPIC-021 owner pattern: a marker-`e2e` contract test that anchors the
+EPIC to its shipped surface. PR1 ships the *contract* (`src/llm/common`) and the
+secret cipher, so the owner asserts that the EPIC doc, the SSOT vocabulary, and
+the code module express the three orthogonal axes and the single-pass secret
+rotation that the litellm migration (PR2/PR3) builds on.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_llm_provider_abstraction_epic023_product_owner_contract() -> None:
+    """EPIC-023 / AC23.1.1 AC23.1.3: the LLM abstraction has a product E2E owner.
+
+    Anchors the EPIC to (a) the SSOT vocabulary of its three orthogonal axes and
+    (b) the secret-rotation contract, so a drift in either surface fails here.
+    """
+    epic = read("docs/project/EPIC-023.llm-provider-abstraction.md")
+    ssot = read("docs/ssot/llm.md")
+    types_src = read("apps/backend/src/llm/common/types.py")
+    secrets_src = read("apps/backend/src/llm/common/secrets.py")
+
+    # Axis 1 — exactly the three universally-compatible protocol families.
+    for family in ("openai-compatible", "anthropic-compatible", "openrouter-compatible"):
+        assert family in ssot
+        assert family in types_src
+
+    # Axis 3 — the fixed scenes are named in both the SSOT and the code enum.
+    for scene in ("extraction.ocr", "extraction.vision", "advisor.chat"):
+        assert scene in ssot
+        assert scene in types_src
+
+    # Binding is the configurable scene x model surface.
+    assert "SceneBinding" in types_src
+    assert "Scene × Model" in ssot or "scene->model" in ssot or "scene → model" in ssot
+
+    # Secret encryption is single-pass rotation over a project-level key.
+    assert "MultiFernet" in secrets_src
+    assert "LLM_ENCRYPTION_KEYS" in ssot
+    assert "rotation" in ssot.lower()
+    assert "single-pass" in epic.lower()
+    assert "one pass" in ssot.lower()


### PR DESCRIPTION
## EPIC-023: migrate AI plumbing to litellm — **PR1 of 3** (the frozen contract)

This is the foundation PR. It introduces **`src/llm/common`**, the contract that
the other two PRs build against in parallel:

- **PR2 (EPIC A)** — litellm `client`/`catalog`/`cost` + rewire `ai_streaming`/`ai_models`/`extraction`.
- **PR3 (EPIC B)** — DB-backed provider config, scene×model matrix, first-run modal.

> ⚠️ PR2 and PR3 **depend on this PR** (they import `src/llm/common`). They are
> siblings of each other (no A↔B dependency) and go green once this merges and
> they rebase onto `main`. All three target `main` (no stacking — CI only runs
> for PRs into `main`).

### What's here

**Three orthogonal axes** (see `docs/ssot/llm.md`), as immutable value types:
- Axis 1 `ProtocolFamily` — `openai-compatible` / `anthropic-compatible` / `openrouter-compatible`. Concrete vendors (Z.AI/GLM, DeepSeek, local vLLM) slot in via a custom `api_base`; not special-cased.
- Axis 2 `ModelSpec` — a dynamic catalogue entry (modalities, free-tier, pricing as `Decimal`).
- Axis 3 `Scene` — the fixed call sites; `SceneBinding` is the configurable `scene → model` surface (model + reasoning depth + fallbacks).

**Seam protocols** (all `@runtime_checkable`) so EPIC A/B implement opposite sides independently:
`ConfigSource`, `LLMClient`, `CatalogProvider`, `CostMeter`.

**Secret encryption** — `SecretCipher` + `FernetCipher` (Fernet/MultiFernet):
provider API keys are encrypted at rest with a project-level key from
`LLM_ENCRYPTION_KEYS` (env/Vault), newest-first. **Rotation is single-pass**:
prepend a new key → `rotate()` every stored secret → drop the old key. Fails
closed (`LLMConfigError`) when no key is set.

### Governance
- `docs/ssot/llm.md` owns the axes/scene/secret vocabulary (registered in `MANIFEST.yaml`).
- `docs/project/EPIC-023…md` defines **AC23.1.1–.5**; EPIC 23 registered in the AC generator.

### Tests & gates (green locally)
- 14 unit tests under `tests/unit/llm/`: secret round-trip, single-pass rotation, fail-closed, protocol conformance, axis typing.
- `check_ac_index` (traceability + protection), `check_manifest`, `generate_env_reference --check`, `check_env_keys`, `ruff`, and the AC-generator tooling tests all pass.

### Notes
- Adds `cryptography` as a direct dep (already resolved transitively in `uv.lock`); CI uses `uv sync` (no `--locked`), so no lock churn.
- No runtime behavior change yet — this PR is pure contract + crypto util; no existing call site is rewired until PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)