### PR TITLE
[finance_report_test_and_doc] Fix prod source type migration drift

### DIFF
--- a/apps/backend/migrations/versions/0040_retire_bank_stmt_source.py
+++ b/apps/backend/migrations/versions/0040_retire_bank_stmt_source.py
@@ -10,10 +10,12 @@ data and code, and this revision drops it from the enum type.
 Drift tolerance (AC13.10.4): this migration does NOT assume a particular enum
 state. It re-runs the defensive ``UPDATE`` first so the type rebuild can never
 fail on a stray row, and it only rebuilds the type when the ``bank_statement``
-label is actually present. Postgres has no ``DROP VALUE``, so we rename-create-
-rebind-drop. The raw string ``'bank_statement'`` is still tolerated at the
-application layer (``normalize_source_type`` and the immutability trigger keep a
-text-level guard) so historical raw values remain harmless.
+label is actually present. During the rebuild it maps any legacy uppercase enum
+labels (for example ``SYSTEM``) to the lowercase labels used by current models.
+Postgres has no ``DROP VALUE``, so we rename-create-rebind-drop. The raw string
+``'bank_statement'`` is still tolerated at the application layer
+(``normalize_source_type`` and the immutability trigger keep a text-level guard)
+so historical raw values remain harmless.
 """
 
 from alembic import op
@@ -37,10 +39,7 @@ _REMAINING_VALUES = (
 def upgrade() -> None:
     # 1. Defensive, idempotent: collapse any residual legacy rows before the
     #    type is rebuilt. Text-cast comparison tolerates either enum state.
-    op.execute(
-        "UPDATE journal_entries SET source_type = 'auto_parsed' "
-        "WHERE source_type::text = 'bank_statement'"
-    )
+    op.execute("UPDATE journal_entries SET source_type = 'auto_parsed' WHERE source_type::text = 'bank_statement'")
 
     # 2. Rebuild the enum without 'bank_statement'. Guarded so the migration is
     #    a no-op on databases where the label was never present.
@@ -61,7 +60,12 @@ def upgrade() -> None:
                 ALTER TABLE journal_entries
                     ALTER COLUMN source_type DROP DEFAULT,
                     ALTER COLUMN source_type TYPE journal_source_type_enum
-                        USING source_type::text::journal_source_type_enum;
+                        USING (
+                            CASE
+                                WHEN source_type::text = 'bank_statement' THEN 'auto_parsed'
+                                ELSE lower(source_type::text)
+                            END
+                        )::journal_source_type_enum;
                 DROP TYPE journal_source_type_enum_old;
             END IF;
         END $$;
@@ -73,6 +77,4 @@ def downgrade() -> None:
     # Re-add the label so the migration is reversible. Idempotent and tolerant
     # of an already-present label (mirrors 0018's defensive ADD VALUE).
     with op.get_context().autocommit_block():
-        op.execute(
-            "ALTER TYPE journal_source_type_enum ADD VALUE IF NOT EXISTS 'bank_statement'"
-        )
+        op.execute("ALTER TYPE journal_source_type_enum ADD VALUE IF NOT EXISTS 'bank_statement'")

--- a/apps/backend/migrations/versions/0040_retire_bank_stmt_source.py
+++ b/apps/backend/migrations/versions/0040_retire_bank_stmt_source.py
@@ -10,7 +10,8 @@ data and code, and this revision drops it from the enum type.
 Drift tolerance (AC13.10.4): this migration does NOT assume a particular enum
 state. It re-runs the defensive ``UPDATE`` first so the type rebuild can never
 fail on a stray row, and it only rebuilds the type when the ``bank_statement``
-label is actually present. During the rebuild it maps any legacy uppercase enum
+label is actually present. During the rebuild it maps any casing of
+``bank_statement`` to ``auto_parsed`` and maps any other legacy uppercase enum
 labels (for example ``SYSTEM``) to the lowercase labels used by current models.
 Postgres has no ``DROP VALUE``, so we rename-create-rebind-drop. The raw string
 ``'bank_statement'`` is still tolerated at the application layer
@@ -39,7 +40,13 @@ _REMAINING_VALUES = (
 def upgrade() -> None:
     # 1. Defensive, idempotent: collapse any residual legacy rows before the
     #    type is rebuilt. Text-cast comparison tolerates either enum state.
-    op.execute("UPDATE journal_entries SET source_type = 'auto_parsed' WHERE source_type::text = 'bank_statement'")
+    op.execute(
+        """
+        UPDATE journal_entries
+        SET source_type = 'auto_parsed'
+        WHERE lower(source_type::text) = 'bank_statement'
+        """
+    )
 
     # 2. Rebuild the enum without 'bank_statement'. Guarded so the migration is
     #    a no-op on databases where the label was never present.
@@ -62,7 +69,7 @@ def upgrade() -> None:
                     ALTER COLUMN source_type TYPE journal_source_type_enum
                         USING (
                             CASE
-                                WHEN source_type::text = 'bank_statement' THEN 'auto_parsed'
+                                WHEN lower(source_type::text) = 'bank_statement' THEN 'auto_parsed'
                                 ELSE lower(source_type::text)
                             END
                         )::journal_source_type_enum;

--- a/apps/backend/tests/infra/test_migrations.py
+++ b/apps/backend/tests/infra/test_migrations.py
@@ -83,16 +83,18 @@ def test_AC13_10_4_retire_bank_statement_value_is_drift_tolerant():
 
     0040 (#896) removes 'bank_statement' from journal_source_type_enum. It must
     (a) re-run the defensive data collapse first so the type rebuild cannot fail
-    on a stray row, (b) only rebuild when the label is actually present, and
-    (c) never compare with a raw enum literal that would error if the label is
-    absent.
+    on a stray row, including uppercase/mixed-case legacy values, (b) only
+    rebuild when the label is actually present, and (c) never compare with a raw
+    enum literal that would error if the label is absent.
     """
     migration = SCRIPT_LOCATION / "versions" / "0040_retire_bank_stmt_source.py"
     source = migration.read_text()
 
     # Defensive, text-cast data collapse before any type surgery.
-    assert "UPDATE journal_entries SET source_type = 'auto_parsed'" in source
-    assert "WHERE source_type::text = 'bank_statement'" in source
+    assert "UPDATE journal_entries" in source
+    assert "SET source_type = 'auto_parsed'" in source
+    assert "WHERE lower(source_type::text) = 'bank_statement'" in source
+    assert "WHEN lower(source_type::text) = 'bank_statement' THEN 'auto_parsed'" in source
     # Rebuild is guarded on the label actually existing (no-op otherwise).
     assert "e.enumlabel = 'bank_statement'" in source
     # Reversible: the label can be re-added without assuming its absence.

--- a/tests/tooling/test_schema_quality_contract.py
+++ b/tests/tooling/test_schema_quality_contract.py
@@ -73,6 +73,15 @@ def test_AC8_13_123_schema_guardrails_scan_real_migration_directory() -> None:
     assert not (ROOT / "apps/backend/tests/migrations/versions").exists()
 
 
+def test_retire_bank_statement_migration_normalizes_uppercase_source_type_drift() -> None:
+    """Enum rebuild tolerates prod rows written with legacy uppercase labels."""
+
+    source = read("apps/backend/migrations/versions/0040_retire_bank_stmt_source.py")
+
+    assert "WHEN source_type::text = 'bank_statement' THEN 'auto_parsed'" in source
+    assert "ELSE lower(source_type::text)" in source
+
+
 def test_AC8_13_124_traceability_gate_and_audit_builder_share_test_surface() -> None:
     """AC8.13.124: AC traceability gate and uploaded audit scan the same roots."""
 

--- a/tests/tooling/test_schema_quality_contract.py
+++ b/tests/tooling/test_schema_quality_contract.py
@@ -78,7 +78,8 @@ def test_retire_bank_statement_migration_normalizes_uppercase_source_type_drift(
 
     source = read("apps/backend/migrations/versions/0040_retire_bank_stmt_source.py")
 
-    assert "WHEN source_type::text = 'bank_statement' THEN 'auto_parsed'" in source
+    assert "lower(source_type::text) = 'bank_statement'" in source
+    assert "WHEN lower(source_type::text) = 'bank_statement' THEN 'auto_parsed'" in source
     assert "ELSE lower(source_type::text)" in source
 
 


### PR DESCRIPTION
## Summary

Fix migration `0040_retire_bank_stmt_source` so production rows with legacy uppercase `journal_entries.source_type` labels (observed: `SYSTEM`) are mapped to current lowercase enum labels during the enum rebuild.

Closes N/A

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-013 — Statement Parsing V2 |
| **AC IDs** | AC13.10.4 |
| **AC source updated** | N/A — existing source_type conflict/migration drift contract |

---

## SSOT Changes

- [x] None — existing SSOT already covers this change

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `15afec67` | Added migration source contract for uppercase source_type drift; failed before implementation. |
| 🟢 Green (passing test) | `a8d0c6f7` | Mapped `bank_statement` to `auto_parsed` and all other source_type text through `lower(...)` during enum rebuild. |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (no new SQLAlchemy enums added)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (not applicable)
- [x] `repo/` submodule updated for production config changes (not applicable)
- [x] `tools/check_env_keys.py` passes (not applicable; no env vars changed)
- [x] `tools/check_manifest.py` passes (not applicable; no SSOT files changed)
- [x] `tools/lint_doc_consistency.py` passes (not applicable; no docs changed)

### CI/CD, Runtime, and VPS Infra Audit

- [x] Not applicable — no workflow, deploy tooling, Dokploy runtime config, VPS host scripts, or logs changed.

---

## Testing

```bash
# Red phase before implementation
uv run pytest tests/tooling/test_schema_quality_contract.py::test_retire_bank_statement_migration_normalizes_uppercase_source_type_drift -q

# Green phase
uv run pytest tests/tooling/test_schema_quality_contract.py -q
cd apps/backend && uv run python -m py_compile migrations/versions/0040_retire_bank_stmt_source.py
cd apps/backend && .venv/bin/ruff check migrations/versions/0040_retire_bank_stmt_source.py
cd apps/backend && .venv/bin/ruff format --check migrations/versions/0040_retire_bank_stmt_source.py

# Diff-aware preflight
apps/backend/.venv/bin/python tools/preflight.py --base origin/main
```

Preflight note: `migration-risk` passed. `backend-format` still reports pre-existing local ruff UP042 findings across unrelated enum files; targeted pinned ruff passed for the changed migration.

---

## Screenshots / Evidence

- Production deploy of `v0.1.15` failed at `0040_retire_bank_stmt_source` with `invalid input value for enum journal_source_type_enum: "SYSTEM"`.
- Production was rolled back and verified healthy on `v0.1.7` before opening this PR.
