### PR TITLE
[finance_report_hacker] chore: quick-wins sweep — router import (#1097), smoke routes (#411), build-time secret-scan (#1277)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -861,6 +861,28 @@ jobs:
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
           echo "Building staging images for commit: $short_sha"
 
+      - name: Build-context Secret Scan (gitleaks)
+        # AC7.18.1 (#1277, secret-scan half): fail-closed gitleaks scan over the
+        # per-component Docker build context BEFORE the image build, so a secret
+        # that entered ./apps/<component> cannot be baked into the published
+        # :<sha> image. Mirrors the lint-job gitleaks gate (pinned + checksummed)
+        # but scoped to the build context. --redact keeps the file/line finding
+        # visible in the logs while masking the secret value. This is the
+        # secret-scan half of #1277 only; image :<sha> retention is out of scope
+        # and #1277 stays open for it.
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION=8.18.4
+          GITLEAKS_SHA256=ba6dbb656933921c775ee5a2d1c13a91046e7952e9d919f9bac4cec61d628e7d
+          ARCHIVE=/tmp/gitleaks.tar.gz
+          curl -sSfL -o "$ARCHIVE" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          tar -xzf "$ARCHIVE" -C /tmp gitleaks
+          echo "Scanning Docker build context: apps/${{ matrix.component }}"
+          /tmp/gitleaks detect --source "apps/${{ matrix.component }}" --no-git --redact \
+            --config .gitleaks.toml --exit-code 1
+
       - name: Log in to Container registry
         # P1a (#879, AC7.12.4): publish :<sha> for main + release-branch commits, and
         # on demand via workflow_dispatch (the rare "preview an unmerged sha" escape hatch).

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -59,6 +59,9 @@ from src.services.annualized_income import generate_annualized_income_schedule
 from src.services.confidence_metric import ConfidenceMetricService
 from src.services.framework_policy import derive_user_framework_policy_result
 from src.services.market_data import ensure_market_data_fresh
+from src.services.performance_report import (
+    build_investment_performance_report_schedule,
+)
 from src.services.report_package import (
     jsonable as _jsonable,
     package_currency as _package_currency,
@@ -253,8 +256,6 @@ async def _personal_report_package_section_payloads(
     currency: str,
     include_restricted: bool = False,
 ) -> dict[str, Any]:
-    from src.routers.portfolio import get_investment_performance_report_schedule
-
     balance_sheet_payload = await generate_balance_sheet(
         db,
         user_id,
@@ -276,9 +277,14 @@ async def _personal_report_package_section_payloads(
         end_date=end_date,
         currency=currency,
     )
-    investment_performance_payload = await get_investment_performance_report_schedule(
-        db=db,
-        user_id=user_id,
+    # #1097 (AC25.5.1): call the service directly instead of importing the
+    # portfolio router handler. The package path already passes validated,
+    # concrete dates and a normalized (uppercased) currency, so the router
+    # handler's input-defaulting/validation is moot here and behavior is
+    # preserved by invoking the same underlying service.
+    investment_performance_payload = await build_investment_performance_report_schedule(
+        db,
+        user_id,
         period_start=start_date,
         period_end=end_date,
         as_of_date=as_of_date,

--- a/apps/backend/tests/api/test_router_boundary.py
+++ b/apps/backend/tests/api/test_router_boundary.py
@@ -1,0 +1,35 @@
+"""EPIC-025 AC25.5.1: no backend router imports a symbol from another router.
+
+A router importing another router's handler couples two HTTP boundaries and
+hides the real owner of the logic (the service layer). This contract scans every
+module under ``apps/backend/src/routers`` and fails if any of them contains a
+``from src.routers.<x> import ...`` statement. The package aggregator
+(``src/routers/__init__.py``) imports the router *modules* themselves, which is
+the legitimate package wiring and is therefore exempt.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROUTERS_DIR = Path(__file__).resolve().parents[2] / "src" / "routers"
+
+
+def _router_module_files() -> list[Path]:
+    # The package __init__ legitimately imports the router modules; exclude it.
+    return sorted(p for p in ROUTERS_DIR.glob("*.py") if p.name != "__init__.py")
+
+
+def test_AC25_5_1_no_router_imports_another_router() -> None:
+    offenders: list[str] = []
+    for path in _router_module_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                # Match `from src.routers.<x> import ...` (a sibling router),
+                # but not `from src.routers import ...` (the package itself).
+                if node.module == "src.routers" or node.module.startswith("src.routers."):
+                    if node.module != "src.routers":
+                        offenders.append(f"{path.name}:{node.lineno} -> from {node.module} import ...")
+    assert not offenders, "router-to-router imports must not exist:\n" + "\n".join(offenders)

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -299,6 +299,35 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 | AC7.16.1 | The shared E2E toolchain-setup composite (`setup-e2e-tests`) retries transient dependency/browser download failures (`uv pip install`, `playwright install`) with bounded exponential backoff and keeps the original external error visible on exhaustion | `test_AC7_16_1_setup_e2e_composite_retries_toolchain_downloads`, `test_AC7_16_1_setup_e2e_composite_does_not_wrap_test_execution` | `tests/tooling/test_staging_toolchain_retry.py` | P0 |
 | AC7.16.2 | The staging deploy_v2 dependency install retries transient download failures with bounded exponential backoff; application deploy/test steps remain fail-fast (not wrapped in retry) | `test_AC7_16_2_staging_deploy_v2_dependency_install_retries`, `test_AC7_16_2_staging_deploy_and_e2e_steps_stay_fail_fast` | `tests/tooling/test_staging_toolchain_retry.py` | P0 |
 
+### AC7.17: Smoke Gate Asserts Only Real Public Frontend Routes (#411)
+
+> The deploy-smoke gate (`tools/_lib/shell/smoke_test.sh`) runs in the staging /
+> PR-preview health gate. Every page route it asserts must correspond to a real,
+> publicly reachable Next.js route under `apps/frontend/src/app` — a smoke check
+> for a non-existent path (e.g. `/dashboard`, which 404s) makes the gate either
+> flap or pass for the wrong reason. The smoke script must not assert a page path
+> that has no `page.tsx` and must not assert a path that 401s for anonymous
+> requests.
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC7.17.1 | Every page route the smoke gate asserts (`check_endpoint "...Page" "$BASE_URL/<route>"`) maps to a real public Next.js route that exists under `apps/frontend/src/app` (route-group folders excluded); the removed `/dashboard` path (no `page.tsx`) is not asserted | `test_AC7_17_1_smoke_asserts_only_existing_public_frontend_routes`, `test_AC7_17_1_smoke_does_not_assert_nonexistent_dashboard_route` | `tests/tooling/test_smoke_routes_contract.py` | P0 |
+
+### AC7.18: Build-Time Secret-Scan Gate on the Image Build Context (#1277)
+
+> The lint job already content-scans the working tree with gitleaks. The image
+> build is a second, independent surface: a secret can enter the Docker build
+> context (`./apps/<component>`) and be baked into a published `:<sha>` image.
+> The `container-images` job must run a fail-closed gitleaks scan over the build
+> context BEFORE `docker/build-push-action`, so a secret in the context fails the
+> build and the finding stays visible in the job logs (redacted value). This is
+> the secret-scan half of #1277 only; image `:<sha>` retention is out of scope
+> and #1277 stays open for it.
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC7.18.1 | The CI `container-images` job runs a gitleaks secret scan over the per-component build context before the image build step, fails closed on detection (`--exit-code 1` / `--no-git`), and keeps the finding visible in logs (`--redact`, no `--no-banner`-only silent pass) | `test_AC7_18_1_container_images_job_has_build_context_secret_scan`, `test_AC7_18_1_build_secret_scan_is_fail_closed_before_build` | `tests/tooling/test_build_secret_scan_contract.py` | P0 |
+
 
 ## 📏 Acceptance Criteria
 

--- a/docs/project/EPIC-025.dry-ssot-simplification.md
+++ b/docs/project/EPIC-025.dry-ssot-simplification.md
@@ -114,6 +114,12 @@ verifiable.
 |----|-------------|---------------|------|----------|
 | AC25.4.1 | Shared reporting fixtures (standard chart of accounts, golden dashboard scenario, standard FX rates) are provided by a single `tests/reporting/_report_fixtures` module and reused, with duplicate per-file `test_user_id` fixtures removed; existing AC traceability is preserved | `test_report_fixtures_shared` | `apps/backend/tests/reporting/test_report_fixtures_shared.py` | P1 |
 
+### AC25.5 — Router boundary: no router imports another router (#1097)
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC25.5.1 | No backend router module imports a symbol from another router (`from src.routers.<x> import ...` is absent across `apps/backend/src/routers`); the personal-report-package assembly calls `services.performance_report.build_investment_performance_report_schedule` directly instead of the portfolio router handler, preserving behavior | `test_AC25_5_1_no_router_imports_another_router` | `apps/backend/tests/api/test_router_boundary.py` | P1 |
+
 ---
 
 ## 📏 Acceptance Criteria

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -13,8 +13,8 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `POST` | `` | `chat_message` | apps/backend/src/routers/chat.py:37 |
 | `DELETE` | `/session/{session_id}` | `delete_session` | apps/backend/src/routers/chat.py:212 |
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:164 |
-| `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:485 |
-| `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:765 |
+| `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:491 |
+| `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:771 |
 | `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:551 |
 | `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:689 |
 | `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:104 |

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -41,7 +41,7 @@ main-only: unified-coverage ─→ unified-coverage-baseline-pr (not required by
 | **frontend-vitest** | Frontend Vitest coverage and JUnit evidence when heavy CI is required | `needs: [changes]` |
 | **frontend-playwright** | Provider-free frontend browser UI proof when heavy CI is required | `needs: [changes]` |
 | **frontend-telemetry-e2e** | Hermetic browser telemetry-emission proof when heavy CI is required | `needs: [changes]` |
-| **container-images** | Build backend and frontend staging images without pushing on PRs; push SHA-tagged images only on `main` | `needs: [changes]` |
+| **container-images** | Fail-closed gitleaks secret scan over each component's Docker build context (`apps/<component>`) before the build, then build backend and frontend staging images without pushing on PRs; push SHA-tagged images only on `main` | `needs: [changes]` |
 | **tooling-coverage** | Run root tooling tests with common/tools coverage and upload LCOV inputs | `needs: [changes]` |
 | **unified-coverage** | Merge backend, frontend Vitest, common, and tools LCOV inputs, audit source-tree/LCOV policy, calculate unified coverage, compare to baseline, upload the coverage context artifact, and update Coveralls on `main` when heavy CI is required | `needs: [changes, backend, frontend-vitest, tooling-coverage]` |
 | **unified-coverage-baseline-pr** | Main-only automation that downloads `unified-coverage-context`, commits a changed `unified-coverage.json` to `automation/unified-coverage-baseline`, and opens or updates the reviewed baseline PR. This job owns write-scoped GitHub token permissions; PR coverage calculation remains read-only. | `needs: [changes, unified-coverage]` |
@@ -367,6 +367,7 @@ git rm unified-coverage.json && git commit -m "chore: remove coverage baseline f
 - CI calls `tools/check_toolchain_contract.py` in lint before dependency installation and `tools/check_ci_metrics_contract.py` in lint before coverage jobs finish. Runtime versions and base images are owned by `toolchain.toml`, mirrored to local tool-manager files, and used by GitHub Actions, Dockerfiles, and `docker-compose.yml`.
 - PR CI avoids Moon bootstrap in heavy runner jobs that execute direct `pytest` and `npm` commands. Backend shards, backend integration, Tier-1 API E2E, and the split frontend jobs use task-native commands directly so GitHub release CDN failures for optional Moon installation cannot mask deterministic code failures. Moon CLI availability and project graph coverage are static contracts over `.moon/toolchain.yml`, `moon.yml`, and app-level `moon.yml` files; runtime execution of Moon remains a local contributor responsibility and is not a PR merge gate unless a future workflow explicitly needs Moon semantics.
 - PR CI dry-runs staging image builds before merge. The `container-images` job uses `docker/build-push-action` for both backend and frontend images with `push: false` on pull requests, then `finish` fails if that validation job fails.
+- Build-time secret scan (AC7.18.1, #1277 secret-scan half): the `container-images` job runs a fail-closed gitleaks scan over each component's Docker build context (`apps/<component>`, `--no-git --redact --exit-code 1`) BEFORE `docker/build-push-action`, so a secret that entered the build context cannot be baked into a published `:<sha>` image; the redacted finding stays visible in the job logs. This is the secret-scan half of #1277 only — image `:<sha>` retention is tracked separately and #1277 stays open for it.
 - Main and release-branch push CI, plus on-demand `workflow_dispatch`, publish SHA-tagged images (P1a, #879). Registry login and image push are guarded by `(github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))) || github.event_name == 'workflow_dispatch'`; registry availability and authorization remain post-merge external-service risks, but Dockerfile, build-context, and build-argument errors are caught before merge.
 - Frontend dependency installation uses `actions/setup-node@v6` with npm cache and deterministic `npm ci`. The lint job runs `npm run audit:prod` after install so production frontend dependency advisories fail before merge; the former duplicate audit in the frontend runtime job is removed, and dev-only advisories remain outside this production gate.
 - GitHub JavaScript action runtime is explicitly validated on Node 24 by setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at the workflow level. This does not change the application toolchain `NODE_VERSION`; it only opts GitHub-hosted JavaScript actions into the runtime that GitHub will make the default.
@@ -649,12 +650,21 @@ BASE_URL=https://report.zitian.party bash tools/smoke_test.sh
 
 | Endpoint | Check |
 |----------|-------|
-| `/` | Homepage loads |
+| `/` | Home / dashboard page loads (there is no separate `/dashboard` route) |
+| `/accounts` | Accounts page loads |
+| `/journal` | Journal page loads |
+| `/statements/upload` | Statement upload page loads (there is no bare `/statements` page) |
+| `/reports` | Reports page loads |
+| `/reconciliation` | Workbench loads |
+| `/login` | Login page loads |
 | `/api/health` | Returns "healthy" |
 | `/api/docs` | Swagger UI loads |
-| `/ping-pong` | Demo page loads |
-| `/reconciliation` | Workbench loads |
 | `/api/ping` | Ping API responds |
+
+> Smoke route integrity (AC7.17.1, #411): every page path the shell smoke gate
+> asserts must map to a real public Next.js route under `apps/frontend/src/app`.
+> `tests/tooling/test_smoke_routes_contract.py` fails if the script asserts a
+> path with no `page.tsx` (e.g. the removed `/dashboard` / bare `/statements`).
 
 ## Deploy E2E Gates
 

--- a/tests/tooling/test_build_secret_scan_contract.py
+++ b/tests/tooling/test_build_secret_scan_contract.py
@@ -1,0 +1,95 @@
+"""EPIC-007 AC7.18.1: build-time secret-scan gate on the image build context (#1277).
+
+The lint job already content-scans the working tree with gitleaks. The image
+build is a second, independent surface: a secret can enter the Docker build
+context (``./apps/<component>``) and be baked into a published ``:<sha>`` image.
+The CI ``container-images`` job must run a fail-closed gitleaks scan over the
+build context BEFORE ``docker/build-push-action``, keeping the finding visible
+in the logs.
+
+This is the secret-scan half of #1277 only — image ``:<sha>`` retention is out
+of scope and #1277 stays open for it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _container_images_job() -> dict:
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+    assert "container-images" in jobs, "ci.yml must define the container-images job"
+    return jobs["container-images"]
+
+
+def _step_names(job: dict) -> list[str]:
+    return [str(step.get("name", "")) for step in job.get("steps", [])]
+
+
+def _secret_scan_step(job: dict) -> dict:
+    for step in job.get("steps", []):
+        text = (str(step.get("name", "")) + " " + str(step.get("run", ""))).lower()
+        if "gitleaks" in text and "secret" in text:
+            return step
+    raise AssertionError(
+        "container-images job has no build-context gitleaks secret-scan step"
+    )
+
+
+def test_AC7_18_1_container_images_job_has_build_context_secret_scan() -> None:
+    job = _container_images_job()
+    step = _secret_scan_step(job)
+    run = str(step.get("run", ""))
+    assert "gitleaks" in run, "secret-scan step must invoke gitleaks"
+    # Scans the per-component build context directory, not just the repo root.
+    assert "apps/" in run or "matrix.component" in run, (
+        "secret-scan step must scan the per-component build context (apps/<component>)"
+    )
+
+
+def test_AC7_18_1_build_secret_scan_is_fail_closed_before_build() -> None:
+    job = _container_images_job()
+    step = _secret_scan_step(job)
+    run = str(step.get("run", ""))
+
+    # Fail-closed: gitleaks must exit non-zero on detection and scan the working
+    # tree (--no-git so it is not tripped by history), and the step must not be
+    # neutralized with `|| true` / `continue-on-error`.
+    assert "--exit-code 1" in run or "--exit-code=1" in run, (
+        "build-context gitleaks scan must fail closed (--exit-code 1)"
+    )
+    assert "--no-git" in run, (
+        "build-context scan must use --no-git (scan the context tree)"
+    )
+    assert step.get("continue-on-error", False) is not True, (
+        "secret-scan step must not be continue-on-error (would not fail the build)"
+    )
+    assert "|| true" not in run, (
+        "secret-scan step must not swallow failures with `|| true`"
+    )
+
+    # The finding must stay visible: use --redact (mask the value, keep the
+    # file/line finding) rather than fully suppressing output.
+    assert "--redact" in run, "secret-scan must keep findings visible via --redact"
+
+    # Gate ordering: the secret scan must come before the image build steps.
+    names = _step_names(job)
+    scan_idx = names.index(str(step.get("name", "")))
+    build_idx = next(
+        (
+            i
+            for i, n in enumerate(names)
+            if "build" in n.lower() and "image" in n.lower()
+        ),
+        None,
+    )
+    assert build_idx is not None, "container-images job must have an image build step"
+    assert scan_idx < build_idx, (
+        "secret-scan must run BEFORE the image build (fail before a secret is baked in)"
+    )

--- a/tests/tooling/test_smoke_routes_contract.py
+++ b/tests/tooling/test_smoke_routes_contract.py
@@ -1,0 +1,80 @@
+"""EPIC-007 AC7.17.1: the deploy-smoke gate asserts only real public routes.
+
+`tools/_lib/shell/smoke_test.sh` runs in the staging / PR-preview health gate.
+Every page route it asserts via ``check_endpoint "...Page" "$BASE_URL/<route>"``
+must map to a real, public Next.js route under ``apps/frontend/src/app``. A check
+for a non-existent path (e.g. the legacy ``/dashboard``, which 404s) makes the
+gate flap or pass for the wrong reason.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SMOKE = REPO_ROOT / "tools" / "_lib" / "shell" / "smoke_test.sh"
+APP_DIR = REPO_ROOT / "apps" / "frontend" / "src" / "app"
+
+
+def _frontend_page_routes() -> set[str]:
+    """Real URL paths that have a Next.js ``page.tsx``.
+
+    Route-group folders ``(group)`` contribute no URL segment; dynamic segments
+    ``[param]`` are skipped (not directly smoke-checkable without an id).
+    """
+    routes: set[str] = set()
+    for page in APP_DIR.rglob("page.tsx"):
+        rel = page.relative_to(APP_DIR).parent
+        segments: list[str] = []
+        skip = False
+        for part in rel.parts:
+            if part.startswith("(") and part.endswith(")"):
+                continue  # route group: no URL segment
+            if part.startswith("[") and part.endswith("]"):
+                skip = True  # dynamic route: not a fixed smoke target
+                break
+            segments.append(part)
+        if skip:
+            continue
+        routes.add("/" + "/".join(segments) if segments else "/")
+    return routes
+
+
+def _smoke_asserted_page_routes() -> list[str]:
+    """Frontend page paths asserted by ``check_endpoint "<name>" "$BASE_URL/<path>"``.
+
+    Captures every ``check_endpoint`` whose URL is a page path on ``$BASE_URL``
+    (i.e. not an ``/api/...`` endpoint), regardless of the human label, so a
+    mislabeled broken route (e.g. ``"Dashboard"`` -> ``/dashboard``) is caught.
+    """
+    text = SMOKE.read_text(encoding="utf-8")
+    routes: list[str] = []
+    pattern = re.compile(r'check_endpoint\s+"[^"]*"\s+"\$\{?BASE_URL\}?(/[^"\s]*)"')
+    for match in pattern.finditer(text):
+        path = match.group(1)
+        if path.startswith("/api/"):
+            continue
+        routes.append(path.rstrip("/") or "/")
+    return routes
+
+
+def test_AC7_17_1_smoke_asserts_only_existing_public_frontend_routes() -> None:
+    real_routes = {r.rstrip("/") or "/" for r in _frontend_page_routes()}
+    asserted = _smoke_asserted_page_routes()
+    assert asserted, (
+        "smoke_test.sh should still assert at least one frontend page route"
+    )
+    missing = [r for r in asserted if (r.rstrip("/") or "/") not in real_routes]
+    assert not missing, (
+        "smoke_test.sh asserts page routes that do not exist under "
+        f"apps/frontend/src/app: {missing}. Existing routes: {sorted(real_routes)}"
+    )
+
+
+def test_AC7_17_1_smoke_does_not_assert_nonexistent_dashboard_route() -> None:
+    asserted = {r.rstrip("/") or "/" for r in _smoke_asserted_page_routes()}
+    assert "/dashboard" not in asserted, (
+        "smoke_test.sh must not assert /dashboard — there is no "
+        "apps/frontend/src/app/.../dashboard/page.tsx, so it 404s"
+    )

--- a/tools/_lib/shell/smoke_test.sh
+++ b/tools/_lib/shell/smoke_test.sh
@@ -167,12 +167,16 @@ echo "ℹ️  S3 Endpoint check: Backend is configured to use 127.0.0.1 (standar
 echo "✓ Networking Strategy"
 
 # --- Read-Only Checks (All Modes) ---
+# NOTE (#411, AC7.17.1): every page path below must correspond to a real public
+# Next.js route under apps/frontend/src/app. The home page ("/") is the dashboard
+# (there is no separate /dashboard route), and statement uploads live at
+# /statements/upload (there is no bare /statements page). tests/tooling/
+# test_smoke_routes_contract.py guards these paths against route drift.
 echo "--- Read-Only Checks ---"
-check_endpoint "Homepage (redirects to dashboard)" "$BASE_URL/" || FAILED=1
-check_endpoint "Dashboard" "$BASE_URL/dashboard" || FAILED=1
+check_endpoint "Home / Dashboard Page" "$BASE_URL/" || FAILED=1
 check_endpoint "Accounts Page" "$BASE_URL/accounts" || FAILED=1
 check_endpoint "Journal Page" "$BASE_URL/journal" || FAILED=1
-check_endpoint "Statements Page" "$BASE_URL/statements" || FAILED=1
+check_endpoint "Statements Upload Page" "$BASE_URL/statements/upload" || FAILED=1
 check_endpoint "Reports Page" "$BASE_URL/reports" || FAILED=1
 check_endpoint "API Health" "$BASE_URL/api/health" "healthy" || FAILED=1
 check_endpoint "API Docs" "$BASE_URL/api/docs" || FAILED=1


### PR DESCRIPTION
## Quick-wins sweep — three small, independent fixes

One mergeable PR bundling three independent fixes, each following the repo's
mandatory order (EPIC → AC → failing test → code → doc). No `repo/` submodule
changes. No CLAUDE.md changes.

### Fix 1 — #1097: kill the last router→router import (behavior-preserving)
`apps/backend/src/routers/reports.py` imported the portfolio **router** handler
`get_investment_performance_report_schedule` from inside the personal-report-package
assembly. That logic already lives in the service layer. The package path now
calls `services.performance_report.build_investment_performance_report_schedule`
directly. The caller already passes validated concrete dates and a normalized
(uppercased, package-resolved) currency, so the router handler's input
defaulting/validation was moot here and behavior is preserved.

- EPIC-025, **AC25.5.1** — no backend router imports a sibling router.
- Test: `apps/backend/tests/api/test_router_boundary.py::test_AC25_5_1_no_router_imports_another_router` — AST-scans every `apps/backend/src/routers/*.py` (excluding the package `__init__.py` aggregator) and fails on any `from src.routers.<x> import ...`.
- Behavior parity verified: 79 existing report-package / portfolio-router tests still pass.

### Fix 2 — #411: smoke expectations vs real frontend routes
`tools/_lib/shell/smoke_test.sh` asserted `/dashboard` and a bare `/statements`,
**neither of which exists** under `apps/frontend/src/app` (both 404). The home
page (`/`) is the dashboard (no separate `/dashboard` route) and statement uploads
live at `/statements/upload`. Replaced the broken checks with real public routes.

- EPIC-007, **AC7.17.1** — every page path the smoke gate asserts maps to a real public Next.js route.
- Tests: `tests/tooling/test_smoke_routes_contract.py::test_AC7_17_1_smoke_asserts_only_existing_public_frontend_routes`, `...::test_AC7_17_1_smoke_does_not_assert_nonexistent_dashboard_route` — derive real routes from `apps/frontend/src/app` (route-groups excluded, dynamic `[param]` skipped) and fail on any asserted page path with no `page.tsx`.
- Existing smoke behavior tests (`AC14.1.5` mocked run, pr-preview gate contract) still pass.

### Fix 3 — #1277 (SECRET-SCAN HALF ONLY): build-time secret-scan gate
The `container-images` CI job now runs a **fail-closed** gitleaks scan over each
component's Docker build context (`apps/<component>`, `--no-git --redact
--exit-code 1`) **before** `docker/build-push-action`, so a secret in the build
context cannot be baked into a published `:<sha>` image. The redacted finding
stays visible in the job logs. Mirrors the lint-job gitleaks idiom (pinned
version + checksum) scoped to the build context.

- EPIC-007, **AC7.18.1** — build-context secret scan exists, is fail-closed, runs before the build.
- Test: `tests/tooling/test_build_secret_scan_contract.py::test_AC7_18_1_container_images_job_has_build_context_secret_scan`, `...::test_AC7_18_1_build_secret_scan_is_fail_closed_before_build`.

> **#1277 stays open for the `:<sha>` retention half.** This PR implements only
> the secret-scan half of #1277; image retention is intentionally out of scope.

### Local validation
- `python tools/generate_ac_registry.py` → OK (registries already include every EPIC-defined AC)
- `python tools/check_ac_index.py` → `[INTEGRITY] PASSED` (1840 AC nodes, 64 @ac_proof edges) + `[PROTECTION] PASSED`
- `python tools/check_workflow_contract.py` → `Workflow contract OK`
- New tests, true red→green confirmed before implementation:
  - Fix 1 failed on `reports.py:256 -> from src.routers.portfolio import ...`, passes after rewire.
  - Fix 2 failed on `['/dashboard', '/statements']`, passes after route fix.
  - Fix 3 failed on "no build-context secret-scan step", passes after adding the gate.
- `ruff check` + `ruff format --check` → clean on all changed/new Python; `bash -n` + `shellcheck -S error` clean on the smoke script; all 9 `.github/workflows/*.yml` parse.
- `moon run :lint`: backend Python lint/format/contract checks pass; frontend `eslint`/`npm run lint` errored only because frontend node deps are not installed in this isolated worktree (no frontend source changed). CI installs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
