### PR TITLE
[finance_report_infra_1108_async] Surface async parse task failures

### DIFF
--- a/apps/backend/src/services/statement_flow.py
+++ b/apps/backend/src/services/statement_flow.py
@@ -61,5 +61,7 @@ async def parse_statement_flow(
             model=model,
             session_maker=async_session_maker,
             request_id=request_id,
-        )
+        ),
+        statement_id=statement_id,
+        request_id=request_id,
     )

--- a/apps/backend/src/services/statement_pipeline.py
+++ b/apps/backend/src/services/statement_pipeline.py
@@ -36,6 +36,14 @@ logger = get_logger(__name__)
 PARSE_DEPLOYMENT = "parse-statement/parse-statement"
 
 
+def _consume_background_task_exception(task: asyncio.Task[None]) -> None:
+    """Retrieve fallback task exceptions after structured telemetry logs them."""
+    try:
+        task.exception()
+    except asyncio.CancelledError:
+        return
+
+
 async def submit_parse_pipeline(
     *,
     statement_id: UUID,
@@ -89,7 +97,7 @@ async def submit_parse_pipeline(
         )
         return None
 
-    return asyncio.create_task(
+    task = asyncio.create_task(
         run_with_async_parse_tracking(
             parse_statement_background(
                 statement_id=statement_id,
@@ -103,6 +111,10 @@ async def submit_parse_pipeline(
                 model=model,
                 session_maker=create_session_maker_from_db(db),
                 request_id=request_id,
-            )
+            ),
+            statement_id=statement_id,
+            request_id=request_id,
         )
     )
+    task.add_done_callback(_consume_background_task_exception)
+    return task

--- a/apps/backend/src/telemetry_metrics.py
+++ b/apps/backend/src/telemetry_metrics.py
@@ -7,12 +7,14 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from src.config import parse_key_value_pairs, settings
+from src.logger import get_logger
 
 _metrics_export_active = False
 _meter: Any | None = None
 _instruments: dict[str, Any] = {}
 _async_parse_in_flight = 0
 _db_pool_observer: Callable[[], dict[str, int]] | None = None
+logger = get_logger(__name__)
 
 
 def _build_otel_resource() -> Any:
@@ -126,6 +128,11 @@ def _create_instruments(meter: Any) -> None:
         unit="1",
         description="Rate-limit rejections by low-cardinality scope.",
     )
+    _instruments["async_parse_failure"] = meter.create_counter(
+        "finance.async_parse.failure",
+        unit="1",
+        description="Async statement parse task failures.",
+    )
     meter.create_observable_gauge(
         "finance.async_parse.in_flight",
         callbacks=[_observe_async_parse_in_flight],
@@ -174,11 +181,45 @@ def increment_async_parse_in_flight(delta: int = 1) -> None:
     set_async_parse_in_flight(_async_parse_in_flight + delta)
 
 
-async def run_with_async_parse_tracking(awaitable: Awaitable[None]) -> None:
+def _safe_error_message(message: str | None, *, limit: int = 300) -> str | None:
+    if not message:
+        return message
+    compact = " ".join(str(message).split())
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[:limit]}..."
+
+
+def record_async_parse_failure(*, error_type: str, task_name: str = "statement_parse") -> None:
+    counter = _instruments.get("async_parse_failure")
+    if counter is not None:
+        counter.add(1, {"task": task_name, "error_type": error_type})
+
+
+async def run_with_async_parse_tracking(
+    awaitable: Awaitable[None],
+    *,
+    statement_id: object | None = None,
+    request_id: str | None = None,
+    task_name: str = "statement_parse",
+) -> None:
     """Track one in-process async statement parse until it completes or fails."""
     increment_async_parse_in_flight(1)
     try:
         await awaitable
+    except Exception as exc:
+        error_type = type(exc).__name__
+        record_async_parse_failure(error_type=error_type, task_name=task_name)
+        logger.exception(
+            "statement.parse.async_task.failed",
+            audit_event="statement.parse.async_task.failed",
+            statement_id=str(statement_id) if statement_id is not None else None,
+            request_id=request_id,
+            task_name=task_name,
+            error_type=error_type,
+            safe_error_message=_safe_error_message(str(exc)),
+        )
+        raise
     finally:
         increment_async_parse_in_flight(-1)
 

--- a/apps/backend/tests/api/test_statement_pipeline.py
+++ b/apps/backend/tests/api/test_statement_pipeline.py
@@ -57,6 +57,45 @@ async def test_AC19_13_1_dispatch_falls_back_to_asyncio_when_prefect_unset(monke
     assert seen["session_maker"] == "session-maker"
 
 
+async def test_AC19_13_1_dispatch_registers_exception_consumer_on_fallback(monkeypatch):
+    """AC19.13.1: fallback tasks retrieve failures after structured telemetry logs them."""
+    monkeypatch.setattr(statement_pipeline.settings, "prefect_api_url", None)
+
+    class FakeTask:
+        def __init__(self) -> None:
+            self.callbacks: list[object] = []
+
+        def add_done_callback(self, callback) -> None:  # noqa: ANN001
+            self.callbacks.append(callback)
+
+    task = FakeTask()
+
+    async def fake_background(**_kwargs):
+        return None
+
+    def fake_tracking(awaitable, **_kwargs):
+        awaitable.close()
+
+        async def noop() -> None:
+            return None
+
+        return noop()
+
+    def fake_create_task(coro):
+        coro.close()
+        return task
+
+    monkeypatch.setattr(statement_pipeline, "parse_statement_background", fake_background)
+    monkeypatch.setattr(statement_pipeline, "run_with_async_parse_tracking", fake_tracking)
+    monkeypatch.setattr(statement_pipeline, "create_session_maker_from_db", lambda db: "session-maker")
+    monkeypatch.setattr(statement_pipeline.asyncio, "create_task", fake_create_task)
+
+    result = await statement_pipeline.submit_parse_pipeline(**_dispatch_kwargs())
+
+    assert result is task
+    assert task.callbacks == [statement_pipeline._consume_background_task_exception]
+
+
 async def test_AC19_13_2_dispatch_submits_serializable_params_to_prefect(monkeypatch):
     """AC19.13.2: PREFECT_API_URL set → submit flow run with serializable params only."""
     monkeypatch.setattr(statement_pipeline.settings, "prefect_api_url", "http://prefect:4200/api")

--- a/apps/backend/tests/infra/test_telemetry_metrics.py
+++ b/apps/backend/tests/infra/test_telemetry_metrics.py
@@ -305,6 +305,55 @@ async def test_AC10_10_3_async_parse_tracking_increments_until_done() -> None:
     assert observation_values(telemetry_metrics._observe_async_parse_in_flight()) == [0]
 
 
+async def test_AC10_12_1_async_parse_tracking_records_failures(monkeypatch) -> None:
+    """AC10.12.1: failed async parse tasks emit a metric and safe log context."""
+    meter = install_fake_otel(monkeypatch)
+    monkeypatch.setattr(
+        telemetry_metrics.settings,
+        "otel_exporter_otlp_endpoint",
+        "http://collector:4318",
+    )
+    telemetry_metrics.configure_otel_metrics()
+    exception_calls: list[tuple[str, dict[str, object]]] = []
+
+    def capture_exception(event: str, **kwargs: object) -> None:
+        exception_calls.append((event, kwargs))
+
+    monkeypatch.setattr(
+        telemetry_metrics,
+        "logger",
+        types.SimpleNamespace(exception=capture_exception),
+    )
+
+    async def parse_work() -> None:
+        raise RuntimeError("provider failed with a compact safe summary")
+
+    with pytest.raises(RuntimeError):
+        await telemetry_metrics.run_with_async_parse_tracking(
+            parse_work(),
+            statement_id="statement-123",
+            request_id="request-123",
+        )
+
+    assert observation_values(telemetry_metrics._observe_async_parse_in_flight()) == [0]
+    assert meter.counters["finance.async_parse.failure"].add_calls == [
+        (1, {"task": "statement_parse", "error_type": "RuntimeError"})
+    ]
+    assert exception_calls == [
+        (
+            "statement.parse.async_task.failed",
+            {
+                "audit_event": "statement.parse.async_task.failed",
+                "statement_id": "statement-123",
+                "request_id": "request-123",
+                "task_name": "statement_parse",
+                "error_type": "RuntimeError",
+                "safe_error_message": "provider failed with a compact safe summary",
+            },
+        )
+    ]
+
+
 def test_AC10_10_3_async_parse_tracking_has_runtime_call_sites() -> None:
     """AC10.10.3: async parse tracking is wired outside tests."""
     pipeline = (REPO_ROOT / "apps" / "backend" / "src" / "services" / "statement_pipeline.py").read_text(
@@ -314,6 +363,28 @@ def test_AC10_10_3_async_parse_tracking_has_runtime_call_sites() -> None:
 
     assert "run_with_async_parse_tracking" in pipeline
     assert "run_with_async_parse_tracking" in flow
+
+
+def test_AC10_12_2_async_parse_tracking_receives_statement_context() -> None:
+    """AC10.12.2: runtime async parse wrappers carry statement/request context."""
+    pipeline = (REPO_ROOT / "apps" / "backend" / "src" / "services" / "statement_pipeline.py").read_text(
+        encoding="utf-8"
+    )
+    flow = (REPO_ROOT / "apps" / "backend" / "src" / "services" / "statement_flow.py").read_text(encoding="utf-8")
+
+    assert "statement_id=statement_id" in pipeline
+    assert "request_id=request_id" in pipeline
+    assert "statement_id=statement_id" in flow
+    assert "request_id=request_id" in flow
+
+
+def test_AC10_12_3_parse_failure_state_and_log_contract_are_preserved() -> None:
+    """AC10.12.3: parse failures still reject statements and emit structured logs."""
+    source = (REPO_ROOT / "apps" / "backend" / "src" / "services" / "statement_parsing.py").read_text(encoding="utf-8")
+
+    assert "refreshed.status = BankStatementStatus.REJECTED" in source
+    assert '"statement.parse.failed"' in source
+    assert "safe_error_message=_safe_error_message(message)" in source
 
 
 def test_AC10_10_4_business_metric_helpers_record_outcomes(monkeypatch) -> None:

--- a/docs/project/EPIC-010.signoz-logging.md
+++ b/docs/project/EPIC-010.signoz-logging.md
@@ -188,6 +188,14 @@ Enable production-grade log observability via SigNoz (OTLP), while keeping local
 | AC10.11.2 | Financial mutations emit stable audit logs for journal post/void and reconciliation accept operations | `test_AC10_11_2_financial_mutation_audit_helpers_and_callsites()` | `infra/test_observability_contract.py` | P0 |
 | AC10.11.3 | Provider/error-body logging uses bounded safe summaries and rejects raw risky payload fields | `test_AC10_11_3_provider_error_body_logging_is_redacted()` | `infra/test_observability_contract.py` | P0 |
 
+### AC10.12: Async Parse Failure Visibility
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC10.12.1 | Failed async statement parse tasks emit a low-cardinality failure metric and safe structured log context | `test_AC10_12_1_async_parse_tracking_records_failures()` | `infra/test_telemetry_metrics.py` | P0 |
+| AC10.12.2 | In-process fallback and Prefect flow wrappers pass statement/request context into async parse tracking | `test_AC10_12_2_async_parse_tracking_receives_statement_context()` | `infra/test_telemetry_metrics.py` | P0 |
+| AC10.12.3 | Parse failure handling still marks statements rejected and emits the existing safe `statement.parse.failed` contract | `test_AC10_12_3_parse_failure_state_and_log_contract_are_preserved()` | `infra/test_telemetry_metrics.py` | P0 |
+
 ## 📏 Acceptance Criteria
 
 > ℹ️ **Non-contiguous AC numbering**: Gaps in `AC10.x.y` numbers reflect deprecated or merged ACs preserved through generated registry indexes plus explicit overrides. Do **not** renumber. New ACs append to the next available index in this EPIC.

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -437,7 +437,7 @@ dependency (delivery speed unaffected).
 
 | AC | Description | Test Anchor | Priority |
 |----|-------------|-------------|----------|
-| AC19.13.1 | Statement parse dispatch is config-gated: with `PREFECT_API_URL` unset, `submit_parse_pipeline` runs the existing in-process `asyncio.create_task` fallback (no Prefect import) and returns the task to track | `test_AC19_13_1_dispatch_falls_back_to_asyncio_when_prefect_unset` | P0 |
+| AC19.13.1 | Statement parse dispatch is config-gated: with `PREFECT_API_URL` unset, `submit_parse_pipeline` runs the existing in-process `asyncio.create_task` fallback (no Prefect import) and returns the task to track | `test_AC19_13_1_dispatch_falls_back_to_asyncio_when_prefect_unset`, `test_AC19_13_1_dispatch_registers_exception_consumer_on_fallback` | P0 |
 | AC19.13.2 | With `PREFECT_API_URL` set, `submit_parse_pipeline` submits a Prefect flow run with serializable params only (no raw bytes, no session maker — the worker re-fetches content and builds its own session) and returns None | `test_AC19_13_2_dispatch_submits_serializable_params_to_prefect` | P0 |
 
 ### AC19.14 — Workflow-event dedupe is transaction-safe (issue #1033)

--- a/docs/ssot/observability-logging.md
+++ b/docs/ssot/observability-logging.md
@@ -130,6 +130,7 @@ counts plus a non-zero failure marker for fast triage.
 | `statement.parse.extraction_completed` | `request_id`, `statement_id`, `model_to_use`, `file_type` | Replaces misleading enqueue wording after extraction returns |
 | `statement.parse.completed` | `request_id`, `statement_id`, `phase`, `progress`, `duration_ms`, `transactions_count` | Marks parse finalization success |
 | `statement.parse.failed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `error_type`, `safe_error_message` | Marks parse failure without leaking source content |
+| `statement.parse.async_task.failed` | `request_id`, `statement_id`, `task_name`, `error_type`, `safe_error_message` | Marks failure of the background task wrapper so fire-and-forget failures are queryable |
 | `statement.brokerage_import.started` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `broker`, `parsed_positions` when known | Shows brokerage import was attempted |
 | `statement.brokerage_import.completed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `broker`, `parsed_positions`, `created_atomic_positions`, `existing_atomic_positions`, `reconcile_created`, `reconcile_updated`, `reconcile_disposed` | Shows brokerage import result counts |
 | `statement.brokerage_import.failed` | `request_id`, `statement_id`, `phase`, `progress`, `model_to_use`, `error_type`, `safe_error_message` | Shows brokerage import failure without leaking payload |
@@ -186,6 +187,13 @@ Audit queries should exclude health checks, SQL echo, and repeated per-day FX or
 portfolio valuation detail logs by default. High-frequency FX valuation detail
 belongs at `debug`; staging audit views should prioritize the events above and
 phase timing lines from GitHub Actions.
+
+### Async Failure Metric
+
+`finance.async_parse.failure` is a counter emitted by the statement parse task
+wrapper. It uses low-cardinality attributes only: `task` and `error_type`.
+Per-statement correlation stays in `statement.parse.async_task.failed` logs via
+`statement_id` and `request_id`; those identifiers must not become metric labels.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds failure logging and a low-cardinality failure counter to the async statement parse wrapper, and passes statement/request context from both in-process fallback and Prefect flow call sites.

Closes #1108
Refs #1073

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-010 — SigNoz Logging Integration |
| **AC IDs** | AC10.12.1, AC10.12.2, AC10.12.3 |
| **AC source updated** | `docs/project/EPIC-010.signoz-logging.md` |

---

## SSOT Changes

- [x] `docs/ssot/observability-logging.md` — documents `statement.parse.async_task.failed` and `finance.async_parse.failure`.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | N/A | Tests were added before implementation in the working tree, not split into a separate red commit. |
| Green (passing test) | `33df6aa` | Implement async parse failure metric/logging and context propagation. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not touched)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable; submodule synced for tests only)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

- [x] Logs do not print raw provider bodies or document content.
- [x] Metric labels remain low-cardinality; `statement_id`/`request_id` stay in logs, not metric labels.
- [x] Proof command includes focused tests for failure metric/logging and runtime call sites.

---

## Testing

```bash
python3 tools/generate_ac_registry.py && python3 tools/check_ac_index.py
python3 tools/check_ssot_ownership.py && python3 tools/check_manifest.py && python3 tools/lint_doc_consistency.py
cd apps/backend && uv run ruff check src tests
cd apps/backend && uv run ruff format --check src tests
cd apps/backend && uv run python -m pytest tests/infra/test_telemetry_metrics.py -q --no-cov
cd apps/backend && uv run python -m pytest tests/infra/test_transaction_boundaries.py -q --no-cov
```

Note: I reset stale local `finance_report_test_*` databases before rerunning `test_transaction_boundaries.py`; the failure was caused by an existing market-data row in a reused worker database, not by this diff.

---

## Screenshots / Evidence

N/A