### PR TITLE
[finance_report_audit] fix+feat(money): wire FX/internal-transfer into net-worth E2E + address #1160/#1161 review

### DIFF
--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -433,6 +433,11 @@ class ExtractionService:
             # into a meaningless NAV. Instead derive the per-currency balance array
             # (each currency an independent closed loop) and persist it additively
             # to the scalar columns; reconciliation then runs per currency.
+            # When per-currency brokerage reconciliation fails we must not stamp the
+            # statement as balance-valid (mirrors the scalar invalid-balance path
+            # below). Capture the failure note here so it propagates into
+            # ``balance_validated`` / ``validation_error`` after the scalar check.
+            per_currency_invalid_note: str | None = None
             if is_brokerage_payload:
                 brokerage_balances = brokerage_currency_balances(
                     extracted,
@@ -443,11 +448,24 @@ class ExtractionService:
                     # Reconcile each currency independently (open + ΣIN − ΣOUT ≈
                     # close per currency); never cross-sum. A snapshot has no cash
                     # flow, so each currency is a zero-net closed loop and must
-                    # reconcile before we persist it.
+                    # reconcile before we trust it.
                     per_currency_result = validate_balance_per_currency(
                         {"balances": brokerage_balances, "transactions": []}
                     )
-                    if not per_currency_result["balance_valid"]:  # pragma: no cover - defensive
+                    if not per_currency_result["balance_valid"]:
+                        # Respect the self-check result: surface the failing
+                        # currencies so the persisted statement carries the invalid
+                        # flag rather than silently looking reconciled (#1160 CR1).
+                        failed = [
+                            f"{r['currency']} (expected {r.get('expected_closing')}, got {r.get('actual_closing')})"
+                            for r in per_currency_result.get("per_currency", [])
+                            if not r.get("balance_valid")
+                        ]
+                        per_currency_invalid_note = (
+                            "Per-currency NAV self-check failed: " + ", ".join(failed)
+                            if failed
+                            else "Per-currency NAV self-check failed"
+                        )
                         logger.warning(
                             "Per-currency brokerage NAV failed self-check",
                             per_currency=per_currency_result["per_currency"],
@@ -455,7 +473,9 @@ class ExtractionService:
                     # Serialize Decimal -> str for the JSONB column (no float). The
                     # scalar opening/closing columns stay populated for the
                     # single-currency degenerate case and backward compatibility;
-                    # this array is additive and never cross-sums currencies.
+                    # this array is additive and never cross-sums currencies. The
+                    # array is still persisted (it is the per-currency evidence), but
+                    # the invalid flag above ensures it is not mistaken for valid.
                     statement.currency_balances = [
                         {
                             "currency": bucket["currency"],
@@ -627,9 +647,16 @@ class ExtractionService:
                 if status == BankStatementStatus.APPROVED and account_id is None:
                     status = BankStatementStatus.PARSED
 
+            # A failing per-currency NAV self-check invalidates the brokerage
+            # balance even when the scalar (cross-summed) check happens to pass:
+            # the array is the authoritative multi-currency evidence (#1160 CR1).
+            if per_currency_invalid_note is not None:
+                is_valid = False
             statement.balance_validated = is_valid
             if has_inferred_csv_balances:
                 statement.validation_error = CSV_INFERRED_BALANCE_REVIEW_NOTE
+            elif per_currency_invalid_note is not None:
+                statement.validation_error = per_currency_invalid_note
             elif not is_valid:
                 statement.validation_error = balance_result["notes"]
             statement.confidence_score = confidence

--- a/apps/backend/src/services/fx_transfer.py
+++ b/apps/backend/src/services/fx_transfer.py
@@ -74,6 +74,12 @@ class TransferLeg:
             raise FxTransferError(f"direction must be 'IN' or 'OUT', got {self.direction!r}")
         if self.amount <= 0:
             raise FxTransferError("transfer leg amount must be positive")
+        # Enforce timezone-aware timestamps at construction (#1161 CR3). Pairing
+        # subtracts two legs' ``occurred_at``; a mix of naive and aware datetimes
+        # raises ``TypeError`` mid-pairing. Reject naive datetimes up front so the
+        # failure is a clear, local FxTransferError instead.
+        if self.occurred_at.tzinfo is None or self.occurred_at.utcoffset() is None:
+            raise FxTransferError("transfer leg occurred_at must be timezone-aware")
 
 
 @dataclass(frozen=True)
@@ -163,6 +169,13 @@ def pair_fx_legs(
     if out_leg.account_id == in_leg.account_id:
         # Same account cannot be both source and destination of a transfer.
         return None
+    if out_leg.currency == in_leg.currency:
+        # A cross-currency conversion requires distinct currencies (#1161 CR2).
+        # A same-currency internal transfer with rate≈1 and matching amounts would
+        # otherwise be misclassified here as an FX conversion. Same-currency
+        # own-account transfers are handled by the (non-FX) internal-transfer path,
+        # not by FX-leg pairing.
+        return None
     if abs(out_leg.occurred_at - in_leg.occurred_at) > time_window:
         return None
 
@@ -184,18 +197,28 @@ def classify_internal_transfer(
     pair: FxLegPair | None,
     *,
     fee: Decimal = Decimal("0"),
+    income: Decimal = Decimal("0"),
+    expense: Decimal = Decimal("0"),
 ) -> TransferClassification:
     """Classify a matched transfer for net-worth aggregation (#1123 AC3).
 
     When ``pair`` is a matched :class:`FxLegPair`, the event is an internal
     (own-account) transfer: the in-leg must NOT register as income and the
-    out-leg must NOT register as expense. Net worth changes only by ``fee``.
+    out-leg must NOT register as expense. Net worth changes only by ``fee``, so
+    income/expense are forced to zero and ``net_worth_delta == -fee``.
 
     When ``pair`` is ``None`` (legs did not pair), no internal-transfer netting is
-    asserted and the caller's normal income/expense classification stands.
+    asserted: the caller's already-classified ``income`` / ``expense`` are carried
+    through unchanged so ``net_worth_delta == income − expense`` matches the
+    documented formula (#1161 CR4). Defaulting both to zero preserves the previous
+    "no-op" behavior for callers that do not pass them.
     """
     if pair is None:
-        return TransferClassification(is_internal_transfer=False)
+        return TransferClassification(
+            is_internal_transfer=False,
+            income_amount=to_money(income),
+            expense_amount=to_money(expense),
+        )
     return TransferClassification(
         is_internal_transfer=True,
         income_amount=Decimal("0.00"),

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Any, ClassVar, cast
 from uuid import UUID
@@ -25,6 +25,7 @@ from src.models import (
     JournalEntryStatus,
     JournalLine,
 )
+from src.models.fx_conversion import FxConversion
 from src.models.layer3 import (
     ManagedPosition,
     ManualValuationComponentType,
@@ -45,6 +46,14 @@ from src.services.fx import (
     get_exchange_rate,
 )
 from src.services.fx_revaluation import RevaluationError, calculate_unrealized_fx_gains
+from src.services.fx_transfer import (
+    DEFAULT_RATE_TOLERANCE,
+    DEFAULT_TIME_WINDOW,
+    FxTransferError,
+    TransferLeg,
+    classify_internal_transfer,
+    pair_fx_legs,
+)
 from src.services.portfolio import AssetNotFoundError, PortfolioService
 from src.services.source_type_priority import normalize_source_type
 from src.utils.money import to_money
@@ -612,6 +621,129 @@ async def get_account_lineage(
     }
 
 
+@dataclass(frozen=True)
+class _InternalTransferAdjustment:
+    """Net-income correction for matched internal (own-account) transfers (#1123 AC3).
+
+    A matched internal transfer is one economic event spanning two legs, not two
+    independent income/expense transactions. Its legs must not double-count as
+    income (in-leg) and expense (out-leg); net income changes only by the fee.
+
+    - ``excluded_entry_ids``: journal entries that are the legs of a matched
+      internal transfer; their INCOME/EXPENSE lines are skipped during net-income
+      aggregation.
+    - ``fee_total``: total fee across matched internal transfers, in the report's
+      target currency. The fee is the only net-income impact of the transfer
+      (it lowers net income, like an expense).
+    """
+
+    excluded_entry_ids: frozenset[UUID]
+    fee_total: Decimal
+
+
+async def _internal_transfer_adjustment(
+    db: AsyncSession,
+    user_id: UUID,
+    target_currency: str,
+    as_of_date: date,
+    *,
+    start_date: date | None = None,
+) -> _InternalTransferAdjustment:
+    """Resolve matched internal transfers into a net-income correction (#1123 AC3).
+
+    Loads the recorded :class:`FxConversion` rows for ``user_id`` whose
+    ``conversion_date`` falls in ``[start_date, as_of_date]`` and that anchor BOTH
+    legs to journal entries (``from_journal_entry_id`` / ``to_journal_entry_id``).
+    Each candidate is re-validated through the deterministic accounting primitives
+    :func:`pair_fx_legs` + :func:`classify_internal_transfer`: only a pair that the
+    primitives still classify as an internal transfer contributes an exclusion, so
+    the reporting layer never invents netting the accounting layer would reject.
+
+    Returns the entry IDs to exclude from income/expense and the converted fee to
+    subtract from net income. This is the live wiring that makes a matched
+    internal transfer net-worth-neutral (minus fees) end to end.
+    """
+    stmt = (
+        select(FxConversion)
+        .where(FxConversion.user_id == user_id)
+        .where(FxConversion.conversion_date <= as_of_date)
+        .where(FxConversion.from_journal_entry_id.is_not(None))
+        .where(FxConversion.to_journal_entry_id.is_not(None))
+    )
+    if start_date:
+        stmt = stmt.where(FxConversion.conversion_date >= start_date)
+
+    result = await db.execute(stmt)
+    conversions = result.scalars().all()
+
+    excluded: set[UUID] = set()
+    fee_total = Decimal("0")
+    for conversion in conversions:
+        # Re-derive the legs and confirm the accounting layer still classifies
+        # this as an internal transfer before excluding anything. occurred_at is
+        # tz-aware midnight on the conversion date (legs share the day; the exact
+        # instant is immaterial to same-day pairing and net-worth netting).
+        when = datetime.combine(conversion.conversion_date, time.min, tzinfo=UTC)
+        try:
+            out_leg = TransferLeg(
+                user_id=conversion.user_id,
+                account_id=conversion.from_account_id,
+                direction="OUT",
+                amount=conversion.amount_from,
+                currency=conversion.currency_from,
+                occurred_at=when,
+            )
+            in_leg = TransferLeg(
+                user_id=conversion.user_id,
+                account_id=conversion.to_account_id,
+                direction="IN",
+                amount=conversion.amount_to,
+                currency=conversion.currency_to,
+                occurred_at=when,
+            )
+            pair = pair_fx_legs(
+                out_leg,
+                in_leg,
+                conversion.rate,
+                tolerance=DEFAULT_RATE_TOLERANCE,
+                time_window=DEFAULT_TIME_WINDOW,
+            )
+        except FxTransferError:
+            # A malformed/ non-conforming conversion row is not trusted to net;
+            # leave its legs to the normal income/expense classification.
+            continue
+
+        classification = classify_internal_transfer(pair, fee=conversion.fee)
+        if not classification.is_internal_transfer:
+            continue
+
+        excluded.add(conversion.from_journal_entry_id)
+        excluded.add(conversion.to_journal_entry_id)
+
+        if conversion.fee and conversion.fee > 0:
+            fee_currency = conversion.fee_currency or conversion.currency_from
+            try:
+                fee_rate = await get_exchange_rate(
+                    db,
+                    fee_currency,
+                    target_currency,
+                    as_of_date,
+                    lazy_load=True,
+                )
+            except FxRateError:
+                # If the fee currency cannot be converted, fall back to leaving the
+                # fee in the normal expense flow (do not silently drop it).
+                excluded.discard(conversion.from_journal_entry_id)
+                excluded.discard(conversion.to_journal_entry_id)
+                continue
+            fee_total += classification.fee_amount * fee_rate
+
+    return _InternalTransferAdjustment(
+        excluded_entry_ids=frozenset(excluded),
+        fee_total=to_money(fee_total),
+    )
+
+
 async def _aggregate_net_income_sql(
     db: AsyncSession,
     user_id: UUID,
@@ -630,6 +762,13 @@ async def _aggregate_net_income_sql(
     spot rate on or before as_of_date; if that is also absent, FxRateError is raised
     and re-raised here as ReportError.
     """
+    # Resolve matched internal (own-account) transfers (#1123 AC3): their legs
+    # must NOT double-count as income/expense; only the fee affects net income.
+    transfer_adjustment = await _internal_transfer_adjustment(
+        db, user_id, target_currency, as_of_date, start_date=start_date
+    )
+    excluded_entry_ids = transfer_adjustment.excluded_entry_ids
+
     # Get distinct currencies for income/expense lines in the period
     currency_stmt = (
         select(JournalLine.currency)
@@ -641,6 +780,8 @@ async def _aggregate_net_income_sql(
         .where(JournalEntry.status.in_(_REPORT_STATUSES))
         .where(JournalEntry.entry_date <= as_of_date)
     )
+    if excluded_entry_ids:
+        currency_stmt = currency_stmt.where(JournalEntry.id.not_in(excluded_entry_ids))
     if start_date:
         currency_stmt = currency_stmt.where(JournalEntry.entry_date >= start_date)
 
@@ -699,6 +840,8 @@ async def _aggregate_net_income_sql(
         .where(JournalEntry.entry_date <= as_of_date)
         .group_by(JournalLine.currency, Account.type, JournalLine.direction)
     )
+    if excluded_entry_ids:
+        agg_stmt = agg_stmt.where(JournalEntry.id.not_in(excluded_entry_ids))
     if start_date:
         agg_stmt = agg_stmt.where(JournalEntry.entry_date >= start_date)
 
@@ -718,6 +861,11 @@ async def _aggregate_net_income_sql(
         # convention), which is the opposite of what the net-income formula needs.
         signed = converted if row.direction == Direction.CREDIT else -converted
         net_income += signed
+
+    # A matched internal transfer's only net-income impact is its fee, which lowers
+    # net income like an expense (#1123 AC3). The transfer legs themselves were
+    # excluded above, so add the fee back here as the sole net-worth effect.
+    net_income -= transfer_adjustment.fee_total
 
     return net_income
 
@@ -1416,6 +1564,13 @@ async def generate_income_statement(
             )
             raise ReportError(str(exc)) from exc
 
+    # Matched internal (own-account) transfers (#1123 AC3): exclude their legs from
+    # income/expense so they do not double-count; only the fee is a real expense.
+    transfer_adjustment = await _internal_transfer_adjustment(
+        db, user_id, target_currency, end_date, start_date=start_date
+    )
+    excluded_entry_ids = transfer_adjustment.excluded_entry_ids
+
     entries_to_include: set[UUID] = set()
     if tags:
         for entry_id, lines_and_accounts in entries_by_id.items():
@@ -1427,6 +1582,7 @@ async def generate_income_statement(
                         break
     else:
         entries_to_include = set(entries_by_id.keys())
+    entries_to_include -= excluded_entry_ids
 
     provenance_inputs_by_account: dict[UUID, list[DataProvenance | None]] = {}
     for entry_id, lines_and_accounts in entries_by_id.items():
@@ -1529,6 +1685,9 @@ async def generate_income_statement(
 
     total_income = _quantize_money(sum((Decimal(str(line["amount"])) for line in income_lines), Decimal("0")))
     total_expenses = _quantize_money(sum((Decimal(str(line["amount"])) for line in expense_lines), Decimal("0")))
+    # The matched internal-transfer fee is the only expense that survives netting
+    # (#1123 AC3); add it to total expenses so net income reflects the fee drag.
+    total_expenses = _quantize_money(total_expenses + transfer_adjustment.fee_total)
     net_income = _quantize_money(total_income - total_expenses)
 
     # Calculate Unrealized FX Gain/Loss for the period

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -635,10 +635,20 @@ class _InternalTransferAdjustment:
     - ``fee_total``: total fee across matched internal transfers, in the report's
       target currency. The fee is the only net-income impact of the transfer
       (it lowers net income, like an expense).
+    - ``fee_by_account``: the converted fee total attributed to the account it was
+      effectively paid from (the conversion's ``from_account_id``), in the target
+      currency. Used to materialise the fee as a real expense LINE so the income
+      statement's lines, totals and trend buckets stay coherent — rather than
+      bumping ``total_expenses`` out of band (#1162 CR2).
+    - ``fee_trend_date``: the earliest conversion date contributing a fee, used to
+      bucket the fee into the correct monthly trend period. ``None`` when there is
+      no fee.
     """
 
     excluded_entry_ids: frozenset[UUID]
     fee_total: Decimal
+    fee_by_account: dict[UUID, Decimal]
+    fee_trend_date: date | None
 
 
 async def _internal_transfer_adjustment(
@@ -678,6 +688,8 @@ async def _internal_transfer_adjustment(
 
     excluded: set[UUID] = set()
     fee_total = Decimal("0")
+    fee_by_account: dict[UUID, Decimal] = {}
+    fee_trend_date: date | None = None
     for conversion in conversions:
         # Re-derive the legs and confirm the accounting layer still classifies
         # this as an internal transfer before excluding anything. occurred_at is
@@ -731,16 +743,33 @@ async def _internal_transfer_adjustment(
                     lazy_load=True,
                 )
             except FxRateError:
-                # If the fee currency cannot be converted, fall back to leaving the
-                # fee in the normal expense flow (do not silently drop it).
-                excluded.discard(conversion.from_journal_entry_id)
-                excluded.discard(conversion.to_journal_entry_id)
+                # The transfer legs are still a matched internal transfer and MUST
+                # stay excluded (otherwise the double-counted income/expense legs
+                # are re-introduced). Only the fee adjustment is omitted when its
+                # currency cannot be converted; keep the exclusions intact.
+                logger.warning(
+                    "Internal-transfer fee FX conversion failed; omitting fee adjustment but keeping leg exclusions",
+                    error_id=ErrorIds.REPORT_FX_FALLBACK,
+                    fee_currency=fee_currency,
+                    target_currency=target_currency,
+                    conversion_date=conversion.conversion_date,
+                )
                 continue
-            fee_total += classification.fee_amount * fee_rate
+            converted_fee = to_money(classification.fee_amount * fee_rate)
+            fee_total += converted_fee
+            # Attribute the fee to the account it was effectively paid from so it can
+            # be materialised as a real expense line (#1162 CR2).
+            fee_by_account[conversion.from_account_id] = (
+                fee_by_account.get(conversion.from_account_id, Decimal("0")) + converted_fee
+            )
+            if fee_trend_date is None or conversion.conversion_date < fee_trend_date:
+                fee_trend_date = conversion.conversion_date
 
     return _InternalTransferAdjustment(
         excluded_entry_ids=frozenset(excluded),
         fee_total=to_money(fee_total),
+        fee_by_account=fee_by_account,
+        fee_trend_date=fee_trend_date,
     )
 
 
@@ -1683,12 +1712,40 @@ async def generate_income_statement(
         provenance_by_account=provenance_by_account,
     )
 
+    # The matched internal-transfer fee is the only expense that survives netting
+    # (#1123 AC3). Materialise it as a real expense LINE attributed to the account
+    # it was paid from, rather than bumping total_expenses out of band, so that
+    # ``total_expenses == sum(expense_lines)`` holds and the fee shows up in the
+    # drill-down and the monthly trend buckets (#1162 CR2).
+    fee_account_name_by_id = {account.id: account.name for account in accounts}
+    for from_account_id, converted_fee in transfer_adjustment.fee_by_account.items():
+        expense_lines.append(
+            {
+                "account_id": from_account_id,
+                "name": fee_account_name_by_id.get(from_account_id, "Internal transfer fee"),
+                "type": AccountType.EXPENSE,
+                "parent_id": None,
+                "amount": _quantize_money(converted_fee),
+                "confidence_tier": None,
+                "provenance": None,
+                "source_currency": target_currency,
+                "allocation_asset_class": None,
+                "allocation_liquidity_class": None,
+                "allocation_source_type": "internal_transfer_fee",
+            }
+        )
+
     total_income = _quantize_money(sum((Decimal(str(line["amount"])) for line in income_lines), Decimal("0")))
     total_expenses = _quantize_money(sum((Decimal(str(line["amount"])) for line in expense_lines), Decimal("0")))
-    # The matched internal-transfer fee is the only expense that survives netting
-    # (#1123 AC3); add it to total expenses so net income reflects the fee drag.
-    total_expenses = _quantize_money(total_expenses + transfer_adjustment.fee_total)
     net_income = _quantize_money(total_income - total_expenses)
+
+    # Add the fee into the correct monthly trend/period bucket so the trends and the
+    # expense totals stay coherent (#1162 CR2). Bucket by the earliest contributing
+    # conversion date; clamp into the reporting window so it always lands in a bucket.
+    if transfer_adjustment.fee_total > 0 and transfer_adjustment.fee_trend_date is not None:
+        fee_period_key = _month_start(min(max(transfer_adjustment.fee_trend_date, start_date), end_date))
+        fee_bucket = period_totals.setdefault(fee_period_key, {"income": Decimal("0"), "expense": Decimal("0")})
+        fee_bucket["expense"] += transfer_adjustment.fee_total
 
     # Calculate Unrealized FX Gain/Loss for the period
     # This requires balance sheets at both points

--- a/apps/backend/src/services/validation.py
+++ b/apps/backend/src/services/validation.py
@@ -129,9 +129,11 @@ def validate_balance_per_currency(extracted: dict[str, Any]) -> dict[str, Any]:
     silently unaccounted in a multi-currency statement.
 
     .. note::
-       Not yet wired into the live extraction-write path: that path still calls
-       the scalar :func:`validate_balance`. Wiring depends on multi-currency
-       payload parsing, deferred to #1123 AC2/AC3/AC4.
+       Wired into the brokerage extraction-write path (#1160): a failing
+       per-currency self-check now marks the persisted statement
+       ``balance_validated=False`` with a ``validation_error`` rather than being
+       silently logged. The scalar :func:`validate_balance` still gates bank
+       running-balance chains; the two are complementary, not competing.
     """
     try:
         buckets = _currency_buckets(extracted)

--- a/apps/backend/tests/accounting/test_fx_transfer.py
+++ b/apps/backend/tests/accounting/test_fx_transfer.py
@@ -337,3 +337,74 @@ def test_invalid_transfer_leg_rejected():
             currency="SGD",
             occurred_at=when,
         )
+
+
+def test_transfer_leg_rejects_naive_datetime():
+    """#1161 CR3: a naive (tz-less) occurred_at is rejected at construction.
+
+    Pairing subtracts two legs' occurred_at; a naive/aware mix raises TypeError
+    mid-pairing. Reject naive datetimes up front so the error is a clear
+    FxTransferError rather than an opaque TypeError deeper in the call.
+    """
+    naive = datetime(2025, 6, 1, 12, 0)  # no tzinfo
+    assert naive.tzinfo is None
+    with pytest.raises(FxTransferError, match="timezone-aware"):
+        TransferLeg(
+            user_id=uuid4(),
+            account_id=uuid4(),
+            direction="OUT",
+            amount=Decimal("100.00"),
+            currency="SGD",
+            occurred_at=naive,
+        )
+
+
+def test_same_currency_legs_never_pair_even_with_unit_rate():
+    """#1161 CR2: same-currency legs never pair, even at rate 1.0 with equal amounts.
+
+    A same-currency own-account transfer (SGD->SGD, amount unchanged, implied rate
+    1.0) must NOT be classified as a cross-currency FX conversion. It is handled by
+    the (non-FX) internal-transfer path, not by FX-leg pairing.
+    """
+    user_id = uuid4()
+    when = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    out_leg = TransferLeg(
+        user_id=user_id,
+        account_id=uuid4(),
+        direction="OUT",
+        amount=Decimal("500.00"),
+        currency="SGD",
+        occurred_at=when,
+    )
+    in_leg = TransferLeg(
+        user_id=user_id,
+        account_id=uuid4(),
+        direction="IN",
+        amount=Decimal("500.00"),  # identical amount -> implied rate exactly 1.0
+        currency="SGD",  # same currency as the out-leg
+        occurred_at=when,
+    )
+    # Even with a perfectly matching unit rate, same-currency legs must not pair.
+    assert pair_fx_legs(out_leg, in_leg, Decimal("1.000000")) is None
+    # And the swapped argument order must also refuse to pair.
+    assert pair_fx_legs(in_leg, out_leg, Decimal("1.000000")) is None
+
+
+def test_unpaired_classification_carries_caller_income_expense():
+    """#1161 CR4: the non-internal (pair is None) branch obeys net_worth = income - expense.
+
+    Previously the unpaired branch zeroed income/expense, silently zeroing net
+    worth. It must now carry the caller's already-classified income/expense so the
+    documented formula holds.
+    """
+    classification = classify_internal_transfer(
+        None,
+        income=Decimal("120.00"),
+        expense=Decimal("45.00"),
+    )
+    assert classification.is_internal_transfer is False
+    assert classification.income_amount == Decimal("120.00")
+    assert classification.expense_amount == Decimal("45.00")
+    assert classification.net_worth_delta == Decimal("75.00")
+    # Backward-compatible default: omitting income/expense is still a net-zero no-op.
+    assert classify_internal_transfer(None).net_worth_delta == Decimal("0.00")

--- a/apps/backend/tests/extraction/test_brokerage_position_extraction_wiring.py
+++ b/apps/backend/tests/extraction/test_brokerage_position_extraction_wiring.py
@@ -358,3 +358,57 @@ async def test_AC_B3_parse_document_persists_currency_balances_without_cross_sum
     # No cross-sum into one scalar: three independent buckets, none equal to 88710.
     assert len(statement.currency_balances) == 3
     assert all(Decimal(b["closing"]) != Decimal("88710.00") for b in statement.currency_balances)
+
+
+async def test_per_currency_nav_self_check_failure_marks_statement_invalid(test_user, monkeypatch):
+    """#1160 CR1: a failing per-currency NAV self-check is respected, not ignored.
+
+    Previously ``validate_balance_per_currency`` could return ``balance_valid=False``
+    yet ``currency_balances`` was persisted as if reconciled — only a warning was
+    logged. The fix surfaces the failure on the persisted statement
+    (``balance_validated`` False + a ``validation_error``), mirroring the scalar
+    invalid-balance path, while still persisting the per-currency evidence array.
+    """
+    from unittest.mock import AsyncMock
+
+    import src.services.extraction as extraction_module
+
+    service = ExtractionService()
+    payload = _load_fixture("ibkr-multicurrency-positions_parsed.json")
+    service.extract_financial_data = AsyncMock(return_value=payload)
+
+    # Force the per-currency self-check to fail for one currency.
+    def _failing_per_currency(_extracted):
+        return {
+            "balance_valid": False,
+            "balance_computable": True,
+            "per_currency": [
+                {
+                    "currency": "USD",
+                    "balance_valid": False,
+                    "expected_closing": "4400.00",
+                    "actual_closing": "4000.00",
+                },
+                {"currency": "HKD", "balance_valid": True},
+            ],
+        }
+
+    monkeypatch.setattr(extraction_module, "validate_balance_per_currency", _failing_per_currency)
+
+    statement, _ = await service.parse_document(
+        file_path=Path("ibkr-multicurrency-2506.pdf"),
+        institution="Interactive Brokers",
+        user_id=test_user.id,
+        file_content=b"%PDF-1.7",
+        file_hash="ibkr-multicurrency-invalid-hash",
+        original_filename="ibkr-multicurrency-2506.pdf",
+    )
+
+    # The per-currency evidence array is still persisted (it is the audit trail)...
+    assert statement.currency_balances is not None
+    assert len(statement.currency_balances) == 3
+    # ...but the statement is NOT marked balance-valid, and the failure is surfaced.
+    assert statement.balance_validated is False
+    assert statement.validation_error is not None
+    assert "USD" in statement.validation_error
+    assert "self-check failed" in statement.validation_error.lower()

--- a/apps/backend/tests/reporting/test_internal_transfer_e2e.py
+++ b/apps/backend/tests/reporting/test_internal_transfer_e2e.py
@@ -1,0 +1,262 @@
+"""AC4.14.9 / AC4.14.10 — internal transfer net-worth neutrality, end to end (#1123 AC3).
+
+These are the *live-wiring* proofs the unit primitives in ``test_fx_transfer.py``
+could not give: a recorded ``fx_conversions`` row whose two legs are booked into
+the ledger (as income / expense accounts — exactly the double-count #1123 warns
+about) must be excluded from the reporting income/expense aggregation, so the
+generated income statement and the cumulative balance-sheet net income treat the
+internal transfer as net-zero except for the fee.
+
+The scenario flows through the *real* ``generate_income_statement`` /
+``generate_balance_sheet`` services against a seeded DB session, asserting the
+actual numbers — not a mocked primitive.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from common.testing.ac_proof import ac_proof
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import (
+    Account,
+    AccountType,
+    Direction,
+    FxRate,
+    JournalEntry,
+    JournalEntrySourceType,
+    JournalEntryStatus,
+    JournalLine,
+)
+from src.models.fx_conversion import FxConversion
+from src.services.fx import clear_fx_cache
+from src.services.reporting import generate_balance_sheet, generate_income_statement
+
+# A representative cross-currency internal transfer: 1360.00 SGD leaves a SGD
+# bank account, 1000.00 USD arrives in a USD bank account, at 1.36 SGD/USD, with a
+# 2.50 SGD fee. Implied rate 1360/1000 = 1.36 == market rate -> a genuine pair.
+_OUT_SGD = Decimal("1360.00")
+_IN_USD = Decimal("1000.00")
+_RATE_SGD_PER_USD = Decimal("1.360000")
+_FEE_SGD = Decimal("2.50")
+_SALARY_SGD = Decimal("5000.00")
+
+_REPORT_DATE = date(2025, 6, 30)
+_PERIOD_START = date(2025, 6, 1)
+_TXN_DATE = date(2025, 6, 15)
+
+
+async def _account(db, user_id, *, name, account_type, currency="SGD") -> Account:
+    account = Account(user_id=user_id, name=name, type=account_type, currency=currency)
+    db.add(account)
+    await db.flush()
+    return account
+
+
+async def _post_entry(
+    db,
+    user_id,
+    *,
+    debit_account,
+    credit_account,
+    amount,
+    currency,
+) -> JournalEntry:
+    entry = JournalEntry(
+        user_id=user_id,
+        entry_date=_TXN_DATE,
+        memo="seed",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(entry)
+    await db.flush()
+    # Non-base-currency (non-SGD) lines require a positive fx_rate to the base
+    # currency, enforced by the ledger DB trigger. SGD lines stay None.
+    line_fx_rate = None if currency.upper() == "SGD" else _RATE_SGD_PER_USD
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=debit_account.id,
+                direction=Direction.DEBIT,
+                amount=amount,
+                currency=currency,
+                fx_rate=line_fx_rate,
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=credit_account.id,
+                direction=Direction.CREDIT,
+                amount=amount,
+                currency=currency,
+                fx_rate=line_fx_rate,
+            ),
+        ]
+    )
+    await db.flush()
+    return entry
+
+
+async def _seed_internal_transfer_scenario(db: AsyncSession, user_id) -> None:
+    """Seed a real internal transfer that is naively double-booked as income+expense.
+
+    The "naive" booking is exactly the bug #1123 AC3 fixes: the transfer-in lands
+    in an INCOME account and the transfer-out in an EXPENSE account. We then record
+    the ``fx_conversions`` link anchoring both journal entries, which the reporting
+    layer uses to net them back out. A genuine 5000 SGD salary is seeded alongside
+    so the exclusion is observable in the totals.
+    """
+    clear_fx_cache()
+    # FX rate USD -> SGD so income-statement / balance-sheet conversion can run.
+    db.add(
+        FxRate(
+            base_currency="USD",
+            quote_currency="SGD",
+            rate=_RATE_SGD_PER_USD,
+            rate_date=_TXN_DATE,
+            source="test",
+        )
+    )
+
+    sgd_bank = await _account(db, user_id, name="SGD Bank", account_type=AccountType.ASSET, currency="SGD")
+    usd_bank = await _account(db, user_id, name="USD Bank", account_type=AccountType.ASSET, currency="USD")
+    salary_income = await _account(db, user_id, name="Salary", account_type=AccountType.INCOME, currency="SGD")
+    transfer_income = await _account(
+        db, user_id, name="Misclassified Transfer In", account_type=AccountType.INCOME, currency="USD"
+    )
+    transfer_expense = await _account(
+        db, user_id, name="Misclassified Transfer Out", account_type=AccountType.EXPENSE, currency="SGD"
+    )
+
+    # Real income: 5000 SGD salary (DEBIT asset, CREDIT income).
+    await _post_entry(
+        db,
+        user_id,
+        debit_account=sgd_bank,
+        credit_account=salary_income,
+        amount=_SALARY_SGD,
+        currency="SGD",
+    )
+
+    # Naive transfer-in booking: 1000 USD arrives, mis-booked as INCOME.
+    in_entry = await _post_entry(
+        db,
+        user_id,
+        debit_account=usd_bank,
+        credit_account=transfer_income,
+        amount=_IN_USD,
+        currency="USD",
+    )
+    # Naive transfer-out booking: 1360 SGD leaves, mis-booked as EXPENSE.
+    out_entry = await _post_entry(
+        db,
+        user_id,
+        debit_account=transfer_expense,
+        credit_account=sgd_bank,
+        amount=_OUT_SGD,
+        currency="SGD",
+    )
+
+    # Record the linking fx_conversions row anchoring BOTH legs. This is the signal
+    # the reporting layer re-validates and uses to net the legs back out.
+    db.add(
+        FxConversion(
+            user_id=user_id,
+            from_account_id=sgd_bank.id,
+            to_account_id=usd_bank.id,
+            amount_from=_OUT_SGD,
+            currency_from="SGD",
+            amount_to=_IN_USD,
+            currency_to="USD",
+            rate=_RATE_SGD_PER_USD,
+            fee=_FEE_SGD,
+            fee_currency="SGD",
+            conversion_date=_TXN_DATE,
+            from_journal_entry_id=out_entry.id,
+            to_journal_entry_id=in_entry.id,
+        )
+    )
+    await db.commit()
+
+
+@ac_proof(
+    "internal-transfer-income-statement-e2e",
+    ac_ids=["AC4.14.9"],
+    scope="behavioral",
+    ci_tier="pr_ci",
+    trust_mode="deterministic_pr",
+    source_classes=["manual_record"],
+    issue="#1123",
+)
+async def test_AC3_internal_transfer_excluded_from_income_statement_e2e(db: AsyncSession, test_user, ac_evidence):
+    """AC4.14.9: the income statement excludes a recorded internal transfer's legs.
+
+    Without the wiring, total_income would be inflated by the 1000 USD (=1360 SGD)
+    transfer-in leg and total_expenses by the 1360 SGD transfer-out leg. With it,
+    income reflects only the 5000 SGD salary and expenses reflect only the 2.50 SGD
+    fee, so net income is 5000 - 2.50 = 4997.50.
+    """
+    await _seed_internal_transfer_scenario(db, test_user.id)
+
+    report = await generate_income_statement(
+        db,
+        test_user.id,
+        start_date=_PERIOD_START,
+        end_date=_REPORT_DATE,
+        currency="SGD",
+    )
+
+    # Income excludes the mis-booked 1360 SGD-equivalent transfer-in leg.
+    assert report["total_income"] == _SALARY_SGD
+    # Expenses are JUST the fee — the 1360 SGD transfer-out leg is netted out.
+    assert report["total_expenses"] == _FEE_SGD
+    # Net income reflects salary minus the fee only.
+    assert report["net_income"] == Decimal("4997.50")
+
+    ac_evidence(
+        ac_id="AC4.14.9",
+        score=1.0,
+        metric="income_statement_excludes_internal_transfer_legs_fee_only",
+        provenance="deterministic",
+        comment="Live-wired internal-transfer exclusion proven end to end via generate_income_statement (#1123 AC3).",
+    )
+
+
+@ac_proof(
+    "internal-transfer-balance-sheet-net-income-e2e",
+    ac_ids=["AC4.14.10"],
+    scope="behavioral",
+    ci_tier="pr_ci",
+    trust_mode="deterministic_pr",
+    source_classes=["manual_record"],
+    issue="#1123",
+)
+async def test_AC3_internal_transfer_net_income_fee_only_e2e(db: AsyncSession, test_user, ac_evidence):
+    """AC4.14.10: cumulative balance-sheet net income excludes the transfer, fee only.
+
+    The balance sheet's cumulative net income (Income - Expenses up to as_of_date)
+    must net the internal transfer's legs out and reflect only the fee, so the
+    figure is 5000 - 2.50 = 4997.50 — the same net-worth contribution as the income
+    statement, confirming a single coherent wiring point.
+    """
+    await _seed_internal_transfer_scenario(db, test_user.id)
+
+    report = await generate_balance_sheet(
+        db,
+        test_user.id,
+        as_of_date=_REPORT_DATE,
+        currency="SGD",
+        include_trust_signals=False,
+    )
+
+    # Net income carries only the real salary minus the transfer fee.
+    assert report["net_income"] == Decimal("4997.50")
+
+    ac_evidence(
+        ac_id="AC4.14.10",
+        score=1.0,
+        metric="balance_sheet_net_income_excludes_internal_transfer_fee_only",
+        provenance="deterministic",
+        comment="Live-wired internal-transfer exclusion proven end to end via generate_balance_sheet (#1123 AC3).",
+    )

--- a/apps/backend/tests/reporting/test_internal_transfer_e2e.py
+++ b/apps/backend/tests/reporting/test_internal_transfer_e2e.py
@@ -214,6 +214,17 @@ async def test_AC3_internal_transfer_excluded_from_income_statement_e2e(db: Asyn
     # Net income reflects salary minus the fee only.
     assert report["net_income"] == Decimal("4997.50")
 
+    # Coherence (#1162 CR2): the fee is a real expense LINE, not an out-of-band bump,
+    # so the expense lines sum exactly to total_expenses and the fee is drill-downable.
+    expense_lines = report["expenses"]
+    expense_line_sum = sum((Decimal(str(line["amount"])) for line in expense_lines), Decimal("0"))
+    assert expense_line_sum == report["total_expenses"]
+    fee_lines = [line for line in expense_lines if Decimal(str(line["amount"])) == _FEE_SGD]
+    assert len(fee_lines) == 1, "internal-transfer fee must appear as a single expense line"
+    assert fee_lines[0]["account_id"] is not None
+    # The fee also lands in a monthly trend expense bucket (charts must see it).
+    assert sum((Decimal(str(t["total_expenses"])) for t in report["trends"]), Decimal("0")) == _FEE_SGD
+
     ac_evidence(
         ac_id="AC4.14.9",
         score=1.0,

--- a/apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py
+++ b/apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py
@@ -325,7 +325,12 @@ async def test_net_income_sql_detects_missing_fx_map_row() -> None:
         )
     ]
 
-    fake_db.execute = AsyncMock(side_effect=[currency_result, agg_result])
+    # _aggregate_net_income_sql first loads internal-transfer FxConversion rows
+    # (#1123 AC3 live wiring); none in this race scenario, so the adjustment is a no-op.
+    transfer_result = MagicMock()
+    transfer_result.scalars.return_value.all.return_value = []
+
+    fake_db.execute = AsyncMock(side_effect=[transfer_result, currency_result, agg_result])
 
     # Patch get_average_rate so we don't need to mock DB FX queries; USD gets a rate
     with patch("src.services.reporting.get_average_rate", new_callable=AsyncMock) as mock_avg:

--- a/docs/project/EPIC-004.reconciliation-engine.md
+++ b/docs/project/EPIC-004.reconciliation-engine.md
@@ -395,7 +395,12 @@ slice adds:
 - FX gain/loss attribution to revaluation over time via the existing
   `fx_revaluation` journal source type, so a same-day round-trip conversion nets
   ~zero realized P&L (minus fee/spread), the rate move being a holding-period
-  revaluation rather than a conversion-event gain (**AC4**).
+  revaluation rather than a conversion-event gain (**AC4**);
+- live wiring of the classification into the reporting net-income / income-statement
+  path (`services/reporting.py::_internal_transfer_adjustment`): a recorded
+  `fx_conversions` row whose legs are anchored to journal entries excludes those
+  legs from income/expense aggregation, so the net-worth/income report reflects the
+  internal transfer as net-zero minus the fee, proven end to end (**AC3 E2E**).
 
 Generalized invariant: **net worth changes only via external in/out + market
 moves + FX revaluation; internal transfers cancel (minus fees).**
@@ -413,3 +418,5 @@ docs/ssot/schema.md (`fx_conversions`).
 | AC4.14.6 | A same-day round-trip conversion nets ~zero realized P&L (minus fee/spread); rate move is attributed to revaluation, not the conversion event | `test_AC4_same_day_round_trip_nets_zero_pnl_minus_fee` | `accounting/test_fx_transfer.py` | P0 |
 | AC4.14.7 | FX revaluation P&L is routed through the `fx_revaluation` journal source type, never booked as conversion-event income/expense | `test_AC4_revaluation_pnl_routed_through_fx_revaluation_source_type` | `accounting/test_fx_transfer.py` | P1 |
 | AC4.14.8 | The `fx_conversions` linking model round-trips its multi-leg fields as Decimal with normalized ISO currencies | `test_AC2_fx_conversion_model_round_trips_decimals` | `accounting/test_fx_transfer.py` | P1 |
+| AC4.14.9 | End to end: a recorded internal transfer whose legs are booked to income/expense accounts is excluded from the income statement so net worth is unchanged except for the fee (live wiring, not just the unit primitive) | `test_AC3_internal_transfer_excluded_from_income_statement_e2e` | `reporting/test_internal_transfer_e2e.py` | P0 |
+| AC4.14.10 | End to end: the cumulative balance-sheet net income excludes a recorded internal transfer's legs and reflects only the fee | `test_AC3_internal_transfer_net_income_fee_only_e2e` | `reporting/test_internal_transfer_e2e.py` | P0 |

--- a/docs/ssot/ac-score-baseline.jsonl
+++ b/docs/ssot/ac-score-baseline.jsonl
@@ -2,6 +2,7 @@
 {"ac_id": "AC2.6.4", "score": 1.0, "metric": "posted_debit_credit_imbalance_is_zero", "provenance": "deterministic"}
 {"ac_id": "AC4.1.4", "score": 1.0, "metric": "description_similarity_pct", "provenance": "deterministic"}
 {"ac_id": "AC4.14.1", "score": 1.0, "metric": "fx_legs_pair_when_implied_rate_within_tolerance", "provenance": "deterministic"}
+{"ac_id": "AC4.14.10", "score": 1.0, "metric": "balance_sheet_net_income_excludes_internal_transfer_fee_only", "provenance": "deterministic"}
 {"ac_id": "AC4.14.2", "score": 1.0, "metric": "fx_legs_do_not_pair_outside_rate_tolerance", "provenance": "deterministic"}
 {"ac_id": "AC4.14.3", "score": 1.0, "metric": "non_candidate_fx_legs_rejected", "provenance": "deterministic"}
 {"ac_id": "AC4.14.4", "score": 1.0, "metric": "internal_transfer_income_and_expense_are_zero", "provenance": "deterministic"}
@@ -9,4 +10,5 @@
 {"ac_id": "AC4.14.6", "score": 1.0, "metric": "same_day_round_trip_realized_pnl_is_negative_fee", "provenance": "deterministic"}
 {"ac_id": "AC4.14.7", "score": 1.0, "metric": "fx_pnl_routes_through_fx_revaluation_source_type", "provenance": "deterministic"}
 {"ac_id": "AC4.14.8", "score": 1.0, "metric": "fx_conversion_model_round_trips_decimal_and_iso_currency", "provenance": "deterministic"}
+{"ac_id": "AC4.14.9", "score": 1.0, "metric": "income_statement_excludes_internal_transfer_legs_fee_only", "provenance": "deterministic"}
 {"ac_id": "AC8.16.1", "score": 1.0, "metric": "superseded_excluded_corrected_total_match", "provenance": "deterministic"}

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -738,6 +738,16 @@ impact is the transfer **fee**, which is a real external outflow. Implemented by
 `classify_internal_transfer` (`services/fx_transfer.py`): `net_worth_delta = −fee`
 for an internal transfer, `income − expense` otherwise.
 
+This classification is **wired into report generation** (#1123 AC3, live):
+`reporting._internal_transfer_adjustment` loads recorded `fx_conversions` rows
+whose legs are anchored to journal entries (`from_journal_entry_id` /
+`to_journal_entry_id`), re-validates each through `pair_fx_legs` +
+`classify_internal_transfer`, and excludes the matched legs from the income /
+expense aggregation in both `generate_income_statement` and the cumulative
+balance-sheet net income — adding back only the (converted) fee. A naively
+double-booked internal transfer therefore nets to zero in the report except for
+its fee, proven end to end in `reporting/test_internal_transfer_e2e.py`.
+
 **FX gain/loss is attributed to revaluation over time, not the conversion event**
 (#1123 AC4). A same-day round-trip conversion A→B→A nets ~zero realized P&L (minus
 fee/spread) because the market rate has not moved


### PR DESCRIPTION
## Summary

Closes the unaddressed Copilot review comments from #1160 and #1161, and — the part that actually closes #1123 — wires the FX / internal-transfer primitives into the **live** net-worth / income-statement report path with a **real end-to-end** test asserting the actual numbers.

## Part 1 — The 6 Copilot review comments (all legitimate)

**From #1160 (`services/extraction.py`):**

1. **Per-currency NAV self-check result was IGNORED.** `validate_balance_per_currency(...)` could return `balance_valid=False`, but `statement.currency_balances` was persisted unconditionally with only a logged warning, despite the "must reconcile before we persist" comment. **Fix:** respect the result — a failing per-currency self-check now sets `balance_validated=False` and surfaces the failing currencies in `validation_error`, mirroring the scalar invalid-balance path. The per-currency evidence array is still persisted (it is the audit trail) but is no longer mistaken for valid. New test `test_per_currency_nav_self_check_failure_marks_statement_invalid`.

**From #1161 (`services/fx_transfer.py`):**

2. **`pair_fx_legs` must reject same-currency legs.** Added the `out_leg.currency == in_leg.currency` guard so a same-currency internal transfer with rate≈1 is no longer misclassified as an FX conversion.
3. **`TransferLeg` must enforce timezone-aware `occurred_at`.** `__post_init__` now raises `FxTransferError` on naive datetimes so a naive/aware mix can't raise `TypeError` mid-pairing.
4. **`classify_internal_transfer` non-paired branch silently zeroed net worth.** It now accepts the caller's already-classified `income`/`expense` so `net_worth_delta == income − expense` matches the documented formula; docstring updated. Defaults preserve the prior no-op behavior.
5. **Test:** `test_same_currency_legs_never_pair_even_with_unit_rate` — same-currency legs never pair, even at rate 1.0 with equal amounts, in both argument orders.
6. **Test:** `test_transfer_leg_rejects_naive_datetime` — naive `occurred_at` is rejected at construction. (Plus `test_unpaired_classification_carries_caller_income_expense` for CR4.)

## Part 2 — Live wiring + end-to-end (closes #1123 AC3)

The primitives existed but nothing in the live report path called them. Wired into `services/reporting.py`:

- `_internal_transfer_adjustment(...)` loads recorded `fx_conversions` rows whose legs are anchored to journal entries (`from/to_journal_entry_id`), re-validates each through `pair_fx_legs` + `classify_internal_transfer`, and returns the journal-entry IDs to exclude from income/expense plus the converted fee.
- `_aggregate_net_income_sql` (cumulative balance-sheet net income) and `generate_income_statement` now exclude those legs and add back only the fee.

**Real E2E test** (`reporting/test_internal_transfer_e2e.py`, integration tier): seeds a cross-currency internal transfer naively double-booked as income (1000 USD in) + expense (1360 SGD out) at 1.36 SGD/USD with a 2.50 SGD fee, alongside a genuine 5000 SGD salary, records the linking `fx_conversions` row, then runs the **real** `generate_income_statement` / `generate_balance_sheet` services and asserts the actual numbers:

- `total_income == 5000.00` — the 1000 USD transfer-in leg is excluded (not double-counted as income).
- `total_expenses == 2.50` — only the fee survives netting (the 1360 SGD transfer-out leg is excluded).
- `net_income == 4997.50` — both from the income statement and the cumulative balance-sheet net income, confirming a single coherent wiring point.

Net worth is therefore unchanged by the internal transfer except for the fee, proven end to end — the proof the unit primitives were missing.

## Part 3 — AC / docs

- EPIC-004 AC4.14: registered **AC4.14.9** (income-statement E2E exclusion) and **AC4.14.10** (balance-sheet net-income E2E); both resolve to real tests in the traceability gate.
- Promoted both to L2/L3: `@ac_proof` edges + `docs/ssot/ac-score-baseline.jsonl` at score 1.0, kept sorted by `ac_id` (#1103 AC-E2 continuation).
- `ssot/reporting.md`: documented the live wiring; `validation.py` docstring updated (per-currency check is now wired, no longer "not yet wired").

## Commands run

- `uv run pytest tests/accounting/test_fx_transfer.py tests/reporting/test_internal_transfer_e2e.py tests/extraction/test_brokerage_position_extraction_wiring.py -o addopts="" -q` → **25 passed**
- Broader: `tests/reporting/test_reporting.py test_reporting_net_worth_components.py test_net_income_average_rates.py test_reporting_fx.py test_income_typed_currency.py test_annualized_income_schedule.py tests/accounting/test_validation.py test_multicurrency_integrity.py` → all green
- `ruff check` / `ruff format --check` on all changed files → clean
- `tools/generate_ac_registry.py`, `tools/check_ac_index.py` → PASS; `tools/build_ac_traceability.py` → AC4.14.9/.10 ✅ real
- `test_committed_baseline_matches_schema` → PASS (baseline sorted)
- `alembic heads` → single head `0042_fx_conversions` (no model change in this PR → no migration needed)
- `uv.lock` churn reverted

## Honest green vs deferred

- **Green / proven E2E:** AC3 net-worth neutrality of a matched internal transfer (income/expense exclusion + fee-only), via the deterministic path the E2E test exercises (legs anchored to journal entries through a recorded `fx_conversions` row).
- **Deferred:** automatic **discovery** of FX/internal-transfer leg pairs directly from the raw ledger (without a pre-recorded `fx_conversions` link) is not in this PR — the wiring consumes recorded conversions. The AC2 pairing primitive and AC4 round-trip P&L remain unit-proven (not yet exercised through a full live report query). The reporting wiring closes the AC3 end-to-end gap; AC2/AC4 live consumption is the remainder.

`Part of #1123`: the AC3 net-worth-neutrality path is now proven end to end (this PR). **Remainder:** AC2 leg-pairing and AC4 round-trip P&L are unit-proven but not yet consumed through a full live report query, and auto-discovery of leg pairs from the raw ledger (without a pre-recorded `fx_conversions` link) is deferred. `Part of #1103`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
