### PR TITLE
[finance_report_audit] feat(ledger): post investment sell + dividend via Entry/post_entry (AC12.34) [PR 1/2]

### DIFF
--- a/apps/backend/src/services/investment_accounting.py
+++ b/apps/backend/src/services/investment_accounting.py
@@ -8,9 +8,9 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.ledger import Entry, post_entry
+from src.ledger import Entry, Leg, post_entry
 from src.models.account import Account, AccountType
-from src.models.journal import Direction, JournalEntry, JournalEntrySourceType
+from src.models.journal import Direction, JournalEntry
 from src.models.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
 from src.models.portfolio import (
     DividendIncome,
@@ -21,7 +21,6 @@ from src.models.portfolio import (
 )
 from src.money import Money, to_money
 from src.quantity import Quantity
-from src.services.accounting import create_journal_entry, post_journal_entry
 from src.unit_price import UnitPrice
 
 INVESTMENT_QUANTITY_UNIT = "units"
@@ -203,61 +202,49 @@ class InvestmentAccountingService:
         )
         realized_pnl = to_money(proceeds - cost_basis)
 
-        lines = [
-            {
-                "account_id": cash_account.id,
-                "direction": Direction.DEBIT,
-                "amount": proceeds,
-                "currency": currency,
-                "fx_rate": fx_rate,
-                "event_type": "investment_sell",
-                "tags": {"asset_identifier": asset_identifier},
-            },
-            {
-                "account_id": investment_account.id,
-                "direction": Direction.CREDIT,
-                "amount": cost_basis,
-                "currency": currency,
-                "fx_rate": fx_rate,
-                "event_type": "investment_sell",
-                "tags": {"asset_identifier": asset_identifier},
-            },
+        sell_tags = {"asset_identifier": asset_identifier}
+        legs = [
+            Leg(cash_account.id, Direction.DEBIT, Money(proceeds, currency), fx_rate, "investment_sell", sell_tags),
+            Leg(
+                investment_account.id,
+                Direction.CREDIT,
+                Money(cost_basis, currency),
+                fx_rate,
+                "investment_sell",
+                sell_tags,
+            ),
         ]
         if realized_pnl > Decimal("0"):
-            lines.append(
-                {
-                    "account_id": pnl_account.id,
-                    "direction": Direction.CREDIT,
-                    "amount": realized_pnl,
-                    "currency": currency,
-                    "fx_rate": fx_rate,
-                    "event_type": "investment_realized_pnl",
-                    "tags": {"asset_identifier": asset_identifier},
-                }
+            legs.append(
+                Leg(
+                    pnl_account.id,
+                    Direction.CREDIT,
+                    Money(realized_pnl, currency),
+                    fx_rate,
+                    "investment_realized_pnl",
+                    sell_tags,
+                )
             )
         elif realized_pnl < Decimal("0"):
-            lines.append(
-                {
-                    "account_id": pnl_account.id,
-                    "direction": Direction.DEBIT,
-                    "amount": abs(realized_pnl),
-                    "currency": currency,
-                    "fx_rate": fx_rate,
-                    "event_type": "investment_realized_pnl",
-                    "tags": {"asset_identifier": asset_identifier},
-                }
+            legs.append(
+                Leg(
+                    pnl_account.id,
+                    Direction.DEBIT,
+                    Money(abs(realized_pnl), currency),
+                    fx_rate,
+                    "investment_realized_pnl",
+                    sell_tags,
+                )
             )
 
-        entry = await create_journal_entry(
+        posted = await post_entry(
             db,
             user_id=user_id,
             entry_date=transaction_date,
             memo=f"Sell {asset_identifier}",
-            source_type=JournalEntrySourceType.SYSTEM,
             source_id=source_id,
-            lines_data=lines,
+            entry=Entry.of(*legs),
         )
-        posted = await self._post_and_load(db, entry.id, user_id)
 
         position_quantity = (Quantity(position.quantity, INVESTMENT_QUANTITY_UNIT) - trade_quantity).quantize()
         position.quantity = position_quantity.value
@@ -334,53 +321,35 @@ class InvestmentAccountingService:
         tax = to_money(withholding_tax)
         net_cash = to_money(gross - tax)
 
-        lines = []
+        div_tags = {"asset_identifier": asset_identifier}
+        legs = []
         if net_cash > Decimal("0"):
-            lines.append(
-                {
-                    "account_id": cash_account.id,
-                    "direction": Direction.DEBIT,
-                    "amount": net_cash,
-                    "currency": currency,
-                    "fx_rate": fx_rate,
-                    "event_type": "investment_dividend",
-                    "tags": {"asset_identifier": asset_identifier},
-                }
+            legs.append(
+                Leg(
+                    cash_account.id,
+                    Direction.DEBIT,
+                    Money(net_cash, currency),
+                    fx_rate,
+                    "investment_dividend",
+                    div_tags,
+                )
             )
         if tax > Decimal("0") and tax_account is not None:
-            lines.append(
-                {
-                    "account_id": tax_account.id,
-                    "direction": Direction.DEBIT,
-                    "amount": tax,
-                    "currency": currency,
-                    "fx_rate": fx_rate,
-                    "event_type": "investment_dividend_tax",
-                    "tags": {"asset_identifier": asset_identifier},
-                }
+            legs.append(
+                Leg(tax_account.id, Direction.DEBIT, Money(tax, currency), fx_rate, "investment_dividend_tax", div_tags)
             )
-        lines.append(
-            {
-                "account_id": income_account.id,
-                "direction": Direction.CREDIT,
-                "amount": gross,
-                "currency": currency,
-                "fx_rate": fx_rate,
-                "event_type": "investment_dividend",
-                "tags": {"asset_identifier": asset_identifier},
-            }
+        legs.append(
+            Leg(income_account.id, Direction.CREDIT, Money(gross, currency), fx_rate, "investment_dividend", div_tags)
         )
 
-        entry = await create_journal_entry(
+        posted = await post_entry(
             db,
             user_id=user_id,
             entry_date=payment_date,
             memo=f"Dividend {asset_identifier}",
-            source_type=JournalEntrySourceType.SYSTEM,
             source_id=source_id,
-            lines_data=lines,
+            entry=Entry.of(*legs),
         )
-        posted = await self._post_and_load(db, entry.id, user_id)
 
         transaction = InvestmentTransaction(
             user_id=user_id,
@@ -552,11 +521,6 @@ class InvestmentAccountingService:
         else:
             query = query.order_by(InvestmentLot.acquisition_date.asc(), InvestmentLot.created_at.asc())
         return list((await db.execute(query)).scalars().all())
-
-    async def _post_and_load(self, db: AsyncSession, entry_id: UUID, user_id: UUID) -> JournalEntry:
-        posted = await post_journal_entry(db, entry_id, user_id)
-        await db.refresh(posted, ["lines"])
-        return posted
 
     def _validate_positive(self, value: Decimal, field: str) -> None:
         if value <= Decimal("0"):

--- a/tests/tooling/test_ledger_module.py
+++ b/tests/tooling/test_ledger_module.py
@@ -67,11 +67,20 @@ def test_AC12_34_3_confidence_tier_lives_in_model_layer():
 
 
 @ac_proof(proof_id="test_ledger_buy_adoption", ac_ids=["AC12.34.4"], ci_tier="pr_ci")
-def test_AC12_34_4_investment_buy_uses_ledger_post():
-    """AC12.34.4: the buy posting uses Entry + post_entry, not hand-built line dicts."""
+def test_AC12_34_4_investment_postings_use_ledger_post():
+    """AC12.34.4: investment buy/sell/dividend post via Entry + post_entry."""
     src = _read("apps/backend/src/services/investment_accounting.py")
-    assert "from src.ledger import Entry, post_entry" in src
-    assert "Entry.transfer(" in src
-    assert "post_entry(" in src
-    # the hand-rolled buy lines_data dict is gone
-    assert '"event_type": "investment_buy"' not in src
+    assert "from src.ledger import Entry, Leg, post_entry" in src
+    assert "Entry.transfer(" in src  # buy
+    assert "Entry.of(" in src  # sell + dividend
+    # all hand-rolled investment line dicts are gone, and the legacy post path is retired
+    for needle in (
+        '"event_type": "investment_buy"',
+        '"event_type": "investment_sell"',
+        '"event_type": "investment_dividend"',
+        "create_journal_entry(",
+        "_post_and_load(",
+    ):
+        assert needle not in src, (
+            f"investment_accounting should no longer contain {needle!r}"
+        )

--- a/tests/tooling/test_ledger_module.py
+++ b/tests/tooling/test_ledger_module.py
@@ -66,7 +66,11 @@ def test_AC12_34_3_confidence_tier_lives_in_model_layer():
     )
 
 
-@ac_proof(proof_id="test_ledger_buy_adoption", ac_ids=["AC12.34.4"], ci_tier="pr_ci")
+@ac_proof(
+    proof_id="test_ledger_investment_postings_adoption",
+    ac_ids=["AC12.34.4"],
+    ci_tier="pr_ci",
+)
 def test_AC12_34_4_investment_postings_use_ledger_post():
     """AC12.34.4: investment buy/sell/dividend post via Entry + post_entry."""
     src = _read("apps/backend/src/services/investment_accounting.py")


### PR DESCRIPTION
**PR 1 of 2** completing the ledger migration. This one finishes `investment_accounting`'s adoption of the ledger module.

## What

`sell` and `dividend` now build typed `Entry.of(Leg(...), ...)` and post via `post_entry` — replacing hand-rolled `lines_data` dicts. Combined with `buy` (already migrated), **all three investment postings go through the single typed `ledger.post_entry` front door**, and their balance is now guaranteed by `Entry` construction (per currency) rather than the create-time runtime check.

Removed the now-dead `_post_and_load` helper and the direct `create_journal_entry`/`post_journal_entry` imports from the service.

## Scope (why not opening-balance / fx_revaluation here)

Those two sit **at/below the post-pipeline layer**: `ledger.post_entry` imports `services.accounting`'s create/post, so importing `post_entry` from `accounting.py` (opening-balance) would re-introduce a cycle, and `fx_revaluation` uses a raw-ORM draft path with different semantics. Both migrate in **PR 2/2**, which folds the post-pipeline into the `ledger` module (`store/`+`api/`) — dissolving the cycle and giving them a clean `post_entry` to call.

## Verification

- Regression: investment/accounting/journal/ledger **383 passed**.
- ledger module + DAG guards pass; AC12.34.4 widened to assert buy/sell/dividend all use Entry+post_entry and the legacy path is gone.
- `ruff` clean.
- mypy: the file's `str`→`Currency` arg-type findings grow by the same repo-wide convention pattern (value-type constructors normalize `str` via `.of()`); pre-existing, consistent with prior merged PRs, and not CI-gated (CI does not run mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)