### PR TITLE
[finance_report_vision] Prove infra2 deploy_v2 cleanup

### DIFF
--- a/tests/tooling/test_data_red_lines_contract.py
+++ b/tests/tooling/test_data_red_lines_contract.py
@@ -37,6 +37,7 @@ DEPLOY_DRIFT_SCAN_ROOTS = [
     "repo/libs/tests",
     "repo/README.md",
     "repo/finance_report",
+    "repo/platform",
 ]
 TEXT_SUFFIXES = {".md", ".py", ".yaml", ".yml", ".txt", ".toml"}
 
@@ -58,13 +59,14 @@ def _subsection(md: str, header: str) -> str:
 def _scan_text_files():
     for rel in DEPLOY_DRIFT_SCAN_ROOTS:
         path = ROOT / rel
+        assert path.exists(), f"deploy drift scan root is missing: {rel}"
         if path.is_file():
             candidates = [path]
         else:
             candidates = [p for p in path.rglob("*") if p.is_file()]
-        for candidate in candidates:
-            if candidate.suffix not in TEXT_SUFFIXES:
-                continue
+        text_candidates = [p for p in candidates if p.suffix in TEXT_SUFFIXES]
+        assert text_candidates, f"deploy drift scan root has no text files: {rel}"
+        for candidate in text_candidates:
             yield candidate.relative_to(ROOT), candidate.read_text(encoding="utf-8")
 
 
@@ -130,7 +132,12 @@ def test_deploy_v2_drift_surfaces_do_not_republish_retired_data_axis():
         "invoke openpanel.setup": "old platform openpanel setup deploy command",
         "invoke authentik.setup": "old platform authentik setup deploy command",
         "invoke minio.setup": "old platform minio setup deploy command",
+        "invoke portal.setup": "old platform portal setup deploy command",
+        "invoke prefect.setup": "old platform prefect setup deploy command",
+        "invoke activepieces.setup": "old platform activepieces setup deploy command",
         "invoke <service>.setup": "old generic service setup deploy command",
+        "v2 public input": "stale data-axis public-input wording",
+        "public input": "stale data-axis public-input wording",
         "data-axis side effects": "future data-axis wording",
         "data axis lands": "future data-axis wording",
         "platform services join when the deployer path is unified": "stale platform cutover wording",


### PR DESCRIPTION
## Summary

Pins `repo/` to the infra2 deploy_v2 cleanup commit and broadens the root drift guard so platform docs/code are covered by the same proof.

Depends on: wangzitian0/infra2#399
Related: #1072

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-007 — Deployment |
| **AC IDs** | AC7.12.6 |
| **AC source updated** | N/A — guard coverage only |

---

## SSOT Changes

- [ ] None — root SSOT already describes deploy_v2/data_lane; this PR strengthens proof coverage and pins infra2 to the cleanup commit.

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | N/A | Existing root guard failed against infra2 `main` before the cleanup branch because stale setup/deploy wording remained. |
| 🟢 Green (passing test) | `aa8eac08` | Root guard scans `repo/platform`, fails closed on missing/empty scan roots, and passes with `repo/` pinned to infra2 `d34964f`. |

---

## Engineering Audit

- [x] `repo/` submodule updated for deploy documentation/proof changes.
- [x] Deploy drift guard covers `repo/platform` and stale public-input wording.
- [x] Drift scan roots fail closed if the submodule/root is missing or empty.
- [x] No env vars, secrets, migrations, frontend code, or SQLAlchemy enums changed.

### CI/CD, Runtime, and VPS Infra Audit

- [x] Public deploy documentation points at deploy_v2; invoke setup tasks remain only as status/repair/debug helpers in infra2.
- [x] No runtime secret logging or VPS host scripts changed in this root PR.
- [x] Proof command includes the root drift guard and infra2 full-suite evidence in the linked infra2 PR.

---

## Testing

```bash
apps/backend/.venv/bin/python -m pytest tests/tooling/test_data_red_lines_contract.py -q
apps/backend/.venv/bin/python -m ruff check tests/tooling/test_data_red_lines_contract.py
git diff --check --ignore-submodules=none
apps/backend/.venv/bin/python tools/preflight.py
```

Results: guard passed (3 tests); ruff passed; diff check passed; preflight reported no additional gates for this diff.

Infra2 proof is in wangzitian0/infra2#399: drift scan clean; guard passed; ruff passed; deploy suite passed (133 tests); full infra2 suite passed (661 tests).

---

## Screenshots / Evidence

N/A
