### PR TITLE
[finance_report_infra] fix(obs): BE→OpenPanel via REST — official Python SDK is incompatible (profileId:null → 400)

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "pymupdf>=1.24.0",
     "cryptography>=42.0.0",
     "litellm>=1.55.0",
-    "openpanel>=0.0.1",
 ]
 
 [project.optional-dependencies]

--- a/apps/backend/src/analytics.py
+++ b/apps/backend/src/analytics.py
@@ -1,22 +1,25 @@
 """Server-side OpenPanel product-analytics emitter (BE->OpenPanel).
 
-The backend half of the OpenPanel integration, symmetric with the frontend's
-official ``@openpanel/nextjs`` SDK: this uses the official ``openpanel`` Python
-package (not a hand-rolled HTTP client) so both sides speak OpenPanel through its
-base SDK.
+The backend half of the OpenPanel integration. Why a thin REST client and NOT the
+official ``openpanel`` Python SDK (which the frontend's ``@openpanel/nextjs`` mirrors)?
 
-Why a backend emitter at all (the frontend already tracks)? Server-side events
-are *authoritative* — they fire from the backend regardless of the browser
-(adblock / no-JS / closed tab), so a conversion the server actually completed
-(e.g. a report package persisted) is never under-counted. This complements, not
-replaces, the FE analytics.
+  The only published ``openpanel`` PyPI package is v0.0.1 and it ALWAYS sends
+  ``"profileId": null`` in the track payload. Our self-hosted OpenPanel validates
+  the body with Zod and rejects null (``Expected string, received null`` -> HTTP 400),
+  and the SDK gives no way to omit the field. Proven against the live instance: the
+  SDK payload 400s; the same payload without ``profileId`` is accepted (200). So the
+  SDK is non-functional here and the documented HTTP ``/track`` contract is the only
+  working server-side path. Revisit if OpenPanel ships a fixed Python SDK.
 
-Config-gated: when ``OPENPANEL_CLIENT_ID`` is unset (local / CI / preview without
-a project) every call is a complete no-op — same posture as the FE SDK and the
-OTel exporter. Failures are swallowed so analytics can never break a request.
+Why a backend emitter at all (the frontend already tracks)? Server-side events are
+*authoritative* — they fire from the backend regardless of the browser (adblock /
+no-JS / closed tab), so a conversion the server actually completed is never
+under-counted. Complements, not replaces, the FE analytics.
 
-Our OpenPanel clients are configured ``ignoreCorsAndSecret=true``, so no
-``client_secret`` is required (the SDK accepts ``client_id`` + ``api_url`` alone).
+Config-gated (no ``OPENPANEL_CLIENT_ID`` => complete no-op), non-blocking (the POST
+runs on a daemon thread so it never sits on the request's critical path), and never
+raises — analytics can never break a request. Our OpenPanel clients are
+``ignoreCorsAndSecret=true``, so the public client-id alone authorizes the write.
 """
 
 from __future__ import annotations
@@ -25,14 +28,13 @@ import logging
 import threading
 from typing import Any
 
+import httpx
+
 from src.config import settings
 
 logger = logging.getLogger(__name__)
 
-# The OpenPanel SDK runs its own background daemon thread + send queue, so we keep
-# ONE module-level client (never one-per-event). Lazily built on first use.
-_client: Any = None
-_client_lock = threading.Lock()
+_TIMEOUT_SECONDS = 5.0
 
 
 def is_configured() -> bool:
@@ -40,49 +42,52 @@ def is_configured() -> bool:
     return bool((settings.openpanel_client_id or "").strip() and (settings.openpanel_api_url or "").strip())
 
 
-def _get_client() -> Any:
-    """Return the shared OpenPanel client, or None when analytics is unconfigured.
+def _track_endpoint() -> str:
+    return (settings.openpanel_api_url or "").strip().rstrip("/") + "/track"
 
-    Built once (double-checked lock) because constructing it spins a daemon thread.
-    ``set_global_properties`` stamps every event with source=backend + the
-    deployment environment, mirroring the FE event contract.
-    """
-    global _client
-    if not is_configured():
-        return None
-    if _client is None:
-        with _client_lock:
-            if _client is None:
-                from openpanel import OpenPanel
 
-                client = OpenPanel(
-                    client_id=settings.openpanel_client_id.strip(),
-                    api_url=settings.openpanel_api_url.strip(),
-                )
-                env = (settings.openpanel_environment or "").strip() or settings.environment
-                try:
-                    client.set_global_properties({"source": "backend", "deployment_environment": env})
-                except Exception as exc:  # noqa: BLE001 — never let analytics setup break a request
-                    logger.debug("OpenPanel set_global_properties failed: %s", exc)
-                _client = client
-    return _client
+def build_payload(event: str, properties: dict[str, Any] | None) -> dict[str, Any]:
+    """OpenPanel ``/track`` body. ``source=backend`` distinguishes server-side events
+    from browser ones; ``deployment_environment`` carries the env for per-env filtering.
+    Deliberately omits ``profileId`` — our OpenPanel rejects a null one (module docstring)."""
+    env = (settings.openpanel_environment or "").strip() or settings.environment
+    return {
+        "type": "track",
+        "payload": {
+            "name": event,
+            "properties": {
+                "source": "backend",
+                "deployment_environment": env,
+                **(properties or {}),
+            },
+        },
+    }
+
+
+def _post(payload: dict[str, Any], client_id: str, endpoint: str) -> None:
+    """Best-effort single POST. Never raises — a telemetry hiccup must not surface."""
+    try:
+        with httpx.Client(timeout=_TIMEOUT_SECONDS) as client:
+            response = client.post(endpoint, json=payload, headers={"openpanel-client-id": client_id})
+        response.raise_for_status()
+    except Exception as exc:  # noqa: BLE001 — analytics must never break a request
+        logger.debug("OpenPanel backend track failed for %r: %s", payload.get("payload", {}).get("name"), exc)
 
 
 def track(event: str, properties: dict[str, Any] | None = None) -> bool:
-    """Emit one OpenPanel event from the backend via the official SDK.
+    """Emit one OpenPanel event from the backend. Returns True if dispatched.
 
-    Returns True if the event was handed to the SDK (which sends it on its own
-    background thread), False when unconfigured. Config-gated and NEVER raises —
-    any error is logged at debug and swallowed so a telemetry hiccup cannot fail
-    the caller's request. Pair with FastAPI ``BackgroundTasks`` to keep even the
-    one-time lazy client init off the response path.
+    Config-gated (no-op + False when no project is wired). The HTTP POST runs on a
+    daemon thread so this is safe to call inline from an async request handler without
+    blocking the event loop or the response, and it never raises.
     """
-    client = _get_client()
-    if client is None:
+    client_id = (settings.openpanel_client_id or "").strip()
+    if not is_configured():
         return False
-    try:
-        client.track(event, properties or {})
-        return True
-    except Exception as exc:  # noqa: BLE001 — analytics must never break a request
-        logger.debug("OpenPanel backend track failed for %r: %s", event, exc)
-        return False
+    payload = build_payload(event, properties)
+    threading.Thread(
+        target=_post,
+        args=(payload, client_id, _track_endpoint()),
+        daemon=True,
+    ).start()
+    return True

--- a/apps/backend/tests/infra/test_analytics.py
+++ b/apps/backend/tests/infra/test_analytics.py
@@ -1,9 +1,10 @@
 """BE->OpenPanel server-side analytics emitter contract (EPIC-024 AC24.2.2).
 
 AC24.2.2 ("the analytics layer actually dispatches an OpenPanel event") realized
-SERVER-SIDE — the 4th telemetry combination (backend product analytics). Uses the
-official ``openpanel`` Python SDK (symmetric with the FE ``@openpanel/nextjs``);
-same posture as the FE: config-gated no-op, non-blocking, never raises.
+SERVER-SIDE — the 4th telemetry combination (backend product analytics). A thin REST
+client (NOT the official openpanel SDK, which sends profileId=null and 400s against our
+self-hosted instance — see src/analytics.py). Same posture as the FE: config-gated
+no-op, non-blocking, never raises.
 """
 
 from __future__ import annotations
@@ -16,86 +17,79 @@ from src import analytics
 from src.config import settings
 
 
-class _FakeOpenPanel:
-    """Stand-in for the official openpanel SDK client. Records init args, global
-    properties, and track() calls (the SDK sends on its own thread; here it's sync)."""
+class _ImmediateThread:
+    """Run the daemon-thread target synchronously so the POST is observable in-test."""
 
-    instances: list[_FakeOpenPanel] = []
+    def __init__(self, target=None, args=(), daemon=None, **_kw: Any) -> None:
+        self._target = target
+        self._args = args
 
-    def __init__(self, *, client_id: str, api_url: str | None = None, **kwargs: Any) -> None:
-        self.client_id = client_id
-        self.api_url = api_url
-        self.global_properties: dict[str, Any] = {}
-        self.tracked: list[tuple[str, dict[str, Any]]] = []
-        type(self).instances.append(self)
-
-    def set_global_properties(self, props: dict[str, Any]) -> None:
-        self.global_properties.update(props)
-
-    def track(self, name: str, properties: dict[str, Any] | None = None) -> None:
-        self.tracked.append((name, properties or {}))
+    def start(self) -> None:
+        self._target(*self._args)
 
 
 @pytest.fixture(autouse=True)
-def _reset(monkeypatch):
-    # the emitter caches one module-level client; reset between tests
-    monkeypatch.setattr(analytics, "_client", None)
-    _FakeOpenPanel.instances = []
-    # patch the official SDK symbol the module imports lazily
-    import openpanel
-
-    monkeypatch.setattr(openpanel, "OpenPanel", _FakeOpenPanel)
-    yield
-    monkeypatch.setattr(analytics, "_client", None)
+def _sync_threads(monkeypatch):
+    monkeypatch.setattr(analytics.threading, "Thread", _ImmediateThread)
 
 
-def _configure(monkeypatch, *, client_id="6e8f9d85-test", api_url="https://openpanel.example/api", env="production"):
+def _configure(monkeypatch, *, client_id="62d5cfe0-test", api_url="https://openpanel.example/api", env="production"):
     monkeypatch.setattr(settings, "openpanel_client_id", client_id)
     monkeypatch.setattr(settings, "openpanel_api_url", api_url)
     monkeypatch.setattr(settings, "openpanel_environment", env)
 
 
 def test_track_is_noop_when_unconfigured(monkeypatch) -> None:
-    """No client-id (local/CI/preview) => complete no-op, SDK never built, returns False."""
+    """No client-id (local/CI/preview) => complete no-op, no POST, returns False."""
     _configure(monkeypatch, client_id="")
+    posted: list[Any] = []
+    monkeypatch.setattr(analytics, "_post", lambda *a: posted.append(a))
     assert analytics.track("report_generated") is False
-    assert _FakeOpenPanel.instances == []
+    assert posted == []
     assert analytics.is_configured() is False
 
 
-def test_track_uses_official_sdk_with_global_source_and_env(monkeypatch) -> None:
-    """Configured => builds one SDK client (client_id + self-hosted api_url),
-    stamps source=backend + deployment_environment globally, and tracks the event."""
+def test_track_posts_to_track_endpoint_with_client_id_and_no_profileid(monkeypatch) -> None:
+    """Configured => POSTs {type:track, payload:{name, properties}} to <api>/track with the
+    openpanel-client-id header; tags source=backend + deployment_environment; and crucially
+    OMITS profileId (the field the official SDK sends as null, which our OpenPanel 400s on)."""
     _configure(monkeypatch)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        analytics,
+        "_post",
+        lambda payload, cid, endpoint: calls.append({"payload": payload, "cid": cid, "endpoint": endpoint}),
+    )
 
     assert analytics.track("report_generated", {"framework_id": "us_gaap_like"}) is True
-
-    assert len(_FakeOpenPanel.instances) == 1
-    client = _FakeOpenPanel.instances[0]
-    assert client.client_id == "6e8f9d85-test"
-    assert client.api_url == "https://openpanel.example/api"
-    assert client.global_properties == {"source": "backend", "deployment_environment": "production"}
-    assert client.tracked == [("report_generated", {"framework_id": "us_gaap_like"})]
-
-
-def test_client_is_built_once_across_calls(monkeypatch) -> None:
-    """The SDK spins a daemon thread; the emitter must reuse ONE client, not one-per-event."""
-    _configure(monkeypatch)
-    analytics.track("a")
-    analytics.track("b")
-    assert len(_FakeOpenPanel.instances) == 1
-    assert [n for n, _ in _FakeOpenPanel.instances[0].tracked] == ["a", "b"]
+    assert len(calls) == 1
+    c = calls[0]
+    assert c["endpoint"] == "https://openpanel.example/api/track"
+    assert c["cid"] == "62d5cfe0-test"
+    body = c["payload"]
+    assert body["type"] == "track"
+    assert "profileId" not in body["payload"]
+    assert body["payload"]["name"] == "report_generated"
+    props = body["payload"]["properties"]
+    assert props["source"] == "backend"
+    assert props["deployment_environment"] == "production"
+    assert props["framework_id"] == "us_gaap_like"
 
 
-def test_track_never_raises_when_sdk_errors(monkeypatch) -> None:
-    """An SDK error is swallowed (returns False) — analytics must never break the request."""
+def test_track_never_raises_on_transport_error(monkeypatch) -> None:
+    """A transport/HTTP error inside _post is swallowed — analytics must never break the
+    request that scheduled it (track still returns True; the failure is logged at debug)."""
     _configure(monkeypatch)
 
-    class _BoomOpenPanel(_FakeOpenPanel):
-        def track(self, *a: Any, **k: Any) -> None:
-            raise RuntimeError("sdk boom")
+    class _BoomClient:
+        def __enter__(self):
+            return self
 
-    import openpanel
+        def __exit__(self, *a):
+            return False
 
-    monkeypatch.setattr(openpanel, "OpenPanel", _BoomOpenPanel)
-    assert analytics.track("report_generated") is False
+        def post(self, *a: Any, **k: Any):
+            raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(analytics.httpx, "Client", lambda *a, **k: _BoomClient())
+    assert analytics.track("report_generated") is True

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -970,7 +970,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "litellm" },
-    { name = "openpanel" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-httpx" },
@@ -1025,7 +1024,6 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litellm", specifier = ">=1.55.0" },
-    { name = "openpanel", specifier = ">=0.0.1" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.24.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.45b0" },
     { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.45b0" },
@@ -2088,18 +2086,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/36/4c926a91554483977608951360c18c2e911592785eb87a6437813f6123f7/openai-2.41.1.tar.gz", hash = "sha256:23d617a0432457ad844973bee8f540be9da90894f7c5686852d2d365da058f57", size = 783584, upload-time = "2026-06-10T16:10:37.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/74/925d7b3892927e9804aaf58d374a45dc28e4420ff90e992272b77286343e/openai-2.41.1-py3-none-any.whl", hash = "sha256:a939565f350cb7443cb843b801b88c716ac8024b492fb94ca269d5f6b1bbefd6", size = 1353380, upload-time = "2026-06-10T16:10:35.756Z" },
-]
-
-[[package]]
-name = "openpanel"
-version = "0.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/d2/1ca167988225113a2162fcc528ef309715f348e1ee2bcaa8405222fea08c/openpanel-0.0.1.tar.gz", hash = "sha256:96a27848d670218c03a75528b95b8e3efbd4898665d57b3ee9c81c4b3c06f922", size = 3721, upload-time = "2024-10-16T14:19:41.923Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/73/44ad513438c56d3e9c8dbdbea647a2f79e8be03a80967eeaa873f29a0527/openpanel-0.0.1-py3-none-any.whl", hash = "sha256:c4d5a31694d4307975bbf70bbb2fa9fae920df0fb4b8ff97fa7b78ee8fe667b2", size = 15865, upload-time = "2024-10-22T19:27:53.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
The BE→OpenPanel emitter (#1190) used the official `openpanel` Python SDK. **It doesn't work against our self-hosted OpenPanel**: the SDK (v0.0.1, the only release) always sends `"profileId": null`, and our instance's Zod validation rejects null → **HTTP 400** (`Expected string, received null`). The SDK offers no way to omit the field.

**Proven on the live instance:**
- SDK payload (with `profileId:null`) → `400 Validation failed`
- identical payload **without** `profileId` → `200` (event lands)

So the SDK is non-functional here and BE→OpenPanel never actually emitted (the deployed staging backend's `track()` returned True but the SDK 400'd internally).

## Fix
Replace the SDK with a **thin httpx `/track` client** sending the documented working payload (no `profileId`), on a **daemon thread** (non-blocking — safe to call inline from the async handler), config-gated, never raises. Drop the `openpanel` dependency.

This is the option I'd originally written; the earlier switch to the SDK was on my (incomplete) info that the SDK was the clean "base package" — it turns out to be incompatible. Revisit if OpenPanel ships a fixed Python SDK.

## Test
`tests/infra/test_analytics.py` (3) — asserts the payload **omits profileId**, posts to `/track` with the client-id header, no-op when unconfigured, never raises. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)