### PR TITLE
[finance_report_ui] #1254-class duplicate-deposit extraction cassette (#1306)

### DIFF
--- a/apps/backend/tests/extraction/test_extraction_cassette_replay.py
+++ b/apps/backend/tests/extraction/test_extraction_cassette_replay.py
@@ -36,8 +36,8 @@ from src.services.ai_streaming import accumulate_stream, stream_ai_json
 # normal off-mode shards there is no key, so self-gate to replay: they SKIP in
 # shards and RUN in the dedicated cassette-replay CI step (LLM_CASSETTE_MODE=replay).
 pytestmark = pytest.mark.skipif(
-    current_mode() is not CassetteMode.REPLAY,
-    reason="cassette-replay only (run with LLM_CASSETTE_MODE=replay)",
+    current_mode() is CassetteMode.OFF,
+    reason="cassette record/replay only (set LLM_CASSETTE_MODE=record to record, replay to run)",
 )
 
 # --- Deterministic, anonymised inputs (synthetic; no real financial data). ---
@@ -115,8 +115,46 @@ async def test_AC23_6_extraction_vision_happy_path_via_replay() -> None:
     pytest.skip("vision cassette not yet recorded")
 
 
-@pytest.mark.skip(reason="needs real #1254-class cassette (see module docstring / issue #1306)")
+_DUP_MODEL = "glm-5.2"
+_DUP_MAX_TOKENS = 512
+_DUP_STATEMENT = (
+    "Opening balance: 1000.00\n"
+    "2026-02-01  Deposit ABC        +250.00\n"
+    "2026-02-01  Deposit ABC        +250.00\n"  # genuine same-date same-amount duplicate
+    "2026-02-03  Service fee         -10.00\n"
+    "Closing balance: 1490.00\n"
+)
+_DUP_MESSAGES = [{"role": "user", "content": _TEXT_PROMPT + "\n\n" + _DUP_STATEMENT}]
+_DUP_OPENING = Decimal("1000.00")
+_DUP_CLOSING = Decimal("1490.00")
+_DUP_DEPOSIT = Decimal("250.00")
+
+
 async def test_AC23_6_extraction_1254_class_dedup_balance_via_replay() -> None:
-    """#1254-class dedup/balance behaviour through the LLM path in replay. Pending
-    a recorded cassette of the duplicate-deposit edge case."""
-    pytest.skip("#1254-class cassette not yet recorded")
+    """#1254-class duplicate-deposit behaviour through the LLM path in replay.
+
+    Two genuine same-date/same-amount deposits must BOTH survive extraction (the
+    #1254 bug dropped one), and the balance chain must reconcile — asserted on the
+    frozen LLM output with NO network and NO key.
+    """
+    stream = stream_ai_json(
+        messages=_DUP_MESSAGES,
+        model=_DUP_MODEL,
+        max_tokens=_DUP_MAX_TOKENS,
+        temperature=0.0,
+        thinking={"type": "disabled"},
+    )
+    content = await accumulate_stream(stream)
+    data = _loads_tolerant(content)
+
+    opening = Decimal(str(data["opening_balance"]))
+    closing = Decimal(str(data["closing_balance"]))
+    txns = data["transactions"]
+    amounts = [Decimal(str(t["amount"])) for t in txns]
+    net = sum(amounts, Decimal("0"))
+
+    # Both same-amount deposits survived (the #1254 oracle: count is preserved).
+    assert sum(1 for a in amounts if a == _DUP_DEPOSIT) == 2
+    assert abs(opening - _DUP_OPENING) <= _TEXT_TOLERANCE
+    assert abs(closing - _DUP_CLOSING) <= _TEXT_TOLERANCE
+    assert abs((opening + net) - closing) <= _TEXT_TOLERANCE

--- a/apps/backend/tests/extraction/test_extraction_cassette_replay.py
+++ b/apps/backend/tests/extraction/test_extraction_cassette_replay.py
@@ -31,10 +31,10 @@ import pytest
 from src.llm.cassette import CassetteMode, current_mode
 from src.services.ai_streaming import accumulate_stream, stream_ai_json
 
-# These drive the real LLM transport, so they are meaningful only in replay (the
-# committed cassette serves the frozen response with no key/network). In the
-# normal off-mode shards there is no key, so self-gate to replay: they SKIP in
-# shards and RUN in the dedicated cassette-replay CI step (LLM_CASSETTE_MODE=replay).
+# These drive the real LLM transport, so they run only in record mode (freeze the
+# real response) or replay mode (serve the committed cassette — no key/network).
+# In the normal off-mode shards there is no key, so they SKIP; run them with
+# LLM_CASSETTE_MODE=record (to (re)record) or =replay (to assert against cassettes).
 pytestmark = pytest.mark.skipif(
     current_mode() is CassetteMode.OFF,
     reason="cassette record/replay only (set LLM_CASSETTE_MODE=record to record, replay to run)",
@@ -153,7 +153,9 @@ async def test_AC23_6_extraction_1254_class_dedup_balance_via_replay() -> None:
     amounts = [Decimal(str(t["amount"])) for t in txns]
     net = sum(amounts, Decimal("0"))
 
-    # Both same-amount deposits survived (the #1254 oracle: count is preserved).
+    # Both same-amount deposits survived (the #1254 oracle: count is preserved)
+    # and no row was dropped or invented overall.
+    assert len(txns) == 3
     assert sum(1 for a in amounts if a == _DUP_DEPOSIT) == 2
     assert abs(opening - _DUP_OPENING) <= _TEXT_TOLERANCE
     assert abs(closing - _DUP_CLOSING) <= _TEXT_TOLERANCE

--- a/apps/backend/tests/fixtures/llm_cassettes/cb5dd1f714784190dab3356c17d635a0e09b8f9fca78abb6023218ca29efcbab.json
+++ b/apps/backend/tests/fixtures/llm_cassettes/cb5dd1f714784190dab3356c17d635a0e09b8f9fca78abb6023218ca29efcbab.json
@@ -1,0 +1,26 @@
+{
+  "fingerprint": "cb5dd1f714784190dab3356c17d635a0e09b8f9fca78abb6023218ca29efcbab",
+  "request": {
+    "decode_params": {
+      "extra_body": {
+        "thinking": {
+          "type": "disabled"
+        }
+      },
+      "max_tokens": 512,
+      "temperature": 0.0
+    },
+    "messages": [
+      {
+        "content": "Extract this bank statement as strict JSON only (no prose, no markdown fence) with keys opening_balance, closing_balance, transactions (a list of {date, description, amount}). Amounts are negative for debits, positive for credits.\n\nOpening balance: 1000.00\n2026-02-01  Deposit ABC        +250.00\n2026-02-01  Deposit ABC        +250.00\n2026-02-03  Service fee         -10.00\nClosing balance: 1490.00\n",
+        "role": "user"
+      }
+    ],
+    "role": "text"
+  },
+  "response": {
+    "stream_text": "{\n  \"opening_balance\": 1000.00,\n  \"closing_balance\": 1490.00,\n  \"transactions\": [\n    {\n      \"date\": \"2026-02-01\",\n      \"description\": \"Deposit ABC\",\n      \"amount\": 250.00\n    },\n    {\n      \"date\": \"2026-02-01\",\n      \"description\": \"Deposit ABC\",\n      \"amount\": 250.00\n    },\n    {\n      \"date\": \"2026-02-03\",\n      \"description\": \"Service fee\",\n      \"amount\": -10.00\n    }\n  ]\n}"
+  },
+  "role": "text",
+  "tag": "flow-only"
+}


### PR DESCRIPTION
Adds the #1254-class slice of #1306 (text path, building on the merged #1320 bridge + #1322 text cassette).

## What
- **#1254-class test**: a statement with two genuine same-date/same-amount deposits; asserts BOTH survive extraction (the #1254 bug dropped one) and the balance chain reconciles — on the frozen real `glm-5.2` output, **Decimal**, no key/network in replay.
- **Gate fix**: skip only in OFF mode (was `not REPLAY`, which also skipped RECORD so cassettes could never be recorded). OFF→skip (shards), RECORD→record, REPLAY→replay. Verified: record runs, replay-no-key passes text+#1254, shards skip all 3.
- **Vision deferred**: the z.ai coding endpoint rejects a hand-built image payload (`BadRequestError 图片输入格式/解析错误`); vision needs the apps real PDF→PNG render path + a document image — tracked as the remaining #1306 follow-up (test stays skip-marked).

## Data hygiene
Synthetic/anonymised statement + cassette — no real financial data.

Part of #1306.