### PR TITLE
[finance_report_ui] Route brokerage CSV uploads before bank CSV parsing (#1255)

### DIFF
--- a/apps/backend/src/services/brokerage_positions.py
+++ b/apps/backend/src/services/brokerage_positions.py
@@ -569,7 +569,10 @@ def parse_brokerage_positions_csv_rows(
     ``market_value``/``currency``...) consumed by ``_parse_structured_positions``
     so the result flows through the existing brokerage import path. Rows missing
     a symbol, quantity, or market value are skipped (a CSV can carry subtotal /
-    blank rows). Monetary and quantity fields are parsed as ``Decimal``.
+    blank rows). Quantity and monetary fields are parsed as ``Decimal`` for
+    precision, then serialized back to ``str`` in the returned dict (JSON-safe
+    payload contract); the importer re-parses them via ``_clean_decimal`` in
+    ``_parse_structured_positions``.
     """
     symbol_col = _find_csv_column(headers, ("symbol", "ticker", "instrument", "security"))
     quantity_col = _find_csv_column(headers, ("quantity", "qty", "shares", "position", "units"))

--- a/apps/backend/src/services/brokerage_positions.py
+++ b/apps/backend/src/services/brokerage_positions.py
@@ -98,8 +98,18 @@ def _parse_date(value: Any) -> date | None:
         return None
 
 
+def _statement_dict(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the nested ``statement`` mapping, or an empty dict when absent.
+
+    Centralizes the ``isinstance(..., dict)`` narrowing so callers get a concrete
+    ``dict[str, Any]`` (not ``dict | Any | None``) for ``.get`` access.
+    """
+    statement = payload.get("statement")
+    return statement if isinstance(statement, dict) else {}
+
+
 def _statement_date(payload: dict[str, Any]) -> date:
-    statement = payload.get("statement") if isinstance(payload.get("statement"), dict) else {}
+    statement = _statement_dict(payload)
     for candidate in (
         payload.get("snapshot_date"),
         payload.get("as_of_date"),
@@ -115,7 +125,7 @@ def _statement_date(payload: dict[str, Any]) -> date:
 
 
 def _payload_currency(payload: dict[str, Any], default: str = "USD") -> str:
-    statement = payload.get("statement") if isinstance(payload.get("statement"), dict) else {}
+    statement = _statement_dict(payload)
     currency = payload.get("currency") or statement.get("currency") or default
     return str(currency).upper()
 
@@ -181,7 +191,7 @@ def looks_like_brokerage_payload(
     if any(key in payload for key in ("positions", "holdings", "securities")):
         return True
 
-    statement = payload.get("statement") if isinstance(payload.get("statement"), dict) else {}
+    statement = _statement_dict(payload)
     broker = detect_broker(
         filename=filename or str(payload.get("file") or ""),
         institution=institution or payload.get("institution") or statement.get("institution"),
@@ -477,6 +487,178 @@ def _generated_brokerage_positions_payload_from_text(
     }
 
 
+class UnsupportedBrokerageCsvError(Exception):
+    """A CSV matched a known brokerage schema we deliberately do not import yet.
+
+    Raised for brokerage CSV shapes that are detected (so they must NOT fall
+    through to the bank transaction parser and surface a misleading
+    "No valid transactions found" error) but are intentionally out of scope —
+    currently brokerage *trade-history* CSVs (side/symbol/fill-quantity/...),
+    which have no positions snapshot to import. The message is user-actionable.
+    """
+
+
+# Header keyword sets used to classify a brokerage CSV by its column names.
+# Matching is done on lower-cased, stripped headers using substring containment
+# so minor broker-specific wording variations ("Mkt Value" vs "Market Value")
+# still classify. Kept deliberately narrow: only schemas we can confidently
+# recognize are routed away from the bank parser.
+_BROKERAGE_POSITIONS_REQUIRED_GROUPS: tuple[tuple[str, ...], ...] = (
+    ("symbol", "ticker", "instrument", "security"),
+    ("quantity", "qty", "shares", "position", "units"),
+    ("market value", "mkt value", "market val", "value", "marketvalue"),
+)
+_BROKERAGE_TRADE_HISTORY_REQUIRED_GROUPS: tuple[tuple[str, ...], ...] = (
+    ("side", "action", "buy/sell", "b/s"),
+    ("symbol", "ticker", "instrument", "security"),
+    ("fill quantity", "fill qty", "filled quantity", "filled qty", "quantity", "qty"),
+    ("fill price", "filled price", "price", "trade price"),
+)
+
+
+def _header_group_matches(headers_lower: list[str], group: tuple[str, ...]) -> bool:
+    return any(any(keyword in header for keyword in group) for header in headers_lower)
+
+
+def _all_header_groups_match(headers_lower: list[str], groups: tuple[tuple[str, ...], ...]) -> bool:
+    return all(_header_group_matches(headers_lower, group) for group in groups)
+
+
+def classify_brokerage_csv(headers: list[str]) -> str | None:
+    """Classify a CSV by its header row into a known brokerage schema.
+
+    Returns ``"positions"`` for a brokerage positions/holdings export,
+    ``"trade_history"`` for a trade/fill export, or ``None`` when the headers do
+    not match any known brokerage schema (so bank CSV parsing proceeds).
+
+    Trade-history is checked first because it shares the symbol/quantity columns
+    of a positions export but adds a trade ``side``; a positions schema never
+    carries a side column, so this ordering keeps the two disjoint.
+    """
+    headers_lower = [h.lower().strip() for h in headers if h]
+    if not headers_lower:
+        return None
+    if _all_header_groups_match(headers_lower, _BROKERAGE_TRADE_HISTORY_REQUIRED_GROUPS):
+        return "trade_history"
+    if _all_header_groups_match(headers_lower, _BROKERAGE_POSITIONS_REQUIRED_GROUPS):
+        return "positions"
+    return None
+
+
+def _find_csv_column(headers: list[str], candidates: tuple[str, ...]) -> str | None:
+    """Return the original-cased header whose lower form contains any candidate."""
+    for header in headers:
+        if not header:
+            continue
+        low = header.lower().strip()
+        if any(keyword in low for keyword in candidates):
+            return header
+    return None
+
+
+def parse_brokerage_positions_csv_rows(
+    headers: list[str],
+    rows: list[dict[str, Any]],
+    *,
+    broker: str,
+    default_currency: str = "USD",
+) -> list[dict[str, Any]]:
+    """Map brokerage positions CSV rows into structured ``positions`` dicts.
+
+    Produces the same per-position shape (``asset_identifier``/``quantity``/
+    ``market_value``/``currency``...) consumed by ``_parse_structured_positions``
+    so the result flows through the existing brokerage import path. Rows missing
+    a symbol, quantity, or market value are skipped (a CSV can carry subtotal /
+    blank rows). Monetary and quantity fields are parsed as ``Decimal``.
+    """
+    symbol_col = _find_csv_column(headers, ("symbol", "ticker", "instrument", "security"))
+    quantity_col = _find_csv_column(headers, ("quantity", "qty", "shares", "position", "units"))
+    value_col = _find_csv_column(headers, ("market value", "mkt value", "market val", "marketvalue", "value"))
+    price_col = _find_csv_column(headers, ("current price", "price", "mark price", "last price"))
+    currency_col = _find_csv_column(headers, ("currency", "ccy"))
+    asset_type_col = _find_csv_column(headers, ("asset type", "asset class", "type", "category"))
+
+    positions: list[dict[str, Any]] = []
+    for row in rows:
+        identifier = str(row.get(symbol_col, "") or "").strip() if symbol_col else ""
+        quantity = _clean_decimal(row.get(quantity_col)) if quantity_col else None
+        market_value = _clean_decimal(row.get(value_col)) if value_col else None
+        if market_value is None and price_col and quantity is not None:
+            price = _clean_decimal(row.get(price_col))
+            if price is not None:
+                market_value = price * quantity
+        if not identifier or quantity is None or market_value is None:
+            continue
+        currency = str(row.get(currency_col, "") or "").strip().upper() if currency_col else ""
+        positions.append(
+            {
+                "symbol": identifier,
+                "asset_identifier": identifier,
+                "quantity": str(quantity),
+                "market_value": str(to_money(market_value)),
+                "currency": currency or default_currency.upper(),
+                "asset_type": (
+                    str(row.get(asset_type_col)).strip() if asset_type_col and row.get(asset_type_col) else None
+                ),
+                "broker": broker,
+            }
+        )
+    return positions
+
+
+def parse_brokerage_csv_payload(
+    headers: list[str],
+    rows: list[dict[str, Any]],
+    *,
+    institution: str,
+    filename: str | None = None,
+) -> dict[str, Any]:
+    """Build a brokerage positions payload from a CSV, or reject unsupported shapes.
+
+    Detects the brokerage CSV schema from ``headers`` and:
+
+    * positions/holdings → returns a ``{"institution", "positions", ...}`` payload
+      that satisfies ``looks_like_brokerage_payload`` and flows into the brokerage
+      position import path (AtomicPosition / reconciliation).
+    * trade-history → raises :class:`UnsupportedBrokerageCsvError` with an
+      actionable message (out of scope; never mapped into bank transactions).
+
+    Raises :class:`UnsupportedBrokerageCsvError` if the schema is brokerage but
+    yields zero importable positions, so the upload fails with a clear message
+    rather than the misleading generic bank "No valid transactions" error.
+    """
+    broker = detect_broker(filename=filename, institution=institution, text=None)
+    if broker == "Unknown Broker":
+        broker = institution
+
+    schema = classify_brokerage_csv(headers)
+    if schema == "trade_history":
+        raise UnsupportedBrokerageCsvError(
+            f"Brokerage trade-history CSV detected for {institution}. Trade-history import is not "
+            "supported yet — please upload a positions/holdings CSV (symbol, quantity, market value) "
+            "or the brokerage account statement (PDF) instead."
+        )
+    if schema != "positions":
+        raise UnsupportedBrokerageCsvError(
+            f"CSV for {institution} did not match a supported brokerage positions schema."
+        )
+
+    positions = parse_brokerage_positions_csv_rows(headers, rows, broker=broker)
+    if not positions:
+        raise UnsupportedBrokerageCsvError(
+            f"Brokerage positions CSV detected for {institution} but no importable positions were "
+            "found (need symbol, quantity, and market value columns with values)."
+        )
+    currency = positions[0]["currency"]
+    return {
+        "institution": broker,
+        "currency": currency,
+        "positions": positions,
+        "transactions": [],
+        "balance_source": "brokerage_positions_csv",
+    }
+
+
 def parse_brokerage_positions(
     payload: dict[str, Any],
     *,
@@ -484,7 +666,7 @@ def parse_brokerage_positions(
     institution: str | None = None,
 ) -> list[BrokeragePositionSnapshot]:
     """Parse brokerage position snapshots from structured or fallback payloads."""
-    statement = payload.get("statement") if isinstance(payload.get("statement"), dict) else {}
+    statement = _statement_dict(payload)
     broker = detect_broker(
         filename=filename or str(payload.get("file") or ""),
         institution=institution or payload.get("institution") or statement.get("institution"),

--- a/apps/backend/src/services/extraction.py
+++ b/apps/backend/src/services/extraction.py
@@ -28,10 +28,13 @@ from src.services.ai_streaming import (
     stream_ai_json,
 )
 from src.services.brokerage_positions import (
+    UnsupportedBrokerageCsvError,
     _generated_brokerage_positions_payload_from_text,
     brokerage_currency_balances,
+    classify_brokerage_csv,
     looks_like_brokerage_document,
     looks_like_brokerage_payload,
+    parse_brokerage_csv_payload,
     parse_brokerage_positions,
 )
 from src.services.chain_repair import RegionReExtractor, repair_under_extraction
@@ -1427,6 +1430,34 @@ class ExtractionService:
         headers = list(reader.fieldnames or [])
         headers_lower = [h.lower().strip() for h in headers]
         institution_lower = institution.lower()
+
+        # Brokerage CSV routing (#1255): bank CSV parsing below only understands
+        # bank transaction schemas (date/description/amount/debit/credit/balance).
+        # Brokerage CSVs use different schemas, so detect them BEFORE bank parsing.
+        # The decisive signal is the header SHAPE (classify_brokerage_csv), not the
+        # broker name: a known broker can still export a bank-style transaction CSV,
+        # which must keep flowing through bank parsing. A positions/holdings CSV is
+        # mapped into a brokerage ``positions`` payload (flows into
+        # BrokeragePositionImportService via looks_like_brokerage_payload); a
+        # trade-history CSV is rejected with an actionable error rather than the
+        # misleading generic bank "No valid transactions found" failure.
+        if classify_brokerage_csv(headers):
+            try:
+                brokerage_payload = parse_brokerage_csv_payload(headers, rows, institution=institution)
+            except UnsupportedBrokerageCsvError as exc:
+                logger.warning(
+                    "Brokerage CSV rejected as unsupported",
+                    institution=institution,
+                    headers=headers,
+                    reason=str(exc),
+                )
+                raise ExtractionError(str(exc)) from exc
+            logger.info(
+                "Brokerage positions CSV parsed",
+                institution=institution,
+                positions_count=len(brokerage_payload.get("positions", [])),
+            )
+            return brokerage_payload
 
         transactions: list[dict[str, Any]] = []
         period_start: date | None = None

--- a/apps/backend/tests/extraction/test_brokerage_csv_routing.py
+++ b/apps/backend/tests/extraction/test_brokerage_csv_routing.py
@@ -1,0 +1,126 @@
+"""Brokerage CSV routing tests (#1255 / AC17.32).
+
+All CSV fixtures are SYNTHETIC: anonymized headers and made-up symbols/amounts,
+no real account data or filenames.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from src.services.brokerage_positions import (
+    UnsupportedBrokerageCsvError,
+    classify_brokerage_csv,
+    parse_brokerage_csv_payload,
+    parse_brokerage_positions,
+    parse_brokerage_positions_csv_rows,
+)
+from src.services.extraction import ExtractionError, ExtractionService
+
+# --- Synthetic brokerage CSV fixtures (no real data) -----------------------
+
+BROKERAGE_POSITIONS_CSV = b"""Symbol,Quantity,Current Price,Market Value,Currency,P&L
+AAA,10,100.00,1000.00,USD,50.00
+BBB,5,20.00,100.00,USD,-10.00
+"""
+
+BROKERAGE_TRADE_HISTORY_CSV = b"""Side,Symbol,Fill Quantity,Fill Price,Fill Amount,Fill Time,Fees,Total
+BUY,AAA,10,100.00,1000.00,2026-01-02 09:30:00,1.00,1001.00
+SELL,BBB,5,20.00,100.00,2026-01-03 10:00:00,1.00,99.00
+"""
+
+BANK_TRANSACTION_CSV = b"""Transaction Date,Reference,Debit Amount,Credit Amount,Transaction Ref1
+15 Jan 2025,REF001,,500.00,SALARY
+16 Jan 2025,REF002,100.00,,GROCERIES
+"""
+
+
+# --- Classifier unit tests --------------------------------------------------
+
+
+def test_classify_brokerage_csv_distinguishes_schemas():
+    """AC17.32.1 AC17.32.2 AC17.32.3: header classifier separates the three CSV shapes."""
+    assert classify_brokerage_csv(["Symbol", "Quantity", "Market Value", "Currency"]) == "positions"
+    assert classify_brokerage_csv(["Side", "Symbol", "Fill Quantity", "Fill Price", "Total"]) == "trade_history"
+    assert classify_brokerage_csv(["Transaction Date", "Debit Amount", "Credit Amount"]) is None
+    assert classify_brokerage_csv([]) is None
+
+
+def test_parse_brokerage_positions_csv_rows_uses_decimal():
+    """AC17.32.1: positions CSV rows map to Decimal-backed position dicts."""
+    headers = ["Symbol", "Quantity", "Market Value", "Currency"]
+    rows = [
+        {"Symbol": "AAA", "Quantity": "10", "Market Value": "1,000.00", "Currency": "usd"},
+        {"Symbol": "", "Quantity": "1", "Market Value": "5.00", "Currency": "USD"},  # skipped: no symbol
+    ]
+    positions = parse_brokerage_positions_csv_rows(headers, rows, broker="Interactive Brokers")
+    assert len(positions) == 1
+    pos = positions[0]
+    assert pos["asset_identifier"] == "AAA"
+    assert Decimal(pos["quantity"]) == Decimal("10")
+    assert Decimal(pos["market_value"]) == Decimal("1000.00")
+    assert pos["currency"] == "USD"
+
+
+# --- AC17.32.1: positions CSV reaches brokerage import path -----------------
+
+
+async def test_AC17_32_1_brokerage_positions_csv_produces_positions_payload():
+    """AC17.32.1: Brokerage positions CSV is mapped into a ``positions`` payload.
+
+    The payload must satisfy the brokerage import contract (parse_brokerage_positions
+    yields snapshots) instead of failing with a bank "No valid transactions" error.
+    """
+    service = ExtractionService()
+    payload = await service._parse_csv_content(BROKERAGE_POSITIONS_CSV, "Interactive Brokers")
+
+    assert "positions" in payload
+    assert len(payload["positions"]) == 2
+    assert payload["balance_source"] == "brokerage_positions_csv"
+    # The payload flows into the brokerage import path.
+    snapshots = parse_brokerage_positions(payload, institution="Interactive Brokers")
+    assert len(snapshots) == 2
+    assert snapshots[0].asset_identifier == "AAA"
+    assert snapshots[0].quantity == Decimal("10")
+    assert snapshots[0].market_value == Decimal("1000.00")
+    assert snapshots[0].currency == "USD"
+
+
+# --- AC17.32.2: trade-history CSV gives an actionable error -----------------
+
+
+async def test_AC17_32_2_brokerage_trade_history_csv_raises_actionable_error():
+    """AC17.32.2: Trade-history CSV raises an actionable unsupported error.
+
+    It must NOT surface the misleading generic bank parse failure.
+    """
+    service = ExtractionService()
+    with pytest.raises(ExtractionError) as excinfo:
+        await service._parse_csv_content(BROKERAGE_TRADE_HISTORY_CSV, "Interactive Brokers")
+
+    message = str(excinfo.value)
+    assert "trade-history" in message.lower()
+    assert "No valid transactions found" not in message
+
+
+def test_parse_brokerage_csv_payload_rejects_trade_history():
+    """AC17.32.2: trade-history schema raises the typed unsupported error."""
+    headers = ["Side", "Symbol", "Fill Quantity", "Fill Price", "Total"]
+    with pytest.raises(UnsupportedBrokerageCsvError, match="trade-history"):
+        parse_brokerage_csv_payload(headers, [], institution="Interactive Brokers")
+
+
+# --- AC17.32.3: bank CSV parsing is unaffected ------------------------------
+
+
+async def test_AC17_32_3_bank_csv_unaffected_by_brokerage_detection():
+    """AC17.32.3: Bank transaction CSV parsing is unchanged (no regression)."""
+    service = ExtractionService()
+    payload = await service._parse_csv_content(BANK_TRANSACTION_CSV, "DBS")
+
+    assert "positions" not in payload
+    assert len(payload["transactions"]) == 2
+    assert payload["transactions"][0]["direction"] == "IN"
+    assert payload["transactions"][0]["amount"] == "500.00"
+    assert payload["transactions"][1]["direction"] == "OUT"
+    assert payload["transactions"][1]["amount"] == "100.00"

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -437,3 +437,21 @@ visible in OpenAPI and the generated frontend client.
 |----|-----------|---------------|------|----------|
 | AC17.31.1 | `prices/update` returns the typed `{updated_count, results}` shape | `test_AC17_31_1_prices_update_returns_typed_batch_response` | `api/test_typed_contract_sweep.py` | P2 |
 | AC17.31.2 | `PATCH {ticker}` for an unknown holding returns a structured 404 | `test_AC17_31_2_patch_unknown_holding_returns_404` | `api/test_typed_contract_sweep.py` | P2 |
+
+### AC17.32: Brokerage CSV Routing ([#1255](https://github.com/wangzitian0/finance_report/issues/1255))
+
+CSV uploads previously routed every `.csv` through the bank transaction parser,
+so brokerage CSVs (positions/holdings or trade-history schemas) failed with a
+misleading generic "No valid transactions found" error and never reached
+`BrokeragePositionImportService`. A header-shape classifier now runs BEFORE bank
+CSV parsing: a brokerage **positions** CSV is mapped into a `positions` payload
+that flows into the brokerage import path, and a brokerage **trade-history** CSV
+(out of scope for mapping) is rejected with an actionable unsupported-document
+error instead of the misleading bank parse failure. Bank CSV parsing is
+unchanged for non-brokerage schemas.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC17.32.1 | Brokerage positions CSV is mapped into a `positions` payload (not a bank parse failure) so it reaches the brokerage import path | `test_AC17_32_1_brokerage_positions_csv_produces_positions_payload` | `extraction/test_brokerage_csv_routing.py` | P1 |
+| AC17.32.2 | Brokerage trade-history CSV raises an actionable unsupported-document error, not the generic bank "No valid transactions" failure | `test_AC17_32_2_brokerage_trade_history_csv_raises_actionable_error` | `extraction/test_brokerage_csv_routing.py` | P1 |
+| AC17.32.3 | Bank transaction CSV parsing is unaffected by brokerage CSV detection (no regression) | `test_AC17_32_3_bank_csv_unaffected_by_brokerage_detection` | `extraction/test_brokerage_csv_routing.py` | P1 |


### PR DESCRIPTION
## Root cause

`POST /statements/upload` routes every `.csv` through the parse pipeline into
`ExtractionService._parse_csv_content()`, whose heuristics + AI fallback only
understand **bank transaction** schemas (date/description/amount/debit/credit/
balance). Brokerage CSVs use different schemas (positions: symbol/quantity/
market value/currency/P&L; trade history: side/symbol/fill quantity/fill price/
fill amount/...), so they fell through to the generic
`No valid transactions found in CSV` error and **never reached**
`parse_brokerage_positions()` / `BrokeragePositionImportService`. Unlike PDF/
image uploads, CSV had no brokerage branching.

## Scope decision

- **In scope — brokerage positions/holdings CSV** → mapped into a brokerage
  `positions` payload that satisfies `looks_like_brokerage_payload()` and flows
  through the existing brokerage import path
  (`import_brokerage_payload_if_present` → `BrokeragePositionImportService` →
  `AtomicPosition` + reconciliation). No parallel import path was invented.
- **Out of scope — brokerage trade-history CSV** → there is no position snapshot
  to import from a fill log, so it is **rejected synchronously** in the parse
  flow with an actionable `UnsupportedBrokerageCsvError` (surfaced as an
  `ExtractionError`, which fails the statement with that message) instead of the
  misleading bank `No valid transactions found` error. Mapping fills into
  investment transactions / position deltas is deliberately deferred.

## Fix

- New header-shape classifier `classify_brokerage_csv(headers)` in
  `brokerage_positions.py` returns `"positions"`, `"trade_history"`, or `None`.
  The **decisive signal is the header shape, not the broker name**, so a known
  broker that exports a bank-style transaction CSV still flows through bank
  parsing unchanged (no false hijacking).
- `parse_brokerage_csv_payload()` builds the `{"institution", "positions", ...}`
  payload (Decimal money/quantity) or raises the typed unsupported error.
- `_parse_csv_content()` runs the classifier **before** any bank parsing; a
  positions CSV returns the brokerage payload, a trade-history CSV raises the
  actionable error.
- Reused the existing `_BROKER_ALIASES` / `detect_broker` registry for the
  broker label; folded the repeated `payload.get("statement")` narrowing into a
  typed `_statement_dict` helper.

## Tests

`apps/backend/tests/extraction/test_brokerage_csv_routing.py` (all fixtures are
SYNTHETIC — anonymized headers, made-up symbols/amounts, no real data/filenames):

- **AC17.32.1** — positions CSV produces a `positions` payload and yields
  brokerage snapshots (not a bank parse failure).
- **AC17.32.2** — trade-history CSV raises an actionable unsupported error,
  asserting the message is NOT the generic bank failure.
- **AC17.32.3** — bank transaction CSV parsing is unaffected (no regression).
- Plus classifier/parser unit tests.

AC IDs **AC17.32.1 / AC17.32.2 / AC17.32.3** added to
`docs/project/EPIC-017.portfolio-management.md`; AC-index gate passes.

## Notes

The upload request/response API surface is unchanged (`api.md --check` clean).
The local-only mypy pre-commit hook (CI does not run mypy) surfaces 8
PRE-EXISTING `extraction.py` type-debt errors unrelated to this change (verified
identical on HEAD); the new/edited `brokerage_positions.py` is mypy-clean.

Closes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)