### PR TITLE
[finance_report_hacker] test(#1146): seeded no-LLM E2E fixture + move journeys into the merge-blocking tier

### DIFF
--- a/apps/backend/tests/e2e/conftest.py
+++ b/apps/backend/tests/e2e/conftest.py
@@ -1,150 +1,19 @@
-"""E2E test configuration and fixtures for Playwright tests."""
+"""E2E test configuration and fixtures.
+
+Hosts the Playwright browser fixtures (``browser`` / ``context`` / ``page``) and
+the API-tier ``seeded_parsed_statement`` fixture used by the non-Playwright,
+no-LLM statement journeys (EPIC-008 / AC8.21). The reusable seeding helper and
+its ``SeededParsedStatement`` handle live in :mod:`tests.factories` so tests can
+import them without depending on ``conftest``.
+"""
 
 from collections.abc import AsyncIterator
-from dataclasses import dataclass, field
-from datetime import date
-from decimal import Decimal
-from uuid import UUID, uuid4
 
 import pytest_asyncio
 from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models.layer1 import DocumentType, UploadedDocument
-from src.models.layer2 import AtomicTransaction, TransactionDirection
-from src.models.statement_enums import BankStatementStatus, Stage1Status
-from src.models.statement_summary import StatementSummary
-from tests.factories import (
-    AtomicTransactionFactory,
-    StatementSummaryFactory,
-    UploadedDocumentFactory,
-)
-
-
-@dataclass
-class SeededParsedStatement:
-    """Handle for a fixture-seeded, already-parsed statement.
-
-    Carries the layered DWD records (ODS document, conform envelope, atomic
-    transactions) injected directly into the test database so the downstream
-    review -> reconcile -> report journeys can run with **zero provider calls**.
-    The provider/LLM extraction seam (``ExtractionService.parse_document`` ->
-    ``stream_ai_json``) is bypassed entirely: the parsed result is materialized
-    by hand, exactly as the extraction pipeline would have persisted it.
-    """
-
-    user_id: UUID
-    document: UploadedDocument
-    statement: StatementSummary
-    transactions: list[AtomicTransaction] = field(default_factory=list)
-
-    @property
-    def id(self) -> UUID:
-        """The statement (DWD conform) id, as the statements API addresses it."""
-        return self.statement.id
-
-    @property
-    def original_filename(self) -> str:
-        """The ODS filename the statement-list row link renders (#1142)."""
-        return self.document.original_filename
-
-
-async def seed_parsed_statement(
-    db: AsyncSession,
-    user_id: UUID,
-    *,
-    institution: str = "DBS",
-    original_filename: str = "dbs_statement_2026_01.pdf",
-    opening_balance: Decimal = Decimal("1000.00"),
-    transactions: list[dict] | None = None,
-) -> SeededParsedStatement:
-    """Inject an already-parsed statement into the database (no provider call).
-
-    Seeds the three layered records the extraction pipeline would have written:
-
-    * ODS ``UploadedDocument`` — carries ``original_filename`` (the field the
-      statement-list stretched-link row renders; empty during real parsing,
-      which is the #1142 invisible-link bug).
-    * DWD ``StatementSummary`` — ``status=PARSED`` / ``stage1_status=PENDING_REVIEW``
-      conform envelope, linked to the ODS document.
-    * Layer-2 ``AtomicTransaction`` rows — joined back to the statement via
-      ``source_documents[*].doc_id == uploaded_document_id`` (the exact join
-      ``resolve_statement_transactions`` performs).
-
-    Returns a :class:`SeededParsedStatement` handle. All amounts use ``Decimal``
-    (never ``float``) per the monetary red line.
-    """
-    rows = (
-        transactions
-        if transactions is not None
-        else [
-            {"description": "Salary", "amount": Decimal("5000.00"), "direction": TransactionDirection.IN},
-            {"description": "Coffee Shop", "amount": Decimal("5.00"), "direction": TransactionDirection.OUT},
-        ]
-    )
-
-    file_hash = uuid4().hex + uuid4().hex[:32]
-    document = await UploadedDocumentFactory.create_async(
-        db,
-        user_id=user_id,
-        file_hash=file_hash,
-        original_filename=original_filename,
-        document_type=DocumentType.BANK_STATEMENT,
-    )
-
-    # Compute the closing balance from the seeded movements so the balance chain
-    # (open + ΣIN − ΣOUT ≈ close) ties out without any provider involvement.
-    closing_balance = opening_balance
-    for row in rows:
-        if row["direction"] == TransactionDirection.IN:
-            closing_balance += row["amount"]
-        else:
-            closing_balance -= row["amount"]
-
-    statement = await StatementSummaryFactory.create_async(
-        db,
-        user_id=user_id,
-        file_hash=file_hash,
-        uploaded_document_id=document.id,
-        institution=institution,
-        currency="SGD",
-        period_start=date(2026, 1, 1),
-        period_end=date(2026, 1, 31),
-        opening_balance=opening_balance,
-        closing_balance=closing_balance,
-        status=BankStatementStatus.PARSED,
-        stage1_status=Stage1Status.PENDING_REVIEW,
-        confidence_score=95,
-    )
-
-    doc_marker = {"doc_id": str(document.id), "doc_type": DocumentType.BANK_STATEMENT.value}
-    seeded_txns: list[AtomicTransaction] = []
-    running_balance = opening_balance
-    for index, row in enumerate(rows):
-        if row["direction"] == TransactionDirection.IN:
-            running_balance += row["amount"]
-        else:
-            running_balance -= row["amount"]
-        txn = await AtomicTransactionFactory.create_async(
-            db,
-            user_id=user_id,
-            source_documents=[doc_marker],
-            txn_date=date(2026, 1, 10 + index),
-            description=row["description"],
-            amount=row["amount"],
-            direction=row["direction"],
-            currency="SGD",
-            balance_after=running_balance,
-        )
-        seeded_txns.append(txn)
-
-    await db.commit()
-    return SeededParsedStatement(
-        user_id=user_id,
-        document=document,
-        statement=statement,
-        transactions=seeded_txns,
-    )
+from tests.factories import SeededParsedStatement, seed_parsed_statement
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -153,7 +22,7 @@ async def seeded_parsed_statement(db: AsyncSession, test_user) -> SeededParsedSt
 
     Enables the no-LLM merge-blocking tier (``-m "... and not llm"``) to run the
     statement review -> reconcile -> report journeys that previously required a
-    real provider. See :func:`seed_parsed_statement`.
+    real provider. See :func:`tests.factories.seed_parsed_statement`.
     """
     return await seed_parsed_statement(db, test_user.id)
 

--- a/apps/backend/tests/e2e/conftest.py
+++ b/apps/backend/tests/e2e/conftest.py
@@ -1,9 +1,161 @@
 """E2E test configuration and fixtures for Playwright tests."""
 
 from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
 
 import pytest_asyncio
 from playwright.async_api import Browser, BrowserContext, Page, async_playwright
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.layer1 import DocumentType, UploadedDocument
+from src.models.layer2 import AtomicTransaction, TransactionDirection
+from src.models.statement_enums import BankStatementStatus, Stage1Status
+from src.models.statement_summary import StatementSummary
+from tests.factories import (
+    AtomicTransactionFactory,
+    StatementSummaryFactory,
+    UploadedDocumentFactory,
+)
+
+
+@dataclass
+class SeededParsedStatement:
+    """Handle for a fixture-seeded, already-parsed statement.
+
+    Carries the layered DWD records (ODS document, conform envelope, atomic
+    transactions) injected directly into the test database so the downstream
+    review -> reconcile -> report journeys can run with **zero provider calls**.
+    The provider/LLM extraction seam (``ExtractionService.parse_document`` ->
+    ``stream_ai_json``) is bypassed entirely: the parsed result is materialized
+    by hand, exactly as the extraction pipeline would have persisted it.
+    """
+
+    user_id: UUID
+    document: UploadedDocument
+    statement: StatementSummary
+    transactions: list[AtomicTransaction] = field(default_factory=list)
+
+    @property
+    def id(self) -> UUID:
+        """The statement (DWD conform) id, as the statements API addresses it."""
+        return self.statement.id
+
+    @property
+    def original_filename(self) -> str:
+        """The ODS filename the statement-list row link renders (#1142)."""
+        return self.document.original_filename
+
+
+async def seed_parsed_statement(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    institution: str = "DBS",
+    original_filename: str = "dbs_statement_2026_01.pdf",
+    opening_balance: Decimal = Decimal("1000.00"),
+    transactions: list[dict] | None = None,
+) -> SeededParsedStatement:
+    """Inject an already-parsed statement into the database (no provider call).
+
+    Seeds the three layered records the extraction pipeline would have written:
+
+    * ODS ``UploadedDocument`` — carries ``original_filename`` (the field the
+      statement-list stretched-link row renders; empty during real parsing,
+      which is the #1142 invisible-link bug).
+    * DWD ``StatementSummary`` — ``status=PARSED`` / ``stage1_status=PENDING_REVIEW``
+      conform envelope, linked to the ODS document.
+    * Layer-2 ``AtomicTransaction`` rows — joined back to the statement via
+      ``source_documents[*].doc_id == uploaded_document_id`` (the exact join
+      ``resolve_statement_transactions`` performs).
+
+    Returns a :class:`SeededParsedStatement` handle. All amounts use ``Decimal``
+    (never ``float``) per the monetary red line.
+    """
+    rows = (
+        transactions
+        if transactions is not None
+        else [
+            {"description": "Salary", "amount": Decimal("5000.00"), "direction": TransactionDirection.IN},
+            {"description": "Coffee Shop", "amount": Decimal("5.00"), "direction": TransactionDirection.OUT},
+        ]
+    )
+
+    file_hash = uuid4().hex + uuid4().hex[:32]
+    document = await UploadedDocumentFactory.create_async(
+        db,
+        user_id=user_id,
+        file_hash=file_hash,
+        original_filename=original_filename,
+        document_type=DocumentType.BANK_STATEMENT,
+    )
+
+    # Compute the closing balance from the seeded movements so the balance chain
+    # (open + ΣIN − ΣOUT ≈ close) ties out without any provider involvement.
+    closing_balance = opening_balance
+    for row in rows:
+        if row["direction"] == TransactionDirection.IN:
+            closing_balance += row["amount"]
+        else:
+            closing_balance -= row["amount"]
+
+    statement = await StatementSummaryFactory.create_async(
+        db,
+        user_id=user_id,
+        file_hash=file_hash,
+        uploaded_document_id=document.id,
+        institution=institution,
+        currency="SGD",
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 1, 31),
+        opening_balance=opening_balance,
+        closing_balance=closing_balance,
+        status=BankStatementStatus.PARSED,
+        stage1_status=Stage1Status.PENDING_REVIEW,
+        confidence_score=95,
+    )
+
+    doc_marker = {"doc_id": str(document.id), "doc_type": DocumentType.BANK_STATEMENT.value}
+    seeded_txns: list[AtomicTransaction] = []
+    running_balance = opening_balance
+    for index, row in enumerate(rows):
+        if row["direction"] == TransactionDirection.IN:
+            running_balance += row["amount"]
+        else:
+            running_balance -= row["amount"]
+        txn = await AtomicTransactionFactory.create_async(
+            db,
+            user_id=user_id,
+            source_documents=[doc_marker],
+            txn_date=date(2026, 1, 10 + index),
+            description=row["description"],
+            amount=row["amount"],
+            direction=row["direction"],
+            currency="SGD",
+            balance_after=running_balance,
+        )
+        seeded_txns.append(txn)
+
+    await db.commit()
+    return SeededParsedStatement(
+        user_id=user_id,
+        document=document,
+        statement=statement,
+        transactions=seeded_txns,
+    )
+
+
+@pytest_asyncio.fixture(scope="function")
+async def seeded_parsed_statement(db: AsyncSession, test_user) -> SeededParsedStatement:
+    """Fixture-seeded, already-parsed statement that bypasses the LLM/OCR provider.
+
+    Enables the no-LLM merge-blocking tier (``-m "... and not llm"``) to run the
+    statement review -> reconcile -> report journeys that previously required a
+    real provider. See :func:`seed_parsed_statement`.
+    """
+    return await seed_parsed_statement(db, test_user.id)
 
 
 @pytest_asyncio.fixture(scope="session")

--- a/apps/backend/tests/e2e/test_seeded_statement_journey.py
+++ b/apps/backend/tests/e2e/test_seeded_statement_journey.py
@@ -6,17 +6,18 @@ fixture — never by a real provider. They carry only ``@pytest.mark.e2e`` (no
 ``@pytest.mark.llm``), so they run in the merge-blocking no-LLM tier
 (``pr-test.yml`` / ``ci.yml backend-e2e-tier1``: ``-m "... and not llm"``).
 
-The point these prove that the legacy ``@pytest.mark.llm`` mega-journeys could not:
-the DOM/CRUD/render assertions on a parsed statement (list row link text, detail
-fields, transactions, report numbers) run pre-merge with zero provider cost, so a
-selector/contract drift fails CI at PR time instead of slipping to staging.
+The point these prove, which the legacy ``@pytest.mark.llm`` mega-journeys could
+not, is this: the DOM/CRUD/render assertions on a parsed statement (list row link
+text, detail fields, transactions, report numbers) run pre-merge with zero
+provider cost, so a selector/contract drift fails CI at PR time instead of
+slipping to staging.
 """
 
 from decimal import Decimal
 
 import pytest
 
-from tests.e2e.conftest import SeededParsedStatement
+from tests.factories import SeededParsedStatement
 
 
 @pytest.mark.e2e

--- a/apps/backend/tests/e2e/test_seeded_statement_journey.py
+++ b/apps/backend/tests/e2e/test_seeded_statement_journey.py
@@ -1,0 +1,101 @@
+"""No-LLM seeded statement journey (EPIC-008 / AC8.21).
+
+These E2E tests exercise the statement review -> reconcile -> report journey for
+an **already-parsed** statement that was injected by the ``seeded_parsed_statement``
+fixture — never by a real provider. They carry only ``@pytest.mark.e2e`` (no
+``@pytest.mark.llm``), so they run in the merge-blocking no-LLM tier
+(``pr-test.yml`` / ``ci.yml backend-e2e-tier1``: ``-m "... and not llm"``).
+
+The point these prove that the legacy ``@pytest.mark.llm`` mega-journeys could not:
+the DOM/CRUD/render assertions on a parsed statement (list row link text, detail
+fields, transactions, report numbers) run pre-merge with zero provider cost, so a
+selector/contract drift fails CI at PR time instead of slipping to staging.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from tests.e2e.conftest import SeededParsedStatement
+
+
+@pytest.mark.e2e
+async def test_seeded_fixture_bypasses_provider(seeded_parsed_statement: SeededParsedStatement):
+    """EPIC-008 / AC8.21.1: the seeded fixture materializes a parsed statement with no provider call.
+
+    GIVEN the ``seeded_parsed_statement`` fixture
+    WHEN it builds the layered records
+    THEN a PARSED statement with linked ODS document and atomic transactions exists,
+    with a non-empty ``original_filename`` and Decimal balances — proving the LLM/OCR
+    extraction seam was bypassed entirely.
+    """
+    seeded = seeded_parsed_statement
+    assert seeded.statement.status.value == "parsed"
+    assert seeded.statement.uploaded_document_id == seeded.document.id
+    # The #1142 invisible-link field: a parsed statement must carry a visible filename.
+    assert seeded.original_filename
+    assert len(seeded.transactions) >= 1
+    # Monetary red line: balances are Decimal, never float.
+    assert isinstance(seeded.statement.opening_balance, Decimal)
+    assert isinstance(seeded.statement.closing_balance, Decimal)
+
+
+@pytest.mark.e2e
+async def test_seeded_statement_list_and_detail_no_llm(client, seeded_parsed_statement: SeededParsedStatement):
+    """EPIC-008 / AC8.21.2: a seeded parsed statement renders through list -> detail with no provider.
+
+    GIVEN a fixture-seeded parsed statement (no LLM)
+    WHEN listing statements and fetching the statement by id via the real API
+    THEN the list row and detail expose ``status=parsed``, a non-empty
+    ``original_filename`` (the stretched-link row label, #1142), and the parsed
+    transactions — the exact assertions that were previously buried in an
+    ``@pytest.mark.llm`` mega-journey.
+    """
+    seeded = seeded_parsed_statement
+
+    list_resp = await client.get("/statements")
+    assert list_resp.status_code == 200, list_resp.text
+    items = list_resp.json()["items"]
+    row = next((it for it in items if it["id"] == str(seeded.id)), None)
+    assert row is not None, "seeded statement must appear in the list"
+    assert row["status"] == "parsed"
+    # #1142: the list row link renders ``original_filename``; a parsed statement
+    # must expose a non-empty value so the row link is never invisible/zero-size.
+    assert row["original_filename"] == seeded.original_filename
+    assert row["original_filename"] != ""
+
+    detail_resp = await client.get(f"/statements/{seeded.id}")
+    assert detail_resp.status_code == 200, detail_resp.text
+    detail = detail_resp.json()
+    assert detail["id"] == str(seeded.id)
+    assert detail["status"] == "parsed"
+    assert detail["institution"] == seeded.statement.institution
+    assert detail["original_filename"] == seeded.original_filename
+    # The parsed transactions resolve via source_documents -> uploaded_document_id.
+    assert len(detail["transactions"]) == len(seeded.transactions)
+
+
+@pytest.mark.e2e
+async def test_seeded_statement_transactions_endpoint_no_llm(client, seeded_parsed_statement: SeededParsedStatement):
+    """EPIC-008 / AC8.21.3: the seeded statement's transactions list resolves with no provider.
+
+    GIVEN a fixture-seeded parsed statement (no LLM)
+    WHEN requesting its transactions endpoint
+    THEN the parsed atomic transactions are returned with their Decimal amounts and
+    directions — the downstream review/reconcile journey runs without any extraction call.
+    """
+    seeded = seeded_parsed_statement
+
+    resp = await client.get(f"/statements/{seeded.id}/transactions")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert len(items) == len(seeded.transactions)
+
+    returned_descriptions = {item["description"] for item in items}
+    expected_descriptions = {txn.description for txn in seeded.transactions}
+    assert returned_descriptions == expected_descriptions
+
+    # Amounts round-trip as Decimal-safe strings (monetary red line).
+    for item in items:
+        assert Decimal(str(item["amount"])) > Decimal("0")
+        assert item["direction"] in {"IN", "OUT"}

--- a/apps/backend/tests/factories.py
+++ b/apps/backend/tests/factories.py
@@ -14,7 +14,8 @@ Usage:
     account = await AccountFactory.create_async(db, name="Cash")
 """
 
-from datetime import UTC, date, datetime
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from typing import TypeVar
 from uuid import UUID, uuid4
@@ -27,7 +28,7 @@ from src.models.journal import Direction, JournalEntry, JournalEntryStatus, Jour
 from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.reconciliation import ReconciliationMatch, ReconciliationStatus
-from src.models.statement_enums import BankStatementStatus
+from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
 from src.models.user import User
 
@@ -249,3 +250,137 @@ class ReconciliationMatchFactory(factory.Factory, AsyncFactoryMixin):
     @classmethod
     def _build_kwargs(cls, atomic_txn_id: UUID, journal_entry_ids: list[str], **kwargs) -> dict:
         return {"atomic_txn_id": atomic_txn_id, "journal_entry_ids": journal_entry_ids, **kwargs}
+
+
+# ---------------------------------------------------------------------------
+# Seeded no-LLM parsed statement (EPIC-008 / AC8.21)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SeededParsedStatement:
+    """Handle for a fixture-seeded, already-parsed statement.
+
+    Carries the layered DWD records (ODS document, conform envelope, atomic
+    transactions) injected directly into the test database so the downstream
+    review -> reconcile -> report journeys can run with **zero provider calls**.
+    The provider/LLM extraction seam (``ExtractionService.parse_document`` ->
+    ``stream_ai_json``) is bypassed entirely: the parsed result is materialized
+    by hand, exactly as the extraction pipeline would have persisted it.
+    """
+
+    user_id: UUID
+    document: UploadedDocument
+    statement: StatementSummary
+    transactions: list[AtomicTransaction] = field(default_factory=list)
+
+    @property
+    def id(self) -> UUID:
+        """The statement (DWD conform) id, as the statements API addresses it."""
+        return self.statement.id
+
+    @property
+    def original_filename(self) -> str:
+        """The ODS filename the statement-list row link renders (#1142)."""
+        return self.document.original_filename
+
+
+async def seed_parsed_statement(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    institution: str = "DBS",
+    original_filename: str = "dbs_statement_2026_01.pdf",
+    opening_balance: Decimal = Decimal("1000.00"),
+    transactions: list[dict] | None = None,
+) -> SeededParsedStatement:
+    """Inject an already-parsed statement into the database (no provider call).
+
+    Seeds the three layered records the extraction pipeline would have written:
+
+    * ODS ``UploadedDocument`` — carries ``original_filename`` (the field the
+      statement-list stretched-link row renders; empty during real parsing,
+      which is the #1142 invisible-link bug).
+    * DWD ``StatementSummary`` — ``status=PARSED`` / ``stage1_status=PENDING_REVIEW``
+      conform envelope, linked to the ODS document.
+    * Layer-2 ``AtomicTransaction`` rows — joined back to the statement via
+      ``source_documents[*].doc_id == uploaded_document_id`` (the exact join
+      ``resolve_statement_transactions`` performs).
+
+    Returns a :class:`SeededParsedStatement` handle. All amounts use ``Decimal``
+    (never ``float``) per the monetary red line.
+    """
+    rows = (
+        transactions
+        if transactions is not None
+        else [
+            {"description": "Salary", "amount": Decimal("5000.00"), "direction": TransactionDirection.IN},
+            {"description": "Coffee Shop", "amount": Decimal("5.00"), "direction": TransactionDirection.OUT},
+        ]
+    )
+
+    file_hash = uuid4().hex + uuid4().hex[:32]
+    document = await UploadedDocumentFactory.create_async(
+        db,
+        user_id=user_id,
+        file_hash=file_hash,
+        original_filename=original_filename,
+        document_type=DocumentType.BANK_STATEMENT,
+    )
+
+    # Compute the closing balance from the seeded movements so the balance chain
+    # (open + ΣIN − ΣOUT ≈ close) ties out without any provider involvement.
+    closing_balance = opening_balance
+    for row in rows:
+        if row["direction"] == TransactionDirection.IN:
+            closing_balance += row["amount"]
+        else:
+            closing_balance -= row["amount"]
+
+    statement = await StatementSummaryFactory.create_async(
+        db,
+        user_id=user_id,
+        file_hash=file_hash,
+        uploaded_document_id=document.id,
+        institution=institution,
+        currency="SGD",
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 1, 31),
+        opening_balance=opening_balance,
+        closing_balance=closing_balance,
+        status=BankStatementStatus.PARSED,
+        stage1_status=Stage1Status.PENDING_REVIEW,
+        confidence_score=95,
+    )
+
+    doc_marker = {"doc_id": str(document.id), "doc_type": DocumentType.BANK_STATEMENT.value}
+    base_date = date(2026, 1, 10)
+    seeded_txns: list[AtomicTransaction] = []
+    running_balance = opening_balance
+    for index, row in enumerate(rows):
+        if row["direction"] == TransactionDirection.IN:
+            running_balance += row["amount"]
+        else:
+            running_balance -= row["amount"]
+        txn = await AtomicTransactionFactory.create_async(
+            db,
+            user_id=user_id,
+            source_documents=[doc_marker],
+            # timedelta keeps the date valid for any transaction count (avoids
+            # day-overflow once index pushes past the month end).
+            txn_date=base_date + timedelta(days=index),
+            description=row["description"],
+            amount=row["amount"],
+            direction=row["direction"],
+            currency="SGD",
+            balance_after=running_balance,
+        )
+        seeded_txns.append(txn)
+
+    await db.commit()
+    return SeededParsedStatement(
+        user_id=user_id,
+        document=document,
+        statement=statement,
+        transactions=seeded_txns,
+    )

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -545,6 +545,33 @@ non-PR events. The classification rule is owned by [ci-cd.md](../ssot/ci-cd.md).
 | AC8.20.2 | Resolved/outdated threads and lower-severity (P2/P3/nit) unresolved threads do NOT block; they are reported | `test_AC8_20_2_resolved_p0_passes`, `test_AC8_20_2_outdated_p0_passes`, `test_AC8_20_2_unresolved_nit_passes_but_reported`, `test_AC8_20_2_empty_passes`, `test_AC8_20_2_mixed_blocks_only_on_active_p0` | `tests/tooling/test_check_pr_review_threads.py` | P1 |
 | AC8.20.3 | The severity classification rule is documented in the CI/CD SSOT | `test_AC8_20_3_severity_rule_documented_in_ssot` | `tests/tooling/test_check_pr_review_threads.py` | P1 |
 
+---
+
+### AC8.21: Seeded No-LLM Statement Journey (provider-free merge tier)
+
+The statement review -> reconcile -> report journey previously needed a real
+provider, so its LLM-independent DOM/CRUD/render assertions were stranded behind
+`@pytest.mark.llm` mega-journeys that only run on the manual staging deploy —
+letting selector/contract drift (and the empty-`original_filename` invisible-link
+bug, #1142) slip past the merge gate. A `seeded_parsed_statement` fixture
+(`apps/backend/tests/e2e/conftest.py`) injects an already-parsed statement —
+ODS `UploadedDocument`, DWD `StatementSummary` (`status=PARSED`), and Layer-2
+`AtomicTransaction` rows joined via `source_documents[*].doc_id` — directly into
+the test database, bypassing the `ExtractionService.parse_document` -> `stream_ai_json`
+seam entirely. The downstream journey then runs in the no-LLM merge-blocking tier
+(`-m "... and not llm"`). This is the reusable enabler for moving the remaining
+LLM-gated journeys (#1146 PR-B/PR-C) into CI; the browser/Playwright selector
+fixes for `test_statement_upload_e2e` / `test_statement_full_journey` /
+`test_four_asset_net_worth_golden_path` and the `_api_url(...)` fix in
+`test_personal_financial_report_package` (#1142) are deferred to that follow-up,
+which runs in the full-stack `pr-test.yml` lane that carries the frontend bundle.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|---|---|---|---|---|
+| AC8.21.1 | A seeded no-LLM fixture materializes an already-parsed statement (PARSED envelope, linked ODS document, atomic transactions, non-empty `original_filename`, Decimal balances) with zero provider calls, bypassing the extraction/LLM seam | `test_seeded_fixture_bypasses_provider` | `apps/backend/tests/e2e/test_seeded_statement_journey.py` | P0 |
+| AC8.21.2 | The previously LLM-gated statement list -> detail journey runs in the no-LLM merge tier via the fixture: the list row and detail expose `status=parsed`, a non-empty `original_filename` (the stretched-link label, #1142), and the parsed transactions | `test_seeded_statement_list_and_detail_no_llm` | `apps/backend/tests/e2e/test_seeded_statement_journey.py` | P0 |
+| AC8.21.3 | The seeded statement's transactions endpoint resolves the parsed atomic transactions (descriptions, Decimal amounts, directions) with no provider call, so the downstream review/reconcile journey runs provider-free | `test_seeded_statement_transactions_endpoint_no_llm` | `apps/backend/tests/e2e/test_seeded_statement_journey.py` | P0 |
+
 ## 5. E2E Suite Ownership
 
 Current test counts and coverage percentages belong to generated reports and CI

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -160,6 +160,23 @@ file.
 | Frontend telemetry E2E | `frontend-telemetry-e2e` job | Hermetic browser telemetry-emission spec with fake same-origin telemetry endpoints; the job builds before `npm run start -- --port` because the telemetry CI config starts an already-built app | Behavioral proof only; not in unified line coverage | Keep isolated from provider-free UI specs because it injects telemetry env via its own Playwright config |
 | Tier 3 Browser E2E | Staging/PR preview/prod smoke jobs | Playwright/HTTP deployment suites (`smoke`, `e2e`, `llm` split) | Behavioral/prod-risk proof only | Keep provider-dependent `llm` in post-merge; split provider-free subset for PR preview |
 
+#### Seeded no-LLM statement fixture (provider-free journeys in the merge tier)
+
+Journeys that depend on a parsed statement (review -> reconcile -> report) must
+not require a real provider to run in the merge-blocking tier. The reusable
+pattern is the `seeded_parsed_statement` fixture in
+`apps/backend/tests/e2e/conftest.py`: it injects an already-parsed statement —
+ODS `UploadedDocument`, DWD `StatementSummary` (`status=PARSED`), and Layer-2
+`AtomicTransaction` rows joined via `source_documents[*].doc_id` — directly into
+the test database via `tests/factories.py`, bypassing the extraction/LLM seam
+(`ExtractionService.parse_document` -> `stream_ai_json`) entirely. A test using
+it carries only `@pytest.mark.e2e` (never `@pytest.mark.llm`), so it runs under
+`-m "(smoke or e2e) and not llm"`. **Tag discipline**: only a test that actually
+calls the extraction service carries `@pytest.mark.llm`; everything provider-free
+seeds its parsed input through this fixture and stays in the merge gate. New
+statement journeys reuse `seed_parsed_statement(...)` rather than uploading a
+real document and waiting on a provider parse.
+
 ### PR vs Main CI Responsibilities
 
 Pull requests run the same heavy CI path as `main` when runtime, tests, tooling,


### PR DESCRIPTION
## Goal (#1146, calibrated slice)

Deliver the **fixture foundation** (PR-A) + the clearest API-tier journey split (the API portion of PR-B) from #1146's plan: a `seeded_parsed_statement` fixture that injects an already-parsed statement with **zero provider calls**, plus statement journey tests moved into the merge-blocking no-LLM tier.

## STEP-0 findings (investigation before building)

- The no-LLM E2E is **already merge-blocking**: `pr-test.yml` runs in-runner `-m "(smoke or e2e) and not llm"`; `ci.yml backend-e2e-tier1` runs `tests/e2e/test_core_journeys.py -m "e2e"`. The residual was the **fixture + split**, not the gate.
- **Provider/LLM seam**: `ExtractionService.parse_document` -> `_extract_json_with_models` -> `stream_ai_json` (`apps/backend/src/services/extraction.py`). Any test hitting this is `@pytest.mark.llm`; everything else is provider-free.
- **What a fixture must seed** to bypass it: the three layered records the pipeline would persist — ODS `UploadedDocument`, DWD `StatementSummary` (`status=PARSED`, `stage1_status=PENDING_REVIEW`), and Layer-2 `AtomicTransaction` rows joined via `source_documents[*].doc_id == uploaded_document_id` (the exact join `resolve_statement_transactions` performs). `original_filename` lives on the ODS document and is what the statement-list stretched-link row renders (the #1142 invisible-link field).
- Tier-1 (`test_core_journeys.py`) runs the real FastAPI app in-process via `AsyncClient`/ASGITransport against Postgres — the cleanest place to land an API-tier seeded journey.

## What this PR delivers

- **`seeded_parsed_statement` fixture** + `seed_parsed_statement(...)` helper in `apps/backend/tests/e2e/conftest.py`, built on `tests/factories.py`. Computes a balance chain that ties out; all amounts are `Decimal` (monetary red line).
- **3 new no-LLM journey tests** in `apps/backend/tests/e2e/test_seeded_statement_journey.py` (`@pytest.mark.e2e`, never `llm`) covering: fixture-bypasses-provider, list -> detail render (status=parsed, non-empty `original_filename`, parsed transactions), and the transactions endpoint.
- **EPIC-008 AC8.21.1-3** registered (next free group on current main).
- **Testing SSOT** (`docs/ssot/ci-cd.md`) documents the reusable seeded no-LLM pattern + the `@pytest.mark.llm` tag discipline.

## AC list

- **AC8.21.1** — seeded no-LLM fixture materializes a parsed statement with zero provider calls (`test_seeded_fixture_bypasses_provider`).
- **AC8.21.2** — previously LLM-gated list -> detail journey runs in the no-LLM merge tier via the fixture (`test_seeded_statement_list_and_detail_no_llm`).
- **AC8.21.3** — seeded statement transactions endpoint resolves provider-free (`test_seeded_statement_transactions_endpoint_no_llm`).

## #1142 items

- **Addressed at the API contract level**: AC8.21.2 asserts a parsed statement exposes a **non-empty `original_filename`** in both the list row and detail — the field whose emptiness causes the invisible stretched-link. This pins the contract pre-merge.
- **Deferred to follow-up** (they require the frontend bundle, only present in the full-stack `pr-test.yml` browser lane — not runnable in this worktree): the 4 Playwright selector fixes (`test_statement_upload_e2e`, `test_statement_full_journey`, `test_four_asset_net_worth_golden_path` `exact=True`) and the `_api_url(...)` fix in `test_personal_financial_report_package`. The seeded fixture here is the enabler those rewrites (#1146 PR-B/PR-C) build on.

## Validation (local, this worktree)

| Command | Result |
|---|---|
| `pytest tests/e2e/test_seeded_statement_journey.py -m "e2e and not llm"` | **3 passed** (against real Postgres, no provider, no MinIO) |
| `tools/generate_ac_registry.py` | OK: registries include every EPIC-defined AC |
| `tools/check_ac_index.py` | **PASSED** (INTEGRITY + PROTECTION; no per-type regression) |
| `tools/check_workflow_contract.py` | **Workflow contract OK** |
| `ruff check` + `ruff format --check` (new files) | clean |
| e2e collection (`--collect-only`) | 62 tests, no import errors |

**CI-only / environment notes**: this worktree has Postgres but **no MinIO/S3**, so the existing upload-based tests (`test_statement_list_and_get`, `test_statement_full_flow`) fail locally with `503` storage errors — a pre-existing environment limitation, **not** a regression from this change (additive conftest imports cannot raise a storage 503). The new fixture-based tests pass precisely because they bypass upload/storage. Full in-runner stack behavior is proven by CI.

## Out of scope / follow-up

- #1146 PR-B/PR-C: browser selector fixes + wiring the browser DOM assertions into `pr-test.yml`, plus the injected-drift reverse check.
- #1146 PR-D: the deployment.md/coverage.md doc-drift fixes + extraction-skill provider wording.
- #1146 PR-E: brokerage-positions + multi-currency LLM fixtures (depends on #1139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)