### PR TITLE
[finance_report_infra] docs(vault): correct app Vault auth to AppRole — fix wrong recovery for the pilot (#257)

### DIFF
--- a/.opencode/skills/domain/secrets-management/SKILL.md
+++ b/.opencode/skills/domain/secrets-management/SKILL.md
@@ -197,14 +197,18 @@ S3_ACCESS_KEY={{ with .Data.data.S3_ACCESS_KEY }}{{ printf "%q" . }}{{ else }}""
 - `{{ printf "%q" . }}` quotes values (handles special chars)
 - `{{ else }}""{{ end }}` provides fallback for missing keys
 
-### Vault Token Types
+### Vault Auth Credentials
 
-| Token Type | Purpose | Scope | Storage |
+Runtime services (incl. the finance_report app — the AppRole **pilot**) authenticate to Vault via **AppRole** (`role_id` + `secret_id`). The old `VAULT_APP_TOKEN` periodic-token model is retired; only IaC Runner still uses it (infra2 `bootstrap.iac_runner.md` §6.4).
+
+| Credential | Purpose | Scope | Storage |
 |------------|---------|-------|---------|
 | `VAULT_ROOT_TOKEN` | Admin operations | All paths, write access | 1Password (`op://Infra2/.../Token`) |
-| `VAULT_APP_TOKEN` | Runtime secret reading | Read-only, service-specific | Dokploy ENV per service |
+| `VAULT_ROLE_ID` + `VAULT_SECRET_ID` | Runtime AppRole login → secret reading | Read-only, per-project/env/service | Dokploy ENV per service (injected by `invoke vault.setup-approle`) |
+| `VAULT_ADDR` | vault-agent connect address | non-secret, but **required** (missing → agent hangs) | Dokploy project-level ENV |
+| `VAULT_APP_TOKEN` *(legacy)* | Runtime secret reading | Read-only, service-specific | Dokploy ENV — **IaC Runner only** (`invoke vault.setup-tokens`) |
 
-**Security Rule**: Never use `VAULT_ROOT_TOKEN` in application containers. Only for `invoke vault.setup-tokens` and manual admin tasks.
+**Security Rule**: Never use `VAULT_ROOT_TOKEN` in application containers. Only for `invoke vault.setup-approle` / `setup-tokens` and manual admin tasks.
 
 ---
 

--- a/.opencode/skills/domain/secrets-management/SKILL.md
+++ b/.opencode/skills/domain/secrets-management/SKILL.md
@@ -199,14 +199,14 @@ S3_ACCESS_KEY={{ with .Data.data.S3_ACCESS_KEY }}{{ printf "%q" . }}{{ else }}""
 
 ### Vault Auth Credentials
 
-Runtime services (incl. the finance_report app — the AppRole **pilot**) authenticate to Vault via **AppRole** (`role_id` + `secret_id`). The old `VAULT_APP_TOKEN` periodic-token model is retired; only IaC Runner still uses it (infra2 `bootstrap.iac_runner.md` §6.4).
+The finance_report app authenticates to Vault via **AppRole** (`role_id` + `secret_id`) — it's the AppRole **pilot**. The `VAULT_APP_TOKEN` periodic-token model is being retired but is **not gone**: IaC Runner (infra2 `bootstrap.iac_runner.md` §6.4) and some legacy deploy paths/services still use it during the migration (e.g. the app's bash deploy preflight in `common/shell/common.sh`).
 
 | Credential | Purpose | Scope | Storage |
 |------------|---------|-------|---------|
 | `VAULT_ROOT_TOKEN` | Admin operations | All paths, write access | 1Password (`op://Infra2/.../Token`) |
 | `VAULT_ROLE_ID` + `VAULT_SECRET_ID` | Runtime AppRole login → secret reading | Read-only, per-project/env/service | Dokploy ENV per service (injected by `invoke vault.setup-approle`) |
 | `VAULT_ADDR` | vault-agent connect address | non-secret, but **required** (missing → agent hangs) | Dokploy project-level ENV |
-| `VAULT_APP_TOKEN` *(legacy)* | Runtime secret reading | Read-only, service-specific | Dokploy ENV — **IaC Runner only** (`invoke vault.setup-tokens`) |
+| `VAULT_APP_TOKEN` *(legacy)* | Runtime secret reading | Read-only, per service | Dokploy ENV — being retired; still used by IaC Runner + some legacy paths (`invoke vault.setup-tokens`) |
 
 **Security Rule**: Never use `VAULT_ROOT_TOKEN` in application containers. Only for `invoke vault.setup-approle` / `setup-tokens` and manual admin tasks.
 

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -310,7 +310,7 @@ so there is no 7-day token to renew or repair — the agent re-authenticates its
 | Property | Value |
 |----------|-------|
 | Auth method | AppRole (`VAULT_ROLE_ID` + `VAULT_SECRET_ID`) |
-| Secrets file path | `/vault/secrets/.env` |
+| Secrets file path | `/secrets/.env` (vault-agent renders to `/vault/secrets`; shared volume mounts into the app as `/secrets`) |
 | Staleness threshold | 1 hour (bootloader warning) |
 
 The AppRole creds are owned by infra2 and injected into the Dokploy compose env.

--- a/docs/ssot/deployment.md
+++ b/docs/ssot/deployment.md
@@ -300,29 +300,37 @@ symptoms, and flapping recovery proof.
 
 ---
 
-## Vault Token Lifecycle
+## Vault Auth (AppRole)
+
+Finance Report is the AppRole **pilot**: its vault-agent authenticates to Vault
+with `role_id` + `secret_id` (`VAULT_ROLE_ID` / `VAULT_SECRET_ID`), not the old
+periodic `VAULT_APP_TOKEN`. The AppRole secret-id is non-expiring (`secret_id_ttl=0`),
+so there is no 7-day token to renew or repair — the agent re-authenticates itself.
 
 | Property | Value |
 |----------|-------|
-| Token period | 168 hours (7 days), renewable by vault-agent |
-| Secrets file path | `/secrets/.env` |
+| Auth method | AppRole (`VAULT_ROLE_ID` + `VAULT_SECRET_ID`) |
+| Secrets file path | `/vault/secrets/.env` |
 | Staleness threshold | 1 hour (bootloader warning) |
 
-`VAULT_APP_TOKEN` is owned by infra2. Finance Report deploys only preflight the
-Dokploy token and must not receive `VAULT_ROOT_TOKEN`.
+The AppRole creds are owned by infra2 and injected into the Dokploy compose env.
+Finance Report deploys must not receive `VAULT_ROOT_TOKEN`. `VAULT_ADDR` is a
+non-secret address but **must be present** — a missing `VAULT_ADDR` makes the
+vault-agent hang (the deploy preflight fails closed on it).
 
-**Repair app token** (when expired):
+**(Re)inject app AppRole creds** (e.g. after a rotation, or if a deploy preflight
+reports missing `VAULT_ROLE_ID`/`VAULT_SECRET_ID`):
 
 ```bash
 # From local machine with infra2 repo
 cd /path/to/infra2
 export VAULT_ROOT_TOKEN="$(op read 'op://Infra2/dexluuvzg5paff3cltmtnlnosm/Token')"
-DEPLOY_ENV=staging invoke vault.setup-tokens --project=finance_report --service=app
+DEPLOY_ENV=staging invoke vault.setup-approle --project=finance_report --service=app --deploy
 ```
 
-The infra2 task updates the matching Dokploy compose env, triggers redeploy,
-tracks the new accessor, and revokes the previous accessor after a successful
-Dokploy update. For database sidecars use `--service=postgres` or
+The infra2 task writes the policy + approle role, fetches a fresh role_id/secret_id,
+updates the matching Dokploy compose env, and triggers a redeploy (waiting for the
+runtime deployment record). For database sidecars use `--service=postgres` or
 `--service=redis`.
 
 **Monitoring**: Bootloader `_check_vault_secrets()` runs in FULL mode and reports:


### PR DESCRIPTION
## Why

Companion to infra2 **#381**. The Vault AppRole migration audit found app-repo docs still describe the retired `VAULT_APP_TOKEN` periodic-token model as current — and give the **wrong recovery procedure for the flagship app**. Finance Report is the AppRole **pilot**: `finance_report/10.app/compose.yaml` is AppRole-only (`VAULT_ROLE_ID`/`VAULT_SECRET_ID`, no `VAULT_APP_TOKEN`).

## What

- **`docs/ssot/deployment.md`** "Vault Token Lifecycle" → "Vault Auth (AppRole)": previously told operators to repair the app with `vault.setup-tokens` (wrong model — would silently no-op since the app has no `VAULT_APP_TOKEN`). Now documents AppRole: there's no 7-day token to renew; (re)inject via `vault.setup-approle --deploy`. Adds that `VAULT_ADDR` must be present (deploy preflight now fails closed on it — infra2 #381).
- **`.opencode/skills/domain/secrets-management/SKILL.md`**: the token-types table now lists `VAULT_ROLE_ID`/`VAULT_SECRET_ID`/`VAULT_ADDR`; `VAULT_APP_TOKEN` marked *(legacy, IaC-Runner-only)*.

Docs only — no test or workflow assertions touch the changed sections (verified: `test_runtime_incident_response_ssot`, `test_ssot_governance_report` green).

## ⚠️ Deeper drift surfaced (out of scope — flagged, not fixed)

While verifying, I found the app's **legacy bash deploy path** still preflights `VAULT_APP_TOKEN` for the app and advises `setup-tokens` repair: `common/shell/common.sh` `verify_vault_app_token()` + `tools/_lib/shell/dokploy_deploy.sh` (enforced by `test_AC8_13_11`). That's **stale for the AppRole pilot** — but it's the app staging/prod **deploy-path** migration (sibling to the deferred iac_runner cutover), touches live deploy behavior + a test contract, and deserves its own deliberate PR. Not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)