### PR TITLE
[finance_report_audit] feat(orm): Money-native fx.convert_money + portfolio holdings flow Money (AC12.35.3)

### DIFF
--- a/apps/backend/src/services/fx.py
+++ b/apps/backend/src/services/fx.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.config import settings
 from src.logger import get_logger
 from src.models import FxRate
-from src.money import ExchangeRate, Money, MoneyError, convert as convert_money
+from src.money import ExchangeRate, Money, MoneyError, convert as _money_convert
 
 logger = get_logger(__name__)
 
@@ -89,7 +89,7 @@ def _append_fx_warning(fx_warnings: list[FxWarning] | None, warning: FxWarning) 
 
 def _convert_money_amount(amount: Decimal, source: str, target: str, rate: Decimal) -> Decimal:
     try:
-        return convert_money(Money(amount, source), ExchangeRate(source, target, rate)).amount
+        return _money_convert(Money(amount, source), ExchangeRate(source, target, rate)).amount
     except MoneyError as exc:
         raise FxRateError(f"Invalid FX conversion boundary for {source}/{target}: {exc}") from exc
 
@@ -238,6 +238,38 @@ async def convert_amount(
         rate = await get_exchange_rate(db, source, target, rate_date, lazy_load=lazy_load)
 
     return _convert_money_amount(amount, source, target, rate)
+
+
+async def convert_money(
+    db: AsyncSession,
+    money: Money,
+    target_currency: str,
+    rate_date: date,
+    *,
+    average_start: date | None = None,
+    average_end: date | None = None,
+    fx_warnings: list[FxWarning] | None = None,
+    lazy_load: bool = False,
+) -> Money:
+    """Money-native FX conversion: ``Money(source) -> Money(target)``.
+
+    Thin typed wrapper over :func:`convert_amount` so business code stays in
+    ``Money`` across the FX boundary instead of unwrapping to ``Decimal``. A
+    same-currency conversion is a no-op (returns ``money`` re-stamped in the target
+    code), so callers no longer need an ``if currency != base`` branch.
+    """
+    converted = await convert_amount(
+        db,
+        amount=money.amount,
+        currency=money.currency.code,
+        target_currency=target_currency,
+        rate_date=rate_date,
+        average_start=average_start,
+        average_end=average_end,
+        fx_warnings=fx_warnings,
+        lazy_load=lazy_load,
+    )
+    return Money(converted, target_currency)
 
 
 async def convert_to_base(

--- a/apps/backend/src/services/portfolio.py
+++ b/apps/backend/src/services/portfolio.py
@@ -34,6 +34,7 @@ from src.schemas.portfolio import (
 )
 from src.schemas.provenance import DataProvenance
 from src.services import fx
+from src.unit_price import UnitPrice
 
 logger = get_logger(__name__)
 
@@ -147,40 +148,27 @@ class PortfolioService:
             # Get latest market price from AtomicPosition (per-unit price)
             latest_price = await self._get_latest_price(db, position, eval_date, user_id)
 
-            # Calculate market value
-            position_quantity = Quantity(position.quantity, PORTFOLIO_QUANTITY_UNIT).quantize()
-            market_value = position_quantity.value * latest_price
-
-            # Convert to base currency if needed
-            if position.currency != settings.base_currency:
-                converted_value = await fx.convert_amount(
+            # Market value as money-per-unit × quantity, converted to base currency.
+            # convert_money is a no-op when already in base, so no if/else branch.
+            position_quantity = position.quantity_qty.quantize()
+            market_value = UnitPrice(latest_price, position.currency, PORTFOLIO_QUANTITY_UNIT) * position_quantity
+            converted_value = (
+                await fx.convert_money(db, market_value, settings.base_currency, rate_date=eval_date, lazy_load=True)
+            ).quantize()
+            converted_cost = (
+                await fx.convert_money(
                     db,
-                    amount=market_value,
-                    currency=position.currency,
-                    target_currency=settings.base_currency,
-                    rate_date=eval_date,
-                    lazy_load=True,
-                )
-                converted_cost = await fx.convert_amount(
-                    db,
-                    amount=position.cost_basis,
-                    currency=position.currency,
-                    target_currency=settings.base_currency,
+                    position.cost_basis_money,
+                    settings.base_currency,
                     rate_date=position.acquisition_date,
                     lazy_load=True,
                 )
-                currency = settings.base_currency
-            else:
-                converted_value = market_value
-                converted_cost = position.cost_basis
-                currency = position.currency
-
-            converted_value = to_money(converted_value)
-            converted_cost = to_money(converted_cost)
+            ).quantize()
+            currency = converted_value.currency.code
 
             # Calculate P&L (unrealized: market_value - cost_basis)
-            unrealized_pnl = to_money(converted_value - converted_cost)
-            unrealized_pnl_ratio = Ratio.fraction_or_zero(unrealized_pnl, converted_cost)
+            unrealized_pnl = converted_value - converted_cost
+            unrealized_pnl_ratio = Ratio.fraction_or_zero(unrealized_pnl.amount, converted_cost.amount)
 
             # Get asset classification from latest AtomicPosition (scoped by user_id)
             asset_type = None
@@ -201,9 +189,9 @@ class PortfolioService:
                 account_id=position.account_id,
                 asset_identifier=position.asset_identifier,
                 quantity=position.quantity,
-                cost_basis=converted_cost,
-                market_value=converted_value,
-                unrealized_pnl=unrealized_pnl,
+                cost_basis=converted_cost.amount,
+                market_value=converted_value.amount,
+                unrealized_pnl=unrealized_pnl.amount,
                 unrealized_pnl_percent=unrealized_pnl_ratio.to_percent(),
                 currency=currency,
                 acquisition_date=position.acquisition_date,

--- a/apps/backend/tests/market_data/test_fx.py
+++ b/apps/backend/tests/market_data/test_fx.py
@@ -593,7 +593,10 @@ async def test_AC12_31_2_convert_amount_routes_through_money_exchange_rate(
         calls.append((money, rate))
         return Money(Decimal("120.00"), "SGD")
 
-    monkeypatch.setattr(fx_service, "convert_money", fake_convert)
+    # ``convert_money`` is now the public Money-native FX helper; the common
+    # money primitive is imported privately as ``_money_convert`` (what
+    # convert_amount routes through).
+    monkeypatch.setattr(fx_service, "_money_convert", fake_convert)
 
     result = await convert_amount(db, Decimal("100.00"), "USD", "SGD", date(2025, 1, 1))
 

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -553,6 +553,7 @@ other models/services follow incrementally.
 |----|-----------|---------------|------|----------|
 | AC12.35.1 | `ManagedPosition` exposes typed read accessors at the ORM boundary — `cost_basis_money`/`unrealized_pnl_money`/`realized_pnl_money` → `Money` (nullable PnL coalesces to zero) and `quantity_qty` → `Quantity` — built from the raw amount + currency columns (kernel `src.money`/`src.quantity`, no service import) {tier:PC} | `test_AC12_35_1_managed_position_exposes_typed_accessors` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
 | AC12.35.2 | Investment accounting updates position state through the typed accessors (`position.cost_basis_money`/`realized_pnl_money`/`quantity_qty`) with `Money`/`Quantity` arithmetic instead of re-wrapping raw `Decimal` columns; writes back `.amount`/`.value` only at the storage edge {tier:PC} | `test_AC12_35_2_investment_accounting_reads_position_via_accessors` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
+| AC12.35.3 | The FX boundary is Money-native: `fx.convert_money(money, target) -> Money` wraps `convert_amount`, and portfolio holdings valuation flows as `Money` end-to-end (`UnitPrice(price) * position.quantity_qty` → `fx.convert_money` → `Money` P&L), collapsing the `if currency != base` Decimal branch {tier:PC} | `test_AC12_35_3_portfolio_holdings_value_flows_as_money` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
 
 ---
 

--- a/tests/tooling/test_decimal_boundary_policy.py
+++ b/tests/tooling/test_decimal_boundary_policy.py
@@ -42,8 +42,10 @@ def test_AC12_31_1_decimal_boundary_policy_is_mece_and_enforced():
         assert phrase in ssot
 
     fx = _read(Path("apps/backend/src/services/fx.py"))
+    # convert_amount routes through the money primitive (imported privately as
+    # _money_convert; the public fx.convert_money is now the Money-native helper).
     assert (
-        "from src.money import ExchangeRate, Money, MoneyError, convert as convert_money"
+        "from src.money import ExchangeRate, Money, MoneyError, convert as _money_convert"
         in fx
     )
     assert "ExchangeRate(source, target, rate)" in fx

--- a/tests/tooling/test_orm_value_type_boundary.py
+++ b/tests/tooling/test_orm_value_type_boundary.py
@@ -52,3 +52,22 @@ def test_AC12_35_2_investment_accounting_reads_position_via_accessors():
     assert "to_money(position.cost_basis" not in src
     assert "position.realized_pnl or Decimal" not in src
     assert "Quantity(position.quantity," not in src
+
+
+@ac_proof(
+    proof_id="test_portfolio_holdings_money_native",
+    ac_ids=["AC12.35.3"],
+    ci_tier="pr_ci",
+)
+def test_AC12_35_3_portfolio_holdings_value_flows_as_money():
+    """AC12.35.3: portfolio holdings valuation flows as Money end-to-end via a
+    Money-native FX convert + the ManagedPosition accessors (no Decimal FX branch)."""
+    fx = _read("apps/backend/src/services/fx.py")
+    assert "async def convert_money(" in fx, (
+        "fx must expose a Money-native convert helper"
+    )
+    src = _read("apps/backend/src/services/portfolio.py")
+    assert "fx.convert_money(" in src
+    assert "position.cost_basis_money" in src
+    assert "position.quantity_qty" in src
+    assert "UnitPrice(latest_price" in src


### PR DESCRIPTION
Continues **#3 (boundary push)** onto the FX-gated portfolio path (the part the Phase-1 pilot deferred).

## What

- **`fx.convert_money(money, target) -> Money`** — thin typed wrapper over `convert_amount` so business stays in `Money` across the FX boundary. Same-currency is a no-op → callers drop the `if currency != base` branch. (The common-`convert` import alias is renamed `_money_convert`; `convert_amount` still routes through it; the AC12.31.2 test's patch target updated accordingly.)
- **`portfolio.get_holdings`** now flows `Money` end-to-end: market value = `UnitPrice(price) * position.quantity_qty` → `fx.convert_money` → `Money` P&L, reading `position.cost_basis_money`. The Decimal FX `if/else` collapses; response fields serialize from `.amount` (**wire shape unchanged**).

This is the real boundary-push payoff: the valuation reads typed values, the FX branch disappears, and the raw `quantity*price` becomes `UnitPrice * Quantity`.

## Scope

`get_holdings` only in this PR. The realized-PnL and snapshot-holdings blocks (same pattern, but with Decimal cross-position accumulators) + `assets`/`performance_report` follow in the next slice — keeping each money-critical PR reviewable.

## Verification

- **493** reporting/assets/networth/portfolio tests pass (behaviour-preserving — quantize-after-convert order preserved, same numbers).
- AC12.35.3 + guard; tier ratchet + AC traceability green; `ruff` clean.
- mypy +1/file (the `str`→Currency constructor convention, consistent with prior PRs, not CI-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)