### PR TITLE
[finance_report_ui] Text extraction cassette replay + keyless-replay bridge fix (#1306)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,24 +441,6 @@ jobs:
             --dist worksteal \
             --junit-xml=test-results/backend-shard-${{ matrix.shard }}.xml
 
-      # EPIC-023 AC23.6 / #1306: replay the recorded extraction cassettes (real
-      # glm-5.2/glm-4.6v responses, frozen) deterministically — NO key, NO
-      # network. LLM_CASSETTE_MODE=replay is scoped to THIS step only (staging
-      # `-m "llm"` gates set no cassette var and stay live/real). Runs ONLY the
-      # extraction-cassette file (which self-skips outside replay mode), so its
-      # AC evidence is emitted exactly once — no duplicate-evidence aggregator
-      # skew. Shard 1 only (the cassettes are shard-independent).
-      - name: LLM extraction cassette replay (deterministic, no key/network)
-        if: ${{ matrix.shard == 1 }}
-        env:
-          LLM_CASSETTE_MODE: replay
-        run: |
-          cd apps/backend
-          uv run pytest -v \
-            tests/extraction/test_extraction_cassette_replay.py \
-            -p no:randomly --no-cov \
-            --junit-xml=test-results/backend-extraction-cassette-replay.xml
-
       - name: Upload coverage artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,7 @@ jobs:
         env:
           LLM_CASSETTE_MODE: replay
         run: |
+          cd apps/backend
           uv run pytest -v \
             tests/extraction/test_extraction_cassette_replay.py \
             -p no:randomly --no-cov \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,6 +441,23 @@ jobs:
             --dist worksteal \
             --junit-xml=test-results/backend-shard-${{ matrix.shard }}.xml
 
+      # EPIC-023 AC23.6 / #1306: replay the recorded extraction cassettes (real
+      # glm-5.2/glm-4.6v responses, frozen) deterministically — NO key, NO
+      # network. LLM_CASSETTE_MODE=replay is scoped to THIS step only (staging
+      # `-m "llm"` gates set no cassette var and stay live/real). Runs ONLY the
+      # extraction-cassette file (which self-skips outside replay mode), so its
+      # AC evidence is emitted exactly once — no duplicate-evidence aggregator
+      # skew. Shard 1 only (the cassettes are shard-independent).
+      - name: LLM extraction cassette replay (deterministic, no key/network)
+        if: ${{ matrix.shard == 1 }}
+        env:
+          LLM_CASSETTE_MODE: replay
+        run: |
+          uv run pytest -v \
+            tests/extraction/test_extraction_cassette_replay.py \
+            -p no:randomly --no-cov \
+            --junit-xml=test-results/backend-extraction-cassette-replay.xml
+
       - name: Upload coverage artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7

--- a/apps/backend/src/services/ai_streaming.py
+++ b/apps/backend/src/services/ai_streaming.py
@@ -14,6 +14,7 @@ from typing import Any
 from uuid import UUID
 
 from src.config import settings
+from src.llm.cassette import CassetteMode, current_mode
 from src.llm.client import litellm_stream, resolve_provider_and_model
 from src.llm.common import LLMConfigError, LLMError, ProviderRef, ReasoningEffort
 from src.llm.env_config import _protocol_for
@@ -115,7 +116,19 @@ async def _stream_ai_base(
     litellm owns the transport. ``user_id`` scopes provider resolution to that
     user's configured provider (else deployment default, else env).
     """
-    if api_key is None and user_id is not None:
+    if current_mode() is CassetteMode.REPLAY:
+        # Replay serves the committed cassette from litellm_stream, keyed on
+        # (role + messages + decode params) — provider-agnostic. Skip provider
+        # resolution so CI replays with NO key and NO configured provider; the
+        # dummy ref satisfies the signature and is never used for a network call.
+        provider = ProviderRef(
+            id="replay",
+            label="replay",
+            protocol=_protocol_for(settings.ai_provider),
+            api_key="replay",
+            api_base=None,
+        )
+    elif api_key is None and user_id is not None:
         # Per-user path: honour a binding's ``provider_id/model`` qualifier so a
         # user with several providers resolves the exact one (the scene-less
         # ``_resolve_provider`` fails closed on >1). ``model`` becomes the bare model.

--- a/apps/backend/tests/extraction/test_extraction_cassette_replay.py
+++ b/apps/backend/tests/extraction/test_extraction_cassette_replay.py
@@ -1,74 +1,118 @@
 """Extraction tests routed through the streaming-cassette bridge in replay.
 
-SCAFFOLD ONLY (EPIC-023 AC23.6 / issue #1306). These wire the first batch of
-LLM-touching extraction tests onto the cassette replay path so the parse
-pipeline's LLM path is exercised in CI WITHOUT a key or network. They are
-**skipped in this PR's CI** because the real cassettes do not exist yet — the
-streaming bridge half (this PR) deliberately does NOT record real extraction
-cassettes (no GLM token). The human operator records them afterwards:
+EPIC-023 AC23.6 / issue #1306. These wire the first batch of LLM-touching
+extraction tests onto the cassette replay path so the parse pipeline's LLM path
+is exercised in CI WITHOUT a key or network. The frozen responses are REAL GLM
+(glm-5.2 / glm-4.6v) completions recorded via the GLM coding plan; in replay
+they are served from committed cassettes (zero key, zero network).
 
-    LLM_CASSETTE_MODE=record make llm-record \\
-        ARGS='tests/extraction/test_extraction_cassette_replay.py -m needs_real_cassette'
+Recording (operator-only, needs the provider key):
 
-then removes the ``needs_real_cassette`` skip (flip the marker) so they run in
-the dedicated replay CI step. The frozen responses must be ground-truth
-validated (``correctness`` tag) at record time; the synthetic placeholders here
-are NOT a substitute and are intentionally absent.
+    AI_PROVIDER=zai AI_BASE_URL=https://api.z.ai/api/coding/paas/v4 \\
+    AI_API_KEY=$GLM_CODING_TOKEN PRIMARY_MODEL=glm-5.2 \\
+    LLM_CASSETTE_MODE=record \\
+        uv run pytest tests/extraction/test_extraction_cassette_replay.py
 
-Until then, every test below is collected but SKIPPED — PR CI stays green and
-the not-yet-recorded path is unmistakably flagged, never silently faked.
+Tests with no cassette yet stay `pytest.skip`-marked (per-test, not module-wide)
+so PR CI stays green and the not-yet-recorded path is unmistakably flagged.
 
-Boundary: these assert provider-agnostic response *handling* through the parse
-pipeline; provider-specific correctness on unseen documents remains the staging
-``-m llm`` live gate's job (which this PR leaves untouched).
+Boundary: these assert provider-agnostic response *handling* + the balance/dedup
+invariants through the parse pipeline. Provider-specific correctness on unseen
+documents remains the staging ``-m llm`` live gate's job (untouched here).
 """
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
-# Module-level skip: the cassettes for these scenes have not been recorded yet.
-# Recording instructions are in the module docstring and the PR final report.
-pytestmark = [
-    pytest.mark.needs_real_cassette,
-    pytest.mark.skip(reason="needs real cassette: run make llm-record (see module docstring / issue #1306)"),
-]
+from src.llm.cassette import CassetteMode, current_mode
+from src.services.ai_streaming import accumulate_stream, stream_ai_json
 
-_RECORD_HINT = (
-    "Record with: LLM_CASSETTE_MODE=record make llm-record "
-    "ARGS='tests/extraction/test_extraction_cassette_replay.py -m needs_real_cassette', "
-    "then remove the needs_real_cassette skip."
+# These drive the real LLM transport, so they are meaningful only in replay (the
+# committed cassette serves the frozen response with no key/network). In the
+# normal off-mode shards there is no key, so self-gate to replay: they SKIP in
+# shards and RUN in the dedicated cassette-replay CI step (LLM_CASSETTE_MODE=replay).
+pytestmark = pytest.mark.skipif(
+    current_mode() is not CassetteMode.REPLAY,
+    reason="cassette-replay only (run with LLM_CASSETTE_MODE=replay)",
 )
+
+# --- Deterministic, anonymised inputs (synthetic; no real financial data). ---
+# The fingerprint keys on (role + messages + decode params), so these MUST stay
+# byte-identical to what was recorded for replay to hit.
+_TEXT_MODEL = "glm-5.2"
+_TEXT_MAX_TOKENS = 512
+_TEXT_PROMPT = (
+    "Extract this bank statement as strict JSON only (no prose, no markdown "
+    "fence) with keys opening_balance, closing_balance, transactions (a list of "
+    "{date, description, amount}). Amounts are negative for debits, positive for "
+    "credits."
+)
+_TEXT_STATEMENT = (
+    "Opening balance: 100.00\n"
+    "2026-01-02  Coffee shop        -5.00\n"
+    "2026-01-05  Salary credit      +50.00\n"
+    "2026-01-09  Groceries          -15.00\n"
+    "Closing balance: 130.00\n"
+)
+_TEXT_MESSAGES = [{"role": "user", "content": _TEXT_PROMPT + "\n\n" + _TEXT_STATEMENT}]
+# Ground truth the cassette is validated against (opening + net == closing).
+_TEXT_OPENING = 100.00
+_TEXT_CLOSING = 130.00
+_TEXT_TXN_COUNT = 3
+
+
+def _loads_tolerant(content: str) -> dict:
+    """Parse a JSON object, stripping a ```json fence if the model added one."""
+    text = content.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else text
+        text = text.rsplit("```", 1)[0]
+    return json.loads(text)
 
 
 async def test_AC23_6_extraction_text_happy_path_via_replay() -> None:
     """Text extraction happy-path through ``litellm_stream`` replay.
 
-    When the real cassette exists: drive a known anonymised text statement through
-    ``ExtractionService`` with ``LLM_CASSETTE_MODE=replay`` and assert the parsed
-    transactions + closing balance match the ground-truth the cassette was
-    validated against — exercised with NO network and NO API key.
+    Drives a known anonymised text statement through the JSON-extraction transport
+    and asserts the LLM-read numbers satisfy the balance chain
+    (opening + Σamounts == closing) and the expected transaction count — exercised
+    with NO network and NO API key in replay. A frozen-wrong response (LLM misread
+    a number) fails these assertions, which is the point.
     """
-    pytest.skip(_RECORD_HINT)
+    stream = stream_ai_json(
+        messages=_TEXT_MESSAGES,
+        model=_TEXT_MODEL,
+        max_tokens=_TEXT_MAX_TOKENS,
+        temperature=0.0,
+        thinking={"type": "disabled"},
+    )
+    content = await accumulate_stream(stream)
+    data = _loads_tolerant(content)
+
+    opening = float(data["opening_balance"])
+    closing = float(data["closing_balance"])
+    txns = data["transactions"]
+    net = sum(float(t["amount"]) for t in txns)
+
+    assert opening == pytest.approx(_TEXT_OPENING, abs=0.01)
+    assert closing == pytest.approx(_TEXT_CLOSING, abs=0.01)
+    assert len(txns) == _TEXT_TXN_COUNT
+    # Balance-chain invariant on the LLM's extraction (the #1254-class oracle).
+    assert (opening + net) == pytest.approx(closing, abs=0.01)
 
 
+@pytest.mark.skip(reason="needs real vision cassette: record glm-4.6v (see module docstring / issue #1306)")
 async def test_AC23_6_extraction_vision_happy_path_via_replay() -> None:
-    """Text+image (vision) extraction happy-path through ``litellm_stream`` replay.
-
-    When the real cassette exists: feed a committed FIXED-BYTES statement image
-    (never regenerated in-test, so a re-render cannot spuriously invalidate the
-    cassette) through the default-config vision path (OCR_MODEL==VISION_MODEL) and
-    assert the parsed result matches ground-truth — no network, no key.
-    """
-    pytest.skip(_RECORD_HINT)
+    """Text+image (vision) extraction happy-path through the default-config vision
+    path (OCR_MODEL==VISION_MODEL). Pending a recorded glm-4.6v cassette."""
+    pytest.skip("vision cassette not yet recorded")
 
 
+@pytest.mark.skip(reason="needs real #1254-class cassette (see module docstring / issue #1306)")
 async def test_AC23_6_extraction_1254_class_dedup_balance_via_replay() -> None:
-    """#1254-class dedup/balance behaviour through the LLM path in replay.
-
-    When the real cassette exists: replay a statement whose LLM output previously
-    triggered the #1254 duplicate/balance edge case and assert the dedup + balance
-    invariants hold end-to-end through the cassette-backed parse — no network, no
-    key.
-    """
-    pytest.skip(_RECORD_HINT)
+    """#1254-class dedup/balance behaviour through the LLM path in replay. Pending
+    a recorded cassette of the duplicate-deposit edge case."""
+    pytest.skip("#1254-class cassette not yet recorded")

--- a/apps/backend/tests/extraction/test_extraction_cassette_replay.py
+++ b/apps/backend/tests/extraction/test_extraction_cassette_replay.py
@@ -24,6 +24,7 @@ documents remains the staging ``-m llm`` live gate's job (untouched here).
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 
 import pytest
 
@@ -58,9 +59,11 @@ _TEXT_STATEMENT = (
     "Closing balance: 130.00\n"
 )
 _TEXT_MESSAGES = [{"role": "user", "content": _TEXT_PROMPT + "\n\n" + _TEXT_STATEMENT}]
-# Ground truth the cassette is validated against (opening + net == closing).
-_TEXT_OPENING = 100.00
-_TEXT_CLOSING = 130.00
+# Ground truth the test asserts on replay (opening + net == closing). Decimal,
+# never float — money invariants must not accrue float rounding artefacts.
+_TEXT_OPENING = Decimal("100.00")
+_TEXT_CLOSING = Decimal("130.00")
+_TEXT_TOLERANCE = Decimal("0.01")
 _TEXT_TXN_COUNT = 3
 
 
@@ -92,16 +95,17 @@ async def test_AC23_6_extraction_text_happy_path_via_replay() -> None:
     content = await accumulate_stream(stream)
     data = _loads_tolerant(content)
 
-    opening = float(data["opening_balance"])
-    closing = float(data["closing_balance"])
+    # Decimal end-to-end (str() before Decimal so a JSON float never seeds it).
+    opening = Decimal(str(data["opening_balance"]))
+    closing = Decimal(str(data["closing_balance"]))
     txns = data["transactions"]
-    net = sum(float(t["amount"]) for t in txns)
+    net = sum((Decimal(str(t["amount"])) for t in txns), Decimal("0"))
 
-    assert opening == pytest.approx(_TEXT_OPENING, abs=0.01)
-    assert closing == pytest.approx(_TEXT_CLOSING, abs=0.01)
+    assert abs(opening - _TEXT_OPENING) <= _TEXT_TOLERANCE
+    assert abs(closing - _TEXT_CLOSING) <= _TEXT_TOLERANCE
     assert len(txns) == _TEXT_TXN_COUNT
     # Balance-chain invariant on the LLM's extraction (the #1254-class oracle).
-    assert (opening + net) == pytest.approx(closing, abs=0.01)
+    assert abs((opening + net) - closing) <= _TEXT_TOLERANCE
 
 
 @pytest.mark.skip(reason="needs real vision cassette: record glm-4.6v (see module docstring / issue #1306)")

--- a/apps/backend/tests/fixtures/llm_cassettes/d69fbafcecb481e614651b1178a5fb9d9e3724718ef7bf623502120bcd27db30.json
+++ b/apps/backend/tests/fixtures/llm_cassettes/d69fbafcecb481e614651b1178a5fb9d9e3724718ef7bf623502120bcd27db30.json
@@ -1,0 +1,26 @@
+{
+  "fingerprint": "d69fbafcecb481e614651b1178a5fb9d9e3724718ef7bf623502120bcd27db30",
+  "request": {
+    "decode_params": {
+      "extra_body": {
+        "thinking": {
+          "type": "disabled"
+        }
+      },
+      "max_tokens": 512,
+      "temperature": 0.0
+    },
+    "messages": [
+      {
+        "content": "Extract this bank statement as strict JSON only (no prose, no markdown fence) with keys opening_balance, closing_balance, transactions (a list of {date, description, amount}). Amounts are negative for debits, positive for credits.\n\nOpening balance: 100.00\n2026-01-02  Coffee shop        -5.00\n2026-01-05  Salary credit      +50.00\n2026-01-09  Groceries          -15.00\nClosing balance: 130.00\n",
+        "role": "user"
+      }
+    ],
+    "role": "text"
+  },
+  "response": {
+    "stream_text": "{\n  \"opening_balance\": 100.00,\n  \"closing_balance\": 130.00,\n  \"transactions\": [\n    {\n      \"date\": \"2026-01-02\",\n      \"description\": \"Coffee shop\",\n      \"amount\": -5.00\n    },\n    {\n      \"date\": \"2026-01-05\",\n      \"description\": \"Salary credit\",\n      \"amount\": 50.00\n    },\n    {\n      \"date\": \"2026-01-09\",\n      \"description\": \"Groceries\",\n      \"amount\": -15.00\n    }\n  ]\n}"
+  },
+  "role": "text",
+  "tag": "flow-only"
+}


### PR DESCRIPTION
Completes the first slice of #1306 on top of the merged #1320 bridge.

## What
- **Keyless-replay bridge fix**: `stream_ai_json` resolved the provider (needs a key) *before* the cassette lookup, so keyless-CI replay raised `AIStreamError`. In replay mode it now skips provider resolution (cassette is keyed on role+messages+params, provider-agnostic). #1320s unit tests missed this — they called `litellm_stream` directly.
- **Real text extraction cassette**: recorded a real `glm-5.2` JSON extraction of a synthetic anonymised statement; the test asserts the balance-chain invariant on the LLM output (`opening + Σ == closing`) — a frozen-wrong read fails it.
- **Self-gating**: tests `skipif(mode != replay)` so off-mode shards skip (no key); a dedicated shard-1 replay step runs ONLY this file (runs nowhere else → no duplicate-evidence aggregator skew, unlike the reverted unit-test step).
- Vision (glm-4.6v) + #1254-class stay skip-marked pending their recordings (next commits).

## Data hygiene
Cassette + fixtures are synthetic/anonymised — no real amounts, names, accounts, paths, or filenames.

Part of #1306.