### PR TITLE
[finance_report_infra] feat(deploy): wire app-repo sender for report-branch-main (#1072)

### DIFF
--- a/.github/workflows/notify-infra2-report-main.yml
+++ b/.github/workflows/notify-infra2-report-main.yml
@@ -1,0 +1,65 @@
+name: Notify infra2 — deploy report-branch-main
+
+# The APP-repo SENDER half of the one auto deploy target (infra2 SSOT §4.6): when app `main`
+# moves, tell infra2 to re-deploy the report-branch-main preview slot so it always reflects
+# "what main looks like right now". Everything else (staging / prod) is manual + a pinned
+# release tag and is NOT triggered here.
+#
+# Receiver: infra2 `.github/workflows/deploy-report-main.yml` (repository_dispatch type
+# `deploy-report-main`), which runs `deploy_v2 --service finance_report/app --type
+# preview/branch --version-ref main --iac-ref main`. This closes the cross-repo half (#370 /
+# finance_report#1072): the receiver previously only fired on manual dispatch.
+#
+# Auth: INFRA2_PAT — a PAT with `repo` scope on wangzitian0/infra2 (GITHUB_TOKEN cannot
+# dispatch cross-repo). Stored as an app-repo secret.
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch: {} # manual re-trigger of a report-branch-main deploy
+
+permissions:
+  contents: read
+
+concurrency:
+  # Collapse bursts of main pushes into one in-flight dispatch; the infra2 receiver also
+  # serializes the actual preview deploy (cancel-in-progress on its own slot).
+  group: notify-infra2-report-main
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: dispatch report-branch-main deploy to infra2
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch repository_dispatch to infra2
+        env:
+          INFRA2_PAT: ${{ secrets.INFRA2_PAT }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${INFRA2_PAT:-}" ]]; then
+            echo "::error::INFRA2_PAT is required to dispatch the report-branch-main deploy to infra2."
+            exit 1
+          fi
+
+          payload="$(jq -nc --arg sha "$GITHUB_SHA" \
+            '{event_type: "deploy-report-main", client_payload: {sha: $sha, ref: "main"}}')"
+
+          http_status="$(curl -sS -o /tmp/infra2_dispatch_resp -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${INFRA2_PAT}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --connect-timeout 10 \
+            --max-time 30 \
+            https://api.github.com/repos/wangzitian0/infra2/dispatches \
+            -d "$payload")"
+
+          echo "infra2 repository_dispatch -> HTTP $http_status (sha=$GITHUB_SHA)"
+          # GitHub returns 204 No Content on a successful dispatch.
+          if [[ "$http_status" != "204" ]]; then
+            sed 's/^/  /' /tmp/infra2_dispatch_resp 2>/dev/null || true
+            echo "::error::infra2 repository_dispatch failed (expected HTTP 204). Check INFRA2_PAT scope/expiry."
+            exit 1
+          fi

--- a/.github/workflows/notify-infra2-report-main.yml
+++ b/.github/workflows/notify-infra2-report-main.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # AC8.13.16: opt JavaScript actions into the Node 24 runtime ahead of the GitHub migration.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   # Collapse bursts of main pushes into one in-flight dispatch; the infra2 receiver also
   # serializes the actual preview deploy (cancel-in-progress on its own slot).

--- a/docs/ssot/ci-gate-inventory.yaml
+++ b/docs/ssot/ci-gate-inventory.yaml
@@ -240,6 +240,18 @@ gates:
     artifacts: [pr-preview-scheduled-cleanup-context]
     failure_semantics: Scheduled or manual preview cleanup could not classify or remove stale resources.
     action: keep
+  - id: notify_infra2_report_main.dispatch
+    category: deploy_ops
+    workflow: .github/workflows/notify-infra2-report-main.yml
+    job: dispatch
+    owner: .github/workflows/notify-infra2-report-main.yml#dispatch
+    triggers: [push, workflow_dispatch]
+    blocks_workflow: false
+    inputs: [main_sha]
+    outputs: [infra2_repository_dispatch]
+    artifacts: []
+    failure_semantics: App main push could not notify infra2 to redeploy the report-branch-main preview (INFRA2_PAT missing/expired or repository_dispatch did not return HTTP 204).
+    action: keep
   - id: pr_test.setup
     category: classify
     workflow: .github/workflows/pr-test.yml


### PR DESCRIPTION
## What

Adds `.github/workflows/notify-infra2-report-main.yml`: on every app `main` push (and manual dispatch), POST a `repository_dispatch` (`event_type=deploy-report-main`, `client_payload={sha, ref:main}`) to `wangzitian0/infra2`.

## Why

This is the **app-repo SENDER** half of the one auto deploy target (infra2 SSOT §4.6 / closes the cross-repo TODO tracked as #370 and finance_report#1072). The infra2 receiver (`deploy-report-main.yml`) already exists but until now only fired on **manual** dispatch — so `report-branch-main` could drift from `main`. With this, the receiver re-deploys the preview slot via `deploy_v2 --service finance_report/app --type preview/branch --version-ref main --iac-ref main` whenever `main` moves.

## Trigger model (unchanged, faithful to §4.6)

| Target | Trigger |
|--------|---------|
| **report-branch-main** | **auto** — app `main` push (this PR) |
| staging / prod | manual + pinned release tag (NOT here) |

## Auth

Uses the pre-provisioned `INFRA2_PAT` app-repo secret (a PAT with `repo` scope on infra2 — `GITHUB_TOKEN` cannot dispatch cross-repo). No new secret required. Fails closed with a clear error if the secret is missing or the dispatch is not HTTP 204.

## Notes

- `concurrency: cancel-in-progress` collapses bursts; the infra2 receiver further serializes the actual deploy on its own slot.
- The matching infra2-side note cleanup (drop the "remaining cross-repo half / #370" TODO comment) ships with the infra2 process-debt PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)