### PR TITLE
[finance_report_test_and_doc] test(e2e): harden staging AI/OCR gate locators

### DIFF
--- a/tests/e2e/test_four_asset_net_worth_golden_path.py
+++ b/tests/e2e/test_four_asset_net_worth_golden_path.py
@@ -96,13 +96,8 @@ def _get_pdf_path(source: str) -> Path:
         text=True,
     )
     if result.returncode != 0:
-        pytest.skip(
-            f"PDF fixture generation failed for {source}.\n"
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
-    pdfs = (
-        sorted(source_dir.glob(f"test_{source}_*.pdf")) if source_dir.exists() else []
-    )
+        pytest.skip(f"PDF fixture generation failed for {source}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+    pdfs = sorted(source_dir.glob(f"test_{source}_*.pdf")) if source_dir.exists() else []
     if not pdfs:
         pytest.skip(f"PDF generation for {source} produced no files in {source_dir}")
     return pdfs[-1]
@@ -130,9 +125,7 @@ async def _auth_headers(page: Page) -> dict[str, str]:
 
 async def _default_image_model(client: httpx.AsyncClient) -> str:
     response = await client.get(_api_url("/llm/catalog?modality=image"))
-    assert response.status_code == 200, (
-        f"model catalog request failed: {response.status_code} {response.text}"
-    )
+    assert response.status_code == 200, f"model catalog request failed: {response.status_code} {response.text}"
     payload = response.json()
     return payload.get("default_model") or payload["models"][0]["id"]
 
@@ -144,9 +137,7 @@ async def _upload_bank_csv(client: httpx.AsyncClient, fixture_path: Path) -> str
             data={"institution": BANK_INSTITUTION},
             files={"file": (fixture_path.name, fh, "text/csv")},
         )
-    assert response.status_code in (200, 201, 202), (
-        f"bank upload failed: {response.status_code} {response.text}"
-    )
+    assert response.status_code in (200, 201, 202), f"bank upload failed: {response.status_code} {response.text}"
     statement_id = response.json().get("id")
     assert statement_id, f"bank upload response missing id: {response.text}"
     return str(statement_id)
@@ -166,9 +157,7 @@ async def _upload_brokerage_pdf(
             data={"institution": institution, "model": model},
             files={"file": (pdf_path.name, fh, "application/pdf")},
         )
-    assert response.status_code in (200, 201, 202), (
-        f"{source} upload failed: {response.status_code} {response.text}"
-    )
+    assert response.status_code in (200, 201, 202), f"{source} upload failed: {response.status_code} {response.text}"
     statement_id = response.json().get("id")
     assert statement_id, f"{source} upload response missing id: {response.text}"
     return str(statement_id)
@@ -245,9 +234,7 @@ async def _create_manual_snapshot(
 
 
 def _line_total(lines: list[dict]) -> Decimal:
-    return sum(
-        (_money(line.get("amount", "0")) for line in lines), Decimal("0.00")
-    ).quantize(Decimal("0.01"))
+    return sum((_money(line.get("amount", "0")) for line in lines), Decimal("0.00")).quantize(Decimal("0.01"))
 
 
 def _lines_by_name(lines: list[dict], token: str) -> list[dict]:
@@ -303,14 +290,10 @@ async def test_four_asset_as_of_net_worth_golden_path(
     report_date = date.today()
     headers = await _auth_headers(page)
 
-    async with httpx.AsyncClient(
-        headers=headers, verify=False, timeout=120.0
-    ) as client:
+    async with httpx.AsyncClient(headers=headers, verify=False, timeout=120.0) as client:
         bank_fixture = _write_bank_fixture(tmp_path, report_date)
         bank_statement_id = await _upload_bank_csv(client, bank_fixture)
-        parsed_bank = await _wait_for_parsed_statement(
-            client, bank_statement_id, gate_name="bank CSV"
-        )
+        parsed_bank = await _wait_for_parsed_statement(client, bank_statement_id, gate_name="bank CSV")
         assert len(parsed_bank.get("transactions") or []) == 2
 
         approve_response = await client.post(
@@ -329,9 +312,7 @@ async def test_four_asset_as_of_net_worth_golden_path(
         )
         journal_payload = journal_response.json()
         assert journal_payload["total"] == 2
-        assert {item["status"].lower() for item in journal_payload["items"]} == {
-            "posted"
-        }
+        assert {item["status"].lower() for item in journal_payload["items"]} == {"posted"}
         assert {item["memo"] for item in journal_payload["items"]} == {
             "Four Asset Salary",
             "Four Asset Rent",
@@ -385,31 +366,23 @@ async def test_four_asset_as_of_net_worth_golden_path(
             brokerage_statement_id,
             gate_name="brokerage PDF",
         )
-        import_response = await client.post(
-            _api_url(f"/statements/{parsed_brokerage['id']}/brokerage/import")
-        )
+        import_response = await client.post(_api_url(f"/statements/{parsed_brokerage['id']}/brokerage/import"))
         assert import_response.status_code == 200, (
             f"brokerage import failed: {import_response.status_code} {import_response.text}"
         )
         import_payload = import_response.json()
-        assert import_payload["parsed_positions"] > 0, (
-            f"no brokerage positions imported: {import_payload}"
-        )
+        assert import_payload["parsed_positions"] > 0, f"no brokerage positions imported: {import_payload}"
 
         holdings_response = await client.get(_api_url("/portfolio/holdings"))
         assert holdings_response.status_code == 200, (
             f"holdings check failed: {holdings_response.status_code} {holdings_response.text}"
         )
         holdings = holdings_response.json()
-        assert len(holdings) >= import_payload["parsed_positions"], (
-            f"missing imported holdings: {holdings}"
+        assert len(holdings) >= import_payload["parsed_positions"], f"missing imported holdings: {holdings}"
+        brokerage_value = sum((_money(item["market_value"]) for item in holdings), Decimal("0.00")).quantize(
+            Decimal("0.01")
         )
-        brokerage_value = sum(
-            (_money(item["market_value"]) for item in holdings), Decimal("0.00")
-        ).quantize(Decimal("0.01"))
-        assert brokerage_value > Decimal("0.00"), (
-            f"brokerage holdings have no market value: {holdings}"
-        )
+        assert brokerage_value > Decimal("0.00"), f"brokerage holdings have no market value: {holdings}"
 
         property_snapshot = await _create_manual_snapshot(
             client,
@@ -437,9 +410,7 @@ async def test_four_asset_as_of_net_worth_golden_path(
         assert esop_snapshot["liquidity_class"] == "restricted"
 
         components_response = await client.get(
-            _api_url(
-                f"/assets/valuation-components?as_of_date={report_date.isoformat()}&include_restricted=true"
-            )
+            _api_url(f"/assets/valuation-components?as_of_date={report_date.isoformat()}&include_restricted=true")
         )
         assert components_response.status_code == 200, (
             f"valuation components check failed: {components_response.status_code} {components_response.text}"
@@ -447,10 +418,7 @@ async def test_four_asset_as_of_net_worth_golden_path(
         components = components_response.json()
         assert _money(components["total_assets"]) == PROPERTY_VALUE + ESOP_VALUE
         assert _money(components["total_liabilities"]) == MORTGAGE_BALANCE
-        assert (
-            _money(components["net_worth_delta"])
-            == PROPERTY_VALUE + ESOP_VALUE - MORTGAGE_BALANCE
-        )
+        assert _money(components["net_worth_delta"]) == PROPERTY_VALUE + ESOP_VALUE - MORTGAGE_BALANCE
 
         balance_response = await client.get(
             _api_url(
@@ -461,27 +429,17 @@ async def test_four_asset_as_of_net_worth_golden_path(
             f"balance sheet check failed: {balance_response.status_code} {balance_response.text}"
         )
         balance_sheet = balance_response.json()
-        asset_lines = [
-            line for line in balance_sheet.get("assets", []) if isinstance(line, dict)
-        ]
-        liability_lines = [
-            line
-            for line in balance_sheet.get("liabilities", [])
-            if isinstance(line, dict)
-        ]
+        asset_lines = [line for line in balance_sheet.get("assets", []) if isinstance(line, dict)]
+        liability_lines = [line for line in balance_sheet.get("liabilities", []) if isinstance(line, dict)]
         market_lines = _lines_by_name(asset_lines, "market valuation adjustment")
         market_total = _line_total(market_lines)
 
-        expected_assets = (
-            BANK_CASH + brokerage_value + PROPERTY_VALUE + ESOP_VALUE
-        ).quantize(Decimal("0.01"))
+        expected_assets = (BANK_CASH + brokerage_value + PROPERTY_VALUE + ESOP_VALUE).quantize(Decimal("0.01"))
         expected_liabilities = MORTGAGE_BALANCE
-        expected_net_worth = (expected_assets - expected_liabilities).quantize(
+        expected_net_worth = (expected_assets - expected_liabilities).quantize(Decimal("0.01"))
+        expected_net_worth_adjustment = (brokerage_value + PROPERTY_VALUE + ESOP_VALUE - MORTGAGE_BALANCE).quantize(
             Decimal("0.01")
         )
-        expected_net_worth_adjustment = (
-            brokerage_value + PROPERTY_VALUE + ESOP_VALUE - MORTGAGE_BALANCE
-        ).quantize(Decimal("0.01"))
 
         assert _line_total_by_name(asset_lines, BANK_INSTITUTION) == BANK_CASH
         assert market_total == brokerage_value, (
@@ -490,41 +448,25 @@ async def test_four_asset_as_of_net_worth_golden_path(
         )
         assert _line_total_by_name(asset_lines, "Four Asset Condo") == PROPERTY_VALUE
         assert _line_total_by_name(asset_lines, "Four Asset ESOP") == ESOP_VALUE
-        assert (
-            _line_total_by_name(liability_lines, "Four Asset Mortgage")
-            == MORTGAGE_BALANCE
-        )
+        assert _line_total_by_name(liability_lines, "Four Asset Mortgage") == MORTGAGE_BALANCE
         assert _money(balance_sheet["total_assets"]) == expected_assets
         assert _money(balance_sheet["total_liabilities"]) == expected_liabilities
-        assert (
-            _money(balance_sheet["total_assets"])
-            - _money(balance_sheet["total_liabilities"])
-            == expected_net_worth
-        )
-        assert (
-            _money(balance_sheet["net_worth_adjustment_gain_loss"])
-            == expected_net_worth_adjustment
-        )
+        assert _money(balance_sheet["total_assets"]) - _money(balance_sheet["total_liabilities"]) == expected_net_worth
+        assert _money(balance_sheet["net_worth_adjustment_gain_loss"]) == expected_net_worth_adjustment
         assert _money(balance_sheet["equation_delta"]) == Decimal("0.00")
         assert balance_sheet["is_balanced"] is True
 
     await page.goto(_get_url("/dashboard"))
     await page.wait_for_load_state("domcontentloaded")
-    await expect(page.get_by_label("Upload-to-report home")).to_be_visible(
-        timeout=10_000
-    )
-    await expect(page.get_by_label("Dashboard analytics")).to_be_visible(
-        timeout=10_000
-    )
+    await expect(page.get_by_label("Upload-to-report home")).to_be_visible(timeout=10_000)
+    await expect(page.get_by_label("Dashboard analytics", exact=True)).to_be_visible(timeout=10_000)
     include_checkbox = page.get_by_label("Include restricted holdings")
     await expect(include_checkbox).to_be_visible(timeout=10_000)
     if not await include_checkbox.is_checked():
         await include_checkbox.check()
 
     await expect(
-        page.locator(".card")
-        .filter(has_text="Total Assets")
-        .filter(has_text=_dashboard_amount(expected_assets))
+        page.locator(".card").filter(has_text="Total Assets").filter(has_text=_dashboard_amount(expected_assets))
     ).to_be_visible(timeout=15_000)
     await expect(
         page.locator(".card")
@@ -532,30 +474,19 @@ async def test_four_asset_as_of_net_worth_golden_path(
         .filter(has_text=_dashboard_amount(expected_liabilities))
     ).to_be_visible(timeout=15_000)
     await expect(
-        page.locator(".card")
-        .filter(has_text="Net Assets")
-        .filter(has_text=_dashboard_amount(expected_net_worth))
+        page.locator(".card").filter(has_text="Net Assets").filter(has_text=_dashboard_amount(expected_net_worth))
     ).to_be_visible(timeout=15_000)
 
     await page.goto(
-        _get_url(
-            f"/reports/balance-sheet?as_of_date={report_date.isoformat()}&currency=SGD"
-            "&include_restricted=true"
-        )
+        _get_url(f"/reports/balance-sheet?as_of_date={report_date.isoformat()}&currency=SGD&include_restricted=true")
     )
     await page.wait_for_load_state("domcontentloaded")
-    await expect(page.get_by_role("heading", name="Balance Sheet")).to_be_visible(
-        timeout=10_000
-    )
-    await expect(
-        page.locator(".card").filter(has_text="Assets").filter(has_text="Total:")
-    ).to_contain_text(
+    await expect(page.get_by_role("heading", name="Balance Sheet")).to_be_visible(timeout=10_000)
+    await expect(page.locator(".card").filter(has_text="Assets").filter(has_text="Total:")).to_contain_text(
         _report_amount(expected_assets),
         timeout=15_000,
     )
-    await expect(
-        page.locator(".card").filter(has_text="Liabilities").filter(has_text="Total:")
-    ).to_contain_text(
+    await expect(page.locator(".card").filter(has_text="Liabilities").filter(has_text="Total:")).to_contain_text(
         _report_amount(expected_liabilities),
         timeout=15_000,
     )

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -27,9 +27,8 @@ from uuid import uuid4
 import httpx
 import pytest
 from common.testing.ac_proof import ac_proof
-from playwright.async_api import Page, expect
-
 from conftest import fail_or_skip_ai_ocr_gate
+from playwright.async_api import Page, expect
 from tools._lib.fixtures.personal_report_package import REPRESENTATIVE_PACKAGE_FIXTURE
 
 APP_URL: str = os.getenv("APP_URL", "http://localhost:3000")
@@ -89,10 +88,7 @@ async def _auth_headers(page: Page) -> dict[str, str]:
 
 def _statement_timeout_message(statement_id: str, last_payload: dict | None) -> str:
     if not last_payload:
-        return (
-            f"statement {statement_id} did not reach parsed within {PARSING_TIMEOUT_MS}ms; "
-            "no poll payload was returned"
-        )
+        return f"statement {statement_id} did not reach parsed within {PARSING_TIMEOUT_MS}ms; no poll payload was returned"
 
     status = last_payload.get("status")
     parsing_progress = last_payload.get("parsing_progress")
@@ -182,7 +178,7 @@ def _get_pdf_path(source: str) -> Path:
 
 def _unique_pdf_copy(src: Path) -> Path:
     tmp = Path(tempfile.mkdtemp())
-    suffix = int((time() * 1000)) % 1_000_000
+    suffix = int(time() * 1000) % 1_000_000
     dest = tmp / f"{src.stem}_{suffix}{src.suffix}"
     shutil.copy2(src, dest)
     with dest.open("ab") as fh:
@@ -581,7 +577,9 @@ async def test_personal_financial_report_package_post_merge_journey(
         await expect(
             page.get_by_text("Investment Performance Report Schedule")
         ).to_be_visible()
-        await expect(page.get_by_text("investment_performance", exact=True)).to_be_visible()
+        await expect(
+            page.get_by_text("investment_performance", exact=True)
+        ).to_be_visible()
 
         property_snapshot = await _create_manual_snapshot(
             client,
@@ -659,7 +657,9 @@ async def test_personal_financial_report_package_post_merge_journey(
         )
 
         snapshots_response = await client.get(
-            f"/assets/valuation-snapshots?as_of_date={fixture_period_end.isoformat()}"
+            _api_url(
+                f"/assets/valuation-snapshots?as_of_date={fixture_period_end.isoformat()}"
+            )
         )
         assert snapshots_response.status_code == 200, (
             f"valuation snapshot list failed: {snapshots_response.status_code} {snapshots_response.text}"
@@ -673,7 +673,7 @@ async def test_personal_financial_report_package_post_merge_journey(
         assert notes_by_source[STOCK_OPTIONS_SOURCE] == STOCK_OPTIONS_NOTES
 
         restricted_response = await client.get(
-            f"/assets/restricted?as_of_date={fixture_period_end.isoformat()}"
+            _api_url(f"/assets/restricted?as_of_date={fixture_period_end.isoformat()}")
         )
         assert restricted_response.status_code == 200, (
             f"restricted holdings check failed: {restricted_response.status_code} {restricted_response.text}"
@@ -867,7 +867,7 @@ async def test_personal_financial_report_package_post_merge_journey(
         assert _money(cash_flow["summary"]["ending_cash"]) == _money(expected_bank_cash)
 
         bs_export = await client.get(
-            "/api/reports/export",
+            _api_url("/reports/export"),
             params={
                 "report_type": "balance-sheet",
                 "format": "csv",
@@ -889,7 +889,7 @@ async def test_personal_financial_report_package_post_merge_journey(
         )
 
         income_export = await client.get(
-            "/api/reports/export",
+            _api_url("/reports/export"),
             params={
                 "report_type": "income-statement",
                 "format": "csv",
@@ -920,7 +920,9 @@ async def test_personal_financial_report_package_post_merge_journey(
     await expect(page.get_by_text("Loading upload-to-report workflow...")).to_be_hidden(
         timeout=30_000
     )
-    await expect(page.get_by_label("Dashboard analytics")).to_be_visible(timeout=10_000)
+    await expect(page.get_by_label("Dashboard analytics", exact=True)).to_be_visible(
+        timeout=10_000
+    )
 
     await page.goto(
         _get_url(

--- a/tests/e2e/test_statement_full_journey.py
+++ b/tests/e2e/test_statement_full_journey.py
@@ -36,6 +36,10 @@ def _get_url(path: str) -> str:
     return f"{APP_URL.rstrip('/')}{path}"
 
 
+def _statement_row(page: Page, institution: str):
+    return page.locator(".relative.block").filter(has_text=institution).first
+
+
 def _get_dbs_pdf_path() -> Path:
     """
     Locate (or generate) the pre-built DBS mock PDF fixture.
@@ -159,11 +163,11 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
     assert statement_id, f"Upload response missing 'id' field: {upload_body}"
     # === AC8.13.2: Poll until "parsed" status badge appears in the list ===
     # The list page polls via TanStack Query every 3 s — we wait up to PARSING_TIMEOUT_MS.
-    statement_row = page.locator(f'a[href="/statements/{statement_id}"]')
+    statement_row = _statement_row(page, INSTITUTION_LABEL)
     await expect(statement_row).to_be_visible(timeout=15_000)
 
-    parsed_badge = statement_row.locator("span.badge", has_text="parsed")
-    rejected_badge = statement_row.locator("span.badge", has_text="rejected")
+    parsed_badge = statement_row.locator("span.badge", has_text=re.compile(r"^Parsed$", re.I))
+    rejected_badge = statement_row.locator("span.badge", has_text=re.compile(r"^Rejected$", re.I))
     # Poll the statement API by ID until parsed, but fail fast with the stored
     # validation error if the AI/OCR provider rejects parsing.
     # This avoids waiting the full PARSING_TIMEOUT_MS when the AI service fails.
@@ -197,7 +201,7 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
         )
 
     # === AC8.13.3: Detail page shows transactions ===
-    await statement_row.click()
+    await page.goto(_get_url(f"/statements/{statement_id}"))
     # Wait for navigation to /statements/{id} explicitly; generic load-state
     # waits can resolve before the Next.js router commits the URL change.
     await expect(page).to_have_url(re.compile(r"/statements/[^/]+$"), timeout=15_000)
@@ -219,9 +223,11 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
 
     await page.goto(_get_url("/statements"))
     await expect(page).to_have_url(re.compile(r"/statements$"), timeout=15_000)
-    approved_row = page.locator(f'a[href="/statements/{statement_id}"]')
+    approved_row = _statement_row(page, INSTITUTION_LABEL)
     await expect(approved_row).to_be_visible(timeout=15_000)
-    await expect(approved_row.locator("span.badge", has_text="approved")).to_be_visible(timeout=15_000)
+    await expect(approved_row.locator("span.badge", has_text=re.compile(r"^Approved$", re.I))).to_be_visible(
+        timeout=15_000
+    )
 
     # === AC8.13.5: Balance sheet report loads ===
     await page.goto(_get_url("/reports/balance-sheet"))

--- a/tests/e2e/test_statement_upload_e2e.py
+++ b/tests/e2e/test_statement_upload_e2e.py
@@ -96,6 +96,10 @@ async def _find_statement_by_institution(page: Page, institution: str) -> dict |
     return None
 
 
+def _statement_row(page: Page, institution: str):
+    return page.locator(".relative.block").filter(has_text=institution).first
+
+
 @pytest.mark.e2e
 @pytest.mark.llm
 async def test_statement_upload_full_flow(authenticated_page_unique: Page) -> None:
@@ -130,8 +134,7 @@ async def test_statement_upload_full_flow(authenticated_page_unique: Page) -> No
     statement_id = upload_body.get("id")
     assert statement_id, f"Upload response missing 'id' field: {upload_body}"
     # Statement row appears in the list with the institution name we provided.
-    statement_row = page.locator("a").filter(has_text="E2E Upload Test Bank").first
-    await expect(statement_row).to_be_visible(timeout=15_000)
+    await expect(_statement_row(page, "E2E Upload Test Bank")).to_be_visible(timeout=15_000)
     # Verify the statement is immediately accessible via the API. Playwright's
     # context request shares the browser cookie jar used by the page.
     api_resp = await page.request.get(_get_url(f"/api/statements/{statement_id}"))
@@ -183,8 +186,13 @@ async def test_model_selection_and_upload(authenticated_page_unique: Page) -> No
         f"Upload endpoint returned unexpected status {upload_resp.status} — "
         f"expected 2xx. Response body: {await upload_resp.text()}"
     )
+    upload_body = await upload_resp.json()
+    statement_id = upload_body.get("id")
+    assert statement_id, f"Upload response missing 'id' field: {upload_body}"
 
-    await expect(page.locator("a").filter(has_text="E2E Model Test Bank").first).to_be_visible(timeout=15_000)
+    await expect(_statement_row(page, "E2E Model Test Bank")).to_be_visible(timeout=15_000)
+    statement = await _find_statement_by_institution(page, "E2E Model Test Bank")
+    assert statement and statement.get("id") == statement_id
 
 
 @pytest.mark.e2e

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -405,7 +405,9 @@ def test_AC8_13_1_to_5_full_statement_journey_contract() -> None:
     assert "# === AC8.13.1: Upload PDF ===" in test_body
     assert "Upload & Parse Statement" in test_body
     assert "# === AC8.13.2: Poll until" in test_body
-    assert 'a[href="/statements/{statement_id}"]' in test_body
+    assert "_statement_row(page, INSTITUTION_LABEL)" in test_body
+    assert '_get_url(f"/statements/{statement_id}")' in test_body
+    assert 'a[href="/statements/{statement_id}"]' not in test_body
     assert "filter(has_text=INSTITUTION_LABEL).first" not in test_body
     assert '"parsed"' in test_body
     assert "# === AC8.13.3: Detail page shows transactions ===" in test_body

--- a/tests/tooling/test_staging_ai_ocr_gate_contract.py
+++ b/tests/tooling/test_staging_ai_ocr_gate_contract.py
@@ -7,9 +7,7 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from tools import staging_ai_ocr_gate_contract as contract
-
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -131,7 +129,9 @@ def test_AC8_13_109_ai_ocr_gate_tests_use_isolated_users() -> None:
             used_fixtures = {arg.arg for arg in node.args.args}
             shared = sorted(used_fixtures & shared_user_fixtures)
             if shared:
-                offenders.append(f"{relative_path}::{node.name} uses {', '.join(shared)}")
+                offenders.append(
+                    f"{relative_path}::{node.name} uses {', '.join(shared)}"
+                )
 
     assert offenders == []
 
@@ -163,6 +163,101 @@ def test_AC8_13_109_ai_ocr_gate_tests_avoid_networkidle_waits() -> None:
         source = (ROOT / relative_path).read_text(encoding="utf-8")
         if "networkidle" in source:
             offenders.append(f"{relative_path} waits for networkidle")
+
+    assert offenders == []
+
+
+def test_AC8_13_109_ai_ocr_gate_httpx_calls_use_absolute_api_urls() -> None:
+    """AC8.13.109: Httpx-backed deployed E2E calls must not use relative URLs."""
+    offenders: list[str] = []
+    relative_prefixes = ("/api/", "/assets/")
+
+    def relative_url_prefix(node: ast.expr) -> str | None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.JoinedStr) and node.values:
+            first_value = node.values[0]
+            if isinstance(first_value, ast.Constant) and isinstance(
+                first_value.value, str
+            ):
+                return first_value.value
+        return None
+
+    for relative_path in contract.gate_files():
+        tree = ast.parse((ROOT / relative_path).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in {"get", "post", "put", "patch", "delete"}:
+                continue
+            if not node.args:
+                continue
+            first_arg = node.args[0]
+            url_prefix = relative_url_prefix(first_arg)
+            if url_prefix and url_prefix.startswith(relative_prefixes):
+                offenders.append(
+                    f"{relative_path}:{node.lineno} uses relative API URL {url_prefix!r}"
+                )
+
+    assert offenders == []
+
+
+def test_AC8_13_109_ai_ocr_gate_dashboard_analytics_locator_is_exact() -> None:
+    """AC8.13.109: Dashboard checks must not also match loading status labels."""
+    offenders: list[str] = []
+
+    for relative_path in contract.gate_files():
+        tree = ast.parse((ROOT / relative_path).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "get_by_label":
+                continue
+            if not node.args:
+                continue
+            first_arg = node.args[0]
+            exact_keyword = next(
+                (kw for kw in node.keywords if kw.arg == "exact"),
+                None,
+            )
+            is_dashboard_analytics = (
+                isinstance(first_arg, ast.Constant)
+                and first_arg.value == "Dashboard analytics"
+            )
+            is_exact = (
+                exact_keyword is not None
+                and isinstance(exact_keyword.value, ast.Constant)
+                and exact_keyword.value.value is True
+            )
+            if is_dashboard_analytics and not is_exact:
+                offenders.append(
+                    f"{relative_path}:{node.lineno} uses inexact Dashboard analytics label"
+                )
+
+    assert offenders == []
+
+
+def test_AC8_13_109_ai_ocr_gate_does_not_assert_hidden_statement_overlay_links() -> (
+    None
+):
+    """AC8.13.109: Statement list checks use visible text/API state, not overlay links."""
+    offenders: list[str] = []
+    forbidden_snippets = [
+        'locator("a").filter(has_text=',
+        "locator('a').filter(has_text=",
+        "locator(f'a[href=",
+        'locator(f"a[href=',
+    ]
+
+    for relative_path in contract.gate_files():
+        source = (ROOT / relative_path).read_text(encoding="utf-8")
+        for snippet in forbidden_snippets:
+            if snippet in source:
+                offenders.append(f"{relative_path} contains {snippet}")
 
     assert offenders == []
 
@@ -212,4 +307,10 @@ def test_AC8_13_137_summarize_junit_tolerates_missing_xml(tmp_path: Path) -> Non
     """AC8.13.137: a missing/unreadable XML yields an empty summary, never a crash,
     so the gate's reporting step can't itself fail the workflow."""
     summary = contract.summarize_junit([tmp_path / "does-not-exist.xml"])
-    assert summary == {"total": 0, "passed": 0, "failed": 0, "skipped": 0, "failed_tests": []}
+    assert summary == {
+        "total": 0,
+        "passed": 0,
+        "failed": 0,
+        "skipped": 0,
+        "failed_tests": [],
+    }


### PR DESCRIPTION
## Summary
- Harden staging AI/OCR E2E tests against hidden statement overlay links and ambiguous dashboard loading labels.
- Use absolute API URLs for httpx export checks in the personal report package journey.
- Add static gate-contract tests so these AI/OCR gate regressions fail locally before staging.

## Validation
- `apps/backend/.venv/bin/python -m pytest tests/tooling/test_staging_ai_ocr_gate_contract.py -q`
- `cd apps/backend && .venv/bin/ruff check ../../tests/e2e/test_statement_upload_e2e.py ../../tests/e2e/test_statement_full_journey.py ../../tests/e2e/test_four_asset_net_worth_golden_path.py ../../tests/e2e/test_personal_financial_report_package.py ../../tests/tooling/test_staging_ai_ocr_gate_contract.py`
- `cd apps/backend && .venv/bin/ruff format --check ../../tests/e2e/test_statement_upload_e2e.py ../../tests/e2e/test_statement_full_journey.py ../../tests/e2e/test_four_asset_net_worth_golden_path.py ../../tests/e2e/test_personal_financial_report_package.py ../../tests/tooling/test_staging_ai_ocr_gate_contract.py`
- `moon run :lint`
- pre-push checks: backend lint, frontend lint, backend tests (`2598 passed`, coverage `96.29%`)

## Note
- `moon run :test` was attempted, but local Podman connection forwarding stayed unavailable (`127.0.0.1:61270 connection refused`) even after starting the default machine. PR CI remains the full environment-backed gate.
