### PR TITLE
[finance_report_vision] refactor(llm): consolidate on one path (drop unused LitellmClient) + real-usage budget + binding params

### DIFF
--- a/apps/backend/src/llm/client.py
+++ b/apps/backend/src/llm/client.py
@@ -1,11 +1,11 @@
-"""litellm-backed transport + scene client (EPIC-023 EPIC A).
+"""litellm-backed transport (EPIC-023 EPIC A).
 
-``litellm_stream`` / ``litellm_complete`` are the single chokepoint that talks to
-litellm; everything provider-specific is resolved by :mod:`src.llm.routing`, and
-``drop_params=True`` lets litellm silently drop fields a given model rejects
-(e.g. Z.AI/GLM rejecting ``seed`` — the quirk that previously needed bespoke
-handling). :class:`LitellmClient` is the scene-keyed surface implementing the
-``LLMClient`` protocol on top of a ``ConfigSource``.
+``litellm_stream`` is the single chokepoint that talks to litellm; everything
+provider-specific is resolved by :mod:`src.llm.routing`, and ``drop_params=True``
+lets litellm silently drop fields a given model rejects (e.g. Z.AI/GLM rejecting
+``seed`` — the quirk that previously needed bespoke handling). Provider/model
+selection is shared via :func:`resolve_provider_and_model`; spend is priced via
+:func:`cost_from_usage`. The service-facing entry point is ``services.ai_streaming``.
 """
 
 from __future__ import annotations
@@ -18,18 +18,13 @@ from typing import Any
 import litellm
 
 from src.llm.common import (
-    ChatResult,
     ConfigSource,
     LLMConfigError,
     LLMError,
     Message,
     ProviderRef,
     ReasoningEffort,
-    Scene,
-    SceneBinding,
-    Usage,
 )
-from src.llm.common.protocols import CostMeter
 from src.llm.routing import build_call
 from src.logger import get_logger
 
@@ -108,8 +103,13 @@ async def litellm_stream(
     seed: int | None = None,
     extra_body: dict[str, Any] | None = None,
     timeout: float | None = None,
+    usage_sink: dict[str, Any] | None = None,
 ) -> AsyncIterator[str]:
-    """Stream text delta chunks for one completion via litellm."""
+    """Stream text delta chunks for one completion via litellm.
+
+    When ``usage_sink`` is given, the final chunk's token usage is written to it
+    (``prompt_tokens`` / ``completion_tokens`` / ``model``) so the caller can record
+    real spend — streaming otherwise exposes no usage object."""
     kwargs = _base_kwargs(
         provider=provider,
         model_id=model_id,
@@ -121,6 +121,9 @@ async def litellm_stream(
         extra_body=extra_body,
     )
     kwargs["stream"] = True
+    if usage_sink is not None:
+        # Ask litellm to emit a final usage-bearing chunk (OpenAI stream_options).
+        kwargs["stream_options"] = {"include_usage": True}
     if timeout is not None:
         kwargs["timeout"] = timeout
 
@@ -130,6 +133,11 @@ async def litellm_stream(
     try:
         response = await litellm.acompletion(**kwargs)
         async for chunk in response:
+            raw_usage = getattr(chunk, "usage", None)
+            if raw_usage is not None and usage_sink is not None:
+                usage_sink["prompt_tokens"] = int(getattr(raw_usage, "prompt_tokens", 0) or 0)
+                usage_sink["completion_tokens"] = int(getattr(raw_usage, "completion_tokens", 0) or 0)
+                usage_sink["model"] = kwargs.get("model")
             choices = getattr(chunk, "choices", None) or []
             if not choices:
                 continue
@@ -156,74 +164,23 @@ async def litellm_stream(
         )
 
 
-async def litellm_complete(
-    messages: Sequence[Message],
-    *,
-    provider: ProviderRef,
-    model_id: str,
-    max_tokens: int | None = None,
-    temperature: float | None = None,
-    reasoning: ReasoningEffort | None = None,
-    extra_body: dict[str, Any] | None = None,
-) -> ChatResult:
-    """Non-streaming completion returning text + usage + cost."""
-    kwargs = _base_kwargs(
-        provider=provider,
-        model_id=model_id,
-        messages=messages,
-        max_tokens=max_tokens,
-        temperature=temperature,
-        reasoning=reasoning,
-        seed=None,
-        extra_body=extra_body,
-    )
+def cost_from_usage(model: str, prompt_tokens: int, completion_tokens: int) -> Decimal | None:
+    """USD cost from real token usage via litellm's price table, or ``None``.
+
+    Returns ``None`` (logging at debug) for models litellm doesn't price — notably
+    Z.AI/GLM — so the budget simply isn't metered for them rather than guessing.
+    Add a per-model price to enforce the ceiling for those providers. Never raises."""
+    if not prompt_tokens and not completion_tokens:
+        return None
     try:
-        response = await litellm.acompletion(**kwargs)
-    except LLMError:
-        raise
-    except Exception as exc:  # noqa: BLE001
-        raise _wrap(exc) from exc
-
-    choices = getattr(response, "choices", None) or []
-    text = ""
-    if choices:
-        msg = getattr(choices[0], "message", None)
-        text = (getattr(msg, "content", None) or "") if msg is not None else ""
-
-    raw_usage = getattr(response, "usage", None)
-    usage = Usage(
-        prompt_tokens=int(getattr(raw_usage, "prompt_tokens", 0) or 0),
-        completion_tokens=int(getattr(raw_usage, "completion_tokens", 0) or 0),
-    )
-    cost = _safe_cost(response)
-    return ChatResult(text=text, model_id=kwargs["model"], usage=usage, cost_usd=cost)
-
-
-def _safe_cost(response: Any) -> Decimal | None:
-    """Best-effort USD cost from litellm; never let cost telemetry break a call."""
-    try:
-        value = litellm.completion_cost(completion_response=response)
-    except Exception:  # noqa: BLE001 - cost is telemetry, not correctness
+        prompt_cost, completion_cost = litellm.cost_per_token(
+            model=model, prompt_tokens=prompt_tokens, completion_tokens=completion_tokens
+        )
+    except Exception:  # noqa: BLE001 - unpriced model -> not metered (telemetry, not correctness)
+        logger.debug("no litellm price for model; spend not metered", model=model)
         return None
-    if value is None:
-        return None
-    return Decimal(str(value))
-
-
-def estimate_cost_usd(model: str, messages: Sequence[Message], completion_text: str) -> Decimal | None:
-    """Best-effort USD cost for a streamed call from prompt + completion text.
-
-    Streaming yields no usage object, so the budget meter would never accumulate on
-    the live path. litellm's pricing table maps many models (it returns ``None`` /
-    raises for ones it doesn't know — e.g. a self-hosted vLLM — in which case spend
-    simply isn't counted for that model). Never raises."""
-    try:
-        value = litellm.completion_cost(model=model, messages=list(messages), completion=completion_text)
-    except Exception:  # noqa: BLE001 - cost is telemetry, not correctness
-        return None
-    if not value:
-        return None
-    return Decimal(str(value))
+    total = (prompt_cost or 0) + (completion_cost or 0)
+    return Decimal(str(total)) if total else None
 
 
 async def resolve_provider_and_model(config_source: ConfigSource, model_id: str) -> tuple[ProviderRef, str]:
@@ -237,9 +194,9 @@ async def resolve_provider_and_model(config_source: ConfigSource, model_id: str)
     several providers an unqualified or unknown-provider id is a config error,
     never a silent fallback to the wrong credentials.
 
-    Shared by :class:`LitellmClient` and the ``ai_streaming`` transport so the
-    per-user binding's provider qualifier is honoured everywhere (a user with
-    several providers must not fail closed on a qualified binding).
+    Used by the ``ai_streaming`` transport so the per-user binding's provider
+    qualifier is honoured everywhere (a user with several providers must not fail
+    closed on a qualified binding).
     """
     providers = await config_source.list_providers()
     if not providers:
@@ -255,65 +212,3 @@ async def resolve_provider_and_model(config_source: ConfigSource, model_id: str)
     if len(providers) == 1:
         return providers[0], model_id
     raise LLMConfigError(f"Ambiguous provider for unqualified model {model_id!r}; qualify as provider_id/model")
-
-
-class LitellmClient:
-    """Scene-keyed ``LLMClient`` resolving config through a ``ConfigSource``."""
-
-    def __init__(self, config_source: ConfigSource, cost_meter: CostMeter | None = None) -> None:
-        self._config = config_source
-        self._cost = cost_meter
-
-    async def _resolve(self, scene: Scene) -> tuple[ProviderRef, str, SceneBinding]:
-        binding = await self._config.get_binding(scene)
-        if binding is None:
-            raise LLMConfigError(f"No model bound for scene {scene.value!r}")
-        provider, model = await self._resolve_provider(binding.model_id)
-        return provider, model, binding
-
-    async def _resolve_provider(self, model_id: str) -> tuple[ProviderRef, str]:
-        return await resolve_provider_and_model(self._config, model_id)
-
-    def stream(
-        self, scene: Scene, messages: Sequence[Message], *, reasoning: ReasoningEffort | None = None
-    ) -> AsyncIterator[str]:
-        return self._stream(scene, messages, reasoning=reasoning)
-
-    def stream_json(
-        self, scene: Scene, messages: Sequence[Message], *, reasoning: ReasoningEffort | None = None
-    ) -> AsyncIterator[str]:
-        # JSON mode is prompt-driven (no response_format) — same rationale as the
-        # legacy path: several providers reject it with multimodal inputs.
-        return self._stream(scene, messages, reasoning=reasoning)
-
-    async def _stream(
-        self, scene: Scene, messages: Sequence[Message], *, reasoning: ReasoningEffort | None
-    ) -> AsyncIterator[str]:
-        if self._cost is not None:
-            await self._cost.check_budget()
-        provider, model, binding = await self._resolve(scene)
-        async for chunk in litellm_stream(
-            messages,
-            provider=provider,
-            model_id=model,
-            max_tokens=binding.max_tokens,
-            reasoning=reasoning or binding.reasoning,
-        ):
-            yield chunk
-
-    async def complete(
-        self, scene: Scene, messages: Sequence[Message], *, reasoning: ReasoningEffort | None = None
-    ) -> ChatResult:
-        if self._cost is not None:
-            await self._cost.check_budget()
-        provider, model, binding = await self._resolve(scene)
-        result = await litellm_complete(
-            messages,
-            provider=provider,
-            model_id=model,
-            max_tokens=binding.max_tokens,
-            reasoning=reasoning or binding.reasoning,
-        )
-        if self._cost is not None:
-            await self._cost.record(scene, result.model_id, result.usage, result.cost_usd)
-        return result

--- a/apps/backend/src/llm/client.py
+++ b/apps/backend/src/llm/client.py
@@ -179,8 +179,9 @@ def cost_from_usage(model: str, prompt_tokens: int, completion_tokens: int) -> D
     except Exception:  # noqa: BLE001 - unpriced model -> not metered (telemetry, not correctness)
         logger.debug("no litellm price for model; spend not metered", model=model)
         return None
-    total = (prompt_cost or 0) + (completion_cost or 0)
-    return Decimal(str(total)) if total else None
+    # Convert each component to Decimal before summing (litellm returns floats).
+    total = Decimal(str(prompt_cost or 0)) + Decimal(str(completion_cost or 0))
+    return total if total else None
 
 
 async def resolve_provider_and_model(config_source: ConfigSource, model_id: str) -> tuple[ProviderRef, str]:

--- a/apps/backend/src/llm/factory.py
+++ b/apps/backend/src/llm/factory.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from src.llm.client import LitellmClient
 from src.llm.common import ConfigSource, ProviderRef, Scene, SceneBinding
 from src.llm.cost import DailyBudgetMeter
 from src.llm.db_config import DbConfigSource
@@ -75,8 +74,3 @@ def get_config_source(user_id: UUID | None = None) -> ConfigSource:
     against the DB (see :class:`LayeredConfigSource`).
     """
     return LayeredConfigSource(DbConfigSource(user_id=user_id), EnvConfigSource())
-
-
-def get_llm_client(user_id: UUID | None = None) -> LitellmClient:
-    """The scene-keyed client for a user, with the shared daily budget guard wired in."""
-    return LitellmClient(get_config_source(user_id), cost_meter=get_budget_meter())

--- a/apps/backend/src/services/ai_advisor.py
+++ b/apps/backend/src/services/ai_advisor.py
@@ -19,7 +19,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
-from src.llm.common import Scene
+from src.llm.common import ReasoningEffort, Scene, SceneBinding
 from src.llm.factory import get_config_source
 from src.logger import get_logger
 from src.models import (
@@ -300,23 +300,21 @@ class StreamRedactor:
         return output
 
 
-async def _bound_scene_model(user_id: UUID | None) -> str | None:
-    """The model a user bound to ``advisor.chat`` (EPIC-023 AC23.4.5), or None.
+async def _bound_scene_binding(user_id: UUID | None) -> SceneBinding | None:
+    """The user's ``advisor.chat`` binding (EPIC-023 AC23.4.5), or None.
 
-    Returns the binding's **qualified** ``provider_id/model`` so the transport can
-    resolve the exact provider — even when the user has several providers (the
-    scene-less resolver fails closed on >1). Best-effort: ``user_id is None`` or any
-    config-resolution error falls back to the env model list rather than breaking
-    chat."""
+    Carries the **qualified** ``provider_id/model`` (so the transport resolves the
+    exact provider even with several configured) plus the configured reasoning depth
+    and ``max_tokens``. Best-effort: ``user_id is None`` or any config-resolution
+    error falls back to the env model list rather than breaking chat — and is logged
+    so a broken per-user config is diagnosable instead of silently ignored."""
     if user_id is None:
         return None
     try:
-        binding = await get_config_source(user_id).get_binding(Scene.ADVISOR_CHAT)
+        return await get_config_source(user_id).get_binding(Scene.ADVISOR_CHAT)
     except Exception:  # noqa: BLE001 - config issues must never break chat
+        logger.warning("advisor.chat binding resolution failed; using env models", exc_info=True)
         return None
-    if binding is None:
-        return None
-    return binding.model_id
 
 
 class AIAdvisorService:
@@ -367,10 +365,11 @@ class AIAdvisorService:
         context = await self.get_financial_context(db, user_id)
         metadata = self.build_chat_grounding_metadata(context, raw_message)
         context_hash = hashlib.sha256(json.dumps(context, sort_keys=True, default=str).encode("utf-8")).hexdigest()
-        # Resolve the user's advisor.chat bound model once (one DB round-trip) and
-        # reuse it for both the cache key and streaming, so the cached entry and the
-        # streamed response can never be keyed/generated under different models.
-        bound_model = await _bound_scene_model(user_id)
+        # Resolve the user's advisor.chat binding once (one DB round-trip) and reuse
+        # it for the cache key and streaming, so the cached entry and the streamed
+        # response can never be keyed/generated under different models.
+        bound = await _bound_scene_binding(user_id)
+        bound_model = bound.model_id if bound else None
         # The cache key must reflect the model that will actually answer: an explicit
         # per-message model, else the bound model, else the env primary.
         model_key = model or bound_model or self.primary_model
@@ -403,7 +402,7 @@ class AIAdvisorService:
                 cache_key,
                 model,
                 user_id,
-                bound_model,
+                bound,
             ),
             model_name=None,
             cached=False,
@@ -941,14 +940,14 @@ class AIAdvisorService:
         cache_key: str,
         preferred_model: str | None,
         user_id: UUID | None = None,
-        bound_model: str | None = None,
+        bound: SceneBinding | None = None,
     ) -> AsyncIterator[str]:
         redactor = StreamRedactor()
         chunks: list[str] = []
         model_used: str | None = None
 
         try:
-            async for chunk, model_name in self._stream_openrouter(messages, preferred_model, user_id, bound_model):
+            async for chunk, model_name in self._stream_openrouter(messages, preferred_model, user_id, bound):
                 model_used = model_name
                 safe_chunk = redactor.process(chunk)
                 if safe_chunk:
@@ -1008,25 +1007,30 @@ class AIAdvisorService:
         messages: list[dict[str, str]],
         preferred_model: str | None,
         user_id: UUID | None = None,
-        bound_model: str | None = None,
+        bound: SceneBinding | None = None,
     ) -> AsyncIterator[tuple[str, str]]:
         from src.constants.error_ids import ErrorIds
         from src.services.ai_streaming import AIStreamError
 
         models = [self.primary_model, *self.fallback_models]
+        # The binding's reasoning/max_tokens apply only when its model is used (no
+        # per-message override). They're hints/caps, harmless if a fallback ignores them.
+        reasoning = bound.reasoning if bound else None
+        max_tokens = bound.max_tokens if bound else None
         if preferred_model:
             models = [preferred_model, *models]
-        elif bound_model:
+            reasoning = max_tokens = None  # explicit per-message model: env defaults
+        elif bound is not None:
             # No per-message override: prefer the user's configured advisor.chat
             # model (EPIC-023 AC23.4.5) so /settings/llm actually takes effect. The
             # bound model is qualified (provider_id/model); ai_streaming resolves the
             # exact provider from the qualifier.
-            models = [bound_model, *models]
+            models = [bound.model_id, *models]
         last_error: Exception | None = None
 
         for i, model in enumerate(models):
             try:
-                async for chunk in self._stream_model(model, messages, user_id):
+                async for chunk in self._stream_model(model, messages, user_id, reasoning, max_tokens):
                     yield chunk, model
                 return
             except AIStreamError as exc:
@@ -1060,12 +1064,19 @@ class AIAdvisorService:
             raise last_error
 
     async def _stream_model(
-        self, model: str, messages: list[dict[str, str]], user_id: UUID | None = None
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        user_id: UUID | None = None,
+        reasoning: ReasoningEffort | None = None,
+        max_tokens: int | None = None,
     ) -> AsyncIterator[str]:
         async for chunk in stream_ai_chat(
             messages=messages,
             model=model,
             user_id=user_id,
+            reasoning=reasoning,
+            max_tokens=max_tokens,
             timeout=120.0,
         ):
             yield chunk

--- a/apps/backend/src/services/ai_streaming.py
+++ b/apps/backend/src/services/ai_streaming.py
@@ -14,11 +14,10 @@ from typing import Any
 from uuid import UUID
 
 from src.config import settings
-from src.llm.client import estimate_cost_usd, litellm_stream, resolve_provider_and_model
-from src.llm.common import LLMBudgetExceeded, LLMConfigError, LLMError, ProviderRef
+from src.llm.client import cost_from_usage, litellm_stream, resolve_provider_and_model
+from src.llm.common import LLMBudgetExceeded, LLMConfigError, LLMError, ProviderRef, ReasoningEffort
 from src.llm.env_config import _protocol_for
 from src.llm.factory import get_budget_meter, get_config_source
-from src.llm.routing import build_call
 from src.logger import get_logger
 
 logger = get_logger(__name__)
@@ -78,6 +77,7 @@ async def _stream_ai_base(
     connect_timeout: float = 10.0,
     max_tokens: int | None = None,
     temperature: float | None = None,
+    reasoning: ReasoningEffort | None = None,
     do_sample: bool | None = None,
     seed: int | None = None,
     thinking: dict[str, Any] | None = None,
@@ -119,7 +119,7 @@ async def _stream_ai_base(
     if thinking is not None:
         extra_body["thinking"] = thinking
 
-    collected: list[str] = []
+    usage_sink: dict[str, Any] = {}
     try:
         async for content in litellm_stream(
             messages,
@@ -127,11 +127,12 @@ async def _stream_ai_base(
             model_id=model,
             max_tokens=max_tokens,
             temperature=temperature,
+            reasoning=reasoning,
             seed=seed,
             extra_body=extra_body or None,
             timeout=timeout,
+            usage_sink=usage_sink,
         ):
-            collected.append(content)
             yield content
     except LLMError as exc:
         logger.error(
@@ -145,10 +146,14 @@ async def _stream_ai_base(
         )
         raise AIStreamError(str(exc), retryable=exc.retryable) from exc
     else:
-        # Record best-effort spend so the daily ceiling actually accumulates.
-        # Cost/telemetry must never break a completed stream.
+        # Record real spend from the streamed token usage so the daily ceiling
+        # actually accumulates. Cost/telemetry must never break a completed stream.
         try:
-            cost = estimate_cost_usd(build_call(provider, model).model, messages, "".join(collected))
+            cost = cost_from_usage(
+                usage_sink.get("model") or model,
+                usage_sink.get("prompt_tokens", 0),
+                usage_sink.get("completion_tokens", 0),
+            )
             await meter.record_cost(model, cost, scene=mode_label)
         except Exception:  # noqa: BLE001 - spend telemetry is not correctness
             logger.debug("llm spend recording skipped", exc_info=True)
@@ -193,15 +198,22 @@ async def stream_ai_chat(
     api_key: str | None = None,
     base_url: str | None = None,
     user_id: UUID | None = None,
+    reasoning: ReasoningEffort | None = None,
+    max_tokens: int | None = None,
     timeout: float = 120.0,
 ) -> AsyncIterator[str]:
-    """Stream chat completions without JSON mode (plain text)."""
+    """Stream chat completions without JSON mode (plain text).
+
+    ``reasoning``/``max_tokens`` let a caller apply a scene binding's configured
+    reasoning depth and token cap (EPIC-023 AC23.4.5)."""
     async for chunk in _stream_ai_base(
         messages=messages,
         model=model,
         api_key=api_key,
         base_url=base_url,
         user_id=user_id,
+        reasoning=reasoning,
+        max_tokens=max_tokens,
         timeout=timeout,
         mode_label="chat mode",
     ):

--- a/apps/backend/src/services/ai_streaming.py
+++ b/apps/backend/src/services/ai_streaming.py
@@ -149,12 +149,16 @@ async def _stream_ai_base(
         # Record real spend from the streamed token usage so the daily ceiling
         # actually accumulates. Cost/telemetry must never break a completed stream.
         try:
+            # Price and record under the same (litellm-prefixed) model id so spend
+            # telemetry matches what was billed and provider-prefixed models don't
+            # collapse onto a bare name.
+            priced_model = usage_sink.get("model") or model
             cost = cost_from_usage(
-                usage_sink.get("model") or model,
+                priced_model,
                 usage_sink.get("prompt_tokens", 0),
                 usage_sink.get("completion_tokens", 0),
             )
-            await meter.record_cost(model, cost, scene=mode_label)
+            await meter.record_cost(priced_model, cost, scene=mode_label)
         except Exception:  # noqa: BLE001 - spend telemetry is not correctness
             logger.debug("llm spend recording skipped", exc_info=True)
 

--- a/apps/backend/tests/ai/test_ai_advisor_service.py
+++ b/apps/backend/tests/ai/test_ai_advisor_service.py
@@ -239,7 +239,7 @@ async def test_stream_openrouter_falls_back(monkeypatch: pytest.MonkeyPatch) -> 
     service.fallback_models = ["fallback"]
     calls: list[str] = []
 
-    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None):
+    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None, _reasoning=None, _max_tokens=None):
         calls.append(model)
         if model == "primary":
             raise AIStreamError(message="fail primary", retryable=True)
@@ -263,7 +263,7 @@ async def test_stream_openrouter_raises_when_all_fail(
     service.primary_model = "primary"
     service.fallback_models = ["fallback"]
 
-    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None):
+    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None, _reasoning=None, _max_tokens=None):
         raise AIStreamError(message=f"fail {model}", retryable=True)
         yield  # pragma: no cover
 
@@ -923,7 +923,7 @@ async def test_stream_openrouter_with_preferred_model(monkeypatch: pytest.Monkey
     service.fallback_models = []
     called_with: list[str] = []
 
-    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None):
+    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None, _reasoning=None, _max_tokens=None):
         called_with.append(model)
         yield "ok"
 
@@ -944,7 +944,7 @@ async def test_stream_openrouter_raises_on_programming_error(monkeypatch: pytest
     service.primary_model = "primary"
     service.fallback_models = []
 
-    async def broken_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None):
+    async def broken_stream_model(model, _messages, _user_id=None, _reasoning=None, _max_tokens=None):
         raise ValueError("bad internal state")
         yield  # pragma: no cover
 
@@ -959,30 +959,35 @@ async def test_AC23_4_5_advisor_uses_user_bound_model_and_threads_user_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """AC23.4.5: with an advisor.chat binding and no per-message override, the user's
-    bound model is tried first and ``user_id`` is threaded to the transport."""
+    bound model is tried first, and its reasoning/max_tokens + user_id reach the transport."""
     from uuid import uuid4
+
+    from src.llm.common import ReasoningEffort, Scene, SceneBinding
 
     service = AIAdvisorService()
     service.primary_model = "env-primary"
     service.fallback_models = ["env-fallback"]
     uid = uuid4()
+    bound = SceneBinding(
+        scene=Scene.ADVISOR_CHAT,
+        model_id="provider1/user-glm-4.6",
+        reasoning=ReasoningEffort.HIGH,
+        max_tokens=4096,
+    )
 
-    tried: list[tuple[str, object]] = []
+    tried: list[tuple[str, object, object, object]] = []
 
-    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None):
-        tried.append((model, _user_id))
+    async def fake_stream_model(model, _messages, _user_id=None, _reasoning=None, _max_tokens=None):
+        tried.append((model, _user_id, _reasoning, _max_tokens))
         yield "ok"
 
     monkeypatch.setattr(service, "_stream_model", fake_stream_model)
 
-    # The resolved (qualified) bound model is passed in; it must be tried first and
-    # user_id threaded to the transport. Provider1/... resolution happens in ai_streaming.
-    async for _chunk, _model in service._stream_openrouter(
-        [{"role": "user", "content": "hi"}], None, uid, "provider1/user-glm-4.6"
-    ):
+    async for _chunk, _model in service._stream_openrouter([{"role": "user", "content": "hi"}], None, uid, bound):
         pass
 
-    assert tried[0] == ("provider1/user-glm-4.6", uid)
+    # Bound (qualified) model tried first, with the binding's reasoning/max_tokens + user_id.
+    assert tried[0] == ("provider1/user-glm-4.6", uid, ReasoningEffort.HIGH, 4096)
 
 
 async def test_AC23_4_5_advisor_provider_resolution_is_user_scoped(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/backend/tests/ai/test_ai_advisor_service.py
+++ b/apps/backend/tests/ai/test_ai_advisor_service.py
@@ -239,7 +239,9 @@ async def test_stream_openrouter_falls_back(monkeypatch: pytest.MonkeyPatch) -> 
     service.fallback_models = ["fallback"]
     calls: list[str] = []
 
-    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None, _reasoning=None, _max_tokens=None):
+    async def fake_stream_model(
+        model: str, _messages: list[dict[str, str]], _user_id=None, _reasoning=None, _max_tokens=None
+    ):
         calls.append(model)
         if model == "primary":
             raise AIStreamError(message="fail primary", retryable=True)
@@ -263,7 +265,9 @@ async def test_stream_openrouter_raises_when_all_fail(
     service.primary_model = "primary"
     service.fallback_models = ["fallback"]
 
-    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None, _reasoning=None, _max_tokens=None):
+    async def fake_stream_model(
+        model: str, _messages: list[dict[str, str]], _user_id=None, _reasoning=None, _max_tokens=None
+    ):
         raise AIStreamError(message=f"fail {model}", retryable=True)
         yield  # pragma: no cover
 
@@ -923,7 +927,9 @@ async def test_stream_openrouter_with_preferred_model(monkeypatch: pytest.Monkey
     service.fallback_models = []
     called_with: list[str] = []
 
-    async def fake_stream_model(model: str, _messages: list[dict[str, str]], _user_id=None, _reasoning=None, _max_tokens=None):
+    async def fake_stream_model(
+        model: str, _messages: list[dict[str, str]], _user_id=None, _reasoning=None, _max_tokens=None
+    ):
         called_with.append(model)
         yield "ok"
 

--- a/apps/backend/tests/unit/llm/test_client.py
+++ b/apps/backend/tests/unit/llm/test_client.py
@@ -1,17 +1,20 @@
-"""litellm transport + scene client (EPIC-023 AC23.2.2, AC23.2.3).
+"""litellm transport + provider resolution (EPIC-023 AC23.2.2, AC23.2.3).
 
 litellm is mocked so these run offline and deterministically — they pin the
 wiring (delta streaming, drop_params, seed/extra_body passthrough, error
-normalisation, scene resolution), not litellm's own behaviour.
+normalisation, provider resolution, cost-from-usage), not litellm's own
+behaviour.
 """
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 import pytest
 
 import src.llm.client as client_mod
-from src.llm.client import LitellmClient, litellm_complete, litellm_stream
-from src.llm.common import LLMConfigError, LLMError, ProtocolFamily, ProviderRef, Scene, SceneBinding
+from src.llm.client import cost_from_usage, litellm_stream, resolve_provider_and_model
+from src.llm.common import LLMConfigError, LLMError, ProtocolFamily, ProviderRef
 
 
 class _Delta:
@@ -31,17 +34,6 @@ class _Chunk:
         self.choices = [_Choice(content)]
 
 
-class _Usage:
-    prompt_tokens = 10
-    completion_tokens = 5
-
-
-class _Response:
-    def __init__(self, content: str) -> None:
-        self.choices = [_Choice(content)]
-        self.usage = _Usage()
-
-
 def _provider() -> ProviderRef:
     return ProviderRef(
         id="env", label="zai", protocol=ProtocolFamily.OPENAI_COMPATIBLE, api_key="k", api_base="https://api.z.ai"
@@ -55,17 +47,14 @@ def captured(monkeypatch):
 
     async def fake_acompletion(**kwargs):
         box["kwargs"] = kwargs
-        if kwargs.get("stream"):
 
-            async def gen():
-                for piece in ("Hel", "", "lo"):
-                    yield _Chunk(piece)
+        async def gen():
+            for piece in ("Hel", "", "lo"):
+                yield _Chunk(piece)
 
-            return gen()
-        return _Response("Hello")
+        return gen()
 
     monkeypatch.setattr(client_mod.litellm, "acompletion", fake_acompletion)
-    monkeypatch.setattr(client_mod.litellm, "completion_cost", lambda completion_response=None: 0.0012)
     return box
 
 
@@ -96,16 +85,6 @@ async def test_AC23_2_2_stream_sets_drop_params_and_passes_seed_extra_body(captu
     assert kw["api_base"] == "https://api.z.ai"
 
 
-async def test_AC23_2_2_complete_returns_text_usage_and_cost(captured):
-    """AC23.2.2: litellm_complete maps text + token usage + USD cost."""
-    result = await litellm_complete([{"role": "user", "content": "hi"}], provider=_provider(), model_id="glm-5.1")
-    assert result.text == "Hello"
-    assert result.usage.prompt_tokens == 10
-    assert result.usage.completion_tokens == 5
-    assert result.usage.total_tokens == 15
-    assert str(result.cost_usd) == "0.0012"
-
-
 async def test_AC23_2_4_reasoning_max_tokens_temperature_passthrough(captured):
     """AC23.2.4: per-scene knobs (reasoning depth, max_tokens, temperature) reach litellm."""
     from src.llm.common import ReasoningEffort
@@ -123,34 +102,6 @@ async def test_AC23_2_4_reasoning_max_tokens_temperature_passthrough(captured):
     assert kw["max_tokens"] == 256
     assert kw["temperature"] == 0.0
     assert kw["reasoning_effort"] == "medium"
-
-
-async def test_AC23_2_2_complete_handles_empty_response_and_missing_cost(monkeypatch):
-    """AC23.2.2: a response with no choices/usage yields empty text + zero usage; cost stays None."""
-
-    class _Empty:
-        choices: list = []
-        usage = None
-
-    async def fake(**kwargs):
-        return _Empty()
-
-    def boom_cost(completion_response=None):
-        raise RuntimeError("no pricing")
-
-    monkeypatch.setattr(client_mod.litellm, "acompletion", fake)
-    monkeypatch.setattr(client_mod.litellm, "completion_cost", boom_cost)
-    result = await litellm_complete([{"role": "user", "content": "x"}], provider=_provider(), model_id="m")
-    assert result.text == ""
-    assert result.usage.total_tokens == 0
-    assert result.cost_usd is None
-
-
-async def test_AC23_2_2_complete_without_cost_meter(captured):
-    """AC23.2.2: a client without a cost meter still completes (no budget hooks)."""
-    cfg = _FakeConfig(SceneBinding(Scene.STATEMENT_SUMMARY, "glm-5.1"), [_provider()])
-    result = await LitellmClient(cfg).complete(Scene.STATEMENT_SUMMARY, [{"role": "user", "content": "hi"}])
-    assert result.text == "Hello"
 
 
 async def test_AC23_2_3_provider_error_is_normalised_to_llmerror(monkeypatch):
@@ -178,13 +129,13 @@ async def test_AC23_2_3_non_retryable_error_classified(monkeypatch):
 
     monkeypatch.setattr(client_mod.litellm, "acompletion", boom)
     with pytest.raises(LLMError) as ei:
-        await litellm_complete([{"role": "user", "content": "x"}], provider=_provider(), model_id="m")
+        async for _ in litellm_stream([{"role": "user", "content": "x"}], provider=_provider(), model_id="m"):
+            pass
     assert ei.value.retryable is False
 
 
 class _FakeConfig:
-    def __init__(self, binding: SceneBinding | None, providers: list[ProviderRef]) -> None:
-        self._binding = binding
+    def __init__(self, providers: list[ProviderRef]) -> None:
         self._providers = providers
 
     async def list_providers(self):
@@ -193,122 +144,63 @@ class _FakeConfig:
     async def get_provider(self, provider_id):
         return next((p for p in self._providers if p.id == provider_id), None)
 
-    async def get_binding(self, scene):
-        return self._binding
 
-    async def is_configured(self):
-        return bool(self._providers)
-
-
-async def test_AC23_2_2_scene_client_resolves_binding_and_streams(captured):
-    """AC23.2.2: LitellmClient resolves a scene's binding through the ConfigSource."""
-    cfg = _FakeConfig(SceneBinding(Scene.ADVISOR_CHAT, "glm-5.1"), [_provider()])
-    cli = LitellmClient(cfg)
-    out = [c async for c in cli.stream(Scene.ADVISOR_CHAT, [{"role": "user", "content": "hi"}])]
-    assert "".join(out) == "Hello"
-
-
-async def test_AC23_2_2_scene_client_stream_json_path(captured):
-    """AC23.2.2: stream_json resolves a scene and streams (prompt-driven JSON, no response_format)."""
-    cfg = _FakeConfig(SceneBinding(Scene.EXTRACTION_JSON, "glm-4.6v"), [_provider()])
-    out = [c async for c in LitellmClient(cfg).stream_json(Scene.EXTRACTION_JSON, [{"role": "user", "content": "x"}])]
-    assert "".join(out) == "Hello"
-    assert "response_format" not in captured["kwargs"]
-
-
-async def test_AC23_2_2_cost_is_none_when_litellm_returns_none(monkeypatch):
-    """AC23.2.2: a None cost from litellm surfaces as None (no spurious zero)."""
-    box: dict = {}
-
-    async def fake(**kwargs):
-        box["k"] = kwargs
-        return _Response("Hi")
-
-    monkeypatch.setattr(client_mod.litellm, "acompletion", fake)
-    monkeypatch.setattr(client_mod.litellm, "completion_cost", lambda completion_response=None: None)
-    result = await litellm_complete([{"role": "user", "content": "x"}], provider=_provider(), model_id="m")
-    assert result.cost_usd is None
-
-
-async def test_AC23_2_2_scene_client_raises_when_scene_unbound(captured):
-    """AC23.2.2: an unbound scene is a config error, not a silent no-op."""
-    cli = LitellmClient(_FakeConfig(None, [_provider()]))
-    with pytest.raises(LLMConfigError):
-        async for _ in cli.stream(Scene.ADVISOR_CHAT, [{"role": "user", "content": "hi"}]):
-            pass
-
-
-async def test_AC23_2_2_scene_client_complete_records_cost(captured):
-    """AC23.2.2 / AC23.2.6: complete() runs the budget check and records spend via the meter."""
-    events: list[tuple] = []
-
-    class _Meter:
-        async def check_budget(self):
-            events.append(("check",))
-
-        async def record(self, scene, model_id, usage, cost_usd):
-            events.append(("record", scene, model_id, str(cost_usd)))
-
-    cfg = _FakeConfig(SceneBinding(Scene.ADVISOR_CHAT, "glm-5.1"), [_provider()])
-    cli = LitellmClient(cfg, cost_meter=_Meter())
-    result = await cli.complete(Scene.ADVISOR_CHAT, [{"role": "user", "content": "hi"}])
-    assert result.text == "Hello"
-    assert ("check",) in events
-    assert any(e[0] == "record" for e in events)
-
-
-async def test_AC23_2_2_resolves_provider_from_qualified_model(captured):
+async def test_AC23_2_2_resolves_provider_from_qualified_model():
     """AC23.2.2: a 'provider_id/model' binding selects that provider among several."""
     p_zai = _provider()
     p_or = ProviderRef(id="router", label="or", protocol=ProtocolFamily.OPENROUTER_COMPATIBLE, api_key="k2")
-    cfg = _FakeConfig(SceneBinding(Scene.ADVISOR_CHAT, "router/deepseek-chat"), [p_zai, p_or])
-    cli = LitellmClient(cfg)
-    async for _ in cli.stream(Scene.ADVISOR_CHAT, [{"role": "user", "content": "hi"}]):
-        pass
-    assert captured["kwargs"]["model"] == "openrouter/deepseek-chat"
+    provider, model = await resolve_provider_and_model(_FakeConfig([p_zai, p_or]), "router/deepseek-chat")
+    assert provider is p_or
+    assert model == "deepseek-chat"
 
 
-async def test_AC23_2_2_ambiguous_unqualified_model_with_many_providers_errors(captured):
+async def test_AC23_2_2_ambiguous_unqualified_model_with_many_providers_errors():
     """AC23.2.2: an unqualified model with >1 provider is rejected, not guessed."""
     p1 = _provider()
     p2 = ProviderRef(id="other", label="o", protocol=ProtocolFamily.OPENAI_COMPATIBLE, api_key="k2")
-    cli = LitellmClient(_FakeConfig(SceneBinding(Scene.ADVISOR_CHAT, "glm-5.1"), [p1, p2]))
     with pytest.raises(LLMConfigError):
-        async for _ in cli.stream(Scene.ADVISOR_CHAT, [{"role": "user", "content": "hi"}]):
-            pass
+        await resolve_provider_and_model(_FakeConfig([p1, p2]), "glm-5.1")
 
 
-async def test_AC23_2_2_no_provider_configured_errors(captured):
-    """AC23.2.2: streaming with zero providers is a config error."""
-    cli = LitellmClient(_FakeConfig(SceneBinding(Scene.ADVISOR_CHAT, "glm-5.1"), []))
+async def test_AC23_2_2_no_provider_configured_errors():
+    """AC23.2.2: resolving with zero providers is a config error."""
     with pytest.raises(LLMConfigError):
-        async for _ in cli.stream(Scene.ADVISOR_CHAT, [{"role": "user", "content": "hi"}]):
-            pass
+        await resolve_provider_and_model(_FakeConfig([]), "glm-5.1")
 
 
-async def test_AC23_2_2_unknown_qualified_provider_raises_not_silently_falls_back(captured):
+async def test_AC23_2_2_unknown_qualified_provider_raises_not_silently_falls_back():
     """AC23.2.2: a provider_id-qualified model whose provider is unknown raises, not silently wrong creds."""
     p1 = _provider()
     p2 = ProviderRef(id="other", label="o", protocol=ProtocolFamily.OPENAI_COMPATIBLE, api_key="k2")
-    cli = LitellmClient(_FakeConfig(SceneBinding(Scene.ADVISOR_CHAT, "ghost/model"), [p1, p2]))
     with pytest.raises(LLMConfigError):
-        async for _ in cli.stream(Scene.ADVISOR_CHAT, [{"role": "user", "content": "hi"}]):
-            pass
+        await resolve_provider_and_model(_FakeConfig([p1, p2]), "ghost/model")
 
 
-async def test_AC23_2_2_single_provider_honours_db_style_qualified_binding(captured):
+async def test_AC23_2_2_single_provider_honours_db_style_qualified_binding():
     """AC23.2.2: a DB binding qualified as provider_id/model strips the id even with one provider."""
     p = ProviderRef(id="env", label="zai", protocol=ProtocolFamily.OPENAI_COMPATIBLE, api_key="k", api_base="https://z")
-    cfg = _FakeConfig(SceneBinding(Scene.EXTRACTION_JSON, "env/glm-5.1"), [p])
-    async for _ in LitellmClient(cfg).stream(Scene.EXTRACTION_JSON, [{"role": "user", "content": "x"}]):
-        pass
-    assert captured["kwargs"]["model"] == "openai/glm-5.1"
+    provider, model = await resolve_provider_and_model(_FakeConfig([p]), "env/glm-5.1")
+    assert provider is p
+    assert model == "glm-5.1"
 
 
-async def test_AC23_2_2_single_provider_keeps_slashed_openrouter_model(captured):
+async def test_AC23_2_2_single_provider_keeps_slashed_openrouter_model():
     """AC23.2.2: with one provider an OpenRouter vendor/model id is used whole, not split as provider."""
     p = ProviderRef(id="env", label="or", protocol=ProtocolFamily.OPENROUTER_COMPATIBLE, api_key="k")
-    cfg = _FakeConfig(SceneBinding(Scene.ADVISOR_CHAT, "deepseek/deepseek-chat"), [p])
-    async for _ in LitellmClient(cfg).stream(Scene.ADVISOR_CHAT, [{"role": "user", "content": "hi"}]):
-        pass
-    assert captured["kwargs"]["model"] == "openrouter/deepseek/deepseek-chat"
+    provider, model = await resolve_provider_and_model(_FakeConfig([p]), "deepseek/deepseek-chat")
+    assert provider is p
+    assert model == "deepseek/deepseek-chat"
+
+
+def test_AC23_2_6_cost_from_usage_prices_known_model_and_skips_unpriced(monkeypatch):
+    """AC23.2.6: a priced model yields a positive Decimal; an unpriced one yields None."""
+    monkeypatch.setattr(client_mod.litellm, "cost_per_token", lambda **kwargs: (0.001, 0.002))
+    priced = cost_from_usage("gpt-4o", prompt_tokens=10, completion_tokens=5)
+    assert isinstance(priced, Decimal)
+    assert priced > 0
+
+    def boom(**kwargs):
+        raise RuntimeError("no pricing")
+
+    monkeypatch.setattr(client_mod.litellm, "cost_per_token", boom)
+    assert cost_from_usage("glm-5.1", prompt_tokens=10, completion_tokens=5) is None

--- a/apps/backend/tests/unit/llm/test_factory.py
+++ b/apps/backend/tests/unit/llm/test_factory.py
@@ -1,8 +1,8 @@
 """Factory wiring: the budget meter must be a shared singleton (EPIC-023 PR5).
 
-A fresh ``DailyBudgetMeter`` per ``get_llm_client()`` would reset ``spent_today``
-to zero every call, so the daily limit would never be enforced. ``get_budget_meter``
-must hand back one shared instance.
+A fresh ``DailyBudgetMeter`` per call would reset ``spent_today`` to zero, so the
+daily limit would never be enforced. ``get_budget_meter`` must hand back one
+shared instance (the live transport in ``ai_streaming`` records spend onto it).
 """
 
 from __future__ import annotations
@@ -11,14 +11,8 @@ import src.llm.factory as factory
 
 
 def test_budget_meter_is_a_process_singleton() -> None:
-    """AC23.4.7: get_budget_meter returns the same instance, and clients share it."""
+    """AC23.4.7: get_budget_meter returns the same shared meter across calls."""
     factory._budget_meter = None  # reset any prior state for a deterministic check
     first = factory.get_budget_meter()
     second = factory.get_budget_meter()
     assert first is second
-
-    client_a = factory.get_llm_client()
-    client_b = factory.get_llm_client()
-    # Both clients hold the *same* meter, so spend accumulates across calls.
-    assert client_a._cost is client_b._cost
-    assert client_a._cost is first

--- a/docs/project/EPIC-023.llm-provider-abstraction.md
+++ b/docs/project/EPIC-023.llm-provider-abstraction.md
@@ -85,7 +85,7 @@ parallel once PR1 merges.
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
 | AC23.2.1 | Provider routing maps each protocol family onto the correct litellm call — `openai`/`anthropic`/`openrouter` prefix, custom `api_base` for OpenAI-compatible endpoints, OpenRouter attribution headers — and normalises an already-qualified model id | `apps/backend/tests/unit/llm/test_routing.py` | P1 |
-| AC23.2.2 | The litellm client streams and completes via litellm with `drop_params` (model-rejected params like `seed` are dropped, not 400'd), resolves a scene's provider/model through the `ConfigSource`, and returns text + token usage + USD cost | `apps/backend/tests/unit/llm/test_client.py` | P1 |
+| AC23.2.2 | The litellm transport streams via litellm with `drop_params` (model-rejected params like `seed` are dropped, not 400'd) and resolves a binding's provider/model through the `ConfigSource` (`resolve_provider_and_model`, honouring the `provider_id/model` qualifier); streamed token usage is captured for spend accounting | `apps/backend/tests/unit/llm/test_client.py` | P1 |
 | AC23.2.3 | Provider failures are normalised to `LLMError` with a retryable verdict (rate-limit/5xx/timeout → retryable; others not) | `apps/backend/tests/unit/llm/test_client.py` | P1 |
 | AC23.2.4 | `EnvConfigSource` projects the existing env settings onto scene bindings (vision/ocr → vision/ocr models, the rest → primary) and reports `is_configured() == False` when no API key, driving the first-run modal | `apps/backend/tests/unit/llm/test_env_config.py` | P1 |
 | AC23.2.5 | The dynamic catalogue lists configured models enriched with litellm pricing, flags the free tier, and filters by provider/modality/free | `apps/backend/tests/unit/llm/test_catalog.py` | P1 |


### PR DESCRIPTION
Answers the third-round review (精简 / bugs / 兜底). Net: **less code, budget actually meters, binding params actually apply.**

## 1. 过度设计 — removed
`LitellmClient` (scene-keyed wrapper) + `get_llm_client` + `litellm_complete` + `_safe_cost` had **no live callers** — the live path (advisor + extraction) runs on `ai_streaming`, which is already unified on the shared litellm transport + `resolve_provider_and_model` + budget meter. The scene client also **couldn't express extraction's per-model JSON-retry loop** (`extraction.py` retries the next model on bad JSON, not just transport errors). So we consolidate on `ai_streaming` and delete the dead layer. Kept: `litellm_stream`, `resolve_provider_and_model`, `DailyBudgetMeter`/`get_budget_meter`, `LitellmCatalog`. AC23.2.2 repointed to the transport + resolver.

## 2. Bugs / 兜底
- **Real-usage budget (replaces the broken estimate).** `litellm_stream` now captures streamed token usage (`stream_options={"include_usage": True}`) into a `usage_sink`; `ai_streaming` records real spend via `cost_from_usage` (litellm price table). ⚠️ **GLM/Z.AI is not in litellm's price table → spend records 0 for the primary provider** (now logged at debug); enforcing the ceiling there needs a per-model price (follow-up). For priced models (OpenRouter/OpenAI) the ceiling now genuinely accumulates + trips.
- **M5 fixed:** `stream_ai_chat` accepts `reasoning`/`max_tokens`; the advisor resolves the `advisor.chat` binding **once** and applies its reasoning depth + token cap (previously silently dropped). Per-message model override still wins (env defaults then).
- **Silent fallback fixed:** `_bound_scene_binding` logs a warning on config-resolution failure instead of swallowing — a broken per-user config is now diagnosable.

## 3. Tests
- `test_client.py` rewritten: transport tests kept (AC23.2.2/.3/.4); provider-resolution tests rewritten to call `resolve_provider_and_model` directly; added `cost_from_usage` test (AC23.2.6). Removed the dead `LitellmClient`/`litellm_complete` tests.
- Advisor tests updated for the binding-object threading + reasoning/max_tokens; `test_AC23_4_5` now asserts the bound model + its reasoning/max_tokens + `user_id` reach the transport.
- 938 backend tests pass (ai + extraction + reconciliation + llm + db-config); AC-index PASSED (1748); ruff + doc-consistency clean.

## Still open (tracked, lower priority)
- Per-model price for GLM/Z.AI so the budget ceiling enforces for the primary provider.
- M1 (`is_configured` vs rotated key), M2 (`/llm/catalog` user-scoping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)