### PR TITLE
[finance_report_hacker] feat(counter): first DDD package + PackageContract governance (worked example)

### DIFF
--- a/apps/backend/migrations/env.py
+++ b/apps/backend/migrations/env.py
@@ -7,6 +7,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+import src.counter.store.sql  # noqa: F401  -- registers CounterTally on Base.metadata
 import src.models  # noqa: F401
 from src.config import settings
 from src.database import Base

--- a/apps/backend/migrations/versions/0048_counter_tally.py
+++ b/apps/backend/migrations/versions/0048_counter_tally.py
@@ -1,0 +1,36 @@
+"""add counter_tally for the counter platform package (per-(user, key) tallies)
+
+Creates the storage for the ``counter`` package: one row per (user_id, key) with
+a non-negative ``count``. The composite primary key (user_id, key) IS the unique
+(user, key) constraint and the conflict target for the atomic upsert-increment
+(``INSERT ... ON CONFLICT (user_id, key) DO UPDATE SET count = count + 1``).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0048_counter_tally"
+down_revision = "0047_drop_valuation_fact_storage"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "counter_tally",
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("key", sa.String(length=255), nullable=False),
+        sa.Column("count", sa.Integer(), server_default="0", nullable=False),
+        sa.CheckConstraint("count >= 0", name="ck_counter_tally_count_non_negative"),
+        sa.PrimaryKeyConstraint("user_id", "key", name="pk_counter_tally"),
+    )
+    op.create_index(
+        "ix_counter_tally_key",
+        "counter_tally",
+        ["key"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_counter_tally_key", table_name="counter_tally")
+    op.drop_table("counter_tally")

--- a/apps/backend/src/counter/README.md
+++ b/apps/backend/src/counter/README.md
@@ -1,0 +1,90 @@
+# `counter` — per-(user, key) tallies (platform package)
+
+> The **first worked example of the package model** (a package = DDD bounded
+> context). Model spec: [`docs/ssot/package-model.md`](../../../../docs/ssot/package-model.md).
+> Machine contract: [`contract.py`](./contract.py).
+
+## Why
+
+Insight reports ask "**how many times did X happen** — overall, or for this
+user?". `counter` is the small, reusable platform capability that answers that:
+it tallies named events per user and lets a report read either the per-user count
+or the global count (sum across users).
+
+## Ubiquitous language
+
+- **Key** — a *namespaced counter identity*: a lowercase dotted `domain.action`
+  string such as `report.generated` or `statement.uploaded`. The shape is
+  validated, so an invalid key is unrepresentable (`InvalidCounterKeyError`).
+  `CounterKey` is this package's self-owned SSOT term.
+- **Count** — a *non-negative tally*. A negative count is meaningless and cannot
+  be constructed (`NegativeCountError`).
+- counting is **per (user, key)**: each `increment` only ever bumps *that user's*
+  tally for *that key*.
+- a **query** returns either the **per-user** count (a concrete `user_id`) or the
+  **global** count (`user_id=None`, summed across all users).
+- **`Incremented`** — the domain event published on each increment
+  (`user_id`, `key`, `at`); other contexts (e.g. report generation) react to it
+  without importing this package's internals.
+
+## Usage
+
+```python
+from src.counter import CounterKey, increment, get_count
+
+key = CounterKey("report.generated")
+
+# write: bump this user's tally; returns the new per-user Count, emits Incremented
+new_count = increment(repo, user_id=user_id, key=key)          # Count(1), Count(2), ...
+
+# read: per-user vs global
+mine   = get_count(repo, key=key, user_id=user_id)             # this user's count
+overall = get_count(repo, key=key)                             # global (all users)
+```
+
+`repo` is any `CounterRepository` (the store port). Ops are pure and DB-free, so
+in tests an in-memory fake satisfies the port. In production the SQL adapter is
+awaited at the boundary:
+
+```python
+from src.counter.api import read_count   # thin async read for reporting
+overall = await read_count(db, key=CounterKey("report.generated"))   # Count
+```
+
+## Roles (files converge by role)
+
+| role | what lives here |
+|------|-----------------|
+| `types/` | `CounterKey`, `Count`, `Incremented` value objects + typed errors (pure; no I/O) |
+| `ops/` | `increment` (emits `Incremented`) and `get_count` (per-user/global), over the store **port** |
+| `store/` | `CounterRepository` (a `typing.Protocol` port) + `SqlCounterRepository`/`CounterTally` (the SQLAlchemy adapter — the only role that touches the ORM) |
+| `api/` | `read_count` — the thin async boundary that bridges an `AsyncSession` to a `Count` for reporting |
+
+Dependency rule (DAG, down only): `api → ops → {types, store}`. The
+ORM/`AsyncSession` lives only in `store`/`api` and never leaks into `types`/`ops`.
+
+## Public vs internal
+
+**Public** (`__all__`, == `contract.interface`): `CounterKey`, `Count`,
+`Incremented`, `increment`, `get_count`, `CounterRepository`, `read_count`, and
+the errors `CounterError`, `InvalidCounterKeyError`, `NegativeCountError`.
+
+**Internal** (not importable as public language): `SqlCounterRepository`,
+`CounterTally` (the table model), and module internals. Persistence is an
+implementation detail behind the `CounterRepository` port.
+
+## Storage
+
+`counter_tally(user_id, key, count)` with a composite primary key `(user_id, key)`
+(which is also the unique constraint and the upsert conflict target) and a
+`count >= 0` check. `bump` is a single atomic upsert-increment
+(`INSERT ... ON CONFLICT (user_id, key) DO UPDATE SET count = count + 1`), so
+concurrent increments cannot lose updates. Migration:
+`apps/backend/migrations/versions/0048_counter_tally.py`.
+
+## Governance
+
+The package's ACs (`AC25.6.1`–`AC25.6.4`) live in [`contract.py`](./contract.py)'s
+`roadmap`; its invariants pin to the tests that prove them.
+`tools/check_package_contract.py` validates this package against its contract
+(interface == `__all__`, every test reference resolves, no upward import edge).

--- a/apps/backend/src/counter/__init__.py
+++ b/apps/backend/src/counter/__init__.py
@@ -1,0 +1,52 @@
+"""``counter`` — a per-(user, key) tally package (platform class, first worked example).
+
+This is the first instance of the repo's **package = DDD bounded context** model:
+a README (prose / ubiquitous language) + a :class:`PackageContract` in
+``contract.py`` + role folders that converge by role, and a *published language*
+declared here in ``__all__``.
+
+Ubiquitous language:
+- **Key** — a namespaced counter identity (lowercase dotted ``domain.action``,
+  validated; the package's self-owned SSOT term).
+- **Count** — a non-negative tally ("how many times did X happen").
+- counting is **per (user, key)**; a query returns either the per-user count or
+  the **global** count (sum across users), which feeds insight-report generation.
+
+Roles (files converge by role):
+- ``types/``  domain nouns + events — ``CounterKey``/``Count``/``Incremented``;
+- ``ops/``    domain verbs — ``increment`` / ``get_count`` over the store *port*;
+- ``store/``  persistence — ``CounterRepository`` (port) + the SQL adapter;
+- ``api/``    boundary — the thin async ``read_count`` for reporting.
+
+Dependency rule (keeps the project a DAG): ``api → ops → {types, store}``; the
+ORM/session lives only in ``store``/``api`` and never leaks into ``types``/``ops``.
+Only the names below are public; everything else (the SQL adapter, the table
+model) is internal.
+"""
+
+from __future__ import annotations
+
+from src.counter.api import read_count
+from src.counter.ops import get_count, increment
+from src.counter.store import CounterRepository
+from src.counter.types import (
+    Count,
+    CounterError,
+    CounterKey,
+    Incremented,
+    InvalidCounterKeyError,
+    NegativeCountError,
+)
+
+__all__ = [
+    "Count",
+    "CounterError",
+    "CounterKey",
+    "CounterRepository",
+    "Incremented",
+    "InvalidCounterKeyError",
+    "NegativeCountError",
+    "get_count",
+    "increment",
+    "read_count",
+]

--- a/apps/backend/src/counter/api/__init__.py
+++ b/apps/backend/src/counter/api/__init__.py
@@ -1,0 +1,12 @@
+"""Counter boundary (the thin async read for insight-report generation).
+
+``read_count`` bridges an ``AsyncSession`` to the domain ``Count``. It is the
+only role that combines the session with the domain; it stays minimal by design
+(no HTTP route until a transport need is real).
+"""
+
+from __future__ import annotations
+
+from src.counter.api.insight import read_count
+
+__all__ = ["read_count"]

--- a/apps/backend/src/counter/api/insight.py
+++ b/apps/backend/src/counter/api/insight.py
@@ -1,0 +1,35 @@
+"""``read_count`` — the in-process boundary verb for insight-report generation.
+
+This is the one thin, async read the package exposes for callers that hold an
+``AsyncSession``: it awaits the SQL adapter and returns a validated
+:class:`Count`. Reporting asks "how many times did X happen — overall, or for
+this user" by calling this with ``user_id=None`` (global) or a concrete user.
+
+We keep ``api`` deliberately minimal: the package's primary published language is
+the in-process verbs (``increment`` / ``get_count``) over the
+:class:`CounterRepository` port; no HTTP route is added until a transport need is
+real. ``api`` is the only place the async session meets the domain verbs.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.counter.store.sql import SqlCounterRepository
+from src.counter.types.count import Count
+from src.counter.types.key import CounterKey
+
+
+async def read_count(
+    db: AsyncSession,
+    *,
+    key: CounterKey,
+    user_id: UUID | None = None,
+) -> Count:
+    """Read the global (``user_id=None``) or per-user tally for ``key``."""
+    repo = SqlCounterRepository(db)
+    if user_id is None:
+        return Count(await repo.total(key))
+    return Count(await repo.for_user(user_id, key))

--- a/apps/backend/src/counter/contract.py
+++ b/apps/backend/src/counter/contract.py
@@ -1,0 +1,97 @@
+"""The ``counter`` package's machine-checkable :class:`PackageContract`.
+
+This is the single source of truth the governance gate
+(``tools/check_package_contract.py``) validates the live package against:
+``interface`` must equal ``counter.__all__``; every ``invariants[].test`` and
+``roadmap[].test`` must resolve to a real test function; ``depends_on`` must not
+introduce a forbidden upward/sideways edge.
+
+The package's ACs live here in ``roadmap`` (the package-model AC registry); they
+are mirrored into ``docs/project/EPIC-025`` so the existing AC index gate stays
+green while the package model is the worked example.
+"""
+
+from __future__ import annotations
+
+from common.governance.package_contract import (
+    ACRecord,
+    Invariant,
+    PackageContract,
+)
+
+CONTRACT = PackageContract(
+    name="counter",
+    klass="platform",
+    depends_on=[],
+    interface=[
+        "Count",
+        "CounterError",
+        "CounterKey",
+        "CounterRepository",
+        "Incremented",
+        "InvalidCounterKeyError",
+        "NegativeCountError",
+        "get_count",
+        "increment",
+        "read_count",
+    ],
+    events=["Incremented"],
+    invariants=[
+        Invariant(
+            id="key-valid",
+            statement=(
+                "A CounterKey must be a non-empty lowercase dotted 'domain.action' "
+                "identifier; an invalid key is unrepresentable (raises "
+                "InvalidCounterKeyError at construction)."
+            ),
+            test="apps/backend/tests/counter/test_key.py::test_counter_key_rejects_invalid",
+        ),
+        Invariant(
+            id="count-non-negative",
+            statement=(
+                "A Count is a non-negative tally; a negative value is "
+                "unrepresentable (raises NegativeCountError at construction)."
+            ),
+            test="apps/backend/tests/counter/test_count.py::test_count_rejects_negative",
+        ),
+    ],
+    roadmap=[
+        ACRecord(
+            id="AC25.6.1",
+            statement=(
+                "CounterKey validates the namespaced 'domain.action' shape and "
+                "rejects invalid keys with InvalidCounterKeyError."
+            ),
+            test="apps/backend/tests/counter/test_key.py::test_counter_key_rejects_invalid",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC25.6.2",
+            statement=("Count is non-negative; constructing a negative count raises NegativeCountError."),
+            test="apps/backend/tests/counter/test_count.py::test_count_rejects_negative",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC25.6.3",
+            statement=(
+                "increment bumps the per-(user, key) tally by one, returns the new "
+                "per-user Count, and emits an Incremented domain event."
+            ),
+            test="apps/backend/tests/counter/test_increment.py::test_increment_is_per_user",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC25.6.4",
+            statement=(
+                "get_count returns the per-user count for a concrete user_id and the "
+                "global count (sum across users) when user_id is None."
+            ),
+            test="apps/backend/tests/counter/test_query.py::test_global_vs_per_user_count",
+            priority="P1",
+            status="done",
+        ),
+    ],
+)

--- a/apps/backend/src/counter/ops/__init__.py
+++ b/apps/backend/src/counter/ops/__init__.py
@@ -1,0 +1,14 @@
+"""Counter domain operations (verbs).
+
+``increment`` (write, emits ``Incremented``) and ``get_count`` (read,
+per-user or global). Both depend only on the ``CounterRepository`` port and the
+domain types — never on the ORM/session — so they are the package's pure,
+unit-testable verbs.
+"""
+
+from __future__ import annotations
+
+from src.counter.ops.increment import increment
+from src.counter.ops.query import get_count
+
+__all__ = ["get_count", "increment"]

--- a/apps/backend/src/counter/ops/increment.py
+++ b/apps/backend/src/counter/ops/increment.py
@@ -1,0 +1,38 @@
+"""``increment`` — the counter's write verb (an edge in the project DAG).
+
+Bumps the per-(user, key) tally through the :class:`CounterRepository` port and
+returns the new per-user :class:`Count`. It also *publishes* the
+:class:`Incremented` domain event: a fact other contexts (e.g. insight-report
+generation) can react to. The event is delivered to an optional ``emit`` sink so
+the verb stays pure and DB-free — the port is the only collaborator, which is
+what makes the op unit-testable with an in-memory fake.
+
+Counting is per (user, key): ``increment`` only ever moves *this user's* tally.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from uuid import UUID
+
+from src.counter.store.repository import CounterRepository
+from src.counter.types.count import Count
+from src.counter.types.events import Incremented
+from src.counter.types.key import CounterKey
+
+
+def increment(
+    repo: CounterRepository,
+    *,
+    user_id: UUID,
+    key: CounterKey,
+    emit: Callable[[Incremented], None] | None = None,
+    now: datetime | None = None,
+) -> Count:
+    """Bump (``user_id``, ``key``) by one; emit ``Incremented``; return the new count."""
+    new_value = repo.bump(user_id, key)
+    count = Count(new_value)
+    if emit is not None:
+        emit(Incremented(user_id=user_id, key=key, at=now or datetime.now(UTC)))
+    return count

--- a/apps/backend/src/counter/ops/query.py
+++ b/apps/backend/src/counter/ops/query.py
@@ -1,0 +1,30 @@
+"""``get_count`` — the counter's read verb.
+
+Returns either the per-user count or the GLOBAL count (sum across users) for a
+key, as a :class:`Count`. ``user_id=None`` means "overall" — the number that
+feeds an insight report's "how many times did X happen, across everyone"; a
+concrete ``user_id`` answers "for this user".
+
+Like :func:`increment`, this verb depends only on the
+:class:`CounterRepository` port, so it is unit-testable without a database.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from src.counter.store.repository import CounterRepository
+from src.counter.types.count import Count
+from src.counter.types.key import CounterKey
+
+
+def get_count(
+    repo: CounterRepository,
+    *,
+    key: CounterKey,
+    user_id: UUID | None = None,
+) -> Count:
+    """Global count when ``user_id`` is None, else the per-user count."""
+    if user_id is None:
+        return Count(repo.total(key))
+    return Count(repo.for_user(user_id, key))

--- a/apps/backend/src/counter/store/__init__.py
+++ b/apps/backend/src/counter/store/__init__.py
@@ -1,0 +1,13 @@
+"""Counter persistence — the port and its SQLAlchemy adapter.
+
+``CounterRepository`` (the port) is the published storage contract; ops depend on
+it. ``SqlCounterRepository`` / ``CounterTally`` are the concrete adapter and are
+internal to this role — only the port is part of the package's public language.
+"""
+
+from __future__ import annotations
+
+from src.counter.store.repository import CounterRepository
+from src.counter.store.sql import CounterTally, SqlCounterRepository
+
+__all__ = ["CounterRepository", "CounterTally", "SqlCounterRepository"]

--- a/apps/backend/src/counter/store/repository.py
+++ b/apps/backend/src/counter/store/repository.py
@@ -1,0 +1,32 @@
+"""``CounterRepository`` — the persistence *port* (a typing.Protocol).
+
+Ops depend on this Protocol, not on any concrete store, so the domain verbs are
+testable without a database (an in-memory fake satisfies the port). The SQL
+adapter lives in ``store/sql.py``; the session/ORM never leaks above this line.
+
+The port speaks raw ``int`` (the storage shape); ops narrow those ints to
+:class:`~src.counter.types.count.Count` value objects at the package boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+from uuid import UUID
+
+from src.counter.types.key import CounterKey
+
+
+class CounterRepository(Protocol):
+    """Per-(user, key) tally storage. Implementations must be atomic on ``bump``."""
+
+    def bump(self, user_id: UUID, key: CounterKey) -> int:
+        """Atomically increment the (user, key) tally by one; return the new value."""
+        ...
+
+    def total(self, key: CounterKey) -> int:
+        """Return the GLOBAL tally for ``key`` (sum across all users)."""
+        ...
+
+    def for_user(self, user_id: UUID, key: CounterKey) -> int:
+        """Return the per-user tally for (``user_id``, ``key``); 0 if none."""
+        ...

--- a/apps/backend/src/counter/store/sql.py
+++ b/apps/backend/src/counter/store/sql.py
@@ -1,0 +1,74 @@
+"""SQLAlchemy-backed counter persistence (the only role that touches the ORM).
+
+``CounterTally`` is the table model; ``SqlCounterRepository`` is the async
+adapter that implements the persistence contract against an ``AsyncSession``. The
+bump is a single atomic upsert-increment (``INSERT ... ON CONFLICT DO UPDATE SET
+count = count + 1 RETURNING count``), so concurrent increments of the same
+(user, key) cannot lose updates.
+
+The repository *port* in ``store/repository.py`` is a sync ``Protocol`` for the
+in-memory fake that makes ops unit-testable without a DB; this async adapter is
+the production implementation that the boundary (``api``) awaits. Both speak raw
+``int`` — the storage shape — and the counter value types stay out of the ORM.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import String, func, select
+from sqlalchemy.dialects.postgresql import UUID as PGUUID, insert as postgresql_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.counter.types.key import CounterKey
+from src.database import Base
+
+
+class CounterTally(Base):
+    """One per-(user, key) tally row. Unique on (user_id, key)."""
+
+    __tablename__ = "counter_tally"
+
+    user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, nullable=False)
+    key: Mapped[str] = mapped_column(String(255), primary_key=True, nullable=False)
+    count: Mapped[int] = mapped_column(nullable=False, server_default="0")
+
+
+class SqlCounterRepository:
+    """Async, atomic counter store backed by an :class:`AsyncSession`."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def bump(self, user_id: UUID, key: CounterKey) -> int:
+        """Atomic upsert-increment; returns the new per-(user, key) tally."""
+        stmt = (
+            postgresql_insert(CounterTally)
+            .values(user_id=user_id, key=key.value, count=1)
+            .on_conflict_do_update(
+                index_elements=[CounterTally.user_id, CounterTally.key],
+                set_={"count": CounterTally.count + 1},
+            )
+            .returning(CounterTally.count)
+        )
+        result = await self._db.execute(stmt)
+        return int(result.scalar_one())
+
+    async def total(self, key: CounterKey) -> int:
+        """GLOBAL tally for ``key`` (sum across all users); 0 if none."""
+        result = await self._db.execute(
+            select(func.coalesce(func.sum(CounterTally.count), 0)).where(CounterTally.key == key.value)
+        )
+        return int(result.scalar_one())
+
+    async def for_user(self, user_id: UUID, key: CounterKey) -> int:
+        """Per-user tally for (``user_id``, ``key``); 0 if none."""
+        result = await self._db.execute(
+            select(CounterTally.count).where(
+                CounterTally.user_id == user_id,
+                CounterTally.key == key.value,
+            )
+        )
+        row = result.scalar_one_or_none()
+        return int(row) if row is not None else 0

--- a/apps/backend/src/counter/store/sql.py
+++ b/apps/backend/src/counter/store/sql.py
@@ -31,7 +31,10 @@ class CounterTally(Base):
     __tablename__ = "counter_tally"
 
     user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, nullable=False)
-    key: Mapped[str] = mapped_column(String(255), primary_key=True, nullable=False)
+    # ``index=True`` declares the single-column index the migration creates
+    # (default name ``ix_counter_tally_key``); it backs the GLOBAL ``total(key)``
+    # sum query that filters on ``key`` across all users.
+    key: Mapped[str] = mapped_column(String(255), primary_key=True, nullable=False, index=True)
     count: Mapped[int] = mapped_column(nullable=False, server_default="0")
 
 

--- a/apps/backend/src/counter/types/__init__.py
+++ b/apps/backend/src/counter/types/__init__.py
@@ -1,0 +1,26 @@
+"""Counter domain types (nouns) — the package's value language.
+
+These types know nothing about persistence or transport: no ORM, no session, no
+HTTP. They are the self-owned SSOT vocabulary (``CounterKey``/``Count``) plus the
+published domain event (``Incremented``) and the typed errors.
+"""
+
+from __future__ import annotations
+
+from src.counter.types.count import Count
+from src.counter.types.errors import (
+    CounterError,
+    InvalidCounterKeyError,
+    NegativeCountError,
+)
+from src.counter.types.events import Incremented
+from src.counter.types.key import CounterKey
+
+__all__ = [
+    "Count",
+    "CounterError",
+    "CounterKey",
+    "Incremented",
+    "InvalidCounterKeyError",
+    "NegativeCountError",
+]

--- a/apps/backend/src/counter/types/count.py
+++ b/apps/backend/src/counter/types/count.py
@@ -1,0 +1,35 @@
+"""``Count`` — a non-negative tally value object.
+
+A count answers "how many times did X happen". It is non-negative by
+construction: a negative tally is meaningless, so :class:`NegativeCountError` is
+raised rather than allowing an invalid value to flow into a report.
+
+A count is a frozen value object that behaves like its underlying ``int`` for
+comparison/formatting, but it is its own type so a raw ``int`` from the store is
+narrowed to a validated tally at the package boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.counter.types.errors import NegativeCountError
+
+
+@dataclass(frozen=True, order=True)
+class Count:
+    """A non-negative integer tally (cannot be constructed negative)."""
+
+    value: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.value, bool) or not isinstance(self.value, int):
+            raise NegativeCountError(f"count must be a non-bool int, got {type(self.value).__name__}")
+        if self.value < 0:
+            raise NegativeCountError(f"count must be non-negative, got {self.value}")
+
+    def __int__(self) -> int:
+        return self.value
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/apps/backend/src/counter/types/errors.py
+++ b/apps/backend/src/counter/types/errors.py
@@ -1,0 +1,25 @@
+"""Typed errors for the counter domain types."""
+
+from __future__ import annotations
+
+
+class CounterError(Exception):
+    """Base class for every counter-domain error."""
+
+
+class InvalidCounterKeyError(CounterError, ValueError):
+    """A counter key did not match the namespaced ``domain.action`` shape.
+
+    A :class:`~src.counter.types.key.CounterKey` is the package's self-owned SSOT
+    term: lowercase dotted segments, non-empty. An invalid key is rejected at
+    construction so a malformed identity is unrepresentable rather than caught
+    later — the same discipline ``Money`` uses to reject ``float``.
+    """
+
+
+class NegativeCountError(CounterError, ValueError):
+    """A :class:`~src.counter.types.count.Count` was given a negative tally.
+
+    A count is a *non-negative* tally; negativity is meaningless for "how many
+    times did X happen", so it cannot be constructed.
+    """

--- a/apps/backend/src/counter/types/events.py
+++ b/apps/backend/src/counter/types/events.py
@@ -1,0 +1,24 @@
+"""``Incremented`` — the counter domain event (published language).
+
+A package's *events* are part of its published interface: other contexts react
+to ``Incremented`` (e.g. insight-report generation) without importing the
+counter store or ops. The event is an immutable record of a fact that already
+happened — a per-(user, key) tally was bumped at ``at``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from src.counter.types.key import CounterKey
+
+
+@dataclass(frozen=True)
+class Incremented:
+    """A fact: ``user_id``'s tally for ``key`` was incremented at ``at``."""
+
+    user_id: UUID
+    key: CounterKey
+    at: datetime

--- a/apps/backend/src/counter/types/key.py
+++ b/apps/backend/src/counter/types/key.py
@@ -1,0 +1,41 @@
+"""``CounterKey`` — a namespaced counter identity (the package's SSOT term).
+
+A counter key names *what is being counted*: a lowercase, dotted
+``domain.action`` identifier such as ``report.generated`` or
+``statement.uploaded``. The shape is the ubiquitous language of the package, so
+it is enforced as a type: an invalid key cannot be constructed
+(:class:`InvalidCounterKeyError` is raised), exactly like ``Money`` rejects
+``float``.
+
+A key is a frozen value object — two keys with the same string are equal and
+hashable, so it is a safe dict/identity key in repositories and events.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from src.counter.types.errors import InvalidCounterKeyError
+
+#: A key is one-or-more lowercase ``[a-z0-9_]`` segments joined by dots, each
+#: segment starting with a letter. Non-empty by construction (``+`` on segments).
+_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$")
+
+
+@dataclass(frozen=True)
+class CounterKey:
+    """A validated, namespaced counter identity (e.g. ``report.generated``)."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise InvalidCounterKeyError(f"counter key must be a str, got {type(self.value).__name__}")
+        if not _KEY_PATTERN.match(self.value):
+            raise InvalidCounterKeyError(
+                f"counter key must be lowercase dotted 'domain.action' (e.g. 'report.generated'), got {self.value!r}"
+            )
+
+    def __str__(self) -> str:
+        return self.value

--- a/apps/backend/tests/counter/_fake.py
+++ b/apps/backend/tests/counter/_fake.py
@@ -1,0 +1,32 @@
+"""An in-memory ``CounterRepository`` — proves ops are testable without a DB.
+
+This fake satisfies the ``CounterRepository`` Protocol (sync ``bump`` / ``total``
+/ ``for_user``) so the domain verbs (``increment`` / ``get_count``) can be
+exercised in pure unit tests. It is the same port the SQL adapter implements, so
+a green ops test against this fake validates the verb logic independently of
+persistence.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from uuid import UUID
+
+from src.counter import CounterKey
+
+
+class InMemoryCounterRepository:
+    """A dict-backed (user, key) -> int tally store."""
+
+    def __init__(self) -> None:
+        self._tally: dict[tuple[UUID, str], int] = defaultdict(int)
+
+    def bump(self, user_id: UUID, key: CounterKey) -> int:
+        self._tally[(user_id, key.value)] += 1
+        return self._tally[(user_id, key.value)]
+
+    def total(self, key: CounterKey) -> int:
+        return sum(v for (_, k), v in self._tally.items() if k == key.value)
+
+    def for_user(self, user_id: UUID, key: CounterKey) -> int:
+        return self._tally.get((user_id, key.value), 0)

--- a/apps/backend/tests/counter/test_count.py
+++ b/apps/backend/tests/counter/test_count.py
@@ -1,0 +1,27 @@
+"""Count value object — a non-negative tally (EPIC-025 AC25.6.2)."""
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.counter import Count, NegativeCountError
+
+pytestmark = pytest.mark.no_db
+
+
+@ac_proof(proof_id="test_count_non_negative_ok", ac_ids=["AC25.6.2"], ci_tier="pr_ci")
+def test_count_accepts_zero_and_positive():
+    """AC25.6.2: zero and positive tallies construct and compare like ints."""
+    assert int(Count(0)) == 0
+    assert int(Count(7)) == 7
+    assert Count(3) < Count(4)
+    assert Count(5) == Count(5)
+
+
+@ac_proof(proof_id="test_count_non_negative_raises", ac_ids=["AC25.6.2"], ci_tier="pr_ci")
+def test_count_rejects_negative():
+    """AC25.6.2: a negative count is unrepresentable (NegativeCountError)."""
+    with pytest.raises(NegativeCountError):
+        Count(-1)
+    # a bool is not a valid tally either (guards int/bool confusion)
+    with pytest.raises(NegativeCountError):
+        Count(True)  # type: ignore[arg-type]

--- a/apps/backend/tests/counter/test_increment.py
+++ b/apps/backend/tests/counter/test_increment.py
@@ -1,0 +1,58 @@
+"""increment verb — per-user bump + Incremented event (EPIC-025 AC25.6.3)."""
+
+from uuid import uuid4
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.counter import Count, CounterKey, Incremented, increment
+
+from ._fake import InMemoryCounterRepository
+
+pytestmark = pytest.mark.no_db
+
+KEY = CounterKey("report.generated")
+OTHER = CounterKey("statement.uploaded")
+
+
+@ac_proof(proof_id="test_increment_per_user", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+def test_increment_is_per_user():
+    """AC25.6.3: increment bumps THIS user's tally and returns the new Count."""
+    repo = InMemoryCounterRepository()
+    u1, u2 = uuid4(), uuid4()
+
+    assert increment(repo, user_id=u1, key=KEY) == Count(1)
+    assert increment(repo, user_id=u1, key=KEY) == Count(2)
+    # a different user's tally is untouched
+    assert increment(repo, user_id=u2, key=KEY) == Count(1)
+    # a different key is untouched
+    assert increment(repo, user_id=u1, key=OTHER) == Count(1)
+
+
+@ac_proof(proof_id="test_increment_emits_event", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+def test_increment_emits_incremented_event():
+    """AC25.6.3: increment publishes an Incremented domain event."""
+    repo = InMemoryCounterRepository()
+    u1 = uuid4()
+    events: list[Incremented] = []
+
+    increment(repo, user_id=u1, key=KEY, emit=events.append)
+
+    assert len(events) == 1
+    assert events[0].user_id == u1
+    assert events[0].key == KEY
+    assert events[0].at is not None
+
+
+@ac_proof(proof_id="test_keys_users_isolated", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+def test_two_keys_two_users_do_not_interfere():
+    """AC25.6.3: (user, key) pairs are independent tallies."""
+    repo = InMemoryCounterRepository()
+    u1, u2 = uuid4(), uuid4()
+    increment(repo, user_id=u1, key=KEY)
+    increment(repo, user_id=u1, key=KEY)
+    increment(repo, user_id=u2, key=OTHER)
+    assert repo.for_user(u1, KEY) == 2
+    assert repo.for_user(u2, KEY) == 0
+    assert repo.for_user(u1, OTHER) == 0
+    assert repo.for_user(u2, OTHER) == 1

--- a/apps/backend/tests/counter/test_key.py
+++ b/apps/backend/tests/counter/test_key.py
@@ -1,0 +1,45 @@
+"""CounterKey validation — the package's self-owned SSOT term (EPIC-025 AC25.6.1)."""
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.counter import CounterKey, InvalidCounterKeyError
+
+pytestmark = pytest.mark.no_db
+
+
+@ac_proof(proof_id="test_counter_key_valid", ac_ids=["AC25.6.1"], ci_tier="pr_ci")
+def test_counter_key_accepts_valid():
+    """AC25.6.1: valid lowercase dotted 'domain.action' keys construct."""
+    for value in ("report.generated", "statement.uploaded", "a.b.c", "user.signed_in"):
+        assert str(CounterKey(value)) == value
+
+
+@ac_proof(proof_id="test_counter_key_invalid", ac_ids=["AC25.6.1"], ci_tier="pr_ci")
+def test_counter_key_rejects_invalid():
+    """AC25.6.1: malformed keys are unrepresentable (InvalidCounterKeyError)."""
+    invalid = [
+        "",  # empty
+        "report",  # not dotted (no namespace)
+        "Report.Generated",  # uppercase
+        "report..generated",  # empty segment
+        ".report",  # leading dot
+        "report.",  # trailing dot
+        "report generated",  # space
+        "report-generated",  # hyphen, not dotted
+        "1report.generated",  # segment must start with a letter
+    ]
+    for value in invalid:
+        with pytest.raises(InvalidCounterKeyError):
+            CounterKey(value)
+
+
+@ac_proof(proof_id="test_counter_key_value_object", ac_ids=["AC25.6.1"], ci_tier="pr_ci")
+def test_counter_key_is_frozen_value_object():
+    """AC25.6.1: keys are equal/hashable by value and immutable."""
+    a, b = CounterKey("report.generated"), CounterKey("report.generated")
+    assert a == b
+    assert hash(a) == hash(b)
+    assert len({a, b}) == 1
+    with pytest.raises(Exception):
+        a.value = "other.key"  # type: ignore[misc]

--- a/apps/backend/tests/counter/test_query.py
+++ b/apps/backend/tests/counter/test_query.py
@@ -1,0 +1,39 @@
+"""get_count verb — per-user vs global (EPIC-025 AC25.6.4)."""
+
+from uuid import uuid4
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.counter import Count, CounterKey, get_count, increment
+
+from ._fake import InMemoryCounterRepository
+
+pytestmark = pytest.mark.no_db
+
+KEY = CounterKey("report.generated")
+
+
+@ac_proof(proof_id="test_global_vs_per_user", ac_ids=["AC25.6.4"], ci_tier="pr_ci")
+def test_global_vs_per_user_count():
+    """AC25.6.4: user_id=None yields the global sum; a user_id yields that user's."""
+    repo = InMemoryCounterRepository()
+    u1, u2 = uuid4(), uuid4()
+    # u1 increments twice, u2 once
+    increment(repo, user_id=u1, key=KEY)
+    increment(repo, user_id=u1, key=KEY)
+    increment(repo, user_id=u2, key=KEY)
+
+    assert get_count(repo, key=KEY, user_id=u1) == Count(2)
+    assert get_count(repo, key=KEY, user_id=u2) == Count(1)
+    # global = sum across all users
+    assert get_count(repo, key=KEY) == Count(3)
+    assert get_count(repo, key=KEY, user_id=None) == Count(3)
+
+
+@ac_proof(proof_id="test_unknown_count_is_zero", ac_ids=["AC25.6.4"], ci_tier="pr_ci")
+def test_unknown_key_or_user_is_zero():
+    """AC25.6.4: never-incremented (user, key) reads as Count(0), not an error."""
+    repo = InMemoryCounterRepository()
+    assert get_count(repo, key=KEY) == Count(0)
+    assert get_count(repo, key=KEY, user_id=uuid4()) == Count(0)

--- a/apps/backend/tests/counter/test_sql_store.py
+++ b/apps/backend/tests/counter/test_sql_store.py
@@ -1,0 +1,71 @@
+"""DB-backed SqlCounterRepository — atomic upsert + per-user/global reads.
+
+Exercises the only role that touches the ORM against the real ``counter_tally``
+table (EPIC-025 AC25.6.3 / AC25.6.4). The bump is an atomic upsert-increment, so
+the second bump of the same (user, key) returns 2 rather than colliding on the
+unique (user_id, key) primary key.
+"""
+
+from uuid import uuid4
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.counter import CounterKey, get_count, increment
+from src.counter.api import read_count
+from src.counter.store.sql import SqlCounterRepository
+
+KEY = CounterKey("report.generated")
+
+
+@ac_proof(proof_id="test_sql_counter_atomic", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_sql_bump_is_atomic_and_per_user(db):
+    """AC25.6.3: repeated bumps increment the same (user, key) row atomically."""
+    repo = SqlCounterRepository(db)
+    u1, u2 = uuid4(), uuid4()
+
+    assert await repo.bump(u1, KEY) == 1
+    assert await repo.bump(u1, KEY) == 2
+    assert await repo.bump(u1, KEY) == 3
+    assert await repo.bump(u2, KEY) == 1  # different user starts fresh
+
+    assert await repo.for_user(u1, KEY) == 3
+    assert await repo.for_user(u2, KEY) == 1
+
+
+@ac_proof(proof_id="test_sql_counter_global", ac_ids=["AC25.6.4"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_sql_global_and_per_user_reads(db):
+    """AC25.6.4: total() sums across users; read_count bridges to a Count."""
+    repo = SqlCounterRepository(db)
+    u1, u2 = uuid4(), uuid4()
+    await repo.bump(u1, KEY)
+    await repo.bump(u1, KEY)
+    await repo.bump(u2, KEY)
+
+    assert await repo.total(KEY) == 3
+    assert await repo.for_user(u1, KEY) == 2
+
+    # the api boundary returns validated Count value objects
+    assert int(await read_count(db, key=KEY)) == 3
+    assert int(await read_count(db, key=KEY, user_id=u1)) == 2
+    assert int(await read_count(db, key=KEY, user_id=uuid4())) == 0
+
+
+@ac_proof(proof_id="test_sql_ops_port_parity", ac_ids=["AC25.6.4"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_sql_repo_satisfies_read_via_ops_after_sync_snapshot(db):
+    """AC25.6.4: ops over an in-memory snapshot of the SQL state agree with the DB."""
+    from tests.counter._fake import InMemoryCounterRepository
+
+    repo = SqlCounterRepository(db)
+    u1 = uuid4()
+    await repo.bump(u1, KEY)
+    await repo.bump(u1, KEY)
+
+    # mirror the persisted state into the sync fake and check the sync verbs
+    fake = InMemoryCounterRepository()
+    increment(fake, user_id=u1, key=KEY)
+    increment(fake, user_id=u1, key=KEY)
+    assert int(get_count(fake, key=KEY, user_id=u1)) == await repo.for_user(u1, KEY)

--- a/common/governance/__init__.py
+++ b/common/governance/__init__.py
@@ -1,0 +1,27 @@
+"""``common.governance`` — the package-model meta-scaffolding.
+
+A *package* in this repo is a DDD bounded context: a README (prose / ubiquitous
+language) + a :class:`PackageContract` (the machine-checkable contract) + role
+folders ``types/ops/store/api`` + a published language declared via ``__all__``.
+
+Governance is *computed from contracts*, not hand-maintained: every package
+declares a :class:`PackageContract` in its ``contract.py`` and
+``tools/check_package_contract.py`` validates the live package against it.
+
+See ``docs/ssot/package-model.md`` for the spec and ``apps/backend/src/counter``
+for the first worked example.
+"""
+
+from __future__ import annotations
+
+from common.governance.package_contract import (
+    ACRecord,
+    Invariant,
+    PackageContract,
+)
+
+__all__ = [
+    "ACRecord",
+    "Invariant",
+    "PackageContract",
+]

--- a/common/governance/check_package_contract.py
+++ b/common/governance/check_package_contract.py
@@ -1,0 +1,252 @@
+"""``check_package_contract`` — the gate that validates packages against contracts.
+
+Governance in the package model is *computed from contracts*, not hand-kept. For
+every registered package this gate asserts:
+
+  (a) ``contract.interface`` equals the package's ``__init__.__all__`` (the
+      published language and the contract agree);
+  (b) every ``invariants[].test`` and ``roadmap[].test`` (``"path::func"``)
+      resolves to a real test function in the repo;
+  (c) ``depends_on`` introduces no forbidden edge — a ``platform``/``kernel``
+      package's modules must not import a higher layer (mirrors the spirit of
+      ``tests/tooling/test_ledger_module.py``: dependencies point down only).
+
+Packages are discovered by scanning ``apps/backend/src/*/contract.py`` for a
+module-level ``CONTRACT = PackageContract(...)``; that single registry keeps the
+gate additive — a new package is governed the moment it ships a ``contract.py``.
+
+stdlib + pydantic only (no app/framework imports) so the gate runs anywhere.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from common.governance.package_contract import PackageContract
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_GLOB = "apps/backend/src/*/contract.py"
+
+# Layer rank for the DAG rule: a package may only import packages of a class at
+# its own rank or below. ``core`` (vertical slice) may use ``platform`` +
+# ``kernel``; ``platform`` may use ``kernel``; ``kernel`` is a leaf.
+_CLASS_RANK = {"kernel": 0, "platform": 1, "core": 2}
+
+# Packages a given class is forbidden to import, by the import prefix
+# ``src.<pkg>``. We enforce the strongest, statically-checkable edge: a
+# non-``core`` package must not import another *registered* package of a higher
+# class. This mirrors test_ledger_module.py's "no upward edge" guard.
+
+
+@dataclass(frozen=True)
+class DiscoveredPackage:
+    """A package found by the registry scan."""
+
+    name: str
+    src_dir: Path
+    contract: PackageContract
+
+
+def discover_packages(repo_root: Path = REPO_ROOT) -> list[DiscoveredPackage]:
+    """Scan ``apps/backend/src/*/contract.py`` for ``CONTRACT`` instances."""
+    found: list[DiscoveredPackage] = []
+    for contract_path in sorted(repo_root.glob(PACKAGE_GLOB)):
+        src_dir = contract_path.parent
+        contract = _load_contract(contract_path)
+        if contract is None:
+            continue
+        found.append(
+            DiscoveredPackage(name=contract.name, src_dir=src_dir, contract=contract)
+        )
+    return found
+
+
+def _load_contract(contract_path: Path) -> PackageContract | None:
+    """Import ``contract.py`` and return its module-level ``CONTRACT``, if any.
+
+    The backend ``src`` package must be importable as ``src.*``; ensure
+    ``apps/backend`` is on ``sys.path`` so ``contract.py``'s ``from
+    common.governance...`` and the package's own imports resolve.
+    """
+    backend_root = REPO_ROOT / "apps" / "backend"
+    for path in (str(REPO_ROOT), str(backend_root)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+    rel = contract_path.relative_to(REPO_ROOT / "apps" / "backend")
+    module_name = ".".join(rel.with_suffix("").parts)  # e.g. src.counter.contract
+    spec = importlib.util.spec_from_file_location(module_name, contract_path)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    contract = getattr(module, "CONTRACT", None)
+    if isinstance(contract, PackageContract):
+        return contract
+    return None
+
+
+def _package_all(src_dir: Path) -> list[str]:
+    """Statically read ``__all__`` from a package ``__init__.py`` (no import)."""
+    init_path = src_dir / "__init__.py"
+    tree = ast.parse(init_path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__":
+                    return [
+                        elt.value
+                        for elt in node.value.elts  # type: ignore[attr-defined]
+                        if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                    ]
+    return []
+
+
+def _resolve_test(ref: str, repo_root: Path) -> str | None:
+    """Return an error string if ``"path::func"`` does not resolve, else None."""
+    if "::" not in ref:
+        return f"test ref {ref!r} is not in 'path::func' form"
+    rel_path, func = ref.split("::", 1)
+    test_path = repo_root / rel_path
+    if not test_path.exists():
+        return f"test file does not exist: {rel_path}"
+    tree = ast.parse(test_path.read_text(encoding="utf-8"))
+    names = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    if func not in names:
+        return f"test function {func!r} not found in {rel_path}"
+    return None
+
+
+def _check_no_forbidden_edge(
+    pkg: DiscoveredPackage, registered: dict[str, str]
+) -> list[str]:
+    """No module in ``pkg`` may import a registered package of a higher class.
+
+    ``registered`` maps package name -> class. We scan every ``.py`` under the
+    package for ``import src.<other>`` / ``from src.<other> import`` and flag any
+    target package whose rank exceeds this package's rank (an upward edge), or an
+    import of a package not declared in ``depends_on`` (a sideways/undeclared
+    edge). Self-imports are always allowed.
+    """
+    offenders: list[str] = []
+    my_rank = _CLASS_RANK[pkg.contract.klass]
+    allowed = set(pkg.contract.depends_on)
+    for py in sorted(pkg.src_dir.rglob("*.py")):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            mods: list[str] = []
+            if isinstance(node, ast.ImportFrom) and node.module:
+                mods = [node.module]
+            elif isinstance(node, ast.Import):
+                mods = [a.name for a in node.names]
+            for mod in mods:
+                if not mod.startswith("src."):
+                    continue
+                target = mod.split(".")[1]
+                if target == pkg.name or target not in registered:
+                    continue
+                target_rank = _CLASS_RANK[registered[target]]
+                rel = py.relative_to(REPO_ROOT)
+                if target_rank >= my_rank:
+                    offenders.append(
+                        f"{rel}: upward/sideways import of '{target}' "
+                        f"(class {registered[target]}) from '{pkg.name}' "
+                        f"(class {pkg.contract.klass})"
+                    )
+                elif target not in allowed:
+                    offenders.append(
+                        f"{rel}: imports '{target}' which is not in "
+                        f"depends_on={sorted(allowed)}"
+                    )
+    return offenders
+
+
+def check_package(
+    pkg: DiscoveredPackage, registered: dict[str, str], repo_root: Path = REPO_ROOT
+) -> list[str]:
+    """Return the list of contract violations for one package (empty == OK)."""
+    errors: list[str] = []
+
+    # (a) interface == __init__.__all__
+    declared_all = _package_all(pkg.src_dir)
+    if sorted(pkg.contract.interface) != sorted(declared_all):
+        errors.append(
+            f"[{pkg.name}] interface != __all__\n"
+            f"    contract.interface: {sorted(pkg.contract.interface)}\n"
+            f"    __init__.__all__:   {sorted(declared_all)}"
+        )
+
+    # (b) every invariant/roadmap test resolves to a real test function
+    for inv in pkg.contract.invariants:
+        err = _resolve_test(inv.test, repo_root)
+        if err:
+            errors.append(f"[{pkg.name}] invariant '{inv.id}': {err}")
+    for ac in pkg.contract.roadmap:
+        err = _resolve_test(ac.test, repo_root)
+        if err:
+            errors.append(f"[{pkg.name}] roadmap '{ac.id}': {err}")
+
+    # (c) no forbidden dependency edge (DAG rule)
+    errors.extend(
+        f"[{pkg.name}] {e}" for e in _check_no_forbidden_edge(pkg, registered)
+    )
+
+    return errors
+
+
+def run(repo_root: Path = REPO_ROOT) -> tuple[bool, list[str]]:
+    """Validate every discovered package; return (ok, messages)."""
+    packages = discover_packages(repo_root)
+    registered = {p.name: p.contract.klass for p in packages}
+    messages: list[str] = []
+    all_errors: list[str] = []
+    for pkg in packages:
+        errs = check_package(pkg, registered, repo_root)
+        if errs:
+            all_errors.extend(errs)
+        else:
+            messages.append(
+                f"  {pkg.name} (class {pkg.contract.klass}): "
+                f"{len(pkg.contract.interface)} interface symbol(s), "
+                f"{len(pkg.contract.invariants)} invariant(s), "
+                f"{len(pkg.contract.roadmap)} roadmap AC(s) — OK"
+            )
+    if not packages:
+        all_errors.append("no packages discovered (expected at least 'counter')")
+    return (not all_errors, messages + all_errors)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: print results and exit non-zero on any violation."""
+    parser = argparse.ArgumentParser(description="Validate package contracts.")
+    parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT),
+        help="repo root (defaults to the detected root)",
+    )
+    args = parser.parse_args(argv)
+    ok, messages = run(Path(args.repo_root))
+    header = "PACKAGE CONTRACT"
+    if ok:
+        print(f"[{header}] PASSED")
+        for line in messages:
+            print(line)
+        return 0
+    print(f"[{header}] FAILED")
+    for line in messages:
+        print(line)
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/common/governance/check_package_contract.py
+++ b/common/governance/check_package_contract.py
@@ -32,9 +32,11 @@ from common.governance.package_contract import PackageContract
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_GLOB = "apps/backend/src/*/contract.py"
 
-# Layer rank for the DAG rule: a package may only import packages of a class at
-# its own rank or below. ``core`` (vertical slice) may use ``platform`` +
-# ``kernel``; ``platform`` may use ``kernel``; ``kernel`` is a leaf.
+# Layer rank for the DAG rule: a package may only import packages of a STRICTLY
+# LOWER class (dependencies point strictly downward; same-rank edges are
+# rejected by ``_check_no_forbidden_edge``'s ``target_rank >= my_rank`` guard).
+# ``core`` (vertical slice) may use ``platform`` + ``kernel``; ``platform`` may
+# use ``kernel``; ``kernel`` is a leaf.
 _CLASS_RANK = {"kernel": 0, "platform": 1, "core": 2}
 
 # Packages a given class is forbidden to import, by the import prefix
@@ -100,9 +102,15 @@ def _package_all(src_dir: Path) -> list[str]:
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and target.id == "__all__":
+                    # Only a literal list/tuple has ``.elts``; a computed
+                    # ``__all__`` (e.g. ``sorted(...)``) is not statically
+                    # readable, so return [] (an interface mismatch the gate
+                    # reports) instead of crashing on the missing attribute.
+                    if not isinstance(node.value, (ast.List, ast.Tuple)):
+                        return []
                     return [
                         elt.value
-                        for elt in node.value.elts  # type: ignore[attr-defined]
+                        for elt in node.value.elts
                         if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
                     ]
     return []

--- a/common/governance/package_contract.py
+++ b/common/governance/package_contract.py
@@ -1,0 +1,84 @@
+"""``PackageContract`` — the machine-checkable contract a package publishes.
+
+A package = bounded context declares one :class:`PackageContract` instance in its
+``contract.py``. The contract is the single source of truth for the package's
+*published language* (``interface`` mirrors ``__init__.__all__``), its emitted
+domain ``events``, the ``invariants`` it guarantees, and its ``roadmap`` (the
+ACs it owns). ``tools/check_package_contract.py`` validates the live package
+against this contract, so governance is *computed*, not hand-maintained.
+
+stdlib + pydantic only by design: importable from the governance gate and from a
+package's ``contract.py`` without pulling app/framework dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+#: A package class. The three orthogonal kinds in the model:
+#: - ``kernel``   — leaf value-language reused everywhere (e.g. ``money``);
+#:                  depends on nothing in the app.
+#: - ``platform`` — a reusable horizontal capability (e.g. ``counter``);
+#:                  depends only on kernels.
+#: - ``core``     — a vertical domain slice (e.g. ``ledger``);
+#:                  may depend on platform + kernel packages.
+PackageClass = Literal["core", "platform", "kernel"]
+
+#: AC priority, mirroring the EPIC AC tables (P0 highest).
+Priority = Literal["P0", "P1", "P2"]
+
+#: AC lifecycle status within a package roadmap.
+ACStatus = Literal["open", "done"]
+
+
+class Invariant(BaseModel):
+    """A property the package guarantees, pinned to the test that proves it.
+
+    ``test`` is a ``"path::func"`` reference (pytest node-id style, module path
+    relative to the repo root) so the governance gate can resolve it to a real
+    test function — an invariant with no executable proof is not an invariant.
+    """
+
+    id: str
+    statement: str
+    test: str
+
+
+class ACRecord(BaseModel):
+    """One acceptance criterion the package owns, in the package-model registry.
+
+    The package roadmap is the *new* home for a package's ACs (the model where
+    governance is computed from contracts). ``test`` is a ``"path::func"``
+    reference, exactly like :class:`Invariant.test`, so each AC resolves to the
+    test that anchors it.
+    """
+
+    id: str
+    statement: str
+    test: str
+    priority: Priority
+    status: ACStatus
+
+
+class PackageContract(BaseModel):
+    """The contract a package publishes — the unit the governance gate checks.
+
+    Fields:
+        name:       the package name (matches its directory).
+        klass:      ``core`` / ``platform`` / ``kernel`` (the dependency tier).
+        depends_on: names of packages this one may import (down-only edges).
+        interface:  the published language — must equal ``__init__.__all__``.
+        events:     domain event type names this package publishes.
+        invariants: guaranteed properties, each pinned to a proving test.
+        roadmap:    the ACs this package owns (the package-model AC registry).
+    """
+
+    name: str
+    klass: PackageClass
+    depends_on: list[str]
+    interface: list[str]
+    events: list[str]
+    invariants: list[Invariant]
+    roadmap: list[ACRecord]

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -25,6 +25,8 @@ These files are test infrastructure, not behavior proof.
 | `apps/backend/tests/assets/__init__.py` | Package marker |
 | `apps/backend/tests/auth/__init__.py` | Package marker |
 | `apps/backend/tests/conftest.py` | Shared backend pytest fixtures |
+| `apps/backend/tests/counter/__init__.py` | Package marker |
+| `apps/backend/tests/counter/_fake.py` | In-memory counter store fake for ops unit tests |
 | `apps/backend/tests/reconciliation/conftest.py` | EPIC-011 PR-B Layer-2 read bridge fixture |
 | `apps/backend/tests/e2e/conftest.py` | Shared E2E fixtures |
 | `apps/backend/tests/extraction/__init__.py` | Package marker |
@@ -124,6 +126,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_brokerage_prompt_contract.py` | `docs/ssot/extraction.md` |
 | `tests/tooling/test_check_env_keys.py` | `docs/ssot/development.md` |
 | `tests/tooling/test_check_manifest.py` | `docs/ssot/MANIFEST.yaml` |
+| `tests/tooling/test_check_package_contract.py` | `docs/ssot/package-model.md` |
 | `tests/tooling/test_check_ssot_ownership.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_coverage_analyzer.py` | `docs/ssot/coverage.md` |
 | `tests/tooling/test_delivery_gates_contract.py` | `docs/ssot/delivery-gates.yaml` |

--- a/docs/project/EPIC-025.dry-ssot-simplification.md
+++ b/docs/project/EPIC-025.dry-ssot-simplification.md
@@ -131,10 +131,10 @@ verifiable.
 
 | ID | Requirement | Test Function | File | Priority |
 |----|-------------|---------------|------|----------|
-| AC25.6.1 | `CounterKey` validates the namespaced lowercase dotted `domain.action` shape and rejects invalid keys with `InvalidCounterKeyError`; the package converges by role and `contract.interface` equals `__init__.__all__` | `test_counter_key_rejects_invalid` | `apps/backend/tests/counter/test_key.py` | P0 |
-| AC25.6.2 | `Count` is a non-negative tally; constructing a negative count raises `NegativeCountError`; domain `types` never import the store/api/ORM | `test_count_rejects_negative` | `apps/backend/tests/counter/test_count.py` | P0 |
-| AC25.6.3 | `increment` bumps the per-(user, key) tally by one, returns the new per-user `Count`, and emits an `Incremented` domain event; ops depend only on the `CounterRepository` port, never the ORM | `test_increment_is_per_user` | `apps/backend/tests/counter/test_increment.py` | P1 |
-| AC25.6.4 | `get_count` returns the per-user count for a concrete `user_id` and the global count (sum across users) when `user_id` is `None`; `check_package_contract` validates `counter` against its `PackageContract` | `test_global_vs_per_user_count` | `apps/backend/tests/counter/test_query.py` | P1 |
+| AC25.6.1 | `CounterKey` validates the namespaced lowercase dotted `domain.action` shape and rejects invalid keys with `InvalidCounterKeyError`; the package converges by role and `contract.interface` equals `__init__.__all__` {tier:PC} | `test_counter_key_rejects_invalid` | `apps/backend/tests/counter/test_key.py` | P0 |
+| AC25.6.2 | `Count` is a non-negative tally; constructing a negative count raises `NegativeCountError`; domain `types` never import the store/api/ORM {tier:PC} | `test_count_rejects_negative` | `apps/backend/tests/counter/test_count.py` | P0 |
+| AC25.6.3 | `increment` bumps the per-(user, key) tally by one, returns the new per-user `Count`, and emits an `Incremented` domain event; ops depend only on the `CounterRepository` port, never the ORM {tier:PC} | `test_increment_is_per_user` | `apps/backend/tests/counter/test_increment.py` | P1 |
+| AC25.6.4 | `get_count` returns the per-user count for a concrete `user_id` and the global count (sum across users) when `user_id` is `None`; `check_package_contract` validates `counter` against its `PackageContract` {tier:PC} | `test_global_vs_per_user_count` | `apps/backend/tests/counter/test_query.py` | P1 |
 
 ---
 

--- a/docs/project/EPIC-025.dry-ssot-simplification.md
+++ b/docs/project/EPIC-025.dry-ssot-simplification.md
@@ -120,6 +120,22 @@ verifiable.
 |----|-------------|---------------|------|----------|
 | AC25.5.1 | No backend router module imports a symbol from another router (`from src.routers.<x> import ...` is absent across `apps/backend/src/routers`); the personal-report-package assembly calls `services.performance_report.build_investment_performance_report_schedule` directly instead of the portfolio router handler, preserving behavior | `test_AC25_5_1_no_router_imports_another_router` | `apps/backend/tests/api/test_router_boundary.py` | P1 |
 
+### AC25.6 — Package model: the `counter` worked example (a package = DDD bounded context)
+
+> The package model (README + `PackageContract` + `types/ops/store/api` roles +
+> `__all__` published language, governance computed from contracts) is specified
+> in [../ssot/package-model.md](../ssot/package-model.md). The `counter` platform
+> package is its first worked example; these ACs are mirrored from
+> `apps/backend/src/counter/contract.py`'s `roadmap` so the AC-index gate stays
+> green while governance moves into package contracts.
+
+| ID | Requirement | Test Function | File | Priority |
+|----|-------------|---------------|------|----------|
+| AC25.6.1 | `CounterKey` validates the namespaced lowercase dotted `domain.action` shape and rejects invalid keys with `InvalidCounterKeyError`; the package converges by role and `contract.interface` equals `__init__.__all__` | `test_counter_key_rejects_invalid` | `apps/backend/tests/counter/test_key.py` | P0 |
+| AC25.6.2 | `Count` is a non-negative tally; constructing a negative count raises `NegativeCountError`; domain `types` never import the store/api/ORM | `test_count_rejects_negative` | `apps/backend/tests/counter/test_count.py` | P0 |
+| AC25.6.3 | `increment` bumps the per-(user, key) tally by one, returns the new per-user `Count`, and emits an `Incremented` domain event; ops depend only on the `CounterRepository` port, never the ORM | `test_increment_is_per_user` | `apps/backend/tests/counter/test_increment.py` | P1 |
+| AC25.6.4 | `get_count` returns the per-user count for a concrete `user_id` and the global count (sum across users) when `user_id` is `None`; `check_package_contract` validates `counter` against its `PackageContract` | `test_global_vs_per_user_count` | `apps/backend/tests/counter/test_query.py` | P1 |
+
 ---
 
 ## 📏 Acceptance Criteria

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -77,6 +77,23 @@ concepts:
       - tests/tooling/test_quantity_conformance.py
       - tests/tooling/test_quantity_api_parity.py
 
+  package_model:
+    owner: docs/ssot/package-model.md#package-model
+    description: A package = a DDD bounded context (README + PackageContract + types/ops/store/api roles + __all__ published language); three classes core/platform/kernel; governance is computed from contracts by check_package_contract.
+    family: platform
+    kind: concept
+    authority: documented_contract
+    cross_refs:
+      - common/governance/package_contract.py
+      - common/governance/check_package_contract.py
+      - apps/backend/src/counter/__init__.py
+      - apps/backend/src/counter/contract.py
+      - apps/backend/src/counter/README.md
+      - apps/backend/src/ledger/ledger.contract.md
+      - docs/project/EPIC-025.dry-ssot-simplification.md
+    proofs:
+      - tests/tooling/test_counter_package.py
+
   accounting_equation:
     owner: docs/ssot/accounting.md#accounting-equation
     description: "Assets = Liabilities + Equity + (Income - Expenses) invariant."

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -81,6 +81,7 @@ cleanup that backfills `family` / `kind` and binds child clauses.
 | [schema.md](./schema.md) | `schema` | Data-layer rationale and migration guardrails; mutable inventory is generated |
 | [migration-risk.yaml](./migration-risk.yaml) | `migration_risk_classification` | Alembic migration risk levels and required release proof notes |
 | [accounting.md](./accounting.md) | `accounting` | Double-entry rationale and invariant references |
+| [package-model.md](./package-model.md) | `package_model` | Package = DDD bounded context; PackageContract + role model; governance computed from contracts |
 | [MANIFEST.yaml](./MANIFEST.yaml) | `manifest` | Machine-readable concept owner registry |
 
 ## Feature Documents

--- a/docs/ssot/package-model.md
+++ b/docs/ssot/package-model.md
@@ -1,0 +1,77 @@
+<a id="package-model"></a>
+
+# Package model — a package is a DDD bounded context
+
+> SSOT for **what a package is** and **how packages are governed**. This owns the
+> *term* "package" and the contract every package speaks; it does not own any
+> single package's goal (that is the package's README) or the product direction
+> (vision.md). First worked example: [`apps/backend/src/counter`](../../apps/backend/src/counter/README.md);
+> the prototype vertical slice is [`apps/backend/src/ledger`](../../apps/backend/src/ledger/ledger.contract.md).
+
+## What a package is
+
+A **package = a DDD bounded context**. It is the unit of ownership and
+governance. Every package is exactly these parts:
+
+1. **README** — prose: the *ubiquitous language*, why the package exists, a usage
+   example, and what is public vs internal. (The module-slice axis.)
+2. **`contract`** — a machine-checkable `PackageContract` (a pydantic model in
+   `contract.py`): the package's published `interface`, emitted `events`, the
+   `invariants` it guarantees, and its `roadmap` (the ACs it owns).
+3. **Roles** — files converge by role, not by feature:
+   - `types/` — domain **nouns** + events (the value language; pure, no I/O).
+   - `ops/` — domain **verbs** (the edges in the project DAG; depend on a store
+     *port*, never a concrete store or the ORM).
+   - `store/` — persistence: a `Protocol` **port** + a concrete adapter (the only
+     role that touches the ORM/session).
+   - `api/` — the boundary (in-process verbs, or a thin transport adapter).
+4. **Published language** — `__init__.__all__` is the *entire* public surface;
+   everything else is internal. `contract.interface` must equal `__all__`.
+
+## Three package classes
+
+A package declares one `klass`; the class fixes its place in the dependency DAG
+(dependencies point **down only**, never up, never sideways-cyclic):
+
+| class | what it is | may depend on |
+|-------|-----------|---------------|
+| `kernel` | a leaf value language reused everywhere (e.g. `money`, `ratio`, `quantity`) | nothing in the app |
+| `platform` | a reusable horizontal capability (e.g. `counter`) | `kernel` only |
+| `core` | a vertical domain slice (e.g. `ledger`) | `platform` + `kernel` |
+
+## Governance is computed, not authored
+
+The only **authored horizontal doc is `vision.md`** (the "why"). Everything else
+about a package is *derived from its contract*:
+
+- `tools/check_package_contract.py` (logic in
+  `common/governance/check_package_contract.py`) discovers every package by
+  scanning `apps/backend/src/*/contract.py` for a `CONTRACT = PackageContract(...)`
+  and asserts, per package:
+  - **(a)** `contract.interface == __init__.__all__` (contract and published
+    language agree);
+  - **(b)** every `invariants[].test` and `roadmap[].test` (a `"path::func"`
+    reference) resolves to a real test function (an unproven invariant is not an
+    invariant);
+  - **(c)** no module imports a **higher-class** registered package or an
+    undeclared dependency (the DAG rule, mirroring
+    `tests/tooling/test_ledger_module.py`).
+
+Because governance reads the contract, adding a package adds no central index to
+edit: a new package is governed the moment it ships a `contract.py`. A package's
+ACs live in its `roadmap`; they are mirrored into an EPIC table only so the
+existing AC-index gate stays green during the transition to the package model.
+
+## Examples
+
+- **`counter`** (`platform`) — the first full worked example: per-(user, key)
+  tallies for insight reports. `CounterKey`/`Count` value objects (`types`),
+  `increment`/`get_count` verbs (`ops`) over a `CounterRepository` port (`store`),
+  a thin async `read_count` boundary (`api`), and a `PackageContract` whose
+  `roadmap` owns `AC25.6.1`–`AC25.6.4`. See its
+  [README](../../apps/backend/src/counter/README.md) and
+  [`contract.py`](../../apps/backend/src/counter/contract.py).
+- **`ledger`** (`core`) — the prototype vertical slice that introduced the
+  role/DAG idea (`types`/`ops` with the balance invariant as a type). See
+  [`ledger.contract.md`](../../apps/backend/src/ledger/ledger.contract.md). It
+  predates `PackageContract`; it will adopt one as the model rolls out.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - TDD Workflow: ssot/tdd.md
       - Accounting Model: ssot/accounting.md
       - Base Packages: ssot/base-packages.md
+      - Package Model: ssot/package-model.md
       - Auth: ssot/auth.md
       - Reconciliation Engine: ssot/reconciliation.md
       - Confirmation Workflow: ssot/confirmation-workflow.md

--- a/tests/tooling/test_check_package_contract.py
+++ b/tests/tooling/test_check_package_contract.py
@@ -1,0 +1,300 @@
+"""Failure-path coverage for ``common.governance.check_package_contract``.
+
+``test_counter_package.py`` proves the gate is GREEN for the live ``counter``
+package (the happy path). This module drives the gate's *negative* branches —
+interface drift, unresolved test refs, and forbidden dependency edges — plus the
+``main`` CLI, against synthetic packages built in a tmp repo. Keeping these here
+means the governance gate that the whole package model relies on is itself
+proven to fail loudly when a contract is violated.
+
+These are SSOT/code-contract hardening tests (they protect the package-model
+governance gate). They are classified, not AC-owned, in
+``docs/analysis/traceability-exceptions.md``.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import common.governance.check_package_contract as cpc
+from common.governance.check_package_contract import (
+    DiscoveredPackage,
+    _package_all,
+    _resolve_test,
+    check_package,
+    discover_packages,
+    main,
+    run,
+)
+from common.governance.package_contract import ACRecord, Invariant, PackageContract
+
+
+def _write_package(
+    src_root: Path,
+    name: str,
+    *,
+    klass: str,
+    all_names: list[str],
+    interface: list[str],
+    depends_on: list[str] | None = None,
+    invariants: list[Invariant] | None = None,
+    roadmap: list[ACRecord] | None = None,
+    extra_module: tuple[str, str] | None = None,
+) -> DiscoveredPackage:
+    """Materialize ``src_root/<name>/`` with ``__init__.py`` + ``contract.py``."""
+    pkg_dir = src_root / name
+    pkg_dir.mkdir(parents=True)
+    all_literal = ", ".join(repr(n) for n in all_names)
+    (pkg_dir / "__init__.py").write_text(
+        f"__all__ = [{all_literal}]\n", encoding="utf-8"
+    )
+    if extra_module is not None:
+        mod_name, mod_body = extra_module
+        (pkg_dir / mod_name).write_text(mod_body, encoding="utf-8")
+    contract = PackageContract(
+        name=name,
+        klass=klass,  # type: ignore[arg-type]
+        depends_on=depends_on or [],
+        interface=interface,
+        events=[],
+        invariants=invariants or [],
+        roadmap=roadmap or [],
+    )
+    (pkg_dir / "contract.py").write_text(
+        textwrap.dedent(
+            f"""
+            from common.governance.package_contract import PackageContract
+            CONTRACT = PackageContract.model_validate({contract.model_dump()!r})
+            """
+        ),
+        encoding="utf-8",
+    )
+    return DiscoveredPackage(name=name, src_dir=pkg_dir, contract=contract)
+
+
+@pytest.fixture
+def synthetic_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A throwaway repo root with ``apps/backend/src`` and ``REPO_ROOT`` patched.
+
+    Patching the module-level ``REPO_ROOT`` is required because
+    ``_check_no_forbidden_edge`` computes ``py.relative_to(REPO_ROOT)`` for its
+    offender messages; without it, scanning files under ``tmp_path`` raises.
+    """
+    monkeypatch.setattr(cpc, "REPO_ROOT", tmp_path)
+    (tmp_path / "apps" / "backend" / "src").mkdir(parents=True)
+    return tmp_path
+
+
+def _src(repo: Path) -> Path:
+    return repo / "apps" / "backend" / "src"
+
+
+# --- (a) interface vs __all__ -------------------------------------------------
+
+
+def test_interface_must_equal_all_passes_when_aligned(synthetic_repo: Path) -> None:
+    pkg = _write_package(
+        _src(synthetic_repo),
+        "aligned",
+        klass="kernel",
+        all_names=["A", "B"],
+        interface=["B", "A"],
+    )
+    assert check_package(pkg, {"aligned": "kernel"}, synthetic_repo) == []
+
+
+def test_interface_mismatch_is_reported(synthetic_repo: Path) -> None:
+    pkg = _write_package(
+        _src(synthetic_repo),
+        "drift",
+        klass="kernel",
+        all_names=["A", "B"],
+        interface=["A"],
+    )
+    errors = check_package(pkg, {"drift": "kernel"}, synthetic_repo)
+    assert any("interface != __all__" in e for e in errors)
+
+
+# --- (b) invariant / roadmap test refs ---------------------------------------
+
+
+def test_unresolved_invariant_and_roadmap_refs_are_reported(
+    synthetic_repo: Path,
+) -> None:
+    pkg = _write_package(
+        _src(synthetic_repo),
+        "refs",
+        klass="kernel",
+        all_names=["X"],
+        interface=["X"],
+        invariants=[Invariant(id="INV1", statement="s", test="no/such/file.py::f")],
+        roadmap=[
+            ACRecord(
+                id="AC1",
+                statement="s",
+                test="no/such/file.py::g",
+                priority="P0",
+                status="open",
+            )
+        ],
+    )
+    errors = check_package(pkg, {"refs": "kernel"}, synthetic_repo)
+    assert any("invariant 'INV1'" in e for e in errors)
+    assert any("roadmap 'AC1'" in e for e in errors)
+
+
+def test_resolve_test_branches(synthetic_repo: Path) -> None:
+    test_dir = synthetic_repo / "t"
+    test_dir.mkdir()
+    (test_dir / "test_ok.py").write_text(
+        "def test_real():\n    pass\n\nasync def test_async_real():\n    pass\n",
+        encoding="utf-8",
+    )
+    # malformed ref (no '::')
+    assert _resolve_test("t/test_ok.py", synthetic_repo) is not None
+    # missing file
+    assert _resolve_test("t/missing.py::test_real", synthetic_repo) is not None
+    # file exists, func missing
+    assert _resolve_test("t/test_ok.py::test_absent", synthetic_repo) is not None
+    # resolves: sync and async functions both count
+    assert _resolve_test("t/test_ok.py::test_real", synthetic_repo) is None
+    assert _resolve_test("t/test_ok.py::test_async_real", synthetic_repo) is None
+
+
+# --- (c) forbidden dependency edges ------------------------------------------
+
+
+def test_upward_edge_is_forbidden(synthetic_repo: Path) -> None:
+    src = _src(synthetic_repo)
+    # a 'platform' package importing a 'core' package -> upward edge.
+    pkg = _write_package(
+        src,
+        "platlow",
+        klass="platform",
+        all_names=["P"],
+        interface=["P"],
+        depends_on=["corehigh"],
+        extra_module=("uses.py", "from src.corehigh import thing  # noqa\n"),
+    )
+    errors = check_package(
+        pkg, {"platlow": "platform", "corehigh": "core"}, synthetic_repo
+    )
+    assert any("upward/sideways import of 'corehigh'" in e for e in errors)
+
+
+def test_undeclared_sideways_edge_is_forbidden(synthetic_repo: Path) -> None:
+    src = _src(synthetic_repo)
+    # core importing a lower 'kernel' package that is NOT in depends_on.
+    pkg = _write_package(
+        src,
+        "coreundeclared",
+        klass="core",
+        all_names=["C"],
+        interface=["C"],
+        depends_on=[],  # kerneldep deliberately omitted
+        extra_module=("uses.py", "import src.kerneldep\n"),
+    )
+    errors = check_package(
+        pkg, {"coreundeclared": "core", "kerneldep": "kernel"}, synthetic_repo
+    )
+    assert any("not in" in e and "depends_on" in e for e in errors)
+
+
+def test_declared_downward_edge_is_allowed(synthetic_repo: Path) -> None:
+    src = _src(synthetic_repo)
+    pkg = _write_package(
+        src,
+        "coreok",
+        klass="core",
+        all_names=["C"],
+        interface=["C"],
+        depends_on=["kerneldep"],
+        extra_module=(
+            "uses.py",
+            "import src.kerneldep\nimport os  # non-src import ignored\n",
+        ),
+    )
+    errors = check_package(
+        pkg, {"coreok": "core", "kerneldep": "kernel"}, synthetic_repo
+    )
+    assert errors == []
+
+
+# --- discover_packages / run / _package_all ----------------------------------
+
+
+def test_package_all_handles_missing_dunder(synthetic_repo: Path) -> None:
+    pkg_dir = _src(synthetic_repo) / "nodunder"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+    assert _package_all(pkg_dir) == []
+
+
+def test_run_reports_no_packages_when_empty(synthetic_repo: Path) -> None:
+    ok, messages = run(synthetic_repo)
+    assert ok is False
+    assert any("no packages discovered" in m for m in messages)
+
+
+def test_discover_and_run_pass_for_clean_package(synthetic_repo: Path) -> None:
+    _write_package(
+        _src(synthetic_repo), "clean", klass="kernel", all_names=["K"], interface=["K"]
+    )
+    discovered = discover_packages(synthetic_repo)
+    assert {p.name for p in discovered} == {"clean"}
+    ok, messages = run(synthetic_repo)
+    assert ok is True
+    assert any("clean (class kernel)" in m for m in messages)
+
+
+def test_run_fails_for_dirty_package(synthetic_repo: Path) -> None:
+    _write_package(
+        _src(synthetic_repo),
+        "dirty",
+        klass="kernel",
+        all_names=["A", "B"],
+        interface=["A"],
+    )
+    ok, messages = run(synthetic_repo)
+    assert ok is False
+    assert any("interface != __all__" in m for m in messages)
+
+
+# --- main CLI -----------------------------------------------------------------
+
+
+def test_main_passes_on_clean_repo(
+    synthetic_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_package(
+        _src(synthetic_repo), "clean", klass="kernel", all_names=["K"], interface=["K"]
+    )
+    rc = main(["--repo-root", str(synthetic_repo)])
+    assert rc == 0
+    assert "PASSED" in capsys.readouterr().out
+
+
+def test_main_fails_on_dirty_repo(
+    synthetic_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_package(
+        _src(synthetic_repo),
+        "dirty",
+        klass="kernel",
+        all_names=["A", "B"],
+        interface=["A"],
+    )
+    rc = main(["--repo-root", str(synthetic_repo)])
+    assert rc == 1
+    assert "FAILED" in capsys.readouterr().out
+
+
+def test_main_fails_on_empty_repo(
+    synthetic_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(["--repo-root", str(synthetic_repo)])
+    assert rc == 1
+    assert "no packages discovered" in capsys.readouterr().out

--- a/tests/tooling/test_check_package_contract.py
+++ b/tests/tooling/test_check_package_contract.py
@@ -233,6 +233,16 @@ def test_package_all_handles_missing_dunder(synthetic_repo: Path) -> None:
     assert _package_all(pkg_dir) == []
 
 
+def test_package_all_tolerates_non_literal_all(synthetic_repo: Path) -> None:
+    """A computed ``__all__`` is not statically readable -> [] (never a crash)."""
+    pkg_dir = _src(synthetic_repo) / "computed"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text(
+        "__all__ = sorted(['B', 'A'])\n", encoding="utf-8"
+    )
+    assert _package_all(pkg_dir) == []
+
+
 def test_run_reports_no_packages_when_empty(synthetic_repo: Path) -> None:
     ok, messages = run(synthetic_repo)
     assert ok is False

--- a/tests/tooling/test_counter_package.py
+++ b/tests/tooling/test_counter_package.py
@@ -1,0 +1,114 @@
+"""counter package + package-model governance guards (EPIC-025 AC25.6.x).
+
+The ``counter`` package is the first worked example of the package model. These
+guards keep its shape honest — roles converge (types/ops never reach down into
+the ORM/session or up into store/api wiring), only ``__all__`` is public — and
+assert that the computed governance gate (``check_package_contract``) passes for
+counter, so the contract and the live package can never silently drift.
+"""
+
+import ast
+from pathlib import Path
+
+from common.governance.check_package_contract import discover_packages, run
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+COUNTER = REPO / "apps/backend/src/counter"
+
+
+def _imported_modules(path: Path) -> set[str]:
+    mods: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            mods.add(node.module)
+        elif isinstance(node, ast.Import):
+            mods.update(a.name for a in node.names)
+    return mods
+
+
+@ac_proof(
+    proof_id="test_counter_converges_by_role", ac_ids=["AC25.6.1"], ci_tier="pr_ci"
+)
+def test_AC25_6_1_counter_converges_by_role():
+    """AC25.6.1: counter exposes types (nouns/events), ops (verbs), store, api."""
+    assert (COUNTER / "types/key.py").exists()
+    assert (COUNTER / "types/count.py").exists()
+    assert (COUNTER / "types/events.py").exists()
+    assert (COUNTER / "ops/increment.py").exists()
+    assert (COUNTER / "ops/query.py").exists()
+    assert (COUNTER / "store/repository.py").exists()
+    assert (COUNTER / "store/sql.py").exists()
+    exports = (COUNTER / "__init__.py").read_text(encoding="utf-8")
+    for name in ("CounterKey", "Count", "Incremented", "increment", "get_count"):
+        assert name in exports, f"counter must export {name}"
+
+
+@ac_proof(proof_id="test_counter_types_pure", ac_ids=["AC25.6.2"], ci_tier="pr_ci")
+def test_AC25_6_2_types_never_import_store_api_or_orm():
+    """AC25.6.2: domain types depend on nothing below them (no store/api/ORM/session).
+
+    The value language must stay free of persistence and transport so it is a
+    pure, reusable vocabulary (the DAG points down only).
+    """
+    offenders: dict[str, set[str]] = {}
+    for path in sorted((COUNTER / "types").glob("*.py")):
+        bad = {
+            m
+            for m in _imported_modules(path)
+            if m.startswith("src.counter.store")
+            or m.startswith("src.counter.api")
+            or m.startswith("src.counter.ops")
+            or "sqlalchemy" in m
+            or m == "src.database"
+        }
+        if bad:
+            offenders[path.name] = bad
+    assert not offenders, f"counter types reach below their layer: {offenders}"
+
+
+@ac_proof(proof_id="test_counter_ops_pure", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+def test_AC25_6_3_ops_never_import_the_orm_session_or_api():
+    """AC25.6.3: ops depend on the store *port* + types only — no ORM/session/api.
+
+    Verbs talk to the ``CounterRepository`` Protocol, never to ``store.sql`` /
+    ``store.__init__`` concretes, the ORM, or the api boundary.
+    """
+    offenders: dict[str, set[str]] = {}
+    for path in sorted((COUNTER / "ops").glob("*.py")):
+        bad = {
+            m
+            for m in _imported_modules(path)
+            if m.startswith("src.counter.store.sql")
+            or m == "src.counter.store"
+            or m.startswith("src.counter.api")
+            or "sqlalchemy" in m
+            or m == "src.database"
+        }
+        if bad:
+            offenders[path.name] = bad
+    assert not offenders, f"counter ops reach into ORM/concretes/api: {offenders}"
+
+
+@ac_proof(proof_id="test_counter_only_all_public", ac_ids=["AC25.6.1"], ci_tier="pr_ci")
+def test_AC25_6_1_only_all_is_the_published_language():
+    """AC25.6.1: the package's contract.interface equals its __init__.__all__."""
+    import src.counter as counter_pkg
+    from src.counter.contract import CONTRACT
+
+    assert sorted(CONTRACT.interface) == sorted(counter_pkg.__all__)
+    assert CONTRACT.name == "counter"
+    assert CONTRACT.klass == "platform"
+
+
+@ac_proof(
+    proof_id="test_counter_contract_gate_passes",
+    ac_ids=["AC25.6.4"],
+    ci_tier="pr_ci",
+)
+def test_AC25_6_4_package_contract_gate_passes_for_counter():
+    """AC25.6.4: check_package_contract discovers and validates counter (green)."""
+    names = {p.name for p in discover_packages(REPO)}
+    assert "counter" in names, f"counter not discovered; found {names}"
+    ok, messages = run(REPO)
+    assert ok, "package contract gate failed:\n" + "\n".join(messages)

--- a/tools/check_package_contract.py
+++ b/tools/check_package_contract.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Command wrapper for the package-contract governance gate.
+
+Validates every package's ``contract.py`` (a ``PackageContract``) against the
+live package: published language (``interface`` == ``__all__``), every
+invariant/roadmap test resolves, and no forbidden dependency edge. See
+``common/governance/check_package_contract.py`` and ``docs/ssot/package-model.md``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.governance.check_package_contract import main  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

The **first instance of the package model** (`package = DDD bounded context`) and the minimal meta-scaffolding that governs packages from their contracts. This sets a precedent pattern, so it prioritizes a clean, self-consistent demonstration over features.

A package = **README** (prose / ubiquitous language) + a pydantic **`PackageContract`** (`contract.py`) + role folders **`types/ops/store/api`** + a **published language** declared via `__all__`. Governance is *computed from contracts*, not hand-maintained.

## A. Meta-scaffolding

- `common/governance/package_contract.py` — pydantic `Invariant` / `ACRecord` / `PackageContract` models (`name`, `klass` ∈ core|platform|kernel, `depends_on`, `interface`, `events`, `invariants`, `roadmap`).
- `tools/check_package_contract.py` (logic in `common/governance/check_package_contract.py`) — discovers packages by scanning `apps/backend/src/*/contract.py` and, per package, asserts:
  - **(a)** `contract.interface == __init__.__all__`;
  - **(b)** every `invariants[].test` and `roadmap[].test` (`"path::func"`) resolves to a real test function;
  - **(c)** no module imports a higher-class registered package or an undeclared dependency (the DAG rule, mirroring `tests/tooling/test_ledger_module.py`).
- `docs/ssot/package-model.md` — the short spec (owns the term "package"); the only authored horizontal doc remains `vision.md`.

## B. The `counter` package (`platform`)

Per-(user, key) tallies that feed insight reports ("how many times did X happen — overall, or for this user?").

- **`types/`** — `CounterKey` (validated namespaced lowercase dotted `domain.action`; the package's self-owned SSOT term; raises `InvalidCounterKeyError`), `Count` (non-negative tally; raises `NegativeCountError`), `Incremented` (published domain event), typed errors. Pure — no I/O.
- **`ops/`** — `increment(repo, *, user_id, key)` bumps the per-user tally, returns the new `Count`, emits `Incremented`; `get_count(repo, *, key, user_id=None)` returns the per-user count, or the **global** count (sum across users) when `user_id is None`. Both depend only on the store port, so they are unit-testable with an in-memory fake.
- **`store/`** — `CounterRepository` (a `typing.Protocol` port) + `SqlCounterRepository`/`CounterTally` (SQLAlchemy adapter; the only role that touches the ORM). Migration `0048_counter_tally` creates `counter_tally(user_id, key, count)` with a composite PK `(user_id, key)` (the unique + upsert conflict target) and `count >= 0`. `bump` is a single atomic `INSERT ... ON CONFLICT DO UPDATE SET count = count + 1`.
- **`api/`** — kept minimal: a thin async `read_count` boundary for reporting. No HTTP route (in-process verbs are the interface).
- **`contract.py`** — the counter `PackageContract`; its `roadmap` owns `AC25.6.1`–`AC25.6.4` and its invariants pin to the tests that prove them.

### Public vs internal
Public (`__all__` == `contract.interface`): `CounterKey`, `Count`, `Incremented`, `increment`, `get_count`, `CounterRepository`, `read_count`, and the errors. Internal: `SqlCounterRepository`, `CounterTally`, module internals — persistence is an implementation detail behind the port.

## C. Tests
- `apps/backend/tests/counter/` — key validation, count non-negativity, per-user increment, per-user vs global isolation, two keys/users don't interfere, ops over an in-memory fake (no DB), plus DB-backed atomic-upsert tests.
- `tests/tooling/test_counter_package.py` — role/DAG discipline (types/ops never import store/api or the ORM session; only `__all__` is public) and that `check_package_contract` passes for counter.
- AC IDs referenced in test docstrings; `AC25.6.x` mirrored into `docs/project/EPIC-025` so the existing AC-index gate stays green (no existing AC dropped/renumbered).

## How governance is computed from the contract
`check_package_contract` reads each package's `contract.py` and validates the live package against it (interface ⇔ `__all__`, every test reference resolves, no upward edge). Adding a package adds no central index to edit — a package is governed the moment it ships a `contract.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)