### PR TITLE
[finance_report_test_and_doc] refactor(dry-ssot): EPIC-025 — close #1158 DRY/SSOT simplification (reporting, statements, FE contracts, tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ registries, and generated reports rather than duplicated here.
 | [EPIC-022](docs/project/EPIC-022.everyday-user-ia.md) | Everyday-user information architecture |
 | [EPIC-023](docs/project/EPIC-023.llm-provider-abstraction.md) | LLM provider abstraction (litellm) |
 | [EPIC-024](docs/project/EPIC-024.frontend-observability.md) | Frontend browser observability |
+| [EPIC-025](docs/project/EPIC-025.dry-ssot-simplification.md) | DRY/SSOT simplification (reporting, statements, FE contracts, tests) |
 
 ## EPIC Status (Generated)
 

--- a/apps/backend/src/routers/income.py
+++ b/apps/backend/src/routers/income.py
@@ -12,7 +12,7 @@ from src.models import Account, AccountType, Direction, JournalEntry, JournalEnt
 from src.schemas.base import normalize_currency_code
 from src.schemas.income import AnnualizedIncomeResponse, FxConversionErrorResponse
 from src.services.fx import FxRateError, convert_amount
-from src.services.reporting import AnnualizedIncomeTotals, income_bucket, resolve_line_currency
+from src.services.reporting_calc import AnnualizedIncomeTotals, income_bucket, resolve_line_currency
 from src.utils import raise_bad_request
 from src.utils.money import to_money
 

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -54,14 +54,13 @@ from src.services.brokerage_statement_payload import (
 from src.services.statement_pipeline import submit_parse_pipeline
 from src.services.statement_posting import auto_create_posted_entries_for_statement, resolve_statement_posting_account
 from src.services.statement_validation import (
-    approve_statement as approve_statement_svc,
     edit_and_approve,
     pending_stage1_review_filter,
-    reject_statement as reject_statement_svc,
     resolve_statement_transactions,
     set_opening_balance,
     validate_balance_chain,
 )
+from src.services.statement_workflow import approve_statement_workflow, reject_statement_workflow
 from src.utils import (
     raise_bad_request,
     raise_internal_error,
@@ -805,9 +804,7 @@ async def approve_statement_stage1(
         elif not statement.account_id:
             await resolve_statement_posting_account(db, statement, user_id)
 
-        statement = await approve_statement_svc(db, statement_id, user_id)
-        created_count = await auto_create_posted_entries_for_statement(db, statement, user_id)
-        await db.commit()
+        created_count = await approve_statement_workflow(db, statement_id, user_id)
     except ValueError as e:
         await db.rollback()
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
@@ -826,9 +823,7 @@ async def reject_statement_stage1(
 ) -> BankStatementResponse:
     """Stage 1: Reject statement."""
     try:
-        statement = await reject_statement_svc(db, statement_id, user_id, reason=decision.notes)
-        await db.commit()
-        await db.refresh(statement)
+        statement = await reject_statement_workflow(db, statement_id, user_id, reason=decision.notes)
         await _queue_statement_reparse(db, statement, user_id)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/apps/backend/src/services/annualized_income.py
+++ b/apps/backend/src/services/annualized_income.py
@@ -27,7 +27,7 @@ from src.schemas import (
     AnnualizedIncomeScheduleResponse,
 )
 from src.services.fx import FxRateError, convert_amount
-from src.services.reporting import income_bucket
+from src.services.reporting_calc import income_bucket
 from src.utils import raise_bad_request
 from src.utils.money import to_money
 

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
-from typing import Any, ClassVar, cast
+from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy import case, func, literal, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.config import settings
 from src.constants.error_ids import ErrorIds
 from src.logger import get_logger
 from src.models import (
@@ -21,7 +20,6 @@ from src.models import (
     AccountType,
     Direction,
     JournalEntry,
-    JournalEntrySourceType,
     JournalEntryStatus,
     JournalLine,
 )
@@ -32,7 +30,6 @@ from src.models.layer3 import (
     ManualValuationLiquidityClass,
     PositionStatus,
 )
-from src.schemas.base import normalize_currency_code
 from src.schemas.provenance import DataProvenance
 from src.services import fx
 from src.services.assets import AssetService
@@ -56,204 +53,32 @@ from src.services.fx_transfer import (
 )
 from src.services.fx_transfer_discovery import discover_fx_conversions
 from src.services.portfolio import AssetNotFoundError, PortfolioService
-from src.services.source_type_priority import normalize_source_type
+from src.services.reporting_calc import (
+    MAX_NET_WORTH_DAILY_POINTS,
+    ReportError,
+    _add_months,
+    _combine_provenance,
+    _iter_periods,
+    _month_end,
+    _month_start,
+    _normalize_currency,
+    _provenance_from_source_type,
+    _quantize_money,
+    _quarter_start,
+    _signed_amount,
+    _worst_confidence_tier,
+)
 from src.utils.money import to_money
 
 logger = get_logger(__name__)
 
 _REPORT_STATUSES = (JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED)
-_IMPORTED_SOURCE_TYPES = {
-    JournalEntrySourceType.AUTO_PARSED,
-    JournalEntrySourceType.AUTO_MATCHED,
-    JournalEntrySourceType.USER_CONFIRMED,
-}
-_MANUAL_SOURCE_TYPES = {JournalEntrySourceType.MANUAL}
-_DERIVED_SOURCE_TYPES = {JournalEntrySourceType.SYSTEM, JournalEntrySourceType.FX_REVALUATION}
 _ALLOCATION_METADATA_KEYS = {
     "source_currency",
     "allocation_asset_class",
     "allocation_liquidity_class",
     "allocation_source_type",
 }
-
-
-class ReportError(Exception):
-    """Raised when report generation fails or input is invalid."""
-
-    pass
-
-
-@dataclass
-class PeriodSpan:
-    start: date
-    end: date
-
-
-def _normalize_currency(code: str | None) -> str:
-    if not code:
-        return normalize_currency_code(settings.base_currency)
-    return normalize_currency_code(code)
-
-
-def resolve_line_currency(line: JournalLine, account: Account, *, base_currency: str) -> str:
-    """Resolve a journal line's effective currency via the canonical fallback chain.
-
-    Centralizes the previously inline ``line.currency || account.currency ||
-    base_currency`` resolution so callers no longer re-implement (and re-normalize)
-    it. The returned code is normalized through :func:`normalize_currency_code`.
-    """
-    return _normalize_currency(line.currency or account.currency or base_currency)
-
-
-def _signed_amount(account_type: AccountType, direction: Direction, amount: Decimal) -> Decimal:
-    if account_type in (AccountType.ASSET, AccountType.EXPENSE):
-        return amount if direction == Direction.DEBIT else -amount
-    return amount if direction == Direction.CREDIT else -amount
-
-
-def income_bucket(account_name: str) -> str | None:
-    normalized = account_name.casefold()
-    if "salary" in normalized or "payroll" in normalized:
-        return "salary"
-    if "bonus" in normalized:
-        return "bonus"
-    if "dividend" in normalized:
-        return "dividend"
-    return None
-
-
-@dataclass
-class AnnualizedIncomeTotals:
-    """Typed intermediate accumulator for annualized income aggregation.
-
-    Replaces the string-keyed ``dict[str, Decimal]`` so the response model can be
-    constructed directly from typed attributes instead of a manual dict hop. All
-    amounts are ``Decimal`` (never ``float`` — see the money decimal rule).
-    """
-
-    salary: Decimal = Decimal("0.00")
-    bonus: Decimal = Decimal("0.00")
-    dividend: Decimal = Decimal("0.00")
-    total: Decimal = Decimal("0.00")
-
-    # Per-line buckets that may be accumulated individually. ``total`` is the
-    # running sum maintained by ``add()`` itself and is deliberately excluded so
-    # passing ``bucket="total"`` cannot double-count.
-    _BUCKETS: ClassVar[frozenset[str]] = frozenset({"salary", "bonus", "dividend"})
-
-    def add(self, bucket: str | None, signed_amount: Decimal) -> None:
-        """Accumulate a signed line amount into its bucket and the running total.
-
-        ``bucket`` must be one of the per-line buckets (or ``None`` for amounts
-        that only affect the running total). Unknown bucket names — including
-        ``"total"`` — raise ``ValueError`` rather than silently double-counting.
-        """
-        if bucket is not None:
-            if bucket not in self._BUCKETS:
-                raise ValueError(f"Unknown income bucket {bucket!r}; expected one of {sorted(self._BUCKETS)} or None")
-            setattr(self, bucket, getattr(self, bucket) + signed_amount)
-        self.total += signed_amount
-
-
-def _quantize_money(amount: Decimal | int) -> Decimal:
-    if isinstance(amount, int):
-        amount = Decimal(amount)
-    return to_money(amount)
-
-
-def _provenance_from_source_type(source_type: JournalEntrySourceType | str | None) -> DataProvenance | None:
-    if source_type is None:
-        return None
-    try:
-        # normalize_source_type folds retired legacy values (e.g. the
-        # bank_statement text retired in 0040) back into the live hierarchy.
-        normalized = normalize_source_type(source_type)
-    except ValueError:
-        return None
-    if normalized in _MANUAL_SOURCE_TYPES:
-        return "manual"
-    if normalized in _IMPORTED_SOURCE_TYPES:
-        return "imported"
-    if normalized in _DERIVED_SOURCE_TYPES:
-        return "derived"
-    return None
-
-
-def _combine_provenance(values: Sequence[DataProvenance | None]) -> DataProvenance | None:
-    known = {value for value in values if value is not None}
-    if not known:
-        return None
-    if len(known) == 1:
-        return next(iter(known))
-    return "derived"
-
-
-def _month_start(value: date) -> date:
-    return value.replace(day=1)
-
-
-def _month_end(value: date) -> date:
-    next_month = value.replace(day=28) + timedelta(days=4)
-    return next_month.replace(day=1) - timedelta(days=1)
-
-
-def _quarter_start(value: date) -> date:
-    month = ((value.month - 1) // 3) * 3 + 1
-    return date(year=value.year, month=month, day=1)
-
-
-def _add_months(value: date, months: int) -> date:
-    year = value.year + (value.month - 1 + months) // 12
-    month = (value.month - 1 + months) % 12 + 1
-    day = min(value.day, _month_end(date(year, month, 1)).day)
-    return date(year, month, day)
-
-
-# Limit to ~1 year of daily data to ensure report performance and prevent memory issues.
-MAX_TREND_POINTS = 366
-MAX_NET_WORTH_DAILY_POINTS = 366
-
-
-def _iter_periods(start: date, end: date, period: str) -> list[PeriodSpan]:
-    spans: list[PeriodSpan] = []
-    cursor = start
-
-    while cursor <= end:
-        if period == "daily":
-            span_start = cursor
-            span_end = cursor
-            next_cursor = cursor + timedelta(days=1)
-        elif period == "weekly":
-            span_start = cursor - timedelta(days=cursor.weekday())
-            span_end = span_start + timedelta(days=6)
-            next_cursor = span_start + timedelta(days=7)
-        elif period == "monthly":
-            span_start = _month_start(cursor)
-            span_end = _month_end(cursor)
-            next_cursor = _add_months(span_start, 1)
-        else:
-            raise ReportError(f"Unsupported period: {period}")
-
-        spans.append(PeriodSpan(start=span_start, end=min(span_end, end)))
-        cursor = next_cursor
-        if len(spans) > MAX_TREND_POINTS:
-            break
-
-    return spans
-
-
-# Confidence tiers ranked by trust (vision Axiom B). The worst-input rule rolls a
-# line/aggregate down to its least-trusted contributor — a defined rollup, never
-# an invented number.
-_CONFIDENCE_TIER_RANK: dict[str, int] = {"LOW": 0, "MEDIUM": 1, "HIGH": 2, "TRUSTED": 3}
-
-
-def _worst_confidence_tier(tiers: Iterable[str | None]) -> str | None:
-    """Return the least-trusted tier among the inputs, or None if none are rated."""
-    present = [tier for tier in tiers if tier]
-    if not present:
-        return None
-    return min(present, key=lambda tier: _CONFIDENCE_TIER_RANK.get(tier, 0))
 
 
 def _build_account_lines(

--- a/apps/backend/src/services/reporting_calc.py
+++ b/apps/backend/src/services/reporting_calc.py
@@ -1,0 +1,217 @@
+"""Pure reporting calculation primitives (EPIC-025 AC25.1.1 / #1158).
+
+DB-free money, currency, accounting-sign, provenance, confidence-tier, and
+period math extracted verbatim from ``reporting.py`` so calculation has a single
+owner separate from query orchestration and API shaping. ``reporting`` imports
+what it needs from here; callers that only need the pure helpers (routers/income,
+annualized_income, tests) import them directly from this module. The extracted
+functions are byte-for-byte identical, so existing semantics are unchanged.
+
+Money is always ``Decimal`` (never ``float`` — see the money decimal rule).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import ClassVar
+
+from src.config import settings
+from src.models import (
+    Account,
+    AccountType,
+    Direction,
+    JournalEntrySourceType,
+    JournalLine,
+)
+from src.schemas.base import normalize_currency_code
+from src.schemas.provenance import DataProvenance
+from src.services.source_type_priority import normalize_source_type
+from src.utils.money import to_money
+
+_IMPORTED_SOURCE_TYPES = {
+    JournalEntrySourceType.AUTO_PARSED,
+    JournalEntrySourceType.AUTO_MATCHED,
+    JournalEntrySourceType.USER_CONFIRMED,
+}
+_MANUAL_SOURCE_TYPES = {JournalEntrySourceType.MANUAL}
+_DERIVED_SOURCE_TYPES = {JournalEntrySourceType.SYSTEM, JournalEntrySourceType.FX_REVALUATION}
+
+# Limit to ~1 year of daily data to ensure report performance and prevent memory issues.
+MAX_TREND_POINTS = 366
+MAX_NET_WORTH_DAILY_POINTS = 366
+
+# Confidence tiers ranked by trust (vision Axiom B). The worst-input rule rolls a
+# line/aggregate down to its least-trusted contributor — a defined rollup, never
+# an invented number.
+_CONFIDENCE_TIER_RANK: dict[str, int] = {"LOW": 0, "MEDIUM": 1, "HIGH": 2, "TRUSTED": 3}
+
+
+class ReportError(Exception):
+    """Raised when report generation fails or input is invalid."""
+
+    pass
+
+
+@dataclass
+class PeriodSpan:
+    start: date
+    end: date
+
+
+def _normalize_currency(code: str | None) -> str:
+    if not code:
+        return normalize_currency_code(settings.base_currency)
+    return normalize_currency_code(code)
+
+
+def resolve_line_currency(line: JournalLine, account: Account, *, base_currency: str) -> str:
+    """Resolve a journal line's effective currency via the canonical fallback chain.
+
+    Centralizes the previously inline ``line.currency || account.currency ||
+    base_currency`` resolution so callers no longer re-implement (and re-normalize)
+    it. The returned code is normalized through :func:`normalize_currency_code`.
+    """
+    return _normalize_currency(line.currency or account.currency or base_currency)
+
+
+def _signed_amount(account_type: AccountType, direction: Direction, amount: Decimal) -> Decimal:
+    if account_type in (AccountType.ASSET, AccountType.EXPENSE):
+        return amount if direction == Direction.DEBIT else -amount
+    return amount if direction == Direction.CREDIT else -amount
+
+
+def income_bucket(account_name: str) -> str | None:
+    normalized = account_name.casefold()
+    if "salary" in normalized or "payroll" in normalized:
+        return "salary"
+    if "bonus" in normalized:
+        return "bonus"
+    if "dividend" in normalized:
+        return "dividend"
+    return None
+
+
+@dataclass
+class AnnualizedIncomeTotals:
+    """Typed intermediate accumulator for annualized income aggregation.
+
+    Replaces the string-keyed ``dict[str, Decimal]`` so the response model can be
+    constructed directly from typed attributes instead of a manual dict hop. All
+    amounts are ``Decimal`` (never ``float`` — see the money decimal rule).
+    """
+
+    salary: Decimal = Decimal("0.00")
+    bonus: Decimal = Decimal("0.00")
+    dividend: Decimal = Decimal("0.00")
+    total: Decimal = Decimal("0.00")
+
+    # Per-line buckets that may be accumulated individually. ``total`` is the
+    # running sum maintained by ``add()`` itself and is deliberately excluded so
+    # passing ``bucket="total"`` cannot double-count.
+    _BUCKETS: ClassVar[frozenset[str]] = frozenset({"salary", "bonus", "dividend"})
+
+    def add(self, bucket: str | None, signed_amount: Decimal) -> None:
+        """Accumulate a signed line amount into its bucket and the running total.
+
+        ``bucket`` must be one of the per-line buckets (or ``None`` for amounts
+        that only affect the running total). Unknown bucket names — including
+        ``"total"`` — raise ``ValueError`` rather than silently double-counting.
+        """
+        if bucket is not None:
+            if bucket not in self._BUCKETS:
+                raise ValueError(f"Unknown income bucket {bucket!r}; expected one of {sorted(self._BUCKETS)} or None")
+            setattr(self, bucket, getattr(self, bucket) + signed_amount)
+        self.total += signed_amount
+
+
+def _quantize_money(amount: Decimal | int) -> Decimal:
+    if isinstance(amount, int):
+        amount = Decimal(amount)
+    return to_money(amount)
+
+
+def _provenance_from_source_type(source_type: JournalEntrySourceType | str | None) -> DataProvenance | None:
+    if source_type is None:
+        return None
+    try:
+        # normalize_source_type folds retired legacy values (e.g. the
+        # bank_statement text retired in 0040) back into the live hierarchy.
+        normalized = normalize_source_type(source_type)
+    except ValueError:
+        return None
+    if normalized in _MANUAL_SOURCE_TYPES:
+        return "manual"
+    if normalized in _IMPORTED_SOURCE_TYPES:
+        return "imported"
+    if normalized in _DERIVED_SOURCE_TYPES:
+        return "derived"
+    return None
+
+
+def _combine_provenance(values: Sequence[DataProvenance | None]) -> DataProvenance | None:
+    known = {value for value in values if value is not None}
+    if not known:
+        return None
+    if len(known) == 1:
+        return next(iter(known))
+    return "derived"
+
+
+def _month_start(value: date) -> date:
+    return value.replace(day=1)
+
+
+def _month_end(value: date) -> date:
+    next_month = value.replace(day=28) + timedelta(days=4)
+    return next_month.replace(day=1) - timedelta(days=1)
+
+
+def _quarter_start(value: date) -> date:
+    month = ((value.month - 1) // 3) * 3 + 1
+    return date(year=value.year, month=month, day=1)
+
+
+def _add_months(value: date, months: int) -> date:
+    year = value.year + (value.month - 1 + months) // 12
+    month = (value.month - 1 + months) % 12 + 1
+    day = min(value.day, _month_end(date(year, month, 1)).day)
+    return date(year, month, day)
+
+
+def _iter_periods(start: date, end: date, period: str) -> list[PeriodSpan]:
+    spans: list[PeriodSpan] = []
+    cursor = start
+
+    while cursor <= end:
+        if period == "daily":
+            span_start = cursor
+            span_end = cursor
+            next_cursor = cursor + timedelta(days=1)
+        elif period == "weekly":
+            span_start = cursor - timedelta(days=cursor.weekday())
+            span_end = span_start + timedelta(days=6)
+            next_cursor = span_start + timedelta(days=7)
+        elif period == "monthly":
+            span_start = _month_start(cursor)
+            span_end = _month_end(cursor)
+            next_cursor = _add_months(span_start, 1)
+        else:
+            raise ReportError(f"Unsupported period: {period}")
+
+        spans.append(PeriodSpan(start=span_start, end=min(span_end, end)))
+        cursor = next_cursor
+        if len(spans) > MAX_TREND_POINTS:
+            break
+
+    return spans
+
+
+def _worst_confidence_tier(tiers: Iterable[str | None]) -> str | None:
+    """Return the least-trusted tier among the inputs, or None if none are rated."""
+    present = [tier for tier in tiers if tier]
+    if not present:
+        return None
+    return min(present, key=lambda tier: _CONFIDENCE_TIER_RANK.get(tier, 0))

--- a/apps/backend/src/services/statement_workflow.py
+++ b/apps/backend/src/services/statement_workflow.py
@@ -1,0 +1,48 @@
+"""Statement Stage-1 workflow contracts (EPIC-025 AC25.2.1 / #1158).
+
+Service-level orchestration that owns the transaction boundary and the Stage-1
+state transition for statement approval/rejection, so routers stay thin (HTTP
+mapping + response shaping only). Behavior-preserving extraction of the inline
+router sequences — same service calls, same commit point, same ordering.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.statement_summary import StatementSummary
+from src.services.statement_posting import auto_create_posted_entries_for_statement
+from src.services.statement_validation import approve_statement, reject_statement
+
+
+async def approve_statement_workflow(db: AsyncSession, statement_id: UUID, user_id: UUID) -> int:
+    """Approve a PARSED statement and post its journal entries as one committed unit.
+
+    Owns the PARSED→APPROVED transition, the auto-posting of journal entries, and
+    the single ``commit`` that makes them durable together. The posting account
+    must already be resolved/bound by the caller within the same DB session.
+    Domain errors (``ValueError``) propagate uncommitted so the caller can map
+    them to HTTP 400 (and roll back the surrounding session). Returns the number
+    of journal entries created.
+    """
+    statement = await approve_statement(db, statement_id, user_id)
+    created_count = await auto_create_posted_entries_for_statement(db, statement, user_id)
+    await db.commit()
+    return created_count
+
+
+async def reject_statement_workflow(
+    db: AsyncSession, statement_id: UUID, user_id: UUID, *, reason: str | None = None
+) -> StatementSummary:
+    """Reject a PARSED statement as one committed unit, returning the refreshed row.
+
+    Owns the PARSED→REJECTED transition and its ``commit``. Re-parse queueing is a
+    caller (router/background) concern and is intentionally excluded so the state
+    transition stays a pure, committed unit.
+    """
+    statement = await reject_statement(db, statement_id, user_id, reason=reason)
+    await db.commit()
+    await db.refresh(statement)
+    return statement

--- a/apps/backend/tests/accounting/test_accounting_equation.py
+++ b/apps/backend/tests/accounting/test_accounting_equation.py
@@ -39,12 +39,6 @@ from src.services.accounting import (
 
 
 @pytest.fixture
-def test_user_id(test_user):
-    """Test user ID — a real persisted users row so production FKs resolve (#991)."""
-    return test_user.id
-
-
-@pytest.fixture
 async def asset_account(db: AsyncSession, test_user_id):
     """Create a test asset account (Bank)."""
     account = Account(

--- a/apps/backend/tests/accounting/test_accounting_integration.py
+++ b/apps/backend/tests/accounting/test_accounting_integration.py
@@ -41,12 +41,6 @@ from tests.factories import UserFactory
 
 
 @pytest.fixture
-async def test_user_id(test_user):
-    """Test user ID — a real persisted users row so production FKs resolve (#991)."""
-    return test_user.id
-
-
-@pytest.fixture
 async def bank_account(db: AsyncSession, test_user_id):
     """Create a test bank account."""
     account = Account(

--- a/apps/backend/tests/accounting/test_accounting_service_errors.py
+++ b/apps/backend/tests/accounting/test_accounting_service_errors.py
@@ -38,11 +38,6 @@ from tests.accounting._ledger_helpers import create_valid_posted_entry
 from tests.factories import UserFactory
 
 
-@pytest.fixture
-async def test_user_id(test_user):
-    return test_user.id
-
-
 async def test_calculate_account_balance_errors(db: AsyncSession, test_user_id):
     with pytest.raises(ValidationError, match="not found"):
         await calculate_account_balance(db, uuid4(), test_user_id)

--- a/apps/backend/tests/accounting/test_core_unit_coverage.py
+++ b/apps/backend/tests/accounting/test_core_unit_coverage.py
@@ -17,7 +17,7 @@ from src.services.investment_accounting import (
     InvestmentAccountingService,
     InvestmentAccountingValidationError,
 )
-from src.services.reporting import (
+from src.services.reporting_calc import (
     _provenance_from_source_type,
     _quantize_money,
     income_bucket,

--- a/apps/backend/tests/api/test_statement_workflow_service.py
+++ b/apps/backend/tests/api/test_statement_workflow_service.py
@@ -1,0 +1,78 @@
+"""EPIC-025 AC25.2.1: statement Stage-1 workflow owns the transaction + transition.
+
+These checks pin the *contract* — the workflow performs the state-transition
+service call, then posts (approve only), then commits as one unit, and the thin
+router delegates to it rather than inlining the sequence. The real PARSED→APPROVED
+/ PARSED→REJECTED behavior against the database is covered by the existing
+``test_statements_router.py`` Stage-1 suite.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import src.routers.statements as statements_router
+from src.services import statement_workflow
+
+
+class _FakeSession:
+    """Records the transaction operations the workflow performs, in order."""
+
+    def __init__(self, calls: list) -> None:
+        self._calls = calls
+
+    async def commit(self) -> None:
+        self._calls.append(("commit",))
+
+    async def refresh(self, obj: object) -> None:
+        self._calls.append(("refresh", obj))
+
+
+async def test_statement_workflow_service(monkeypatch):
+    """AC25.2.1: approve/reject workflows own the commit + Stage-1 transition as one
+    ordered unit, and the router delegates to them (no inline approve/reject+commit)."""
+    statement_id = uuid4()
+    user_id = uuid4()
+
+    # --- approve: transition -> post -> commit, returns entries created ---
+    approve_calls: list = []
+    approved_statement = SimpleNamespace(id=statement_id, name="approved")
+
+    async def fake_approve(db, sid, uid):
+        assert (sid, uid) == (statement_id, user_id)
+        approve_calls.append(("approve_statement",))
+        return approved_statement
+
+    async def fake_post(db, statement, uid):
+        assert statement is approved_statement
+        approve_calls.append(("auto_post",))
+        return 3
+
+    monkeypatch.setattr(statement_workflow, "approve_statement", fake_approve)
+    monkeypatch.setattr(statement_workflow, "auto_create_posted_entries_for_statement", fake_post)
+
+    created = await statement_workflow.approve_statement_workflow(_FakeSession(approve_calls), statement_id, user_id)
+    assert created == 3
+    assert approve_calls == [("approve_statement",), ("auto_post",), ("commit",)]
+
+    # --- reject: transition -> commit -> refresh, returns refreshed statement ---
+    reject_calls: list = []
+    rejected_statement = SimpleNamespace(id=statement_id, name="rejected")
+
+    async def fake_reject(db, sid, uid, *, reason):
+        assert (sid, uid, reason) == (statement_id, user_id, "looks wrong")
+        reject_calls.append(("reject_statement",))
+        return rejected_statement
+
+    monkeypatch.setattr(statement_workflow, "reject_statement", fake_reject)
+
+    result = await statement_workflow.reject_statement_workflow(
+        _FakeSession(reject_calls), statement_id, user_id, reason="looks wrong"
+    )
+    assert result is rejected_statement
+    assert reject_calls == [("reject_statement",), ("commit",), ("refresh", rejected_statement)]
+
+    # --- delegation: the router uses the workflow contracts, not inline *_svc calls ---
+    assert statements_router.approve_statement_workflow is statement_workflow.approve_statement_workflow
+    assert statements_router.reject_statement_workflow is statement_workflow.reject_statement_workflow
+    assert not hasattr(statements_router, "approve_statement_svc")
+    assert not hasattr(statements_router, "reject_statement_svc")

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -732,12 +732,12 @@ async def test_pending_review_and_decisions(db, monkeypatch, storage_stub, model
     # in #1099 (AC12.29.5); drive the same state transition via the service layer.
     statement_id = created_ids[0]
 
-    approved = await statements_router.approve_statement_svc(db, statement_id, test_user.id)
+    approved = await statement_validation_mod.approve_statement(db, statement_id, test_user.id)
     await db.commit()
     assert approved.status == BankStatementStatus.APPROVED
 
     # Test reject (state transitions are allowed on the same statement).
-    rejected = await statements_router.reject_statement_svc(db, statement_id, test_user.id, reason="Incorrect data")
+    rejected = await statement_validation_mod.reject_statement(db, statement_id, test_user.id, reason="Incorrect data")
     await db.commit()
     assert rejected.status == BankStatementStatus.REJECTED
 
@@ -1151,7 +1151,7 @@ async def test_retry_statement_success(db, monkeypatch, storage_stub, model_cata
     await upload_file.close()
     await wait_for_background_tasks()
 
-    rejected = await statements_router.reject_statement_svc(db, created.id, test_user.id, reason="Low confidence")
+    rejected = await statement_validation_mod.reject_statement(db, created.id, test_user.id, reason="Low confidence")
     await db.commit()
     assert rejected.status == BankStatementStatus.REJECTED
 
@@ -1217,7 +1217,7 @@ async def test_retry_statement_extraction_failure(db, monkeypatch, storage_stub,
     await upload_file.close()
     await wait_for_background_tasks()
 
-    rejected = await statements_router.reject_statement_svc(db, created.id, test_user.id, reason="Low confidence")
+    rejected = await statement_validation_mod.reject_statement(db, created.id, test_user.id, reason="Low confidence")
     await db.commit()
     assert rejected.status == BankStatementStatus.REJECTED
 
@@ -3124,7 +3124,7 @@ async def test_AC16_34_2_reject_clears_conflict_resolution(db, test_user):
     await db.refresh(statement)
     assert statement.stage1_conflicts_resolved_at is not None
 
-    await statements_router.reject_statement_svc(db, statement_id, test_user.id, reason="reparse")
+    await statement_validation_mod.reject_statement(db, statement_id, test_user.id, reason="reparse")
     await db.commit()
     await db.refresh(statement)
     assert statement.stage1_conflicts_resolved_at is None

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -392,6 +392,16 @@ async def test_user(db: AsyncSession):
     return user
 
 
+@pytest.fixture(scope="function")
+def test_user_id(test_user):
+    """Test user ID — a real persisted users row so production FKs resolve (#991).
+
+    Shared single definition (EPIC-025 / #1158); previously re-declared
+    identically in every accounting/reporting test module.
+    """
+    return test_user.id
+
+
 @pytest_asyncio.fixture(scope="function")
 async def client(db_engine, test_user, test_database_url):
     """Create async test client with database initialized."""

--- a/apps/backend/tests/e2e/test_epic025_dry_ssot_e2e.py
+++ b/apps/backend/tests/e2e/test_epic025_dry_ssot_e2e.py
@@ -1,0 +1,63 @@
+"""Product E2E owner test for EPIC-025 (DRY/SSOT simplification).
+
+EPIC-025 is a behavior-preserving refactor; this Tier-1 API E2E proves the
+refactored reporting path still produces correct numbers end to end
+(request → router → reporting → reporting_calc → DB → response), so the
+extraction cannot silently change financial output.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+TEST_DATE = date(2024, 6, 15)
+
+
+async def _create_account(client, name, acct_type, currency="SGD"):
+    resp = await client.post("/accounts", json={"name": name, "type": acct_type, "currency": currency})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _post_balanced_entry(client, *, debit_id, credit_id, amount, currency="SGD"):
+    create = await client.post(
+        "/journal-entries",
+        json={
+            "entry_date": TEST_DATE.isoformat(),
+            "memo": "EPIC-025 opening balance",
+            "lines": [
+                {"account_id": debit_id, "direction": "DEBIT", "amount": amount, "currency": currency},
+                {"account_id": credit_id, "direction": "CREDIT", "amount": amount, "currency": currency},
+            ],
+        },
+    )
+    assert create.status_code == 201, create.text
+    entry_id = create.json()["id"]
+    posted = await client.post(f"/journal-entries/{entry_id}/postings")
+    assert posted.status_code == 200, posted.text
+    return entry_id
+
+
+@pytest.mark.e2e
+async def test_epic025_reporting_calc_extraction_preserves_balance_sheet(client, test_user):
+    """EPIC-025 / AC25.1.1: the balance-sheet report still computes correct totals
+    end to end after the pure reporting math moved into ``services.reporting_calc``.
+
+    GIVEN a balanced opening entry (Bank 1000 ← Opening Equity 1000)
+    WHEN requesting the balance sheet via the API
+    THEN the accounting equation holds with the exact numbers — proving the
+    extraction is behavior-preserving across the real request stack.
+    """
+    bank_id = await _create_account(client, "Bank", "ASSET")
+    equity_id = await _create_account(client, "Opening Equity", "EQUITY")
+    await _post_balanced_entry(client, debit_id=bank_id, credit_id=equity_id, amount="1000.00")
+
+    resp = await client.get("/reports/balance-sheet")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert Decimal(str(data["total_assets"])) == Decimal("1000.00")
+    assert Decimal(str(data["total_liabilities"])) == Decimal("0.00")
+    assert Decimal(str(data["total_equity"])) == Decimal("1000.00")
+    assert Decimal(str(data["equation_delta"])) == Decimal("0.00")
+    assert data["is_balanced"] is True

--- a/apps/backend/tests/infra/test_transaction_boundaries.py
+++ b/apps/backend/tests/infra/test_transaction_boundaries.py
@@ -26,6 +26,10 @@ ALLOWED_SERVICE_COMMIT_BOUNDARIES = {
     ("statement_parsing.py", "parse_statement_background"),
     ("statement_parsing.py", "parse_statement_background.update_progress"),
     ("statement_parsing_supervisor.py", "reset_stale_parsing_jobs"),
+    # EPIC-025 AC25.2.1 (#1158): the Stage-1 approve/reject workflow owns its
+    # transaction boundary at the service layer so the router stays thin.
+    ("statement_workflow.py", "approve_statement_workflow"),
+    ("statement_workflow.py", "reject_statement_workflow"),
 }
 
 

--- a/apps/backend/tests/reporting/_report_fixtures.py
+++ b/apps/backend/tests/reporting/_report_fixtures.py
@@ -7,6 +7,8 @@ are identical (name, type, currency, order) to the inlined originals.
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import Account, AccountType
@@ -23,7 +25,7 @@ STANDARD_CHART_SPEC: tuple[tuple[str, AccountType], ...] = (
 )
 
 
-async def build_standard_chart_of_accounts(db: AsyncSession, user_id, *, currency: str = "SGD") -> list[Account]:
+async def build_standard_chart_of_accounts(db: AsyncSession, user_id: UUID, *, currency: str = "SGD") -> list[Account]:
     """Create and persist the standard chart of accounts, returning them in spec order."""
     accounts = [
         Account(user_id=user_id, name=name, type=acct_type, currency=currency)

--- a/apps/backend/tests/reporting/_report_fixtures.py
+++ b/apps/backend/tests/reporting/_report_fixtures.py
@@ -1,0 +1,36 @@
+"""Shared reporting-test builders (EPIC-025 AC25.4.1 / #1158).
+
+Single source of truth for the standard chart of accounts that reporting tests
+previously re-declared per module. Behavior-preserving: the produced accounts
+are identical (name, type, currency, order) to the inlined originals.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import Account, AccountType
+
+# The standard 5-account SGD chart used across reporting tests, in a stable
+# order: (Cash ASSET, Credit Card LIABILITY, Owner Equity EQUITY, Salary INCOME,
+# Dining EXPENSE).
+STANDARD_CHART_SPEC: tuple[tuple[str, AccountType], ...] = (
+    ("Cash", AccountType.ASSET),
+    ("Credit Card", AccountType.LIABILITY),
+    ("Owner Equity", AccountType.EQUITY),
+    ("Salary", AccountType.INCOME),
+    ("Dining", AccountType.EXPENSE),
+)
+
+
+async def build_standard_chart_of_accounts(db: AsyncSession, user_id, *, currency: str = "SGD") -> list[Account]:
+    """Create and persist the standard chart of accounts, returning them in spec order."""
+    accounts = [
+        Account(user_id=user_id, name=name, type=acct_type, currency=currency)
+        for name, acct_type in STANDARD_CHART_SPEC
+    ]
+    db.add_all(accounts)
+    await db.commit()
+    for account in accounts:
+        await db.refresh(account)
+    return accounts

--- a/apps/backend/tests/reporting/test_annualized_income_schedule.py
+++ b/apps/backend/tests/reporting/test_annualized_income_schedule.py
@@ -21,7 +21,7 @@ from src.models.layer3 import (
     ManualValuationLiquidityClass,
     ManualValuationSnapshot,
 )
-from src.services.reporting import income_bucket
+from src.services.reporting_calc import income_bucket
 
 
 def test_AC11_11_1_income_bucket_maps_report_package_income_accounts():

--- a/apps/backend/tests/reporting/test_fx_revaluation.py
+++ b/apps/backend/tests/reporting/test_fx_revaluation.py
@@ -36,11 +36,6 @@ from src.services.fx_revaluation import (
 
 
 @pytest.fixture
-async def test_user_id(test_user):
-    return test_user.id
-
-
-@pytest.fixture
 async def usd_asset_account(db: AsyncSession, test_user_id):
     account = Account(
         user_id=test_user_id,

--- a/apps/backend/tests/reporting/test_income_typed_currency.py
+++ b/apps/backend/tests/reporting/test_income_typed_currency.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models import Account, AccountType, Direction, JournalEntry, JournalEntryStatus, JournalLine
 from src.schemas.base import normalize_currency_code
 from src.schemas.income import AnnualizedIncomeResponse, FxConversionErrorResponse
-from src.services.reporting import AnnualizedIncomeTotals, resolve_line_currency
+from src.services.reporting_calc import AnnualizedIncomeTotals, resolve_line_currency
 
 
 def test_AC5_32_1_currency_code_type_validates_and_normalizes():

--- a/apps/backend/tests/reporting/test_report_fixtures_shared.py
+++ b/apps/backend/tests/reporting/test_report_fixtures_shared.py
@@ -1,0 +1,76 @@
+"""EPIC-025 AC25.4.1: shared reporting fixtures have a single source of truth."""
+
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import (
+    AccountType,
+    Direction,
+    JournalEntry,
+    JournalEntrySourceType,
+    JournalEntryStatus,
+    JournalLine,
+)
+from src.services.reporting import generate_balance_sheet
+from tests.reporting._report_fixtures import (
+    STANDARD_CHART_SPEC,
+    build_standard_chart_of_accounts,
+)
+
+
+async def test_report_fixtures_shared(db: AsyncSession, test_user_id):
+    """AC25.4.1: the shared chart-of-accounts builder and the shared `test_user_id`
+    fixture (root conftest) replace the per-module duplicates without changing the
+    accounts produced — five persisted SGD accounts in the canonical order, usable
+    to generate a balanced balance sheet."""
+    accounts = await build_standard_chart_of_accounts(db, test_user_id)
+
+    # Single source of truth: builder output matches the declared spec exactly.
+    assert [(a.name, a.type) for a in accounts] == list(STANDARD_CHART_SPEC)
+    assert all(a.id is not None for a in accounts)  # persisted
+    assert all(a.currency == "SGD" for a in accounts)
+    assert [a.type for a in accounts] == [
+        AccountType.ASSET,
+        AccountType.LIABILITY,
+        AccountType.EQUITY,
+        AccountType.INCOME,
+        AccountType.EXPENSE,
+    ]
+
+    # The shared fixtures still drive a balanced report (behavior preserved).
+    cash, _liability, equity, *_rest = accounts
+    entry = JournalEntry(
+        user_id=test_user_id,
+        entry_date=date.today(),
+        memo="Owner contribution",
+        source_type=JournalEntrySourceType.MANUAL,
+        status=JournalEntryStatus.POSTED,
+    )
+    db.add(entry)
+    await db.flush()
+    db.add_all(
+        [
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=cash.id,
+                direction=Direction.DEBIT,
+                amount=Decimal("1000.00"),
+                currency="SGD",
+            ),
+            JournalLine(
+                journal_entry_id=entry.id,
+                account_id=equity.id,
+                direction=Direction.CREDIT,
+                amount=Decimal("1000.00"),
+                currency="SGD",
+            ),
+        ]
+    )
+    await db.commit()
+
+    report = await generate_balance_sheet(db, test_user_id, as_of_date=date.today(), currency="SGD")
+    assert report["total_assets"] == Decimal("1000.00")
+    assert report["total_equity"] == Decimal("1000.00")
+    assert report["is_balanced"] is True

--- a/apps/backend/tests/reporting/test_reporting.py
+++ b/apps/backend/tests/reporting/test_reporting.py
@@ -9,7 +9,6 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import (
-    Account,
     AccountType,
     Direction,
     JournalEntry,
@@ -31,54 +30,13 @@ from src.services.reporting import (
     get_account_trend,
     get_category_breakdown,
 )
-
-
-@pytest.fixture
-def test_user_id(test_user):
-    """Test user ID — a real persisted users row so production FKs resolve (#991)."""
-    return test_user.id
+from tests.reporting._report_fixtures import build_standard_chart_of_accounts
 
 
 @pytest.fixture
 async def chart_of_accounts(db: AsyncSession, test_user_id):
-    """Create a minimal chart of accounts for reporting."""
-    accounts = [
-        Account(
-            user_id=test_user_id,
-            name="Cash",
-            type=AccountType.ASSET,
-            currency="SGD",
-        ),
-        Account(
-            user_id=test_user_id,
-            name="Credit Card",
-            type=AccountType.LIABILITY,
-            currency="SGD",
-        ),
-        Account(
-            user_id=test_user_id,
-            name="Owner Equity",
-            type=AccountType.EQUITY,
-            currency="SGD",
-        ),
-        Account(
-            user_id=test_user_id,
-            name="Salary",
-            type=AccountType.INCOME,
-            currency="SGD",
-        ),
-        Account(
-            user_id=test_user_id,
-            name="Dining",
-            type=AccountType.EXPENSE,
-            currency="SGD",
-        ),
-    ]
-    db.add_all(accounts)
-    await db.commit()
-    for account in accounts:
-        await db.refresh(account)
-    return accounts
+    """Create a minimal chart of accounts for reporting (shared builder, #1158)."""
+    return await build_standard_chart_of_accounts(db, test_user_id)
 
 
 async def test_balance_sheet_equation(db: AsyncSession, chart_of_accounts, test_user_id):

--- a/apps/backend/tests/reporting/test_reporting.py
+++ b/apps/backend/tests/reporting/test_reporting.py
@@ -1544,7 +1544,7 @@ def test_iter_periods_daily_limit():
     """Test that _iter_periods respects the MAX_TREND_POINTS limit."""
     from datetime import date, timedelta
 
-    from src.services.reporting import MAX_TREND_POINTS, _iter_periods
+    from src.services.reporting_calc import MAX_TREND_POINTS, _iter_periods
 
     # 1000 days span
     start = date(2020, 1, 1)

--- a/apps/backend/tests/reporting/test_reporting_calc_extraction.py
+++ b/apps/backend/tests/reporting/test_reporting_calc_extraction.py
@@ -1,0 +1,62 @@
+"""EPIC-025 AC25.1.1: reporting calculation primitives have a single owner."""
+
+from datetime import date
+from decimal import Decimal
+
+from src.models import AccountType, Direction
+from src.services import reporting as reporting_service, reporting_calc
+
+
+def test_reporting_calc_extraction():
+    """AC25.1.1: pure reporting math lives in ``services.reporting_calc`` and is
+    re-used by ``services.reporting`` (same objects, not copies), so accounting
+    sign rules, period boundaries, income-bucket classification, money
+    quantization, and confidence-tier rollup are unchanged."""
+    # The orchestration module re-exports the extracted primitives — identical
+    # objects, guaranteeing no behavioral fork between the two modules.
+    for name in (
+        "ReportError",
+        "_signed_amount",
+        "_quantize_money",
+        "_combine_provenance",
+        "_worst_confidence_tier",
+        "_iter_periods",
+        "_month_start",
+        "_month_end",
+        "_add_months",
+    ):
+        assert getattr(reporting_service, name) is getattr(reporting_calc, name), name
+
+    # Accounting sign rule: assets/expenses increase on DEBIT, the rest on CREDIT.
+    assert reporting_calc._signed_amount(AccountType.ASSET, Direction.DEBIT, Decimal("5.00")) == Decimal("5.00")
+    assert reporting_calc._signed_amount(AccountType.ASSET, Direction.CREDIT, Decimal("5.00")) == Decimal("-5.00")
+    assert reporting_calc._signed_amount(AccountType.INCOME, Direction.CREDIT, Decimal("5.00")) == Decimal("5.00")
+    assert reporting_calc._signed_amount(AccountType.LIABILITY, Direction.DEBIT, Decimal("5.00")) == Decimal("-5.00")
+
+    # Money quantization stays at 2dp Decimal (never float).
+    quantized = reporting_calc._quantize_money(Decimal("10.005"))
+    assert isinstance(quantized, Decimal)
+    assert quantized == Decimal("10.00") or quantized == Decimal("10.01")  # bankers' rounding tolerant
+
+    # Income-bucket classification.
+    assert reporting_calc.income_bucket("Monthly Salary") == "salary"
+    assert reporting_calc.income_bucket("Year-end Bonus") == "bonus"
+    assert reporting_calc.income_bucket("Dividend payout") == "dividend"
+    assert reporting_calc.income_bucket("Groceries") is None
+
+    # Confidence-tier worst-input rollup and provenance combination.
+    assert reporting_calc._worst_confidence_tier(["HIGH", "LOW", "TRUSTED"]) == "LOW"
+    assert reporting_calc._worst_confidence_tier([None, None]) is None
+    assert reporting_calc._combine_provenance(["imported", "imported"]) == "imported"
+    assert reporting_calc._combine_provenance(["imported", "manual"]) == "derived"
+
+    # Period boundary math.
+    assert reporting_calc._month_start(date(2026, 2, 14)) == date(2026, 2, 1)
+    assert reporting_calc._month_end(date(2026, 2, 14)) == date(2026, 2, 28)
+    assert reporting_calc._add_months(date(2026, 1, 31), 1) == date(2026, 2, 28)
+    spans = reporting_calc._iter_periods(date(2026, 1, 1), date(2026, 1, 3), "daily")
+    assert [(s.start, s.end) for s in spans] == [
+        (date(2026, 1, 1), date(2026, 1, 1)),
+        (date(2026, 1, 2), date(2026, 1, 2)),
+        (date(2026, 1, 3), date(2026, 1, 3)),
+    ]

--- a/apps/backend/tests/reporting/test_reporting_calc_extraction.py
+++ b/apps/backend/tests/reporting/test_reporting_calc_extraction.py
@@ -33,10 +33,11 @@ def test_reporting_calc_extraction():
     assert reporting_calc._signed_amount(AccountType.INCOME, Direction.CREDIT, Decimal("5.00")) == Decimal("5.00")
     assert reporting_calc._signed_amount(AccountType.LIABILITY, Direction.DEBIT, Decimal("5.00")) == Decimal("-5.00")
 
-    # Money quantization stays at 2dp Decimal (never float).
+    # Money quantization stays at 2dp Decimal (never float), using the canonical
+    # ROUND_HALF_EVEN rule: 10.005 rounds to the even 10.00.
     quantized = reporting_calc._quantize_money(Decimal("10.005"))
     assert isinstance(quantized, Decimal)
-    assert quantized == Decimal("10.00") or quantized == Decimal("10.01")  # bankers' rounding tolerant
+    assert quantized == Decimal("10.00")
 
     # Income-bucket classification.
     assert reporting_calc.income_bucket("Monthly Salary") == "salary"

--- a/apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py
+++ b/apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py
@@ -27,11 +27,6 @@ from src.services.reporting import (
 )
 
 
-@pytest.fixture
-def test_user_id(test_user):
-    return test_user.id
-
-
 async def test_reporting_extreme_fallbacks_failure_reporting(db: AsyncSession, test_user_id):
     """Cover lines 270-277 and 426-433 where all FX fallbacks fail."""
     acc_usd = Account(user_id=test_user_id, name="USD Cash", type=AccountType.ASSET, currency="USD")

--- a/apps/backend/tests/reporting/test_reporting_fx.py
+++ b/apps/backend/tests/reporting/test_reporting_fx.py
@@ -28,11 +28,6 @@ from src.services.reporting import (
 
 
 @pytest.fixture
-def test_user_id(test_user):
-    return test_user.id
-
-
-@pytest.fixture
 async def multi_currency_accounts(db: AsyncSession, test_user_id):
     """Create accounts in different currencies."""
     accounts = [

--- a/apps/frontend/src/__tests__/contractTypes.test.ts
+++ b/apps/frontend/src/__tests__/contractTypes.test.ts
@@ -1,0 +1,101 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+import type { Schemas } from "@/lib/api-schema";
+import type {
+  AccountListResponse,
+  BankStatementListResponse,
+  JournalEntryListResponse,
+  ListResponse,
+  ManagedPositionListResponse,
+  ManualValuationSnapshotListResponse,
+  ProcessingPendingListResponse,
+  ReconciliationMatchListResponse,
+  UnmatchedTransactionsResponse,
+} from "@/lib/types";
+
+/**
+ * EPIC-025 AC25.3: the frontend contract layer derives from single sources of
+ * truth instead of re-declaring shapes. These checks are partly compile-time
+ * (a drift would fail `tsc`/`npm run build`) and partly source-scans that fail
+ * if a duplicate envelope or a second raw-fetch boundary is reintroduced.
+ */
+describe("frontend contract consolidation (EPIC-025 / #1158)", () => {
+  it("AC25.3.1: every list response derives from the single ListResponse<T> envelope", () => {
+    // Compile-time: each list response must be mutually assignable with
+    // ListResponse<itsItem>. If any wrapper drifts from {items,total}, tsc fails.
+    const account: AccountListResponse = { items: [], total: 0 };
+    const asEnvelope: ListResponse<AccountListResponse["items"][number]> = account;
+    const backAgain: AccountListResponse = asEnvelope;
+    expect(backAgain.total).toBe(0);
+
+    // A representative assignment for every other wrapper keeps them pinned to
+    // the generic without re-declaring the envelope inline.
+    const wrappers: ListResponse<unknown>[] = [
+      account satisfies ListResponse<unknown>,
+      { items: [], total: 0 } satisfies JournalEntryListResponse,
+      { items: [], total: 0 } satisfies BankStatementListResponse,
+      { items: [], total: 0 } satisfies UnmatchedTransactionsResponse,
+      { items: [], total: 0 } satisfies ReconciliationMatchListResponse,
+      { items: [], total: 0 } satisfies ManagedPositionListResponse,
+      { items: [], total: 0 } satisfies ManualValuationSnapshotListResponse,
+      { items: [], total: 0 } satisfies ProcessingPendingListResponse,
+    ];
+    expect(wrappers).toHaveLength(8);
+
+    // Source-scan: the `{ items: …[]; total: number }` envelope appears exactly
+    // once in types.ts — the generic definition. Any re-introduced per-entity
+    // duplicate would push the count above one and fail here.
+    const typesSource = readFileSync(resolve(__dirname, "../lib/types.ts"), "utf8");
+    const inlineEnvelope = /items:\s*[A-Za-z0-9_]+\[\];\s*\n\s*total:\s*number;/g;
+    expect(typesSource.match(inlineEnvelope)).toHaveLength(1);
+    expect(typesSource).toContain("export interface ListResponse<T> {");
+  });
+
+  it("AC25.3.1: OpenAPI-mirrored contract types resolve to a real generated Schemas key (drift guard)", () => {
+    // These compile-time references fail `tsc` if the backend renames/removes a
+    // schema and the generated `api-types.ts` is regenerated, surfacing FE↔BE
+    // contract drift instead of letting it pass silently.
+    const account: Schemas["AccountResponse"] | null = null;
+    const journal: Schemas["JournalEntryResponse"] | null = null;
+    const balanceSheet: Schemas["BalanceSheetResponse"] | null = null;
+    const income: Schemas["IncomeStatementResponse"] | null = null;
+    const cashFlow: Schemas["CashFlowResponse"] | null = null;
+    const statement: Schemas["BankStatementResponse"] | null = null;
+
+    expect([account, journal, balanceSheet, income, cashFlow, statement]).toEqual([
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  it("AC25.3.2: lib/api.ts is the single raw-fetch boundary in the frontend", () => {
+    const sourceFiles: string[] = [];
+    const visit = (path: string) => {
+      const stat = statSync(path);
+      if (stat.isDirectory()) {
+        for (const entry of readdirSync(path)) visit(resolve(path, entry));
+        return;
+      }
+      if (!/\.(ts|tsx)$/.test(path)) return;
+      if (/\.test\.(ts|tsx)$/.test(path)) return;
+      if (path.endsWith("/lib/api.ts")) return; // the sanctioned boundary
+      sourceFiles.push(path);
+    };
+    visit(resolve(__dirname, ".."));
+
+    // Match a bare `fetch(` call but not `refetch(`, `apiFetch(`, or `.fetch(`.
+    const rawFetch = /(?<![A-Za-z0-9_.])fetch\(/;
+    const offenders = sourceFiles
+      .filter((file) => rawFetch.test(readFileSync(file, "utf8")))
+      .map((file) => file.replace(resolve(__dirname, "..") + "/", ""));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -9,6 +9,16 @@ export type MoneyValue = DecimalValue;
 export type DataProvenance = "imported" | "manual" | "derived";
 export const MONEY_VALUE_CONTRACT = "decimal-string" as const;
 
+/**
+ * Single source of truth for the paginated list envelope returned by every
+ * `GET /…` collection endpoint. Per-entity list responses derive from this
+ * (`ListResponse<Account>`, …) instead of re-declaring `{ items; total }`.
+ */
+export interface ListResponse<T> {
+  items: T[];
+  total: number;
+}
+
 export interface Account {
   id: string;
   name: string;
@@ -21,10 +31,7 @@ export interface Account {
   balance?: MoneyValue;
 }
 
-export interface AccountListResponse {
-  items: Account[];
-  total: number;
-}
+export type AccountListResponse = ListResponse<Account>;
 
 export interface JournalLine {
   id: string;
@@ -50,10 +57,7 @@ export interface JournalEntry {
 
 export type JournalEntrySummary = Schemas["JournalEntrySummary"];
 
-export interface JournalEntryListResponse {
-  items: JournalEntry[];
-  total: number;
-}
+export type JournalEntryListResponse = ListResponse<JournalEntry>;
 
 export interface BankStatementTransaction {
   id: string;
@@ -109,10 +113,7 @@ export interface BankStatement {
   transactions: BankStatementTransaction[];
 }
 
-export interface BankStatementListResponse {
-  items: BankStatement[];
-  total: number;
-}
+export type BankStatementListResponse = ListResponse<BankStatement>;
 
 export type ReportLine = Schemas["ReportLine"];
 
@@ -432,10 +433,7 @@ export type ValuationComponentsResponse = Schemas["ValuationComponentsResponse"]
 
 export type ReconciliationStatsResponse = Schemas["ReconciliationStatsResponse"];
 
-export interface UnmatchedTransactionsResponse {
-  items: BankStatementTransactionSummary[];
-  total: number;
-}
+export type UnmatchedTransactionsResponse = ListResponse<BankStatementTransactionSummary>;
 
 export interface TrendPoint {
   period_start: string;
@@ -494,10 +492,7 @@ export interface ReconciliationMatchResponse {
   entries: JournalEntrySummary[];
 }
 
-export interface ReconciliationMatchListResponse {
-  items: ReconciliationMatchResponse[];
-  total: number;
-}
+export type ReconciliationMatchListResponse = ListResponse<ReconciliationMatchResponse>;
 
 export interface ManagedPosition {
   id: string;
@@ -516,10 +511,7 @@ export interface ManagedPosition {
   account_name?: string | null;
 }
 
-export interface ManagedPositionListResponse {
-  items: ManagedPosition[];
-  total: number;
-}
+export type ManagedPositionListResponse = ListResponse<ManagedPosition>;
 
 export interface ReconcilePositionsResponse {
   message: string;
@@ -590,10 +582,7 @@ export interface ManualValuationSnapshot {
   updated_at: string;
 }
 
-export interface ManualValuationSnapshotListResponse {
-  items: ManualValuationSnapshot[];
-  total: number;
-}
+export type ManualValuationSnapshotListResponse = ListResponse<ManualValuationSnapshot>;
 
 // ── Portfolio Management (EPIC-017) ──────────────────────────────────
 
@@ -721,10 +710,7 @@ export type ProcessingSummaryResponse = Schemas["ProcessingSummaryResponse"];
 
 export type ProcessingPendingItem = Schemas["ProcessingPendingItem"];
 
-export interface ProcessingPendingListResponse {
-  items: ProcessingPendingItem[];
-  total: number;
-}
+export type ProcessingPendingListResponse = ListResponse<ProcessingPendingItem>;
 
 // ── Brokerage Import (EPIC-017 / statement import completion) ─────────────
 

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -36,6 +36,7 @@ These files are test infrastructure, not behavior proof.
 | `apps/backend/tests/portfolio/__init__.py` | Package marker |
 | `apps/backend/tests/reconciliation/__init__.py` | Package marker |
 | `apps/backend/tests/reporting/__init__.py` | Package marker |
+| `apps/backend/tests/reporting/_report_fixtures.py` | Shared reporting chart-of-accounts test builder |
 | `tests/tooling/__init__.py` | Package marker |
 | `tests/tooling/conftest.py` | Shared tooling-test fixtures |
 | `tests/e2e/conftest.py` | Shared top-level E2E fixtures |

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -547,6 +547,7 @@ Product E2E ownership index:
 | `apps/backend/tests/e2e/test_core_journeys.py` | Backend core journey E2E; AC8.1-AC8.12 references live in the test file |
 | `apps/backend/tests/e2e/test_e2e_flows.py` | Backend extended flow E2E; AC references live in the test file |
 | `apps/backend/tests/e2e/test_epic022_ia.py` | EPIC-022 everyday-user IA shell product owner E2E; AC22.1 references live in the test file |
+| `apps/backend/tests/e2e/test_epic025_dry_ssot_e2e.py` | EPIC-025 DRY/SSOT product owner E2E; AC25.1.1 (reporting_calc extraction is behavior-preserving) references live in the test file |
 | `tests/e2e/test_application_ai_advisor_epic021.py` | Application AI Advisor product owner E2E; AC21.1 references live in the test file |
 | `tests/e2e/test_auth_flows.py` | Deployed auth flow E2E; AC references live in the test file |
 | `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | Critical proof: AC8.13.10 |

--- a/docs/project/EPIC-025.dry-ssot-simplification.md
+++ b/docs/project/EPIC-025.dry-ssot-simplification.md
@@ -1,0 +1,145 @@
+# EPIC-025: DRY/SSOT Simplification — Reporting, Statements, FE Contracts, Tests
+
+> **Status**: 🚧 In Progress
+> **Vision Anchor**: `decision-7-tech-stack`
+> **Owner**: Platform / Backend / Frontend
+> **Phase**: Hardening
+> **Dependencies**: EPIC-005 (Reporting), EPIC-003 (Statement Workflow), EPIC-022 (Everyday-User IA)
+
+---
+
+## 🎯 Objective
+
+Close the DRY/SSOT backlog (issue #1158) intentionally deferred from the CI-gate
+cleanup. Four large surfaces mix responsibilities or duplicate shared shapes:
+reporting calculation vs. orchestration, statement router vs. workflow services,
+hand-written frontend contracts vs. OpenAPI-generated types, and repeated test
+fixtures. This EPIC removes the duplication **without changing any behavior** —
+financial semantics, accounting invariants, AC traceability, and CI gate
+coverage are preserved. Each slice is behavior-preserving and independently
+verifiable.
+
+---
+
+## 🧭 Plan (STAR)
+
+### Situation
+- **Anchor**: The engineering tech-stack discipline (`decision-7-tech-stack`) —
+  prefer code-owned / generated single sources of truth over duplicated prose,
+  shapes, and inline orchestration.
+- **Gap**: `reporting.py` (2.3k LoC) mixes pure calculation with orchestration;
+  `routers/statements.py` owns transaction/state-transition boundaries that
+  belong in services; `lib/types.ts` re-rolls the `{items,total}` envelope and
+  drifts from OpenAPI; reporting tests duplicate chart-of-accounts / golden
+  scenario / FX-rate fixtures.
+
+### Tasks
+- **Reporting**: extract pure calculation helpers into `services/reporting_calc.py`.
+- **Statements**: move approve/reject transaction + state orchestration into a
+  `services/statement_workflow.py` contract; keep the router thin.
+- **Frontend**: introduce a single `ListResponse<T>` envelope, an OpenAPI
+  drift-guard, and pin `lib/api.ts` as the only raw-`fetch` boundary.
+- **Tests**: extract shared reporting fixtures; drop duplicate `test_user_id`.
+
+### Actions
+1. Create `reporting_calc.py` (pure, DB-free money/period/classification math);
+   `reporting.py` imports from it. Public report outputs are byte-identical.
+2. Create `statement_workflow.py` with `approve_statement_workflow` /
+   `reject_statement_workflow` owning their transaction boundary; routes delegate.
+3. Add `ListResponse<T>` to `lib/types.ts`; derive the three list wrappers;
+   add `contractTypes.test.ts` (OpenAPI drift + single fetch boundary).
+4. Add `tests/reporting/_report_fixtures.py`; adopt it in reporting tests; remove
+   duplicate `test_user_id` fixtures.
+
+### Result
+- No behavioral change: existing reporting / statement / frontend tests stay green.
+- Duplicated shapes and inline orchestration collapse to single owners.
+
+---
+
+## ✅ Scope
+
+- **In**: behavior-preserving extraction/consolidation of the four surfaces above.
+- **Out**: any change to financial formulas, accounting sign rules, FX
+  conversion, state-machine semantics, API request/response wire shapes, or AC
+  coverage. No new product features.
+
+---
+
+## ✅ Must Have
+
+- Reporting calculation helpers live in one importable module; report totals and
+  the balance-sheet equation are unchanged.
+- Statement approve/reject expose a service-level workflow that owns its
+  transaction boundary; the router only maps HTTP↔service.
+- The frontend list envelope has a single definition; `lib/api.ts` is the only
+  module issuing raw `fetch`.
+- Shared reporting test fixtures have one definition; AC traceability is intact.
+
+---
+
+## 🌟 Nice to Have
+
+- Further extraction of reporting export/CSV into a dedicated serializer.
+- Generic typed client helpers over `Paths` for path-level FE↔BE typing.
+
+---
+
+## 🧪 Test Cases
+
+> **Test Organization**: Tests organized by feature blocks using ACx.y.z numbering.
+
+### AC25.1 — Reporting calculation extraction
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC25.1.1 | Pure reporting math (money quantization, accounting sign rules, period boundaries, income-bucket classification) is provided by `services.reporting_calc` and re-used by `services.reporting`; the balance-sheet equation and report totals are unchanged | `test_reporting_calc_extraction` | `apps/backend/tests/reporting/test_reporting_calc_extraction.py` | P1 |
+
+### AC25.2 — Statement workflow service contract
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC25.2.1 | `approve_statement_workflow` / `reject_statement_workflow` own the transaction + state transition (PARSED→APPROVED/REJECTED) at the service layer, returning the updated statement; the router delegates and stays thin | `test_statement_workflow_service` | `apps/backend/tests/api/test_statement_workflow_service.py` | P1 |
+
+### AC25.3 — Frontend contract consolidation
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC25.3.1 | The list-response envelope has a single `ListResponse<T>` definition and the per-entity list responses derive from it; declared OpenAPI-mirrored contract types resolve to a real generated `Schemas[...]` key (drift guard) | `contractTypes drift` | `apps/frontend/src/__tests__/contractTypes.test.ts` | P1 |
+| AC25.3.2 | `lib/api.ts` is the single raw-`fetch` boundary — no other frontend source module issues a raw `fetch(` call | `contractTypes fetch boundary` | `apps/frontend/src/__tests__/contractTypes.test.ts` | P1 |
+
+### AC25.4 — Test fixture consolidation
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC25.4.1 | Shared reporting fixtures (standard chart of accounts, golden dashboard scenario, standard FX rates) are provided by a single `tests/reporting/_report_fixtures` module and reused, with duplicate per-file `test_user_id` fixtures removed; existing AC traceability is preserved | `test_report_fixtures_shared` | `apps/backend/tests/reporting/test_report_fixtures_shared.py` | P1 |
+
+---
+
+## 📏 Acceptance Criteria
+
+### 🟢 Must Have
+
+| Standard | Verification | Status |
+|----------|--------------|--------|
+| Reporting math has one owner | `reporting_calc` imported by `reporting` | 🚧 |
+| Report behavior unchanged | Existing reporting suite green | 🚧 |
+| Statement workflow owns its txn | Service test transitions + commits | 🚧 |
+| One FE list envelope + fetch boundary | `contractTypes.test.ts` green | 🚧 |
+| One reporting fixture source | `_report_fixtures` adopted | 🚧 |
+
+### 🚫 Not Acceptable
+
+- Any change to financial formulas, sign rules, FX conversion, or wire shapes.
+- A statement transitioning without its posting transaction committed atomically.
+- A second raw-`fetch` boundary in the frontend.
+- Loss of any existing AC's test reference.
+
+---
+
+## 🔗 References
+
+- Issue: #1158
+- SSOT Reporting: [../ssot/schema.md](../ssot/schema.md)
+- Reporting EPIC: [EPIC-005.*](.) · Statement workflow EPIC: [EPIC-003.*](.)
+- FE typed contract: `apps/frontend/src/lib/api-schema.ts`

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -15,6 +15,6 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:142 |
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:475 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:755 |
-| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:557 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:695 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:556 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:694 |
 | `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:102 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
           - "EPIC-022: Everyday-User IA": project/EPIC-022.everyday-user-ia.md
           - "EPIC-023: LLM Provider Abstraction": project/EPIC-023.llm-provider-abstraction.md
           - "EPIC-024: Frontend Browser Observability": project/EPIC-024.frontend-observability.md
+          - "EPIC-025: DRY/SSOT Simplification": project/EPIC-025.dry-ssot-simplification.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary

Closes #1158 — the DRY/SSOT simplification backlog deferred from the CI-gate cleanup — as **four behavior-preserving slices** under a new **EPIC-025**. No financial formulas, accounting sign rules, FX conversion, statement state-machine semantics, API wire shapes, or AC coverage change. The full backend suite (**2529 passed**, 96.41% coverage) and frontend suite (**870 passed**) stay green.

Mandatory order followed: EPIC → AC → test → code → doc. New EPIC-025 + AC registry + mkdocs nav + traceability-exceptions; `check_ac_index` and `lint_doc_consistency` PASS.

## Slices

### AC25.1 — Reporting calculation extraction
- New `apps/backend/src/services/reporting_calc.py` owns the pure, DB-free math (money quantization, accounting sign rules, period boundaries, income-bucket classification, provenance/confidence-tier rollup), extracted **verbatim** from `reporting.py`.
- `reporting.py` imports what it needs; `routers/income`, `services/annualized_income`, and tests import the pure helpers directly. `reporting.py` shrinks ~175 lines with no behavior change (re-export identity verified; existing reporting suite green).

### AC25.2 — Statement workflow into service contracts
- New `apps/backend/src/services/statement_workflow.py` with `approve_statement_workflow` / `reject_statement_workflow` that own the Stage-1 transaction boundary + state transition (PARSED→APPROVED/REJECTED). `routers/statements.py` delegates and stays thin (HTTP mapping + response shaping). Same service calls, same commit point, same ordering.
- Registered in `ALLOWED_SERVICE_COMMIT_BOUNDARIES` (AC12.26.1) as a documented boundary.

### AC25.3 — Frontend contract consolidation
- Collapsed eight duplicated `{ items; total }` list wrappers in `lib/types.ts` into a single generic `ListResponse<T>`.
- New `contractTypes.test.ts`: OpenAPI drift guard (contract types resolve to real generated `Schemas[...]` keys) + asserts `lib/api.ts` is the single raw-`fetch` boundary. `tsc` clean.

### AC25.4 — Test/fixture consolidation
- New `tests/reporting/_report_fixtures.py` shared chart-of-accounts builder; `test_reporting.py` adopts it.
- Hoisted the 7 duplicated `test_user_id` fixtures into the root `conftest.py`. AC traceability preserved.

## Verification
- Backend: `2529 passed`, coverage 96.41% (pre-push hook, xdist).
- Frontend: `870 passed`; `tsc` + ESLint clean.
- Gates: ruff + ruff-format clean; `check_ac_index` PASS; `lint_doc_consistency` clean.

## Notes for review
- Behavior-preserving refactor only; the existing reporting/statement/frontend suites are the safety net and are green.
- New AC tests (AC25.1.1/25.2.1/25.3.1/25.3.2/25.4.1) pin the extraction contracts so the simplifications can't silently regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)