### PR TITLE
[finance_report_test_and_doc] chore(deploy): infra2 pin → 2555055 + release-images tag-promote (deploy_v2 migration PR A)

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,130 @@
+# Release Images — promote main-CI :<sha> images to a :vX.Y.Z release tag
+#
+# Trigger: push of a vX.Y.Z tag.
+#
+# The tag-based deploy_v2 staging/prod deploys pull the :vX.Y.Z image
+# (resolve_image_ref(vX.Y.Z) -> IMAGE_TAG=vX.Y.Z), so the release-tagged image
+# must exist BEFORE staging deploys it. This job promotes the environment-
+# independent :<sha7> images that main CI (ci.yml `container-images`) already
+# published — via a manifest copy (`docker buildx imagetools create`), so it is
+# zero-rebuild. The same digest then flows :<sha> -> :vX.Y.Z -> staging -> prod
+# (promote-not-rebuild). It does NOT require a prior staging deploy: in the
+# tag-based model staging runs AFTER this job (staging deploys the tag).
+#
+# SSOT: docs/ssot/deployment.md (release process), repo/docs/ssot/core.environments.md §4.6.
+
+name: Release Images
+
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
+
+jobs:
+  promote:
+    name: Promote SHA images to release tag
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: version
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify source CI passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow ci.yml \
+              --commit "$GITHUB_SHA" \
+              --limit 20 \
+              --json databaseId,status,conclusion,event,headBranch \
+              --jq '[.[] | select(.event == "push" and .headBranch == "main" and .status == "completed" and .conclusion == "success")][0].databaseId // ""'
+          )"
+          if [ -z "$run_id" ]; then
+            echo "::error::No successful main CI run found for $GITHUB_SHA — the :<sha> images may not be published. Tag a commit that passed main CI."
+            exit 1
+          fi
+          echo "Using successful main CI run: $run_id"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Promote SHA images to release tag
+        id: promote
+        run: |
+          short_sha="$(git rev-parse --short "$GITHUB_SHA")"
+          tag="${{ steps.version.outputs.tag }}"
+
+          backend_sha_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${short_sha}"
+          frontend_sha_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${short_sha}"
+
+          backend_version_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend:${tag}"
+          frontend_version_image="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend:${tag}"
+
+          # Inspect and check SHA images exist (published by main CI).
+          backend_sha_digest="$(docker buildx imagetools inspect "$backend_sha_image" | grep -i '^Digest:' | awk '{print $2}')"
+          frontend_sha_digest="$(docker buildx imagetools inspect "$frontend_sha_image" | grep -i '^Digest:' | awk '{print $2}')"
+
+          if [ -z "$backend_sha_digest" ] || [ -z "$frontend_sha_digest" ]; then
+            echo "::error::main-CI SHA images not found for $short_sha"
+            exit 1
+          fi
+
+          echo "Found backend SHA image digest: $backend_sha_digest"
+          echo "Found frontend SHA image digest: $frontend_sha_digest"
+
+          # Promote (manifest copy, zero rebuild).
+          docker buildx imagetools create --tag "$backend_version_image" "$backend_sha_image"
+          docker buildx imagetools create --tag "$frontend_version_image" "$frontend_sha_image"
+
+          # Verify the promoted digests match the source digests exactly.
+          backend_promoted_digest="$(docker buildx imagetools inspect "$backend_version_image" | grep -i '^Digest:' | awk '{print $2}')"
+          frontend_promoted_digest="$(docker buildx imagetools inspect "$frontend_version_image" | grep -i '^Digest:' | awk '{print $2}')"
+
+          if [ "$backend_sha_digest" != "$backend_promoted_digest" ]; then
+            echo "::error::Backend digests differ! Expected $backend_sha_digest, got $backend_promoted_digest"
+            exit 1
+          fi
+
+          if [ "$frontend_sha_digest" != "$frontend_promoted_digest" ]; then
+            echo "::error::Frontend digests differ! Expected $frontend_sha_digest, got $frontend_promoted_digest"
+            exit 1
+          fi
+
+          echo "backend_digest=$backend_sha_digest" >> "$GITHUB_OUTPUT"
+          echo "frontend_digest=$frontend_sha_digest" >> "$GITHUB_OUTPUT"
+          echo "✅ Release $tag promoted (promote-not-rebuild): $short_sha -> $tag"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Release Images — ${{ steps.version.outputs.tag }}"
+            echo ""
+            echo "Promoted main-CI SHA images to the release tag (zero rebuild)."
+            echo ""
+            echo "- backend digest: \`${{ steps.promote.outputs.backend_digest }}\`"
+            echo "- frontend digest: \`${{ steps.promote.outputs.frontend_digest }}\`"
+            echo ""
+            echo "Next: deploy staging on this tag (\`deploy_v2 --type staging --version-ref ${{ steps.version.outputs.tag }}\`)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ssot/ci-gate-inventory.yaml
+++ b/docs/ssot/ci-gate-inventory.yaml
@@ -300,6 +300,18 @@ gates:
     artifacts: [pr-test-cleanup-context]
     failure_semantics: PR test cleanup failed after runner-local or preview work.
     action: keep
+  - id: release_images.promote
+    category: deploy_ops
+    workflow: .github/workflows/release-images.yml
+    job: promote
+    owner: release images workflow
+    triggers: [push]
+    blocks_workflow: true
+    inputs: [release_tag, main_ci_sha_images]
+    outputs: [release_tag_images]
+    artifacts: []
+    failure_semantics: Release tag image promotion or digest verification failed.
+    action: keep
   - id: production_release.build
     category: deploy_ops
     workflow: .github/workflows/production-release.yml


### PR DESCRIPTION
**PR A of 2** — migrating app staging/prod to infra2 `deploy_v2` (tag-based). See approved plan; PR B (new deploy workflows + retire legacy) follows once this lands.

**Additive — no behavior change until a `vX.Y.Z` tag is pushed.** Legacy `staging-deploy.yml` / `production-release.yml` stay the live deploy path until PR B.

## Changes
1. **Bump `repo/` submodule `18896e40 → 2555055`** (latest infra2). deploy_v2 tooling was already present at the old pin; this brings the freshest `deploy_primitive` + AppRole finalization PR B builds on. Gap is non-deploy obs/vault only: OpenPanel compose inject (#389), OTel hardening (#392), one-off script cleanup (#393). ⚠️ #389 injects `OPENPANEL_*` into the backend compose, so the next deploy will carry it.
2. **Add `.github/workflows/release-images.yml`**: on a `vX.Y.Z` tag push, promote the environment-independent main-CI `:<sha7>` images to `:vX.Y.Z` via `docker buildx imagetools create` (zero rebuild, digest-verified, gated on a successful main CI run for the tagged SHA). The tag-based `deploy_v2` staging/prod deploys pull `:vX.Y.Z` (`resolve_image_ref(vX.Y.Z) → IMAGE_TAG=vX.Y.Z`), so the tag image must exist *before* staging deploys it. It does **not** require a prior staging deploy (staging runs after, on the tag) — that chicken-and-egg is why this is a standalone publish step, not the legacy promote-after-staging build job.
3. **Register the new `promote` job** in `docs/ssot/ci-gate-inventory.yaml` (`deploy_ops`), fixing the two contract tests that enumerate workflow jobs / require the Node24 opt-in.

## Verification (local)
- Full `tests/tooling` suite: **1599 passed**, 3 skipped (incl. `test_AC8_13_142` gate inventory + `test_AC8_13_16` Node24 contract now green).
- `test_AC10_9_4` observability contract (reads `repo/docs/ssot/ops.alerting.md`): passes at pin 2555055.
- SSOT ownership / manifest / doc-consistency gates: exit 0. `release-images.yml` YAML valid.
- pre-push hook (backend lint + frontend lint + full backend suite): ✅ all checks passed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)