### PR TITLE
[finance_report_audit] feat(money): align FE/BE money API surface + cross-language parity guard (#1167)

### DIFF
--- a/apps/frontend/src/lib/money/currency.ts
+++ b/apps/frontend/src/lib/money/currency.ts
@@ -3,14 +3,10 @@
 // reference impl in common/money/currency.py; both ends are kept in lockstep by
 // common/money/conformance/vectors.json.
 
+import { InvalidCurrencyError } from "./errors";
 import { ISO_4217_CODES } from "./iso4217";
 
-export class InvalidCurrencyError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "InvalidCurrencyError";
-  }
-}
+export { InvalidCurrencyError };
 
 /** Normalize (trim + upper-case) and validate an ISO-4217 alphabetic code. */
 export function normalizeCurrency(code: string): string {

--- a/apps/frontend/src/lib/money/errors.ts
+++ b/apps/frontend/src/lib/money/errors.ts
@@ -1,0 +1,34 @@
+// Typed money errors — the TS mirror of common/money/errors.py / src.money.errors,
+// so the frontend and backend expose the same money error surface (#1167).
+// Callers can catch MoneyError for any money-domain violation, or the subtype.
+
+export class MoneyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MoneyError";
+  }
+}
+
+/** A float (JS number) / non-finite value was supplied where a Decimal is required. */
+export class FloatNotAllowedError extends MoneyError {
+  constructor(message: string) {
+    super(message);
+    this.name = "FloatNotAllowedError";
+  }
+}
+
+/** A currency code is not a recognised ISO-4217 alphabetic code. */
+export class InvalidCurrencyError extends MoneyError {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidCurrencyError";
+  }
+}
+
+/** An operation combined two different currencies without conversion. */
+export class CurrencyMismatchError extends MoneyError {
+  constructor(message: string) {
+    super(message);
+    this.name = "CurrencyMismatchError";
+  }
+}

--- a/apps/frontend/src/lib/money/index.ts
+++ b/apps/frontend/src/lib/money/index.ts
@@ -3,12 +3,15 @@
 // Proven consistent with the Python reference impl via the shared conformance
 // vectors (common/money/conformance/vectors.json), see money.conformance.test.ts.
 
-export { Currency, InvalidCurrencyError, normalizeCurrency } from "./currency";
+// Typed error hierarchy — mirrors common/money/errors.py / src.money.errors so
+// the frontend and backend expose the same money error surface (API-parity guard).
+export { MoneyError, FloatNotAllowedError, InvalidCurrencyError, CurrencyMismatchError } from "./errors";
+export { Currency, normalizeCurrency } from "./currency";
 export { ISO_4217_CODES } from "./iso4217";
 export {
   Money,
   convert,
-  CurrencyMismatchError,
+  MONEY_QUANTUM,
   MONEY_DP,
   DEFAULT_ROUNDING,
   type AmountInput,

--- a/apps/frontend/src/lib/money/money.conformance.test.ts
+++ b/apps/frontend/src/lib/money/money.conformance.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 import Decimal from "decimal.js";
 import { describe, expect, it } from "vitest";
 
-import { Currency, InvalidCurrencyError, ISO_4217_CODES } from "./index";
+import { Currency, FloatNotAllowedError, InvalidCurrencyError, ISO_4217_CODES } from "./index";
 import { Money, convert, type RoundingName } from "./money";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -68,9 +68,9 @@ describe("money conformance (cross-language standard #1167)", () => {
 describe("money value-type laws (TS rendering of the contract)", () => {
   it("rejects float (JS number) amounts and rates", () => {
     // @ts-expect-error number is intentionally not assignable to AmountInput
-    expect(() => new Money(10.0, "USD")).toThrow(TypeError);
+    expect(() => new Money(10.0, "USD")).toThrow(FloatNotAllowedError);
     // @ts-expect-error number rate is rejected
-    expect(() => convert(new Money("1.00", "USD"), 1.2, "EUR")).toThrow(TypeError);
+    expect(() => convert(new Money("1.00", "USD"), 1.2, "EUR")).toThrow(FloatNotAllowedError);
   });
 
   it("is same-currency only for arithmetic and comparison", () => {
@@ -89,7 +89,7 @@ describe("money value-type laws (TS rendering of the contract)", () => {
   });
 
   it("rejects non-finite Decimal amounts and rates", () => {
-    expect(() => new Money(new Decimal(Infinity), "USD")).toThrow(TypeError);
-    expect(() => convert(new Money("1.00", "USD"), new Decimal(Infinity), "EUR")).toThrow(TypeError);
+    expect(() => new Money(new Decimal(Infinity), "USD")).toThrow(FloatNotAllowedError);
+    expect(() => convert(new Money("1.00", "USD"), new Decimal(Infinity), "EUR")).toThrow(FloatNotAllowedError);
   });
 });

--- a/apps/frontend/src/lib/money/money.ts
+++ b/apps/frontend/src/lib/money/money.ts
@@ -7,13 +7,9 @@
 import Decimal from "decimal.js";
 
 import { Currency } from "./currency";
+import { CurrencyMismatchError, FloatNotAllowedError } from "./errors";
 
-export class CurrencyMismatchError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "CurrencyMismatchError";
-  }
-}
+export { CurrencyMismatchError };
 
 export type RoundingName = "ROUND_HALF_EVEN" | "ROUND_HALF_UP";
 
@@ -23,6 +19,9 @@ const ROUNDING: Record<RoundingName, Decimal.Rounding> = {
 };
 
 export const MONEY_DP = 2;
+// Aligned with the backend `MONEY_QUANTUM` (Decimal("0.01")) so both ends expose
+// the same canonical money quantum identifier (the API-parity guard checks this).
+export const MONEY_QUANTUM = new Decimal("0.01");
 export const DEFAULT_ROUNDING: RoundingName = "ROUND_HALF_EVEN";
 
 /** Amount input: a Decimal or a decimal STRING. Never a JS number (float). */
@@ -36,9 +35,9 @@ function coerceDecimal(value: Decimal | string, what: string): Decimal {
     d = new Decimal(value);
   } else {
     // Deliberately reject `number` (and anything else) — JS numbers are IEEE-754 floats.
-    throw new TypeError(`${what} must be a Decimal or decimal string, not a number`);
+    throw new FloatNotAllowedError(`${what} must be a Decimal or decimal string, not a number`);
   }
-  if (!d.isFinite()) throw new TypeError(`${what} must be finite`);
+  if (!d.isFinite()) throw new FloatNotAllowedError(`${what} must be finite`);
   return d;
 }
 

--- a/common/money/conformance/vectors.json
+++ b/common/money/conformance/vectors.json
@@ -2,6 +2,17 @@
   "_comment": "Language-neutral money standard (#1167). The SINGLE financial standard every end must honour. Both the Python reference impl (common/money) and the TypeScript impl (apps/frontend/src/lib/money) load THIS file and must reproduce every expected value exactly. Divergence turns CI red on either end. Amounts and rates are decimal STRINGS (never JSON floats). See common/money/conformance/README.md and docs/ssot/accounting.md#money-type.",
   "money_quantum": "0.01",
   "default_rounding": "ROUND_HALF_EVEN",
+  "shared_api": [
+    "Money",
+    "Currency",
+    "convert",
+    "ISO_4217_CODES",
+    "MONEY_QUANTUM",
+    "MoneyError",
+    "FloatNotAllowedError",
+    "InvalidCurrencyError",
+    "CurrencyMismatchError"
+  ],
   "iso4217": [
     "AED",
     "AFN",

--- a/common/money/contract/money.contract.md
+++ b/common/money/contract/money.contract.md
@@ -42,3 +42,19 @@
 Conformance to 1–4 (for the deterministic cases) is enforced by the vectors; the
 construction-rejection laws are enforced by each stack's own unit tests against
 this contract.
+
+## Shared API surface (identifier parity)
+
+The vectors lock *behaviour*; `vectors.json["shared_api"]` locks the *identifier
+surface* so the two ends cannot drift in naming/coverage. Every name below MUST
+be exported by **both** `apps/backend/src/money` (`__all__`) and
+`apps/frontend/src/lib/money` (`index.ts`), enforced by
+`tests/tooling/test_money_api_parity.py`:
+
+`Money`, `Currency`, `convert`, `ISO_4217_CODES`, `MONEY_QUANTUM`, `MoneyError`,
+`FloatNotAllowedError`, `InvalidCurrencyError`, `CurrencyMismatchError`.
+
+Intentionally **per-end** (NOT part of the shared surface): backend-only
+`to_money`, `CurrencyBalance(s)`, the `adopt` helpers; frontend-only display
+formatters (`formatCurrencyLocale`, …) and the loose Decimal helpers
+(`sumAmounts`, …) inherited from the former `lib/currency`.

--- a/tests/tooling/test_money_api_parity.py
+++ b/tests/tooling/test_money_api_parity.py
@@ -1,0 +1,70 @@
+"""Cross-language money API-parity guard (EPIC-002 AC2.19, #1167).
+
+The conformance vectors lock money *behaviour* across ends; this locks the
+*identifier surface*. Every name in ``vectors.json["shared_api"]`` MUST be
+exported by BOTH the backend money module (``apps/backend/src/money/__init__.py``
+``__all__``) and the frontend money module (``apps/frontend/src/lib/money/index.ts``
+exports), so the two value-type APIs cannot silently drift (e.g. ``MONEY_DP`` vs
+``MONEY_QUANTUM``, or a missing error type). Display/loose helpers are
+intentionally per-end and are NOT part of the shared surface.
+"""
+
+import ast
+import json
+import re
+from pathlib import Path
+
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+VECTORS = json.loads((REPO / "common/money/conformance/vectors.json").read_text())
+SHARED_API = set(VECTORS["shared_api"])
+
+
+def _backend_exports() -> set[str]:
+    """Names in the backend money module's ``__all__``."""
+    src = (REPO / "apps/backend/src/money/__init__.py").read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets
+        ):
+            return {el.value for el in node.value.elts if isinstance(el, ast.Constant)}
+    return set()
+
+
+def _frontend_exports() -> set[str]:
+    """Identifiers re-exported from the frontend money module's index.ts."""
+    src = (REPO / "apps/frontend/src/lib/money/index.ts").read_text()
+    # Collect names inside every `export { ... }` block (strip `type ` + aliases).
+    names: set[str] = set()
+    for block in re.findall(r"export\s*\{([^}]*)\}", src):
+        for raw in block.split(","):
+            name = raw.strip().removeprefix("type ").strip()
+            if name:
+                names.add(name)
+    return names
+
+
+@ac_proof(
+    proof_id="test_money_shared_api_backend",
+    ac_ids=["AC2.19.1"],
+    ci_tier="pr_ci",
+    issue="#1167",
+)
+def test_AC2_19_1_backend_exposes_shared_money_api():
+    """AC2.19.1: the backend money module exports the full shared value-type surface."""
+    missing = SHARED_API - _backend_exports()
+    assert not missing, f"backend src.money missing shared API: {sorted(missing)}"
+
+
+@ac_proof(
+    proof_id="test_money_shared_api_frontend",
+    ac_ids=["AC2.19.1"],
+    ci_tier="pr_ci",
+    issue="#1167",
+)
+def test_AC2_19_1_frontend_exposes_shared_money_api():
+    """AC2.19.1: the frontend money module exports the full shared value-type surface."""
+    missing = SHARED_API - _frontend_exports()
+    assert not missing, f"frontend lib/money missing shared API: {sorted(missing)}"


### PR DESCRIPTION
## Why
The conformance vectors lock money **behaviour** across ends, but **not the identifier surface** — so `lib/money` (FE) and `src.money` (BE) had drifted: `MONEY_DP` vs `MONEY_QUANTUM`, and the FE lacked the `MoneyError`/`FloatNotAllowedError` hierarchy. This aligns the shared value-type surface and adds a guard so it can't drift again. **No caller churn.**

## Changes
**Frontend (`apps/frontend/src/lib/money`):**
- New `errors.ts` mirroring `src.money.errors`: `MoneyError` → `FloatNotAllowedError`/`InvalidCurrencyError`/`CurrencyMismatchError` (one hierarchy). `currency.ts`/`money.ts` import + re-export these instead of ad-hoc `Error` subclasses.
- `Money` construction now throws `FloatNotAllowedError` (was `TypeError`) for float/non-finite input.
- Add `MONEY_QUANTUM` (`Decimal("0.01")`) to match the backend identifier.

**Standard + guard:**
- `vectors.json` gains **`shared_api`** — the identifier set both ends MUST export.
- `tests/tooling/test_money_api_parity.py` statically asserts both `src.money.__all__` and `lib/money/index.ts` export the full `shared_api`.
- Contract doc records the shared surface and the intentionally **per-end** parts (BE: `to_money`/`CurrencyBalances`/`adopt`; FE: display formatters + loose Decimal helpers).

## Scope (your call: "align API + parity guard, no caller churn")
This is the bounded option — value-type surface aligned + guarded. The loose value-math helpers (`sumAmounts`/`multiplyAmount`/…) remain FE-only free functions for now; making them intrinsic `Money` methods (closing the cross-currency hole on the FE) is the larger follow-up we discussed.

## Verification
- ✅ FE vitest money 59 + full 913 green; eslint + tsc (money) clean.
- ✅ Backend money 54 + tooling money/parity green; the parity guard passes both ends.
- ✅ doc-consistency / manifest / ownership / ac-index / SSOT-governance green.

Refs #1167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)