### PR TITLE
[finance_report_audit] fix(ledger): harden Entry value object (review follow-up to #1285)

### DIFF
--- a/apps/backend/src/ledger/__init__.py
+++ b/apps/backend/src/ledger/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from src.ledger.ops import post_entry
 from src.ledger.types import (
-    EmptyEntryError,
+    DegenerateEntryError,
     Entry,
     LedgerError,
     Leg,
@@ -26,7 +26,7 @@ from src.ledger.types import (
 
 __all__ = [
     "Entry",
-    "EmptyEntryError",
+    "DegenerateEntryError",
     "Leg",
     "LedgerError",
     "UnbalancedEntryError",

--- a/apps/backend/src/ledger/types/__init__.py
+++ b/apps/backend/src/ledger/types/__init__.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from src.ledger.types.entry import Entry, Leg
 from src.ledger.types.errors import (
-    EmptyEntryError,
+    DegenerateEntryError,
     LedgerError,
     UnbalancedEntryError,
 )
 
 __all__ = [
     "Entry",
-    "EmptyEntryError",
+    "DegenerateEntryError",
     "Leg",
     "LedgerError",
     "UnbalancedEntryError",

--- a/apps/backend/src/ledger/types/entry.py
+++ b/apps/backend/src/ledger/types/entry.py
@@ -22,7 +22,7 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from src.ledger.types.errors import EmptyEntryError, UnbalancedEntryError
+from src.ledger.types.errors import DegenerateEntryError, UnbalancedEntryError
 from src.models.journal import Direction
 from src.money import Money
 
@@ -39,6 +39,8 @@ class Leg:
     tags: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
+        if not isinstance(self.direction, Direction):
+            raise TypeError(f"leg direction must be a Direction, got {type(self.direction).__name__}")
         if not isinstance(self.money, Money):
             raise TypeError(f"leg amount must be Money, got {type(self.money).__name__}")
         if not self.money.is_positive():
@@ -52,8 +54,8 @@ class Entry:
     legs: tuple[Leg, ...] = field(default=())
 
     def __post_init__(self) -> None:
-        if not self.legs:
-            raise EmptyEntryError("an entry needs at least two legs")
+        if len(self.legs) < 2:
+            raise DegenerateEntryError(f"an entry needs at least two legs, got {len(self.legs)}")
         net_by_currency: dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
         for leg in self.legs:
             code = leg.money.currency.code

--- a/apps/backend/src/ledger/types/errors.py
+++ b/apps/backend/src/ledger/types/errors.py
@@ -16,5 +16,10 @@ class UnbalancedEntryError(LedgerError, ValueError):
     """
 
 
-class EmptyEntryError(LedgerError, ValueError):
-    """An entry was constructed with no legs."""
+class DegenerateEntryError(LedgerError, ValueError):
+    """An entry was constructed with fewer than two legs.
+
+    A double-entry posting needs at least one debit and one credit; an empty or
+    single-leg entry is degenerate (and could never balance), so it is rejected
+    with a clear error rather than a confusing "unbalanced" one.
+    """

--- a/apps/backend/tests/ledger/test_entry.py
+++ b/apps/backend/tests/ledger/test_entry.py
@@ -7,7 +7,7 @@ import pytest
 from common.testing.ac_proof import ac_proof
 
 from src.ledger import Entry, Leg, UnbalancedEntryError
-from src.ledger.types.errors import EmptyEntryError
+from src.ledger.types.errors import DegenerateEntryError
 from src.models.journal import Direction
 from src.money import Money
 
@@ -42,8 +42,11 @@ def test_AC12_34_1_unbalanced_entry_is_unconstructable():
             Leg(A, Direction.DEBIT, _m("100.00")),
             Leg(B, Direction.CREDIT, _m("80.00")),
         )
-    with pytest.raises(EmptyEntryError):
+    with pytest.raises(DegenerateEntryError):
         Entry.of()
+    # a single-leg entry is degenerate (clear error, not a confusing "unbalanced")
+    with pytest.raises(DegenerateEntryError):
+        Entry.of(Leg(A, Direction.DEBIT, _m("10.00")))
 
 
 @ac_proof(proof_id="test_entry_per_currency", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
@@ -72,3 +75,10 @@ def test_AC12_34_1_legs_must_be_positive():
         Leg(A, Direction.DEBIT, _m("0.00"))
     with pytest.raises(UnbalancedEntryError):
         Leg(A, Direction.DEBIT, _m("-1.00"))
+
+
+@ac_proof(proof_id="test_entry_leg_direction", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+def test_AC12_34_1_leg_direction_must_be_typed():
+    """AC12.34.1: a non-Direction direction is rejected (no silent credit)."""
+    with pytest.raises(TypeError):
+        Leg(A, "DEBIT", _m("10.00"))  # type: ignore[arg-type]


### PR DESCRIPTION
Follow-up to #1285 (merged) addressing the two Copilot review points on `Entry` — both hardening the template's "unconstructable when wrong" guarantee before 6 other modules copy it.

- **`Leg.direction` is now validated**: a non-`Direction` value (e.g. the string `"DEBIT"`) raises `TypeError` instead of being silently treated as a credit and corrupting the per-currency balance.
- **`Entry` requires ≥ 2 legs**: a single-leg (or empty) entry raises a clear `DegenerateEntryError` (renamed from `EmptyEntryError`, now covering the single-leg case) instead of a confusing "unbalanced" error.

Regression tests added for both. Verified: ledger unit tests + module/DAG guards pass; investment path (which builds `Entry.transfer`) still green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)