### PR TITLE
[finance_report_ui] Make report package reader-first

### DIFF
--- a/apps/frontend/playwright/report-readiness.spec.ts
+++ b/apps/frontend/playwright/report-readiness.spec.ts
@@ -172,7 +172,7 @@ async function expectNoDocumentHorizontalScroll(page: Page) {
   expect(metrics.scrollX).toBe(0);
 }
 
-test.describe("AC19.8.7 AC19.8.8 AC22.8.4 report package smoke", () => {
+test.describe("AC19.8.7 AC19.8.8 AC22.8.4 AC22.19 report package smoke", () => {
   for (const scenario of [
     { name: "desktop", viewport: { width: 1440, height: 1000 } },
     { name: "mobile", viewport: { width: 390, height: 844 } },
@@ -204,13 +204,33 @@ test.describe("AC19.8.7 AC19.8.8 AC22.8.4 report package smoke", () => {
       await expect(
         tableOfContents.getByRole("link", { name: "Balance Sheet" }),
       ).toHaveAttribute("href", "#package-section-balance_sheet");
+
+      const readinessSection = page.locator("#package-readiness");
       await expect(
-        page.getByText("processing_account_unresolved"),
+        readinessSection.getByText("Processing account unresolved"),
+      ).toBeVisible();
+      await expect(
+        readinessSection.getByText(
+          "Processing account balance cannot be converted to SGD: No FX rate available for USD/SGD.",
+        ),
       ).toBeVisible();
       await expect(page.getByRole("link", { name: "Blocked" })).toHaveAttribute(
         "href",
         "/accounts/processing",
       );
+
+      const readinessAuditDetails = readinessSection.locator("details", {
+        hasText: "Readiness audit details",
+      });
+      const rawBlockerCode = readinessAuditDetails.getByText(
+        "processing_account_unresolved",
+      );
+      await expect(readinessAuditDetails).not.toHaveAttribute("open", "");
+      await expect(rawBlockerCode).toHaveCount(2);
+      await expect(rawBlockerCode.first()).toBeHidden();
+      await readinessAuditDetails.getByText("Readiness audit details").click();
+      await expect(rawBlockerCode.first()).toBeVisible();
+
       await expect(
         page.getByRole("heading", { name: "Balance Sheet" }),
       ).toBeVisible();

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -581,6 +581,16 @@ function expectPackageDates(path: string, reportDate: string, startDate: string)
   expect(params.get("as_of_date")).toBe(reportDate);
 }
 
+function expectInsideClosedAuditDetails(text: string | RegExp) {
+  const node = screen.getAllByText(text)[0];
+  expect(node).toBeDefined();
+  const details = node.closest("details");
+  expect(details).not.toBeNull();
+  expect(details).not.toHaveAttribute("open");
+  expect(within(details as HTMLElement).getByText(/audit details/i)).toBeInTheDocument();
+  return details as HTMLElement;
+}
+
 describe("PersonalReportPackagePage", () => {
   afterEach(() => {
     mockedApiDownload.mockReset();
@@ -749,19 +759,15 @@ describe("PersonalReportPackagePage", () => {
       ),
       expect.objectContaining({ signal: expect.any(Object) }),
     );
-    expect(await screen.findByText("Framework Policy")).toBeInTheDocument();
+    expect(await screen.findByText("Reporting Basis")).toBeInTheDocument();
     expect(
-      screen.getAllByText("personal_us_gaap_like").length,
+      screen.getAllByText("US-like").length,
     ).toBeGreaterThanOrEqual(1);
-    expect(
-      screen.getAllByText(
-        "policy-result:personal_us_gaap_like:2025-05-20:2026-05-20:fixture",
-      ).length,
-    ).toBeGreaterThanOrEqual(1);
-    expect(
-      screen.getByText("assets.marketable_securities"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("unsupported_policy_domain")).toBeInTheDocument();
+    expectInsideClosedAuditDetails(
+      "policy-result:personal_us_gaap_like:2025-05-20:2026-05-20:fixture",
+    );
+    expectInsideClosedAuditDetails("assets.marketable_securities");
+    expectInsideClosedAuditDetails("unsupported_policy_domain");
   });
 
   it("AC20.6.1 keeps framework package sections pinned to the selected report date", async () => {
@@ -770,7 +776,7 @@ describe("PersonalReportPackagePage", () => {
     renderPackagePage();
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await screen.findByText("Framework Policy");
+    await screen.findByText("Reporting Basis");
 
     fireEvent.change(screen.getByLabelText("Package report date"), {
       target: { value: "2026-04-30" },
@@ -807,7 +813,7 @@ describe("PersonalReportPackagePage", () => {
     renderPackagePage();
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await screen.findByText("Framework Policy");
+    await screen.findByText("Reporting Basis");
 
     fireEvent.change(screen.getByLabelText("Package report date"), {
       target: { value: "2024-03-01" },
@@ -850,7 +856,7 @@ describe("PersonalReportPackagePage", () => {
     renderPackagePage();
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await screen.findByText("Framework Policy");
+    await screen.findByText("Reporting Basis");
 
     const callCountBeforeEmptyDate = mockedApiFetch.mock.calls.length;
     fireEvent.change(screen.getByLabelText("Package report date"), {
@@ -1069,12 +1075,13 @@ describe("PersonalReportPackagePage", () => {
     expect(
       screen.getByText("HK-like selected for this package."),
     ).toBeInTheDocument();
-    expect(screen.getAllByText("personal_hkfrs_like").length).toBeGreaterThan(
+    expect(screen.getAllByText("HK-like").length).toBeGreaterThan(
       0,
     );
-    expect(await screen.findByText("Framework Policy")).toBeInTheDocument();
+    expect(await screen.findByText("Reporting Basis")).toBeInTheDocument();
     expect(screen.getAllByText("0").length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText("none")).toBeInTheDocument();
+    expectInsideClosedAuditDetails("personal_hkfrs_like");
+    expectInsideClosedAuditDetails("none");
   });
 
   it("AC20.6.1 ignores stale framework package responses when selection changes", async () => {
@@ -1156,6 +1163,9 @@ describe("PersonalReportPackagePage", () => {
         )
       ).length,
     ).toBeGreaterThanOrEqual(1);
+    expectInsideClosedAuditDetails(
+      "policy-result:personal_hkfrs_like:2025-05-20:2026-05-20:fixture",
+    );
     expect(
       screen.queryByText(
         "policy-result:personal_us_gaap_like:2025-05-20:2026-05-20:fixture",
@@ -1206,10 +1216,10 @@ describe("PersonalReportPackagePage", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
     // Wait for the framework package output to load, then assert the sections.
-    await screen.findByText("Source Trust");
+    await screen.findByText("Evidence Coverage");
 
     // Human section titles are present...
-    for (const heading of ["Report Readiness", "Source Trust", "Framework Policy", "Traceability Appendix"]) {
+    for (const heading of ["Report Readiness", "Evidence Coverage", "Reporting Basis", "Traceability Summary"]) {
       expect(screen.getAllByText(heading).length).toBeGreaterThanOrEqual(1);
     }
     // ...and the raw snake_case section eyebrows are gone.
@@ -1243,10 +1253,10 @@ describe("PersonalReportPackagePage", () => {
     });
     for (const [label, href] of [
       ["Report Readiness", "#package-readiness"],
-      ["Source Trust", "#package-source-trust"],
-      ["Framework Policy", "#package-framework-policy"],
+      ["Evidence Coverage", "#package-source-trust"],
+      ["Reporting Basis", "#package-framework-policy"],
       ["Balance Sheet ready", "#package-section-balance_sheet"],
-      ["Traceability Appendix ready", "#package-section-traceability_appendix"],
+      ["Traceability Summary", "#package-traceability-detail"],
     ] as const) {
       expect(within(toc).getByRole("link", { name: label })).toHaveAttribute(
         "href",
@@ -1309,7 +1319,7 @@ describe("PersonalReportPackagePage", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Pending source review")).toBeInTheDocument();
-    expect(screen.getByText("pending_review")).toBeInTheDocument();
+    expectInsideClosedAuditDetails("pending_review");
     expect(screen.getByText("Balance validation mismatch")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -1347,32 +1357,100 @@ describe("PersonalReportPackagePage", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
 
-    const sourceTrust = await screen.findByText("Source Trust");
+    const sourceTrust = await screen.findByText("Evidence Coverage");
     // The traceability section is titled by its human label (AC22.8.1), not the
     // raw section_id; it must render after the source-trust summary.
-    const traceability = (await screen.findAllByText("Traceability Appendix")).at(-1)!;
+    const traceability = await screen.findByRole("heading", { name: "Traceability Summary" });
     expect(traceability).toBeDefined();
     expect(
       sourceTrust.compareDocumentPosition(traceability) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    expect(screen.getByText("7 classes")).toBeInTheDocument();
+    expect(screen.getByText("7 evidence classes")).toBeInTheDocument();
+    expect(screen.getByText("Verified by automated checks")).toBeInTheDocument();
+    expect(screen.getByText("Verified with live extraction checks")).toBeInTheDocument();
+    expect(screen.getByText("Manual evidence")).toBeInTheDocument();
+    expect(screen.getByText("Missing or unsupported evidence")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "bank_statement, brokerage_statement, property_statement, liability_statement, esop_rsu_plan, csv_export, manual_record",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("bank_statement, brokerage_statement"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "property_statement, liability_statement, esop_rsu_plan, manual_record",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("missing_source_coverage, pending_review"),
-    ).toBeInTheDocument();
+      screen.getAllByText(
+        "Bank statements, Brokerage statements, Property statements, Liability statements, ESOP / RSU plans, CSV exports, Manual records",
+      ).length,
+    ).toBeGreaterThanOrEqual(1);
+    expectInsideClosedAuditDetails("bank_statement, brokerage_statement");
+    expectInsideClosedAuditDetails(
+      "property_statement, liability_statement, esop_rsu_plan, manual_record",
+    );
+    expectInsideClosedAuditDetails("missing_source_coverage, pending_review");
+  });
+
+  it("AC22.19.1 renders the loaded package with reader-first labels before proof internals", async () => {
+    mockPackageApi();
+
+    renderPackagePage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
+
+    expect(await screen.findByRole("heading", { name: "Evidence Coverage" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Reporting Basis" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Traceability Summary" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Framework Policy" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Source Trust" })).not.toBeInTheDocument();
+    expect(screen.getByText("Missing or unsupported evidence")).toBeInTheDocument();
+    expect(screen.getByText("Report lines with evidence")).toBeInTheDocument();
+    expect(screen.getByText("Reporting gaps")).toBeInTheDocument();
+
+    expectInsideClosedAuditDetails("Deterministic PR");
+    expectInsideClosedAuditDetails("Post-merge LLM/OCR");
+    expectInsideClosedAuditDetails("Framework Policy Result");
+    expectInsideClosedAuditDetails("unsupported_policy_domain");
+    expectInsideClosedAuditDetails("pending_review");
+  });
+
+  it("AC22.19.2 keeps proof and policy internals in keyboard-reachable audit details", async () => {
+    mockPackageApi();
+
+    renderPackagePage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
+    await screen.findByRole("heading", { name: "Reporting Basis" });
+
+    for (const summary of [
+      "Readiness audit details",
+      "Evidence audit details",
+      "Reporting basis audit details",
+      "Traceability audit details",
+      "Export audit details",
+    ]) {
+      const details = screen.getByText(summary).closest("details");
+      expect(details).not.toBeNull();
+      expect(details).not.toHaveAttribute("open");
+      fireEvent.click(screen.getByText(summary));
+      expect(details).toHaveAttribute("open");
+    }
+
+    expect(screen.getByText("Matrix Version")).toBeInTheDocument();
+    expect(screen.getByText("balance_sheet.total_assets")).toBeInTheDocument();
+    expect(screen.getByText("trusted_or_explicit_manual_input")).toBeInTheDocument();
+    expect(screen.getAllByText("TRUSTED").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("hybrid")).toBeInTheDocument();
+    expect(screen.getByText("static_contract_note")).toBeInTheDocument();
+  });
+
+  it("AC22.19.3 keeps export proof metadata behind a print-hidden export audit disclosure", async () => {
+    mockPackageApi();
+
+    renderPackagePage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
+    await screen.findByRole("heading", { name: "Export Options" });
+
+    expect(screen.queryByRole("heading", { name: "Export Contract" })).not.toBeInTheDocument();
+    expect(screen.getByText("Snapshot exports are built from the selected reporting basis and evidence references.")).toBeInTheDocument();
+    const exportAudit = screen.getByText("Export audit details").closest("details");
+    expect(exportAudit).not.toBeNull();
+    expect(exportAudit).toHaveClass("print:hidden");
+    expectInsideClosedAuditDetails("Framework Policy Matrix Version");
+    expectInsideClosedAuditDetails(/atomic_position:private-token/);
   });
 
   it("AC5.9.4 renders export contract metadata", async () => {
@@ -1381,14 +1459,12 @@ describe("PersonalReportPackagePage", () => {
     renderPackagePage();
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await screen.findByRole("heading", { name: "Export Contract" });
+    await screen.findByRole("heading", { name: "Export Options" });
     expect(screen.getByText("json, csv")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "package_id, section_id, line_id, label, amount, currency, source_state, selected_framework_id, framework_policy_result_id, framework_policy_matrix_version, evidence_bundle_references",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Framework Policy Result")).toBeInTheDocument();
+    expectInsideClosedAuditDetails(
+      "package_id, section_id, line_id, label, amount, currency, source_state, selected_framework_id, framework_policy_result_id, framework_policy_matrix_version, evidence_bundle_references",
+    );
+    expectInsideClosedAuditDetails("Framework Policy Result");
     expect(screen.getAllByText("1.0").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("string")).toBeInTheDocument();
     expect(
@@ -1448,40 +1524,35 @@ describe("PersonalReportPackagePage", () => {
     renderPackagePage();
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await screen.findByText("balance_sheet.total_assets");
+    await screen.findByRole("heading", { name: "Traceability Summary" });
     expect(
-      screen.getAllByText("Traceability Appendix").length,
+      screen.getAllByText("Traceability Summary").length,
     ).toBeGreaterThanOrEqual(1);
-    expect(
-      screen.getByText("posted_reconciled_journal_lines_and_manual_valuations"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("bank_statement, manual_valuation_snapshot"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        `statement_transaction:${statementTxnId}, manual_valuation_snapshot:val-456`,
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("posted, reconciled")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        `journal_entry:${journalEntryId}, journal_line:${journalLineId}`,
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("trusted_or_explicit_manual_input"),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText("Total Assets").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Source available").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Ledger available").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("4 evidence anchors")).toBeInTheDocument();
+    expectInsideClosedAuditDetails("balance_sheet.total_assets");
+    expectInsideClosedAuditDetails(
+      "posted_reconciled_journal_lines_and_manual_valuations",
+    );
+    expectInsideClosedAuditDetails("bank_statement, manual_valuation_snapshot");
+    expectInsideClosedAuditDetails(
+      `statement_transaction:${statementTxnId}, manual_valuation_snapshot:val-456`,
+    );
+    expectInsideClosedAuditDetails("posted, reconciled");
+    expectInsideClosedAuditDetails(
+      `journal_entry:${journalEntryId}, journal_line:${journalLineId}`,
+    );
+    expectInsideClosedAuditDetails("trusted_or_explicit_manual_input");
     expect(screen.getAllByText("TRUSTED").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("hybrid")).toBeInTheDocument();
-    expect(screen.getByText("4 anchors")).toBeInTheDocument();
-    expect(screen.getByText("unclassified")).toBeInTheDocument();
-    expect(screen.getByText("0 anchors")).toBeInTheDocument();
-    expect(screen.getByText("static_contract_note")).toBeInTheDocument();
-    expect(screen.getByText("manual_only_source")).toBeInTheDocument();
-    expect(
-      screen.getByText("explicit_manual_input_required"),
-    ).toBeInTheDocument();
+    expectInsideClosedAuditDetails("hybrid");
+    expectInsideClosedAuditDetails("4 anchors");
+    expectInsideClosedAuditDetails("unclassified");
+    expectInsideClosedAuditDetails("0 anchors");
+    expectInsideClosedAuditDetails("static_contract_note");
+    expectInsideClosedAuditDetails("manual_only_source");
+    expectInsideClosedAuditDetails("explicit_manual_input_required");
   });
 
   it("AC18.9.4 AC18.9.5 AC18.9.6 opens an Evidence Graph lineage panel from report traceability", async () => {
@@ -1490,11 +1561,11 @@ describe("PersonalReportPackagePage", () => {
     renderPackagePage();
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await screen.findByText("balance_sheet.total_assets");
+    await screen.findByRole("heading", { name: "Traceability Summary" });
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Trace lineage for balance_sheet.total_assets",
+        name: "Trace evidence for Total Assets",
       }),
     );
 
@@ -1541,10 +1612,10 @@ describe("PersonalReportPackagePage", () => {
     renderPackagePage();
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await screen.findByText("balance_sheet.total_assets");
+    await screen.findByRole("heading", { name: "Traceability Summary" });
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Trace lineage for balance_sheet.total_assets",
+        name: "Trace evidence for Total Assets",
       }),
     );
 
@@ -1568,10 +1639,10 @@ describe("PersonalReportPackagePage", () => {
     renderPackagePage();
 
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-    await screen.findByText("balance_sheet.total_assets");
+    await screen.findByRole("heading", { name: "Traceability Summary" });
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Trace lineage for balance_sheet.total_assets",
+        name: "Trace evidence for Total Assets",
       }),
     );
 
@@ -1622,10 +1693,10 @@ describe("PersonalReportPackagePage", () => {
       const { unmount } = renderPackagePage();
 
       fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
-      await screen.findByText("balance_sheet.total_assets");
+      await screen.findByRole("heading", { name: "Traceability Summary" });
       fireEvent.click(
         screen.getByRole("button", {
-          name: "Trace lineage for balance_sheet.total_assets",
+          name: "Trace evidence for Total Assets",
         }),
       );
 

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -582,13 +582,20 @@ function expectPackageDates(path: string, reportDate: string, startDate: string)
 }
 
 function expectInsideClosedAuditDetails(text: string | RegExp) {
-  const node = screen.getAllByText(text)[0];
-  expect(node).toBeDefined();
-  const details = node.closest("details");
+  const details = screen
+    .getAllByText(text)
+    .map((node) => node.closest("details"))
+    .find((candidate): candidate is HTMLDetailsElement =>
+      candidate instanceof HTMLDetailsElement &&
+      Boolean(within(candidate).queryByText(/audit details/i)),
+    );
+  if (!details) {
+    throw new Error(`Expected ${String(text)} inside closed audit details.`);
+  }
   expect(details).not.toBeNull();
   expect(details).not.toHaveAttribute("open");
-  expect(within(details as HTMLElement).getByText(/audit details/i)).toBeInTheDocument();
-  return details as HTMLElement;
+  expect(within(details).getByText(/audit details/i)).toBeInTheDocument();
+  return details;
 }
 
 describe("PersonalReportPackagePage", () => {
@@ -1391,6 +1398,7 @@ describe("PersonalReportPackagePage", () => {
     fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
 
     expect(await screen.findByRole("heading", { name: "Evidence Coverage" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Evidence Coverage" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Reporting Basis" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Traceability Summary" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Framework Policy" })).not.toBeInTheDocument();
@@ -1404,6 +1412,44 @@ describe("PersonalReportPackagePage", () => {
     expectInsideClosedAuditDetails("Framework Policy Result");
     expectInsideClosedAuditDetails("unsupported_policy_domain");
     expectInsideClosedAuditDetails("pending_review");
+  });
+
+  it("AC22.19.1 humanizes review states in the reader-first package layer", async () => {
+    mockPackageApi(readiness, {
+      ...frameworkPolicy,
+      decisions: [
+        {
+          ...frameworkPolicy.decisions[0],
+          domain: "manual_private_asset",
+          classification: "Private asset.",
+          presentation: "Private asset presentation.",
+          review_state: "pending_review",
+        },
+      ],
+    }, {
+      ...traceabilityAppendix,
+      status: "pending_review",
+    });
+
+    renderPackagePage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "US-like" }));
+
+    const policyLabel = await screen.findByText("Manual Private Asset");
+    const policyArticle = policyLabel.closest("article");
+    if (!(policyArticle instanceof HTMLElement)) {
+      throw new Error("Expected framework policy decision article.");
+    }
+    expect(within(policyArticle).getByText("Pending Review")).toBeInTheDocument();
+    expect(within(policyArticle).queryByText("pending_review")).not.toBeInTheDocument();
+
+    const traceabilityHeading = screen.getByRole("heading", { name: "Traceability Summary" });
+    const traceabilitySection = traceabilityHeading.closest("section");
+    if (!(traceabilitySection instanceof HTMLElement)) {
+      throw new Error("Expected traceability section.");
+    }
+    expect(within(traceabilitySection).getAllByText("Pending Review").length).toBeGreaterThanOrEqual(1);
+    expect(within(traceabilitySection).queryByText("pending_review")).not.toBeInTheDocument();
   });
 
   it("AC22.19.2 keeps proof and policy internals in keyboard-reachable audit details", async () => {

--- a/apps/frontend/src/components/reports/package/PackageChrome.tsx
+++ b/apps/frontend/src/components/reports/package/PackageChrome.tsx
@@ -189,30 +189,41 @@ export function PackageFrameworkSelection({
         </div>
       </div>
       {selectedFrameworkId ? (
-        <dl className="mt-5 grid md:grid-cols-4 gap-3 text-sm">
-          <div>
-            <dt className="text-xs text-muted">Selected Framework</dt>
-            <dd className="mt-1 font-mono text-xs">{selectedFrameworkId}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Report Period</dt>
-            <dd className="mt-1 font-mono text-xs">
-              {reportPeriodStart(reportDate)} to {reportDate}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Policy Endpoint</dt>
-            <dd className="mt-1 font-mono text-xs">
-              {contract.framework_policy_endpoint}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted">Supported Frameworks</dt>
-            <dd className="mt-1 font-mono text-xs">
-              {contract.supported_frameworks.join(", ")}
-            </dd>
-          </div>
-        </dl>
+        <>
+          <dl className="mt-5 grid gap-3 text-sm md:grid-cols-2">
+            <div>
+              <dt className="text-xs text-muted">Reporting basis</dt>
+              <dd className="mt-1 font-semibold">{selectedFrameworkLabel}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted">Report period</dt>
+              <dd className="mt-1 font-medium">
+                {reportPeriodStart(reportDate)} to {reportDate}
+              </dd>
+            </div>
+          </dl>
+          <details className="mt-4 rounded border border-[var(--border)] p-3 text-sm print:hidden">
+            <summary className="cursor-pointer font-medium">Framework setup audit details</summary>
+            <dl className="mt-3 grid gap-3 md:grid-cols-2">
+              <div>
+                <dt className="text-xs text-muted">Selected Framework</dt>
+                <dd className="mt-1 font-mono text-xs">{selectedFrameworkId}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted">Policy Endpoint</dt>
+                <dd className="mt-1 font-mono text-xs">
+                  {contract.framework_policy_endpoint}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted">Supported Frameworks</dt>
+                <dd className="mt-1 font-mono text-xs">
+                  {contract.supported_frameworks.join(", ")}
+                </dd>
+              </div>
+            </dl>
+          </details>
+        </>
       ) : null}
     </section>
   );

--- a/apps/frontend/src/components/reports/package/PackageReadinessSections.tsx
+++ b/apps/frontend/src/components/reports/package/PackageReadinessSections.tsx
@@ -5,7 +5,13 @@ import type {
   PersonalReportPackageReadinessResponse,
 } from "@/lib/types";
 
-import { renderCsv } from "./shared";
+import {
+  countLabel,
+  FRAMEWORK_LABELS,
+  humanizeIdentifier,
+  renderCsv,
+  renderSourceClasses,
+} from "./shared";
 
 type SourceTrustSummary = NonNullable<
   PersonalReportPackageReadinessResponse["source_trust_summary"]
@@ -65,9 +71,6 @@ export function PackageReadinessSection({
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <p className="font-medium">{blocker.label}</p>
-                  <p className="text-xs font-mono text-muted mt-1">
-                    {blocker.code}
-                  </p>
                 </div>
                 <Link
                   className="badge badge-muted"
@@ -81,6 +84,42 @@ export function PackageReadinessSection({
           ))}
         </div>
       ) : null}
+      <details className="mt-5 rounded border border-[var(--border)] p-3 text-sm print:hidden">
+        <summary className="cursor-pointer font-medium">Readiness audit details</summary>
+        <dl className="mt-3 grid gap-3 md:grid-cols-2">
+          <div>
+            <dt className="text-xs text-muted">Package state</dt>
+            <dd className="mt-1 font-mono text-xs">{readiness.state}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Action href</dt>
+            <dd className="mt-1 font-mono text-xs">{readiness.action_href}</dd>
+          </div>
+        </dl>
+        {readiness.blockers.length ? (
+          <div className="mt-4 grid gap-3 lg:grid-cols-2">
+            {readiness.blockers.map((blocker) => (
+              <article key={blocker.code} className="rounded border border-[var(--border)] p-3">
+                <p className="font-mono text-xs">{blocker.code}</p>
+                <dl className="mt-2 space-y-1 text-xs">
+                  <div className="flex justify-between gap-3">
+                    <dt className="text-muted">Blocker code</dt>
+                    <dd className="font-mono text-right">{blocker.code}</dd>
+                  </div>
+                  <div className="flex justify-between gap-3">
+                    <dt className="text-muted">Severity</dt>
+                    <dd className="font-mono text-right">{blocker.severity}</dd>
+                  </div>
+                  <div className="flex justify-between gap-3">
+                    <dt className="text-muted">Action href</dt>
+                    <dd className="font-mono text-right">{blocker.action_href}</dd>
+                  </div>
+                </dl>
+              </article>
+            ))}
+          </div>
+        ) : null}
+      </details>
     </section>
   );
 }
@@ -90,50 +129,78 @@ export function PackageSourceTrustSection({
 }: {
   summary: SourceTrustSummary;
 }) {
+  const coverageItems = [
+    {
+      label: "Imported evidence",
+      values: summary.source_classes,
+    },
+    {
+      label: "Verified by automated checks",
+      values: summary.deterministic_pr_source_classes,
+    },
+    {
+      label: "Verified with live extraction checks",
+      values: summary.post_merge_llm_ocr_source_classes,
+    },
+    {
+      label: "Manual evidence",
+      values: summary.manual_trusted_source_classes,
+    },
+    {
+      label: "Missing or unsupported evidence",
+      values: summary.gap_source_classes,
+    },
+  ];
+
   return (
     <section id="package-source-trust" className="card p-5 mb-6" aria-label="Source trust summary">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <h2 className="font-semibold">Source Trust</h2>
+          <h2 className="font-semibold">Evidence Coverage</h2>
         </div>
         <span className="badge badge-muted">
-          {summary.source_classes.length} classes
+          {countLabel(summary.source_classes.length, "evidence class", "evidence classes")}
         </span>
       </div>
       <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
-        <div>
-          <dt className="text-xs text-muted">Deterministic PR</dt>
-          <dd className="mt-1 font-mono text-xs">
-            {renderCsv(summary.deterministic_pr_source_classes)}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-xs text-muted">Post-merge LLM/OCR</dt>
-          <dd className="mt-1 font-mono text-xs">
-            {renderCsv(summary.post_merge_llm_ocr_source_classes)}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-xs text-muted">Manual Trusted</dt>
-          <dd className="mt-1 font-mono text-xs">
-            {renderCsv(summary.manual_trusted_source_classes)}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-xs text-muted">Trust Gaps</dt>
-          <dd className="mt-1 font-mono text-xs">
-            {renderCsv(summary.gap_source_classes)}
-          </dd>
-        </div>
+        {coverageItems.map((item) => (
+          <div key={item.label} className="rounded border border-[var(--border)] p-3">
+            <dt className="text-xs text-muted">{item.label}</dt>
+            <dd className="mt-1 font-medium">{renderSourceClasses(item.values)}</dd>
+          </div>
+        ))}
       </dl>
-      {summary.blocker_codes.length ? (
-        <div className="mt-4">
-          <p className="text-xs text-muted">Blocker Codes</p>
-          <p className="mt-1 font-mono text-xs">
-            {summary.blocker_codes.join(", ")}
-          </p>
-        </div>
-      ) : null}
+      <details className="mt-4 rounded border border-[var(--border)] p-3 text-sm print:hidden">
+        <summary className="cursor-pointer font-medium">Evidence audit details</summary>
+        <dl className="mt-3 grid gap-3 md:grid-cols-2">
+          <div>
+            <dt className="text-xs text-muted">Source classes</dt>
+            <dd className="mt-1 font-mono text-xs">{renderCsv(summary.source_classes)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Deterministic PR</dt>
+            <dd className="mt-1 font-mono text-xs">{renderCsv(summary.deterministic_pr_source_classes)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Post-merge LLM/OCR</dt>
+            <dd className="mt-1 font-mono text-xs">{renderCsv(summary.post_merge_llm_ocr_source_classes)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Manual Trusted</dt>
+            <dd className="mt-1 font-mono text-xs">{renderCsv(summary.manual_trusted_source_classes)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Trust Gaps</dt>
+            <dd className="mt-1 font-mono text-xs">{renderCsv(summary.gap_source_classes)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Blocker Codes</dt>
+            <dd className="mt-1 font-mono text-xs">
+              {summary.blocker_codes.join(", ") || "none"}
+            </dd>
+          </div>
+        </dl>
+      </details>
     </section>
   );
 }
@@ -143,30 +210,30 @@ export function PackageFrameworkPolicySection({
 }: {
   policy: FrameworkPolicyResult;
 }) {
+  const frameworkLabel = FRAMEWORK_LABELS[policy.framework_id] ?? humanizeIdentifier(policy.framework_id);
+
   return (
     <section id="package-framework-policy" className="card p-5 mb-6">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <h2 className="font-semibold">Framework Policy</h2>
-          <p className="mt-2 max-w-3xl break-words font-mono text-xs text-muted">
-            {policy.result_id}
+          <h2 className="font-semibold">Reporting Basis</h2>
+          <p className="mt-2 text-sm text-muted">
+            {frameworkLabel} basis for the selected report period.
           </p>
         </div>
         <span className="badge badge-muted">
-          {policy.framework_id}
+          {frameworkLabel}
         </span>
       </div>
       <dl className="mt-5 grid md:grid-cols-4 gap-3 text-sm">
         <div>
-          <dt className="text-xs text-muted">Framework</dt>
-          <dd className="mt-1 font-mono text-xs">
-            {policy.framework_id}
-          </dd>
+          <dt className="text-xs text-muted">Reporting basis</dt>
+          <dd className="mt-1 font-semibold">{frameworkLabel}</dd>
         </div>
         <div>
-          <dt className="text-xs text-muted">Matrix Version</dt>
+          <dt className="text-xs text-muted">Required statements</dt>
           <dd className="mt-1 font-semibold">
-            {policy.matrix_version}
+            {policy.required_statements.length}
           </dd>
         </div>
         <div>
@@ -176,7 +243,7 @@ export function PackageFrameworkPolicySection({
           </dd>
         </div>
         <div>
-          <dt className="text-xs text-muted">Gaps</dt>
+          <dt className="text-xs text-muted">Reporting gaps</dt>
           <dd className="mt-1 font-semibold">
             {policy.gaps.length}
           </dd>
@@ -186,52 +253,96 @@ export function PackageFrameworkPolicySection({
         {policy.decisions.map((decision) => (
           <article
             key={`${decision.domain}:${decision.line_mappings.balance_sheet ?? decision.presentation}`}
-            className="border border-[var(--border)] rounded p-3"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <p className="font-medium">{decision.domain}</p>
-                <p className="mt-1 text-xs font-mono text-muted">
-                  {decision.review_state}
-                </p>
+              className="border border-[var(--border)] rounded p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-medium">{humanizeIdentifier(decision.domain)}</p>
+                  <p className="mt-1 text-sm text-muted">{decision.classification}</p>
+                </div>
+                <span className="badge badge-muted">
+                  Accepted
+                </span>
               </div>
-              <span className="badge badge-muted">
-                {decision.confidence_tier}
-              </span>
-            </div>
-            <dl className="mt-3 space-y-1 text-xs">
-              {Object.entries(decision.line_mappings).map(
-                ([section, line]) => (
-                  <div
-                    key={`${decision.domain}:${section}`}
-                    className="flex justify-between gap-3"
-                  >
-                    <dt className="text-muted">{section}</dt>
-                    <dd className="font-mono text-right">{line}</dd>
-                  </div>
-                ),
-              )}
-            </dl>
-          </article>
-        ))}
+              <p className="mt-3 text-sm text-muted">{decision.presentation}</p>
+            </article>
+          ))}
         {policy.gaps.map((gap) => (
           <article
             key={`${gap.code}:${gap.fact_id}`}
             className="border border-[var(--border)] rounded p-3"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <p className="font-medium">{gap.code}</p>
-                <p className="mt-1 text-xs font-mono text-muted">
-                  {gap.fact_id}
-                </p>
-              </div>
-              <span className="badge badge-muted">{gap.instrument_type}</span>
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-medium">{humanizeIdentifier(gap.domain)}</p>
+                  <p className="mt-1 text-sm text-muted">{gap.reason}</p>
+                </div>
+              <span className="badge badge-warning">
+                {gap.blocker ? "Blocks trusted output" : "Needs review"}
+              </span>
             </div>
-            <p className="mt-3 text-sm text-muted">{gap.reason}</p>
+            {gap.remediation ? (
+              <p className="mt-3 text-sm text-muted">{gap.remediation}</p>
+            ) : null}
           </article>
         ))}
       </div>
+      <details className="mt-5 rounded border border-[var(--border)] p-3 text-sm print:hidden">
+        <summary className="cursor-pointer font-medium">Reporting basis audit details</summary>
+        <dl className="mt-3 grid gap-3 md:grid-cols-2">
+          <div>
+            <dt className="text-xs text-muted">Framework</dt>
+            <dd className="mt-1 font-mono text-xs">{policy.framework_id}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted">Matrix Version</dt>
+            <dd className="mt-1 font-semibold">{policy.matrix_version}</dd>
+          </div>
+          <div className="md:col-span-2">
+            <dt className="text-xs text-muted">Framework Policy Result</dt>
+            <dd className="mt-1 break-words font-mono text-xs">{policy.result_id}</dd>
+          </div>
+        </dl>
+        <div className="mt-4 grid gap-3 lg:grid-cols-2">
+          {policy.decisions.map((decision) => (
+            <article
+              key={`audit:${decision.domain}:${decision.line_mappings.balance_sheet ?? decision.presentation}`}
+              className="rounded border border-[var(--border)] p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-medium">{decision.domain}</p>
+                  <p className="mt-1 text-xs font-mono text-muted">{decision.review_state}</p>
+                </div>
+                <span className="badge badge-muted">{decision.confidence_tier}</span>
+              </div>
+              <dl className="mt-3 space-y-1 text-xs">
+                {Object.entries(decision.line_mappings).map(([section, line]) => (
+                  <div key={`${decision.domain}:${section}`} className="flex justify-between gap-3">
+                    <dt className="text-muted">{section}</dt>
+                    <dd className="font-mono text-right">{line}</dd>
+                  </div>
+                ))}
+              </dl>
+            </article>
+          ))}
+          {policy.gaps.map((gap) => (
+            <article
+              key={`audit:${gap.code}:${gap.fact_id}`}
+              className="rounded border border-[var(--border)] p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-medium">{gap.code}</p>
+                  <p className="mt-1 text-xs font-mono text-muted">{gap.fact_id}</p>
+                </div>
+                <span className="badge badge-muted">{gap.instrument_type}</span>
+              </div>
+              <p className="mt-3 text-sm text-muted">{gap.reason}</p>
+            </article>
+          ))}
+        </div>
+      </details>
     </section>
   );
 }

--- a/apps/frontend/src/components/reports/package/PackageReadinessSections.tsx
+++ b/apps/frontend/src/components/reports/package/PackageReadinessSections.tsx
@@ -153,7 +153,7 @@ export function PackageSourceTrustSection({
   ];
 
   return (
-    <section id="package-source-trust" className="card p-5 mb-6" aria-label="Source trust summary">
+    <section id="package-source-trust" className="card p-5 mb-6" aria-label="Evidence Coverage">
       <div className="flex items-start justify-between gap-3">
         <div>
           <h2 className="font-semibold">Evidence Coverage</h2>
@@ -261,7 +261,7 @@ export function PackageFrameworkPolicySection({
                   <p className="mt-1 text-sm text-muted">{decision.classification}</p>
                 </div>
                 <span className="badge badge-muted">
-                  Accepted
+                  {decision.review_state === "accepted" ? "Accepted" : humanizeIdentifier(decision.review_state)}
                 </span>
               </div>
               <p className="mt-3 text-sm text-muted">{decision.presentation}</p>

--- a/apps/frontend/src/components/reports/package/PackageScheduleSections.tsx
+++ b/apps/frontend/src/components/reports/package/PackageScheduleSections.tsx
@@ -5,7 +5,7 @@ import type {
   PersonalReportPackageNotesResponse,
 } from "@/lib/types";
 
-import { formatScheduleCurrency, sectionAnchorId } from "./shared";
+import { formatScheduleCurrency, FRAMEWORK_LABELS, sectionAnchorId } from "./shared";
 
 export function PackageSectionCards({
   sections,
@@ -27,16 +27,6 @@ export function PackageSectionCards({
             <span className="badge badge-muted">{section.status}</span>
           </div>
           <dl className="mt-4 space-y-2 text-sm">
-            <div className="flex justify-between gap-3">
-              <dt className="text-muted">Owner</dt>
-              <dd className="font-medium">{section.owner_epic}</dd>
-            </div>
-            <div className="flex justify-between gap-3">
-              <dt className="text-muted">Endpoint</dt>
-              <dd className="font-mono text-xs text-right">
-                {section.source_endpoint}
-              </dd>
-            </div>
             {section.blocking_issue ? (
               <div className="flex justify-between gap-3">
                 <dt className="text-muted">Follow-up</dt>
@@ -44,6 +34,25 @@ export function PackageSectionCards({
               </div>
             ) : null}
           </dl>
+          <details className="mt-4 rounded border border-[var(--border)] p-3 text-sm print:hidden">
+            <summary className="cursor-pointer font-medium">Section audit details</summary>
+            <dl className="mt-3 space-y-2">
+              <div className="flex justify-between gap-3">
+                <dt className="text-muted">Section ID</dt>
+                <dd className="font-mono text-xs text-right">{section.section_id}</dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="text-muted">Owner</dt>
+                <dd className="font-medium">{section.owner_epic}</dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="text-muted">Endpoint</dt>
+                <dd className="font-mono text-xs text-right">
+                  {section.source_endpoint}
+                </dd>
+              </div>
+            </dl>
+          </details>
         </section>
       ))}
     </div>
@@ -229,20 +238,19 @@ export function PackageExportContractSection({
   policy: FrameworkPolicyResult;
   evidenceReferences: string[];
 }) {
+  const frameworkLabel = FRAMEWORK_LABELS[policy.framework_id] ?? policy.framework_id;
+
   return (
     <section id="package-export-contract" className="card p-5">
-      <h2 className="font-semibold">Export Contract</h2>
+      <h2 className="font-semibold">Export Options</h2>
+      <p className="mt-2 text-sm text-muted">
+        Snapshot exports are built from the selected reporting basis and evidence references.
+      </p>
       <dl className="mt-4 space-y-2 text-sm">
         <div className="flex justify-between gap-3">
           <dt className="text-muted">Formats</dt>
           <dd className="font-medium">
             {contract.export_contract.formats.join(", ")}
-          </dd>
-        </div>
-        <div className="flex justify-between gap-3">
-          <dt className="text-muted">CSV Columns</dt>
-          <dd className="font-mono text-xs text-right">
-            {contract.export_contract.csv_columns.join(", ")}
           </dd>
         </div>
         <div className="flex justify-between gap-3">
@@ -252,22 +260,37 @@ export function PackageExportContractSection({
           </dd>
         </div>
         <div className="flex justify-between gap-3">
-          <dt className="text-muted">Framework Policy Result</dt>
-          <dd className="max-w-md break-words font-mono text-xs text-right">
-            {policy.result_id}
-          </dd>
-        </div>
-        <div className="flex justify-between gap-3">
-          <dt className="text-muted">Framework Policy Matrix Version</dt>
-          <dd className="font-medium">{policy.matrix_version}</dd>
-        </div>
-        <div className="flex justify-between gap-3">
-          <dt className="text-muted">Evidence Bundle References</dt>
-          <dd className="max-w-md break-words font-mono text-xs text-right">
-            {evidenceReferences.join(", ") || "none"}
-          </dd>
+          <dt className="text-muted">Reporting basis</dt>
+          <dd className="font-medium">{frameworkLabel}</dd>
         </div>
       </dl>
+      <details className="mt-4 rounded border border-[var(--border)] p-3 text-sm print:hidden">
+        <summary className="cursor-pointer font-medium">Export audit details</summary>
+        <dl className="mt-3 space-y-2">
+          <div className="flex justify-between gap-3">
+            <dt className="text-muted">CSV Columns</dt>
+            <dd className="font-mono text-xs text-right">
+              {contract.export_contract.csv_columns.join(", ")}
+            </dd>
+          </div>
+          <div className="flex justify-between gap-3">
+            <dt className="text-muted">Framework Policy Result</dt>
+            <dd className="max-w-md break-words font-mono text-xs text-right">
+              {policy.result_id}
+            </dd>
+          </div>
+          <div className="flex justify-between gap-3">
+            <dt className="text-muted">Framework Policy Matrix Version</dt>
+            <dd className="font-medium">{policy.matrix_version}</dd>
+          </div>
+          <div className="flex justify-between gap-3">
+            <dt className="text-muted">Evidence Bundle References</dt>
+            <dd className="max-w-md break-words font-mono text-xs text-right">
+              {evidenceReferences.join(", ") || "none"}
+            </dd>
+          </div>
+        </dl>
+      </details>
     </section>
   );
 }

--- a/apps/frontend/src/components/reports/package/PackageSnapshotsCard.tsx
+++ b/apps/frontend/src/components/reports/package/PackageSnapshotsCard.tsx
@@ -2,7 +2,7 @@ import { Download, FileJson, Printer, Save } from "lucide-react";
 
 import type { PersonalReportPackageSnapshotSummary } from "@/lib/types";
 
-import { formatSnapshotTimestamp, snapshotDownloadLabel } from "./shared";
+import { formatSnapshotTimestamp, FRAMEWORK_LABELS, snapshotDownloadLabel } from "./shared";
 
 export function PackageSnapshotsCard({
   snapshots,
@@ -78,8 +78,8 @@ export function PackageSnapshotsCard({
                         {snapshot.status === "trusted" ? "Trusted" : "Draft"}
                       </span>
                     </td>
-                    <td className="py-3 pr-4 font-mono text-xs">
-                      {snapshot.framework_id}
+                    <td className="py-3 pr-4">
+                      {FRAMEWORK_LABELS[snapshot.framework_id] ?? snapshot.framework_id}
                     </td>
                     <td className="py-3 pr-4 font-mono text-xs">
                       {snapshot.start_date} to {snapshot.end_date}

--- a/apps/frontend/src/components/reports/package/PackageTraceability.tsx
+++ b/apps/frontend/src/components/reports/package/PackageTraceability.tsx
@@ -6,7 +6,12 @@ import type {
   PersonalReportPackageTraceabilityResponse,
 } from "@/lib/types";
 
-import { renderAnchorDetail, type LineagePanelState } from "./shared";
+import {
+  countLabel,
+  humanizeIdentifier,
+  renderAnchorDetail,
+  type LineagePanelState,
+} from "./shared";
 
 export function PackageTraceabilitySection({
   appendix,
@@ -15,93 +20,67 @@ export function PackageTraceabilitySection({
   appendix: PersonalReportPackageTraceabilityResponse;
   onTrace: (line: PersonalReportPackageTraceabilityLine) => void;
 }) {
+  const linesWithEvidence = appendix.lines.filter(
+    (line) =>
+      line.source_anchor.state === "available" ||
+      line.ledger_anchor.state === "available",
+  ).length;
+
   return (
     <section id="package-traceability-detail" className="card p-5 mb-6">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <h2 className="font-semibold">{appendix.label}</h2>
+          <h2 className="font-semibold">Traceability Summary</h2>
         </div>
         <span className="badge badge-muted">
           {appendix.status}
         </span>
       </div>
-      <div className="mt-5 overflow-x-auto">
-        <table className="min-w-full text-sm">
-          <thead className="text-left text-xs text-muted">
-            <tr>
-              <th className="py-2 pr-4 font-medium">Line</th>
-              <th className="py-2 pr-4 font-medium">Source</th>
-              <th className="py-2 pr-4 font-medium">Ledger</th>
-              <th className="py-2 pr-4 font-medium">Review</th>
-              <th className="py-2 font-medium">Confidence</th>
-              <th className="py-2 pl-4 font-medium">Lineage</th>
-            </tr>
-          </thead>
-          <tbody>
-            {appendix.lines.map((line) => (
-              <tr
-                key={line.line_id}
-                className="border-t border-[var(--border)] align-top"
+      <dl className="mt-5 grid gap-3 text-sm md:grid-cols-3">
+        <div>
+          <dt className="text-xs text-muted">Report lines with evidence</dt>
+          <dd className="mt-1 font-semibold">{linesWithEvidence}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Completeness warnings</dt>
+          <dd className="mt-1 font-semibold">{appendix.completeness_warnings.length}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted">Appendix status</dt>
+          <dd className="mt-1 font-semibold">{humanizeIdentifier(appendix.status)}</dd>
+        </div>
+      </dl>
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        {appendix.lines.map((line) => (
+          <article key={line.line_id} className="rounded border border-[var(--border)] p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-medium">{line.label}</p>
+                <p className="mt-1 text-xs text-muted">{humanizeIdentifier(line.section_id)}</p>
+              </div>
+              <button
+                type="button"
+                className="btn-secondary inline-flex h-9 w-9 items-center justify-center p-0"
+                aria-label={`Trace evidence for ${line.label}`}
+                title="Trace evidence"
+                onClick={() => onTrace(line)}
               >
-                <td className="py-3 pr-4">
-                  <p className="font-mono text-xs">{line.line_id}</p>
-                  <p className="mt-1 text-xs text-muted">{line.label}</p>
-                </td>
-                <td className="py-3 pr-4">
-                  <p className="font-mono text-xs">{line.source_state}</p>
-                  {renderAnchorDetail(
-                    (line.source_anchor.source_types ?? []).join(", ") ||
-                      line.source_anchor.state,
-                    line.source_anchor.identifiers,
-                  )}
-                </td>
-                <td className="py-3 pr-4">
-                  <p className="font-mono text-xs">
-                    {line.ledger_anchor.state}
-                  </p>
-                  {renderAnchorDetail(
-                    (line.ledger_anchor.entry_statuses ?? []).join(", ") ||
-                      line.ledger_anchor.unavailable_reason ||
-                      line.ledger_anchor.state,
-                    line.ledger_anchor.identifiers,
-                  )}
-                </td>
-                <td className="py-3 pr-4 font-mono text-xs">
-                  {line.review_state}
-                </td>
-                <td className="py-3">
-                  <div className="flex flex-col gap-2">
-                    <span className="badge badge-muted">
-                      {line.confidence_tier}
-                    </span>
-                    <span className="font-mono text-xs text-muted">
-                      {line.proof_level ?? "unclassified"}
-                    </span>
-                    <span className="font-mono text-xs text-muted">
-                      {line.anchor_count ?? 0} anchors
-                    </span>
-                    {line.blocker_codes?.length ? (
-                      <span className="font-mono text-xs text-muted">
-                        {line.blocker_codes.join(", ")}
-                      </span>
-                    ) : null}
-                  </div>
-                </td>
-                <td className="py-3 pl-4">
-                  <button
-                    type="button"
-                    className="btn-secondary inline-flex h-9 w-9 items-center justify-center p-0"
-                    aria-label={`Trace lineage for ${line.line_id}`}
-                    title="Trace lineage"
-                    onClick={() => onTrace(line)}
-                  >
-                    <Network aria-hidden="true" className="h-4 w-4" />
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+                <Network aria-hidden="true" className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2 text-xs">
+              <span className="badge badge-muted">
+                Source {humanizeIdentifier(line.source_anchor.state).toLowerCase()}
+              </span>
+              <span className="badge badge-muted">
+                Ledger {humanizeIdentifier(line.ledger_anchor.state).toLowerCase()}
+              </span>
+              <span className="badge badge-muted">
+                {countLabel(line.anchor_count ?? 0, "evidence anchor")}
+              </span>
+            </div>
+          </article>
+        ))}
       </div>
       <div className="mt-5 grid lg:grid-cols-2 gap-4">
         {appendix.completeness_warnings.map((warning) => (
@@ -112,11 +91,8 @@ export function PackageTraceabilitySection({
             <div className="flex items-start justify-between gap-3">
               <div>
                 <p className="font-medium">{warning.label}</p>
-                <p className="text-xs font-mono text-muted mt-1">
-                  {warning.code}
-                </p>
               </div>
-              <span className="badge badge-muted">{warning.state}</span>
+              <span className="badge badge-muted">{humanizeIdentifier(warning.state)}</span>
             </div>
             {warning.remediation ? (
               <p className="mt-3 text-sm text-muted">{warning.remediation}</p>
@@ -124,6 +100,96 @@ export function PackageTraceabilitySection({
           </article>
         ))}
       </div>
+      <details className="mt-5 rounded border border-[var(--border)] p-3 text-sm print:hidden">
+        <summary className="cursor-pointer font-medium">Traceability audit details</summary>
+        <p className="mt-3 text-xs text-muted">{appendix.label}</p>
+        <div className="mt-3 overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="text-left text-xs text-muted">
+              <tr>
+                <th className="py-2 pr-4 font-medium">Line</th>
+                <th className="py-2 pr-4 font-medium">Source</th>
+                <th className="py-2 pr-4 font-medium">Ledger</th>
+                <th className="py-2 pr-4 font-medium">Review</th>
+                <th className="py-2 font-medium">Confidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {appendix.lines.map((line) => (
+                <tr
+                  key={line.line_id}
+                  className="border-t border-[var(--border)] align-top"
+                >
+                  <td className="py-3 pr-4">
+                    <p className="font-mono text-xs">{line.line_id}</p>
+                    <p className="mt-1 text-xs text-muted">{line.label}</p>
+                  </td>
+                  <td className="py-3 pr-4">
+                    <p className="font-mono text-xs">{line.source_state}</p>
+                    {renderAnchorDetail(
+                      (line.source_anchor.source_types ?? []).join(", ") ||
+                        line.source_anchor.state,
+                      line.source_anchor.identifiers,
+                    )}
+                  </td>
+                  <td className="py-3 pr-4">
+                    <p className="font-mono text-xs">
+                      {line.ledger_anchor.state}
+                    </p>
+                    {renderAnchorDetail(
+                      (line.ledger_anchor.entry_statuses ?? []).join(", ") ||
+                        line.ledger_anchor.unavailable_reason ||
+                        line.ledger_anchor.state,
+                      line.ledger_anchor.identifiers,
+                    )}
+                  </td>
+                  <td className="py-3 pr-4 font-mono text-xs">
+                    {line.review_state}
+                  </td>
+                  <td className="py-3">
+                    <div className="flex flex-col gap-2">
+                      <span className="badge badge-muted">
+                        {line.confidence_tier}
+                      </span>
+                      <span className="font-mono text-xs text-muted">
+                        {line.proof_level ?? "unclassified"}
+                      </span>
+                      <span className="font-mono text-xs text-muted">
+                        {line.anchor_count ?? 0} anchors
+                      </span>
+                      {line.blocker_codes?.length ? (
+                        <span className="font-mono text-xs text-muted">
+                          {line.blocker_codes.join(", ")}
+                        </span>
+                      ) : null}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="mt-4 grid gap-3 lg:grid-cols-2">
+          {appendix.completeness_warnings.map((warning) => (
+            <article
+              key={`audit:${warning.code}`}
+              className="rounded border border-[var(--border)] p-3"
+            >
+              <p className="font-medium">{warning.label}</p>
+              <dl className="mt-2 space-y-1 text-xs">
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted">Code</dt>
+                  <dd className="font-mono text-right">{warning.code}</dd>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted">State</dt>
+                  <dd className="font-mono text-right">{warning.state}</dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+        </div>
+      </details>
     </section>
   );
 }

--- a/apps/frontend/src/components/reports/package/PackageTraceability.tsx
+++ b/apps/frontend/src/components/reports/package/PackageTraceability.tsx
@@ -33,7 +33,7 @@ export function PackageTraceabilitySection({
           <h2 className="font-semibold">Traceability Summary</h2>
         </div>
         <span className="badge badge-muted">
-          {appendix.status}
+          {humanizeIdentifier(appendix.status)}
         </span>
       </div>
       <dl className="mt-5 grid gap-3 text-sm md:grid-cols-3">

--- a/apps/frontend/src/components/reports/package/shared.tsx
+++ b/apps/frontend/src/components/reports/package/shared.tsx
@@ -14,6 +14,19 @@ export const FRAMEWORK_LABELS: Record<string, string> = {
   personal_hkfrs_like: "HK-like",
 };
 
+const SOURCE_CLASS_LABELS: Record<string, string> = {
+  bank_statement: "Bank statements",
+  brokerage_statement: "Brokerage statements",
+  settlement_note: "Settlement notes",
+  esop_rsu_plan: "ESOP / RSU plans",
+  property_statement: "Property statements",
+  liability_statement: "Liability statements",
+  csv_export: "CSV exports",
+  manual_record: "Manual records",
+  manual_valuation_snapshot: "Manual valuation snapshots",
+  package_contract: "Package contract",
+};
+
 export type LineagePanelState = {
   line: PersonalReportPackageTraceabilityLine;
   response: EvidenceLineageResponse | null;
@@ -41,8 +54,8 @@ export function packageTocLinks(
   if (includeOutputSections) {
     links.push(
       { id: "package-readiness", label: "Report Readiness" },
-      { id: "package-source-trust", label: "Source Trust" },
-      { id: "package-framework-policy", label: "Framework Policy" },
+      { id: "package-source-trust", label: "Evidence Coverage" },
+      { id: "package-framework-policy", label: "Reporting Basis" },
     );
   }
   links.push(
@@ -53,7 +66,10 @@ export function packageTocLinks(
     })),
   );
   if (includeOutputSections) {
-    links.push({ id: "package-export-contract", label: "Export Contract" });
+    links.push(
+      { id: "package-traceability-detail", label: "Traceability Summary" },
+      { id: "package-export-contract", label: "Export Options" },
+    );
   }
   return links;
 }
@@ -69,6 +85,34 @@ export function formatScheduleCurrency(
 
 export function renderCsv(values?: string[]): string {
   return values && values.length ? values.join(", ") : "none";
+}
+
+export function countLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function humanizeIdentifier(value?: string | null): string {
+  if (!value) return "Not recorded";
+  const spaced = value.replace(/[._-]+/g, " ").trim();
+  if (!spaced) return "Not recorded";
+  return spaced
+    .split(/\s+/)
+    .map((word) => {
+      const upper = word.toUpperCase();
+      if (["AI", "CSV", "ESOP", "FX", "GAAP", "HK", "LLM", "OCR", "PR", "RSU", "US"].includes(upper)) {
+        return upper;
+      }
+      return `${word.slice(0, 1).toUpperCase()}${word.slice(1).toLowerCase()}`;
+    })
+    .join(" ");
+}
+
+export function sourceClassLabel(sourceClass: string): string {
+  return SOURCE_CLASS_LABELS[sourceClass] ?? humanizeIdentifier(sourceClass);
+}
+
+export function renderSourceClasses(values?: string[]): string {
+  return values && values.length ? values.map(sourceClassLabel).join(", ") : "none";
 }
 
 export function renderAnchorDetail(primary: string, identifiers?: string[]) {

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -418,3 +418,16 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 | AC22.18.1 | The legacy `/events` alias is removed from `ROUTE_CONFIG` so `/notifications` is the single canonical path/label; the `/events`→`/notifications` redirect is unchanged | `navigation.test.ts`, `nextConfigRedirects.test.ts` | P1 |
 | AC22.18.2 | A typed `track(event, props)` analytics wrapper dispatches through the OpenPanel command queue, is strictly non-blocking (never throws, no-op when unconfigured), exposes a taxonomy of ≥6 named product events, and strips PII (emails, monetary amounts, account numbers) from event properties before sending | `analyticsTrack.test.ts` | P1 |
 | AC22.18.3 | The core product funnel is instrumented through the wrapper — signup, statement upload started/succeeded/failed, Stage-1 review approved, and report generated — with tests asserting `track()` is invoked on each action | `loginPage.test.tsx`, `StatementUploader.test.tsx`, `statementReviewPage.test.tsx`, `personalReportPackagePage.test.tsx` | P1 |
+
+### AC22.19 — Reader-First Report Package With Audit Details
+
+> #1210 follow-up slice. The Personal Report Package must read as a terminal
+> user deliverable by default. Low-level proof and framework-policy internals
+> remain available for audit review, but they are not the primary reading layer
+> of the loaded package.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC22.19.1 | The loaded report package uses reader-facing labels for evidence coverage, reporting basis, and traceability summary, with proof-system labels such as `Deterministic PR`, `Post-merge LLM/OCR`, `Framework Policy`, raw gap codes, raw blocker codes, and policy result IDs kept out of the primary visible layer | `personalReportPackagePage.test.tsx` | P1 |
+| AC22.19.2 | Explicit `Audit details` disclosures keep the same source-trust, framework-policy, traceability, blocker, matrix-version, line-id, confidence, review-state, and evidence-reference details keyboard reachable and screen-reader comprehensible | `personalReportPackagePage.test.tsx` | P1 |
+| AC22.19.3 | Print/save and export metadata default to the reader-first hierarchy; raw CSV columns, policy result IDs, matrix version, and evidence bundle references are available only in an explicit audit/export-details disclosure | `personalReportPackagePage.test.tsx` | P1 |

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -439,6 +439,13 @@ framework is selected, the page must show setup guidance and the contract-backed
 table of contents without loading framework-scoped output. While selected
 framework data is loading, the page must reserve the package layout with
 skeleton placeholders instead of a blank or text-only loading screen.
+The loaded package has two presentation layers: the default reader layer uses
+plain-language labels for evidence coverage, reporting basis, source coverage,
+and traceability summaries; explicit audit-details disclosures retain raw
+source-trust classes, blocker codes, framework policy result IDs, matrix
+versions, line IDs, confidence tiers, review states, and export column metadata.
+This is a presentation boundary only: the frontend must not drop or recompute
+the policy, source-trust, readiness, traceability, or export facts.
 
 Package readiness:
 


### PR DESCRIPTION
## Summary
- Make the Personal Report Package default to reader-facing labels for evidence coverage, reporting basis, traceability, and export options.
- Move raw proof/source-trust/framework-policy/traceability/export metadata into explicit audit-details disclosures without changing API contracts or dropping data.
- Register AC22.19 and document the reader-vs-audit presentation boundary in reporting SSOT.

## Delivery standard
- Default package view avoids proof-system vocabulary such as Deterministic PR, Post-merge LLM/OCR, Framework Policy, raw blocker/gap codes, policy result IDs, and matrix versions.
- The same proof/policy/source details remain available through keyboard-reachable audit details.
- Print/save/export defaults to the reader-first hierarchy; raw export metadata is behind an explicit print-hidden export audit disclosure.

## Validation
- `npm test -- personalReportPackagePage.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `uv run --with pyyaml python tools/preflight.py`

Closes #1210