### PR TITLE
[finance_report_vision] fix(llm): EPIC-023 PR5 — per-user config hardening (AC23.4.7–.10)

### DIFF
--- a/apps/backend/src/llm/client.py
+++ b/apps/backend/src/llm/client.py
@@ -35,6 +35,20 @@ from src.logger import get_logger
 
 logger = get_logger(__name__)
 
+
+def _harden_litellm_logging() -> None:
+    """Stop litellm from printing request bodies (which carry the provider api_key
+    + prompt) to stdout. Best-effort + guarded so a renamed attribute in a future
+    litellm version can never break import."""
+    for attr, value in (("turn_off_message_logging", True), ("set_verbose", False), ("suppress_debug_info", True)):
+        try:
+            setattr(litellm, attr, value)
+        except Exception:  # noqa: BLE001 - logging hardening is never fatal
+            pass
+
+
+_harden_litellm_logging()
+
 # litellm exception names that represent transient conditions worth retrying.
 _RETRYABLE_EXC = frozenset(
     {"RateLimitError", "Timeout", "APIConnectionError", "ServiceUnavailableError", "InternalServerError"}

--- a/apps/backend/src/llm/db_config.py
+++ b/apps/backend/src/llm/db_config.py
@@ -92,7 +92,13 @@ class DbConfigSource:
         except (ValueError, TypeError):
             return None
         async with self._maker() as session:
-            row = await session.get(LlmProvider, pid)
+            # Scope the lookup to the same scope bindings are read from (the user's
+            # own rows, else the deployment default). Resolving by bare primary key
+            # would return — and decrypt — another tenant's provider key.
+            scope = await self._scope(session)
+            row = (
+                await session.execute(select(LlmProvider).where(LlmProvider.id == pid, LlmProvider.user_id == scope))
+            ).scalar_one_or_none()
         if row is None:
             return None
         return self._to_ref(row, self._cipher())

--- a/apps/backend/src/llm/factory.py
+++ b/apps/backend/src/llm/factory.py
@@ -48,6 +48,23 @@ class LayeredConfigSource:
         return await self._primary.is_configured() or await self._fallback.is_configured()
 
 
+_budget_meter: DailyBudgetMeter | None = None
+
+
+def get_budget_meter() -> DailyBudgetMeter:
+    """The process-wide daily budget meter.
+
+    The meter accumulates spend in memory, so it MUST be a singleton — a fresh
+    ``DailyBudgetMeter()`` per request would reset ``spent_today`` to zero and the
+    ``AI_DAILY_LIMIT_USD`` ceiling would never be enforced. (Per-process is still
+    a floor: separate workers each keep their own tally — see ``DailyBudgetMeter``.)
+    """
+    global _budget_meter
+    if _budget_meter is None:
+        _budget_meter = DailyBudgetMeter()
+    return _budget_meter
+
+
 def get_config_source(user_id: UUID | None = None) -> ConfigSource:
     """The config source for a user: their DB providers/bindings, falling back to
     the deployment default, then the env config.
@@ -61,5 +78,5 @@ def get_config_source(user_id: UUID | None = None) -> ConfigSource:
 
 
 def get_llm_client(user_id: UUID | None = None) -> LitellmClient:
-    """The scene-keyed client for a user, with the daily budget guard wired in."""
-    return LitellmClient(get_config_source(user_id), cost_meter=DailyBudgetMeter())
+    """The scene-keyed client for a user, with the shared daily budget guard wired in."""
+    return LitellmClient(get_config_source(user_id), cost_meter=get_budget_meter())

--- a/apps/backend/src/routers/llm.py
+++ b/apps/backend/src/routers/llm.py
@@ -13,7 +13,8 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Query, status
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
+from sqlalchemy.exc import IntegrityError
 
 from src.deps import CurrentUserId, DbSession
 from src.llm.catalog import LitellmCatalog
@@ -35,11 +36,15 @@ from src.schemas.llm import (
     LlmScenesResponse,
     LlmScenesUpdate,
 )
-from src.utils import raise_bad_request, raise_not_found, raise_service_unavailable
+from src.utils import raise_bad_request, raise_conflict, raise_not_found, raise_service_unavailable
 
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/llm", tags=["llm"])
+
+# Per-user provider ceiling: providers are cheap to create (one encrypt + INSERT),
+# so cap them to keep an authenticated user from growing the table unbounded.
+MAX_PROVIDERS_PER_USER = 25
 
 
 @router.get("/config/status", response_model=LlmConfigStatusResponse)
@@ -78,6 +83,12 @@ async def create_provider(
         # Never store a plaintext key: refuse the write rather than degrade.
         raise_service_unavailable("LLM secret encryption is not configured.", cause=exc)
 
+    count = (
+        await db.execute(select(func.count()).select_from(LlmProvider).where(LlmProvider.user_id == user_id))
+    ).scalar_one()
+    if count >= MAX_PROVIDERS_PER_USER:
+        raise_conflict(f"Provider limit reached ({MAX_PROVIDERS_PER_USER}); delete one before adding another.")
+
     sealed = cipher.encrypt(payload.api_key)
     provider = LlmProvider(
         user_id=user_id,
@@ -88,7 +99,11 @@ async def create_provider(
         api_base=payload.api_base,
     )
     db.add(provider)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise_conflict("Provider could not be created due to a conflict.", cause=exc)
     await db.refresh(provider)
     return LlmProviderResponse.model_validate(provider)
 
@@ -187,5 +202,11 @@ async def put_scenes(
                 max_tokens=b.max_tokens,
             )
         )
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        # Concurrent writes for the same user can collide on the per-scope unique
+        # index; surface a retryable conflict rather than a 500.
+        await db.rollback()
+        raise_conflict("Scene bindings could not be saved due to a concurrent update; retry.", cause=exc)
     return await get_scenes(db, user_id)

--- a/apps/backend/src/schemas/llm.py
+++ b/apps/backend/src/schemas/llm.py
@@ -8,6 +8,7 @@ so the API and the runtime contract can never drift.
 
 from __future__ import annotations
 
+import ipaddress
 from datetime import datetime
 from decimal import Decimal
 from urllib.parse import urlparse
@@ -17,6 +18,27 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from src.llm.common import Modality, ProtocolFamily, ReasoningEffort, Scene
 from src.schemas.base import BaseResponse
+
+# Hostnames that resolve to the host/loopback or local-only zones, rejected for
+# ``api_base`` so a user-supplied provider endpoint cannot point the backend at
+# internal services (SSRF). IP literals are checked structurally below.
+_BLOCKED_API_BASE_HOSTS = frozenset({"localhost", "metadata.google.internal", "metadata"})
+
+
+def _api_base_host_is_blocked(host: str) -> bool:
+    """True if ``host`` is loopback/link-local/private/reserved or a local-only name.
+
+    Structural check only (IP-literal ranges + a name denylist); it does not resolve
+    DNS — egress-time SSRF protection (DNS rebinding) belongs at the HTTP-client
+    layer. This rejects the common foot-guns at config-write time."""
+    h = host.lower().strip("[]")  # tolerate bracketed IPv6
+    if h in _BLOCKED_API_BASE_HOSTS or h.endswith((".internal", ".local")):
+        return True
+    try:
+        ip = ipaddress.ip_address(h)
+    except ValueError:
+        return False  # a regular hostname (not an IP literal)
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
 
 
 class LlmConfigStatusResponse(BaseModel):
@@ -55,6 +77,9 @@ class LlmProviderCreate(BaseModel):
         parsed = urlparse(trimmed)
         if parsed.scheme not in ("http", "https") or not parsed.netloc:
             raise ValueError("api_base must be an absolute http(s) URL")
+        host = parsed.hostname
+        if host is None or _api_base_host_is_blocked(host):
+            raise ValueError("api_base host is not allowed (loopback/private/link-local/metadata)")
         return trimmed
 
 

--- a/apps/backend/src/schemas/llm.py
+++ b/apps/backend/src/schemas/llm.py
@@ -32,6 +32,7 @@ def _api_base_host_is_blocked(host: str) -> bool:
     DNS — egress-time SSRF protection (DNS rebinding) belongs at the HTTP-client
     layer. This rejects the common foot-guns at config-write time."""
     h = host.lower().strip("[]")  # tolerate bracketed IPv6
+    h = h.rstrip(".")  # a trailing-dot FQDN (localhost. / vault.internal.) resolves the same
     if h in _BLOCKED_API_BASE_HOSTS or h.endswith((".internal", ".local")):
         return True
     try:

--- a/apps/backend/tests/integration/test_llm_api.py
+++ b/apps/backend/tests/integration/test_llm_api.py
@@ -122,6 +122,31 @@ async def test_AC23_4_2_delete_non_uuid_is_not_found(client: AsyncClient) -> Non
     assert resp.status_code == 404
 
 
+@pytest.mark.parametrize(
+    "api_base",
+    ["http://localhost:8080", "http://169.254.169.254/latest/meta-data", "http://10.0.0.5", "https://vault.internal"],
+)
+async def test_AC23_4_2_provider_rejects_ssrf_api_base(client: AsyncClient, cipher, api_base: str) -> None:
+    """AC23.4.9: api_base pointing at loopback/private/link-local/metadata/.internal is rejected (422)."""
+    resp = await client.post(
+        "/llm/providers",
+        json={"label": "x", "protocol": "openai-compatible", "api_key": "sk-x", "api_base": api_base},
+    )
+    assert resp.status_code == 422
+
+
+async def test_AC23_4_2_provider_count_capped(client: AsyncClient, cipher, monkeypatch) -> None:
+    """AC23.4.10: creating providers beyond the per-user cap returns 409."""
+    monkeypatch.setattr("src.routers.llm.MAX_PROVIDERS_PER_USER", 2)
+    await _create_provider(client, label="p1")
+    await _create_provider(client, label="p2")
+    resp = await client.post(
+        "/llm/providers",
+        json={"label": "p3", "protocol": "openai-compatible", "api_key": "sk-x"},
+    )
+    assert resp.status_code == 409
+
+
 async def test_AC23_4_3_catalog_lists_models_with_filters(client: AsyncClient) -> None:
     """AC23.4.3: the catalogue lists configured models and honours modality/free filters."""
     resp = await client.get("/llm/catalog")

--- a/apps/backend/tests/integration/test_llm_api.py
+++ b/apps/backend/tests/integration/test_llm_api.py
@@ -124,9 +124,18 @@ async def test_AC23_4_2_delete_non_uuid_is_not_found(client: AsyncClient) -> Non
 
 @pytest.mark.parametrize(
     "api_base",
-    ["http://localhost:8080", "http://169.254.169.254/latest/meta-data", "http://10.0.0.5", "https://vault.internal"],
+    [
+        "http://localhost:8080",
+        "http://169.254.169.254/latest/meta-data",
+        "http://10.0.0.5",
+        "https://vault.internal",
+        # trailing-dot FQDNs resolve to the same host and must not bypass the guard
+        "http://localhost.",
+        "https://vault.internal.",
+        "https://metadata.google.internal./computeMetadata/v1/",
+    ],
 )
-async def test_AC23_4_2_provider_rejects_ssrf_api_base(client: AsyncClient, cipher, api_base: str) -> None:
+async def test_AC23_4_9_provider_rejects_ssrf_api_base(client: AsyncClient, cipher, api_base: str) -> None:
     """AC23.4.9: api_base pointing at loopback/private/link-local/metadata/.internal is rejected (422)."""
     resp = await client.post(
         "/llm/providers",
@@ -135,7 +144,7 @@ async def test_AC23_4_2_provider_rejects_ssrf_api_base(client: AsyncClient, ciph
     assert resp.status_code == 422
 
 
-async def test_AC23_4_2_provider_count_capped(client: AsyncClient, cipher, monkeypatch) -> None:
+async def test_AC23_4_10_provider_count_capped(client: AsyncClient, cipher, monkeypatch) -> None:
     """AC23.4.10: creating providers beyond the per-user cap returns 409."""
     monkeypatch.setattr("src.routers.llm.MAX_PROVIDERS_PER_USER", 2)
     await _create_provider(client, label="p1")

--- a/apps/backend/tests/integration/test_llm_db_config.py
+++ b/apps/backend/tests/integration/test_llm_db_config.py
@@ -80,6 +80,39 @@ async def test_AC23_3_1_db_config_reads_providers_and_bindings(db, cipher):
     assert binding.max_tokens == 8192
 
 
+async def test_get_provider_is_user_scoped_no_cross_tenant_key_disclosure(db, cipher):
+    """AC23.4.8: get_provider must not resolve — or decrypt — another user's provider by id."""
+    from uuid import uuid4
+
+    from src.models import User
+
+    user_a = User(email=f"a-{uuid4()}@example.com", hashed_password="x")
+    user_b = User(email=f"b-{uuid4()}@example.com", hashed_password="x")
+    db.add_all([user_a, user_b])
+    await db.flush()
+
+    sealed = cipher.encrypt("sk-user-a-secret")
+    provider_a = LlmProvider(
+        user_id=user_a.id,
+        label="a-provider",
+        protocol=ProtocolFamily.OPENAI_COMPATIBLE,
+        api_key_ciphertext=sealed.ciphertext,
+        api_key_version=sealed.key_version,
+    )
+    db.add(provider_a)
+    await db.flush()
+
+    # User B's source must not see user A's provider, by id or in the list.
+    source_b = DbConfigSource(user_id=user_b.id, session_maker=_same_session_maker(db), cipher=cipher)
+    assert await source_b.get_provider(str(provider_a.id)) is None
+    assert all(p.id != str(provider_a.id) for p in await source_b.list_providers())
+
+    # User A's own source resolves it (and decrypts) — the scope is per-owner, not global.
+    source_a = DbConfigSource(user_id=user_a.id, session_maker=_same_session_maker(db), cipher=cipher)
+    ref = await source_a.get_provider(str(provider_a.id))
+    assert ref is not None and ref.api_key == "sk-user-a-secret"
+
+
 async def test_AC23_3_2_layered_uses_db_first_then_env(db, cipher, monkeypatch):
     """AC23.3.2: with no DB binding for a scene, the layered source falls back to env config."""
     monkeypatch.setattr(settings, "ai_api_key", "env-key", raising=False)

--- a/apps/backend/tests/integration/test_llm_db_config.py
+++ b/apps/backend/tests/integration/test_llm_db_config.py
@@ -80,7 +80,7 @@ async def test_AC23_3_1_db_config_reads_providers_and_bindings(db, cipher):
     assert binding.max_tokens == 8192
 
 
-async def test_get_provider_is_user_scoped_no_cross_tenant_key_disclosure(db, cipher):
+async def test_AC23_4_8_get_provider_is_user_scoped_no_cross_tenant_key_disclosure(db, cipher):
     """AC23.4.8: get_provider must not resolve — or decrypt — another user's provider by id."""
     from uuid import uuid4
 

--- a/apps/backend/tests/unit/llm/test_factory.py
+++ b/apps/backend/tests/unit/llm/test_factory.py
@@ -1,0 +1,24 @@
+"""Factory wiring: the budget meter must be a shared singleton (EPIC-023 PR5).
+
+A fresh ``DailyBudgetMeter`` per ``get_llm_client()`` would reset ``spent_today``
+to zero every call, so the daily limit would never be enforced. ``get_budget_meter``
+must hand back one shared instance.
+"""
+
+from __future__ import annotations
+
+import src.llm.factory as factory
+
+
+def test_budget_meter_is_a_process_singleton() -> None:
+    """AC23.4.7: get_budget_meter returns the same instance, and clients share it."""
+    factory._budget_meter = None  # reset any prior state for a deterministic check
+    first = factory.get_budget_meter()
+    second = factory.get_budget_meter()
+    assert first is second
+
+    client_a = factory.get_llm_client()
+    client_b = factory.get_llm_client()
+    # Both clients hold the *same* meter, so spend accumulates across calls.
+    assert client_a._cost is client_b._cost
+    assert client_a._cost is first

--- a/docs/project/EPIC-023.llm-provider-abstraction.md
+++ b/docs/project/EPIC-023.llm-provider-abstraction.md
@@ -123,14 +123,6 @@ parallel once PR1 merges.
 | AC23.4.4 | `GET/PUT /llm/scenes` round-trips the current user's scene→model bindings (model + reasoning + fallbacks), validated against their providers | `apps/backend/tests/integration/test_llm_api.py` | P1 |
 | AC23.4.5 | Per-user config resolves through the scene-keyed seam: `get_config_source(user_id)` / `get_llm_client(user_id)` resolve a user's binding for a scene (qualified by provider id), falling back to the deployment default then the env model. (Threading `user_id` into the legacy `ai_streaming`/`extraction` transport call sites is the EPIC-023 follow-up noted under Scope Slices — it migrates transport-coupled tests and is verified via the post-merge AI/OCR gate.) | `apps/backend/tests/integration/test_llm_api.py` | P1 |
 | AC23.4.6 | The legacy `services/ai_models.py` + `routers/ai_models.py` are removed; remaining model lookups (`statements`, `chat`) resolve through `LitellmCatalog`, and the dead `AI_MODEL_CATALOG_SOURCE` config is dropped | `apps/backend/tests/integration/test_llm_api.py` | P1 |
-
-#### AC23.4.7–.10 — hardening (PR5, from the per-user review)
-> Security/correctness fixes found reviewing the per-user surface: a shared budget
-> meter, tenant-scoped provider resolution, an SSRF guard on `api_base`, and a
-> per-user provider cap.
-
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
 | AC23.4.7 | The daily budget meter is a process-wide singleton (`get_budget_meter`), so `get_llm_client()` reuses one accumulator and the `AI_DAILY_LIMIT_USD` ceiling is actually enforced across requests (a fresh meter per call would reset spend to zero) | `apps/backend/tests/unit/llm/test_factory.py` | P1 |
 | AC23.4.8 | `DbConfigSource.get_provider` is scoped to the caller's scope (own rows, else deployment default); it never resolves or decrypts another tenant's provider by id | `apps/backend/tests/integration/test_llm_db_config.py` | P1 |
 | AC23.4.9 | `api_base` rejects loopback/private/link-local/reserved IPs and local-only names (`localhost`, `*.internal`, metadata) at the schema boundary, closing the obvious SSRF foot-guns | `apps/backend/tests/integration/test_llm_api.py` | P1 |

--- a/docs/project/EPIC-023.llm-provider-abstraction.md
+++ b/docs/project/EPIC-023.llm-provider-abstraction.md
@@ -123,3 +123,15 @@ parallel once PR1 merges.
 | AC23.4.4 | `GET/PUT /llm/scenes` round-trips the current user's scene→model bindings (model + reasoning + fallbacks), validated against their providers | `apps/backend/tests/integration/test_llm_api.py` | P1 |
 | AC23.4.5 | Per-user config resolves through the scene-keyed seam: `get_config_source(user_id)` / `get_llm_client(user_id)` resolve a user's binding for a scene (qualified by provider id), falling back to the deployment default then the env model. (Threading `user_id` into the legacy `ai_streaming`/`extraction` transport call sites is the EPIC-023 follow-up noted under Scope Slices — it migrates transport-coupled tests and is verified via the post-merge AI/OCR gate.) | `apps/backend/tests/integration/test_llm_api.py` | P1 |
 | AC23.4.6 | The legacy `services/ai_models.py` + `routers/ai_models.py` are removed; remaining model lookups (`statements`, `chat`) resolve through `LitellmCatalog`, and the dead `AI_MODEL_CATALOG_SOURCE` config is dropped | `apps/backend/tests/integration/test_llm_api.py` | P1 |
+
+#### AC23.4.7–.10 — hardening (PR5, from the per-user review)
+> Security/correctness fixes found reviewing the per-user surface: a shared budget
+> meter, tenant-scoped provider resolution, an SSRF guard on `api_base`, and a
+> per-user provider cap.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC23.4.7 | The daily budget meter is a process-wide singleton (`get_budget_meter`), so `get_llm_client()` reuses one accumulator and the `AI_DAILY_LIMIT_USD` ceiling is actually enforced across requests (a fresh meter per call would reset spend to zero) | `apps/backend/tests/unit/llm/test_factory.py` | P1 |
+| AC23.4.8 | `DbConfigSource.get_provider` is scoped to the caller's scope (own rows, else deployment default); it never resolves or decrypts another tenant's provider by id | `apps/backend/tests/integration/test_llm_db_config.py` | P1 |
+| AC23.4.9 | `api_base` rejects loopback/private/link-local/reserved IPs and local-only names (`localhost`, `*.internal`, metadata) at the schema boundary, closing the obvious SSRF foot-guns | `apps/backend/tests/integration/test_llm_api.py` | P1 |
+| AC23.4.10 | Provider creation is capped per user (`MAX_PROVIDERS_PER_USER`); exceeding it returns 409 instead of growing the table unbounded | `apps/backend/tests/integration/test_llm_api.py` | P1 |


### PR DESCRIPTION
Hardening fixes from reviewing the per-user model-selection mechanism (the EPIC-023 PR4 surface). Security/correctness only — no behaviour change to the happy path. New ACs **AC23.4.7–.10**.

## Fixes
| Sev | Fix | Where |
|-----|-----|-------|
| **C2 / AC23.4.7** | The daily budget meter is now a **process singleton** (`get_budget_meter`). `get_llm_client()` previously built a fresh `DailyBudgetMeter()` per call, so `spent_today` reset to 0 every request and `AI_DAILY_LIMIT_USD` was never enforced. | `llm/factory.py`, `llm/cost.py` |
| **C1 / AC23.4.8** | `DbConfigSource.get_provider` is **scope-filtered** (own rows, else deployment default). It previously fetched any provider by bare PK and **decrypted another tenant's key** — latent confused-deputy once the scene client is on the live path. | `llm/db_config.py` |
| **H2 / AC23.4.9** | `api_base` rejects **loopback/private/link-local/reserved IPs** and local-only names (`localhost`, `*.internal`, `*.local`, metadata) at the schema boundary — closes the obvious SSRF foot-guns. (DNS-rebinding/egress-time enforcement still belongs at the HTTP-client layer; noted.) | `schemas/llm.py` |
| **H3 / AC23.4.10** | Per-user **provider cap** (`MAX_PROVIDERS_PER_USER=25`) → 409, preventing unbounded table growth. | `routers/llm.py` |
| **M3** | Provider-create and scenes-PUT map `IntegrityError` → **409 (with rollback)** instead of a 500. | `routers/llm.py` |
| **L3** | Harden **litellm logging** at import (`turn_off_message_logging` / `set_verbose=False` / `suppress_debug_info`) so request bodies + provider keys are never printed. | `llm/client.py` |

## Not in this PR (deliberate)
- **H1** — actually threading `user_id`/scene bindings onto the live AI paths (`ai_streaming`/`extraction`/`ai_advisor`/`chat`) so per-user model choices take effect at runtime. That is the larger follow-up (separate PR) and is what makes the per-user selection functional; until then `/settings/llm` configures the resolution layer but the live transport still uses the env/deployment model. AC23.4.5 already documents this.
- **M1** (is_configured doesn't detect rotated-out keys), **M2** (`/llm/catalog` shows env models, not the user's), **M4** (PUT/scenes concurrency now maps to 409), **L1/L2** — tracked, low priority.

## Verification (local)
- 80 backend tests pass (unit/llm + db_config + api), incl. new tests: budget singleton, cross-tenant `get_provider` returns None + own resolves, SSRF api_base (localhost / 169.254.169.254 / 10.x / *.internal) → 422, provider cap → 409.
- AC-index PASSED (1739 nodes), doc-consistency clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)