### PR TITLE
[finance_report_vision] Define stable valuation taxonomy contract (#1221, AC11.21)

### DIFF
--- a/apps/backend/src/constants/valuation_taxonomy.py
+++ b/apps/backend/src/constants/valuation_taxonomy.py
@@ -100,7 +100,8 @@ class ValuationL2(str, Enum):
 
 
 # ---------------------------------------------------------------------------
-# L2 -> (L1 parent, default economic side). Every L2 code has exactly one row.
+# L2 -> L1 parent. Every L2 code has exactly one parent row. The default
+# economic side is derived from the parent via L1_DEFAULT_SIDE (below).
 # ---------------------------------------------------------------------------
 
 L2_PARENT: dict[ValuationL2, ValuationL1] = {

--- a/apps/backend/src/constants/valuation_taxonomy.py
+++ b/apps/backend/src/constants/valuation_taxonomy.py
@@ -1,0 +1,177 @@
+"""Stable valuation taxonomy contract (#1221, EPIC-011 AC11.21).
+
+Single source of truth for the small, durable set of valuation classes that
+report generation, net worth, allocation, and framework-policy logic depend on.
+
+Design rule (the whole point of this contract): jurisdiction-, scheme-, and
+vendor-specific names (CPF, 401k, MPF, SRS, IRA, social-security personal
+accounts, specific insurers/brokers) are NEVER stable taxonomy codes. Those
+details are extracted as metadata and *mapped onto* these classes. Durable
+economic meaning lives in the three report-stable dimensions
+(``EconomicSide``, ``ValuationRole``, ``LiquidityClass``) plus a small L1/L2
+class tree — never in product names.
+
+This module is pure contract: no database tables, no LLM prompts, no report
+behavior. Storage (#1222), the legacy adapter (#1223), LLM classification
+(#1224), and report consumption (#1225) all validate against it.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+# ---------------------------------------------------------------------------
+# Report-stable dimensions — the durable economic meaning reports consume.
+# ---------------------------------------------------------------------------
+
+
+class EconomicSide(str, Enum):
+    """Which side of net worth a valuation contributes to.
+
+    ``NON_ASSET`` is the explicit exclusion class: e.g. an insurance *coverage*
+    amount is a protection figure, not owned value, so it never enters net
+    worth even though it is a number on a statement.
+    """
+
+    ASSET = "asset"
+    LIABILITY = "liability"
+    NON_ASSET = "non_asset"
+
+
+class ValuationRole(str, Enum):
+    """How the valuation participates in reports."""
+
+    NET_WORTH_COMPONENT = "net_worth_component"
+    COVERAGE_AMOUNT = "coverage_amount"
+    INFORMATIONAL = "informational"
+
+
+class LiquidityClass(str, Enum):
+    """Liquidity presentation dimension (stable)."""
+
+    LIQUID = "liquid"
+    RESTRICTED = "restricted"
+    ILLIQUID = "illiquid"
+    LIABILITY = "liability"
+
+
+# ---------------------------------------------------------------------------
+# Stable L1 / L2 class tree — small and durable by design.
+# ---------------------------------------------------------------------------
+
+
+class ValuationL1(str, Enum):
+    """Top-level stable valuation class."""
+
+    CASH = "cash"
+    MARKETABLE_INVESTMENT = "marketable_investment"
+    RETIREMENT_AND_BENEFIT = "retirement_and_benefit"
+    RESTRICTED_COMPENSATION = "restricted_compensation"
+    REAL_ESTATE = "real_estate"
+    LIABILITY = "liability"
+    OTHER_ASSET = "other_asset"
+    NON_ASSET = "non_asset"
+
+
+class ValuationL2(str, Enum):
+    """Second-level stable subdivisions. Limited and jurisdiction-agnostic."""
+
+    # cash
+    CASH_DEPOSIT = "cash_deposit"
+    # marketable_investment
+    PUBLIC_EQUITY = "public_equity"
+    FUND = "fund"
+    BOND = "bond"
+    # retirement_and_benefit
+    MANDATORY_RETIREMENT = "mandatory_retirement"
+    VOLUNTARY_RETIREMENT = "voluntary_retirement"
+    LONG_TERM_BENEFIT = "long_term_benefit"
+    # restricted_compensation
+    EQUITY_AWARD = "equity_award"
+    # real_estate
+    PROPERTY = "property"
+    # liability
+    SECURED_LIABILITY = "secured_liability"
+    UNSECURED_LIABILITY = "unsecured_liability"
+    TAX_LIABILITY = "tax_liability"
+    # non_asset / fallback
+    PROTECTION_COVERAGE = "protection_coverage"
+    UNCLASSIFIED = "unclassified"
+
+
+# ---------------------------------------------------------------------------
+# L2 -> (L1 parent, default economic side). Every L2 code has exactly one row.
+# ---------------------------------------------------------------------------
+
+L2_PARENT: dict[ValuationL2, ValuationL1] = {
+    ValuationL2.CASH_DEPOSIT: ValuationL1.CASH,
+    ValuationL2.PUBLIC_EQUITY: ValuationL1.MARKETABLE_INVESTMENT,
+    ValuationL2.FUND: ValuationL1.MARKETABLE_INVESTMENT,
+    ValuationL2.BOND: ValuationL1.MARKETABLE_INVESTMENT,
+    ValuationL2.MANDATORY_RETIREMENT: ValuationL1.RETIREMENT_AND_BENEFIT,
+    ValuationL2.VOLUNTARY_RETIREMENT: ValuationL1.RETIREMENT_AND_BENEFIT,
+    ValuationL2.LONG_TERM_BENEFIT: ValuationL1.RETIREMENT_AND_BENEFIT,
+    ValuationL2.EQUITY_AWARD: ValuationL1.RESTRICTED_COMPENSATION,
+    ValuationL2.PROPERTY: ValuationL1.REAL_ESTATE,
+    ValuationL2.SECURED_LIABILITY: ValuationL1.LIABILITY,
+    ValuationL2.UNSECURED_LIABILITY: ValuationL1.LIABILITY,
+    ValuationL2.TAX_LIABILITY: ValuationL1.LIABILITY,
+    ValuationL2.PROTECTION_COVERAGE: ValuationL1.NON_ASSET,
+    ValuationL2.UNCLASSIFIED: ValuationL1.OTHER_ASSET,
+}
+
+L1_DEFAULT_SIDE: dict[ValuationL1, EconomicSide] = {
+    ValuationL1.CASH: EconomicSide.ASSET,
+    ValuationL1.MARKETABLE_INVESTMENT: EconomicSide.ASSET,
+    ValuationL1.RETIREMENT_AND_BENEFIT: EconomicSide.ASSET,
+    ValuationL1.RESTRICTED_COMPENSATION: EconomicSide.ASSET,
+    ValuationL1.REAL_ESTATE: EconomicSide.ASSET,
+    ValuationL1.LIABILITY: EconomicSide.LIABILITY,
+    ValuationL1.OTHER_ASSET: EconomicSide.ASSET,
+    ValuationL1.NON_ASSET: EconomicSide.NON_ASSET,
+}
+
+# Tokens that must never appear in a stable taxonomy code. Jurisdiction names,
+# statutory-scheme names, and vendor/issuer names belong in extracted metadata,
+# not in the durable contract.
+FORBIDDEN_CODE_TOKENS: tuple[str, ...] = (
+    "cpf",
+    "mpf",
+    "srs",
+    "ira",
+    "401k",
+    "403b",
+    "roth",
+    "social_security",
+    "socialsecurity",
+    "provident",
+    "esop",
+    "rsu",
+    "singapore",
+    "china",
+    "usa",
+    "fidelity",
+    "vanguard",
+    "schwab",
+    "prudential",
+    "manulife",
+    "insurer",
+)
+
+
+def default_side_for_l1(l1: ValuationL1) -> EconomicSide:
+    """Return the report-stable economic side a given L1 class defaults to."""
+
+    return L1_DEFAULT_SIDE[l1]
+
+
+def parent_l1(l2: ValuationL2) -> ValuationL1:
+    """Return the single L1 parent a given L2 code rolls up to."""
+
+    return L2_PARENT[l2]
+
+
+def all_stable_codes() -> list[str]:
+    """Every stable taxonomy code string (L1 + L2) for guard checks."""
+
+    return [c.value for c in ValuationL1] + [c.value for c in ValuationL2]

--- a/apps/backend/tests/assets/test_valuation_taxonomy_contract.py
+++ b/apps/backend/tests/assets/test_valuation_taxonomy_contract.py
@@ -1,0 +1,86 @@
+"""Stable valuation taxonomy contract tests (#1221, EPIC-011 AC11.21).
+
+These pin the durable contract that storage (#1222), the legacy adapter
+(#1223), LLM classification (#1224), and report consumption (#1225) depend on.
+The guard test is the load-bearing one: it rejects any attempt to smuggle a
+jurisdiction-, scheme-, or vendor-specific name back into the stable codes.
+"""
+
+from src.constants.valuation_taxonomy import (
+    FORBIDDEN_CODE_TOKENS,
+    L1_DEFAULT_SIDE,
+    L2_PARENT,
+    EconomicSide,
+    LiquidityClass,
+    ValuationL1,
+    ValuationL2,
+    ValuationRole,
+    all_stable_codes,
+    default_side_for_l1,
+    parent_l1,
+)
+
+
+def test_l1_taxonomy_covers_required_stable_classes():
+    """AC11.21.1: L1 defines the required durable classes incl. fallbacks."""
+    required = {
+        "cash",
+        "marketable_investment",
+        "retirement_and_benefit",
+        "restricted_compensation",
+        "real_estate",
+        "liability",
+        "other_asset",  # fallback asset
+        "non_asset",  # fallback non-net-worth (e.g. coverage)
+    }
+    assert {c.value for c in ValuationL1} == required
+
+
+def test_report_stable_dimensions_present():
+    """AC11.21.2: economic_side, valuation_role, liquidity_class are defined.
+
+    Insurance cash value vs coverage is expressible: an asset side plus a
+    coverage role, so a coverage amount can be excluded from net worth.
+    """
+    assert {s.value for s in EconomicSide} == {"asset", "liability", "non_asset"}
+    assert ValuationRole.COVERAGE_AMOUNT.value == "coverage_amount"
+    assert ValuationRole.NET_WORTH_COMPONENT.value == "net_worth_component"
+    assert {c.value for c in LiquidityClass} == {
+        "liquid",
+        "restricted",
+        "illiquid",
+        "liability",
+    }
+
+
+def test_stable_codes_reject_vendor_jurisdiction_scheme_tokens():
+    """AC11.21.3: no stable code carries a forbidden product/jurisdiction token.
+
+    Guards against CPF/401k/MPF/SRS/IRA/RSU/ESOP/insurer/country names creeping
+    back into the durable taxonomy. Those belong in extracted metadata only.
+    """
+    violations = []
+    for code in all_stable_codes():
+        lowered = code.lower()
+        for token in FORBIDDEN_CODE_TOKENS:
+            if token in lowered:
+                violations.append((code, token))
+    assert not violations, (
+        f"Stable taxonomy codes must not contain jurisdiction/scheme/vendor tokens; offenders: {violations}"
+    )
+
+
+def test_l2_maps_to_single_l1_and_default_side():
+    """AC11.21.4: every L2 has exactly one L1 parent with a default side."""
+    # Every L2 member is mapped, and nothing extra is mapped.
+    assert set(L2_PARENT) == set(ValuationL2)
+    # Every L1 has a default economic side, and nothing extra.
+    assert set(L1_DEFAULT_SIDE) == set(ValuationL1)
+    # The lookup helpers agree with the tables for every member.
+    for l2 in ValuationL2:
+        parent = parent_l1(l2)
+        assert isinstance(parent, ValuationL1)
+        assert default_side_for_l1(parent) is L1_DEFAULT_SIDE[parent]
+    # Liabilities roll up to the liability side; coverage to non_asset.
+    assert default_side_for_l1(parent_l1(ValuationL2.SECURED_LIABILITY)) is (EconomicSide.LIABILITY)
+    assert default_side_for_l1(parent_l1(ValuationL2.PROTECTION_COVERAGE)) is (EconomicSide.NON_ASSET)

--- a/apps/backend/tests/assets/test_valuation_taxonomy_contract.py
+++ b/apps/backend/tests/assets/test_valuation_taxonomy_contract.py
@@ -39,8 +39,10 @@ def test_l1_taxonomy_covers_required_stable_classes():
 def test_report_stable_dimensions_present():
     """AC11.21.2: economic_side, valuation_role, liquidity_class are defined.
 
-    Insurance cash value vs coverage is expressible: an asset side plus a
-    coverage role, so a coverage amount can be excluded from net worth.
+    Insurance cash value vs coverage is expressible by side + role: cash value
+    is an asset-side net-worth component, whereas a coverage amount sits on the
+    non_asset side with the coverage_amount role, so it is excluded from net
+    worth.
     """
     assert {s.value for s in EconomicSide} == {"asset", "liability", "non_asset"}
     assert ValuationRole.COVERAGE_AMOUNT.value == "coverage_amount"

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -271,6 +271,25 @@ restricted compensation.
 | AC11.20.2 | Net-worth allocation groups retirement accounts, social-security personal balances, legacy CPF, and insurance cash value under the retirement-and-benefit asset class | `test_AC11_20_2_net_worth_allocation_groups_retirement_and_benefit_assets()` | `reporting/test_reporting_net_worth_components.py` | P1 |
 | AC11.20.3 | The assets page labels retirement and benefit asset entry options as assets, with insurance represented only by cash value | `test_AC11_20_3_assets_page_surfaces_retirement_and_benefit_asset_labels()` | `apps/frontend/src/__tests__/assetsPage.test.tsx` | P1 |
 
+### AC11.21: Stable Valuation Taxonomy Contract (#1221)
+
+The durable L1/L2 valuation taxonomy that report generation, net worth,
+allocation, and framework-policy logic depend on. Jurisdiction-, scheme-, and
+vendor-specific names (CPF, 401k, MPF, SRS, IRA, social-security personal
+accounts, specific insurers/brokers) are extracted as metadata and mapped onto
+this small stable set — they are never stable taxonomy codes. Durable economic
+meaning lives in three report-stable dimensions (`economic_side`,
+`valuation_role`, `liquidity_class`) plus the L1/L2 class tree. This AC owns the
+contract language only; storage (#1222), adapter (#1223), LLM classification
+(#1224), and report consumption (#1225) build on it.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.21.1 | Stable L1 taxonomy defines the required durable classes (cash, marketable investment, retirement/benefit, restricted compensation, real estate, liability, and asset/non-asset fallbacks) | `test_l1_taxonomy_covers_required_stable_classes()` | `assets/test_valuation_taxonomy_contract.py` | P0 |
+| AC11.21.2 | The contract exposes `economic_side`, `valuation_role`, and `liquidity_class` as report-stable dimensions, expressing insurance cash value (asset) vs coverage amount (non-asset) | `test_report_stable_dimensions_present()` | `assets/test_valuation_taxonomy_contract.py` | P0 |
+| AC11.21.3 | A deterministic guard rejects jurisdiction-, scheme-, and vendor-specific tokens in stable taxonomy codes | `test_stable_codes_reject_vendor_jurisdiction_scheme_tokens()` | `assets/test_valuation_taxonomy_contract.py` | P0 |
+| AC11.21.4 | Every L2 code maps to exactly one L1 parent with a default economic side | `test_l2_maps_to_single_l1_and_default_side()` | `assets/test_valuation_taxonomy_contract.py` | P0 |
+
 ## Implementation Pattern Ownership
 
 Do not copy reusable code patterns, router examples, migration guardrails, or

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -293,6 +293,8 @@ concepts:
   stable_valuation_taxonomy:
     owner: docs/ssot/assets.md#stable-valuation-taxonomy
     description: Durable L1/L2 valuation classes and report-stable dimensions (economic_side, valuation_role, liquidity_class) that reports depend on.
+    family: assets
+    kind: concept
     cross_refs:
       - docs/ssot/reporting.md
       - docs/project/EPIC-011.asset-lifecycle.md

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -290,6 +290,13 @@ concepts:
       - docs/ssot/reporting.md
       - docs/ssot/schema.md
 
+  stable_valuation_taxonomy:
+    owner: docs/ssot/assets.md#stable-valuation-taxonomy
+    description: Durable L1/L2 valuation classes and report-stable dimensions (economic_side, valuation_role, liquidity_class) that reports depend on.
+    cross_refs:
+      - docs/ssot/reporting.md
+      - docs/project/EPIC-011.asset-lifecycle.md
+
   # ── Market data ────────────────────────────────────────────────────────
   market_data:
     owner: docs/ssot/market_data.md

--- a/docs/ssot/assets.md
+++ b/docs/ssot/assets.md
@@ -246,6 +246,43 @@ readiness blocker rather than being rejected (see AC11.9.5).
   snapshot's source-anchor detail records its `valuation_basis` enum value
   (AC11.9.10).
 
+<a id="stable-valuation-taxonomy"></a>
+
+### Stable Valuation Taxonomy Contract (#1221)
+
+The stable valuation taxonomy is the small, durable vocabulary that report
+generation, net worth, allocation, and framework-policy logic depend on. It is
+defined in code at `apps/backend/src/constants/valuation_taxonomy.py` and pinned
+by `apps/backend/tests/assets/test_valuation_taxonomy_contract.py` (EPIC-011
+AC11.21). The legacy `ManualValuationComponentType` enum is **not** retired by
+this contract; it becomes a legacy input hint that later issues (#1223) map onto
+these stable classes.
+
+**Design rule.** Jurisdiction-, scheme-, and vendor-specific names (CPF, 401k,
+MPF, SRS, IRA, social-security personal accounts, specific insurers/brokers) are
+extracted as metadata and mapped onto the stable set — they are never stable
+taxonomy codes. A deterministic guard test rejects such tokens in any stable
+code. Durable economic meaning lives in three report-stable dimensions plus a
+small L1/L2 class tree:
+
+- **`economic_side`**: `asset` · `liability` · `non_asset`. The `non_asset` side
+  is the explicit exclusion class — e.g. an insurance *coverage* amount is a
+  protection figure, not owned value, so it never enters net worth.
+- **`valuation_role`**: `net_worth_component` · `coverage_amount` ·
+  `informational`. Insurance cash value is an asset net-worth component;
+  coverage amount carries the `coverage_amount` role on the `non_asset` side.
+- **`liquidity_class`**: `liquid` · `restricted` · `illiquid` · `liability`
+  (the existing presentation dimension).
+
+**L1 classes**: `cash`, `marketable_investment`, `retirement_and_benefit`,
+`restricted_compensation`, `real_estate`, `liability`, plus `other_asset` and
+`non_asset` fallbacks. **L2** is a limited, jurisdiction-agnostic subdivision
+(e.g. `mandatory_retirement`/`voluntary_retirement` under
+`retirement_and_benefit`, `equity_award` under `restricted_compensation`,
+`property` under `real_estate`). Every L2 code maps to exactly one L1 parent with
+a default `economic_side`. Field definitions and the full L2 set live in the
+contract module; this SSOT section owns the vocabulary, not the enum members.
+
 ---
 
 ## 7. Design Constraints


### PR DESCRIPTION
## Goal

Step 1 of 3 (PR 1 of 2) in the valuation taxonomy program. Closes the contract-language slice of #1221: define the durable L1/L2 valuation taxonomy that report generation, net worth, allocation, and framework-policy logic depend on.

## What

- **New contract module** `apps/backend/src/constants/valuation_taxonomy.py` — pure contract, no DB tables / no LLM / no report behavior:
  - Report-stable dimensions: `EconomicSide` (asset/liability/non_asset), `ValuationRole` (net_worth_component/coverage_amount/informational), `LiquidityClass`.
  - L1 classes: cash, marketable_investment, retirement_and_benefit, restricted_compensation, real_estate, liability, + other_asset/non_asset fallbacks. Limited jurisdiction-agnostic L2 set, each mapping to one L1 parent + default side.
  - `FORBIDDEN_CODE_TOKENS` + helpers.
- **Guard**: deterministic test rejects jurisdiction/scheme/vendor tokens (CPF, 401k, MPF, SRS, IRA, RSU, ESOP, insurers, country names) from stable codes. Insurance cash value (asset) vs coverage amount (non_asset) is expressed via `economic_side` + `valuation_role`, not product names.
- **SSOT**: `docs/ssot/assets.md#stable-valuation-taxonomy` + MANIFEST owner entry.
- **EPIC-011 AC11.21.1–4** registered; `ac_registry.yaml` regenerated; `check_ac_index.py` green.

## MECE scope

Contract language only. **Out of scope** (later issues): storage tables (#1222), legacy adapter (#1223), LLM classification (#1224), report switch-over (#1225), frontend (#1226). The legacy `ManualValuationComponentType` enum is untouched — it stays a legacy input hint.

## Verification

- `tests/assets/test_valuation_taxonomy_contract.py` — 4 ACs pass.
- `check_ac_index.py` integrity + protection floors PASS.
- Pinned ruff (venv 0.14.11, as CI) check + format clean. (Local preflight's PATH ruff 0.15.17 flags pre-existing `str, Enum` UP042 across the repo — a known version-skew false positive, not from this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)