### PR TITLE
[finance_report_ui] Add report source intake checklist

### DIFF
--- a/apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx
+++ b/apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx
@@ -17,6 +17,16 @@ import type {
 } from "@/lib/types"
 
 const showToastMock = vi.fn()
+const navigationState = vi.hoisted(() => ({
+  sourceClass: null as string | null,
+}))
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () =>
+    new URLSearchParams(
+      navigationState.sourceClass ? { source_class: navigationState.sourceClass } : undefined,
+    ),
+}))
 
 vi.mock("@/components/ui/Toast", () => ({
   useToast: () => ({ showToast: showToastMock }),
@@ -101,6 +111,7 @@ describe("GuidedEvidenceForm", () => {
   beforeEach(() => {
     mockedApiFetch.mockReset()
     showToastMock.mockReset()
+    navigationState.sourceClass = null
   })
 
   afterEach(() => {
@@ -464,6 +475,14 @@ describe("GuidedEvidenceForm", () => {
     expect(
       screen.getByRole("form", { name: "Guided evidence form" }),
     ).toBeInTheDocument()
+  })
+
+  it("AC19.15.1 opens guided evidence at the requested source class", () => {
+    navigationState.sourceClass = "liability_statement"
+    mockListOnly()
+    render(<GuidedEvidencePage />, { wrapper: createWrapper() })
+
+    expect(screen.getByLabelText("Source class")).toHaveValue("liability_statement")
   })
 
   it("covers all three guided source classes and seven valuation bases", () => {

--- a/apps/frontend/src/__tests__/sourceIntakeChecklist.test.tsx
+++ b/apps/frontend/src/__tests__/sourceIntakeChecklist.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, within } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  REQUIRED_REPORT_SOURCE_CLASSES,
+  SourceIntakeChecklist,
+} from "@/components/source-intake/SourceIntakeChecklist"
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+describe("SourceIntakeChecklist", () => {
+  it("AC19.15.1 renders every required source class with intake links", () => {
+    render(<SourceIntakeChecklist />)
+
+    expect(REQUIRED_REPORT_SOURCE_CLASSES).toEqual([
+      "bank_statement",
+      "brokerage_statement",
+      "settlement_note",
+      "esop_rsu_plan",
+      "property_statement",
+      "liability_statement",
+      "csv_export",
+      "manual_record",
+    ])
+
+    const checklist = screen.getByRole("region", { name: "Report source intake checklist" })
+    for (const label of [
+      "Bank statements",
+      "Brokerage statements",
+      "Settlement notes",
+      "ESOP / RSU plans",
+      "Property statements",
+      "Liability statements",
+      "CSV exports",
+      "Manual records",
+    ]) {
+      expect(within(checklist).getByText(label)).toBeInTheDocument()
+    }
+
+    expect(screen.getByRole("link", { name: "Upload bank statements" })).toHaveAttribute("href", "/upload")
+    expect(screen.getByRole("link", { name: "Upload brokerage statements" })).toHaveAttribute("href", "/upload")
+    expect(screen.getByRole("link", { name: "Capture settlement notes" })).toHaveAttribute("href", "/upload")
+    expect(screen.getByRole("link", { name: "Add ESOP / RSU plans" })).toHaveAttribute(
+      "href",
+      "/portfolio/evidence?source_class=esop_rsu_plan",
+    )
+    expect(screen.getByRole("link", { name: "Add property statements" })).toHaveAttribute(
+      "href",
+      "/portfolio/evidence?source_class=property_statement",
+    )
+    expect(screen.getByRole("link", { name: "Add liability statements" })).toHaveAttribute(
+      "href",
+      "/portfolio/evidence?source_class=liability_statement",
+    )
+    expect(screen.getByRole("link", { name: "Upload CSV exports" })).toHaveAttribute("href", "/upload")
+    expect(screen.getByRole("link", { name: "Enter manual records" })).toHaveAttribute("href", "/journal")
+  })
+
+  it("AC19.15.2 labels readiness gaps and manual-trusted source classes", () => {
+    render(
+      <SourceIntakeChecklist
+        sourceTrustSummary={{
+          source_classes: ["bank_statement", "property_statement", "manual_record"],
+          deterministic_pr_source_classes: ["bank_statement", "property_statement", "manual_record"],
+          post_merge_llm_ocr_source_classes: ["bank_statement"],
+          manual_trusted_source_classes: ["property_statement", "manual_record"],
+          gap_source_classes: ["manual_record"],
+          blocker_codes: ["missing_source_coverage"],
+        }}
+      />,
+    )
+
+    expect(within(screen.getByTestId("source-intake-bank_statement")).getByText("Import supported")).toBeInTheDocument()
+    expect(within(screen.getByTestId("source-intake-property_statement")).getByText("Manual-trusted")).toBeInTheDocument()
+    expect(within(screen.getByTestId("source-intake-manual_record")).getByText("Needs source")).toBeInTheDocument()
+    expect(screen.queryByText("Automatically imported manual evidence")).not.toBeInTheDocument()
+  })
+
+  it("AC19.15.2 distinguishes deterministic proof from sources outside the current summary", () => {
+    render(
+      <SourceIntakeChecklist
+        sourceTrustSummary={{
+          source_classes: ["csv_export"],
+          deterministic_pr_source_classes: ["csv_export"],
+          post_merge_llm_ocr_source_classes: [],
+          manual_trusted_source_classes: [],
+          gap_source_classes: [],
+          blocker_codes: [],
+        }}
+      />,
+    )
+
+    expect(within(screen.getByTestId("source-intake-csv_export")).getByText("Deterministic proof")).toBeInTheDocument()
+    expect(within(screen.getByTestId("source-intake-bank_statement")).getByText("Planned source")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/app/(main)/portfolio/evidence/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/evidence/page.tsx
@@ -8,9 +8,23 @@
  * API via the typed client inside the form component.
  */
 
-import GuidedEvidenceForm from "@/components/assets/GuidedEvidenceForm";
+import { useSearchParams } from "next/navigation";
+
+import GuidedEvidenceForm, {
+  SOURCE_CLASS_CONFIGS,
+  type EvidenceSourceClass,
+} from "@/components/assets/GuidedEvidenceForm";
+
+function sourceClassFromQuery(value: string | null): EvidenceSourceClass | undefined {
+  return SOURCE_CLASS_CONFIGS.some((config) => config.value === value)
+    ? (value as EvidenceSourceClass)
+    : undefined;
+}
 
 export default function GuidedEvidencePage() {
+  const searchParams = useSearchParams();
+  const initialSourceClass = sourceClassFromQuery(searchParams.get("source_class"));
+
   return (
     <div className="p-6">
       <div className="page-header">
@@ -21,7 +35,7 @@ export default function GuidedEvidencePage() {
           labelled manual-trusted across reports and the traceability appendix.
         </p>
       </div>
-      <GuidedEvidenceForm />
+      <GuidedEvidenceForm initialSourceClass={initialSourceClass} />
     </div>
   );
 }

--- a/apps/frontend/src/app/(main)/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/upload/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 
+import { SourceIntakeChecklist } from "@/components/source-intake/SourceIntakeChecklist";
 import StatementUploader from "@/components/statements/StatementUploader";
 import { FlowStepBanner } from "@/components/workflow/FlowStepBanner";
 import { InfoHint } from "@/components/ui/InfoHint";
@@ -104,12 +105,16 @@ export default function UploadPage() {
         <div className="p-6">
             <PageHeader
                 title="Upload"
-                description="Upload a bank statement — we parse it, then you review and approve it to update your reports."
+                description="Upload statements, add guided evidence, and keep every report source class visible before you read reports."
                 className="sm:block"
             />
 
             <div className="mb-6">
                 <FlowStepBanner current="upload" />
+            </div>
+
+            <div className="mb-6">
+                <SourceIntakeChecklist />
             </div>
 
             {/* Upload Section */}

--- a/apps/frontend/src/components/source-intake/SourceIntakeChecklist.tsx
+++ b/apps/frontend/src/components/source-intake/SourceIntakeChecklist.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import Link from "next/link";
+import {
+  BriefcaseBusiness,
+  Building2,
+  ClipboardList,
+  FileSpreadsheet,
+  FileText,
+  Home,
+  Landmark,
+  PencilLine,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Badge, type BadgeVariant } from "@/components/ui";
+import type { PersonalReportPackageReadinessResponse } from "@/lib/types";
+
+export const REQUIRED_REPORT_SOURCE_CLASSES = [
+  "bank_statement",
+  "brokerage_statement",
+  "settlement_note",
+  "esop_rsu_plan",
+  "property_statement",
+  "liability_statement",
+  "csv_export",
+  "manual_record",
+] as const;
+
+type ReportSourceClass = (typeof REQUIRED_REPORT_SOURCE_CLASSES)[number];
+
+type SourceTrustSummary = NonNullable<
+  PersonalReportPackageReadinessResponse["source_trust_summary"]
+>;
+
+interface SourceIntakeItem {
+  id: ReportSourceClass;
+  label: string;
+  description: string;
+  href: string;
+  ctaLabel: string;
+  defaultStatus: string;
+  defaultVariant: BadgeVariant;
+  icon: LucideIcon;
+}
+
+const SOURCE_INTAKE_ITEMS: SourceIntakeItem[] = [
+  {
+    id: "bank_statement",
+    label: "Bank statements",
+    description: "Bank PDF or CSV exports used for cash, income, expense, and transfer lines.",
+    href: "/upload",
+    ctaLabel: "Upload bank statements",
+    defaultStatus: "Import supported",
+    defaultVariant: "success",
+    icon: Landmark,
+  },
+  {
+    id: "brokerage_statement",
+    label: "Brokerage statements",
+    description: "Brokerage PDFs, CSVs, or structured payloads for holdings and investment activity.",
+    href: "/upload",
+    ctaLabel: "Upload brokerage statements",
+    defaultStatus: "Import supported",
+    defaultVariant: "success",
+    icon: BriefcaseBusiness,
+  },
+  {
+    id: "settlement_note",
+    label: "Settlement notes",
+    description: "Broker settlement evidence captured from the brokerage import flow.",
+    href: "/upload",
+    ctaLabel: "Capture settlement notes",
+    defaultStatus: "Structured capture",
+    defaultVariant: "info",
+    icon: FileText,
+  },
+  {
+    id: "esop_rsu_plan",
+    label: "ESOP / RSU plans",
+    description: "Employer grant or vesting documents for restricted compensation evidence.",
+    href: "/portfolio/evidence?source_class=esop_rsu_plan",
+    ctaLabel: "Add ESOP / RSU plans",
+    defaultStatus: "Manual-trusted",
+    defaultVariant: "info",
+    icon: Building2,
+  },
+  {
+    id: "property_statement",
+    label: "Property statements",
+    description: "Appraisals and property statements with an explicit valuation basis and as-of date.",
+    href: "/portfolio/evidence?source_class=property_statement",
+    ctaLabel: "Add property statements",
+    defaultStatus: "Manual-trusted",
+    defaultVariant: "info",
+    icon: Home,
+  },
+  {
+    id: "liability_statement",
+    label: "Liability statements",
+    description: "Loan, mortgage, credit-card, or other liability balances with source anchors.",
+    href: "/portfolio/evidence?source_class=liability_statement",
+    ctaLabel: "Add liability statements",
+    defaultStatus: "Manual-trusted",
+    defaultVariant: "info",
+    icon: ClipboardList,
+  },
+  {
+    id: "csv_export",
+    label: "CSV exports",
+    description: "Bank, brokerage, or wallet CSV exports parsed through the direct CSV path.",
+    href: "/upload",
+    ctaLabel: "Upload CSV exports",
+    defaultStatus: "Deterministic proof",
+    defaultVariant: "success",
+    icon: FileSpreadsheet,
+  },
+  {
+    id: "manual_record",
+    label: "Manual records",
+    description: "Balanced user-entered journal entries that remain explicitly manual in reports.",
+    href: "/journal",
+    ctaLabel: "Enter manual records",
+    defaultStatus: "Manual-trusted",
+    defaultVariant: "info",
+    icon: PencilLine,
+  },
+];
+
+function statusForSourceClass(
+  item: SourceIntakeItem,
+  summary?: SourceTrustSummary,
+): { label: string; variant: BadgeVariant } {
+  if (!summary) {
+    return { label: item.defaultStatus, variant: item.defaultVariant };
+  }
+  if (summary.gap_source_classes.includes(item.id)) {
+    return { label: "Needs source", variant: "warning" };
+  }
+  if (summary.manual_trusted_source_classes.includes(item.id)) {
+    return { label: "Manual-trusted", variant: "info" };
+  }
+  if (summary.post_merge_llm_ocr_source_classes.includes(item.id)) {
+    return { label: "Import supported", variant: "success" };
+  }
+  if (summary.deterministic_pr_source_classes.includes(item.id)) {
+    return { label: "Deterministic proof", variant: "success" };
+  }
+  return { label: "Planned source", variant: "muted" };
+}
+
+export function SourceIntakeChecklist({
+  sourceTrustSummary,
+}: {
+  sourceTrustSummary?: SourceTrustSummary;
+}) {
+  return (
+    <section
+      aria-label="Report source intake checklist"
+      className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-4"
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-base font-semibold">Source intake checklist</h2>
+          <p className="mt-1 max-w-3xl text-sm text-muted">
+            Add the source classes that make report readiness trustworthy. Manual evidence stays labelled manual-trusted.
+          </p>
+        </div>
+        <Badge variant="muted">{SOURCE_INTAKE_ITEMS.length} source classes</Badge>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {SOURCE_INTAKE_ITEMS.map((item) => {
+          const Icon = item.icon;
+          const status = statusForSourceClass(item, sourceTrustSummary);
+          return (
+            <article
+              key={item.id}
+              data-testid={`source-intake-${item.id}`}
+              className="flex min-h-[13rem] flex-col rounded-lg border border-[var(--border)] p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-start gap-3">
+                  <span className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--background-muted)]">
+                    <Icon className="h-4 w-4 text-[var(--accent)]" aria-hidden="true" />
+                  </span>
+                  <div className="min-w-0">
+                    <h3 className="text-sm font-semibold">{item.label}</h3>
+                    <p className="mt-1 break-words font-mono text-[0.7rem] text-muted">
+                      {item.id}
+                    </p>
+                  </div>
+                </div>
+                <Badge variant={status.variant}>{status.label}</Badge>
+              </div>
+
+              <p className="mt-3 flex-1 text-sm text-muted">{item.description}</p>
+
+              <Link
+                href={item.href}
+                className="btn-secondary mt-4 inline-flex min-h-10 items-center justify-center text-sm"
+              >
+                {item.ctaLabel}
+              </Link>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -455,6 +455,20 @@ insert now runs inside a SAVEPOINT and recovers the existing row on conflict, mi
 | AC19.14.2 | A duplicate `(user_id, dedupe_key)` insert recovers via savepoint, returns the existing row, and leaves the outer transaction usable for subsequent reads/flushes | `test_AC19_14_2_duplicate_insert_does_not_poison_outer_transaction` | P0 |
 | AC19.14.3 | Concurrent `sync_workflow_events_for_user` runs over the same source state do not 500 on the workflow-event dedupe key and create the derived uploaded event exactly once | `test_AC19_14_3_sync_tolerates_concurrent_event_creation` | P0 |
 
+### AC19.15 — Source Intake Checklist For Report Coverage (issue #1208)
+
+The Upload entry must no longer imply that report readiness is only about bank
+statements. It should expose every required source class from
+`docs/ssot/source-coverage-matrix.yaml`, point each class to the existing intake
+path, and keep manual-trusted inputs clearly distinct from uploaded/imported
+sources. This slice is UI guidance only; it does not introduce new parsers or
+change backend source-trust decisions.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC19.15.1 | The Upload page renders a source intake checklist covering bank statements, brokerage statements, settlement notes, ESOP/RSU plans, property statements, liability statements, CSV exports, and manual records, with each item linked to its existing intake path | `AC19.15.1 renders every required source class with intake links` | P1 |
+| AC19.15.2 | Source intake status labels treat readiness gaps as action-required, identify manual-trusted classes separately, and never claim manual evidence is imported automatically | `AC19.15.2 labels readiness gaps and manual-trusted source classes` | P1 |
+
 ## How To Build It
 
 ### Backend

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -30,6 +30,21 @@ blockers, notes, and source links. If an input is missing, stale, ambiguous, or
 outside the implemented contract, the report must disclose the limitation or
 block readiness instead of silently filling the gap.
 
+### 1.1.1 Source Intake UI Contract
+
+The Upload surface may consume the required source classes from
+`docs/ssot/source-coverage-matrix.yaml` as a user-facing checklist before
+statement upload. Frontend routes may map those backend ingestion paths to the
+existing user workflows (`/upload`, `/portfolio/evidence`, `/journal`), but the
+frontend does not own source-trust classification. Package readiness and
+source-trust endpoints remain authoritative for whether a source class is a gap,
+manual-trusted, imported/supported, or ready for trusted report output.
+
+Manual evidence classes such as ESOP/RSU plans, property statements, liability
+statements, and manual records must stay visibly manual-trusted. The Upload UI
+must not imply they are automatically imported or parsed when the underlying
+contract is an explicit user-entered evidence path.
+
 ### 1.2 Report Snapshot Determinism
 
 `report_snapshots` stores generated ADS report payloads. Regeneration may keep


### PR DESCRIPTION
## Summary
- Closes #1208.
- Adds an Upload-page source intake checklist for all required report source classes from the source coverage matrix.
- Links existing intake paths for statement uploads, guided evidence, and manual journal records without adding new parsers.
- Deep-links guided evidence to the requested source class.

## Delivery Standard
- AC19.15.1 and AC19.15.2 registered in EPIC-019.
- Frontend tests cover all required source classes, intake links, readiness-gap labels, manual-trusted labels, deterministic proof fallback, and guided evidence deep-link behavior.
- SSOT reporting note clarifies that source-trust classification remains backend-readiness authority.

## Validation
- `npm test -- sourceIntakeChecklist.test.tsx`
- `npm test -- guidedEvidenceForm.test.tsx`
- `npm test -- statementsPage.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `uv run --with pyyaml python tools/check_source_coverage_matrix.py`
- `uv run --with pyyaml python tools/check_ac_index.py`
- `uv run --with pyyaml python tools/preflight.py`
