### PR TITLE
[finance_report_ui] Clarify source intake readiness fallback

### DIFF
--- a/apps/frontend/src/__tests__/sourceIntakeChecklist.test.tsx
+++ b/apps/frontend/src/__tests__/sourceIntakeChecklist.test.tsx
@@ -46,7 +46,7 @@ describe("SourceIntakeChecklist", () => {
 
     expect(screen.getByRole("link", { name: "Upload bank statements" })).toHaveAttribute("href", "/upload")
     expect(screen.getByRole("link", { name: "Upload brokerage statements" })).toHaveAttribute("href", "/upload")
-    expect(screen.getByRole("link", { name: "Capture settlement notes" })).toHaveAttribute("href", "/upload")
+    expect(screen.getByRole("link", { name: "Upload brokerage evidence" })).toHaveAttribute("href", "/upload")
     expect(screen.getByRole("link", { name: "Add ESOP / RSU plans" })).toHaveAttribute(
       "href",
       "/portfolio/evidence?source_class=esop_rsu_plan",
@@ -61,6 +61,16 @@ describe("SourceIntakeChecklist", () => {
     )
     expect(screen.getByRole("link", { name: "Upload CSV exports" })).toHaveAttribute("href", "/upload")
     expect(screen.getByRole("link", { name: "Enter manual records" })).toHaveAttribute("href", "/journal")
+  })
+
+  it("AC19.15.2 keeps intake paths usable when readiness status is unavailable", () => {
+    render(<SourceIntakeChecklist readinessState="unavailable" />)
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Readiness status unavailable; showing intake paths.",
+    )
+    expect(screen.getByText("Readiness unavailable")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Upload brokerage evidence" })).toHaveAttribute("href", "/upload")
   })
 
   it("AC19.15.2 labels readiness gaps and manual-trusted source classes", () => {

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -172,6 +172,21 @@ describe("StatementsPage", () => {
     )
   })
 
+  it("AC19.15.2 keeps source intake paths usable when readiness is unavailable", async () => {
+    mockStatementsPageApi({
+      statements: [{ items: [] }],
+      readiness: new Error("readiness unavailable"),
+    })
+
+    render(<StatementsPage />)
+
+    await waitFor(() =>
+      expect(screen.getByText("Readiness status unavailable; showing intake paths.")).toBeInTheDocument(),
+    )
+    expect(screen.getByText("Readiness unavailable")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Upload brokerage evidence" })).toHaveAttribute("href", "/upload")
+  })
+
   it("AC22.5.x surfaces a parsed statement as ready-to-review with a direct review deep-link", async () => {
     routerPushMock.mockClear()
     mockStatementsPageApi({

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -187,6 +187,21 @@ describe("StatementsPage", () => {
     expect(screen.getByRole("link", { name: "Upload brokerage evidence" })).toHaveAttribute("href", "/upload")
   })
 
+  it("AC19.15.2 treats a missing source trust summary as readiness unavailable", async () => {
+    mockStatementsPageApi({
+      statements: [{ items: [] }],
+      readiness: { ...DEFAULT_READINESS, source_trust_summary: undefined },
+    })
+
+    render(<StatementsPage />)
+
+    await waitFor(() =>
+      expect(screen.getByText("Readiness status unavailable; showing intake paths.")).toBeInTheDocument(),
+    )
+    expect(screen.getByText("Readiness unavailable")).toBeInTheDocument()
+    expect(within(screen.getByTestId("source-intake-manual_record")).getByText("Manual-trusted")).toBeInTheDocument()
+  })
+
   it("AC22.5.x surfaces a parsed statement as ready-to-review with a direct review deep-link", async () => {
     routerPushMock.mockClear()
     mockStatementsPageApi({

--- a/apps/frontend/src/app/(main)/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/upload/page.tsx
@@ -5,7 +5,10 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 
-import { SourceIntakeChecklist } from "@/components/source-intake/SourceIntakeChecklist";
+import {
+    SourceIntakeChecklist,
+    type SourceIntakeReadinessState,
+} from "@/components/source-intake/SourceIntakeChecklist";
 import StatementUploader from "@/components/statements/StatementUploader";
 import { FlowStepBanner } from "@/components/workflow/FlowStepBanner";
 import { InfoHint } from "@/components/ui/InfoHint";
@@ -61,6 +64,8 @@ export default function UploadPage() {
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [deletingStatementId, setDeletingStatementId] = useState<string | null>(null);
     const [sourceTrustSummary, setSourceTrustSummary] = useState<SourceTrustSummary | undefined>();
+    const [sourceTrustReadinessState, setSourceTrustReadinessState] =
+        useState<SourceIntakeReadinessState>("loading");
 
     const fetchStatements = useCallback(async () => {
         try {
@@ -90,10 +95,12 @@ export default function UploadPage() {
         )
             .then((readiness) => {
                 setSourceTrustSummary(readiness.source_trust_summary);
+                setSourceTrustReadinessState("loaded");
             })
             .catch((err) => {
                 if (!(err instanceof DOMException && err.name === "AbortError")) {
                     setSourceTrustSummary(undefined);
+                    setSourceTrustReadinessState("unavailable");
                 }
             });
 
@@ -151,7 +158,10 @@ export default function UploadPage() {
             </div>
 
             <div className="mb-6">
-                <SourceIntakeChecklist sourceTrustSummary={sourceTrustSummary} />
+                <SourceIntakeChecklist
+                    readinessState={sourceTrustReadinessState}
+                    sourceTrustSummary={sourceTrustSummary}
+                />
             </div>
 
             {/* Upload Section */}

--- a/apps/frontend/src/app/(main)/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/upload/page.tsx
@@ -94,8 +94,9 @@ export default function UploadPage() {
             { signal: controller.signal },
         )
             .then((readiness) => {
-                setSourceTrustSummary(readiness.source_trust_summary);
-                setSourceTrustReadinessState("loaded");
+                const trustSummary = readiness.source_trust_summary;
+                setSourceTrustSummary(trustSummary);
+                setSourceTrustReadinessState(trustSummary ? "loaded" : "unavailable");
             })
             .catch((err) => {
                 if (!(err instanceof DOMException && err.name === "AbortError")) {

--- a/apps/frontend/src/components/source-intake/SourceIntakeChecklist.tsx
+++ b/apps/frontend/src/components/source-intake/SourceIntakeChecklist.tsx
@@ -33,6 +33,8 @@ type SourceTrustSummary = NonNullable<
   PersonalReportPackageReadinessResponse["source_trust_summary"]
 >;
 
+export type SourceIntakeReadinessState = "loading" | "loaded" | "unavailable";
+
 interface SourceIntakeItem {
   id: ReportSourceClass;
   label: string;
@@ -68,9 +70,9 @@ const SOURCE_INTAKE_ITEMS: SourceIntakeItem[] = [
   {
     id: "settlement_note",
     label: "Settlement notes",
-    description: "Broker settlement evidence captured from the brokerage import flow.",
+    description: "Broker settlement evidence starts with brokerage uploads, then flows through import and review.",
     href: "/upload",
-    ctaLabel: "Capture settlement notes",
+    ctaLabel: "Upload brokerage evidence",
     defaultStatus: "Structured capture",
     defaultVariant: "info",
     icon: FileText,
@@ -150,10 +152,14 @@ function statusForSourceClass(
 }
 
 export function SourceIntakeChecklist({
+  readinessState = "loaded",
   sourceTrustSummary,
 }: {
+  readinessState?: SourceIntakeReadinessState;
   sourceTrustSummary?: SourceTrustSummary;
 }) {
+  const showUnavailable = readinessState === "unavailable";
+
   return (
     <section
       aria-label="Report source intake checklist"
@@ -166,8 +172,25 @@ export function SourceIntakeChecklist({
             Add the source classes that make report readiness trustworthy. Manual evidence stays labelled manual-trusted.
           </p>
         </div>
-        <Badge variant="muted">{SOURCE_INTAKE_ITEMS.length} source classes</Badge>
+        <div className="flex flex-wrap gap-2 sm:justify-end">
+          <Badge variant="muted">{SOURCE_INTAKE_ITEMS.length} source classes</Badge>
+          {readinessState === "loading" ? (
+            <Badge variant="muted">Checking readiness</Badge>
+          ) : null}
+          {showUnavailable ? (
+            <Badge variant="warning">Readiness unavailable</Badge>
+          ) : null}
+        </div>
       </div>
+
+      {showUnavailable ? (
+        <p
+          role="status"
+          className="mt-3 rounded border border-[var(--border)] bg-[var(--background-muted)] px-3 py-2 text-sm text-muted"
+        >
+          Readiness status unavailable; showing intake paths.
+        </p>
+      ) : null}
 
       <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         {SOURCE_INTAKE_ITEMS.map((item) => {


### PR DESCRIPTION
## Summary
- keep the source intake checklist usable when report readiness is unavailable
- add explicit loading/unavailable readiness badges and fallback status copy
- clarify settlement-note intake so users upload brokerage evidence first

## Tests
- npm test -- sourceIntakeChecklist.test.tsx statementsPage.test.tsx
- npm run lint
- npm run typecheck
- apps/backend/.venv/bin/python tools/preflight.py --base origin/main

Closes #1234