### PR TITLE
[finance_report_infra_1107_logging] Harden structured observability events

### DIFF
--- a/apps/backend/src/auth.py
+++ b/apps/backend/src/auth.py
@@ -1,5 +1,6 @@
 """Authentication helpers for request-scoped user context."""
 
+from typing import cast
 from uuid import UUID
 
 from fastapi import Depends, HTTPException, Request, status
@@ -8,22 +9,29 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.database import get_db
+from src.logger import get_logger
 from src.models import User
+from src.observability_events import (
+    bind_authenticated_user_context,
+    log_security_warning,
+)
 from src.security import decode_access_token
 
 AUTH_COOKIE_NAME = "finance_access_token"
+logger = get_logger(__name__)
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login", auto_error=False)
 
 
 async def get_current_user_id(
-    request: Request = None,
+    request: Request = cast(Request, None),
     token: str | None = Depends(oauth2_scheme),
     db: AsyncSession = Depends(get_db),
 ) -> UUID:
     """Resolve the current user ID from JWT token."""
     resolved_token = token or (request.cookies.get(AUTH_COOKIE_NAME) if request else None)
     if not resolved_token:
+        log_security_warning(logger, "auth.failure", reason="missing_token")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Not authenticated",
@@ -32,6 +40,7 @@ async def get_current_user_id(
 
     payload = decode_access_token(resolved_token)
     if not payload:
+        log_security_warning(logger, "auth.failure", reason="invalid_token")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not validate credentials",
@@ -40,6 +49,7 @@ async def get_current_user_id(
 
     user_id_str = payload.get("sub")
     if not user_id_str:
+        log_security_warning(logger, "auth.failure", reason="missing_subject")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token missing subject",
@@ -49,6 +59,7 @@ async def get_current_user_id(
     try:
         user_uuid = UUID(user_id_str)
     except ValueError:
+        log_security_warning(logger, "auth.failure", reason="invalid_subject")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid user ID format in token",
@@ -58,10 +69,12 @@ async def get_current_user_id(
     # Performance optimization: verify user existence (optional, but safer)
     result = await db.execute(select(User.id).where(User.id == user_uuid))
     if result.scalar_one_or_none() is None:
+        log_security_warning(logger, "auth.failure", reason="user_not_found", user_id=user_uuid)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    bind_authenticated_user_context(user_uuid)
     return user_uuid

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -28,6 +28,7 @@ from src.observability import (
     log_observability_startup,
     mark_fastapi_instrumentation_active,
 )
+from src.observability_events import log_security_warning
 from src.rate_limit import api_rate_limiter
 from src.routers import (
     accounts,
@@ -67,6 +68,7 @@ from src.telemetry_metrics import (
     configure_otel_metrics,
     http_route_label_from_scope,
     record_http_request,
+    record_rate_limit_rejected,
 )
 from src.utils.exceptions import BaseAppException
 
@@ -251,10 +253,26 @@ async def global_rate_limit_middleware(request: Request, call_next: Any) -> Resp
     client_ip = request.client.host if request.client else "unknown"
     allowed, retry_after = api_rate_limiter.is_allowed(client_ip)
     if not allowed:
+        request_id = request.headers.get("X-Request-ID", str(uuid4()))
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            request_id=request_id,
+            method=request.method,
+            path=path,
+        )
+        record_rate_limit_rejected(scope="global_api")
+        log_security_warning(
+            logger,
+            "rate_limit.rejected",
+            reason="global_api_rate_limit",
+            client_ip=client_ip,
+            path=path,
+            retry_after=retry_after,
+        )
         return JSONResponse(
             status_code=429,
             content={"detail": "Rate limit exceeded. Please try again later."},
-            headers={"Retry-After": str(retry_after)},
+            headers={"Retry-After": str(retry_after), "X-Request-ID": request_id},
         )
     return await call_next(request)
 

--- a/apps/backend/src/observability_events.py
+++ b/apps/backend/src/observability_events.py
@@ -1,0 +1,125 @@
+"""Structured observability event helpers for audit and security logs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+import structlog
+
+from src.services.pii_redaction import detect_pii
+
+RISKY_LOG_FIELD_NAMES = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "cookies",
+        "api_key",
+        "token",
+        "secret",
+        "password",
+        "prompt",
+        "raw_prompt",
+        "raw_response",
+        "response_body",
+        "error_body",
+        "provider_body",
+        "provider_response",
+    }
+)
+MAX_SAFE_ERROR_CHARS = 300
+
+
+def _redact_detected_pii(text: str) -> str:
+    matches = detect_pii(text)
+    if not matches:
+        return text
+
+    redacted = text
+    for match in sorted(matches, key=lambda item: item.start, reverse=True):
+        label = f"[{match.pii_type.value.upper()}]"
+        redacted = redacted[: match.start] + label + redacted[match.end :]
+    return redacted
+
+
+def bind_authenticated_user_context(user_id: UUID | str) -> None:
+    """Bind the authenticated user id into structlog contextvars."""
+    structlog.contextvars.bind_contextvars(user_id=str(user_id))
+
+
+def current_request_id() -> str | None:
+    value = structlog.contextvars.get_contextvars().get("request_id")
+    return str(value) if value else None
+
+
+def safe_error_message(message: object, *, limit: int = MAX_SAFE_ERROR_CHARS) -> str:
+    """Return a one-line bounded error summary that is safe for logs."""
+    text = _redact_detected_pii(" ".join(str(message).split()))
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def safe_log_fields(fields: Mapping[str, Any]) -> dict[str, Any]:
+    """Return log fields with risky raw body/secret keys redacted."""
+    safe: dict[str, Any] = {}
+    for key, value in fields.items():
+        normalized = key.lower()
+        if normalized in RISKY_LOG_FIELD_NAMES:
+            safe[key] = "[REDACTED]"
+        elif isinstance(value, Mapping):
+            safe[key] = safe_log_fields(value)
+        else:
+            safe[key] = value
+    return safe
+
+
+def log_financial_mutation(
+    logger: Any,
+    event: str,
+    *,
+    user_id: UUID | str,
+    action: str,
+    resource_type: str,
+    resource_id: UUID | str,
+    **fields: Any,
+) -> None:
+    """Emit one financial mutation audit event with stable common fields."""
+    logger.info(
+        event,
+        **safe_log_fields(
+            {
+                "audit_event": event,
+                "user_id": str(user_id),
+                "request_id": current_request_id(),
+                "action": action,
+                "resource_type": resource_type,
+                "resource_id": str(resource_id),
+                **fields,
+            }
+        ),
+    )
+
+
+def log_security_warning(
+    logger: Any,
+    event: str,
+    *,
+    reason: str,
+    user_id: UUID | str | None = None,
+    client_ip: str | None = None,
+    **fields: Any,
+) -> None:
+    """Emit one security-relevant warning without raw credentials or payloads."""
+    payload: dict[str, Any] = {
+        "audit_event": event,
+        "request_id": current_request_id(),
+        "reason": reason,
+    }
+    if user_id is not None:
+        payload["user_id"] = str(user_id)
+    if client_ip is not None:
+        payload["client_ip"] = client_ip
+    payload.update(fields)
+    logger.warning(event, **safe_log_fields(payload))

--- a/apps/backend/src/routers/auth.py
+++ b/apps/backend/src/routers/auth.py
@@ -12,9 +12,11 @@ from src.config import settings
 from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
 from src.models import User
+from src.observability_events import bind_authenticated_user_context, log_security_warning
 from src.rate_limit import RateLimiter, auth_rate_limiter, register_rate_limiter
 from src.schemas.auth import AuthResponse, LoginRequest, RegisterRequest
 from src.security import create_access_token
+from src.telemetry_metrics import record_rate_limit_rejected
 from src.utils import raise_bad_request, raise_not_found, raise_too_many_requests, raise_unauthorized
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -47,6 +49,15 @@ def _check_rate_limit(request: Request, limiter: RateLimiter, error_msg: str) ->
     client_ip = _get_client_ip(request)
     allowed, retry_after = limiter.is_allowed(client_ip)
     if not allowed:
+        record_rate_limit_rejected(scope="auth_route")
+        log_security_warning(
+            logger,
+            "rate_limit.rejected",
+            reason="auth_route_rate_limit",
+            client_ip=client_ip,
+            path=request.url.path,
+            retry_after=retry_after,
+        )
         raise_too_many_requests(error_msg, retry_after=retry_after)
 
 
@@ -152,12 +163,15 @@ async def login(
     user = result.scalar_one_or_none()
 
     if not user or not verify_password(data.password, user.hashed_password):
-        logger.warning(
-            "Failed login attempt",
+        log_security_warning(
+            logger,
+            "auth.failure",
+            reason="invalid_login",
             client_ip=_get_client_ip(request),
         )
         raise_unauthorized("Invalid email or password")
 
+    bind_authenticated_user_context(user.id)
     logger.info(
         "Successful login",
         user_id=str(user.id),

--- a/apps/backend/src/routers/journal.py
+++ b/apps/backend/src/routers/journal.py
@@ -6,7 +6,9 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
 from src.deps import CurrentUserId, DbSession
+from src.logger import get_logger
 from src.models import JournalEntry, JournalEntryStatus
+from src.observability_events import log_financial_mutation
 from src.schemas import (
     JournalEntryCreate,
     JournalEntryListResponse,
@@ -22,6 +24,7 @@ from src.services import (
 from src.utils import raise_bad_request, raise_not_found
 
 router = APIRouter(prefix="/journal-entries", tags=["journal-entries"])
+logger = get_logger(__name__)
 
 
 @router.post("", response_model=JournalEntryResponse, status_code=status.HTTP_201_CREATED)
@@ -118,6 +121,15 @@ async def post_entry(
         entry = await post_journal_entry(db, entry_id, user_id)
         await db.commit()
         await db.refresh(entry, ["lines"])
+        log_financial_mutation(
+            logger,
+            "journal.entry.posted",
+            user_id=user_id,
+            action="post",
+            resource_type="journal_entry",
+            resource_id=entry.id,
+            status=entry.status.value,
+        )
         return JournalEntryResponse.model_validate(entry)
     except ValidationError as e:
         raise_bad_request(str(e), cause=e)
@@ -133,6 +145,16 @@ async def void_entry(
     try:
         reversal_entry = await void_journal_entry(db, entry_id, void_request.reason, user_id)
         await db.commit()
+        log_financial_mutation(
+            logger,
+            "journal.entry.voided",
+            user_id=user_id,
+            action="void",
+            resource_type="journal_entry",
+            resource_id=entry_id,
+            reversal_entry_id=str(reversal_entry.id),
+            reason_length=len(void_request.reason or ""),
+        )
         return JournalEntryResponse.model_validate(reversal_entry)
     except ValidationError as e:
         raise_bad_request(str(e), cause=e)

--- a/apps/backend/src/routers/reconciliation.py
+++ b/apps/backend/src/routers/reconciliation.py
@@ -19,6 +19,7 @@ from src.models import (
     StatementSummary,
 )
 from src.models.layer2 import AtomicTransaction
+from src.observability_events import log_financial_mutation
 from src.schemas.reconciliation import (
     AnomalyResponse,
     BatchAcceptRequest,
@@ -340,6 +341,15 @@ async def accept_match(
             raise_not_found("Match", cause=exc)
         raise_bad_request(str(exc), cause=exc)
     await db.refresh(match, ["atomic_transaction"])
+    log_financial_mutation(
+        logger,
+        "reconciliation.match.accepted",
+        user_id=user_id,
+        action="accept",
+        resource_type="reconciliation_match",
+        resource_id=match.id,
+        status=match.status.value,
+    )
     entry_summaries = await _load_entry_summaries(db, [match], user_id)
     return _build_match_response(
         match,
@@ -380,6 +390,16 @@ async def batch_accept(
 ) -> ReconciliationMatchListResponse:
     matches = await batch_accept_service(db, payload.match_ids, user_id=user_id)
     await db.commit()
+    log_financial_mutation(
+        logger,
+        "reconciliation.match.batch_accepted",
+        user_id=user_id,
+        action="batch_accept",
+        resource_type="reconciliation_match",
+        resource_id="batch",
+        requested_count=len(payload.match_ids),
+        accepted_count=len(matches),
+    )
     if not matches:
         return ReconciliationMatchListResponse(items=[], total=0)
 

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -20,6 +20,7 @@ from src.models import DocumentType
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
+from src.observability_events import safe_error_message
 from src.prompts import get_parsing_prompt
 from src.services.ai_streaming import (
     AIStreamError,
@@ -785,15 +786,15 @@ class ExtractionService:
             response = await client.post(layout_url, headers=headers, json=payload)
 
         if response.status_code != 200:
-            error_body = response.text[:500]
+            safe_summary = safe_error_message(response.text)
             logger.error(
                 "OCR layout parsing failed",
                 provider=settings.ai_provider,
                 model=self.ocr_model,
                 status_code=response.status_code,
-                error_body=error_body,
+                safe_error_message=safe_summary,
             )
-            raise ExtractionError(f"OCR layout parsing failed: HTTP {response.status_code}: {error_body}")
+            raise ExtractionError(f"OCR layout parsing failed: HTTP {response.status_code}: {safe_summary}")
 
         result = response.json()
         markdown = result.get("md_results")

--- a/apps/backend/src/telemetry_metrics.py
+++ b/apps/backend/src/telemetry_metrics.py
@@ -121,6 +121,11 @@ def _create_instruments(meter: Any) -> None:
         unit="1",
         description="Confidence north-star score observations.",
     )
+    _instruments["rate_limit_rejected"] = meter.create_counter(
+        "finance.rate_limit.rejected",
+        unit="1",
+        description="Rate-limit rejections by low-cardinality scope.",
+    )
     meter.create_observable_gauge(
         "finance.async_parse.in_flight",
         callbacks=[_observe_async_parse_in_flight],
@@ -284,3 +289,9 @@ def record_confidence_north_star(*, score: float, source: str = "scheduled") -> 
     histogram = _instruments.get("confidence_north_star")
     if histogram is not None:
         histogram.record(score, {"source": source})
+
+
+def record_rate_limit_rejected(*, scope: str) -> None:
+    counter = _instruments.get("rate_limit_rejected")
+    if counter is not None:
+        counter.add(1, {"scope": scope})

--- a/apps/backend/tests/auth/test_auth.py
+++ b/apps/backend/tests/auth/test_auth.py
@@ -7,6 +7,7 @@ and invalid credential scenarios including token validation and session manageme
 from uuid import uuid4
 
 import pytest
+import structlog
 from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
@@ -69,6 +70,19 @@ async def test_get_current_user_id_direct(db, test_user):
     token = create_access_token(data={"sub": str(test_user.id)})
     user_id = await get_current_user_id(token=token, db=db)
     assert user_id == test_user.id
+
+
+async def test_AC10_11_1_get_current_user_id_binds_user_context(db, test_user):
+    """AC10.11.1: Auth dependency binds user_id into structured log context."""
+    from src.security import create_access_token
+
+    structlog.contextvars.clear_contextvars()
+    token = create_access_token(data={"sub": str(test_user.id)})
+
+    user_id = await get_current_user_id(token=token, db=db)
+
+    assert user_id == test_user.id
+    assert structlog.contextvars.get_contextvars()["user_id"] == str(test_user.id)
 
 
 async def test_get_current_user_id_invalid_user_db(db):

--- a/apps/backend/tests/auth/test_auth_router_unit.py
+++ b/apps/backend/tests/auth/test_auth_router_unit.py
@@ -141,6 +141,26 @@ def test_check_rate_limit_blocks_when_exceeded() -> None:
     assert "Retry-After" in exc_info.value.headers
 
 
+def test_check_rate_limit_logs_route_path(monkeypatch) -> None:
+    """Auth route rate-limit logs include the route path for triage."""
+    import src.routers.auth as auth_module
+
+    limiter = RateLimiter(RateLimitConfig(max_requests=1, window_seconds=60, block_seconds=300))
+    request = _mock_request("10.0.0.101")
+    calls: list[dict[str, object]] = []
+
+    def capture_warning(*args, **kwargs) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(auth_module, "log_security_warning", capture_warning)
+
+    _check_rate_limit(request, limiter, "Rate limited")
+    with pytest.raises(HTTPException):
+        _check_rate_limit(request, limiter, "Rate limited")
+
+    assert calls[-1]["path"] == "/auth/test"
+
+
 async def test_successful_login_resets_rate_limit(db: AsyncSession) -> None:
     """Successful login should reset the rate limiter for that IP."""
     # Create user

--- a/apps/backend/tests/infra/test_observability_contract.py
+++ b/apps/backend/tests/infra/test_observability_contract.py
@@ -6,6 +6,7 @@ import json
 import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError
@@ -13,6 +14,7 @@ from pydantic import ValidationError
 from src import (
     logger as logger_module,
     observability as observability_module,
+    observability_events,
     telemetry_metrics as telemetry_metrics_module,
 )
 from src.config import Settings
@@ -226,6 +228,91 @@ def test_AC10_9_2_observability_startup_log_uses_runtime_contract(monkeypatch) -
     assert fields["deployment_environment"] == "staging"
     assert fields["alert_rule_name"] == "FinanceReportBackendErrorLogs"
     assert "otel_exporter_otlp_endpoint" not in fields
+
+
+def test_AC10_11_1_security_warning_redacts_credentials() -> None:
+    """AC10.11.1: Security warning helper never emits raw credentials."""
+    mock_logger = Mock()
+
+    observability_events.log_security_warning(
+        mock_logger,
+        "auth.failure",
+        reason="invalid_token",
+        client_ip="203.0.113.10",
+        token="raw-token",
+        authorization="Bearer raw-token",
+    )
+
+    mock_logger.warning.assert_called_once()
+    (event,) = mock_logger.warning.call_args.args
+    fields = mock_logger.warning.call_args.kwargs
+    assert event == "auth.failure"
+    assert fields["audit_event"] == "auth.failure"
+    assert fields["reason"] == "invalid_token"
+    assert fields["client_ip"] == "203.0.113.10"
+    assert fields["token"] == "[REDACTED]"
+    assert fields["authorization"] == "[REDACTED]"
+
+
+def test_AC10_11_2_financial_mutation_audit_helpers_and_callsites() -> None:
+    """AC10.11.2: Financial mutation audit events are stable and wired."""
+    mock_logger = Mock()
+    user_id = uuid4()
+    entry_id = uuid4()
+
+    observability_events.log_financial_mutation(
+        mock_logger,
+        "journal.entry.posted",
+        user_id=user_id,
+        action="post",
+        resource_type="journal_entry",
+        resource_id=entry_id,
+        response_body="must not leak",
+    )
+
+    mock_logger.info.assert_called_once()
+    (event,) = mock_logger.info.call_args.args
+    fields = mock_logger.info.call_args.kwargs
+    assert event == "journal.entry.posted"
+    assert fields["audit_event"] == "journal.entry.posted"
+    assert fields["user_id"] == str(user_id)
+    assert fields["resource_id"] == str(entry_id)
+    assert fields["response_body"] == "[REDACTED]"
+
+    journal = _read(REPO_ROOT / "apps" / "backend" / "src" / "routers" / "journal.py")
+    reconciliation = _read(REPO_ROOT / "apps" / "backend" / "src" / "routers" / "reconciliation.py")
+    assert "journal.entry.posted" in journal
+    assert "journal.entry.voided" in journal
+    assert "reconciliation.match.accepted" in reconciliation
+    assert "log_financial_mutation" in journal
+    assert "log_financial_mutation" in reconciliation
+
+
+def test_AC10_11_3_provider_error_body_logging_is_redacted() -> None:
+    """AC10.11.3: Raw provider bodies are redacted or summarized before logging."""
+    safe = observability_events.safe_log_fields(
+        {
+            "error_body": "provider raw response with prompt and account 123456789",
+            "nested": {"provider_response": "raw JSON"},
+        }
+    )
+    assert safe["error_body"] == "[REDACTED]"
+    assert safe["nested"]["provider_response"] == "[REDACTED]"
+
+    long_message = "x" * 500
+    assert observability_events.safe_error_message(long_message).endswith("...")
+    assert len(observability_events.safe_error_message(long_message)) <= 300
+
+    pii_message = observability_events.safe_error_message("provider failed for alice@example.com and account 123456789")
+    assert "alice@example.com" not in pii_message
+    assert "123456789" not in pii_message
+    assert "[EMAIL]" in pii_message
+    assert "[BANK_ACCOUNT]" in pii_message
+
+    extraction = _read(REPO_ROOT / "apps" / "backend" / "src" / "services" / "extraction.py")
+    assert "error_body=" not in extraction
+    assert "safe_error_message=" in extraction
+    assert "OCR layout parsing failed: HTTP {response.status_code}: {error_body}" not in extraction
 
 
 async def test_AC10_9_3_health_response_includes_redacted_observability_status(monkeypatch) -> None:

--- a/apps/backend/tests/infra/test_rate_limit.py
+++ b/apps/backend/tests/infra/test_rate_limit.py
@@ -123,6 +123,7 @@ async def test_global_rate_limit_middleware_blocks_after_limit(public_client: As
         response = await public_client.post("/auth/login", json={"email": "x@x.com", "password": "x"})
         assert response.status_code == 429
         assert "Retry-After" in response.headers
+        assert response.headers["X-Request-ID"]
         data = response.json()
         assert "Rate limit exceeded" in data["detail"]
 

--- a/apps/backend/tests/infra/test_telemetry_metrics.py
+++ b/apps/backend/tests/infra/test_telemetry_metrics.py
@@ -345,3 +345,18 @@ def test_AC10_10_4_business_metric_helpers_record_outcomes(monkeypatch) -> None:
     ]
     assert meter.counters["finance.reconciliation.match.outcome"].add_calls == [(1, {"outcome": "accepted"})]
     assert meter.histograms["finance.confidence_north_star"].record_calls == [(0.98, {"source": "scheduled"})]
+
+
+def test_AC10_11_1_rate_limit_rejections_record_alert_metric(monkeypatch) -> None:
+    """AC10.11.1: rate-limit rejections emit the metric used by saturation alerts."""
+    meter = install_fake_otel(monkeypatch)
+    monkeypatch.setattr(
+        telemetry_metrics.settings,
+        "otel_exporter_otlp_endpoint",
+        "http://collector:4318",
+    )
+    telemetry_metrics.configure_otel_metrics()
+
+    telemetry_metrics.record_rate_limit_rejected(scope="global_api")
+
+    assert meter.counters["finance.rate_limit.rejected"].add_calls == [(1, {"scope": "global_api"})]

--- a/docs/project/EPIC-010.signoz-logging.md
+++ b/docs/project/EPIC-010.signoz-logging.md
@@ -180,6 +180,14 @@ Enable production-grade log observability via SigNoz (OTLP), while keeping local
 | AC10.10.3 | DB pool and async parse in-flight gauges expose current saturation values | `test_AC10_10_3_saturation_gauges_observe_current_values()` | `infra/test_telemetry_metrics.py` | P0 |
 | AC10.10.4 | Business metric helpers cover parse, AI-provider, reconciliation, and confidence signals | `test_AC10_10_4_business_metric_helpers_record_outcomes()` | `infra/test_telemetry_metrics.py` | P0 |
 
+### AC10.11: Logging Content Hardening
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC10.11.1 | Authenticated requests bind `user_id` into structured log context and authentication/rate-limit failures emit warning events plus the rate-limit rejection metric without credentials | `test_AC10_11_1_get_current_user_id_binds_user_context()`, `test_AC10_11_1_security_warning_redacts_credentials()`, `test_AC10_11_1_rate_limit_rejections_record_alert_metric()` | `auth/test_auth.py`, `infra/test_observability_contract.py`, `infra/test_telemetry_metrics.py` | P0 |
+| AC10.11.2 | Financial mutations emit stable audit logs for journal post/void and reconciliation accept operations | `test_AC10_11_2_financial_mutation_audit_helpers_and_callsites()` | `infra/test_observability_contract.py` | P0 |
+| AC10.11.3 | Provider/error-body logging uses bounded safe summaries and rejects raw risky payload fields | `test_AC10_11_3_provider_error_body_logging_is_redacted()` | `infra/test_observability_contract.py` | P0 |
+
 ## 📏 Acceptance Criteria
 
 > ℹ️ **Non-contiguous AC numbering**: Gaps in `AC10.x.y` numbers reflect deprecated or merged ACs preserved through generated registry indexes plus explicit overrides. Do **not** renumber. New ACs append to the next available index in this EPIC.

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -12,7 +12,7 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/valuation-snapshots/{snapshot_id}` | `delete_valuation_snapshot` | apps/backend/src/routers/assets.py:186 |
 | `POST` | `` | `chat_message` | apps/backend/src/routers/chat.py:37 |
 | `DELETE` | `/session/{session_id}` | `delete_session` | apps/backend/src/routers/chat.py:212 |
-| `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:142 |
+| `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:164 |
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:485 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:765 |
 | `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:551 |

--- a/docs/ssot/observability-logging.md
+++ b/docs/ssot/observability-logging.md
@@ -10,6 +10,9 @@
 - `apps/frontend/src/components/statements/StatementUploader.tsx` - Model selection and upload logging
 - `apps/backend/src/routers/statements.py` - Upload request and background task logging
 - `apps/backend/src/routers/reconciliation.py` - Reconciliation run audit checkpoints
+- `apps/backend/src/observability_events.py` - Shared audit/security event helpers and risky-field redaction
+- `apps/backend/src/auth.py` - Authenticated `user_id` log-context binding and auth failure warnings
+- `apps/backend/src/routers/journal.py` - Journal post/void mutation audit events
 - `apps/backend/src/services/statement_parsing.py` - Async parse progress and brokerage import checkpoints
 - `apps/backend/src/routers/llm.py` - LLM config + model catalog request/response logging (EPIC-023; replaced `routers/ai_models.py`)
 - `apps/backend/src/services/extraction.py` - Model selection and HTTP error logging
@@ -133,6 +136,19 @@ counts plus a non-zero failure marker for fast triage.
 | `reconciliation.run.started` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `limit` | Shows reconciliation was explicitly started |
 | `reconciliation.run.completed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `limit`, `matches_created`, `auto_accepted`, `pending_review`, `unmatched` | Shows reconciliation result counts |
 | `reconciliation.run.failed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `limit`, `error_type`, `safe_error_message` | Shows reconciliation failure without leaking transaction details |
+| `journal.entry.posted` | `request_id`, `user_id`, `action`, `resource_type`, `resource_id`, `status` | Audits a journal entry moving from draft to posted without logging entry lines or memo text |
+| `journal.entry.voided` | `request_id`, `user_id`, `action`, `resource_type`, `resource_id`, `reversal_entry_id`, `reason_length` | Audits a void operation without logging the free-text void reason |
+| `reconciliation.match.accepted` | `request_id`, `user_id`, `action`, `resource_type`, `resource_id`, `status` | Audits a single reconciliation match acceptance |
+| `reconciliation.match.batch_accepted` | `request_id`, `user_id`, `action`, `resource_type`, `resource_id`, `requested_count`, `accepted_count` | Audits batch acceptance without listing transaction descriptions |
+| `auth.failure` | `request_id`, `reason`, optional `user_id`, optional `client_ip` | Warns on authentication failures without logging credentials |
+| `rate_limit.rejected` | `request_id`, `reason`, `client_ip`, `retry_after`, optional `path` | Warns on auth/global rate-limit rejection without logging request bodies |
+
+#### Alert-Support Metrics
+
+`finance.rate_limit.rejected` is emitted when global or auth-route rate limiting
+rejects a request. It uses one low-cardinality label, `scope`, with values such
+as `global_api` and `auth_route`; raw IP addresses stay in warning logs and must
+not become metric labels.
 
 #### Progress Phases
 
@@ -156,6 +172,13 @@ file hashes, raw AI prompts/responses, provider API keys, session cookies,
 Vault/Dokploy/GitHub tokens, email addresses, or bank account numbers. File
 hashes are truncated to a prefix suitable for correlation, and error fields use
 safe summaries capped before emission.
+
+The backend helper `observability_events.safe_log_fields()` redacts risky field
+names (`authorization`, `cookie`, `token`, `api_key`, `prompt`, `raw_response`,
+`response_body`, `error_body`, `provider_body`, and `provider_response`) before
+new audit/security events are emitted. Provider failures must log status/model
+metadata and a bounded `safe_error_message`; raw provider bodies are not an
+allowed log field.
 
 #### Noise Control
 


### PR DESCRIPTION
## Summary

Adds safe structured observability helpers, binds authenticated user context, audits financial mutations, logs auth/rate-limit security warnings, and redacts risky provider/error payload fields.

Closes #1107
Refs #1073

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-010 — SigNoz Logging Integration |
| **AC IDs** | AC10.11.1, AC10.11.2, AC10.11.3 |
| **AC source updated** | `docs/project/EPIC-010.signoz-logging.md` |

---

## SSOT Changes

- [x] `docs/ssot/observability-logging.md` — documents security/audit event names, safe field redaction, and the `finance.rate_limit.rejected` alert-support metric.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | N/A | Tests were added before implementation in the working tree, not split into a separate red commit. |
| Green (passing test) | `e6a6248` | Implement structured logging helpers, call sites, redaction, and rate-limit metric. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not touched)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable; submodule synced for tests only)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys.
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged.
- [x] Proof command includes focused tests for redaction and lifecycle-safe log fields.

---

## Testing

```bash
python3 tools/generate_ac_registry.py && python3 tools/check_ac_index.py
python3 tools/check_ssot_ownership.py && python3 tools/check_manifest.py && python3 tools/lint_doc_consistency.py
python3 tools/audit_router_contracts.py --output docs/reference/router-contract-maturity.md
cd apps/backend && uv run python ../../tools/generate_api_reference.py --check
cd apps/backend && uv run python ../../tools/generate_openapi_spec.py --check
cd apps/backend && uv run ruff check src tests
cd apps/backend && uv run ruff format --check src tests
cd apps/backend && uv run python -m pytest tests/auth/test_auth.py tests/infra/test_observability_contract.py tests/infra/test_telemetry_metrics.py -q --no-cov
cd apps/backend && uv run python -m pytest tests/infra/test_transaction_boundaries.py -q --no-cov
```

---

## Screenshots / Evidence

N/A