### PR TITLE
[finance_report_infra_1073_observability] Add deploy failure SigNoz pivots

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -623,6 +623,8 @@ jobs:
             echo "failure_domain=${failure_domain}"
             echo "failed_step=${failed_step}"
             echo "failure_summary=${failure_summary}"
+            echo "signoz_logs_query_url=https://signoz.zitian.party/logs?service.name=finance-report-backend&deployment.environment=production&service.version=${{ steps.version.outputs.tag }}&github.run_id=${{ github.run_id }}"
+            echo "signoz_traces_query_url=https://signoz.zitian.party/traces?service.name=finance-report-backend&deployment.environment=production&service.version=${{ steps.version.outputs.tag }}&github.run_id=${{ github.run_id }}"
             echo "marker=prod_safe"
           } > ci-context/production-deploy-context.txt
 

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -438,6 +438,8 @@ jobs:
             echo "- Failure domain: ${failure_domain}"
             echo "- Failed step: ${failed_step}"
             echo "- Failure summary: ${failure_summary}"
+            echo "- SigNoz logs: https://signoz.zitian.party/logs?service.name=finance-report-backend&deployment.environment=staging&service.version=${{ inputs.tag }}&github.run_id=${{ github.run_id }}"
+            echo "- SigNoz traces: https://signoz.zitian.party/traces?service.name=finance-report-backend&deployment.environment=staging&service.version=${{ inputs.tag }}&github.run_id=${{ github.run_id }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Write staging deploy context
@@ -467,6 +469,8 @@ jobs:
             echo "failure_domain=${{ steps.deploy_failure_context.outputs.failure_domain }}"
             echo "failed_step=${{ steps.deploy_failure_context.outputs.failed_step }}"
             echo "failure_summary=${{ steps.deploy_failure_context.outputs.failure_summary }}"
+            echo "signoz_logs_query_url=https://signoz.zitian.party/logs?service.name=finance-report-backend&deployment.environment=staging&service.version=${{ inputs.tag }}&github.run_id=${{ github.run_id }}"
+            echo "signoz_traces_query_url=https://signoz.zitian.party/traces?service.name=finance-report-backend&deployment.environment=staging&service.version=${{ inputs.tag }}&github.run_id=${{ github.run_id }}"
             echo "strict_e2e_gates=true"
             echo "marker=(smoke or e2e) and not llm"
           } > ci-context/staging-deploy-context.txt

--- a/docs/project/EPIC-010.signoz-logging.md
+++ b/docs/project/EPIC-010.signoz-logging.md
@@ -169,6 +169,7 @@ Enable production-grade log observability via SigNoz (OTLP), while keeping local
 | AC10.9.2 | Startup logs emit one structured observability runtime event for SigNoz/Lark alert triage | `test_AC10_9_2_observability_startup_log_uses_runtime_contract()` | `infra/test_observability_contract.py` | P0 |
 | AC10.9.3 | `/health` includes the same redacted observability status so deploy checks can prove app-side alert readiness | `test_AC10_9_3_health_response_includes_redacted_observability_status()` | `infra/test_observability_contract.py` | P0 |
 | AC10.9.4 | Finance Report docs declare the app-owned alerting contract while infra2 remains the shared SigNoz/Lark automation owner | `test_AC10_9_4_observability_docs_declare_shared_alerting_pipeline()` | `infra/test_observability_contract.py` | P0 |
+| AC10.9.5 | Deploy failure snapshots and deploy contexts include non-secret platform health fields plus run-to-SigNoz log/trace query links | `test_AC10_9_5_snapshot_includes_platform_health_and_signoz_links()`, `test_AC10_9_5_main_missing_inputs_still_prints_signoz_links()` | `tests/tooling/test_dokploy_failure_snapshot.py` | P0 |
 
 ## 📏 Acceptance Criteria
 

--- a/docs/ssot/observability.md
+++ b/docs/ssot/observability.md
@@ -326,7 +326,7 @@ infra2/platform (repo submodule)
 
 | Gap | Risk | Mitigation |
 |-----|------|------------|
-| **OTEL ingestion not fully verified at deploy** | Logs can be configured but absent from SigNoz if collector ingestion or rule automation drifts | Production smoke verifies the app-side observability contract; SigNoz log queries and Lark delivery remain manual live gates |
+| **OTEL ingestion not fully verified at deploy** | Logs can be configured but absent from SigNoz if collector ingestion or rule automation drifts | Production smoke verifies the app-side observability contract; deploy contexts include SigNoz log/trace pivots by service, environment, version, and GitHub run |
 | **Vault availability not checked by App** | N/A - vault-agent handles this before app starts | Vault HA in infra2 |
 | **secrets.ctmpl ↔ config.py drift** | Missing env vars cause 500s | `tools/check_env_keys.py` + pre-commit |
 | **infra2 submodule version lag** | New secrets not deployed | Manual sync required after adding vars |
@@ -339,6 +339,9 @@ After staging or production deploys, keep observability verification narrow:
    environment, alert rule, and alerting pipeline without secret URLs or keys.
 2. Confirm SigNoz has recent `finance-report-backend` logs for the target
    `deployment.environment`.
+   Deploy contexts and failure summaries include pre-built SigNoz log/trace
+   query links carrying `service.name`, `deployment.environment`,
+   `service.version`, and `github.run_id`.
 3. If logs or alerts are missing during an incident, route through
    [runtime-incident-response.md](./runtime-incident-response.md) instead of
    adding environment-specific debugging steps here.

--- a/tests/tooling/test_dokploy_failure_snapshot.py
+++ b/tests/tooling/test_dokploy_failure_snapshot.py
@@ -53,6 +53,41 @@ def test_render_markdown_includes_failure_domain() -> None:
     assert "dokploy-deployment-error" in md
 
 
+def test_AC10_9_5_snapshot_includes_platform_health_and_signoz_links() -> None:
+    """AC10.9.5: deploy failure snapshots carry platform health and SigNoz pivots."""
+    links = snapshot.build_signoz_query_links(
+        signoz_url="https://signoz.zitian.party",
+        service_name="finance-report-backend",
+        deployment_environment="staging",
+        service_version="v0.1.3",
+        github_run_id="12345",
+    )
+    platform_health = snapshot.load_platform_health(
+        '{"target_container_status":"restarting",'
+        '"target_container_restart_count":7,'
+        '"host_load_1m":25.5,'
+        '"host_memory_used_pct":91.2,'
+        '"vault_agent_error_loop":true,'
+        '"secret_should_not_pass":"x"}'
+    )
+
+    snap = snapshot.build_snapshot(
+        "https://api",
+        "k",
+        "cid",
+        platform_health=platform_health,
+        signoz_links=links,
+    )
+
+    assert snap["target_container_status"] == "restarting"
+    assert snap["target_container_restart_count"] == 7
+    assert snap["host_load_1m"] == 25.5
+    assert snap["vault_agent_error_loop"] is True
+    assert "secret_should_not_pass" not in snap
+    assert "deployment.environment=staging" in snap["signoz_logs_query_url"]
+    assert "github.run_id=12345" in snap["signoz_traces_query_url"]
+
+
 class _FakeResponse:
     def __init__(self, payload: bytes) -> None:
         self._payload = payload
@@ -135,6 +170,34 @@ def test_main_happy_path_prints_snapshot(monkeypatch, capsys) -> None:
     out = capsys.readouterr().out
     assert rc == 0
     assert "dokploy-deployment-error" in out
+
+
+def test_AC10_9_5_main_missing_inputs_still_prints_signoz_links(capsys) -> None:
+    """AC10.9.5: missing Dokploy inputs do not suppress run-to-SigNoz pivots."""
+    rc = snapshot.main(
+        [
+            "--compose-id",
+            "",
+            "--api-url",
+            "",
+            "--api-key",
+            "",
+            "--signoz-url",
+            "https://signoz.zitian.party",
+            "--deployment-environment",
+            "production",
+            "--service-version",
+            "v0.1.3",
+            "--github-run-id",
+            "456",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "snapshot-skipped-missing-inputs" in out
+    assert "signoz_logs_query_url" in out
+    assert "github.run_id=456" in out
 
 
 def test_build_snapshot_no_deployments(monkeypatch) -> None:

--- a/tests/tooling/test_dokploy_failure_snapshot.py
+++ b/tests/tooling/test_dokploy_failure_snapshot.py
@@ -200,6 +200,34 @@ def test_AC10_9_5_main_missing_inputs_still_prints_signoz_links(capsys) -> None:
     assert "github.run_id=456" in out
 
 
+def test_AC10_9_5_main_does_not_emit_empty_github_run_filter(capsys) -> None:
+    """AC10.9.5: SigNoz pivots require a concrete GitHub run id."""
+    rc = snapshot.main(
+        [
+            "--compose-id",
+            "",
+            "--api-url",
+            "",
+            "--api-key",
+            "",
+            "--signoz-url",
+            "https://signoz.zitian.party",
+            "--deployment-environment",
+            "production",
+            "--service-version",
+            "v0.1.3",
+            "--github-run-id",
+            "",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "snapshot-skipped-missing-inputs" in out
+    assert "signoz_logs_query_url" not in out
+    assert "github.run_id=" not in out
+
+
 def test_build_snapshot_no_deployments(monkeypatch) -> None:
     monkeypatch.setattr(
         snapshot,

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -793,6 +793,8 @@ def test_AC8_13_76_ci_environment_gates_publish_failure_path_context() -> None:
         "failure_summary=${{ steps.deploy_failure_context.outputs.failure_summary }}"
         in staging
     )
+    assert "signoz_logs_query_url=https://signoz.zitian.party/logs?service.name=finance-report-backend&deployment.environment=staging" in staging
+    assert "github.run_id=${{ github.run_id }}" in staging
     assert "staging-ai-ocr-test-context" in staging
     assert "test-results/staging-ai-ocr-version.xml" in staging
     assert "test-results/staging-ai-ocr-gate.xml" in staging

--- a/tools/dokploy_failure_snapshot.py
+++ b/tools/dokploy_failure_snapshot.py
@@ -24,6 +24,7 @@ import json
 import os
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -33,6 +34,13 @@ if str(ROOT_DIR) not in sys.path:
 
 # Compose/deployment states Dokploy reports once a rollout has actually started.
 _ACTIVE_STATES = {"running", "done", "success", "successful"}
+_PLATFORM_HEALTH_FIELDS = (
+    "target_container_status",
+    "target_container_restart_count",
+    "host_load_1m",
+    "host_memory_used_pct",
+    "vault_agent_error_loop",
+)
 
 
 def _api_get(api_url: str, api_key: str, path: str) -> dict:
@@ -68,7 +76,50 @@ def _classify(compose_status: str, deployments: list[dict]) -> str:
     return "dokploy-rollout-incomplete"
 
 
-def build_snapshot(api_url: str, api_key: str, compose_id: str) -> dict:
+def build_signoz_query_links(
+    *,
+    signoz_url: str,
+    service_name: str,
+    deployment_environment: str,
+    service_version: str,
+    github_run_id: str,
+) -> dict[str, str]:
+    """Build stable SigNoz pivot links for the deployed version/run."""
+    base = signoz_url.rstrip("/")
+    filters = {
+        "service.name": service_name,
+        "deployment.environment": deployment_environment,
+        "service.version": service_version,
+        "github.run_id": github_run_id,
+    }
+    encoded = urllib.parse.urlencode(filters)
+    return {
+        "signoz_logs_query_url": f"{base}/logs?{encoded}",
+        "signoz_traces_query_url": f"{base}/traces?{encoded}",
+    }
+
+
+def load_platform_health(raw_json: str | None) -> dict[str, object]:
+    """Return only the non-secret platform health fields the deploy summary needs."""
+    if not raw_json:
+        return {}
+    try:
+        payload = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return {"platform_health_error": "invalid-json"}
+    if not isinstance(payload, dict):
+        return {"platform_health_error": "not-an-object"}
+    return {key: payload[key] for key in _PLATFORM_HEALTH_FIELDS if key in payload}
+
+
+def build_snapshot(
+    api_url: str,
+    api_key: str,
+    compose_id: str,
+    *,
+    platform_health: dict[str, object] | None = None,
+    signoz_links: dict[str, str] | None = None,
+) -> dict:
     try:
         data = _api_get(api_url, api_key, f"compose.one?composeId={compose_id}")
     except (urllib.error.URLError, ValueError, TimeoutError) as exc:
@@ -76,6 +127,8 @@ def build_snapshot(api_url: str, api_key: str, compose_id: str) -> dict:
             "compose_id": compose_id,
             "error": f"could not read Dokploy compose: {type(exc).__name__}",
             "platform_failure_domain": "dokploy-api-unreachable",
+            **(platform_health or {}),
+            **(signoz_links or {}),
         }
 
     deployments = [d for d in (data.get("deployments") or []) if isinstance(d, dict)]
@@ -95,6 +148,8 @@ def build_snapshot(api_url: str, api_key: str, compose_id: str) -> dict:
         "latest_deployment_title": str(latest.get("title") or ""),
         "latest_deployment_error": str(latest.get("errorMessage") or "")[:500],
         "platform_failure_domain": _classify(compose_status, deployments),
+        **(platform_health or {}),
+        **(signoz_links or {}),
     }
 
 
@@ -113,7 +168,15 @@ def render_markdown(snapshot: dict) -> str:
         "latest_deployment_title",
         "latest_deployment_error",
         "platform_failure_domain",
+        "target_container_status",
+        "target_container_restart_count",
+        "host_load_1m",
+        "host_memory_used_pct",
+        "vault_agent_error_loop",
+        "signoz_logs_query_url",
+        "signoz_traces_query_url",
         "error",
+        "platform_health_error",
     ):
         if key in snapshot and snapshot[key] != "":
             lines.append(f"| {key} | {snapshot[key]} |")
@@ -125,10 +188,28 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--compose-id", required=True)
     parser.add_argument("--api-url", default=os.getenv("DOKPLOY_API_URL", ""))
     parser.add_argument("--api-key", default=os.getenv("DOKPLOY_API_KEY", ""))
+    parser.add_argument("--platform-health-json", default="")
+    parser.add_argument("--signoz-url", default="")
+    parser.add_argument("--service-name", default="finance-report-backend")
+    parser.add_argument("--deployment-environment", default="")
+    parser.add_argument("--service-version", default="")
+    parser.add_argument("--github-run-id", default=os.getenv("GITHUB_RUN_ID", ""))
     parser.add_argument(
         "--markdown", action="store_true", help="Also print a Markdown table"
     )
     args = parser.parse_args(argv)
+    platform_health = load_platform_health(args.platform_health_json)
+    signoz_links = (
+        build_signoz_query_links(
+            signoz_url=args.signoz_url,
+            service_name=args.service_name,
+            deployment_environment=args.deployment_environment,
+            service_version=args.service_version,
+            github_run_id=args.github_run_id,
+        )
+        if args.signoz_url and args.deployment_environment and args.service_version
+        else {}
+    )
 
     if not args.compose_id or not args.api_url or not args.api_key:
         # Missing inputs must not fail the calling job; emit a clear marker.
@@ -137,12 +218,20 @@ def main(argv: list[str] | None = None) -> int:
                 {
                     "platform_failure_domain": "snapshot-skipped-missing-inputs",
                     "compose_id": args.compose_id or "",
+                    **platform_health,
+                    **signoz_links,
                 }
             )
         )
         return 0
 
-    snapshot = build_snapshot(args.api_url, args.api_key, args.compose_id)
+    snapshot = build_snapshot(
+        args.api_url,
+        args.api_key,
+        args.compose_id,
+        platform_health=platform_health,
+        signoz_links=signoz_links,
+    )
     print(json.dumps(snapshot, indent=2, sort_keys=True))
     if args.markdown:
         print(render_markdown(snapshot))

--- a/tools/dokploy_failure_snapshot.py
+++ b/tools/dokploy_failure_snapshot.py
@@ -207,7 +207,10 @@ def main(argv: list[str] | None = None) -> int:
             service_version=args.service_version,
             github_run_id=args.github_run_id,
         )
-        if args.signoz_url and args.deployment_environment and args.service_version
+        if args.signoz_url
+        and args.deployment_environment
+        and args.service_version
+        and args.github_run_id
         else {}
     )
 


### PR DESCRIPTION
## Summary
- Add non-secret platform health fields to Dokploy failure snapshots.
- Add run-to-SigNoz log and trace query links to staging/production deploy contexts.
- Register AC10.9.5 and update observability SSOT.

## Issue
- Part of #1073
- Refs #768
- Refs #621

## Validation
- `uv run --project apps/backend python -m pytest tests/tooling/test_dokploy_failure_snapshot.py tests/tooling/test_post_merge_e2e_gates.py -q --no-cov` (101 passed)
- `uv run --project apps/backend python tools/generate_ac_registry.py`
- `uv run --project apps/backend python tools/check_ac_index.py`
- `moon run :lint`
- `moon run :test` attempted, blocked locally because Podman machine immediately returns to stopped and Podman socket refuses connection (`dial tcp 127.0.0.1:61270: connect: connection refused`).

## Checklist
- [x] EPIC AC updated
- [x] Tests reference AC10.9.5
- [x] SSOT observability docs updated
- [x] SigNoz links contain service, environment, version, and GitHub run filters
- [x] Platform health input is allowlisted to non-secret fields