### PR TITLE
[finance_report_ui] Add trust-first reports cockpit

### DIFF
--- a/apps/frontend/src/__tests__/reportsCockpit.test.tsx
+++ b/apps/frontend/src/__tests__/reportsCockpit.test.tsx
@@ -179,12 +179,12 @@ describe("Reports cockpit (EPIC-022 AC22.3)", () => {
   })
 
   it("AC5.37.1 renders non-blocked readiness states without blocker copy", async () => {
-    for (const [state, label] of [
-      ["ready", "Ready"],
-      ["generated", "Generated"],
-      ["processing", "Processing"],
-      ["stale", "Stale"],
-      ["draft", "Draft"],
+    for (const [state, label, badgeClass] of [
+      ["ready", "Ready", "badge-success"],
+      ["generated", "Generated", "badge-success"],
+      ["processing", "Processing", "badge-warning"],
+      ["stale", "Stale", "badge-error"],
+      ["draft", "Draft", "badge-muted"],
     ] as const) {
       mockedApiFetch.mockImplementation((path: string) => {
         if (path === "/api/income/annualized") {
@@ -218,6 +218,10 @@ describe("Reports cockpit (EPIC-022 AC22.3)", () => {
       const cockpit = await screen.findByRole("region", { name: "Report readiness cockpit" })
       expect(cockpit).toHaveTextContent(`Current package state is ${label.toLowerCase()}.`)
       expect(cockpit).toHaveTextContent("unknown source")
+      const statusBadge = Array.from(cockpit.querySelectorAll(".badge")).find(
+        (badge) => badge.textContent === label,
+      )
+      expect(statusBadge).toHaveClass(badgeClass)
       expect(screen.getByRole("link", { name: "Open readiness path" })).toHaveAttribute("href", "/reports/package")
       view.unmount()
     }

--- a/apps/frontend/src/__tests__/reportsCockpit.test.tsx
+++ b/apps/frontend/src/__tests__/reportsCockpit.test.tsx
@@ -15,6 +15,47 @@ vi.mock("@/lib/api", () => ({
 
 const mockedApiFetch = vi.mocked(apiFetch)
 
+const readiness = {
+  package_id: "personal-financial-report-package",
+  state: "blocked",
+  label: "Blocked",
+  action_href: "/review",
+  blocking_count: 2,
+  blockers: [
+    {
+      code: "pending_review",
+      label: "Pending source review",
+      severity: "blocking",
+      count: 1,
+      reason: "Statement review must be completed before reports are trusted.",
+      action_href: "/review",
+    },
+    {
+      code: "missing_source_coverage",
+      label: "Missing source coverage",
+      severity: "blocking",
+      count: 1,
+      reason: "Manual records need explicit source anchors.",
+      action_href: "/journal",
+    },
+  ],
+  source_summary: {
+    statements: 3,
+    posted_journal_entries: 4,
+    manual_valuations: 1,
+  },
+  source_trust_summary: {
+    source_classes: ["bank_statement", "manual_record"],
+    deterministic_pr_source_classes: ["bank_statement", "manual_record"],
+    post_merge_llm_ocr_source_classes: ["bank_statement"],
+    manual_trusted_source_classes: ["manual_record"],
+    gap_source_classes: ["manual_record"],
+    blocker_codes: ["missing_source_coverage"],
+  },
+  generated_at: null,
+  stale_since: null,
+}
+
 beforeEach(() => {
   mockedApiFetch.mockReset()
   mockedApiFetch.mockImplementation((path: string) => {
@@ -24,6 +65,9 @@ beforeEach(() => {
     if (path === "/api/reconciliation/stats") {
       // match_rate is a 0–100 percentage from the backend, not a fraction.
       return Promise.resolve({ match_rate: 92, unmatched_transactions: 3 })
+    }
+    if (path.startsWith("/api/reports/package/readiness?")) {
+      return Promise.resolve(readiness)
     }
     return Promise.resolve({})
   })
@@ -76,5 +120,143 @@ describe("Reports cockpit (EPIC-022 AC22.3)", () => {
 
     await waitFor(() => expect(screen.getByText("Cash Flow Statement")).toBeInTheDocument())
     expect(screen.getByText("Personal Report Package")).toBeInTheDocument()
+  })
+
+  it("AC5.37.1 renders trust-first readiness before report cards", async () => {
+    render(<ReportsPage />)
+
+    const cockpit = await screen.findByRole("region", { name: "Report readiness cockpit" })
+    expect(cockpit).toHaveTextContent("Blocked")
+    expect(cockpit).toHaveTextContent("2 blockers")
+    expect(cockpit).toHaveTextContent("1 trust gap")
+    expect(cockpit).toHaveTextContent("Manual records")
+    expect(cockpit).toHaveTextContent("Pending source review")
+    expect(screen.getByRole("link", { name: "Resolve report blockers" })).toHaveAttribute("href", "/review")
+
+    const bodyText = document.body.textContent ?? ""
+    expect(bodyText.indexOf("Report readiness")).toBeLessThan(bodyText.indexOf("Balance Sheet"))
+  })
+
+  it("AC5.37.2 preserves report navigation when readiness is unavailable", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/income/annualized") {
+        return Promise.resolve({ annualized_total: "120000.00", currency: "SGD" })
+      }
+      if (path === "/api/reconciliation/stats") {
+        return Promise.resolve({ match_rate: 92, unmatched_transactions: 3 })
+      }
+      if (path.startsWith("/api/reports/package/readiness?")) {
+        return Promise.reject(new Error("readiness down"))
+      }
+      return Promise.resolve({})
+    })
+
+    render(<ReportsPage />)
+
+    expect(await screen.findByText("Readiness unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Balance Sheet")).toBeInTheDocument()
+    expect(screen.getByText("Income Statement")).toBeInTheDocument()
+  })
+
+  it("AC5.37.2 shows a checking state while readiness is still loading", () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/income/annualized") {
+        return Promise.resolve({ annualized_total: "120000.00", currency: "SGD" })
+      }
+      if (path === "/api/reconciliation/stats") {
+        return Promise.resolve({ match_rate: 92, unmatched_transactions: 3 })
+      }
+      if (path.startsWith("/api/reports/package/readiness?")) {
+        return new Promise(() => undefined)
+      }
+      return Promise.resolve({})
+    })
+
+    render(<ReportsPage />)
+
+    expect(screen.getByRole("region", { name: "Report readiness cockpit" })).toHaveTextContent("Checking report readiness")
+    expect(screen.getByText("Balance Sheet")).toBeInTheDocument()
+  })
+
+  it("AC5.37.1 renders non-blocked readiness states without blocker copy", async () => {
+    for (const [state, label] of [
+      ["ready", "Ready"],
+      ["generated", "Generated"],
+      ["processing", "Processing"],
+      ["stale", "Stale"],
+      ["draft", "Draft"],
+    ] as const) {
+      mockedApiFetch.mockImplementation((path: string) => {
+        if (path === "/api/income/annualized") {
+          return Promise.resolve({ annualized_total: "120000.00", currency: "SGD" })
+        }
+        if (path === "/api/reconciliation/stats") {
+          return Promise.resolve({ match_rate: 92, unmatched_transactions: 3 })
+        }
+        if (path.startsWith("/api/reports/package/readiness?")) {
+          return Promise.resolve({
+            ...readiness,
+            state,
+            label,
+            action_href: "/reports/package",
+            blocking_count: 0,
+            blockers: [],
+            source_trust_summary: {
+              source_classes: ["unknown_source"],
+              deterministic_pr_source_classes: [],
+              post_merge_llm_ocr_source_classes: [],
+              manual_trusted_source_classes: [],
+              gap_source_classes: ["unknown_source"],
+              blocker_codes: [],
+            },
+          })
+        }
+        return Promise.resolve({})
+      })
+
+      const view = render(<ReportsPage />)
+      const cockpit = await screen.findByRole("region", { name: "Report readiness cockpit" })
+      expect(cockpit).toHaveTextContent(`Current package state is ${label.toLowerCase()}.`)
+      expect(cockpit).toHaveTextContent("unknown source")
+      expect(screen.getByRole("link", { name: "Open readiness path" })).toHaveAttribute("href", "/reports/package")
+      view.unmount()
+    }
+  })
+
+  it("AC5.37.1 renders an all-clear source gap state when readiness has no gaps", async () => {
+    mockedApiFetch.mockImplementation((path: string) => {
+      if (path === "/api/income/annualized") {
+        return Promise.resolve({ annualized_total: "120000.00", currency: "SGD" })
+      }
+      if (path === "/api/reconciliation/stats") {
+        return Promise.resolve({ match_rate: 92, unmatched_transactions: 3 })
+      }
+      if (path.startsWith("/api/reports/package/readiness?")) {
+        return Promise.resolve({
+          ...readiness,
+          state: "ready",
+          label: "Ready",
+          action_href: "/reports/package",
+          blocking_count: 0,
+          blockers: [],
+          source_trust_summary: {
+            source_classes: ["bank_statement"],
+            deterministic_pr_source_classes: ["bank_statement"],
+            post_merge_llm_ocr_source_classes: ["bank_statement"],
+            manual_trusted_source_classes: [],
+            gap_source_classes: [],
+            blocker_codes: [],
+          },
+        })
+      }
+      return Promise.resolve({})
+    })
+
+    render(<ReportsPage />)
+
+    const cockpit = await screen.findByRole("region", { name: "Report readiness cockpit" })
+    expect(cockpit).toHaveTextContent("0 trust gaps")
+    expect(cockpit).toHaveTextContent("No source gaps reported.")
+    expect(cockpit).toHaveTextContent("No blockers reported.")
   })
 })

--- a/apps/frontend/src/app/(main)/reports/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/page.tsx
@@ -6,8 +6,10 @@ import { BarChart2, TrendingUp, DollarSign, FileText, CalendarClock, ShieldCheck
 
 import { apiFetch } from "@/lib/api";
 import { formatCurrencyLocale } from "@/lib/money";
+import { Badge, type BadgeVariant } from "@/components/ui";
 import { InfoHint, type GlossaryTerm } from "@/components/ui/InfoHint";
-import type { AnnualizedIncomeResponse, ReconciliationStatsResponse } from "@/lib/types";
+import { reportPeriodStart } from "@/hooks/usePersonalReportPackage";
+import type { AnnualizedIncomeResponse, PersonalReportPackageReadinessResponse, ReconciliationStatsResponse } from "@/lib/types";
 
 // The four reports an everyday user reads (EPIC-022 AC22.3.1). Everything else
 // lives behind "More" (AC22.3.2).
@@ -16,9 +18,70 @@ const MORE_REPORTS = [
     { id: "personal-package", title: "Personal Report Package", description: "Stable package contract for statements, schedules, notes, and traceability", icon: FileText, href: "/reports/package" },
 ];
 
+type ReadinessLoadState = "loading" | "ready" | "error";
+
+const SOURCE_CLASS_LABELS: Record<string, string> = {
+    bank_statement: "Bank statements",
+    brokerage_statement: "Brokerage statements",
+    settlement_note: "Settlement notes",
+    esop_rsu_plan: "ESOP / RSU plans",
+    property_statement: "Property statements",
+    liability_statement: "Liability statements",
+    csv_export: "CSV exports",
+    manual_record: "Manual records",
+};
+
+function packageReadinessQuery(): string {
+    const reportDate = new Date().toISOString().slice(0, 10);
+    const params = new URLSearchParams({
+        start_date: reportPeriodStart(reportDate),
+        end_date: reportDate,
+        as_of_date: reportDate,
+    });
+    return `?${params.toString()}`;
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`) {
+    return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function sourceClassLabel(sourceClass: string): string {
+    return SOURCE_CLASS_LABELS[sourceClass] ?? sourceClass.replaceAll("_", " ");
+}
+
+function readinessVariant(state?: PersonalReportPackageReadinessResponse["state"]): BadgeVariant {
+    switch (state) {
+        case "ready":
+        case "generated":
+            return "success";
+        case "blocked":
+            return "error";
+        case "processing":
+            return "info";
+        case "stale":
+            return "warning";
+        case "draft":
+        default:
+            return "muted";
+    }
+}
+
+function isPackageReadiness(value: unknown): value is PersonalReportPackageReadinessResponse {
+    const candidate = value as Partial<PersonalReportPackageReadinessResponse> | null;
+    return Boolean(
+        candidate &&
+        typeof candidate.label === "string" &&
+        typeof candidate.action_href === "string" &&
+        typeof candidate.blocking_count === "number" &&
+        Array.isArray(candidate.blockers),
+    );
+}
+
 export default function ReportsPage() {
     const [annualized, setAnnualized] = useState<AnnualizedIncomeResponse | null>(null);
     const [stats, setStats] = useState<ReconciliationStatsResponse | null>(null);
+    const [readiness, setReadiness] = useState<PersonalReportPackageReadinessResponse | null>(null);
+    const [readinessState, setReadinessState] = useState<ReadinessLoadState>("loading");
     const [showMore, setShowMore] = useState(false);
 
     useEffect(() => {
@@ -29,6 +92,26 @@ export default function ReportsPage() {
         apiFetch<ReconciliationStatsResponse>("/api/reconciliation/stats")
             .then((data) => active && setStats(data))
             .catch(() => active && setStats(null));
+        apiFetch<PersonalReportPackageReadinessResponse>(`/api/reports/package/readiness${packageReadinessQuery()}`)
+            .then((data) => {
+                if (!isPackageReadiness(data)) {
+                    if (active) {
+                        setReadiness(null);
+                        setReadinessState("error");
+                    }
+                    return;
+                }
+                if (active) {
+                    setReadiness(data);
+                    setReadinessState("ready");
+                }
+            })
+            .catch(() => {
+                if (active) {
+                    setReadiness(null);
+                    setReadinessState("error");
+                }
+            });
         return () => {
             active = false;
         };
@@ -44,6 +127,8 @@ export default function ReportsPage() {
                 <h1 className="page-title">Reports</h1>
                 <p className="page-description">The four reports you read most. Open one to drill any amount down to its source transactions.</p>
             </div>
+
+            <ReportsReadinessCockpit readiness={readiness} loadState={readinessState} />
 
             <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-4 mb-6">
                 <ReportNavCard title="Balance Sheet" description="Assets, liabilities, and equity at a point in time" icon={BarChart2} href="/reports/balance-sheet" />
@@ -97,6 +182,127 @@ export default function ReportsPage() {
                 <p className="text-center text-xs text-muted mt-3">All financial reports maintain this fundamental balance</p>
             </div>
         </div>
+    );
+}
+
+function ReportsReadinessCockpit({
+    readiness,
+    loadState,
+}: {
+    readiness: PersonalReportPackageReadinessResponse | null;
+    loadState: ReadinessLoadState;
+}) {
+    const sourceTrust = readiness?.source_trust_summary;
+    const gapClasses = sourceTrust?.gap_source_classes ?? [];
+    const sourceClassCount = sourceTrust?.source_classes.length ?? 0;
+    const blockers = readiness?.blockers ?? [];
+
+    if (loadState === "error") {
+        return (
+            <section aria-label="Report readiness cockpit" className="card p-5 mb-6">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                        <h2 className="font-semibold">Report readiness</h2>
+                        <p className="mt-2 text-sm text-muted">
+                            Readiness unavailable. Report navigation stays available, but trust status should be checked before relying on output.
+                        </p>
+                    </div>
+                    <Badge variant="warning">Readiness unavailable</Badge>
+                </div>
+                <Link href="/reports/package" className="btn-secondary mt-4 inline-flex text-sm">
+                    Open report package
+                </Link>
+            </section>
+        );
+    }
+
+    if (loadState === "loading" || !readiness) {
+        return (
+            <section aria-label="Report readiness cockpit" className="card p-5 mb-6" aria-busy="true">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                        <h2 className="font-semibold">Report readiness</h2>
+                        <p className="mt-2 text-sm text-muted">Checking report readiness before showing trust status.</p>
+                    </div>
+                    <Badge variant="muted">Checking</Badge>
+                </div>
+            </section>
+        );
+    }
+
+    return (
+        <section aria-label="Report readiness cockpit" className="card p-5 mb-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                    <h2 className="font-semibold">Report readiness</h2>
+                    <p className="mt-2 text-sm text-muted">
+                        {readiness.state === "blocked"
+                            ? `${countLabel(readiness.blocking_count, "blocker")} must be resolved before reports are trusted.`
+                            : `Current package state is ${readiness.label.toLowerCase()}.`}
+                    </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant={readinessVariant(readiness.state)}>{readiness.label}</Badge>
+                    <Link href={readiness.action_href} className="btn-secondary text-sm">
+                        {readiness.blocking_count > 0 ? "Resolve report blockers" : "Open readiness path"}
+                    </Link>
+                </div>
+            </div>
+
+            <dl className="mt-5 grid gap-3 text-sm md:grid-cols-4">
+                <div>
+                    <dt className="text-xs text-muted">Readiness</dt>
+                    <dd className="mt-1 font-semibold">{readiness.label}</dd>
+                </div>
+                <div>
+                    <dt className="text-xs text-muted">Blockers</dt>
+                    <dd className="mt-1 font-semibold">{countLabel(readiness.blocking_count, "blocker")}</dd>
+                </div>
+                <div>
+                    <dt className="text-xs text-muted">Source classes</dt>
+                    <dd className="mt-1 font-semibold">{countLabel(sourceClassCount, "class", "classes")}</dd>
+                </div>
+                <div>
+                    <dt className="text-xs text-muted">Trust gaps</dt>
+                    <dd className="mt-1 font-semibold">{countLabel(gapClasses.length, "trust gap")}</dd>
+                </div>
+            </dl>
+
+            <div className="mt-5 grid gap-4 lg:grid-cols-2">
+                <div className="rounded border border-[var(--border)] p-3">
+                    <h3 className="text-sm font-semibold">Source gaps</h3>
+                    {gapClasses.length ? (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                            {gapClasses.map((sourceClass) => (
+                                <Badge key={sourceClass} variant="warning">
+                                    {sourceClassLabel(sourceClass)}
+                                </Badge>
+                            ))}
+                        </div>
+                    ) : (
+                        <p className="mt-2 text-sm text-muted">No source gaps reported.</p>
+                    )}
+                </div>
+                <div className="rounded border border-[var(--border)] p-3">
+                    <h3 className="text-sm font-semibold">Blocking actions</h3>
+                    {blockers.length ? (
+                        <ul className="mt-3 space-y-3">
+                            {blockers.slice(0, 2).map((blocker) => (
+                                <li key={blocker.code}>
+                                    <div className="flex items-start justify-between gap-3">
+                                        <p className="text-sm font-medium">{blocker.label}</p>
+                                        <Badge variant="muted">{blocker.count}</Badge>
+                                    </div>
+                                    <p className="mt-1 text-xs text-muted">{blocker.reason}</p>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="mt-2 text-sm text-muted">No blockers reported.</p>
+                    )}
+                </div>
+            </div>
+        </section>
     );
 }
 

--- a/apps/frontend/src/app/(main)/reports/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/page.tsx
@@ -18,7 +18,7 @@ const MORE_REPORTS = [
     { id: "personal-package", title: "Personal Report Package", description: "Stable package contract for statements, schedules, notes, and traceability", icon: FileText, href: "/reports/package" },
 ];
 
-type ReadinessLoadState = "loading" | "ready" | "error";
+type ReadinessLoadState = "loading" | "loaded" | "error";
 
 const SOURCE_CLASS_LABELS: Record<string, string> = {
     bank_statement: "Bank statements",
@@ -55,10 +55,9 @@ function readinessVariant(state?: PersonalReportPackageReadinessResponse["state"
         case "generated":
             return "success";
         case "blocked":
+        case "stale":
             return "error";
         case "processing":
-            return "info";
-        case "stale":
             return "warning";
         case "draft":
         default:
@@ -103,7 +102,7 @@ export default function ReportsPage() {
                 }
                 if (active) {
                     setReadiness(data);
-                    setReadinessState("ready");
+                    setReadinessState("loaded");
                 }
             })
             .catch(() => {

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -592,3 +592,15 @@ an unknown value is rejected with 422 instead of silently returning an empty lis
 |----|-----------|---------------|------|----------|
 | AC5.36.1 | An unknown `report_type` returns 422 | `test_AC5_36_1_report_snapshots_unknown_type_returns_422` | `api/test_typed_contract_sweep.py` | P2 |
 | AC5.36.2 | A valid `report_type` returns a typed list | `test_AC5_36_2_report_snapshots_valid_type_returns_typed_list` | `api/test_typed_contract_sweep.py` | P2 |
+
+### AC5.37: Trust-First Reports Cockpit ([#1209](https://github.com/wangzitian0/finance_report/issues/1209))
+
+The Reports landing page must answer whether report output is currently
+trustworthy before it presents the report navigation cards. It consumes the
+existing package readiness/source-trust contract and does not duplicate
+readiness derivation or source-trust rules in the frontend.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC5.37.1 | The Reports cockpit renders package readiness state, blocker count, next action, and source-gap summary before report cards | `AC5.37.1 renders trust-first readiness before report cards` | `frontend/src/__tests__/reportsCockpit.test.tsx` | P1 |
+| AC5.37.2 | If readiness loading fails, the Reports cockpit shows a contained unavailable state while preserving report navigation | `AC5.37.2 preserves report navigation when readiness is unavailable` | `frontend/src/__tests__/reportsCockpit.test.tsx` | P1 |

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -444,6 +444,12 @@ Package readiness:
 - Purpose: return the user-scoped readiness state and blocker links before the
   report package renders output. This endpoint is the package-owned fact source;
   workflow summary APIs may aggregate it but must not duplicate its derivation.
+- Reports landing consumption: `/reports` may show a trust-first cockpit before
+  report navigation by reading this endpoint through the shared frontend API
+  client. The landing page may summarize `state`, `blocking_count`,
+  `blockers`, and `source_trust_summary.gap_source_classes`, but it must not
+  reimplement readiness priority, source-trust classification, or blocker
+  derivation in frontend code.
 - Response contract:
   - `package_id`: always `personal-financial-report-package`
   - `state`: closed enum of `draft`, `processing`, `blocked`, `ready`,


### PR DESCRIPTION
## Summary
- Add a trust-first readiness cockpit above the Reports navigation cards.
- Consume the existing package readiness endpoint through `apiFetch` and summarize readiness state, blocker count, next action, and source gaps without duplicating backend derivation rules.
- Preserve Reports navigation with a contained unavailable state when readiness cannot load.

## Delivery standard
- Reports answers whether output is currently trustworthy before users choose a report.
- Readiness failures do not block report navigation.
- AC5.37 is registered in EPIC-005 and SSOT reporting guidance documents the frontend consumption boundary.

## Validation
- `npm test -- reportsCockpit.test.tsx reportsPage.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `uv run --with pyyaml python tools/preflight.py`

Closes #1209