### PR TITLE
[finance_report_vision] Add LLM valuation classification contract + review gates (#1224, AC11.24)

### DIFF
--- a/apps/backend/src/schemas/valuation.py
+++ b/apps/backend/src/schemas/valuation.py
@@ -40,41 +40,40 @@ class ValuationClassificationLLMOutput(BaseModel):
     """The bounded output a model returns when classifying one valuation fact."""
 
     # Raw extracted values — echoed for auditability; jurisdiction/issuer/scheme
-    # stay metadata and are never promoted into the stable codes.
+    # stay metadata and are never promoted into the stable codes. Numeric and
+    # currency bounds match the AtomicValuationFact storage constraints so the
+    # contract rejects values that would later fail or be silently rounded.
     raw_label: str
     issuer: str | None = None
     jurisdiction: str | None = None
     scheme_name: str | None = None
-    amount: Decimal
-    currency: str
+    amount: Decimal = Field(ge=0, max_digits=18, decimal_places=2)
+    currency: str = Field(min_length=3, max_length=3, description="ISO-4217 code")
     as_of_date: date
     evidence_spans: list[ValuationEvidenceSpan] = Field(
         default_factory=list, description="Pointers back to where each value was read in the source."
     )
 
     # Stable classification — bound to the contract; out-of-contract values are
-    # rejected by enum validation.
+    # rejected by enum validation. confidence precision matches the
+    # ValuationClassification Numeric(5,4) column.
     l1: ValuationL1
     l2: ValuationL2 | None = None
     economic_side: EconomicSide
     valuation_role: ValuationRole
     liquidity_class: LiquidityClass
-    confidence: Decimal
+    confidence: Decimal = Field(ge=0, le=1, max_digits=5, decimal_places=4)
     rationale: str
 
-    model_config = ConfigDict(from_attributes=True)
+    # extra="forbid" keeps the bounded contract deterministic: prompt/model drift
+    # that adds unknown keys fails loudly instead of being silently ignored.
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
 
-    @field_validator("currency")
+    @field_validator("currency", mode="before")
     @classmethod
-    def _normalize_currency(cls, value: str) -> str:
-        return value.strip().upper()
-
-    @field_validator("confidence")
-    @classmethod
-    def _confidence_in_unit_interval(cls, value: Decimal) -> Decimal:
-        if not (Decimal("0") <= value <= Decimal("1")):
-            raise ValueError("confidence must be within [0, 1]")
-        return value
+    def _normalize_currency(cls, value: object) -> object:
+        # Normalize before the length constraint runs so " usd " -> "USD".
+        return value.strip().upper() if isinstance(value, str) else value
 
     @model_validator(mode="after")
     def _stable_code_consistency(self) -> ValuationClassificationLLMOutput:

--- a/apps/backend/src/schemas/valuation.py
+++ b/apps/backend/src/schemas/valuation.py
@@ -1,0 +1,95 @@
+"""Constrained LLM valuation-classification output contract (#1224, EPIC-011 AC11.24).
+
+The schema the model must fill to classify a raw valuation fact into the stable
+taxonomy (``src.constants.valuation_taxonomy``). Binding the taxonomy fields to
+the contract enums means the model cannot invent new report classes — an
+out-of-contract code is a validation error, not a silently-accepted value. The
+model adapts provider/jurisdiction/plan specifics (CPF, 401k, MPF, social
+security, insurers) into these stable codes; the raw specifics are echoed back
+as auditable metadata.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.constants.valuation_taxonomy import (
+    EconomicSide,
+    LiquidityClass,
+    ValuationL1,
+    ValuationL2,
+    ValuationRole,
+    parent_l1,
+)
+
+
+class ValuationEvidenceSpan(BaseModel):
+    """A pointer back to where in the source a value was read."""
+
+    page: int | None = None
+    bbox: list[float] | None = None
+    text: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ValuationClassificationLLMOutput(BaseModel):
+    """The bounded output a model returns when classifying one valuation fact."""
+
+    # Raw extracted values — echoed for auditability; jurisdiction/issuer/scheme
+    # stay metadata and are never promoted into the stable codes.
+    raw_label: str
+    issuer: str | None = None
+    jurisdiction: str | None = None
+    scheme_name: str | None = None
+    amount: Decimal
+    currency: str
+    as_of_date: date
+    evidence_spans: list[ValuationEvidenceSpan] = Field(
+        default_factory=list, description="Pointers back to where each value was read in the source."
+    )
+
+    # Stable classification — bound to the contract; out-of-contract values are
+    # rejected by enum validation.
+    l1: ValuationL1
+    l2: ValuationL2 | None = None
+    economic_side: EconomicSide
+    valuation_role: ValuationRole
+    liquidity_class: LiquidityClass
+    confidence: Decimal
+    rationale: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("currency")
+    @classmethod
+    def _normalize_currency(cls, value: str) -> str:
+        return value.strip().upper()
+
+    @field_validator("confidence")
+    @classmethod
+    def _confidence_in_unit_interval(cls, value: Decimal) -> Decimal:
+        if not (Decimal("0") <= value <= Decimal("1")):
+            raise ValueError("confidence must be within [0, 1]")
+        return value
+
+    @model_validator(mode="after")
+    def _stable_code_consistency(self) -> ValuationClassificationLLMOutput:
+        # An L2 code must roll up to its declared L1 parent.
+        if self.l2 is not None and parent_l1(self.l2) != self.l1:
+            raise ValueError(f"l2 '{self.l2.value}' does not roll up to l1 '{self.l1.value}'")
+        # A coverage amount is a non_asset (excluded from net worth); conversely
+        # only a non_asset may carry the coverage_amount role.
+        is_coverage = self.valuation_role == ValuationRole.COVERAGE_AMOUNT
+        is_non_asset = self.economic_side == EconomicSide.NON_ASSET
+        if is_coverage and not is_non_asset:
+            raise ValueError("coverage_amount role requires economic_side=non_asset")
+        if is_non_asset and self.valuation_role not in (
+            ValuationRole.COVERAGE_AMOUNT,
+            ValuationRole.INFORMATIONAL,
+        ):
+            raise ValueError("non_asset side must carry coverage_amount or informational role")
+        return self

--- a/apps/backend/src/services/valuation_classification.py
+++ b/apps/backend/src/services/valuation_classification.py
@@ -1,0 +1,97 @@
+"""Valuation classification review gating + persistence mapping (#1224, AC11.24).
+
+Turns a validated ``ValuationClassificationLLMOutput`` into a gated result: a
+low-confidence or ambiguous classification enters review (``PENDING``) instead of
+being trusted for reports, while a confident one is auto-approved. The prompt and
+model identifiers are carried through so they are persisted with the
+classification. No live LLM call is made here — this is the deterministic
+contract + gate that wraps whatever transport produces the output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from src.constants.valuation_taxonomy import EconomicSide
+from src.models.valuation import ValuationReviewStatus
+from src.schemas.valuation import ValuationClassificationLLMOutput
+
+# Versioned so every persisted classification records what produced it.
+VALUATION_CLASSIFICATION_PROMPT_VERSION = "valuation-classify-v1"
+
+# At or above this confidence a classification is trusted for report use; below
+# it the classification is routed to review. Mirrors the extraction confidence
+# gate, expressed on the 0..1 scale.
+REVIEW_CONFIDENCE_THRESHOLD = Decimal("0.85")
+
+
+@dataclass(frozen=True)
+class GatedValuationClassification:
+    """An LLM classification plus its review decision and provenance versions."""
+
+    output: ValuationClassificationLLMOutput
+    review_status: ValuationReviewStatus
+    model_version: str
+    prompt_version: str
+
+    @property
+    def contributes_to_net_worth(self) -> bool:
+        """Non-asset valuations (e.g. insurance coverage) never enter net worth."""
+
+        return self.output.economic_side != EconomicSide.NON_ASSET
+
+    @property
+    def is_trusted_for_reports(self) -> bool:
+        return self.review_status == ValuationReviewStatus.APPROVED
+
+
+def gate_classification(
+    output: ValuationClassificationLLMOutput,
+    *,
+    model_version: str,
+    prompt_version: str = VALUATION_CLASSIFICATION_PROMPT_VERSION,
+) -> GatedValuationClassification:
+    """Route a validated classification to review or trusted use by confidence."""
+
+    review_status = (
+        ValuationReviewStatus.APPROVED
+        if output.confidence >= REVIEW_CONFIDENCE_THRESHOLD
+        else ValuationReviewStatus.PENDING
+    )
+    return GatedValuationClassification(
+        output=output,
+        review_status=review_status,
+        model_version=model_version,
+        prompt_version=prompt_version,
+    )
+
+
+def build_classification_fields(
+    *,
+    valuation_fact_id: UUID,
+    user_id: UUID,
+    gated: GatedValuationClassification,
+) -> dict:
+    """Persistence kwargs for a ``ValuationClassification`` row.
+
+    Carries the stable codes, confidence, review status, and — per AC11.24 — the
+    prompt and model versions that produced the classification.
+    """
+
+    o = gated.output
+    return {
+        "valuation_fact_id": valuation_fact_id,
+        "user_id": user_id,
+        "l1": o.l1,
+        "l2": o.l2,
+        "economic_side": o.economic_side,
+        "valuation_role": o.valuation_role,
+        "liquidity_class": o.liquidity_class,
+        "confidence": o.confidence,
+        "review_status": gated.review_status,
+        "model_version": gated.model_version,
+        "prompt_version": gated.prompt_version,
+        "rationale": o.rationale,
+    }

--- a/apps/backend/src/services/valuation_classification.py
+++ b/apps/backend/src/services/valuation_classification.py
@@ -26,6 +26,10 @@ VALUATION_CLASSIFICATION_PROMPT_VERSION = "valuation-classify-v1"
 # gate, expressed on the 0..1 scale.
 REVIEW_CONFIDENCE_THRESHOLD = Decimal("0.85")
 
+# Matches the ValuationClassification.model_version / prompt_version columns
+# (String(120)); guard at the boundary so over-long ids fail fast, not at flush.
+_MAX_VERSION_LENGTH = 120
+
 
 @dataclass(frozen=True)
 class GatedValuationClassification:
@@ -54,6 +58,10 @@ def gate_classification(
     prompt_version: str = VALUATION_CLASSIFICATION_PROMPT_VERSION,
 ) -> GatedValuationClassification:
     """Route a validated classification to review or trusted use by confidence."""
+
+    for name, value in (("model_version", model_version), ("prompt_version", prompt_version)):
+        if len(value) > _MAX_VERSION_LENGTH:
+            raise ValueError(f"{name} exceeds {_MAX_VERSION_LENGTH} characters")
 
     review_status = (
         ValuationReviewStatus.APPROVED

--- a/apps/backend/tests/assets/test_valuation_classification_contract.py
+++ b/apps/backend/tests/assets/test_valuation_classification_contract.py
@@ -123,6 +123,24 @@ def test_llm_output_rejects_out_of_contract_codes():
         ValuationClassificationLLMOutput.model_validate(_payload(confidence="1.4"))
 
 
+def test_storage_boundary_constraints_are_enforced_at_the_contract():
+    """AC11.24.6: amount/currency/confidence/extra match storage so persistence can't fail late."""
+    # currency is normalized before the length check ( " usd " -> "USD").
+    assert ValuationClassificationLLMOutput.model_validate(_payload(currency=" usd ")).currency == "USD"
+
+    # Negative amount, >2dp amount, non-3-char currency, >4dp confidence, and
+    # unknown keys are all rejected at the boundary (match the storage columns).
+    for bad in (
+        {"amount": "-1.00"},
+        {"amount": "10.999"},
+        {"currency": "US"},
+        {"confidence": "0.95001"},
+        {"unexpected_field": "x"},
+    ):
+        with pytest.raises(ValidationError):
+            ValuationClassificationLLMOutput.model_validate(_payload(**bad))
+
+
 def test_cash_value_is_asset_coverage_amount_excluded_from_net_worth():
     """AC11.24.2: insurance cash value is an asset; coverage is excluded."""
     cash_value = ValuationClassificationLLMOutput.model_validate(FIXTURES["insurance_cash_value"][0])
@@ -171,3 +189,8 @@ def test_prompt_and_model_version_persisted():
     assert fields["prompt_version"] == VALUATION_CLASSIFICATION_PROMPT_VERSION
     assert fields["review_status"] is ValuationReviewStatus.APPROVED
     assert fields["l1"] is ValuationL1.RETIREMENT_AND_BENEFIT
+
+    # An over-long version id fails fast at the gate, not at DB flush
+    # (matches the String(120) columns).
+    with pytest.raises(ValueError):
+        gate_classification(output, model_version="x" * 121)

--- a/apps/backend/tests/assets/test_valuation_classification_contract.py
+++ b/apps/backend/tests/assets/test_valuation_classification_contract.py
@@ -1,0 +1,173 @@
+"""LLM valuation-classification contract + gating tests (#1224, EPIC-011 AC11.24).
+
+Deterministic fixtures cover CPF/provident fund, a 401k-style employer plan, a
+China social-security personal account, insurance cash value, and an insurance
+coverage amount. They prove the bounded schema rejects out-of-contract codes,
+that cash value is an asset while coverage is a non-asset excluded from net
+worth, that low-confidence output is routed to review, and that prompt/model
+versions are persisted.
+"""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.constants.valuation_taxonomy import (
+    EconomicSide,
+    ValuationL1,
+    ValuationL2,
+    ValuationRole,
+)
+from src.models.valuation import ValuationReviewStatus
+from src.schemas.valuation import ValuationClassificationLLMOutput
+from src.services.valuation_classification import (
+    REVIEW_CONFIDENCE_THRESHOLD,
+    VALUATION_CLASSIFICATION_PROMPT_VERSION,
+    build_classification_fields,
+    gate_classification,
+)
+
+
+def _payload(**overrides) -> dict:
+    base = {
+        "raw_label": "CPF Ordinary Account",
+        "issuer": "CPF Board",
+        "jurisdiction": "SG",
+        "scheme_name": "Central Provident Fund",
+        "amount": "150000.00",
+        "currency": "sgd",
+        "as_of_date": "2026-03-31",
+        "evidence_spans": [{"page": 1, "text": "OA balance 150,000.00"}],
+        "l1": "retirement_and_benefit",
+        "l2": "mandatory_retirement",
+        "economic_side": "asset",
+        "valuation_role": "net_worth_component",
+        "liquidity_class": "restricted",
+        "confidence": "0.95",
+        "rationale": "Statutory retirement balance.",
+    }
+    base.update(overrides)
+    return base
+
+
+# Deterministic fixtures: (label, overrides, expected (l1, l2, economic_side)).
+FIXTURES = {
+    "cpf_provident_fund": (
+        _payload(),
+        (ValuationL1.RETIREMENT_AND_BENEFIT, ValuationL2.MANDATORY_RETIREMENT, EconomicSide.ASSET),
+    ),
+    "employer_401k": (
+        _payload(
+            raw_label="Fidelity 401(k)",
+            issuer="Fidelity",
+            jurisdiction="US",
+            scheme_name="401(k)",
+            l2="voluntary_retirement",
+            confidence="0.93",
+        ),
+        (ValuationL1.RETIREMENT_AND_BENEFIT, ValuationL2.VOLUNTARY_RETIREMENT, EconomicSide.ASSET),
+    ),
+    "china_social_security_personal": (
+        _payload(
+            raw_label="个人社保账户",
+            issuer="人力资源和社会保障局",
+            jurisdiction="CN",
+            scheme_name="社会保险个人账户",
+            l2="mandatory_retirement",
+            confidence="0.90",
+        ),
+        (ValuationL1.RETIREMENT_AND_BENEFIT, ValuationL2.MANDATORY_RETIREMENT, EconomicSide.ASSET),
+    ),
+    "insurance_cash_value": (
+        _payload(
+            raw_label="Whole-life policy cash value",
+            issuer="Prudential",
+            scheme_name="WholeLife",
+            l2="long_term_benefit",
+            confidence="0.88",
+        ),
+        (ValuationL1.RETIREMENT_AND_BENEFIT, ValuationL2.LONG_TERM_BENEFIT, EconomicSide.ASSET),
+    ),
+    "insurance_coverage_amount": (
+        _payload(
+            raw_label="Death benefit coverage",
+            issuer="Prudential",
+            scheme_name="WholeLife",
+            l1="non_asset",
+            l2="protection_coverage",
+            economic_side="non_asset",
+            valuation_role="coverage_amount",
+            liquidity_class="illiquid",
+            confidence="0.90",
+        ),
+        (ValuationL1.NON_ASSET, ValuationL2.PROTECTION_COVERAGE, EconomicSide.NON_ASSET),
+    ),
+}
+
+
+def test_llm_output_rejects_out_of_contract_codes():
+    """AC11.24.1: bounded schema accepts valid output, rejects invented codes."""
+    ok = ValuationClassificationLLMOutput.model_validate(_payload())
+    assert ok.l1 is ValuationL1.RETIREMENT_AND_BENEFIT
+    assert ok.currency == "SGD"  # normalized
+
+    # A jurisdiction/scheme name is not a stable code.
+    with pytest.raises(ValidationError):
+        ValuationClassificationLLMOutput.model_validate(_payload(l1="cpf"))
+    # An L2 that does not roll up to its L1 is rejected.
+    with pytest.raises(ValidationError):
+        ValuationClassificationLLMOutput.model_validate(_payload(l1="real_estate", l2="mandatory_retirement"))
+    # Confidence outside [0, 1] is rejected.
+    with pytest.raises(ValidationError):
+        ValuationClassificationLLMOutput.model_validate(_payload(confidence="1.4"))
+
+
+def test_cash_value_is_asset_coverage_amount_excluded_from_net_worth():
+    """AC11.24.2: insurance cash value is an asset; coverage is excluded."""
+    cash_value = ValuationClassificationLLMOutput.model_validate(FIXTURES["insurance_cash_value"][0])
+    cash_gated = gate_classification(cash_value, model_version="glm-4.6v")
+    assert cash_value.economic_side is EconomicSide.ASSET
+    assert cash_gated.contributes_to_net_worth is True
+
+    coverage = ValuationClassificationLLMOutput.model_validate(FIXTURES["insurance_coverage_amount"][0])
+    coverage_gated = gate_classification(coverage, model_version="glm-4.6v")
+    assert coverage.economic_side is EconomicSide.NON_ASSET
+    assert coverage.valuation_role is ValuationRole.COVERAGE_AMOUNT
+    assert coverage_gated.contributes_to_net_worth is False
+
+    # A coverage amount must be non_asset — asset-side coverage is rejected.
+    with pytest.raises(ValidationError):
+        ValuationClassificationLLMOutput.model_validate(
+            _payload(valuation_role="coverage_amount", economic_side="asset")
+        )
+
+
+def test_low_confidence_routes_to_review():
+    """AC11.24.3: low confidence enters review; confident output is approved."""
+    high = ValuationClassificationLLMOutput.model_validate(_payload(confidence="0.95"))
+    assert gate_classification(high, model_version="m").review_status is ValuationReviewStatus.APPROVED
+
+    threshold = str(REVIEW_CONFIDENCE_THRESHOLD - REVIEW_CONFIDENCE_THRESHOLD.__class__("0.10"))
+    low = ValuationClassificationLLMOutput.model_validate(_payload(confidence=threshold))
+    low_gated = gate_classification(low, model_version="m")
+    assert low_gated.review_status is ValuationReviewStatus.PENDING
+    assert low_gated.is_trusted_for_reports is False
+
+
+def test_deterministic_fixtures_classify_to_expected_codes():
+    """AC11.24.4: each deterministic fixture parses to its expected stable codes."""
+    for label, (payload, expected) in FIXTURES.items():
+        output = ValuationClassificationLLMOutput.model_validate(payload)
+        assert (output.l1, output.l2, output.economic_side) == expected, label
+
+
+def test_prompt_and_model_version_persisted():
+    """AC11.24.5: prompt + model version flow into the persisted classification."""
+    output = ValuationClassificationLLMOutput.model_validate(_payload())
+    gated = gate_classification(output, model_version="glm-4.6v")
+    fields = build_classification_fields(valuation_fact_id=uuid4(), user_id=uuid4(), gated=gated)
+    assert fields["model_version"] == "glm-4.6v"
+    assert fields["prompt_version"] == VALUATION_CLASSIFICATION_PROMPT_VERSION
+    assert fields["review_status"] is ValuationReviewStatus.APPROVED
+    assert fields["l1"] is ValuationL1.RETIREMENT_AND_BENEFIT

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -346,7 +346,8 @@ transport and no report switch-over (that is #1225).
 | AC11.24.2 | Insurance cash value classifies as an asset that contributes to net worth; a coverage amount is a non-asset excluded from net worth | `test_cash_value_is_asset_coverage_amount_excluded_from_net_worth()` | `assets/test_valuation_classification_contract.py` | P0 |
 | AC11.24.3 | Low-confidence classifications route to review; confident ones are auto-approved for trusted use | `test_low_confidence_routes_to_review()` | `assets/test_valuation_classification_contract.py` | P0 |
 | AC11.24.4 | Deterministic fixtures (CPF/provident, 401k, China social-security personal account, insurance cash value, insurance coverage amount) classify to the expected stable codes | `test_deterministic_fixtures_classify_to_expected_codes()` | `assets/test_valuation_classification_contract.py` | P0 |
-| AC11.24.5 | Prompt version and model identifier are persisted with the classification output | `test_prompt_and_model_version_persisted()` | `assets/test_valuation_classification_contract.py` | P0 |
+| AC11.24.5 | Prompt version and model identifier are persisted with the classification output (and over-long ids fail fast) | `test_prompt_and_model_version_persisted()` | `assets/test_valuation_classification_contract.py` | P0 |
+| AC11.24.6 | The contract enforces the storage boundary constraints — non-negative 2dp amount, 3-char normalized currency, 4dp confidence, and forbidden unknown keys | `test_storage_boundary_constraints_are_enforced_at_the_contract()` | `assets/test_valuation_classification_contract.py` | P0 |
 
 ## Implementation Pattern Ownership
 

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -329,6 +329,25 @@ adapter's `liquidity_class` is cross-checked against the live legacy
 | AC11.23.3 | A snapshot projects onto the stable read-model preserving source, as-of date, currency, value, and valuation basis | `test_adapt_snapshot_preserves_fact_fields_in_stable_view()` | `assets/test_valuation_adapter.py` | P0 |
 | AC11.23.4 | Legacy CPF/insurance cash value/RSU/mortgage fixtures classify to the expected stable L1/L2 (cash value is an asset, not coverage) | `test_legacy_fixtures_classify_to_expected_stable_codes()` | `assets/test_valuation_adapter.py` | P0 |
 
+### AC11.24: LLM Valuation Classification Contract + Review Gates (#1224)
+
+The bounded LLM output contract for classifying a raw valuation fact into the
+stable taxonomy (AC11.21), plus deterministic review gating. The model adapts
+provider/jurisdiction/plan specifics (CPF, 401k, MPF, social security, insurers)
+into stable codes; the taxonomy fields are bound to the contract enums so the
+model cannot invent new report classes. Low-confidence or ambiguous output is
+routed to review instead of trusted report use, and the prompt + model versions
+are persisted with each classification. Contract/gating only — no live LLM
+transport and no report switch-over (that is #1225).
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC11.24.1 | The bounded output schema accepts a valid classification and rejects out-of-contract codes, mismatched L1/L2, and out-of-range confidence | `test_llm_output_rejects_out_of_contract_codes()` | `assets/test_valuation_classification_contract.py` | P0 |
+| AC11.24.2 | Insurance cash value classifies as an asset that contributes to net worth; a coverage amount is a non-asset excluded from net worth | `test_cash_value_is_asset_coverage_amount_excluded_from_net_worth()` | `assets/test_valuation_classification_contract.py` | P0 |
+| AC11.24.3 | Low-confidence classifications route to review; confident ones are auto-approved for trusted use | `test_low_confidence_routes_to_review()` | `assets/test_valuation_classification_contract.py` | P0 |
+| AC11.24.4 | Deterministic fixtures (CPF/provident, 401k, China social-security personal account, insurance cash value, insurance coverage amount) classify to the expected stable codes | `test_deterministic_fixtures_classify_to_expected_codes()` | `assets/test_valuation_classification_contract.py` | P0 |
+| AC11.24.5 | Prompt version and model identifier are persisted with the classification output | `test_prompt_and_model_version_persisted()` | `assets/test_valuation_classification_contract.py` | P0 |
+
 ## Implementation Pattern Ownership
 
 Do not copy reusable code patterns, router examples, migration guardrails, or

--- a/docs/ssot/assets.md
+++ b/docs/ssot/assets.md
@@ -292,6 +292,17 @@ unchanged. The adapter's `liquidity_class` is pinned to the legacy
 `_DEFAULT_LIQUIDITY_CLASS` table by test, so report switch-over (#1225) is
 behaviour-preserving.
 
+**LLM classification contract (#1224).** The bounded model output that classifies
+a raw valuation fact into these stable codes is
+`apps/backend/src/schemas/valuation.py` (`ValuationClassificationLLMOutput`),
+with review gating in `apps/backend/src/services/valuation_classification.py`. The
+taxonomy fields are bound to the contract enums, so out-of-contract codes are
+rejected rather than accepted; a coverage amount must be `non_asset`
+/`coverage_amount` (excluded from net worth) while insurance cash value is an
+asset. Low-confidence output routes to review (`ValuationReviewStatus.PENDING`)
+instead of trusted report use, and the prompt + model versions are persisted with
+the classification.
+
 ---
 
 ## 7. Design Constraints


### PR DESCRIPTION
## Goal

Step 2 of 3 (PR 2 of 2) in the valuation taxonomy program. Closes the contract + gating slice of #1224: a bounded LLM output schema that classifies a raw valuation fact into the AC11.21 stable taxonomy, with deterministic review gating. Independent of #1223 (the other step-2 PR); both base on `main`.

## What

- **`src/schemas/valuation.py`** — `ValuationClassificationLLMOutput`: raw extracted values (echoed for audit) + stable codes **bound to the contract enums**, so an out-of-contract code is a `ValidationError`, not a silently-accepted value. Validators enforce: L2 rolls up to its L1, coverage-amount ⇔ non_asset, confidence ∈ [0,1], currency normalization.
- **`src/services/valuation_classification.py`** — confidence-threshold review gating (`< 0.85` → `PENDING` review; else `APPROVED` for trusted use), `contributes_to_net_worth` (false for non_asset coverage), and `build_classification_fields()` carrying **prompt + model versions** into the persisted row.
- **Deterministic fixtures** — CPF/provident fund, 401k-style employer plan, China social-security personal account, insurance cash value (asset), insurance coverage amount (non_asset, excluded from net worth).

## Why bounded

The model adapts jurisdiction/provider/plan specifics into stable codes; those specifics stay raw metadata. Backend validation rejects invented report classes and routes uncertain output to review instead of trusted consumption — the auditability requirement from the issue.

## MECE scope

Contract + validation + gating only. **Out of scope**: live LLM transport wiring, report switch-over (#1225), frontend (#1226), new persistence (uses #1222 models).

## Verification

- `tests/assets/test_valuation_classification_contract.py` — 5 ACs pass (rejects out-of-contract/mismatched/over-range; cash-value-asset vs coverage-excluded; review routing; deterministic fixtures; version persistence).
- preflight ac-traceability / ssot-ownership / doc-consistency / api-reference / transaction-boundary / openapi-spec green. (`schema-validate` is a preflight-only, non-CI gate already noisy on `main`; my schema adds no new warning. `backend-format` PATH ruff UP042 is the known repo-wide false positive — pinned ruff clean.)

## Coordination note

This PR and #1223 both add adjacent sections to `EPIC-011` and `docs/ssot/assets.md`. Whichever merges second will need a trivial rebase (adjacent additive paragraphs) — I'll handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)