### PR TITLE
[finance_report_infra] docs(vault): SKILL.md — AppRole is the runtime model, VAULT_APP_TOKEN retired (#257)

### DIFF
--- a/.opencode/skills/domain/secrets-management/SKILL.md
+++ b/.opencode/skills/domain/secrets-management/SKILL.md
@@ -123,10 +123,13 @@ DOKPLOY_API_KEY        # Deployment automation
 DOKPLOY_URL
 VAULT_ADDR             # Vault server URL
 VAULT_ROOT_TOKEN       # Admin operations only
-VAULT_ROLE_ID          # Per-service AppRole credential (runtime read-only)
-VAULT_SECRET_ID        # Per-service AppRole credential (runtime read-only)
 VPS_HOST               # Production server
 ```
+
+> **NOT direnv-managed:** the per-service runtime AppRole creds `VAULT_ROLE_ID` /
+> `VAULT_SECRET_ID` are sensitive and are **injected by infra2 into each service's
+> Dokploy ENV** (`invoke vault.setup-approle`). Never put them in `.envrc`, a local
+> `.env`, or commit them anywhere.
 
 ---
 
@@ -200,14 +203,16 @@ S3_ACCESS_KEY={{ with .Data.data.S3_ACCESS_KEY }}{{ printf "%q" . }}{{ else }}""
 
 ### Vault Auth Credentials
 
-The finance_report app authenticates to Vault via **AppRole** (`role_id` + `secret_id`) — it was the AppRole **pilot**, and every infra2 service has since migrated too (iac_runner included). The `VAULT_APP_TOKEN` periodic-token model is **retired**: no live service uses it. The only remaining reference is the app's legacy bash deploy-preflight (`common/shell/common.sh` `verify_vault_app_token`), which will go away with the deploy_v2 cutover of staging/prod.
+The finance_report app authenticates to Vault via **AppRole** (`role_id` + `secret_id`) — it was the AppRole **pilot**, and every infra2 service has since migrated too (iac_runner included). The `VAULT_APP_TOKEN` periodic-token model is **retired for runtime auth** — no vault-agent uses it anymore.
+
+> ⚠️ **It is still operationally load-bearing — do NOT delete it yet.** The legacy bash deploy path (`tools/_lib/shell/dokploy_deploy.sh` → `common/shell/common.sh` `verify_vault_app_token`, asserted by `test_AC8_13_11`) requires `VAULT_APP_TOKEN` to be present in the app's Dokploy ENV, or the staging/prod deploy **fails the preflight**. It can only be removed once the deploy_v2 cutover replaces that bash path.
 
 | Credential | Purpose | Scope | Storage |
 |------------|---------|-------|---------|
 | `VAULT_ROOT_TOKEN` | Admin operations | All paths, write access | 1Password (`op://Infra2/.../Token`) |
 | `VAULT_ROLE_ID` + `VAULT_SECRET_ID` | Runtime AppRole login → secret reading | Read-only, per-project/env/service | Dokploy ENV per service (injected by `invoke vault.setup-approle`) |
 | `VAULT_ADDR` | vault-agent connect address | non-secret, but **required** (missing → agent hangs) | Dokploy project-level ENV |
-| `VAULT_APP_TOKEN` *(retired)* | — | — | Old periodic-token model; no live service uses it (only a vestigial app bash deploy-preflight remains) |
+| `VAULT_APP_TOKEN` *(legacy)* | Runtime auth: **retired**. Still required by the bash deploy-preflight (`test_AC8_13_11`) | Must remain present in the app's Dokploy ENV | Dokploy ENV — keep until the deploy_v2 cutover removes the bash path |
 
 **Security Rule**: Never use `VAULT_ROOT_TOKEN` in application containers. Only for `invoke vault.setup-approle` / `setup-tokens` and manual admin tasks.
 

--- a/.opencode/skills/domain/secrets-management/SKILL.md
+++ b/.opencode/skills/domain/secrets-management/SKILL.md
@@ -123,7 +123,8 @@ DOKPLOY_API_KEY        # Deployment automation
 DOKPLOY_URL
 VAULT_ADDR             # Vault server URL
 VAULT_ROOT_TOKEN       # Admin operations only
-VAULT_APP_TOKEN        # Per-service read-only
+VAULT_ROLE_ID          # Per-service AppRole credential (runtime read-only)
+VAULT_SECRET_ID        # Per-service AppRole credential (runtime read-only)
 VPS_HOST               # Production server
 ```
 
@@ -178,7 +179,7 @@ Backend reads this when it needs to generate links back to the frontend (e.g., O
        ▼
 ┌─────────────────┐
 │  Application    │  Reads from /etc/vault/secrets (env file)
-│  Container      │  or directly from Vault via VAULT_APP_TOKEN
+│  Container      │  (vault-agent authenticates via AppRole)
 └─────────────────┘
 ```
 
@@ -199,14 +200,14 @@ S3_ACCESS_KEY={{ with .Data.data.S3_ACCESS_KEY }}{{ printf "%q" . }}{{ else }}""
 
 ### Vault Auth Credentials
 
-The finance_report app authenticates to Vault via **AppRole** (`role_id` + `secret_id`) — it's the AppRole **pilot**. The `VAULT_APP_TOKEN` periodic-token model is being retired but is **not gone**: IaC Runner (infra2 `bootstrap.iac_runner.md` §6.4) and some legacy deploy paths/services still use it during the migration (e.g. the app's bash deploy preflight in `common/shell/common.sh`).
+The finance_report app authenticates to Vault via **AppRole** (`role_id` + `secret_id`) — it was the AppRole **pilot**, and every infra2 service has since migrated too (iac_runner included). The `VAULT_APP_TOKEN` periodic-token model is **retired**: no live service uses it. The only remaining reference is the app's legacy bash deploy-preflight (`common/shell/common.sh` `verify_vault_app_token`), which will go away with the deploy_v2 cutover of staging/prod.
 
 | Credential | Purpose | Scope | Storage |
 |------------|---------|-------|---------|
 | `VAULT_ROOT_TOKEN` | Admin operations | All paths, write access | 1Password (`op://Infra2/.../Token`) |
 | `VAULT_ROLE_ID` + `VAULT_SECRET_ID` | Runtime AppRole login → secret reading | Read-only, per-project/env/service | Dokploy ENV per service (injected by `invoke vault.setup-approle`) |
 | `VAULT_ADDR` | vault-agent connect address | non-secret, but **required** (missing → agent hangs) | Dokploy project-level ENV |
-| `VAULT_APP_TOKEN` *(legacy)* | Runtime secret reading | Read-only, per service | Dokploy ENV — being retired; still used by IaC Runner + some legacy paths (`invoke vault.setup-tokens`) |
+| `VAULT_APP_TOKEN` *(retired)* | — | — | Old periodic-token model; no live service uses it (only a vestigial app bash deploy-preflight remains) |
 
 **Security Rule**: Never use `VAULT_ROOT_TOKEN` in application containers. Only for `invoke vault.setup-approle` / `setup-tokens` and manual admin tasks.
 
@@ -357,7 +358,7 @@ moon run :dev -- --check -- --critical-only
 ✅ Validate all variables at startup (Pydantic Settings)  
 ✅ Use `Field(validation_alias=...)` for case variations  
 ✅ Store secrets in Vault, never in `.env.example`  
-✅ Use per-service `VAULT_APP_TOKEN` (read-only)  
+✅ Use per-service AppRole creds (`VAULT_ROLE_ID`/`VAULT_SECRET_ID`, read-only)  
 ✅ Rotate `SECRET_KEY` and `VAULT_ROOT_TOKEN` regularly  
 
 ### DON'T
@@ -365,7 +366,7 @@ moon run :dev -- --check -- --critical-only
 ❌ Commit `.env` files to git (add to `.gitignore`)  
 ❌ Use `VAULT_ROOT_TOKEN` in application containers  
 ❌ Hardcode secrets in `config.py` defaults  
-❌ Share `VAULT_APP_TOKEN` across services  
+❌ Share AppRole creds (`VAULT_ROLE_ID`/`VAULT_SECRET_ID`) across services  
 ❌ Use generic container names in shared networks  
 ❌ Skip CI validation (`check_env_keys.py`)  
 ❌ Modify Vault secrets without updating `secrets.ctmpl`  


### PR DESCRIPTION
## Why
The AppRole migration is now complete — iac_runner migrated (#379), and the clickhouse `token_file` artifacts are deleted (infra2 PR #384). So the `secrets-management` skill's `VAULT_APP_TOKEN` references (incl. the "still used by IaC Runner" note I added in #1178) are stale.

## What
`.opencode/skills/domain/secrets-management/SKILL.md`:
- **Auth-credentials section + table** → `VAULT_APP_TOKEN` marked *(retired)*: no live service uses it.
- **Infra-vars list, the vault-agent diagram, the DO/DON'T best practices** → point to AppRole creds (`VAULT_ROLE_ID`/`VAULT_SECRET_ID`) instead of `VAULT_APP_TOKEN`.

## Deliberately NOT changed (flagged)
The **one** genuine remaining `VAULT_APP_TOKEN` reference is the app's **legacy bash deploy preflight** — `common/shell/common.sh` `verify_vault_app_token` (asserted by `test_AC8_13_11`, called from `dokploy_deploy.sh`). It *errors* on a missing token, so it's load-bearing for the legacy bash staging/prod deploy path, not a harmless no-op. Removing it belongs with the **deploy_v2 cutover** of staging/prod (replacing the bash path), not a doc/cleanup pass — so I left it and called it out here.

Companion: infra2 **#384** (clickhouse dead-artifact deletion + VAULT_ADDR entrypoint guard) and **#382** (token-machinery removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)