### PR TITLE
[finance_report_audit] feat(ledger): Entry value object + vertical-slice module template (AC12.34)

### DIFF
--- a/apps/backend/src/ledger/__init__.py
+++ b/apps/backend/src/ledger/__init__.py
@@ -1,0 +1,34 @@
+"""``ledger`` — the double-entry domain module (template vertical slice).
+
+This module is the worked example of the project's target shape: a *vertical
+domain slice* whose files converge by role —
+
+- ``types/``  domain nouns (``Entry``/``Leg``) — the balance invariant lives here
+- ``ops/``    domain verbs (``post_entry``) — the edges in the project DAG
+- ``store/``  persistence (currently ``src.models.journal`` / ``services.accounting``;
+              to be folded in as the module matures)
+- ``api/``    boundary (currently ``src.routers`` + ``src.schemas.journal``)
+
+Dependency rule (keeps the project a DAG): ``api → ops → {types, store} → kernel``
+(``src.money`` etc.); never upward. See ``ledger.contract.md``.
+"""
+
+from __future__ import annotations
+
+from src.ledger.ops import post_entry
+from src.ledger.types import (
+    EmptyEntryError,
+    Entry,
+    LedgerError,
+    Leg,
+    UnbalancedEntryError,
+)
+
+__all__ = [
+    "Entry",
+    "EmptyEntryError",
+    "Leg",
+    "LedgerError",
+    "UnbalancedEntryError",
+    "post_entry",
+]

--- a/apps/backend/src/ledger/ledger.contract.md
+++ b/apps/backend/src/ledger/ledger.contract.md
@@ -1,0 +1,53 @@
+# ledger module contract (template vertical slice)
+
+> The first **vertical domain module** in the backend — the worked example of the
+> target shape every other domain (portfolio, market, ingest, reconcile, report,
+> advisor) should follow. Authoritative prose:
+> [`docs/ssot/base-packages.md`](../../../../docs/ssot/base-packages.md) and the
+> module/role model in the project DAG discussion.
+
+## Roles (files converge by role)
+
+| role | what lives here | status |
+|------|-----------------|--------|
+| `types/` | domain **nouns** — `Entry`, `Leg` (the balance invariant) | ✅ this module |
+| `ops/` | domain **verbs** — `post_entry` (edges in the project DAG) | ✅ this module |
+| `store/` | persistence — `src.models.journal`, `services.accounting` | ⏳ legacy location, fold in next |
+| `api/` | boundary — `src.routers`, `src.schemas.journal` | ⏳ legacy location, fold in next |
+
+## The dependency rule (what makes the project a DAG)
+
+```
+api → ops → { types, store } → kernel (src.money / src.ratio / …)
+```
+
+- Dependencies point **down only**; never upward, never sideways-cyclic.
+- The model layer must **not** import a service (the previous
+  `models.journal → services.confidence_tier` cycle was removed by moving
+  `derive_confidence_tier` next to the enum it maps). Enforced by
+  `tests/tooling/test_ledger_module.py`.
+- Cross-module calls are explicit verbs: e.g. `portfolio` / `investment` call
+  `ledger.post_entry`; `ledger` knows nothing about them.
+
+## Invariants
+
+1. **An entry cannot exist unbalanced.** `Entry` raises `UnbalancedEntryError` at
+   construction unless debits == credits **per currency** (stronger than the
+   legacy currency-blind `abs(debit-credit) < 0.01` check). This makes the
+   system's central invariant a type, like `Money` rejecting `float`.
+2. **Legs are positive `Money`.** No zero/negative lines; direction carries sign.
+3. **Policy stays in callers.** Which account is debited/credited for a
+   buy/sell/dividend is the caller's account-selection policy; `ledger` only
+   guarantees the result balances and persists it.
+
+## Usage
+
+```python
+from src.ledger import Entry, post_entry
+
+posted = await post_entry(
+    db, user_id=user_id, entry_date=d, memo="Buy AAPL", source_id=src,
+    entry=Entry.transfer(debit=investment_acct, credit=cash_acct, money=gross,
+                         event_type="investment_buy", tags={...}),
+)
+```

--- a/apps/backend/src/ledger/ops/__init__.py
+++ b/apps/backend/src/ledger/ops/__init__.py
@@ -1,0 +1,7 @@
+"""Ledger domain operations (verbs)."""
+
+from __future__ import annotations
+
+from src.ledger.ops.post import post_entry
+
+__all__ = ["post_entry"]

--- a/apps/backend/src/ledger/ops/post.py
+++ b/apps/backend/src/ledger/ops/post.py
@@ -1,0 +1,60 @@
+"""``post_entry`` — the ledger's posting verb (an edge in the project DAG).
+
+Takes a balanced :class:`~src.ledger.types.entry.Entry` and persists it as a
+posted ``JournalEntry``. The balance invariant is already guaranteed by ``Entry``
+construction; this op only translates legs to the storage shape and runs the
+existing create + post pipeline (account ownership, fx-rate, system-account, and
+posting-status checks remain in ``services.accounting``).
+
+This is the single typed front door for "record a transaction"; callers build an
+``Entry`` (their account-selection policy) and hand it here instead of hand-rolling
+``lines_data`` dicts.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.ledger.types.entry import Entry
+from src.models.journal import JournalEntry, JournalEntrySourceType
+from src.services.accounting import create_journal_entry, post_journal_entry
+
+
+async def post_entry(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    entry_date: date,
+    memo: str,
+    entry: Entry,
+    source_type: JournalEntrySourceType = JournalEntrySourceType.SYSTEM,
+    source_id: UUID | None = None,
+) -> JournalEntry:
+    """Persist a balanced :class:`Entry` and return the posted journal entry."""
+    lines_data = [
+        {
+            "account_id": leg.account_id,
+            "direction": leg.direction,
+            "amount": leg.money.amount,
+            "currency": leg.money.currency.code,
+            "fx_rate": leg.fx_rate,
+            "event_type": leg.event_type,
+            "tags": leg.tags,
+        }
+        for leg in entry.legs
+    ]
+    created = await create_journal_entry(
+        db,
+        user_id=user_id,
+        entry_date=entry_date,
+        memo=memo,
+        lines_data=lines_data,
+        source_type=source_type,
+        source_id=source_id,
+    )
+    posted = await post_journal_entry(db, created.id, user_id)
+    await db.refresh(posted, ["lines"])
+    return posted

--- a/apps/backend/src/ledger/types/__init__.py
+++ b/apps/backend/src/ledger/types/__init__.py
@@ -1,0 +1,18 @@
+"""Ledger domain types (nouns)."""
+
+from __future__ import annotations
+
+from src.ledger.types.entry import Entry, Leg
+from src.ledger.types.errors import (
+    EmptyEntryError,
+    LedgerError,
+    UnbalancedEntryError,
+)
+
+__all__ = [
+    "Entry",
+    "EmptyEntryError",
+    "Leg",
+    "LedgerError",
+    "UnbalancedEntryError",
+]

--- a/apps/backend/src/ledger/types/entry.py
+++ b/apps/backend/src/ledger/types/entry.py
@@ -1,0 +1,88 @@
+"""``Entry`` — the balanced double-entry value object (the ledger's core noun).
+
+The crown-jewel invariant of a double-entry system is *debits == credits*. Today
+that invariant lives as a scattered runtime check (``abs(debit - credit) < 0.01``
+re-implemented in several services). ``Entry`` makes it a **type**: an entry that
+does not balance *per currency* cannot be constructed — :class:`UnbalancedEntryError`
+is raised at construction, exactly like :class:`~src.money.Money` rejects ``float``.
+
+This is the *invariant* (a value object), not the *policy*: which account is
+debited/credited for a buy/sell/dividend stays in the domain ``ops`` (and the
+persistence stays in ``store``). ``Entry`` only guarantees the result balances.
+
+Balance is checked **per currency** (stronger than the legacy currency-blind sum):
+for every currency, the sum of debit amounts must equal the sum of credit amounts.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from src.ledger.types.errors import EmptyEntryError, UnbalancedEntryError
+from src.models.journal import Direction
+from src.money import Money
+
+
+@dataclass(frozen=True)
+class Leg:
+    """One debit or credit line: a positive :class:`Money` amount on an account."""
+
+    account_id: UUID
+    direction: Direction
+    money: Money
+    fx_rate: Decimal | None = None
+    event_type: str | None = None
+    tags: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.money, Money):
+            raise TypeError(f"leg amount must be Money, got {type(self.money).__name__}")
+        if not self.money.is_positive():
+            raise UnbalancedEntryError(f"leg amount must be positive, got {self.money}")
+
+
+@dataclass(frozen=True)
+class Entry:
+    """An immutable, balanced set of legs. Cannot be constructed unbalanced."""
+
+    legs: tuple[Leg, ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        if not self.legs:
+            raise EmptyEntryError("an entry needs at least two legs")
+        net_by_currency: dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
+        for leg in self.legs:
+            code = leg.money.currency.code
+            if leg.direction == Direction.DEBIT:
+                net_by_currency[code] += leg.money.amount
+            else:
+                net_by_currency[code] -= leg.money.amount
+        unbalanced = {c: n for c, n in net_by_currency.items() if n != 0}
+        if unbalanced:
+            raise UnbalancedEntryError(f"entry does not balance per currency: {unbalanced}")
+
+    @classmethod
+    def of(cls, *legs: Leg) -> Entry:
+        """Build an entry from explicit legs (validates balance)."""
+        return cls(tuple(legs))
+
+    @classmethod
+    def transfer(
+        cls,
+        *,
+        debit: UUID,
+        credit: UUID,
+        money: Money,
+        fx_rate: Decimal | None = None,
+        event_type: str | None = None,
+        tags: dict[str, Any] | None = None,
+    ) -> Entry:
+        """The common two-leg case: move ``money`` from ``credit`` to ``debit``."""
+        return cls.of(
+            Leg(debit, Direction.DEBIT, money, fx_rate, event_type, tags),
+            Leg(credit, Direction.CREDIT, money, fx_rate, event_type, tags),
+        )

--- a/apps/backend/src/ledger/types/errors.py
+++ b/apps/backend/src/ledger/types/errors.py
@@ -1,0 +1,20 @@
+"""Typed errors for the ledger domain types."""
+
+from __future__ import annotations
+
+
+class LedgerError(Exception):
+    """Base class for every ledger-domain error."""
+
+
+class UnbalancedEntryError(LedgerError, ValueError):
+    """An entry's debits and credits do not net to zero per currency.
+
+    This is the system's central invariant: a double-entry posting must balance.
+    ``Entry`` raises this at construction so an unbalanced entry is unrepresentable
+    rather than caught later by a runtime check.
+    """
+
+
+class EmptyEntryError(LedgerError, ValueError):
+    """An entry was constructed with no legs."""

--- a/apps/backend/src/models/journal.py
+++ b/apps/backend/src/models/journal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import enum
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
 from sqlalchemy import DECIMAL, CheckConstraint, Date, DateTime, Enum, ForeignKey, String, Text, event
@@ -41,6 +41,31 @@ class JournalEntrySourceType(str, enum.Enum):
     # ``normalize_source_type`` and the immutability trigger's text guards.
     SYSTEM = "system"
     FX_REVALUATION = "fx_revaluation"
+
+
+ConfidenceTier = Literal["TRUSTED", "HIGH", "MEDIUM", "LOW"]
+
+# Source-type → UI confidence tier (EPIC-018). Co-located with the enum it maps so
+# the model layer never needs to import a service (keeps the dependency a DAG).
+_SOURCE_TYPE_TIERS: dict[str, ConfidenceTier] = {
+    "manual": "TRUSTED",
+    "user_confirmed": "HIGH",
+    "auto_matched": "MEDIUM",
+    "auto_parsed": "LOW",
+    "bank_statement": "LOW",
+    "system": "LOW",
+    "fx_revaluation": "LOW",
+}
+
+
+def derive_confidence_tier(
+    source_type: JournalEntrySourceType | str | None,
+) -> ConfidenceTier:
+    """Map a journal ``source_type`` to the EPIC-018 UI confidence tier contract."""
+    if source_type is None:
+        return "LOW"
+    value = source_type.value if isinstance(source_type, JournalEntrySourceType) else str(source_type)
+    return _SOURCE_TYPE_TIERS.get(value, "LOW")
 
 
 class Direction(str, enum.Enum):
@@ -102,8 +127,6 @@ class JournalEntry(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     @property
     def confidence_tier(self) -> str:
         """Derived UI confidence tier based on source type."""
-        from src.services.confidence_tier import derive_confidence_tier
-
         return derive_confidence_tier(self.source_type)
 
 

--- a/apps/backend/src/services/confidence_tier.py
+++ b/apps/backend/src/services/confidence_tier.py
@@ -1,28 +1,21 @@
-"""Confidence tier derivation from journal source type."""
+"""Confidence tier derivation.
 
-from typing import Literal
+``ConfidenceTier`` and ``derive_confidence_tier`` now live in the model layer
+(:mod:`src.models.journal`, co-located with ``JournalEntrySourceType``) so the
+model no longer imports a service — the previous ``model → service`` import cycle
+is removed. They are re-exported here for the existing call sites.
 
-from src.models.journal import JournalEntrySourceType
+``derive_reconciliation_score_tier`` stays here: it maps a numeric score (not a
+journal enum) and has no model dependency.
+"""
 
-ConfidenceTier = Literal["TRUSTED", "HIGH", "MEDIUM", "LOW"]
+from src.models.journal import ConfidenceTier, derive_confidence_tier
 
-
-def derive_confidence_tier(source_type: JournalEntrySourceType | str | None) -> ConfidenceTier:
-    """Map journal source_type to the EPIC-018 UI confidence tier contract."""
-    if source_type is None:
-        return "LOW"
-
-    value = source_type.value if isinstance(source_type, JournalEntrySourceType) else str(source_type)
-    tiers: dict[str, ConfidenceTier] = {
-        "manual": "TRUSTED",
-        "user_confirmed": "HIGH",
-        "auto_matched": "MEDIUM",
-        "auto_parsed": "LOW",
-        "bank_statement": "LOW",
-        "system": "LOW",
-        "fx_revaluation": "LOW",
-    }
-    return tiers.get(value, "LOW")
+__all__ = [
+    "ConfidenceTier",
+    "derive_confidence_tier",
+    "derive_reconciliation_score_tier",
+]
 
 
 def derive_reconciliation_score_tier(score: int | None) -> ConfidenceTier:

--- a/apps/backend/src/services/investment_accounting.py
+++ b/apps/backend/src/services/investment_accounting.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.ledger import Entry, post_entry
 from src.models.account import Account, AccountType
 from src.models.journal import Direction, JournalEntry, JournalEntrySourceType
 from src.models.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
@@ -89,35 +90,23 @@ class InvestmentAccountingService:
             cost_basis_method=cost_basis_method,
         )
 
-        entry = await create_journal_entry(
+        # Dr investment / Cr cash — a balanced two-leg transfer. Entry guarantees
+        # the balance invariant at construction; post_entry persists + posts it.
+        posted = await post_entry(
             db,
             user_id=user_id,
             entry_date=transaction_date,
             memo=f"Buy {asset_identifier}",
-            source_type=JournalEntrySourceType.SYSTEM,
             source_id=source_id,
-            lines_data=[
-                {
-                    "account_id": investment_account.id,
-                    "direction": Direction.DEBIT,
-                    "amount": amount,
-                    "currency": currency,
-                    "fx_rate": fx_rate,
-                    "event_type": "investment_buy",
-                    "tags": {"asset_identifier": asset_identifier},
-                },
-                {
-                    "account_id": cash_account.id,
-                    "direction": Direction.CREDIT,
-                    "amount": amount,
-                    "currency": currency,
-                    "fx_rate": fx_rate,
-                    "event_type": "investment_buy",
-                    "tags": {"asset_identifier": asset_identifier},
-                },
-            ],
+            entry=Entry.transfer(
+                debit=investment_account.id,
+                credit=cash_account.id,
+                money=gross,
+                fx_rate=fx_rate,
+                event_type="investment_buy",
+                tags={"asset_identifier": asset_identifier},
+            ),
         )
-        posted = await self._post_and_load(db, entry.id, user_id)
 
         transaction = InvestmentTransaction(
             user_id=user_id,

--- a/apps/backend/tests/ledger/test_entry.py
+++ b/apps/backend/tests/ledger/test_entry.py
@@ -1,0 +1,74 @@
+"""Entry value-object laws — the double-entry balance invariant (EPIC-012 AC12.34)."""
+
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.ledger import Entry, Leg, UnbalancedEntryError
+from src.ledger.types.errors import EmptyEntryError
+from src.models.journal import Direction
+from src.money import Money
+
+pytestmark = pytest.mark.no_db
+
+A, B, C = uuid4(), uuid4(), uuid4()
+
+
+def _m(x: str, ccy: str = "USD") -> Money:
+    return Money(Decimal(x), ccy)
+
+
+@ac_proof(proof_id="test_entry_balances", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+def test_AC12_34_1_balanced_entry_constructs():
+    """AC12.34.1: a balanced transfer / multi-leg entry constructs."""
+    e = Entry.transfer(debit=A, credit=B, money=_m("10.00"))
+    assert len(e.legs) == 2
+    # 3-leg balanced (sell shape: dr cash = cr cost + cr pnl)
+    e3 = Entry.of(
+        Leg(A, Direction.DEBIT, _m("100.00")),
+        Leg(B, Direction.CREDIT, _m("80.00")),
+        Leg(C, Direction.CREDIT, _m("20.00")),
+    )
+    assert len(e3.legs) == 3
+
+
+@ac_proof(proof_id="test_entry_unbalanced_raises", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+def test_AC12_34_1_unbalanced_entry_is_unconstructable():
+    """AC12.34.1: an unbalanced entry cannot be constructed."""
+    with pytest.raises(UnbalancedEntryError):
+        Entry.of(
+            Leg(A, Direction.DEBIT, _m("100.00")),
+            Leg(B, Direction.CREDIT, _m("80.00")),
+        )
+    with pytest.raises(EmptyEntryError):
+        Entry.of()
+
+
+@ac_proof(proof_id="test_entry_per_currency", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+def test_AC12_34_1_balance_is_checked_per_currency():
+    """AC12.34.1: balance is per currency, not a currency-blind sum."""
+    # each currency balances on its own
+    ok = Entry.of(
+        Leg(A, Direction.DEBIT, _m("10.00", "USD")),
+        Leg(B, Direction.CREDIT, _m("10.00", "USD")),
+        Leg(A, Direction.DEBIT, _m("5.00", "SGD")),
+        Leg(B, Direction.CREDIT, _m("5.00", "SGD")),
+    )
+    assert len(ok.legs) == 4
+    # currency-blind sum is zero (10 USD dr vs 10 SGD cr) but per-currency it is NOT
+    with pytest.raises(UnbalancedEntryError):
+        Entry.of(
+            Leg(A, Direction.DEBIT, _m("10.00", "USD")),
+            Leg(B, Direction.CREDIT, _m("10.00", "SGD")),
+        )
+
+
+@ac_proof(proof_id="test_entry_leg_positive", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+def test_AC12_34_1_legs_must_be_positive():
+    """AC12.34.1: a leg amount must be positive (no zero/negative lines)."""
+    with pytest.raises(UnbalancedEntryError):
+        Leg(A, Direction.DEBIT, _m("0.00"))
+    with pytest.raises(UnbalancedEntryError):
+        Leg(A, Direction.DEBIT, _m("-1.00"))

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -522,6 +522,22 @@ vectors) but adopted on the backend first.
 | AC12.33.2 | Cross-language conformance: the Python reference and shipped backend reproduce the shared `vectors.json` groups (`predicates`/`sum`/`tolerance` for money, `fraction_or_zero` for ratio) | `test_AC12_33_2_money_composite_matches_standard`, `test_AC12_33_2_ratio_fraction_or_zero_matches_standard`, `test_AC12_33_2_backend_composite_matches_standard` | `tests/tooling/test_composite_ops.py`, `apps/backend/tests/accounting/test_composite_ops_backend.py` | P1 |
 | AC12.33.3 | Adoption: zero-denominator ratio branching routes through `Ratio.fraction_or_zero` (retiring the local `_ratio_or_zero` helper in portfolio, plus performance-report and reconciliation-stats call sites), and investment accounting uses `Money` predicates + `Money.sum` instead of naked `Decimal("0")` comparisons | `test_AC12_33_3_zero_denominator_branching_routes_through_ratio`, `test_AC12_33_3_money_predicates_and_sum_adopted` | `tests/tooling/test_composite_ops_adoption.py` | P1 |
 
+### AC12.34: Ledger module — `Entry` value object + vertical-slice template ([#1253](https://github.com/wangzitian0/finance_report/issues/1253))
+
+The first **vertical domain module** (`src/ledger`) as the template every other
+domain follows: files converge by role (`types/` nouns, `ops/` verbs), and the
+project's layer-DAG rule is enforced (model layer never imports a service). Its
+core noun `Entry` makes the double-entry balance invariant a **type** — an
+unbalanced entry is unconstructable (`UnbalancedEntryError`), replacing scattered
+runtime `abs(debit-credit) < 0.01` checks.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC12.34.1 | `Entry`/`Leg` make double-entry a value object: a balanced transfer/multi-leg entry constructs; an unbalanced one raises `UnbalancedEntryError`; balance is checked **per currency**; legs must be positive `Money`; empty entries raise | `test_AC12_34_1_balanced_entry_constructs` (+ siblings) | `apps/backend/tests/ledger/test_entry.py` | P1 |
+| AC12.34.2 | The ledger module converges by role — `types/` (nouns) + `ops/` (verbs) — and exports `Entry`/`Leg`/`post_entry`/`UnbalancedEntryError` | `test_AC12_34_2_ledger_module_converges_by_role` | `tests/tooling/test_ledger_module.py` | P1 |
+| AC12.34.3 | Layer-DAG rule: the model layer imports no service (no upward edge / import cycle); `derive_confidence_tier` lives in the model and the service re-exports it (the old `models.journal → services.confidence_tier` cycle is removed) | `test_AC12_34_3_model_layer_never_imports_a_service`, `test_AC12_34_3_confidence_tier_lives_in_model_layer` | `tests/tooling/test_ledger_module.py` | P1 |
+| AC12.34.4 | Adoption: the investment buy posting builds a typed `Entry` and posts via `ledger.post_entry` instead of hand-rolling balanced `lines_data` dicts | `test_AC12_34_4_investment_buy_uses_ledger_post` | `tests/tooling/test_ledger_module.py` | P1 |
+
 ---
 
 *Planning snapshot captured: January 2026*

--- a/tests/tooling/test_ledger_module.py
+++ b/tests/tooling/test_ledger_module.py
@@ -1,0 +1,77 @@
+"""ledger module + project-DAG guards (EPIC-012 AC12.34).
+
+The ledger module is the template vertical slice. These guards keep its shape and
+the project's layer-DAG rule honest: nouns/verbs converge by role, and the model
+layer never depends on a service (no upward edges / import cycles).
+"""
+
+import ast
+from pathlib import Path
+
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "apps/backend/src"
+
+
+def _read(path: str) -> str:
+    return (REPO / path).read_text(encoding="utf-8")
+
+
+@ac_proof(proof_id="test_ledger_module_shape", ac_ids=["AC12.34.2"], ci_tier="pr_ci")
+def test_AC12_34_2_ledger_module_converges_by_role():
+    """AC12.34.2: ledger exposes types (nouns) + ops (verbs) as a vertical slice."""
+    assert (SRC / "ledger/types/entry.py").exists()
+    assert (SRC / "ledger/ops/post.py").exists()
+    exports = _read("apps/backend/src/ledger/__init__.py")
+    for name in ("Entry", "Leg", "post_entry", "UnbalancedEntryError"):
+        assert name in exports, f"ledger must export {name}"
+
+
+@ac_proof(
+    proof_id="test_models_have_no_service_deps", ac_ids=["AC12.34.3"], ci_tier="pr_ci"
+)
+def test_AC12_34_3_model_layer_never_imports_a_service():
+    """AC12.34.3: the model layer has no upward edge into services (DAG rule).
+
+    Previously models/journal.py imported services.confidence_tier inside a
+    property — a model→service cycle. That edge is gone; this guard prevents any
+    model from importing a service again (top-level or in-method).
+    """
+    offenders = []
+    for path in sorted((SRC / "models").glob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            mods = []
+            if isinstance(node, ast.ImportFrom) and node.module:
+                mods = [node.module]
+            elif isinstance(node, ast.Import):
+                mods = [a.name for a in node.names]
+            if any(m.startswith("src.services") for m in mods):
+                offenders.append(path.name)
+    assert not offenders, (
+        f"model layer imports services (upward edge): {sorted(set(offenders))}"
+    )
+
+
+@ac_proof(
+    proof_id="test_confidence_tier_relocated", ac_ids=["AC12.34.3"], ci_tier="pr_ci"
+)
+def test_AC12_34_3_confidence_tier_lives_in_model_layer():
+    """AC12.34.3: derive_confidence_tier moved to the model; service re-exports it."""
+    journal = _read("apps/backend/src/models/journal.py")
+    assert "def derive_confidence_tier(" in journal
+    shim = _read("apps/backend/src/services/confidence_tier.py")
+    assert (
+        "from src.models.journal import ConfidenceTier, derive_confidence_tier" in shim
+    )
+
+
+@ac_proof(proof_id="test_ledger_buy_adoption", ac_ids=["AC12.34.4"], ci_tier="pr_ci")
+def test_AC12_34_4_investment_buy_uses_ledger_post():
+    """AC12.34.4: the buy posting uses Entry + post_entry, not hand-built line dicts."""
+    src = _read("apps/backend/src/services/investment_accounting.py")
+    assert "from src.ledger import Entry, post_entry" in src
+    assert "Entry.transfer(" in src
+    assert "post_entry(" in src
+    # the hand-rolled buy lines_data dict is gone
+    assert '"event_type": "investment_buy"' not in src


### PR DESCRIPTION
## What

The first **vertical domain module** (`src/ledger`) — the worked template for the project's target shape: files converge by role, dependencies form a DAG (no upward edges).

- **`ledger/types/entry.py`** — `Entry`/`Leg` make the double-entry **balance invariant a type**: an unbalanced entry is *unconstructable* (`UnbalancedEntryError`), checked **per currency** (stronger than the legacy currency-blind `abs(debit-credit) < 0.01`). Like `Money` rejecting `float`, the system's central invariant is now unrepresentable-when-wrong instead of a scattered runtime check.
- **`ledger/ops/post.py`** — `post_entry`, the typed posting verb: takes a balanced `Entry`, runs the existing create+post pipeline. Account/fx/system checks stay in `services.accounting`; account-selection *policy* stays in callers.
- **`ledger.contract.md`** — roles (`types`/`ops`/`store`/`api`), the dependency rule, invariants.

## DAG fix (real cycle removed)

The one real import cycle was `models.journal → services.confidence_tier` (a model importing a service via an in-method import). Fixed by moving `derive_confidence_tier` next to the enum it maps (`models/journal.py`); `services/confidence_tier` re-exports it (all 6 callers unchanged). A new guard forbids **any** model from importing a service.

## Adoption (before/after)

The investment **buy** posting now builds `Entry.transfer(debit=…, credit=…, money=gross, …)` and calls `post_entry` — replacing a hand-rolled ~28-line balanced `lines_data` dict, with balance now guaranteed by construction. Sell/dividend stay on the legacy path (their zero-amount-leg policy is worth settling separately).

## Scope

`store/` (ORM) and `api/` (router/schemas) remain in their legacy locations for now — the contract documents them as the next fold-in. This PR establishes the new `types`+`ops` layers + the DAG rule + one proven migration, as the template the other 6 domains copy.

## Verification

- New tests: `Entry` laws (per-currency balance, positive legs, unbalanced/empty raise) + module/DAG guards.
- Regression: investment/accounting/journal/confidence/reconciliation **687 passed**; tooling guards + traceability **129 passed**; backend ledger/confidence **25 passed**.
- `ruff` clean; mypy adds **zero** new errors (`ledger/` is fully clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)