### PR TITLE
[finance_report_audit] feat(money): narrow-waist CI guard (EPIC-002 AC2.23, #1172)

### DIFF
--- a/common/money/guard.py
+++ b/common/money/guard.py
@@ -43,12 +43,19 @@ def scan_text_for_float(text: str) -> list[str]:
         # float(...) cast
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "float":
             offending.append(f"{node.lineno}: float as cast")
-        # def f(x: float) / -> float
-        elif isinstance(node, ast.FunctionDef):
+        # def / async def f(x: float, *args: float, **kwargs: float) -> float
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             if _annotation_is_float(node.returns):
                 offending.append(f"{node.lineno}: float as return annotation")
-            for arg in [*node.args.args, *node.args.posonlyargs, *node.args.kwonlyargs]:
-                if _annotation_is_float(arg.annotation):
+            args = node.args
+            for arg in [
+                *args.args,
+                *args.posonlyargs,
+                *args.kwonlyargs,
+                args.vararg,
+                args.kwarg,
+            ]:
+                if arg is not None and _annotation_is_float(arg.annotation):
                     offending.append(f"{arg.lineno}: float as parameter annotation")
         # x: float = ...
         elif isinstance(node, ast.AnnAssign) and _annotation_is_float(node.annotation):

--- a/common/money/guard.py
+++ b/common/money/guard.py
@@ -1,0 +1,88 @@
+"""Narrow-waist guard — keep the money standard from eroding (#1167 / #1172).
+
+Two invariants this guard enforces so the money "narrow waist" cannot silently
+decay back into ad-hoc money handling:
+
+1. **No ``float`` in the money modules.** The whole point of the value types is
+   that ``float`` is unrepresentable for money. A ``float(...)`` cast or a
+   ``: float`` annotation inside the money modules would reopen the red line.
+   (``isinstance(x, float)`` — the *rejection* of float — is explicitly allowed.)
+
+2. **A conformance suite per stack.** The cross-language standard
+   (``common/money/conformance/vectors.json``) is only meaningful if every stack
+   actually runs it. If a stack's conformance suite is deleted/renamed, the two
+   ends can drift again — so its absence is a violation.
+
+Pure functions over text/paths so the gate test can both scan the real tree
+(expects clean) and an injected sample (expects a violation).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _annotation_is_float(node: ast.expr | None) -> bool:
+    return isinstance(node, ast.Name) and node.id == "float"
+
+
+def scan_text_for_float(text: str) -> list[str]:
+    """Return offending ``float`` uses in money *type positions*.
+
+    Uses ``ast`` so it flags only the real things — a ``float(...)`` call or a
+    ``: float`` / ``-> float`` annotation — and never docstring/comment prose or
+    ``isinstance(x, float)`` (which is the *rejection* of float, the desired
+    behaviour). Returns ``"<lineno>: float as <kind>"`` strings.
+    """
+    tree = ast.parse(text)
+    offending: list[str] = []
+    for node in ast.walk(tree):
+        # float(...) cast
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "float":
+            offending.append(f"{node.lineno}: float as cast")
+        # def f(x: float) / -> float
+        elif isinstance(node, ast.FunctionDef):
+            if _annotation_is_float(node.returns):
+                offending.append(f"{node.lineno}: float as return annotation")
+            for arg in [*node.args.args, *node.args.posonlyargs, *node.args.kwonlyargs]:
+                if _annotation_is_float(arg.annotation):
+                    offending.append(f"{arg.lineno}: float as parameter annotation")
+        # x: float = ...
+        elif isinstance(node, ast.AnnAssign) and _annotation_is_float(node.annotation):
+            offending.append(f"{node.lineno}: float as variable annotation")
+    return sorted(set(offending))
+
+
+def python_money_module_paths(repo_root: Path = REPO_ROOT) -> list[Path]:
+    """Python files that make up the money narrow waist (the runtime impls)."""
+    roots = [repo_root / "common" / "money", repo_root / "apps" / "backend" / "src" / "money"]
+    files: list[Path] = []
+    for root in roots:
+        if root.exists():
+            files.extend(sorted(p for p in root.rglob("*.py") if "conformance" not in p.parts))
+    return files
+
+
+def float_violations(repo_root: Path = REPO_ROOT) -> list[str]:
+    """Scan the money modules; return ``path:line`` violations (empty == clean)."""
+    violations: list[str] = []
+    for path in python_money_module_paths(repo_root):
+        for hit in scan_text_for_float(path.read_text(encoding="utf-8")):
+            violations.append(f"{path.relative_to(repo_root).as_posix()}:{hit}")
+    return violations
+
+
+# One conformance suite per stack that consumes the standard. Absence == drift.
+REQUIRED_CONFORMANCE_SUITES = (
+    "tests/tooling/test_money_conformance.py",  # Python reference impl
+    "apps/backend/tests/accounting/test_money_conformance_backend.py",  # shipped backend path
+    "apps/frontend/src/lib/money/money.conformance.test.ts",  # frontend impl
+)
+
+
+def missing_conformance_suites(repo_root: Path = REPO_ROOT) -> list[str]:
+    """Return required conformance suites that are absent (empty == all present)."""
+    return [rel for rel in REQUIRED_CONFORMANCE_SUITES if not (repo_root / rel).exists()]

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -491,10 +491,20 @@ banker's-rounding-vs-`decimal.js`-HALF_UP divergence).
 |----|-----------|---------------|------|----------|
 | AC2.21.1 | `CurrencyBalances` holds one balance per currency with no scalar accessor (a multi-currency statement is structurally inexpressible as a scalar) and round-trips the `StatementSummary.currency_balances` JSONB shape; closes the representation gap behind #1139/#1123 | `test_AC2_21_1_multi_currency_balance_is_not_a_scalar` (+ siblings) | `tests/tooling/test_money_value_type.py` | P0 |
 
-> **Deferred to sibling issues (not in #1170):** AC2.22 (route materiality
-> call-sites through `Money` — #1171) and AC2.23 (narrow-waist CI guard + L2/L3
-> promotion — #1172). They are registered when that work starts, per the
-> EPIC→AC→Test→Code→Doc order.
+### AC2.23: Narrow-waist CI guard ([#1172](https://github.com/wangzitian0/finance_report/issues/1172))
+
+A CI guard keeps the money standard from eroding: the money modules stay
+`float`-free and every stack keeps a conformance suite, so the cross-language
+narrow waist cannot silently decay back into ad-hoc money handling.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC2.23.1 | The guard flags a money-shaped `float` violation on an injected sample and reports none on the real money modules; each stack (Python reference, shipped backend, frontend) keeps a conformance suite | `test_AC2_23_1_guard_flags_injected_float_violation` (+ siblings) | `tests/tooling/test_money_narrow_waist_guard.py` | P0 |
+
+> **Deferred to sibling issue (not yet started):** AC2.22 (route materiality
+> call-sites through `Money` — #1171). The L2/L3 *score-baseline* promotion of the
+> money invariants is tracked in its established home #1103 (the assurance
+> backlog). Registered when that work starts, per the EPIC→AC→Test→Code→Doc order.
 
 ---
 

--- a/tests/tooling/test_money_narrow_waist_guard.py
+++ b/tests/tooling/test_money_narrow_waist_guard.py
@@ -28,6 +28,9 @@ rate: float = 1.0  # money-shaped float at module level
 def bad(amount: float, currency: str) -> float:  # money-shaped float pair
     total = float(amount)  # cast back to float
     return total
+
+async def worse(*args: float, **kwargs: float) -> float:  # async + *args/**kwargs float
+    return 0
 """
 
 

--- a/tests/tooling/test_money_narrow_waist_guard.py
+++ b/tests/tooling/test_money_narrow_waist_guard.py
@@ -1,0 +1,84 @@
+"""Narrow-waist guard gate (EPIC-002 AC2.23, #1167 / #1172).
+
+Locks the money standard against erosion: the money modules stay float-free and
+every stack keeps a conformance suite. The hard test proves the guard actually
+bites — it flags an injected violation and passes on the real tree.
+"""
+
+from pathlib import Path
+
+from common.money.guard import (
+    float_violations,
+    missing_conformance_suites,
+    scan_text_for_float,
+)
+from common.testing.ac_proof import ac_proof
+
+_CLEAN_SNIPPET = """
+from decimal import Decimal
+def f(amount: Decimal, currency: str) -> Decimal:
+    if isinstance(amount, float):
+        raise TypeError("no float")
+    return amount
+"""
+
+_VIOLATION_SNIPPET = """
+rate: float = 1.0  # money-shaped float at module level
+
+def bad(amount: float, currency: str) -> float:  # money-shaped float pair
+    total = float(amount)  # cast back to float
+    return total
+"""
+
+
+@ac_proof(
+    proof_id="test_money_guard_flags_injected_violation",
+    ac_ids=["AC2.23.1"],
+    ci_tier="pr_ci",
+    issue="#1172",
+)
+def test_AC2_23_1_guard_flags_injected_float_violation():
+    """AC2.23.1: the guard reports money-shaped float on a violation, none on clean."""
+    hits = scan_text_for_float(_VIOLATION_SNIPPET)
+    assert hits, "guard must flag a money-shaped float violation"
+    assert any("cast" in h for h in hits)
+    assert any("annotation" in h for h in hits)
+    # The clean snippet (which *rejects* float via isinstance) is not flagged.
+    assert scan_text_for_float(_CLEAN_SNIPPET) == []
+
+
+@ac_proof(
+    proof_id="test_money_modules_are_float_free",
+    ac_ids=["AC2.23.1"],
+    ci_tier="pr_ci",
+    issue="#1172",
+)
+def test_AC2_23_1_money_modules_are_float_free():
+    """AC2.23.1: the real money modules contain no float in money type positions."""
+    assert float_violations() == []
+
+
+@ac_proof(
+    proof_id="test_money_conformance_suite_per_stack",
+    ac_ids=["AC2.23.1"],
+    ci_tier="pr_ci",
+    issue="#1172",
+)
+def test_AC2_23_1_conformance_suite_present_in_every_stack():
+    """AC2.23.1: each stack keeps a conformance suite so the ends cannot drift."""
+    assert missing_conformance_suites() == []
+
+
+@ac_proof(
+    proof_id="test_money_guard_reports_violation_with_path",
+    ac_ids=["AC2.23.1"],
+    ci_tier="pr_ci",
+    issue="#1172",
+)
+def test_AC2_23_1_float_violations_reports_offending_path(tmp_path: Path):
+    """AC2.23.1: float_violations surfaces an offending money-module file by path."""
+    money_dir = tmp_path / "common" / "money"
+    money_dir.mkdir(parents=True)
+    (money_dir / "bad.py").write_text("def f(x: float) -> None:\n    return None\n")
+    violations = float_violations(repo_root=tmp_path)
+    assert any("common/money/bad.py" in v for v in violations)


### PR DESCRIPTION
## What & why
PR **3 of 3** for #1167. A CI guard that keeps the money narrow-waist from eroding back into ad-hoc money handling.

- **`common/money/guard.py`** — **AST-based** scanner (not regex, so docstrings and `isinstance(x, float)` are never false-positived). Flags `float` in money *type positions* (`float(...)` cast, `: float` / `-> float` annotations) across the money modules, and verifies **every stack keeps a conformance suite** (Python reference, shipped backend, frontend) so the two ends can't silently drift.
- **`tests/tooling/test_money_narrow_waist_guard.py`** — AC2.23.1.

## Hard test (verification)
- ✅ Guard **flags an injected** money-shaped `float` violation (`float(...)` cast + `: float`/`-> float`/`x: float` annotations) and reports **none on the real money modules** (green on the branch).
- ✅ Asserts a conformance suite exists per stack.
- ✅ 100% coverage of `guard.py`; all governance gates green locally (registry, doc-consistency, ac-index, manifest, ownership, SSOT governance, critical-proof, no-AC-classification).

## Scope note
This is the **guard** half of #1172. The L2/L3 **score-baseline** promotion of the money invariants stays in its established home **#1103** (the assurance backlog) to avoid destabilizing the ratchet.

## Sequencing
Stacked on **#1174** (base = `issue-1170-money-primitives`). Merge #1174 first, then this retargets to `main`.

Refs #1167. Closes #1172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)