### PR TITLE
[finance_report_hacker] fix(skills): correct broken tool ref in ac-workflow + guard skill→tool drift

### DIFF
--- a/.opencode/skills/domain/ac-workflow/SKILL.md
+++ b/.opencode/skills/domain/ac-workflow/SKILL.md
@@ -28,7 +28,7 @@ drift if you don't regenerate:
 
 ```bash
 apps/backend/.venv/bin/python tools/generate_ac_registry.py     # sync the index
-apps/backend/.venv/bin/python tools/check_ac_traceability.py    # gate: every mandatory AC has a real CI test
+apps/backend/.venv/bin/python tools/check_ac_index.py           # gate: every mandatory AC has a real CI test
 ```
 
 The **preflight** skill runs both automatically when it sees an EPIC/registry

--- a/.opencode/skills/domain/preflight/SKILL.md
+++ b/.opencode/skills/domain/preflight/SKILL.md
@@ -50,3 +50,9 @@ gate there with a test in `tests/tooling/test_preflight.py`.
 - It never runs destructive tools (purge/cleanup/deploy). Those stay manual.
 - For an EPIC/AC change specifically, see the **ac-workflow** skill for the full
   EPIC→AC→test ritual that preflight's `ac-traceability` gate verifies.
+- The `backend-format` gate runs `ruff` from your **PATH**, not the project-pinned
+  one. If your PATH ruff is a different version than the repo pins
+  (`apps/backend/.venv/bin/ruff --version`), it can report false-positive format
+  failures on files **outside your diff**. CI uses the pinned version, so when
+  `backend-format` flags a file you didn't touch, re-check with
+  `apps/backend/.venv/bin/ruff format --check src tests` before assuming it's real.

--- a/.opencode/skills/domain/preflight/SKILL.md
+++ b/.opencode/skills/domain/preflight/SKILL.md
@@ -27,7 +27,7 @@ Exit code is non-zero if any gate fails; the summary names which one.
 
 | You touched | It runs |
 |---|---|
-| `docs/project/EPIC*.md`, `docs/ac_registry*.yaml`, `docs/infra_registry*.yaml` | `generate_ac_registry.py` → `check_ac_traceability.py` |
+| `docs/project/EPIC*.md`, `docs/ac_registry*.yaml`, `docs/infra_registry*.yaml` | `generate_ac_registry.py` → `check_ac_index.py` |
 | `docs/ssot/*` | `check_ssot_ownership.py`, `check_manifest.py` |
 | `docs/*`, `mkdocs.yml`, `vision.md`, `README.md` | `lint_doc_consistency.py` |
 | `apps/backend/*schema*.py` | `validate_schemas.py` |
@@ -54,5 +54,6 @@ gate there with a test in `tests/tooling/test_preflight.py`.
   one. If your PATH ruff is a different version than the repo pins
   (`apps/backend/.venv/bin/ruff --version`), it can report false-positive format
   failures on files **outside your diff**. CI uses the pinned version, so when
-  `backend-format` flags a file you didn't touch, re-check with
-  `apps/backend/.venv/bin/ruff format --check src tests` before assuming it's real.
+  `backend-format` flags a file you didn't touch, re-check with the pinned ruff from
+  the backend dir — `cd apps/backend && .venv/bin/ruff format --check src tests` —
+  before assuming it's real.

--- a/tests/tooling/test_agent_runtime_symlinks.py
+++ b/tests/tooling/test_agent_runtime_symlinks.py
@@ -199,22 +199,48 @@ def test_claude_settings_enable_mcp_baseline() -> None:
     )
 
 
-_TOOL_REF = re.compile(r"\btools/[A-Za-z0-9_./-]+\.py\b")
+# Explicit `tools/<x>.py` path — must exist at exactly that path.
+_TOOL_PATH_REF = re.compile(r"\btools/[A-Za-z0-9_./-]+\.py\b")
+# Bare backticked `<name>.py` (no path) — skills often cite a tool script by
+# filename alone (e.g. a preflight mapping cell). Those must still resolve to a
+# real file somewhere in the repo, or the same drift slips past a path-only check.
+_BARE_PY_REF = re.compile(r"`([A-Za-z0-9_-]+\.py)`")
+_PY_SKIP_DIRS = {".git", "node_modules", ".venv", "venv", "__pycache__", "worktrees"}
+
+
+def _repo_py_basenames() -> set[str]:
+    """All `*.py` basenames tracked in the repo (heavy/vendored dirs pruned)."""
+    names: set[str] = set()
+    for dirpath, dirnames, filenames in os.walk(ROOT):
+        dirnames[:] = [d for d in dirnames if d not in _PY_SKIP_DIRS]
+        names.update(fn for fn in filenames if fn.endswith(".py"))
+    return names
 
 
 def test_skill_docs_reference_existing_tools() -> None:
-    """Every ``tools/<x>.py`` path a canonical SKILL.md tells agents to run must
-    resolve to a real file.
+    """Every tool script a canonical SKILL.md tells agents to run must resolve.
 
     Skills are static markdown; when a tool is renamed or moved, nothing fails the
-    skill until an agent follows a now-dead command. (This guard exists because the
-    ac-workflow skill shipped a reference to ``tools/check_ac_traceability.py``,
-    which never existed — the real gate is ``tools/check_ac_index.py``.)
+    skill until an agent follows a now-dead command. Two citation styles are checked:
+
+    * explicit ``tools/<x>.py`` paths must exist at that path;
+    * bare backticked ``<name>.py`` filenames (no path) must match a real ``*.py``
+      file somewhere in the repo.
+
+    (This guard exists because the ac-workflow and preflight skills both shipped
+    references to ``check_ac_traceability.py`` — which never existed; the real gate
+    is ``check_ac_index.py`` — and the bare-filename form slipped past a path-only
+    matcher.)
     """
+    repo_basenames = _repo_py_basenames()
     missing: list[str] = []
     for skill_md in sorted(OPENCODE_SKILLS.rglob("SKILL.md")):
         text = skill_md.read_text(encoding="utf-8")
-        for ref in _TOOL_REF.findall(text):
+        rel = skill_md.relative_to(ROOT)
+        for ref in _TOOL_PATH_REF.findall(text):
             if not (ROOT / ref).is_file():
-                missing.append(f"{skill_md.relative_to(ROOT)} -> {ref}")
+                missing.append(f"{rel} -> {ref}")
+        for name in _BARE_PY_REF.findall(text):
+            if name not in repo_basenames:
+                missing.append(f"{rel} -> {name} (no such file in repo)")
     assert not missing, f"SKILL.md files reference non-existent tools: {sorted(set(missing))}"

--- a/tests/tooling/test_agent_runtime_symlinks.py
+++ b/tests/tooling/test_agent_runtime_symlinks.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -196,3 +197,24 @@ def test_claude_settings_enable_mcp_baseline() -> None:
     assert not missing, (
         f".claude/settings.json does not enable baseline MCP servers: {sorted(missing)}"
     )
+
+
+_TOOL_REF = re.compile(r"\btools/[A-Za-z0-9_./-]+\.py\b")
+
+
+def test_skill_docs_reference_existing_tools() -> None:
+    """Every ``tools/<x>.py`` path a canonical SKILL.md tells agents to run must
+    resolve to a real file.
+
+    Skills are static markdown; when a tool is renamed or moved, nothing fails the
+    skill until an agent follows a now-dead command. (This guard exists because the
+    ac-workflow skill shipped a reference to ``tools/check_ac_traceability.py``,
+    which never existed — the real gate is ``tools/check_ac_index.py``.)
+    """
+    missing: list[str] = []
+    for skill_md in sorted(OPENCODE_SKILLS.rglob("SKILL.md")):
+        text = skill_md.read_text(encoding="utf-8")
+        for ref in _TOOL_REF.findall(text):
+            if not (ROOT / ref).is_file():
+                missing.append(f"{skill_md.relative_to(ROOT)} -> {ref}")
+    assert not missing, f"SKILL.md files reference non-existent tools: {sorted(set(missing))}"


### PR DESCRIPTION
## Problems (surfaced during the #1099 work)
1. **`ac-workflow` skill references a non-existent tool.** It tells agents to run `tools/check_ac_traceability.py`, which doesn't exist — the real traceability gate is `tools/check_ac_index.py` (what preflight's `ac-traceability` gate runs). Following the skill verbatim errors with `No such file or directory`.
2. **Nothing catches that class of drift.** Skills are static markdown; when a tool is renamed/removed, no test fails until an agent follows the dead command.
3. **`backend-format` preflight gate uses PATH `ruff`, not the pinned version** → false-positive format failures on out-of-diff files when local ruff ≠ pinned ruff (hit this every run locally; CI is fine because its PATH ruff *is* pinned).

## Fixes
- **ac-workflow**: `tools/check_ac_traceability.py` → `tools/check_ac_index.py`.
- **New guard** `test_skill_docs_reference_existing_tools` (in `tests/tooling/test_agent_runtime_symlinks.py`, beside the existing multi-runtime symlink-drift guards): scans every canonical `SKILL.md` for `tools/<x>.py` refs and asserts each resolves. Would have caught #1, and runs in CI's Tooling/Common Coverage job.
- **preflight skill**: documented the ruff PATH-vs-pinned gotcha + how to re-check (`apps/backend/.venv/bin/ruff format --check src tests`).

Edits are on the canonical `.opencode/skills/...` files; Claude Code (`.claude/skills`) and Codex (`.codex/skills`) read them via symlink, so every runtime gets them.

## Verification
`tests/tooling/test_agent_runtime_symlinks.py` — **11 passed**; the guard covers 7 distinct tool refs across all skills, all resolving. Lint clean.

## Re: "is there a framework-provided discovery tool for this?"
No. Claude Code / Codex / OpenCode don't ship a linter that validates tool references *inside* SKILL.md bodies — they validate frontmatter on load and (Claude Code) have `/doctor` for install health, but not deep content/reference checks. This repo already guards the multi-runtime *bridge* (`test_agent_runtime_symlinks.py`); this PR adds the missing *content* check to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)