### PR TITLE
[finance_report_audit] Enforce decimal boundary policy

### DIFF
--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -23,9 +23,12 @@ from src.models.layer3 import (
     PositionStatus,
 )
 from src.money import to_money
+from src.quantity import Quantity
 from src.schemas.provenance import DataProvenance
 
 logger = get_logger(__name__)
+
+ASSET_QUANTITY_UNIT = "units"
 
 
 class AssetServiceError(Exception):
@@ -57,6 +60,14 @@ class DepreciationResult:
     method: str
     useful_life_years: int
     salvage_value: Decimal
+
+
+def _quantity(value: Decimal) -> Quantity:
+    return Quantity(value, ASSET_QUANTITY_UNIT)
+
+
+def _quantity_is_zero(value: Decimal) -> bool:
+    return _quantity(value).quantize() == Quantity.zero(ASSET_QUANTITY_UNIT)
 
 
 @dataclass
@@ -562,7 +573,7 @@ class AssetService:
                         "latest_snapshot_date": snap.snapshot_date.isoformat(),
                     }
 
-                if quantity == Decimal("0"):
+                if _quantity_is_zero(quantity):
                     position.status = PositionStatus.DISPOSED
                     position.disposal_date = snap.snapshot_date
                     result.disposed += 1
@@ -574,7 +585,7 @@ class AssetService:
 
             else:
                 # Create position for non-zero quantities (positive or negative)
-                if quantity != Decimal("0"):
+                if not _quantity_is_zero(quantity):
                     logger.info("Creating new managed position", asset=snap.asset_identifier)
                     position = ManagedPosition(
                         user_id=user_id,

--- a/apps/backend/src/services/fx.py
+++ b/apps/backend/src/services/fx.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.config import settings
 from src.logger import get_logger
 from src.models import FxRate
+from src.money import ExchangeRate, Money, convert as convert_money
 
 logger = get_logger(__name__)
 
@@ -84,6 +85,10 @@ def _normalize_currency(code: str) -> str:
 def _append_fx_warning(fx_warnings: list[FxWarning] | None, warning: FxWarning) -> None:
     if fx_warnings is not None and warning not in fx_warnings:
         fx_warnings.append(warning)
+
+
+def _convert_money_amount(amount: Decimal, source: str, target: str, rate: Decimal) -> Decimal:
+    return convert_money(Money(amount, source), ExchangeRate(source, target, rate)).amount
 
 
 async def get_exchange_rate(
@@ -229,7 +234,7 @@ async def convert_amount(
     else:
         rate = await get_exchange_rate(db, source, target, rate_date, lazy_load=lazy_load)
 
-    return amount * rate
+    return _convert_money_amount(amount, source, target, rate)
 
 
 async def convert_to_base(

--- a/apps/backend/src/services/fx.py
+++ b/apps/backend/src/services/fx.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.config import settings
 from src.logger import get_logger
 from src.models import FxRate
-from src.money import ExchangeRate, Money, convert as convert_money
+from src.money import ExchangeRate, Money, MoneyError, convert as convert_money
 
 logger = get_logger(__name__)
 
@@ -88,7 +88,10 @@ def _append_fx_warning(fx_warnings: list[FxWarning] | None, warning: FxWarning) 
 
 
 def _convert_money_amount(amount: Decimal, source: str, target: str, rate: Decimal) -> Decimal:
-    return convert_money(Money(amount, source), ExchangeRate(source, target, rate)).amount
+    try:
+        return convert_money(Money(amount, source), ExchangeRate(source, target, rate)).amount
+    except MoneyError as exc:
+        raise FxRateError(f"Invalid FX conversion boundary for {source}/{target}: {exc}") from exc
 
 
 async def get_exchange_rate(

--- a/apps/backend/src/services/investment_accounting.py
+++ b/apps/backend/src/services/investment_accounting.py
@@ -84,10 +84,13 @@ class InvestmentAccountingService:
         self._validate_positive(quantity, "quantity")
         self._validate_non_negative(unit_price, "unit_price")
         self._validate_non_negative(fees, "fees")
+        trade_quantity = _quantized_quantity(quantity)
+        if _quantity_is_zero(trade_quantity):
+            raise InvestmentAccountingValidationError("quantity must round to a non-zero quantity")
 
         cash_account = await self._get_account(db, user_id, cash_account_id, AccountType.ASSET)
         investment_account = await self._get_account(db, user_id, investment_account_id, AccountType.ASSET)
-        amount = _money(quantity * unit_price + fees)
+        amount = _money(trade_quantity * unit_price + fees)
         if amount <= Decimal("0"):
             raise InvestmentAccountingValidationError("buy amount must be positive")
 
@@ -139,7 +142,7 @@ class InvestmentAccountingService:
             transaction_date=transaction_date,
             transaction_type=InvestmentTransactionType.BUY,
             asset_identifier=asset_identifier,
-            quantity=_quantized_quantity(quantity),
+            quantity=trade_quantity,
             unit_price=_quantized_unit_rate(unit_price),
             gross_amount=amount,
             fees=_money(fees),
@@ -157,14 +160,14 @@ class InvestmentAccountingService:
             opening_transaction_id=transaction.id,
             asset_identifier=asset_identifier,
             acquisition_date=transaction_date,
-            original_quantity=_quantized_quantity(quantity),
-            remaining_quantity=_quantized_quantity(quantity),
-            unit_cost=_quantized_unit_rate(amount / quantity),
+            original_quantity=trade_quantity,
+            remaining_quantity=trade_quantity,
+            unit_cost=_quantized_unit_rate(amount / trade_quantity),
             currency=currency,
         )
         db.add(lot)
 
-        position.quantity = _quantized_quantity(position.quantity + quantity)
+        position.quantity = _quantized_quantity(position.quantity + trade_quantity)
         position.cost_basis = _money(position.cost_basis + amount)
         position.cost_basis_method = cost_basis_method
         position.status = PositionStatus.ACTIVE
@@ -196,6 +199,9 @@ class InvestmentAccountingService:
         self._validate_positive(quantity, "quantity")
         self._validate_non_negative(unit_price, "unit_price")
         self._validate_non_negative(fees, "fees")
+        trade_quantity = _quantized_quantity(quantity)
+        if _quantity_is_zero(trade_quantity):
+            raise InvestmentAccountingValidationError("quantity must round to a non-zero quantity")
 
         cash_account = await self._get_account(db, user_id, cash_account_id, AccountType.ASSET)
         investment_account = await self._get_account(db, user_id, investment_account_id, AccountType.ASSET)
@@ -207,14 +213,14 @@ class InvestmentAccountingService:
             asset_identifier=asset_identifier,
         )
 
-        proceeds = _money(quantity * unit_price - fees)
+        proceeds = _money(trade_quantity * unit_price - fees)
         if proceeds <= Decimal("0"):
             raise InvestmentAccountingValidationError("sell proceeds must be positive")
         cost_basis = await self._consume_lots(
             db,
             user_id=user_id,
             position=position,
-            quantity=quantity,
+            quantity=trade_quantity,
             method=cost_basis_method,
             disposal_date=transaction_date,
         )
@@ -276,7 +282,7 @@ class InvestmentAccountingService:
         )
         posted = await self._post_and_load(db, entry.id, user_id)
 
-        position.quantity = _quantized_quantity(position.quantity - quantity)
+        position.quantity = _quantized_quantity(position.quantity - trade_quantity)
         position.cost_basis = _money(position.cost_basis - cost_basis)
         position.realized_pnl = _money((position.realized_pnl or Decimal("0.00")) + realized_pnl)
         position.cost_basis_method = cost_basis_method
@@ -292,7 +298,7 @@ class InvestmentAccountingService:
             transaction_date=transaction_date,
             transaction_type=InvestmentTransactionType.SELL,
             asset_identifier=asset_identifier,
-            quantity=_quantized_quantity(quantity),
+            quantity=trade_quantity,
             unit_price=_quantized_unit_rate(unit_price),
             gross_amount=proceeds,
             fees=_money(fees),
@@ -469,7 +475,7 @@ class InvestmentAccountingService:
             user_id=user_id,
             account_id=account_id,
             asset_identifier=asset_identifier,
-            quantity=Decimal("0.000000"),
+            quantity=Quantity.zero(INVESTMENT_QUANTITY_UNIT).quantize().value,
             cost_basis=Decimal("0.00"),
             currency=currency,
             acquisition_date=transaction_date,
@@ -518,7 +524,11 @@ class InvestmentAccountingService:
 
         if method == CostBasisMethod.AVGCOST:
             avg_unit_cost = _quantized_unit_rate(
-                sum((lot.remaining_quantity * lot.unit_cost for lot in lots), Decimal("0.00")) / total_available
+                sum(
+                    (_quantized_quantity(lot.remaining_quantity) * lot.unit_cost for lot in lots),
+                    Decimal("0.00"),
+                )
+                / total_available
             )
             for lot in lots:
                 lot.unit_cost = avg_unit_cost
@@ -526,14 +536,14 @@ class InvestmentAccountingService:
         remaining_to_sell = _quantized_quantity(quantity)
         cost_basis = Decimal("0.00")
         for lot in lots:
-            if remaining_to_sell <= Decimal("0"):
+            if remaining_to_sell <= Quantity.zero(INVESTMENT_QUANTITY_UNIT).value:
                 break
-            consumed = min(lot.remaining_quantity, remaining_to_sell)
-            cost_basis += consumed * lot.unit_cost
-            lot.remaining_quantity = _quantized_quantity(lot.remaining_quantity - consumed)
+            consumed_quantity = min(_quantized_quantity(lot.remaining_quantity), remaining_to_sell)
+            cost_basis += consumed_quantity * lot.unit_cost
+            lot.remaining_quantity = _quantized_quantity(lot.remaining_quantity - consumed_quantity)
             if _quantity_is_zero(lot.remaining_quantity):
                 lot.disposed_date = disposal_date
-            remaining_to_sell = _quantized_quantity(remaining_to_sell - consumed)
+            remaining_to_sell = _quantized_quantity(remaining_to_sell - consumed_quantity)
 
         await db.flush()
         return _money(cost_basis)
@@ -550,7 +560,7 @@ class InvestmentAccountingService:
             select(InvestmentLot)
             .where(InvestmentLot.user_id == user_id)
             .where(InvestmentLot.position_id == position_id)
-            .where(InvestmentLot.remaining_quantity > Decimal("0"))
+            .where(InvestmentLot.remaining_quantity > Quantity.zero(INVESTMENT_QUANTITY_UNIT).value)
         )
         if method == CostBasisMethod.LIFO:
             query = query.order_by(InvestmentLot.acquisition_date.desc(), InvestmentLot.created_at.desc())

--- a/apps/backend/src/services/market_data.py
+++ b/apps/backend/src/services/market_data.py
@@ -25,9 +25,11 @@ from src.models.account import Account
 from src.models.journal import JournalEntry, JournalLine
 from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition, PositionStatus
+from src.quantity import Quantity
 
 logger = get_logger(__name__)
 
+MARKET_DATA_QUANTITY_UNIT = "units"
 _RATE_QUANT = Decimal("0.000001")
 _PRICE_QUANT = Decimal("0.000001")
 _DEFAULT_INCREMENTAL_LOOKBACK_DAYS = 7
@@ -44,6 +46,10 @@ _STOOQ_DAILY_URL = "https://stooq.com/q/d/l/"
 # which is not a ticker and would 404 against Yahoo on every lookup.
 _TICKER_MAX_LENGTH = 15
 _TICKER_PATTERN = re.compile(r"^\^?[A-Za-z0-9]+([.\-=][A-Za-z0-9]+)*$")
+
+
+def _quantity_zero() -> Decimal:
+    return Quantity.zero(MARKET_DATA_QUANTITY_UNIT).value
 
 
 @dataclass(frozen=True)
@@ -862,7 +868,7 @@ async def _active_stock_symbols(db: AsyncSession, user_id: UUID | None) -> list[
     stmt = (
         select(ManagedPosition.asset_identifier)
         .where(ManagedPosition.status == PositionStatus.ACTIVE)
-        .where(ManagedPosition.quantity != Decimal("0"))
+        .where(ManagedPosition.quantity != _quantity_zero())
         .order_by(ManagedPosition.asset_identifier)
     )
     if user_id is not None:
@@ -1161,9 +1167,11 @@ _FX_SYNC_SPEC = _MarketSyncSpec(
     ),
     persist_observation=_persist_fx_rate,
     observation_date=_observation_date,
-    observation_matches_scope=lambda observation, scope: isinstance(observation, FxRateObservation)
-    and _normalize_currency(observation.base_currency) == scope[0]
-    and _normalize_currency(observation.quote_currency) == scope[1],
+    observation_matches_scope=lambda observation, scope: (
+        isinstance(observation, FxRateObservation)
+        and _normalize_currency(observation.base_currency) == scope[0]
+        and _normalize_currency(observation.quote_currency) == scope[1]
+    ),
 )
 
 
@@ -1180,8 +1188,9 @@ _STOCK_SYNC_SPEC = _MarketSyncSpec(
     ),
     persist_observation=_persist_stock_price,
     observation_date=_observation_date,
-    observation_matches_scope=lambda observation, scope: isinstance(observation, StockPriceObservation)
-    and _normalize_symbol(observation.symbol) == scope,
+    observation_matches_scope=lambda observation, scope: (
+        isinstance(observation, StockPriceObservation) and _normalize_symbol(observation.symbol) == scope
+    ),
 )
 
 

--- a/apps/backend/src/services/reporting.py
+++ b/apps/backend/src/services/reporting.py
@@ -32,6 +32,7 @@ from src.models.layer3 import (
 )
 from src.money import to_money
 from src.money.adopt import restate, restate_unrounded
+from src.quantity import Quantity
 from src.ratio import Ratio
 from src.schemas.provenance import DataProvenance
 from src.services import fx
@@ -75,12 +76,17 @@ from src.services.reporting_calc import (
 logger = get_logger(__name__)
 
 _REPORT_STATUSES = (JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED)
+REPORTING_QUANTITY_UNIT = "units"
 _ALLOCATION_METADATA_KEYS = {
     "source_currency",
     "allocation_asset_class",
     "allocation_liquidity_class",
     "allocation_source_type",
 }
+
+
+def _quantity_value(value: Decimal) -> Decimal:
+    return Quantity(value, REPORTING_QUANTITY_UNIT).quantize().value
 
 
 def _build_account_lines(
@@ -802,7 +808,7 @@ async def _portfolio_market_basis_by_account(
             )
             continue
 
-        market_value = position.quantity * latest_price
+        market_value = _quantity_value(position.quantity) * latest_price
         cost_basis = position.cost_basis
         source_currency = position.currency.upper()
         if source_currency != target_currency:

--- a/apps/backend/tests/market_data/test_fx.py
+++ b/apps/backend/tests/market_data/test_fx.py
@@ -5,12 +5,14 @@ from decimal import Decimal
 
 import httpx
 import pytest
+from common.testing.ac_proof import ac_proof
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
 from src.models import FxRate
+from src.money import ExchangeRate, Money
 from src.services import fx as fx_service, market_data
 from src.services.fx import (
     FxRateError,
@@ -547,7 +549,7 @@ async def test_get_average_rate(db: AsyncSession):
 
 
 async def test_convert_amount(db: AsyncSession):
-    """Convert amount should apply FX rate without rounding prematurely."""
+    """Convert amount should apply the stored FX rate."""
     rate = FxRate(
         base_currency="USD",
         quote_currency="SGD",
@@ -564,6 +566,42 @@ async def test_convert_amount(db: AsyncSession):
     result = await convert_amount(db, amount, "USD", "SGD", date(2025, 1, 1))
 
     assert result == expected
+
+
+@ac_proof(
+    proof_id="test_fx_convert_amount_uses_typed_money_exchange_rate",
+    ac_ids=["AC12.31.2"],
+    ci_tier="pr_ci",
+)
+async def test_AC12_31_2_convert_amount_routes_through_money_exchange_rate(
+    db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    """AC12.31.2: service boundary wraps storage Decimal in Money + ExchangeRate."""
+    rate = FxRate(
+        base_currency="USD",
+        quote_currency="SGD",
+        rate=Decimal("1.200000"),
+        rate_date=date(2025, 1, 1),
+        source="test",
+    )
+    db.add(rate)
+    await db.commit()
+
+    calls: list[tuple[Money, ExchangeRate]] = []
+
+    def fake_convert(money: Money, rate: ExchangeRate) -> Money:
+        calls.append((money, rate))
+        return Money(Decimal("120.00"), "SGD")
+
+    monkeypatch.setattr(fx_service, "convert_money", fake_convert)
+
+    result = await convert_amount(db, Decimal("100.00"), "USD", "SGD", date(2025, 1, 1))
+
+    assert result == Decimal("120.00")
+    assert len(calls) == 1
+    money, typed_rate = calls[0]
+    assert money == Money(Decimal("100.00"), "USD")
+    assert typed_rate == ExchangeRate("USD", "SGD", Decimal("1.200000"))
 
 
 async def test_get_exchange_rate_same_currency(db: AsyncSession):

--- a/apps/backend/tests/market_data/test_fx.py
+++ b/apps/backend/tests/market_data/test_fx.py
@@ -604,6 +604,19 @@ async def test_AC12_31_2_convert_amount_routes_through_money_exchange_rate(
     assert typed_rate == ExchangeRate("USD", "SGD", Decimal("1.200000"))
 
 
+@pytest.mark.no_db
+async def test_convert_amount_wraps_invalid_currency_as_fx_rate_error(monkeypatch: pytest.MonkeyPatch):
+    """Legacy/provider rate rows with non-ISO codes should not leak Money errors."""
+
+    async def fake_get_exchange_rate(*args, **kwargs) -> Decimal:
+        return Decimal("60000.000000")
+
+    monkeypatch.setattr(fx_service, "get_exchange_rate", fake_get_exchange_rate)
+
+    with pytest.raises(FxRateError, match="Invalid FX conversion boundary"):
+        await convert_amount(None, Decimal("0.50"), "BTC", "USD", date(2025, 1, 1))  # type: ignore[arg-type]
+
+
 async def test_get_exchange_rate_same_currency(db: AsyncSession):
     result = await get_exchange_rate(db, "usd", "USD", date(2025, 1, 1))
     assert result == Decimal("1")

--- a/apps/frontend/src/app/(main)/assets/page.tsx
+++ b/apps/frontend/src/app/(main)/assets/page.tsx
@@ -48,6 +48,7 @@ const VALUATION_SOURCES: Array<{ value: ManualValuationSource; label: string }> 
     { value: "property_valuation", label: "Property valuation" },
     { value: "other_document", label: "Other source document" },
 ];
+type AmountValue = ReturnType<typeof parseAmount>;
 
 function labelForValuationType(type: ManualValuationComponentType): string {
     return VALUATION_TYPES.find((item) => item.value === type)?.label ?? type;
@@ -147,7 +148,7 @@ export default function AssetsPage() {
         const existing = totals[currency] ?? parseAmount(0);
         totals[currency] = existing.add(parseAmount(pos.cost_basis));
         return totals;
-    }, {} as Record<string, import("decimal.js").Decimal>);
+    }, {} as Record<string, AmountValue>);
     const allocationByCurrency = Object.entries(totalsByCurrency)
         .sort((a, b) => b[1].comparedTo(a[1]))
         .map(([currency, total]) => ({
@@ -452,7 +453,7 @@ export default function AssetsPage() {
                             const existing = totals[currency] ?? parseAmount(0);
                             totals[currency] = existing.add(parseAmount(p.cost_basis));
                             return totals;
-                        }, {} as Record<string, import("decimal.js").Decimal>);
+                        }, {} as Record<string, AmountValue>);
                         return (
                             <div key={broker} className="card">
                                 <div className="card-header flex items-center justify-between">

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -472,6 +472,20 @@ the previous naked-`Decimal` rate boundary.
 | AC12.30.3 | Money conversion uses typed `ExchangeRate(base, quote, rate)` instead of a naked rate; source/target mismatch raises and the Python/backend/frontend conformance vectors route through `ExchangeRate` | `test_AC12_30_3_convert_accepts_typed_exchange_rate` (+ siblings) | `tests/tooling/test_money_value_type.py`, `tests/tooling/test_money_conformance.py`, `apps/backend/tests/accounting/test_money_backend_module.py`, `apps/frontend/src/lib/money/money.conformance.test.ts` | P1 |
 | AC12.30.4 | Quantity adoption: frontend quantity formatting is public only from `lib/quantity`, and targeted backend quantity hot paths use `Quantity` for 6-dp quantization/zero checks instead of local naked-`Decimal` quantity helpers | `test_AC12_30_4_frontend_quantity_formatting_is_not_exported_from_money`, `test_AC12_30_4_backend_quantity_hot_paths_use_quantity_type` | `tests/tooling/test_quantity_adoption.py` | P1 |
 
+### AC12.31: Decimal Boundary Policy and Migration
+
+Raw `Decimal` remains the storage/interchange substrate, but it is no longer a
+domain concept by itself. The base-element narrow waists own business semantics:
+`Money` for currency amounts, `Ratio` for dimensionless proportions, and
+`Quantity` for shares/units/contracts. New service code must either cross an
+explicit boundary or use the typed value package.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC12.31.1 | The SSOT declares a MECE raw-`Decimal` boundary policy: allowed at base packages, DB/schema/API contracts, parser/provider adapters, generated code, and tests/fixtures; forbidden as naked business semantics in migrated service/application hot paths | `test_AC12_31_1_decimal_boundary_policy_is_mece_and_enforced` | `tests/tooling/test_decimal_boundary_policy.py` | P1 |
+| AC12.31.2 | The FX service preserves the legacy `Decimal` return contract for DB/API callers but routes cross-currency conversion through `Money(amount, source)` plus `ExchangeRate(source, target, rate)` | `test_AC12_31_2_convert_amount_routes_through_money_exchange_rate` | `apps/backend/tests/market_data/test_fx.py` | P1 |
+| AC12.31.3 | Migrated quantity/reporting/application hotspots use `Quantity` helpers instead of naked quantity-zero comparisons or `quantity * price`, and frontend app pages do not import `decimal.js` types directly | `test_AC12_31_3_migrated_hotspots_use_base_packages` | `tests/tooling/test_decimal_boundary_policy.py` | P1 |
+
 ---
 
 *Planning snapshot captured: January 2026*

--- a/docs/ssot/base-packages.md
+++ b/docs/ssot/base-packages.md
@@ -40,7 +40,51 @@ Nothing else currently qualifies — see the per-domain verdicts in the #1167
 audit (date/period, confidence scoring, source-type, lineage, attention are app
 logic or presentation, not base packages).
 
-## 3. The canonical structure (every base package has these)
+## 3. Raw Decimal boundary policy
+
+`Decimal` is the storage/interchange substrate for exact numeric values; it is
+not, by itself, a business value type. Once a value crosses into service/domain
+logic, code should use the MECE base element that owns the semantics:
+
+- `Money` for currency amounts and same-currency arithmetic;
+- `ExchangeRate` inside `money` for directed cross-currency conversion;
+- `Ratio` for dimensionless proportions, percentages, and shares of a whole;
+- `Quantity` for shares, units, lots, contracts, and quantity comparisons.
+
+### Allowed raw Decimal boundaries
+
+Raw `Decimal` is allowed only where the surrounding layer is explicitly a
+boundary or test fixture:
+
+1. **Base packages** — `common/money`, `common/ratio`, `common/quantity` and the
+   backend/frontend runtime copies may use `Decimal`/`decimal.js` internally.
+2. **DB models and migrations** — SQLAlchemy `Numeric` columns, Alembic
+   migrations, and repository/query predicates store exact numeric values.
+3. **Schemas and API contracts** — Pydantic/TypeScript API shapes may expose
+   exact decimals as string-backed fields while preserving existing wire shapes.
+4. **Parser and provider adapters** — OCR, CSV/PDF parsers, market-data
+   providers, and import adapters may parse external numbers into raw
+   `Decimal` before handing them to domain services.
+5. **Tests, fixtures, and generated code** — tests may build exact inputs and
+   assert exact outputs; generated API types may mirror the wire contract.
+
+### Forbidden raw Decimal zones
+
+Raw `Decimal` is forbidden as naked business semantics in migrated
+service/domain calculations and frontend application code. In those zones:
+
+- money math must construct `Money`, and cross-currency conversion must call
+  `money.convert(Money, ExchangeRate)`;
+- percentage/proportion math must construct `Ratio`;
+- quantity comparisons and quantity arithmetic must construct `Quantity`;
+- frontend app pages/components must not import `decimal.js` types directly;
+  they should consume `lib/money`, `lib/ratio`, or `lib/quantity` helpers.
+
+Legacy code that has not yet crossed this boundary must be either migrated or
+kept behind a narrow, documented adapter. New raw-`Decimal` service/application
+hotspots require an AC/test update that explains the boundary.
+
+## 4. The canonical structure (every base package has these)
 
 1. **Value type** — immutable/frozen, Decimal-backed, carries its unit; **rejects
    `float`** at construction.
@@ -65,7 +109,7 @@ logic or presentation, not base packages).
 11. **Three guards** — no-`float` (the money narrow-waist guard), one conformance
     suite per stack, and identifier-parity (`test_<x>_api_parity.py`).
 
-## 4. Why per-end copies (not one shared runtime)
+## 5. Why per-end copies (not one shared runtime)
 
 The frontend is TypeScript and cannot import the Python package; the deployed
 images do not ship `common/`. So the **standard** (contract + conformance

--- a/tests/tooling/test_decimal_boundary_policy.py
+++ b/tests/tooling/test_decimal_boundary_policy.py
@@ -33,9 +33,14 @@ def test_AC12_31_1_decimal_boundary_policy_is_mece_and_enforced():
         assert phrase in ssot
 
     fx = _read(Path("apps/backend/src/services/fx.py"))
-    assert "from src.money import ExchangeRate, Money, convert as convert_money" in fx
+    assert (
+        "from src.money import ExchangeRate, Money, MoneyError, convert as convert_money"
+        in fx
+    )
     assert "ExchangeRate(source, target, rate)" in fx
     assert "Money(amount, source)" in fx
+    assert "except MoneyError as exc:" in fx
+    assert "raise FxRateError(" in fx
     assert "return amount * rate" not in fx
 
 

--- a/tests/tooling/test_decimal_boundary_policy.py
+++ b/tests/tooling/test_decimal_boundary_policy.py
@@ -1,0 +1,81 @@
+"""Decimal boundary-policy guards (EPIC-012 AC12.31)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _read(path: Path) -> str:
+    return (REPO / path).read_text(encoding="utf-8")
+
+
+@ac_proof(
+    proof_id="test_decimal_boundary_policy", ac_ids=["AC12.31.1"], ci_tier="pr_ci"
+)
+def test_AC12_31_1_decimal_boundary_policy_is_mece_and_enforced():
+    """AC12.31.1: raw Decimal is an explicit boundary, not domain semantics."""
+    ssot = _read(Path("docs/ssot/base-packages.md"))
+    for phrase in [
+        "Raw Decimal boundary policy",
+        "Allowed raw Decimal boundaries",
+        "Forbidden raw Decimal zones",
+        "DB models and migrations",
+        "Schemas and API contracts",
+        "Parser and provider adapters",
+        "Tests, fixtures, and generated code",
+        "service/domain calculations",
+    ]:
+        assert phrase in ssot
+
+    fx = _read(Path("apps/backend/src/services/fx.py"))
+    assert "from src.money import ExchangeRate, Money, convert as convert_money" in fx
+    assert "ExchangeRate(source, target, rate)" in fx
+    assert "Money(amount, source)" in fx
+    assert "return amount * rate" not in fx
+
+
+@ac_proof(
+    proof_id="test_decimal_boundary_migrated_hotspots",
+    ac_ids=["AC12.31.3"],
+    ci_tier="pr_ci",
+)
+def test_AC12_31_3_migrated_hotspots_use_base_packages():
+    """AC12.31.3: migrated money/quantity/frontend hotspots stay behind base packages."""
+    quantity_service_files = [
+        Path("apps/backend/src/services/assets.py"),
+        Path("apps/backend/src/services/investment_accounting.py"),
+        Path("apps/backend/src/services/market_data.py"),
+        Path("apps/backend/src/services/reporting.py"),
+    ]
+    naked_quantity_zero = re.compile(
+        r"(?:quantity|remaining_quantity)\s*(?:==|!=|>|<|>=|<=)\s*Decimal\(\"0(?:\.0+)?\"\)"
+    )
+    for path in quantity_service_files:
+        src = _read(path)
+        assert "from src.quantity import Quantity" in src, f"{path} must use Quantity"
+        assert not naked_quantity_zero.search(src), (
+            f"{path} has a naked Decimal quantity-zero comparison"
+        )
+
+    reporting = _read(Path("apps/backend/src/services/reporting.py"))
+    assert "position.quantity * latest_price" not in reporting
+    assert "def _quantity_value(" in reporting
+
+    investment = _read(Path("apps/backend/src/services/investment_accounting.py"))
+    assert "trade_quantity = _quantized_quantity(quantity)" in investment
+    assert "amount = _money(quantity * unit_price" not in investment
+    assert "proceeds = _money(quantity * unit_price" not in investment
+    assert "lot.remaining_quantity * lot.unit_cost" not in investment
+    assert "consumed_quantity" in investment
+
+    frontend_app_leaks: list[str] = []
+    for path in (REPO / "apps/frontend/src/app").rglob("*.[tj]sx"):
+        src = path.read_text(encoding="utf-8")
+        if 'import("decimal.js").Decimal' in src:
+            frontend_app_leaks.append(str(path.relative_to(REPO)))
+    assert frontend_app_leaks == []


### PR DESCRIPTION
## Summary

Enforce the Decimal boundary policy by routing migrated FX and quantity hotspots through Money/ExchangeRate/Quantity while preserving existing wire/storage Decimal contracts.

Closes N/A

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-012 — Foundation libs |
| **AC IDs** | AC12.31.1, AC12.31.2, AC12.31.3 |
| **AC source updated** | Owning EPIC |

---

## SSOT Changes

- [ ] `docs/ssot/MANIFEST.yaml` — added/updated concept(s): _list them_
- [x] `docs/ssot/base-packages.md` — added the raw Decimal boundary policy and allowed/forbidden zones
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `66a4c356` | Added AC12.31 static/behavior tests for Decimal boundary policy, typed FX conversion, and migrated quantity/frontend hotspots |
| 🟢 Green (passing test) | `7070a6ef` | Routed FX through Money/ExchangeRate, migrated Quantity hotspots, removed frontend app decimal.js type leak, and documented SSOT policy |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no enum changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable; no env changes)
- [x] `repo/` submodule updated for production config changes (not applicable; no production config changes)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes (not applicable; existing SSOT file updated)
- [x] `tools/lint_doc_consistency.py` passes via `moon run :lint`

### CI/CD, Runtime, and VPS Infra Audit

Required when this PR changes workflows, deploy tooling, Dokploy runtime config,
VPS host scripts, or logs:

- [x] Lifecycle ownership is unified: not applicable; no infra/runtime workflow changes
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged
- [x] VPS host hygiene is managed by a Dokploy server schedule and does not require GitHub SSH or Vault credentials
- [x] Cleanup is scoped: not applicable; no cleanup changes
- [x] Proof command includes focused tests for redaction, lifecycle cleanup, and host hygiene: not applicable; no infra/logging changes

---

## Testing

```bash
moon run :lint
PYTHONPATH=. uv run pytest tests/tooling/test_decimal_boundary_policy.py tests/tooling/test_quantity_adoption.py -q
PYTHONPATH=/Users/SP14016/zitian/finance_report_audit:/Users/SP14016/zitian/finance_report_audit/apps/backend uv run pytest apps/backend/tests/market_data/test_fx.py apps/backend/tests/reporting/test_fx_average_rate_fallback.py apps/backend/tests/portfolio/test_investment_accounting.py apps/backend/tests/reporting/test_reporting_net_worth_components.py -q --no-cov
uv run --with pyyaml python tools/generate_ac_registry.py --check
uv run --with pyyaml python tools/check_ac_index.py
npm run typecheck
```

Local full test note: `moon run :test -- --smart` and `moon run :test -- --fast` were attempted but could not start the local test database because Podman refused the configured socket (`127.0.0.1:61270`) even after `podman machine stop/start`. CI should run this in a clean runner.

---

## Screenshots / Evidence

_N/A_