### PR TITLE
[finance_report_ui] Fix source intake readiness summary

### DIFF
--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -1,12 +1,30 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import StatementsPage from "@/app/(main)/upload/page"
 import { apiFetch } from "@/lib/api"
-import type { BankStatement } from "@/lib/types"
+import type { BankStatement, PersonalReportPackageReadinessResponse } from "@/lib/types"
 
 const showToastMock = vi.fn()
+
+const DEFAULT_READINESS: PersonalReportPackageReadinessResponse = {
+  package_id: "personal-financial-report-package",
+  state: "ready",
+  label: "Ready",
+  action_href: "/reports/package",
+  blocking_count: 0,
+  blockers: [],
+  source_summary: {},
+  source_trust_summary: {
+    source_classes: ["bank_statement"],
+    deterministic_pr_source_classes: ["bank_statement"],
+    post_merge_llm_ocr_source_classes: ["bank_statement"],
+    manual_trusted_source_classes: [],
+    gap_source_classes: [],
+    blocker_codes: [],
+  },
+}
 
 vi.mock("next/link", () => ({
   default: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
@@ -50,6 +68,38 @@ vi.mock("@/lib/api", () => ({
 describe("StatementsPage", () => {
   const mockedApiFetch = vi.mocked(apiFetch)
 
+  function resolveQueued(queue: unknown[], fallback: unknown) {
+    const next = queue.length ? queue.shift() : fallback
+    return next instanceof Error ? Promise.reject(next) : Promise.resolve(next)
+  }
+
+  function mockStatementsPageApi({
+    statements,
+    readiness = DEFAULT_READINESS,
+    deletes = [],
+  }: {
+    statements: unknown[]
+    readiness?: unknown
+    deletes?: unknown[]
+  }) {
+    const statementQueue = [...statements]
+    const deleteQueue = [...deletes]
+
+    mockedApiFetch.mockImplementation((path, options) => {
+      const url = String(path)
+      if (url.startsWith("/api/reports/package/readiness")) {
+        return resolveQueued([readiness], DEFAULT_READINESS)
+      }
+      if (url === "/api/statements") {
+        return resolveQueued(statementQueue, { items: [] })
+      }
+      if (url.startsWith("/api/statements/") && options?.method === "DELETE") {
+        return resolveQueued(deleteQueue, undefined)
+      }
+      return Promise.resolve({})
+    })
+  }
+
   beforeEach(() => {
     mockedApiFetch.mockReset()
     showToastMock.mockReset()
@@ -59,10 +109,11 @@ describe("StatementsPage", () => {
   })
 
   it("AC16.14.10 AC22.1.8 renders the uploader and upload history (loading, error, empty, populated)", async () => {
-    mockedApiFetch
-      .mockRejectedValueOnce(new Error("load failed"))
-      .mockResolvedValueOnce({ items: [] })
-      .mockResolvedValueOnce({
+    mockStatementsPageApi({
+      statements: [
+        new Error("load failed"),
+        { items: [] },
+        {
         items: [
           {
             id: "s1",
@@ -80,7 +131,9 @@ describe("StatementsPage", () => {
             validation_error: null,
           },
         ],
-      })
+        },
+      ],
+    })
 
     render(<StatementsPage />)
 
@@ -91,24 +144,53 @@ describe("StatementsPage", () => {
     await waitFor(() => expect(screen.getByText("stmt.pdf")).toBeInTheDocument())
   })
 
+  it("AC19.15.2 feeds source intake checklist from report readiness source trust", async () => {
+    mockStatementsPageApi({
+      statements: [{ items: [] }],
+      readiness: {
+        ...DEFAULT_READINESS,
+        source_trust_summary: {
+          source_classes: ["bank_statement", "manual_record"],
+          deterministic_pr_source_classes: ["bank_statement"],
+          post_merge_llm_ocr_source_classes: ["bank_statement"],
+          manual_trusted_source_classes: [],
+          gap_source_classes: ["manual_record"],
+          blocker_codes: ["manual_evidence_missing"],
+        },
+      },
+    })
+
+    render(<StatementsPage />)
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("source-intake-manual_record")).getByText("Needs source")).toBeInTheDocument(),
+    )
+    expect(within(screen.getByTestId("source-intake-bank_statement")).getByText("Import supported")).toBeInTheDocument()
+    expect(mockedApiFetch).toHaveBeenCalledWith(expect.stringContaining("/api/reports/package/readiness?"))
+  })
+
   it("AC22.5.x surfaces a parsed statement as ready-to-review with a direct review deep-link", async () => {
     routerPushMock.mockClear()
-    mockedApiFetch.mockResolvedValueOnce({
-      items: [
+    mockStatementsPageApi({
+      statements: [
         {
-          id: "s9",
-          original_filename: "ready.pdf",
-          institution: "DBS",
-          status: "parsed",
-          period_start: "2026-01-01",
-          period_end: "2026-01-31",
-          currency: "SGD",
-          confidence_score: 90,
-          transactions: [],
-          opening_balance: 100,
-          closing_balance: 200,
-          balance_validated: true,
-          validation_error: null,
+          items: [
+            {
+              id: "s9",
+              original_filename: "ready.pdf",
+              institution: "DBS",
+              status: "parsed",
+              period_start: "2026-01-01",
+              period_end: "2026-01-31",
+              currency: "SGD",
+              confidence_score: 90,
+              transactions: [],
+              opening_balance: 100,
+              closing_balance: 200,
+              balance_validated: true,
+              validation_error: null,
+            },
+          ],
         },
       ],
     })
@@ -126,22 +208,26 @@ describe("StatementsPage", () => {
   })
 
   it("AC22.5.x maps every status to a plain-language label (no raw 'uploaded')", async () => {
-    mockedApiFetch.mockResolvedValueOnce({
-      items: [
+    mockStatementsPageApi({
+      statements: [
         {
-          id: "s10",
-          original_filename: "fresh.pdf",
-          institution: "DBS",
-          status: "uploaded",
-          period_start: null,
-          period_end: null,
-          currency: "SGD",
-          confidence_score: null,
-          transactions: [],
-          opening_balance: null,
-          closing_balance: null,
-          balance_validated: null,
-          validation_error: null,
+          items: [
+            {
+              id: "s10",
+              original_filename: "fresh.pdf",
+              institution: "DBS",
+              status: "uploaded",
+              period_start: null,
+              period_end: null,
+              currency: "SGD",
+              confidence_score: null,
+              transactions: [],
+              opening_balance: null,
+              closing_balance: null,
+              balance_validated: null,
+              validation_error: null,
+            },
+          ],
         },
       ],
     })
@@ -154,38 +240,42 @@ describe("StatementsPage", () => {
   })
 
   it("AC22.5.x labels rejected statements and falls back gracefully for unknown statuses", async () => {
-    mockedApiFetch.mockResolvedValueOnce({
-      items: [
+    mockStatementsPageApi({
+      statements: [
         {
-          id: "s11",
-          original_filename: "rejected.pdf",
-          institution: "DBS",
-          status: "rejected",
-          period_start: "2026-01-01",
-          period_end: "2026-01-31",
-          currency: "SGD",
-          confidence_score: 40,
-          transactions: [],
-          opening_balance: 0,
-          closing_balance: 0,
-          balance_validated: false,
-          validation_error: "Could not read totals",
-        },
-        {
-          id: "s12",
-          original_filename: "weird.pdf",
-          institution: "DBS",
-          // Defensive: a status outside the known union still renders, unstyled.
-          status: "frobnicating" as unknown as BankStatement["status"],
-          period_start: "2026-01-01",
-          period_end: "2026-01-31",
-          currency: "SGD",
-          confidence_score: 50,
-          transactions: [],
-          opening_balance: 0,
-          closing_balance: 0,
-          balance_validated: null,
-          validation_error: null,
+          items: [
+            {
+              id: "s11",
+              original_filename: "rejected.pdf",
+              institution: "DBS",
+              status: "rejected",
+              period_start: "2026-01-01",
+              period_end: "2026-01-31",
+              currency: "SGD",
+              confidence_score: 40,
+              transactions: [],
+              opening_balance: 0,
+              closing_balance: 0,
+              balance_validated: false,
+              validation_error: "Could not read totals",
+            },
+            {
+              id: "s12",
+              original_filename: "weird.pdf",
+              institution: "DBS",
+              // Defensive: a status outside the known union still renders, unstyled.
+              status: "frobnicating" as unknown as BankStatement["status"],
+              period_start: "2026-01-01",
+              period_end: "2026-01-31",
+              currency: "SGD",
+              confidence_score: 50,
+              transactions: [],
+              opening_balance: 0,
+              closing_balance: 0,
+              balance_validated: null,
+              validation_error: null,
+            },
+          ],
         },
       ],
     })
@@ -199,22 +289,26 @@ describe("StatementsPage", () => {
   })
 
   it("AC16.14.11 AC22.11.1 enables polling with an honest parsing state (no fabricated progress)", async () => {
-    mockedApiFetch.mockResolvedValueOnce({
-      items: [
+    mockStatementsPageApi({
+      statements: [
         {
-          id: "s2",
-          original_filename: "parsing.pdf",
-          institution: "DBS",
-          status: "parsing",
-          period_start: null,
-          period_end: null,
-          currency: null,
-          confidence_score: null,
-          transactions: [],
-          opening_balance: null,
-          closing_balance: null,
-          balance_validated: null,
-          validation_error: null,
+          items: [
+            {
+              id: "s2",
+              original_filename: "parsing.pdf",
+              institution: "DBS",
+              status: "parsing",
+              period_start: null,
+              period_end: null,
+              currency: null,
+              confidence_score: null,
+              transactions: [],
+              opening_balance: null,
+              closing_balance: null,
+              balance_validated: null,
+              validation_error: null,
+            },
+          ],
         },
       ],
     })
@@ -233,28 +327,31 @@ describe("StatementsPage", () => {
   })
 
   it("AC16.14.12 delete action calls delete API and toast", async () => {
-    mockedApiFetch
-      .mockResolvedValueOnce({
-        items: [
-          {
-            id: "s3",
-            original_filename: "delete.pdf",
-            institution: "DBS",
-            status: "approved",
-            period_start: "2026-01-01",
-            period_end: "2026-01-31",
-            currency: "SGD",
-            confidence_score: 88,
-            transactions: [],
-            opening_balance: 50,
-            closing_balance: 70,
-            balance_validated: true,
-            validation_error: null,
-          },
-        ],
-      })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce({ items: [] })
+    mockStatementsPageApi({
+      statements: [
+        {
+          items: [
+            {
+              id: "s3",
+              original_filename: "delete.pdf",
+              institution: "DBS",
+              status: "approved",
+              period_start: "2026-01-01",
+              period_end: "2026-01-31",
+              currency: "SGD",
+              confidence_score: 88,
+              transactions: [],
+              opening_balance: 50,
+              closing_balance: 70,
+              balance_validated: true,
+              validation_error: null,
+            },
+          ],
+        },
+        { items: [] },
+      ],
+      deletes: [undefined],
+    })
 
     render(<StatementsPage />)
     await waitFor(() => expect(screen.getByText("delete.pdf")).toBeInTheDocument())
@@ -269,22 +366,26 @@ describe("StatementsPage", () => {
 })
 
   it("AC16.28.2 AC16.28.3 exposes statement delete action with an accessible label", async () => {
-    mockedApiFetch.mockResolvedValueOnce({
-      items: [
+    mockStatementsPageApi({
+      statements: [
         {
-          id: "s3",
-          original_filename: "delete.pdf",
-          institution: "DBS",
-          status: "approved",
-          period_start: "2026-01-01",
-          period_end: "2026-01-31",
-          currency: "SGD",
-          confidence_score: 88,
-          transactions: [],
-          opening_balance: 50,
-          closing_balance: 70,
-          balance_validated: true,
-          validation_error: null,
+          items: [
+            {
+              id: "s3",
+              original_filename: "delete.pdf",
+              institution: "DBS",
+              status: "approved",
+              period_start: "2026-01-01",
+              period_end: "2026-01-31",
+              currency: "SGD",
+              confidence_score: 88,
+              transactions: [],
+              opening_balance: 50,
+              closing_balance: 70,
+              balance_validated: true,
+              validation_error: null,
+            },
+          ],
         },
       ],
     })
@@ -296,27 +397,30 @@ describe("StatementsPage", () => {
   })
 
   it("test_AC8_13_48 renders missing statement values and surfaces delete failures", async () => {
-    mockedApiFetch
-      .mockResolvedValueOnce({
-        items: [
-          {
-            id: "s4",
-            original_filename: "needs-review.pdf",
-            institution: "Unknown",
-            status: "parsed",
-            period_start: null,
-            period_end: null,
-            currency: null,
-            confidence_score: null,
-            transactions: [],
-            opening_balance: null,
-            closing_balance: undefined,
-            balance_validated: false,
-            validation_error: "Balance mismatch",
-          },
-        ],
-      })
-      .mockRejectedValueOnce(new Error("delete failed"))
+    mockStatementsPageApi({
+      statements: [
+        {
+          items: [
+            {
+              id: "s4",
+              original_filename: "needs-review.pdf",
+              institution: "Unknown",
+              status: "parsed",
+              period_start: null,
+              period_end: null,
+              currency: null,
+              confidence_score: null,
+              transactions: [],
+              opening_balance: null,
+              closing_balance: undefined,
+              balance_validated: false,
+              validation_error: "Balance mismatch",
+            },
+          ],
+        },
+      ],
+      deletes: [new Error("delete failed")],
+    })
 
     render(<StatementsPage />)
 
@@ -337,7 +441,7 @@ describe("StatementsPage", () => {
   })
 
   it("test_AC8_13_49 ignores delete confirmation when no statement is selected", async () => {
-    mockedApiFetch.mockResolvedValueOnce({ items: [] })
+    mockStatementsPageApi({ statements: [{ items: [] }] })
 
     render(<StatementsPage />)
 

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -96,7 +96,7 @@ describe("StatementsPage", () => {
       if (url.startsWith("/api/statements/") && options?.method === "DELETE") {
         return resolveQueued(deleteQueue, undefined)
       }
-      return Promise.resolve({})
+      return Promise.reject(new Error(`Unexpected apiFetch call: ${url}`))
     })
   }
 
@@ -166,7 +166,10 @@ describe("StatementsPage", () => {
       expect(within(screen.getByTestId("source-intake-manual_record")).getByText("Needs source")).toBeInTheDocument(),
     )
     expect(within(screen.getByTestId("source-intake-bank_statement")).getByText("Import supported")).toBeInTheDocument()
-    expect(mockedApiFetch).toHaveBeenCalledWith(expect.stringContaining("/api/reports/package/readiness?"))
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/reports/package/readiness?"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
   })
 
   it("AC22.5.x surfaces a parsed statement as ready-to-review with a direct review deep-link", async () => {

--- a/apps/frontend/src/app/(main)/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/upload/page.tsx
@@ -82,20 +82,23 @@ export default function UploadPage() {
     }, [fetchStatements]);
 
     useEffect(() => {
-        let active = true;
+        const controller = new AbortController();
 
         apiFetch<PersonalReportPackageReadinessResponse>(
             `/api/reports/package/readiness${packageReadinessQuery()}`,
+            { signal: controller.signal },
         )
             .then((readiness) => {
-                if (active) setSourceTrustSummary(readiness.source_trust_summary);
+                setSourceTrustSummary(readiness.source_trust_summary);
             })
-            .catch(() => {
-                if (active) setSourceTrustSummary(undefined);
+            .catch((err) => {
+                if (!(err instanceof DOMException && err.name === "AbortError")) {
+                    setSourceTrustSummary(undefined);
+                }
             });
 
         return () => {
-            active = false;
+            controller.abort();
         };
     }, []);
 

--- a/apps/frontend/src/app/(main)/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/upload/page.tsx
@@ -13,8 +13,9 @@ import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import { useToast } from "@/components/ui/Toast";
 import { Alert, Badge, Button, EmptyState, IconButton, LoadingState, PageHeader } from "@/components/ui";
 import type { BadgeVariant } from "@/components/ui";
+import { reportPeriodStart } from "@/hooks/usePersonalReportPackage";
 import { apiFetch } from "@/lib/api";
-import { BankStatement, BankStatementListResponse } from "@/lib/types";
+import { BankStatement, BankStatementListResponse, PersonalReportPackageReadinessResponse } from "@/lib/types";
 import { formatCurrencyLocale } from "@/lib/money";
 
 // Plain-language status for everyday users. "parsed" means the AI finished and
@@ -36,6 +37,20 @@ function statusDisplay(status: string): { label: string; variant: BadgeVariant }
     }
 }
 
+type SourceTrustSummary = NonNullable<
+    PersonalReportPackageReadinessResponse["source_trust_summary"]
+>;
+
+function packageReadinessQuery(): string {
+    const reportDate = new Date().toISOString().slice(0, 10);
+    const params = new URLSearchParams({
+        start_date: reportPeriodStart(reportDate),
+        end_date: reportDate,
+        as_of_date: reportDate,
+    });
+    return `?${params.toString()}`;
+}
+
 export default function UploadPage() {
     const { showToast } = useToast();
     const router = useRouter();
@@ -45,6 +60,7 @@ export default function UploadPage() {
     const [polling, setPolling] = useState(false);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [deletingStatementId, setDeletingStatementId] = useState<string | null>(null);
+    const [sourceTrustSummary, setSourceTrustSummary] = useState<SourceTrustSummary | undefined>();
 
     const fetchStatements = useCallback(async () => {
         try {
@@ -64,6 +80,24 @@ export default function UploadPage() {
     useEffect(() => {
         fetchStatements();
     }, [fetchStatements]);
+
+    useEffect(() => {
+        let active = true;
+
+        apiFetch<PersonalReportPackageReadinessResponse>(
+            `/api/reports/package/readiness${packageReadinessQuery()}`,
+        )
+            .then((readiness) => {
+                if (active) setSourceTrustSummary(readiness.source_trust_summary);
+            })
+            .catch(() => {
+                if (active) setSourceTrustSummary(undefined);
+            });
+
+        return () => {
+            active = false;
+        };
+    }, []);
 
     useEffect(() => {
         if (!polling) return;
@@ -114,7 +148,7 @@ export default function UploadPage() {
             </div>
 
             <div className="mb-6">
-                <SourceIntakeChecklist />
+                <SourceIntakeChecklist sourceTrustSummary={sourceTrustSummary} />
             </div>
 
             {/* Upload Section */}


### PR DESCRIPTION
## Summary

Follow-up to merged #1216 / issue #1208. This PR addresses the Copilot CR that the Upload page rendered the source intake checklist without authoritative readiness/source-trust data.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-019 — Event-driven upload-to-report UX |
| **AC IDs** | AC19.15.2 |
| **AC source updated** | N/A — AC already registered by #1216 |

---

## SSOT Changes

- [x] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | N/A | Post-merge CR follow-up on existing AC19.15.2 behavior |
| 🟢 Green (passing test) | `8c452c4d` | Feed Upload checklist from package readiness source-trust summary and cover it in `statementsPage.test.tsx` |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` — N/A
- [x] `repo/` submodule updated for production config changes — N/A
- [x] `tools/check_env_keys.py` passes — N/A, no env vars changed
- [x] `tools/check_manifest.py` passes — N/A, no SSOT files changed
- [x] `tools/lint_doc_consistency.py` passes — N/A, no docs changed

### CI/CD, Runtime, and VPS Infra Audit

N/A — this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
npm test -- statementsPage.test.tsx sourceIntakeChecklist.test.tsx
npm run typecheck
npm run lint
```

---

## Screenshots / Evidence

N/A — behavior is covered by AC19.15.2 regression test.
