### PR TITLE
[finance_report_audit] feat(orm): reporting portfolio valuation flows Money via fx.convert_money (AC12.35.3)

### DIFF
--- a/apps/backend/src/services/reporting/portfolio_market.py
+++ b/apps/backend/src/services/reporting/portfolio_market.py
@@ -73,12 +73,12 @@ async def _portfolio_market_basis_by_account(
             continue
 
         source_currency = position.currency.upper()
-        # Value/cost flow as Money; convert only when the position is non-base
-        # (per-position values are not quantized here — accumulators are Decimal).
+        # Value/cost flow as Money; convert only when source and target currencies
+        # differ (per-position values are not quantized here — accumulators are Decimal).
         position_quantity = position.quantity_qty.quantize()
         market_value = UnitPrice(latest_price, source_currency, REPORTING_QUANTITY_UNIT) * position_quantity
         cost_basis = position.cost_basis_money
-        if source_currency != target_currency:
+        if source_currency != target_currency.upper():
             try:
                 market_value = await fx.convert_money(
                     db, market_value, target_currency, rate_date=portfolio_eval_date, lazy_load=True

--- a/apps/backend/src/services/reporting/portfolio_market.py
+++ b/apps/backend/src/services/reporting/portfolio_market.py
@@ -21,7 +21,6 @@ from src.models.layer3 import (
     ManualValuationLiquidityClass,
     PositionStatus,
 )
-from src.quantity import Quantity
 from src.services import fx
 from src.services.fx import (
     FxRateError,
@@ -32,6 +31,7 @@ from src.services.reporting_calc import (
     ReportError,
     _quantize_money,
 )
+from src.unit_price import UnitPrice
 
 logger = get_logger(__name__)
 
@@ -72,27 +72,19 @@ async def _portfolio_market_basis_by_account(
             )
             continue
 
-        position_quantity = Quantity(position.quantity, REPORTING_QUANTITY_UNIT).quantize()
-        market_value = position_quantity.value * latest_price
-        cost_basis = position.cost_basis
         source_currency = position.currency.upper()
+        # Value/cost flow as Money; convert only when the position is non-base
+        # (per-position values are not quantized here — accumulators are Decimal).
+        position_quantity = position.quantity_qty.quantize()
+        market_value = UnitPrice(latest_price, source_currency, REPORTING_QUANTITY_UNIT) * position_quantity
+        cost_basis = position.cost_basis_money
         if source_currency != target_currency:
             try:
-                market_value = await fx.convert_amount(
-                    db,
-                    amount=market_value,
-                    currency=source_currency,
-                    target_currency=target_currency,
-                    rate_date=portfolio_eval_date,
-                    lazy_load=True,
+                market_value = await fx.convert_money(
+                    db, market_value, target_currency, rate_date=portfolio_eval_date, lazy_load=True
                 )
-                cost_basis = await fx.convert_amount(
-                    db,
-                    amount=cost_basis,
-                    currency=source_currency,
-                    target_currency=target_currency,
-                    rate_date=position.acquisition_date,
-                    lazy_load=True,
+                cost_basis = await fx.convert_money(
+                    db, cost_basis, target_currency, rate_date=position.acquisition_date, lazy_load=True
                 )
             except FxRateError as exc:
                 raise ReportError(str(exc)) from exc
@@ -106,8 +98,8 @@ async def _portfolio_market_basis_by_account(
                 "source_currencies": set(),
             },
         )
-        basis["market_value"] = Decimal(str(basis["market_value"])) + market_value
-        basis["cost_basis"] = Decimal(str(basis["cost_basis"])) + cost_basis
+        basis["market_value"] = Decimal(str(basis["market_value"])) + market_value.amount
+        basis["cost_basis"] = Decimal(str(basis["cost_basis"])) + cost_basis.amount
         basis["source_currencies"].add(source_currency)
 
     return basis_by_account

--- a/tests/tooling/test_base_package_migration_cleanup.py
+++ b/tests/tooling/test_base_package_migration_cleanup.py
@@ -212,8 +212,10 @@ def test_AC12_31_7_backend_quantity_business_code_uses_value_type():
     ]
     for path in BACKEND_QUANTITY_ADAPTER_FILES:
         src = _read(path)
-        assert "from src.quantity import Quantity" in src, (
-            f"{path} must use the Quantity value type"
+        # value type used by direct import OR via a model .quantity_qty accessor
+        # (the #3 boundary push: reporting reads Quantity off the ORM accessor).
+        assert "from src.quantity import Quantity" in src or "quantity_qty" in src, (
+            f"{path} must use the Quantity value type (import or .quantity_qty accessor)"
         )
         for needle in forbidden_local_adapters:
             assert needle not in src, (
@@ -245,10 +247,8 @@ def test_AC12_31_7_backend_quantity_business_code_uses_value_type():
     assert "snapshot_quantity.is_zero()" in portfolio
 
     reporting = _read(Path("apps/backend/src/services/reporting"))
-    assert (
-        "position_quantity = Quantity(position.quantity, REPORTING_QUANTITY_UNIT).quantize()"
-        in reporting
-    )
+    # Quantity flows via the ManagedPosition.quantity_qty accessor (#3 boundary push).
+    assert "position_quantity = position.quantity_qty.quantize()" in reporting
 
 
 @ac_proof(

--- a/tests/tooling/test_base_package_migration_cleanup.py
+++ b/tests/tooling/test_base_package_migration_cleanup.py
@@ -214,7 +214,7 @@ def test_AC12_31_7_backend_quantity_business_code_uses_value_type():
         src = _read(path)
         # value type used by direct import OR via a model .quantity_qty accessor
         # (the #3 boundary push: reporting reads Quantity off the ORM accessor).
-        assert "from src.quantity import Quantity" in src or "quantity_qty" in src, (
+        assert "from src.quantity import Quantity" in src or ".quantity_qty" in src, (
             f"{path} must use the Quantity value type (import or .quantity_qty accessor)"
         )
         for needle in forbidden_local_adapters:

--- a/tests/tooling/test_decimal_boundary_policy.py
+++ b/tests/tooling/test_decimal_boundary_policy.py
@@ -74,7 +74,7 @@ def test_AC12_31_3_migrated_hotspots_use_base_packages():
     for path in quantity_service_files:
         src = _read(path)
         # value type via direct import OR a model .quantity_qty accessor (#3 push)
-        assert "from src.quantity import Quantity" in src or "quantity_qty" in src, (
+        assert "from src.quantity import Quantity" in src or ".quantity_qty" in src, (
             f"{path} must use Quantity (import or .quantity_qty accessor)"
         )
         assert "quantized_quantity_value" not in src

--- a/tests/tooling/test_decimal_boundary_policy.py
+++ b/tests/tooling/test_decimal_boundary_policy.py
@@ -73,7 +73,10 @@ def test_AC12_31_3_migrated_hotspots_use_base_packages():
     )
     for path in quantity_service_files:
         src = _read(path)
-        assert "from src.quantity import Quantity" in src, f"{path} must use Quantity"
+        # value type via direct import OR a model .quantity_qty accessor (#3 push)
+        assert "from src.quantity import Quantity" in src or "quantity_qty" in src, (
+            f"{path} must use Quantity (import or .quantity_qty accessor)"
+        )
         assert "quantized_quantity_value" not in src
         assert "quantity_is_zero" not in src
         assert "quantity_zero_value" not in src
@@ -83,10 +86,9 @@ def test_AC12_31_3_migrated_hotspots_use_base_packages():
 
     reporting = _read(Path("apps/backend/src/services/reporting"))
     assert "position.quantity * latest_price" not in reporting
-    assert (
-        "position_quantity = Quantity(position.quantity, REPORTING_QUANTITY_UNIT).quantize()"
-        in reporting
-    )
+    # Quantity flows via the ManagedPosition.quantity_qty accessor (#3 boundary push);
+    # market value is UnitPrice(price) * quantity, no raw quantity*price.
+    assert "position_quantity = position.quantity_qty.quantize()" in reporting
 
     investment = _read(Path("apps/backend/src/services/investment_accounting.py"))
     assert (

--- a/tests/tooling/test_orm_value_type_boundary.py
+++ b/tests/tooling/test_orm_value_type_boundary.py
@@ -71,3 +71,9 @@ def test_AC12_35_3_portfolio_holdings_value_flows_as_money():
     assert "position.cost_basis_money" in src
     assert "position.quantity_qty" in src
     assert "UnitPrice(latest_price" in src
+
+    # reporting's portfolio valuation also flows Money via the same helpers
+    market = _read("apps/backend/src/services/reporting/portfolio_market.py")
+    assert "fx.convert_money(" in market
+    assert "position.cost_basis_money" in market
+    assert "position.quantity_qty" in market


### PR DESCRIPTION
Extends **#3 (boundary push)** to the reporting portfolio valuation.

## What

`_portfolio_market_basis_by_account` (reporting) now flows `Money`:
- market value = `UnitPrice(price) * position.quantity_qty` → `fx.convert_money(target)` → `Money`; cost via `position.cost_basis_money`.
- Converts to the report's `target_currency` (not just base); `FxRateError → ReportError` preserved.
- Per-position values are not quantized (Decimal accumulators add `.amount`) — matches prior behaviour exactly.

## Guards

- AC12.35.3 extended to assert `portfolio_market.py` uses the Money-native helpers.
- Quantity-adoption guards (AC12.31.3 / .7) now accept the `.quantity_qty` accessor as Quantity value-type usage — reporting no longer needs a direct `from src.quantity import Quantity` (it reads Quantity off the ORM accessor). Caught **pre-push** by running the full tooling guard suite locally.

## Verification

- **351** reporting/portfolio/net-worth tests pass (behaviour-preserving).
- Full tooling guard suite (**1631**) + `ruff` green — run locally before pushing (per the guard-brittleness lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)