### PR TITLE
[finance_report_ui] fix(observability): runtime-inject FE OTel endpoint (server layout props)

### DIFF
--- a/apps/frontend/src/__tests__/frontendTelemetry.test.tsx
+++ b/apps/frontend/src/__tests__/frontendTelemetry.test.tsx
@@ -8,10 +8,32 @@ vi.mock("@/lib/otel", () => ({ initOtel }))
 import { FrontendTelemetry } from "@/components/FrontendTelemetry"
 
 describe("FrontendTelemetry (AC24.1.1)", () => {
-  it("AC24.1.1 renders nothing and calls initOtel once on mount", () => {
+  it("AC24.1.1 renders nothing and forwards runtime props to initOtel as the env map", () => {
     initOtel.mockClear()
-    const { container } = render(<FrontendTelemetry />)
+    const { container } = render(
+      <FrontendTelemetry
+        endpoint="https://otel.zitian.party/v1/traces"
+        environment="staging"
+        serviceVersion="abc1234"
+      />,
+    )
     expect(container).toBeEmptyDOMElement()
     expect(initOtel).toHaveBeenCalledTimes(1)
+    // Config comes from server-injected props (runtime), not client NEXT_PUBLIC.
+    expect(initOtel).toHaveBeenCalledWith({
+      NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT: "https://otel.zitian.party/v1/traces",
+      NEXT_PUBLIC_DEPLOYMENT_ENVIRONMENT: "staging",
+      NEXT_PUBLIC_GIT_SHA: "abc1234",
+    })
+  })
+
+  it("AC24.1.1 stays a no-op when no endpoint prop is supplied (gated)", () => {
+    initOtel.mockClear()
+    render(<FrontendTelemetry />)
+    expect(initOtel).toHaveBeenCalledWith({
+      NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT: undefined,
+      NEXT_PUBLIC_DEPLOYMENT_ENVIRONMENT: undefined,
+      NEXT_PUBLIC_GIT_SHA: undefined,
+    })
   })
 })

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -84,10 +84,17 @@ export default function RootLayout({
             environment={process.env.OPENPANEL_ENVIRONMENT}
           />
         ) : null}
-        {/* Browser OTel → SigNoz. A complete no-op until
-            NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT is set; mounts once,
-            never blocks render. */}
-        <FrontendTelemetry />
+        {/* Browser OTel → SigNoz. Config is read HERE (server, at request time)
+            and passed as props — same runtime-injection pattern as <Analytics>
+            above — so one promoted image serves every env via its container
+            `environment:` block (NEXT_PUBLIC_* would otherwise inline at build
+            time and never pick up the per-env runtime value). No-op until the
+            endpoint is set; mounts once, never blocks render. */}
+        <FrontendTelemetry
+          endpoint={process.env.NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT}
+          environment={process.env.NEXT_PUBLIC_DEPLOYMENT_ENVIRONMENT}
+          serviceVersion={process.env.NEXT_PUBLIC_GIT_SHA}
+        />
         <Providers>
           <AuthGuard>
             {children}

--- a/apps/frontend/src/components/FrontendTelemetry.tsx
+++ b/apps/frontend/src/components/FrontendTelemetry.tsx
@@ -4,20 +4,38 @@ import { useEffect } from "react";
 
 import { initOtel } from "@/lib/otel";
 
+export interface FrontendTelemetryProps {
+  /** OTLP/HTTP endpoint, supplied at runtime by the server layout. */
+  endpoint?: string;
+  /** `deployment.environment` (e.g. staging / production / pr-<N>). */
+  environment?: string;
+  /** Short git sha for `service.version`. */
+  serviceVersion?: string;
+}
+
 /**
  * Mounts browser OpenTelemetry tracing exactly once on the client.
  *
- * Renders nothing. `initOtel` is a complete no-op until
- * `NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT` is configured, is idempotent, and
- * swallows its own errors — so this component is always safe to mount next to
- * `<Analytics>` in the root layout and never blocks render. Keeping the heavy
- * SDK behind a `"use client"` boundary + a `useEffect` keeps it out of the
- * server bundle.
+ * Config arrives as props read server-side at request time (runtime injection,
+ * mirroring `<Analytics>`) — NOT from client-inlined `NEXT_PUBLIC_*` — so a single
+ * promoted image picks up each environment's values from its container env.
+ * Renders nothing. `initOtel` is a complete no-op when `endpoint` is empty, is
+ * idempotent, and swallows its own errors — always safe to mount, never blocks
+ * render. The heavy SDK stays behind the `"use client"` + `useEffect` boundary,
+ * out of the server bundle.
  */
-export function FrontendTelemetry(): null {
+export function FrontendTelemetry({
+  endpoint,
+  environment,
+  serviceVersion,
+}: FrontendTelemetryProps): null {
   useEffect(() => {
-    initOtel();
-  }, []);
+    initOtel({
+      NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT: endpoint,
+      NEXT_PUBLIC_DEPLOYMENT_ENVIRONMENT: environment,
+      NEXT_PUBLIC_GIT_SHA: serviceVersion,
+    });
+  }, [endpoint, environment, serviceVersion]);
 
   return null;
 }


### PR DESCRIPTION
## Why
The FE browser OTel SDK read `NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT` in **client** code → Next.js inlines `NEXT_PUBLIC_*` at **build time**, so on the shared promoted image (one image across staging/prod, per-env values supplied via the container `environment:` block at runtime) it would **never** activate. That's why FE telemetry stayed dormant even with the endpoint wired in compose.

## Fix
Mirror the existing `<Analytics>` (OpenPanel) pattern exactly: the **server** `RootLayout` reads the values from `process.env` at request time and passes them as **props** to `<FrontendTelemetry>`, which forwards them to `initOtel`. Now runtime-injected per environment, no rebuild, still a complete no-op when the endpoint is unset.

- `layout.tsx`: pass `endpoint`/`environment`/`serviceVersion` props (read server-side).
- `FrontendTelemetry.tsx`: accept props → `initOtel({...})`.
- `otel.ts`: unchanged (already accepts an env map).

## Tests
- `frontendTelemetry.test.tsx`: asserts props are forwarded to `initOtel`, and the no-endpoint case stays gated.
- Full FE suite (901) + coverage, tsc, lint, AC traceability all green.

After merge: deploying `finance_report/app` to **staging** will light up real `finance-report-frontend` spans in SigNoz (the `otel.zitian.party` ingest + CORS is already live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)