### PR TITLE
[finance_report_hacker] ci(#755): block unresolved P0/P1 review threads at merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,17 @@ jobs:
       - name: Workflow Contract Check
         run: |
           uv run --with pyyaml python tools/check_workflow_contract.py
+      - name: PR Review Thread Merge Gate
+        # Issue #755 (scope 2a): block merge while an unresolved P0/P1 (or
+        # unresolved Copilot-authored) review thread is open. Skips cleanly on
+        # non-PR events because PR_NUMBER is empty (the checker exits 0).
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          uv run python tools/check_pr_review_threads.py
 
   schema-migrations:
     name: Schema Migration Contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed by the PR Review Thread Merge Gate step: `gh api graphql` reads
+      # the PR's review threads. The top-level `permissions:` block restricts
+      # GITHUB_TOKEN to actions/contents read, so grant pull-requests read here.
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
         with:

--- a/common/ci/check_pr_review_threads.py
+++ b/common/ci/check_pr_review_threads.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Merge-time gate that blocks unresolved P0/P1 PR review threads.
+
+This contract supports issue #755 (scope 2a): a PR must not merge while a
+high-severity review thread is still open. It fetches the PR's review threads
+via the GitHub GraphQL API (`gh api graphql`), classifies each thread's
+severity from documented markers, and exits non-zero when any *unresolved*
+thread is classified blocking (P0/P1).
+
+Severity classification rule (documented in ``docs/ssot/ci-cd.md`` — keep both
+in sync). A thread is **BLOCKING** (P0/P1) when the first comment body matches
+the marker regex ``\\b(P0|P1)\\b`` (case-insensitive) OR the first comment is
+Copilot-authored AND it is not explicitly marked a lower severity (its body
+contains ``P2``/``P3``/``nit``). Everything else is **LOWER** severity.
+
+Decision: exit 1 if any thread is *unresolved* AND classified BLOCKING.
+Resolved or outdated threads never block. Lower-severity unresolved threads are
+printed (reported) but do NOT block. The gate is bootstrap-safe: a fresh PR
+with no unresolved P0/P1 passes, and a non-PR invocation (no PR number) skips
+cleanly with exit 0.
+
+The GraphQL call is isolated behind the :func:`fetch_threads` seam so tests can
+inject canned JSON without any network access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import enum
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import Any
+
+# Authors whose review threads are treated as blocking by default. GitHub has
+# spelled the Copilot reviewer login differently over time; cover the known
+# variants (compared case-insensitively).
+COPILOT_AUTHORS: frozenset[str] = frozenset(
+    {
+        "copilot",
+        "github-copilot[bot]",
+        "copilot-pull-request-reviewer[bot]",
+    }
+)
+
+# Explicit high-severity markers. Word-boundary, case-insensitive.
+BLOCKING_MARKER = re.compile(r"\b(P0|P1)\b", re.IGNORECASE)
+
+# Explicit lower-severity markers. A Copilot thread carrying one of these is
+# treated as lower severity instead of the Copilot default.
+LOWER_MARKER = re.compile(r"\b(P2|P3|nit)\b", re.IGNORECASE)
+
+# A fetcher takes (pr_number, repo) and returns the parsed `gh api graphql`
+# JSON envelope.
+FetchThreads = Callable[[int, str], dict[str, Any]]
+
+_GRAPHQL_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          isOutdated
+          comments(first: 1) {
+            nodes {
+              body
+              url
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class Severity(enum.Enum):
+    """Severity classes for a review thread."""
+
+    BLOCKING = "blocking"  # P0/P1 (or Copilot default)
+    LOWER = "lower"  # P2/P3/nit/plain comment
+
+
+def _first_comment(thread: dict[str, Any]) -> dict[str, Any]:
+    """Return the first comment node of a thread, or an empty dict."""
+    nodes = (thread.get("comments") or {}).get("nodes") or []
+    return nodes[0] if nodes else {}
+
+
+def _comment_author(comment: dict[str, Any]) -> str:
+    return ((comment.get("author") or {}).get("login") or "").strip()
+
+
+def classify_thread(thread: dict[str, Any]) -> Severity:
+    """Classify a review thread's severity from its first comment.
+
+    See module docstring for the exact, documented rule.
+    """
+    comment = _first_comment(thread)
+    body = comment.get("body") or ""
+    author = _comment_author(comment).lower()
+
+    if BLOCKING_MARKER.search(body):
+        return Severity.BLOCKING
+
+    if author in COPILOT_AUTHORS and not LOWER_MARKER.search(body):
+        return Severity.BLOCKING
+
+    return Severity.LOWER
+
+
+def _thread_url(thread: dict[str, Any]) -> str:
+    return _first_comment(thread).get("url") or "(no url)"
+
+
+def _thread_nodes(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract reviewThreads nodes from the GraphQL envelope, defensively."""
+    repo = ((payload or {}).get("data") or {}).get("repository") or {}
+    pr = repo.get("pullRequest") or {}
+    return (pr.get("reviewThreads") or {}).get("nodes") or []
+
+
+def fetch_threads(pr_number: int, repo: str) -> dict[str, Any]:
+    """Fetch review threads via `gh api graphql` (the real, network seam).
+
+    ``repo`` is ``owner/name``. Returns the parsed JSON envelope. This function
+    is patched/replaced in tests so no network call is made there.
+    """
+    owner, _, name = repo.partition("/")
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={_GRAPHQL_QUERY}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={pr_number}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def run(
+    pr_number: int | None,
+    repo: str,
+    fetch_threads: FetchThreads = fetch_threads,
+) -> int:
+    """Evaluate the gate. Return 0 (pass/skip) or 1 (block).
+
+    Skips cleanly (exit 0, no fetch) when ``pr_number`` is None — e.g. a
+    non-pull_request workflow event.
+    """
+    if pr_number is None:
+        print(
+            "PR review thread gate: no PR number (non-PR event); skipping.",
+            file=sys.stderr,
+        )
+        return 0
+
+    payload = fetch_threads(pr_number, repo)
+    nodes = _thread_nodes(payload)
+
+    blocking: list[dict[str, Any]] = []
+    lower_unresolved: list[dict[str, Any]] = []
+
+    for thread in nodes:
+        if thread.get("isResolved"):
+            continue  # resolved threads never block
+        if thread.get("isOutdated"):
+            continue  # outdated threads never block
+        severity = classify_thread(thread)
+        if severity is Severity.BLOCKING:
+            blocking.append(thread)
+        else:
+            lower_unresolved.append(thread)
+
+    total = len(nodes)
+    print(
+        f"PR review thread gate (PR #{pr_number}, {repo}): "
+        f"{total} thread(s); {len(blocking)} unresolved blocking (P0/P1), "
+        f"{len(lower_unresolved)} unresolved lower-severity (reported, "
+        f"non-blocking)."
+    )
+
+    for thread in lower_unresolved:
+        body = (_first_comment(thread).get("body") or "").strip().splitlines()
+        snippet = body[0] if body else ""
+        print(f"  [report] lower-severity unresolved: {_thread_url(thread)} :: {snippet}")
+
+    if blocking:
+        print(
+            "BLOCKED: unresolved P0/P1 (or Copilot) review thread(s) must be resolved before merge:",
+            file=sys.stderr,
+        )
+        for thread in blocking:
+            body = (_first_comment(thread).get("body") or "").strip().splitlines()
+            snippet = body[0] if body else ""
+            print(
+                f"  - {_thread_url(thread)} :: {snippet}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print("PR review thread gate OK: no unresolved P0/P1 review threads.")
+    return 0
+
+
+def _resolve_pr_number(arg_value: int | None) -> int | None:
+    """PR number from --pr-number, else $PR_NUMBER env, else None."""
+    if arg_value is not None:
+        return arg_value
+    env_value = os.environ.get("PR_NUMBER", "").strip()
+    if not env_value or env_value.lower() in {"none", "null"}:
+        return None
+    try:
+        return int(env_value)
+    except ValueError:
+        return None
+
+
+def _resolve_repo(arg_value: str | None) -> str:
+    """Repo (owner/name) from --repo, else $GITHUB_REPOSITORY."""
+    return (arg_value or os.environ.get("GITHUB_REPOSITORY") or "").strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        default=None,
+        help="PR number (defaults to $PR_NUMBER; skips cleanly if absent).",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Repository as owner/name (defaults to $GITHUB_REPOSITORY).",
+    )
+    args = parser.parse_args(argv)
+
+    pr_number = _resolve_pr_number(args.pr_number)
+    repo = _resolve_repo(args.repo)
+
+    if pr_number is not None and not repo:
+        print(
+            "PR review thread gate: a PR number was supplied but no repo (--repo / $GITHUB_REPOSITORY); skipping.",
+            file=sys.stderr,
+        )
+        return 0
+
+    # Bind through the module attribute so tests can monkeypatch fetch_threads.
+    return run(pr_number, repo, fetch_threads=fetch_threads)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/common/ci/check_pr_review_threads.py
+++ b/common/ci/check_pr_review_threads.py
@@ -19,6 +19,13 @@ printed (reported) but do NOT block. The gate is bootstrap-safe: a fresh PR
 with no unresolved P0/P1 passes, and a non-PR invocation (no PR number) skips
 cleanly with exit 0.
 
+Fail-closed semantics: :func:`fetch_threads` paginates until
+``pageInfo.hasNextPage`` is false (so a PR with >100 review threads cannot hide
+a blocking thread beyond the first page), and raises rather than silently
+truncating if a page is missing its cursor. When a PR number is supplied but
+the repo cannot be resolved (a likely CI misconfiguration), :func:`main`
+exits 1 instead of skipping, so the merge gate is never silently disabled.
+
 The GraphQL call is isolated behind the :func:`fetch_threads` seam so tests can
 inject canned JSON without any network access.
 """
@@ -58,10 +65,14 @@ LOWER_MARKER = re.compile(r"\b(P2|P3|nit)\b", re.IGNORECASE)
 FetchThreads = Callable[[int, str], dict[str, Any]]
 
 _GRAPHQL_QUERY = """
-query($owner: String!, $name: String!, $number: Int!) {
+query($owner: String!, $name: String!, $number: Int!, $after: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
         nodes {
           isResolved
           isOutdated
@@ -78,6 +89,10 @@ query($owner: String!, $name: String!, $number: Int!) {
   }
 }
 """
+
+# Hard ceiling on pagination so a pathological PR cannot loop forever; 100
+# pages * 100 threads/page = 10k threads, far beyond any real PR.
+_MAX_PAGES = 100
 
 
 class Severity(enum.Enum):
@@ -119,39 +134,80 @@ def _thread_url(thread: dict[str, Any]) -> str:
     return _first_comment(thread).get("url") or "(no url)"
 
 
-def _thread_nodes(payload: dict[str, Any]) -> list[dict[str, Any]]:
-    """Extract reviewThreads nodes from the GraphQL envelope, defensively."""
+def _review_threads(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the reviewThreads object from one GraphQL page, defensively."""
     repo = ((payload or {}).get("data") or {}).get("repository") or {}
     pr = repo.get("pullRequest") or {}
-    return (pr.get("reviewThreads") or {}).get("nodes") or []
+    return pr.get("reviewThreads") or {}
+
+
+def _thread_nodes(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract reviewThreads nodes from the GraphQL envelope, defensively."""
+    return _review_threads(payload).get("nodes") or []
+
+
+def _wrap_nodes(nodes: list[dict[str, Any]]) -> dict[str, Any]:
+    """Wrap merged thread nodes back into the standard GraphQL envelope shape."""
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {"reviewThreads": {"nodes": nodes}},
+            }
+        }
+    }
+
+
+def _graphql_page(owner: str, name: str, pr_number: int, after: str | None) -> dict[str, Any]:
+    """Run one `gh api graphql` page request and return the parsed JSON."""
+    cmd = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={_GRAPHQL_QUERY}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={name}",
+        "-F",
+        f"number={pr_number}",
+    ]
+    if after:
+        cmd += ["-F", f"after={after}"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(result.stdout)
 
 
 def fetch_threads(pr_number: int, repo: str) -> dict[str, Any]:
-    """Fetch review threads via `gh api graphql` (the real, network seam).
+    """Fetch ALL review threads via `gh api graphql` (the real, network seam).
 
-    ``repo`` is ``owner/name``. Returns the parsed JSON envelope. This function
-    is patched/replaced in tests so no network call is made there.
+    Paginates through `reviewThreads` until `pageInfo.hasNextPage` is false, so
+    a PR with more than 100 review threads cannot let unresolved blocking
+    threads beyond the first page slip past the merge gate. Returns a single
+    merged JSON envelope. This function is patched/replaced in tests so no
+    network call is made there.
     """
     owner, _, name = repo.partition("/")
-    result = subprocess.run(
-        [
-            "gh",
-            "api",
-            "graphql",
-            "-f",
-            f"query={_GRAPHQL_QUERY}",
-            "-F",
-            f"owner={owner}",
-            "-F",
-            f"name={name}",
-            "-F",
-            f"number={pr_number}",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
+    all_nodes: list[dict[str, Any]] = []
+    after: str | None = None
+    for _ in range(_MAX_PAGES):
+        payload = _graphql_page(owner, name, pr_number, after)
+        threads = _review_threads(payload)
+        all_nodes.extend(threads.get("nodes") or [])
+        page_info = threads.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            return _wrap_nodes(all_nodes)
+        after = page_info.get("endCursor")
+        if not after:
+            # hasNextPage is true but no cursor: cannot safely continue. Fail
+            # closed rather than silently dropping later pages.
+            raise RuntimeError(
+                "PR review thread gate: GraphQL reported more pages but no "
+                "endCursor; cannot guarantee all threads were read."
+            )
+    raise RuntimeError(
+        f"PR review thread gate: exceeded the page limit ({_MAX_PAGES}) while reading review threads; failing closed."
     )
-    return json.loads(result.stdout)
 
 
 def run(
@@ -256,11 +312,15 @@ def main(argv: list[str] | None = None) -> int:
     repo = _resolve_repo(args.repo)
 
     if pr_number is not None and not repo:
+        # A PR number is present but the repo cannot be resolved — almost
+        # certainly a CI misconfiguration (e.g. a typo'd env var). Fail closed
+        # rather than silently disabling a merge-blocking contract.
         print(
-            "PR review thread gate: a PR number was supplied but no repo (--repo / $GITHUB_REPOSITORY); skipping.",
+            "PR review thread gate: a PR number was supplied but the repo could "
+            "not be resolved (--repo / $GITHUB_REPOSITORY); failing closed.",
             file=sys.stderr,
         )
-        return 0
+        return 1
 
     # Bind through the module attribute so tests can monkeypatch fetch_threads.
     return run(pr_number, repo, fetch_threads=fetch_threads)

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -524,6 +524,25 @@ regression.
 | AC8.19.1 | Login auth controls (mode-toggle register button and inline register CTA) expose distinct `data-testid` hooks and accessible names, so no duplicate accessible-name ambiguity remains while the visible text stays "Register" | `AC8.19.1 login register controls expose distinct test ids and accessible names` | `apps/frontend/src/__tests__/loginPage.test.tsx` | P1 |
 | AC8.19.2 | Registration E2E targets the mode-toggle register control by test id, switching into register mode without a strict-mode locator failure | `test_registration_api_path`, `test_full_registration_flow` | `tests/e2e/test_auth_flows.py` | P1 |
 
+### AC8.20: PR Review Thread Merge Gate
+
+A merge-time CI gate (issue #755 scope 2a) blocks a PR while a high-severity
+review thread is still open. It reads the PR's review threads through the GitHub
+GraphQL API (`gh api graphql`) and classifies each thread's severity from a
+documented marker rule: a thread is **blocking (P0/P1)** when its first comment
+body matches `\b(P0|P1)\b` (case-insensitive) or is Copilot-authored and not
+explicitly marked a lower severity (`P2`/`P3`/`nit`); everything else is lower
+severity. Only *unresolved* blocking threads fail the gate; resolved, outdated,
+and lower-severity unresolved threads are reported but never block. The gate is
+bootstrap-safe (a fresh PR with no unresolved P0/P1 passes) and skips cleanly on
+non-PR events. The classification rule is owned by [ci-cd.md](../ssot/ci-cd.md).
+
+| AC ID | Test Case | Test Function | File | Priority |
+|---|---|---|---|---|
+| AC8.20.1 | The checker blocks (exit 1) when an unresolved P0/P1 (or unresolved Copilot) review thread exists | `test_AC8_20_1_unresolved_p0_blocks`, `test_AC8_20_1_unresolved_copilot_blocks`, `test_AC8_20_1_blocking_thread_url_is_printed` | `tests/tooling/test_check_pr_review_threads.py` | P1 |
+| AC8.20.2 | Resolved/outdated threads and lower-severity (P2/P3/nit) unresolved threads do NOT block; they are reported | `test_AC8_20_2_resolved_p0_passes`, `test_AC8_20_2_outdated_p0_passes`, `test_AC8_20_2_unresolved_nit_passes_but_reported`, `test_AC8_20_2_empty_passes`, `test_AC8_20_2_mixed_blocks_only_on_active_p0` | `tests/tooling/test_check_pr_review_threads.py` | P1 |
+| AC8.20.3 | The severity classification rule is documented in the CI/CD SSOT | `test_AC8_20_3_severity_rule_documented_in_ssot` | `tests/tooling/test_check_pr_review_threads.py` | P1 |
+
 ## 5. E2E Suite Ownership
 
 Current test counts and coverage percentages belong to generated reports and CI

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -498,6 +498,9 @@ concepts:
 
   pr_review_thread_merge_gate:
     owner: docs/ssot/ci-cd.md#pr-review-thread-merge-gate
+    family: delivery
+    kind: concept
+    authority: documented_contract
     description: Merge-time gate that blocks unresolved P0/P1 (and Copilot-authored) PR review threads, and the documented severity classification rule.
     cross_refs:
       - docs/project/EPIC-008.testing-strategy.md

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -496,6 +496,15 @@ concepts:
       - docs/ssot/coverage.md
       - .github/workflows/ci.yml
 
+  pr_review_thread_merge_gate:
+    owner: docs/ssot/ci-cd.md#pr-review-thread-merge-gate
+    description: Merge-time gate that blocks unresolved P0/P1 (and Copilot-authored) PR review threads, and the documented severity classification rule.
+    cross_refs:
+      - docs/project/EPIC-008.testing-strategy.md
+      - .github/workflows/ci.yml
+    proofs:
+      - tests/tooling/test_check_pr_review_threads.py
+
   ci_gate_inventory:
     owner: docs/ssot/ci-gate-inventory.yaml
     family: delivery

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -238,6 +238,42 @@ Tier 1, Tier 2, and Tier 3 evidence.
 
 ---
 
+## PR Review Thread Merge Gate
+
+`tools/check_pr_review_threads.py` (logic in
+`common/ci/check_pr_review_threads.py`) is a merge-time gate that blocks a PR
+while a high-severity review thread is still open. It runs as a step in the
+`lint` job of `.github/workflows/ci.yml` on `pull_request` events, reading the
+PR's review threads through the GitHub GraphQL API (`gh api graphql`). It is
+bootstrap-safe and skips cleanly (exit 0) on non-PR events (no PR number).
+
+### Severity classification rule
+
+For each review thread the gate inspects the **first comment**:
+
+- A thread is **blocking (P0/P1)** when either:
+  - the first comment body matches the marker regex `\b(P0|P1)\b`
+    (case-insensitive), OR
+  - the first comment is **Copilot-authored** (`author.login` in
+    `copilot`, `github-copilot[bot]`,
+    `copilot-pull-request-reviewer[bot]`) AND the body is **not** explicitly
+    marked a lower severity (it does not contain `P2`, `P3`, or `nit`).
+- Every other thread is **lower severity**.
+
+### Decision
+
+- The gate **exits 1** (blocks merge) when any thread is **unresolved** AND
+  classified **blocking**.
+- **Resolved** and **outdated** threads never block, regardless of severity.
+- **Lower-severity unresolved** threads (e.g. `P2`/`P3`/`nit`) do **not** block;
+  they are printed in the summary so reviewers can still see them.
+
+The gate prints a summary with the thread counts and, when it blocks, the URLs
+of the offending threads. Resolve or mark the thread resolved on GitHub to clear
+the gate.
+
+---
+
 ## No-Regression Coverage Gate
 
 The CI workflow enforces a **no-regression policy** for test coverage.

--- a/tests/tooling/test_check_pr_review_threads.py
+++ b/tests/tooling/test_check_pr_review_threads.py
@@ -18,6 +18,7 @@ no network call is made. Mirrors the pytest + ``common.*`` import convention of
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -223,6 +224,82 @@ class TestMain:
         payload = _payload(_thread(body="P0: bug", is_resolved=False))
         monkeypatch.setattr(gate, "fetch_threads", lambda pr_number, repo: payload)
         assert gate.main(["--repo", "o/r", "--pr-number", "1"]) == 1
+
+    def test_main_fails_closed_when_pr_present_but_repo_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A PR number with no resolvable repo is a misconfig — fail closed (1)."""
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        called = False
+
+        def fetch(pr_number: int, repo: str) -> dict[str, Any]:
+            nonlocal called
+            called = True
+            return _payload()
+
+        monkeypatch.setattr(gate, "fetch_threads", fetch)
+        assert gate.main(["--pr-number", "1"]) == 1
+        # The gate must not silently pass: it fails before fetching.
+        assert called is False
+
+
+# ---------------------------------------------------------------------------
+# fetch_threads pagination — a PR with >100 review threads must not truncate.
+# ---------------------------------------------------------------------------
+
+
+def _page(nodes: list[dict[str, Any]], *, has_next: bool, cursor: str | None) -> Any:
+    """Build a subprocess.run result whose stdout is one GraphQL page."""
+
+    class _Result:
+        stdout = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "pageInfo": {
+                                    "hasNextPage": has_next,
+                                    "endCursor": cursor,
+                                },
+                                "nodes": nodes,
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+    return _Result()
+
+
+class TestFetchPagination:
+    def test_fetch_threads_follows_all_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """fetch_threads concatenates every page until hasNextPage is false."""
+        pages = [
+            _page([_thread(body="t1")], has_next=True, cursor="c1"),
+            _page([_thread(body="t2")], has_next=True, cursor="c2"),
+            _page([_thread(body="t3")], has_next=False, cursor=None),
+        ]
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            calls.append(cmd)
+            return pages[len(calls) - 1]
+
+        monkeypatch.setattr(gate.subprocess, "run", fake_run)
+        merged = gate.fetch_threads(1, "o/r")
+        nodes = gate._thread_nodes(merged)
+        assert len(nodes) == 3
+        # Three page requests; pages 2 and 3 pass the prior endCursor.
+        assert len(calls) == 3
+        assert any("after=c1" in part for part in calls[1])
+        assert any("after=c2" in part for part in calls[2])
+
+    def test_fetch_threads_fails_closed_when_cursor_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """hasNextPage true but no endCursor must raise (never silently drop)."""
+        page = _page([_thread(body="t1")], has_next=True, cursor=None)
+        monkeypatch.setattr(gate.subprocess, "run", lambda cmd, **kw: page)
+        with pytest.raises(RuntimeError):
+            gate.fetch_threads(1, "o/r")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tooling/test_check_pr_review_threads.py
+++ b/tests/tooling/test_check_pr_review_threads.py
@@ -1,0 +1,242 @@
+"""Tests for the PR review-thread merge gate (common.ci.check_pr_review_threads).
+
+This gate blocks a PR at merge time when an unresolved P0/P1 (or unresolved
+Copilot-authored) review thread exists, while resolved/outdated threads and
+lower-severity (P2/P3/nit) unresolved threads never block.
+
+Acceptance criteria (EPIC-008, AC group AC8.20):
+  AC8.20.1 — the checker blocks (exit 1) when an unresolved P0/P1 (or unresolved
+             Copilot) review thread exists.
+  AC8.20.2 — resolved/outdated threads and lower-severity (P2/P3/nit) unresolved
+             threads do NOT block; they are reported.
+  AC8.20.3 — the severity classification rule is documented in the CI/CD SSOT.
+
+All cases feed canned GraphQL JSON to the injectable ``fetch_threads`` seam so
+no network call is made. Mirrors the pytest + ``common.*`` import convention of
+``tests/tooling/test_check_manifest.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from common.ci import check_pr_review_threads as gate
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build canned GraphQL review-thread payloads.
+# ---------------------------------------------------------------------------
+
+
+def _thread(
+    *,
+    is_resolved: bool = False,
+    is_outdated: bool = False,
+    author: str = "some-human",
+    body: str = "please fix this",
+    url: str = "https://github.com/o/r/pull/1#discussion_r1",
+) -> dict[str, Any]:
+    """Build one reviewThreads node mirroring the GraphQL response shape."""
+    return {
+        "isResolved": is_resolved,
+        "isOutdated": is_outdated,
+        "comments": {
+            "nodes": [
+                {"author": {"login": author}, "body": body, "url": url},
+            ]
+        },
+    }
+
+
+def _payload(*threads: dict[str, Any]) -> dict[str, Any]:
+    """Wrap thread nodes in the full `gh api graphql` envelope."""
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {"nodes": list(threads)},
+                }
+            }
+        }
+    }
+
+
+def _run(payload: dict[str, Any]) -> int:
+    """Run the gate with an injected fetcher returning the canned payload."""
+    return gate.run(
+        pr_number=1,
+        repo="o/r",
+        fetch_threads=lambda pr_number, repo: payload,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Severity classification (the documented rule).
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyThread:
+    def test_explicit_p0_marker_is_blocking(self) -> None:
+        thread = _thread(body="P0: this corrupts balances")
+        assert gate.classify_thread(thread) == gate.Severity.BLOCKING
+
+    def test_explicit_p1_marker_is_blocking(self) -> None:
+        thread = _thread(body="this is a P1 problem")
+        assert gate.classify_thread(thread) == gate.Severity.BLOCKING
+
+    def test_marker_is_case_insensitive(self) -> None:
+        thread = _thread(body="p1 regression")
+        assert gate.classify_thread(thread) == gate.Severity.BLOCKING
+
+    def test_copilot_thread_is_blocking_by_default(self) -> None:
+        thread = _thread(author="copilot-pull-request-reviewer[bot]", body="suggestion")
+        assert gate.classify_thread(thread) == gate.Severity.BLOCKING
+
+    def test_copilot_alias_github_copilot_bot_is_blocking(self) -> None:
+        thread = _thread(author="github-copilot[bot]", body="consider this")
+        assert gate.classify_thread(thread) == gate.Severity.BLOCKING
+
+    def test_copilot_thread_marked_nit_is_not_blocking(self) -> None:
+        thread = _thread(author="copilot-pull-request-reviewer[bot]", body="nit: rename var")
+        assert gate.classify_thread(thread) == gate.Severity.LOWER
+
+    def test_copilot_thread_marked_p2_is_not_blocking(self) -> None:
+        thread = _thread(author="copilot-pull-request-reviewer[bot]", body="P2: minor style")
+        assert gate.classify_thread(thread) == gate.Severity.LOWER
+
+    def test_plain_human_nit_is_lower(self) -> None:
+        thread = _thread(body="nit: tiny wording")
+        assert gate.classify_thread(thread) == gate.Severity.LOWER
+
+    def test_plain_human_comment_is_lower(self) -> None:
+        thread = _thread(body="what do you think about this?")
+        assert gate.classify_thread(thread) == gate.Severity.LOWER
+
+
+# ---------------------------------------------------------------------------
+# Decision: AC8.20.1 — blocking cases exit 1.
+# ---------------------------------------------------------------------------
+
+
+class TestBlocking:
+    def test_AC8_20_1_unresolved_p0_blocks(self) -> None:
+        """AC8.20.1: an unresolved P0 review thread exits 1."""
+        payload = _payload(_thread(body="P0: must fix", is_resolved=False))
+        assert _run(payload) == 1
+
+    def test_AC8_20_1_unresolved_copilot_blocks(self) -> None:
+        """AC8.20.1: an unresolved Copilot review thread exits 1."""
+        payload = _payload(_thread(author="copilot-pull-request-reviewer[bot]", is_resolved=False))
+        assert _run(payload) == 1
+
+    def test_AC8_20_1_blocking_thread_url_is_printed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """AC8.20.1: the blocking thread's url is named in the summary."""
+        url = "https://github.com/o/r/pull/1#discussion_r999"
+        payload = _payload(_thread(body="P1: bug", url=url, is_resolved=False))
+        assert _run(payload) == 1
+        captured = capsys.readouterr()
+        assert url in (captured.out + captured.err)
+
+
+# ---------------------------------------------------------------------------
+# Decision: AC8.20.2 — resolved/outdated/lower-severity never block.
+# ---------------------------------------------------------------------------
+
+
+class TestNonBlocking:
+    def test_AC8_20_2_resolved_p0_passes(self) -> None:
+        """AC8.20.2: a resolved P0 thread does not block."""
+        payload = _payload(_thread(body="P0: was fixed", is_resolved=True))
+        assert _run(payload) == 0
+
+    def test_AC8_20_2_outdated_p0_passes(self) -> None:
+        """AC8.20.2: an outdated (unresolved) P0 thread does not block."""
+        payload = _payload(_thread(body="P0: stale", is_resolved=False, is_outdated=True))
+        assert _run(payload) == 0
+
+    def test_AC8_20_2_unresolved_nit_passes_but_reported(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """AC8.20.2: an unresolved nit does not block but is reported."""
+        payload = _payload(_thread(body="nit: rename", is_resolved=False))
+        assert _run(payload) == 0
+        captured = capsys.readouterr()
+        # Lower-severity unresolved threads are surfaced, not silently dropped.
+        assert "nit" in (captured.out + captured.err).lower()
+
+    def test_AC8_20_2_empty_passes(self) -> None:
+        """AC8.20.2: a PR with no review threads passes (bootstrap-safe)."""
+        assert _run(_payload()) == 0
+
+    def test_AC8_20_2_mixed_blocks_only_on_active_p0(self) -> None:
+        """A resolved P0 plus an unresolved nit still passes."""
+        payload = _payload(
+            _thread(body="P0: fixed", is_resolved=True),
+            _thread(body="nit: trivial", is_resolved=False),
+        )
+        assert _run(payload) == 0
+
+
+# ---------------------------------------------------------------------------
+# Injectability + non-PR / bootstrap safety.
+# ---------------------------------------------------------------------------
+
+
+class TestSeamAndSafety:
+    def test_run_uses_injected_fetcher_without_network(self) -> None:
+        """The fetch seam is honored; no real `gh` call happens in tests."""
+        calls: list[tuple[int, str]] = []
+
+        def fake_fetch(pr_number: int, repo: str) -> dict[str, Any]:
+            calls.append((pr_number, repo))
+            return _payload()
+
+        assert gate.run(pr_number=7, repo="o/r", fetch_threads=fake_fetch) == 0
+        assert calls == [(7, "o/r")]
+
+    def test_run_skips_cleanly_when_pr_number_missing(self) -> None:
+        """Non-PR events (no PR number) skip the gate without blocking."""
+        sentinel_called = False
+
+        def fetch(pr_number: int, repo: str) -> dict[str, Any]:
+            nonlocal sentinel_called
+            sentinel_called = True
+            return _payload()
+
+        assert gate.run(pr_number=None, repo="o/r", fetch_threads=fetch) == 0
+        assert sentinel_called is False
+
+
+# ---------------------------------------------------------------------------
+# main(): CLI entrypoint wiring.
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_main_skips_without_pr_number(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PR_NUMBER", raising=False)
+        assert gate.main(["--repo", "o/r"]) == 0
+
+    def test_main_blocks_with_injected_blocking_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = _payload(_thread(body="P0: bug", is_resolved=False))
+        monkeypatch.setattr(gate, "fetch_threads", lambda pr_number, repo: payload)
+        assert gate.main(["--repo", "o/r", "--pr-number", "1"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC8.20.3 — the classification rule is documented in the CI/CD SSOT.
+# ---------------------------------------------------------------------------
+
+
+def test_AC8_20_3_severity_rule_documented_in_ssot() -> None:
+    """AC8.20.3: docs/ssot/ci-cd.md documents the gate and its severity rule."""
+    ci_cd = (_REPO_ROOT / "docs" / "ssot" / "ci-cd.md").read_text(encoding="utf-8")
+    assert "PR Review Thread Merge Gate" in ci_cd
+    # The exact marker rule and the Copilot-author list must be documented.
+    assert r"\b(P0|P1)\b" in ci_cd
+    assert "copilot-pull-request-reviewer[bot]" in ci_cd
+    # Resolved/outdated and lower-severity non-blocking semantics are documented.
+    assert "outdated" in ci_cd.lower()
+    assert "do **not** block" in ci_cd or "do not block" in ci_cd

--- a/tools/check_pr_review_threads.py
+++ b/tools/check_pr_review_threads.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Command wrapper for the PR review-thread merge gate."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.ci.check_pr_review_threads import main  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements **issue #755 scope 2a**: a merge-time CI gate that blocks a PR while
an unresolved **P0/P1** (or unresolved **Copilot-authored**) review thread is
still open. No such gate existed before.

The gate runs as a `pull_request` step in the `lint` job of `ci.yml`, reads the
PR's review threads through the GitHub GraphQL API (`gh api graphql`), and exits
non-zero when any unresolved thread is classified blocking.

### Severity classification rule (documented)
A thread is **blocking (P0/P1)** when its first comment body matches
`\b(P0|P1)\b` (case-insensitive) **OR** is Copilot-authored
(`copilot` / `github-copilot[bot]` / `copilot-pull-request-reviewer[bot]`) and
not explicitly marked a lower severity (`P2`/`P3`/`nit`). Everything else is
lower severity.

### Decision
- Exit 1 when any **unresolved** thread is **blocking**.
- **Resolved** and **outdated** threads never block.
- **Lower-severity unresolved** threads are reported (printed) but do not block.
- Bootstrap-safe: a fresh PR with no unresolved P0/P1 passes; non-PR events skip
  cleanly (exit 0). The GraphQL call is behind an injectable `fetch_threads`
  seam so tests run with canned JSON and no network.

## ACs (EPIC-008, group AC8.20)
- **AC8.20.1** — checker blocks (exit 1) on an unresolved P0/P1 (or Copilot) thread.
- **AC8.20.2** — resolved/outdated and lower-severity (P2/P3/nit) unresolved
  threads do NOT block; they are reported.
- **AC8.20.3** — the classification rule is documented in the CI/CD SSOT.

## Changes
- `common/ci/check_pr_review_threads.py` — gate logic (injectable fetch seam).
- `tools/check_pr_review_threads.py` — thin command wrapper.
- `tests/tooling/test_check_pr_review_threads.py` — pytest, canned GraphQL fixtures.
- `docs/project/EPIC-008.testing-strategy.md` — AC group AC8.20.
- `docs/ssot/ci-cd.md` — "PR Review Thread Merge Gate" section + classification rule.
- `docs/ssot/MANIFEST.yaml` — `pr_review_thread_merge_gate` concept.
- `.github/workflows/ci.yml` — gate step in the `lint` job (pull_request only).

## Local validation
```
python tools/check_ac_index.py            -> PASS (rc 0)
python tools/check_workflow_contract.py   -> PASS (rc 0, "Workflow contract OK")
python tools/check_manifest.py            -> PASS (rc 0)  [with submodule populated]
python tools/check_ssot_ownership.py      -> PASS (rc 0)
python tools/check_ci_metrics_contract.py -> PASS (rc 0)
tools/lint_doc_consistency.py             -> PASS
pytest tests/tooling/test_check_pr_review_threads.py  -> 22 passed
pytest test_ci_gate_inventory + test_delivery_gates_contract -> 6 passed
ruff check + ruff format --check (new files)          -> clean
all 9 workflow YAML files parse                       -> ok
generate_ac_registry.py                               -> registry index up to date (no diff)
```

Closes #755 (scope 2a only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
