### PR TITLE
[finance_report_test_and_doc] fix(deploy): verify_vault_app_token skips AppRole composes (AC8.13.11)

### DIFF
--- a/common/shell/common.sh
+++ b/common/shell/common.sh
@@ -322,6 +322,8 @@ verify_vault_app_token() {
   local repair_env="${4:-staging}"
   local token=""
   local vault_addr=""
+  local role_id=""
+  local secret_id=""
   local lookup_file
   local error_file
   local http_code
@@ -332,8 +334,20 @@ verify_vault_app_token() {
     case "$line" in
       VAULT_APP_TOKEN=*) token="${line#VAULT_APP_TOKEN=}" ;;
       VAULT_ADDR=*) vault_addr="${line#VAULT_ADDR=}" ;;
+      VAULT_ROLE_ID=*) role_id="${line#VAULT_ROLE_ID=}" ;;
+      VAULT_SECRET_ID=*) secret_id="${line#VAULT_SECRET_ID=}" ;;
     esac
   done <<< "$env_content"
+
+  # AppRole services (VAULT_ROLE_ID/VAULT_SECRET_ID present) authenticate via approle
+  # login, not a static token. The AppRole migration retired VAULT_APP_TOKEN; any leftover
+  # is unused and may linger expired, so gating on its presence would hard-block an
+  # otherwise-healthy AppRole deploy. Skip the token preflight, fail-closed otherwise.
+  # Mirrors the infra2 Python preflight (repo/tools/deploy_primitive.py).
+  if [[ -n "$role_id" && -n "$secret_id" ]]; then
+    echo "$context: AppRole auth detected (VAULT_ROLE_ID/VAULT_SECRET_ID present); VAULT_APP_TOKEN is unused, skipping token preflight" >&2
+    return 0
+  fi
 
   if [[ -z "$token" ]]; then
     echo "ERROR: $context failed: VAULT_APP_TOKEN is missing" >&2

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -506,6 +506,46 @@ def test_AC8_13_11_deploy_preflights_vault_token_before_redeploy() -> None:
     )
 
 
+def _run_verify_vault_app_token(env_content: str) -> subprocess.CompletedProcess:
+    """Source common.sh and invoke verify_vault_app_token against env_content."""
+    script = (
+        'source "$1"\n'
+        'verify_vault_app_token "$2" "preflight" 172800 "staging"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script, "bash", "common/shell/common.sh", env_content],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_AC8_13_11_deploy_preflight_skips_vault_token_for_approle_services() -> None:
+    """AC8.13.11: the Vault token preflight skips (does not hard-fail) when the
+    Dokploy compose authenticates via AppRole (VAULT_ROLE_ID/VAULT_SECRET_ID present)
+    and carries no VAULT_APP_TOKEN. The AppRole migration retired the static token, so
+    gating staging/production deploys on its presence would hard-block every deploy of
+    a migrated service. Mirrors the infra2 Python preflight tools/deploy_primitive.py."""
+    approle_env = (
+        "VAULT_ADDR=https://vault.zitian.party\n"
+        "VAULT_ROLE_ID=role-abc\n"
+        "VAULT_SECRET_ID=secret-xyz"
+    )
+    result = _run_verify_vault_app_token(approle_env)
+    assert result.returncode == 0, (
+        "AppRole compose (no VAULT_APP_TOKEN) must pass the preflight, got "
+        f"exit {result.returncode}: {result.stderr}"
+    )
+    assert "VAULT_APP_TOKEN is missing" not in result.stderr
+    assert "AppRole" in result.stderr
+
+    # A non-AppRole compose with no token still hard-fails (token-based auth path intact).
+    legacy_env = "VAULT_ADDR=https://vault.zitian.party"
+    legacy = _run_verify_vault_app_token(legacy_env)
+    assert legacy.returncode == 1
+    assert "VAULT_APP_TOKEN is missing" in legacy.stderr
+
+
 def test_AC8_13_12_ai_ocr_gate_failure_includes_statement_context() -> None:
     """AC8.13.12: AI/OCR gate failures include statement validation context."""
     conftest = read("tests/e2e/conftest.py")


### PR DESCRIPTION
## Problem

The first staging (and production) deploy after the Vault **AppRole migration** fails at the deploy step:

```
ERROR: Dokploy VAULT_APP_TOKEN preflight failed: VAULT_APP_TOKEN is missing
```

Discovered while deploying `5e88cc6` to staging — staging-deploy run [27683526244](https://github.com/wangzitian0/finance_report/actions/runs/27683526244) failed at `Deploy to Staging`. The live staging Dokploy compose env has `VAULT_ROLE_ID` + `VAULT_SECRET_ID` and **no** `VAULT_APP_TOKEN`.

## Root cause — cross-repo drift

The AppRole migration (infra2 #369/#382, "retire static-token machinery") retired `VAULT_APP_TOKEN` from the staging/production Dokploy compose envs (now `VAULT_ROLE_ID`/`VAULT_SECRET_ID`) and **added an AppRole-aware skip to the infra2 Python preflight** (`repo/tools/deploy_primitive.py`):

```python
if _env_value(env_text, "VAULT_ROLE_ID") and _env_value(env_text, "VAULT_SECRET_ID"):
    return  # AppRole auth -> any leftover VAULT_APP_TOKEN is unused; do not gate on it
```

The **app-repo shell preflight** `verify_vault_app_token()` in `common/shell/common.sh` was never given the same skip. Both `staging-deploy.yml` and `production-release.yml` (:492) call `tools/dokploy_deploy.sh` → this shell preflight, so **every staging/prod deploy of a migrated service hard-fails** until this lands.

## Fix

Mirror the merged Python logic in the shell function: when `VAULT_ROLE_ID` **and** `VAULT_SECRET_ID` are present, the service authenticates via AppRole and any `VAULT_APP_TOKEN` is unused — skip the token preflight. Fail-closed otherwise (token-based composes still require a valid, renewable token).

## Test

`tests/tooling/test_post_merge_e2e_gates.py::test_AC8_13_11_deploy_preflight_skips_vault_token_for_approle_services` — behavioral: sources `common.sh` and asserts an AppRole env (no token) **passes** while a legacy env (no token) still **hard-fails**. Confirmed red before the fix, green after. Existing preflight test (`..._before_redeploy`) unchanged and still passing.

- `apps/backend/.venv/bin/python tools/preflight.py` → relevant `tooling` gate green (1597 passed)
- pre-push: backend lint + frontend lint + full backend suite (2573 passed, 96.42% coverage)

## Scope note

This unblocks **both** staging and production deploys. The separate `report-branch-main` preview red (a timing race in the #1072 app-repo deploy sender that fires before CI publishes the `:<sha>` image) is **not** addressed here — filing separately.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)