### PR TITLE
[finance_report_vision] Add atomic valuation facts + classification storage (#1222, AC11.22)

### DIFF
--- a/apps/backend/migrations/versions/0046_valuation_fact_storage.py
+++ b/apps/backend/migrations/versions/0046_valuation_fact_storage.py
@@ -1,0 +1,155 @@
+"""add atomic valuation facts and stable classification storage (#1222)"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0046_valuation_fact_storage"
+down_revision = "0045_ret_benefit_assets"
+branch_labels = None
+depends_on = None
+
+
+_L1 = (
+    "cash",
+    "marketable_investment",
+    "retirement_and_benefit",
+    "restricted_compensation",
+    "real_estate",
+    "liability",
+    "other_asset",
+    "non_asset",
+)
+_L2 = (
+    "cash_deposit",
+    "public_equity",
+    "fund",
+    "bond",
+    "mandatory_retirement",
+    "voluntary_retirement",
+    "long_term_benefit",
+    "equity_award",
+    "property",
+    "secured_liability",
+    "unsecured_liability",
+    "tax_liability",
+    "protection_coverage",
+    "unclassified",
+)
+_ECONOMIC_SIDE = ("asset", "liability", "non_asset")
+_VALUATION_ROLE = ("net_worth_component", "coverage_amount", "informational")
+_LIQUIDITY = ("liquid", "restricted", "illiquid", "liability")
+_REVIEW_STATUS = ("pending", "approved", "rejected")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "atomic_valuation_facts",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("as_of_date", sa.Date(), nullable=False),
+        sa.Column("amount", sa.Numeric(precision=18, scale=2), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("raw_label", sa.Text(), nullable=False),
+        sa.Column("issuer", sa.String(length=200), nullable=True),
+        sa.Column("jurisdiction", sa.String(length=100), nullable=True),
+        sa.Column("scheme_name", sa.String(length=200), nullable=True),
+        sa.Column("source_document_anchor", postgresql.JSONB(), nullable=True),
+        sa.Column("raw_payload", postgresql.JSONB(), nullable=True),
+        sa.Column("evidence_spans", postgresql.JSONB(), nullable=True),
+        sa.Column("dedup_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("amount >= 0", name="ck_atomic_valuation_facts_amount_non_negative"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_atomic_valuation_facts_user_dedup_hash",
+        "atomic_valuation_facts",
+        ["user_id", "dedup_hash"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_atomic_valuation_facts_user_as_of",
+        "atomic_valuation_facts",
+        ["user_id", "as_of_date"],
+    )
+    op.create_index(
+        "ix_atomic_valuation_facts_user_id",
+        "atomic_valuation_facts",
+        ["user_id"],
+    )
+
+    op.create_table(
+        "valuation_classifications",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("valuation_fact_id", sa.UUID(), nullable=False),
+        sa.Column("l1", sa.Enum(*_L1, name="valuation_l1_enum"), nullable=False),
+        sa.Column("l2", sa.Enum(*_L2, name="valuation_l2_enum"), nullable=True),
+        sa.Column(
+            "economic_side",
+            sa.Enum(*_ECONOMIC_SIDE, name="valuation_economic_side_enum"),
+            nullable=False,
+        ),
+        sa.Column(
+            "valuation_role",
+            sa.Enum(*_VALUATION_ROLE, name="valuation_role_enum"),
+            nullable=False,
+        ),
+        sa.Column(
+            "liquidity_class",
+            sa.Enum(*_LIQUIDITY, name="valuation_liquidity_class_enum"),
+            nullable=False,
+        ),
+        sa.Column("confidence", sa.Numeric(precision=5, scale=4), nullable=False),
+        sa.Column(
+            "review_status",
+            sa.Enum(*_REVIEW_STATUS, name="valuation_review_status_enum"),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("model_version", sa.String(length=120), nullable=True),
+        sa.Column("prompt_version", sa.String(length=120), nullable=True),
+        sa.Column("rationale", sa.Text(), nullable=True),
+        sa.Column("version", sa.Integer(), server_default="1", nullable=False),
+        sa.Column("superseded_by_id", sa.UUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "confidence >= 0 AND confidence <= 1",
+            name="ck_valuation_classifications_confidence_unit_interval",
+        ),
+        sa.CheckConstraint("version >= 1", name="ck_valuation_classifications_version_positive"),
+        sa.ForeignKeyConstraint(["valuation_fact_id"], ["atomic_valuation_facts.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["superseded_by_id"], ["valuation_classifications.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_valuation_classifications_current_per_fact",
+        "valuation_classifications",
+        ["valuation_fact_id"],
+        unique=True,
+        postgresql_where=sa.text("superseded_by_id IS NULL"),
+    )
+    op.create_index(
+        "ix_valuation_classifications_user_id",
+        "valuation_classifications",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("valuation_classifications")
+    op.drop_table("atomic_valuation_facts")
+    for enum_name in (
+        "valuation_review_status_enum",
+        "valuation_liquidity_class_enum",
+        "valuation_role_enum",
+        "valuation_economic_side_enum",
+        "valuation_l2_enum",
+        "valuation_l1_enum",
+    ):
+        op.execute(f"DROP TYPE IF EXISTS {enum_name}")

--- a/apps/backend/migrations/versions/0046_valuation_fact_storage.py
+++ b/apps/backend/migrations/versions/0046_valuation_fact_storage.py
@@ -63,6 +63,7 @@ def upgrade() -> None:
         sa.CheckConstraint("amount >= 0", name="ck_atomic_valuation_facts_amount_non_negative"),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "id", name="uq_atomic_valuation_facts_user_id_id"),
     )
     op.create_index(
         "uq_atomic_valuation_facts_user_dedup_hash",
@@ -122,7 +123,12 @@ def upgrade() -> None:
             name="ck_valuation_classifications_confidence_unit_interval",
         ),
         sa.CheckConstraint("version >= 1", name="ck_valuation_classifications_version_positive"),
-        sa.ForeignKeyConstraint(["valuation_fact_id"], ["atomic_valuation_facts.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["user_id", "valuation_fact_id"],
+            ["atomic_valuation_facts.user_id", "atomic_valuation_facts.id"],
+            name="fk_valuation_classifications_user_fact",
+            ondelete="CASCADE",
+        ),
         sa.ForeignKeyConstraint(["superseded_by_id"], ["valuation_classifications.id"], ondelete="SET NULL"),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -51,6 +51,11 @@ from src.models.reconciliation import ReconciliationMatch, ReconciliationMatchJo
 from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
 from src.models.user import AiFeedback, User
+from src.models.valuation import (
+    AtomicValuationFact,
+    ValuationClassification,
+    ValuationReviewStatus,
+)
 from src.models.workflow import (
     WorkflowEvent,
     WorkflowEventFamily,
@@ -69,6 +74,7 @@ __all__ = [
     "AtomicPositionSourceDocument",
     "AtomicTransaction",
     "AtomicTransactionSourceDocument",
+    "AtomicValuationFact",
     "BankStatementStatus",
     "ChatMessage",
     "ChatMessageRole",
@@ -122,6 +128,8 @@ __all__ = [
     "TransactionDirection",
     "UploadedDocument",
     "User",
+    "ValuationClassification",
+    "ValuationReviewStatus",
     "WorkflowEvent",
     "WorkflowEventFamily",
     "WorkflowEventSeverity",

--- a/apps/backend/src/models/valuation.py
+++ b/apps/backend/src/models/valuation.py
@@ -1,0 +1,170 @@
+"""Atomic valuation facts and their stable classifications (#1222, EPIC-011 AC11.22).
+
+Storage-only slice of the valuation taxonomy program. ``AtomicValuationFact``
+holds a raw, point-in-time extracted valuation (the durable fact), and
+``ValuationClassification`` holds a versionable stable classification that
+references a fact and is bound to the stable taxonomy contract in
+``src.constants.valuation_taxonomy``. No LLM, no legacy bridge, and no report or
+UI change lives here — those are owned by #1223/#1224/#1225/#1226.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+from uuid import UUID
+
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    Enum as SQLEnum,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.constants.valuation_taxonomy import (
+    EconomicSide,
+    LiquidityClass,
+    ValuationL1,
+    ValuationL2,
+    ValuationRole,
+)
+from src.database import Base
+from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
+
+
+def _enum_values(obj: type[Enum]) -> list[str]:
+    """Persist enum *values* (not names) so DB labels match the contract."""
+
+    return [e.value for e in obj]
+
+
+class ValuationReviewStatus(str, Enum):
+    """Review-gate state for a stable valuation classification.
+
+    Storage-level state only; the gating *behaviour* (when low-confidence
+    classifications must enter review before trusted report use) is owned by
+    later issues (#1224 LLM contract, #1226 frontend).
+    """
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class AtomicValuationFact(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
+    """Raw, point-in-time extracted valuation fact (pre-classification).
+
+    Jurisdiction, issuer, and scheme/plan names are captured here as raw
+    metadata; they are never promoted into the stable taxonomy contract.
+    """
+
+    __tablename__ = "atomic_valuation_facts"
+    __table_args__ = (
+        CheckConstraint("amount >= 0", name="ck_atomic_valuation_facts_amount_non_negative"),
+        # Idempotent ingestion: a fact's dedup hash is unique per owner.
+        Index(
+            "uq_atomic_valuation_facts_user_dedup_hash",
+            "user_id",
+            "dedup_hash",
+            unique=True,
+        ),
+        Index("ix_atomic_valuation_facts_user_as_of", "user_id", "as_of_date"),
+    )
+
+    as_of_date: Mapped[date] = mapped_column(Date, nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(18, 2), nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    raw_label: Mapped[str] = mapped_column(Text, nullable=False)
+    issuer: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    jurisdiction: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    scheme_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    source_document_anchor: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    raw_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    evidence_spans: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    dedup_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    classifications: Mapped[list[ValuationClassification]] = relationship(
+        "ValuationClassification",
+        back_populates="valuation_fact",
+        cascade="all, delete-orphan",
+    )
+
+
+class ValuationClassification(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
+    """Versionable stable classification of an ``AtomicValuationFact``.
+
+    The taxonomy columns are bound to the contract enums, so codes outside the
+    stable contract are rejected at persistence. Reclassification appends a new
+    version and supersedes the prior head, so prior model output is never
+    destroyed.
+    """
+
+    __tablename__ = "valuation_classifications"
+    __table_args__ = (
+        CheckConstraint(
+            "confidence >= 0 AND confidence <= 1",
+            name="ck_valuation_classifications_confidence_unit_interval",
+        ),
+        CheckConstraint("version >= 1", name="ck_valuation_classifications_version_positive"),
+        # Append-only head: at most one current (non-superseded) classification
+        # per fact; superseded history rows accumulate freely.
+        Index(
+            "uq_valuation_classifications_current_per_fact",
+            "valuation_fact_id",
+            unique=True,
+            postgresql_where=text("superseded_by_id IS NULL"),
+        ),
+    )
+
+    valuation_fact_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("atomic_valuation_facts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    l1: Mapped[ValuationL1] = mapped_column(
+        SQLEnum(ValuationL1, name="valuation_l1_enum", values_callable=_enum_values),
+        nullable=False,
+    )
+    l2: Mapped[ValuationL2 | None] = mapped_column(
+        SQLEnum(ValuationL2, name="valuation_l2_enum", values_callable=_enum_values),
+        nullable=True,
+    )
+    economic_side: Mapped[EconomicSide] = mapped_column(
+        SQLEnum(EconomicSide, name="valuation_economic_side_enum", values_callable=_enum_values),
+        nullable=False,
+    )
+    valuation_role: Mapped[ValuationRole] = mapped_column(
+        SQLEnum(ValuationRole, name="valuation_role_enum", values_callable=_enum_values),
+        nullable=False,
+    )
+    liquidity_class: Mapped[LiquidityClass] = mapped_column(
+        SQLEnum(LiquidityClass, name="valuation_liquidity_class_enum", values_callable=_enum_values),
+        nullable=False,
+    )
+    confidence: Mapped[Decimal] = mapped_column(Numeric(5, 4), nullable=False)
+    review_status: Mapped[ValuationReviewStatus] = mapped_column(
+        SQLEnum(ValuationReviewStatus, name="valuation_review_status_enum", values_callable=_enum_values),
+        nullable=False,
+        default=ValuationReviewStatus.PENDING,
+        server_default=ValuationReviewStatus.PENDING.value,
+    )
+    model_version: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    prompt_version: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
+    superseded_by_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("valuation_classifications.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    valuation_fact: Mapped[AtomicValuationFact] = relationship("AtomicValuationFact", back_populates="classifications")

--- a/apps/backend/src/models/valuation.py
+++ b/apps/backend/src/models/valuation.py
@@ -20,15 +20,17 @@ from sqlalchemy import (
     Date,
     Enum as SQLEnum,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     Numeric,
     String,
     Text,
+    UniqueConstraint,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from src.constants.valuation_taxonomy import (
     EconomicSide,
@@ -70,6 +72,9 @@ class AtomicValuationFact(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     __tablename__ = "atomic_valuation_facts"
     __table_args__ = (
         CheckConstraint("amount >= 0", name="ck_atomic_valuation_facts_amount_non_negative"),
+        # Composite-FK target: lets ValuationClassification enforce same-owner
+        # references at the DB level (mirrors EvidenceNode/EvidenceEdge).
+        UniqueConstraint("user_id", "id", name="uq_atomic_valuation_facts_user_id_id"),
         # Idempotent ingestion: a fact's dedup hash is unique per owner.
         Index(
             "uq_atomic_valuation_facts_user_dedup_hash",
@@ -92,12 +97,6 @@ class AtomicValuationFact(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     evidence_spans: Mapped[list | None] = mapped_column(JSONB, nullable=True)
     dedup_hash: Mapped[str] = mapped_column(String(64), nullable=False)
 
-    classifications: Mapped[list[ValuationClassification]] = relationship(
-        "ValuationClassification",
-        back_populates="valuation_fact",
-        cascade="all, delete-orphan",
-    )
-
 
 class ValuationClassification(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     """Versionable stable classification of an ``AtomicValuationFact``.
@@ -115,6 +114,15 @@ class ValuationClassification(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
             name="ck_valuation_classifications_confidence_unit_interval",
         ),
         CheckConstraint("version >= 1", name="ck_valuation_classifications_version_positive"),
+        # Same-owner reference: a classification can only point at a fact owned by
+        # the same user (composite FK mirrors EvidenceEdge). DB ON DELETE CASCADE
+        # removes classifications when their fact is deleted.
+        ForeignKeyConstraint(
+            ["user_id", "valuation_fact_id"],
+            ["atomic_valuation_facts.user_id", "atomic_valuation_facts.id"],
+            name="fk_valuation_classifications_user_fact",
+            ondelete="CASCADE",
+        ),
         # Append-only head: at most one current (non-superseded) classification
         # per fact; superseded history rows accumulate freely.
         Index(
@@ -125,11 +133,7 @@ class ValuationClassification(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
         ),
     )
 
-    valuation_fact_id: Mapped[UUID] = mapped_column(
-        PGUUID(as_uuid=True),
-        ForeignKey("atomic_valuation_facts.id", ondelete="CASCADE"),
-        nullable=False,
-    )
+    valuation_fact_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
     l1: Mapped[ValuationL1] = mapped_column(
         SQLEnum(ValuationL1, name="valuation_l1_enum", values_callable=_enum_values),
         nullable=False,
@@ -166,5 +170,3 @@ class ValuationClassification(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
         ForeignKey("valuation_classifications.id", ondelete="SET NULL"),
         nullable=True,
     )
-
-    valuation_fact: Mapped[AtomicValuationFact] = relationship("AtomicValuationFact", back_populates="classifications")

--- a/apps/backend/tests/assets/test_valuation_fact_storage.py
+++ b/apps/backend/tests/assets/test_valuation_fact_storage.py
@@ -169,6 +169,22 @@ async def test_valuation_classification_is_append_only_per_fact(db, test_user):
     assert heads[0].l2 is ValuationL2.VOLUNTARY_RETIREMENT
 
 
+async def test_valuation_classification_rejects_cross_user_fact_reference(db, test_user):
+    """AC11.22.5: same-owner composite FK rejects another user's fact reference."""
+    fact = _fact(test_user.id)
+    db.add(fact)
+    other = User(email=f"other-{uuid4()}@example.com", hashed_password="x")
+    db.add(other)
+    await db.flush()
+
+    # A classification owned by `other` cannot reference test_user's fact: the
+    # (user_id, valuation_fact_id) composite FK has no matching fact row.
+    with pytest.raises(IntegrityError):
+        async with db.begin_nested():
+            db.add(_classification(fact.id, other.id))
+            await db.flush()
+
+
 def test_manual_valuation_model_is_unchanged_by_storage_addition():
     """AC11.22.4: legacy manual valuation model + enum values are untouched."""
     # No legacy enum value removed (regression guard for the strangler approach).

--- a/apps/backend/tests/assets/test_valuation_fact_storage.py
+++ b/apps/backend/tests/assets/test_valuation_fact_storage.py
@@ -1,0 +1,189 @@
+"""Atomic valuation fact + classification storage tests (#1222, EPIC-011 AC11.22).
+
+Storage-only proofs: persistence + dedup, contract-bound stable fields, the
+append-only versioning invariant, and that the legacy manual valuation model is
+left untouched. No LLM / adapter / report behaviour is exercised here.
+"""
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+from src.constants.valuation_taxonomy import (
+    EconomicSide,
+    LiquidityClass,
+    ValuationL1,
+    ValuationL2,
+    ValuationRole,
+)
+from src.models.layer3 import ManualValuationComponentType, ManualValuationSnapshot
+from src.models.user import User
+from src.models.valuation import (
+    AtomicValuationFact,
+    ValuationClassification,
+    ValuationReviewStatus,
+)
+
+
+def _fact(user_id, *, dedup_hash="hash-1", amount="1000.00"):
+    return AtomicValuationFact(
+        user_id=user_id,
+        as_of_date=date(2026, 5, 31),
+        amount=Decimal(amount),
+        currency="SGD",
+        raw_label="CPF Ordinary Account",
+        issuer="CPF Board",
+        jurisdiction="SG",
+        scheme_name="Central Provident Fund",
+        source_document_anchor={"document_id": str(uuid4()), "page": 1},
+        raw_payload={"line": "OA balance", "value": amount},
+        evidence_spans=[{"page": 1, "bbox": [0, 0, 10, 10]}],
+        dedup_hash=dedup_hash,
+    )
+
+
+def _classification(fact_id, user_id, **overrides):
+    base = dict(
+        valuation_fact_id=fact_id,
+        user_id=user_id,
+        l1=ValuationL1.RETIREMENT_AND_BENEFIT,
+        l2=ValuationL2.MANDATORY_RETIREMENT,
+        economic_side=EconomicSide.ASSET,
+        valuation_role=ValuationRole.NET_WORTH_COMPONENT,
+        liquidity_class=LiquidityClass.RESTRICTED,
+        confidence=Decimal("0.9500"),
+        rationale="Statutory retirement balance.",
+        model_version="glm-4.6v",
+        prompt_version="valuation-classify-v1",
+    )
+    base.update(overrides)
+    return ValuationClassification(**base)
+
+
+async def test_atomic_valuation_fact_persists_and_dedup_hash_is_unique_per_user(db, test_user):
+    """AC11.22.1: fact persists with Decimal amount + metadata; dedup is per-user."""
+    fact = _fact(test_user.id)
+    db.add(fact)
+    await db.commit()
+    await db.refresh(fact)
+
+    assert fact.amount == Decimal("1000.00")
+    assert fact.currency == "SGD"
+    assert fact.raw_label == "CPF Ordinary Account"
+    assert fact.jurisdiction == "SG"
+    assert fact.evidence_spans[0]["page"] == 1
+    assert fact.dedup_hash == "hash-1"
+
+    # Same (user, dedup_hash) is rejected — idempotent ingestion.
+    with pytest.raises(IntegrityError):
+        async with db.begin_nested():
+            db.add(_fact(test_user.id, dedup_hash="hash-1"))
+            await db.flush()
+
+    # Same hash for a *different* user is allowed.
+    other = User(email=f"other-{uuid4()}@example.com", hashed_password="x")
+    db.add(other)
+    await db.flush()
+    db.add(_fact(other.id, dedup_hash="hash-1"))
+    await db.commit()
+
+
+async def test_valuation_classification_persists_stable_fields_and_rejects_out_of_contract_codes(db, test_user):
+    """AC11.22.2: stable fields persist; codes outside the contract are rejected."""
+    fact = _fact(test_user.id)
+    db.add(fact)
+    await db.flush()
+
+    clf = _classification(fact.id, test_user.id)
+    db.add(clf)
+    await db.commit()
+    await db.refresh(clf)
+
+    assert clf.l1 is ValuationL1.RETIREMENT_AND_BENEFIT
+    assert clf.l2 is ValuationL2.MANDATORY_RETIREMENT
+    assert clf.economic_side is EconomicSide.ASSET
+    assert clf.valuation_role is ValuationRole.NET_WORTH_COMPONENT
+    assert clf.liquidity_class is LiquidityClass.RESTRICTED
+    assert clf.confidence == Decimal("0.9500")
+    # Defaults: review gate starts pending, version starts at 1.
+    assert clf.review_status is ValuationReviewStatus.PENDING
+    assert clf.version == 1
+    assert clf.model_version == "glm-4.6v"
+
+    # A jurisdiction/scheme-specific code (e.g. "cpf") is not a stable taxonomy
+    # value, so it is rejected at persistence.
+    with pytest.raises(SQLAlchemyError):
+        async with db.begin_nested():
+            bad = _classification(fact.id, test_user.id, l1="cpf")
+            db.add(bad)
+            await db.flush()
+
+
+async def test_valuation_classification_is_append_only_per_fact(db, test_user):
+    """AC11.22.3: reclassification appends a version; history is preserved."""
+    fact = _fact(test_user.id)
+    db.add(fact)
+    await db.flush()
+
+    v1 = _classification(fact.id, test_user.id, l2=ValuationL2.MANDATORY_RETIREMENT)
+    db.add(v1)
+    await db.commit()
+    await db.refresh(v1)
+
+    # Two current (non-superseded) heads for one fact are rejected.
+    with pytest.raises(IntegrityError):
+        async with db.begin_nested():
+            db.add(_classification(fact.id, test_user.id))
+            await db.flush()
+
+    # Proper reclassification uses the ordered hand-off (matching the manual
+    # snapshot pattern) so neither the self-FK nor the partial unique index is
+    # ever violated: park the new row under the prior head, demote the old head,
+    # then promote the new row.
+    v2 = _classification(
+        fact.id,
+        test_user.id,
+        l2=ValuationL2.VOLUNTARY_RETIREMENT,
+        version=2,
+        superseded_by_id=v1.id,
+    )
+    db.add(v2)
+    await db.flush()
+    v1.superseded_by_id = v2.id
+    await db.flush()
+    v2.superseded_by_id = None
+    await db.commit()
+
+    rows = (
+        (await db.execute(select(ValuationClassification).where(ValuationClassification.valuation_fact_id == fact.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2  # prior model output not destroyed
+    heads = [r for r in rows if r.superseded_by_id is None]
+    assert len(heads) == 1 and heads[0].id == v2.id
+    assert heads[0].l2 is ValuationL2.VOLUNTARY_RETIREMENT
+
+
+def test_manual_valuation_model_is_unchanged_by_storage_addition():
+    """AC11.22.4: legacy manual valuation model + enum values are untouched."""
+    # No legacy enum value removed (regression guard for the strangler approach).
+    legacy_values = {e.value for e in ManualValuationComponentType}
+    assert {
+        "property_value",
+        "mortgage_balance",
+        "cpf_balance",
+        "retirement_account",
+        "social_security_personal_account",
+        "insurance_cash_value",
+        "esop",
+        "rsu",
+        "stock_options",
+        "other_asset",
+        "other_liability",
+    } <= legacy_values
+    assert ManualValuationSnapshot.__tablename__ == "manual_valuation_snapshots"

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -290,6 +290,25 @@ contract language only; storage (#1222), adapter (#1223), LLM classification
 | AC11.21.3 | A deterministic guard rejects jurisdiction-, scheme-, and vendor-specific tokens in stable taxonomy codes | `test_stable_codes_reject_vendor_jurisdiction_scheme_tokens()` | `assets/test_valuation_taxonomy_contract.py` | P0 |
 | AC11.21.4 | Every L2 code maps to exactly one L1 parent with a default economic side | `test_l2_maps_to_single_l1_and_default_side()` | `assets/test_valuation_taxonomy_contract.py` | P0 |
 
+### AC11.22: Atomic Valuation Fact + Classification Storage (#1222)
+
+Persistence for raw extracted valuation facts (`atomic_valuation_facts`) and
+their versionable stable classification (`valuation_classifications`), bound to
+the AC11.21 taxonomy contract. Storage only: no LLM, no legacy bridge, and no
+report/UI behaviour change. Jurisdiction/issuer/scheme are raw metadata on the
+fact; the classification columns are bound to the stable contract enums so codes
+outside the contract are rejected at persistence. Reclassification appends a
+version and supersedes the prior head, so prior model output is never destroyed.
+Tables are additive (Alembic revision `0046_valuation_fact_storage`,
+auto-classified low risk); no legacy enum value is removed.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.22.1 | `AtomicValuationFact` persists a point-in-time fact (Decimal amount, currency, as-of, raw label, issuer, jurisdiction, scheme, anchors, payload, evidence spans) with a per-user-unique dedup hash | `test_atomic_valuation_fact_persists_and_dedup_hash_is_unique_per_user()` | `assets/test_valuation_fact_storage.py` | P0 |
+| AC11.22.2 | `ValuationClassification` persists stable taxonomy fields bound to the contract (L1/L2, economic_side, valuation_role, liquidity_class, confidence, review status, model/prompt version, rationale) and rejects codes outside the contract | `test_valuation_classification_persists_stable_fields_and_rejects_out_of_contract_codes()` | `assets/test_valuation_fact_storage.py` | P0 |
+| AC11.22.3 | Classification is append-only/versionable: at most one current head per fact, superseded history preserved | `test_valuation_classification_is_append_only_per_fact()` | `assets/test_valuation_fact_storage.py` | P0 |
+| AC11.22.4 | Existing manual valuation model and enum values are unchanged by the storage addition (no legacy enum value removed) | `test_manual_valuation_model_is_unchanged_by_storage_addition()` | `assets/test_valuation_fact_storage.py` | P0 |
+
 ## Implementation Pattern Ownership
 
 Do not copy reusable code patterns, router examples, migration guardrails, or

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -308,6 +308,7 @@ auto-classified low risk); no legacy enum value is removed.
 | AC11.22.2 | `ValuationClassification` persists stable taxonomy fields bound to the contract (L1/L2, economic_side, valuation_role, liquidity_class, confidence, review status, model/prompt version, rationale) and rejects codes outside the contract | `test_valuation_classification_persists_stable_fields_and_rejects_out_of_contract_codes()` | `assets/test_valuation_fact_storage.py` | P0 |
 | AC11.22.3 | Classification is append-only/versionable: at most one current head per fact, superseded history preserved | `test_valuation_classification_is_append_only_per_fact()` | `assets/test_valuation_fact_storage.py` | P0 |
 | AC11.22.4 | Existing manual valuation model and enum values are unchanged by the storage addition (no legacy enum value removed) | `test_manual_valuation_model_is_unchanged_by_storage_addition()` | `assets/test_valuation_fact_storage.py` | P0 |
+| AC11.22.5 | A classification cannot reference a fact owned by a different user (same-owner composite FK) | `test_valuation_classification_rejects_cross_user_fact_reference()` | `assets/test_valuation_fact_storage.py` | P0 |
 
 ## Implementation Pattern Ownership
 

--- a/docs/ssot/schema.md
+++ b/docs/ssot/schema.md
@@ -45,7 +45,7 @@ Examples:
 |---|---|
 | DIM | `accounts`, `classification_rules`, market/security/institution reference data |
 | ODS | `uploaded_documents`, `manual_valuation_snapshots` |
-| DWD | `atomic_transactions`, `atomic_positions`, `statement_summaries`, `journal_entries`, `journal_lines` |
+| DWD | `atomic_transactions`, `atomic_positions`, `atomic_valuation_facts` (raw point-in-time valuation facts), `valuation_classifications` (versionable stable taxonomy classification of a fact; #1222), `statement_summaries`, `journal_entries`, `journal_lines` |
 | DWM | `reconciliation_matches`, `consistency_checks`, `fx_conversions` (links a cross-currency transfer's out-leg + in-leg into one multi-leg event; #1123 AC2) |
 | DWS | `managed_positions`, `investment_lots`, derived balances and period aggregates |
 | ADS | `report_snapshots` |


### PR DESCRIPTION
## Goal

Step 1 of 3 (PR 2 of 2) in the valuation taxonomy program. Closes the storage slice of #1222: persistence for raw extracted valuation facts and their versionable stable classification, building on the AC11.21 contract (merged in #1260).

## What

- **`AtomicValuationFact`** (`atomic_valuation_facts`) — raw point-in-time fact: Decimal `amount`, `currency`, `as_of_date`, `raw_label`, `issuer`/`jurisdiction`/`scheme_name` (raw metadata, never promoted to stable codes), `source_document_anchor`/`raw_payload`/`evidence_spans` (JSONB), and a per-user-unique `dedup_hash` for idempotent ingestion.
- **`ValuationClassification`** (`valuation_classifications`) — versionable stable classification bound to the contract enums (`l1`/`l2`, `economic_side`, `valuation_role`, `liquidity_class`), plus `confidence`, `review_status` (pending default), `model_version`/`prompt_version`, `rationale`. Append-only: a partial unique index keeps one current head per fact; reclassification supersedes via `superseded_by_id` so prior model output is preserved.
- **Alembic `0046_valuation_fact_storage`** (down_revision `0045`) — additive `create_table`, auto-classified **low** risk (no migration-risk entry needed). Verified locally: `alembic upgrade head` + `alembic check` report **no autogen drift**, single head `0046` (no dual-head).
- **EPIC-011 AC11.22.1–4** registered; `check_ac_index` integrity + protection PASS. `schema.md` DWD layer documents both tables.

## MECE scope

Storage only. **Out of scope** (later issues): LLM classification (#1224), legacy adapter (#1223), report switch-over (#1225), frontend (#1226). The legacy `ManualValuationComponentType` enum is untouched — AC11.22.4 regression-guards that no value was removed.

## Verification

- `tests/assets/test_valuation_fact_storage.py` — 4 ACs pass (persist+dedup, contract-bound fields + out-of-contract rejection, append-only versioning, legacy-unchanged).
- `alembic check` clean against PostgreSQL; preflight ac-traceability / ssot-ownership / doc-consistency / migration-risk all green.
- Pinned ruff (venv 0.14.11, as CI) check + format clean. (Local preflight's PATH ruff 0.15.17 flags pre-existing `str, Enum` UP042 repo-wide — known version-skew false positive.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)