### PR TITLE
[finance_report_infra_1105_metrics] Add backend OTEL metrics pillar

### DIFF
--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -62,12 +62,18 @@ from src.schemas.errors import (
 from src.services.market_data_scheduler import run_market_data_scheduler
 from src.services.statement_parsing_supervisor import run_parsing_supervisor
 from src.services.storage_sweep import run_storage_sweep
-from src.telemetry_metrics import configure_otel_metrics, record_http_request
+from src.telemetry_metrics import (
+    configure_database_pool_metrics,
+    configure_otel_metrics,
+    http_route_label_from_scope,
+    record_http_request,
+)
 from src.utils.exceptions import BaseAppException
 
 # Initialize logging early
 configure_logging()
 configure_otel_metrics()
+configure_database_pool_metrics(engine)
 logger = get_logger(__name__)
 
 
@@ -195,7 +201,7 @@ async def logging_middleware(request: Request, call_next: Any) -> Response:
         )
         record_http_request(
             method=request.method,
-            route=request.scope.get("route").path if request.scope.get("route") else request.url.path,
+            route=http_route_label_from_scope(request.scope),
             status_code=response.status_code,
             duration_ms=round(duration * 1000, 2),
         )
@@ -207,7 +213,7 @@ async def logging_middleware(request: Request, call_next: Any) -> Response:
         duration = time.perf_counter() - start_time
         record_http_request(
             method=request.method,
-            route=request.scope.get("route").path if request.scope.get("route") else request.url.path,
+            route=http_route_label_from_scope(request.scope),
             status_code=500,
             duration_ms=round(duration * 1000, 2),
         )

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -62,10 +62,12 @@ from src.schemas.errors import (
 from src.services.market_data_scheduler import run_market_data_scheduler
 from src.services.statement_parsing_supervisor import run_parsing_supervisor
 from src.services.storage_sweep import run_storage_sweep
+from src.telemetry_metrics import configure_otel_metrics, record_http_request
 from src.utils.exceptions import BaseAppException
 
 # Initialize logging early
 configure_logging()
+configure_otel_metrics()
 logger = get_logger(__name__)
 
 
@@ -191,12 +193,24 @@ async def logging_middleware(request: Request, call_next: Any) -> Response:
             status_code=response.status_code,
             duration_ms=round(duration * 1000, 2),
         )
+        record_http_request(
+            method=request.method,
+            route=request.scope.get("route").path if request.scope.get("route") else request.url.path,
+            status_code=response.status_code,
+            duration_ms=round(duration * 1000, 2),
+        )
 
         # Inject Request-ID into response headers
         response.headers["X-Request-ID"] = request_id
         return response
     except Exception as exc:
         duration = time.perf_counter() - start_time
+        record_http_request(
+            method=request.method,
+            route=request.scope.get("route").path if request.scope.get("route") else request.url.path,
+            status_code=500,
+            duration_ms=round(duration * 1000, 2),
+        )
         logger.exception(
             "HTTP Request Failed",
             duration_ms=round(duration * 1000, 2),

--- a/apps/backend/src/observability.py
+++ b/apps/backend/src/observability.py
@@ -40,11 +40,18 @@ def get_observability_status() -> dict[str, Any]:
     """
     resource_attributes = parse_key_value_pairs(settings.otel_resource_attributes)
     exporter_configured = bool(settings.otel_exporter_otlp_endpoint)
+    try:
+        from src.telemetry_metrics import is_metrics_export_active
+
+        metrics_export_enabled = is_metrics_export_active()
+    except Exception:  # pragma: no cover - defensive import guard
+        metrics_export_enabled = False
 
     return {
         "otel_exporter_configured": exporter_configured,
         "logs_export_enabled": exporter_configured,
         "traces_export_enabled": exporter_configured,
+        "metrics_export_enabled": metrics_export_enabled,
         # Real init state: True only when FastAPI request instrumentation was
         # actually applied to the app instance (not merely configured).
         "request_instrumentation_active": _fastapi_instrumentation_active,

--- a/apps/backend/src/services/statement_flow.py
+++ b/apps/backend/src/services/statement_flow.py
@@ -17,6 +17,7 @@ from src.database import async_session_maker
 from src.logger import get_logger
 from src.services import StorageService
 from src.services.statement_parsing import parse_statement_background
+from src.telemetry_metrics import run_with_async_parse_tracking
 
 logger = get_logger(__name__)
 
@@ -47,16 +48,18 @@ async def parse_statement_flow(
     )
     storage = StorageService()
     content = await run_in_threadpool(storage.get_object, storage_key)
-    await parse_statement_background(
-        statement_id=UUID(statement_id),
-        filename=filename,
-        institution=institution,
-        user_id=UUID(user_id),
-        account_id=UUID(account_id) if account_id else None,
-        file_hash=file_hash,
-        storage_key=storage_key,
-        content=content,
-        model=model,
-        session_maker=async_session_maker,
-        request_id=request_id,
+    await run_with_async_parse_tracking(
+        parse_statement_background(
+            statement_id=UUID(statement_id),
+            filename=filename,
+            institution=institution,
+            user_id=UUID(user_id),
+            account_id=UUID(account_id) if account_id else None,
+            file_hash=file_hash,
+            storage_key=storage_key,
+            content=content,
+            model=model,
+            session_maker=async_session_maker,
+            request_id=request_id,
+        )
     )

--- a/apps/backend/src/services/statement_pipeline.py
+++ b/apps/backend/src/services/statement_pipeline.py
@@ -28,6 +28,7 @@ from src.config import settings
 from src.database import create_session_maker_from_db
 from src.logger import get_logger
 from src.services.statement_parsing import parse_statement_background
+from src.telemetry_metrics import run_with_async_parse_tracking
 
 logger = get_logger(__name__)
 
@@ -89,17 +90,19 @@ async def submit_parse_pipeline(
         return None
 
     return asyncio.create_task(
-        parse_statement_background(
-            statement_id=statement_id,
-            filename=filename,
-            institution=institution,
-            user_id=user_id,
-            account_id=account_id,
-            file_hash=file_hash,
-            storage_key=storage_key,
-            content=content,
-            model=model,
-            session_maker=create_session_maker_from_db(db),
-            request_id=request_id,
+        run_with_async_parse_tracking(
+            parse_statement_background(
+                statement_id=statement_id,
+                filename=filename,
+                institution=institution,
+                user_id=user_id,
+                account_id=account_id,
+                file_hash=file_hash,
+                storage_key=storage_key,
+                content=content,
+                model=model,
+                session_maker=create_session_maker_from_db(db),
+                request_id=request_id,
+            )
         )
     )

--- a/apps/backend/src/telemetry_metrics.py
+++ b/apps/backend/src/telemetry_metrics.py
@@ -1,0 +1,231 @@
+"""OpenTelemetry metrics wiring for backend runtime signals."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from src.config import parse_key_value_pairs, settings
+
+_metrics_export_active = False
+_meter: Any | None = None
+_instruments: dict[str, Any] = {}
+_async_parse_in_flight = 0
+_db_pool_observer: Callable[[], dict[str, int]] | None = None
+
+
+def _build_otel_resource() -> Any:
+    from opentelemetry.sdk.resources import Resource
+
+    attributes = {
+        "service.name": settings.otel_service_name,
+        "service.version": settings.git_commit_sha,
+        "git.commit": settings.git_commit_sha,
+    }
+    attributes.update(parse_key_value_pairs(settings.otel_resource_attributes))
+    return Resource.create(attributes)
+
+
+def _build_otlp_metrics_endpoint(endpoint: str) -> str:
+    trimmed = endpoint.rstrip("/")
+    if trimmed.endswith("/v1/metrics"):
+        return trimmed
+    return f"{trimmed}/v1/metrics"
+
+
+def mark_metrics_export_active(active: bool = True) -> None:
+    global _metrics_export_active
+    _metrics_export_active = active
+
+
+def is_metrics_export_active() -> bool:
+    return _metrics_export_active
+
+
+def configure_otel_metrics() -> None:
+    """Configure OTLP metric export when the shared OTEL endpoint is present."""
+    global _meter
+    if not settings.otel_exporter_otlp_endpoint:
+        mark_metrics_export_active(False)
+        return
+
+    try:
+        from opentelemetry import metrics
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    except Exception:  # pragma: no cover - defensive import guard
+        logging.getLogger(__name__).warning(
+            "OTEL metric exporter not available",
+            exc_info=True,
+        )
+        mark_metrics_export_active(False)
+        return
+
+    exporter = OTLPMetricExporter(endpoint=_build_otlp_metrics_endpoint(settings.otel_exporter_otlp_endpoint))
+    reader = PeriodicExportingMetricReader(exporter)
+    provider = MeterProvider(resource=_build_otel_resource(), metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+    _meter = metrics.get_meter("finance-report-backend")
+    _create_instruments(_meter)
+    mark_metrics_export_active(True)
+
+
+def _create_instruments(meter: Any) -> None:
+    _instruments["http_request_count"] = meter.create_counter(
+        "http.server.request.count",
+        unit="1",
+        description="HTTP requests handled by route and status class.",
+    )
+    _instruments["http_request_duration"] = meter.create_histogram(
+        "http.server.request.duration",
+        unit="ms",
+        description="HTTP request duration in milliseconds.",
+    )
+    _instruments["statement_parse_outcome"] = meter.create_counter(
+        "finance.statement_parse.outcome",
+        unit="1",
+        description="Statement parse outcomes.",
+    )
+    _instruments["ai_provider_latency"] = meter.create_histogram(
+        "finance.ai_provider.latency",
+        unit="ms",
+        description="AI provider call latency by model and outcome.",
+    )
+    _instruments["reconciliation_match_outcome"] = meter.create_counter(
+        "finance.reconciliation.match.outcome",
+        unit="1",
+        description="Reconciliation match outcomes.",
+    )
+    _instruments["confidence_north_star"] = meter.create_histogram(
+        "finance.confidence_north_star",
+        unit="1",
+        description="Confidence north-star score observations.",
+    )
+    meter.create_observable_gauge(
+        "finance.async_parse.in_flight",
+        callbacks=[_observe_async_parse_in_flight],
+        unit="1",
+        description="In-flight async statement parse tasks.",
+    )
+    meter.create_observable_gauge(
+        "db.pool.size",
+        callbacks=[_observe_db_pool_size],
+        unit="1",
+        description="SQLAlchemy DB pool size.",
+    )
+    meter.create_observable_gauge(
+        "db.pool.checkedout",
+        callbacks=[_observe_db_pool_checkedout],
+        unit="1",
+        description="SQLAlchemy DB pool checked-out connections.",
+    )
+    meter.create_observable_gauge(
+        "db.pool.overflow",
+        callbacks=[_observe_db_pool_overflow],
+        unit="1",
+        description="SQLAlchemy DB pool overflow connections.",
+    )
+
+
+def _observation(value: int | float, attributes: dict[str, str] | None = None) -> Any:
+    try:
+        from opentelemetry.metrics import Observation
+
+        return Observation(value, attributes or {})
+    except Exception:  # pragma: no cover - used only when tests use simple callbacks
+        return (value, attributes or {})
+
+
+def _observe_async_parse_in_flight(_options: object | None = None) -> list[Any]:
+    return [_observation(_async_parse_in_flight)]
+
+
+def set_async_parse_in_flight(count: int) -> None:
+    global _async_parse_in_flight
+    _async_parse_in_flight = max(0, count)
+
+
+def set_db_pool_observer(observer: Callable[[], dict[str, int]] | None) -> None:
+    global _db_pool_observer
+    _db_pool_observer = observer
+
+
+def _db_pool_values() -> dict[str, int]:
+    if _db_pool_observer is not None:
+        return _db_pool_observer()
+    return {"size": 0, "checkedout": 0, "overflow": 0}
+
+
+def _observe_db_pool_size(_options: object | None = None) -> list[Any]:
+    return [_observation(_db_pool_values().get("size", 0))]
+
+
+def _observe_db_pool_checkedout(_options: object | None = None) -> list[Any]:
+    return [_observation(_db_pool_values().get("checkedout", 0))]
+
+
+def _observe_db_pool_overflow(_options: object | None = None) -> list[Any]:
+    return [_observation(_db_pool_values().get("overflow", 0))]
+
+
+def _status_class(status_code: int) -> str:
+    if status_code < 100:
+        return "unknown"
+    return f"{status_code // 100}xx"
+
+
+def record_http_request(
+    *,
+    method: str,
+    route: str,
+    status_code: int,
+    duration_ms: float,
+) -> None:
+    attributes = {
+        "http.request.method": method,
+        "http.route": route,
+        "http.response.status_code_class": _status_class(status_code),
+    }
+    counter = _instruments.get("http_request_count")
+    histogram = _instruments.get("http_request_duration")
+    if counter is not None:
+        counter.add(1, attributes)
+    if histogram is not None:
+        histogram.record(duration_ms, attributes)
+
+
+def record_statement_parse_outcome(*, outcome: str, parser: str = "default") -> None:
+    counter = _instruments.get("statement_parse_outcome")
+    if counter is not None:
+        counter.add(1, {"outcome": outcome, "parser": parser})
+
+
+def record_ai_provider_call(
+    *,
+    provider: str,
+    model: str,
+    outcome: str,
+    duration_ms: float,
+) -> None:
+    histogram = _instruments.get("ai_provider_latency")
+    if histogram is not None:
+        histogram.record(
+            duration_ms,
+            {"provider": provider, "model": model, "outcome": outcome},
+        )
+
+
+def record_reconciliation_match_outcome(*, outcome: str) -> None:
+    counter = _instruments.get("reconciliation_match_outcome")
+    if counter is not None:
+        counter.add(1, {"outcome": outcome})
+
+
+def record_confidence_north_star(*, score: float, source: str = "scheduled") -> None:
+    histogram = _instruments.get("confidence_north_star")
+    if histogram is not None:
+        histogram.record(score, {"source": source})

--- a/apps/backend/src/telemetry_metrics.py
+++ b/apps/backend/src/telemetry_metrics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from src.config import parse_key_value_pairs, settings
@@ -39,6 +39,13 @@ def mark_metrics_export_active(active: bool = True) -> None:
     _metrics_export_active = active
 
 
+def _clear_metrics_state() -> None:
+    global _meter
+    _meter = None
+    _instruments.clear()
+    mark_metrics_export_active(False)
+
+
 def is_metrics_export_active() -> bool:
     return _metrics_export_active
 
@@ -47,7 +54,7 @@ def configure_otel_metrics() -> None:
     """Configure OTLP metric export when the shared OTEL endpoint is present."""
     global _meter
     if not settings.otel_exporter_otlp_endpoint:
-        mark_metrics_export_active(False)
+        _clear_metrics_state()
         return
 
     try:
@@ -62,7 +69,7 @@ def configure_otel_metrics() -> None:
             "OTEL metric exporter not available",
             exc_info=True,
         )
-        mark_metrics_export_active(False)
+        _clear_metrics_state()
         return
 
     exporter = OTLPMetricExporter(endpoint=_build_otlp_metrics_endpoint(settings.otel_exporter_otlp_endpoint))
@@ -72,6 +79,15 @@ def configure_otel_metrics() -> None:
     _meter = metrics.get_meter("finance-report-backend")
     _create_instruments(_meter)
     mark_metrics_export_active(True)
+
+
+def http_route_label_from_scope(scope: dict[str, Any]) -> str:
+    """Return a low-cardinality route label for FastAPI/Starlette request scopes."""
+    route = scope.get("route")
+    route_path = getattr(route, "path", None)
+    if isinstance(route_path, str) and route_path:
+        return route_path
+    return "__unmatched__"
 
 
 def _create_instruments(meter: Any) -> None:
@@ -149,9 +165,48 @@ def set_async_parse_in_flight(count: int) -> None:
     _async_parse_in_flight = max(0, count)
 
 
+def increment_async_parse_in_flight(delta: int = 1) -> None:
+    set_async_parse_in_flight(_async_parse_in_flight + delta)
+
+
+async def run_with_async_parse_tracking(awaitable: Awaitable[None]) -> None:
+    """Track one in-process async statement parse until it completes or fails."""
+    increment_async_parse_in_flight(1)
+    try:
+        await awaitable
+    finally:
+        increment_async_parse_in_flight(-1)
+
+
 def set_db_pool_observer(observer: Callable[[], dict[str, int]] | None) -> None:
     global _db_pool_observer
     _db_pool_observer = observer
+
+
+def configure_database_pool_metrics(async_engine: Any) -> None:
+    """Wire DB pool gauges to a SQLAlchemy engine when pool stats are available."""
+    sync_engine = getattr(async_engine, "sync_engine", async_engine)
+    pool = getattr(sync_engine, "pool", None)
+    if pool is None:
+        set_db_pool_observer(None)
+        return
+
+    set_db_pool_observer(
+        lambda: {
+            "size": _pool_stat(pool, "size"),
+            "checkedout": _pool_stat(pool, "checkedout"),
+            "overflow": _pool_stat(pool, "overflow"),
+        }
+    )
+
+
+def _pool_stat(pool: Any, name: str) -> int:
+    value = getattr(pool, name, 0)
+    try:
+        resolved = value() if callable(value) else value
+        return max(0, int(resolved or 0))
+    except Exception:
+        return 0
 
 
 def _db_pool_values() -> dict[str, int]:

--- a/apps/backend/tests/infra/test_observability_contract.py
+++ b/apps/backend/tests/infra/test_observability_contract.py
@@ -10,7 +10,11 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from pydantic import ValidationError
 
-from src import logger as logger_module, observability as observability_module
+from src import (
+    logger as logger_module,
+    observability as observability_module,
+    telemetry_metrics as telemetry_metrics_module,
+)
 from src.config import Settings
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -181,12 +185,14 @@ def test_AC10_9_1_observability_status_is_redacted_and_alert_ready(monkeypatch) 
         "deployment.environment=production,team=finance-report",
     )
     monkeypatch.setattr(observability_module.settings, "environment", "production")
+    telemetry_metrics_module.mark_metrics_export_active(False)
 
     status = observability_module.get_observability_status()
 
     assert status["otel_exporter_configured"] is True
     assert status["logs_export_enabled"] is True
     assert status["traces_export_enabled"] is True
+    assert status["metrics_export_enabled"] is False
     assert status["service_name"] == "finance-report-backend"
     assert status["deployment_environment"] == "production"
     assert status["resource_attributes"] == {
@@ -206,6 +212,7 @@ def test_AC10_9_2_observability_startup_log_uses_runtime_contract(monkeypatch) -
     monkeypatch.setattr(observability_module.settings, "otel_service_name", "finance-report-backend")
     monkeypatch.setattr(observability_module.settings, "otel_resource_attributes", None)
     monkeypatch.setattr(observability_module.settings, "environment", "staging")
+    telemetry_metrics_module.mark_metrics_export_active(False)
     mock_logger = Mock()
 
     observability_module.log_observability_startup(mock_logger)
@@ -215,6 +222,7 @@ def test_AC10_9_2_observability_startup_log_uses_runtime_contract(monkeypatch) -
     fields = mock_logger.info.call_args.kwargs
     assert event == "Observability runtime configured"
     assert fields["otel_exporter_configured"] is False
+    assert fields["metrics_export_enabled"] is False
     assert fields["deployment_environment"] == "staging"
     assert fields["alert_rule_name"] == "FinanceReportBackendErrorLogs"
     assert "otel_exporter_otlp_endpoint" not in fields

--- a/apps/backend/tests/infra/test_telemetry_metrics.py
+++ b/apps/backend/tests/infra/test_telemetry_metrics.py
@@ -1,0 +1,217 @@
+"""OTEL metrics contract tests for EPIC-010."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from src import telemetry_metrics
+
+pytestmark = pytest.mark.no_db
+
+
+class FakeInstrument:
+    def __init__(self) -> None:
+        self.add_calls: list[tuple[int, dict[str, str]]] = []
+        self.record_calls: list[tuple[float, dict[str, str]]] = []
+
+    def add(self, value: int, attributes: dict[str, str]) -> None:
+        self.add_calls.append((value, attributes))
+
+    def record(self, value: float, attributes: dict[str, str]) -> None:
+        self.record_calls.append((value, attributes))
+
+
+class FakeMeter:
+    def __init__(self) -> None:
+        self.counters: dict[str, FakeInstrument] = {}
+        self.histograms: dict[str, FakeInstrument] = {}
+        self.gauges: dict[str, object] = {}
+
+    def create_counter(self, name: str, **_kwargs: object) -> FakeInstrument:
+        instrument = FakeInstrument()
+        self.counters[name] = instrument
+        return instrument
+
+    def create_histogram(self, name: str, **_kwargs: object) -> FakeInstrument:
+        instrument = FakeInstrument()
+        self.histograms[name] = instrument
+        return instrument
+
+    def create_observable_gauge(self, name: str, **kwargs: object) -> None:
+        self.gauges[name] = kwargs["callbacks"]
+
+
+def install_fake_otel(monkeypatch: pytest.MonkeyPatch) -> FakeMeter:
+    meter = FakeMeter()
+
+    class FakeResource:
+        @staticmethod
+        def create(attributes: dict[str, str]) -> types.SimpleNamespace:
+            return types.SimpleNamespace(attributes=attributes)
+
+    class FakeExporter:
+        def __init__(self, endpoint: str) -> None:
+            self.endpoint = endpoint
+
+    class FakeReader:
+        def __init__(self, exporter: FakeExporter) -> None:
+            self.exporter = exporter
+
+    class FakeProvider:
+        def __init__(self, resource: object, metric_readers: list[FakeReader]) -> None:
+            self.resource = resource
+            self.metric_readers = metric_readers
+
+    def make_module(name: str, is_pkg: bool = False) -> types.ModuleType:
+        module = types.ModuleType(name)
+        if is_pkg:
+            module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+        return module
+
+    opentelemetry = make_module("opentelemetry", is_pkg=True)
+    metrics = make_module("opentelemetry.metrics")
+    metrics.get_meter = lambda _name: meter
+    metrics.set_meter_provider = lambda _provider: None
+    metrics.Observation = lambda value, attributes=None: (value, attributes or {})
+
+    exporter = make_module("opentelemetry.exporter", is_pkg=True)
+    otlp = make_module("opentelemetry.exporter.otlp", is_pkg=True)
+    proto = make_module("opentelemetry.exporter.otlp.proto", is_pkg=True)
+    http = make_module("opentelemetry.exporter.otlp.proto.http", is_pkg=True)
+    metric_exporter = make_module("opentelemetry.exporter.otlp.proto.http.metric_exporter")
+    metric_exporter.OTLPMetricExporter = FakeExporter
+
+    sdk = make_module("opentelemetry.sdk", is_pkg=True)
+    sdk_metrics = make_module("opentelemetry.sdk.metrics")
+    sdk_metrics.MeterProvider = FakeProvider
+    sdk_metrics_export = make_module("opentelemetry.sdk.metrics.export")
+    sdk_metrics_export.PeriodicExportingMetricReader = FakeReader
+    sdk_resources = make_module("opentelemetry.sdk.resources")
+    sdk_resources.Resource = FakeResource
+
+    opentelemetry.metrics = metrics
+    opentelemetry.exporter = exporter
+    exporter.otlp = otlp
+    otlp.proto = proto
+    proto.http = http
+    http.metric_exporter = metric_exporter
+    opentelemetry.sdk = sdk
+    sdk.metrics = sdk_metrics
+    sdk.resources = sdk_resources
+    sdk_metrics.export = sdk_metrics_export
+    return meter
+
+
+def test_AC10_10_1_configure_metrics_is_noop_without_endpoint(monkeypatch) -> None:
+    """AC10.10.1: metrics export is disabled when OTEL endpoint is absent."""
+    monkeypatch.setattr(telemetry_metrics.settings, "otel_exporter_otlp_endpoint", None)
+    telemetry_metrics.mark_metrics_export_active(True)
+
+    telemetry_metrics.configure_otel_metrics()
+
+    assert telemetry_metrics.is_metrics_export_active() is False
+
+
+def test_AC10_10_1_configure_metrics_creates_otlp_provider(monkeypatch) -> None:
+    """AC10.10.1: MeterProvider and OTLP exporter use the shared endpoint."""
+    meter = install_fake_otel(monkeypatch)
+    monkeypatch.setattr(
+        telemetry_metrics.settings,
+        "otel_exporter_otlp_endpoint",
+        "http://collector:4318",
+    )
+    monkeypatch.setattr(telemetry_metrics.settings, "otel_service_name", "finance-report-backend")
+    monkeypatch.setattr(
+        telemetry_metrics.settings,
+        "otel_resource_attributes",
+        "deployment.environment=staging",
+    )
+
+    telemetry_metrics.configure_otel_metrics()
+
+    assert telemetry_metrics.is_metrics_export_active() is True
+    assert "http.server.request.count" in meter.counters
+    assert "http.server.request.duration" in meter.histograms
+    assert "db.pool.size" in meter.gauges
+    assert "finance.async_parse.in_flight" in meter.gauges
+
+
+def test_AC10_10_2_red_metrics_record_low_cardinality_labels(monkeypatch) -> None:
+    """AC10.10.2: HTTP RED metrics record route and status class."""
+    meter = install_fake_otel(monkeypatch)
+    monkeypatch.setattr(
+        telemetry_metrics.settings,
+        "otel_exporter_otlp_endpoint",
+        "http://collector:4318",
+    )
+    telemetry_metrics.configure_otel_metrics()
+
+    telemetry_metrics.record_http_request(
+        method="GET",
+        route="/api/health",
+        status_code=200,
+        duration_ms=12.5,
+    )
+
+    counter = meter.counters["http.server.request.count"]
+    histogram = meter.histograms["http.server.request.duration"]
+    assert counter.add_calls == [
+        (
+            1,
+            {
+                "http.request.method": "GET",
+                "http.route": "/api/health",
+                "http.response.status_code_class": "2xx",
+            },
+        )
+    ]
+    assert histogram.record_calls[0][0] == 12.5
+
+
+def test_AC10_10_3_saturation_gauges_observe_current_values(monkeypatch) -> None:
+    """AC10.10.3: async and DB pool gauges expose current saturation values."""
+    install_fake_otel(monkeypatch)
+    telemetry_metrics.set_async_parse_in_flight(3)
+    telemetry_metrics.set_db_pool_observer(lambda: {"size": 5, "checkedout": 2, "overflow": 1})
+
+    assert telemetry_metrics._observe_async_parse_in_flight() == [(3, {})]
+    assert telemetry_metrics._observe_db_pool_size() == [(5, {})]
+    assert telemetry_metrics._observe_db_pool_checkedout() == [(2, {})]
+    assert telemetry_metrics._observe_db_pool_overflow() == [(1, {})]
+
+    telemetry_metrics.set_db_pool_observer(None)
+
+
+def test_AC10_10_4_business_metric_helpers_record_outcomes(monkeypatch) -> None:
+    """AC10.10.4: parse, AI, reconciliation, and confidence helpers record metrics."""
+    meter = install_fake_otel(monkeypatch)
+    monkeypatch.setattr(
+        telemetry_metrics.settings,
+        "otel_exporter_otlp_endpoint",
+        "http://collector:4318",
+    )
+    telemetry_metrics.configure_otel_metrics()
+
+    telemetry_metrics.record_statement_parse_outcome(outcome="success", parser="csv")
+    telemetry_metrics.record_ai_provider_call(
+        provider="openrouter",
+        model="glm-5.1",
+        outcome="success",
+        duration_ms=321.0,
+    )
+    telemetry_metrics.record_reconciliation_match_outcome(outcome="accepted")
+    telemetry_metrics.record_confidence_north_star(score=0.98, source="scheduled")
+
+    assert meter.counters["finance.statement_parse.outcome"].add_calls == [(1, {"outcome": "success", "parser": "csv"})]
+    assert meter.histograms["finance.ai_provider.latency"].record_calls == [
+        (
+            321.0,
+            {"provider": "openrouter", "model": "glm-5.1", "outcome": "success"},
+        )
+    ]
+    assert meter.counters["finance.reconciliation.match.outcome"].add_calls == [(1, {"outcome": "accepted"})]
+    assert meter.histograms["finance.confidence_north_star"].record_calls == [(0.98, {"source": "scheduled"})]

--- a/apps/backend/tests/infra/test_telemetry_metrics.py
+++ b/apps/backend/tests/infra/test_telemetry_metrics.py
@@ -2,14 +2,28 @@
 
 from __future__ import annotations
 
+import builtins
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
 from src import telemetry_metrics
 
 pytestmark = pytest.mark.no_db
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics_state():
+    telemetry_metrics._clear_metrics_state()
+    telemetry_metrics.set_async_parse_in_flight(0)
+    telemetry_metrics.set_db_pool_observer(None)
+    yield
+    telemetry_metrics._clear_metrics_state()
+    telemetry_metrics.set_async_parse_in_flight(0)
+    telemetry_metrics.set_db_pool_observer(None)
 
 
 class FakeInstrument:
@@ -106,6 +120,10 @@ def install_fake_otel(monkeypatch: pytest.MonkeyPatch) -> FakeMeter:
     return meter
 
 
+def observation_values(observations: list[object]) -> list[object]:
+    return [item[0] if isinstance(item, tuple) else getattr(item, "value") for item in observations]
+
+
 def test_AC10_10_1_configure_metrics_is_noop_without_endpoint(monkeypatch) -> None:
     """AC10.10.1: metrics export is disabled when OTEL endpoint is absent."""
     monkeypatch.setattr(telemetry_metrics.settings, "otel_exporter_otlp_endpoint", None)
@@ -114,6 +132,7 @@ def test_AC10_10_1_configure_metrics_is_noop_without_endpoint(monkeypatch) -> No
     telemetry_metrics.configure_otel_metrics()
 
     assert telemetry_metrics.is_metrics_export_active() is False
+    assert telemetry_metrics._instruments == {}
 
 
 def test_AC10_10_1_configure_metrics_creates_otlp_provider(monkeypatch) -> None:
@@ -138,6 +157,62 @@ def test_AC10_10_1_configure_metrics_creates_otlp_provider(monkeypatch) -> None:
     assert "http.server.request.duration" in meter.histograms
     assert "db.pool.size" in meter.gauges
     assert "finance.async_parse.in_flight" in meter.gauges
+
+
+def test_AC10_10_1_reconfigure_failure_clears_stale_instruments(monkeypatch) -> None:
+    """AC10.10.1: disabled or failed reconfiguration does not keep stale instruments."""
+    meter = install_fake_otel(monkeypatch)
+    monkeypatch.setattr(
+        telemetry_metrics.settings,
+        "otel_exporter_otlp_endpoint",
+        "http://collector:4318",
+    )
+    telemetry_metrics.configure_otel_metrics()
+    telemetry_metrics.record_http_request(
+        method="GET",
+        route="/api/health",
+        status_code=200,
+        duration_ms=1.0,
+    )
+    assert meter.counters["http.server.request.count"].add_calls
+
+    monkeypatch.setattr(telemetry_metrics.settings, "otel_exporter_otlp_endpoint", None)
+    telemetry_metrics.configure_otel_metrics()
+    telemetry_metrics.record_http_request(
+        method="GET",
+        route="/api/health",
+        status_code=200,
+        duration_ms=1.0,
+    )
+
+    assert telemetry_metrics.is_metrics_export_active() is False
+    assert telemetry_metrics._instruments == {}
+    assert len(meter.counters["http.server.request.count"].add_calls) == 1
+
+
+def test_AC10_10_1_import_failure_clears_stale_instruments(monkeypatch) -> None:
+    """AC10.10.1: importer failures also clear stale metric instruments."""
+    install_fake_otel(monkeypatch)
+    monkeypatch.setattr(
+        telemetry_metrics.settings,
+        "otel_exporter_otlp_endpoint",
+        "http://collector:4318",
+    )
+    telemetry_metrics.configure_otel_metrics()
+    assert telemetry_metrics._instruments
+
+    real_import = builtins.__import__
+
+    def fail_metric_exporter_import(name, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        if name == "opentelemetry.exporter.otlp.proto.http.metric_exporter":
+            raise ImportError("blocked")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_metric_exporter_import)
+    telemetry_metrics.configure_otel_metrics()
+
+    assert telemetry_metrics.is_metrics_export_active() is False
+    assert telemetry_metrics._instruments == {}
 
 
 def test_AC10_10_2_red_metrics_record_low_cardinality_labels(monkeypatch) -> None:
@@ -172,6 +247,15 @@ def test_AC10_10_2_red_metrics_record_low_cardinality_labels(monkeypatch) -> Non
     assert histogram.record_calls[0][0] == 12.5
 
 
+def test_AC10_10_2_unmatched_routes_use_low_cardinality_fallback() -> None:
+    """AC10.10.2: unmatched request paths do not become raw http.route labels."""
+    route = types.SimpleNamespace(path="/api/accounts/{account_id}")
+
+    assert telemetry_metrics.http_route_label_from_scope({"route": route}) == "/api/accounts/{account_id}"
+    assert telemetry_metrics.http_route_label_from_scope({"route": None}) == "__unmatched__"
+    assert telemetry_metrics.http_route_label_from_scope({}) == "__unmatched__"
+
+
 def test_AC10_10_3_saturation_gauges_observe_current_values(monkeypatch) -> None:
     """AC10.10.3: async and DB pool gauges expose current saturation values."""
     install_fake_otel(monkeypatch)
@@ -184,6 +268,52 @@ def test_AC10_10_3_saturation_gauges_observe_current_values(monkeypatch) -> None
     assert telemetry_metrics._observe_db_pool_overflow() == [(1, {})]
 
     telemetry_metrics.set_db_pool_observer(None)
+
+
+def test_AC10_10_3_db_pool_gauges_bind_to_sqlalchemy_engine() -> None:
+    """AC10.10.3: DB pool gauges read the runtime SQLAlchemy pool."""
+
+    class Pool:
+        def size(self) -> int:
+            return 7
+
+        def checkedout(self) -> int:
+            return 3
+
+        def overflow(self) -> int:
+            return 1
+
+    engine = types.SimpleNamespace(sync_engine=types.SimpleNamespace(pool=Pool()))
+
+    telemetry_metrics.configure_database_pool_metrics(engine)
+
+    assert observation_values(telemetry_metrics._observe_db_pool_size()) == [7]
+    assert observation_values(telemetry_metrics._observe_db_pool_checkedout()) == [3]
+    assert observation_values(telemetry_metrics._observe_db_pool_overflow()) == [1]
+
+
+async def test_AC10_10_3_async_parse_tracking_increments_until_done() -> None:
+    """AC10.10.3: async parse in-flight gauge follows the task lifecycle."""
+    observed: list[list[object]] = []
+
+    async def parse_work() -> None:
+        observed.append(observation_values(telemetry_metrics._observe_async_parse_in_flight()))
+
+    await telemetry_metrics.run_with_async_parse_tracking(parse_work())
+
+    assert observed == [[1]]
+    assert observation_values(telemetry_metrics._observe_async_parse_in_flight()) == [0]
+
+
+def test_AC10_10_3_async_parse_tracking_has_runtime_call_sites() -> None:
+    """AC10.10.3: async parse tracking is wired outside tests."""
+    pipeline = (REPO_ROOT / "apps" / "backend" / "src" / "services" / "statement_pipeline.py").read_text(
+        encoding="utf-8"
+    )
+    flow = (REPO_ROOT / "apps" / "backend" / "src" / "services" / "statement_flow.py").read_text(encoding="utf-8")
+
+    assert "run_with_async_parse_tracking" in pipeline
+    assert "run_with_async_parse_tracking" in flow
 
 
 def test_AC10_10_4_business_metric_helpers_record_outcomes(monkeypatch) -> None:

--- a/docs/project/EPIC-010.signoz-logging.md
+++ b/docs/project/EPIC-010.signoz-logging.md
@@ -170,6 +170,15 @@ Enable production-grade log observability via SigNoz (OTLP), while keeping local
 | AC10.9.3 | `/health` includes the same redacted observability status so deploy checks can prove app-side alert readiness | `test_AC10_9_3_health_response_includes_redacted_observability_status()` | `infra/test_observability_contract.py` | P0 |
 | AC10.9.4 | Finance Report docs declare the app-owned alerting contract while infra2 remains the shared SigNoz/Lark automation owner | `test_AC10_9_4_observability_docs_declare_shared_alerting_pipeline()` | `infra/test_observability_contract.py` | P0 |
 
+### AC10.10: Backend OTEL Metrics Pillar
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC10.10.1 | MeterProvider and OTLP metric exporter are endpoint-gated and no-op safe when unset | `test_AC10_10_1_configure_metrics_is_noop_without_endpoint()`, `test_AC10_10_1_configure_metrics_creates_otlp_provider()` | `infra/test_telemetry_metrics.py` | P0 |
+| AC10.10.2 | RED request-count and request-duration metrics use low-cardinality route/status labels | `test_AC10_10_2_red_metrics_record_low_cardinality_labels()` | `infra/test_telemetry_metrics.py` | P0 |
+| AC10.10.3 | DB pool and async parse in-flight gauges expose current saturation values | `test_AC10_10_3_saturation_gauges_observe_current_values()` | `infra/test_telemetry_metrics.py` | P0 |
+| AC10.10.4 | Business metric helpers cover parse, AI-provider, reconciliation, and confidence signals | `test_AC10_10_4_business_metric_helpers_record_outcomes()` | `infra/test_telemetry_metrics.py` | P0 |
+
 ## 📏 Acceptance Criteria
 
 > ℹ️ **Non-contiguous AC numbering**: Gaps in `AC10.x.y` numbers reflect deprecated or merged ACs preserved through generated registry indexes plus explicit overrides. Do **not** renumber. New ACs append to the next available index in this EPIC.

--- a/docs/ssot/observability.md
+++ b/docs/ssot/observability.md
@@ -157,6 +157,7 @@ whatever infra2 injects and fast-fails if a required value is absent.
 |----------|--------------|
 | App starts without SigNoz | Run backend with no OTEL vars; logs appear in stdout |
 | Logs export to SigNoz | Set OTEL vars; confirm logs appear in SigNoz UI |
+| Metrics export to SigNoz | Set OTEL vars; RED, saturation, and business metrics use the OTLP metrics exporter |
 | Sensitive data excluded | Review log payloads for keys like `password`, `token` |
 | Environment filtering works | Filter by `deployment.environment=production` in SigNoz |
 | App alert readiness is visible | `/health.observability` and startup logs expose service `finance-report-backend`, rule `FinanceReportBackendErrorLogs`, and no collector/webhook URL |
@@ -175,6 +176,7 @@ Required fields:
 | `otel_exporter_configured` | Whether OTLP export is configured at runtime |
 | `logs_export_enabled` | Whether structured logs should be exported to SigNoz |
 | `traces_export_enabled` | Whether traces should be exported to SigNoz |
+| `metrics_export_enabled` | Whether the OTEL metrics provider/exporter was actually initialized |
 | `service_name` | OTEL service name; production value is `finance-report-backend` |
 | `deployment_environment` | Effective environment from `deployment.environment` or app environment fallback |
 | `resource_attributes` | Parsed non-secret OTEL resource attributes |


### PR DESCRIPTION
## Summary
- Add backend OTLP metrics setup for the shared OTEL endpoint.
- Record HTTP RED metrics, runtime saturation gauges, and finance-domain metric helpers.
- Expose `metrics_export_enabled` in the observability runtime contract and document AC10.10.

## Issue
- Part of #1073
- Refs #1105

## Validation
- `uv run python -m pytest tests/infra/test_telemetry_metrics.py tests/infra/test_observability_contract.py -q --no-cov` (23 passed)
- `uv run --project apps/backend python tools/generate_ac_registry.py`
- `uv run --project apps/backend python tools/check_ac_index.py`
- `moon run :lint`
- `moon run :test` attempted, blocked locally because Podman machine immediately returns to stopped and Podman socket refuses connection (`dial tcp 127.0.0.1:61270: connect: connection refused`).

## Checklist
- [x] EPIC AC updated
- [x] Tests reference AC10.10.x
- [x] SSOT observability docs updated
- [x] Metrics use low-cardinality attributes
- [x] No metric payload includes secrets or raw document data