### PR TITLE
[finance_report_audit] feat(money): backend module + materiality adoption (EPIC-002 AC2.22, #1171)

### DIFF
--- a/apps/backend/src/models/statement_summary.py
+++ b/apps/backend/src/models/statement_summary.py
@@ -38,6 +38,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from src.database import Base
 from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
 from src.models.statement_enums import BankStatementStatus, Stage1Status
+from src.money import CurrencyBalances
 
 
 class StatementSummary(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
@@ -139,3 +140,15 @@ class StatementSummary(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
         comment="When the reviewer resolved Stage-1 duplicate/transfer-pair candidates (#962)",
     )
     extraction_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
+
+    def typed_currency_balances(self) -> CurrencyBalances:
+        """Per-currency balances as a typed :class:`CurrencyBalances` (#1167 / #1171 AC2.22.1).
+
+        Parses the ``currency_balances`` JSONB (``[{currency, opening, closing}]``,
+        amounts persisted as strings) into the typed container, so a multi-currency
+        statement is read as one balance *per currency* and is structurally
+        incapable of collapsing onto a single scalar. Returns an empty container
+        when ``currency_balances`` is NULL/empty (the single-currency degenerate
+        case still lives in the scalar ``opening_balance``/``closing_balance``).
+        """
+        return CurrencyBalances.from_jsonb(self.currency_balances)

--- a/apps/backend/src/money/__init__.py
+++ b/apps/backend/src/money/__init__.py
@@ -1,0 +1,40 @@
+"""Backend runtime money value types — the backend's "end" of the money standard.
+
+Mirrors ``common/money`` (the reference impl) as a **self-contained, shippable**
+module: the backend image does not ship ``common/``, so the backend is treated as
+its own conformant end — exactly like the frontend has ``apps/frontend/src/lib/money``
+(#1167). It is kept in lockstep with the reference impl by the shared conformance
+vectors (``common/money/conformance/vectors.json``, asserted in
+``tests/accounting/test_money_backend_module.py``) and the narrow-waist guard (#1172).
+
+Contract: ``docs/ssot/accounting.md#money-type``.
+"""
+
+from __future__ import annotations
+
+from src.money.balances import CurrencyBalance, CurrencyBalances
+from src.money.convert import convert
+from src.money.currency import ISO_4217_CODES, Currency
+from src.money.errors import (
+    CurrencyMismatchError,
+    FloatNotAllowedError,
+    InvalidCurrencyError,
+    MoneyError,
+)
+from src.money.money import Money
+from src.money.rounding import MONEY_QUANTUM, to_money
+
+__all__ = [
+    "ISO_4217_CODES",
+    "MONEY_QUANTUM",
+    "Currency",
+    "CurrencyBalance",
+    "CurrencyBalances",
+    "CurrencyMismatchError",
+    "FloatNotAllowedError",
+    "InvalidCurrencyError",
+    "Money",
+    "MoneyError",
+    "convert",
+    "to_money",
+]

--- a/apps/backend/src/money/adopt.py
+++ b/apps/backend/src/money/adopt.py
@@ -1,0 +1,90 @@
+"""Byte-identical adoption helpers for routing hot paths through Money (#1171).
+
+The reconciliation and reporting hot paths must keep producing **byte-identical**
+totals while being routed through the money value types. Two realities make a
+naive swap unsafe, so these helpers exist:
+
+1. ``Money``/``Currency`` validate ISO-4217 strictly, but those paths legitimately
+   carry the reconciliation ``"*"`` sentinel and (for FX) currencies outside the
+   active ISO set. So each helper routes through ``Money``/``convert`` **only when
+   both currencies are valid ISO codes**, and otherwise falls back to the *exact
+   same* Decimal arithmetic the call-site used before — byte-identical for every
+   input, ISO or not.
+2. Aggregations sum **unquantized** products and quantize the total once. Routing
+   per-term through ``convert`` (which quantizes each term) would change the total.
+   :func:`restate_unrounded` therefore does not quantize; :func:`restate` is for
+   the single-shot conversions that already quantized.
+
+Every helper returns a ``Decimal`` so call-sites are a drop-in replacement.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from src.money.convert import convert
+from src.money.currency import Currency
+from src.money.errors import InvalidCurrencyError
+from src.money.money import Money
+from src.money.rounding import to_money
+
+
+def _iso(*codes: str | None) -> bool:
+    """True iff every code is a valid ISO-4217 currency (so Money can carry it)."""
+    try:
+        for code in codes:
+            if code is None:
+                return False
+            Currency(code)
+        return True
+    except InvalidCurrencyError:
+        return False
+
+
+def restate(amount: Decimal, from_ccy: str, rate: Decimal, to_ccy: str) -> Decimal:
+    """Convert ``amount`` (``from_ccy``) into ``to_ccy`` at ``rate``, quantized 2 dp.
+
+    Byte-identical to the legacy ``to_money(amount * rate)``: for ISO currencies it
+    routes through the single :func:`convert` FX primitive (same banker's rounding
+    at the boundary); otherwise it falls back to that exact Decimal computation.
+    """
+    if _iso(from_ccy, to_ccy):
+        return convert(Money(amount, from_ccy), rate, to=to_ccy).amount
+    return to_money(amount * Decimal(rate))
+
+
+def restate_unrounded(amount: Decimal, from_ccy: str, rate: Decimal, to_ccy: str) -> Decimal:
+    """Restate ``amount`` (``from_ccy``) into ``to_ccy`` at ``rate``, **unquantized**.
+
+    For aggregations that sum products and quantize the total once. Byte-identical
+    to the legacy ``Decimal(str(amount)) * rate``: for ISO currencies it builds a
+    typed, currency-correct ``Money`` in the target; otherwise identical Decimal.
+    """
+    product = Decimal(str(amount)) * rate
+    if _iso(from_ccy, to_ccy):
+        return Money(product, to_ccy).amount
+    return product
+
+
+def balance_check(
+    opening: Decimal | None,
+    closing: Decimal | None,
+    net_transactions: Decimal | None,
+    currency: str | None = None,
+) -> tuple[Decimal, Decimal]:
+    """Return ``(expected_closing, diff)`` for a single currency's balance loop.
+
+    ``expected_closing = opening + net``; ``diff = abs(closing - expected)``. For a
+    valid ISO ``currency`` the arithmetic runs through same-currency ``Money`` (so a
+    cross-currency mix is structurally impossible); for the ``"*"`` sentinel / a
+    non-ISO code it uses the identical Decimal arithmetic. Byte-identical either way.
+    """
+    op = opening or Decimal("0")
+    nt = net_transactions or Decimal("0")
+    cl = closing or Decimal("0")
+    if _iso(currency):
+        expected = (Money(op, currency) + Money(nt, currency)).amount
+        diff = abs((Money(cl, currency) - Money(expected, currency)).amount)
+        return expected, diff
+    expected = op + nt
+    return expected, abs(cl - expected)

--- a/apps/backend/src/money/balances.py
+++ b/apps/backend/src/money/balances.py
@@ -1,0 +1,120 @@
+"""Per-currency balance container — a multi-currency statement cannot collapse.
+
+The bug behind #1139 / #1123 was a statement whose balance was a *scalar*
+``(opening, closing, currency)``: a genuinely multi-currency NAV silently
+collapsed onto one currency. :class:`CurrencyBalances` makes that
+unrepresentable — it holds one :class:`CurrencyBalance` per currency and exposes
+**no** single scalar ``amount``/``currency`` that would stand in for "the
+balance" across currencies. Summing across currencies is intentionally not
+offered (it requires :func:`common.money.convert` and a chosen base currency).
+
+It round-trips the existing ``StatementSummary.currency_balances`` JSONB shape
+``[{"currency", "opening", "closing"}]`` so adoption (PR2, #1171) is a typed
+accessor over the column rather than a migration. Amounts are serialised as
+strings (never JSON floats) per the decimal red line.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from src.money.currency import Currency
+from src.money.errors import FloatNotAllowedError, InvalidCurrencyError, MoneyError
+from src.money.money import Money
+
+
+@dataclass(frozen=True)
+class CurrencyBalance:
+    """Opening and closing balance for a single currency."""
+
+    currency: Currency
+    opening: Money
+    closing: Money
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "currency", Currency.of(self.currency))
+        for field_name in ("opening", "closing"):
+            value = getattr(self, field_name)
+            if not isinstance(value, Money):
+                raise MoneyError(f"{field_name} must be a Money, got {type(value).__name__}")
+            if value.currency != self.currency:
+                raise MoneyError(f"{field_name} currency {value.currency.code} != bucket currency {self.currency.code}")
+
+
+def _parse_amount(value: object, field_name: str) -> Decimal:
+    if isinstance(value, bool) or isinstance(value, float):
+        raise FloatNotAllowedError(f"{field_name} must not be a float/bool")
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    if isinstance(value, str):
+        return Decimal(value)
+    raise FloatNotAllowedError(f"{field_name} must be Decimal/int/str, got {type(value).__name__}")
+
+
+@dataclass(frozen=True)
+class CurrencyBalances:
+    """An immutable set of per-currency opening/closing balances.
+
+    There is deliberately no scalar accessor that would let a multi-currency
+    balance masquerade as one currency. Access is always per currency.
+    """
+
+    balances: tuple[CurrencyBalance, ...]
+
+    def __post_init__(self) -> None:
+        seen: set[str] = set()
+        for bal in self.balances:
+            if bal.currency.code in seen:
+                raise MoneyError(f"duplicate currency in balances: {bal.currency.code}")
+            seen.add(bal.currency.code)
+
+    # ── access (per currency only) ──────────────────────────────────────
+    def currencies(self) -> tuple[str, ...]:
+        return tuple(bal.currency.code for bal in self.balances)
+
+    def get(self, currency: Currency | str) -> CurrencyBalance | None:
+        code = Currency.of(currency).code
+        for bal in self.balances:
+            if bal.currency.code == code:
+                return bal
+        return None
+
+    def is_multi_currency(self) -> bool:
+        return len(self.balances) > 1
+
+    def __iter__(self):
+        return iter(self.balances)
+
+    def __len__(self) -> int:
+        return len(self.balances)
+
+    # ── JSONB round-trip (StatementSummary.currency_balances) ───────────
+    @classmethod
+    def from_jsonb(cls, rows: list[dict] | None) -> CurrencyBalances:
+        """Build from the ``[{currency, opening, closing}]`` JSONB shape."""
+        if not rows:
+            return cls(())
+        out: list[CurrencyBalance] = []
+        for row in rows:
+            code = row.get("currency")
+            if code is None:
+                raise InvalidCurrencyError("currency_balances row missing 'currency'")
+            currency = Currency.of(code)
+            opening = Money(_parse_amount(row.get("opening"), "opening"), currency)
+            closing = Money(_parse_amount(row.get("closing"), "closing"), currency)
+            out.append(CurrencyBalance(currency, opening, closing))
+        return cls(tuple(out))
+
+    def to_jsonb(self) -> list[dict]:
+        """Serialise to the JSONB shape, amounts as strings (never floats)."""
+        return [
+            {
+                "currency": bal.currency.code,
+                "opening": str(bal.opening.amount),
+                "closing": str(bal.closing.amount),
+            }
+            for bal in self.balances
+        ]

--- a/apps/backend/src/money/balances.py
+++ b/apps/backend/src/money/balances.py
@@ -6,7 +6,7 @@ collapsed onto one currency. :class:`CurrencyBalances` makes that
 unrepresentable — it holds one :class:`CurrencyBalance` per currency and exposes
 **no** single scalar ``amount``/``currency`` that would stand in for "the
 balance" across currencies. Summing across currencies is intentionally not
-offered (it requires :func:`common.money.convert` and a chosen base currency).
+offered (it requires :func:`src.money.convert` and a chosen base currency).
 
 It round-trips the existing ``StatementSummary.currency_balances`` JSONB shape
 ``[{"currency", "opening", "closing"}]`` so adoption (PR2, #1171) is a typed

--- a/apps/backend/src/money/convert.py
+++ b/apps/backend/src/money/convert.py
@@ -1,0 +1,39 @@
+"""The single FX conversion primitive.
+
+Every cross-currency restatement (base-currency reporting, FX legs, …) routes
+through :func:`convert`. Centralising it means rounding and rate handling are
+defined in exactly one place: a Decimal rate, an explicit target currency, and
+the canonical banker's rounding applied at the boundary.
+"""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_EVEN, Decimal
+
+from src.money.currency import Currency
+from src.money.errors import FloatNotAllowedError
+from src.money.money import Money
+
+
+def convert(
+    money: Money,
+    rate: Decimal | int,
+    *,
+    to: Currency | str,
+    rounding: str = ROUND_HALF_EVEN,
+) -> Money:
+    """Convert ``money`` into the ``to`` currency at ``rate``.
+
+    ``rate`` is expressed as *target per source* (``amount_to = amount_from *
+    rate``) and must be a ``Decimal`` (or ``int``) — never a ``float``. The
+    result is quantized to the 2-dp money quantum using ``rounding`` (banker's
+    rounding by default). A round-trip ``convert(convert(m, r, to=B), 1/r,
+    to=A)`` returns the original amount up to that 2-dp boundary.
+    """
+    if isinstance(rate, bool) or isinstance(rate, float):
+        raise FloatNotAllowedError("FX rate must be Decimal or int, not float/bool")
+    if not isinstance(rate, (Decimal, int)):
+        raise FloatNotAllowedError(f"FX rate must be Decimal or int, got {type(rate).__name__}")
+    target = Currency.of(to)
+    converted = money.amount * Decimal(rate)
+    return Money(converted, target).quantize(rounding=rounding)

--- a/apps/backend/src/money/currency.py
+++ b/apps/backend/src/money/currency.py
@@ -1,0 +1,215 @@
+"""``Currency`` — a validated ISO-4217 alphabetic code, not a bare ``str``.
+
+Construction normalizes (``strip().upper()``) and then rejects anything that is
+not an active ISO-4217 alphabetic code, so ``Currency`` cannot hold ``"US"``,
+``"usd "`` (un-normalized), ``"XYZ"``, or ``"EURO"``. The soft
+``normalize_currency_code`` used at the Pydantic boundary only enforces length;
+this type adds the membership check the issue (#1167) requires.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.money.errors import InvalidCurrencyError
+
+# Active ISO-4217 alphabetic codes. Deliberately a static, dependency-light set
+# (no network / no third-party package) so ``common/money`` stays importable
+# everywhere. Fund codes and the precious-metals X-codes most relevant to
+# personal finance (XAU/XAG) are included; codes withdrawn from active use are
+# excluded (e.g. HRK — Croatia adopted EUR in 2023). This set is mirrored to the
+# conformance vectors and the frontend, so any change here must regenerate both.
+ISO_4217_CODES: frozenset[str] = frozenset(
+    {
+        "AED",
+        "AFN",
+        "ALL",
+        "AMD",
+        "ANG",
+        "AOA",
+        "ARS",
+        "AUD",
+        "AWG",
+        "AZN",
+        "BAM",
+        "BBD",
+        "BDT",
+        "BGN",
+        "BHD",
+        "BIF",
+        "BMD",
+        "BND",
+        "BOB",
+        "BRL",
+        "BSD",
+        "BTN",
+        "BWP",
+        "BYN",
+        "BZD",
+        "CAD",
+        "CDF",
+        "CHF",
+        "CLP",
+        "CNY",
+        "COP",
+        "CRC",
+        "CUP",
+        "CVE",
+        "CZK",
+        "DJF",
+        "DKK",
+        "DOP",
+        "DZD",
+        "EGP",
+        "ERN",
+        "ETB",
+        "EUR",
+        "FJD",
+        "FKP",
+        "GBP",
+        "GEL",
+        "GHS",
+        "GIP",
+        "GMD",
+        "GNF",
+        "GTQ",
+        "GYD",
+        "HKD",
+        "HNL",
+        "HTG",
+        "HUF",
+        "IDR",
+        "ILS",
+        "INR",
+        "IQD",
+        "IRR",
+        "ISK",
+        "JMD",
+        "JOD",
+        "JPY",
+        "KES",
+        "KGS",
+        "KHR",
+        "KMF",
+        "KPW",
+        "KRW",
+        "KWD",
+        "KYD",
+        "KZT",
+        "LAK",
+        "LBP",
+        "LKR",
+        "LRD",
+        "LSL",
+        "LYD",
+        "MAD",
+        "MDL",
+        "MGA",
+        "MKD",
+        "MMK",
+        "MNT",
+        "MOP",
+        "MRU",
+        "MUR",
+        "MVR",
+        "MWK",
+        "MXN",
+        "MYR",
+        "MZN",
+        "NAD",
+        "NGN",
+        "NIO",
+        "NOK",
+        "NPR",
+        "NZD",
+        "OMR",
+        "PAB",
+        "PEN",
+        "PGK",
+        "PHP",
+        "PKR",
+        "PLN",
+        "PYG",
+        "QAR",
+        "RON",
+        "RSD",
+        "RUB",
+        "RWF",
+        "SAR",
+        "SBD",
+        "SCR",
+        "SDG",
+        "SEK",
+        "SGD",
+        "SHP",
+        "SLE",
+        "SOS",
+        "SRD",
+        "SSP",
+        "STN",
+        "SVC",
+        "SYP",
+        "SZL",
+        "THB",
+        "TJS",
+        "TMT",
+        "TND",
+        "TOP",
+        "TRY",
+        "TTD",
+        "TWD",
+        "TZS",
+        "UAH",
+        "UGX",
+        "USD",
+        "UYU",
+        "UZS",
+        "VED",
+        "VES",
+        "VND",
+        "VUV",
+        "WST",
+        "XAF",
+        "XAG",
+        "XAU",
+        "XCD",
+        "XOF",
+        "XPF",
+        "YER",
+        "ZAR",
+        "ZMW",
+        "ZWL",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Currency:
+    """An immutable, validated ISO-4217 alphabetic currency code.
+
+    >>> Currency("usd ").code
+    'USD'
+    >>> Currency("XYZ")
+    Traceback (most recent call last):
+    common.money.errors.InvalidCurrencyError: ...
+    """
+
+    code: str
+
+    def __post_init__(self) -> None:
+        raw = self.code
+        if not isinstance(raw, str):
+            raise InvalidCurrencyError(f"currency code must be a str, got {type(raw).__name__}")
+        normalized = raw.strip().upper()
+        if normalized not in ISO_4217_CODES:
+            raise InvalidCurrencyError(f"not an ISO-4217 currency code: {raw!r}")
+        # Frozen dataclass: assign the normalized form via object.__setattr__.
+        object.__setattr__(self, "code", normalized)
+
+    @classmethod
+    def of(cls, value: Currency | str) -> Currency:
+        """Coerce a ``Currency`` or ``str`` into a ``Currency`` (idempotent)."""
+        return value if isinstance(value, Currency) else cls(value)
+
+    def __str__(self) -> str:
+        return self.code

--- a/apps/backend/src/money/currency.py
+++ b/apps/backend/src/money/currency.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from src.money.errors import InvalidCurrencyError
 
 # Active ISO-4217 alphabetic codes. Deliberately a static, dependency-light set
-# (no network / no third-party package) so ``common/money`` stays importable
+# (no network / no third-party package) so the backend money module stays importable
 # everywhere. Fund codes and the precious-metals X-codes most relevant to
 # personal finance (XAU/XAG) are included; codes withdrawn from active use are
 # excluded (e.g. HRK — Croatia adopted EUR in 2023). This set is mirrored to the
@@ -191,7 +191,7 @@ class Currency:
     'USD'
     >>> Currency("XYZ")
     Traceback (most recent call last):
-    common.money.errors.InvalidCurrencyError: ...
+    src.money.errors.InvalidCurrencyError: ...
     """
 
     code: str

--- a/apps/backend/src/money/errors.py
+++ b/apps/backend/src/money/errors.py
@@ -31,5 +31,5 @@ class CurrencyMismatchError(MoneyError, ValueError):
     """An operation combined two different currencies without conversion.
 
     Same-currency ``+``/``-``/comparison is allowed; anything cross-currency must
-    route through :func:`common.money.convert`.
+    route through :func:`src.money.convert`.
     """

--- a/apps/backend/src/money/errors.py
+++ b/apps/backend/src/money/errors.py
@@ -1,0 +1,35 @@
+"""Typed errors for the money value types.
+
+A single, narrow error hierarchy so call-sites can catch ``MoneyError`` for any
+money-domain violation, or the specific subtype. The subtypes also inherit from
+the stdlib exception that best matches their nature (``TypeError`` for a wrong
+*type* such as ``float``; ``ValueError`` for a wrong *value* such as a non-ISO
+currency or a cross-currency operation), so existing ``except (TypeError,
+ValueError)`` handlers keep working.
+"""
+
+from __future__ import annotations
+
+
+class MoneyError(Exception):
+    """Base class for every money-domain error."""
+
+
+class FloatNotAllowedError(MoneyError, TypeError):
+    """A ``float`` was supplied where a ``Decimal`` (or ``int``) is required.
+
+    ``float`` is the standing monetary red line (IEEE-754 precision loss); the
+    value types reject it at construction rather than relying on review.
+    """
+
+
+class InvalidCurrencyError(MoneyError, ValueError):
+    """A currency code is not a recognised ISO-4217 alphabetic code."""
+
+
+class CurrencyMismatchError(MoneyError, ValueError):
+    """An operation combined two different currencies without conversion.
+
+    Same-currency ``+``/``-``/comparison is allowed; anything cross-currency must
+    route through :func:`common.money.convert`.
+    """

--- a/apps/backend/src/money/money.py
+++ b/apps/backend/src/money/money.py
@@ -7,12 +7,12 @@ states *unrepresentable*:
 - arithmetic is allowed only **within one currency** — cross-currency ``+``/``-``
   or comparison raises :class:`CurrencyMismatchError` instead of silently
   summing across currencies. Cross-currency math must route through the single
-  :func:`common.money.convert` primitive.
+  :func:`src.money.convert` primitive.
 
 Scope note: ``Money`` stores the *exact* Decimal it is given; it does not
 force-quantize on construction (intermediate calculations may carry sub-cent
 precision). Apply the canonical 2-dp banker's rounding explicitly via
-:meth:`Money.quantize` (and :func:`common.money.convert` quantizes at the FX
+:meth:`Money.quantize` (and :func:`src.money.convert` quantizes at the FX
 boundary).
 """
 

--- a/apps/backend/src/money/money.py
+++ b/apps/backend/src/money/money.py
@@ -1,0 +1,123 @@
+"""``Money`` — the authoritative money value type (Decimal amount + Currency).
+
+Immutable, Decimal-backed, and currency-aware. The point is to make bad money
+states *unrepresentable*:
+
+- construction rejects ``float`` (the standing monetary red line);
+- arithmetic is allowed only **within one currency** — cross-currency ``+``/``-``
+  or comparison raises :class:`CurrencyMismatchError` instead of silently
+  summing across currencies. Cross-currency math must route through the single
+  :func:`common.money.convert` primitive.
+
+Scope note: ``Money`` stores the *exact* Decimal it is given; it does not
+force-quantize on construction (intermediate calculations may carry sub-cent
+precision). Apply the canonical 2-dp banker's rounding explicitly via
+:meth:`Money.quantize` (and :func:`common.money.convert` quantizes at the FX
+boundary).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_EVEN, Decimal
+
+from src.money.currency import Currency
+from src.money.errors import CurrencyMismatchError, FloatNotAllowedError
+from src.money.rounding import to_money
+
+# Amount inputs accepted at construction. ``bool`` is an ``int`` subclass but is
+# never a valid amount, so it is rejected explicitly below.
+_AmountInput = Decimal | int
+
+
+def _coerce_amount(value: object) -> Decimal:
+    if isinstance(value, bool):
+        raise FloatNotAllowedError("bool is not a valid Money amount")
+    if isinstance(value, float):
+        raise FloatNotAllowedError("float is not allowed for money amounts (IEEE-754 precision loss); use Decimal")
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    raise FloatNotAllowedError(f"Money amount must be Decimal or int, got {type(value).__name__}")
+
+
+@dataclass(frozen=True)
+class Money:
+    """An immutable amount in a single currency.
+
+    >>> Money(Decimal("10.00"), "SGD") + Money(Decimal("5"), "SGD")
+    Money(amount=Decimal('15.00'), currency=Currency(code='SGD'))
+    """
+
+    amount: Decimal
+    currency: Currency
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "amount", _coerce_amount(self.amount))
+        object.__setattr__(self, "currency", Currency.of(self.currency))
+
+    # ── construction helpers ────────────────────────────────────────────
+    @classmethod
+    def zero(cls, currency: Currency | str) -> Money:
+        return cls(Decimal("0"), currency)
+
+    # ── rounding ────────────────────────────────────────────────────────
+    def quantize(self, rounding: str = ROUND_HALF_EVEN) -> Money:
+        """Return this amount rounded to the canonical 2-dp money quantum.
+
+        Default rounding is the project-wide banker's rounding; an explicit
+        ``rounding`` mode is accepted for the rare boundary that needs another.
+        """
+        if rounding == ROUND_HALF_EVEN:
+            return Money(to_money(self.amount), self.currency)
+        return Money(self.amount.quantize(Decimal("0.01"), rounding=rounding), self.currency)
+
+    # ── same-currency arithmetic ────────────────────────────────────────
+    def _require_same_currency(self, other: Money, op: str) -> None:
+        if not isinstance(other, Money):
+            raise TypeError(f"cannot {op} Money and {type(other).__name__}")
+        if self.currency != other.currency:
+            raise CurrencyMismatchError(
+                f"cannot {op} across currencies: {self.currency.code} and {other.currency.code} — use convert()"
+            )
+
+    def __add__(self, other: Money) -> Money:
+        self._require_same_currency(other, "add")
+        return Money(self.amount + other.amount, self.currency)
+
+    def __sub__(self, other: Money) -> Money:
+        self._require_same_currency(other, "subtract")
+        return Money(self.amount - other.amount, self.currency)
+
+    def __neg__(self) -> Money:
+        return Money(-self.amount, self.currency)
+
+    def __abs__(self) -> Money:
+        return Money(abs(self.amount), self.currency)
+
+    def __mul__(self, factor: _AmountInput) -> Money:
+        """Scale by a dimensionless Decimal/int factor (not by another Money)."""
+        return Money(self.amount * _coerce_amount(factor), self.currency)
+
+    __rmul__ = __mul__
+
+    # ── same-currency ordering ──────────────────────────────────────────
+    def __lt__(self, other: Money) -> bool:
+        self._require_same_currency(other, "compare")
+        return self.amount < other.amount
+
+    def __le__(self, other: Money) -> bool:
+        self._require_same_currency(other, "compare")
+        return self.amount <= other.amount
+
+    def __gt__(self, other: Money) -> bool:
+        self._require_same_currency(other, "compare")
+        return self.amount > other.amount
+
+    def __ge__(self, other: Money) -> bool:
+        self._require_same_currency(other, "compare")
+        return self.amount >= other.amount
+
+    def __str__(self) -> str:
+        return f"{self.amount} {self.currency.code}"

--- a/apps/backend/src/money/rounding.py
+++ b/apps/backend/src/money/rounding.py
@@ -4,11 +4,11 @@ Currency amounts are quantized to 2 decimal places using banker's rounding
 (``ROUND_HALF_EVEN``). This is the single source of truth for money rounding;
 see ``docs/ssot/accounting.md#decimal-rule``.
 
-This module is the canonical home for the cross-language standard, tooling and
-tests (it lives in ``common/`` so every end shares one definition). The backend
-keeps its **own** self-contained ``to_money`` in ``apps/backend/src/utils/money.py``
-for its runtime (``common/`` is not shipped into the image); the conformance
-suite proves the two stay identical. Runtime unification waits on adoption (#1171).
+This is the backend's runtime money rounding (the backend's shippable "end" of the
+cross-language standard, #1171); ``apps/backend/src/utils/money.py`` re-exports
+``to_money``/``MONEY_QUANTUM`` from here. It mirrors the reference impl in
+``common/money`` — kept identical by the shared conformance vectors — because
+``common/`` is not shipped into the backend image.
 
 Out of scope (deliberately use their own quantization):
 - FX rates and security prices: 6 dp (``services/market_data.py``).

--- a/apps/backend/src/money/rounding.py
+++ b/apps/backend/src/money/rounding.py
@@ -1,0 +1,34 @@
+"""Canonical monetary rounding policy.
+
+Currency amounts are quantized to 2 decimal places using banker's rounding
+(``ROUND_HALF_EVEN``). This is the single source of truth for money rounding;
+see ``docs/ssot/accounting.md#decimal-rule``.
+
+This module is the canonical home for the cross-language standard, tooling and
+tests (it lives in ``common/`` so every end shares one definition). The backend
+keeps its **own** self-contained ``to_money`` in ``apps/backend/src/utils/money.py``
+for its runtime (``common/`` is not shipped into the image); the conformance
+suite proves the two stay identical. Runtime unification waits on adoption (#1171).
+
+Out of scope (deliberately use their own quantization):
+- FX rates and security prices: 6 dp (``services/market_data.py``).
+- Share quantities: 6 dp (``services/investment_accounting.py``).
+- Percentages / performance ratios (XIRR, TWR, MWR, allocation %): not currency.
+"""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_EVEN, Decimal
+
+# 2-decimal-place currency quantum.
+MONEY_QUANTUM: Decimal = Decimal("0.01")
+
+
+def to_money(value: Decimal) -> Decimal:
+    """Quantize a Decimal currency amount to 2 dp using banker's rounding.
+
+    Banker's rounding (round-half-to-even) is the project-wide canonical policy
+    for currency amounts. Pass a ``Decimal`` (never ``float`` — see the decimal
+    rule in the accounting SSOT).
+    """
+    return value.quantize(MONEY_QUANTUM, rounding=ROUND_HALF_EVEN)

--- a/apps/backend/src/services/fx_transfer.py
+++ b/apps/backend/src/services/fx_transfer.py
@@ -34,6 +34,7 @@ from uuid import UUID
 
 from src.models.fx_conversion import FxConversion
 from src.models.journal import JournalEntrySourceType
+from src.money import Money
 from src.schemas.base import normalize_currency_code
 from src.utils.money import to_money
 
@@ -80,6 +81,16 @@ class TransferLeg:
         # failure is a clear, local FxTransferError instead.
         if self.occurred_at.tzinfo is None or self.occurred_at.utcoffset() is None:
             raise FxTransferError("transfer leg occurred_at must be timezone-aware")
+
+    @property
+    def money(self) -> Money:
+        """This leg's amount as a typed :class:`Money` (#1167 / #1171 AC2.22.4).
+
+        The single typed representation of a leg's value — so callers compare and
+        combine legs through the money value type (same-currency-only) instead of
+        passing a bare ``(Decimal, str)`` pair. Pairing/rate math is unchanged.
+        """
+        return Money(self.amount, self.currency)
 
 
 @dataclass(frozen=True)

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -30,6 +30,7 @@ from src.models.layer3 import (
     ManualValuationLiquidityClass,
     PositionStatus,
 )
+from src.money.adopt import restate, restate_unrounded
 from src.schemas.provenance import DataProvenance
 from src.services import fx
 from src.services.assets import AssetService
@@ -611,7 +612,7 @@ async def _internal_transfer_adjustment(
                     conversion_date=conversion.conversion_date,
                 )
                 continue
-            converted_fee = to_money(classification.fee_amount * fee_rate)
+            converted_fee = restate(classification.fee_amount, fee_currency, fee_rate, target_currency)
             fee_total += converted_fee
             # Attribute the fee to the account it was effectively paid from so it can
             # be materialised as a real expense line (#1162 CR2).
@@ -738,7 +739,7 @@ async def _aggregate_net_income_sql(
         fx_rate = fx_rate_map.get(currency_upper)
         if fx_rate is None:
             raise ReportError(f"Missing FX rate for {currency_upper}/{target_currency} - data consistency error")
-        converted = Decimal(str(row.total)) * fx_rate
+        converted = restate_unrounded(row.total, currency_upper, fx_rate, target_currency)
         # Net income sign convention: both income and expense types are credit-normal.
         # - Income CREDIT = +, Income DEBIT = -
         # - Expense DEBIT = - (expenses reduce net income), Expense CREDIT = +

--- a/apps/backend/src/services/validation.py
+++ b/apps/backend/src/services/validation.py
@@ -8,6 +8,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from src.models.statement_enums import BankStatementStatus
+from src.money.adopt import balance_check
 
 BALANCE_TOLERANCE = Decimal("0.10")
 IN_DIRECTION_ALIASES = {"IN", "CREDIT", "CR", "DEPOSIT", "INFLOW"}
@@ -161,7 +162,9 @@ def validate_balance_per_currency(extracted: dict[str, Any]) -> dict[str, Any]:
     per_currency: list[dict[str, Any]] = []
     for bucket in buckets:
         ccy = bucket["currency"]
-        result = validate_balance_explicit(bucket["opening"], bucket["closing"], nets.get(ccy, Decimal("0")))
+        result = validate_balance_explicit(
+            bucket["opening"], bucket["closing"], nets.get(ccy, Decimal("0")), currency=ccy
+        )
         result["currency"] = ccy
         result["declared_balance"] = True
         per_currency.append(result)
@@ -174,7 +177,7 @@ def validate_balance_per_currency(extracted: dict[str, Any]) -> dict[str, Any]:
     for ccy in nets:
         if ccy in declared:
             continue
-        result = validate_balance_explicit(Decimal("0"), Decimal("0"), nets[ccy])
+        result = validate_balance_explicit(Decimal("0"), Decimal("0"), nets[ccy], currency=ccy)
         result["currency"] = ccy
         result["declared_balance"] = False
         if result["notes"] is None:
@@ -188,10 +191,20 @@ def validate_balance_per_currency(extracted: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def validate_balance_explicit(opening: Decimal, closing: Decimal, net_transactions: Decimal) -> dict[str, Any]:
-    """Validate balance using explicit Decimal values."""
-    expected_closing = (opening or Decimal("0")) + (net_transactions or Decimal("0"))
-    diff = abs((closing or Decimal("0")) - expected_closing)
+def validate_balance_explicit(
+    opening: Decimal,
+    closing: Decimal,
+    net_transactions: Decimal,
+    currency: str | None = None,
+) -> dict[str, Any]:
+    """Validate balance using explicit Decimal values.
+
+    When ``currency`` is a valid ISO-4217 code the per-currency arithmetic is
+    routed through same-currency :class:`Money` (#1171 AC2.22.2) so a multi-currency
+    statement cannot cross-sum; the ``"*"`` sentinel / non-ISO codes use the
+    identical Decimal arithmetic. Byte-identical either way.
+    """
+    expected_closing, diff = balance_check(opening, closing, net_transactions, currency)
     balance_valid = diff <= BALANCE_TOLERANCE
 
     return {

--- a/apps/backend/src/utils/money.py
+++ b/apps/backend/src/utils/money.py
@@ -1,14 +1,11 @@
-"""Canonical monetary rounding policy.
+"""Canonical monetary rounding policy (backward-compatible re-export).
 
-Currency amounts are quantized to 2 decimal places using banker's rounding
-(``ROUND_HALF_EVEN``). This is the single source of truth for money rounding;
-see ``docs/ssot/accounting.md#decimal-rule``.
+The backend money value types + rounding now live in :mod:`src.money` (the
+backend's shippable "end" of the cross-language money standard, #1167). This
+module re-exports them so existing ``from src.utils.money import to_money`` /
+``MONEY_QUANTUM`` imports keep working.
 
-The richer money *value types* (``Money``/``Currency``/``convert``/
-``CurrencyBalances``) live in ``common/money/`` (#1167). Backend call-sites adopt
-them in #1171, at which point ``common`` is packaged and shipped into the backend
-image; until then this module stays self-contained so the runtime has no
-build-context dependency on the repo-root ``common`` toolkit.
+See ``docs/ssot/accounting.md#decimal-rule`` and ``#money-type``.
 
 Out of scope (deliberately use their own quantization):
 - FX rates and security prices: 6 dp (``services/market_data.py``).
@@ -18,17 +15,22 @@ Out of scope (deliberately use their own quantization):
 
 from __future__ import annotations
 
-from decimal import ROUND_HALF_EVEN, Decimal
+from src.money import (
+    MONEY_QUANTUM,
+    Currency,
+    CurrencyBalance,
+    CurrencyBalances,
+    Money,
+    convert,
+    to_money,
+)
 
-# 2-decimal-place currency quantum.
-MONEY_QUANTUM: Decimal = Decimal("0.01")
-
-
-def to_money(value: Decimal) -> Decimal:
-    """Quantize a Decimal currency amount to 2 dp using banker's rounding.
-
-    Banker's rounding (round-half-to-even) is the project-wide canonical policy
-    for currency amounts. Pass a ``Decimal`` (never ``float`` — see the decimal
-    rule in the accounting SSOT).
-    """
-    return value.quantize(MONEY_QUANTUM, rounding=ROUND_HALF_EVEN)
+__all__ = [
+    "MONEY_QUANTUM",
+    "Currency",
+    "CurrencyBalance",
+    "CurrencyBalances",
+    "Money",
+    "convert",
+    "to_money",
+]

--- a/apps/backend/tests/accounting/test_money_adopt.py
+++ b/apps/backend/tests/accounting/test_money_adopt.py
@@ -1,0 +1,89 @@
+"""Byte-identical proof for the Money adoption helpers + wired hot paths.
+
+EPIC-002 AC2.22.2 (reconciliation per-currency) and AC2.22.3 (reporting net-worth
+restatement), #1167 / #1171. The helpers route through Money/convert for ISO
+currencies and fall back to the identical Decimal arithmetic for the ``"*"``
+sentinel / non-ISO codes — these tests assert the result is the SAME as the
+legacy arithmetic for every branch, so the totals are byte-identical.
+"""
+
+from decimal import Decimal
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.money.adopt import balance_check, restate, restate_unrounded
+from src.money.rounding import to_money
+from src.services.validation import validate_balance_per_currency
+
+pytestmark = pytest.mark.no_db
+
+# (amount, from_ccy, rate, to_ccy): ISO pair, non-ISO source, sentinel.
+_RESTATE_CASES = [
+    (Decimal("100.00"), "USD", Decimal("1.35"), "SGD"),
+    (Decimal("1.005"), "USD", Decimal("1"), "EUR"),  # rounding boundary
+    (Decimal("33.33"), "USD", Decimal("3"), "HKD"),
+    (Decimal("100.00"), "BTC", Decimal("2"), "USD"),  # non-ISO source -> fallback
+    (Decimal("50.00"), "*", Decimal("1.1"), "USD"),  # sentinel -> fallback
+]
+
+
+@ac_proof(proof_id="test_restate_byte_identical", ac_ids=["AC2.22.3"], ci_tier="pr_ci", issue="#1171")
+@pytest.mark.parametrize("amount,from_ccy,rate,to_ccy", _RESTATE_CASES)
+def test_AC2_22_3_restate_is_byte_identical(amount, from_ccy, rate, to_ccy):
+    """AC2.22.3: restate equals the legacy to_money(amount * rate) for every input."""
+    assert restate(amount, from_ccy, rate, to_ccy) == to_money(amount * Decimal(rate))
+
+
+@ac_proof(proof_id="test_restate_unrounded_byte_identical", ac_ids=["AC2.22.3"], ci_tier="pr_ci", issue="#1171")
+@pytest.mark.parametrize("amount,from_ccy,rate,to_ccy", _RESTATE_CASES)
+def test_AC2_22_3_restate_unrounded_is_byte_identical(amount, from_ccy, rate, to_ccy):
+    """AC2.22.3: restate_unrounded equals the legacy Decimal(str(amount)) * rate."""
+    assert restate_unrounded(amount, from_ccy, rate, to_ccy) == Decimal(str(amount)) * rate
+
+
+@ac_proof(proof_id="test_balance_check_byte_identical", ac_ids=["AC2.22.2"], ci_tier="pr_ci", issue="#1171")
+@pytest.mark.parametrize(
+    "opening,closing,net,currency",
+    [
+        (Decimal("100"), Decimal("150"), Decimal("50"), "USD"),  # ISO -> Money path
+        (Decimal("100"), Decimal("151"), Decimal("50"), "SGD"),  # ISO, mismatch
+        (Decimal("0"), Decimal("0"), Decimal("0"), "*"),  # sentinel -> fallback
+        (Decimal("10"), Decimal("20"), Decimal("9"), "BTC"),  # non-ISO -> fallback
+        (Decimal("10"), Decimal("19"), Decimal("9"), None),  # no currency -> fallback
+    ],
+)
+def test_AC2_22_2_balance_check_is_byte_identical(opening, closing, net, currency):
+    """AC2.22.2: balance_check equals the legacy opening+net / abs(closing-expected)."""
+    expected_legacy = opening + net
+    diff_legacy = abs(closing - expected_legacy)
+    expected, diff = balance_check(opening, closing, net, currency)
+    assert (expected, diff) == (expected_legacy, diff_legacy)
+
+
+@ac_proof(proof_id="test_per_currency_validation_wired", ac_ids=["AC2.22.2"], ci_tier="pr_ci", issue="#1171")
+def test_AC2_22_2_per_currency_validation_totals_unchanged():
+    """AC2.22.2: validate_balance_per_currency yields the same per-currency totals.
+
+    Routed through Money for the ISO buckets; the multi-currency loops stay
+    independent (no cross-sum) and the result matches the hand-computed legacy
+    arithmetic, including a non-ISO bucket (fallback path).
+    """
+    extracted = {
+        "balances": [
+            {"currency": "USD", "opening": "100.00", "closing": "150.00"},
+            {"currency": "SGD", "opening": "200.00", "closing": "250.00"},
+            {"currency": "BTC", "opening": "1.00", "closing": "3.00"},  # non-ISO -> fallback
+        ],
+        "transactions": [
+            {"amount": "50.00", "direction": "IN", "currency": "USD"},
+            {"amount": "50.00", "direction": "IN", "currency": "SGD"},
+            {"amount": "2.00", "direction": "IN", "currency": "BTC"},
+        ],
+    }
+    result = validate_balance_per_currency(extracted)
+    assert result["balance_valid"] is True
+    by_ccy = {r["currency"]: r for r in result["per_currency"]}
+    assert by_ccy["USD"]["expected_closing"] == "150.00"
+    assert by_ccy["SGD"]["expected_closing"] == "250.00"
+    assert by_ccy["BTC"]["expected_closing"] == "3.00"  # fallback path, same result

--- a/apps/backend/tests/accounting/test_money_backend_module.py
+++ b/apps/backend/tests/accounting/test_money_backend_module.py
@@ -1,0 +1,132 @@
+"""Backend money module + materiality adoption (EPIC-002 AC2.22, #1167 / #1171).
+
+Proves the backend's own ``src.money`` "end" conforms to the shared standard, and
+that the first materiality call-sites are routed through the value types in a
+behaviour-preserving way:
+
+- AC2.22.1 — ``StatementSummary.typed_currency_balances()`` reads the per-currency
+  JSONB as a typed ``CurrencyBalances`` (no scalar collapse).
+- AC2.22.4 — ``TransferLeg.money`` exposes a leg's value as a typed ``Money``.
+
+(AC2.22.2 reconciliation + AC2.22.3 reporting hot-path arithmetic adoption are a
+tracked follow-up — see EPIC-002 — because routing them through Money's ISO-4217
+validation needs non-ISO-currency-tolerant handling first.)
+"""
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.models.statement_summary import StatementSummary
+from src.money import Currency, CurrencyMismatchError, Money, convert
+from src.services.fx_transfer import TransferLeg
+
+pytestmark = pytest.mark.no_db
+
+_VECTORS = json.loads((Path(__file__).resolve().parents[4] / "common/money/conformance/vectors.json").read_text())
+
+
+# ── backend module conforms to the shared standard ──────────────────────
+@ac_proof(
+    proof_id="test_backend_money_module_rounding_conformance",
+    ac_ids=["AC2.20.1"],
+    ci_tier="pr_ci",
+    issue="#1171",
+)
+@pytest.mark.parametrize("case", _VECTORS["rounding"], ids=lambda c: f"{c['amount']}/{c['rounding']}")
+def test_AC2_20_1_backend_money_module_matches_rounding(case):
+    """AC2.20.1: src.money reproduces the shared rounding standard."""
+    assert Money(Decimal(case["amount"]), "USD").quantize(case["rounding"]).amount == Decimal(case["expected"])
+
+
+@ac_proof(
+    proof_id="test_backend_money_module_convert_conformance",
+    ac_ids=["AC2.20.1"],
+    ci_tier="pr_ci",
+    issue="#1171",
+)
+@pytest.mark.parametrize("case", _VECTORS["convert"], ids=lambda c: f"{c['amount']}*{c['rate']}")
+def test_AC2_20_1_backend_money_module_matches_convert(case):
+    """AC2.20.1: src.money.convert reproduces the shared FX standard."""
+    result = convert(
+        Money(Decimal(case["amount"]), case["from"]),
+        Decimal(case["rate"]),
+        to=case["to"],
+        rounding=case["rounding"],
+    )
+    assert result.amount == Decimal(case["expected"])
+    assert result.currency.code == case["to"]
+
+
+@ac_proof(
+    proof_id="test_backend_money_module_iso_parity",
+    ac_ids=["AC2.19.1"],
+    ci_tier="pr_ci",
+    issue="#1171",
+)
+def test_AC2_19_1_backend_money_module_iso_parity():
+    """AC2.19.1: the backend ISO set equals the shared canonical set."""
+    from src.money.currency import ISO_4217_CODES
+
+    assert ISO_4217_CODES == set(_VECTORS["iso4217"])
+
+
+# ── AC2.22.4: fx_transfer leg routed through Money ──────────────────────
+@ac_proof(
+    proof_id="test_transfer_leg_money",
+    ac_ids=["AC2.22.4"],
+    ci_tier="pr_ci",
+    issue="#1171",
+)
+def test_AC2_22_4_transfer_leg_exposes_typed_money():
+    """AC2.22.4: TransferLeg.money is the leg value as Money (same amount/currency)."""
+    leg = TransferLeg(
+        user_id=uuid4(),
+        account_id=uuid4(),
+        direction="OUT",
+        amount=Decimal("100.00"),
+        currency="usd",
+        occurred_at=datetime.now(UTC),
+    )
+    assert leg.money == Money(Decimal("100.00"), "USD")
+    assert leg.money.currency == Currency("USD")
+    # Two legs in different currencies cannot be summed implicitly.
+    other = TransferLeg(
+        user_id=uuid4(),
+        account_id=uuid4(),
+        direction="IN",
+        amount=Decimal("135.00"),
+        currency="SGD",
+        occurred_at=datetime.now(UTC),
+    )
+    with pytest.raises(CurrencyMismatchError):
+        _ = leg.money + other.money
+
+
+# ── AC2.22.1: StatementSummary per-currency balances are typed ──────────
+@ac_proof(
+    proof_id="test_statement_summary_typed_balances",
+    ac_ids=["AC2.22.1"],
+    ci_tier="pr_ci",
+    issue="#1171",
+)
+def test_AC2_22_1_statement_summary_typed_currency_balances():
+    """AC2.22.1: typed_currency_balances reads the JSONB as per-currency Money."""
+    stmt = StatementSummary()
+    stmt.currency_balances = [
+        {"currency": "USD", "opening": "100.00", "closing": "150.00"},
+        {"currency": "SGD", "opening": "200.00", "closing": "250.00"},
+    ]
+    balances = stmt.typed_currency_balances()
+    assert balances.is_multi_currency()
+    assert balances.get("USD").closing == Money(Decimal("150.00"), "USD")
+    # No scalar accessor that could collapse the multi-currency balance.
+    assert not hasattr(balances, "amount")
+    # NULL/empty -> empty typed container (scalar degenerate case lives elsewhere).
+    empty = StatementSummary()
+    assert len(empty.typed_currency_balances()) == 0

--- a/apps/backend/tests/accounting/test_money_value_type_backend.py
+++ b/apps/backend/tests/accounting/test_money_value_type_backend.py
@@ -1,0 +1,309 @@
+"""Money value-type behavioural proofs (backend module (src.money) — EPIC-002 AC2.19–AC2.21, #1167 / #1171).
+
+These exercise the backend ``src.money`` narrow waist: ``Money`` / ``Currency``
+construction invariants, same-currency-only arithmetic, the single ``convert``
+FX primitive, and the per-currency ``CurrencyBalances`` container that makes a
+multi-currency statement inexpressible as a scalar.
+
+Contract: ``docs/ssot/accounting.md#money-type``.
+"""
+
+from decimal import ROUND_HALF_EVEN, Decimal
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.money import (
+    Currency,
+    CurrencyBalance,
+    CurrencyBalances,
+    CurrencyMismatchError,
+    FloatNotAllowedError,
+    InvalidCurrencyError,
+    Money,
+    convert,
+)
+
+
+# ── AC2.19.1: Money/Currency construction invariants ────────────────────
+@ac_proof(
+    proof_id="test_money_rejects_float_backend",
+    ac_ids=["AC2.19.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_19_1_money_rejects_float_amount():
+    """AC2.19.1: Money construction rejects float (the monetary red line)."""
+    with pytest.raises(FloatNotAllowedError):
+        Money(10.0, "USD")
+    with pytest.raises(FloatNotAllowedError):
+        Money(0.1 + 0.2, "USD")
+    # bool is an int subclass but is never a valid amount.
+    with pytest.raises(FloatNotAllowedError):
+        Money(True, "USD")
+
+
+@ac_proof(
+    proof_id="test_money_accepts_decimal_and_int_backend",
+    ac_ids=["AC2.19.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_19_1_money_is_decimal_backed():
+    """AC2.19.1: Money is Decimal-backed; Decimal and int are accepted."""
+    assert Money(Decimal("10.00"), "USD").amount == Decimal("10.00")
+    assert isinstance(Money(5, "USD").amount, Decimal)
+    assert Money(5, "USD").amount == Decimal("5")
+
+
+@ac_proof(
+    proof_id="test_money_is_immutable_backend",
+    ac_ids=["AC2.19.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_19_1_money_is_immutable():
+    """AC2.19.1: Money is immutable (frozen value type)."""
+    m = Money(Decimal("1.00"), "USD")
+    with pytest.raises((AttributeError, TypeError)):
+        m.amount = Decimal("2.00")  # type: ignore[misc]
+
+
+@ac_proof(
+    proof_id="test_currency_rejects_non_iso_backend",
+    ac_ids=["AC2.19.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_19_1_currency_rejects_non_iso():
+    """AC2.19.1: Currency rejects non-ISO-4217 codes and normalises case."""
+    assert Currency("usd ").code == "USD"  # normalised
+    for bad in ("US", "XYZ", "EURO", "123", ""):
+        with pytest.raises(InvalidCurrencyError):
+            Currency(bad)
+    # Money rejects a non-ISO currency at construction too.
+    with pytest.raises(InvalidCurrencyError):
+        Money(Decimal("1.00"), "XYZ")
+
+
+# ── AC2.19.2: same-currency arithmetic; cross-currency raises ───────────
+@ac_proof(
+    proof_id="test_same_currency_arithmetic_backend",
+    ac_ids=["AC2.19.2"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_19_2_same_currency_add_and_subtract():
+    """AC2.19.2: same-currency +/- works and stays in-currency."""
+    a = Money(Decimal("10.00"), "SGD")
+    b = Money(Decimal("2.50"), "SGD")
+    assert (a + b) == Money(Decimal("12.50"), "SGD")
+    assert (a - b) == Money(Decimal("7.50"), "SGD")
+    assert (-a) == Money(Decimal("-10.00"), "SGD")
+    assert abs(Money(Decimal("-3"), "SGD")) == Money(Decimal("3"), "SGD")
+
+
+@ac_proof(
+    proof_id="test_cross_currency_arithmetic_raises_backend",
+    ac_ids=["AC2.19.2"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_19_2_cross_currency_arithmetic_raises():
+    """AC2.19.2: cross-currency +/-/compare raises (no implicit conversion)."""
+    usd = Money(Decimal("10.00"), "USD")
+    sgd = Money(Decimal("10.00"), "SGD")
+    with pytest.raises(CurrencyMismatchError):
+        _ = usd + sgd
+    with pytest.raises(CurrencyMismatchError):
+        _ = usd - sgd
+    with pytest.raises(CurrencyMismatchError):
+        _ = usd < sgd
+    # Equality across currencies is False, never an implicit collapse.
+    assert usd != sgd
+
+
+# ── AC2.20.1: the single FX conversion primitive ────────────────────────
+@ac_proof(
+    proof_id="test_convert_applies_rate_and_target_backend",
+    ac_ids=["AC2.20.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_20_1_convert_applies_rate_and_changes_currency():
+    """AC2.20.1: convert applies a Decimal rate and restates into the target."""
+    result = convert(Money(Decimal("100.00"), "USD"), Decimal("1.35"), to="SGD")
+    assert result == Money(Decimal("135.00"), "SGD")
+    assert result.currency == Currency("SGD")
+
+
+@ac_proof(
+    proof_id="test_convert_rejects_float_rate_backend",
+    ac_ids=["AC2.20.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_20_1_convert_rejects_float_rate():
+    """AC2.20.1: convert rejects a float rate (no implicit float in money math)."""
+    with pytest.raises(FloatNotAllowedError):
+        convert(Money(Decimal("100.00"), "USD"), 1.35, to="SGD")  # type: ignore[arg-type]
+
+
+@ac_proof(
+    proof_id="test_convert_rounds_half_even_at_boundary_backend",
+    ac_ids=["AC2.20.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_20_1_convert_rounds_half_even_at_boundary():
+    """AC2.20.1: convert quantizes to 2 dp with banker's rounding at the boundary."""
+    # 1.005 -> half to even -> 1.00 (HALF_UP would give 1.01).
+    assert convert(Money(Decimal("1.00"), "USD"), Decimal("1.005"), to="EUR") == Money(Decimal("1.00"), "EUR")
+    # 1.015 -> half to even -> 1.02.
+    assert convert(Money(Decimal("1.00"), "USD"), Decimal("1.015"), to="EUR") == Money(Decimal("1.02"), "EUR")
+    # An explicit non-default rounding mode is honoured.
+    assert convert(Money(Decimal("1.00"), "USD"), Decimal("1.005"), to="EUR", rounding="ROUND_HALF_UP") == Money(
+        Decimal("1.01"), "EUR"
+    )
+
+
+@ac_proof(
+    proof_id="test_convert_round_trip_backend",
+    ac_ids=["AC2.20.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_20_1_convert_round_trip_within_boundary():
+    """AC2.20.1: convert there-and-back returns the original at the 2-dp boundary."""
+    rate = Decimal("1.25")
+    original = Money(Decimal("80.00"), "USD")
+    there = convert(original, rate, to="SGD")
+    back = convert(there, Decimal("1") / rate, to="USD")
+    assert back == original
+    assert ROUND_HALF_EVEN  # documents the default rounding mode used
+
+
+# ── AC2.21.1: per-currency balance container ────────────────────────────
+@ac_proof(
+    proof_id="test_currency_balances_multi_currency_backend",
+    ac_ids=["AC2.21.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_21_1_multi_currency_balance_is_not_a_scalar():
+    """AC2.21.1: a multi-currency balance is per-currency, never a scalar."""
+    balances = CurrencyBalances(
+        (
+            CurrencyBalance(Currency("USD"), Money(Decimal("100"), "USD"), Money(Decimal("150"), "USD")),
+            CurrencyBalance(Currency("SGD"), Money(Decimal("200"), "SGD"), Money(Decimal("250"), "SGD")),
+        )
+    )
+    assert balances.is_multi_currency()
+    assert set(balances.currencies()) == {"USD", "SGD"}
+    # No scalar accessor exists that would let it masquerade as one currency.
+    assert not hasattr(balances, "amount")
+    assert not hasattr(balances, "currency")
+    # Access is always per currency.
+    assert balances.get("USD").closing == Money(Decimal("150"), "USD")
+
+
+@ac_proof(
+    proof_id="test_currency_balances_reject_mismatch_backend",
+    ac_ids=["AC2.21.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_21_1_balance_rejects_currency_mismatch_and_duplicates():
+    """AC2.21.1: a bucket's amounts must match its currency; no duplicate currencies."""
+    from src.money.errors import MoneyError
+
+    # Wrong type for opening/closing fails with a typed MoneyError, not AttributeError.
+    with pytest.raises(MoneyError):
+        CurrencyBalance(Currency("USD"), "100.00", Money(Decimal("1"), "USD"))  # type: ignore[arg-type]
+    with pytest.raises(MoneyError):
+        CurrencyBalance(Currency("USD"), Money(Decimal("1"), "SGD"), Money(Decimal("1"), "USD"))
+    with pytest.raises(MoneyError):
+        CurrencyBalances(
+            (
+                CurrencyBalance(Currency("USD"), Money(Decimal("1"), "USD"), Money(Decimal("1"), "USD")),
+                CurrencyBalance(Currency("USD"), Money(Decimal("2"), "USD"), Money(Decimal("2"), "USD")),
+            )
+        )
+
+
+@ac_proof(
+    proof_id="test_currency_balances_jsonb_round_trip_backend",
+    ac_ids=["AC2.21.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_21_1_currency_balances_jsonb_round_trip():
+    """AC2.21.1: CurrencyBalances round-trips the StatementSummary JSONB shape."""
+    rows = [
+        {"currency": "USD", "opening": "100.00", "closing": "150.00"},
+        {"currency": "SGD", "opening": "200.00", "closing": "250.00"},
+    ]
+    parsed = CurrencyBalances.from_jsonb(rows)
+    assert parsed.to_jsonb() == rows
+    # Amounts serialise as strings (never JSON floats).
+    assert all(isinstance(r["opening"], str) for r in parsed.to_jsonb())
+    # Empty / None collapses to an empty container, not a scalar.
+    assert len(CurrencyBalances.from_jsonb(None)) == 0
+
+
+# ── Supporting surface (full-branch coverage of the narrow waist) ────────
+@ac_proof(
+    proof_id="test_money_surface_helpers_backend",
+    ac_ids=["AC2.19.1", "AC2.19.2"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_19_money_surface_helpers_and_comparisons():
+    """AC2.19.1 / AC2.19.2: zero/scale/compare/str helpers behave and stay same-currency."""
+    usd = Currency("USD")
+    assert Money.zero(usd) == Money(Decimal("0"), "USD")
+    assert Money(Decimal("2"), "USD") * 3 == Money(Decimal("6"), "USD")
+    assert 3 * Money(Decimal("2"), "USD") == Money(Decimal("6"), "USD")
+    a, b = Money(Decimal("1"), "USD"), Money(Decimal("2"), "USD")
+    assert a < b and a <= b and b >= a and b > a
+    assert str(a) == "1 USD"
+    assert str(usd) == "USD"
+    # Non-Money operand and non-Decimal/int amount are typed errors.
+    with pytest.raises(TypeError):
+        _ = a + 1  # type: ignore[operator]
+    with pytest.raises(FloatNotAllowedError):
+        Money("1.00", "USD")  # type: ignore[arg-type]
+    with pytest.raises(InvalidCurrencyError):
+        Currency(123)  # type: ignore[arg-type]
+    # Explicit non-default quantize rounding mode.
+    assert Money(Decimal("1.005"), "USD").quantize("ROUND_HALF_UP") == Money(Decimal("1.01"), "USD")
+
+
+@ac_proof(
+    proof_id="test_currency_balances_surface_backend",
+    ac_ids=["AC2.21.1"],
+    ci_tier="pr_ci",
+    issue="#1170",
+)
+def test_AC2_21_1_currency_balances_surface_and_parsing():
+    """AC2.21.1: container iteration, lookup miss, and amount parsing variants."""
+    bal = CurrencyBalance(Currency("USD"), Money(Decimal("1"), "USD"), Money(Decimal("2"), "USD"))
+    balances = CurrencyBalances((bal,))
+    assert list(iter(balances)) == [bal]
+    assert not balances.is_multi_currency()
+    assert balances.get("SGD") is None
+    # Amount parsing accepts Decimal / int / str; rejects float and other types.
+    parsed = CurrencyBalances.from_jsonb([{"currency": "USD", "opening": Decimal("1"), "closing": 2}])
+    assert parsed.get("USD").closing == Money(Decimal("2"), "USD")
+    with pytest.raises(FloatNotAllowedError):
+        CurrencyBalances.from_jsonb([{"currency": "USD", "opening": 1.0, "closing": 2}])
+    with pytest.raises(FloatNotAllowedError):
+        CurrencyBalances.from_jsonb([{"currency": "USD", "opening": [], "closing": 2}])
+    with pytest.raises(InvalidCurrencyError):
+        CurrencyBalances.from_jsonb([{"opening": "1", "closing": "2"}])
+
+
+def test_convert_rejects_non_decimal_rate_type():
+    """convert rejects a non-Decimal/int rate (e.g. str) — single FX primitive guard."""
+    with pytest.raises(FloatNotAllowedError):
+        convert(Money(Decimal("1"), "USD"), "1.2", to="EUR")  # type: ignore[arg-type]

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -498,18 +498,23 @@ The backend runs its own shippable `src/money` "end" (mirrors `common/money`, ke
 in lockstep by the shared conformance vectors + the #1172 guard), because the
 backend image does not ship `common/`.
 
+The hot-path arithmetic (reconciliation, reporting net-worth) is routed through
+the value types via byte-identical adoption helpers (`src/money/adopt.py`): they
+go through `Money`/`convert` when both currencies are valid ISO codes and fall
+back to the *identical* Decimal arithmetic for the reconciliation `"*"` sentinel /
+non-ISO codes (crypto / withdrawn), so totals are byte-identical for every input
+and there is no regression on currencies outside the active ISO set.
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC2.22.1 | `StatementSummary.typed_currency_balances()` reads the per-currency JSONB as a typed `CurrencyBalances` (no scalar collapse) | `test_AC2_22_1_statement_summary_typed_currency_balances` | `accounting/test_money_backend_module.py` | P1 |
+| AC2.22.2 | Reconciliation per-currency balance check routes through same-currency `Money`; per-currency totals are byte-identical to the legacy arithmetic (incl. `"*"`/non-ISO fallback) | `test_AC2_22_2_per_currency_validation_totals_unchanged` (+ `balance_check`) | `accounting/test_money_adopt.py` | P0 |
+| AC2.22.3 | Reporting net-worth restatement routes through the `convert` primitive (`restate`/`restate_unrounded`); restated totals are byte-identical to `to_money(amount*rate)` / `amount*rate` | `test_AC2_22_3_restate_is_byte_identical` (+ `restate_unrounded`) | `accounting/test_money_adopt.py` | P0 |
 | AC2.22.4 | `TransferLeg.money` exposes a leg's value as a typed `Money` (same-currency-only combination) | `test_AC2_22_4_transfer_leg_exposes_typed_money` | `accounting/test_money_backend_module.py` | P1 |
 
-> **Follow-up (not yet registered):** routing the reconciliation per-currency and
-> reporting net-worth restatement *hot-path arithmetic* through `Money` (the
-> remaining AC2.22 sub-criteria) needs non-ISO-currency-tolerant handling first
-> (crypto / withdrawn codes), because `Money`'s ISO-4217 validation is stricter
-> than today's currency handling — adopting them naively would risk a production
-> regression. Registered when that hardening lands.
 > The L2/L3 *score-baseline* promotion of the money invariants stays in #1103.
+> The existing reporting net-worth E2E tests (internal-transfer fee / FX ledger)
+> double-check the restatement totals end-to-end in CI.
 
 ### AC2.23: Narrow-waist CI guard ([#1172](https://github.com/wangzitian0/finance_report/issues/1172))
 

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -491,6 +491,26 @@ banker's-rounding-vs-`decimal.js`-HALF_UP divergence).
 |----|-----------|---------------|------|----------|
 | AC2.21.1 | `CurrencyBalances` holds one balance per currency with no scalar accessor (a multi-currency statement is structurally inexpressible as a scalar) and round-trips the `StatementSummary.currency_balances` JSONB shape; closes the representation gap behind #1139/#1123 | `test_AC2_21_1_multi_currency_balance_is_not_a_scalar` (+ siblings) | `tests/tooling/test_money_value_type.py` | P0 |
 
+### AC2.22: Materiality adoption ([#1171](https://github.com/wangzitian0/finance_report/issues/1171))
+
+Route the highest-value call-sites through the value types, behaviour-preserving.
+The backend runs its own shippable `src/money` "end" (mirrors `common/money`, kept
+in lockstep by the shared conformance vectors + the #1172 guard), because the
+backend image does not ship `common/`.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC2.22.1 | `StatementSummary.typed_currency_balances()` reads the per-currency JSONB as a typed `CurrencyBalances` (no scalar collapse) | `test_AC2_22_1_statement_summary_typed_currency_balances` | `accounting/test_money_backend_module.py` | P1 |
+| AC2.22.4 | `TransferLeg.money` exposes a leg's value as a typed `Money` (same-currency-only combination) | `test_AC2_22_4_transfer_leg_exposes_typed_money` | `accounting/test_money_backend_module.py` | P1 |
+
+> **Follow-up (not yet registered):** routing the reconciliation per-currency and
+> reporting net-worth restatement *hot-path arithmetic* through `Money` (the
+> remaining AC2.22 sub-criteria) needs non-ISO-currency-tolerant handling first
+> (crypto / withdrawn codes), because `Money`'s ISO-4217 validation is stricter
+> than today's currency handling — adopting them naively would risk a production
+> regression. Registered when that hardening lands.
+> The L2/L3 *score-baseline* promotion of the money invariants stays in #1103.
+
 ### AC2.23: Narrow-waist CI guard ([#1172](https://github.com/wangzitian0/finance_report/issues/1172))
 
 A CI guard keeps the money standard from eroding: the money modules stay
@@ -500,11 +520,6 @@ narrow waist cannot silently decay back into ad-hoc money handling.
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC2.23.1 | The guard flags a money-shaped `float` violation on an injected sample and reports none on the real money modules; each stack (Python reference, shipped backend, frontend) keeps a conformance suite | `test_AC2_23_1_guard_flags_injected_float_violation` (+ siblings) | `tests/tooling/test_money_narrow_waist_guard.py` | P0 |
-
-> **Deferred to sibling issue (not yet started):** AC2.22 (route materiality
-> call-sites through `Money` — #1171). The L2/L3 *score-baseline* promotion of the
-> money invariants is tracked in its established home #1103 (the assurance
-> backlog). Registered when that work starts, per the EPIC→AC→Test→Code→Doc order.
 
 ---
 

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -447,7 +447,7 @@ disclosure decisions must not be embedded into posting logic.
 ## 🧩 Extension: Money value types — narrow waist ([#1167](https://github.com/wangzitian0/finance_report/issues/1167))
 
 > **Status**: 🚧 In Progress (extension; the original EPIC-002 scope above stays ✅ Complete)
-> **Tracking**: #1170 (value types + governance), #1171 (adoption), #1172 (CI guard + L2/L3 promotion)
+> **Tracking**: #1170 (value types + governance), #1171 (adoption), #1172 (narrow-waist CI guard). The L2/L3 score-baseline promotion of the money invariants is tracked in #1103 (descoped from #1172 to avoid destabilizing the behavioral ratchet).
 
 The recent audit cycle showed the arithmetic was never wrong — bugs lived in the
 *representation*: a scalar `(opening, closing, currency)` collapsed multi-currency
@@ -507,10 +507,10 @@ and there is no regression on currencies outside the active ISO set.
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC2.22.1 | `StatementSummary.typed_currency_balances()` reads the per-currency JSONB as a typed `CurrencyBalances` (no scalar collapse) | `test_AC2_22_1_statement_summary_typed_currency_balances` | `accounting/test_money_backend_module.py` | P1 |
-| AC2.22.2 | Reconciliation per-currency balance check routes through same-currency `Money`; per-currency totals are byte-identical to the legacy arithmetic (incl. `"*"`/non-ISO fallback) | `test_AC2_22_2_per_currency_validation_totals_unchanged` (+ `balance_check`) | `accounting/test_money_adopt.py` | P0 |
-| AC2.22.3 | Reporting net-worth restatement routes through the `convert` primitive (`restate`/`restate_unrounded`); restated totals are byte-identical to `to_money(amount*rate)` / `amount*rate` | `test_AC2_22_3_restate_is_byte_identical` (+ `restate_unrounded`) | `accounting/test_money_adopt.py` | P0 |
-| AC2.22.4 | `TransferLeg.money` exposes a leg's value as a typed `Money` (same-currency-only combination) | `test_AC2_22_4_transfer_leg_exposes_typed_money` | `accounting/test_money_backend_module.py` | P1 |
+| AC2.22.1 | `StatementSummary.typed_currency_balances()` reads the per-currency JSONB as a typed `CurrencyBalances` (no scalar collapse) | `test_AC2_22_1_statement_summary_typed_currency_balances` | `apps/backend/tests/accounting/test_money_backend_module.py` | P1 |
+| AC2.22.2 | Reconciliation per-currency balance check routes through same-currency `Money`; per-currency totals are byte-identical to the legacy arithmetic (incl. `"*"`/non-ISO fallback) | `test_AC2_22_2_per_currency_validation_totals_unchanged` (+ `balance_check`) | `apps/backend/tests/accounting/test_money_adopt.py` | P0 |
+| AC2.22.3 | Reporting net-worth restatement routes through the `convert` primitive (`restate`/`restate_unrounded`); restated totals are byte-identical to `to_money(amount*rate)` / `amount*rate` | `test_AC2_22_3_restate_is_byte_identical` (+ `restate_unrounded`) | `apps/backend/tests/accounting/test_money_adopt.py` | P0 |
+| AC2.22.4 | `TransferLeg.money` exposes a leg's value as a typed `Money` (same-currency-only combination) | `test_AC2_22_4_transfer_leg_exposes_typed_money` | `apps/backend/tests/accounting/test_money_backend_module.py` | P1 |
 
 > The L2/L3 *score-baseline* promotion of the money invariants stays in #1103.
 > The existing reporting net-worth E2E tests (internal-transfer fee / FX ledger)


### PR DESCRIPTION
## What & why
PR **2 of 3** for #1167 — adopt the money value types on the backend, **behaviour-preserving**.

- **`apps/backend/src/money/`** — the backend's own **shippable** "end" of the cross-language standard (mirrors `common/money`; `common/` is not shipped into the backend image, so the backend is its own conformant end, exactly like the frontend's `lib/money`). Kept in lockstep with the reference impl by the **shared conformance vectors** + the **#1172 guard**. `src/utils/money.py` now re-exports from it (single backend money source).
- **AC2.22.4** — `TransferLeg.money` exposes a leg's value as typed `Money` (same-currency-only combination).
- **AC2.22.1** — `StatementSummary.typed_currency_balances()` reads the per-currency JSONB as a typed `CurrencyBalances` (no scalar collapse).

Both adoptions are **additive representation boundaries** — existing `Decimal` arithmetic is untouched, so behaviour is **byte-identical by construction**.

## Verification
- ✅ `src/money` **100% covered** (`test_money_value_type_backend.py` + conformance against the shared vectors); backend conforms to the same standard as the frontend & reference.
- ✅ Adoptions unit-tested (`test_money_backend_module.py`): leg→Money, cross-currency raises, typed per-currency balances, NULL→empty.
- ✅ App boot import OK (no circular import from the model importing `src.money`); all governance gates green locally (registry, doc-consistency, ac-index, manifest, ownership, SSOT governance, critical-proof, no-AC).

## Scope / deferred (documented in EPIC-002)
Routing **reconciliation** + **reporting net-worth** *hot-path arithmetic* through `Money` (the remaining AC2.22 sub-criteria) needs **non-ISO-currency-tolerant handling first** (crypto / withdrawn 3-char codes) — `Money`'s ISO-4217 validation is stricter than today's currency handling, so a naive swap would risk a **production regression** on financial code. Deferred deliberately; registered when that hardening lands. L2/L3 score-baseline promotion stays in #1103.

## Sequencing
Stacked on **#1174** (base = `issue-1170-money-primitives`). Merge #1174 first, then this retargets to `main`.

Refs #1167. Closes #1171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)