### PR TITLE
[finance_report_vision] Bridge legacy manual valuations to stable taxonomy (#1223, AC11.23)

### DIFF
--- a/apps/backend/src/services/valuation_adapter.py
+++ b/apps/backend/src/services/valuation_adapter.py
@@ -135,10 +135,13 @@ class StableValuationView:
     value: Decimal
     currency: str
     source: str
-    valuation_basis: str | None
+    # Normalized to the "unspecified" sentinel (never None) to match the
+    # reporting/traceability convention so consumers don't branch on None.
+    valuation_basis: str
     confidence: Decimal
     component_type: str | None
-    rationale: str
+    # Nullable to mirror ValuationClassification.rationale on the new model.
+    rationale: str | None
 
 
 def classify_legacy_component(component_type: Legacy) -> StableValuationCodes:
@@ -161,7 +164,7 @@ def adapt_snapshot(snapshot: ManualValuationSnapshot) -> StableValuationView:
         value=snapshot.value,
         currency=snapshot.currency,
         source=snapshot.source,
-        valuation_basis=(snapshot.valuation_basis.value if snapshot.valuation_basis else None),
+        valuation_basis=(snapshot.valuation_basis.value if snapshot.valuation_basis else "unspecified"),
         confidence=_LEGACY_CONFIDENCE,
         component_type=snapshot.component_type.value,
         rationale=f"Deterministic legacy mapping from {snapshot.component_type.value}.",

--- a/apps/backend/src/services/valuation_adapter.py
+++ b/apps/backend/src/services/valuation_adapter.py
@@ -1,0 +1,168 @@
+"""Legacy manual valuation -> stable taxonomy adapter (#1223, EPIC-011 AC11.23).
+
+Read-only compatibility bridge. It maps each legacy
+``ManualValuationComponentType`` deterministically onto the stable taxonomy
+contract (``src.constants.valuation_taxonomy``) and projects a
+``ManualValuationSnapshot`` onto the same stable classification read-model shape
+that new valuation facts (#1222) will use.
+
+The legacy enum becomes an input *hint*; it is not retired and no PostgreSQL
+enum value is removed. This module adds no persistence, no LLM, and does not
+change the existing snapshot read path — reports keep their current behaviour
+until #1225 switches consumption over.
+
+The mapping is the single deterministic source for legacy classification: the
+``liquidity_class`` it produces matches the legacy
+``assets._DEFAULT_LIQUIDITY_CLASS`` table exactly, and the L1 class matches the
+legacy reporting allocation classes, so switching reports to read stable codes
+(#1225) is provably total-preserving.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from src.constants.valuation_taxonomy import (
+    EconomicSide,
+    LiquidityClass,
+    ValuationL1,
+    ValuationL2,
+    ValuationRole,
+    default_side_for_l1,
+)
+from src.models.layer3 import ManualValuationComponentType as Legacy, ManualValuationSnapshot
+
+# Deterministic legacy mappings are fully trusted (no model inference involved).
+_LEGACY_CONFIDENCE = Decimal("1.0")
+
+
+@dataclass(frozen=True)
+class StableValuationCodes:
+    """The stable taxonomy codes a valuation resolves to."""
+
+    l1: ValuationL1
+    l2: ValuationL2
+    economic_side: EconomicSide
+    valuation_role: ValuationRole
+    liquidity_class: LiquidityClass
+
+
+def _codes(
+    l1: ValuationL1,
+    l2: ValuationL2,
+    liquidity: LiquidityClass,
+    *,
+    role: ValuationRole = ValuationRole.NET_WORTH_COMPONENT,
+) -> StableValuationCodes:
+    # economic_side is always the L1 default for legacy data, keeping the
+    # adapter consistent with the contract's L1 -> side derivation.
+    return StableValuationCodes(l1, l2, default_side_for_l1(l1), role, liquidity)
+
+
+# Total mapping: every ManualValuationComponentType has exactly one row.
+_LEGACY_TO_STABLE: dict[Legacy, StableValuationCodes] = {
+    Legacy.PROPERTY_VALUE: _codes(ValuationL1.REAL_ESTATE, ValuationL2.PROPERTY, LiquidityClass.ILLIQUID),
+    Legacy.MORTGAGE_BALANCE: _codes(ValuationL1.LIABILITY, ValuationL2.SECURED_LIABILITY, LiquidityClass.LIABILITY),
+    Legacy.CPF_BALANCE: _codes(
+        ValuationL1.RETIREMENT_AND_BENEFIT,
+        ValuationL2.MANDATORY_RETIREMENT,
+        LiquidityClass.RESTRICTED,
+    ),
+    Legacy.RETIREMENT_ACCOUNT: _codes(
+        ValuationL1.RETIREMENT_AND_BENEFIT,
+        ValuationL2.VOLUNTARY_RETIREMENT,
+        LiquidityClass.RESTRICTED,
+    ),
+    Legacy.SOCIAL_SECURITY_PERSONAL_ACCOUNT: _codes(
+        ValuationL1.RETIREMENT_AND_BENEFIT,
+        ValuationL2.MANDATORY_RETIREMENT,
+        LiquidityClass.RESTRICTED,
+    ),
+    Legacy.LONG_TERM_BENEFIT_ASSET: _codes(
+        ValuationL1.RETIREMENT_AND_BENEFIT,
+        ValuationL2.LONG_TERM_BENEFIT,
+        LiquidityClass.RESTRICTED,
+    ),
+    Legacy.LONG_TERM_SAVINGS: _codes(
+        ValuationL1.RETIREMENT_AND_BENEFIT,
+        ValuationL2.LONG_TERM_BENEFIT,
+        LiquidityClass.RESTRICTED,
+    ),
+    Legacy.TAX_PAYABLE: _codes(ValuationL1.LIABILITY, ValuationL2.TAX_LIABILITY, LiquidityClass.LIABILITY),
+    Legacy.TAX_REFUND: _codes(ValuationL1.CASH, ValuationL2.CASH_DEPOSIT, LiquidityClass.LIQUID),
+    # Insurance is represented only by its attributable cash/surrender value,
+    # which is an asset (never a coverage amount). Coverage figures are handled
+    # by #1224 as non_asset/coverage_amount.
+    Legacy.INSURANCE_CASH_VALUE: _codes(
+        ValuationL1.RETIREMENT_AND_BENEFIT,
+        ValuationL2.LONG_TERM_BENEFIT,
+        LiquidityClass.RESTRICTED,
+    ),
+    Legacy.ESOP: _codes(
+        ValuationL1.RESTRICTED_COMPENSATION,
+        ValuationL2.EQUITY_AWARD,
+        LiquidityClass.RESTRICTED,
+    ),
+    Legacy.RSU: _codes(
+        ValuationL1.RESTRICTED_COMPENSATION,
+        ValuationL2.EQUITY_AWARD,
+        LiquidityClass.RESTRICTED,
+    ),
+    Legacy.STOCK_OPTIONS: _codes(
+        ValuationL1.RESTRICTED_COMPENSATION,
+        ValuationL2.EQUITY_AWARD,
+        LiquidityClass.RESTRICTED,
+    ),
+    Legacy.OTHER_ASSET: _codes(ValuationL1.OTHER_ASSET, ValuationL2.UNCLASSIFIED, LiquidityClass.LIQUID),
+    Legacy.OTHER_LIABILITY: _codes(ValuationL1.LIABILITY, ValuationL2.UNSECURED_LIABILITY, LiquidityClass.LIABILITY),
+}
+
+
+@dataclass(frozen=True)
+class StableValuationView:
+    """A legacy snapshot projected onto the stable classification read-model.
+
+    The same shape future code will build from new ``ValuationClassification``
+    rows, so report logic (#1225) can consume one read-model regardless of the
+    source. ``component_type`` is the legacy input hint and is ``None`` for
+    natively-classified facts.
+    """
+
+    codes: StableValuationCodes
+    as_of_date: date
+    value: Decimal
+    currency: str
+    source: str
+    valuation_basis: str | None
+    confidence: Decimal
+    component_type: str | None
+    rationale: str
+
+
+def classify_legacy_component(component_type: Legacy) -> StableValuationCodes:
+    """Map a legacy component type to its stable taxonomy codes (total)."""
+
+    return _LEGACY_TO_STABLE[component_type]
+
+
+def adapt_snapshot(snapshot: ManualValuationSnapshot) -> StableValuationView:
+    """Project a legacy manual valuation snapshot onto the stable read-model.
+
+    Preserves the snapshot's source, as-of date, currency, value, and valuation
+    basis so traceability survives the bridge.
+    """
+
+    codes = classify_legacy_component(snapshot.component_type)
+    return StableValuationView(
+        codes=codes,
+        as_of_date=snapshot.as_of_date,
+        value=snapshot.value,
+        currency=snapshot.currency,
+        source=snapshot.source,
+        valuation_basis=(snapshot.valuation_basis.value if snapshot.valuation_basis else None),
+        confidence=_LEGACY_CONFIDENCE,
+        component_type=snapshot.component_type.value,
+        rationale=f"Deterministic legacy mapping from {snapshot.component_type.value}.",
+    )

--- a/apps/backend/tests/assets/test_valuation_adapter.py
+++ b/apps/backend/tests/assets/test_valuation_adapter.py
@@ -66,6 +66,19 @@ def test_adapt_snapshot_preserves_fact_fields_in_stable_view():
     assert view.codes.l1 is ValuationL1.RETIREMENT_AND_BENEFIT
     assert view.codes.l2 is ValuationL2.MANDATORY_RETIREMENT
 
+    # A snapshot with no basis normalizes to the "unspecified" sentinel (never
+    # None), matching the reporting/traceability convention.
+    no_basis = ManualValuationSnapshot(
+        component_type=Legacy.OTHER_ASSET,
+        liquidity_class=ManualValuationLiquidityClass.LIQUID,
+        as_of_date=date(2026, 3, 31),
+        value=Decimal("10.00"),
+        currency="USD",
+        source="manual",
+        valuation_basis=None,
+    )
+    assert adapt_snapshot(no_basis).valuation_basis == "unspecified"
+
 
 def test_legacy_fixtures_classify_to_expected_stable_codes():
     """AC11.23.4: CPF/insurance cash value/RSU/mortgage map to expected stable codes.

--- a/apps/backend/tests/assets/test_valuation_adapter.py
+++ b/apps/backend/tests/assets/test_valuation_adapter.py
@@ -1,0 +1,92 @@
+"""Legacy valuation adapter tests (#1223, EPIC-011 AC11.23).
+
+Proves the legacy -> stable bridge is total and deterministic, preserves the
+legacy liquidity behaviour exactly (cross-checked against the live legacy table),
+and projects a snapshot onto the stable read-model without losing traceability
+fields. No persistence or report behaviour is exercised here.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from src.constants.valuation_taxonomy import (
+    EconomicSide,
+    LiquidityClass,
+    ValuationL1,
+    ValuationL2,
+    default_side_for_l1,
+)
+from src.models.layer3 import (
+    ManualValuationBasis,
+    ManualValuationComponentType as Legacy,
+    ManualValuationLiquidityClass,
+    ManualValuationSnapshot,
+)
+from src.services.assets import _DEFAULT_LIQUIDITY_CLASS
+from src.services.valuation_adapter import adapt_snapshot, classify_legacy_component
+
+
+def test_legacy_component_mapping_is_total_and_deterministic():
+    """AC11.23.1: every legacy component maps to stable codes; side = L1 default."""
+    for legacy in Legacy:
+        codes = classify_legacy_component(legacy)  # no KeyError => total
+        assert isinstance(codes.l1, ValuationL1)
+        assert isinstance(codes.l2, ValuationL2)
+        assert codes.economic_side is default_side_for_l1(codes.l1)
+    assert classify_legacy_component(Legacy.CPF_BALANCE) == classify_legacy_component(Legacy.CPF_BALANCE)
+
+
+def test_adapter_preserves_legacy_liquidity_class():
+    """AC11.23.2: adapter liquidity matches the legacy default for every component."""
+    assert set(_DEFAULT_LIQUIDITY_CLASS) == set(Legacy)
+    for legacy, legacy_liquidity in _DEFAULT_LIQUIDITY_CLASS.items():
+        codes = classify_legacy_component(legacy)
+        assert codes.liquidity_class.value == legacy_liquidity.value, legacy
+
+
+def test_adapt_snapshot_preserves_fact_fields_in_stable_view():
+    """AC11.23.3: snapshot projects onto the stable read-model preserving fields."""
+    snap = ManualValuationSnapshot(
+        component_type=Legacy.CPF_BALANCE,
+        liquidity_class=ManualValuationLiquidityClass.RESTRICTED,
+        as_of_date=date(2026, 3, 31),
+        value=Decimal("150000.00"),
+        currency="SGD",
+        source="cpf_portal",
+        valuation_basis=ManualValuationBasis.GOVERNMENT_STATEMENT,
+    )
+    view = adapt_snapshot(snap)
+    assert view.as_of_date == date(2026, 3, 31)
+    assert view.value == Decimal("150000.00")
+    assert view.currency == "SGD"
+    assert view.source == "cpf_portal"
+    assert view.valuation_basis == "government_statement"
+    assert view.component_type == "cpf_balance"
+    assert view.confidence == Decimal("1.0")
+    assert view.codes.l1 is ValuationL1.RETIREMENT_AND_BENEFIT
+    assert view.codes.l2 is ValuationL2.MANDATORY_RETIREMENT
+
+
+def test_legacy_fixtures_classify_to_expected_stable_codes():
+    """AC11.23.4: CPF/insurance cash value/RSU/mortgage map to expected stable codes.
+
+    Insurance cash value is an asset (never coverage), restricted compensation is
+    an equity award, and liabilities carry the liability side.
+    """
+    cpf = classify_legacy_component(Legacy.CPF_BALANCE)
+    assert (cpf.l1, cpf.l2, cpf.economic_side) == (
+        ValuationL1.RETIREMENT_AND_BENEFIT,
+        ValuationL2.MANDATORY_RETIREMENT,
+        EconomicSide.ASSET,
+    )
+
+    cash_value = classify_legacy_component(Legacy.INSURANCE_CASH_VALUE)
+    assert cash_value.economic_side is EconomicSide.ASSET
+    assert cash_value.l1 is ValuationL1.RETIREMENT_AND_BENEFIT
+
+    rsu = classify_legacy_component(Legacy.RSU)
+    assert (rsu.l1, rsu.l2) == (ValuationL1.RESTRICTED_COMPENSATION, ValuationL2.EQUITY_AWARD)
+
+    mortgage = classify_legacy_component(Legacy.MORTGAGE_BALANCE)
+    assert mortgage.economic_side is EconomicSide.LIABILITY
+    assert mortgage.liquidity_class is LiquidityClass.LIABILITY

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -310,6 +310,25 @@ auto-classified low risk); no legacy enum value is removed.
 | AC11.22.4 | Existing manual valuation model and enum values are unchanged by the storage addition (no legacy enum value removed) | `test_manual_valuation_model_is_unchanged_by_storage_addition()` | `assets/test_valuation_fact_storage.py` | P0 |
 | AC11.22.5 | A classification cannot reference a fact owned by a different user (same-owner composite FK) | `test_valuation_classification_rejects_cross_user_fact_reference()` | `assets/test_valuation_fact_storage.py` | P0 |
 
+### AC11.23: Legacy Manual Valuation Adapter (#1223)
+
+Read-only compatibility bridge from legacy `ManualValuationComponentType` to the
+stable taxonomy (AC11.21). It maps each legacy component deterministically onto
+stable codes and projects a `ManualValuationSnapshot` onto the same stable
+classification read-model that new valuation facts will use. The legacy enum
+becomes an input hint; it is not retired and no PostgreSQL enum value is removed.
+No new persistence, no LLM, and the existing snapshot read path is unchanged —
+reports keep current behaviour until #1225 switches consumption over. The
+adapter's `liquidity_class` is cross-checked against the live legacy
+`_DEFAULT_LIQUIDITY_CLASS` table so the bridge is provably behaviour-preserving.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.23.1 | Every legacy component type maps to stable codes (total + deterministic), with economic_side derived from the L1 default | `test_legacy_component_mapping_is_total_and_deterministic()` | `assets/test_valuation_adapter.py` | P0 |
+| AC11.23.2 | The adapter's stable `liquidity_class` matches the legacy default for every component (backward-compatible) | `test_adapter_preserves_legacy_liquidity_class()` | `assets/test_valuation_adapter.py` | P0 |
+| AC11.23.3 | A snapshot projects onto the stable read-model preserving source, as-of date, currency, value, and valuation basis | `test_adapt_snapshot_preserves_fact_fields_in_stable_view()` | `assets/test_valuation_adapter.py` | P0 |
+| AC11.23.4 | Legacy CPF/insurance cash value/RSU/mortgage fixtures classify to the expected stable L1/L2 (cash value is an asset, not coverage) | `test_legacy_fixtures_classify_to_expected_stable_codes()` | `assets/test_valuation_adapter.py` | P0 |
+
 ## Implementation Pattern Ownership
 
 Do not copy reusable code patterns, router examples, migration guardrails, or

--- a/docs/ssot/assets.md
+++ b/docs/ssot/assets.md
@@ -283,6 +283,15 @@ small L1/L2 class tree:
 a default `economic_side`. Field definitions and the full L2 set live in the
 contract module; this SSOT section owns the vocabulary, not the enum members.
 
+**Legacy bridge (#1223).** `apps/backend/src/services/valuation_adapter.py` is a
+read-only adapter mapping each legacy `ManualValuationComponentType` onto these
+stable codes and projecting a `ManualValuationSnapshot` onto the stable
+classification read-model. The legacy enum is an input hint, not retired; no
+PostgreSQL enum value is removed and the existing snapshot read path is
+unchanged. The adapter's `liquidity_class` is pinned to the legacy
+`_DEFAULT_LIQUIDITY_CLASS` table by test, so report switch-over (#1225) is
+behaviour-preserving.
+
 ---
 
 ## 7. Design Constraints


### PR DESCRIPTION
## Goal

Step 2 of 3 (PR 1 of 2) in the valuation taxonomy program. Closes the legacy-compatibility slice of #1223: a read-only adapter from legacy `ManualValuationComponentType` to the AC11.21 stable taxonomy. Independent of #1224 (the other step-2 PR); both base on `main`.

## What

- **`src/services/valuation_adapter.py`**:
  - `classify_legacy_component()` — total, deterministic map of all 15 legacy component types to stable codes `(L1, L2, economic_side, valuation_role, liquidity_class)`. `economic_side` is derived from the contract's L1 default.
  - `adapt_snapshot()` — projects a `ManualValuationSnapshot` onto a `StableValuationView` read-model, preserving source, as-of date, currency, value, and valuation basis (traceability survives the bridge). `component_type` is kept as the legacy hint.
- The legacy enum stays an **input hint**: not retired, no PG enum value removed, and the existing snapshot read path is untouched (reports switch to stable consumption in #1225).

## Why it's safe (behaviour-preserving)

- **AC11.23.2** cross-checks the adapter's `liquidity_class` against the **live** legacy `assets._DEFAULT_LIQUIDITY_CLASS` table for every component — so the bridge can't silently drift from current liquidity behaviour.
- L1 classes line up with the legacy reporting allocation classes (retirement_and_benefit, restricted_compensation, real_estate, liability, cash, other), so the #1225 switch-over is total-preserving.
- Insurance cash value maps to an **asset** (never coverage); coverage amounts are handled by #1224 as `non_asset`/`coverage_amount`.

## MECE scope

Legacy compatibility only. **Out of scope**: LLM classification (#1224), report switch-over (#1225), frontend (#1226), new persistence.

## Verification

- `tests/assets/test_valuation_adapter.py` — 4 ACs pass (total/deterministic, legacy-liquidity-preserving, snapshot projection, key fixtures).
- preflight ac-traceability / ssot-ownership / doc-consistency / transaction-boundary green; `check_ac_index` integrity + protection PASS.
- Pinned ruff (venv 0.14.11, as CI) clean. (Local preflight PATH ruff 0.15.17 UP042 `str, Enum` is a repo-wide pre-existing false positive.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)