### PR TITLE
[finance_report_audit] feat(unit_price): money-per-quantity base package (#1253, EPIC-012 AC12.32)

### DIFF
--- a/apps/backend/src/quantity/quantity.py
+++ b/apps/backend/src/quantity/quantity.py
@@ -72,7 +72,14 @@ class Quantity:
         return Quantity(abs(self.value), self.unit)
 
     def __mul__(self, factor: _QuantityInput) -> Quantity:
-        return Quantity(self.value * _coerce(factor, "factor"), self.unit)
+        # Scale by a dimensionless Decimal/int factor. float/bool stay a hard red
+        # line (raise); any other type yields NotImplemented so a reflected
+        # operand can handle it — e.g. quantity * UnitPrice -> Money.
+        if isinstance(factor, (Decimal, int)) and not isinstance(factor, bool):
+            return Quantity(self.value * factor, self.unit)
+        if isinstance(factor, (bool, float)):
+            return Quantity(self.value * _coerce(factor, "factor"), self.unit)
+        return NotImplemented
 
     __rmul__ = __mul__
 

--- a/apps/backend/src/quantity/quantity.py
+++ b/apps/backend/src/quantity/quantity.py
@@ -72,12 +72,11 @@ class Quantity:
         return Quantity(abs(self.value), self.unit)
 
     def __mul__(self, factor: _QuantityInput) -> Quantity:
-        # Scale by a dimensionless Decimal/int factor. float/bool stay a hard red
-        # line (raise); any other type yields NotImplemented so a reflected
-        # operand can handle it — e.g. quantity * UnitPrice -> Money.
-        if isinstance(factor, (Decimal, int)) and not isinstance(factor, bool):
-            return Quantity(self.value * factor, self.unit)
-        if isinstance(factor, (bool, float)):
+        # Scale by a dimensionless factor, routed through _coerce so the value-type
+        # invariants hold (finiteness check; float/bool stay a hard red line).
+        # Any other operand type yields NotImplemented so a reflected op can handle
+        # it — e.g. quantity * UnitPrice -> Money.
+        if isinstance(factor, (Decimal, int, float)):  # bool is an int subclass
             return Quantity(self.value * _coerce(factor, "factor"), self.unit)
         return NotImplemented
 

--- a/apps/backend/src/services/investment_accounting.py
+++ b/apps/backend/src/services/investment_accounting.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import date
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 from uuid import UUID
 
 from sqlalchemy import select
@@ -18,12 +18,12 @@ from src.models.portfolio import (
     InvestmentTransaction,
     InvestmentTransactionType,
 )
-from src.money import to_money
+from src.money import Money, to_money
 from src.quantity import Quantity
 from src.services.accounting import create_journal_entry, post_journal_entry
+from src.unit_price import UnitPrice
 
 INVESTMENT_QUANTITY_UNIT = "units"
-UNIT_RATE_QUANTUM = Decimal("0.000001")
 
 
 class InvestmentAccountingError(Exception):
@@ -41,10 +41,6 @@ class InvestmentAccountingResult:
     transaction: InvestmentTransaction
     journal_entry: JournalEntry
     position: ManagedPosition
-
-
-def _quantized_unit_rate(value: Decimal) -> Decimal:
-    return value.quantize(UNIT_RATE_QUANTUM, rounding=ROUND_HALF_UP)
 
 
 class InvestmentAccountingService:
@@ -77,7 +73,8 @@ class InvestmentAccountingService:
 
         cash_account = await self._get_account(db, user_id, cash_account_id, AccountType.ASSET)
         investment_account = await self._get_account(db, user_id, investment_account_id, AccountType.ASSET)
-        amount = to_money(trade_quantity.value * unit_price + fees)
+        buy_price = UnitPrice(unit_price, currency, INVESTMENT_QUANTITY_UNIT)
+        amount = (buy_price * trade_quantity + Money(fees, currency)).quantize().amount
         if amount <= Decimal("0"):
             raise InvestmentAccountingValidationError("buy amount must be positive")
 
@@ -130,7 +127,7 @@ class InvestmentAccountingService:
             transaction_type=InvestmentTransactionType.BUY,
             asset_identifier=asset_identifier,
             quantity=trade_quantity.value,
-            unit_price=_quantized_unit_rate(unit_price),
+            unit_price=buy_price.quantize().rate,
             gross_amount=amount,
             fees=to_money(fees),
             currency=currency,
@@ -149,7 +146,7 @@ class InvestmentAccountingService:
             acquisition_date=transaction_date,
             original_quantity=trade_quantity.value,
             remaining_quantity=trade_quantity.value,
-            unit_cost=_quantized_unit_rate(amount / trade_quantity.value),
+            unit_cost=UnitPrice.from_total(Money(amount, currency), trade_quantity).quantize().rate,
             currency=currency,
         )
         db.add(lot)
@@ -201,7 +198,8 @@ class InvestmentAccountingService:
             asset_identifier=asset_identifier,
         )
 
-        proceeds = to_money(trade_quantity.value * unit_price - fees)
+        sell_price = UnitPrice(unit_price, currency, INVESTMENT_QUANTITY_UNIT)
+        proceeds = (sell_price * trade_quantity - Money(fees, currency)).quantize().amount
         if proceeds <= Decimal("0"):
             raise InvestmentAccountingValidationError("sell proceeds must be positive")
         cost_basis = await self._consume_lots(
@@ -288,7 +286,7 @@ class InvestmentAccountingService:
             transaction_type=InvestmentTransactionType.SELL,
             asset_identifier=asset_identifier,
             quantity=trade_quantity.value,
-            unit_price=_quantized_unit_rate(unit_price),
+            unit_price=sell_price.quantize().rate,
             gross_amount=proceeds,
             fees=to_money(fees),
             currency=currency,
@@ -514,18 +512,19 @@ class InvestmentAccountingService:
             )
 
         if method == CostBasisMethod.AVGCOST:
-            avg_unit_cost = _quantized_unit_rate(
-                sum(
-                    (lot_quantity.value * lot.unit_cost for lot, lot_quantity in lot_quantities),
-                    Decimal("0.00"),
-                )
-                / total_available.value
+            total_cost = sum(
+                (
+                    UnitPrice(lot.unit_cost, position.currency, INVESTMENT_QUANTITY_UNIT) * lot_quantity
+                    for lot, lot_quantity in lot_quantities
+                ),
+                Money.zero(position.currency),
             )
+            avg_unit_cost = UnitPrice.from_total(total_cost, total_available).quantize().rate
             for lot in lots:
                 lot.unit_cost = avg_unit_cost
 
         remaining_to_sell = quantity
-        cost_basis = Decimal("0.00")
+        cost_basis = Money.zero(position.currency)
         for lot, lot_quantity in lot_quantities:
             if remaining_to_sell.is_zero():
                 break
@@ -533,7 +532,7 @@ class InvestmentAccountingService:
                 lot_quantity,
                 remaining_to_sell,
             )
-            cost_basis += consumed_quantity.value * lot.unit_cost
+            cost_basis += UnitPrice(lot.unit_cost, position.currency, INVESTMENT_QUANTITY_UNIT) * consumed_quantity
             lot_remaining = (lot_quantity - consumed_quantity).quantize()
             lot.remaining_quantity = lot_remaining.value
             if lot_remaining.is_zero():
@@ -541,7 +540,7 @@ class InvestmentAccountingService:
             remaining_to_sell = (remaining_to_sell - consumed_quantity).quantize()
 
         await db.flush()
-        return to_money(cost_basis)
+        return cost_basis.quantize().amount
 
     async def _open_lots(
         self,

--- a/apps/backend/src/services/market_data.py
+++ b/apps/backend/src/services/market_data.py
@@ -26,12 +26,14 @@ from src.models.journal import JournalEntry, JournalLine
 from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition, PositionStatus
 from src.quantity import Quantity
+from src.unit_price import UNIT_PRICE_QUANTUM
 
 logger = get_logger(__name__)
 
 MARKET_DATA_QUANTITY_UNIT = "units"
 _RATE_QUANT = Decimal("0.000001")
-_PRICE_QUANT = Decimal("0.000001")
+# Security prices share the canonical unit-price quantum (6 dp, ROUND_HALF_UP).
+_PRICE_QUANT = UNIT_PRICE_QUANTUM
 _DEFAULT_INCREMENTAL_LOOKBACK_DAYS = 7
 _PROVIDER_DISAGREEMENT_THRESHOLD = Decimal("0.02")
 _FRESHNESS_THRESHOLD = timedelta(hours=24)

--- a/apps/backend/src/unit_price/__init__.py
+++ b/apps/backend/src/unit_price/__init__.py
@@ -1,0 +1,41 @@
+"""``src.unit_price`` — shipped backend unit-price (money-per-quantity) narrow waist."""
+
+from __future__ import annotations
+
+from src.unit_price.errors import (
+    CurrencyMismatchError,
+    FloatNotAllowedError,
+    InvalidUnitPricePayloadError,
+    UndefinedUnitPriceError,
+    UnitMismatchError,
+    UnitPriceError,
+)
+from src.unit_price.unit_price import (
+    UNIT_PRICE_DP,
+    UNIT_PRICE_QUANTUM,
+    UNIT_PRICE_ROUNDING,
+    UnitPrice,
+)
+from src.unit_price.wire import (
+    unit_price_from_db_fields,
+    unit_price_from_wire,
+    unit_price_to_db_fields,
+    unit_price_to_wire,
+)
+
+__all__ = [
+    "UNIT_PRICE_DP",
+    "UNIT_PRICE_QUANTUM",
+    "UNIT_PRICE_ROUNDING",
+    "CurrencyMismatchError",
+    "FloatNotAllowedError",
+    "InvalidUnitPricePayloadError",
+    "UndefinedUnitPriceError",
+    "UnitMismatchError",
+    "UnitPrice",
+    "UnitPriceError",
+    "unit_price_from_db_fields",
+    "unit_price_from_wire",
+    "unit_price_to_db_fields",
+    "unit_price_to_wire",
+]

--- a/apps/backend/src/unit_price/errors.py
+++ b/apps/backend/src/unit_price/errors.py
@@ -1,0 +1,27 @@
+"""Typed errors for the unit-price value type (mirrors common/unit_price/errors.py)."""
+
+from __future__ import annotations
+
+
+class UnitPriceError(Exception):
+    """Base class for every unit-price-domain error."""
+
+
+class FloatNotAllowedError(UnitPriceError, TypeError):
+    """A ``float``/``bool`` was supplied where an exact ``Decimal`` is required."""
+
+
+class CurrencyMismatchError(UnitPriceError, ValueError):
+    """An operation combined unit prices in different currencies."""
+
+
+class UnitMismatchError(UnitPriceError, ValueError):
+    """A unit price was applied to a quantity in a different unit."""
+
+
+class UndefinedUnitPriceError(UnitPriceError, ZeroDivisionError):
+    """A unit price was derived from a zero quantity (``total / 0`` is undefined)."""
+
+
+class InvalidUnitPricePayloadError(UnitPriceError, ValueError):
+    """A serialized unit-price payload is missing or malformed."""

--- a/apps/backend/src/unit_price/unit_price.py
+++ b/apps/backend/src/unit_price/unit_price.py
@@ -1,0 +1,127 @@
+"""``UnitPrice`` — money-per-quantity composite value type (mirrors common/unit_price).
+
+Backend runtime copy: identical semantics to ``common/unit_price/unit_price.py``,
+importing the shipped ``src.money`` / ``src.quantity`` types. The conformance
+suite proves the two stay identical (``common/`` is not shipped into the image).
+See ``docs/ssot/base-packages.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+
+from src.money.currency import Currency
+from src.money.money import Money
+from src.quantity.quantity import Quantity
+from src.quantity.unit import Unit
+from src.unit_price.errors import (
+    CurrencyMismatchError,
+    FloatNotAllowedError,
+    UndefinedUnitPriceError,
+    UnitMismatchError,
+)
+
+# Price/unit-rate quantum: 6 dp, ROUND_HALF_UP. Deliberately NOT the 2-dp money
+# quantum — prices and unit costs carry sub-cent precision.
+UNIT_PRICE_DP: int = 6
+UNIT_PRICE_QUANTUM = Decimal("0.000001")
+UNIT_PRICE_ROUNDING: str = ROUND_HALF_UP
+
+_RateInput = Decimal | int
+
+
+def _coerce_rate(value: object) -> Decimal:
+    if isinstance(value, bool):
+        raise FloatNotAllowedError("bool is not a valid unit-price rate")
+    if isinstance(value, float):
+        raise FloatNotAllowedError("float is not allowed for unit-price rates (IEEE-754 precision loss); use Decimal")
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise FloatNotAllowedError("unit-price rate must be finite")
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    raise FloatNotAllowedError(f"unit-price rate must be Decimal or int, got {type(value).__name__}")
+
+
+@dataclass(frozen=True)
+class UnitPrice:
+    """An immutable money-per-unit rate (a price/unit cost)."""
+
+    rate: Decimal
+    currency: Currency
+    unit: Unit
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "rate", _coerce_rate(self.rate))
+        object.__setattr__(self, "currency", Currency.of(self.currency))
+        object.__setattr__(self, "unit", Unit.of(self.unit))
+
+    @classmethod
+    def zero(cls, currency: Currency | str, unit: Unit | str) -> UnitPrice:
+        return cls(Decimal("0"), currency, unit)
+
+    @classmethod
+    def from_total(cls, total: Money, quantity: Quantity) -> UnitPrice:
+        if not isinstance(total, Money):
+            raise TypeError(f"UnitPrice.from_total expects Money total, got {type(total).__name__}")
+        if not isinstance(quantity, Quantity):
+            raise TypeError(f"UnitPrice.from_total expects Quantity, got {type(quantity).__name__}")
+        if quantity.value.is_zero():
+            raise UndefinedUnitPriceError("cannot derive a unit price from zero quantity")
+        return cls(total.amount / quantity.value, total.currency, quantity.unit)
+
+    def is_zero(self) -> bool:
+        return self.rate.is_zero()
+
+    def quantize(self, rounding: str = UNIT_PRICE_ROUNDING) -> UnitPrice:
+        return UnitPrice(
+            self.rate.quantize(UNIT_PRICE_QUANTUM, rounding=rounding),
+            self.currency,
+            self.unit,
+        )
+
+    def __mul__(self, quantity: Quantity) -> Money:
+        if not isinstance(quantity, Quantity):
+            raise TypeError(f"UnitPrice can only be multiplied by a Quantity, got {type(quantity).__name__}")
+        if self.unit != quantity.unit:
+            raise UnitMismatchError(f"cannot price a {quantity.unit.code} quantity with a {self.unit.code} unit price")
+        return Money(self.rate * quantity.value, self.currency)
+
+    __rmul__ = __mul__
+
+    def __neg__(self) -> UnitPrice:
+        return UnitPrice(-self.rate, self.currency, self.unit)
+
+    def __abs__(self) -> UnitPrice:
+        return UnitPrice(abs(self.rate), self.currency, self.unit)
+
+    def _require_same_kind(self, other: UnitPrice, op: str) -> None:
+        if not isinstance(other, UnitPrice):
+            raise TypeError(f"cannot {op} UnitPrice and {type(other).__name__}")
+        if self.currency != other.currency:
+            raise CurrencyMismatchError(
+                f"cannot {op} across currencies: {self.currency.code} and {other.currency.code}"
+            )
+        if self.unit != other.unit:
+            raise UnitMismatchError(f"cannot {op} across units: {self.unit.code} and {other.unit.code}")
+
+    def __lt__(self, other: UnitPrice) -> bool:
+        self._require_same_kind(other, "compare")
+        return self.rate < other.rate
+
+    def __le__(self, other: UnitPrice) -> bool:
+        self._require_same_kind(other, "compare")
+        return self.rate <= other.rate
+
+    def __gt__(self, other: UnitPrice) -> bool:
+        self._require_same_kind(other, "compare")
+        return self.rate > other.rate
+
+    def __ge__(self, other: UnitPrice) -> bool:
+        self._require_same_kind(other, "compare")
+        return self.rate >= other.rate
+
+    def __str__(self) -> str:
+        return f"{self.rate} {self.currency.code}/{self.unit.code}"

--- a/apps/backend/src/unit_price/wire.py
+++ b/apps/backend/src/unit_price/wire.py
@@ -1,0 +1,83 @@
+"""Boundary codecs for unit-price values (mirrors common/unit_price/wire.py)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal, InvalidOperation
+
+from src.unit_price.errors import FloatNotAllowedError, InvalidUnitPricePayloadError
+from src.unit_price.unit_price import UnitPrice
+
+UnitPriceWire = dict[str, str]
+UnitPriceDbFields = dict[str, Decimal | str]
+
+
+def _decimal_to_wire(value: Decimal) -> str:
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    if text in {"", "-0"}:
+        return "0"
+    return text
+
+
+def _decimal_from_wire(value: object, what: str = "unit-price rate") -> Decimal:
+    if isinstance(value, bool):
+        raise FloatNotAllowedError(f"bool is not a valid {what}")
+    if isinstance(value, float):
+        raise FloatNotAllowedError(f"float is not allowed for {what}; use a decimal string")
+    if not isinstance(value, str):
+        raise FloatNotAllowedError(f"{what} must be encoded as a decimal string, got {type(value).__name__}")
+    try:
+        parsed = Decimal(value)
+    except (InvalidOperation, ValueError) as exc:
+        raise InvalidUnitPricePayloadError(f"{what} is not a valid decimal string") from exc
+    if not parsed.is_finite():
+        raise FloatNotAllowedError(f"{what} must be finite")
+    return parsed
+
+
+def _payload_mapping(payload: object) -> Mapping[str, object]:
+    if not isinstance(payload, Mapping):
+        raise InvalidUnitPricePayloadError(f"UnitPrice payload must be an object, got {type(payload).__name__}")
+    return payload
+
+
+def _field(payload: Mapping[str, object], key: str) -> object:
+    try:
+        return payload[key]
+    except KeyError as exc:
+        raise InvalidUnitPricePayloadError(f"UnitPrice payload missing {key!r}") from exc
+
+
+def unit_price_to_wire(unit_price: UnitPrice) -> UnitPriceWire:
+    if not isinstance(unit_price, UnitPrice):
+        raise TypeError(f"unit_price_to_wire expects UnitPrice, got {type(unit_price).__name__}")
+    return {
+        "rate": _decimal_to_wire(unit_price.rate),
+        "currency": unit_price.currency.code,
+        "unit": unit_price.unit.code,
+    }
+
+
+def unit_price_from_wire(payload: object) -> UnitPrice:
+    fields = _payload_mapping(payload)
+    return UnitPrice(
+        _decimal_from_wire(_field(fields, "rate")),
+        _field(fields, "currency"),  # type: ignore[arg-type]
+        _field(fields, "unit"),  # type: ignore[arg-type]
+    )
+
+
+def unit_price_to_db_fields(unit_price: UnitPrice) -> UnitPriceDbFields:
+    if not isinstance(unit_price, UnitPrice):
+        raise TypeError(f"unit_price_to_db_fields expects UnitPrice, got {type(unit_price).__name__}")
+    return {
+        "rate": unit_price.rate,
+        "currency": unit_price.currency.code,
+        "unit": unit_price.unit.code,
+    }
+
+
+def unit_price_from_db_fields(rate: object, currency: object, unit: object) -> UnitPrice:
+    return UnitPrice(rate, currency, unit)  # type: ignore[arg-type]

--- a/apps/backend/tests/accounting/test_unit_price_backend.py
+++ b/apps/backend/tests/accounting/test_unit_price_backend.py
@@ -1,0 +1,61 @@
+"""Backend unit-price module conformance (EPIC-012 AC12.32)."""
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.money import Money
+from src.quantity import Quantity
+from src.unit_price import (
+    UNIT_PRICE_DP,
+    UNIT_PRICE_QUANTUM,
+    UNIT_PRICE_ROUNDING,
+    FloatNotAllowedError,
+    UndefinedUnitPriceError,
+    UnitMismatchError,
+    UnitPrice,
+)
+
+pytestmark = pytest.mark.no_db
+
+_VECTORS = json.loads((Path(__file__).resolve().parents[4] / "common/unit_price/conformance/vectors.json").read_text())
+
+
+@ac_proof(proof_id="test_unit_price_backend_value_type", ac_ids=["AC12.32.1"], ci_tier="pr_ci")
+def test_AC12_32_1_backend_unit_price_value_type_laws():
+    """AC12.32.1: src.unit_price rejects float, uses the 6-dp policy, guards units."""
+    assert UNIT_PRICE_DP == 6
+    assert UNIT_PRICE_QUANTUM == Decimal("0.000001")
+    assert UNIT_PRICE_ROUNDING == "ROUND_HALF_UP"
+    with pytest.raises(FloatNotAllowedError):
+        UnitPrice(0.1, "USD", "shares")
+    with pytest.raises(FloatNotAllowedError):
+        UnitPrice(True, "USD", "shares")
+    price = UnitPrice(Decimal("10.50"), "SGD", "shares")
+    assert price * Quantity(Decimal("3"), "shares") == Money(Decimal("31.50"), "SGD")
+    with pytest.raises(UnitMismatchError):
+        price * Quantity(Decimal("1"), "contracts")
+    with pytest.raises(UndefinedUnitPriceError):
+        UnitPrice.from_total(Money(Decimal("1.00"), "USD"), Quantity(Decimal("0"), "shares"))
+
+
+@ac_proof(proof_id="test_unit_price_backend_matches_vectors", ac_ids=["AC12.32.2"], ci_tier="pr_ci")
+def test_AC12_32_2_backend_unit_price_matches_standard():
+    """AC12.32.2: the shipped backend reproduces the shared conformance vectors."""
+    for case in _VECTORS["quantize"]:
+        got = UnitPrice(Decimal(case["rate"]), case["currency"], case["unit"]).quantize()
+        assert got.rate == Decimal(case["expected"]), case
+    for case in _VECTORS["product"]:
+        money = UnitPrice(Decimal(case["rate"]), case["currency"], case["unit"]) * Quantity(
+            Decimal(case["quantity"]), case["unit"]
+        )
+        assert money == Money(Decimal(case["expected_amount"]), case["currency"]), case
+    for case in _VECTORS["from_total"]:
+        derived = UnitPrice.from_total(
+            Money(Decimal(case["amount"]), case["currency"]),
+            Quantity(Decimal(case["quantity"]), case["unit"]),
+        )
+        assert derived.quantize().rate == Decimal(case["expected_rate_6dp"]), case

--- a/common/quantity/quantity.py
+++ b/common/quantity/quantity.py
@@ -80,7 +80,14 @@ class Quantity:
         return Quantity(abs(self.value), self.unit)
 
     def __mul__(self, factor: _QuantityInput) -> Quantity:
-        return Quantity(self.value * _coerce(factor, "factor"), self.unit)
+        # Scale by a dimensionless Decimal/int factor. float/bool stay a hard red
+        # line (raise); any other type yields NotImplemented so a reflected
+        # operand can handle it — e.g. quantity * UnitPrice -> Money.
+        if isinstance(factor, (Decimal, int)) and not isinstance(factor, bool):
+            return Quantity(self.value * factor, self.unit)
+        if isinstance(factor, (bool, float)):
+            return Quantity(self.value * _coerce(factor, "factor"), self.unit)
+        return NotImplemented
 
     __rmul__ = __mul__
 

--- a/common/quantity/quantity.py
+++ b/common/quantity/quantity.py
@@ -80,12 +80,11 @@ class Quantity:
         return Quantity(abs(self.value), self.unit)
 
     def __mul__(self, factor: _QuantityInput) -> Quantity:
-        # Scale by a dimensionless Decimal/int factor. float/bool stay a hard red
-        # line (raise); any other type yields NotImplemented so a reflected
-        # operand can handle it — e.g. quantity * UnitPrice -> Money.
-        if isinstance(factor, (Decimal, int)) and not isinstance(factor, bool):
-            return Quantity(self.value * factor, self.unit)
-        if isinstance(factor, (bool, float)):
+        # Scale by a dimensionless factor, routed through _coerce so the value-type
+        # invariants hold (finiteness check; float/bool stay a hard red line).
+        # Any other operand type yields NotImplemented so a reflected op can handle
+        # it — e.g. quantity * UnitPrice -> Money.
+        if isinstance(factor, (Decimal, int, float)):  # bool is an int subclass
             return Quantity(self.value * _coerce(factor, "factor"), self.unit)
         return NotImplemented
 

--- a/common/unit_price/__init__.py
+++ b/common/unit_price/__init__.py
@@ -1,0 +1,41 @@
+"""``common.unit_price`` — the project's unit-price (money-per-quantity) narrow waist."""
+
+from __future__ import annotations
+
+from common.unit_price.errors import (
+    CurrencyMismatchError,
+    FloatNotAllowedError,
+    InvalidUnitPricePayloadError,
+    UndefinedUnitPriceError,
+    UnitMismatchError,
+    UnitPriceError,
+)
+from common.unit_price.unit_price import (
+    UNIT_PRICE_DP,
+    UNIT_PRICE_QUANTUM,
+    UNIT_PRICE_ROUNDING,
+    UnitPrice,
+)
+from common.unit_price.wire import (
+    unit_price_from_db_fields,
+    unit_price_from_wire,
+    unit_price_to_db_fields,
+    unit_price_to_wire,
+)
+
+__all__ = [
+    "UNIT_PRICE_DP",
+    "UNIT_PRICE_QUANTUM",
+    "UNIT_PRICE_ROUNDING",
+    "CurrencyMismatchError",
+    "FloatNotAllowedError",
+    "InvalidUnitPricePayloadError",
+    "UndefinedUnitPriceError",
+    "UnitMismatchError",
+    "UnitPrice",
+    "UnitPriceError",
+    "unit_price_from_db_fields",
+    "unit_price_from_wire",
+    "unit_price_to_db_fields",
+    "unit_price_to_wire",
+]

--- a/common/unit_price/conformance/README.md
+++ b/common/unit_price/conformance/README.md
@@ -1,0 +1,31 @@
+# Unit-price conformance vectors — the cross-language unit-price standard
+
+`vectors.json` is the **single source of truth** for unit-price behaviour across
+every end (EPIC-012 AC12.32). It is language-neutral data, consumed at **test
+time only**.
+
+## The Rule
+
+Every unit-price implementation loads `vectors.json` and must reproduce every
+expected value:
+
+| Stack | Implementation | Conformance test |
+|-------|----------------|------------------|
+| Python reference | `common/unit_price` | `tests/tooling/test_unit_price_conformance.py` |
+| Backend runtime | `apps/backend/src/unit_price` | `apps/backend/tests/accounting/test_unit_price_backend.py` |
+| Frontend | _(P2 follow-up — display helpers, see #1253)_ | _(pending)_ |
+
+The canonical unit-price policy is **6 dp, ROUND_HALF_UP** (the price/unit-rate
+quantum, deliberately **not** the 2-dp money quantum). A unit price carries both
+a `Currency` and a `Unit`; applying it to a quantity yields `Money` only when the
+units agree.
+
+## Vector Groups
+
+- **`quantize`** — `UnitPrice(rate, currency, unit).quantize()` expected rates.
+- **`product`** — `unit_price * quantity` expected (exact, unquantized) money
+  amounts.
+- **`from_total`** — `UnitPrice.from_total(money, quantity).quantize()` expected
+  6-dp rates (`Money / Quantity`).
+- **`from_total_undefined`** — zero-quantity totals that must raise.
+- **`unit_mismatch`** — quantity/price unit mismatches that must raise.

--- a/common/unit_price/conformance/__init__.py
+++ b/common/unit_price/conformance/__init__.py
@@ -1,0 +1,13 @@
+"""Loader for the shared unit-price conformance vectors."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_vectors() -> dict[str, Any]:
+    return json.loads(
+        (Path(__file__).with_name("vectors.json")).read_text(encoding="utf-8")
+    )

--- a/common/unit_price/conformance/vectors.json
+++ b/common/unit_price/conformance/vectors.json
@@ -1,0 +1,44 @@
+{
+  "_comment": "Language-neutral unit-price standard (EPIC-012 AC12.32). The Python reference impl (common/unit_price), backend runtime (src.unit_price), and any future TypeScript frontend (apps/frontend/src/lib/unit_price) load THIS file and must reproduce every expected value. Values are decimal STRINGS, never JSON floats. A unit price is money-per-quantity: it carries a currency and a unit. Rate quantum is 6 dp ROUND_HALF_UP (the price/unit-rate quantum, NOT the 2-dp money quantum).",
+  "unit_price_quantum": "0.000001",
+  "unit_price_dp": 6,
+  "default_rounding": "ROUND_HALF_UP",
+  "shared_api": [
+    "UnitPrice",
+    "UNIT_PRICE_QUANTUM",
+    "UNIT_PRICE_DP",
+    "UNIT_PRICE_ROUNDING",
+    "UnitPriceError",
+    "FloatNotAllowedError",
+    "CurrencyMismatchError",
+    "UnitMismatchError",
+    "UndefinedUnitPriceError",
+    "InvalidUnitPricePayloadError",
+    "unit_price_to_wire",
+    "unit_price_from_wire"
+  ],
+  "quantize": [
+    {"rate": "10.5", "currency": "SGD", "unit": "shares", "expected": "10.500000"},
+    {"rate": "1.2345674", "currency": "USD", "unit": "shares", "expected": "1.234567"},
+    {"rate": "1.2345675", "currency": "USD", "unit": "shares", "expected": "1.234568"},
+    {"rate": "-1.2345675", "currency": "USD", "unit": "shares", "expected": "-1.234568"},
+    {"rate": "0.0000004", "currency": "USD", "unit": "shares", "expected": "0.000000"},
+    {"rate": "0.0000005", "currency": "USD", "unit": "shares", "expected": "0.000001"}
+  ],
+  "product": [
+    {"rate": "10.50", "currency": "SGD", "unit": "shares", "quantity": "3", "expected_amount": "31.50"},
+    {"rate": "1.1", "currency": "USD", "unit": "shares", "quantity": "3", "expected_amount": "3.3"},
+    {"rate": "2.5", "currency": "USD", "unit": "units", "quantity": "0", "expected_amount": "0"}
+  ],
+  "from_total": [
+    {"amount": "100.00", "currency": "SGD", "quantity": "4", "unit": "shares", "expected_rate_6dp": "25.000000"},
+    {"amount": "100.00", "currency": "USD", "quantity": "3", "unit": "shares", "expected_rate_6dp": "33.333333"},
+    {"amount": "10.00", "currency": "USD", "quantity": "7", "unit": "units", "expected_rate_6dp": "1.428571"}
+  ],
+  "from_total_undefined": [
+    {"amount": "10.00", "currency": "USD", "quantity": "0", "unit": "shares"}
+  ],
+  "unit_mismatch": [
+    {"rate": "5", "currency": "USD", "unit": "shares", "quantity": "2", "quantity_unit": "contracts"}
+  ]
+}

--- a/common/unit_price/contract/unit_price.contract.md
+++ b/common/unit_price/contract/unit_price.contract.md
@@ -1,0 +1,55 @@
+# UnitPrice module contract (language-neutral interface)
+
+> The **interface** half of the unit-price module's SSOT; the conformance half
+> is [`../conformance/vectors.json`](../conformance/vectors.json). Authoritative
+> prose: [`docs/ssot/base-packages.md`](../../../docs/ssot/base-packages.md).
+
+## Types
+
+- **`UnitPrice`** — an immutable `(rate, currency, unit)` triple: *money per one
+  unit of a quantity* (share price, unit cost, per-contract rate).
+  - `rate` is Decimal-backed. **`float`/`bool` are rejected** at construction.
+  - `currency` is a `Currency` (from `money`); `unit` is a `Unit` (from
+    `quantity`). Both are normalized at construction.
+  - The exact rate is stored; rounding happens only via `quantize()`.
+
+## Operations & Laws
+
+| Operation | Law |
+|-----------|-----|
+| construct `UnitPrice(rate, currency, unit)` | rejects float/bool; normalizes currency + unit; immutable |
+| `zero(currency, unit)` / `is_zero()` | typed zero construction and predicate |
+| `quantize(rounding)` | **6 dp; default `ROUND_HALF_UP`** — the price/unit-rate quantum, NOT the 2-dp money quantum |
+| `unit_price * quantity` → `Money` | extends a quantity at this price; **unit must match** (else typed error); amount is exact/unquantized — quantize at the money boundary. Written price-first: `Quantity` rejects non-scalar right-multiplication to protect the float red line |
+| `from_total(money, quantity)` → `UnitPrice` | `Money / Quantity`; keeps the money's currency and the quantity's unit; **zero quantity is undefined** (raises) |
+| `neg` / `abs` | keeps currency + unit |
+| `compare` | **same currency AND same unit only**; otherwise typed error |
+| `unit_price_to_wire` / `unit_price_from_wire` | JSON boundary; rate is a decimal string, currency/unit are string codes; JSON numbers rejected |
+| `unit_price_to_db_fields` / `unit_price_from_db_fields` | DB boundary for Python/backend code; rate is an exact `Decimal`, currency/unit are strings |
+
+## Invariants
+
+1. **No float** in unit-price paths.
+2. **Unit-price quantization is 6 dp / `ROUND_HALF_UP`** unless an explicit mode
+   is passed — distinct from the 2-dp money quantum.
+3. **A unit price applies to a quantity only when units agree**, and the product
+   is `Money` in the price's currency, never a naked `Decimal`.
+4. **No cross-currency / cross-unit comparison** of unit prices.
+5. **Boundary codecs are package-owned.** Wire payloads use decimal strings
+   (never JSON numbers); DB adapters expose exact `Decimal` rates only at the
+   storage edge. Malformed payloads raise typed unit-price errors.
+
+## Shared API Surface
+
+`vectors.json["shared_api"]` is exported by `apps/backend/src/unit_price`
+(`__all__`), enforced by `tests/tooling/test_unit_price_api_parity.py`:
+
+`UnitPrice`, `UNIT_PRICE_QUANTUM`, `UNIT_PRICE_DP`, `UNIT_PRICE_ROUNDING`,
+`UnitPriceError`, `FloatNotAllowedError`, `CurrencyMismatchError`,
+`UnitMismatchError`, `UndefinedUnitPriceError`, `InvalidUnitPricePayloadError`,
+`unit_price_to_wire`, `unit_price_from_wire`.
+
+A TypeScript frontend implementation is a **P2 follow-up** (#1253): there are no
+frontend unit-price call sites today, and frontend display helpers (nullable /
+signed price display) are explicitly P2 in the issue. The conformance vectors are
+already language-neutral so frontend adoption is purely additive.

--- a/common/unit_price/errors.py
+++ b/common/unit_price/errors.py
@@ -1,0 +1,35 @@
+"""Typed errors for the unit-price value type (mirrors the money/quantity hierarchy).
+
+A single narrow hierarchy so call-sites can catch ``UnitPriceError`` for any
+unit-price-domain violation, or the specific subtype.
+"""
+
+from __future__ import annotations
+
+
+class UnitPriceError(Exception):
+    """Base class for every unit-price-domain error."""
+
+
+class FloatNotAllowedError(UnitPriceError, TypeError):
+    """A ``float``/``bool`` was supplied where an exact ``Decimal`` is required.
+
+    ``float`` is the standing numeric red line (IEEE-754 precision loss); the
+    value type rejects it at construction rather than relying on review.
+    """
+
+
+class CurrencyMismatchError(UnitPriceError, ValueError):
+    """An operation combined unit prices in different currencies."""
+
+
+class UnitMismatchError(UnitPriceError, ValueError):
+    """A unit price was applied to a quantity in a different unit."""
+
+
+class UndefinedUnitPriceError(UnitPriceError, ZeroDivisionError):
+    """A unit price was derived from a zero quantity (``total / 0`` is undefined)."""
+
+
+class InvalidUnitPricePayloadError(UnitPriceError, ValueError):
+    """A serialized unit-price payload is missing or malformed."""

--- a/common/unit_price/unit_price.py
+++ b/common/unit_price/unit_price.py
@@ -1,0 +1,185 @@
+"""``UnitPrice`` — the authoritative money-per-quantity composite value type.
+
+A unit price is *money per one unit of a quantity* (a share price, a unit cost,
+a per-contract rate). It is the composite that kept reappearing as raw
+``Decimal`` glue at portfolio/market-data call sites — ``quantity.value * price``
+to get an amount, ``amount / quantity.value`` to get a rate, plus a local 6-dp
+``quantize`` helper duplicated per service. ``UnitPrice`` owns that semantics so
+the glue and the duplicated quantum disappear.
+
+Design (mirrors :class:`common.money.Money` / :class:`common.quantity.Quantity`):
+
+- construction rejects ``float``/``bool`` (the standing monetary red line);
+- a unit price carries **both** a :class:`~common.money.currency.Currency` and a
+  :class:`~common.quantity.unit.Unit`, so applying it to a quantity yields
+  :class:`~common.money.money.Money` in the right currency only when the units
+  agree;
+- the exact rate is stored; rounding happens only via :meth:`quantize` (6 dp,
+  ``ROUND_HALF_UP`` — the price/unit-rate quantum, not the 2-dp money quantum).
+
+Algebra:
+
+- ``unit_price * quantity -> Money`` (the product of a quantity and its unit
+  price); written price-first because :class:`Quantity` deliberately rejects
+  non-scalar right-multiplication to protect the float red line.
+- ``UnitPrice.from_total(money, quantity) -> UnitPrice`` (``Money / Quantity``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+
+from common.money.currency import Currency
+from common.money.money import Money
+from common.quantity.quantity import Quantity
+from common.quantity.unit import Unit
+from common.unit_price.errors import (
+    CurrencyMismatchError,
+    FloatNotAllowedError,
+    UndefinedUnitPriceError,
+    UnitMismatchError,
+)
+
+# Price/unit-rate quantum: 6 dp, ROUND_HALF_UP. Deliberately NOT the 2-dp money
+# quantum — prices and unit costs carry sub-cent precision (see the rounding
+# carve-out in common/money/rounding.py and docs/ssot/base-packages.md).
+UNIT_PRICE_DP: int = 6
+UNIT_PRICE_QUANTUM = Decimal("0.000001")
+UNIT_PRICE_ROUNDING: str = ROUND_HALF_UP
+
+_RateInput = Decimal | int
+
+
+def _coerce_rate(value: object) -> Decimal:
+    if isinstance(value, bool):
+        raise FloatNotAllowedError("bool is not a valid unit-price rate")
+    if isinstance(value, float):
+        raise FloatNotAllowedError(
+            "float is not allowed for unit-price rates (IEEE-754 precision loss); "
+            "use Decimal"
+        )
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise FloatNotAllowedError("unit-price rate must be finite")
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    raise FloatNotAllowedError(
+        f"unit-price rate must be Decimal or int, got {type(value).__name__}"
+    )
+
+
+@dataclass(frozen=True)
+class UnitPrice:
+    """An immutable money-per-unit rate (a price/unit cost).
+
+    >>> UnitPrice(Decimal("10.50"), "SGD", "shares") * Quantity(Decimal("3"), "shares")
+    Money(amount=Decimal('31.50'), currency=Currency(code='SGD'))
+    """
+
+    rate: Decimal
+    currency: Currency
+    unit: Unit
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "rate", _coerce_rate(self.rate))
+        object.__setattr__(self, "currency", Currency.of(self.currency))
+        object.__setattr__(self, "unit", Unit.of(self.unit))
+
+    # ── construction helpers ────────────────────────────────────────────
+    @classmethod
+    def zero(cls, currency: Currency | str, unit: Unit | str) -> UnitPrice:
+        return cls(Decimal("0"), currency, unit)
+
+    @classmethod
+    def from_total(cls, total: Money, quantity: Quantity) -> UnitPrice:
+        """Derive ``Money / Quantity`` — a total spread over a quantity.
+
+        The result keeps the total's currency and the quantity's unit. A zero
+        quantity is undefined and raises :class:`UndefinedUnitPriceError`.
+        """
+        if not isinstance(total, Money):
+            raise TypeError(
+                f"UnitPrice.from_total expects Money total, got {type(total).__name__}"
+            )
+        if not isinstance(quantity, Quantity):
+            raise TypeError(
+                f"UnitPrice.from_total expects Quantity, got {type(quantity).__name__}"
+            )
+        if quantity.value.is_zero():
+            raise UndefinedUnitPriceError(
+                "cannot derive a unit price from zero quantity"
+            )
+        return cls(total.amount / quantity.value, total.currency, quantity.unit)
+
+    def is_zero(self) -> bool:
+        return self.rate.is_zero()
+
+    # ── rounding ────────────────────────────────────────────────────────
+    def quantize(self, rounding: str = UNIT_PRICE_ROUNDING) -> UnitPrice:
+        return UnitPrice(
+            self.rate.quantize(UNIT_PRICE_QUANTUM, rounding=rounding),
+            self.currency,
+            self.unit,
+        )
+
+    # ── apply to a quantity → Money ─────────────────────────────────────
+    def __mul__(self, quantity: Quantity) -> Money:
+        """``unit_price * quantity`` — extend a quantity at this price into Money.
+
+        The quantity's unit must match this price's unit. The amount is exact
+        (unquantized); apply :meth:`Money.quantize` at the money boundary.
+        """
+        if not isinstance(quantity, Quantity):
+            raise TypeError(
+                "UnitPrice can only be multiplied by a Quantity, got "
+                f"{type(quantity).__name__}"
+            )
+        if self.unit != quantity.unit:
+            raise UnitMismatchError(
+                f"cannot price a {quantity.unit.code} quantity with a "
+                f"{self.unit.code} unit price"
+            )
+        return Money(self.rate * quantity.value, self.currency)
+
+    __rmul__ = __mul__
+
+    # ── same currency+unit helpers ──────────────────────────────────────
+    def __neg__(self) -> UnitPrice:
+        return UnitPrice(-self.rate, self.currency, self.unit)
+
+    def __abs__(self) -> UnitPrice:
+        return UnitPrice(abs(self.rate), self.currency, self.unit)
+
+    def _require_same_kind(self, other: UnitPrice, op: str) -> None:
+        if not isinstance(other, UnitPrice):
+            raise TypeError(f"cannot {op} UnitPrice and {type(other).__name__}")
+        if self.currency != other.currency:
+            raise CurrencyMismatchError(
+                f"cannot {op} across currencies: {self.currency.code} and "
+                f"{other.currency.code}"
+            )
+        if self.unit != other.unit:
+            raise UnitMismatchError(
+                f"cannot {op} across units: {self.unit.code} and {other.unit.code}"
+            )
+
+    def __lt__(self, other: UnitPrice) -> bool:
+        self._require_same_kind(other, "compare")
+        return self.rate < other.rate
+
+    def __le__(self, other: UnitPrice) -> bool:
+        self._require_same_kind(other, "compare")
+        return self.rate <= other.rate
+
+    def __gt__(self, other: UnitPrice) -> bool:
+        self._require_same_kind(other, "compare")
+        return self.rate > other.rate
+
+    def __ge__(self, other: UnitPrice) -> bool:
+        self._require_same_kind(other, "compare")
+        return self.rate >= other.rate
+
+    def __str__(self) -> str:
+        return f"{self.rate} {self.currency.code}/{self.unit.code}"

--- a/common/unit_price/wire.py
+++ b/common/unit_price/wire.py
@@ -1,0 +1,104 @@
+"""Boundary codecs for unit-price values.
+
+Wire payloads use decimal strings (never JSON numbers); DB adapters expose the
+exact ``Decimal`` rate at the storage edge. Currency/unit cross the boundary as
+their canonical string codes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal, InvalidOperation
+
+from common.unit_price.errors import FloatNotAllowedError, InvalidUnitPricePayloadError
+from common.unit_price.unit_price import UnitPrice
+
+UnitPriceWire = dict[str, str]
+UnitPriceDbFields = dict[str, Decimal | str]
+
+
+def _decimal_to_wire(value: Decimal) -> str:
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    if text in {"", "-0"}:
+        return "0"
+    return text
+
+
+def _decimal_from_wire(value: object, what: str = "unit-price rate") -> Decimal:
+    if isinstance(value, bool):
+        raise FloatNotAllowedError(f"bool is not a valid {what}")
+    if isinstance(value, float):
+        raise FloatNotAllowedError(
+            f"float is not allowed for {what}; use a decimal string"
+        )
+    if not isinstance(value, str):
+        raise FloatNotAllowedError(
+            f"{what} must be encoded as a decimal string, got {type(value).__name__}"
+        )
+    try:
+        parsed = Decimal(value)
+    except (InvalidOperation, ValueError) as exc:
+        raise InvalidUnitPricePayloadError(
+            f"{what} is not a valid decimal string"
+        ) from exc
+    if not parsed.is_finite():
+        raise FloatNotAllowedError(f"{what} must be finite")
+    return parsed
+
+
+def _payload_mapping(payload: object) -> Mapping[str, object]:
+    if not isinstance(payload, Mapping):
+        raise InvalidUnitPricePayloadError(
+            f"UnitPrice payload must be an object, got {type(payload).__name__}"
+        )
+    return payload
+
+
+def _field(payload: Mapping[str, object], key: str) -> object:
+    try:
+        return payload[key]
+    except KeyError as exc:
+        raise InvalidUnitPricePayloadError(
+            f"UnitPrice payload missing {key!r}"
+        ) from exc
+
+
+def unit_price_to_wire(unit_price: UnitPrice) -> UnitPriceWire:
+    if not isinstance(unit_price, UnitPrice):
+        raise TypeError(
+            f"unit_price_to_wire expects UnitPrice, got {type(unit_price).__name__}"
+        )
+    return {
+        "rate": _decimal_to_wire(unit_price.rate),
+        "currency": unit_price.currency.code,
+        "unit": unit_price.unit.code,
+    }
+
+
+def unit_price_from_wire(payload: object) -> UnitPrice:
+    fields = _payload_mapping(payload)
+    return UnitPrice(
+        _decimal_from_wire(_field(fields, "rate")),
+        _field(fields, "currency"),  # type: ignore[arg-type]
+        _field(fields, "unit"),  # type: ignore[arg-type]
+    )
+
+
+def unit_price_to_db_fields(unit_price: UnitPrice) -> UnitPriceDbFields:
+    if not isinstance(unit_price, UnitPrice):
+        raise TypeError(
+            f"unit_price_to_db_fields expects UnitPrice, got {type(unit_price).__name__}"
+        )
+    return {
+        "rate": unit_price.rate,
+        "currency": unit_price.currency.code,
+        "unit": unit_price.unit.code,
+    }
+
+
+def unit_price_from_db_fields(
+    rate: object, currency: object, unit: object
+) -> UnitPrice:
+    return UnitPrice(rate, currency, unit)  # type: ignore[arg-type]

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -490,6 +490,22 @@ explicit boundary or use the typed value package.
 | AC12.31.6 | Post-merge cleanup retires remaining base-package drift: confidence percent display calls Ratio helpers directly and SSOT FX examples use `Money`/`ExchangeRate` instead of hand-rolled Decimal conversion | `test_AC12_31_6_confidence_percent_wrapper_is_retired`, `test_AC12_31_6_ssot_fx_examples_use_money_exchange_rate` | `tests/tooling/test_base_package_migration_cleanup.py` | P1 |
 | AC12.31.7 | Backend Quantity migration cleanup keeps `Quantity` objects in service calculations, removes service-local and package-level Decimal-to-Decimal quantity facades, and permits raw `Decimal` only at DB/model/SQL boundaries | `test_AC12_31_7_backend_quantity_business_code_uses_value_type`, `test_AC12_31_7_backend_quantity_value_type_handles_storage_edges` | `tests/tooling/test_base_package_migration_cleanup.py` | P1 |
 
+### AC12.32: UnitPrice — money-per-quantity composite value type ([#1253](https://github.com/wangzitian0/finance_report/issues/1253))
+
+The composite base element after `money`/`ratio`/`quantity` (see
+[base-packages.md](../ssot/base-packages.md)): a `UnitPrice` (rate + `Currency` +
+`Unit`) that owns money-per-quantity semantics — `unit_price * quantity -> Money`,
+`UnitPrice.from_total(money, quantity)` (`Money / Quantity`), and the 6-dp
+price/unit-rate quantum — so portfolio/market-data services stop re-deriving the
+`quantity.value * price` extension, the `amount / quantity.value` rate, and a
+duplicated local `quantize` helper as raw `Decimal` glue.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC12.32.1 | `UnitPrice(rate, currency, unit)` rejects float/bool, is Decimal-backed/immutable, quantizes to 6 dp / ROUND_HALF_UP, applies to a same-unit `Quantity` to yield `Money` (unit/currency mismatch raises), and derives from `Money / Quantity` via `from_total` (zero quantity undefined → raises) | `test_AC12_32_1_unit_price_rejects_float_and_is_decimal_backed` (+ siblings) | `tests/tooling/test_unit_price_value_type.py`, `apps/backend/tests/accounting/test_unit_price_backend.py` | P1 |
+| AC12.32.2 | Cross-language conformance: the Python reference (`common/unit_price`) and shipped backend (`src.unit_price`) reproduce the same `vectors.json` (quantize / product / from_total) and export the same `shared_api` (identifier-parity guard). Frontend is a P2 follow-up | `test_AC12_32_2_unit_price_quantize_matches_standard` (+ siblings), `test_AC12_32_2_backend_exposes_shared_unit_price_api` | `tests/tooling/test_unit_price_conformance.py`, `tests/tooling/test_unit_price_api_parity.py`, `apps/backend/tests/accounting/test_unit_price_backend.py` | P1 |
+| AC12.32.3 | UnitPrice adoption: investment accounting prices buys/sells and lot/avg-cost through `UnitPrice` (removing the local `_quantized_unit_rate` helper and `UNIT_RATE_QUANTUM` literal), and market-data single-sources the price quantum from `UNIT_PRICE_QUANTUM` | `test_AC12_32_3_investment_accounting_uses_unit_price`, `test_AC12_32_3_market_data_price_quantum_is_single_sourced` | `tests/tooling/test_unit_price_adoption.py` | P1 |
+
 ---
 
 *Planning snapshot captured: January 2026*

--- a/docs/ssot/base-packages.md
+++ b/docs/ssot/base-packages.md
@@ -30,12 +30,23 @@ A domain earns a base package only if it is **all** of:
 | `money` | `Money` (amount + `Currency`), plus typed `ExchangeRate` for conversion | 2 dp, **ROUND_HALF_EVEN** (banker's); FX rates positive Decimal | ✅ shipped (#1167, EPIC-012 AC12.30) |
 | `ratio` | `Ratio` (dimensionless) | percent 2 dp, **ROUND_HALF_UP** | ✅ shipped (#1167, EPIC-012 AC12.9) |
 | `quantity` | `Quantity` (shares/units/contracts) + `Unit` | 6 dp, **ROUND_HALF_UP** | ✅ shipped (EPIC-012 AC12.30) |
+| `unit_price` | `UnitPrice` (money-per-quantity: `rate` + `Currency` + `Unit`) | 6 dp, **ROUND_HALF_UP** (price/unit-rate quantum) | ✅ shipped (#1253, EPIC-012 AC12.32) |
 
 `Currency` lives **inside** `money` (not separate). `ExchangeRate` is also
 inside `money`: it is the typed parameter for the single cross-currency
-conversion primitive, not a fourth base package. `Price` / unit price is a
-derived composite (`Money / Quantity`) and remains outside the primitive family
-until portfolio/market-data migration proves a separate package is needed.
+conversion primitive, not a fourth base package.
+
+`UnitPrice` is the **composite** member: money-per-quantity (a share price, a
+unit cost, a per-contract rate). It was deliberately deferred until
+portfolio/market-data migration proved the need — that threshold is now met (the
+same `quantity.value * price` extension, `amount / quantity.value` rate, and a
+local 6-dp `quantize` helper were duplicated across `investment_accounting`,
+`market_data`, `portfolio`, and `reporting`). `UnitPrice` owns
+`unit_price * quantity -> Money`, `UnitPrice.from_total(money, quantity)`
+(`Money / Quantity`), and the price quantum, so that glue stops reappearing. It
+depends on `money` (for `Currency`) and `quantity` (for `Unit`); applying a price
+to a quantity yields `Money` only when the units agree.
+
 Nothing else currently qualifies — see the per-domain verdicts in the #1167
 audit (date/period, confidence scoring, source-type, lineage, attention are app
 logic or presentation, not base packages).
@@ -84,6 +95,7 @@ Each base package owns the codecs that cross storage/wire boundaries:
 | `money` | `money_to_wire` / `money_from_wire`; `exchange_rate_to_wire` / `exchange_rate_from_wire` | `money_to_db_fields` / `money_from_db_fields`; `exchange_rate_to_db_fields` / `exchange_rate_from_db_fields` |
 | `ratio` | `ratio_to_wire` / `ratio_from_wire` | `ratio_to_db_value` / `ratio_from_db_value` |
 | `quantity` | `quantity_to_wire` / `quantity_from_wire` | `quantity_to_db_fields` / `quantity_from_db_fields` |
+| `unit_price` | `unit_price_to_wire` / `unit_price_from_wire` | `unit_price_to_db_fields` / `unit_price_from_db_fields` |
 
 Wire codecs serialize decimals as JSON strings, never JSON numbers. DB adapters
 return exact `Decimal` storage fields plus their semantic key (`currency` or
@@ -156,3 +168,4 @@ the standard; it is dev/test-time only, never shipped into a runtime image.
 - `money`: [accounting.md#money-type](accounting.md), `common/money/`, `apps/backend/src/money/`, `apps/frontend/src/lib/money/`
 - `ratio`: [EPIC-012 AC12.9](../project/EPIC-012.foundation-libs.md), `common/ratio/`, `apps/backend/src/ratio/`, `apps/frontend/src/lib/ratio/`
 - `quantity`: [EPIC-012 AC12.30](../project/EPIC-012.foundation-libs.md), `common/quantity/`, `apps/backend/src/quantity/`, `apps/frontend/src/lib/quantity/`
+- `unit_price`: [EPIC-012 AC12.32](../project/EPIC-012.foundation-libs.md), `common/unit_price/`, `apps/backend/src/unit_price/` (frontend `apps/frontend/src/lib/unit_price/` is a P2 follow-up — no frontend call sites today; conformance vectors are already language-neutral so adoption is additive)

--- a/tests/tooling/test_base_package_migration_cleanup.py
+++ b/tests/tooling/test_base_package_migration_cleanup.py
@@ -130,7 +130,7 @@ def test_AC12_31_5_backend_money_adapters_are_not_duplicated():
     """AC12.31.5: backend services use the shared Money rounding adapter directly."""
     for path in BACKEND_MONEY_ADAPTER_FILES:
         src = _read(path)
-        assert "from src.money import to_money" in src, (
+        assert re.search(r"from src\.money import [^\n]*to_money", src), (
             f"{path} must import the backend Money adapter"
         )
         assert "def _money(" not in src, f"{path} still defines a local money adapter"
@@ -228,7 +228,9 @@ def test_AC12_31_7_backend_quantity_business_code_uses_value_type():
     )
     assert "trade_quantity.is_zero()" in investment
     assert "quantity=trade_quantity.value" in investment
-    assert "trade_quantity.value * unit_price" in investment
+    # unit price now flows through the UnitPrice value type (#1253 / AC12.32),
+    # keeping trade_quantity a Quantity object in the money calculation.
+    assert "buy_price * trade_quantity" in investment
 
     portfolio = _read(Path("apps/backend/src/services/portfolio.py"))
     assert (

--- a/tests/tooling/test_quantity_value_type.py
+++ b/tests/tooling/test_quantity_value_type.py
@@ -39,6 +39,14 @@ def test_AC12_30_1_quantity_rejects_float_and_is_decimal_backed():
     q = Quantity(Decimal("0.125"), "shares")
     with pytest.raises((AttributeError, TypeError)):
         q.value = Decimal("0.2")  # type: ignore[misc]
+    # scalar multiplication keeps the value-type invariants: float/bool and
+    # non-finite Decimal factors are rejected, never silently scaled.
+    with pytest.raises(FloatNotAllowedError):
+        q * 1.5
+    with pytest.raises(FloatNotAllowedError):
+        q * Decimal("NaN")
+    with pytest.raises(FloatNotAllowedError):
+        q * Decimal("Infinity")
 
 
 @ac_proof(

--- a/tests/tooling/test_unit_price_adoption.py
+++ b/tests/tooling/test_unit_price_adoption.py
@@ -1,0 +1,49 @@
+"""UnitPrice adoption guards (EPIC-012 AC12.32).
+
+The UnitPrice base package should own the money-per-quantity semantics that
+portfolio/market-data services used to re-derive as raw ``Decimal`` glue: the
+``quantity * price`` extension, the ``total / quantity`` rate, and the 6-dp price
+quantum. These guards stop the local helpers and the duplicated quantum from
+returning.
+"""
+
+from pathlib import Path
+
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _read(path: Path) -> str:
+    return (REPO / path).read_text(encoding="utf-8")
+
+
+@ac_proof(
+    proof_id="test_unit_price_investment_adoption",
+    ac_ids=["AC12.32.3"],
+    ci_tier="pr_ci",
+)
+def test_AC12_32_3_investment_accounting_uses_unit_price():
+    """AC12.32.3: investment accounting prices via UnitPrice, not local Decimal helpers."""
+    src = _read(Path("apps/backend/src/services/investment_accounting.py"))
+    assert "from src.unit_price import UnitPrice" in src
+    # typed call sites replace the raw quantity*price / amount/quantity glue
+    assert "buy_price * trade_quantity" in src
+    assert "sell_price * trade_quantity" in src
+    assert "UnitPrice.from_total(" in src
+    # the duplicated local quantum + helper are gone
+    assert "_quantized_unit_rate" not in src
+    assert "UNIT_RATE_QUANTUM" not in src
+    assert "trade_quantity.value * unit_price" not in src
+
+
+@ac_proof(
+    proof_id="test_unit_price_market_data_adoption",
+    ac_ids=["AC12.32.3"],
+    ci_tier="pr_ci",
+)
+def test_AC12_32_3_market_data_price_quantum_is_single_sourced():
+    """AC12.32.3: market-data prices reuse the package quantum, not a local literal."""
+    src = _read(Path("apps/backend/src/services/market_data.py"))
+    assert "from src.unit_price import UNIT_PRICE_QUANTUM" in src
+    assert "_PRICE_QUANT = UNIT_PRICE_QUANTUM" in src

--- a/tests/tooling/test_unit_price_api_parity.py
+++ b/tests/tooling/test_unit_price_api_parity.py
@@ -1,0 +1,47 @@
+"""Cross-language unit-price API-parity guard (EPIC-012 AC12.32).
+
+The shipped backend ``src.unit_price`` must export the full shared surface so the
+reference (``common/unit_price``) and runtime stay identical. A TypeScript
+frontend is a P2 follow-up (#1253); when it lands, add its export check here.
+"""
+
+import ast
+import json
+from pathlib import Path
+
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+SHARED_API = set(
+    json.loads((REPO / "common/unit_price/conformance/vectors.json").read_text())[
+        "shared_api"
+    ]
+)
+
+
+def _exports(init_path: Path) -> set[str]:
+    src = init_path.read_text()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets
+        ):
+            return {el.value for el in node.value.elts if isinstance(el, ast.Constant)}
+    return set()
+
+
+@ac_proof(
+    proof_id="test_unit_price_shared_api_common", ac_ids=["AC12.32.2"], ci_tier="pr_ci"
+)
+def test_AC12_32_2_common_exposes_shared_unit_price_api():
+    """AC12.32.2: the reference unit-price module exports the full shared surface."""
+    missing = SHARED_API - _exports(REPO / "common/unit_price/__init__.py")
+    assert not missing, f"common.unit_price missing shared API: {sorted(missing)}"
+
+
+@ac_proof(
+    proof_id="test_unit_price_shared_api_backend", ac_ids=["AC12.32.2"], ci_tier="pr_ci"
+)
+def test_AC12_32_2_backend_exposes_shared_unit_price_api():
+    """AC12.32.2: the shipped backend unit-price module exports the full shared surface."""
+    missing = SHARED_API - _exports(REPO / "apps/backend/src/unit_price/__init__.py")
+    assert not missing, f"backend src.unit_price missing shared API: {sorted(missing)}"

--- a/tests/tooling/test_unit_price_conformance.py
+++ b/tests/tooling/test_unit_price_conformance.py
@@ -1,0 +1,95 @@
+"""Python side of the cross-language unit-price conformance suite (EPIC-012 AC12.32)."""
+
+from decimal import Decimal
+
+import pytest
+from common.money import Money
+from common.quantity import Quantity
+from common.testing.ac_proof import ac_proof
+from common.unit_price import (
+    UNIT_PRICE_DP,
+    UNIT_PRICE_QUANTUM,
+    UNIT_PRICE_ROUNDING,
+    UndefinedUnitPriceError,
+    UnitMismatchError,
+    UnitPrice,
+)
+from common.unit_price.conformance import load_vectors
+
+VECTORS = load_vectors()
+
+
+@ac_proof(
+    proof_id="test_unit_price_conformance_constants",
+    ac_ids=["AC12.32.2"],
+    ci_tier="pr_ci",
+)
+def test_AC12_32_2_unit_price_policy_matches_standard():
+    """AC12.32.2: the price quantum/policy matches the shared standard."""
+    assert str(UNIT_PRICE_QUANTUM) == VECTORS["unit_price_quantum"]
+    assert UNIT_PRICE_DP == VECTORS["unit_price_dp"]
+    assert UNIT_PRICE_ROUNDING == VECTORS["default_rounding"]
+
+
+@ac_proof(
+    proof_id="test_unit_price_conformance_quantize",
+    ac_ids=["AC12.32.2"],
+    ci_tier="pr_ci",
+)
+@pytest.mark.parametrize(
+    "case", VECTORS["quantize"], ids=lambda c: f"{c['rate']}/{c['unit']}"
+)
+def test_AC12_32_2_unit_price_quantize_matches_standard(case):
+    """AC12.32.2: Python UnitPrice.quantize matches the shared 6-dp standard."""
+    got = UnitPrice(Decimal(case["rate"]), case["currency"], case["unit"]).quantize()
+    assert got.rate == Decimal(case["expected"]), case
+
+
+@ac_proof(
+    proof_id="test_unit_price_conformance_product",
+    ac_ids=["AC12.32.2"],
+    ci_tier="pr_ci",
+)
+@pytest.mark.parametrize(
+    "case", VECTORS["product"], ids=lambda c: f"{c['rate']}x{c['quantity']}"
+)
+def test_AC12_32_2_unit_price_product_matches_standard(case):
+    """AC12.32.2: price * quantity reproduces the shared (exact) money amount."""
+    price = UnitPrice(Decimal(case["rate"]), case["currency"], case["unit"])
+    money = price * Quantity(Decimal(case["quantity"]), case["unit"])
+    assert money == Money(Decimal(case["expected_amount"]), case["currency"]), case
+
+
+@ac_proof(
+    proof_id="test_unit_price_conformance_from_total",
+    ac_ids=["AC12.32.2"],
+    ci_tier="pr_ci",
+)
+@pytest.mark.parametrize(
+    "case", VECTORS["from_total"], ids=lambda c: f"{c['amount']}/{c['quantity']}"
+)
+def test_AC12_32_2_unit_price_from_total_matches_standard(case):
+    """AC12.32.2: from_total(...).quantize() reproduces the shared 6-dp rate."""
+    derived = UnitPrice.from_total(
+        Money(Decimal(case["amount"]), case["currency"]),
+        Quantity(Decimal(case["quantity"]), case["unit"]),
+    )
+    assert derived.quantize().rate == Decimal(case["expected_rate_6dp"]), case
+
+
+@ac_proof(
+    proof_id="test_unit_price_conformance_errors", ac_ids=["AC12.32.2"], ci_tier="pr_ci"
+)
+def test_AC12_32_2_unit_price_error_cases_match_standard():
+    """AC12.32.2: zero-quantity and unit-mismatch raise per the shared standard."""
+    for case in VECTORS["from_total_undefined"]:
+        with pytest.raises(UndefinedUnitPriceError):
+            UnitPrice.from_total(
+                Money(Decimal(case["amount"]), case["currency"]),
+                Quantity(Decimal(case["quantity"]), case["unit"]),
+            )
+    for case in VECTORS["unit_mismatch"]:
+        with pytest.raises(UnitMismatchError):
+            UnitPrice(Decimal(case["rate"]), case["currency"], case["unit"]) * Quantity(
+                Decimal(case["quantity"]), case["quantity_unit"]
+            )

--- a/tests/tooling/test_unit_price_value_type.py
+++ b/tests/tooling/test_unit_price_value_type.py
@@ -1,0 +1,91 @@
+"""UnitPrice value-type laws (EPIC-012 AC12.32).
+
+The fourth base-element value type: a money-per-quantity composite that owns the
+``quantity * price`` / ``total / quantity`` semantics and the 6-dp price quantum,
+so portfolio/market-data services stop re-deriving them as raw ``Decimal`` glue.
+"""
+
+from decimal import Decimal
+
+import pytest
+from common.money import Money
+from common.quantity import Quantity
+from common.testing.ac_proof import ac_proof
+from common.unit_price import (
+    UNIT_PRICE_DP,
+    UNIT_PRICE_QUANTUM,
+    UNIT_PRICE_ROUNDING,
+    CurrencyMismatchError,
+    FloatNotAllowedError,
+    UndefinedUnitPriceError,
+    UnitMismatchError,
+    UnitPrice,
+)
+
+
+@ac_proof(
+    proof_id="test_unit_price_rejects_float", ac_ids=["AC12.32.1"], ci_tier="pr_ci"
+)
+def test_AC12_32_1_unit_price_rejects_float_and_is_decimal_backed():
+    """AC12.32.1: UnitPrice rejects float/bool, is Decimal-backed and immutable."""
+    with pytest.raises(FloatNotAllowedError):
+        UnitPrice(0.125, "SGD", "shares")
+    with pytest.raises(FloatNotAllowedError):
+        UnitPrice(True, "SGD", "shares")
+    assert isinstance(UnitPrice(1, "SGD", "shares").rate, Decimal)
+    price = UnitPrice(Decimal("1.25"), "SGD", "shares")
+    with pytest.raises((AttributeError, TypeError)):
+        price.rate = Decimal("2")  # type: ignore[misc]
+
+
+@ac_proof(proof_id="test_unit_price_policy", ac_ids=["AC12.32.1"], ci_tier="pr_ci")
+def test_AC12_32_1_unit_price_quantum_is_six_dp_half_up():
+    """AC12.32.1: the price quantum is 6 dp / ROUND_HALF_UP, not the money quantum."""
+    assert UNIT_PRICE_DP == 6
+    assert UNIT_PRICE_QUANTUM == Decimal("0.000001")
+    assert UNIT_PRICE_ROUNDING == "ROUND_HALF_UP"
+    assert UnitPrice(Decimal("1.2345675"), "USD", "shares").quantize().rate == Decimal(
+        "1.234568"
+    )
+
+
+@ac_proof(proof_id="test_unit_price_product", ac_ids=["AC12.32.1"], ci_tier="pr_ci")
+def test_AC12_32_1_unit_price_times_quantity_is_money():
+    """AC12.32.1: price * quantity yields exact Money in the price's currency."""
+    price = UnitPrice(Decimal("10.50"), "SGD", "shares")
+    qty = Quantity(Decimal("3"), "shares")
+    assert price * qty == Money(Decimal("31.50"), "SGD")
+    assert qty * price == Money(Decimal("31.50"), "SGD")  # __rmul__
+    # exact / unquantized: sub-cent precision is preserved until the money boundary
+    assert (
+        UnitPrice(Decimal("1.005"), "USD", "shares") * Quantity(Decimal("1"), "shares")
+    ).amount == Decimal("1.005")
+    with pytest.raises(UnitMismatchError):
+        price * Quantity(Decimal("3"), "contracts")
+
+
+@ac_proof(proof_id="test_unit_price_from_total", ac_ids=["AC12.32.1"], ci_tier="pr_ci")
+def test_AC12_32_1_unit_price_from_total_is_money_over_quantity():
+    """AC12.32.1: from_total derives Money / Quantity; zero quantity is undefined."""
+    derived = UnitPrice.from_total(
+        Money(Decimal("100.00"), "SGD"), Quantity(Decimal("4"), "shares")
+    )
+    assert derived.quantize().rate == Decimal("25.000000")
+    assert derived.currency.code == "SGD"
+    assert derived.unit.code == "shares"
+    with pytest.raises(UndefinedUnitPriceError):
+        UnitPrice.from_total(
+            Money(Decimal("10.00"), "USD"), Quantity(Decimal("0"), "shares")
+        )
+
+
+@ac_proof(proof_id="test_unit_price_compare", ac_ids=["AC12.32.1"], ci_tier="pr_ci")
+def test_AC12_32_1_unit_price_compare_requires_same_currency_and_unit():
+    """AC12.32.1: comparison is same-currency AND same-unit only."""
+    a = UnitPrice(Decimal("5"), "USD", "shares")
+    b = UnitPrice(Decimal("7"), "USD", "shares")
+    assert a < b and b > a
+    with pytest.raises(CurrencyMismatchError):
+        a < UnitPrice(Decimal("7"), "SGD", "shares")
+    with pytest.raises(UnitMismatchError):
+        a < UnitPrice(Decimal("7"), "USD", "contracts")


### PR DESCRIPTION
## What

Closes #1253 (P0#1). Adds **`UnitPrice`** — the composite base element after `money` / `ratio` / `quantity` — so portfolio/market-data services stop re-deriving money-per-quantity as raw `Decimal` glue.

`UnitPrice` carries a `Currency` **and** a `Unit`:
- `unit_price * quantity -> Money` (unit must match; exact/unquantized amount, quantize at the money boundary)
- `UnitPrice.from_total(money, quantity)` = `Money / Quantity` (zero quantity → `UndefinedUnitPriceError`)
- owns the 6-dp / ROUND_HALF_UP **price quantum** `UNIT_PRICE_QUANTUM` (distinct from the 2-dp money quantum)
- rejects float/bool, immutable, cross-currency/cross-unit compare raises, wire/db codecs, typed error hierarchy

Mirrors the existing base-package shape: common reference (`common/unit_price`), shipped backend mirror (`src.unit_price`), language-neutral conformance vectors, contract doc, and the no-float / conformance / api-parity guards.

## Adoption (behaviour-preserving)

- `investment_accounting.py`: buy/sell gross, lot/avg unit cost, and txn unit price flow through `UnitPrice`; removed local `_quantized_unit_rate` helper + `UNIT_RATE_QUANTUM` literal.
- `market_data.py`: `_PRICE_QUANT` single-sourced from `UNIT_PRICE_QUANTUM`.
- `Quantity.__mul__` returns `NotImplemented` for non-scalars (float/bool stay a hard red line) so `quantity * UnitPrice` dispatches to the reflected op.

## SSOT / AC

- `docs/ssot/base-packages.md`: promotes `UnitPrice` from deferred to family member (+ codec table, Used-by).
- `docs/project/EPIC-012`: **AC12.32** (.1 value-type laws, .2 cross-language conformance, .3 adoption).

## Scope

Only **P0#1** of the issue. Frontend is a **P2 follow-up** (no FE call sites today; vectors are already language-neutral). P0#2 (`Money.sum/is_zero`), P0#3 (`MoneyTolerance`, conflicts with the reconciliation Non-goal), and P1/P2 are intentionally deferred.

## Verification

- New tests: 30 tooling + 2 backend.
- Regression: investment/market_data/portfolio **253 passed**; accounting+reporting **594 passed**; AC-traceability gates **168 passed**; base-package guards green (two guards that pinned the old code shape updated to the new `UnitPrice` shape).
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)