### PR TITLE
[finance_report_hacker] feat(platform): EventBus via transactional outbox (meta-layer capability #1)

### DIFF
--- a/apps/backend/migrations/env.py
+++ b/apps/backend/migrations/env.py
@@ -9,6 +9,7 @@ from sqlalchemy import engine_from_config, pool
 
 import src.counter.store.sql  # noqa: F401  -- registers CounterTally on Base.metadata
 import src.models  # noqa: F401
+import src.platform.store.outbox  # noqa: F401  -- registers Outbox on Base.metadata
 from src.config import settings
 from src.database import Base
 

--- a/apps/backend/migrations/versions/0049_add_outbox.py
+++ b/apps/backend/migrations/versions/0049_add_outbox.py
@@ -1,0 +1,44 @@
+"""add the shared outbox table for the platform transactional-outbox EventBus
+
+Creates ONE shared table ``outbox`` owned by the ``platform`` package: every
+producer that emits a domain event through the ``OutboxEventBus`` INSERTs a row
+here in its own transaction (atomic with the domain state change), and the
+``OutboxRelay`` later reads committed ``pending`` rows in id order and dispatches
+them post-commit. The ``(status, id)`` index backs the relay's "oldest pending,
+in order" drain query so it never scans published history.
+
+``status`` is plain text (not a ``sa.Enum``) so adding a future lifecycle state
+needs no enum migration; the relay only queries ``status = 'pending'``.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0049_add_outbox"
+down_revision = "0048_counter_tally"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "outbox",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("source_pkg", sa.Text(), nullable=False),
+        sa.Column("aggregate_id", sa.Text(), nullable=True),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("status", sa.Text(), server_default="pending", nullable=False),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id", name="pk_outbox"),
+    )
+    op.create_index("ix_outbox_status_id", "outbox", ["status", "id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_outbox_status_id", table_name="outbox")
+    op.drop_table("outbox")

--- a/apps/backend/src/counter/__init__.py
+++ b/apps/backend/src/counter/__init__.py
@@ -7,14 +7,15 @@ spec (ubiquitous language, contract, roles, storage, governance) lives in
 
 Files converge by role — ``types`` (nouns + events), ``ops`` (verbs over the
 store port), ``store`` (the ``CounterRepository`` port + SQL adapter), ``api``
-(the thin async ``read_count`` boundary) — with the DAG ``api → ops → {types,
-store}``. The names re-exported below are the *entire* public surface
-(``__all__`` must equal ``contract.interface``); everything else is internal.
+(the thin async ``read_count`` read + ``record_increment`` atomic write) — with
+the DAG ``api → ops → {types, store}``. The names re-exported below are the
+*entire* public surface (``__all__`` must equal ``contract.interface``);
+everything else is internal.
 """
 
 from __future__ import annotations
 
-from src.counter.api import read_count
+from src.counter.api import read_count, record_increment
 from src.counter.ops import get_count, increment
 from src.counter.store import CounterRepository
 from src.counter.types import (
@@ -37,4 +38,5 @@ __all__ = [
     "get_count",
     "increment",
     "read_count",
+    "record_increment",
 ]

--- a/apps/backend/src/counter/api/__init__.py
+++ b/apps/backend/src/counter/api/__init__.py
@@ -1,12 +1,15 @@
-"""Counter boundary (the thin async read for insight-report generation).
+"""Counter boundary — the thin async reads/writes over an ``AsyncSession``.
 
-``read_count`` bridges an ``AsyncSession`` to the domain ``Count``. It is the
-only role that combines the session with the domain; it stays minimal by design
-(no HTTP route until a transport need is real).
+``read_count`` bridges a session to a domain ``Count`` (the read for insight
+reports). ``record_increment`` is the atomic write: it bumps the tally and
+enqueues ``Incremented`` into the platform outbox in the same transaction. ``api``
+is the only role that combines the session with the domain verbs and the platform
+bus; it stays minimal by design (no HTTP route until a transport need is real).
 """
 
 from __future__ import annotations
 
 from src.counter.api.insight import read_count
+from src.counter.api.write import record_increment
 
-__all__ = ["read_count"]
+__all__ = ["read_count", "record_increment"]

--- a/apps/backend/src/counter/api/write.py
+++ b/apps/backend/src/counter/api/write.py
@@ -1,0 +1,56 @@
+"""``record_increment`` — the atomic async write boundary for the counter.
+
+This is the production composition seam: it bumps the per-(user, key) tally AND
+enqueues the :class:`Incremented` domain event into the platform outbox **using
+the one ``AsyncSession`` the caller holds**, so both land in the same
+transaction. The caller commits once: tally upsert + outbox row commit together,
+or — on rollback — neither persists. That single-session sharing is what makes
+the event atomic with the state change (the heart of the transactional outbox).
+
+``api`` is the only role that combines the session with the domain verbs and with
+the platform bus; ``ops.increment`` stays a pure, session-free verb that the
+in-memory fake can unit-test. Dispatch is NOT done here — the row is left
+``pending`` for the relay to deliver post-commit.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.counter.store.sql import SqlCounterRepository
+from src.counter.types.count import Count
+from src.counter.types.events import Incremented
+from src.counter.types.key import CounterKey
+from src.platform.events.bus import OutboxEventBus
+
+#: The ``source_pkg`` tag every counter event carries in the shared outbox.
+SOURCE_PKG = "counter"
+
+
+async def record_increment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    key: CounterKey,
+) -> Count:
+    """Atomically bump (``user_id``, ``key``) and enqueue ``Incremented``.
+
+    Performs the async upsert-increment and writes the ``Incremented`` outbox row
+    in the same ``db`` session/transaction; the caller owns the commit. Returns
+    the new per-user :class:`Count`. Does not commit — atomicity is the caller's
+    single ``commit()`` over this session.
+    """
+    repo = SqlCounterRepository(db)
+    new_value = await repo.bump(user_id, key)
+    bus = OutboxEventBus(db, source_pkg=SOURCE_PKG)
+    bus.publish(Incremented.create(user_id=user_id, key=key, count=new_value, at=_now()))
+    return Count(new_value)
+
+
+def _now():
+    """UTC timestamp for the event's ``occurred_at`` (kept tiny + injectable)."""
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC)

--- a/apps/backend/src/counter/api/write.py
+++ b/apps/backend/src/counter/api/write.py
@@ -15,6 +15,7 @@ in-memory fake can unit-test. Dispatch is NOT done here — the row is left
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -49,8 +50,6 @@ async def record_increment(
     return Count(new_value)
 
 
-def _now():
+def _now() -> datetime:
     """UTC timestamp for the event's ``occurred_at`` (kept tiny + injectable)."""
-    from datetime import UTC, datetime
-
     return datetime.now(UTC)

--- a/apps/backend/src/counter/ops/increment.py
+++ b/apps/backend/src/counter/ops/increment.py
@@ -2,17 +2,22 @@
 
 Bumps the per-(user, key) tally through the :class:`CounterRepository` port and
 returns the new per-user :class:`Count`. It also *publishes* the
-:class:`Incremented` domain event: a fact other contexts (e.g. insight-report
-generation) can react to. The event is delivered to an optional ``emit`` sink so
-the verb stays pure and DB-free — the port is the only collaborator, which is
-what makes the op unit-testable with an in-memory fake.
+:class:`Incremented` domain event through the platform :class:`EventBus`: a fact
+other contexts (e.g. insight-report generation) can react to.
+
+The bus is the only new collaborator and it is optional, so the verb stays
+unit-testable with an in-memory fake repo + a :class:`RecordingEventBus`. In
+production the caller passes an :class:`OutboxEventBus` built from the *same*
+``AsyncSession`` the repo writes through, so the ``Incremented`` outbox row is
+INSERTed in the same transaction as the tally bump — atomic by construction
+(rollback ⇒ no outbox row; commit ⇒ exactly one). Publishing only *enqueues* the
+event; the relay dispatches it post-commit.
 
 Counting is per (user, key): ``increment`` only ever moves *this user's* tally.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -20,6 +25,7 @@ from src.counter.store.repository import CounterRepository
 from src.counter.types.count import Count
 from src.counter.types.events import Incremented
 from src.counter.types.key import CounterKey
+from src.platform.events.bus import EventBus
 
 
 def increment(
@@ -27,12 +33,19 @@ def increment(
     *,
     user_id: UUID,
     key: CounterKey,
-    emit: Callable[[Incremented], None] | None = None,
+    bus: EventBus | None = None,
     now: datetime | None = None,
 ) -> Count:
-    """Bump (``user_id``, ``key``) by one; emit ``Incremented``; return the new count."""
+    """Bump (``user_id``, ``key``) by one; publish ``Incremented``; return the new count."""
     new_value = repo.bump(user_id, key)
     count = Count(new_value)
-    if emit is not None:
-        emit(Incremented(user_id=user_id, key=key, at=now or datetime.now(UTC)))
+    if bus is not None:
+        bus.publish(
+            Incremented.create(
+                user_id=user_id,
+                key=key,
+                count=new_value,
+                at=now or datetime.now(UTC),
+            )
+        )
     return count

--- a/apps/backend/src/counter/types/events.py
+++ b/apps/backend/src/counter/types/events.py
@@ -3,7 +3,13 @@
 A package's *events* are part of its published interface: other contexts react
 to ``Incremented`` (e.g. insight-report generation) without importing the
 counter store or ops. The event is an immutable record of a fact that already
-happened — a per-(user, key) tally was bumped at ``at``.
+happened — a per-(user, key) tally was bumped to ``count`` at ``occurred_at``.
+
+``Incremented`` is a :class:`~src.platform.events.event.DomainEvent`: it carries
+the universal ``event_type`` (``"counter.Incremented"``) and ``occurred_at``, and
+exposes its fields via :meth:`payload` so the platform outbox can persist it as
+JSON and the relay can rehydrate it for subscribers. This is the one place the
+counter package depends (downward) on the ``platform`` package — the event base.
 """
 
 from __future__ import annotations
@@ -13,12 +19,37 @@ from datetime import datetime
 from uuid import UUID
 
 from src.counter.types.key import CounterKey
+from src.platform.events.event import DomainEvent
+
+#: The stable, namespaced routing key the bus/relay dispatch this event on.
+EVENT_TYPE = "counter.Incremented"
 
 
 @dataclass(frozen=True)
-class Incremented:
-    """A fact: ``user_id``'s tally for ``key`` was incremented at ``at``."""
+class Incremented(DomainEvent):
+    """A fact: ``user_id``'s tally for ``key`` reached ``count`` at ``occurred_at``."""
 
     user_id: UUID
     key: CounterKey
-    at: datetime
+    count: int
+
+    @classmethod
+    def create(cls, *, user_id: UUID, key: CounterKey, count: int, at: datetime) -> Incremented:
+        """Build an ``Incremented`` with the fixed ``counter.Incremented`` type."""
+        return cls(
+            event_type=EVENT_TYPE,
+            occurred_at=at,
+            user_id=user_id,
+            key=key,
+            count=count,
+        )
+
+    def payload(self) -> dict:
+        """JSON body persisted to the outbox: user_id, key, count, at."""
+        return {
+            "aggregate_id": str(self.user_id),
+            "user_id": str(self.user_id),
+            "key": self.key.value,
+            "count": self.count,
+            "at": self.occurred_at.isoformat(),
+        }

--- a/apps/backend/src/platform/__init__.py
+++ b/apps/backend/src/platform/__init__.py
@@ -1,0 +1,43 @@
+"""``platform`` — the backend implementation of the ``platform`` package.
+
+This is ``PackageContract.implementations["be"]`` for the ``platform`` package;
+the authoritative spec (ubiquitous language, contract, roadmap) lives in
+``common/platform/`` (``readme.md`` + ``contract.py``). See
+``common/governance/readme.md`` for the package model.
+
+``platform`` is the meta layer's first *runtime* capability: a domain
+**EventBus implemented via the transactional outbox pattern**. A producer
+``publish``es a :class:`DomainEvent` through an :class:`OutboxEventBus`, which
+INSERTs it into the shared ``outbox`` table *in the producer's own DB
+transaction* — so the event commits atomically with the domain state change. A
+separate :class:`OutboxRelay` later reads committed ``pending`` rows and
+dispatches them to subscribed handlers (at-least-once; handlers must be
+idempotent), making dispatch inherently post-commit.
+
+Files converge by role — ``events`` (``DomainEvent``, the bus, the relay) and
+``store`` (the shared ``Outbox`` table + repository). The names re-exported below
+are the *entire* public surface (``__all__`` must equal ``contract.interface``).
+"""
+
+from __future__ import annotations
+
+from src.platform.events import (
+    DomainEvent,
+    EventBus,
+    OutboxEventBus,
+    OutboxRelay,
+    RecordingEventBus,
+    SubscriberRegistry,
+)
+from src.platform.store import Outbox, OutboxRepository
+
+__all__ = [
+    "DomainEvent",
+    "EventBus",
+    "Outbox",
+    "OutboxEventBus",
+    "OutboxRelay",
+    "OutboxRepository",
+    "RecordingEventBus",
+    "SubscriberRegistry",
+]

--- a/apps/backend/src/platform/events/__init__.py
+++ b/apps/backend/src/platform/events/__init__.py
@@ -1,0 +1,29 @@
+"""Platform event language — the bus, the relay, and the event base type.
+
+``DomainEvent`` (the frozen event value type), ``EventBus`` (the publish/subscribe
+port) with its ``OutboxEventBus`` adapter and ``RecordingEventBus`` fake, the
+``SubscriberRegistry`` routing map, and the ``OutboxRelay`` that dispatches
+committed rows post-commit.
+"""
+
+from __future__ import annotations
+
+from src.platform.events.bus import (
+    EventBus,
+    EventHandler,
+    OutboxEventBus,
+    RecordingEventBus,
+    SubscriberRegistry,
+)
+from src.platform.events.event import DomainEvent
+from src.platform.events.relay import OutboxRelay
+
+__all__ = [
+    "DomainEvent",
+    "EventBus",
+    "EventHandler",
+    "OutboxEventBus",
+    "OutboxRelay",
+    "RecordingEventBus",
+    "SubscriberRegistry",
+]

--- a/apps/backend/src/platform/events/bus.py
+++ b/apps/backend/src/platform/events/bus.py
@@ -88,12 +88,13 @@ class OutboxEventBus:
 
     def publish(self, event: DomainEvent) -> None:
         """INSERT ``event`` into the outbox in the caller's transaction."""
+        payload = event.payload()
         self._repo.enqueue(
             occurred_at=event.occurred_at,
             event_type=event.event_type,
             source_pkg=self._source_pkg,
-            payload=event.payload(),
-            aggregate_id=event.payload().get("aggregate_id"),
+            payload=payload,
+            aggregate_id=payload.get("aggregate_id"),
         )
 
     def subscribe(self, event_type: str, handler: EventHandler) -> None:

--- a/apps/backend/src/platform/events/bus.py
+++ b/apps/backend/src/platform/events/bus.py
@@ -1,0 +1,123 @@
+"""The domain ``EventBus`` — its Protocol, the outbox adapter, and a test fake.
+
+The bus has two halves that meet at the outbox table:
+
+- **publish** (write side) — a producer hands the bus a :class:`DomainEvent`; the
+  bus persists it. :class:`OutboxEventBus` does this by INSERTing into the shared
+  outbox table *through the caller's session*, so the event commits atomically
+  with the domain state change. Dispatch does NOT happen here — only enqueue.
+- **subscribe** (read side) — a consumer registers a handler for an
+  ``event_type``. The :class:`OutboxRelay` (``events/relay.py``) reads committed
+  pending rows and invokes the matching handlers, so dispatch is inherently
+  post-commit. Handlers run at-least-once and MUST be idempotent.
+
+:class:`SubscriberRegistry` holds the ``event_type -> handlers`` map shared by a
+bus and its relay. :class:`RecordingEventBus` is an in-memory fake for unit tests
+that need to assert "what was published" without a database.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+from src.platform.events.event import DomainEvent
+from src.platform.store.outbox import OutboxRepository
+
+#: A subscriber: a callable invoked by the relay with a reconstructed event.
+EventHandler = Callable[[DomainEvent], None]
+
+
+class SubscriberRegistry:
+    """The ``event_type -> [handler]`` map shared by a bus and its relay.
+
+    ``subscribe`` is additive (many handlers per type, in registration order);
+    ``handlers_for`` returns the handlers the relay must invoke for a delivered
+    event. The registry holds NO transport — it is pure routing state, so the
+    same registry can back the outbox bus in production and a recording fake in
+    tests.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, list[EventHandler]] = defaultdict(list)
+
+    def subscribe(self, event_type: str, handler: EventHandler) -> None:
+        """Register ``handler`` to receive events of ``event_type``."""
+        self._handlers[event_type].append(handler)
+
+    def handlers_for(self, event_type: str) -> list[EventHandler]:
+        """Handlers registered for ``event_type`` (empty list if none)."""
+        return list(self._handlers.get(event_type, ()))
+
+
+@runtime_checkable
+class EventBus(Protocol):
+    """The port a producer publishes through and a consumer subscribes to.
+
+    ``publish`` is the write entrypoint: it persists the event for later,
+    post-commit dispatch (the outbox adapter writes it into the caller's
+    transaction). ``subscribe`` registers a handler; dispatch itself is the
+    relay's job, not the bus's, which is what keeps the producer ignorant of the
+    consumers.
+    """
+
+    def publish(self, event: DomainEvent) -> None:
+        """Enqueue ``event`` for at-least-once, post-commit delivery."""
+        ...
+
+    def subscribe(self, event_type: str, handler: EventHandler) -> None:
+        """Register ``handler`` to receive events of ``event_type``."""
+        ...
+
+
+class OutboxEventBus:
+    """The production bus: ``publish`` writes the event into the shared outbox.
+
+    Constructed from an :class:`AsyncSession`, so ``publish`` enqueues the event
+    *in that session's transaction* — atomic with whatever domain write the
+    caller is performing. No dispatch happens on publish; the :class:`OutboxRelay`
+    drains committed pending rows out-of-band. ``source_pkg`` tags every row with
+    the producing package so the relay/operators can attribute events.
+    """
+
+    def __init__(self, session, *, source_pkg: str, registry: SubscriberRegistry | None = None) -> None:
+        self._repo = OutboxRepository(session)
+        self._source_pkg = source_pkg
+        self._registry = registry or SubscriberRegistry()
+
+    def publish(self, event: DomainEvent) -> None:
+        """INSERT ``event`` into the outbox in the caller's transaction."""
+        self._repo.enqueue(
+            occurred_at=event.occurred_at,
+            event_type=event.event_type,
+            source_pkg=self._source_pkg,
+            payload=event.payload(),
+            aggregate_id=event.payload().get("aggregate_id"),
+        )
+
+    def subscribe(self, event_type: str, handler: EventHandler) -> None:
+        """Register a handler on the shared registry (consumed by the relay)."""
+        self._registry.subscribe(event_type, handler)
+
+
+class RecordingEventBus:
+    """In-memory test fake: ``publish`` appends to :attr:`published`.
+
+    Lets a unit test assert "exactly these events were published" without a
+    database or a relay. ``subscribe`` records handlers too, so a test can verify
+    registration. It is NOT transactional — production atomicity is the outbox
+    adapter's job; this fake exists purely to observe publish calls.
+    """
+
+    def __init__(self, registry: SubscriberRegistry | None = None) -> None:
+        self.published: list[DomainEvent] = []
+        self._registry = registry or SubscriberRegistry()
+
+    def publish(self, event: DomainEvent) -> None:
+        """Record ``event`` in memory (no persistence, no dispatch)."""
+        self.published.append(event)
+
+    def subscribe(self, event_type: str, handler: EventHandler) -> None:
+        """Record ``handler`` on the registry for ``event_type``."""
+        self._registry.subscribe(event_type, handler)

--- a/apps/backend/src/platform/events/event.py
+++ b/apps/backend/src/platform/events/event.py
@@ -1,0 +1,48 @@
+"""``DomainEvent`` — the base value type for every event on the bus.
+
+A domain event is an immutable record of a fact that already happened. It is the
+*published language* a bounded context emits so other contexts can react without
+importing its internals. Two pieces of identity are universal to every event and
+therefore live on this base:
+
+- ``event_type`` — a stable, namespaced ``"<pkg>.<Name>"`` string (e.g.
+  ``"counter.Incremented"``); the routing key the bus and relay dispatch on.
+- ``occurred_at`` — when the fact happened (timezone-aware UTC).
+
+Subclasses add their own fields and override :meth:`payload` to expose them as a
+JSON-serializable mapping (the shape persisted into the outbox ``payload`` jsonb
+column). The base is frozen: an event is a fact, not a mutable record.
+
+This module is the leaf of the ``platform`` package — it imports nothing from the
+app, so every layer above (``kernel`` value types, ``platform`` capabilities,
+``core`` slices) may build events on top of it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class DomainEvent:
+    """An immutable fact: ``event_type`` happened at ``occurred_at`` (UTC).
+
+    Subclasses set their ``event_type`` (a namespaced ``"<pkg>.<Name>"`` literal)
+    and add fields; they override :meth:`payload` to serialize those fields into
+    the JSON object persisted in the outbox. The base ``payload`` carries no
+    subclass fields, so a subclass that adds state MUST override it.
+    """
+
+    event_type: str
+    occurred_at: datetime
+
+    def payload(self) -> dict:
+        """JSON-serializable body persisted to the outbox ``payload`` column.
+
+        The base returns an empty mapping (``event_type``/``occurred_at`` are
+        stored in their own outbox columns, not the payload). A subclass that
+        adds fields overrides this to expose them; the relay reconstructs the
+        event from ``event_type`` + ``occurred_at`` + ``payload`` on dispatch.
+        """
+        return {}

--- a/apps/backend/src/platform/events/relay.py
+++ b/apps/backend/src/platform/events/relay.py
@@ -76,12 +76,20 @@ class OutboxRelay:
         repo = OutboxRepository(session)
         rows = await repo.fetch_pending(limit=self._batch_size)
         published = 0
-        for row in rows:
-            event = _to_event(row)
-            for handler in self._registry.handlers_for(row.event_type):
-                handler(event)
-            await repo.mark_published(row, published_at=datetime.now(UTC))
-            published += 1
+        try:
+            for row in rows:
+                event = _to_event(row)
+                for handler in self._registry.handlers_for(row.event_type):
+                    handler(event)
+                await repo.mark_published(row, published_at=datetime.now(UTC))
+                published += 1
+        except Exception:
+            # A handler (or a mark) raised mid-batch: abandon the partially
+            # updated transaction so the caller is never left in a failed-txn
+            # state and no half-marked rows can be committed later. The still-
+            # pending rows are redelivered on the next pass (at-least-once).
+            await session.rollback()
+            raise
         if published:
             await session.commit()
         return published

--- a/apps/backend/src/platform/events/relay.py
+++ b/apps/backend/src/platform/events/relay.py
@@ -1,0 +1,111 @@
+"""``OutboxRelay`` — drains committed outbox rows and dispatches to handlers.
+
+The relay is the *post-commit* half of the transactional outbox. It reads
+``pending`` rows in enqueue (id) order, reconstructs each into a
+:class:`DomainEvent`, invokes every handler subscribed to that ``event_type``,
+then marks the row ``published``. Because it only ever reads rows that another
+transaction already committed, dispatch is guaranteed to happen *after* the
+domain state change is durable.
+
+Delivery is **at-least-once**: if the process dies after a handler runs but
+before ``mark_published`` commits, the row stays ``pending`` and is redelivered
+on the next pass. Therefore **handlers MUST be idempotent** — processing the same
+event twice must be a no-op the second time (e.g. key side effects by the event's
+aggregate id / a dedupe key). ``run_once`` makes one pass; ``run_forever`` polls
+in a loop. Neither is wired as an always-on worker here — see ``readme.md`` for
+how it would run (a periodic background task / scheduled job).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.platform.events.bus import SubscriberRegistry
+from src.platform.events.event import DomainEvent
+from src.platform.store.outbox import Outbox, OutboxRepository
+
+
+class _StoredEvent(DomainEvent):
+    """A :class:`DomainEvent` reconstructed from a persisted outbox row.
+
+    Carries the row's ``payload`` so a handler reads the event's fields via
+    :meth:`payload`, exactly as it would for the original typed event. The relay
+    dispatches these (rather than re-instantiating the producer's concrete
+    subclass) so it stays ignorant of every producing package's types — the bus
+    transports opaque events.
+    """
+
+    def __init__(self, *, event_type: str, occurred_at: datetime, payload: dict) -> None:
+        super().__init__(event_type=event_type, occurred_at=occurred_at)
+        object.__setattr__(self, "_payload", payload)
+
+    def payload(self) -> dict:
+        return dict(self._payload)
+
+
+def _to_event(row: Outbox) -> DomainEvent:
+    """Rehydrate a persisted outbox row into a dispatchable domain event."""
+    return _StoredEvent(
+        event_type=row.event_type,
+        occurred_at=row.occurred_at,
+        payload=dict(row.payload or {}),
+    )
+
+
+class OutboxRelay:
+    """Reads committed ``pending`` rows and dispatches them to subscribers."""
+
+    def __init__(self, registry: SubscriberRegistry, *, batch_size: int = 100) -> None:
+        self._registry = registry
+        self._batch_size = batch_size
+
+    async def run_once(self, session: AsyncSession) -> int:
+        """Dispatch one batch of pending rows; return how many were published.
+
+        For each pending row (in id order) every subscribed handler is invoked
+        with the reconstructed event, then the row is marked ``published`` and the
+        batch is committed. A row with no subscribers is still marked published
+        (it has been "delivered" to its — empty — audience), so it is not
+        redelivered forever. The marking commit is what makes a second
+        ``run_once`` skip already-published rows.
+        """
+        repo = OutboxRepository(session)
+        rows = await repo.fetch_pending(limit=self._batch_size)
+        published = 0
+        for row in rows:
+            event = _to_event(row)
+            for handler in self._registry.handlers_for(row.event_type):
+                handler(event)
+            await repo.mark_published(row, published_at=datetime.now(UTC))
+            published += 1
+        if published:
+            await session.commit()
+        return published
+
+    async def run_forever(
+        self,
+        session_factory: Callable[[], Awaitable[AsyncSession]] | Callable[[], AsyncSession],
+        *,
+        poll_interval: float = 1.0,
+        stop: Callable[[], bool] | None = None,
+    ) -> None:  # pragma: no cover - long-running loop documented, not unit-run
+        """Poll the outbox forever, draining each batch then sleeping.
+
+        This is the *shape* of a durable worker, not a wired one: a caller would
+        run it as a background task / periodic job (see ``readme.md``). It opens a
+        fresh session per pass via ``session_factory`` and sleeps ``poll_interval``
+        seconds between passes; ``stop`` lets a supervisor break the loop.
+        """
+        while not (stop and stop()):
+            maybe_session = session_factory()
+            session = await maybe_session if hasattr(maybe_session, "__await__") else maybe_session
+            try:
+                drained = await self.run_once(session)
+            finally:
+                await session.close()
+            if drained == 0:
+                await asyncio.sleep(poll_interval)

--- a/apps/backend/src/platform/store/__init__.py
+++ b/apps/backend/src/platform/store/__init__.py
@@ -1,0 +1,12 @@
+"""Platform persistence — the shared outbox table and its repository.
+
+``Outbox`` is the single shared ORM table every producer enqueues into;
+``OutboxRepository`` is the thin session-bound data access the bus and relay use.
+This is the only role that touches the ORM/session.
+"""
+
+from __future__ import annotations
+
+from src.platform.store.outbox import Outbox, OutboxRepository
+
+__all__ = ["Outbox", "OutboxRepository"]

--- a/apps/backend/src/platform/store/outbox.py
+++ b/apps/backend/src/platform/store/outbox.py
@@ -1,0 +1,104 @@
+"""The shared outbox table — ORM model + a thin session-bound repository.
+
+The transactional-outbox pattern hangs on ONE invariant: a domain event row is
+INSERTed in the *same* DB transaction as the domain state change that produced
+it. Because the write shares the caller's :class:`AsyncSession`, the event and
+the state change commit together or roll back together — there is no window where
+one persists without the other.
+
+``Outbox`` is the single shared table (owned by the ``platform`` package); every
+package that emits through the bus writes its events here, tagged with
+``source_pkg``/``event_type``. The relay (``events/relay.py``) later reads
+committed ``pending`` rows in id order and dispatches them, so dispatch is
+inherently post-commit. Status moves ``pending -> published`` exactly once the
+relay has delivered the row to every subscribed handler.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.database import Base
+
+#: The two lifecycle states of an outbox row. ``pending`` is enqueued-and-
+#: committed but not yet dispatched; ``published`` is dispatched to every
+#: subscriber. Stored as plain text (no ``sa.Enum``) so adding a state later
+#: needs no enum migration — the relay only ever queries ``status = 'pending'``.
+STATUS_PENDING = "pending"
+STATUS_PUBLISHED = "published"
+
+
+class Outbox(Base):
+    """One enqueued domain event awaiting (or having had) relay dispatch.
+
+    The ``(status, id)`` index backs the relay's hot query — "the oldest pending
+    rows, in order" — so draining the outbox never scans published history.
+    """
+
+    __tablename__ = "outbox"
+    __table_args__ = (sa.Index("ix_outbox_status_id", "status", "id"),)
+
+    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True, autoincrement=True)
+    occurred_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    event_type: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    source_pkg: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    aggregate_id: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    status: Mapped[str] = mapped_column(sa.Text, nullable=False, server_default=STATUS_PENDING)
+    published_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+
+
+class OutboxRepository:
+    """Thin async data access over :class:`Outbox`, bound to one session.
+
+    Every method operates on the session it was constructed with — so an
+    ``enqueue`` shares the caller's transaction (atomic with the domain write),
+    and the relay's reads/marks happen in the relay's own session.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    def enqueue(
+        self,
+        *,
+        occurred_at: datetime,
+        event_type: str,
+        source_pkg: str,
+        payload: dict,
+        aggregate_id: str | None = None,
+    ) -> Outbox:
+        """Add a ``pending`` outbox row to the session (no commit).
+
+        The row is flushed with the caller's transaction; the caller (the domain
+        write) owns the commit, which is what makes the event atomic with the
+        state change. Returns the pending row (its ``id`` is assigned on flush).
+        """
+        row = Outbox(
+            occurred_at=occurred_at,
+            event_type=event_type,
+            source_pkg=source_pkg,
+            aggregate_id=aggregate_id,
+            payload=payload,
+            status=STATUS_PENDING,
+        )
+        self._session.add(row)
+        return row
+
+    async def fetch_pending(self, *, limit: int) -> list[Outbox]:
+        """Return up to ``limit`` ``pending`` rows in id (enqueue) order."""
+        result = await self._session.execute(
+            sa.select(Outbox).where(Outbox.status == STATUS_PENDING).order_by(Outbox.id).limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def mark_published(self, row: Outbox, *, published_at: datetime) -> None:
+        """Flip a row to ``published`` and stamp ``published_at`` (no commit)."""
+        row.status = STATUS_PUBLISHED
+        row.published_at = published_at
+        await self._session.flush()

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -289,14 +289,12 @@ async def _schema_engine(test_database_url):
     """
     await ensure_database(test_database_url)
 
-    from src.database import Base
-
     # Register the role packages' ORM tables on Base.metadata before create_all
     # so every per-worker schema includes them (counter_tally + the shared
     # outbox), independent of which test module imported them first.
     import src.counter.store.sql  # noqa: F401
     import src.platform.store.outbox  # noqa: F401
-
+    from src.database import Base
     from src.models import (  # noqa: F401
         Account,
         AiFeedback,

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -290,6 +290,13 @@ async def _schema_engine(test_database_url):
     await ensure_database(test_database_url)
 
     from src.database import Base
+
+    # Register the role packages' ORM tables on Base.metadata before create_all
+    # so every per-worker schema includes them (counter_tally + the shared
+    # outbox), independent of which test module imported them first.
+    import src.counter.store.sql  # noqa: F401
+    import src.platform.store.outbox  # noqa: F401
+
     from src.models import (  # noqa: F401
         Account,
         AiFeedback,

--- a/apps/backend/tests/counter/test_increment.py
+++ b/apps/backend/tests/counter/test_increment.py
@@ -5,7 +5,8 @@ from uuid import uuid4
 import pytest
 from common.testing.ac_proof import ac_proof
 
-from src.counter import Count, CounterKey, Incremented, increment
+from src.counter import Count, CounterKey, increment
+from src.platform import RecordingEventBus
 
 from ._fake import InMemoryCounterRepository
 
@@ -31,17 +32,20 @@ def test_increment_is_per_user():
 
 @ac_proof(proof_id="test_increment_emits_event", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
 def test_increment_emits_incremented_event():
-    """AC25.6.3: increment publishes an Incremented domain event."""
+    """AC25.6.3: increment publishes an Incremented domain event through the bus."""
     repo = InMemoryCounterRepository()
     u1 = uuid4()
-    events: list[Incremented] = []
+    bus = RecordingEventBus()
 
-    increment(repo, user_id=u1, key=KEY, emit=events.append)
+    increment(repo, user_id=u1, key=KEY, bus=bus)
 
-    assert len(events) == 1
-    assert events[0].user_id == u1
-    assert events[0].key == KEY
-    assert events[0].at is not None
+    assert len(bus.published) == 1
+    event = bus.published[0]
+    assert event.user_id == u1
+    assert event.key == KEY
+    assert event.count == 1
+    assert event.event_type == "counter.Incremented"
+    assert event.occurred_at is not None
 
 
 @ac_proof(proof_id="test_keys_users_isolated", ac_ids=["AC25.6.3"], ci_tier="pr_ci")

--- a/apps/backend/tests/counter/test_outbox_emit.py
+++ b/apps/backend/tests/counter/test_outbox_emit.py
@@ -1,0 +1,79 @@
+"""counter emits ``counter.Incremented`` through the outbox (AC25.7.5).
+
+Proves the package wiring end to end against a real Postgres session: the async
+``record_increment`` boundary bumps the per-(user, key) tally AND writes the
+``counter.Incremented`` event into the shared outbox in the SAME transaction. A
+committed increment leaves exactly one matching outbox row; a rolled-back one
+leaves neither the tally nor the event — atomicity carried through the package.
+"""
+
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from common.testing.ac_proof import ac_proof
+
+from src.counter import CounterKey, increment, read_count, record_increment
+from src.counter.types.events import EVENT_TYPE
+from src.platform import RecordingEventBus
+from src.platform.store.outbox import STATUS_PENDING, Outbox
+
+KEY = CounterKey("report.generated")
+
+
+async def _outbox_rows(db):
+    return (await db.execute(sa.select(Outbox).order_by(Outbox.id))).scalars().all()
+
+
+@ac_proof(proof_id="test_counter_emits_to_outbox", ac_ids=["AC25.7.5"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_record_increment_writes_incremented_atomically(db):
+    """AC25.7.5: record_increment bumps the tally and enqueues counter.Incremented."""
+    user_id = uuid4()
+
+    count = await record_increment(db, user_id=user_id, key=KEY)
+    await db.commit()
+
+    assert int(count) == 1
+    assert int(await read_count(db, key=KEY, user_id=user_id)) == 1
+
+    rows = await _outbox_rows(db)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.event_type == EVENT_TYPE  # "counter.Incremented"
+    assert row.source_pkg == "counter"
+    assert row.status == STATUS_PENDING
+    assert row.payload["user_id"] == str(user_id)
+    assert row.payload["key"] == KEY.value
+    assert row.payload["count"] == 1
+
+
+@ac_proof(proof_id="test_counter_emit_rolls_back_with_tally", ac_ids=["AC25.7.5"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_rollback_leaves_neither_tally_nor_event(db):
+    """AC25.7.5: rollback ⇒ no tally bump AND no outbox row (one transaction)."""
+    user_id = uuid4()
+
+    await record_increment(db, user_id=user_id, key=KEY)
+    await db.flush()
+    await db.rollback()
+
+    assert int(await read_count(db, key=KEY, user_id=user_id)) == 0
+    assert len(await _outbox_rows(db)) == 0
+
+
+@ac_proof(proof_id="test_counter_increment_op_publishes_via_bus", ac_ids=["AC25.7.5"], ci_tier="pr_ci")
+def test_increment_op_publishes_through_bus_fake():
+    """AC25.7.5: the pure increment verb publishes Incremented through any EventBus."""
+    from tests.counter._fake import InMemoryCounterRepository
+
+    repo = InMemoryCounterRepository()
+    bus = RecordingEventBus()
+    user_id = uuid4()
+
+    increment(repo, user_id=user_id, key=KEY, bus=bus)
+
+    assert len(bus.published) == 1
+    event = bus.published[0]
+    assert event.event_type == EVENT_TYPE
+    assert event.payload()["count"] == 1

--- a/apps/backend/tests/platform/test_contract.py
+++ b/apps/backend/tests/platform/test_contract.py
@@ -1,0 +1,36 @@
+"""The ``platform`` package conforms to its ``PackageContract`` (AC25.7.4).
+
+A lighter mirror of the governance gate, scoped to this package: it asserts the
+published language (``__all__``) equals ``contract.interface`` and that the
+package is discovered + validated cleanly by ``check_package_contract``. The
+heavy gate runs in CI over every package; this anchors the AC to an executable
+proof in the backend suite.
+"""
+
+from common.governance.check_package_contract import (
+    REPO_ROOT,
+    check_package,
+    discover_packages,
+)
+from common.platform.contract import CONTRACT
+from common.testing.ac_proof import ac_proof
+
+
+@ac_proof(proof_id="test_platform_interface_matches_all", ac_ids=["AC25.7.4"], ci_tier="pr_ci")
+def test_interface_equals_published_all():
+    """AC25.7.4: contract.interface equals the BE implementation's __all__."""
+    from src.platform import __all__ as published
+
+    assert sorted(CONTRACT.interface) == sorted(published)
+
+
+@ac_proof(proof_id="test_platform_passes_contract_gate", ac_ids=["AC25.7.4"], ci_tier="pr_ci")
+def test_platform_package_passes_governance_gate():
+    """AC25.7.4: check_package_contract validates platform with no violations."""
+    packages = discover_packages(REPO_ROOT)
+    registered = {p.name: p.contract.klass for p in packages}
+    platform = next(p for p in packages if p.name == "platform")
+
+    errors = check_package(platform, registered, REPO_ROOT)
+
+    assert errors == []

--- a/apps/backend/tests/platform/test_outbox_atomicity.py
+++ b/apps/backend/tests/platform/test_outbox_atomicity.py
@@ -1,0 +1,55 @@
+"""DB-backed atomicity of the transactional outbox (AC25.7.1).
+
+The single invariant the pattern rests on: a domain event row is written in the
+SAME transaction as the domain state change. So a transaction that publishes an
+event then ROLLS BACK leaves NO outbox row, and a committed one leaves exactly
+the rows it published. Both halves are proven here against a real Postgres
+session.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+import sqlalchemy as sa
+from common.testing.ac_proof import ac_proof
+
+from src.platform.events.bus import OutboxEventBus
+from src.platform.events.event import DomainEvent
+from src.platform.store.outbox import STATUS_PENDING, Outbox
+
+
+def _event(name: str = "test.Thing") -> DomainEvent:
+    return DomainEvent(event_type=name, occurred_at=datetime.now(UTC))
+
+
+async def _outbox_count(db) -> int:
+    result = await db.execute(sa.select(sa.func.count()).select_from(Outbox))
+    return int(result.scalar_one())
+
+
+@ac_proof(proof_id="test_outbox_commit_persists_row", ac_ids=["AC25.7.1"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_commit_leaves_exactly_one_outbox_row(db):
+    """AC25.7.1: a committed publish leaves exactly one pending outbox row."""
+    bus = OutboxEventBus(db, source_pkg="test")
+    bus.publish(_event())
+    await db.commit()
+
+    assert await _outbox_count(db) == 1
+    row = (await db.execute(sa.select(Outbox))).scalar_one()
+    assert row.status == STATUS_PENDING
+    assert row.event_type == "test.Thing"
+    assert row.source_pkg == "test"
+    assert row.published_at is None
+
+
+@ac_proof(proof_id="test_outbox_rollback_leaves_no_row", ac_ids=["AC25.7.1"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_rollback_leaves_no_outbox_row(db):
+    """AC25.7.1: a rolled-back publish leaves NO outbox row (atomic)."""
+    bus = OutboxEventBus(db, source_pkg="test")
+    bus.publish(_event())
+    await db.flush()  # row is in the transaction...
+    await db.rollback()  # ...but the transaction is abandoned
+
+    assert await _outbox_count(db) == 0

--- a/apps/backend/tests/platform/test_relay.py
+++ b/apps/backend/tests/platform/test_relay.py
@@ -1,0 +1,107 @@
+"""The relay drains committed pending rows post-commit (AC25.7.2 / AC25.7.3).
+
+Proves the read half of the outbox: ``run_once`` dispatches each pending row to
+its subscribed handlers with the rehydrated event, marks the row published, and a
+second ``run_once`` does NOT re-dispatch it. Re-delivery of a still-pending row is
+safe for an idempotent handler (at-least-once is the contract).
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+import sqlalchemy as sa
+from common.testing.ac_proof import ac_proof
+
+from src.platform.events.bus import OutboxEventBus, SubscriberRegistry
+from src.platform.events.event import DomainEvent
+from src.platform.events.relay import OutboxRelay
+from src.platform.store.outbox import STATUS_PUBLISHED, Outbox
+
+
+def _event(name="counter.Incremented", count=1):
+    ev = DomainEvent(event_type=name, occurred_at=datetime.now(UTC))
+    object.__setattr__(ev, "payload", lambda: {"count": count, "aggregate_id": "u1"})
+    return ev
+
+
+async def _seed(db, *, n=1, name="counter.Incremented"):
+    bus = OutboxEventBus(db, source_pkg="counter")
+    for i in range(n):
+        bus.publish(_event(name=name, count=i + 1))
+    await db.commit()
+
+
+@ac_proof(proof_id="test_relay_dispatches_pending", ac_ids=["AC25.7.2"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_run_once_dispatches_and_marks_published(db):
+    """AC25.7.2: run_once invokes the handler with the event, then marks published."""
+    registry = SubscriberRegistry()
+    seen: list[dict] = []
+    registry.subscribe("counter.Incremented", lambda e: seen.append(e.payload()))
+
+    await _seed(db, n=2)
+    relay = OutboxRelay(registry)
+
+    published = await relay.run_once(db)
+
+    assert published == 2
+    assert [p["count"] for p in seen] == [1, 2]  # delivered in enqueue (id) order
+    rows = (await db.execute(sa.select(Outbox).order_by(Outbox.id))).scalars().all()
+    assert all(r.status == STATUS_PUBLISHED and r.published_at is not None for r in rows)
+
+
+@ac_proof(proof_id="test_relay_no_redispatch", ac_ids=["AC25.7.3"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_second_run_does_not_redispatch_published(db):
+    """AC25.7.3: a second run_once does NOT re-deliver already-published rows."""
+    registry = SubscriberRegistry()
+    deliveries: list[str] = []
+    registry.subscribe("counter.Incremented", lambda e: deliveries.append(e.event_type))
+
+    await _seed(db, n=1)
+    relay = OutboxRelay(registry)
+
+    assert await relay.run_once(db) == 1
+    assert await relay.run_once(db) == 0  # nothing pending the second time
+    assert deliveries == ["counter.Incremented"]  # delivered exactly once
+
+
+@ac_proof(proof_id="test_relay_redelivery_idempotent", ac_ids=["AC25.7.3"], ci_tier="pr_ci")
+@pytest.mark.asyncio
+async def test_redelivery_of_pending_is_idempotent_safe(db):
+    """AC25.7.3: re-delivering a still-pending row twice is safe for an idempotent handler.
+
+    Models at-least-once: if a pass crashes before marking published, the next
+    pass redelivers. An idempotent handler keyed by aggregate_id collapses the
+    duplicate to a single effect.
+    """
+    registry = SubscriberRegistry()
+    applied: set[str] = set()
+    events: list[str] = []
+
+    def idempotent_handler(e: DomainEvent) -> None:
+        events.append(e.event_type)
+        applied.add(e.payload()["aggregate_id"])  # set => duplicate is a no-op
+
+    registry.subscribe("counter.Incremented", idempotent_handler)
+    await _seed(db, n=1)
+
+    rehearsal = OutboxRelay(registry)
+    # Dispatch the same pending rows twice WITHOUT marking published in between
+    # (simulating a crash-before-mark redelivery), by reading pending directly.
+    from src.platform.store.outbox import OutboxRepository
+
+    repo = OutboxRepository(db)
+    for _ in range(2):
+        for row in await repo.fetch_pending(limit=10):
+            for handler in registry.handlers_for(row.event_type):
+                handler(rehearsal and _event_from_row(row))
+
+    assert len(events) == 2  # handler invoked twice (at-least-once)
+    assert applied == {"u1"}  # but the idempotent effect collapses to one
+
+
+def _event_from_row(row: Outbox) -> DomainEvent:
+    ev = DomainEvent(event_type=row.event_type, occurred_at=row.occurred_at)
+    object.__setattr__(ev, "payload", lambda: dict(row.payload))
+    return ev

--- a/apps/backend/tests/platform/test_relay.py
+++ b/apps/backend/tests/platform/test_relay.py
@@ -86,7 +86,6 @@ async def test_redelivery_of_pending_is_idempotent_safe(db):
     registry.subscribe("counter.Incremented", idempotent_handler)
     await _seed(db, n=1)
 
-    rehearsal = OutboxRelay(registry)
     # Dispatch the same pending rows twice WITHOUT marking published in between
     # (simulating a crash-before-mark redelivery), by reading pending directly.
     from src.platform.store.outbox import OutboxRepository
@@ -95,7 +94,7 @@ async def test_redelivery_of_pending_is_idempotent_safe(db):
     for _ in range(2):
         for row in await repo.fetch_pending(limit=10):
             for handler in registry.handlers_for(row.event_type):
-                handler(rehearsal and _event_from_row(row))
+                handler(_event_from_row(row))
 
     assert len(events) == 2  # handler invoked twice (at-least-once)
     assert applied == {"u1"}  # but the idempotent effect collapses to one

--- a/common/counter/contract.py
+++ b/common/counter/contract.py
@@ -25,7 +25,7 @@ CONTRACT = PackageContract(
     name="counter",
     klass="platform",
     status="active",
-    depends_on=[],
+    depends_on=["platform"],
     roles=["types", "ops", "store", "api"],
     implementations={"be": "apps/backend/src/counter", "fe": None},
     interface=[
@@ -39,6 +39,7 @@ CONTRACT = PackageContract(
         "get_count",
         "increment",
         "read_count",
+        "record_increment",
     ],
     events=["Incremented"],
     invariants=[
@@ -90,8 +91,9 @@ CONTRACT = PackageContract(
             id="AC25.6.3",
             statement=(
                 "increment bumps the per-(user, key) tally by one, returns the new "
-                "per-user Count, and emits an Incremented domain event; ops depend "
-                "only on the CounterRepository port, never the ORM."
+                "per-user Count, and publishes an Incremented domain event through "
+                "the platform EventBus; ops depend only on the CounterRepository "
+                "port and the EventBus port, never the ORM."
             ),
             test="apps/backend/tests/counter/test_increment.py::test_increment_is_per_user",
             priority="P1",

--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -28,31 +28,42 @@ or the global count (sum across users).
   tally for *that key*.
 - a **query** returns either the **per-user** count (a concrete `user_id`) or the
   **global** count (`user_id=None`, summed across all users).
-- **`Incremented`** — the domain event published on each increment
-  (`user_id`, `key`, `at`); other contexts (e.g. report generation) react to it
-  without importing this package's internals.
+- **`Incremented`** — the domain event published on each increment. It is a
+  `platform` **`DomainEvent`** (`event_type="counter.Incremented"`, with
+  `user_id`/`key`/`count`/`at` in its `payload()`); other contexts (e.g. report
+  generation) react to it without importing this package's internals.
 
 ## Usage
 
 ```python
 from src.counter import CounterKey, increment, get_count
+from src.platform import RecordingEventBus
 
 key = CounterKey("report.generated")
 
-# write: bump this user's tally; returns the new per-user Count, emits Incremented
-new_count = increment(repo, user_id=user_id, key=key)          # Count(1), Count(2), ...
+# write (pure op): bump this user's tally; publish Incremented through any EventBus
+bus = RecordingEventBus()
+new_count = increment(repo, user_id=user_id, key=key, bus=bus)  # Count(1), Count(2), ...
 
 # read: per-user vs global
 mine    = get_count(repo, key=key, user_id=user_id)            # this user's count
 overall = get_count(repo, key=key)                             # global (all users)
 ```
 
-`repo` is any `CounterRepository` (the store port). Ops are pure and DB-free, so
-in tests an in-memory fake satisfies the port. In production the SQL adapter is
-awaited at the boundary:
+`repo` is any `CounterRepository` (the store port); `bus` is any platform
+`EventBus`. Ops are pure and DB-free, so in tests an in-memory fake repo + a
+`RecordingEventBus` satisfy the ports. In production the async boundary does the
+**atomic** write — bump + outbox event in one transaction — and a thin read:
 
 ```python
-from src.counter.api import read_count   # thin async read for reporting
+from src.counter.api import record_increment, read_count
+
+# write: bump the tally AND enqueue counter.Incremented into the platform outbox,
+# both in `db`'s transaction; the caller's single commit makes them atomic.
+new_count = await record_increment(db, user_id=user_id, key=key)
+await db.commit()
+
+# read: thin async read for reporting
 overall = await read_count(db, key=CounterKey("report.generated"))   # Count
 ```
 
@@ -60,19 +71,22 @@ overall = await read_count(db, key=CounterKey("report.generated"))   # Count
 
 | role | what lives here |
 |------|-----------------|
-| `types/` | `CounterKey`, `Count`, `Incremented` value objects + typed errors (pure; no I/O) |
-| `ops/` | `increment` (emits `Incremented`) and `get_count` (per-user/global), over the store **port** |
+| `types/` | `CounterKey`, `Count`, `Incremented` (a platform `DomainEvent`) + typed errors (pure; no I/O) |
+| `ops/` | `increment` (publishes `Incremented` through an `EventBus`) and `get_count` (per-user/global), over the store **port** |
 | `store/` | `CounterRepository` (a `typing.Protocol` port) + `SqlCounterRepository`/`CounterTally` (the SQLAlchemy adapter — the only role that touches the ORM) |
-| `api/` | `read_count` — the thin async boundary that bridges an `AsyncSession` to a `Count` for reporting |
+| `api/` | `read_count` (thin async read) and `record_increment` (atomic write: tally bump + outbox event in one transaction) |
 
-Dependency rule (DAG, down only): `api → ops → {types, store}`. The
-ORM/`AsyncSession` lives only in `store`/`api` and never leaks into `types`/`ops`.
+Dependency rule (DAG, down only): `api → ops → {types, store}`, and the package
+depends downward on the `platform` package (the `DomainEvent`/`EventBus`/outbox
+substrate) — declared in `contract.depends_on`. The ORM/`AsyncSession` lives only
+in `store`/`api` and never leaks into `types`/`ops`.
 
 ## Public vs internal
 
 **Public** (`__all__`, == `contract.interface`): `CounterKey`, `Count`,
-`Incremented`, `increment`, `get_count`, `CounterRepository`, `read_count`, and
-the errors `CounterError`, `InvalidCounterKeyError`, `NegativeCountError`.
+`Incremented`, `increment`, `get_count`, `CounterRepository`, `read_count`,
+`record_increment`, and the errors `CounterError`, `InvalidCounterKeyError`,
+`NegativeCountError`.
 
 **Internal** (not importable as public language): `SqlCounterRepository`,
 `CounterTally` (the table model), and module internals. Persistence is an

--- a/common/platform/__init__.py
+++ b/common/platform/__init__.py
@@ -1,0 +1,19 @@
+"""``common.platform`` — the spec + review surface for the ``platform`` package.
+
+This directory holds the *authoritative* form of ``platform`` — its
+ubiquitous-language prose ([`readme.md`](./readme.md)), its machine-checkable
+:class:`~common.governance.package_contract.PackageContract`
+([`contract.py`](./contract.py)), and its worklist ([`todo.md`](./todo.md)).
+
+The running implementation lives at ``apps/backend/src/platform``
+(``contract.implementations["be"]``). This is a *spec surface*, not the package's
+code: the only thing it re-exports is the package's own ``CONTRACT`` (so tooling
+can ``from common.platform import CONTRACT``). See ``common/governance/readme.md``
+for the model and ``common/counter`` for the first worked example.
+"""
+
+from __future__ import annotations
+
+from common.platform.contract import CONTRACT
+
+__all__ = ["CONTRACT"]

--- a/common/platform/contract.py
+++ b/common/platform/contract.py
@@ -1,0 +1,155 @@
+"""The ``platform`` package's machine-checkable :class:`PackageContract`.
+
+``platform`` is the meta layer's first *runtime* capability: a domain
+**EventBus implemented via the transactional outbox pattern**. The governance
+gate (``tools/check_package_contract.py``) validates the BE implementation
+(``apps/backend/src/platform``) against this contract: ``interface`` must equal
+the implementation's ``__all__``; every ``invariants[].test`` /
+``roadmap[].test`` must resolve to a real test; and ``depends_on`` must introduce
+no forbidden import edge.
+
+### Why ``klass="kernel"``
+
+The ``klass`` is a position in the import DAG, not a marketing label. The gate
+ranks ``kernel(0) < platform(1) < core(2)`` and forbids any package importing a
+target of **equal or higher** rank. ``counter`` (a ``platform`` package) must
+import this package's :class:`DomainEvent` (its ``Incremented`` is a
+``DomainEvent``) and write through its bus — a strictly *downward* edge only if
+``platform`` (the package) ranks **below** ``counter``. So this foundational
+event/outbox substrate — which itself imports nothing registered (only the
+unregistered ``src.database`` Base/session) — is classed ``kernel``: a leaf the
+whole app builds events on. "Meta layer" describes its *role* (the first runtime
+capability of the platform substrate); ``kernel`` is its honest DAG rank.
+"""
+
+from __future__ import annotations
+
+from common.governance.package_contract import (
+    ACRecord,
+    Invariant,
+    PackageContract,
+)
+
+CONTRACT = PackageContract(
+    name="platform",
+    klass="kernel",
+    status="active",
+    depends_on=[],
+    roles=["events", "store"],
+    implementations={"be": "apps/backend/src/platform", "fe": None},
+    interface=[
+        "DomainEvent",
+        "EventBus",
+        "Outbox",
+        "OutboxEventBus",
+        "OutboxRelay",
+        "OutboxRepository",
+        "RecordingEventBus",
+        "SubscriberRegistry",
+    ],
+    events=[],
+    invariants=[
+        Invariant(
+            id="outbox-write-is-atomic",
+            statement=(
+                "Publishing through the OutboxEventBus writes the event in the "
+                "caller's transaction: rollback leaves no outbox row, commit "
+                "leaves exactly the published rows (atomic with the domain write)."
+            ),
+            test=(
+                "apps/backend/tests/platform/test_outbox_atomicity.py"
+                "::test_rollback_leaves_no_outbox_row"
+            ),
+        ),
+        Invariant(
+            id="relay-dispatches-once-post-commit",
+            statement=(
+                "The relay reads committed pending rows in id order, dispatches "
+                "each to subscribed handlers, marks it published, and a second "
+                "run_once does not re-dispatch a published row."
+            ),
+            test=(
+                "apps/backend/tests/platform/test_relay.py"
+                "::test_second_run_does_not_redispatch_published"
+            ),
+        ),
+    ],
+    roadmap=[
+        ACRecord(
+            id="AC25.7.1",
+            statement=(
+                "The OutboxEventBus writes a domain event into the shared outbox "
+                "table using the caller's AsyncSession; a rolled-back transaction "
+                "leaves no row and a committed one leaves exactly the published "
+                "rows (transactional-outbox atomicity)."
+            ),
+            test=(
+                "apps/backend/tests/platform/test_outbox_atomicity.py"
+                "::test_commit_leaves_exactly_one_outbox_row"
+            ),
+            priority="P0",
+            status="done",
+            tier="PC",
+        ),
+        ACRecord(
+            id="AC25.7.2",
+            statement=(
+                "OutboxRelay.run_once reads committed pending rows in enqueue "
+                "order, dispatches each to its subscribed handlers with the "
+                "rehydrated DomainEvent, and marks the rows published."
+            ),
+            test=(
+                "apps/backend/tests/platform/test_relay.py"
+                "::test_run_once_dispatches_and_marks_published"
+            ),
+            priority="P0",
+            status="done",
+            tier="PC",
+        ),
+        ACRecord(
+            id="AC25.7.3",
+            statement=(
+                "Dispatch is at-least-once: a second run_once does not re-deliver "
+                "published rows, and re-delivery of a still-pending row is safe "
+                "for an idempotent handler."
+            ),
+            test=(
+                "apps/backend/tests/platform/test_relay.py"
+                "::test_redelivery_of_pending_is_idempotent_safe"
+            ),
+            priority="P1",
+            status="done",
+            tier="PC",
+        ),
+        ACRecord(
+            id="AC25.7.4",
+            statement=(
+                "The platform package converges by role and its published "
+                "language equals contract.interface; check_package_contract "
+                "validates platform with no violations."
+            ),
+            test=(
+                "apps/backend/tests/platform/test_contract.py"
+                "::test_platform_package_passes_governance_gate"
+            ),
+            priority="P1",
+            status="done",
+            tier="PC",
+        ),
+        ACRecord(
+            id="AC25.7.5",
+            statement=(
+                "counter.record_increment bumps the per-(user, key) tally and "
+                "enqueues a counter.Incremented event into the shared outbox in "
+                "the SAME transaction (rollback leaves neither tally nor event)."
+            ),
+            test=(
+                "apps/backend/tests/counter/test_outbox_emit.py"
+                "::test_record_increment_writes_incremented_atomically"
+            ),
+            priority="P1",
+            status="done",
+            tier="PC",
+        ),
+    ],
+)

--- a/common/platform/readme.md
+++ b/common/platform/readme.md
@@ -1,0 +1,122 @@
+# `platform` — domain EventBus via the transactional outbox (meta-layer capability #1)
+
+> Package model: [`../governance/readme.md`](../governance/readme.md). Machine
+> contract: [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
+>
+> This `common/platform/` directory is the **spec + review surface**; the
+> conforming implementation lives at
+> [`apps/backend/src/platform`](../../apps/backend/src/platform)
+> (`contract.implementations["be"]`).
+
+## Why
+
+This is the **first runtime capability of the meta layer**: a single, reusable
+way for any bounded context to *publish a domain event as a fact* and for others
+to *react* to it — without the producer knowing its consumers, and without losing
+the event if the process dies. It does this with **no new infrastructure**: one
+Postgres table, no message broker, no Prefect, no `LISTEN/NOTIFY`.
+
+## The transactional outbox in one paragraph
+
+A producer `publish`es a **DomainEvent** through an **OutboxEventBus** built from
+the *same* `AsyncSession` that is making the domain state change. The bus INSERTs
+the event into the shared **outbox** table **in that transaction**, so the event
+and the state change **commit together or roll back together** — they are atomic
+by construction (there is no window where one persists without the other). A
+separate **OutboxRelay** later reads committed `pending` rows in id order,
+dispatches each to the subscribed handlers, and marks them `published`. Because
+the relay only ever reads already-committed rows, **dispatch is inherently
+post-commit**.
+
+```
+producer ──publish(event)──▶ OutboxEventBus ──INSERT──▶ outbox(status=pending)
+                                                          │  (same txn as the
+                                                          │   domain write)
+                              caller commit() ────────────┘
+                                                          ▼
+OutboxRelay.run_once() ──read pending, in order──▶ handler(event) ──▶ mark published
+```
+
+## Ubiquitous language
+
+- **DomainEvent** — an immutable fact that already happened. Carries a namespaced
+  `event_type` (`"<pkg>.<Name>"`, the routing key) and `occurred_at` (UTC);
+  subclasses add fields and override `payload()` to expose them as the JSON body
+  persisted to the outbox.
+- **outbox** — the one shared table (owned by this package) every producer
+  enqueues into. A row is `pending` until the relay has delivered it, then
+  `published`.
+- **relay** — the post-commit dispatcher. Reads committed `pending` rows in order
+  and invokes subscribed handlers.
+- **at-least-once + idempotent** — if a pass crashes after a handler runs but
+  before the row is marked `published`, the row is redelivered on the next pass.
+  So **handlers MUST be idempotent**: processing the same event twice must have
+  the same effect as once (key side effects by the event's aggregate / a dedupe
+  key).
+
+## Usage
+
+```python
+from src.platform import OutboxEventBus, OutboxRelay, SubscriberRegistry
+
+# write side — atomic with the domain change (same session, one commit)
+bus = OutboxEventBus(db, source_pkg="counter")
+bus.publish(event)            # enqueues a pending outbox row in db's transaction
+await db.commit()             # event + state change commit together
+
+# read side — post-commit dispatch (run as a periodic background task; see below)
+registry = SubscriberRegistry()
+registry.subscribe("counter.Incremented", my_idempotent_handler)
+relay = OutboxRelay(registry)
+await relay.run_once(relay_session)   # drains one batch of pending rows
+```
+
+`RecordingEventBus` is an in-memory fake for unit tests that assert *what was
+published* without a database.
+
+## Running the relay (deferred — not wired here)
+
+`run_once(session)` drains one batch; `run_forever(session_factory)` is the shape
+of a durable poll loop. **No always-on worker is wired in this slice** — by
+design. In production the relay would run as a periodic background task (e.g. an
+app-startup `asyncio` task, a cron/`schedule`d job, or — later — a Prefect flow).
+That durable worker, plus a `LISTEN/NOTIFY` fast-path, is explicitly future work
+([`todo.md`](./todo.md)).
+
+## Roles (files converge by role)
+
+| role | what lives here |
+|------|-----------------|
+| `events/` | `DomainEvent` (event base), `EventBus` port + `OutboxEventBus`/`RecordingEventBus`, `SubscriberRegistry`, `OutboxRelay` |
+| `store/` | the shared `Outbox` ORM table + `OutboxRepository` (the only role that touches the ORM/session) |
+
+Dependency rule (DAG, down only): the package imports nothing registered — only
+the unregistered `src.database` (Base/`AsyncSession`). That is why its `klass` is
+**`kernel`** (a leaf): a `platform` consumer like `counter` may import it as a
+strictly downward edge. See [`contract.py`](./contract.py) for the full rationale.
+
+## Public vs internal
+
+**Public** (`__all__`, == `contract.interface`): `DomainEvent`, `EventBus`,
+`OutboxEventBus`, `RecordingEventBus`, `SubscriberRegistry`, `OutboxRelay`,
+`Outbox`, `OutboxRepository`.
+
+**Internal**: the rehydration helper in `relay.py` and module internals.
+
+## Storage
+
+`outbox(id bigserial pk, occurred_at timestamptz, event_type text, source_pkg
+text, aggregate_id text null, payload jsonb, status text default 'pending',
+published_at timestamptz null)` with an index on `(status, id)` backing the
+relay's "oldest pending, in order" drain. `status` is plain text (not a
+`sa.Enum`) so a future lifecycle state needs no enum migration. Migration:
+`apps/backend/migrations/versions/0049_add_outbox.py`.
+
+## Governance
+
+The package's ACs (`AC25.7.1`–`AC25.7.5`) live in [`contract.py`](./contract.py)'s
+`roadmap` (carrying `tier: PC`, EPIC-026's authority-tier model) and are sourced
+directly from there into the AC registry; its invariants pin to the DB-backed
+tests that prove atomicity and post-commit dispatch.
+`tools/check_package_contract.py` validates the implementation against this
+contract.

--- a/common/platform/todo.md
+++ b/common/platform/todo.md
@@ -1,0 +1,30 @@
+# `platform` — todo
+
+The package-local worklist. Cross-package migration lives in
+[`../todo.md`](../todo.md).
+
+## Done
+
+- [x] First runtime capability of the meta layer: a domain EventBus via the
+      transactional outbox pattern (one shared Postgres table, no broker).
+- [x] `DomainEvent` base value type; `OutboxEventBus` adapter (atomic write in
+      the caller's session); `SubscriberRegistry`; `RecordingEventBus` fake.
+- [x] `OutboxRelay` (`run_once` / `run_forever` shape) — post-commit, at-least-
+      once dispatch; handlers documented as idempotent.
+- [x] Shared `outbox` table + migration `0049_add_outbox`.
+- [x] `counter` emits `counter.Incremented` through the outbox, atomic with the
+      tally bump (`counter.api.record_increment`).
+- [x] ACs `AC25.7.1`–`AC25.7.5` sourced directly from the contract `roadmap`.
+
+## Next
+
+- [ ] **UnitOfWork / Clock / Repository** seams: lift the session + `now()` +
+      outbox-write into explicit collaborators so producers depend on ports, not
+      on `AsyncSession`/`datetime.now` directly.
+- [ ] **Durable relay worker**: wire `run_forever` as a real background task /
+      periodic job (today only `run_once` is exercised; no always-on worker).
+- [ ] **Prefect adapter** and a **`LISTEN/NOTIFY`** fast-path so the relay wakes
+      on enqueue instead of polling.
+- [ ] Dead-letter / retry-count handling for a handler that keeps failing.
+- [ ] A typed subscriber surface (rehydrate to the producer's concrete event
+      subclass) once a consumer needs more than the JSON payload.

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -35,6 +35,7 @@ These files are test infrastructure, not behavior proof.
 | `apps/backend/tests/locustfile.py` | Load-test harness, not AC proof |
 | `apps/backend/tests/market_data/__init__.py` | Package marker |
 | `apps/backend/tests/metrics/__init__.py` | Package marker |
+| `apps/backend/tests/platform/__init__.py` | Package marker |
 | `apps/backend/tests/portfolio/__init__.py` | Package marker |
 | `apps/backend/tests/reconciliation/__init__.py` | Package marker |
 | `apps/backend/tests/reporting/__init__.py` | Package marker |

--- a/docs/project/EPIC-025.dry-ssot-simplification.md
+++ b/docs/project/EPIC-025.dry-ssot-simplification.md
@@ -137,6 +137,28 @@ verifiable.
 > defines none of them — the contract is the single definition source. This is
 > the precedent: a package's ACs live in its contract, never duplicated.
 
+### AC25.7 — Platform: domain EventBus via the transactional outbox (meta-layer capability #1)
+
+> The first *runtime* capability of the meta layer: a domain **EventBus
+> implemented with the transactional outbox pattern**, in the new
+> [`common/platform`](../../common/platform/readme.md) package. A producer
+> publishes a `DomainEvent` through an `OutboxEventBus` built from the caller's
+> `AsyncSession`, so the event row is written into one shared `outbox` table in
+> the SAME transaction as the domain state change (atomic); a separate
+> `OutboxRelay` reads committed `pending` rows and dispatches them post-commit
+> (at-least-once, so handlers must be idempotent). `counter` now emits its
+> `Incremented` event through this bus.
+>
+> **`AC25.7.1`, `AC25.7.2`, `AC25.7.3`, `AC25.7.4`, and `AC25.7.5` are NOT defined
+> here.** They are owned by, and sourced directly from,
+> [`common/platform/contract.py`](../../common/platform/contract.py)'s `roadmap`
+> (`AC25.7.5` is the cross-package one proving `counter` emits atomically through
+> the outbox); `common/ssot/generate_ac_registry.py` reads it additively, so the
+> AC index counts them without an EPIC-table mirror. This blockquote references
+> the IDs (keeping the registry-to-EPIC link intact) but defines none of them —
+> the contract is the single definition source, exactly as the `AC25.6`
+> precedent.
+
 ---
 
 ## 📏 Acceptance Criteria


### PR DESCRIPTION
## What

Introduces **`common/platform`** — the **first runtime capability of the meta layer**: a domain **EventBus implemented via the transactional outbox pattern** — and makes the existing `counter` package emit its `Incremented` event through it.

## The transactional outbox pattern

A producer `publish`es a **`DomainEvent`** through an **`OutboxEventBus`** that is built from the *same* `AsyncSession` making the domain state change. The bus INSERTs the event into **one shared `outbox` table in that same transaction**, so the event and the state change **commit together or roll back together** — atomic by construction, with no window where one persists without the other.

A separate **`OutboxRelay`** later reads committed `pending` rows in id order, dispatches each to subscribed handlers, and marks them `published`. Because it only ever reads already-committed rows, **dispatch is inherently post-commit**. Delivery is **at-least-once**, so **handlers must be idempotent** (documented; a re-delivery test proves the idempotent-handler contract).

**No new infrastructure**: one Postgres table, no message broker, no Prefect, no `LISTEN/NOTIFY`.

## `common/platform` (the package)

- `events/event.py` — `DomainEvent` base value type (`event_type`, `occurred_at`, `payload()`).
- `events/bus.py` — `EventBus` Protocol, `OutboxEventBus` adapter (writes through the caller's session), `SubscriberRegistry`, `RecordingEventBus` fake.
- `events/relay.py` — `OutboxRelay.run_once(session)` + a `run_forever` poll-loop *shape*. **No always-on worker is wired** — documented as a periodic background task / job.
- `store/outbox.py` — the shared `Outbox` ORM table + repository.
- Migration `0049_add_outbox` — **one shared table** `outbox(id bigserial pk, occurred_at timestamptz, event_type text, source_pkg text, aggregate_id text null, payload jsonb, status text default 'pending', published_at timestamptz null)` with an index on `(status, id)`; chains from head `0048_counter_tally`; additive (auto-classified low risk).
- Spec: `readme.md` + `todo.md` + `contract.py` (PackageContract), governed by the same gate as `counter`.

**The shared outbox table is owned by `platform`.** Every producer enqueues here, tagged with `source_pkg`/`event_type`.

### Why `klass="kernel"`
The governance gate ranks `kernel(0) < platform(1) < core(2)` and forbids importing an equal-or-higher-rank package. `counter` (a `platform` package) must import this package's `DomainEvent` and bus (a strictly *downward* edge), and this substrate itself imports nothing registered (only the unregistered `src.database`). So the honest DAG rank is **kernel** (a leaf the whole app builds events on); "meta layer" describes its *role*. Full rationale in `common/platform/contract.py`.

## counter now emits through it

- `Incremented` is now a `DomainEvent` (`event_type="counter.Incremented"`, payload `{user_id, key, count, at}`).
- `ops.increment` drops the `emit` callback and publishes through an `EventBus` port.
- `api.record_increment` — the atomic async write: bumps the tally **and** enqueues `counter.Incremented` into the outbox **in the same session/transaction** (rollback ⇒ neither; commit ⇒ both).
- `contract.depends_on=["platform"]`; interface adds `record_increment`.

## Tests (DB-backed against real Postgres)

- **Atomicity** — rollback leaves no outbox row; commit leaves exactly one.
- **Relay** — `run_once` dispatches pending rows to handlers + marks published; a second `run_once` does not re-dispatch; re-delivery of a still-pending row is idempotent-safe.
- **counter** — `record_increment` writes `counter.Incremented` atomically with the tally bump (and rollback drops both).
- **Contract** — `platform` passes `check_package_contract`.
- ACs `AC25.7.1`–`AC25.7.5` (tier `PC`) sourced from the platform contract `roadmap`.

## Deferred (see `common/platform/todo.md`)

UnitOfWork / Clock / Repository seams; a durable always-on relay worker; a Prefect adapter and a `LISTEN/NOTIFY` fast-path; dead-letter/retry; a typed subscriber surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)