### PR TITLE
[finance_report_ui] test(observability): E2E proof FE OTel spans + OpenPanel events emit (#1169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,6 +660,14 @@ jobs:
         run: npm run test:e2e -- --reporter=line,html
         working-directory: apps/frontend
 
+      - name: Run Frontend Telemetry-Emission E2E (#1169 / EPIC-024 AC24.2)
+        # Real-browser proof that browser OTel spans export to /v1/traces and
+        # OpenPanel events dispatch. Runs under its own config because it injects
+        # the OTel + OpenPanel config via webServer.env (hermetic: every
+        # telemetry destination is intercepted in-test).
+        run: npm run test:e2e:telemetry
+        working-directory: apps/frontend
+
       - name: Upload frontend coverage
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright (generated artifacts)
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:telemetry": "playwright test --config playwright.telemetry.config.ts",
     "audit:prod": "npm audit --omit=dev",
     "gen:api-types": "openapi-typescript openapi.json -o src/lib/api-types.ts",
     "check:api-types": "openapi-typescript openapi.json -o /tmp/api-types.check.ts && diff -q src/lib/api-types.ts /tmp/api-types.check.ts"

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -2,6 +2,11 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './playwright',
+  // The #1169 telemetry-emission spec (EPIC-024 AC24.2) needs the browser-OTel
+  // and OpenPanel config injected via `webServer.env`; it runs under its own
+  // `playwright.telemetry.config.ts` and would be a no-op (telemetry disabled)
+  // under this default server, so it is excluded here.
+  testIgnore: 'telemetry-emission.spec.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/apps/frontend/playwright.telemetry.config.ts
+++ b/apps/frontend/playwright.telemetry.config.ts
@@ -1,0 +1,66 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Dedicated Playwright config for the #1169 telemetry-emission E2E
+ * (EPIC-024 AC24.2). It runs its OWN Next.js server with the browser-OTel and
+ * OpenPanel config supplied via `webServer.env`, so the real root layout mounts
+ * `<FrontendTelemetry>` + `<Analytics>` with active config — without forcing
+ * telemetry on for every other E2E in the default `playwright.config.ts`.
+ *
+ * Hermetic: the configured OTLP collector + OpenPanel endpoints/script are
+ * fakes intercepted in-test (no real SigNoz/OpenPanel is contacted). The values
+ * below are read at REQUEST time by the `force-dynamic` server layout, so
+ * passing them through `webServer.env` (rather than baking them into the build)
+ * is sufficient.
+ */
+const PORT = process.env.TELEMETRY_E2E_PORT || '3210';
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+// Fake, never-contacted endpoints — all SAME-ORIGIN as the app so the
+// production CSP (`script-src 'self'`, `connect-src 'self'`) permits them. The
+// spec intercepts these routes with `page.route`, so no real telemetry backend
+// is hit (the paths need not exist on the server); we only assert that the
+// browser tries to emit to them.
+const TELEMETRY_ENV = {
+  // Browser OTel → OTLP/HTTP collector. Read by the server layout and passed to
+  // <FrontendTelemetry> as the `endpoint` prop.
+  NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT: `${BASE_URL}/v1/traces`,
+  NEXT_PUBLIC_DEPLOYMENT_ENVIRONMENT: 'e2e-telemetry',
+  NEXT_PUBLIC_GIT_SHA: 'e2e-test-sha',
+  // OpenPanel page-view analytics. Read by the server layout and passed to
+  // <Analytics>. The script + api are stubbed in-test, also same-origin.
+  OPENPANEL_CLIENT_ID: 'e2e-telemetry-client',
+  OPENPANEL_API_URL: `${BASE_URL}/openpanel-api`,
+  OPENPANEL_SCRIPT_URL: `${BASE_URL}/openpanel-op1.js`,
+  OPENPANEL_ENVIRONMENT: 'e2e-telemetry',
+  NEXT_PUBLIC_APP_URL: BASE_URL,
+};
+
+export default defineConfig({
+  testDir: './playwright',
+  testMatch: 'telemetry-emission.spec.ts',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'line' : 'list',
+  webServer: {
+    command: process.env.CI
+      ? `npm run start -- --port ${PORT}`
+      : `npm run build && npm run start -- --port ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    env: TELEMETRY_ENV,
+  },
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/apps/frontend/playwright/telemetry-emission.spec.ts
+++ b/apps/frontend/playwright/telemetry-emission.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test, type Request } from "@playwright/test";
+
+/**
+ * EPIC-024 AC24.2 — real-browser proof that FE telemetry actually EMITS (#1169).
+ *
+ * Runs under `playwright.telemetry.config.ts`, whose `webServer.env` configures
+ * the browser-OTel OTLP endpoint and the OpenPanel client id, so the real root
+ * layout mounts `<FrontendTelemetry>` + `<Analytics>` with active config. This
+ * spec then asserts, in a real Chromium browser, the two outbound emissions:
+ *
+ *  - AC24.2.1: the browser OTel SDK POSTs an OTLP payload to the configured
+ *    `/v1/traces` collector endpoint.
+ *  - AC24.2.2: the OpenPanel analytics layer dispatches a page-view/event
+ *    (`window.op` is installed, an `init` command is enqueued, and an outbound
+ *    event POST reaches the OpenPanel API).
+ *
+ * Hermetic: every telemetry destination is intercepted with `page.route` and
+ * fulfilled locally — no real SigNoz collector, no real OpenPanel cloud, and the
+ * `op1.js` SDK script is replaced by a tiny stub that honors the documented
+ * `window.op` queue contract. No assertion depends on a real backend being up.
+ */
+
+const OTLP_TRACES_PATH = "/v1/traces";
+const OPENPANEL_API_GLOB = "**/openpanel-api/**";
+const OPENPANEL_SCRIPT_GLOB = "**/openpanel-op1.js**";
+
+// A minimal stand-in for the OpenPanel `op1.js` SDK. It honors the public
+// `window.op` queue contract (the init snippet installs a queue at
+// `window.op.q`) and emulates the documented behavior: drain queued commands,
+// auto-fire a screen-view on init, and POST every event to the OpenPanel API so
+// the test can observe a real outbound analytics request.
+const OPENPANEL_SDK_STUB = `
+(function () {
+  // Same-origin api path so the app CSP (connect-src 'self') permits the POST.
+  var api = "/openpanel-api";
+  function emit(name, args) {
+    try {
+      fetch(api + "/track", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: name, args: args }),
+        keepalive: true,
+      });
+    } catch (e) {}
+  }
+  var queued = (window.op && window.op.q) || [];
+  // Replace the bootstrap queue proxy with a live dispatcher.
+  window.op = function () {
+    var args = [].slice.call(arguments);
+    emit(args[0], args.slice(1));
+  };
+  queued.forEach(function (cmd) {
+    emit(cmd[0], cmd.slice(1));
+    // The real SDK auto-tracks a screen view once initialized.
+    if (cmd[0] === "init") {
+      emit("screen_view", [{ __path: location.pathname, __title: document.title }]);
+    }
+  });
+})();
+`;
+
+test.describe("AC24.2 FE telemetry + analytics emission (#1169)", () => {
+  test("emits a browser OTel span as an OTLP POST to the /v1/traces endpoint (AC24.2.1) and dispatches an OpenPanel event via window.op (AC24.2.2)", async ({
+    page,
+  }) => {
+    const otlpRequests: Request[] = [];
+    const openpanelEventRequests: Request[] = [];
+
+    // Intercept the OTLP collector: capture each export POST, then 200 it so the
+    // exporter sees success (no real SigNoz contacted).
+    await page.route(`**${OTLP_TRACES_PATH}`, async (route) => {
+      if (route.request().method() === "POST") {
+        otlpRequests.push(route.request());
+      }
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+
+    // Intercept the OpenPanel SDK script with the queue-honoring stub.
+    await page.route(OPENPANEL_SCRIPT_GLOB, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/javascript",
+        body: OPENPANEL_SDK_STUB,
+      });
+    });
+
+    // Intercept every OpenPanel API call (the outbound event POSTs).
+    await page.route(OPENPANEL_API_GLOB, async (route) => {
+      if (route.request().method() === "POST") {
+        openpanelEventRequests.push(route.request());
+      }
+      await route.fulfill({ status: 202, contentType: "application/json", body: "{}" });
+    });
+
+    // Skip auth so the app shell renders without a backend.
+    await page.addInitScript(() => {
+      localStorage.setItem("finance_user_id", "telemetry-e2e-user");
+      localStorage.setItem("finance_user_email", "telemetry-e2e@example.com");
+    });
+    // Stub backend API so the page renders deterministically.
+    await page.route("**/api/**", async (route) => {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    // --- AC24.2.2: OpenPanel analytics emission ---------------------------
+    // The bootstrap queue proxy is installed by the inline init snippet.
+    await expect
+      .poll(() => page.evaluate(() => typeof (window as unknown as { op?: unknown }).op))
+      .toBe("function");
+    // An outbound OpenPanel event POST actually fired (init/screen_view).
+    await expect
+      .poll(() => openpanelEventRequests.length, { timeout: 15_000 })
+      .toBeGreaterThan(0);
+
+    // --- AC24.2.1: browser OTel OTLP export -------------------------------
+    // Drive client-side activity so the FetchInstrumentation/document-load
+    // produce spans, then wait for the BatchSpanProcessor to flush an export.
+    await page.evaluate(() => {
+      // A few client fetches give the fetch-instrumentation spans to export.
+      void fetch("/api/workflow/status").catch(() => {});
+      void fetch("/api/statements").catch(() => {});
+    });
+    await expect
+      .poll(() => otlpRequests.length, { timeout: 20_000 })
+      .toBeGreaterThan(0);
+
+    // The export targeted the configured /v1/traces collector with a payload.
+    const traceReq = otlpRequests[0];
+    expect(new URL(traceReq.url()).pathname).toBe(OTLP_TRACES_PATH);
+    expect(traceReq.method()).toBe("POST");
+    expect(traceReq.postData() ?? traceReq.postDataBuffer()).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/__tests__/telemetryEmission.test.ts
+++ b/apps/frontend/src/__tests__/telemetryEmission.test.ts
@@ -20,7 +20,7 @@
  * Hermetic by construction: no real SigNoz collector and no real OpenPanel SDK
  * script are contacted.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 // Real exporter/provider — the exact classes wired in src/lib/otel.ts.
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
@@ -38,17 +38,20 @@ describe("AC24.2 FE telemetry + analytics emission (#1169)", () => {
   })
 
   // AC24.2.1 — a finished browser span is actually emitted through the real
-  // OTLP/HTTP exporter that `src/lib/otel.ts` ships, targeting /v1/traces.
-  it("emits a browser OTel span as an OTLP POST to the /v1/traces endpoint (AC24.2.1)", async () => {
+  // OTLP/HTTP exporter that `src/lib/otel.ts` ships. This asserts the pipeline
+  // hands the span to `OTLPTraceExporter.export()` (the in-browser POST origin);
+  // the real `POST /v1/traces` over the wire is asserted end-to-end in the
+  // companion `playwright/telemetry-emission.spec.ts`.
+  it("emits a finished browser OTel span to the real OTLP exporter's export() (AC24.2.1)", async () => {
     // The SAME exporter class the app uses, pointed at a /v1/traces endpoint.
     const exporter = new OTLPTraceExporter({ url: OTLP_TRACES_ENDPOINT })
     // Spy on the emission boundary: every finished span the pipeline drains is
-    // handed to export() — this is where a real OTLP POST is issued in-browser.
-    // We short-circuit the success callback so forceFlush() resolves
-    // deterministically: happy-dom's fetch/transport cannot drain the real HTTP
-    // export (that POST is asserted for real in the Playwright companion), but
-    // the call to export() proves the pipeline emitted the span to the OTLP
-    // exporter the app ships.
+    // handed to export(), which is where the real OTLP POST WOULD be issued in a
+    // real browser run. Here export() is mocked — we short-circuit the success
+    // callback so forceFlush() resolves deterministically (happy-dom's
+    // fetch/transport cannot drain the real HTTP export; that POST is asserted
+    // for real in the Playwright companion). The export() call itself proves the
+    // pipeline emitted the span to the OTLP exporter the app ships.
     const exportSpy = vi
       .spyOn(exporter, "export")
       .mockImplementation((_spans, resultCallback) => {
@@ -63,7 +66,9 @@ describe("AC24.2 FE telemetry + analytics emission (#1169)", () => {
     provider.getTracer("ac24.2.1-emission-test").startSpan("web-vital.LCP").end()
     await provider.forceFlush()
 
-    // The exporter actually received a finished span to emit to /v1/traces.
+    // The exporter actually received a finished span to emit (the POST to
+    // /v1/traces is what export() performs in a real browser; asserted for real
+    // in the Playwright companion).
     expect(exportSpy).toHaveBeenCalledTimes(1)
     const [exportedSpans] = exportSpy.mock.calls[0]
     expect(exportedSpans).toHaveLength(1)

--- a/apps/frontend/src/__tests__/telemetryEmission.test.ts
+++ b/apps/frontend/src/__tests__/telemetryEmission.test.ts
@@ -1,0 +1,98 @@
+/**
+ * EPIC-024 AC24.2 — automated proof that FE telemetry actually EMITS (#1169).
+ *
+ * The AC24.1 suites (`otel.test.ts`, `frontendTelemetry.test.tsx`) mock the OTel
+ * SDK and assert the *wiring contract* — no span is ever handed to the exporter
+ * and no event ever reaches OpenPanel in those tests. This suite closes that
+ * gap with a deterministic, hermetic emission proof:
+ *
+ *  - OTel (AC24.2.1): the real `OTLPTraceExporter` from `src/lib/otel.ts` is
+ *    placed behind the same `WebTracerProvider` + span processor the app wires,
+ *    and we assert the pipeline actually delivers a finished span to the
+ *    exporter's `export()` (emission through the real pipeline, not "wired").
+ *    The OTLP/HTTP `POST` to `/v1/traces` itself rides a real `fetch`, which is
+ *    asserted end-to-end in the companion `playwright/telemetry-emission.spec.ts`
+ *    (happy-dom's `fetch`/transport cannot drain the exporter deterministically).
+ *  - OpenPanel (AC24.2.2): the real `track()` from `src/lib/analytics.ts` is
+ *    driven against a recording `window.op` stub (the global the OpenPanel SDK
+ *    installs), and we assert the event is actually dispatched.
+ *
+ * Hermetic by construction: no real SigNoz collector and no real OpenPanel SDK
+ * script are contacted.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Real exporter/provider — the exact classes wired in src/lib/otel.ts.
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+import { SimpleSpanProcessor, WebTracerProvider } from "@opentelemetry/sdk-trace-web"
+
+import { ANALYTICS_EVENTS, track } from "@/lib/analytics"
+
+const OTLP_TRACES_ENDPOINT = "http://collector.test/v1/traces"
+
+describe("AC24.2 FE telemetry + analytics emission (#1169)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    // Drop any window.op stub installed by a test so suites stay isolated.
+    delete (window as unknown as { op?: unknown }).op
+  })
+
+  // AC24.2.1 — a finished browser span is actually emitted through the real
+  // OTLP/HTTP exporter that `src/lib/otel.ts` ships, targeting /v1/traces.
+  it("emits a browser OTel span as an OTLP POST to the /v1/traces endpoint (AC24.2.1)", async () => {
+    // The SAME exporter class the app uses, pointed at a /v1/traces endpoint.
+    const exporter = new OTLPTraceExporter({ url: OTLP_TRACES_ENDPOINT })
+    // Spy on the emission boundary: every finished span the pipeline drains is
+    // handed to export() — this is where a real OTLP POST is issued in-browser.
+    // We short-circuit the success callback so forceFlush() resolves
+    // deterministically: happy-dom's fetch/transport cannot drain the real HTTP
+    // export (that POST is asserted for real in the Playwright companion), but
+    // the call to export() proves the pipeline emitted the span to the OTLP
+    // exporter the app ships.
+    const exportSpy = vi
+      .spyOn(exporter, "export")
+      .mockImplementation((_spans, resultCallback) => {
+        resultCallback({ code: 0 })
+      })
+
+    // SimpleSpanProcessor exports synchronously on span.end() + forceFlush, so
+    // the emission is deterministic (no 5s BatchSpanProcessor delay to wait on).
+    const provider = new WebTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    })
+    provider.getTracer("ac24.2.1-emission-test").startSpan("web-vital.LCP").end()
+    await provider.forceFlush()
+
+    // The exporter actually received a finished span to emit to /v1/traces.
+    expect(exportSpy).toHaveBeenCalledTimes(1)
+    const [exportedSpans] = exportSpy.mock.calls[0]
+    expect(exportedSpans).toHaveLength(1)
+    expect(exportedSpans[0].name).toBe("web-vital.LCP")
+  })
+
+  // AC24.2.2 — the analytics layer actually dispatches an OpenPanel event via
+  // the global `window.op` command queue installed by the OpenPanel SDK.
+  it("dispatches an OpenPanel event via window.op when configured (AC24.2.2)", () => {
+    const opCalls: unknown[][] = []
+    // Recording stub for the OpenPanel global the real SDK installs. track()
+    // dispatches through window.op('track', …); we assert that dispatch fires.
+    ;(window as unknown as { op: (...args: unknown[]) => void }).op = (...args: unknown[]) => {
+      opCalls.push(args)
+    }
+
+    track(ANALYTICS_EVENTS.REPORT_GENERATED, { surface: "reports" })
+
+    expect(opCalls).toHaveLength(1)
+    const [command, event, props] = opCalls[0]
+    expect(command).toBe("track")
+    expect(event).toBe(ANALYTICS_EVENTS.REPORT_GENERATED)
+    expect(props).toMatchObject({ surface: "reports" })
+  })
+
+  // AC24.2.2 (negative half) — with no OpenPanel global installed (no client id
+  // configured), track() is a complete no-op and never throws.
+  it("is a hermetic no-op when OpenPanel is not configured (AC24.2.2)", () => {
+    expect((window as unknown as { op?: unknown }).op).toBeUndefined()
+    expect(() => track(ANALYTICS_EVENTS.UPLOAD_STARTED)).not.toThrow()
+  })
+})

--- a/docs/project/EPIC-024.frontend-observability.md
+++ b/docs/project/EPIC-024.frontend-observability.md
@@ -100,10 +100,12 @@ triaging issues.
 
 ### Emission Proof (#1169)
 - [x] Hermetic integration test driving the real exporter + `track()` and
-  asserting the OTLP `/v1/traces` POST and the OpenPanel `window.op` dispatch
+  asserting the span reaches `OTLPTraceExporter.export()` (the in-browser POST
+  origin) and the OpenPanel `window.op` dispatch fires
   (`src/__tests__/telemetryEmission.test.ts`).
-- [x] Real-browser Playwright smoke confirming the same wiring end-to-end with
-  a stubbed collector + OpenPanel script (`playwright/telemetry-emission.spec.ts`).
+- [x] Real-browser Playwright smoke asserting the actual outbound `POST
+  /v1/traces` (and OpenPanel dispatch) end-to-end against a stubbed collector +
+  OpenPanel script (`playwright/telemetry-emission.spec.ts`).
 
 ---
 
@@ -137,7 +139,7 @@ real SigNoz/OpenPanel contacted).
 
 | ID | Requirement | Test Function | File | Priority |
 |----|-------------|---------------|------|----------|
-| AC24.2.1 | With the OTLP endpoint configured, the real browser OTel exporter emits an outbound `POST` to the `/v1/traces` collector endpoint (span actually exported, not merely wired); asserted against a stubbed collector so the test is hermetic | `emits a browser OTel span as an OTLP POST to the /v1/traces endpoint (AC24.2.1)` | `playwright/telemetry-emission.spec.ts`, `src/__tests__/telemetryEmission.test.ts` | P1 |
+| AC24.2.1 | With the OTLP endpoint configured, the real browser OTel exporter emits a span (span actually exported, not merely wired): the vitest proof asserts the span reaches `OTLPTraceExporter.export()`, and the Playwright spec asserts the actual outbound `POST /v1/traces` over the wire; both hermetic against a stubbed collector | vitest `emits a finished browser OTel span to the real OTLP exporter's export() (AC24.2.1)` + Playwright `POST /v1/traces` spec | `playwright/telemetry-emission.spec.ts`, `src/__tests__/telemetryEmission.test.ts` | P1 |
 | AC24.2.2 | With the OpenPanel client id configured, the analytics layer actually dispatches an OpenPanel event/page-view (`window.op('track'\|'screenView', …)` invoked); asserted against a stubbed `window.op`/endpoint so the test is hermetic | `dispatches an OpenPanel event via window.op when configured (AC24.2.2)` | `playwright/telemetry-emission.spec.ts`, `src/__tests__/telemetryEmission.test.ts` | P1 |
 
 ---

--- a/docs/project/EPIC-024.frontend-observability.md
+++ b/docs/project/EPIC-024.frontend-observability.md
@@ -61,6 +61,9 @@ triaging issues.
 - **Opt-in by default**: no endpoint → no SDK behavior.
 - **PII scrubbing** of URLs and attributes.
 - **OpenPanel query CLI** for frontend product-analytics triage.
+- **Automated emission proof** that, when configured, browser OTel spans are
+  actually exported to `/v1/traces` and OpenPanel events are actually dispatched
+  (hermetic: collector + OpenPanel stubbed).
 
 ---
 
@@ -95,13 +98,22 @@ triaging issues.
 ### Documentation
 - [x] Document `NEXT_PUBLIC_OTEL_*` and `OPENPANEL_API_KEY` env vars (PR body).
 
+### Emission Proof (#1169)
+- [x] Hermetic integration test driving the real exporter + `track()` and
+  asserting the OTLP `/v1/traces` POST and the OpenPanel `window.op` dispatch
+  (`src/__tests__/telemetryEmission.test.ts`).
+- [x] Real-browser Playwright smoke confirming the same wiring end-to-end with
+  a stubbed collector + OpenPanel script (`playwright/telemetry-emission.spec.ts`).
+
 ---
 
 ## 🧪 Test Cases
 
 > **Test Organization**: Tests organized by feature blocks using ACx.y.z numbering.
 > **Coverage**: See `apps/frontend/src/__tests__/otel.test.ts`,
-> `apps/frontend/src/__tests__/frontendTelemetry.test.tsx`, and
+> `apps/frontend/src/__tests__/frontendTelemetry.test.tsx`,
+> `apps/frontend/src/__tests__/telemetryEmission.test.ts`,
+> `apps/frontend/playwright/telemetry-emission.spec.ts`, and
 > `tests/tooling/test_openpanel_query.py`.
 
 ### AC24.1: Browser OTel + OpenPanel Query CLI
@@ -112,6 +124,21 @@ triaging issues.
 | AC24.1.2 | The PII scrub strips query strings and fragments from captured URLs and drops sensitive attributes (emails, amounts, account numbers) before any span is emitted | `otel.test.ts` | P1 |
 | AC24.1.3 | Uncaught errors (`window.onerror`) and unhandled promise rejections are captured as span exceptions with a scrubbed page URL | `otel.test.ts` | P1 |
 | AC24.1.4 | The OpenPanel query CLI exists, reads its API key from `OPENPANEL_API_KEY` (never a CLI flag), and supports events/funnels with an `--env` filter | `test_openpanel_query.py` | P1 |
+
+### AC24.2: FE Telemetry + Analytics Emission Is Proven by an Automated Test
+
+The AC24.1 tests verify the *wiring contract* against a mocked SDK (no span
+ever leaves the exporter, no event ever reaches OpenPanel). AC24.2 closes that
+gap with an end-to-end emission proof: when telemetry is configured, the
+browser OTel exporter actually POSTs an OTLP payload to the `/v1/traces`
+endpoint, and the analytics layer actually dispatches an OpenPanel
+event/page-view — both asserted hermetically (collector + OpenPanel stubbed, no
+real SigNoz/OpenPanel contacted).
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC24.2.1 | With the OTLP endpoint configured, the real browser OTel exporter emits an outbound `POST` to the `/v1/traces` collector endpoint (span actually exported, not merely wired); asserted against a stubbed collector so the test is hermetic | `emits a browser OTel span as an OTLP POST to the /v1/traces endpoint (AC24.2.1)` | `playwright/telemetry-emission.spec.ts`, `src/__tests__/telemetryEmission.test.ts` | P1 |
+| AC24.2.2 | With the OpenPanel client id configured, the analytics layer actually dispatches an OpenPanel event/page-view (`window.op('track'\|'screenView', …)` invoked); asserted against a stubbed `window.op`/endpoint so the test is hermetic | `dispatches an OpenPanel event via window.op when configured (AC24.2.2)` | `playwright/telemetry-emission.spec.ts`, `src/__tests__/telemetryEmission.test.ts` | P1 |
 
 ---
 


### PR DESCRIPTION
## What & why

Closes the verification gap in **EPIC-024 (frontend browser observability)**: the
existing AC24.1 suites mock the OTel SDK and OpenPanel, so they prove the *wiring
contract* but **no span is ever exported and no analytics event is ever
dispatched** in those tests. This PR adds an automated, hermetic proof that the
browser OTel spans **and** OpenPanel events actually **emit** (issue #1169).

## Approach — two layers, both hermetic

**Real-browser E2E (primary)** — `apps/frontend/playwright/telemetry-emission.spec.ts`
- Runs under a dedicated `playwright.telemetry.config.ts` whose `webServer.env`
  configures the OTLP endpoint + OpenPanel client id. The `force-dynamic` root
  layout reads these at request time, so the real `<FrontendTelemetry>` +
  `<Analytics>` mount with **active** config.
- Intercepts the OTLP `/v1/traces` collector, the OpenPanel `op1.js` script, and
  the OpenPanel API via `page.route`, then asserts in real Chromium:
  - **AC24.2.1** — the browser OTel SDK POSTs an OTLP payload to `/v1/traces`.
  - **AC24.2.2** — an OpenPanel page-view/event POST fires via `window.op`.
- Fully hermetic: no real SigNoz/OpenPanel is contacted. All telemetry
  destinations are **same-origin** so the app's production CSP
  (`script-src`/`connect-src 'self'`) permits them — the fake stubs only work
  same-origin, which mirrors how prod allows `*.zitian.party`.

**Deterministic integration (companion)** — `src/__tests__/telemetryEmission.test.ts`
- Drives the **real** `OTLPTraceExporter` behind the app's `WebTracerProvider`
  and asserts a finished span is emitted to the exporter; drives the real
  `track()` against a recording `window.op` stub and asserts the event is
  dispatched.
- happy-dom's `fetch`/transport cannot drain the real OTLP HTTP export
  deterministically, so the actual `/v1/traces` POST is proven in the Playwright
  layer; this layer provides a fast, deterministic CI-stage reference.

## Wiring
- `playwright.config.ts` `testIgnore`s the spec (it is a no-op without the
  injected config). CI runs it via the new `test:e2e:telemetry` script in a
  dedicated step after the default Playwright lane.
- EPIC-024 registers **AC24.2.1 / AC24.2.2**; both resolve to real references in
  CI-required stages (`frontend_playwright_ci` + `frontend_vitest`).

## Gates (all green locally)
- `npx tsc --noEmit` ✓ · `npx next lint` ✓
- `npx vitest run --coverage` — 904 tests pass, thresholds (98/98/84/98) met ✓
- Telemetry E2E green (local + `CI=true`) ✓
- `tools/check_ac_index.py` exit 0 (1724 AC nodes; AC24.2.x counted as
  `has_real_ref`) ✓ · `tools/lint_doc_consistency.py` exit 0 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)