### PR TITLE
[finance_report_vision] ai_advisor split review follow-ups (#1299)

### DIFF
--- a/apps/backend/src/services/ai_advisor/_base.py
+++ b/apps/backend/src/services/ai_advisor/_base.py
@@ -7,7 +7,7 @@ import re
 from src.logger import get_logger
 from src.prompts.ai_advisor import DISCLAIMER_EN, DISCLAIMER_ZH
 
-logger = get_logger(__name__)
+logger = get_logger("src.services.ai_advisor")
 
 MAX_CONTEXT_MESSAGES = 20
 CACHE_TTL_SECONDS = 3600

--- a/apps/backend/tests/infra/test_transaction_boundaries.py
+++ b/apps/backend/tests/infra/test_transaction_boundaries.py
@@ -65,7 +65,7 @@ def _service_commit_calls() -> list[tuple[str, str, int]]:
     calls: list[tuple[str, str, int]] = []
     for path in sorted(SERVICE_ROOT.rglob("*.py")):
         tree = ast.parse(path.read_text(), filename=str(path))
-        visitor = _CommitCallVisitor(str(path.relative_to(SERVICE_ROOT)))
+        visitor = _CommitCallVisitor(path.relative_to(SERVICE_ROOT).as_posix())
         visitor.visit(tree)
         calls.extend(visitor.calls)
     return calls


### PR DESCRIPTION
## Why

Two Copilot comments on #1299 were valid but the PR was merged before the fixes were pushed. Carrying them here.

## What

- **`test_transaction_boundaries`**: the AST commit-boundary guard now builds its filename key with `path.relative_to(SERVICE_ROOT).as_posix()`, so it's portable on Windows/local dev (the `ALLOWED_SERVICE_COMMIT_BOUNDARIES` keys are POSIX-style with `/`).
- **`ai_advisor/_base`**: pin the shared logger name to `"src.services.ai_advisor"` rather than `__name__` (`...._base` after the split) so log-stream names / observability filters stay stable across the refactor.

## Verification

- `test_transaction_boundaries` passes; ai_advisor imports cleanly; pinned ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)