### PR TITLE
[finance_report_ui] Add source intake SSOT parity guard

### DIFF
--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -469,6 +469,10 @@ change backend source-trust decisions.
 | AC19.15.1 | The Upload page renders a source intake checklist covering bank statements, brokerage statements, settlement notes, ESOP/RSU plans, property statements, liability statements, CSV exports, and manual records, with each item linked to its existing intake path | `AC19.15.1 renders every required source class with intake links` | P1 |
 | AC19.15.2 | Source intake status labels treat readiness gaps as action-required, identify manual-trusted classes separately, and never claim manual evidence is imported automatically | `AC19.15.2 labels readiness gaps and manual-trusted source classes` | P1 |
 
+Traceability note: AC19.15 is tracked in this EPIC-local product UI table, and
+issue #1233 adds a tooling parity guard so the Upload checklist cannot drift from
+`docs/ssot/source-coverage-matrix.yaml` without failing CI.
+
 ## How To Build It
 
 ### Backend

--- a/tests/tooling/test_source_intake_checklist_contract.py
+++ b/tests/tooling/test_source_intake_checklist_contract.py
@@ -52,9 +52,7 @@ def _extract_source_intake_item_ids(source: str) -> list[str]:
     return re.findall(r'\bid: "([^"]+)"', items_block.group(1))
 
 
-def test_AC19_15_1_AC19_15_2_issue_1233_source_intake_checklist_matches_source_coverage_matrix() -> (
-    None
-):
+def test_AC19_15_issue_1233_source_intake_matches_ssot_matrix() -> None:
     """AC19.15.1 AC19.15.2: Checklist classes must stay aligned with SSOT."""
     ssot_required = _source_coverage_required_classes()
     checklist_source = CHECKLIST.read_text(encoding="utf-8")

--- a/tests/tooling/test_source_intake_checklist_contract.py
+++ b/tests/tooling/test_source_intake_checklist_contract.py
@@ -1,0 +1,78 @@
+"""Source intake checklist contract tests."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "docs" / "ssot" / "source-coverage-matrix.yaml"
+CHECKLIST = (
+    ROOT
+    / "apps"
+    / "frontend"
+    / "src"
+    / "components"
+    / "source-intake"
+    / "SourceIntakeChecklist.tsx"
+)
+
+
+def _source_coverage_required_classes() -> list[str]:
+    payload = yaml.safe_load(MATRIX.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    required = payload["required_source_classes"]
+    assert isinstance(required, list)
+    return [str(item) for item in required]
+
+
+def _extract_string_array(source: str, const_name: str) -> list[str]:
+    match = re.search(
+        rf"export const {re.escape(const_name)} = \[(.*?)\] as const;",
+        source,
+        flags=re.DOTALL,
+    )
+    assert match, f"{const_name} array not found"
+    parsed = ast.literal_eval(f"[{match.group(1)}]")
+    assert isinstance(parsed, list)
+    return [str(item) for item in parsed]
+
+
+def _extract_source_intake_item_ids(source: str) -> list[str]:
+    items_block = re.search(
+        r"const SOURCE_INTAKE_ITEMS: SourceIntakeItem\[] = \[(.*?)\];",
+        source,
+        flags=re.DOTALL,
+    )
+    assert items_block, "SOURCE_INTAKE_ITEMS block not found"
+    return re.findall(r'\bid: "([^"]+)"', items_block.group(1))
+
+
+def test_AC19_15_1_AC19_15_2_issue_1233_source_intake_checklist_matches_source_coverage_matrix() -> (
+    None
+):
+    """AC19.15.1 AC19.15.2: Checklist classes must stay aligned with SSOT."""
+    ssot_required = _source_coverage_required_classes()
+    checklist_source = CHECKLIST.read_text(encoding="utf-8")
+    exported_required = _extract_string_array(
+        checklist_source,
+        "REQUIRED_REPORT_SOURCE_CLASSES",
+    )
+    rendered_item_ids = _extract_source_intake_item_ids(checklist_source)
+
+    assert exported_required == ssot_required
+    assert rendered_item_ids == ssot_required
+    assert ssot_required == [
+        "bank_statement",
+        "brokerage_statement",
+        "settlement_note",
+        "esop_rsu_plan",
+        "property_statement",
+        "liability_statement",
+        "csv_export",
+        "manual_record",
+    ]


### PR DESCRIPTION
## Summary

Closes #1233.

Adds a tooling contract test that keeps the Upload source intake checklist aligned with `docs/ssot/source-coverage-matrix.yaml`, and documents the AC19.15 traceability note in EPIC-019.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-019 — Event-driven upload-to-report UX |
| **AC IDs** | AC19.15.1, AC19.15.2 |
| **AC source updated** | EPIC-019 traceability note |

---

## SSOT Changes

- [x] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | N/A | Focused test-only guard for merged #1208 behavior |
| 🟢 Green (passing test) | `fedbe1cc` | `test_AC19_15_1_AC19_15_2_issue_1233_source_intake_checklist_matches_source_coverage_matrix` passes |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` — N/A
- [x] `repo/` submodule updated for production config changes — N/A
- [x] `tools/check_env_keys.py` passes — N/A, no env changes
- [x] `tools/check_manifest.py` passes — N/A, no SSOT ownership changes
- [x] `tools/lint_doc_consistency.py` passes via preflight

### CI/CD, Runtime, and VPS Infra Audit

N/A — this PR does not change workflows, deploy tooling, Dokploy runtime config, VPS host scripts, or logs.

---

## Testing

```bash
uv run --with pyyaml pytest tests/tooling/test_source_intake_checklist_contract.py
uv run --with pyyaml python tools/check_ac_index.py
npm test -- sourceIntakeChecklist.test.tsx
apps/backend/.venv/bin/python tools/preflight.py --base origin/main
```

---

## Screenshots / Evidence

N/A — tooling contract only.
