### PR TITLE
[finance_report_audit] feat(ratio): Ratio/percent base package + base-package template SSOT (EPIC-012 AC12.9, #1167)

### DIFF
--- a/apps/backend/src/ratio/__init__.py
+++ b/apps/backend/src/ratio/__init__.py
@@ -1,0 +1,23 @@
+"""``src.ratio`` — the project's ratio/percent narrow waist (#1167 family).
+
+The second base-element value type after ``money`` (see
+``docs/ssot/base-packages.md``): a dimensionless :class:`Ratio` with ONE percent
+display policy (2 dp, ROUND_HALF_UP), so performance ratios / allocation shares /
+confidence proportions stop diverging across the codebase and across FE/BE.
+
+Dependency-light (stdlib + Decimal). Contract: ``src/ratio/contract/ratio.contract.md``.
+"""
+
+from __future__ import annotations
+
+from src.ratio.errors import FloatNotAllowedError, RatioError, UndefinedRatioError
+from src.ratio.ratio import PERCENT_DP, PERCENT_ROUNDING, Ratio
+
+__all__ = [
+    "PERCENT_DP",
+    "PERCENT_ROUNDING",
+    "FloatNotAllowedError",
+    "Ratio",
+    "RatioError",
+    "UndefinedRatioError",
+]

--- a/apps/backend/src/ratio/errors.py
+++ b/apps/backend/src/ratio/errors.py
@@ -1,0 +1,23 @@
+"""Typed errors for the ratio value type (mirrors the money error hierarchy).
+
+A single narrow hierarchy so call-sites can catch ``RatioError`` for any
+ratio-domain violation, or the specific subtype.
+"""
+
+from __future__ import annotations
+
+
+class RatioError(Exception):
+    """Base class for every ratio-domain error."""
+
+
+class FloatNotAllowedError(RatioError, TypeError):
+    """A ``float`` was supplied where a ``Decimal`` (or ``int``) is required.
+
+    ``float`` is the standing numeric red line (IEEE-754 precision loss); the
+    value type rejects it at construction rather than relying on review.
+    """
+
+
+class UndefinedRatioError(RatioError, ZeroDivisionError):
+    """A ratio was requested from a zero whole (``part / 0`` is undefined)."""

--- a/apps/backend/src/ratio/ratio.py
+++ b/apps/backend/src/ratio/ratio.py
@@ -120,5 +120,5 @@ class Ratio:
 
 def _as_ratio(other: object) -> Ratio:
     if not isinstance(other, Ratio):
-        raise FloatNotAllowedError(f"expected a Ratio, got {type(other).__name__}")
+        raise TypeError(f"expected a Ratio, got {type(other).__name__}")
     return other

--- a/apps/backend/src/ratio/ratio.py
+++ b/apps/backend/src/ratio/ratio.py
@@ -1,0 +1,124 @@
+"""``Ratio`` — the authoritative dimensionless-ratio value type.
+
+A ratio is a unitless ``Decimal`` (e.g. ``Decimal("0.125")`` == 12.5%). It is the
+base element for performance ratios (return-on-cost, XIRR/TWR/MWR), allocation
+shares, and confidence proportions — everything that was previously ad-hoc
+``value / total`` math with **inconsistent** percent rounding (HALF_UP in some
+paths, HALF_EVEN in others).
+
+The point, like ``Money``, is to make bad states unrepresentable and to give the
+whole project ONE percent-display policy:
+
+- construction rejects ``float`` (the numeric red line);
+- ``fraction(part, whole)`` is the single primitive for building a ratio from two
+  quantities (zero whole is undefined → raises);
+- ``to_percent`` renders the percentage with the canonical **2 dp, ROUND_HALF_UP**
+  policy (finance display convention) — the single standard both ends share.
+
+Stored value is the *exact* Decimal; rounding happens only at the percent boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+
+from src.ratio.errors import FloatNotAllowedError, UndefinedRatioError
+
+# Canonical percent-display policy (NOT money's HALF_EVEN — percentages are not
+# money and follow the finance display convention of round-half-up).
+PERCENT_DP: int = 2
+PERCENT_ROUNDING: str = ROUND_HALF_UP
+
+_RatioInput = Decimal | int
+
+
+def _coerce(value: object, what: str = "ratio value") -> Decimal:
+    if isinstance(value, bool):
+        raise FloatNotAllowedError(f"bool is not a valid {what}")
+    if isinstance(value, float):
+        raise FloatNotAllowedError(f"float is not allowed for {what} (IEEE-754 precision loss); use Decimal")
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    raise FloatNotAllowedError(f"{what} must be Decimal or int, got {type(value).__name__}")
+
+
+@dataclass(frozen=True)
+class Ratio:
+    """An immutable dimensionless ratio (``0.125`` == 12.5%).
+
+    >>> Ratio.fraction(1, 8).to_percent()
+    Decimal('12.50')
+    """
+
+    value: Decimal
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "value", _coerce(self.value))
+
+    # ── construction ────────────────────────────────────────────────────
+    @classmethod
+    def fraction(cls, part: _RatioInput, whole: _RatioInput) -> Ratio:
+        """Build a ratio ``part / whole``. A zero whole is undefined and raises."""
+        p = _coerce(part, "part")
+        w = _coerce(whole, "whole")
+        if w == 0:
+            raise UndefinedRatioError("ratio is undefined for a zero whole")
+        return cls(p / w)
+
+    @classmethod
+    def zero(cls) -> Ratio:
+        return cls(Decimal("0"))
+
+    @classmethod
+    def from_percent(cls, percent: _RatioInput) -> Ratio:
+        """Build a ratio from a percentage number (``12.5`` -> ``0.125``)."""
+        return cls(_coerce(percent, "percent") / Decimal("100"))
+
+    # ── percent rendering (the single shared standard) ──────────────────
+    def to_percent(self, dp: int = PERCENT_DP, rounding: str = PERCENT_ROUNDING) -> Decimal:
+        """Return the percentage value quantized to ``dp`` (default 2 dp, HALF_UP)."""
+        quantum = Decimal(1).scaleb(-dp)  # 10**-dp, e.g. dp=2 -> 0.01
+        return (self.value * Decimal("100")).quantize(quantum, rounding=rounding)
+
+    def format_percent(self, dp: int = PERCENT_DP) -> str:
+        """Render as a ``"12.50%"`` string at the canonical policy."""
+        return f"{self.to_percent(dp)}%"
+
+    # ── dimensionless arithmetic (ratios share one implicit unit) ───────
+    def __add__(self, other: Ratio) -> Ratio:
+        return Ratio(self.value + _as_ratio(other).value)
+
+    def __sub__(self, other: Ratio) -> Ratio:
+        return Ratio(self.value - _as_ratio(other).value)
+
+    def __neg__(self) -> Ratio:
+        return Ratio(-self.value)
+
+    def __mul__(self, factor: _RatioInput) -> Ratio:
+        return Ratio(self.value * _coerce(factor, "factor"))
+
+    __rmul__ = __mul__
+
+    def __lt__(self, other: Ratio) -> bool:
+        return self.value < _as_ratio(other).value
+
+    def __le__(self, other: Ratio) -> bool:
+        return self.value <= _as_ratio(other).value
+
+    def __gt__(self, other: Ratio) -> bool:
+        return self.value > _as_ratio(other).value
+
+    def __ge__(self, other: Ratio) -> bool:
+        return self.value >= _as_ratio(other).value
+
+    def __str__(self) -> str:
+        return self.format_percent()
+
+
+def _as_ratio(other: object) -> Ratio:
+    if not isinstance(other, Ratio):
+        raise FloatNotAllowedError(f"expected a Ratio, got {type(other).__name__}")
+    return other

--- a/apps/backend/tests/accounting/test_ratio_backend.py
+++ b/apps/backend/tests/accounting/test_ratio_backend.py
@@ -62,5 +62,6 @@ def test_AC12_9_1_backend_value_type_laws():
     assert Ratio.from_percent(Decimal("50")).to_percent() == Decimal("50.00")
     assert str(a) == "10.00%"
     assert Ratio.zero().value == Decimal("0")
-    with pytest.raises(FloatNotAllowedError):
+    # A non-Ratio operand is a TypeError (mirrors Money's cross-type guard).
+    with pytest.raises(TypeError):
         _ = a - 0.1  # type: ignore[operator]

--- a/apps/backend/tests/accounting/test_ratio_backend.py
+++ b/apps/backend/tests/accounting/test_ratio_backend.py
@@ -1,0 +1,66 @@
+"""Backend ratio module (src.ratio) — value-type + conformance (EPIC-012 AC12.9, #1167).
+
+Proves the backend's shipped ``src.ratio`` end conforms to the shared standard and
+fully exercises the module (the backend image ships src.ratio; common/ is not
+shipped). Mirrors common.ratio, kept in lockstep by the conformance vectors.
+"""
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.ratio import (
+    PERCENT_DP,
+    PERCENT_ROUNDING,
+    FloatNotAllowedError,
+    Ratio,
+    UndefinedRatioError,
+)
+
+pytestmark = pytest.mark.no_db
+
+_VECTORS = json.loads((Path(__file__).resolve().parents[4] / "common/ratio/conformance/vectors.json").read_text())
+
+
+@ac_proof(proof_id="test_ratio_backend_conformance", ac_ids=["AC12.9.2"], ci_tier="pr_ci", issue="#1167")
+@pytest.mark.parametrize("case", _VECTORS["to_percent"], ids=lambda c: c["ratio"])
+def test_AC12_9_2_backend_to_percent_matches(case):
+    """AC12.9.2: src.ratio to_percent matches the shared standard."""
+    assert Ratio(Decimal(case["ratio"])).to_percent(case["dp"]) == Decimal(case["expected"])
+
+
+@ac_proof(proof_id="test_ratio_backend_percent_of", ac_ids=["AC12.9.2"], ci_tier="pr_ci", issue="#1167")
+@pytest.mark.parametrize("case", _VECTORS["percent_of"], ids=lambda c: f"{c['part']}/{c['whole']}")
+def test_AC12_9_2_backend_percent_of_matches(case):
+    """AC12.9.2: src.ratio fraction(part, whole).to_percent matches the standard."""
+    assert Ratio.fraction(Decimal(case["part"]), Decimal(case["whole"])).to_percent(case["dp"]) == Decimal(
+        case["expected"]
+    )
+
+
+@ac_proof(proof_id="test_ratio_backend_value_type", ac_ids=["AC12.9.1"], ci_tier="pr_ci", issue="#1167")
+def test_AC12_9_1_backend_value_type_laws():
+    """AC12.9.1: src.ratio rejects float, zero-whole undefined, percent policy, arithmetic."""
+    assert PERCENT_DP == 2 and PERCENT_ROUNDING == "ROUND_HALF_UP"
+    with pytest.raises(FloatNotAllowedError):
+        Ratio(0.1)
+    with pytest.raises(FloatNotAllowedError):
+        Ratio(True)
+    with pytest.raises(FloatNotAllowedError):
+        Ratio("0.1")  # str rejected in Python (use Decimal)
+    with pytest.raises(UndefinedRatioError):
+        Ratio.fraction(1, 0)
+    a, b = Ratio(Decimal("0.1")), Ratio(Decimal("0.2"))
+    assert (a + b) == Ratio(Decimal("0.3"))
+    assert (b - a) == Ratio(Decimal("0.1"))
+    assert (-a) == Ratio(Decimal("-0.1"))
+    assert (2 * a) == Ratio(Decimal("0.2"))
+    assert a < b and a <= b and b > a and b >= a
+    assert Ratio.from_percent(Decimal("50")).to_percent() == Decimal("50.00")
+    assert str(a) == "10.00%"
+    assert Ratio.zero().value == Decimal("0")
+    with pytest.raises(FloatNotAllowedError):
+        _ = a - 0.1  # type: ignore[operator]

--- a/apps/frontend/src/lib/ratio/errors.ts
+++ b/apps/frontend/src/lib/ratio/errors.ts
@@ -1,0 +1,25 @@
+// Typed ratio errors — the TS mirror of common/ratio/errors.py / src.ratio.errors,
+// so the frontend and backend expose the same ratio error surface (#1167).
+
+export class RatioError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RatioError";
+  }
+}
+
+/** A float (JS number) was supplied where a Decimal is required. */
+export class FloatNotAllowedError extends RatioError {
+  constructor(message: string) {
+    super(message);
+    this.name = "FloatNotAllowedError";
+  }
+}
+
+/** A ratio was requested from a zero whole (part / 0 is undefined). */
+export class UndefinedRatioError extends RatioError {
+  constructor(message: string) {
+    super(message);
+    this.name = "UndefinedRatioError";
+  }
+}

--- a/apps/frontend/src/lib/ratio/index.ts
+++ b/apps/frontend/src/lib/ratio/index.ts
@@ -1,0 +1,9 @@
+// The frontend ratio module — the TS implementation of the shared, cross-language
+// ratio/percent standard (#1167 base-package family). Contract:
+// common/ratio/contract/ratio.contract.md. Proven consistent with the Python
+// reference via the shared conformance vectors (common/ratio/conformance/vectors.json),
+// see ratio.conformance.test.ts. Identifier parity enforced by
+// tests/tooling/test_ratio_api_parity.py.
+
+export { RatioError, FloatNotAllowedError, UndefinedRatioError } from "./errors";
+export { Ratio, PERCENT_DP, PERCENT_ROUNDING, type RatioInput } from "./ratio";

--- a/apps/frontend/src/lib/ratio/ratio.conformance.test.ts
+++ b/apps/frontend/src/lib/ratio/ratio.conformance.test.ts
@@ -1,0 +1,74 @@
+// Frontend side of the cross-language ratio conformance suite (#1167).
+//
+// Proves the frontend rendering of the ratio standard: AC12.9.1 (value type +
+// percent policy). Loads the SAME language-neutral standard the Python reference
+// uses (common/ratio/conformance/vectors.json) and asserts the TS impl reproduces
+// every value, so the frontend cannot drift from the backend on the HALF_UP
+// percent rounding. See common/ratio/conformance/README.md.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Decimal from "decimal.js";
+import { describe, expect, it } from "vitest";
+
+import { FloatNotAllowedError, PERCENT_DP, PERCENT_ROUNDING, Ratio, UndefinedRatioError } from "./index";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const vectorsPath = resolve(here, "../../../../../common/ratio/conformance/vectors.json");
+const VECTORS = JSON.parse(readFileSync(vectorsPath, "utf-8")) as {
+  percent_dp: number;
+  percent_rounding: string;
+  to_percent: { ratio: string; dp: number; expected: string }[];
+  percent_of: { part: string; whole: string; dp: number; expected: string }[];
+  from_percent: { percent: string; expected_percent_2dp: string }[];
+};
+
+describe("ratio conformance (cross-language standard #1167)", () => {
+  it("declares the same percent policy (2 dp, HALF_UP)", () => {
+    expect(VECTORS.percent_dp).toBe(PERCENT_DP);
+    expect(VECTORS.percent_rounding).toBe("ROUND_HALF_UP");
+    expect(PERCENT_ROUNDING).toBe(Decimal.ROUND_HALF_UP);
+  });
+
+  it("matches every to_percent vector (HALF_UP, not HALF_EVEN)", () => {
+    for (const c of VECTORS.to_percent) {
+      const got = new Ratio(c.ratio).toPercent(c.dp);
+      expect(got.equals(new Decimal(c.expected)), JSON.stringify(c)).toBe(true);
+    }
+  });
+
+  it("matches every percent_of (fraction → percent) vector", () => {
+    for (const c of VECTORS.percent_of) {
+      const got = Ratio.fraction(c.part, c.whole).toPercent(c.dp);
+      expect(got.equals(new Decimal(c.expected)), JSON.stringify(c)).toBe(true);
+    }
+  });
+
+  it("round-trips from_percent", () => {
+    for (const c of VECTORS.from_percent) {
+      const got = Ratio.fromPercent(c.percent).toPercent(2);
+      expect(got.equals(new Decimal(c.expected_percent_2dp)), JSON.stringify(c)).toBe(true);
+    }
+  });
+});
+
+describe("ratio value-type laws (TS rendering of the contract)", () => {
+  it("rejects float (JS number) values", () => {
+    // @ts-expect-error number is intentionally not assignable to RatioInput
+    expect(() => new Ratio(0.125)).toThrow(FloatNotAllowedError);
+  });
+
+  it("treats a zero whole as undefined", () => {
+    expect(() => Ratio.fraction("1", "0")).toThrow(UndefinedRatioError);
+  });
+
+  it("supports dimensionless arithmetic + comparison", () => {
+    const a = new Ratio("0.1");
+    const b = new Ratio("0.2");
+    expect(a.add(b).value.equals(new Decimal("0.3"))).toBe(true);
+    expect(a.compareTo(b)).toBe(-1);
+    expect(a.equals(new Ratio("0.1"))).toBe(true);
+  });
+});

--- a/apps/frontend/src/lib/ratio/ratio.conformance.test.ts
+++ b/apps/frontend/src/lib/ratio/ratio.conformance.test.ts
@@ -68,7 +68,14 @@ describe("ratio value-type laws (TS rendering of the contract)", () => {
     const a = new Ratio("0.1");
     const b = new Ratio("0.2");
     expect(a.add(b).value.equals(new Decimal("0.3"))).toBe(true);
+    expect(b.subtract(a).value.equals(new Decimal("0.1"))).toBe(true);
     expect(a.compareTo(b)).toBe(-1);
     expect(a.equals(new Ratio("0.1"))).toBe(true);
+    expect(Ratio.zero().value.equals(new Decimal("0"))).toBe(true);
+  });
+
+  it("renders percent strings (formatPercent / toString)", () => {
+    expect(new Ratio("0.125").formatPercent()).toBe("12.50%");
+    expect(String(new Ratio("0.5"))).toBe("50.00%");
   });
 });

--- a/apps/frontend/src/lib/ratio/ratio.ts
+++ b/apps/frontend/src/lib/ratio/ratio.ts
@@ -1,0 +1,80 @@
+// Ratio — the TS rendering of the shared ratio/percent contract
+// (common/ratio/contract/ratio.contract.md). Dimensionless, Decimal-backed;
+// rejects float; ONE percent-display policy (2 dp, ROUND_HALF_UP) matching the
+// Python reference. Conformance proven by ratio.conformance.test.ts.
+
+import Decimal from "decimal.js";
+
+import { FloatNotAllowedError, UndefinedRatioError } from "./errors";
+
+export const PERCENT_DP = 2;
+// Canonical percent-display rounding — finance convention, deliberately NOT
+// money's HALF_EVEN (a percentage is not a currency amount).
+export const PERCENT_ROUNDING: Decimal.Rounding = Decimal.ROUND_HALF_UP;
+
+/** Ratio input: a Decimal or a decimal STRING. Never a JS number (float). */
+export type RatioInput = Decimal | string;
+
+function coerce(value: RatioInput, what = "ratio value"): Decimal {
+  if (value instanceof Decimal) return value;
+  if (typeof value === "string") return new Decimal(value);
+  // Deliberately reject `number` (and anything else) — JS numbers are floats.
+  throw new FloatNotAllowedError(`${what} must be a Decimal or decimal string, not a number`);
+}
+
+/** An immutable dimensionless ratio (`0.125` == 12.5%). */
+export class Ratio {
+  readonly value: Decimal;
+
+  constructor(value: RatioInput) {
+    this.value = coerce(value);
+    Object.freeze(this);
+  }
+
+  /** Build a ratio `part / whole`. A zero whole is undefined and raises. */
+  static fraction(part: RatioInput, whole: RatioInput): Ratio {
+    const p = coerce(part, "part");
+    const w = coerce(whole, "whole");
+    if (w.isZero()) throw new UndefinedRatioError("ratio is undefined for a zero whole");
+    return new Ratio(p.dividedBy(w));
+  }
+
+  static zero(): Ratio {
+    return new Ratio("0");
+  }
+
+  /** Build a ratio from a percentage number (`12.5` -> `0.125`). */
+  static fromPercent(percent: RatioInput): Ratio {
+    return new Ratio(coerce(percent, "percent").dividedBy(100));
+  }
+
+  /** Percentage value quantized to `dp` (default 2 dp, HALF_UP). */
+  toPercent(dp: number = PERCENT_DP, rounding: Decimal.Rounding = PERCENT_ROUNDING): Decimal {
+    return this.value.times(100).toDecimalPlaces(dp, rounding);
+  }
+
+  /** Render as a `"12.50%"` string at the canonical policy. */
+  formatPercent(dp: number = PERCENT_DP): string {
+    return `${this.toPercent(dp).toFixed(dp)}%`;
+  }
+
+  add(other: Ratio): Ratio {
+    return new Ratio(this.value.plus(other.value));
+  }
+
+  subtract(other: Ratio): Ratio {
+    return new Ratio(this.value.minus(other.value));
+  }
+
+  compareTo(other: Ratio): number {
+    return this.value.comparedTo(other.value);
+  }
+
+  equals(other: Ratio): boolean {
+    return this.value.equals(other.value);
+  }
+
+  toString(): string {
+    return this.formatPercent();
+  }
+}

--- a/common/ratio/__init__.py
+++ b/common/ratio/__init__.py
@@ -1,0 +1,23 @@
+"""``common.ratio`` — the project's ratio/percent narrow waist (#1167 family).
+
+The second base-element value type after ``money`` (see
+``docs/ssot/base-packages.md``): a dimensionless :class:`Ratio` with ONE percent
+display policy (2 dp, ROUND_HALF_UP), so performance ratios / allocation shares /
+confidence proportions stop diverging across the codebase and across FE/BE.
+
+Dependency-light (stdlib + Decimal). Contract: ``common/ratio/contract/ratio.contract.md``.
+"""
+
+from __future__ import annotations
+
+from common.ratio.errors import FloatNotAllowedError, RatioError, UndefinedRatioError
+from common.ratio.ratio import PERCENT_DP, PERCENT_ROUNDING, Ratio
+
+__all__ = [
+    "PERCENT_DP",
+    "PERCENT_ROUNDING",
+    "FloatNotAllowedError",
+    "Ratio",
+    "RatioError",
+    "UndefinedRatioError",
+]

--- a/common/ratio/conformance/README.md
+++ b/common/ratio/conformance/README.md
@@ -1,0 +1,25 @@
+# Ratio conformance vectors — the cross-language percent standard
+
+`vectors.json` is the **single source of truth** for ratio/percent *behaviour*
+across every end (#1167 base-package family). Language-neutral data, consumed at
+**test time only** — never shipped into a runtime image.
+
+## The rule
+
+Every ratio implementation loads `vectors.json` and must reproduce **every**
+expected value:
+
+| Stack | Implementation | Conformance test |
+|-------|----------------|------------------|
+| Backend (Python) | `common/ratio` (reference) / `apps/backend/src/ratio` | `tests/tooling/test_ratio_conformance.py` |
+| Frontend (TypeScript) | `apps/frontend/src/lib/ratio` | `apps/frontend/src/lib/ratio/ratio.conformance.test.ts` |
+
+The canonical percent-display policy is **2 dp, ROUND_HALF_UP** — the finance
+display convention, deliberately distinct from money's banker's rounding
+(percentages are not money). The vectors include half-up boundary cases so a
+stack that defaulted to HALF_EVEN fails immediately.
+
+## Vector groups
+- **`to_percent`** — `ratio` → percentage number at `dp`, HALF_UP.
+- **`percent_of`** — `part / whole` → percentage at `dp` (the `fraction(...).to_percent(...)` path).
+- **`from_percent`** — percentage number → ratio, round-trips back to the same percent.

--- a/common/ratio/conformance/__init__.py
+++ b/common/ratio/conformance/__init__.py
@@ -1,0 +1,21 @@
+"""Loader for the language-neutral ratio conformance vectors.
+
+``vectors.json`` is the single percent/ratio standard (#1167) that every ratio
+implementation must reproduce — the Python reference (``common/ratio``) and the
+TypeScript impl (``apps/frontend/src/lib/ratio``). Each stack loads the same file
+and asserts every expected value; divergence (e.g. HALF_UP vs HALF_EVEN) turns CI
+red on whichever end drifted.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+VECTORS_PATH = Path(__file__).resolve().parent / "vectors.json"
+
+
+def load_vectors() -> dict[str, Any]:
+    """Return the parsed ratio conformance standard from ``vectors.json``."""
+    return json.loads(VECTORS_PATH.read_text(encoding="utf-8"))

--- a/common/ratio/conformance/vectors.json
+++ b/common/ratio/conformance/vectors.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Language-neutral ratio/percent standard (#1167 base-package family). Both the Python reference impl (common/ratio) and the TypeScript impl (apps/frontend/src/lib/ratio) load THIS file and must reproduce every expected value. Numbers are decimal STRINGS, never JSON floats. Percent display policy is 2 dp ROUND_HALF_UP. See common/ratio/conformance/README.md and common/ratio/contract/ratio.contract.md.",
+  "percent_dp": 2,
+  "percent_rounding": "ROUND_HALF_UP",
+  "shared_api": ["Ratio", "RatioError", "FloatNotAllowedError", "PERCENT_DP", "PERCENT_ROUNDING"],
+  "to_percent": [
+    {"ratio": "0.125", "dp": 2, "expected": "12.50"},
+    {"ratio": "0.12005", "dp": 2, "expected": "12.01", "note": "HALF_UP (HALF_EVEN would give 12.00)"},
+    {"ratio": "0.12004", "dp": 2, "expected": "12.00"},
+    {"ratio": "0.005", "dp": 2, "expected": "0.50"},
+    {"ratio": "1", "dp": 2, "expected": "100.00"},
+    {"ratio": "-0.075", "dp": 1, "expected": "-7.5"},
+    {"ratio": "0", "dp": 2, "expected": "0.00"},
+    {"ratio": "0.123455", "dp": 4, "expected": "12.3455"}
+  ],
+  "percent_of": [
+    {"part": "1", "whole": "8", "dp": 2, "expected": "12.50"},
+    {"part": "2", "whole": "3", "dp": 2, "expected": "66.67"},
+    {"part": "1", "whole": "3", "dp": 4, "expected": "33.3333"},
+    {"part": "3", "whole": "8", "dp": 2, "expected": "37.50"},
+    {"part": "0", "whole": "10", "dp": 2, "expected": "0.00"},
+    {"part": "7", "whole": "8", "dp": 2, "expected": "87.50"}
+  ],
+  "from_percent": [
+    {"percent": "12.5", "expected_percent_2dp": "12.50"},
+    {"percent": "100", "expected_percent_2dp": "100.00"}
+  ]
+}

--- a/common/ratio/contract/ratio.contract.md
+++ b/common/ratio/contract/ratio.contract.md
@@ -1,0 +1,37 @@
+# Ratio module contract (language-neutral interface)
+
+> The **interface** half of the ratio module's SSOT; the **conformance** half is
+> [`../conformance/vectors.json`](../conformance/vectors.json). Second instance of
+> the base-package template — see [`docs/ssot/base-packages.md`](../../../docs/ssot/base-packages.md).
+
+## Type
+
+- **`Ratio`** — an immutable, `Decimal`-backed **dimensionless** ratio
+  (`0.125` == 12.5%). Construction **rejects `float`/`bool`**. Stores the exact
+  `Decimal`; rounding happens only at the percent boundary.
+
+## Operations & laws
+
+| Operation | Law |
+|-----------|-----|
+| construct `Ratio(value)` | rejects float; immutable |
+| `fraction(part, whole)` | the single primitive to build from two quantities; **zero whole is undefined → raises** |
+| `from_percent(p)` | `p / 100` |
+| `to_percent(dp=2, rounding=HALF_UP)` | percentage value quantized to `dp` with the canonical policy |
+| `format_percent(dp=2)` | `"12.50%"` string |
+| `add`/`sub`/`compare`/`neg`/`*scalar` | dimensionless arithmetic (ratios share one implicit unit) |
+
+## Invariants (every end)
+
+1. **No float** in ratio paths — values are `Decimal`.
+2. **Percent display is `ROUND_HALF_UP` at 2 dp** unless an explicit `dp`/mode is
+   passed. This is the one project-wide percent policy; it is intentionally NOT
+   money's `ROUND_HALF_EVEN` (a percentage is not a currency amount).
+3. **Zero whole is undefined** — `fraction(x, 0)` raises, never silently 0.
+
+## Shared API surface (identifier parity)
+
+`vectors.json["shared_api"]` — exported by **both** `apps/backend/src/ratio`
+(`__all__`) and `apps/frontend/src/lib/ratio` (`index.ts`), enforced by
+`tests/tooling/test_ratio_api_parity.py`:
+`Ratio`, `RatioError`, `FloatNotAllowedError`, `PERCENT_DP`, `PERCENT_ROUNDING`.

--- a/common/ratio/errors.py
+++ b/common/ratio/errors.py
@@ -1,0 +1,23 @@
+"""Typed errors for the ratio value type (mirrors the money error hierarchy).
+
+A single narrow hierarchy so call-sites can catch ``RatioError`` for any
+ratio-domain violation, or the specific subtype.
+"""
+
+from __future__ import annotations
+
+
+class RatioError(Exception):
+    """Base class for every ratio-domain error."""
+
+
+class FloatNotAllowedError(RatioError, TypeError):
+    """A ``float`` was supplied where a ``Decimal`` (or ``int``) is required.
+
+    ``float`` is the standing numeric red line (IEEE-754 precision loss); the
+    value type rejects it at construction rather than relying on review.
+    """
+
+
+class UndefinedRatioError(RatioError, ZeroDivisionError):
+    """A ratio was requested from a zero whole (``part / 0`` is undefined)."""

--- a/common/ratio/ratio.py
+++ b/common/ratio/ratio.py
@@ -120,5 +120,5 @@ class Ratio:
 
 def _as_ratio(other: object) -> Ratio:
     if not isinstance(other, Ratio):
-        raise FloatNotAllowedError(f"expected a Ratio, got {type(other).__name__}")
+        raise TypeError(f"expected a Ratio, got {type(other).__name__}")
     return other

--- a/common/ratio/ratio.py
+++ b/common/ratio/ratio.py
@@ -1,0 +1,124 @@
+"""``Ratio`` — the authoritative dimensionless-ratio value type.
+
+A ratio is a unitless ``Decimal`` (e.g. ``Decimal("0.125")`` == 12.5%). It is the
+base element for performance ratios (return-on-cost, XIRR/TWR/MWR), allocation
+shares, and confidence proportions — everything that was previously ad-hoc
+``value / total`` math with **inconsistent** percent rounding (HALF_UP in some
+paths, HALF_EVEN in others).
+
+The point, like ``Money``, is to make bad states unrepresentable and to give the
+whole project ONE percent-display policy:
+
+- construction rejects ``float`` (the numeric red line);
+- ``fraction(part, whole)`` is the single primitive for building a ratio from two
+  quantities (zero whole is undefined → raises);
+- ``to_percent`` renders the percentage with the canonical **2 dp, ROUND_HALF_UP**
+  policy (finance display convention) — the single standard both ends share.
+
+Stored value is the *exact* Decimal; rounding happens only at the percent boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+
+from common.ratio.errors import FloatNotAllowedError, UndefinedRatioError
+
+# Canonical percent-display policy (NOT money's HALF_EVEN — percentages are not
+# money and follow the finance display convention of round-half-up).
+PERCENT_DP: int = 2
+PERCENT_ROUNDING: str = ROUND_HALF_UP
+
+_RatioInput = Decimal | int
+
+
+def _coerce(value: object, what: str = "ratio value") -> Decimal:
+    if isinstance(value, bool):
+        raise FloatNotAllowedError(f"bool is not a valid {what}")
+    if isinstance(value, float):
+        raise FloatNotAllowedError(f"float is not allowed for {what} (IEEE-754 precision loss); use Decimal")
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    raise FloatNotAllowedError(f"{what} must be Decimal or int, got {type(value).__name__}")
+
+
+@dataclass(frozen=True)
+class Ratio:
+    """An immutable dimensionless ratio (``0.125`` == 12.5%).
+
+    >>> Ratio.fraction(1, 8).to_percent()
+    Decimal('12.50')
+    """
+
+    value: Decimal
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "value", _coerce(self.value))
+
+    # ── construction ────────────────────────────────────────────────────
+    @classmethod
+    def fraction(cls, part: _RatioInput, whole: _RatioInput) -> Ratio:
+        """Build a ratio ``part / whole``. A zero whole is undefined and raises."""
+        p = _coerce(part, "part")
+        w = _coerce(whole, "whole")
+        if w == 0:
+            raise UndefinedRatioError("ratio is undefined for a zero whole")
+        return cls(p / w)
+
+    @classmethod
+    def zero(cls) -> Ratio:
+        return cls(Decimal("0"))
+
+    @classmethod
+    def from_percent(cls, percent: _RatioInput) -> Ratio:
+        """Build a ratio from a percentage number (``12.5`` -> ``0.125``)."""
+        return cls(_coerce(percent, "percent") / Decimal("100"))
+
+    # ── percent rendering (the single shared standard) ──────────────────
+    def to_percent(self, dp: int = PERCENT_DP, rounding: str = PERCENT_ROUNDING) -> Decimal:
+        """Return the percentage value quantized to ``dp`` (default 2 dp, HALF_UP)."""
+        quantum = Decimal(1).scaleb(-dp)  # 10**-dp, e.g. dp=2 -> 0.01
+        return (self.value * Decimal("100")).quantize(quantum, rounding=rounding)
+
+    def format_percent(self, dp: int = PERCENT_DP) -> str:
+        """Render as a ``"12.50%"`` string at the canonical policy."""
+        return f"{self.to_percent(dp)}%"
+
+    # ── dimensionless arithmetic (ratios share one implicit unit) ───────
+    def __add__(self, other: Ratio) -> Ratio:
+        return Ratio(self.value + _as_ratio(other).value)
+
+    def __sub__(self, other: Ratio) -> Ratio:
+        return Ratio(self.value - _as_ratio(other).value)
+
+    def __neg__(self) -> Ratio:
+        return Ratio(-self.value)
+
+    def __mul__(self, factor: _RatioInput) -> Ratio:
+        return Ratio(self.value * _coerce(factor, "factor"))
+
+    __rmul__ = __mul__
+
+    def __lt__(self, other: Ratio) -> bool:
+        return self.value < _as_ratio(other).value
+
+    def __le__(self, other: Ratio) -> bool:
+        return self.value <= _as_ratio(other).value
+
+    def __gt__(self, other: Ratio) -> bool:
+        return self.value > _as_ratio(other).value
+
+    def __ge__(self, other: Ratio) -> bool:
+        return self.value >= _as_ratio(other).value
+
+    def __str__(self) -> str:
+        return self.format_percent()
+
+
+def _as_ratio(other: object) -> Ratio:
+    if not isinstance(other, Ratio):
+        raise FloatNotAllowedError(f"expected a Ratio, got {type(other).__name__}")
+    return other

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -137,6 +137,19 @@ This EPIC addresses technical debt in the foundational libraries that all module
 | AC12.8.3 | Log exception without traceback | `test_log_exception_without_traceback()` | `infra/test_logger.py` | P0 |
 | AC12.8.4 | Log exception with custom level | `test_log_exception_custom_level()` | `infra/test_logger.py` | P0 |
 
+### AC12.9: Ratio / percent value type ([#1167](https://github.com/wangzitian0/finance_report/issues/1167))
+
+The second base-element value type after `money` (see
+[base-packages.md](../ssot/base-packages.md)): a dimensionless `Ratio` with ONE
+percent-display policy (2 dp, **ROUND_HALF_UP**), shared FE/BE via conformance
+vectors, so performance ratios / allocation shares / confidence proportions stop
+diverging across the codebase and across ends.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC12.9.1 | `Ratio` rejects float, is Decimal-backed/immutable; `fraction(part, whole)` builds it (zero whole undefined → raises); percent display is the canonical 2 dp / ROUND_HALF_UP; dimensionless arithmetic | `test_AC12_9_1_ratio_rejects_float_and_is_decimal_backed` (+ siblings) | `tests/tooling/test_ratio_value_type.py`, `apps/backend/tests/accounting/test_ratio_backend.py` | P1 |
+| AC12.9.2 | Cross-language conformance: the Python reference, shipped backend `src.ratio`, and frontend `lib/ratio` reproduce the same `vectors.json` (to_percent / percent_of / from_percent) and export the same `shared_api` (identifier-parity guard) | `test_AC12_9_2_to_percent_matches_standard` (+ siblings) | `tests/tooling/test_ratio_conformance.py`, `tests/tooling/test_ratio_api_parity.py` | P1 |
+
 ### AC12.10: Logging - Build Processors
 
 | ID | Test Case | Test Function | File | Priority |

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -54,7 +54,7 @@ concepts:
   base_packages:
     owner: docs/ssot/base-packages.md
     description: The family of value-type narrow-waist base packages (money, ratio, ...) and the canonical structure each follows (#1167).
-    family: foundation
+    family: platform
     kind: concept
     authority: documented_contract
     cross_refs:

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -51,6 +51,24 @@ concepts:
       - tests/tooling/test_money_value_type.py
       - tests/tooling/test_money_conformance.py
 
+  base_packages:
+    owner: docs/ssot/base-packages.md
+    description: The family of value-type narrow-waist base packages (money, ratio, ...) and the canonical structure each follows (#1167).
+    family: foundation
+    kind: concept
+    authority: documented_contract
+    cross_refs:
+      - common/ratio/__init__.py
+      - common/ratio/contract/ratio.contract.md
+      - common/ratio/conformance/vectors.json
+      - apps/backend/src/ratio/__init__.py
+      - apps/frontend/src/lib/ratio/index.ts
+      - docs/project/EPIC-012.foundation-libs.md
+    proofs:
+      - tests/tooling/test_ratio_value_type.py
+      - tests/tooling/test_ratio_conformance.py
+      - tests/tooling/test_ratio_api_parity.py
+
   accounting_equation:
     owner: docs/ssot/accounting.md#accounting-equation
     description: "Assets = Liabilities + Equity + (Income - Expenses) invariant."

--- a/docs/ssot/base-packages.md
+++ b/docs/ssot/base-packages.md
@@ -1,0 +1,74 @@
+# Base packages (value-type narrow waists)
+
+> **SSOT Key**: `base_packages`
+> **Core definition**: the family of shared value-type "narrow waist" packages,
+> the rule for what qualifies, and the canonical structure every one must follow.
+
+A *base package* is a small, dependency-light value type that makes a class of
+bad states unrepresentable and is shared, by a **language-neutral standard**,
+across every end (backend Python + frontend TypeScript). `money` (#1167) is the
+reference instance; this doc generalises it so the family stays uniform and
+bounded.
+
+## 1. What qualifies (all five must hold)
+
+A domain earns a base package only if it is **all** of:
+
+1. **A shared algorithm** — real computation, not just a DTO.
+2. **Cross-language** — computed/rendered on both backend and frontend, so the two
+   can drift.
+3. **Correctness-critical** — a wrong value is a real bug.
+4. **Currently ad-hoc / duplicated** — no single standard today.
+5. **A primitive, not business logic** — domain-specific weights/policies
+   (reconciliation scoring, attention ranking, source-type rules) do **not**
+   qualify; they consume primitives, they are not primitives.
+
+## 2. The family (bounded on purpose)
+
+| Package | Value type | Quantum / policy | Status |
+|---------|-----------|------------------|--------|
+| `money` | `Money` (amount + `Currency`) | 2 dp, **ROUND_HALF_EVEN** (banker's) | ✅ shipped (#1167) |
+| `ratio` | `Ratio` (dimensionless) | percent 2 dp, **ROUND_HALF_UP** | ✅ shipped (#1167, EPIC-012 AC12.9) |
+| `quantity` | `Quantity` (shares/units/price/rate) | 6 dp | candidate (not built) |
+
+`Currency` lives **inside** `money` (not separate). Nothing else currently
+qualifies — see the per-domain verdicts in the #1167 audit (date/period,
+confidence scoring, source-type, lineage, attention are app logic or
+presentation, not base packages).
+
+## 3. The canonical structure (every base package has these)
+
+1. **Value type** — immutable/frozen, Decimal-backed, carries its unit; **rejects
+   `float`** at construction.
+2. **Construction + validation** — normalise input, validate the unit, reject
+   `float`/`bool`.
+3. **Same-unit arithmetic** — `add`/`sub`/`compare`/`neg`/`*scalar`;
+   **cross-unit raises** (no implicit mixing).
+4. **Quantization** — one defined quantum + rounding policy + explicit override.
+5. **Single conversion primitive** — the one allowed cross-unit move
+   (money: `convert(rate)`; ratio: `fraction(part, whole)` / `↔ percent`).
+6. **Per-key container** (where applicable) — aggregation that makes cross-key
+   summing structurally impossible (money: `CurrencyBalances`).
+7. **Serialization** — to/from the wire as **strings** (never JSON float).
+8. **Typed error hierarchy** — base `XError` → `FloatNotAllowed` / `Invalid…` /
+   `…Mismatch`.
+9. **The language-neutral standard** — `contract/<x>.contract.md` (interface) +
+   `conformance/vectors.json` (golden cases) + `shared_api` (identifier set).
+10. **Per-end implementations** — Python reference (`common/<x>`), backend runtime
+    (`apps/backend/src/<x>`), frontend (`apps/frontend/src/lib/<x>`) — each
+    conformance-tested against the **same** vectors.
+11. **Three guards** — no-`float` (the money narrow-waist guard), one conformance
+    suite per stack, and identifier-parity (`test_<x>_api_parity.py`).
+
+## 4. Why per-end copies (not one shared runtime)
+
+The frontend is TypeScript and cannot import the Python package; the deployed
+images do not ship `common/`. So the **standard** (contract + conformance
+vectors) is shared at *test time*, and each end keeps its own idiomatic
+implementation verified against it. `common/<x>` is the reference + the home of
+the standard; it is dev/test-time only, never shipped into a runtime image.
+
+## Used by
+
+- `money`: [accounting.md#money-type](accounting.md), `common/money/`, `apps/backend/src/money/`, `apps/frontend/src/lib/money/`
+- `ratio`: [EPIC-012 AC12.9](../project/EPIC-012.foundation-libs.md), `common/ratio/`, `apps/backend/src/ratio/`, `apps/frontend/src/lib/ratio/`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Runtime Incident Response: ssot/runtime-incident-response.md
       - TDD Workflow: ssot/tdd.md
       - Accounting Model: ssot/accounting.md
+      - Base Packages: ssot/base-packages.md
       - Auth: ssot/auth.md
       - Reconciliation Engine: ssot/reconciliation.md
       - Confirmation Workflow: ssot/confirmation-workflow.md

--- a/tests/tooling/test_ratio_api_parity.py
+++ b/tests/tooling/test_ratio_api_parity.py
@@ -1,0 +1,54 @@
+"""Cross-language ratio API-parity guard (EPIC-012 AC12.9, #1167).
+
+Mirrors the money parity guard: every name in ``vectors.json["shared_api"]`` MUST
+be exported by BOTH the backend ratio module (``apps/backend/src/ratio/__init__.py``
+``__all__``) and the frontend ratio module (``apps/frontend/src/lib/ratio/index.ts``),
+so the two value-type APIs cannot silently drift.
+"""
+
+import ast
+import json
+import re
+from pathlib import Path
+
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+SHARED_API = set(json.loads((REPO / "common/ratio/conformance/vectors.json").read_text())["shared_api"])
+
+
+def _backend_exports() -> set[str]:
+    src = (REPO / "apps/backend/src/ratio/__init__.py").read_text()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets
+        ):
+            return {el.value for el in node.value.elts if isinstance(el, ast.Constant)}
+    return set()
+
+
+def _frontend_exports() -> set[str]:
+    src = (REPO / "apps/frontend/src/lib/ratio/index.ts").read_text()
+    names: set[str] = set()
+    for block in re.findall(r"export\s*\{([^}]*)\}", src):
+        for raw in block.split(","):
+            name = raw.strip().removeprefix("type ").strip()
+            if " as " in name:
+                name = name.split(" as ")[-1].strip()
+            if name:
+                names.add(name)
+    return names
+
+
+@ac_proof(proof_id="test_ratio_shared_api_backend", ac_ids=["AC12.9.2"], ci_tier="pr_ci", issue="#1167")
+def test_AC12_9_2_backend_exposes_shared_ratio_api():
+    """AC12.9.2: the backend ratio module exports the full shared surface."""
+    missing = SHARED_API - _backend_exports()
+    assert not missing, f"backend src.ratio missing shared API: {sorted(missing)}"
+
+
+@ac_proof(proof_id="test_ratio_shared_api_frontend", ac_ids=["AC12.9.2"], ci_tier="pr_ci", issue="#1167")
+def test_AC12_9_2_frontend_exposes_shared_ratio_api():
+    """AC12.9.2: the frontend ratio module exports the full shared surface."""
+    missing = SHARED_API - _frontend_exports()
+    assert not missing, f"frontend lib/ratio missing shared API: {sorted(missing)}"

--- a/tests/tooling/test_ratio_conformance.py
+++ b/tests/tooling/test_ratio_conformance.py
@@ -37,4 +37,5 @@ def test_AC12_9_2_from_percent_round_trip():
         assert Ratio.from_percent(Decimal(case["percent"])).to_percent(2) == Decimal(
             case["expected_percent_2dp"]
         ), case
-    assert str(PERCENT_DP) and PERCENT_ROUNDING == VECTORS["percent_rounding"]
+    assert PERCENT_DP == VECTORS["percent_dp"]
+    assert PERCENT_ROUNDING == VECTORS["percent_rounding"]

--- a/tests/tooling/test_ratio_conformance.py
+++ b/tests/tooling/test_ratio_conformance.py
@@ -1,0 +1,40 @@
+"""Python side of the cross-language ratio conformance suite (EPIC-012 AC12.9, #1167).
+
+Drives the Python reference (``common.ratio``) off the SAME vectors the TypeScript
+frontend uses (``common/ratio/conformance/vectors.json``). Divergence on the
+HALF_UP percent policy turns this (or its TS mirror) red.
+"""
+
+from decimal import Decimal
+
+import pytest
+from common.ratio import PERCENT_DP, PERCENT_ROUNDING, Ratio
+from common.ratio.conformance import load_vectors
+from common.testing.ac_proof import ac_proof
+
+VECTORS = load_vectors()
+
+
+@ac_proof(proof_id="test_ratio_conformance_to_percent", ac_ids=["AC12.9.2"], ci_tier="pr_ci", issue="#1167")
+@pytest.mark.parametrize("case", VECTORS["to_percent"], ids=lambda c: f"{c['ratio']}/{c['dp']}")
+def test_AC12_9_2_to_percent_matches_standard(case):
+    """AC12.9.2: Python to_percent matches the shared HALF_UP standard."""
+    assert Ratio(Decimal(case["ratio"])).to_percent(case["dp"]) == Decimal(case["expected"]), case
+
+
+@ac_proof(proof_id="test_ratio_conformance_percent_of", ac_ids=["AC12.9.2"], ci_tier="pr_ci", issue="#1167")
+@pytest.mark.parametrize("case", VECTORS["percent_of"], ids=lambda c: f"{c['part']}/{c['whole']}")
+def test_AC12_9_2_percent_of_matches_standard(case):
+    """AC12.9.2: Python fraction(part, whole).to_percent matches the standard."""
+    got = Ratio.fraction(Decimal(case["part"]), Decimal(case["whole"])).to_percent(case["dp"])
+    assert got == Decimal(case["expected"]), case
+
+
+@ac_proof(proof_id="test_ratio_conformance_from_percent", ac_ids=["AC12.9.2"], ci_tier="pr_ci", issue="#1167")
+def test_AC12_9_2_from_percent_round_trip():
+    """AC12.9.2: from_percent round-trips back to the same percent."""
+    for case in VECTORS["from_percent"]:
+        assert Ratio.from_percent(Decimal(case["percent"])).to_percent(2) == Decimal(
+            case["expected_percent_2dp"]
+        ), case
+    assert str(PERCENT_DP) and PERCENT_ROUNDING == VECTORS["percent_rounding"]

--- a/tests/tooling/test_ratio_value_type.py
+++ b/tests/tooling/test_ratio_value_type.py
@@ -71,5 +71,6 @@ def test_AC12_9_1_dimensionless_arithmetic_and_compare():
     assert a < b and a <= b and b > a and b >= a
     assert str(Ratio(Decimal("0.5"))) == "50.00%"
     assert Ratio.zero() == Ratio(Decimal("0"))
-    with pytest.raises(FloatNotAllowedError):
+    # A non-Ratio operand is a TypeError (mirrors Money's cross-type guard).
+    with pytest.raises(TypeError):
         _ = a + 0.1  # type: ignore[operator]

--- a/tests/tooling/test_ratio_value_type.py
+++ b/tests/tooling/test_ratio_value_type.py
@@ -1,0 +1,75 @@
+"""Ratio value-type behavioural proofs (EPIC-012 AC12.9, #1167 base-package family).
+
+Exercises the ``common.ratio`` narrow waist: construction (rejects float),
+``fraction`` (zero-whole undefined), the single percent-display policy
+(2 dp / HALF_UP), and dimensionless arithmetic.
+
+Contract: ``common/ratio/contract/ratio.contract.md``.
+"""
+
+from decimal import ROUND_HALF_EVEN, Decimal
+
+import pytest
+from common.ratio import (
+    PERCENT_DP,
+    PERCENT_ROUNDING,
+    FloatNotAllowedError,
+    Ratio,
+    RatioError,
+    UndefinedRatioError,
+)
+from common.testing.ac_proof import ac_proof
+
+
+@ac_proof(proof_id="test_ratio_rejects_float", ac_ids=["AC12.9.1"], ci_tier="pr_ci", issue="#1167")
+def test_AC12_9_1_ratio_rejects_float_and_is_decimal_backed():
+    """AC12.9.1: Ratio rejects float/bool, is Decimal-backed and immutable."""
+    with pytest.raises(FloatNotAllowedError):
+        Ratio(0.125)
+    with pytest.raises(FloatNotAllowedError):
+        Ratio(True)
+    with pytest.raises(FloatNotAllowedError):
+        Ratio("0.1")  # str not accepted in Python (use Decimal); FE accepts string
+    assert isinstance(Ratio(1).value, Decimal)
+    r = Ratio(Decimal("0.125"))
+    with pytest.raises((AttributeError, TypeError)):
+        r.value = Decimal("0.2")  # type: ignore[misc]
+
+
+@ac_proof(proof_id="test_ratio_percent_policy", ac_ids=["AC12.9.1"], ci_tier="pr_ci", issue="#1167")
+def test_AC12_9_1_percent_display_is_half_up_two_dp():
+    """AC12.9.1: percent display is the canonical 2 dp / ROUND_HALF_UP (not HALF_EVEN)."""
+    assert PERCENT_DP == 2
+    assert PERCENT_ROUNDING != ROUND_HALF_EVEN  # explicitly NOT money's rounding
+    # 12.005% -> HALF_UP -> 12.01 (HALF_EVEN would give 12.00)
+    assert Ratio(Decimal("0.12005")).to_percent() == Decimal("12.01")
+    assert Ratio(Decimal("0.125")).to_percent() == Decimal("12.50")
+    assert Ratio(Decimal("0.125")).format_percent() == "12.50%"
+    assert Ratio(Decimal("0.123455")).to_percent(4) == Decimal("12.3455")
+
+
+@ac_proof(proof_id="test_ratio_fraction", ac_ids=["AC12.9.1"], ci_tier="pr_ci", issue="#1167")
+def test_AC12_9_1_fraction_and_zero_whole_is_undefined():
+    """AC12.9.1: fraction(part, whole) builds the ratio; a zero whole raises."""
+    assert Ratio.fraction(1, 8).to_percent() == Decimal("12.50")
+    assert Ratio.fraction(Decimal("2"), Decimal("3")).to_percent() == Decimal("66.67")
+    assert Ratio.from_percent(Decimal("12.5")).to_percent() == Decimal("12.50")
+    with pytest.raises(UndefinedRatioError):
+        Ratio.fraction(1, 0)
+    assert isinstance(UndefinedRatioError("x"), RatioError)
+
+
+@ac_proof(proof_id="test_ratio_arithmetic", ac_ids=["AC12.9.1"], ci_tier="pr_ci", issue="#1167")
+def test_AC12_9_1_dimensionless_arithmetic_and_compare():
+    """AC12.9.1: ratios add/sub/scale/compare (dimensionless)."""
+    a, b = Ratio(Decimal("0.1")), Ratio(Decimal("0.2"))
+    assert (a + b) == Ratio(Decimal("0.3"))
+    assert (b - a) == Ratio(Decimal("0.1"))
+    assert (-a) == Ratio(Decimal("-0.1"))
+    assert (a * 3) == Ratio(Decimal("0.3"))
+    assert (3 * a) == Ratio(Decimal("0.3"))
+    assert a < b and a <= b and b > a and b >= a
+    assert str(Ratio(Decimal("0.5"))) == "50.00%"
+    assert Ratio.zero() == Ratio(Decimal("0"))
+    with pytest.raises(FloatNotAllowedError):
+        _ = a + 0.1  # type: ignore[operator]


### PR DESCRIPTION
## What
The **second** value-type narrow waist after `money` — `ratio` (percent) — **plus the codified base-package template** so the family stays uniform and bounded. **Doc + package + tests together; call-site migration deferred** (as agreed).

## Template / governance (the "think it through once" part)
- **`docs/ssot/base-packages.md`** — the **5-point qualification rule**, the **bounded family** (money ✅ / ratio ✅ / quantity = candidate, nothing else), and the **11-point canonical structure** every base package follows (value type, validation, same-unit arithmetic, quantization, single conversion, container, serialization, error hierarchy, language-neutral standard, per-end impls, three guards).
- MANIFEST `base_packages` concept; added to mkdocs nav.

## `ratio` package (mirrors money exactly)
- `common/ratio/` (Python reference) + `apps/backend/src/ratio/` (shipped backend end) + `apps/frontend/src/lib/ratio/` (TS end). All load the **same** `conformance/vectors.json`.
- `Ratio`: dimensionless, Decimal-backed, **rejects float**; `fraction(part, whole)` (**zero whole → raises**); `from_percent`; and the **single percent-display policy `to_percent(dp=2, ROUND_HALF_UP)`** — finance convention, deliberately **not** money's HALF_EVEN (this is the standard that ends the current HALF_UP↔HALF_EVEN split).
- Error hierarchy mirrors money; `contract/ratio.contract.md` documents the surface.
- **EPIC-012 AC12.9.1** (value type + percent policy) / **AC12.9.2** (cross-language conformance + identifier-parity guard).

## Verification
- ✅ tooling ratio value-type + conformance + api-parity (21) ; backend mirror (15) ; FE vitest conformance (7).
- ✅ **100% coverage** of `common/ratio` and `src/ratio`; both ends reproduce the same vectors (HALF_UP); parity guard green.
- ✅ eslint + tsc (ratio) clean; doc-consistency / manifest / ownership / ac-index / SSOT-governance green; new doc in mkdocs nav.

## Next (separate)
Converge the ~15 ad-hoc percentage sites (XIRR/TWR/MWR, allocation%, confidence proportion, FE `formatReturnPercent`/`Math.round`) onto `Ratio` — the deferred migration.

Refs #1167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)