### PR TITLE
[finance_report_infra_618_tier2] Add Tier 2 deployed HTTP proof gate

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -333,6 +333,14 @@ jobs:
           
           run_timed_phase "Phase 1: Smoke Check (Shell)" \
             bash tools/smoke_test.sh "$APP_URL" staging
+
+          run_timed_phase "Phase 1b: Tier 2 HTTP E2E (Python)" \
+            python3 tools/tier2_http_e2e.py \
+              --base-url "$APP_URL" \
+              --expected-sha "$EXPECTED_SHA" \
+              --mode staging \
+              --json-report test-results/staging-tier2-http.json \
+              --junit-xml test-results/staging-tier2-http.xml
           
           # Parallelize non-LLM tests only. Real AI/OCR calls are run once below
           # to avoid four workers hitting the provider at the same time.

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -77,7 +77,7 @@ Integration tests and E2E tests are intentionally different in this project:
 | Integration (backend) | Backend tests marked `integration` | Explicit CI stage: `backend-integration` job, marker-scoped and service-backed | Not included in unified coverage by default; AC proof channel only |
 | Tier 1 API E2E (`-m e2e`) | `apps/backend/tests/e2e/test_core_journeys.py` ASGI/API contract flows | Explicit CI stage: `backend-e2e-tier1` job with marker override and explicit Tier-1 scope | Behavioral proof for ACs and regression risk; **not included in unified line coverage** |
 | Frontend Playwright | Provider-free specs under `apps/frontend/playwright` | Explicit CI stage inside the `frontend` job after build and Vitest; env-gated specs are not required proof | Browser UI behavioral proof only, not part of unified line coverage |
-| Tier 2 HTTP E2E | Deploy-aware HTTP-level flows in staging/prod | Not a CI-shard job today; kept for staged/manual/prod smoke command evolution | Behavioral proof only, not part of unified line coverage |
+| Tier 2 HTTP E2E | Deploy-aware HTTP-level flows through `tools/tier2_http_e2e.py` | Staging deploy after shell smoke and before broader deployed E2E | Behavioral proof only, not part of unified line coverage |
 | Tier 3 Browser E2E | `tests/e2e` Playwright/browser scenarios | Post-merge staging/prod gates and PR preview where appropriate | Behavioral proof only; AC pass rate requires real pass (skip and stub-only do not count) |
 
 ### Stage-by-Stage Semantics
@@ -492,6 +492,20 @@ The operator entry point is `tools/purge_test_accounts.py` (dry-run by default;
 `--apply` to delete; runbook in `docs/contributing/staging-test-account-cleanup.md`).
 
 ---
+
+### AC8.18: Tier 2 Deployed HTTP E2E Proof Semantics
+
+Tier 2 is the lightweight deployed-HTTP lane between Tier 1 in-process API E2E
+and Tier 3 browser/provider-heavy E2E. It proves the deployed URL, routing,
+version, public API reachability, frontend reachability, and unauthenticated
+protection boundary through real HTTP. It is not a line-coverage input and a
+not-run/env-gated advisory report is never proof eligible.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|---|---|---|---|---|
+| AC8.18.1 | The Tier 2 command fails closed unless a deployed base URL and expected deployed version are supplied | `test_AC8_18_1_tier2_http_command_fails_closed_without_deployed_inputs` | `tests/tooling/test_tier2_http_e2e.py` | P0 |
+| AC8.18.2 | Tier 2 reports carry `proof_tier=tier2_http`; advisory/env-gated not-run output is marked `proof_eligible=false`, while passing reports require concrete HTTP checks | `test_AC8_18_2_tier2_http_report_is_proof_tiered_and_skip_ineligible`, `test_AC8_18_2_tier2_http_success_report_requires_real_http_checks`, `test_AC8_18_2_tier2_http_handles_non_object_health_json`, `test_AC8_18_2_tier2_http_accepts_short_and_full_sha_match` | `tests/tooling/test_tier2_http_e2e.py` | P0 |
+| AC8.18.3 | Staging runs Tier 2 after shell smoke and before Tier 3/browser E2E, and the execution matrix names `deployment_tier2_http_e2e` separately | `test_AC8_18_3_staging_workflow_runs_tier2_http_before_tier3_browser_e2e`, `test_AC8_18_3_test_execution_matrix_names_tier2_http_stage` | `tests/tooling/test_tier2_http_e2e.py` | P0 |
 
 ## 5. E2E Suite Ownership
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -147,7 +147,7 @@ file.
 | Integration (backend marker) | `backend-integration` job (`-m "integration"`) | `apps/backend/tests/**/*` marker-scoped integration suites with service-backed env | Not part of unified line baseline yet | Add sharding when count growth justifies it; keep explicit marker gate in CI |
 | Tooling/common contracts | `tooling-coverage` job | `tests/tooling/` with `--cov=common --cov=tools` | Feeds unified line coverage (common/tools components) | Keep parallel to app tests so tooling failures and LCOV inputs are independently visible |
 | Tier 1 API E2E | `backend-e2e-tier1` job (`apps/backend/tests/e2e/test_core_journeys.py` with `-m "e2e"`) | Serial backend contract/HTTP/DB/S3 API behavioral paths with Postgres and MinIO bucket readiness; PR runs use `--maxfail=1`, while push/main Tier-1 E2E runs without `--maxfail=1` so one JUnit artifact reports all failing journeys | Behavioral proof only; AC traceability-backed | Stabilize a deterministic API subset first, then scale by marker or folder |
-| Tier 2 HTTP E2E | PR/staging/prod HTTP command windows | Not in unified coverage baseline | Behavioral proof only | Introduce marker-pinned CI smoke before post-merge where network stability allows |
+| Tier 2 HTTP E2E | `tools/tier2_http_e2e.py` against deployed PR/staging/prod URLs | Not in unified coverage baseline | Behavioral proof only; reports carry `proof_tier=tier2_http` | Keep the command strict in deployed gates; advisory/env-gated not-run reports are never proof eligible |
 | Frontend Playwright | `frontend` job | Provider-free browser UI specs under `apps/frontend/playwright` | Behavioral proof only; not in unified line coverage | Env-gated specs stay non-required until their env is provided in CI |
 | Tier 3 Browser E2E | Staging/PR preview/prod smoke jobs | Playwright/HTTP deployment suites (`smoke`, `e2e`, `llm` split) | Behavioral/prod-risk proof only | Keep provider-dependent `llm` in post-merge; split provider-free subset for PR preview |
 
@@ -205,6 +205,27 @@ migration risk contract classifies the risk and required evidence so staging is
 used for the issues it can realistically catch, while production residual risk
 is handled through preflight, backup, feature-flag, idempotency, and
 post-deploy controls.
+
+### Tier 2 HTTP E2E Command
+
+Tier 2 deployed HTTP proof runs through:
+
+```bash
+python3 tools/tier2_http_e2e.py \
+  --base-url "$APP_URL" \
+  --expected-sha "$EXPECTED_SHA" \
+  --mode staging \
+  --json-report test-results/staging-tier2-http.json \
+  --junit-xml test-results/staging-tier2-http.xml
+```
+
+The staging deploy workflow runs this command after `tools/smoke_test.sh` and
+before the broader `pytest tests/e2e` deployed suite. Missing `--base-url` or
+`--expected-sha` is a hard command failure in deployed gates. Local advisory
+usage may opt into `--advisory-if-missing`, but that report is explicitly
+`proof_eligible=false` and cannot satisfy AC proof. The JSON and JUnit reports
+carry `proof_tier=tier2_http` so dashboards can distinguish unit, integration,
+Tier 1, Tier 2, and Tier 3 evidence.
 
 ---
 

--- a/docs/ssot/test-execution-matrix.yaml
+++ b/docs/ssot/test-execution-matrix.yaml
@@ -24,6 +24,9 @@ rules:
   - path: tests/tooling/
     stage: tooling_ci
     ci_required: true
+  - path: tools/tier2_http_e2e.py
+    stage: deployment_tier2_http_e2e
+    ci_required: false
   - path: tests/e2e/
     stage: deployment_e2e
     ci_required: true

--- a/tests/tooling/test_tier2_http_e2e.py
+++ b/tests/tooling/test_tier2_http_e2e.py
@@ -1,0 +1,152 @@
+"""Tests for the Tier 2 deployed HTTP E2E command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from xml.etree import ElementTree
+
+from tools import tier2_http_e2e
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_AC8_18_1_tier2_http_command_fails_closed_without_deployed_inputs(capsys) -> None:
+    """AC8.18.1: Tier 2 HTTP E2E requires deployed URL and expected version inputs."""
+    status = tier2_http_e2e.main([], environ={})
+
+    assert status == 2
+    assert "base_url" in capsys.readouterr().err
+
+
+def test_AC8_18_2_tier2_http_report_is_proof_tiered_and_skip_ineligible(tmp_path: Path) -> None:
+    """AC8.18.2: Advisory/env-gated reports are explicit non-proof, not green proof."""
+    report_path = tmp_path / "tier2.json"
+    junit_path = tmp_path / "tier2.xml"
+
+    status = tier2_http_e2e.main(
+        [
+            "--advisory-if-missing",
+            "--json-report",
+            str(report_path),
+            "--junit-xml",
+            str(junit_path),
+        ],
+        environ={},
+    )
+
+    assert status == 0
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["proof_tier"] == "tier2_http"
+    assert report["status"] == "not_run"
+    assert report["proof_eligible"] is False
+    assert report["env_gated"] is True
+
+    suite = ElementTree.parse(junit_path).getroot()
+    properties_node = suite.find("properties")
+    assert properties_node is not None
+    properties = {prop.attrib["name"]: prop.attrib["value"] for prop in properties_node}
+    assert properties["proof_tier"] == "tier2_http"
+    assert properties["proof_eligible"] == "False"
+    assert suite.attrib["skipped"] == "1"
+
+
+def test_AC8_18_2_tier2_http_success_report_requires_real_http_checks() -> None:
+    """AC8.18.2: Passing reports come from concrete HTTP checks with no skipped tests."""
+
+    def requester(url: str, _timeout_seconds: float) -> tier2_http_e2e.HttpResponse:
+        if url.endswith("/api/health"):
+            return tier2_http_e2e.HttpResponse(200, '{"status":"healthy","git_sha":"abc123"}')
+        if url.endswith("/api/ping"):
+            return tier2_http_e2e.HttpResponse(200, '{"ok":true}')
+        if url.endswith("/api/statements"):
+            return tier2_http_e2e.HttpResponse(401, '{"detail":"Not authenticated"}')
+        return tier2_http_e2e.HttpResponse(200, "<html></html>")
+
+    report = tier2_http_e2e.run_tier2_http_e2e(
+        tier2_http_e2e.Tier2Config(
+            base_url="https://report-staging.example.com",
+            expected_sha="abc123",
+        ),
+        requester=requester,
+    )
+
+    assert report["proof_tier"] == "tier2_http"
+    assert report["status"] == "passed"
+    assert report["proof_eligible"] is True
+    assert [check["name"] for check in report["checks"]] == [
+        "api_health_http_200",
+        "deployed_version_matches_expected",
+        "api_ping_http_200",
+        "frontend_http_success",
+        "protected_api_requires_auth",
+    ]
+
+
+def test_AC8_18_2_tier2_http_handles_non_object_health_json() -> None:
+    """AC8.18.2: Non-object health JSON fails the version check without crashing."""
+
+    def requester(url: str, _timeout_seconds: float) -> tier2_http_e2e.HttpResponse:
+        if url.endswith("/api/health"):
+            return tier2_http_e2e.HttpResponse(200, "[]")
+        if url.endswith("/api/ping"):
+            return tier2_http_e2e.HttpResponse(200, '{"ok":true}')
+        if url.endswith("/api/statements"):
+            return tier2_http_e2e.HttpResponse(401, '{"detail":"Not authenticated"}')
+        return tier2_http_e2e.HttpResponse(200, "<html></html>")
+
+    report = tier2_http_e2e.run_tier2_http_e2e(
+        tier2_http_e2e.Tier2Config(
+            base_url="https://report-staging.example.com",
+            expected_sha="abc123",
+        ),
+        requester=requester,
+    )
+
+    version_check = next(check for check in report["checks"] if check["name"] == "deployed_version_matches_expected")
+    assert report["status"] == "failed"
+    assert version_check["passed"] is False
+
+
+def test_AC8_18_2_tier2_http_accepts_short_and_full_sha_match() -> None:
+    """AC8.18.2: Deployed version checks allow either side to be an abbreviated SHA."""
+
+    def requester(url: str, _timeout_seconds: float) -> tier2_http_e2e.HttpResponse:
+        if url.endswith("/api/health"):
+            return tier2_http_e2e.HttpResponse(200, '{"status":"healthy","git_sha":"abc123456789"}')
+        if url.endswith("/api/ping"):
+            return tier2_http_e2e.HttpResponse(200, '{"ok":true}')
+        if url.endswith("/api/statements"):
+            return tier2_http_e2e.HttpResponse(401, '{"detail":"Not authenticated"}')
+        return tier2_http_e2e.HttpResponse(200, "<html></html>")
+
+    report = tier2_http_e2e.run_tier2_http_e2e(
+        tier2_http_e2e.Tier2Config(
+            base_url="https://report-staging.example.com",
+            expected_sha="abc123",
+        ),
+        requester=requester,
+    )
+
+    assert report["status"] == "passed"
+
+
+def test_AC8_18_3_staging_workflow_runs_tier2_http_before_tier3_browser_e2e() -> None:
+    """AC8.18.3: Staging runs Tier 2 HTTP proof before broader deployed E2E."""
+    workflow = (ROOT / ".github/workflows/staging-deploy.yml").read_text(encoding="utf-8")
+    e2e_step = workflow.split("id: staging_e2e_tests", 1)[1].split("- name: Classify staging", 1)[0]
+
+    tier2_index = e2e_step.index("tools/tier2_http_e2e.py")
+    tier3_index = e2e_step.index("pytest tests/e2e")
+    assert tier2_index < tier3_index
+    assert '--base-url "$APP_URL"' in e2e_step
+    assert '--expected-sha "$EXPECTED_SHA"' in e2e_step
+    assert "test-results/staging-tier2-http.xml" in e2e_step
+
+
+def test_AC8_18_3_test_execution_matrix_names_tier2_http_stage() -> None:
+    """AC8.18.3: The matrix distinguishes Tier 2 from Tier 1 and Tier 3 proof."""
+    matrix = (ROOT / "docs/ssot/test-execution-matrix.yaml").read_text(encoding="utf-8")
+
+    assert "path: tools/tier2_http_e2e.py" in matrix
+    assert "stage: deployment_tier2_http_e2e" in matrix

--- a/tools/generate_fixtures.py
+++ b/tools/generate_fixtures.py
@@ -6,10 +6,15 @@ import sys
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-if str(ROOT_DIR) not in sys.path:
-    sys.path.insert(0, str(ROOT_DIR))
+if str(ROOT_DIR) in sys.path:
+    sys.path.remove(str(ROOT_DIR))
+sys.path.insert(0, str(ROOT_DIR))
 
 from tools._lib.fixtures.generate_fixtures import main  # noqa: E402
+
+if str(ROOT_DIR) in sys.path:
+    sys.path.remove(str(ROOT_DIR))
+sys.path.insert(0, str(ROOT_DIR))
 
 if __name__ == "__main__":  # pragma: no cover
     asyncio.run(main())

--- a/tools/seed_fx_rates.py
+++ b/tools/seed_fx_rates.py
@@ -5,10 +5,15 @@ import sys
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-if str(ROOT_DIR) not in sys.path:
-    sys.path.insert(0, str(ROOT_DIR))
+if str(ROOT_DIR) in sys.path:
+    sys.path.remove(str(ROOT_DIR))
+sys.path.insert(0, str(ROOT_DIR))
 
 from tools._lib.market_data.seed_fx_rates import main  # noqa: E402
+
+if str(ROOT_DIR) in sys.path:
+    sys.path.remove(str(ROOT_DIR))
+sys.path.insert(0, str(ROOT_DIR))
 
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/tools/tier2_http_e2e.py
+++ b/tools/tier2_http_e2e.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Tier 2 deployed HTTP E2E probe.
+
+This command is intentionally narrower than the browser E2E suite: it proves
+that a deployed URL serves the expected version through real HTTP routing and
+basic authenticated/unauthenticated API boundaries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from urllib.parse import urljoin
+from xml.etree import ElementTree
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) in sys.path:
+    sys.path.remove(str(ROOT_DIR))
+sys.path.insert(0, str(ROOT_DIR))
+
+PROOF_TIER = "tier2_http"
+BASE_URL_ENV_VARS = ("TIER2_HTTP_BASE_URL", "APP_URL", "FRONTEND_URL")
+
+
+@dataclass(frozen=True)
+class HttpResponse:
+    status_code: int
+    body: str
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    url: str
+    passed: bool
+    status_code: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class Tier2Config:
+    base_url: str
+    expected_sha: str
+    mode: str = "staging"
+    timeout_seconds: float = 10.0
+
+
+RequestFunc = Callable[[str, float], HttpResponse]
+
+
+def normalize_base_url(base_url: str) -> str:
+    trimmed = base_url.strip().rstrip("/")
+    if not trimmed.startswith(("http://", "https://")):
+        raise ValueError("Tier 2 HTTP E2E requires an http:// or https:// base URL")
+    return trimmed
+
+
+def deployed_input_report(*, mode: str, missing_inputs: Sequence[str]) -> dict[str, object]:
+    return {
+        "proof_tier": PROOF_TIER,
+        "mode": mode,
+        "status": "not_run",
+        "proof_eligible": False,
+        "env_gated": True,
+        "missing_inputs": list(missing_inputs),
+        "checks": [],
+    }
+
+
+def request_http(url: str, timeout_seconds: float) -> HttpResponse:
+    request = urllib.request.Request(url, headers={"User-Agent": "finance-report-tier2-http-e2e"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            return HttpResponse(status_code=response.status, body=body)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return HttpResponse(status_code=exc.code, body=body, error=str(exc))
+    except urllib.error.URLError as exc:
+        return HttpResponse(status_code=0, body="", error=str(exc.reason))
+
+
+def _json_field(body: str, *field_names: str) -> str | None:
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    for field_name in field_names:
+        value = payload.get(field_name)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _sha_matches(actual: str, expected: str) -> bool:
+    return bool(actual and expected) and (
+        actual == expected or actual.startswith(expected) or expected.startswith(actual)
+    )
+
+
+def _result(name: str, url: str, response: HttpResponse, passed: bool, detail: str) -> CheckResult:
+    if not passed and response.error:
+        detail = f"{detail}: {response.error}"
+    return CheckResult(
+        name=name,
+        url=url,
+        passed=passed,
+        status_code=response.status_code,
+        detail=detail,
+    )
+
+
+def run_tier2_http_e2e(config: Tier2Config, requester: RequestFunc = request_http) -> dict[str, object]:
+    base_url = normalize_base_url(config.base_url)
+    checks: list[CheckResult] = []
+
+    health_url = urljoin(f"{base_url}/", "api/health")
+    health = requester(health_url, config.timeout_seconds)
+    checks.append(
+        _result(
+            "api_health_http_200",
+            health_url,
+            health,
+            health.status_code == 200 and "healthy" in health.body.lower(),
+            "GET /api/health must return HTTP 200 with healthy body",
+        )
+    )
+    deployed_version = _json_field(health.body, "git_sha", "version") or ""
+    checks.append(
+        _result(
+            "deployed_version_matches_expected",
+            health_url,
+            health,
+            _sha_matches(deployed_version, config.expected_sha),
+            f"deployed version must match expected_sha={config.expected_sha}",
+        )
+    )
+
+    ping_url = urljoin(f"{base_url}/", "api/ping")
+    ping = requester(ping_url, config.timeout_seconds)
+    checks.append(
+        _result(
+            "api_ping_http_200",
+            ping_url,
+            ping,
+            ping.status_code == 200,
+            "GET /api/ping must return HTTP 200",
+        )
+    )
+
+    frontend_url = f"{base_url}/"
+    frontend = requester(frontend_url, config.timeout_seconds)
+    checks.append(
+        _result(
+            "frontend_http_success",
+            frontend_url,
+            frontend,
+            200 <= frontend.status_code < 400,
+            "GET / must return a frontend success/redirect response",
+        )
+    )
+
+    protected_url = urljoin(f"{base_url}/", "api/statements")
+    protected = requester(protected_url, config.timeout_seconds)
+    checks.append(
+        _result(
+            "protected_api_requires_auth",
+            protected_url,
+            protected,
+            protected.status_code in {401, 429},
+            "GET /api/statements without credentials must return 401 or rate-limit 429",
+        )
+    )
+
+    passed = all(check.passed for check in checks)
+    return {
+        "proof_tier": PROOF_TIER,
+        "mode": config.mode,
+        "base_url": base_url,
+        "expected_sha": config.expected_sha,
+        "status": "passed" if passed else "failed",
+        "proof_eligible": passed,
+        "env_gated": False,
+        "checks": [asdict(check) for check in checks],
+    }
+
+
+def write_json_report(report: Mapping[str, object], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_junit_report(report: Mapping[str, object], path: Path) -> None:
+    checks = report.get("checks", [])
+    if not isinstance(checks, list):
+        checks = []
+    failures = sum(1 for check in checks if isinstance(check, dict) and not check.get("passed"))
+    skipped = 1 if report.get("status") == "not_run" else 0
+    tests = len(checks) if checks else skipped
+
+    suite = ElementTree.Element(
+        "testsuite",
+        {
+            "name": "tier2-http-e2e",
+            "tests": str(tests),
+            "failures": str(failures),
+            "skipped": str(skipped),
+        },
+    )
+    properties = ElementTree.SubElement(suite, "properties")
+    for key in ("proof_tier", "mode", "status", "proof_eligible", "env_gated"):
+        ElementTree.SubElement(properties, "property", {"name": key, "value": str(report.get(key))})
+
+    if report.get("status") == "not_run":
+        case = ElementTree.SubElement(suite, "testcase", {"classname": PROOF_TIER, "name": "not_run"})
+        ElementTree.SubElement(case, "skipped", {"message": ",".join(report.get("missing_inputs", []))})
+    else:
+        for check in checks:
+            if not isinstance(check, dict):
+                continue
+            case = ElementTree.SubElement(
+                suite,
+                "testcase",
+                {"classname": PROOF_TIER, "name": str(check.get("name"))},
+            )
+            if not check.get("passed"):
+                ElementTree.SubElement(case, "failure", {"message": str(check.get("detail"))})
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ElementTree.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def _env_value(environ: Mapping[str, str], names: Sequence[str]) -> str | None:
+    for name in names:
+        value = environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Tier 2 deployed HTTP E2E checks.")
+    parser.add_argument(
+        "--base-url", help="Deployed app base URL. Falls back to TIER2_HTTP_BASE_URL/APP_URL/FRONTEND_URL."
+    )
+    parser.add_argument("--expected-sha", help="Expected deployed git_sha/version. Falls back to EXPECTED_SHA.")
+    parser.add_argument("--mode", default="staging", help="Environment label for reports.")
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    parser.add_argument("--json-report", type=Path)
+    parser.add_argument("--junit-xml", type=Path)
+    parser.add_argument(
+        "--advisory-if-missing",
+        action="store_true",
+        help="Return success for local advisory runs with missing inputs, but write proof_eligible=false reports.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    requester: RequestFunc = request_http,
+) -> int:
+    args = parse_args(argv)
+    env = environ if environ is not None else {}
+    base_url = args.base_url or _env_value(env, BASE_URL_ENV_VARS)
+    expected_sha = args.expected_sha or env.get("EXPECTED_SHA")
+
+    missing_inputs = []
+    if not base_url:
+        missing_inputs.append("base_url")
+    if not expected_sha:
+        missing_inputs.append("expected_sha")
+    if missing_inputs:
+        report = deployed_input_report(mode=args.mode, missing_inputs=missing_inputs)
+        if args.json_report:
+            write_json_report(report, args.json_report)
+        if args.junit_xml:
+            write_junit_report(report, args.junit_xml)
+        message = f"Tier 2 HTTP E2E missing required deployed input(s): {', '.join(missing_inputs)}"
+        if args.advisory_if_missing:
+            print(message)
+            return 0
+        print(message, file=sys.stderr)
+        return 2
+
+    try:
+        config = Tier2Config(
+            base_url=base_url,
+            expected_sha=expected_sha,
+            mode=args.mode,
+            timeout_seconds=args.timeout_seconds,
+        )
+        report = run_tier2_http_e2e(config, requester=requester)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if args.json_report:
+        write_json_report(report, args.json_report)
+    if args.junit_xml:
+        write_junit_report(report, args.junit_xml)
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:], environ=dict(os.environ)))


### PR DESCRIPTION
## Summary

Adds a strict Tier 2 deployed HTTP E2E command, wires it into staging between shell smoke and broader deployed E2E, and documents proof-tier/pass-fail semantics so env-gated not-run output cannot count as proof.

Closes #618
Refs #1073

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 — Comprehensive Testing Strategy |
| **AC IDs** | AC8.18.1, AC8.18.2, AC8.18.3 |
| **AC source updated** | `docs/project/EPIC-008.testing-strategy.md` |

---

## SSOT Changes

- [x] `docs/ssot/ci-cd.md` — defines Tier 2 command, placement, report tier, and strict missing-input policy.
- [x] `docs/ssot/test-execution-matrix.yaml` — adds `deployment_tier2_http_e2e` as a distinct stage.
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red (failing test) | N/A | Tests were added before implementation in the working tree, not split into a separate red commit. |
| Green (passing test) | `8d2ddf4` | Implement Tier 2 HTTP command, staging placement, docs, and wrapper bootstrap fixes. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (not touched)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable; submodule synced for tests only)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes

### CI/CD, Runtime, and VPS Infra Audit

- [x] Lifecycle ownership is unchanged; this only adds a read-only deployed HTTP proof command.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys.
- [x] Proof command includes focused tests for strict missing-input behavior and proof eligibility semantics.

---

## Testing

```bash
python3 tools/generate_ac_registry.py && python3 tools/check_ac_index.py
python3 tools/check_ssot_ownership.py && python3 tools/check_manifest.py && python3 tools/lint_doc_consistency.py
cd apps/backend && uv run ruff format --check ../../tools/tier2_http_e2e.py ../../tools/generate_fixtures.py ../../tools/seed_fx_rates.py ../../tests/tooling/test_tier2_http_e2e.py
cd apps/backend && uv run ruff check ../../tools/tier2_http_e2e.py ../../tools/generate_fixtures.py ../../tools/seed_fx_rates.py ../../tests/tooling/test_tier2_http_e2e.py
cd apps/backend && uv run python -m pytest ../../tests/tooling/test_tier2_http_e2e.py ../../tests/tooling/test_common_tooling_modules.py::test_AC8_13_56_python_tool_wrappers_bootstrap_repo_root_when_run_directly -q --no-cov
apps/backend/.venv/bin/python -m pytest tests/tooling/ -q --no-cov
```

---

## Screenshots / Evidence

N/A