### PR TITLE
[finance_report_vision] Clean residual deploy_v2 drift

### DIFF
--- a/.opencode/skills/domain/infra-operations/SKILL.md
+++ b/.opencode/skills/domain/infra-operations/SKILL.md
@@ -19,10 +19,17 @@ cd repo && uv run invoke --list
 
 ## Tool Priority
 
-1. **`invoke`** — Primary (type-safe, idempotent)
-2. **`tools/debug.py`** — Unified debugging
-3. **`libs` API** — For automation
-4. **SSH** — Emergency only (read-only)
+1. **`deploy_v2` front door** — Required for staging/prod deploys.
+   - GitHub workflow: `repo/.github/workflows/deploy.yml`
+   - Local/manual equivalent: `cd repo && python -m tools.deploy_v2 ...`
+2. **`invoke`** — Secrets, status, bootstrap, and targeted repair tasks.
+3. **`tools/debug.py`** — Unified debugging.
+4. **`libs` API** — Automation internals only.
+5. **SSH** — Emergency investigation only (read-only).
+
+Deploy identity is always `deploy_v2(service, type, version_ref, iac_ref)`.
+`data_lane` is derived from the target environment; never pass data as an
+operator input.
 
 ---
 
@@ -80,25 +87,54 @@ invoke env.set DATABASE_URL "postgresql://..." finance_report app production
 invoke env.list-all finance_report app production
 ```
 
+### Deploy Front Door
+
+```bash
+cd repo
+
+# App staging: pin both the app release and infra2 IaC ref.
+python -m tools.deploy_v2 \
+  --service finance_report/app \
+  --type staging \
+  --version-ref vX.Y.Z \
+  --iac-ref vX.Y.Z \
+  --domain zitian.party
+
+# App prod: promote the same release tag after staging proof and code review.
+python -m tools.deploy_v2 \
+  --service finance_report/app \
+  --type prod \
+  --version-ref vX.Y.Z \
+  --iac-ref vX.Y.Z \
+  --domain zitian.party \
+  --staging-validated \
+  --code-reviewed
+
+# Platform/backing service: artifact identity is the iac_ref-pinned stack.
+python -m tools.deploy_v2 \
+  --service platform/redis \
+  --type staging \
+  --iac-ref vX.Y.Z \
+  --domain zitian.party
+```
+
 ### Finance Report (`fr-*`)
 
 ```bash
-invoke fr-app.setup       # Deploy app
 invoke fr-app.status      # Check health
-invoke fr-postgres.setup  # Deploy PostgreSQL
-invoke fr-redis.setup     # Deploy Redis
+invoke fr-postgres.status # Check PostgreSQL
+invoke fr-redis.status    # Check Redis
 ```
+
+`fr-*.setup` tasks are lower-level bootstrap/repair tasks. They are not the
+staging/prod deploy front door.
 
 ### Platform Services
 
-```bash
-invoke postgres.setup              # Shared PostgreSQL
-invoke redis.setup                 # Shared Redis
-invoke vault.setup                 # Vault cluster
-invoke authentik.setup             # Authentik SSO
-invoke minio.setup                 # MinIO storage
-invoke signoz.setup                # SigNoz observability
-```
+Platform and backing services are `iac_pinned` deploy_v2 targets. Use
+`--service platform/<name>` with `--type staging|prod` and a pinned `--iac-ref`.
+Low-level setup tasks may still exist for bootstrap/repair internals, but they are
+not the staging/prod deploy front door.
 
 ---
 
@@ -125,18 +161,23 @@ client = get_dokploy()
 compose = client.get_compose("A6V-hbJlgHMwgPDoTDnhH")
 compose_id = compose["composeId"]  # Extract ID
 client.update_compose_env(compose_id, {"DEBUG": "true"})
-client.deploy_compose(compose_id)
 ```
+
+Do not trigger deploys through the Dokploy client directly; use `deploy_v2` so
+the coordinate, review/data red lines, rollout wait, and effective-config checks
+run in one place.
 
 ### Deployer (`libs/deployer.py`)
 
 ```python
-from libs.deployer import Deployer
-from libs.config import VPS
+from libs.service_registry import service_attrs
 
-deployer = Deployer(vps=VPS.MAIN)
-deployer.compose_up("finance_report", "production", "docker-compose.prod.yml")
+services = service_attrs()
 ```
+
+`Deployer` is an internal backend for platform sync and iac_runner. Operators
+should invoke platform deploys through `deploy_v2` / iac_runner, not by calling
+compose methods directly.
 
 ---
 
@@ -149,7 +190,7 @@ deployer.compose_up("finance_report", "production", "docker-compose.prod.yml")
 **Fix**:
 ```bash
 python tools/debug.py containers --env production
-invoke fr-app.setup
+# Re-run the relevant deploy_v2 workflow/command for the affected service.
 ```
 
 ### Env Var Missing
@@ -159,7 +200,7 @@ invoke fr-app.setup
 **Fix**:
 ```bash
 invoke env.set DATABASE_URL "postgresql://..." finance_report app production
-invoke fr-app.setup
+# Re-run the relevant deploy_v2 workflow/command so the service consumes the change.
 ```
 
 ### Deployment Failed
@@ -170,7 +211,7 @@ invoke fr-app.setup
 ```bash
 python tools/debug.py logs backend --tail 100
 # Fix issue, then:
-invoke fr-app.setup
+cd repo && python -m tools.deploy_v2 --service finance_report/app --type staging --version-ref vX.Y.Z --iac-ref vX.Y.Z --domain zitian.party
 ```
 
 ### DB Connection Failed
@@ -181,7 +222,7 @@ invoke fr-app.setup
 ```bash
 invoke fr-postgres.status
 # Verify DATABASE_URL container name matches environment
-invoke fr-app.setup
+# Re-run the relevant deploy_v2 workflow/command after fixing config.
 ```
 
 ### Secret Not Syncing
@@ -191,7 +232,7 @@ invoke fr-app.setup
 **Fix**:
 ```bash
 invoke env.get <KEY> finance_report app production
-invoke fr-app.setup
+# Re-run the relevant deploy_v2 workflow/command so the service consumes the secret.
 ```
 
 ---
@@ -205,11 +246,11 @@ invoke fr-app.setup
 invoke env.set DATABASE_URL "postgresql://..." myapp api production
 
 # 2. Dependencies
-invoke postgres.setup
-invoke redis.setup
+cd repo && python -m tools.deploy_v2 --service platform/postgres --type staging --iac-ref vX.Y.Z --domain zitian.party
+cd repo && python -m tools.deploy_v2 --service platform/redis --type staging --iac-ref vX.Y.Z --domain zitian.party
 
-# 3. Deploy
-invoke myapp.setup
+# 3. Register the service in IaC/service_registry, then deploy through deploy_v2.
+cd repo && python -m tools.deploy_v2 --service myapp/api --type staging --iac-ref vX.Y.Z --domain zitian.party
 
 # 4. Verify
 python tools/debug.py logs myapp --tail 50
@@ -220,7 +261,7 @@ curl https://myapp.zitian.party/health
 
 ```bash
 invoke env.set DEBUG false finance_report app production
-invoke fr-app.setup
+cd repo && python -m tools.deploy_v2 --service finance_report/app --type prod --version-ref vX.Y.Z --iac-ref vX.Y.Z --domain zitian.party --staging-validated --code-reviewed
 curl https://report.zitian.party/health
 ```
 
@@ -231,7 +272,7 @@ NEW_PASSWORD=$(openssl rand -base64 32)
 invoke env.set DB_PASSWORD "$NEW_PASSWORD" finance_report app production
 docker exec finance_report-postgres psql -U postgres -c "ALTER USER myuser PASSWORD '$NEW_PASSWORD';"
 invoke env.set DATABASE_URL "postgresql://myuser:$NEW_PASSWORD@finance_report-postgres:5432/finance_report" finance_report app production
-invoke fr-app.setup
+cd repo && python -m tools.deploy_v2 --service finance_report/app --type prod --version-ref vX.Y.Z --iac-ref vX.Y.Z --domain zitian.party --staging-validated --code-reviewed
 ```
 
 ---
@@ -244,7 +285,7 @@ invoke fr-app.setup
 ssh root@$VPS_HOST "uptime"
 ssh root@$VPS_HOST "docker ps"
 ssh root@$VPS_HOST "systemctl restart docker"  # If needed
-invoke fr-app.setup
+# Re-run the relevant deploy_v2 workflow/command after the host is stable.
 ```
 
 ### Database Corruption
@@ -256,7 +297,7 @@ scp root@$VPS_HOST:/tmp/backup.sql ./
 
 # Restore
 docker exec -i finance_report-postgres psql -U postgres < backup.sql
-invoke fr-app.setup
+# Re-run the relevant deploy_v2 workflow/command after restore validation.
 ```
 
 ### Vault Sealed
@@ -265,7 +306,7 @@ invoke fr-app.setup
 # Get keys from 1Password (bootstrap/vault)
 ssh root@$VPS_HOST
 docker exec -it vault vault operator unseal <KEY>  # Repeat 3x
-invoke fr-app.setup
+# Re-run the relevant deploy_v2 workflow/command after Vault is healthy.
 ```
 
 ---
@@ -348,9 +389,8 @@ invoke env.set DEBUG false finance_report app production
 invoke env.list-all finance_report app production
 
 # Deploy
-invoke fr-app.setup
-invoke fr-postgres.setup
-invoke fr-redis.setup
+cd repo && python -m tools.deploy_v2 --service finance_report/app --type staging --version-ref vX.Y.Z --iac-ref vX.Y.Z --domain zitian.party
+cd repo && python -m tools.deploy_v2 --service platform/redis --type staging --iac-ref vX.Y.Z --domain zitian.party
 
 # Health
 invoke fr-app.status

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -111,9 +111,9 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 
 ### Phase 6: Deployment & Verification
 
-- [x] Deploy postgres: `invoke finance_report.postgres.setup`
-- [x] Deploy redis: `invoke finance_report.redis.setup`
-- [x] Deploy app: `invoke finance_report.app.setup`
+- [x] Deploy postgres (historical initial provision; current deploy path is `deploy_v2`)
+- [x] Deploy redis (historical initial provision; current deploy path is `deploy_v2`)
+- [x] Deploy app (historical initial provision; current deploy path is `deploy_v2`)
 - [x] Verify health checks
 - [x] Test `https://report.${INTERNAL_DOMAIN}`
 

--- a/docs/ssot/environments.md
+++ b/docs/ssot/environments.md
@@ -218,7 +218,7 @@ This App doc does not enumerate those values.
 
 ---
 
-## Data Axis & Red Lines
+## Data Lane & Red Lines
 
 An environment still has a **code artifact** and a **data lane**, but data is
 not a public `deploy_v2` coordinate. The current deploy front door is

--- a/tests/tooling/test_data_red_lines_contract.py
+++ b/tests/tooling/test_data_red_lines_contract.py
@@ -29,6 +29,17 @@ DATA_RED_LINES = {
 # SSOT (e.g. the Staging environment) cannot satisfy the assertion.
 DATA_SOURCES = ["empty", "staging", "anonymized prod snapshot"]
 
+DEPLOY_DRIFT_SCAN_ROOTS = [
+    "docs",
+    ".opencode/skills/domain",
+    "repo/docs",
+    "repo/tools",
+    "repo/libs/tests",
+    "repo/README.md",
+    "repo/finance_report",
+]
+TEXT_SUFFIXES = {".md", ".py", ".yaml", ".yml", ".txt", ".toml"}
+
 
 def _subsection(md: str, header: str) -> str:
     """Text from ``header`` up to the next same-or-higher-level heading, lowercased."""
@@ -42,6 +53,19 @@ def _subsection(md: str, header: str) -> str:
         if capturing:
             out.append(line)
     return "\n".join(out).lower()
+
+
+def _scan_text_files():
+    for rel in DEPLOY_DRIFT_SCAN_ROOTS:
+        path = ROOT / rel
+        if path.is_file():
+            candidates = [path]
+        else:
+            candidates = [p for p in path.rglob("*") if p.is_file()]
+        for candidate in candidates:
+            if candidate.suffix not in TEXT_SUFFIXES:
+                continue
+            yield candidate.relative_to(ROOT), candidate.read_text(encoding="utf-8")
 
 
 def test_AC7_12_6_environments_define_data_axis_and_red_lines():
@@ -84,3 +108,43 @@ def test_AC7_12_6_deploy_v2_data_lane_is_derived_not_public_axis():
         "environments.md must describe data_lane as derived from deploy_v2, not as "
         "a public deploy coordinate."
     )
+
+
+def test_deploy_v2_drift_surfaces_do_not_republish_retired_data_axis():
+    """Deploy docs/tests/code must not drift back to the retired public data axis."""
+    retired_public_contract = "deploy(env, code, " + "data)"
+    banned_snippets = {
+        retired_public_contract: "retired public deploy tuple",
+        'parser.add_argument(\n        "--data"': "primitive data override CLI",
+        "invoke fr-app.setup": "old prefixed app setup deploy command",
+        "invoke fr-postgres.setup": "old prefixed postgres setup deploy command",
+        "invoke fr-redis.setup": "old prefixed redis setup deploy command",
+        "invoke finance_report.app.setup": "old namespaced app setup deploy command",
+        "invoke finance_report.postgres.setup": "old namespaced postgres setup deploy command",
+        "invoke finance_report.redis.setup": "old namespaced redis setup deploy command",
+        "invoke postgres.setup": "old platform postgres setup deploy command",
+        "invoke redis.setup": "old platform redis setup deploy command",
+        "invoke clickhouse.setup": "old platform clickhouse setup deploy command",
+        "invoke signoz.setup": "old platform signoz setup deploy command",
+        "invoke alerting.setup": "old platform alerting setup deploy command",
+        "invoke openpanel.setup": "old platform openpanel setup deploy command",
+        "invoke authentik.setup": "old platform authentik setup deploy command",
+        "invoke minio.setup": "old platform minio setup deploy command",
+        "invoke <service>.setup": "old generic service setup deploy command",
+        "data-axis side effects": "future data-axis wording",
+        "data axis lands": "future data-axis wording",
+        "platform services join when the deployer path is unified": "stale platform cutover wording",
+        "cutover 未做": "stale platform cutover wording",
+        "尚未接管": "stale platform cutover wording",
+    }
+
+    offenders = []
+    for rel, text in _scan_text_files():
+        lowered = text.lower()
+        for snippet, reason in banned_snippets.items():
+            haystack = lowered if snippet.isascii() else text
+            needle = snippet.lower() if snippet.isascii() else snippet
+            if needle in haystack:
+                offenders.append(f"{rel}: {reason}: {snippet!r}")
+
+    assert not offenders, "deploy_v2 drift found:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary

Clean the remaining retired deploy-surface drift after #1219: deploy_v2 is the deploy front door, data_lane is derived, and setup commands are no longer documented as staging/prod deploy paths.

Refs #1072

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-007 — Deployment |
| **AC IDs** | AC7.12.6 |
| **AC source updated** | Existing EPIC wording only; no new AC IDs |

---

## SSOT Changes

- [x] `docs/ssot/environments.md` — renamed data wording to derived data lane.
- [x] `repo/docs/ssot/core.environments.md` — synced infra2 deploy_v2 trigger/platform cutover reality.
- [x] `repo/docs/ssot/platform.automation.md`, `repo/docs/ssot/db.*.md`, `repo/docs/ssot/ops.*.md`, `repo/docs/ssot/platform.openpanel.md`, `repo/docs/ssot/template.md` — replaced active setup-command deploy instructions with deploy_v2 examples.
- [x] `.opencode/skills/domain/infra-operations/SKILL.md` — updated agent operations guidance to use deploy_v2 and treat setup tasks as bootstrap/repair only.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Red | N/A | Drift cleanup of already-shipped deploy_v2 contract; no behavior-first red phase. |
| Green | `59576388` / infra2 `77d801a` | Added drift guard and updated docs/tooling to pass. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no SQLAlchemy enum changes.
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` — N/A, no frontend env changes.
- [x] `repo/` submodule updated for production config changes — yes, points to infra2 `77d801a`.
- [x] `tools/check_env_keys.py` passes — N/A, no env keys changed.
- [x] `tools/check_manifest.py` passes — covered by preflight SSOT gates.
- [x] `tools/lint_doc_consistency.py` passes — covered by preflight doc-consistency gate.

### CI/CD, Runtime, and VPS Infra Audit

- [x] Lifecycle ownership is unified: docs and agent guidance now point staging/prod deploys to deploy_v2.
- [x] Logs do not print raw Dokploy API bodies, full env strings, tokens, `.env`, PEM content, or SSH keys.
- [x] API/CLI diagnostics show only allowlisted effective-state diffs; unchanged and secret fields are not logged.
- [x] VPS host hygiene is unchanged.
- [x] Cleanup scope is unchanged.
- [x] Proof command includes focused deploy/source-shape tests.

---

## Testing

```bash
apps/backend/.venv/bin/python -m pytest tests/tooling/test_data_red_lines_contract.py
apps/backend/.venv/bin/python -m pytest tests/tooling/test_issue_575_effective_env_verify.py tests/tooling/test_post_merge_e2e_gates.py tests/tooling/test_data_red_lines_contract.py
apps/backend/.venv/bin/python tools/generate_ac_registry.py && apps/backend/.venv/bin/python tools/check_ac_index.py
apps/backend/.venv/bin/python tools/preflight.py
cd repo && uv run ruff check tools/deploy_primitive.py tools/deploy_v2.py tools/deploy_contract.py tools/deploy_env_config.py tools/resolve_deploy_ref.py libs/tests/test_deploy_primitive.py
# infra2 tests run from /tmp to avoid repo/platform shadowing stdlib platform:
/Users/SP14016/zitian/finance_report_vision/apps/backend/.venv/bin/python - <<'PY'
import platform
import sys
from pathlib import Path
import pytest
repo = Path('/Users/SP14016/zitian/finance_report_vision/repo')
sys.path.insert(0, str(repo))
sys.modules.pop('tools', None)
raise SystemExit(pytest.main([
    str(repo / 'libs/tests/test_deploy_primitive.py'),
    str(repo / 'libs/tests/test_deploy_v2.py'),
    str(repo / 'libs/tests/test_deploy_contract.py'),
]))
PY
```

---

## Screenshots / Evidence

N/A — docs/tooling cleanup only.
