### PR TITLE
[finance_report_audit] feat(money-pipeline): per-currency brokerage NAV + under-extraction corpus + report-input AC assurance (#1139 #1140 #1103)

### DIFF
--- a/apps/backend/src/services/brokerage_positions.py
+++ b/apps/backend/src/services/brokerage_positions.py
@@ -388,6 +388,64 @@ def parse_brokerage_positions(
     return []
 
 
+def brokerage_currency_balances(
+    payload: dict[str, Any],
+    *,
+    filename: str | None = None,
+    institution: str | None = None,
+) -> list[dict[str, Any]]:
+    """Derive the per-currency NAV array for a brokerage statement (#1139 AC-B3).
+
+    A multi-currency brokerage statement (IBKR / Futu / Wise) holds positions in
+    several currencies at once. Collapsing them into a single scalar
+    ``opening_balance`` / ``closing_balance`` would cross-sum unrelated currencies
+    into a meaningless number. Instead each currency is an independent closed loop:
+    its closing NAV is the sum of that currency's position market values, and —
+    because a position snapshot carries no intra-period cash flow — its opening
+    equals its closing (net == 0, so ``open + ΣIN − ΣOUT ≈ close`` holds per
+    currency). The result is the ``[{currency, opening, closing}]`` shape consumed
+    by :func:`src.services.validation.validate_balance_per_currency` and persisted
+    on ``StatementSummary.currency_balances``.
+
+    An explicitly declared ``balances`` array on the payload (a broker that prints
+    a real opening/closing cash ladder per currency) is authoritative and returned
+    as-is — the derived position NAV only fills currencies that ladder omits, so a
+    declared opening is never overwritten by the snapshot-equals-NAV degenerate.
+
+    Currencies are NEVER summed across; the array is empty when no positions and no
+    declared balances exist, so callers can leave ``currency_balances`` NULL.
+    """
+    by_currency: dict[str, Decimal] = {}
+    for snapshot in parse_brokerage_positions(payload, filename=filename, institution=institution):
+        ccy = (snapshot.currency or "*").strip().upper() or "*"
+        by_currency[ccy] = by_currency.get(ccy, Decimal("0")) + snapshot.market_value
+
+    # Explicit per-currency cash ladders win over the derived snapshot NAV.
+    declared: dict[str, dict[str, Any]] = {}
+    raw_balances = payload.get("balances")
+    if isinstance(raw_balances, list):
+        for entry in raw_balances:
+            if not isinstance(entry, dict):
+                continue
+            ccy = (entry.get("currency") or "*").strip().upper() or "*"
+            declared[ccy] = {
+                "currency": ccy,
+                "opening": to_money(_clean_decimal(entry.get("opening")) or Decimal("0")),
+                "closing": to_money(_clean_decimal(entry.get("closing")) or Decimal("0")),
+            }
+
+    balances: list[dict[str, Any]] = []
+    for ccy in sorted({*by_currency, *declared}):
+        if ccy in declared:
+            balances.append(declared[ccy])
+            continue
+        nav = to_money(by_currency[ccy])
+        # Snapshot statement: opening == closing == NAV (no intra-period cash flow),
+        # so the per-currency reconciliation is a zero-net closed loop.
+        balances.append({"currency": ccy, "opening": nav, "closing": nav})
+    return balances
+
+
 def _dedup_hash(user_id: UUID, snapshot: BrokeragePositionSnapshot) -> str:
     material = "|".join(
         [

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -27,6 +27,7 @@ from src.services.ai_streaming import (
     stream_ai_json,
 )
 from src.services.brokerage_positions import (
+    brokerage_currency_balances,
     looks_like_brokerage_document,
     looks_like_brokerage_payload,
 )
@@ -40,6 +41,7 @@ from src.services.validation import (
     route_by_threshold,
     validate_balance,
     validate_balance_explicit,
+    validate_balance_per_currency,
 )
 
 logger = get_logger(__name__)
@@ -424,6 +426,44 @@ class ExtractionService:
                 extraction_metadata={"extraction_payload": extracted},
             )
             statement._extracted_payload = extracted
+
+            # Per-currency brokerage NAV (#1139 AC-B3): a multi-currency brokerage
+            # statement holds positions in several currencies at once. Persisting
+            # only the scalar opening/closing would cross-sum unrelated currencies
+            # into a meaningless NAV. Instead derive the per-currency balance array
+            # (each currency an independent closed loop) and persist it additively
+            # to the scalar columns; reconciliation then runs per currency.
+            if is_brokerage_payload:
+                brokerage_balances = brokerage_currency_balances(
+                    extracted,
+                    filename=original_filename or (file_path.name if file_path else None),
+                    institution=final_institution,
+                )
+                if brokerage_balances:
+                    # Reconcile each currency independently (open + ΣIN − ΣOUT ≈
+                    # close per currency); never cross-sum. A snapshot has no cash
+                    # flow, so each currency is a zero-net closed loop and must
+                    # reconcile before we persist it.
+                    per_currency_result = validate_balance_per_currency(
+                        {"balances": brokerage_balances, "transactions": []}
+                    )
+                    if not per_currency_result["balance_valid"]:  # pragma: no cover - defensive
+                        logger.warning(
+                            "Per-currency brokerage NAV failed self-check",
+                            per_currency=per_currency_result["per_currency"],
+                        )
+                    # Serialize Decimal -> str for the JSONB column (no float). The
+                    # scalar opening/closing columns stay populated for the
+                    # single-currency degenerate case and backward compatibility;
+                    # this array is additive and never cross-sums currencies.
+                    statement.currency_balances = [
+                        {
+                            "currency": bucket["currency"],
+                            "opening": str(bucket["opening"]),
+                            "closing": str(bucket["closing"]),
+                        }
+                        for bucket in brokerage_balances
+                    ]
 
             transactions: list[AtomicTransaction] = []
             net_transactions = Decimal("0.00")

--- a/apps/backend/tests/extraction/test_brokerage_position_extraction_wiring.py
+++ b/apps/backend/tests/extraction/test_brokerage_position_extraction_wiring.py
@@ -31,6 +31,7 @@ from src.models.statement_summary import StatementSummary
 from src.prompts import BROKERAGE_POSITIONS_PROMPT, SYSTEM_PROMPT, get_parsing_prompt
 from src.services.brokerage_positions import (
     BrokeragePositionImportService,
+    brokerage_currency_balances,
     looks_like_brokerage_document,
     parse_brokerage_positions,
 )
@@ -290,3 +291,70 @@ async def test_AC_B6_positions_payload_imports_via_service(db, test_user):
     total_market_value = sum((row.market_value for row in rows), Decimal("0"))
     expected_total = sum((Decimal(p["market_value"]) for p in fixture["positions"]), Decimal("0"))
     assert total_market_value == expected_total
+
+
+# --------------------------------------------------------------------------- AC-B3
+
+
+def test_AC_B3_multi_currency_brokerage_emits_per_currency_balances():
+    """AC17.4.13 (AC-B3): A multi-currency brokerage snapshot yields one NAV bucket per currency.
+
+    USD = 2124 + 2276 = 4400, HKD = 80500, SGD = 3810. The currencies must NOT be
+    cross-summed into a single scalar (88710) — each currency is an independent
+    closed loop whose opening == closing == its own position NAV.
+    """
+    fixture = _load_fixture("ibkr-multicurrency-positions_parsed.json")
+
+    balances = brokerage_currency_balances(fixture, filename="ibkr-multicurrency-2506.pdf")
+
+    by_currency = {b["currency"]: b for b in balances}
+    # Every distinct position currency round-trips as its own bucket.
+    assert set(by_currency) == {"USD", "HKD", "SGD"}
+    assert by_currency["USD"]["closing"] == Decimal("4400.00")
+    assert by_currency["HKD"]["closing"] == Decimal("80500.00")
+    assert by_currency["SGD"]["closing"] == Decimal("3810.00")
+    # Snapshot has no cash flow: opening == closing per currency (zero-net loop).
+    for bucket in balances:
+        assert bucket["opening"] == bucket["closing"]
+    # No cross-sum: no bucket carries the meaningless 88710 aggregate, and the
+    # number of buckets equals the number of distinct currencies.
+    assert all(b["closing"] != Decimal("88710.00") for b in balances)
+    assert len(balances) == 3
+
+
+async def test_AC_B3_parse_document_persists_currency_balances_without_cross_sum(test_user):
+    """AC17.4.13 (AC-B3): parse_document persists the per-currency NAV array on the statement.
+
+    The scalar opening/closing stay None for the position snapshot (no running-balance
+    chain), while ``currency_balances`` carries the independent per-currency NAV — the
+    multi-currency NAV no longer collapses to one scalar. Decimal-safe round-trip: the
+    JSONB values are strings that parse back to the exact per-currency NAV.
+    """
+    from unittest.mock import AsyncMock
+
+    service = ExtractionService()
+    payload = _load_fixture("ibkr-multicurrency-positions_parsed.json")
+    service.extract_financial_data = AsyncMock(return_value=payload)
+
+    statement, transactions = await service.parse_document(
+        file_path=Path("ibkr-multicurrency-2506.pdf"),
+        institution="Interactive Brokers",
+        user_id=test_user.id,
+        file_content=b"%PDF-1.7",
+        file_hash="ibkr-multicurrency-hash",
+        original_filename="ibkr-multicurrency-2506.pdf",
+    )
+
+    assert transactions == []
+    assert statement.status == BankStatementStatus.PARSED
+    # The per-currency NAV is persisted; it does not collapse to a single scalar.
+    assert statement.currency_balances is not None
+    by_currency = {b["currency"]: b for b in statement.currency_balances}
+    assert set(by_currency) == {"USD", "HKD", "SGD"}
+    # Decimal round-trip: stored strings parse back to the exact per-currency NAV.
+    assert Decimal(by_currency["USD"]["closing"]) == Decimal("4400.00")
+    assert Decimal(by_currency["HKD"]["closing"]) == Decimal("80500.00")
+    assert Decimal(by_currency["SGD"]["closing"]) == Decimal("3810.00")
+    # No cross-sum into one scalar: three independent buckets, none equal to 88710.
+    assert len(statement.currency_balances) == 3
+    assert all(Decimal(b["closing"]) != Decimal("88710.00") for b in statement.currency_balances)

--- a/apps/backend/tests/extraction/test_chain_break_repair.py
+++ b/apps/backend/tests/extraction/test_chain_break_repair.py
@@ -16,13 +16,24 @@ tests stay reproducible in CI.
 
 from __future__ import annotations
 
+import json
 from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock
 
 from src.services.chain_repair import (
     ChainRepairResult,
     repair_under_extraction,
 )
+from src.services.extraction import ExtractionService
 from src.services.validation import detect_balance_chain_break, validate_balance
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def _load_corpus() -> dict:
+    with (FIXTURES / "clean_bank_dropped_row_corpus.json").open() as fh:
+        return json.load(fh)
 
 
 # --------------------------------------------------------------------------- #
@@ -239,3 +250,54 @@ def test_AC13_20_7_regression_fixture_detects_and_repairs():
     assert result.repaired is True
     # 3) the repaired payload now reconciles under the same hard self-check guard
     assert validate_balance(result.payload)["balance_valid"] is True
+
+
+# --------------------------------------------------------------------------- #
+# AC-C3 end-to-end: the regression-corpus fixture drives the repair pass through
+# the live ExtractionService retry loop with an injected RegionReExtractor.
+# --------------------------------------------------------------------------- #
+async def test_AC13_20_8_corpus_fixture_triggers_repair_end_to_end():
+    """AC13.20.8 (AC-C3): the clean-bank dropped-row corpus fixture triggers the chain-break
+    detector + repair_under_extraction hook end-to-end through ExtractionService.
+
+    Unlike AC13.20.7 (which calls the bare detector/hook functions), this drives the
+    actual ``_extract_with_balance_retry`` path: every model attempt returns the
+    under-extracted (dropped-row) payload so the whole-document retry never
+    reconciles, the repair pass runs the deterministic detector, and the injected
+    ``RegionReExtractor`` re-extracts the dropped region exactly once — yielding a
+    reconciling parse without any live LLM.
+    """
+    corpus = _load_corpus()
+    under_extracted = corpus["dropped_row"]
+    clean = corpus["clean"]
+
+    # Sanity: the corpus shapes are what AC-C3 needs — the dropped-row chain breaks
+    # at the documented index and the clean shape reconciles.
+    assert validate_balance(under_extracted)["balance_valid"] is False
+    assert detect_balance_chain_break(under_extracted["transactions"]).index == corpus["break_index"]
+    assert validate_balance(clean)["balance_valid"] is True
+
+    service = ExtractionService()
+    # Every attempt yields the same under-extracted parse (recall is the problem;
+    # re-sampling alone does not recover the dropped row), forcing the retry loop to
+    # fall through to the repair pass.
+    service.extract_financial_data = AsyncMock(return_value=dict(under_extracted))
+    # Inject the deterministic region re-extractor that recovers the dropped row.
+    backend = _RecordingReExtractor(repaired_payload=clean)
+    service.region_reextractor = backend
+
+    result = await service._extract_with_balance_retry(
+        file_content=b"%PDF-1.7",
+        institution="DBS",
+        file_type="pdf",
+        file_url=None,
+        force_model=None,
+        filename="dbs-dropped-row-2503.pdf",
+    )
+
+    # The injected re-extractor fired exactly once and the returned parse now
+    # reconciles under the same hard self-check guard.
+    assert len(backend.calls) == 1
+    assert backend.calls[0]["break_info"].index == corpus["break_index"]
+    assert validate_balance(result)["balance_valid"] is True
+    assert result is clean

--- a/apps/backend/tests/fixtures/clean_bank_dropped_row_corpus.json
+++ b/apps/backend/tests/fixtures/clean_bank_dropped_row_corpus.json
@@ -1,0 +1,29 @@
+{
+  "description": "Regression-corpus shape for clean-bank under-extraction (#1140 AC-C3). A clean DBS statement whose running balance_after chain is consistent, plus the same statement with one middle row dropped so the chain breaks. The true opening/closing stay the real statement values so the per-currency self-check also flags the under-extraction.",
+  "clean": {
+    "institution": "DBS",
+    "currency": "SGD",
+    "period_start": "2025-03-01",
+    "period_end": "2025-03-31",
+    "opening_balance": "2000.00",
+    "closing_balance": "2350.00",
+    "transactions": [
+      {"date": "2025-03-04", "amount": "600.00", "direction": "IN", "balance_after": "2600.00"},
+      {"date": "2025-03-12", "amount": "450.00", "direction": "OUT", "balance_after": "2150.00"},
+      {"date": "2025-03-22", "amount": "200.00", "direction": "IN", "balance_after": "2350.00"}
+    ]
+  },
+  "dropped_row": {
+    "institution": "DBS",
+    "currency": "SGD",
+    "period_start": "2025-03-01",
+    "period_end": "2025-03-31",
+    "opening_balance": "2000.00",
+    "closing_balance": "2350.00",
+    "transactions": [
+      {"date": "2025-03-04", "amount": "600.00", "direction": "IN", "balance_after": "2600.00"},
+      {"date": "2025-03-22", "amount": "200.00", "direction": "IN", "balance_after": "2350.00"}
+    ]
+  },
+  "break_index": 1
+}

--- a/apps/backend/tests/fixtures/ibkr-multicurrency-positions_parsed.json
+++ b/apps/backend/tests/fixtures/ibkr-multicurrency-positions_parsed.json
@@ -1,0 +1,52 @@
+{
+  "file": "ibkr-multicurrency-2506.pdf",
+  "institution": "Interactive Brokers",
+  "account_last4": "7421",
+  "currency": "USD",
+  "snapshot_date": "2026-06-30",
+  "period_start": "2026-06-01",
+  "period_end": "2026-06-30",
+  "positions": [
+    {
+      "symbol": "AAPL",
+      "quantity": "10",
+      "price": "212.40",
+      "market_value": "2124.00",
+      "currency": "USD",
+      "asset_type": "stock",
+      "sector": "Technology",
+      "geography": "US"
+    },
+    {
+      "symbol": "MSFT",
+      "quantity": "5",
+      "price": "455.20",
+      "market_value": "2276.00",
+      "currency": "USD",
+      "asset_type": "stock",
+      "sector": "Technology",
+      "geography": "US"
+    },
+    {
+      "symbol": "0700.HK",
+      "quantity": "200",
+      "price": "402.50",
+      "market_value": "80500.00",
+      "currency": "HKD",
+      "asset_type": "stock",
+      "sector": "Communication Services",
+      "geography": "HK"
+    },
+    {
+      "symbol": "D05.SI",
+      "quantity": "100",
+      "price": "38.10",
+      "market_value": "3810.00",
+      "currency": "SGD",
+      "asset_type": "stock",
+      "sector": "Financials",
+      "geography": "SG"
+    }
+  ],
+  "transactions": []
+}

--- a/apps/backend/tests/integration/test_augmentation_seam_e2e.py
+++ b/apps/backend/tests/integration/test_augmentation_seam_e2e.py
@@ -25,6 +25,7 @@ from datetime import date
 from decimal import Decimal
 from uuid import UUID
 
+from common.testing.ac_proof import ac_proof
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import Account, AccountType, JournalEntrySourceType, User
@@ -69,6 +70,15 @@ async def _posted(
     await post_journal_entry(db, entry.id, user_id)
 
 
+@ac_proof(
+    "report-input-selection-excludes-superseded-pr",
+    ac_ids=["AC8.16.1"],
+    scope="behavioral",
+    ci_tier="pr_ci",
+    trust_mode="deterministic_pr",
+    source_classes=["manual_record", "bank_statement"],
+    issue="#1103 / #990 / #992",
+)
 async def test_AC8_16_1_augmentation_seam_excludes_superseded_and_surfaces_confidence(
     db: AsyncSession, test_user: User, ac_evidence
 ) -> None:

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -400,9 +400,14 @@ soft metric:
   finalizing. The actual re-extraction is behind an injectable interface so CI
   exercises the trigger logic without a live model; it is a safe no-op when there
   is no detector signal or no repair backend is wired.
-- **AC-C3 (regression fixture)** — a synthetic clean bank-statement shape with a
-  deliberately-dropped row, asserting the detector finds the correct break index
-  and the repair hook is invoked.
+- **AC-C3 (regression fixture / corpus)** — a synthetic clean bank-statement shape
+  with a deliberately-dropped row, asserting the detector finds the correct break
+  index and the repair hook is invoked. A corpus fixture
+  (`clean_bank_dropped_row_corpus.json`) also drives the detector + repair hook
+  **end-to-end** through `ExtractionService._extract_with_balance_retry` with an
+  injected `RegionReExtractor`, proving the live wiring fires (not just the bare
+  functions). Actual extraction **recall** stays a tracked **soft** metric — no
+  hard CI gate.
 
 Extraction **recall** stays a **soft metric** (tracked, no hard CI gate); the
 self-check balance guard and these deterministic seams stay hard-tested.
@@ -416,3 +421,4 @@ self-check balance guard and these deterministic seams stay hard-tested.
 | AC13.20.5 | AC-C2: a clean/reconciling chain never invokes the repair hook | `test_AC13_20_5_repair_hook_not_invoked_on_clean_chain()` | `extraction/test_chain_break_repair.py` | P1 |
 | AC13.20.6 | AC-C2: when no repair backend is injected, the hook is a safe no-op returning the original payload | `test_AC13_20_6_repair_is_safe_noop_without_backend()` | `extraction/test_chain_break_repair.py` | P1 |
 | AC13.20.7 | AC-C3: the synthetic dropped-row fixture drives the detector to the correct index and triggers the repair hook | `test_AC13_20_7_regression_fixture_detects_and_repairs()` | `extraction/test_chain_break_repair.py` | P1 |
+| AC13.20.8 | AC-C3: the clean-bank dropped-row regression-corpus fixture triggers the chain-break detector + `repair_under_extraction` end-to-end through `ExtractionService._extract_with_balance_retry` with an injected `RegionReExtractor` (recall stays a soft metric) | `test_AC13_20_8_corpus_fixture_triggers_repair_end_to_end()` | `extraction/test_chain_break_repair.py` | P1 |

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -157,6 +157,7 @@ be treated as current work.
 | AC17.4.10 | AC-B2 Brokerage positions output schema flows into AtomicPosition-ready snapshots via the existing consumer parser | `test_AC_B2_positions_prompt_payload_is_understood_by_consumer_parser` | `extraction/test_brokerage_position_extraction_wiring.py` | P0 |
 | AC17.4.11 | AC-B5 Zero-position brokerage doc is surfaced as a visible review flag (stage1 pending-review + note) | `test_AC_B5_zero_position_brokerage_doc_raises_visible_review_flag` | `extraction/test_brokerage_position_extraction_wiring.py` | P1 |
 | AC17.4.12 | AC-B4/B6 Moomoo holdings TABLE extracts and imports: AtomicPosition rows == table rows with exact market_value (#1088) | `test_AC_B4_AC_B6_moomoo_positions_table_extracts_and_imports`, `test_AC_B6_positions_payload_imports_via_service` | `extraction/test_brokerage_position_extraction_wiring.py` | P0 |
+| AC17.4.13 | AC-B3 A multi-currency brokerage statement persists a per-currency NAV array (`currency_balances`) instead of collapsing to a single scalar opening/closing: each currency's NAV is the sum of that currency's positions, every currency round-trips independently, and no currency is cross-summed into another (#1139) | `test_AC_B3_multi_currency_brokerage_emits_per_currency_balances`, `test_AC_B3_parse_document_persists_currency_balances_without_cross_sum` | `extraction/test_brokerage_position_extraction_wiring.py` | P0 |
 
 ### AC17.5: Investment Accounting (Journal Entries)
 

--- a/docs/ssot/extraction.md
+++ b/docs/ssot/extraction.md
@@ -102,6 +102,12 @@ write path and no dual-write flag.
   [reconciliation.md#per-currency-balance-reconciliation](reconciliation.md#per-currency-balance-reconciliation).
   (#1123 AC1; FX pairing / transfer net-worth / FX P&L deferred as #1123
   AC2/AC3/AC4.)
+- A multi-currency **brokerage** statement populates `currency_balances` from its
+  parsed positions: each currency's NAV is the sum of that currency's position
+  market values, persisted as an independent `{currency, opening, closing}` bucket
+  (a position snapshot has no intra-period cash flow, so `opening == closing`). The
+  multi-currency NAV therefore never collapses to a single scalar, and each
+  currency reconciles on its own closed loop. (#1139 AC-B3 / EPIC-017 AC17.4.13.)
 - Enums `BankStatementStatus` and `Stage1Status` live in
   `src/models/statement_enums.py`.
 


### PR DESCRIPTION
Closes the "money pipeline finishing" slices, built on infra already merged to main. Three independent commits.

## ACs covered

| AC | EPIC | What it proves |
|----|------|----------------|
| **AC17.4.13** (AC-B3) | EPIC-017 | A multi-currency brokerage statement persists a per-currency NAV array (`currency_balances`) instead of collapsing to a single scalar opening/closing; each currency round-trips independently and is never cross-summed. |
| **AC13.20.8** (AC-C3) | EPIC-013 | The clean-bank dropped-row regression-corpus fixture drives the chain-break detector + `repair_under_extraction` end-to-end through `ExtractionService._extract_with_balance_retry` with an injected `RegionReExtractor`. |
| **AC8.16.1** (AC-E3) | EPIC-008 | Report-input-selection (excludes superseded / surfaces low-confidence) promoted into the L2 critical-proof matrix via `@ac_proof`; L3 baseline already present. |

## Per task

### #1139 AC-B3 — per-currency brokerage NAV
- New `brokerage_currency_balances()` (`services/brokerage_positions.py`): groups parsed positions by currency, sums each currency's market value into its own NAV bucket (`opening == closing` for a cashflow-free snapshot); an explicit declared `balances` ladder wins over the derived NAV. Decimal throughout.
- `extraction.parse_document` now populates `StatementSummary.currency_balances` for brokerage payloads and reconciles via `validate_balance_per_currency` (never cross-summing). Additive to the scalar columns; brokerage routing/`balance_validated` contract unchanged.
- Synthetic multi-currency IBKR fixture (USD 4400 / HKD 80500 / SGD 3810) + 2 deterministic tests asserting each currency round-trips and no bucket equals the cross-sum (88710).

### #1140 AC-C3 — regression corpus (deterministic scope closed)
- New corpus fixture `clean_bank_dropped_row_corpus.json` (clean shape + dropped-middle-row variant).
- `test_AC13_20_8_corpus_fixture_triggers_repair_end_to_end` drives it through the live retry loop with an injected deterministic `RegionReExtractor` double — the detector pinpoints the break and the repair hook fires exactly once, yielding a reconciling parse. No live LLM.
- Actual extraction **recall stays a tracked SOFT metric** (no hard CI gate); only the deterministic detector + repair seam and the hard balance self-check are gated.

### #1103 AC-E3 — report-input assurance into L2/L3
- Attached `@ac_proof("report-input-selection-excludes-superseded-pr", ac_ids=["AC8.16.1"], deterministic_pr, pr_ci)` to the existing augmentation-layer numeric E2E (`test_augmentation_seam_e2e.py`), entering it into the L2 critical-proof matrix.
- L3 deterministic baseline for AC8.16.1 (`superseded_excluded_corrected_total_match=1.0`) already exists in `ac-score-baseline.jsonl`; the test's existing `ac_evidence` feeds it. Single AC family only — no mass promotion.

Part of #1103 (AC-E3 only; AC-E2 lands with #1123).

## Verification
- `uv run pytest tests/extraction/ tests/integration/test_augmentation_seam_e2e.py tests/integration/test_cross_user_report_isolation_e2e.py tests/portfolio/test_brokerage_position_parsing.py -o addopts="" -q` → **546 passed**.
- `uv run ruff check` / `ruff format --check` on all changed files → clean.
- `tools/generate_ac_registry.py` + `tools/check_ac_index.py` → INTEGRITY + PROTECTION PASSED (11 @ac_proof edges, has_proof 47≥45, has_score 4≥3).
- No SQLAlchemy model change → no Alembic migration required.

Closes #1139
Closes #1140
Part of #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)