### PR TITLE
[finance_report_hacker] fix report-main dispatch after image build

### DIFF
--- a/.github/workflows/notify-infra2-report-main.yml
+++ b/.github/workflows/notify-infra2-report-main.yml
@@ -1,20 +1,24 @@
 name: Notify infra2 — deploy report-branch-main
 
-# The APP-repo SENDER half of the one auto deploy target (infra2 SSOT §4.6): when app `main`
-# moves, tell infra2 to re-deploy the report-branch-main preview slot so it always reflects
-# "what main looks like right now". Everything else (staging / prod) is manual + a pinned
-# release tag and is NOT triggered here.
+# The APP-repo SENDER half of the one auto deploy target (infra2 SSOT §4.6): when
+# app `main` passes CI, tell infra2 to re-deploy the report-branch-main preview
+# slot for that exact successful SHA. Everything else (staging / prod) is manual
+# + a pinned release tag and is NOT triggered here.
 #
 # Receiver: infra2 `.github/workflows/deploy-report-main.yml` (repository_dispatch type
-# `deploy-report-main`), which runs `deploy_v2 --service finance_report/app --type
-# preview/branch --version-ref main --iac-ref main`. This closes the cross-repo half (#370 /
-# finance_report#1072): the receiver previously only fired on manual dispatch.
+# `deploy-report-main`), which validates the successful-main SHA and runs
+# `deploy_v2 --service finance_report/app --type preview/branch --version-ref main
+# --expected-sha <successful-main-sha> --iac-ref main`. This closes the cross-repo
+# half (#370 / finance_report#1072): the receiver previously only fired on manual
+# dispatch.
 #
 # Auth: INFRA2_PAT — a PAT with `repo` scope on wangzitian0/infra2 (GITHUB_TOKEN cannot
 # dispatch cross-repo). Stored as an app-repo secret.
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: ["main"]
   workflow_dispatch: {} # manual re-trigger of a report-branch-main deploy
 
@@ -34,12 +38,15 @@ concurrency:
 jobs:
   dispatch:
     name: dispatch report-branch-main deploy to infra2
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Dispatch repository_dispatch to infra2
         env:
           INFRA2_PAT: ${{ secrets.INFRA2_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
@@ -48,7 +55,34 @@ jobs:
             exit 1
           fi
 
-          payload="$(jq -nc --arg sha "$GITHUB_SHA" \
+          latest_main_sha="$(
+            curl -fsS \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
+              | jq -r '.object.sha // ""'
+          )"
+          if [[ -z "${latest_main_sha:-}" ]]; then
+            echo "::error::Could not resolve current main SHA before infra2 dispatch."
+            exit 1
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
+            dispatch_sha="${WORKFLOW_RUN_SHA:-}"
+            if [[ -z "${dispatch_sha:-}" ]]; then
+              echo "::error::No workflow_run head SHA resolved for report-branch-main deploy."
+              exit 1
+            fi
+            if [[ "$dispatch_sha" != "$latest_main_sha" ]]; then
+              echo "Skipping stale CI completion: workflow_run_sha=$dispatch_sha latest_main_sha=$latest_main_sha"
+              exit 0
+            fi
+          else
+            dispatch_sha="$latest_main_sha"
+          fi
+
+          payload="$(jq -nc --arg sha "$dispatch_sha" \
             '{event_type: "deploy-report-main", client_payload: {sha: $sha, ref: "main"}}')"
 
           http_status="$(curl -sS -o /tmp/infra2_dispatch_resp -w '%{http_code}' -X POST \
@@ -60,7 +94,7 @@ jobs:
             https://api.github.com/repos/wangzitian0/infra2/dispatches \
             -d "$payload")"
 
-          echo "infra2 repository_dispatch -> HTTP $http_status (sha=$GITHUB_SHA)"
+          echo "infra2 repository_dispatch -> HTTP $http_status (sha=$dispatch_sha)"
           # GitHub returns 204 No Content on a successful dispatch.
           if [[ "$http_status" != "204" ]]; then
             sed 's/^/  /' /tmp/infra2_dispatch_resp 2>/dev/null || true

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -418,6 +418,7 @@ job inventories or scenario counts into this EPIC.
 | AC8.13.143 | Main CI automatically opens or updates a reviewed baseline PR when `unified-coverage.json` rises, while PR CI keeps the committed no-regression gate and no new required status context is introduced | `test_AC8_13_143_unified_coverage_updates_baseline_through_pr_not_direct_main_push` | `tests/tooling/test_post_merge_e2e_gates.py` | P1 |
 | AC8.13.144 | Production release rolls back through deploy_v2 to the pre-deploy production version and confirms health when a post-deploy route, infrastructure, smoke, or read-only E2E gate fails after mutation | `test_AC8_13_144_production_release_rolls_back_with_deploy_v2_after_post_deploy_failure` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 | AC8.13.145 | Backend Tier-1 API E2E keeps PR fail-fast for speed but push/main runs the full Tier-1 suite so the JUnit artifact reports every failing API journey in one run | `test_AC8_13_145_backend_tier1_pr_fail_fast_but_main_reports_all_failures` | `tests/tooling/test_post_merge_e2e_gates.py` | P1 |
+| AC8.13.146 | The report-branch-main auto preview dispatch runs only after successful main CI publishes SHA images, skips stale workflow_run completions, and infra2 deploy_v2 refuses to deploy branch-form `main` unless it resolves to the exact payload SHA | `test_AC8_13_146_report_main_dispatch_waits_for_ci_images` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
 
 ### AC8.14: Product Trust Proof Mirrors
 

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -356,6 +356,13 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - Staging checks out the dispatched release `tag` and deploys that exact tag. Staging is a pre-prod canary: approx prod, only slightly ahead.
 - Staging deploy context artifacts record run metadata, the release tag, the checked-out commit SHA, image names, pre-deploy staging version, and structured failure domain, failed step, and failure summary. Early failures are split between checkout/tag resolution, classification normalization, uv/Python/deploy_v2 dependency setup, deploy_v2 rollout/effective-config verification, public route health, E2E setup, and application smoke/E2E without manually scraping the raw job log first. The classifier fails closed: a failed classification step is never reported as `not-required`, and an unexpected failed step is reported as `unclassified-build-deploy-failure` rather than `none`.
 - Main CI builds SHA-tagged images. `release-images.yml` promotes main-CI SHA images to the immutable release tag (`:vX.Y.Z`) with `docker buildx imagetools create --prefer-index=false` and verifies promoted digests; staging deploy consumes the release tag without rebuilding, retagging, or moving a `staging` tag. The commit image tag is exactly the first 7 hex characters of the release commit (`sha7`); deployment workflows must not rely on Git's adaptive `--short` length.
+- The report-branch-main preview is the only automatic main-following preview.
+  Its app-side sender runs after successful `CI` `workflow_run`, not directly on
+  `push`, so backend/frontend SHA images have been published before infra2 is
+  notified. The infra2 receiver passes branch-form `main` to `deploy_v2` and
+  requires that resolution to match the exact completed CI SHA from the
+  `repository_dispatch` payload, preventing newer in-progress main pushes from
+  racing GHCR image publication.
 - Deploy health covers deploy_v2/Dokploy rollout, effective-config verification, `/api/health`, shell smoke checks, and core non-LLM E2E.
 - Runtime incident classification for route, dependency, observability, secrets, stale-version, and flapping failures is owned by [runtime-incident-response.md](./runtime-incident-response.md). This CI/CD SSOT owns where the gates run and what they block, not the shared incident playbooks.
 - The fixed staging/prod deploy path uses the infra2 Python Dokploy client. It reports method, endpoint, HTTP status, and reason phrase on API failures, but never raw response bodies, auth headers, or full environment payloads.

--- a/docs/ssot/ci-gate-inventory.yaml
+++ b/docs/ssot/ci-gate-inventory.yaml
@@ -258,12 +258,12 @@ gates:
     workflow: .github/workflows/notify-infra2-report-main.yml
     job: dispatch
     owner: .github/workflows/notify-infra2-report-main.yml#dispatch
-    triggers: [push, workflow_dispatch]
+    triggers: [workflow_run, workflow_dispatch]
     blocks_workflow: false
-    inputs: [main_sha]
+    inputs: [successful_main_ci_sha]
     outputs: [infra2_repository_dispatch]
     artifacts: []
-    failure_semantics: App main push could not notify infra2 to redeploy the report-branch-main preview (INFRA2_PAT missing/expired or repository_dispatch did not return HTTP 204).
+    failure_semantics: Successful app main CI could not notify infra2 to redeploy the report-branch-main preview guarded by the exact completed SHA (INFRA2_PAT missing/expired, stale CI completion skipped, or repository_dispatch did not return HTTP 204).
     action: keep
   - id: pr_test.setup
     category: classify

--- a/docs/ssot/delivery-gates.yaml
+++ b/docs/ssot/delivery-gates.yaml
@@ -66,6 +66,19 @@ gates:
     description: >
       Promote main-CI SHA images to immutable release tags with digest verification.
 
+  - id: report-main-preview
+    workflow: .github/workflows/notify-infra2-report-main.yml
+    job: dispatch
+    trigger: workflow_run          # after app main CI completes successfully
+    blocking: false
+    image_free: false
+    description: >
+      Notify infra2 to redeploy the report-branch-main preview only after main CI
+      has published the SHA-tagged backend/frontend images. The receiver requires
+      deploy_v2's branch-form `main` resolution to match the exact successful SHA
+      from the repository_dispatch payload, so a newer in-progress main push cannot
+      race image publication.
+
   - id: production-release
     workflow: .github/workflows/production-release.yml
     job: deploy

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -1222,6 +1222,55 @@ def test_AC8_13_145_backend_tier1_pr_fail_fast_but_main_reports_all_failures() -
     assert "category: runtime_test" in inventory
 
 
+def test_AC8_13_146_report_main_dispatch_waits_for_ci_images() -> None:
+    """AC8.13.146: report-branch-main deploys only successful CI SHA images."""
+    notify = read(".github/workflows/notify-infra2-report-main.yml")
+    notify_yaml = yaml.safe_load(notify)
+    notify_on = notify_yaml.get(True) or notify_yaml.get("on")
+
+    assert "push" not in notify_on
+    assert notify_on["workflow_run"]["workflows"] == ["CI"]
+    assert notify_on["workflow_run"]["types"] == ["completed"]
+    assert notify_on["workflow_run"]["branches"] == ["main"]
+    assert "workflow_dispatch" in notify_on
+
+    dispatch_job = notify_yaml["jobs"]["dispatch"]
+    assert "github.event.workflow_run.conclusion == 'success'" in dispatch_job["if"]
+    assert "github.event.workflow_run.head_branch == 'main'" in dispatch_job["if"]
+    dispatch_script = "\n".join(
+        step.get("run", "")
+        for step in dispatch_job["steps"]
+        if isinstance(step, dict)
+    )
+    assert "WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}" in notify
+    assert "/git/ref/heads/main" in dispatch_script
+    assert 'dispatch_sha="${WORKFLOW_RUN_SHA:-}"' in dispatch_script
+    assert 'dispatch_sha="$latest_main_sha"' in dispatch_script
+    assert "$GITHUB_SHA" not in dispatch_script
+    assert "Skipping stale CI completion" in dispatch_script
+    assert '--arg sha "$dispatch_sha"' in dispatch_script
+
+    receiver = read("repo/.github/workflows/deploy-report-main.yml")
+    receiver_yaml = yaml.safe_load(receiver)
+    receiver_env = receiver_yaml["jobs"]["deploy"]["env"]
+    assert receiver_env["DISPATCH_SHA"] == "${{ github.event.client_payload.sha }}"
+    receiver_script = "\n".join(
+        step.get("run", "")
+        for step in receiver_yaml["jobs"]["deploy"]["steps"]
+        if isinstance(step, dict)
+    )
+    assert '[[ "${GITHUB_EVENT_NAME}" == "repository_dispatch" && -z "${DISPATCH_SHA:-}" ]]' in receiver_script
+    assert "client_payload.sha" in receiver
+    assert "--version-ref main" in receiver_script
+    assert 'deploy_args+=(--expected-sha "$DISPATCH_SHA")' in receiver_script
+    assert "--expected-sha" in read("repo/tools/deploy_v2.py")
+
+    delivery_gates = yaml.safe_load(read("docs/ssot/delivery-gates.yaml"))["gates"]
+    report_gate = next(gate for gate in delivery_gates if gate["id"] == "report-main-preview")
+    assert report_gate["trigger"] == "workflow_run"
+    assert report_gate["blocking"] is False
+
+
 def test_AC8_13_68_ci_runs_e2e_epic_traceability_gate() -> None:
     """AC8.13.68: CI gates product E2E tests and project EPIC ownership."""
     workflow = read(".github/workflows/ci.yml")


### PR DESCRIPTION
## Summary
- Move `notify-infra2-report-main` from push-triggered dispatch to successful `CI` `workflow_run` dispatch so SHA images exist before infra2 is notified.
- Dispatch the completed CI SHA, skip stale CI completions when `main` has already moved, and update SSOT/AC coverage.
- Pin the infra2 submodule to the receiver fix that deploys the payload SHA instead of floating `main`.

## Dependency
- Merge infra2 PR first: https://github.com/wangzitian0/infra2/pull/403

## Verification
- `apps/backend/.venv/bin/python -m pytest tests/tooling/test_post_merge_e2e_gates.py -k AC8_13_146 -q`
- `apps/backend/.venv/bin/python -m pytest tests/tooling/test_delivery_gates_contract.py tests/tooling/test_ci_gate_inventory.py -q`
- `apps/backend/.venv/bin/ruff check tests/tooling/test_post_merge_e2e_gates.py repo/libs/tests/test_iac_runner_deploy_result.py`
- `apps/backend/.venv/bin/python tools/generate_ac_registry.py`
- `apps/backend/.venv/bin/python tools/check_ac_index.py`
- `apps/backend/.venv/bin/python tools/preflight.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ../apps/backend/.venv/bin/python -m pytest libs/tests/test_iac_runner_deploy_result.py -k report_branch_main -q` in `repo/`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ../apps/backend/.venv/bin/python -m pytest libs/tests/test_deploy_v2.py libs/tests/test_preview_lifecycle.py -q` in `repo/`