### PR TITLE
[finance_report_audit] chore(ratio): migrate percentage call-sites to Ratio

### DIFF
--- a/apps/backend/src/ratio/ratio.py
+++ b/apps/backend/src/ratio/ratio.py
@@ -72,6 +72,10 @@ class Ratio:
     def zero(cls) -> Ratio:
         return cls(Decimal("0"))
 
+    def is_zero(self) -> bool:
+        """Return whether this typed ratio is exactly zero."""
+        return self.value.is_zero()
+
     @classmethod
     def from_percent(cls, percent: _RatioInput) -> Ratio:
         """Build a ratio from a percentage number (``12.5`` -> ``0.125``)."""

--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -1,7 +1,7 @@
 """Portfolio management API router."""
 
 from datetime import date
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, Field
@@ -16,6 +16,7 @@ from src.models.portfolio import (
     InvestmentTransactionType,
 )
 from src.money import to_money
+from src.ratio import Ratio
 from src.schemas.portfolio import (
     BrokerageImportRequest,
     BrokerageImportResponse,
@@ -46,6 +47,11 @@ _MAX_LIST_LIMIT = 500
 
 _portfolio_service = portfolio_service
 _brokerage_import_service = BrokeragePositionImportService()
+
+
+def _canonical_percent(value: Decimal) -> Decimal:
+    percent_ratio = Ratio.from_percent(value)
+    return percent_ratio.to_percent()
 
 
 class AllocationBreakdownResponse(BaseModel):
@@ -359,10 +365,9 @@ async def get_performance(
     except PerformanceError as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
 
-    _two_dp = Decimal("0.01")
-    xirr = xirr.quantize(_two_dp, rounding=ROUND_HALF_UP)
-    twr = twr.quantize(_two_dp, rounding=ROUND_HALF_UP)
-    mwr = mwr.quantize(_two_dp, rounding=ROUND_HALF_UP)
+    xirr = _canonical_percent(xirr)
+    twr = _canonical_percent(twr)
+    mwr = _canonical_percent(mwr)
     logger.info("Performance calculated", xirr=float(xirr), twr=float(twr), mwr=float(mwr))
     return PerformanceMetricsResponse(xirr=xirr, time_weighted_return=twr, money_weighted_return=mwr)
 

--- a/apps/backend/src/services/allocation.py
+++ b/apps/backend/src/services/allocation.py
@@ -13,6 +13,7 @@ from src.config import settings
 from src.logger import get_logger
 from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition, PositionStatus
+from src.ratio import Ratio
 from src.services import fx
 from src.services.performance import batch_latest_atomic_positions
 
@@ -92,12 +93,12 @@ def _build_allocation(
 
     breakdowns = []
     for category, value in category_values.items():
-        percentage = (value / total_value * Decimal("100")) if total_value > 0 else Decimal("0")
+        allocation_ratio = Ratio.fraction(value, total_value) if total_value > Decimal("0") else Ratio.zero()
         breakdowns.append(
             AllocationBreakdown(
                 category=category,
                 value=value,
-                percentage=percentage,
+                percentage=allocation_ratio.to_percent(),
                 count=category_counts[category],
             )
         )

--- a/apps/backend/src/services/performance.py
+++ b/apps/backend/src/services/performance.py
@@ -12,6 +12,7 @@ from src.logger import get_logger
 from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition, PositionStatus
 from src.models.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType
+from src.ratio import Ratio
 from src.services import fx
 
 logger = get_logger(__name__)
@@ -184,7 +185,8 @@ async def calculate_xirr(
     # XIRR formula: Sum of (cash_flow_i / (1 + xirr)^(days_i / 365)) = 0
     try:
         xirr = _xirr_newton(amounts, day_offsets, guess=Decimal("0.1"), max_iter=100, tolerance=Decimal("1e-6"))
-        return xirr * Decimal("100")  # Convert to percentage
+        xirr_ratio = Ratio(xirr)
+        return xirr_ratio.to_percent()
     except (ValueError, RuntimeError) as e:
         logger.error(f"XIRR calculation failed: {e}", cash_flows=cash_flows)
         raise XIRRCalculationError(f"XIRR calculation failed to converge: {e}") from e
@@ -342,15 +344,15 @@ async def calculate_time_weighted_return(
 
     if start_value == Decimal("0"):
         if end_value == Decimal("0"):
-            return Decimal("0")  # No change
+            twr_ratio = Ratio.zero()
+            return twr_ratio.to_percent()
         raise InsufficientDataError("Cannot calculate TWR with zero starting value and non-zero ending value")
 
     # TWR = (End_Value - Start_Value - Net_Cash_Flow) / Start_Value
     # Simplified for single period (no sub-periods)
     gain = end_value - start_value - net_cash_flow
-    twr = (gain / start_value) * Decimal("100")  # Convert to percentage
-
-    return twr
+    twr_ratio = Ratio.fraction(gain, start_value)
+    return twr_ratio.to_percent()
 
 
 async def calculate_money_weighted_return(
@@ -416,10 +418,12 @@ async def calculate_dividend_yield(
     current_value = await _get_portfolio_value(db, user_id, as_of_date)
     if current_value == Decimal("0"):
         if annual_dividends == Decimal("0"):
-            return Decimal("0")
+            dividend_yield_ratio = Ratio.zero()
+            return dividend_yield_ratio.to_percent()
         raise InsufficientDataError("Cannot calculate dividend yield with zero current portfolio value")
 
-    return (annual_dividends / current_value * Decimal("100")).quantize(Decimal("0.01"))
+    dividend_yield_ratio = Ratio.fraction(annual_dividends, current_value)
+    return dividend_yield_ratio.to_percent()
 
 
 async def _get_portfolio_value(

--- a/apps/backend/src/services/performance_report.py
+++ b/apps/backend/src/services/performance_report.py
@@ -11,7 +11,7 @@ failure (the router maps it to HTTP 422). Behavior unchanged.
 from __future__ import annotations
 
 from datetime import date
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 
 from sqlalchemy import select
 
@@ -21,6 +21,7 @@ from src.models.layer3 import ManagedPosition, PositionStatus
 from src.models.market_data import StockPrice
 from src.models.portfolio import MarketDataOverride, PriceSource
 from src.money import to_money
+from src.ratio import Ratio
 from src.schemas.portfolio import (
     HoldingResponse,
     InvestmentPerformanceAllocationRow,
@@ -42,7 +43,8 @@ def _money(value: Decimal) -> Decimal:
 def _percent(value: Decimal | None) -> Decimal | None:
     if value is None:
         return None
-    return Decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    percent_ratio = Ratio.from_percent(value)
+    return percent_ratio.to_percent()
 
 
 def _source_document_links(source_documents: object) -> list[str]:
@@ -248,17 +250,15 @@ async def build_investment_performance_report_schedule(
                 current_value, current_count = grouped.get(category, (Decimal("0.00"), 0))
                 grouped[category] = (current_value + row.market_value, current_count + 1)
             for category, (value, count) in grouped.items():
-                percentage = Decimal("0.00")
-                if total_market_value:
-                    percentage = (value / total_market_value * Decimal("100")).quantize(
-                        Decimal("0.01"), rounding=ROUND_HALF_UP
-                    )
+                allocation_ratio = (
+                    Ratio.fraction(value, total_market_value) if total_market_value != Decimal("0.00") else Ratio.zero()
+                )
                 allocation_rows.append(
                     InvestmentPerformanceAllocationRow(
                         dimension=dimension,
                         category=category,
                         value=_money(value),
-                        percentage=percentage,
+                        percentage=allocation_ratio.to_percent(),
                         count=count,
                     )
                 )

--- a/apps/backend/src/services/portfolio.py
+++ b/apps/backend/src/services/portfolio.py
@@ -22,6 +22,7 @@ from src.models.portfolio import (
     PriceSource,
 )
 from src.money import to_money
+from src.ratio import Ratio
 from src.schemas.portfolio import (
     HoldingResponse,
     PortfolioSummaryResponse,
@@ -34,6 +35,12 @@ from src.schemas.provenance import DataProvenance
 from src.services import fx
 
 logger = get_logger(__name__)
+
+
+def _ratio_or_zero(part: Decimal, whole: Decimal) -> Ratio:
+    if whole == Decimal("0"):
+        return Ratio.zero()
+    return Ratio.fraction(part, whole)
 
 
 def _derive_provenance(source_documents: object) -> DataProvenance | None:
@@ -175,10 +182,7 @@ class PortfolioService:
 
             # Calculate P&L (unrealized: market_value - cost_basis)
             unrealized_pnl = to_money(converted_value - converted_cost)
-            if converted_cost != Decimal("0"):
-                unrealized_pnl_percent = (unrealized_pnl / converted_cost) * Decimal("100")
-            else:
-                unrealized_pnl_percent = Decimal("0")
+            unrealized_pnl_ratio = _ratio_or_zero(unrealized_pnl, converted_cost)
 
             # Get asset classification from latest AtomicPosition (scoped by user_id)
             asset_type = None
@@ -202,7 +206,7 @@ class PortfolioService:
                 cost_basis=converted_cost,
                 market_value=converted_value,
                 unrealized_pnl=unrealized_pnl,
-                unrealized_pnl_percent=unrealized_pnl_percent.quantize(Decimal("0.01")),
+                unrealized_pnl_percent=unrealized_pnl_ratio.to_percent(),
                 currency=currency,
                 acquisition_date=position.acquisition_date,
                 disposal_date=position.disposal_date,
@@ -312,10 +316,7 @@ class PortfolioService:
             converted_cost_basis = to_money(converted_cost_basis)
 
             unrealized_pnl = to_money(converted_market_value - converted_cost_basis)
-            if converted_cost_basis != Decimal("0"):
-                unrealized_pnl_percent = (unrealized_pnl / converted_cost_basis) * Decimal("100")
-            else:
-                unrealized_pnl_percent = Decimal("0")
+            unrealized_pnl_ratio = _ratio_or_zero(unrealized_pnl, converted_cost_basis)
 
             holdings.append(
                 HoldingResponse(
@@ -327,7 +328,7 @@ class PortfolioService:
                     cost_basis=converted_cost_basis,
                     market_value=converted_market_value,
                     unrealized_pnl=unrealized_pnl,
-                    unrealized_pnl_percent=unrealized_pnl_percent.quantize(Decimal("0.01")),
+                    unrealized_pnl_percent=unrealized_pnl_ratio.to_percent(),
                     currency=currency,
                     acquisition_date=position.acquisition_date,
                     disposal_date=snapshot.snapshot_date if status == PositionStatus.DISPOSED else None,
@@ -464,10 +465,7 @@ class PortfolioService:
             # Calculate P&L based on cost basis method
             realized_pnl = converted_disposal - converted_cost
 
-            if converted_cost != Decimal("0"):
-                realized_pnl_percent = (realized_pnl / converted_cost) * Decimal("100")
-            else:
-                realized_pnl_percent = Decimal("0")
+            realized_pnl_ratio = _ratio_or_zero(realized_pnl, converted_cost)
 
             total_realized_pnl += realized_pnl
             total_converted_cost += converted_cost
@@ -481,24 +479,21 @@ class PortfolioService:
                     "cost_basis": converted_cost,
                     "disposal_value": converted_disposal,
                     "realized_pnl": realized_pnl,
-                    "realized_pnl_percent": realized_pnl_percent.quantize(Decimal("0.01")),
+                    "realized_pnl_percent": realized_pnl_ratio.to_percent(),
                     "currency": position.currency,
                     "cost_basis_method": position.cost_basis_method,
                 }
             )
 
         # Calculate overall percent using converted costs (not raw costs)
-        if total_converted_cost != Decimal("0"):
-            total_realized_pnl_percent = (total_realized_pnl / total_converted_cost) * Decimal("100")
-        else:
-            total_realized_pnl_percent = Decimal("0")
+        total_realized_pnl_ratio = _ratio_or_zero(total_realized_pnl, total_converted_cost)
 
         await db.flush()
         return RealizedPnLResponse(
             period_start=period_start,
             period_end=period_end,
             total_realized_pnl=to_money(total_realized_pnl),
-            total_realized_pnl_percent=total_realized_pnl_percent.quantize(Decimal("0.01")),
+            total_realized_pnl_percent=total_realized_pnl_ratio.to_percent(),
             positions_count=len(disposed_positions),
             details=details,
         )
@@ -582,6 +577,7 @@ class PortfolioService:
             total_cost_basis += converted_cost
             total_unrealized_pnl += unrealized_pnl
 
+            unrealized_pnl_ratio = _ratio_or_zero(unrealized_pnl, converted_cost)
             details.append(
                 {
                     "asset_identifier": position.asset_identifier,
@@ -590,26 +586,19 @@ class PortfolioService:
                     "market_value": converted_market,
                     "cost_basis": converted_cost,
                     "unrealized_pnl": unrealized_pnl,
-                    "unrealized_pnl_percent": (
-                        (unrealized_pnl / converted_cost * Decimal("100"))
-                        if converted_cost != Decimal("0")
-                        else Decimal("0")
-                    ).quantize(Decimal("0.01")),
+                    "unrealized_pnl_percent": unrealized_pnl_ratio.to_percent(),
                     "currency": currency,
                 }
             )
 
         # Calculate overall percent
-        if total_cost_basis != Decimal("0"):
-            total_unrealized_pnl_percent = (total_unrealized_pnl / total_cost_basis) * Decimal("100")
-        else:
-            total_unrealized_pnl_percent = Decimal("0")
+        total_unrealized_pnl_ratio = _ratio_or_zero(total_unrealized_pnl, total_cost_basis)
 
         await db.flush()
         return UnrealizedPnLResponse(
             as_of_date=eval_date,
             total_unrealized_pnl=to_money(total_unrealized_pnl),
-            total_unrealized_pnl_percent=total_unrealized_pnl_percent.quantize(Decimal("0.01")),
+            total_unrealized_pnl_percent=total_unrealized_pnl_ratio.to_percent(),
             total_market_value=to_money(total_market_value),
             total_cost_basis=to_money(total_cost_basis),
             holdings_count=len(positions),
@@ -728,20 +717,17 @@ class PortfolioService:
 
         # Calculate net P&L and percentages
         net_pnl = total_unrealized_pnl
-        if total_cost_basis != Decimal("0"):
-            net_pnl_percent = (net_pnl / total_cost_basis) * Decimal("100")
-        else:
-            net_pnl_percent = Decimal("0")
+        net_pnl_ratio = _ratio_or_zero(net_pnl, total_cost_basis)
 
         return PortfolioSummaryResponse(
             total_market_value=to_money(total_market_value),
             total_cost_basis=to_money(total_cost_basis),
             total_unrealized_pnl=to_money(total_unrealized_pnl),
-            total_unrealized_pnl_percent=net_pnl_percent.quantize(Decimal("0.01")),
+            total_unrealized_pnl_percent=net_pnl_ratio.to_percent(),
             total_realized_pnl=Decimal("0"),  # Phase 1 only
-            total_realized_pnl_percent=Decimal("0"),
+            total_realized_pnl_percent=Ratio.zero().to_percent(),
             net_pnl=to_money(net_pnl),
-            net_pnl_percent=net_pnl_percent.quantize(Decimal("0.01")),
+            net_pnl_percent=net_pnl_ratio.to_percent(),
             holdings_count=len(holdings),
             active_positions_count=active_positions_count,
             disposed_positions_count=disposed_positions_count,

--- a/apps/backend/src/services/reconciliation_stats.py
+++ b/apps/backend/src/services/reconciliation_stats.py
@@ -14,6 +14,7 @@ from src.models import (
     ReconciliationMatch,
     ReconciliationStatus,
 )
+from src.ratio import Ratio
 
 logger = get_logger(__name__)
 
@@ -106,8 +107,10 @@ async def get_reconciliation_stats(
                 buckets["90-100"] += 1
         score_distribution = buckets
 
-    # Compute match rate with zero-division guard
-    match_rate = float(round((matched / total) * 100, 2)) if total else 0.0
+    # Compute match rate with zero-division guard. The API still exposes a JSON
+    # number, but the percent boundary is the shared Ratio policy.
+    match_rate_ratio = Ratio.fraction(matched, total) if total else Ratio.zero()
+    match_rate = float(match_rate_ratio.to_percent())
 
     return ReconciliationStats(
         total_transactions=total,

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -32,6 +32,7 @@ from src.models.layer3 import (
 )
 from src.money import to_money
 from src.money.adopt import restate, restate_unrounded
+from src.ratio import Ratio
 from src.schemas.provenance import DataProvenance
 from src.services import fx
 from src.services.assets import AssetService
@@ -1304,7 +1305,8 @@ def _add_liability_allocation_line(
 def _allocation_percentage(value: Decimal, net_worth: Decimal) -> Decimal | None:
     if net_worth == Decimal("0.00"):
         return None
-    return (value / net_worth * Decimal("100")).quantize(Decimal("0.01"))
+    allocation_ratio = Ratio.fraction(value, net_worth)
+    return allocation_ratio.to_percent()
 
 
 async def get_net_worth_allocation_schedule(

--- a/apps/backend/tests/accounting/test_ratio_backend.py
+++ b/apps/backend/tests/accounting/test_ratio_backend.py
@@ -62,6 +62,8 @@ def test_AC12_9_1_backend_value_type_laws():
     assert Ratio.from_percent(Decimal("50")).to_percent() == Decimal("50.00")
     assert str(a) == "10.00%"
     assert Ratio.zero().value == Decimal("0")
+    assert Ratio.zero().is_zero()
+    assert not a.is_zero()
     # A non-Ratio operand is a TypeError (mirrors Money's cross-type guard).
     with pytest.raises(TypeError):
         _ = a - 0.1  # type: ignore[operator]

--- a/apps/frontend/src/__tests__/confidence.test.ts
+++ b/apps/frontend/src/__tests__/confidence.test.ts
@@ -27,13 +27,13 @@ function snapshot(
 
 describe("confidence helpers (#1003 / #1055 PR4)", () => {
   describe("parseProportion", () => {
-    it("returns null for null/undefined/blank/non-numeric and parses real values", () => {
+    it("returns null for null/undefined/blank/non-numeric/number and parses Decimal strings", () => {
       expect(parseProportion(null)).toBeNull();
       expect(parseProportion(undefined)).toBeNull();
       expect(parseProportion("  ")).toBeNull();
       expect(parseProportion("abc")).toBeNull();
       expect(parseProportion("0.25")).toBe(0.25);
-      expect(parseProportion(0.5)).toBe(0.5);
+      expect(parseProportion(0.5 as never)).toBeNull();
     });
   });
 

--- a/apps/frontend/src/app/(main)/portfolio/[ticker]/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/[ticker]/page.tsx
@@ -7,8 +7,9 @@ import { useState } from "react";
 
 import { apiFetch } from "@/lib/api";
 import { DividendEvent, PortfolioHolding, RealizedLot } from "@/lib/types";
-import { compareAmounts, formatAmount, formatCurrencyLocale, formatQuantity } from "@/lib/money";
+import { compareAmounts, formatCurrencyLocale, formatQuantity } from "@/lib/money";
 import { formatDateDisplay } from "@/lib/date";
+import { formatSignedPercentFromPercentValue } from "@/lib/ratio/format";
 
 function getPnlColor(value: string): string {
     const comparison = compareAmounts(value, "0");
@@ -17,8 +18,7 @@ function getPnlColor(value: string): string {
 }
 
 function formatPnlPercent(value: string): string {
-    const sign = compareAmounts(value, "0") > 0 ? "+" : "";
-    return `${sign}${formatAmount(value, 2)}%`;
+    return formatSignedPercentFromPercentValue(value);
 }
 
 export default function HoldingDetailPage() {

--- a/apps/frontend/src/app/(main)/portfolio/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/page.tsx
@@ -11,28 +11,18 @@ import { PerformanceCard } from "@/components/portfolio/PerformanceCard";
 import { HoldingsTable } from "@/components/portfolio/HoldingsTable";
 import { AllocationChart } from "@/components/portfolio/AllocationChart";
 import { InvestmentPerformanceSchedule } from "@/components/portfolio/InvestmentPerformanceSchedule";
-import { amountToChartNumber, formatAmount, formatCurrencyLocale, sumAmounts } from "@/lib/money";
+import { amountToChartNumber, formatCurrencyLocale, sumAmounts } from "@/lib/money";
+import { clampPercentWidthFromPercentValue, formatPercentFromPercentValue } from "@/lib/ratio/format";
 import type { InvestmentPerformanceReportSchedule, NetWorthAllocationResponse, NetWorthAllocationRow } from "@/lib/types";
 
 const REPORT_CURRENCY = "SGD";
 
 function allocationBarWidth(percentage: string | null): string {
-    if (percentage === null) return "0%";
-    try {
-        const value = Math.abs(amountToChartNumber(percentage));
-        return `${Math.min(100, Math.max(0, value))}%`;
-    } catch {
-        return "0%";
-    }
+    return clampPercentWidthFromPercentValue(percentage);
 }
 
 function formatAllocationPercent(percentage: string | null): string {
-    if (percentage === null) return "N/A";
-    try {
-        return `${formatAmount(percentage, 1)}%`;
-    } catch {
-        return "N/A";
-    }
+    return formatPercentFromPercentValue(percentage, { dp: 1 });
 }
 
 function formatAllocationLabel(value: string): string {

--- a/apps/frontend/src/components/portfolio/HoldingsTable.tsx
+++ b/apps/frontend/src/components/portfolio/HoldingsTable.tsx
@@ -2,8 +2,9 @@
 
 import Link from "next/link";
 import { PortfolioHolding } from "@/lib/types";
-import { compareAmounts, formatAmount, formatCurrencyLocale, formatQuantity } from "@/lib/money";
+import { compareAmounts, formatCurrencyLocale, formatQuantity } from "@/lib/money";
 import { formatDateDisplay } from "@/lib/date";
+import { formatSignedPercentFromPercentValue } from "@/lib/ratio/format";
 import { ProvenanceBadge } from "@/components/ui/ProvenanceBadge";
 
 interface HoldingsTableProps {
@@ -18,8 +19,7 @@ function getPnlColor(value: string): string {
 }
 
 function formatPnlPercent(value: string): string {
-    const sign = compareAmounts(value, "0") > 0 ? "+" : "";
-    return `${sign}${formatAmount(value, 2)}%`;
+    return formatSignedPercentFromPercentValue(value);
 }
 
 export function HoldingsTable({ holdings, showDisposed = false }: HoldingsTableProps) {

--- a/apps/frontend/src/components/portfolio/InvestmentPerformanceSchedule.tsx
+++ b/apps/frontend/src/components/portfolio/InvestmentPerformanceSchedule.tsx
@@ -2,19 +2,13 @@
 
 import { FileText, Link2 } from "lucide-react";
 
-import { compareAmounts, formatCurrencyLocale, formatAmount } from "@/lib/money";
+import { compareAmounts, formatCurrencyLocale } from "@/lib/money";
 import { computeMarketValuePerformance } from "@/lib/portfolioPerformance";
+import { formatSignedPercentFromPercentValue } from "@/lib/ratio/format";
 import type { InvestmentPerformanceReportSchedule } from "@/lib/types";
 
 function formatPercent(value: string | null): string {
-    if (value === null) return "N/A";
-    try {
-        const comparison = compareAmounts(value, "0");
-        const sign = comparison > 0 ? "+" : "";
-        return `${sign}${formatAmount(value, 2)}%`;
-    } catch {
-        return "N/A";
-    }
+    return formatSignedPercentFromPercentValue(value);
 }
 
 function metricClass(value: string | null): string {

--- a/apps/frontend/src/components/portfolio/PerformanceCard.tsx
+++ b/apps/frontend/src/components/portfolio/PerformanceCard.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { compareAmounts, formatAmount, formatCurrencyLocale } from "@/lib/money";
+import { compareAmounts, formatCurrencyLocale } from "@/lib/money";
 import { computeMarketValuePerformance } from "@/lib/portfolioPerformance";
+import { formatSignedPercentFromPercentValue } from "@/lib/ratio/format";
 import type { InvestmentPerformanceReportSchedule } from "@/lib/types";
 
 function formatReturnPercent(value: string | null): string {
-    if (value === null) return "N/A";
-    const sign = compareAmounts(value, "0") > 0 ? "+" : "";
-    return `${sign}${formatAmount(value, 2)}%`;
+    return formatSignedPercentFromPercentValue(value);
 }
 
 function amountClass(value: string | null): string {

--- a/apps/frontend/src/lib/attention.ts
+++ b/apps/frontend/src/lib/attention.ts
@@ -12,6 +12,7 @@ import type {
   ProcessingPendingItem,
   ReconciliationStatsResponse,
 } from "@/lib/types";
+import { percentNumberFromPercentValue } from "@/lib/ratio/format";
 
 export type AttentionKind =
   | "statement_review"
@@ -49,8 +50,8 @@ export const PROCESSING_STALE_DAYS = 7;
 export const LOW_CONFIDENCE_THRESHOLD = 50;
 
 function clampConfidence(value: number): number {
-  // `value || 0` folds NaN/undefined to 0 without a separate branch.
-  return Math.max(0, Math.min(100, Math.round(value || 0)));
+  const percent = percentNumberFromPercentValue(String(value), { dp: 0, fallback: 0 }) ?? 0;
+  return Math.max(0, Math.min(100, percent));
 }
 
 /**

--- a/apps/frontend/src/lib/confidence.ts
+++ b/apps/frontend/src/lib/confidence.ts
@@ -12,17 +12,19 @@ import type {
   ConfidenceNorthStarResponse,
   CorrectionLoopReplayResponse,
 } from "@/lib/types";
+import {
+  formatPercentFromRatioValue,
+  percentNumberFromRatioValue,
+  ratioNumberFromRatioValue,
+} from "@/lib/ratio/format";
 
 /**
  * Parse a proportion to a finite number, or `null` for a missing/blank/non-finite
  * value. `Number("")` and `Number("  ")` coerce to 0, so blank strings must be
  * rejected explicitly rather than silently treated as 0.
  */
-export function parseProportion(value: string | number | null | undefined): number | null {
-  if (value === null || value === undefined) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const proportion = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(proportion) ? proportion : null;
+export function parseProportion(value: string | null | undefined): number | null {
+  return ratioNumberFromRatioValue(value);
 }
 
 /**
@@ -31,10 +33,8 @@ export function parseProportion(value: string | number | null | undefined): numb
  * parse with Number only at the display boundary. A non-finite or missing
  * value renders as an em dash rather than "NaN%".
  */
-export function formatProportionPercent(value: string | number, decimals = 1): string {
-  const proportion = parseProportion(value);
-  if (proportion === null) return "—";
-  return `${(proportion * 100).toFixed(decimals)}%`;
+export function formatProportionPercent(value: string, decimals = 1): string {
+  return formatPercentFromRatioValue(value, { dp: decimals });
 }
 
 export type TrendDirection = "down" | "up" | "flat";
@@ -84,7 +84,7 @@ export function toSparklinePoints(
     }))
     // Drop blank/non-finite points so a missing value can't inject a bogus 0% datapoint.
     .filter((point): point is { label: string; proportion: number } => point.proportion !== null)
-    .map((point) => ({ label: point.label, value: point.proportion * 100 }));
+    .map((point) => ({ label: point.label, value: percentNumberFromRatioValue(String(point.proportion)) ?? 0 }));
 }
 
 export interface ReplaySummary {

--- a/apps/frontend/src/lib/portfolioPerformance.ts
+++ b/apps/frontend/src/lib/portfolioPerformance.ts
@@ -1,4 +1,5 @@
-import { compareAmounts, divideAmount, multiplyAmount, sumAmounts } from "./money";
+import { compareAmounts, sumAmounts } from "./money";
+import { formatPercentValueFromParts } from "@/lib/ratio/format";
 import type { InvestmentPerformanceReportSchedule } from "./types";
 
 /**
@@ -31,10 +32,7 @@ export function computeMarketValuePerformance(
 
     let returnOnCostPercent: string | null = null;
     if (compareAmounts(totalCostBasis, "0") !== 0) {
-        returnOnCostPercent = multiplyAmount(
-            divideAmount(schedule.unrealized_pnl, totalCostBasis),
-            "100",
-        ).toFixed(2);
+        returnOnCostPercent = formatPercentValueFromParts(schedule.unrealized_pnl, totalCostBasis.toString());
     }
 
     return {

--- a/apps/frontend/src/lib/ratio/format.test.ts
+++ b/apps/frontend/src/lib/ratio/format.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampPercentWidthFromPercentValue,
+  formatPercentValueFromParts,
+  formatPercentFromPercentValue,
+  formatPercentFromRatioValue,
+  formatSignedPercentFromPercentValue,
+  percentNumberFromPercentValue,
+  percentNumberFromRatioValue,
+} from "./format";
+
+describe("ratio percent formatting helpers (EPIC-012 AC12.9.3)", () => {
+  it("test_AC12_9_3_ratio_format_helpers_use_canonical_percent_policy", () => {
+    expect(formatPercentFromRatioValue("0.12005")).toBe("12.01%");
+    expect(formatPercentFromPercentValue("12.005")).toBe("12.01%");
+    expect(formatPercentFromPercentValue("12.005", { dp: 1 })).toBe("12.0%");
+    expect(formatSignedPercentFromPercentValue("8.25")).toBe("+8.25%");
+    expect(formatSignedPercentFromPercentValue("-1.5")).toBe("-1.50%");
+    expect(formatPercentValueFromParts("1", "8")).toBe("12.50");
+    expect(formatPercentValueFromParts("1", "0")).toBeNull();
+    expect(formatPercentValueFromParts("1", "0", { fallback: "—" })).toBe("—");
+  });
+
+  it("test_AC12_9_3_ratio_format_helpers_guard_invalid_or_missing_inputs", () => {
+    expect(formatPercentFromRatioValue("")).toBe("—");
+    expect(formatPercentFromRatioValue("not-a-number")).toBe("—");
+    expect(formatPercentFromRatioValue(0.125 as never)).toBe("—");
+    expect(formatPercentFromPercentValue(null)).toBe("N/A");
+    expect(formatPercentFromPercentValue(12.5 as never)).toBe("N/A");
+    expect(formatSignedPercentFromPercentValue("not-a-number")).toBe("N/A");
+  });
+
+  it("test_AC12_9_3_ratio_format_helpers_return_chart_boundary_numbers", () => {
+    expect(percentNumberFromRatioValue("0.125")).toBe(12.5);
+    expect(percentNumberFromPercentValue("79.5", { dp: 0 })).toBe(80);
+    expect(clampPercentWidthFromPercentValue("-150.00")).toBe("100%");
+    expect(clampPercentWidthFromPercentValue("12.345")).toBe("12.35%");
+    expect(clampPercentWidthFromPercentValue(null)).toBe("0%");
+  });
+});

--- a/apps/frontend/src/lib/ratio/format.ts
+++ b/apps/frontend/src/lib/ratio/format.ts
@@ -1,0 +1,110 @@
+import Decimal from "decimal.js";
+
+import { Ratio, type RatioInput } from "./ratio";
+
+type NullablePercentInput = RatioInput | null | undefined;
+
+interface PercentFormatOptions {
+  dp?: number;
+  fallback?: string;
+}
+
+interface PercentNumberOptions {
+  dp?: number;
+  fallback?: number | null;
+}
+
+function normalizeInput(value: NullablePercentInput): RatioInput | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Decimal) return value;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function ratioFromRatioValue(value: NullablePercentInput): Ratio | null {
+  const normalized = normalizeInput(value);
+  if (normalized === null) return null;
+  try {
+    return new Ratio(normalized);
+  } catch {
+    return null;
+  }
+}
+
+function ratioFromPercentValue(value: NullablePercentInput): Ratio | null {
+  const normalized = normalizeInput(value);
+  if (normalized === null) return null;
+  try {
+    return Ratio.fromPercent(normalized);
+  } catch {
+    return null;
+  }
+}
+
+function formatRatioPercent(ratio: Ratio | null, dp: number, fallback: string, signed: boolean): string {
+  if (ratio === null) return fallback;
+  const percent = ratio.toPercent(dp);
+  const sign = signed && percent.greaterThan(0) ? "+" : "";
+  return `${sign}${percent.toFixed(dp)}%`;
+}
+
+export function formatPercentFromRatioValue(value: NullablePercentInput, options: PercentFormatOptions = {}): string {
+  const { dp = 2, fallback = "—" } = options;
+  return formatRatioPercent(ratioFromRatioValue(value), dp, fallback, false);
+}
+
+export function formatPercentFromPercentValue(value: NullablePercentInput, options: PercentFormatOptions = {}): string {
+  const { dp = 2, fallback = "N/A" } = options;
+  return formatRatioPercent(ratioFromPercentValue(value), dp, fallback, false);
+}
+
+export function formatSignedPercentFromPercentValue(
+  value: NullablePercentInput,
+  options: PercentFormatOptions = {},
+): string {
+  const { dp = 2, fallback = "N/A" } = options;
+  return formatRatioPercent(ratioFromPercentValue(value), dp, fallback, true);
+}
+
+export function formatPercentValueFromParts(
+  part: RatioInput,
+  whole: RatioInput,
+  options: PercentFormatOptions = {},
+): string | null {
+  const { dp = 2, fallback = "N/A" } = options;
+  try {
+    return Ratio.fraction(part, whole).toPercent(dp).toFixed(dp);
+  } catch {
+    return fallback === "N/A" ? null : fallback;
+  }
+}
+
+export function ratioNumberFromRatioValue(value: NullablePercentInput): number | null {
+  const ratio = ratioFromRatioValue(value);
+  return ratio === null ? null : ratio.value.toNumber();
+}
+
+export function percentNumberFromRatioValue(
+  value: NullablePercentInput,
+  options: PercentNumberOptions = {},
+): number | null {
+  const { dp = 2, fallback = null } = options;
+  const ratio = ratioFromRatioValue(value);
+  return ratio === null ? fallback : ratio.toPercent(dp).toNumber();
+}
+
+export function percentNumberFromPercentValue(
+  value: NullablePercentInput,
+  options: PercentNumberOptions = {},
+): number | null {
+  const { dp = 2, fallback = null } = options;
+  const ratio = ratioFromPercentValue(value);
+  return ratio === null ? fallback : ratio.toPercent(dp).toNumber();
+}
+
+export function clampPercentWidthFromPercentValue(value: NullablePercentInput): string {
+  const percent = percentNumberFromPercentValue(value, { dp: 2, fallback: 0 }) ?? 0;
+  const bounded = Math.min(100, Math.max(0, Math.abs(percent)));
+  return `${new Decimal(bounded).toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toString()}%`;
+}

--- a/apps/frontend/src/lib/ratio/index.ts
+++ b/apps/frontend/src/lib/ratio/index.ts
@@ -7,3 +7,13 @@
 
 export { RatioError, FloatNotAllowedError, UndefinedRatioError } from "./errors";
 export { Ratio, PERCENT_DP, PERCENT_ROUNDING, type RatioInput } from "./ratio";
+export {
+  clampPercentWidthFromPercentValue,
+  formatPercentValueFromParts,
+  formatPercentFromPercentValue,
+  formatPercentFromRatioValue,
+  formatSignedPercentFromPercentValue,
+  percentNumberFromPercentValue,
+  percentNumberFromRatioValue,
+  ratioNumberFromRatioValue,
+} from "./format";

--- a/apps/frontend/src/lib/ratio/ratio.conformance.test.ts
+++ b/apps/frontend/src/lib/ratio/ratio.conformance.test.ts
@@ -72,6 +72,8 @@ describe("ratio value-type laws (TS rendering of the contract)", () => {
     expect(a.compareTo(b)).toBe(-1);
     expect(a.equals(new Ratio("0.1"))).toBe(true);
     expect(Ratio.zero().value.equals(new Decimal("0"))).toBe(true);
+    expect(Ratio.zero().isZero()).toBe(true);
+    expect(a.isZero()).toBe(false);
   });
 
   it("renders percent strings (formatPercent / toString)", () => {

--- a/apps/frontend/src/lib/ratio/ratio.ts
+++ b/apps/frontend/src/lib/ratio/ratio.ts
@@ -43,6 +43,10 @@ export class Ratio {
     return new Ratio("0");
   }
 
+  isZero(): boolean {
+    return this.value.isZero();
+  }
+
   /** Build a ratio from a percentage number (`12.5` -> `0.125`). */
   static fromPercent(percent: RatioInput): Ratio {
     return new Ratio(coerce(percent, "percent").dividedBy(100));

--- a/common/ratio/contract/ratio.contract.md
+++ b/common/ratio/contract/ratio.contract.md
@@ -19,6 +19,7 @@
 | `from_percent(p)` | `p / 100` |
 | `to_percent(dp=2, rounding=HALF_UP)` | percentage value quantized to `dp` with the canonical policy |
 | `format_percent(dp=2)` | `"12.50%"` string |
+| `is_zero()` / `isZero()` | typed zero predicate; call-sites should not compare `Ratio` to naked numeric zero |
 | `add`/`sub`/`compare`/`neg`/`*scalar` | dimensionless arithmetic (ratios share one implicit unit) |
 
 ## Invariants (every end)
@@ -28,6 +29,8 @@
    passed. This is the one project-wide percent policy; it is intentionally NOT
    money's `ROUND_HALF_EVEN` (a percentage is not a currency amount).
 3. **Zero whole is undefined** — `fraction(x, 0)` raises, never silently 0.
+4. **Typed zero checks** — compare ratio values with `Ratio`/`is_zero`, not with
+   `0`, `0.0`, or raw `Decimal("0")` at call-sites.
 
 ## Shared API surface (identifier parity)
 

--- a/common/ratio/ratio.py
+++ b/common/ratio/ratio.py
@@ -72,6 +72,10 @@ class Ratio:
     def zero(cls) -> Ratio:
         return cls(Decimal("0"))
 
+    def is_zero(self) -> bool:
+        """Return whether this typed ratio is exactly zero."""
+        return self.value.is_zero()
+
     @classmethod
     def from_percent(cls, percent: _RatioInput) -> Ratio:
         """Build a ratio from a percentage number (``12.5`` -> ``0.125``)."""

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -149,6 +149,7 @@ diverging across the codebase and across ends.
 |----|-----------|---------------|------|----------|
 | AC12.9.1 | `Ratio` rejects float, is Decimal-backed/immutable; `fraction(part, whole)` builds it (zero whole undefined → raises); percent display is the canonical 2 dp / ROUND_HALF_UP; dimensionless arithmetic | `test_AC12_9_1_ratio_rejects_float_and_is_decimal_backed` (+ siblings) | `tests/tooling/test_ratio_value_type.py`, `apps/backend/tests/accounting/test_ratio_backend.py` | P1 |
 | AC12.9.2 | Cross-language conformance: the Python reference, shipped backend `src.ratio`, and frontend `lib/ratio` reproduce the same `vectors.json` (to_percent / percent_of / from_percent) and export the same `shared_api` (identifier-parity guard) | `test_AC12_9_2_to_percent_matches_standard` (+ siblings) | `tests/tooling/test_ratio_conformance.py`, `tests/tooling/test_ratio_api_parity.py` | P1 |
+| AC12.9.3 | Ratio adoption: portfolio performance/P&L percentages, allocation shares, reconciliation match rate, and frontend confidence/portfolio percent formatting route through the Ratio narrow waist without changing API shapes | `test_AC12_9_3_backend_percentage_call_sites_route_through_ratio`, `test_AC12_9_3_ratio_format_helpers_use_canonical_percent_policy` (+ siblings) | `tests/tooling/test_ratio_adoption.py`, `apps/frontend/src/lib/ratio/format.test.ts` | P1 |
 
 ### AC12.10: Logging - Build Processors
 

--- a/tests/tooling/test_ratio_adoption.py
+++ b/tests/tooling/test_ratio_adoption.py
@@ -1,0 +1,97 @@
+"""Ratio adoption guards for percentage call-sites (EPIC-012 AC12.9, #1200).
+
+The Ratio base package shipped in #1199. These tests keep the follow-up
+migration honest: business percentages should use ``Ratio`` for the percent
+boundary instead of hand-rolled ``* 100`` / ``quantize(0.01)`` math.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+
+BACKEND_RATIO_ADOPTION_FILES = [
+    Path("apps/backend/src/services/performance.py"),
+    Path("apps/backend/src/services/portfolio.py"),
+    Path("apps/backend/src/services/allocation.py"),
+    Path("apps/backend/src/services/performance_report.py"),
+    Path("apps/backend/src/services/reporting.py"),
+    Path("apps/backend/src/services/reconciliation_stats.py"),
+]
+
+FRONTEND_RATIO_ADOPTION_FILES = [
+    Path("apps/frontend/src/lib/portfolioPerformance.ts"),
+    Path("apps/frontend/src/lib/confidence.ts"),
+    Path("apps/frontend/src/lib/attention.ts"),
+    Path("apps/frontend/src/components/portfolio/PerformanceCard.tsx"),
+    Path("apps/frontend/src/components/portfolio/InvestmentPerformanceSchedule.tsx"),
+    Path("apps/frontend/src/components/portfolio/HoldingsTable.tsx"),
+    Path("apps/frontend/src/app/(main)/portfolio/page.tsx"),
+    Path("apps/frontend/src/app/(main)/portfolio/[ticker]/page.tsx"),
+]
+
+
+def _read(path: Path) -> str:
+    return (REPO / path).read_text(encoding="utf-8")
+
+
+@ac_proof(proof_id="test_ratio_backend_adoption", ac_ids=["AC12.9.3"], ci_tier="pr_ci", issue="#1200")
+def test_AC12_9_3_backend_percentage_call_sites_route_through_ratio():
+    """AC12.9.3: targeted backend percentage files use Ratio, not manual percent math."""
+    for path in BACKEND_RATIO_ADOPTION_FILES:
+        src = _read(path)
+        assert "from src.ratio import Ratio" in src, f"{path} must import Ratio"
+        assert "Ratio.fraction(" in src or "Ratio.from_percent(" in src, f"{path} must route percentages through Ratio"
+
+    forbidden = [
+        '* Decimal("100")',
+        '* Decimal("100"))',
+        '* Decimal("100"))',
+        '* 100, 2',
+        '* 100)).',
+        '.quantize(Decimal("0.01")',
+    ]
+    for path in BACKEND_RATIO_ADOPTION_FILES:
+        src = _read(path)
+        for pattern in forbidden:
+            assert pattern not in src, f"{path} still hand-rolls a percent boundary with {pattern!r}"
+
+
+@ac_proof(proof_id="test_ratio_backend_adoption_keeps_ratio_typed", ac_ids=["AC12.9.3"], ci_tier="pr_ci", issue="#1200")
+def test_AC12_9_3_backend_adoption_keeps_ratio_typed_until_boundary():
+    """AC12.9.3: adoption code should not construct Ratio and unwrap it on the same expression."""
+    inline_boundary = re.compile(r"Ratio(?:\.fraction|\.from_percent)?\([^()\n]*\)\.to_percent\(")
+    for path in BACKEND_RATIO_ADOPTION_FILES + [Path("apps/backend/src/routers/portfolio.py")]:
+        src = _read(path)
+        assert not inline_boundary.search(src), f"{path} constructs Ratio and immediately unwraps it to Decimal"
+
+    portfolio = _read(Path("apps/backend/src/services/portfolio.py"))
+    assert "def _ratio_or_zero(" in portfolio
+    assert "def _percent_or_zero(" not in portfolio
+
+    reconciliation = _read(Path("apps/backend/src/services/reconciliation_stats.py"))
+    assert "Decimal(matched)" not in reconciliation
+    assert "Decimal(total)" not in reconciliation
+
+
+@ac_proof(proof_id="test_ratio_frontend_adoption", ac_ids=["AC12.9.3"], ci_tier="pr_ci", issue="#1200")
+def test_AC12_9_3_frontend_percentage_call_sites_use_ratio_helpers():
+    """AC12.9.3: targeted frontend percentage files use ratio formatting helpers."""
+    helper_import = "@/lib/ratio/format"
+    for path in FRONTEND_RATIO_ADOPTION_FILES:
+        src = _read(path)
+        assert helper_import in src, f"{path} must use the shared ratio format helpers"
+
+    forbidden_by_file = {
+        Path("apps/frontend/src/lib/portfolioPerformance.ts"): ["multiplyAmount("],
+        Path("apps/frontend/src/lib/confidence.ts"): ["* 100).toFixed", "proportion * 100"],
+        Path("apps/frontend/src/lib/attention.ts"): ["Math.round("],
+    }
+    for path, patterns in forbidden_by_file.items():
+        src = _read(path)
+        for pattern in patterns:
+            assert pattern not in src, f"{path} still hand-rolls percentage formatting with {pattern!r}"

--- a/tests/tooling/test_ratio_value_type.py
+++ b/tests/tooling/test_ratio_value_type.py
@@ -71,6 +71,8 @@ def test_AC12_9_1_dimensionless_arithmetic_and_compare():
     assert a < b and a <= b and b > a and b >= a
     assert str(Ratio(Decimal("0.5"))) == "50.00%"
     assert Ratio.zero() == Ratio(Decimal("0"))
+    assert Ratio.zero().is_zero()
+    assert not a.is_zero()
     # A non-Ratio operand is a TypeError (mirrors Money's cross-type guard).
     with pytest.raises(TypeError):
         _ = a + 0.1  # type: ignore[operator]


### PR DESCRIPTION
## Summary

Routes existing ad-hoc business percentage calculations and displays through the `Ratio` narrow waist without changing API response shapes.

Closes #1200
Refs #1167
Refs #1199

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-012 — Foundation Libraries Enhancement |
| **AC IDs** | AC12.9.3 |
| **AC source updated** | Owning EPIC: `docs/project/EPIC-012.foundation-libs.md` |

---

## SSOT Changes

- [x] None — existing SSOT (`docs/ssot/base-packages.md`) already covers Ratio; this PR adds adoption proof under EPIC-012.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `local pre-implementation` | `test_AC12_9_3_backend_percentage_call_sites_route_through_ratio` failed on missing Ratio imports/manual percent math; `format.test.ts` failed on missing `lib/ratio/format` helper. |
| 🟢 Green (passing test) | `69fe0c83` | Implement Ratio adoption helpers/call-site migration; targeted tests and preflight pass. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no schema/migration changes.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A, no env vars.
- [x] `repo/` submodule updated for production config changes (if applicable) — N/A, no production config; existing local `repo/` drift is unrelated and unstaged.
- [x] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env vars.
- [x] `tools/check_manifest.py` passes (if SSOT files changed) — N/A, no SSOT owner change.
- [x] `tools/lint_doc_consistency.py` passes — covered by preflight.

### CI/CD, Runtime, and VPS Infra Audit

N/A — no workflow, deployment, runtime config, VPS script, or log changes.

---

## Testing

```bash
apps/backend/.venv/bin/python -m pytest tests/tooling/test_ratio_adoption.py tests/tooling/test_ratio_value_type.py tests/tooling/test_ratio_conformance.py tests/tooling/test_ratio_api_parity.py -q
npm test -- --run src/lib/ratio/format.test.ts src/lib/ratio/ratio.conformance.test.ts src/__tests__/confidence.test.ts src/__tests__/portfolioPerformance.test.ts src/__tests__/performanceCard.test.tsx src/__tests__/investmentPerformanceSchedule.test.tsx src/__tests__/portfolioPage.test.tsx src/__tests__/holdingsTable.test.tsx
cd apps/backend && .venv/bin/python -m pytest tests/portfolio/test_performance_service.py tests/portfolio/test_allocation_service.py tests/reconciliation/test_reconciliation_stats.py tests/reporting/test_reporting_net_worth_components.py tests/portfolio/test_portfolio_service.py tests/portfolio/test_portfolio_router.py tests/reporting/test_reports_router.py -q --no-cov
cd apps/backend && .venv/bin/ruff check src tests && .venv/bin/ruff format --check src tests
npm run typecheck
npm run lint
PATH="$PWD/apps/backend/.venv/bin:$PATH" apps/backend/.venv/bin/python tools/preflight.py
```

Preflight passed all relevant gates with the project-pinned ruff first in PATH. The first preflight attempt failed only because PATH had ruff `0.15.17`, which reports existing `UP042` suggestions; the backend-pinned ruff is `0.14.11` and matches CI/local project config.

---

## Screenshots / Evidence

N/A — internal value-type adoption; no visual layout changes intended.