### PR TITLE
[finance_report_vision] feat(llm): EPIC-023 PR3 — DB config foundation + cut AI streaming onto litellm (AC23.3.1/.2)

### DIFF
--- a/apps/backend/migrations/versions/0043_llm_provider_config.py
+++ b/apps/backend/migrations/versions/0043_llm_provider_config.py
@@ -48,7 +48,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("api_key_ciphertext", sa.String(), nullable=False),
-        sa.Column("api_key_version", sa.Integer(), nullable=False),
+        sa.Column("api_key_version", sa.BigInteger(), nullable=False),
         sa.Column("api_base", sa.String(length=500), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),

--- a/apps/backend/migrations/versions/0043_llm_provider_config.py
+++ b/apps/backend/migrations/versions/0043_llm_provider_config.py
@@ -1,0 +1,89 @@
+"""llm provider config: provider instances + scene->model bindings (EPIC-023 EPIC B)
+
+Adds two additive, deployment-scoped tables for DB-backed LLM configuration:
+
+- ``llm_providers``: a configured provider instance per row. The API key is
+  stored encrypted (Fernet ciphertext + the key fingerprint that sealed it; see
+  ``src/llm/common/secrets.py``), never as plaintext.
+- ``llm_scene_bindings``: one row per scene (unique) pinning which provider+model
+  serves it, plus per-scene reasoning depth / free-tier preference / fallbacks.
+
+Migration risk: low (new additive tables, no backfill, no changes to existing
+tables). Three new enum types back the protocol family, scene, and reasoning
+depth columns.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0043_llm_provider_config"
+down_revision = "0042_fx_conversions"
+branch_labels = None
+depends_on = None
+
+
+_PROTOCOL_VALUES = ("openai-compatible", "anthropic-compatible", "openrouter-compatible")
+_SCENE_VALUES = ("extraction.ocr", "extraction.vision", "extraction.json", "advisor.chat", "statement.summary")
+_REASONING_VALUES = ("none", "low", "medium", "high")
+
+
+def _create_enum(name: str, values: tuple[str, ...]) -> None:
+    labels = ", ".join(f"'{v}'" for v in values)
+    op.execute(f"DO $$ BEGIN CREATE TYPE {name} AS ENUM ({labels}); EXCEPTION WHEN duplicate_object THEN null; END $$;")
+
+
+def upgrade() -> None:
+    _create_enum("llm_protocol_family_enum", _PROTOCOL_VALUES)
+    _create_enum("llm_scene_enum", _SCENE_VALUES)
+    _create_enum("llm_reasoning_effort_enum", _REASONING_VALUES)
+
+    op.create_table(
+        "llm_providers",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("label", sa.String(length=100), nullable=False),
+        sa.Column(
+            "protocol",
+            postgresql.ENUM(*_PROTOCOL_VALUES, name="llm_protocol_family_enum", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("api_key_ciphertext", sa.String(), nullable=False),
+        sa.Column("api_key_version", sa.Integer(), nullable=False),
+        sa.Column("api_base", sa.String(length=500), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        "llm_scene_bindings",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "scene",
+            postgresql.ENUM(*_SCENE_VALUES, name="llm_scene_enum", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("provider_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("model", sa.String(length=200), nullable=False),
+        sa.Column(
+            "reasoning",
+            postgresql.ENUM(*_REASONING_VALUES, name="llm_reasoning_effort_enum", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("prefer_free", sa.Boolean(), nullable=False),
+        sa.Column("fallback_model_ids", sa.String(), nullable=False),
+        sa.Column("max_tokens", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["provider_id"], ["llm_providers.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("scene", name="uq_llm_scene_bindings_scene"),
+    )
+    op.create_index("ix_llm_scene_bindings_provider_id", "llm_scene_bindings", ["provider_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llm_scene_bindings_provider_id", table_name="llm_scene_bindings")
+    op.drop_table("llm_scene_bindings")
+    op.drop_table("llm_providers")
+    op.execute("DROP TYPE IF EXISTS llm_reasoning_effort_enum")
+    op.execute("DROP TYPE IF EXISTS llm_scene_enum")
+    op.execute("DROP TYPE IF EXISTS llm_protocol_family_enum")

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "opentelemetry-instrumentation-sqlalchemy>=0.45b0",
     "opentelemetry-instrumentation-httpx>=0.45b0",
     "bcrypt==4.0.1",
-    "httpx-sse>=0.4.3",
     "pymupdf>=1.24.0",
     "cryptography>=42.0.0",
     "litellm>=1.55.0",

--- a/apps/backend/src/llm/__init__.py
+++ b/apps/backend/src/llm/__init__.py
@@ -18,25 +18,10 @@ cipher) that the litellm client implementation (EPIC A) and the DB-backed
 configuration layer (EPIC B) both build against. Importing from ``common`` keeps
 the two halves decoupled so they can evolve in parallel.
 
-This top-level package re-exports the EPIC A litellm surface (client, catalogue,
-cost, env config). Provider-specific routing lives in :mod:`src.llm.routing`.
+The package ``__init__`` is intentionally import-light: it does NOT eagerly pull
+in the litellm-dependent surface (``client``/``catalog``/``cost``). That keeps
+``from src.llm.common import …`` litellm-free, so lightweight consumers (e.g. the
+SQLAlchemy models, run in minimal tooling environments without litellm installed)
+can use the contract without the heavy dependency. Import the implementations
+explicitly from their submodules (``src.llm.client``, ``src.llm.catalog``, …).
 """
-
-from __future__ import annotations
-
-from src.llm.catalog import LitellmCatalog
-from src.llm.client import LitellmClient, litellm_complete, litellm_stream
-from src.llm.cost import DailyBudgetMeter
-from src.llm.env_config import EnvConfigSource
-from src.llm.routing import LitellmCall, build_call
-
-__all__ = [
-    "LitellmClient",
-    "litellm_stream",
-    "litellm_complete",
-    "LitellmCatalog",
-    "DailyBudgetMeter",
-    "EnvConfigSource",
-    "LitellmCall",
-    "build_call",
-]

--- a/apps/backend/src/llm/client.py
+++ b/apps/backend/src/llm/client.py
@@ -213,25 +213,29 @@ class LitellmClient:
     async def _resolve_provider(self, model_id: str) -> tuple[ProviderRef, str]:
         """Resolve ``model_id`` to ``(provider, bare_model)``.
 
-        Convention: with a single configured provider the binding's ``model_id``
-        is used as-is (it may contain slashes — OpenRouter's ``vendor/model``).
-        With multiple providers a binding MUST qualify as ``provider_id/model``
-        (split once; the model part may still contain slashes); an unqualified or
-        unknown-provider id is a config error rather than a silent fallback to the
+        A binding may qualify its model as ``provider_id/model`` (DB-backed config
+        always does, so the exact provider is selected even with several
+        configured). If the leading segment is a known provider id, it is used and
+        stripped — for any provider count. Otherwise: with a single provider the
+        whole ``model_id`` is the model (it may contain slashes — OpenRouter's
+        ``vendor/model``); with several providers an unqualified or
+        unknown-provider id is a config error, never a silent fallback to the
         wrong credentials.
         """
         providers = await self._config.list_providers()
         if not providers:
             raise LLMConfigError("No LLM provider configured")
+        if "/" in model_id:
+            provider_id, _, model = model_id.partition("/")
+            provider = await self._config.get_provider(provider_id)
+            if provider is not None:
+                return provider, model
+            if len(providers) == 1:
+                return providers[0], model_id
+            raise LLMConfigError(f"Unknown provider id {provider_id!r} in model {model_id!r}")
         if len(providers) == 1:
             return providers[0], model_id
-        if "/" not in model_id:
-            raise LLMConfigError(f"Ambiguous provider for unqualified model {model_id!r}; qualify as provider_id/model")
-        provider_id, _, model = model_id.partition("/")
-        provider = await self._config.get_provider(provider_id)
-        if provider is None:
-            raise LLMConfigError(f"Unknown provider id {provider_id!r} in model {model_id!r}")
-        return provider, model
+        raise LLMConfigError(f"Ambiguous provider for unqualified model {model_id!r}; qualify as provider_id/model")
 
     def stream(
         self, scene: Scene, messages: Sequence[Message], *, reasoning: ReasoningEffort | None = None

--- a/apps/backend/src/llm/db_config.py
+++ b/apps/backend/src/llm/db_config.py
@@ -1,0 +1,87 @@
+"""DB-backed ``ConfigSource`` (EPIC-023 EPIC B).
+
+Reads provider instances + scene bindings from ``llm_providers`` /
+``llm_scene_bindings``, decrypting each provider's API key on the way out. Bindings
+are returned with their model qualified as ``{provider_id}/{model}`` so the client
+resolves the exact provider even when several are configured.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from src.database import async_session_maker
+from src.llm.common import Encrypted, ProviderRef, Scene, SceneBinding
+from src.llm.common.secrets import SecretCipher, build_cipher
+from src.models import LlmProvider, LlmSceneBinding
+
+
+class DbConfigSource:
+    """``ConfigSource`` over the ``llm_providers`` / ``llm_scene_bindings`` tables."""
+
+    def __init__(
+        self,
+        session_maker: async_sessionmaker | None = None,
+        cipher: SecretCipher | None = None,
+    ) -> None:
+        # Short-lived read sessions, decoupled from request scope.
+        self._maker = session_maker or async_session_maker
+        self._cipher_override = cipher
+
+    def _cipher(self) -> SecretCipher:
+        return self._cipher_override or build_cipher()
+
+    def _to_ref(self, row: LlmProvider, cipher: SecretCipher) -> ProviderRef:
+        api_key = cipher.decrypt(Encrypted(ciphertext=row.api_key_ciphertext, key_version=row.api_key_version))
+        return ProviderRef(
+            id=str(row.id),
+            label=row.label,
+            protocol=row.protocol,
+            api_key=api_key,
+            api_base=row.api_base,
+        )
+
+    async def list_providers(self) -> list[ProviderRef]:
+        async with self._maker() as session:
+            rows = (await session.execute(select(LlmProvider))).scalars().all()
+        if not rows:
+            return []
+        cipher = self._cipher()
+        return [self._to_ref(row, cipher) for row in rows]
+
+    async def get_provider(self, provider_id: str) -> ProviderRef | None:
+        try:
+            pid = UUID(provider_id)
+        except (ValueError, TypeError):
+            return None
+        async with self._maker() as session:
+            row = await session.get(LlmProvider, pid)
+        if row is None:
+            return None
+        return self._to_ref(row, self._cipher())
+
+    async def get_binding(self, scene: Scene) -> SceneBinding | None:
+        async with self._maker() as session:
+            row = (
+                await session.execute(select(LlmSceneBinding).where(LlmSceneBinding.scene == scene))
+            ).scalar_one_or_none()
+        if row is None:
+            return None
+        fallbacks = tuple(m.strip() for m in row.fallback_model_ids.split(",") if m.strip())
+        return SceneBinding(
+            scene=scene,
+            # Qualify with the provider id so the client resolves the exact provider.
+            model_id=f"{row.provider_id}/{row.model}",
+            reasoning=row.reasoning,
+            prefer_free=row.prefer_free,
+            fallback_model_ids=fallbacks,
+            max_tokens=row.max_tokens,
+        )
+
+    async def is_configured(self) -> bool:
+        async with self._maker() as session:
+            count = (await session.execute(select(func.count()).select_from(LlmProvider))).scalar_one()
+        return count > 0

--- a/apps/backend/src/llm/factory.py
+++ b/apps/backend/src/llm/factory.py
@@ -17,23 +17,30 @@ from src.llm.env_config import EnvConfigSource
 
 
 class LayeredConfigSource:
-    """DB-primary config with an env fallback, behind the ``ConfigSource`` contract."""
+    """DB-primary config with an env fallback, behind the ``ConfigSource`` contract.
+
+    The fallback is **all-or-nothing**: if the primary (DB) has any provider, every
+    lookup — providers *and* bindings — is served from the primary; otherwise every
+    lookup comes from the fallback (env). This avoids mixing sources (e.g. an env
+    binding's unqualified model resolved against DB providers), which would
+    misroute or raise an ambiguity error.
+    """
 
     def __init__(self, primary: ConfigSource, fallback: ConfigSource) -> None:
         self._primary = primary
         self._fallback = fallback
 
+    async def _active(self) -> ConfigSource:
+        return self._primary if await self._primary.is_configured() else self._fallback
+
     async def list_providers(self) -> list[ProviderRef]:
-        primary = await self._primary.list_providers()
-        return primary if primary else await self._fallback.list_providers()
+        return await (await self._active()).list_providers()
 
     async def get_provider(self, provider_id: str) -> ProviderRef | None:
-        found = await self._primary.get_provider(provider_id)
-        return found if found is not None else await self._fallback.get_provider(provider_id)
+        return await (await self._active()).get_provider(provider_id)
 
     async def get_binding(self, scene: Scene) -> SceneBinding | None:
-        binding = await self._primary.get_binding(scene)
-        return binding if binding is not None else await self._fallback.get_binding(scene)
+        return await (await self._active()).get_binding(scene)
 
     async def is_configured(self) -> bool:
         return await self._primary.is_configured() or await self._fallback.is_configured()

--- a/apps/backend/src/llm/factory.py
+++ b/apps/backend/src/llm/factory.py
@@ -1,0 +1,49 @@
+"""Wiring for the LLM client + config source (EPIC-023 EPIC B).
+
+The app resolves config DB-first with an env fallback: a deployment that has
+configured providers in the DB uses them; one that only has the legacy
+``AI_*`` env vars keeps working unchanged; one with neither is *unconfigured*
+(``is_configured() == False``), which the first-run modal keys off. This is what
+lets the DB-backed config land without breaking existing env-only deploys.
+"""
+
+from __future__ import annotations
+
+from src.llm.client import LitellmClient
+from src.llm.common import ConfigSource, ProviderRef, Scene, SceneBinding
+from src.llm.cost import DailyBudgetMeter
+from src.llm.db_config import DbConfigSource
+from src.llm.env_config import EnvConfigSource
+
+
+class LayeredConfigSource:
+    """DB-primary config with an env fallback, behind the ``ConfigSource`` contract."""
+
+    def __init__(self, primary: ConfigSource, fallback: ConfigSource) -> None:
+        self._primary = primary
+        self._fallback = fallback
+
+    async def list_providers(self) -> list[ProviderRef]:
+        primary = await self._primary.list_providers()
+        return primary if primary else await self._fallback.list_providers()
+
+    async def get_provider(self, provider_id: str) -> ProviderRef | None:
+        found = await self._primary.get_provider(provider_id)
+        return found if found is not None else await self._fallback.get_provider(provider_id)
+
+    async def get_binding(self, scene: Scene) -> SceneBinding | None:
+        binding = await self._primary.get_binding(scene)
+        return binding if binding is not None else await self._fallback.get_binding(scene)
+
+    async def is_configured(self) -> bool:
+        return await self._primary.is_configured() or await self._fallback.is_configured()
+
+
+def get_config_source() -> ConfigSource:
+    """The deployment's config source: DB providers/bindings over env fallback."""
+    return LayeredConfigSource(DbConfigSource(), EnvConfigSource())
+
+
+def get_llm_client() -> LitellmClient:
+    """The shared scene-keyed client, with the daily budget guard wired in."""
+    return LitellmClient(get_config_source(), cost_meter=DailyBudgetMeter())

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -34,6 +34,7 @@ from src.models.layer3 import (
     TransactionClassification,
 )
 from src.models.layer4 import ReportSnapshot, ReportType
+from src.models.llm_config import LlmProvider, LlmSceneBinding
 from src.models.market_data import FxRate, MarketDataSyncState, StockPrice
 from src.models.metrics import ConfidenceMetricSnapshot
 from src.models.ping_state import PingState
@@ -111,6 +112,8 @@ __all__ = [
     "ReportSnapshot",
     "ReportType",
     "RuleType",
+    "LlmProvider",
+    "LlmSceneBinding",
     "StatementSummary",
     "Stage1Status",
     "StockPrice",

--- a/apps/backend/src/models/llm_config.py
+++ b/apps/backend/src/models/llm_config.py
@@ -1,0 +1,73 @@
+"""DB-backed LLM provider configuration (EPIC-023 EPIC B).
+
+These tables hold the *operational* LLM config the SSOT vocabulary
+(``docs/ssot/llm.md``) describes: provider instances (with their API key
+encrypted at rest) and the scene→model bindings. They are deployment-scoped
+(not user-owned) — a single per-deployment configuration, edited via the
+``/llm`` API / first-run modal. The Python enums are reused from
+``src/llm/common`` so the DB and the runtime contract can never drift.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import Boolean, Enum, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.database import Base
+from src.llm.common import ProtocolFamily, ReasoningEffort, Scene
+from src.models.base import TimestampMixin, UUIDMixin
+
+
+def _enum_values(enum_cls: type) -> list[str]:
+    return [member.value for member in enum_cls]
+
+
+class LlmProvider(Base, UUIDMixin, TimestampMixin):
+    """A configured provider instance; the API key is stored encrypted."""
+
+    __tablename__ = "llm_providers"
+
+    label: Mapped[str] = mapped_column(String(100), nullable=False)
+    protocol: Mapped[ProtocolFamily] = mapped_column(
+        Enum(
+            ProtocolFamily,
+            name="llm_protocol_family_enum",
+            values_callable=_enum_values,
+        ),
+        nullable=False,
+    )
+    # Fernet ciphertext + the key fingerprint that sealed it (see src/llm/common/secrets.py).
+    api_key_ciphertext: Mapped[str] = mapped_column(String, nullable=False)
+    api_key_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    api_base: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+
+class LlmSceneBinding(Base, UUIDMixin, TimestampMixin):
+    """Which provider+model (and how) a scene resolves to. One row per scene."""
+
+    __tablename__ = "llm_scene_bindings"
+
+    scene: Mapped[Scene] = mapped_column(
+        Enum(Scene, name="llm_scene_enum", values_callable=_enum_values),
+        nullable=False,
+        unique=True,
+    )
+    provider_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("llm_providers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    model: Mapped[str] = mapped_column(String(200), nullable=False)
+    reasoning: Mapped[ReasoningEffort] = mapped_column(
+        Enum(ReasoningEffort, name="llm_reasoning_effort_enum", values_callable=_enum_values),
+        nullable=False,
+        default=ReasoningEffort.NONE,
+    )
+    prefer_free: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # Comma-separated fallback model ids (kept as text for a simple additive schema).
+    fallback_model_ids: Mapped[str] = mapped_column(String, nullable=False, default="")
+    max_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/apps/backend/src/models/llm_config.py
+++ b/apps/backend/src/models/llm_config.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from sqlalchemy import Boolean, Enum, ForeignKey, Integer, String
+from sqlalchemy import BigInteger, Boolean, Enum, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -40,8 +40,10 @@ class LlmProvider(Base, UUIDMixin, TimestampMixin):
         nullable=False,
     )
     # Fernet ciphertext + the key fingerprint that sealed it (see src/llm/common/secrets.py).
+    # BigInteger: the fingerprint is an unsigned 32-bit value (sha256[:4], up to ~4.3e9)
+    # which overflows a signed int32 column.
     api_key_ciphertext: Mapped[str] = mapped_column(String, nullable=False)
-    api_key_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    api_key_version: Mapped[int] = mapped_column(BigInteger, nullable=False)
     api_base: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
 

--- a/apps/backend/src/services/ai_advisor.py
+++ b/apps/backend/src/services/ai_advisor.py
@@ -1019,8 +1019,6 @@ class AIAdvisorService:
         async for chunk in stream_ai_chat(
             messages=messages,
             model=model,
-            api_key=self.api_key,
-            base_url=self.base_url,
             timeout=120.0,
         ):
             yield chunk

--- a/apps/backend/src/services/ai_streaming.py
+++ b/apps/backend/src/services/ai_streaming.py
@@ -52,6 +52,13 @@ async def _resolve_provider(api_key: str | None, base_url: str | None) -> Provid
     providers = await get_config_source().list_providers()
     if not providers:
         raise AIStreamError("AI provider not configured", retryable=False)
+    if len(providers) > 1:
+        # This scene-less path can't disambiguate; fail closed rather than route a
+        # prompt to a nondeterministically-chosen provider. Multi-provider use must
+        # go through the scene-keyed client (provider_id/model bindings).
+        raise AIStreamError(
+            "Multiple AI providers configured; this path needs exactly one default provider", retryable=False
+        )
     return providers[0]
 
 
@@ -102,7 +109,8 @@ async def _stream_ai_base(
     except LLMError as exc:
         logger.error(
             "AI provider streaming failed",
-            provider=settings.ai_provider,
+            provider=provider.label,  # resolved provider (DB or env), not the env AI_PROVIDER
+            provider_id=provider.id,
             model=model,
             mode=mode_label,
             error=str(exc),

--- a/apps/backend/src/services/ai_streaming.py
+++ b/apps/backend/src/services/ai_streaming.py
@@ -1,18 +1,22 @@
-"""AI provider streaming utilities for OpenAI-compatible chat models.
+"""AI provider streaming utilities (litellm transport).
 
-The public function names remain for backward compatibility with existing
-call sites, but configuration is provider-neutral.
+EPIC-023 PR3: the transport is litellm (via :mod:`src.llm.client`), not raw
+httpx. These functions keep their signatures for the existing call sites
+(extraction, the AI advisor, reconciliation scoring), but provider selection now
+comes from the layered config (DB providers first, env fallback) and litellm
+handles provider routing + dropping model-rejected params (e.g. Z.AI/GLM
+``seed``). When a caller passes an explicit ``api_key``/``base_url`` those win
+(back-compat / tests); otherwise the configured default provider is resolved.
 """
 
-import json
-import time
 from collections.abc import AsyncIterator
 from typing import Any
 
-import httpx
-from httpx_sse import aconnect_sse
-
 from src.config import settings
+from src.llm.client import litellm_stream
+from src.llm.common import LLMError, ProviderRef
+from src.llm.env_config import _protocol_for
+from src.llm.factory import get_config_source
 from src.logger import get_logger
 
 logger = get_logger(__name__)
@@ -22,17 +26,33 @@ class AIStreamError(Exception):
     """Raised when AI provider streaming fails."""
 
     def __init__(self, message: str, retryable: bool = False):
-        """
-        Initialize AI provider streaming error.
+        """Initialize AI provider streaming error.
 
-        Args:
-            message: Error description
-            retryable: Whether this error can be retried (e.g., HTTP 429 rate limits,
-                       HTTP 5xx server errors). Network timeouts raise httpx exceptions
-                       directly and are not wrapped.
+        ``retryable`` mirrors litellm's verdict on the underlying provider error
+        (HTTP 429 / 5xx / timeout → retryable), preserving the prior contract.
         """
         super().__init__(message)
         self.retryable = retryable
+
+
+async def _resolve_provider(api_key: str | None, base_url: str | None) -> ProviderRef:
+    """Resolve the provider for a transport call.
+
+    Explicit ``api_key`` wins (its protocol is taken from ``AI_PROVIDER``);
+    otherwise resolve the configured default provider (DB-first, env fallback).
+    """
+    if api_key:
+        return ProviderRef(
+            id="explicit",
+            label=settings.ai_provider,
+            protocol=_protocol_for(settings.ai_provider),
+            api_key=api_key,
+            api_base=base_url or getattr(settings, "ai_base_url", None) or None,
+        )
+    providers = await get_config_source().list_providers()
+    if not providers:
+        raise AIStreamError("AI provider not configured", retryable=False)
+    return providers[0]
 
 
 async def _stream_ai_base(
@@ -42,7 +62,7 @@ async def _stream_ai_base(
     api_key: str | None = None,
     base_url: str | None = None,
     timeout: float,
-    connect_timeout: float,
+    connect_timeout: float = 10.0,
     max_tokens: int | None = None,
     temperature: float | None = None,
     do_sample: bool | None = None,
@@ -51,185 +71,44 @@ async def _stream_ai_base(
     response_format: dict[str, str] | None = None,
     mode_label: str = "streaming",
 ) -> AsyncIterator[str]:
+    """Stream delta chunks via litellm.
+
+    ``do_sample``/``thinking`` are Z.AI/GLM-specific knobs forwarded through
+    ``extra_body``; ``seed`` is a native param litellm drops for models that
+    reject it. ``response_format`` and ``connect_timeout`` are accepted for
+    signature compatibility but unused — JSON mode stays prompt-driven and
+    litellm owns the transport.
     """
-    Base streaming implementation for OpenAI-compatible chat APIs.
+    provider = await _resolve_provider(api_key, base_url)
 
-    Internal helper that handles the common logic for both JSON and chat modes.
-    """
-    if not api_key:
-        api_key = getattr(settings, "ai_api_key", None)
-    if not isinstance(api_key, str) or not api_key:
-        raise AIStreamError("AI provider API key not configured", retryable=False)
-
-    if not base_url:
-        base_url = getattr(settings, "ai_base_url", None)
-    if not isinstance(base_url, str) or not base_url:
-        raise AIStreamError("AI provider base URL not configured", retryable=False)
-
-    chat_path = getattr(settings, "ai_chat_completions_path", "/chat/completions")
-    if not isinstance(chat_path, str) or not chat_path:
-        chat_path = "/chat/completions"
-    chat_url = f"{base_url.rstrip('/')}/{chat_path.lstrip('/')}"
-
-    payload: dict[str, Any] = {
-        "model": model,
-        "stream": True,
-        "messages": messages,
-    }
-    if response_format:
-        payload["response_format"] = response_format
-    if max_tokens is not None:
-        payload["max_tokens"] = max_tokens
-    if temperature is not None:
-        payload["temperature"] = temperature
+    extra_body: dict[str, Any] = {}
     if do_sample is not None:
-        payload["do_sample"] = do_sample
-    if seed is not None:
-        payload["seed"] = seed
+        extra_body["do_sample"] = do_sample
     if thinking is not None:
-        payload["thinking"] = thinking
+        extra_body["thinking"] = thinking
 
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
-    if settings.ai_provider == "openrouter":
-        headers["HTTP-Referer"] = "https://finance-report.local"
-        headers["X-Title"] = "Finance Report Backend"
-
-    timeout_config = httpx.Timeout(timeout, connect=connect_timeout, read=timeout)
-    start_time = time.perf_counter()
-    chunk_count = 0
-    total_chars = 0
-
-    logger.info(
-        "Starting AI provider streaming request",
-        provider=settings.ai_provider,
-        model=model,
-        mode=mode_label,
-        timeout=timeout,
-    )
-
-    async with (
-        httpx.AsyncClient(timeout=timeout_config) as client,
-        aconnect_sse(
-            client,
-            "POST",
-            chat_url,
-            headers=headers,
-            json=payload,
-        ) as event_source,
-    ):
-        if event_source.response.status_code != 200:
-            error_text = await event_source.response.aread()
-            error_body = error_text.decode("utf-8", errors="replace")
-            error_message = f"HTTP {event_source.response.status_code}: {error_body}"
-            retryable = event_source.response.status_code in (429, 500, 502, 503, 504)
-
-            logger.error(
-                "AI provider HTTP error",
-                provider=settings.ai_provider,
-                model=model,
-                status_code=event_source.response.status_code,
-                error_body=error_body[:500],
-                retryable=retryable,
-                mode=mode_label,
-                headers=dict(event_source.response.headers),
-            )
-
-            raise AIStreamError(error_message, retryable=retryable)
-
-        chunk_count = 0
-        content_count = 0
-
-        async for event in event_source.aiter_sse():
-            # Ignore SSE comments (some providers emit progress comments)
-            if event.data.startswith(":") or not event.data.strip():
-                continue
-
-            if event.data == "[DONE]":
-                break
-
-            chunk_count += 1
-
-            try:
-                chunk_data = json.loads(event.data)
-
-                # Check for mid-stream errors (OpenAI-compatible providers can
-                # send an error object in the response body)
-                if "error" in chunk_data:
-                    error_info = chunk_data["error"]
-                    error_msg = error_info.get("message", str(error_info))
-                    error_code = error_info.get("code", "unknown")
-                    logger.error(
-                        f"AI provider mid-stream error ({mode_label})",
-                        provider=settings.ai_provider,
-                        error_code=error_code,
-                        error_message=error_msg,
-                        model=model,
-                    )
-                    raise AIStreamError(
-                        f"Mid-stream error: {error_msg}", retryable=error_code in ("server_error", "timeout")
-                    )
-
-                choices = chunk_data.get("choices", [])
-                if not choices:
-                    continue
-
-                choice = choices[0]
-
-                # Check for error finish_reason
-                finish_reason = choice.get("finish_reason")
-                if finish_reason == "error":
-                    logger.error(
-                        f"AI provider stream terminated with error ({mode_label})",
-                        provider=settings.ai_provider,
-                        model=model,
-                        chunk_data_preview=str(chunk_data)[:500],
-                    )
-                    raise AIStreamError("Stream terminated with error", retryable=True)
-
-                delta = choice.get("delta", {})
-                content = delta.get("content", "")
-                if content:
-                    content_count += 1
-                    total_chars += len(content)
-                    yield content
-
-            except json.JSONDecodeError:
-                logger.warning(
-                    f"Failed to parse JSON in SSE event ({mode_label})",
-                    data_preview=event.data[:200],
-                )
-                continue
-
-        # Log summary for debugging empty responses
-        if chunk_count > 0 and content_count == 0:
-            logger.warning(
-                f"AI provider stream received chunks but no content ({mode_label})",
-                provider=settings.ai_provider,
-                model=model,
-                chunk_count=chunk_count,
-                content_count=content_count,
-            )
-        elif chunk_count == 0:
-            logger.warning(
-                f"AI provider stream received no chunks ({mode_label})",
-                provider=settings.ai_provider,
-                model=model,
-            )
-
-    duration_ms = (time.perf_counter() - start_time) * 1000
-    logger.info(
-        "AI provider streaming completed",
-        provider=settings.ai_provider,
-        model=model,
-        mode=mode_label,
-        duration_ms=round(duration_ms, 2),
-        chunk_count=chunk_count,
-        content_count=content_count,
-        total_chars=total_chars,
-    )
+    try:
+        async for content in litellm_stream(
+            messages,
+            provider=provider,
+            model_id=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            seed=seed,
+            extra_body=extra_body or None,
+            timeout=timeout,
+        ):
+            yield content
+    except LLMError as exc:
+        logger.error(
+            "AI provider streaming failed",
+            provider=settings.ai_provider,
+            model=model,
+            mode=mode_label,
+            error=str(exc),
+            retryable=exc.retryable,
+        )
+        raise AIStreamError(str(exc), retryable=exc.retryable) from exc
 
 
 async def stream_ai_json(
@@ -245,30 +124,18 @@ async def stream_ai_json(
     seed: int | None = None,
     thinking: dict[str, Any] | None = None,
 ) -> AsyncIterator[str]:
-    """
-    Stream OpenAI-compatible chat completions for JSON extraction.
-
-    Yields raw delta content chunks. For vision models, this includes
-    the full JSON response as it's generated.
-
-    Note: We intentionally do NOT set response_format={"type": "json_object"}
-    because many providers (e.g., ModelRun for qwen-free models) do not support
-    this parameter with multimodal/PDF inputs, returning HTTP 400 "Value error".
-    The prompt already instructs the AI to return valid JSON.
-    """
+    """Stream chat completions for JSON extraction (prompt-driven JSON, no response_format)."""
     async for chunk in _stream_ai_base(
         messages=messages,
         model=model,
         api_key=api_key,
         base_url=base_url,
         timeout=timeout,
-        connect_timeout=10.0,
         max_tokens=max_tokens,
         temperature=temperature,
         do_sample=do_sample,
         seed=seed,
         thinking=thinking,
-        response_format=None,
         mode_label="JSON extraction",
     ):
         yield chunk
@@ -282,22 +149,13 @@ async def stream_ai_chat(
     base_url: str | None = None,
     timeout: float = 120.0,
 ) -> AsyncIterator[str]:
-    """
-    Stream OpenAI-compatible chat completions without JSON mode.
-
-    Yields raw delta content chunks for plain text chat responses.
-
-    Note: timeout increased to 120s to handle AI model cold starts and
-    complex financial context processing which can take longer than typical API calls.
-    """
+    """Stream chat completions without JSON mode (plain text)."""
     async for chunk in _stream_ai_base(
         messages=messages,
         model=model,
         api_key=api_key,
         base_url=base_url,
         timeout=timeout,
-        connect_timeout=10.0,
-        response_format=None,
         mode_label="chat mode",
     ):
         yield chunk

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -984,8 +984,6 @@ class ExtractionService:
                 stream = stream_ai_json(
                     messages=messages,
                     model=model,
-                    api_key=self.api_key,
-                    base_url=self.base_url,
                     timeout=settings.ai_json_timeout_seconds,
                     max_tokens=settings.ai_json_max_tokens,
                     temperature=0.0,
@@ -1676,8 +1674,6 @@ class ExtractionService:
         stream = stream_ai_json(
             messages=messages,
             model=self.primary_model,
-            api_key=self.api_key,
-            base_url=self.base_url,
             timeout=30.0,
         )
         content = await accumulate_stream(stream)

--- a/apps/backend/src/services/reconciliation_scoring.py
+++ b/apps/backend/src/services/reconciliation_scoring.py
@@ -268,8 +268,6 @@ async def ai_semantic_score(
         stream = stream_ai_json(
             messages=messages,
             model=settings.primary_model,
-            api_key=settings.ai_api_key,
-            base_url=settings.ai_base_url,
             timeout=30.0,
         )
         content = await accumulate_stream(stream)

--- a/apps/backend/tests/ai/test_ai_streaming.py
+++ b/apps/backend/tests/ai/test_ai_streaming.py
@@ -71,7 +71,8 @@ async def test_stream_ai_json_uses_explicit_credentials(litellm_stub, monkeypatc
 
 
 async def test_stream_ai_json_forwards_zai_knobs_and_seed(litellm_stub, monkeypatch):
-    """do_sample/thinking ride extra_body; seed is a native (droppable) param."""
+    """AC13.16.1: a provided seed is forwarded in the request payload (deterministic
+    decoding, #989). do_sample/thinking ride extra_body; seed is a native (droppable) param."""
     _explicit_provider(monkeypatch)
     await accumulate_stream(
         stream_ai_json(
@@ -97,7 +98,11 @@ async def test_stream_resolves_default_provider_from_config(litellm_stub, monkey
         async def list_providers(self):
             return [
                 ProviderRef(
-                    id="env", label="zai", protocol=ProtocolFamily.OPENAI_COMPATIBLE, api_key="cfg", api_base="https://z"
+                    id="env",
+                    label="zai",
+                    protocol=ProtocolFamily.OPENAI_COMPATIBLE,
+                    api_key="cfg",
+                    api_base="https://z",
                 )
             ]
 

--- a/apps/backend/tests/ai/test_ai_streaming.py
+++ b/apps/backend/tests/ai/test_ai_streaming.py
@@ -124,6 +124,21 @@ async def test_stream_raises_when_no_provider_configured(monkeypatch):
         await accumulate_stream(stream_ai_json([{"role": "user", "content": "x"}], "glm-5.1"))
 
 
+async def test_stream_fails_closed_with_multiple_providers(monkeypatch):
+    """Scene-less path can't disambiguate >1 provider -> fail closed (no nondeterministic routing)."""
+
+    class _Multi:
+        async def list_providers(self):
+            return [
+                ProviderRef(id="a", label="a", protocol=ProtocolFamily.OPENAI_COMPATIBLE, api_key="k1"),
+                ProviderRef(id="b", label="b", protocol=ProtocolFamily.OPENROUTER_COMPATIBLE, api_key="k2"),
+            ]
+
+    monkeypatch.setattr(ai_streaming, "get_config_source", lambda: _Multi())
+    with pytest.raises(AIStreamError):
+        await accumulate_stream(stream_ai_json([{"role": "user", "content": "x"}], "glm-5.1"))
+
+
 async def test_litellm_error_becomes_retryable_aistreamerror(monkeypatch):
     """A litellm provider failure surfaces as a retryable AIStreamError."""
     _explicit_provider(monkeypatch)

--- a/apps/backend/tests/ai/test_ai_streaming.py
+++ b/apps/backend/tests/ai/test_ai_streaming.py
@@ -1,624 +1,135 @@
-"""Tests for the provider-neutral AI streaming utilities."""
+"""ai_streaming delegates to litellm (EPIC-023 PR3 cutover).
 
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+The old httpx/SSE transport is gone; these tests pin the litellm delegation:
+provider resolution (explicit creds vs configured default), JSON/chat streaming,
+Z.AI knob passthrough, and error normalisation. litellm is mocked so they run
+offline. (The litellm transport itself is covered by tests/unit/llm/test_client.py.)
+"""
 
-import httpx
+from __future__ import annotations
+
 import pytest
-from httpx_sse import ServerSentEvent
-
-from src.services.ai_streaming import (
-    AIStreamError,
-    _stream_ai_base,
-    accumulate_stream,
-    stream_ai_chat,
-    stream_ai_json,
-)
-
-
-class MockAsyncIterator:
-    """Helper to create async iterators for testing."""
-
-    def __init__(self, items: list[Any]):
-        self.items = items
-        self.index = 0
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        if self.index >= len(self.items):
-            raise StopAsyncIteration
-        item = self.items[self.index]
-        self.index += 1
-        return item
-
-
-async def mock_stream_generator(chunks: list[str]):
-    """Helper to create async generator for streaming mock."""
-    for chunk in chunks:
-        yield chunk
-
-
-class TestStreamApiKeyFallback:
-    """Tests for API key fallback to settings."""
-
-    async def test_stream_uses_settings_api_key_when_not_provided(self):
-        """AC6.7.3: Stream uses settings API key when not provided."""
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                with patch("src.services.ai_streaming.settings") as mock_settings:
-                    mock_settings.ai_api_key = "settings-api-key"
-                    mock_settings.ai_base_url = "https://test.openrouter.ai/api/v1"
-
-                    chunks = []
-                    async for chunk in stream_ai_chat(
-                        messages=[{"role": "user", "content": "Hi"}],
-                        model="test-model",
-                    ):
-                        chunks.append(chunk)
-
-                    assert chunks == ["Hello"]
-
-    async def test_stream_raises_when_no_api_key_available(self):
-        """AC6.7.3: Stream raises error when no API key available."""
-        with patch("src.services.ai_streaming.settings") as mock_settings:
-            mock_settings.ai_api_key = None
-
-            with pytest.raises(AIStreamError) as exc_info:
-                async for _ in stream_ai_chat(
-                    messages=[{"role": "user", "content": "Hi"}],
-                    model="test-model",
-                ):
-                    pass
-
-            assert "API key not configured" in str(exc_info.value)
-            assert exc_info.value.retryable is False
-
-
-class TestStreamAIChat:
-    """Tests for stream_ai_chat function."""
-
-    async def test_stream_ai_chat_success(self):
-        """AC6.7.1: Successful streaming chat completion."""
-        # Mock SSE events
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
-            ServerSentEvent(data='{"choices":[{"delta":{"content":" world"}}]}'),
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                chunks = []
-                async for chunk in stream_ai_chat(
-                    messages=[{"role": "user", "content": "Hi"}],
-                    model="test-model",
-                    api_key="test-key",
-                ):
-                    chunks.append(chunk)
-
-                assert chunks == ["Hello", " world"]
-
-    async def test_stream_adds_openrouter_headers_for_legacy_provider(self):
-        """OpenRouter provider keeps required attribution headers."""
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with (
-            patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client),
-            patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect,
-            patch("src.services.ai_streaming.settings") as mock_settings,
-        ):
-            mock_settings.ai_provider = "openrouter"
-            mock_settings.ai_chat_completions_path = "/chat/completions"
-            mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-            chunks = []
-            async for chunk in stream_ai_chat(
-                messages=[{"role": "user", "content": "Hi"}],
-                model="test-model",
-                api_key="test-key",
-                base_url="https://openrouter.ai/api/v1",
-            ):
-                chunks.append(chunk)
-
-            headers = mock_aconnect.call_args.kwargs["headers"]
-            assert chunks == ["Hello"]
-            assert headers["HTTP-Referer"] == "https://finance-report.local"
-            assert headers["X-Title"] == "Finance Report Backend"
-
-    async def test_stream_omits_openrouter_headers_for_zai_provider(self):
-        """Provider-neutral GLM access does not send OpenRouter-only headers."""
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with (
-            patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client),
-            patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect,
-            patch("src.services.ai_streaming.settings") as mock_settings,
-        ):
-            mock_settings.ai_provider = "zai"
-            mock_settings.ai_chat_completions_path = "/chat/completions"
-            mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-            chunks = []
-            async for chunk in stream_ai_chat(
-                messages=[{"role": "user", "content": "Hi"}],
-                model="glm-5.1",
-                api_key="test-key",
-                base_url="https://api.z.ai/api/coding/paas/v4",
-            ):
-                chunks.append(chunk)
-
-            headers = mock_aconnect.call_args.kwargs["headers"]
-            assert chunks == ["Hello"]
-            assert "HTTP-Referer" not in headers
-            assert "X-Title" not in headers
-
-    async def test_stream_ai_chat_handles_http_error(self):
-        """AC6.7.2: Stream handles HTTP errors."""
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 500
-        mock_response.aread = AsyncMock(return_value=b"Internal Server Error")
-        mock_response.headers = {"content-type": "text/plain"}
-
-        mock_event_source = MagicMock()
-        mock_event_source.response = mock_response
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                with pytest.raises(AIStreamError) as exc_info:
-                    async for _ in stream_ai_chat(
-                        messages=[{"role": "user", "content": "Hi"}],
-                        model="test-model",
-                        api_key="test-key",
-                    ):
-                        pass
-
-                assert "HTTP 500" in str(exc_info.value)
-                assert "Internal Server Error" in str(exc_info.value)
-
-    async def test_stream_ai_chat_handles_done_signal(self):
-        """AC6.7.1: Stream stops on [DONE] signal."""
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                chunks = []
-                async for chunk in stream_ai_chat(
-                    messages=[{"role": "user", "content": "Hi"}],
-                    model="test-model",
-                    api_key="test-key",
-                ):
-                    chunks.append(chunk)
-
-                assert chunks == ["Hello"]
-                assert "Should not appear" not in "".join(chunks)
-
-    async def test_stream_ai_chat_handles_malformed_json(self):
-        """AC6.7.1: Stream skips malformed JSON and continues."""
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
-            ServerSentEvent(data="{invalid json}"),
-            ServerSentEvent(data='{"choices":[{"delta":{"content":" world"}}]}'),
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                chunks = []
-                async for chunk in stream_ai_chat(
-                    messages=[{"role": "user", "content": "Hi"}],
-                    model="test-model",
-                    api_key="test-key",
-                ):
-                    chunks.append(chunk)
-
-                # Should skip malformed chunk but continue streaming
-                assert chunks == ["Hello", " world"]
-
-
-class TestStreamAIJson:
-    """Tests for stream_ai_json function."""
-
-    async def test_stream_ai_json_success(self):
-        """AC6.7.1: Successful JSON mode streaming."""
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"{\\"result\\":"}}]}'),
-            ServerSentEvent(data='{"choices":[{"delta":{"content":" \\"success\\"}"}}]}'),
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                chunks = []
-                async for chunk in stream_ai_json(
-                    messages=[{"role": "user", "content": "Hi"}],
-                    model="test-model",
-                    api_key="test-key",
-                    timeout=360.0,
-                    max_tokens=8192,
-                    temperature=0.0,
-                    do_sample=False,
-                    thinking={"type": "disabled"},
-                ):
-                    chunks.append(chunk)
-
-                payload = mock_aconnect.call_args.kwargs["json"]
-                assert chunks == ['{"result":', ' "success"}']
-                assert payload["max_tokens"] == 8192
-                assert payload["temperature"] == 0.0
-                assert payload["do_sample"] is False
-                assert payload["thinking"] == {"type": "disabled"}
-                assert "seed" not in payload
-
-    async def test_stream_ai_json_includes_seed_when_provided(self):
-        """AC13.16.1: A provided seed is forwarded in the request payload for
-        deterministic decoding (#989)."""
-        events = [ServerSentEvent(data="[DONE]")]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                async for _ in stream_ai_json(
-                    messages=[{"role": "user", "content": "Hi"}],
-                    model="test-model",
-                    api_key="test-key",
-                    timeout=360.0,
-                    max_tokens=8192,
-                    temperature=0.0,
-                    do_sample=False,
-                    seed=42,
-                ):
-                    pass
-
-                payload = mock_aconnect.call_args.kwargs["json"]
-                assert payload["seed"] == 42
-
-
-class TestStreamErrorHandling:
-    """Tests for OpenRouter stream error handling."""
-
-    async def test_stream_handles_mid_stream_error(self):
-        """AC6.7.2: Stream handles mid-stream error in response body."""
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
-            ServerSentEvent(data='{"error":{"message":"Model overloaded","code":"server_error"}}'),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                with pytest.raises(AIStreamError) as exc_info:
-                    chunks = []
-                    async for chunk in stream_ai_chat(
-                        messages=[{"role": "user", "content": "Hi"}],
-                        model="test-model",
-                        api_key="test-key",
-                    ):
-                        chunks.append(chunk)
-
-                assert "Mid-stream error" in str(exc_info.value)
-                assert exc_info.value.retryable is True  # server_error is retryable
-
-    async def test_stream_handles_mid_stream_error_not_retryable(self):
-        """AC6.7.2: Mid-stream error with non-retryable code."""
-        events = [
-            ServerSentEvent(data='{"error":{"message":"Invalid request","code":"invalid_request"}}'),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                with pytest.raises(AIStreamError) as exc_info:
-                    async for _ in stream_ai_chat(
-                        messages=[{"role": "user", "content": "Hi"}],
-                        model="test-model",
-                        api_key="test-key",
-                    ):
-                        pass
-
-                assert exc_info.value.retryable is False  # invalid_request is not retryable
-
-    async def test_stream_handles_finish_reason_error(self):
-        """AC6.7.2: Stream handles finish_reason error."""
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"},"finish_reason":"error"}]}'),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                with pytest.raises(AIStreamError) as exc_info:
-                    async for _ in stream_ai_chat(
-                        messages=[{"role": "user", "content": "Hi"}],
-                        model="test-model",
-                        api_key="test-key",
-                    ):
-                        pass
-
-                assert "terminated with error" in str(exc_info.value)
-                assert exc_info.value.retryable is True
-
-    async def test_stream_ignores_sse_comments(self):
-        """AC6.7.1: SSE comments are ignored during streaming."""
-        events = [
-            ServerSentEvent(data=": OPENROUTER PROCESSING"),
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
-            ServerSentEvent(data="   "),  # Empty/whitespace data
-            ServerSentEvent(data='{"choices":[{"delta":{"content":" world"}}]}'),
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                chunks = []
-                async for chunk in stream_ai_chat(
-                    messages=[{"role": "user", "content": "Hi"}],
-                    model="test-model",
-                    api_key="test-key",
-                ):
-                    chunks.append(chunk)
-
-                # Should only get actual content, not comments
-                assert chunks == ["Hello", " world"]
-
-    async def test_stream_logs_warning_chunks_but_no_content(self):
-        """AC6.7.2: Warning logged when chunks received but no content."""
-        # Chunks with empty choices (no content extracted)
-        events = [
-            ServerSentEvent(data='{"choices":[{"delta":{}}]}'),
-            ServerSentEvent(data='{"choices":[{"delta":{"role":"assistant"}}]}'),
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                with patch("src.services.ai_streaming.logger") as mock_logger:
-                    chunks = []
-                    async for chunk in stream_ai_chat(
-                        messages=[{"role": "user", "content": "Hi"}],
-                        model="test-model",
-                        api_key="test-key",
-                    ):
-                        chunks.append(chunk)
-
-                    assert chunks == []  # No content extracted
-
-                    # Verify warning was logged about empty content
-                    warning_calls = [call for call in mock_logger.warning.call_args_list]
-                    assert any("no content" in str(call).lower() for call in warning_calls)
-
-    async def test_stream_logs_warning_no_chunks(self):
-        """AC6.7.2: Warning logged when no chunks received."""
-        events = [
-            ServerSentEvent(data="[DONE]"),  # Immediately done, no chunks
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                with patch("src.services.ai_streaming.logger") as mock_logger:
-                    chunks = []
-                    async for chunk in stream_ai_chat(
-                        messages=[{"role": "user", "content": "Hi"}],
-                        model="test-model",
-                        api_key="test-key",
-                    ):
-                        chunks.append(chunk)
-
-                    assert chunks == []
-
-                    # Verify warning was logged about no chunks
-                    warning_calls = [call for call in mock_logger.warning.call_args_list]
-                    assert any("no chunks" in str(call).lower() for call in warning_calls)
-
-    async def test_stream_skips_empty_choices(self):
-        """AC6.7.1: Events with empty choices are skipped."""
-        events = [
-            ServerSentEvent(data='{"choices":[]}'),  # Empty choices
-            ServerSentEvent(data='{"choices":[{"delta":{"content":"Hello"}}]}'),
-            ServerSentEvent(data="{}"),  # No choices key
-            ServerSentEvent(data="[DONE]"),
-        ]
-
-        mock_event_source = MagicMock()
-        mock_event_source.response.status_code = 200
-        mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.__aenter__.return_value = mock_client
-
-        with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-            with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-                mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-                chunks = []
-                async for chunk in stream_ai_chat(
-                    messages=[{"role": "user", "content": "Hi"}],
-                    model="test-model",
-                    api_key="test-key",
-                ):
-                    chunks.append(chunk)
-
-                assert chunks == ["Hello"]
-
-
-class TestAccumulateStream:
-    """Tests for accumulate_stream helper."""
-
-    async def test_accumulate_stream(self):
-        """AC6.7.1: Accumulate chunks into single string."""
-        stream = mock_stream_generator(["Hello", " ", "world"])
-        result = await accumulate_stream(stream)
-        assert result == "Hello world"
-
-    async def test_accumulate_stream_empty(self):
-        """AC6.7.1: Accumulate empty stream returns empty string."""
-        stream = mock_stream_generator([])
-        result = await accumulate_stream(stream)
-        assert result == ""
-
-
-async def test_stream_base_includes_response_format_payload() -> None:
-    events = [ServerSentEvent(data='{"choices":[{"delta":{"content":"{}"}}]}'), ServerSentEvent(data="[DONE]")]
-    mock_event_source = MagicMock()
-    mock_event_source.response.status_code = 200
-    mock_event_source.aiter_sse = MagicMock(return_value=MockAsyncIterator(events))
-
-    mock_client = AsyncMock(spec=httpx.AsyncClient)
-    mock_client.__aenter__.return_value = mock_client
-
-    with patch("src.services.ai_streaming.httpx.AsyncClient", return_value=mock_client):
-        with patch("src.services.ai_streaming.aconnect_sse") as mock_aconnect:
-            mock_aconnect.return_value.__aenter__.return_value = mock_event_source
-
-            chunks = []
-            async for chunk in _stream_ai_base(
-                messages=[{"role": "user", "content": "json"}],
-                model="test-model",
-                api_key="test-key",
-                timeout=30,
-                connect_timeout=10,
-                response_format={"type": "json_object"},
-                mode_label="test",
-            ):
-                chunks.append(chunk)
-
-            assert chunks == ["{}"]
-            assert mock_aconnect.call_args.kwargs["json"]["response_format"] == {"type": "json_object"}
+
+import src.llm.client as client_mod
+import src.services.ai_streaming as ai_streaming
+from src.config import settings
+from src.llm.common import ProtocolFamily, ProviderRef
+from src.services.ai_streaming import AIStreamError, accumulate_stream, stream_ai_chat, stream_ai_json
+
+pytestmark = pytest.mark.no_db
+
+
+class _Delta:
+    def __init__(self, c):
+        self.content = c
+
+
+class _Choice:
+    def __init__(self, c):
+        self.delta = _Delta(c)
+
+
+class _Chunk:
+    def __init__(self, c):
+        self.choices = [_Choice(c)]
+
+
+@pytest.fixture
+def litellm_stub(monkeypatch):
+    """Capture litellm kwargs and serve canned stream chunks."""
+    box: dict = {}
+
+    async def fake_acompletion(**kwargs):
+        box["kwargs"] = kwargs
+
+        async def gen():
+            for piece in ('{"ok"', ": true}"):
+                yield _Chunk(piece)
+
+        return gen()
+
+    monkeypatch.setattr(client_mod.litellm, "acompletion", fake_acompletion)
+    return box
+
+
+def _explicit_provider(monkeypatch):
+    monkeypatch.setattr(settings, "ai_provider", "zai", raising=False)
+    monkeypatch.setattr(settings, "ai_base_url", "https://api.z.ai", raising=False)
+
+
+async def test_stream_ai_json_uses_explicit_credentials(litellm_stub, monkeypatch):
+    """An explicit api_key/base_url routes via litellm with the openai-compatible prefix."""
+    _explicit_provider(monkeypatch)
+    text = await accumulate_stream(
+        stream_ai_json([{"role": "user", "content": "x"}], "glm-4.6v", api_key="sk-explicit")
+    )
+    assert text == '{"ok": true}'
+    kw = litellm_stub["kwargs"]
+    assert kw["model"] == "openai/glm-4.6v"
+    assert kw["api_base"] == "https://api.z.ai"
+    assert kw["drop_params"] is True
+
+
+async def test_stream_ai_json_forwards_zai_knobs_and_seed(litellm_stub, monkeypatch):
+    """do_sample/thinking ride extra_body; seed is a native (droppable) param."""
+    _explicit_provider(monkeypatch)
+    await accumulate_stream(
+        stream_ai_json(
+            [{"role": "user", "content": "x"}],
+            "glm-4.6v",
+            api_key="k",
+            do_sample=False,
+            thinking={"type": "disabled"},
+            seed=9,
+            temperature=0.0,
+        )
+    )
+    kw = litellm_stub["kwargs"]
+    assert kw["extra_body"] == {"do_sample": False, "thinking": {"type": "disabled"}}
+    assert kw["seed"] == 9
+    assert kw["temperature"] == 0.0
+
+
+async def test_stream_resolves_default_provider_from_config(litellm_stub, monkeypatch):
+    """With no explicit key, the configured default provider is resolved."""
+
+    class _Cfg:
+        async def list_providers(self):
+            return [
+                ProviderRef(
+                    id="env", label="zai", protocol=ProtocolFamily.OPENAI_COMPATIBLE, api_key="cfg", api_base="https://z"
+                )
+            ]
+
+    monkeypatch.setattr(ai_streaming, "get_config_source", lambda: _Cfg())
+    text = await accumulate_stream(stream_ai_chat([{"role": "user", "content": "hi"}], "glm-5.1"))
+    assert text == '{"ok": true}'
+    assert litellm_stub["kwargs"]["model"] == "openai/glm-5.1"
+
+
+async def test_stream_raises_when_no_provider_configured(monkeypatch):
+    """No explicit key and no configured provider -> AIStreamError (not configured)."""
+
+    class _Empty:
+        async def list_providers(self):
+            return []
+
+    monkeypatch.setattr(ai_streaming, "get_config_source", lambda: _Empty())
+    with pytest.raises(AIStreamError):
+        await accumulate_stream(stream_ai_json([{"role": "user", "content": "x"}], "glm-5.1"))
+
+
+async def test_litellm_error_becomes_retryable_aistreamerror(monkeypatch):
+    """A litellm provider failure surfaces as a retryable AIStreamError."""
+    _explicit_provider(monkeypatch)
+
+    class RateLimitError(Exception):
+        pass
+
+    async def boom(**kwargs):
+        raise RateLimitError("429")
+
+    monkeypatch.setattr(client_mod.litellm, "acompletion", boom)
+    with pytest.raises(AIStreamError) as ei:
+        await accumulate_stream(stream_ai_chat([{"role": "user", "content": "x"}], "glm-5.1", api_key="k"))
+    assert ei.value.retryable is True

--- a/apps/backend/tests/integration/test_llm_db_config.py
+++ b/apps/backend/tests/integration/test_llm_db_config.py
@@ -1,12 +1,18 @@
-"""DB-backed LLM config + env-fallback layering (EPIC-023 AC23.3.1, AC23.3.2)."""
+"""DB-backed LLM config + env-fallback layering (EPIC-023 AC23.3.1, AC23.3.2).
+
+DbConfigSource is pointed at the test's own session, so rows are written with
+``flush`` (not ``commit``) and stay inside the test transaction — the db-fixture
+rollback cleans up and nothing leaks across parallel xdist workers sharing a DB.
+"""
 
 from __future__ import annotations
+
+from contextlib import asynccontextmanager
 
 import pytest
 from cryptography.fernet import Fernet
 
 from src.config import settings
-from src.database import create_session_maker_from_db
 from src.llm.common import FernetCipher, ProtocolFamily, ReasoningEffort, Scene
 from src.llm.db_config import DbConfigSource
 from src.llm.env_config import EnvConfigSource
@@ -19,17 +25,15 @@ def cipher() -> FernetCipher:
     return FernetCipher([Fernet.generate_key().decode("ascii")])
 
 
-@pytest.fixture(autouse=True)
-async def _clean_llm_tables(db):
-    """These tests commit rows (so DbConfigSource's own session sees them), which the
-    db-fixture rollback can't undo. Truncate the LLM tables before each test for a
-    deterministic, idempotent slate across runs."""
-    from sqlalchemy import delete
+def _same_session_maker(session):
+    """A session_maker that hands DbConfigSource the test's own (uncommitted)
+    session, so flushed rows are visible without committing and rollback isolates."""
 
-    await db.execute(delete(LlmSceneBinding))
-    await db.execute(delete(LlmProvider))
-    await db.commit()
-    yield
+    @asynccontextmanager
+    async def _cm():
+        yield session
+
+    return lambda: _cm()
 
 
 async def test_AC23_3_1_db_config_reads_providers_and_bindings(db, cipher):
@@ -55,17 +59,18 @@ async def test_AC23_3_1_db_config_reads_providers_and_bindings(db, cipher):
             max_tokens=8192,
         )
     )
-    await db.commit()
+    await db.flush()
 
-    source = DbConfigSource(session_maker=create_session_maker_from_db(db), cipher=cipher)
+    source = DbConfigSource(session_maker=_same_session_maker(db), cipher=cipher)
 
     providers = await source.list_providers()
-    assert len(providers) == 1
-    assert providers[0].api_key == "sk-db-secret"  # decrypted, never plaintext at rest
-    assert providers[0].protocol is ProtocolFamily.OPENAI_COMPATIBLE
-    assert providers[0].api_base == "https://api.z.ai"
+    mine = [p for p in providers if p.id == str(provider.id)]
+    assert len(mine) == 1
+    assert mine[0].api_key == "sk-db-secret"  # decrypted, never plaintext at rest
+    assert mine[0].protocol is ProtocolFamily.OPENAI_COMPATIBLE
+    assert mine[0].api_base == "https://api.z.ai"
     assert await source.is_configured() is True
-    assert await source.get_provider(providers[0].id) is not None
+    assert await source.get_provider(str(provider.id)) is not None
 
     binding = await source.get_binding(Scene.EXTRACTION_JSON)
     assert binding is not None
@@ -73,33 +78,33 @@ async def test_AC23_3_1_db_config_reads_providers_and_bindings(db, cipher):
     assert binding.reasoning is ReasoningEffort.MEDIUM
     assert binding.fallback_model_ids == ("glm-5-turbo", "glm-5")
     assert binding.max_tokens == 8192
-    assert await source.get_binding(Scene.ADVISOR_CHAT) is None
 
 
 async def test_AC23_3_2_layered_uses_db_first_then_env(db, cipher, monkeypatch):
-    """AC23.3.2: with the DB empty, the layered source falls back to env config."""
+    """AC23.3.2: with no DB binding for a scene, the layered source falls back to env config."""
     monkeypatch.setattr(settings, "ai_api_key", "env-key", raising=False)
     monkeypatch.setattr(settings, "ai_provider", "zai", raising=False)
     monkeypatch.setattr(settings, "ai_base_url", "https://api.z.ai", raising=False)
     monkeypatch.setattr(settings, "primary_model", "glm-5.1", raising=False)
 
+    # DbConfigSource with no rows in this transaction -> layered resolves via env.
     layered = LayeredConfigSource(
-        DbConfigSource(session_maker=create_session_maker_from_db(db), cipher=cipher),
+        DbConfigSource(session_maker=_same_session_maker(db), cipher=cipher),
         EnvConfigSource(),
     )
     assert await layered.is_configured() is True
-    providers = await layered.list_providers()
-    assert providers[0].id == "env"
     binding = await layered.get_binding(Scene.ADVISOR_CHAT)
     assert binding is not None and binding.model_id == "glm-5.1"
+    assert any(p.id == "env" for p in await layered.list_providers())
 
 
 async def test_AC23_3_2_unconfigured_when_db_and_env_both_empty(db, cipher, monkeypatch):
-    """AC23.3.2: no DB providers and no env key -> unconfigured (drives the first-run modal)."""
+    """AC23.3.2: no DB providers (this transaction) and no env key -> unconfigured."""
     monkeypatch.setattr(settings, "ai_api_key", "", raising=False)
     layered = LayeredConfigSource(
-        DbConfigSource(session_maker=create_session_maker_from_db(db), cipher=cipher),
+        DbConfigSource(session_maker=_same_session_maker(db), cipher=cipher),
         EnvConfigSource(),
     )
+    # No DB provider in this transaction and no env key -> unconfigured.
     assert await layered.is_configured() is False
     assert await layered.list_providers() == []

--- a/apps/backend/tests/integration/test_llm_db_config.py
+++ b/apps/backend/tests/integration/test_llm_db_config.py
@@ -19,6 +19,19 @@ def cipher() -> FernetCipher:
     return FernetCipher([Fernet.generate_key().decode("ascii")])
 
 
+@pytest.fixture(autouse=True)
+async def _clean_llm_tables(db):
+    """These tests commit rows (so DbConfigSource's own session sees them), which the
+    db-fixture rollback can't undo. Truncate the LLM tables before each test for a
+    deterministic, idempotent slate across runs."""
+    from sqlalchemy import delete
+
+    await db.execute(delete(LlmSceneBinding))
+    await db.execute(delete(LlmProvider))
+    await db.commit()
+    yield
+
+
 async def test_AC23_3_1_db_config_reads_providers_and_bindings(db, cipher):
     """AC23.3.1: DbConfigSource decrypts the provider key and qualifies bindings by provider id."""
     sealed = cipher.encrypt("sk-db-secret")

--- a/apps/backend/tests/integration/test_llm_db_config.py
+++ b/apps/backend/tests/integration/test_llm_db_config.py
@@ -1,0 +1,92 @@
+"""DB-backed LLM config + env-fallback layering (EPIC-023 AC23.3.1, AC23.3.2)."""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+
+from src.config import settings
+from src.database import create_session_maker_from_db
+from src.llm.common import FernetCipher, ProtocolFamily, ReasoningEffort, Scene
+from src.llm.db_config import DbConfigSource
+from src.llm.env_config import EnvConfigSource
+from src.llm.factory import LayeredConfigSource
+from src.models import LlmProvider, LlmSceneBinding
+
+
+@pytest.fixture
+def cipher() -> FernetCipher:
+    return FernetCipher([Fernet.generate_key().decode("ascii")])
+
+
+async def test_AC23_3_1_db_config_reads_providers_and_bindings(db, cipher):
+    """AC23.3.1: DbConfigSource decrypts the provider key and qualifies bindings by provider id."""
+    sealed = cipher.encrypt("sk-db-secret")
+    provider = LlmProvider(
+        label="zai",
+        protocol=ProtocolFamily.OPENAI_COMPATIBLE,
+        api_key_ciphertext=sealed.ciphertext,
+        api_key_version=sealed.key_version,
+        api_base="https://api.z.ai",
+    )
+    db.add(provider)
+    await db.flush()
+    db.add(
+        LlmSceneBinding(
+            scene=Scene.EXTRACTION_JSON,
+            provider_id=provider.id,
+            model="glm-5.1",
+            reasoning=ReasoningEffort.MEDIUM,
+            prefer_free=False,
+            fallback_model_ids="glm-5-turbo, glm-5",
+            max_tokens=8192,
+        )
+    )
+    await db.commit()
+
+    source = DbConfigSource(session_maker=create_session_maker_from_db(db), cipher=cipher)
+
+    providers = await source.list_providers()
+    assert len(providers) == 1
+    assert providers[0].api_key == "sk-db-secret"  # decrypted, never plaintext at rest
+    assert providers[0].protocol is ProtocolFamily.OPENAI_COMPATIBLE
+    assert providers[0].api_base == "https://api.z.ai"
+    assert await source.is_configured() is True
+    assert await source.get_provider(providers[0].id) is not None
+
+    binding = await source.get_binding(Scene.EXTRACTION_JSON)
+    assert binding is not None
+    assert binding.model_id == f"{provider.id}/glm-5.1"
+    assert binding.reasoning is ReasoningEffort.MEDIUM
+    assert binding.fallback_model_ids == ("glm-5-turbo", "glm-5")
+    assert binding.max_tokens == 8192
+    assert await source.get_binding(Scene.ADVISOR_CHAT) is None
+
+
+async def test_AC23_3_2_layered_uses_db_first_then_env(db, cipher, monkeypatch):
+    """AC23.3.2: with the DB empty, the layered source falls back to env config."""
+    monkeypatch.setattr(settings, "ai_api_key", "env-key", raising=False)
+    monkeypatch.setattr(settings, "ai_provider", "zai", raising=False)
+    monkeypatch.setattr(settings, "ai_base_url", "https://api.z.ai", raising=False)
+    monkeypatch.setattr(settings, "primary_model", "glm-5.1", raising=False)
+
+    layered = LayeredConfigSource(
+        DbConfigSource(session_maker=create_session_maker_from_db(db), cipher=cipher),
+        EnvConfigSource(),
+    )
+    assert await layered.is_configured() is True
+    providers = await layered.list_providers()
+    assert providers[0].id == "env"
+    binding = await layered.get_binding(Scene.ADVISOR_CHAT)
+    assert binding is not None and binding.model_id == "glm-5.1"
+
+
+async def test_AC23_3_2_unconfigured_when_db_and_env_both_empty(db, cipher, monkeypatch):
+    """AC23.3.2: no DB providers and no env key -> unconfigured (drives the first-run modal)."""
+    monkeypatch.setattr(settings, "ai_api_key", "", raising=False)
+    layered = LayeredConfigSource(
+        DbConfigSource(session_maker=create_session_maker_from_db(db), cipher=cipher),
+        EnvConfigSource(),
+    )
+    assert await layered.is_configured() is False
+    assert await layered.list_providers() == []

--- a/apps/backend/tests/unit/llm/test_catalog.py
+++ b/apps/backend/tests/unit/llm/test_catalog.py
@@ -12,6 +12,18 @@ from src.llm.catalog import LitellmCatalog
 from src.llm.common import Modality
 
 
+@pytest.fixture(autouse=True)
+def _clear_settings_model_caches():
+    """``settings.fallback_models``/``vision_fallback_models`` are ``cached_property``;
+    monkeypatching the ``*_str`` fields won't refresh them. Clear the cache around each
+    test so a test value never leaks into another test (or vice-versa)."""
+    for key in ("fallback_models", "vision_fallback_models"):
+        settings.__dict__.pop(key, None)
+    yield
+    for key in ("fallback_models", "vision_fallback_models"):
+        settings.__dict__.pop(key, None)
+
+
 @pytest.fixture
 def patched(monkeypatch):
     monkeypatch.setattr(settings, "primary_model", "glm-5.1", raising=False)

--- a/apps/backend/tests/unit/llm/test_client.py
+++ b/apps/backend/tests/unit/llm/test_client.py
@@ -296,6 +296,15 @@ async def test_AC23_2_2_unknown_qualified_provider_raises_not_silently_falls_bac
             pass
 
 
+async def test_AC23_2_2_single_provider_honours_db_style_qualified_binding(captured):
+    """AC23.2.2: a DB binding qualified as provider_id/model strips the id even with one provider."""
+    p = ProviderRef(id="env", label="zai", protocol=ProtocolFamily.OPENAI_COMPATIBLE, api_key="k", api_base="https://z")
+    cfg = _FakeConfig(SceneBinding(Scene.EXTRACTION_JSON, "env/glm-5.1"), [p])
+    async for _ in LitellmClient(cfg).stream(Scene.EXTRACTION_JSON, [{"role": "user", "content": "x"}]):
+        pass
+    assert captured["kwargs"]["model"] == "openai/glm-5.1"
+
+
 async def test_AC23_2_2_single_provider_keeps_slashed_openrouter_model(captured):
     """AC23.2.2: with one provider an OpenRouter vendor/model id is used whole, not split as provider."""
     p = ProviderRef(id="env", label="or", protocol=ProtocolFamily.OPENROUTER_COMPATIBLE, api_key="k")

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -969,7 +969,6 @@ dependencies = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
-    { name = "httpx-sse" },
     { name = "litellm" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
@@ -1024,7 +1023,6 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.1.0" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "httpx-sse", specifier = ">=0.4.3" },
     { name = "litellm", specifier = ">=1.55.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.24.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.45b0" },
@@ -1532,15 +1530,6 @@ wheels = [
 [package.optional-dependencies]
 http2 = [
     { name = "h2" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]

--- a/docs/project/EPIC-013.statement-parsing-v2.md
+++ b/docs/project/EPIC-013.statement-parsing-v2.md
@@ -348,7 +348,7 @@ because Z.AI/GLM validates params strictly and some models (e.g. the default
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC13.16.1 | A provided seed is forwarded in the streaming request payload | `test_stream_ai_json_includes_seed_when_provided()` | `ai/test_ai_streaming.py` | P1 |
+| AC13.16.1 | A provided seed is forwarded in the streaming request payload | `test_stream_ai_json_forwards_zai_knobs_and_seed()` | `ai/test_ai_streaming.py` | P1 |
 | AC13.16.2 | Extraction forwards the configured `ai_json_seed` to the model call | `test_extraction_forwards_configured_seed()` | `extraction/test_seed_determinism.py` | P1 |
 | AC13.16.3 | Extraction pins `temperature=0` / `do_sample=False` alongside the seed | `test_extraction_decoding_is_deterministic_by_default()` | `extraction/test_seed_determinism.py` | P1 |
 | AC13.16.4 | Empty `AI_JSON_SEED` parses as None (omitted) instead of raising | `test_empty_seed_env_is_treated_as_none()` | `extraction/test_seed_determinism.py` | P1 |

--- a/docs/project/EPIC-023.llm-provider-abstraction.md
+++ b/docs/project/EPIC-023.llm-provider-abstraction.md
@@ -91,10 +91,12 @@ parallel once PR1 merges.
 | AC23.2.5 | The dynamic catalogue lists configured models enriched with litellm pricing, flags the free tier, and filters by provider/modality/free | `apps/backend/tests/unit/llm/test_catalog.py` | P1 |
 | AC23.2.6 | The daily budget meter blocks once the USD limit is reached, rolls over per UTC day, and records spend (replacing the unenforced `AI_DAILY_LIMIT_USD`) | `apps/backend/tests/unit/llm/test_cost.py` | P1 |
 
-### AC23.3 — DB-backed configuration & first-run
-> PR3 slice (EPIC B). Provider/binding tables, the DB config source layered over
-> env, the `/llm` API, the first-run modal, and the cutover of the existing call
-> sites onto the litellm client.
+### AC23.3 — DB-backed configuration & cutover
+> PR3 slice (EPIC B): the provider/binding tables, the DB config source layered
+> over env (all-or-nothing), and the cutover of the existing call sites onto the
+> litellm client. The `/llm` API, the first-run modal, and the scene×model page
+> ship in PR4 (with their own ACs) — that is where `LitellmCatalog`/`LitellmClient`
+> are consumed and `services/ai_models.py` is retired.
 
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|

--- a/docs/project/EPIC-023.llm-provider-abstraction.md
+++ b/docs/project/EPIC-023.llm-provider-abstraction.md
@@ -90,3 +90,13 @@ parallel once PR1 merges.
 | AC23.2.4 | `EnvConfigSource` projects the existing env settings onto scene bindings (vision/ocr → vision/ocr models, the rest → primary) and reports `is_configured() == False` when no API key, driving the first-run modal | `apps/backend/tests/unit/llm/test_env_config.py` | P1 |
 | AC23.2.5 | The dynamic catalogue lists configured models enriched with litellm pricing, flags the free tier, and filters by provider/modality/free | `apps/backend/tests/unit/llm/test_catalog.py` | P1 |
 | AC23.2.6 | The daily budget meter blocks once the USD limit is reached, rolls over per UTC day, and records spend (replacing the unenforced `AI_DAILY_LIMIT_USD`) | `apps/backend/tests/unit/llm/test_cost.py` | P1 |
+
+### AC23.3 — DB-backed configuration & first-run
+> PR3 slice (EPIC B). Provider/binding tables, the DB config source layered over
+> env, the `/llm` API, the first-run modal, and the cutover of the existing call
+> sites onto the litellm client.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC23.3.1 | `DbConfigSource` reads provider instances (decrypting the at-rest API key) and scene bindings (qualified by provider id) from `llm_providers` / `llm_scene_bindings` | `apps/backend/tests/integration/test_llm_db_config.py` | P1 |
+| AC23.3.2 | Config resolves DB-first with an env fallback; `is_configured()` is true when either has a provider and false when both are empty (driving the first-run modal) | `apps/backend/tests/integration/test_llm_db_config.py` | P1 |


### PR DESCRIPTION
## EPIC-023 — PR3: DB config foundation + the litellm cutover

Re-scoped by ROI (with @wangzitian0): the highest-value remaining work is making
the litellm surface from PR1/PR2 **actually do something** and removing the old
transport — not the config UI. So PR3 delivers that; the `/llm` API + first-run
modal + catalog retirement land in PR4 (where `LitellmCatalog`/`LitellmClient` are
consumed).

### What's here

**DB config foundation** (`AC23.3.1`, `AC23.3.2`)
- Migration `0043` + `llm_providers` / `llm_scene_bindings` tables (deployment-scoped;
  API key stored as Fernet ciphertext + key fingerprint). Verified via real Postgres
  `alembic upgrade head` + `alembic check` (zero model/migration drift).
- `DbConfigSource` (decrypts keys, qualifies bindings by provider id) +
  `LayeredConfigSource` (DB-first, env fallback) + `get_llm_client()` factory.

**The cutover (keystone)** — `ai_streaming` reimplemented on litellm:
- `drop_params` eliminates the Z.AI/GLM `seed`-400 class; `do_sample`/`thinking`
  ride `extra_body`; provider routing is litellm's. **The httpx + SSE transport is
  gone; `httpx-sse` dependency removed.**
- Provider creds now resolve from the layered config (DB providers first, env
  fallback) — so `DbConfigSource` is on the live path. Call sites (extraction ×2,
  advisor, reconciliation scoring) drop their explicit env creds.

### Tests & gates
- 723 tests green across `tests/unit/llm`, `tests/integration/test_llm_db_config.py`,
  `tests/ai`, `tests/extraction` (xdist-parallel, CI-default fallbacks). The
  transport-internal `test_ai_streaming.py` was rewritten to litellm delegation;
  DB tests are transaction-isolated (flush, not commit) so they're xdist-safe.
- `check_ac_index`, `lint_doc_consistency`, SSOT governance, e2e EPIC traceability,
  migration-risk, ruff — all green locally.

### Deferred to PR4 (config UX)
`/llm/*` API (providers CRUD / status / catalog / scenes) + first-run modal +
scene×model page, and retiring `services/ai_models.py` in favour of `LitellmCatalog`
(done there, alongside the `/llm/catalog` endpoint that replaces `/ai/models`).
Live Z.AI/vision parity for the cutover is covered by the post-merge AI/OCR e2e gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)