### PR TITLE
[finance_report_hacker] test(#755): Dokploy response-parsing contract tests (scope 2b finance-side)

### DIFF
--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -259,6 +259,11 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 > `GIT_COMMIT_SHA`, `IAC_CONFIG_HASH`) before the long health wait and fail fast
 > on stale Dokploy config. The fixed staging/prod path is now infra2
 > `deploy_v2` / `deploy_primitive`, not the retired app-side bash deploy script.
+>
+> Making the fixed staging/prod `deploy_primitive` no-new-deployment path raise a
+> consistent classified error (matching the PR-preview `DokployNoNewDeploymentRecord`
+> semantics) instead of a generic `TimeoutError` is tracked as cross-repo infra2
+> work in the `repo/` submodule and is out of scope for this finance-side EPIC.
 
 | ID | Requirement | Test Function | File | Priority |
 |----|-------------|---------------|------|----------|
@@ -281,6 +286,18 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 | AC7.15.1 | The CI/deploy SSOT references the live workflow job ids and triggers through a checked contract (not stale prose), and CI lint runs `tools/check_workflow_contract.py` | `test_AC7_15_1_real_repo_passes_the_workflow_contract`, `test_AC7_15_1_ci_workflow_wires_the_workflow_contract_gate` | `tests/tooling/test_workflow_contract.py` | P0 |
 | AC7.15.2 | Issue templates use only labels that exist in the current repository taxonomy (stale `infra`/`feature` and any unknown label fail) | `test_AC7_15_2_stale_issue_template_label_fails`, `test_AC7_15_2_unknown_issue_template_label_fails` | `tests/tooling/test_workflow_contract.py` | P0 |
 | AC7.15.3 | The contract FAILS when a workflow job id, trigger, or issue-template label drifts from the documented standard (e.g. `classify-changes` prose, a `push` trigger re-added to staging-deploy, or a renamed classifier job) | `test_AC7_15_3_stale_ci_classifier_job_name_fails`, `test_AC7_15_3_stale_staging_push_trigger_prose_fails`, `test_AC7_15_3_staging_push_trigger_in_workflow_fails`, `test_AC7_15_3_renamed_classifier_job_in_workflow_fails`, `test_AC7_15_3_main_cli_returns_contract_result` | `tests/tooling/test_workflow_contract.py` | P0 |
+
+### AC7.17: Dokploy deployment-response parsing contract (#755 scope 2b)
+
+> The local PR-preview parser helpers (`deployment_ids`, `deployment_signatures`
+> in `tools/_lib/dev/pr_preview_lifecycle.py`) must tolerate malformed Dokploy
+> deployment-list responses — empty lists, non-dict entries, missing/None
+> deploymentId, and missing/null/non-string timestamp fields — without raising.
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC7.17.1 | `deployment_ids()` safely parses empty lists, non-dict entries, and missing/None deploymentId without raising | `test_AC7_17_1_deployment_ids_parses_empty_list`, `test_AC7_17_1_deployment_ids_filters_non_dict_entries`, `test_AC7_17_1_deployment_ids_skips_missing_or_none_deployment_id` | `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
+| AC7.17.2 | `deployment_signatures()` safely coerces missing/null/non-string timestamp fields without raising | `test_AC7_17_2_deployment_signatures_parses_empty_and_non_list`, `test_AC7_17_2_deployment_signatures_filters_non_dict_entries`, `test_AC7_17_2_deployment_signatures_coerces_non_string_timestamp_fields` | `tests/tooling/test_pr_preview_lifecycle.py` | P0 |
 
 
 ## 📏 Acceptance Criteria

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -3127,8 +3127,10 @@ def test_AC7_17_1_deployment_ids_filters_non_dict_entries() -> None:
 
 
 def test_AC7_17_1_deployment_ids_skips_missing_or_none_deployment_id() -> None:
-    """AC7.17.1: deployment_ids() drops entries with a missing, None, or empty
-    deploymentId and coerces non-string ids to str."""
+    """AC7.17.1: deployment_ids() drops entries whose deploymentId is missing,
+    None, or otherwise falsy (empty string, 0) — matching the helper's
+    ``if deployment_id:`` guard — and coerces truthy non-string ids to str
+    (e.g. integer ``123`` -> ``"123"``)."""
     lifecycle = lifecycle_module()
 
     ids = lifecycle.deployment_ids(

--- a/tests/tooling/test_pr_preview_lifecycle.py
+++ b/tests/tooling/test_pr_preview_lifecycle.py
@@ -3094,3 +3094,101 @@ def test_AC7_13_5_ci_cd_docs_describe_failure_modes() -> None:
     lowered = ci_cd.lower()
     assert "no new deployment" in lowered
     assert "rollback" in lowered or "roll back" in lowered
+
+
+def test_AC7_17_1_deployment_ids_parses_empty_list() -> None:
+    """AC7.17.1: deployment_ids() returns an empty set for an empty list and
+    for non-list inputs without raising."""
+    lifecycle = lifecycle_module()
+
+    assert lifecycle.deployment_ids([]) == set()
+    assert lifecycle.deployment_ids(None) == set()
+    assert lifecycle.deployment_ids("not-a-list") == set()
+    assert lifecycle.deployment_ids({"deploymentId": "dep-1"}) == set()
+
+
+def test_AC7_17_1_deployment_ids_filters_non_dict_entries() -> None:
+    """AC7.17.1: deployment_ids() skips non-dict entries (strings, None,
+    integers) instead of crashing on the malformed records."""
+    lifecycle = lifecycle_module()
+
+    ids = lifecycle.deployment_ids(
+        [
+            "not-a-dict",
+            None,
+            42,
+            ["nested"],
+            {"deploymentId": "dep-1"},
+            {"deploymentId": "dep-2", "status": "running"},
+        ]
+    )
+
+    assert ids == {"dep-1", "dep-2"}
+
+
+def test_AC7_17_1_deployment_ids_skips_missing_or_none_deployment_id() -> None:
+    """AC7.17.1: deployment_ids() drops entries with a missing, None, or empty
+    deploymentId and coerces non-string ids to str."""
+    lifecycle = lifecycle_module()
+
+    ids = lifecycle.deployment_ids(
+        [
+            {"status": "running"},
+            {"deploymentId": None},
+            {"deploymentId": ""},
+            {"deploymentId": 0},
+            {"deploymentId": 123},
+            {"deploymentId": "dep-real"},
+        ]
+    )
+
+    assert ids == {"123", "dep-real"}
+
+
+def test_AC7_17_2_deployment_signatures_parses_empty_and_non_list() -> None:
+    """AC7.17.2: deployment_signatures() returns an empty mapping for empty
+    lists and non-list inputs without raising."""
+    lifecycle = lifecycle_module()
+
+    assert lifecycle.deployment_signatures([]) == {}
+    assert lifecycle.deployment_signatures(None) == {}
+    assert lifecycle.deployment_signatures("not-a-list") == {}
+
+
+def test_AC7_17_2_deployment_signatures_filters_non_dict_entries() -> None:
+    """AC7.17.2: deployment_signatures() skips non-dict entries and entries
+    with a missing/None deploymentId instead of crashing."""
+    lifecycle = lifecycle_module()
+
+    signatures = lifecycle.deployment_signatures(
+        [
+            "not-a-dict",
+            None,
+            7,
+            {"status": "running"},
+            {"deploymentId": None, "status": "running"},
+            {"deploymentId": "dep-1", "status": "running", "createdAt": "t1"},
+        ]
+    )
+
+    assert signatures == {"dep-1": ("running", "t1", "", "")}
+
+
+def test_AC7_17_2_deployment_signatures_coerces_non_string_timestamp_fields() -> None:
+    """AC7.17.2: deployment_signatures() safely coerces missing, null, and
+    non-string (integer) status/timestamp fields to strings without raising."""
+    lifecycle = lifecycle_module()
+
+    signatures = lifecycle.deployment_signatures(
+        [
+            {
+                "deploymentId": "dep-int",
+                "status": 200,
+                "createdAt": 1718000000,
+                "startedAt": None,
+                # finishedAt intentionally missing
+            },
+        ]
+    )
+
+    assert signatures["dep-int"] == ("200", "1718000000", "", "")


### PR DESCRIPTION
## Summary

Issue #755 **scope 2b (finance-side residual)**: contract-test hardening for the local Dokploy deployment-response **parsing** helpers in `tools/_lib/dev/pr_preview_lifecycle.py`.

Scope #1 (#756/#758, #575) is already implemented. This PR closes the finance-side gap of missing edge-case coverage for the two local parser helpers:

- `deployment_ids()` — extracts `deploymentId` from a list of dicts.
- `deployment_signatures()` — extracts status/createdAt/startedAt/finishedAt.

## Acceptance Criteria (new group AC7.17, EPIC-007)

- **AC7.17.1** — `deployment_ids()` safely parses empty lists, non-dict entries, and missing/None `deploymentId` without raising.
- **AC7.17.2** — `deployment_signatures()` safely coerces missing/null/non-string (integer) timestamp fields without raising.

## Tests (TDD)

Added to `tests/tooling/test_pr_preview_lifecycle.py` (matching the existing AC7.13 contract style):

- empty / non-list input → empty result
- non-dict entries (str/None/int/list) → filtered out, no crash
- missing / None / empty / non-string `deploymentId` → handled, coerced to `str`
- integer / null / missing status & timestamp fields → coerced safely

The current helpers already handle every case via the `str(... or "")` coercion pattern, so these are legitimate **characterization** tests (same lineage as the AC7.13 suite). **No helper change was required** — no case crashed.

## Out of scope (cross-repo)

The classified-error consistency fix for the **fixed staging/prod** `deploy_primitive.wait_for_rollout()` path (raising a generic `TimeoutError` instead of a classified `DokployNoNewDeploymentRecord`) lives in the **infra2 submodule (`repo/`)** and is tracked as cross-repo work. This PR does not touch `repo/`. A note documenting this was added near AC7.14 in EPIC-007.

## Local validation

- `python tools/check_ac_index.py` → **PASSED** (`[INTEGRITY] PASSED`, `[PROTECTION] PASSED`; 1796 AC nodes)
- `python tools/check_workflow_contract.py` → **`Workflow contract OK`**
- `pytest tests/tooling/test_pr_preview_lifecycle.py -k AC7_17` → **6 passed**
- `pytest tests/tooling/test_pr_preview_lifecycle.py` → **81 passed, 1 failed**; the single failure is `test_AC8_13_100_infra2_route_canary_is_available`, a pre-existing environmental failure that asserts on `repo/` submodule files not populated in this local worktree (passes in CI where the submodule is checked out; unrelated to this change).
- `ruff check` / `ruff format --check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)