### PR TITLE
[finance_report_ui] Add real-financial-data redaction red line + generated-fixture rule

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -59,3 +59,11 @@ body:
         - [ ] ...
     validations:
       required: false
+  - type: checkboxes
+    id: data_hygiene
+    attributes:
+      label: "Data hygiene"
+      description: "See the financial-data red line in [red-lines.md](../../docs/agents/red-lines.md)."
+      options:
+        - label: "No real financial data — amounts, balances, account numbers, holder names, local paths, or real statement filenames are redacted or generated/anonymized."
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,6 +45,7 @@ Closes #<!-- issue number -->
 - [ ] `tools/check_env_keys.py` passes (if env vars changed)
 - [ ] `tools/check_manifest.py` passes (if SSOT files changed)
 - [ ] `tools/lint_doc_consistency.py` passes
+- [ ] No real financial data — amounts, balances, account numbers, holder names, local paths, or real statement filenames are redacted or generated/anonymized.
 
 ### CI/CD, Runtime, and VPS Infra Audit
 

--- a/docs/agents/orchestration.md
+++ b/docs/agents/orchestration.md
@@ -91,7 +91,10 @@ Use this cascade **before processing any task**:
      through `docs/infra_registry.yaml`
    - Historical, deprecated, or non-derived metadata is explicit in
      `docs/ac_registry_overrides.yaml`
-3. **Test**: Write failing tests that reference the AC IDs (red phase)
+3. **Test**: Write failing tests that reference the AC IDs (red phase).
+   Regression fixtures and test data MUST be generated/anonymized, never
+   derived from real user uploads or real statements — see the financial-data
+   red line in [red-lines.md](./red-lines.md).
 4. **Code**: Write minimal code to make the tests pass (green phase)
 5. **Doc**: Update SSOT docs and README
 

--- a/docs/agents/red-lines.md
+++ b/docs/agents/red-lines.md
@@ -15,6 +15,13 @@
 | 3 | **NEVER skip entry balance validation** or post entries without accounting equation check | `test_post_unbalanced_entry_rejected` |
 | 4 | **NEVER use raw `fetch()` in frontend** — use `lib/api.ts` wrapper | `apps/frontend/src/lib/api.ts` |
 | 5 | **NEVER create `sa.Enum` without `name="..."`** parameter | `test_enums_have_explicit_names` |
+| 6 | **NEVER put real financial data in issues / PRs / reports / commits / logs** — real amounts, balances, account/card numbers, account holder names, local file paths, or real statement filenames. Use redacted or generated/anonymized values. | Issue/PR redaction checklist (issue + PR templates); generated-fixture rule in [orchestration.md](./orchestration.md); see "Financial-data hygiene" below |
+
+### Financial-data hygiene
+
+Sensitive financial data includes: monetary amounts and balances; account, card, or IBAN numbers; account holder or counterparty names; local file paths; and real statement filenames.
+
+When a bug is found from real data, reproduce it with a **GENERATED/anonymized fixture** — never paste or commit the real document, its filename, or its values.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a governance red line + templates forcing redaction of real financial data, plus a rule that regression fixtures must be generated/anonymized.

## Motivation

The staging-audit bug issues **#1254–#1257** were first filed containing **real financial data** — real amounts, balances, account/statement filenames, and local file paths — before being manually redacted. The repo had **no rule or template forcing redaction**, and **no rule that regression fixtures must be synthetic**. This PR adds both so the leak cannot recur silently.

## Changes (5 surgical, docs/templates only)

1. **`docs/agents/red-lines.md`** — New security rule **#6**: *NEVER put real financial data in issues / PRs / reports / commits / logs* (amounts, balances, account/card numbers, holder names, local paths, real statement filenames — use redacted or generated/anonymized values). Enforcement column points to the issue/PR redaction checklists and the generated-fixture rule. Added a short **"Financial-data hygiene"** subsection listing what counts as sensitive data and stating that bugs found from real data must be reproduced with a GENERATED/anonymized fixture (no real-data examples included).
2. **`docs/agents/orchestration.md`** — TDD step 3 ("Test") now states regression fixtures and test data MUST be generated/anonymized, never derived from real user uploads/statements, cross-linked back to `red-lines.md`.
3. **`AGENTS.md`** — **Intentionally skipped (see CLAUDE.md note below).** In this repo `CLAUDE.md` is a **symlink to `AGENTS.md`** (`CLAUDE.md -> AGENTS.md`), so editing `AGENTS.md` would edit `CLAUDE.md`, which the repo prohibits AI from modifying without authorization. There is no way to add the cross-reference to `AGENTS.md` without touching the prohibited file, so per the "skip rather than force it" instruction it was left untouched. The full red line is still reachable from these files via the existing `red-lines.md` link.
4. **Issue + PR templates**
   - `.github/ISSUE_TEMPLATE/issue.yml` (the `bug`-labeled defect template) — added a required `checkboxes` **"Data hygiene"** item: *"No real financial data — amounts, balances, account numbers, holder names, local paths, or real statement filenames are redacted or generated/anonymized."* Matches the existing YAML-form style.
   - `.github/pull_request_template.md` — same checklist line added to the Engineering Audit block (Markdown `- [ ]` style).
5. **`CLAUDE.md` not touched** — the quick-reference NEVER-list could later mirror this new red line, but was **intentionally left untouched pending owner authorization** (and, as noted above, `CLAUDE.md` is the same inode as `AGENTS.md` via symlink).

## How the rule is enforced

The red line is the policy; the **issue and PR template checklists** are the enforcement surface — every new bug report and every PR now carries an explicit data-hygiene acknowledgement, and the TDD step makes synthetic fixtures the mandated reproduction path.

## AC / traceability

Pure docs + GitHub-template change: no code, no API surface, no money math, no new test. The AC traceability gate is satisfied by existing tests/ACs (no new AC required). Verified locally: `tools/check_ac_index.py`, `tools/lint_doc_consistency.py`, and `tools/check_workflow_contract.py` all pass; the change classifier marks this docs/CI-paths-only.

## Testing

```bash
python3 tools/lint_doc_consistency.py
python3 tools/check_workflow_contract.py
python3 tools/check_ac_index.py
```

## Screenshots / Evidence

_N/A — docs and GitHub templates only._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
