### PR TITLE
[finance_report_vision] refactor(base-packages): one shared Decimal-scalar codec per layer (AC12.36)

### DIFF
--- a/apps/backend/src/decimal_scalar.py
+++ b/apps/backend/src/decimal_scalar.py
@@ -1,0 +1,101 @@
+"""Shared Decimal-scalar codec — the single boundary primitive the backend's
+base-package value types route their raw-``Decimal`` conversions through.
+
+Backend mirror of ``common/decimal_scalar.py`` (the reference impl). The backend
+ships self-contained — it does not import ``common`` at runtime — so it keeps its
+own copy, exactly like the ``money`` / ``quantity`` / ``ratio`` / ``unit_price``
+value types are mirrored under ``apps/backend/src`` (#1167). Kept byte-for-byte in
+step with the reference impl.
+
+``base-packages.md`` §3 ("Raw Decimal boundary policy") requires that hand-written
+semantic conversion at a value boundary go through *the owning base-package
+codec*, never local ``Decimal(str(...))`` glue. Each base package used to
+re-implement that codec — a byte-identical ``_decimal_to_wire``, a
+``_decimal_from_wire`` / ``_payload_mapping`` / ``_field`` triad, and a
+construction-time ``_coerce`` — differing only by which typed error it raised.
+This module is that codec, factored once; each package supplies its own error
+classes so the narrow per-domain error hierarchy is preserved.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+
+
+def decimal_to_wire(value: Decimal) -> str:
+    """Canonical wire form for a ``Decimal``: fixed-point notation with trailing
+    zeros trimmed, and a single ``"0"`` for any zero (including ``-0``)."""
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    if text in {"", "-0"}:
+        return "0"
+    return text
+
+
+def coerce_decimal(
+    value: object,
+    what: str,
+    *,
+    float_error: type[Exception],
+    require_finite: bool = False,
+) -> Decimal:
+    """Coerce a construction-time input to ``Decimal``.
+
+    Accepts ``Decimal`` and ``int`` (the exact numeric inputs); rejects ``bool``
+    and ``float`` (the standing numeric red line) and any other type by raising
+    ``float_error``. When ``require_finite`` is set, a non-finite ``Decimal``
+    (NaN / Infinity) is rejected too.
+    """
+    if isinstance(value, bool):
+        raise float_error(f"bool is not a valid {what}")
+    if isinstance(value, float):
+        raise float_error(f"float is not allowed for {what} (IEEE-754 precision loss); use Decimal")
+    if isinstance(value, Decimal):
+        if require_finite and not value.is_finite():
+            raise float_error(f"{what} must be finite")
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    raise float_error(f"{what} must be Decimal or int, got {type(value).__name__}")
+
+
+@dataclass(frozen=True)
+class WireCodec:
+    """The wire-boundary triad (parse / mapping / field) bound to one package's
+    typed errors. Wire payloads carry decimals as strings, never JSON numbers.
+    """
+
+    float_error: type[Exception]
+    payload_error: type[Exception]
+
+    def parse(self, value: object, what: str) -> Decimal:
+        """Decode a wire decimal string into a finite ``Decimal``."""
+        if isinstance(value, bool):
+            raise self.float_error(f"bool is not a valid {what}")
+        if isinstance(value, float):
+            raise self.float_error(f"float is not allowed for {what}; use a decimal string")
+        if not isinstance(value, str):
+            raise self.float_error(f"{what} must be encoded as a decimal string, got {type(value).__name__}")
+        try:
+            parsed = Decimal(value)
+        except (InvalidOperation, ValueError) as exc:
+            raise self.payload_error(f"{what} is not a valid decimal string") from exc
+        if not parsed.is_finite():
+            raise self.float_error(f"{what} must be finite")
+        return parsed
+
+    def mapping(self, payload: object, what: str) -> Mapping[str, object]:
+        """Require ``payload`` to be a mapping (the object envelope of a wire payload)."""
+        if not isinstance(payload, Mapping):
+            raise self.payload_error(f"{what} payload must be an object, got {type(payload).__name__}")
+        return payload
+
+    def field(self, payload: Mapping[str, object], key: str, what: str) -> object:
+        """Read a required ``key`` from a wire payload mapping."""
+        try:
+            return payload[key]
+        except KeyError as exc:
+            raise self.payload_error(f"{what} payload missing {key!r}") from exc

--- a/apps/backend/src/money/money.py
+++ b/apps/backend/src/money/money.py
@@ -22,25 +22,18 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal
 
+from src.decimal_scalar import coerce_decimal
 from src.money.currency import Currency
 from src.money.errors import CurrencyMismatchError, FloatNotAllowedError
 from src.money.rounding import to_money
 
 # Amount inputs accepted at construction. ``bool`` is an ``int`` subclass but is
-# never a valid amount, so it is rejected explicitly below.
+# never a valid amount, so it is rejected explicitly by the shared codec below.
 _AmountInput = Decimal | int
 
 
 def _coerce_amount(value: object) -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError("bool is not a valid Money amount")
-    if isinstance(value, float):
-        raise FloatNotAllowedError("float is not allowed for money amounts (IEEE-754 precision loss); use Decimal")
-    if isinstance(value, Decimal):
-        return value
-    if isinstance(value, int):
-        return Decimal(value)
-    raise FloatNotAllowedError(f"Money amount must be Decimal or int, got {type(value).__name__}")
+    return coerce_decimal(value, "Money amount", float_error=FloatNotAllowedError)
 
 
 @dataclass(frozen=True)

--- a/apps/backend/src/money/wire.py
+++ b/apps/backend/src/money/wire.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 
+from src.decimal_scalar import WireCodec, decimal_to_wire as _decimal_to_wire
 from src.money.errors import FloatNotAllowedError, InvalidMoneyPayloadError
 from src.money.exchange_rate import ExchangeRate
 from src.money.money import Money
@@ -14,43 +15,20 @@ ExchangeRateWire = dict[str, str]
 MoneyDbFields = dict[str, Decimal | str]
 ExchangeRateDbFields = dict[str, Decimal | str]
 
-
-def _decimal_to_wire(value: Decimal) -> str:
-    text = format(value, "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    if text in {"", "-0"}:
-        return "0"
-    return text
+# The shared scalar codec bound to money's typed errors (parse / mapping / field).
+_CODEC = WireCodec(FloatNotAllowedError, InvalidMoneyPayloadError)
 
 
 def _decimal_from_wire(value: object, what: str) -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(f"float is not allowed for {what}; use a decimal string")
-    if not isinstance(value, str):
-        raise FloatNotAllowedError(f"{what} must be encoded as a decimal string, got {type(value).__name__}")
-    try:
-        parsed = Decimal(value)
-    except (InvalidOperation, ValueError) as exc:
-        raise InvalidMoneyPayloadError(f"{what} is not a valid decimal string") from exc
-    if not parsed.is_finite():
-        raise FloatNotAllowedError(f"{what} must be finite")
-    return parsed
+    return _CODEC.parse(value, what)
 
 
 def _payload_mapping(payload: object, what: str) -> Mapping[str, object]:
-    if not isinstance(payload, Mapping):
-        raise InvalidMoneyPayloadError(f"{what} payload must be an object, got {type(payload).__name__}")
-    return payload
+    return _CODEC.mapping(payload, what)
 
 
 def _field(payload: Mapping[str, object], key: str, what: str) -> object:
-    try:
-        return payload[key]
-    except KeyError as exc:
-        raise InvalidMoneyPayloadError(f"{what} payload missing {key!r}") from exc
+    return _CODEC.field(payload, key, what)
 
 
 def money_to_wire(money: Money) -> MoneyWire:

--- a/apps/backend/src/quantity/quantity.py
+++ b/apps/backend/src/quantity/quantity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 
+from src.decimal_scalar import coerce_decimal
 from src.quantity.errors import FloatNotAllowedError, UnitMismatchError
 from src.quantity.unit import Unit
 from src.ratio import Ratio
@@ -17,17 +18,7 @@ _QuantityInput = Decimal | int
 
 
 def _coerce(value: object, what: str = "quantity value") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(f"float is not allowed for {what} (IEEE-754 precision loss); use Decimal")
-    if isinstance(value, Decimal):
-        if not value.is_finite():
-            raise FloatNotAllowedError(f"{what} must be finite")
-        return value
-    if isinstance(value, int):
-        return Decimal(value)
-    raise FloatNotAllowedError(f"{what} must be Decimal or int, got {type(value).__name__}")
+    return coerce_decimal(value, what, float_error=FloatNotAllowedError, require_finite=True)
 
 
 @dataclass(frozen=True)
@@ -76,7 +67,7 @@ class Quantity:
         # invariants hold (finiteness check; float/bool stay a hard red line).
         # Any other operand type yields NotImplemented so a reflected op can handle
         # it — e.g. quantity * UnitPrice -> Money.
-        if isinstance(factor, (Decimal, int, float)):  # bool is an int subclass
+        if isinstance(factor, Decimal | int | float):  # bool is an int subclass
             return Quantity(self.value * _coerce(factor, "factor"), self.unit)
         return NotImplemented
 

--- a/apps/backend/src/quantity/wire.py
+++ b/apps/backend/src/quantity/wire.py
@@ -3,51 +3,29 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 
+from src.decimal_scalar import WireCodec, decimal_to_wire as _decimal_to_wire
 from src.quantity.errors import FloatNotAllowedError, InvalidQuantityPayloadError
 from src.quantity.quantity import Quantity
 
 QuantityWire = dict[str, str]
 QuantityDbFields = dict[str, Decimal | str]
 
-
-def _decimal_to_wire(value: Decimal) -> str:
-    text = format(value, "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    if text in {"", "-0"}:
-        return "0"
-    return text
+# The shared scalar codec bound to quantity's typed errors (parse / mapping / field).
+_CODEC = WireCodec(FloatNotAllowedError, InvalidQuantityPayloadError)
 
 
 def _decimal_from_wire(value: object, what: str = "quantity value") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(f"float is not allowed for {what}; use a decimal string")
-    if not isinstance(value, str):
-        raise FloatNotAllowedError(f"{what} must be encoded as a decimal string, got {type(value).__name__}")
-    try:
-        parsed = Decimal(value)
-    except (InvalidOperation, ValueError) as exc:
-        raise InvalidQuantityPayloadError(f"{what} is not a valid decimal string") from exc
-    if not parsed.is_finite():
-        raise FloatNotAllowedError(f"{what} must be finite")
-    return parsed
+    return _CODEC.parse(value, what)
 
 
 def _payload_mapping(payload: object) -> Mapping[str, object]:
-    if not isinstance(payload, Mapping):
-        raise InvalidQuantityPayloadError(f"Quantity payload must be an object, got {type(payload).__name__}")
-    return payload
+    return _CODEC.mapping(payload, "Quantity")
 
 
 def _field(payload: Mapping[str, object], key: str) -> object:
-    try:
-        return payload[key]
-    except KeyError as exc:
-        raise InvalidQuantityPayloadError(f"Quantity payload missing {key!r}") from exc
+    return _CODEC.field(payload, key, "Quantity")
 
 
 def quantity_to_wire(quantity: Quantity) -> QuantityWire:

--- a/apps/backend/src/ratio/ratio.py
+++ b/apps/backend/src/ratio/ratio.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 
+from src.decimal_scalar import coerce_decimal
 from src.ratio.errors import FloatNotAllowedError, UndefinedRatioError
 
 # Canonical percent-display policy (NOT money's HALF_EVEN — percentages are not
@@ -34,15 +35,7 @@ _RatioInput = Decimal | int
 
 
 def _coerce(value: object, what: str = "ratio value") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(f"float is not allowed for {what} (IEEE-754 precision loss); use Decimal")
-    if isinstance(value, Decimal):
-        return value
-    if isinstance(value, int):
-        return Decimal(value)
-    raise FloatNotAllowedError(f"{what} must be Decimal or int, got {type(value).__name__}")
+    return coerce_decimal(value, what, float_error=FloatNotAllowedError)
 
 
 @dataclass(frozen=True)

--- a/apps/backend/src/ratio/wire.py
+++ b/apps/backend/src/ratio/wire.py
@@ -2,35 +2,19 @@
 
 from __future__ import annotations
 
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 
+from src.decimal_scalar import WireCodec, decimal_to_wire as _decimal_to_wire
 from src.ratio.errors import FloatNotAllowedError, InvalidRatioPayloadError
 from src.ratio.ratio import Ratio
 
-
-def _decimal_to_wire(value: Decimal) -> str:
-    text = format(value, "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    if text in {"", "-0"}:
-        return "0"
-    return text
+# The shared scalar codec bound to ratio's typed errors (ratio wire is a bare
+# decimal string, so only ``parse`` is needed — no payload envelope).
+_CODEC = WireCodec(FloatNotAllowedError, InvalidRatioPayloadError)
 
 
 def _decimal_from_wire(value: object, what: str = "ratio value") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(f"float is not allowed for {what}; use a decimal string")
-    if not isinstance(value, str):
-        raise FloatNotAllowedError(f"{what} must be encoded as a decimal string, got {type(value).__name__}")
-    try:
-        parsed = Decimal(value)
-    except (InvalidOperation, ValueError) as exc:
-        raise InvalidRatioPayloadError(f"{what} is not a valid decimal string") from exc
-    if not parsed.is_finite():
-        raise FloatNotAllowedError(f"{what} must be finite")
-    return parsed
+    return _CODEC.parse(value, what)
 
 
 def ratio_to_wire(ratio: Ratio) -> str:

--- a/apps/backend/src/unit_price/unit_price.py
+++ b/apps/backend/src/unit_price/unit_price.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 
+from src.decimal_scalar import coerce_decimal
 from src.money.currency import Currency
 from src.money.money import Money
 from src.quantity.quantity import Quantity
@@ -32,17 +33,7 @@ _RateInput = Decimal | int
 
 
 def _coerce_rate(value: object) -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError("bool is not a valid unit-price rate")
-    if isinstance(value, float):
-        raise FloatNotAllowedError("float is not allowed for unit-price rates (IEEE-754 precision loss); use Decimal")
-    if isinstance(value, Decimal):
-        if not value.is_finite():
-            raise FloatNotAllowedError("unit-price rate must be finite")
-        return value
-    if isinstance(value, int):
-        return Decimal(value)
-    raise FloatNotAllowedError(f"unit-price rate must be Decimal or int, got {type(value).__name__}")
+    return coerce_decimal(value, "unit-price rate", float_error=FloatNotAllowedError, require_finite=True)
 
 
 @dataclass(frozen=True)

--- a/apps/backend/src/unit_price/wire.py
+++ b/apps/backend/src/unit_price/wire.py
@@ -3,51 +3,29 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 
+from src.decimal_scalar import WireCodec, decimal_to_wire as _decimal_to_wire
 from src.unit_price.errors import FloatNotAllowedError, InvalidUnitPricePayloadError
 from src.unit_price.unit_price import UnitPrice
 
 UnitPriceWire = dict[str, str]
 UnitPriceDbFields = dict[str, Decimal | str]
 
-
-def _decimal_to_wire(value: Decimal) -> str:
-    text = format(value, "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    if text in {"", "-0"}:
-        return "0"
-    return text
+# The shared scalar codec bound to unit-price's typed errors (parse / mapping / field).
+_CODEC = WireCodec(FloatNotAllowedError, InvalidUnitPricePayloadError)
 
 
 def _decimal_from_wire(value: object, what: str = "unit-price rate") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(f"float is not allowed for {what}; use a decimal string")
-    if not isinstance(value, str):
-        raise FloatNotAllowedError(f"{what} must be encoded as a decimal string, got {type(value).__name__}")
-    try:
-        parsed = Decimal(value)
-    except (InvalidOperation, ValueError) as exc:
-        raise InvalidUnitPricePayloadError(f"{what} is not a valid decimal string") from exc
-    if not parsed.is_finite():
-        raise FloatNotAllowedError(f"{what} must be finite")
-    return parsed
+    return _CODEC.parse(value, what)
 
 
 def _payload_mapping(payload: object) -> Mapping[str, object]:
-    if not isinstance(payload, Mapping):
-        raise InvalidUnitPricePayloadError(f"UnitPrice payload must be an object, got {type(payload).__name__}")
-    return payload
+    return _CODEC.mapping(payload, "UnitPrice")
 
 
 def _field(payload: Mapping[str, object], key: str) -> object:
-    try:
-        return payload[key]
-    except KeyError as exc:
-        raise InvalidUnitPricePayloadError(f"UnitPrice payload missing {key!r}") from exc
+    return _CODEC.field(payload, key, "UnitPrice")
 
 
 def unit_price_to_wire(unit_price: UnitPrice) -> UnitPriceWire:

--- a/apps/backend/tests/accounting/test_decimal_scalar_backend.py
+++ b/apps/backend/tests/accounting/test_decimal_scalar_backend.py
@@ -1,0 +1,64 @@
+"""Behavioural coverage for the backend's shared Decimal-scalar codec mirror (AC12.36.2).
+
+The backend ships ``src.decimal_scalar`` as a self-contained copy of
+``common.decimal_scalar`` (the value types route through it). This exercises every
+branch directly so the mirror stays covered independent of the value-type suites.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from src.decimal_scalar import WireCodec, coerce_decimal, decimal_to_wire
+
+pytestmark = pytest.mark.no_db
+
+
+class _FloatError(TypeError):
+    pass
+
+
+class _PayloadError(ValueError):
+    pass
+
+
+def test_decimal_to_wire_trims_and_normalizes_zero():
+    assert decimal_to_wire(Decimal("10.5000")) == "10.5"
+    assert decimal_to_wire(Decimal("3")) == "3"
+    assert decimal_to_wire(Decimal("-0")) == "0"
+    assert decimal_to_wire(Decimal("0.00")) == "0"
+
+
+def test_coerce_decimal_accepts_and_rejects():
+    assert coerce_decimal(Decimal("1.25"), "x", float_error=_FloatError) == Decimal("1.25")
+    assert coerce_decimal(7, "x", float_error=_FloatError) == Decimal("7")
+    for bad in (True, 1.5, "1.5", None):
+        with pytest.raises(_FloatError):
+            coerce_decimal(bad, "x", float_error=_FloatError)
+
+
+def test_coerce_decimal_require_finite():
+    assert coerce_decimal(Decimal("NaN"), "x", float_error=_FloatError).is_nan()
+    for bad in (Decimal("NaN"), Decimal("Infinity")):
+        with pytest.raises(_FloatError):
+            coerce_decimal(bad, "x", float_error=_FloatError, require_finite=True)
+
+
+def test_wire_codec_parse_mapping_field():
+    codec = WireCodec(_FloatError, _PayloadError)
+    assert codec.parse("1.50", "x") == Decimal("1.50")
+    for bad in (True, 1.5, b"1"):
+        with pytest.raises(_FloatError):
+            codec.parse(bad, "x")
+    with pytest.raises(_PayloadError):
+        codec.parse("not-a-number", "x")
+    with pytest.raises(_FloatError):
+        codec.parse("Infinity", "x")
+    assert codec.mapping({"a": "1"}, "X") == {"a": "1"}
+    with pytest.raises(_PayloadError):
+        codec.mapping(["x"], "X")
+    assert codec.field({"a": "1"}, "a", "X") == "1"
+    with pytest.raises(_PayloadError):
+        codec.field({"a": "1"}, "missing", "X")

--- a/common/decimal_scalar.py
+++ b/common/decimal_scalar.py
@@ -1,0 +1,110 @@
+"""Shared Decimal-scalar codec — the single boundary primitive the base-package
+value types route their raw-``Decimal`` conversions through.
+
+``base-packages.md`` §3 ("Raw Decimal boundary policy") requires that hand-written
+semantic conversion at a value boundary go through *the owning base-package
+codec*, never local ``Decimal(str(...))`` glue. Each base package
+(``money`` / ``quantity`` / ``ratio`` / ``unit_price``) used to re-implement that
+codec — a byte-identical ``_decimal_to_wire``, a ``_decimal_from_wire`` /
+``_payload_mapping`` / ``_field`` triad, and a construction-time ``_coerce`` —
+differing only by which typed error it raised. This module is that codec, factored
+once; each package supplies its own error classes so the narrow per-domain error
+hierarchy (``Invalid*PayloadError`` / ``FloatNotAllowedError``) is preserved.
+
+Pure and dependency-light on purpose: it imports no base package, so it stays a
+substrate primitive rather than a fifth base package (the family is bounded —
+``base-packages.md`` §2). The backend keeps its own mirror under
+``apps/backend/src/decimal_scalar.py`` for the same self-contained-shipping reason
+the value types themselves are mirrored (#1167).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+
+
+def decimal_to_wire(value: Decimal) -> str:
+    """Canonical wire form for a ``Decimal``: fixed-point notation with trailing
+    zeros trimmed, and a single ``"0"`` for any zero (including ``-0``)."""
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    if text in {"", "-0"}:
+        return "0"
+    return text
+
+
+def coerce_decimal(
+    value: object,
+    what: str,
+    *,
+    float_error: type[Exception],
+    require_finite: bool = False,
+) -> Decimal:
+    """Coerce a construction-time input to ``Decimal``.
+
+    Accepts ``Decimal`` and ``int`` (the exact numeric inputs); rejects ``bool``
+    and ``float`` (the standing numeric red line) and any other type by raising
+    ``float_error``. When ``require_finite`` is set, a non-finite ``Decimal``
+    (NaN / Infinity) is rejected too.
+    """
+    if isinstance(value, bool):
+        raise float_error(f"bool is not a valid {what}")
+    if isinstance(value, float):
+        raise float_error(
+            f"float is not allowed for {what} (IEEE-754 precision loss); use Decimal"
+        )
+    if isinstance(value, Decimal):
+        if require_finite and not value.is_finite():
+            raise float_error(f"{what} must be finite")
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    raise float_error(f"{what} must be Decimal or int, got {type(value).__name__}")
+
+
+@dataclass(frozen=True)
+class WireCodec:
+    """The wire-boundary triad (parse / mapping / field) bound to one package's
+    typed errors. Wire payloads carry decimals as strings, never JSON numbers.
+    """
+
+    float_error: type[Exception]
+    payload_error: type[Exception]
+
+    def parse(self, value: object, what: str) -> Decimal:
+        """Decode a wire decimal string into a finite ``Decimal``."""
+        if isinstance(value, bool):
+            raise self.float_error(f"bool is not a valid {what}")
+        if isinstance(value, float):
+            raise self.float_error(
+                f"float is not allowed for {what}; use a decimal string"
+            )
+        if not isinstance(value, str):
+            raise self.float_error(
+                f"{what} must be encoded as a decimal string, got {type(value).__name__}"
+            )
+        try:
+            parsed = Decimal(value)
+        except (InvalidOperation, ValueError) as exc:
+            raise self.payload_error(f"{what} is not a valid decimal string") from exc
+        if not parsed.is_finite():
+            raise self.float_error(f"{what} must be finite")
+        return parsed
+
+    def mapping(self, payload: object, what: str) -> Mapping[str, object]:
+        """Require ``payload`` to be a mapping (the object envelope of a wire payload)."""
+        if not isinstance(payload, Mapping):
+            raise self.payload_error(
+                f"{what} payload must be an object, got {type(payload).__name__}"
+            )
+        return payload
+
+    def field(self, payload: Mapping[str, object], key: str, what: str) -> object:
+        """Read a required ``key`` from a wire payload mapping."""
+        try:
+            return payload[key]
+        except KeyError as exc:
+            raise self.payload_error(f"{what} payload missing {key!r}") from exc

--- a/common/money/money.py
+++ b/common/money/money.py
@@ -22,30 +22,18 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal
 
+from common.decimal_scalar import coerce_decimal
 from common.money.currency import Currency
 from common.money.errors import CurrencyMismatchError, FloatNotAllowedError
 from common.money.rounding import to_money
 
 # Amount inputs accepted at construction. ``bool`` is an ``int`` subclass but is
-# never a valid amount, so it is rejected explicitly below.
+# never a valid amount, so it is rejected explicitly by the shared codec below.
 _AmountInput = Decimal | int
 
 
 def _coerce_amount(value: object) -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError("bool is not a valid Money amount")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(
-            "float is not allowed for money amounts (IEEE-754 precision loss); "
-            "use Decimal"
-        )
-    if isinstance(value, Decimal):
-        return value
-    if isinstance(value, int):
-        return Decimal(value)
-    raise FloatNotAllowedError(
-        f"Money amount must be Decimal or int, got {type(value).__name__}"
-    )
+    return coerce_decimal(value, "Money amount", float_error=FloatNotAllowedError)
 
 
 @dataclass(frozen=True)
@@ -69,7 +57,9 @@ class Money:
         return cls(Decimal("0"), currency)
 
     @classmethod
-    def sum(cls, items: Iterable[Money], *, currency: Currency | str | None = None) -> Money:
+    def sum(
+        cls, items: Iterable[Money], *, currency: Currency | str | None = None
+    ) -> Money:
         """Add up same-currency ``Money`` values (replaces ``sum(xs, Decimal(0))``).
 
         Cross-currency items raise via ``+``. An empty iterable needs an explicit
@@ -78,7 +68,9 @@ class Money:
         total: Money | None = None
         for item in items:
             if not isinstance(item, Money):
-                raise TypeError(f"Money.sum expects Money items, got {type(item).__name__}")
+                raise TypeError(
+                    f"Money.sum expects Money items, got {type(item).__name__}"
+                )
             total = item if total is None else total + item
         if total is None:
             if currency is None:
@@ -109,7 +101,9 @@ class Money:
         """
         if rounding == ROUND_HALF_EVEN:
             return Money(to_money(self.amount), self.currency)
-        return Money(self.amount.quantize(Decimal("0.01"), rounding=rounding), self.currency)
+        return Money(
+            self.amount.quantize(Decimal("0.01"), rounding=rounding), self.currency
+        )
 
     # ── same-currency arithmetic ────────────────────────────────────────
     def _require_same_currency(self, other: Money, op: str) -> None:

--- a/common/money/wire.py
+++ b/common/money/wire.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 
+from common.decimal_scalar import WireCodec
+from common.decimal_scalar import decimal_to_wire as _decimal_to_wire
 from common.money.errors import FloatNotAllowedError, InvalidMoneyPayloadError
 from common.money.exchange_rate import ExchangeRate
 from common.money.money import Money
@@ -14,49 +16,20 @@ ExchangeRateWire = dict[str, str]
 MoneyDbFields = dict[str, Decimal | str]
 ExchangeRateDbFields = dict[str, Decimal | str]
 
-
-def _decimal_to_wire(value: Decimal) -> str:
-    text = format(value, "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    if text in {"", "-0"}:
-        return "0"
-    return text
+# The shared scalar codec bound to money's typed errors (parse / mapping / field).
+_CODEC = WireCodec(FloatNotAllowedError, InvalidMoneyPayloadError)
 
 
 def _decimal_from_wire(value: object, what: str) -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(
-            f"float is not allowed for {what}; use a decimal string"
-        )
-    if not isinstance(value, str):
-        raise FloatNotAllowedError(
-            f"{what} must be encoded as a decimal string, got {type(value).__name__}"
-        )
-    try:
-        parsed = Decimal(value)
-    except (InvalidOperation, ValueError) as exc:
-        raise InvalidMoneyPayloadError(f"{what} is not a valid decimal string") from exc
-    if not parsed.is_finite():
-        raise FloatNotAllowedError(f"{what} must be finite")
-    return parsed
+    return _CODEC.parse(value, what)
 
 
 def _payload_mapping(payload: object, what: str) -> Mapping[str, object]:
-    if not isinstance(payload, Mapping):
-        raise InvalidMoneyPayloadError(
-            f"{what} payload must be an object, got {type(payload).__name__}"
-        )
-    return payload
+    return _CODEC.mapping(payload, what)
 
 
 def _field(payload: Mapping[str, object], key: str, what: str) -> object:
-    try:
-        return payload[key]
-    except KeyError as exc:
-        raise InvalidMoneyPayloadError(f"{what} payload missing {key!r}") from exc
+    return _CODEC.field(payload, key, what)
 
 
 def money_to_wire(money: Money) -> MoneyWire:

--- a/common/quantity/quantity.py
+++ b/common/quantity/quantity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 
+from common.decimal_scalar import coerce_decimal
 from common.quantity.errors import FloatNotAllowedError, UnitMismatchError
 from common.quantity.unit import Unit
 from common.ratio import Ratio
@@ -17,20 +18,8 @@ _QuantityInput = Decimal | int
 
 
 def _coerce(value: object, what: str = "quantity value") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(
-            f"float is not allowed for {what} (IEEE-754 precision loss); use Decimal"
-        )
-    if isinstance(value, Decimal):
-        if not value.is_finite():
-            raise FloatNotAllowedError(f"{what} must be finite")
-        return value
-    if isinstance(value, int):
-        return Decimal(value)
-    raise FloatNotAllowedError(
-        f"{what} must be Decimal or int, got {type(value).__name__}"
+    return coerce_decimal(
+        value, what, float_error=FloatNotAllowedError, require_finite=True
     )
 
 
@@ -84,7 +73,7 @@ class Quantity:
         # invariants hold (finiteness check; float/bool stay a hard red line).
         # Any other operand type yields NotImplemented so a reflected op can handle
         # it — e.g. quantity * UnitPrice -> Money.
-        if isinstance(factor, (Decimal, int, float)):  # bool is an int subclass
+        if isinstance(factor, Decimal | int | float):  # bool is an int subclass
             return Quantity(self.value * _coerce(factor, "factor"), self.unit)
         return NotImplemented
 

--- a/common/quantity/wire.py
+++ b/common/quantity/wire.py
@@ -3,59 +3,30 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 
+from common.decimal_scalar import WireCodec
+from common.decimal_scalar import decimal_to_wire as _decimal_to_wire
 from common.quantity.errors import FloatNotAllowedError, InvalidQuantityPayloadError
 from common.quantity.quantity import Quantity
 
 QuantityWire = dict[str, str]
 QuantityDbFields = dict[str, Decimal | str]
 
-
-def _decimal_to_wire(value: Decimal) -> str:
-    text = format(value, "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    if text in {"", "-0"}:
-        return "0"
-    return text
+# The shared scalar codec bound to quantity's typed errors (parse / mapping / field).
+_CODEC = WireCodec(FloatNotAllowedError, InvalidQuantityPayloadError)
 
 
 def _decimal_from_wire(value: object, what: str = "quantity value") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(
-            f"float is not allowed for {what}; use a decimal string"
-        )
-    if not isinstance(value, str):
-        raise FloatNotAllowedError(
-            f"{what} must be encoded as a decimal string, got {type(value).__name__}"
-        )
-    try:
-        parsed = Decimal(value)
-    except (InvalidOperation, ValueError) as exc:
-        raise InvalidQuantityPayloadError(
-            f"{what} is not a valid decimal string"
-        ) from exc
-    if not parsed.is_finite():
-        raise FloatNotAllowedError(f"{what} must be finite")
-    return parsed
+    return _CODEC.parse(value, what)
 
 
 def _payload_mapping(payload: object) -> Mapping[str, object]:
-    if not isinstance(payload, Mapping):
-        raise InvalidQuantityPayloadError(
-            f"Quantity payload must be an object, got {type(payload).__name__}"
-        )
-    return payload
+    return _CODEC.mapping(payload, "Quantity")
 
 
 def _field(payload: Mapping[str, object], key: str) -> object:
-    try:
-        return payload[key]
-    except KeyError as exc:
-        raise InvalidQuantityPayloadError(f"Quantity payload missing {key!r}") from exc
+    return _CODEC.field(payload, key, "Quantity")
 
 
 def quantity_to_wire(quantity: Quantity) -> QuantityWire:

--- a/common/ratio/ratio.py
+++ b/common/ratio/ratio.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 
+from common.decimal_scalar import coerce_decimal
 from common.ratio.errors import FloatNotAllowedError, UndefinedRatioError
 
 # Canonical percent-display policy (NOT money's HALF_EVEN — percentages are not
@@ -34,19 +35,7 @@ _RatioInput = Decimal | int
 
 
 def _coerce(value: object, what: str = "ratio value") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(
-            f"float is not allowed for {what} (IEEE-754 precision loss); use Decimal"
-        )
-    if isinstance(value, Decimal):
-        return value
-    if isinstance(value, int):
-        return Decimal(value)
-    raise FloatNotAllowedError(
-        f"{what} must be Decimal or int, got {type(value).__name__}"
-    )
+    return coerce_decimal(value, what, float_error=FloatNotAllowedError)
 
 
 @dataclass(frozen=True)

--- a/common/ratio/wire.py
+++ b/common/ratio/wire.py
@@ -2,39 +2,20 @@
 
 from __future__ import annotations
 
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 
+from common.decimal_scalar import WireCodec
+from common.decimal_scalar import decimal_to_wire as _decimal_to_wire
 from common.ratio.errors import FloatNotAllowedError, InvalidRatioPayloadError
 from common.ratio.ratio import Ratio
 
-
-def _decimal_to_wire(value: Decimal) -> str:
-    text = format(value, "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    if text in {"", "-0"}:
-        return "0"
-    return text
+# The shared scalar codec bound to ratio's typed errors (ratio wire is a bare
+# decimal string, so only ``parse`` is needed — no payload envelope).
+_CODEC = WireCodec(FloatNotAllowedError, InvalidRatioPayloadError)
 
 
 def _decimal_from_wire(value: object, what: str = "ratio value") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(
-            f"float is not allowed for {what}; use a decimal string"
-        )
-    if not isinstance(value, str):
-        raise FloatNotAllowedError(
-            f"{what} must be encoded as a decimal string, got {type(value).__name__}"
-        )
-    try:
-        parsed = Decimal(value)
-    except (InvalidOperation, ValueError) as exc:
-        raise InvalidRatioPayloadError(f"{what} is not a valid decimal string") from exc
-    if not parsed.is_finite():
-        raise FloatNotAllowedError(f"{what} must be finite")
-    return parsed
+    return _CODEC.parse(value, what)
 
 
 def ratio_to_wire(ratio: Ratio) -> str:

--- a/common/unit_price/unit_price.py
+++ b/common/unit_price/unit_price.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 
+from common.decimal_scalar import coerce_decimal
 from common.money.currency import Currency
 from common.money.money import Money
 from common.quantity.quantity import Quantity
@@ -52,21 +53,8 @@ _RateInput = Decimal | int
 
 
 def _coerce_rate(value: object) -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError("bool is not a valid unit-price rate")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(
-            "float is not allowed for unit-price rates (IEEE-754 precision loss); "
-            "use Decimal"
-        )
-    if isinstance(value, Decimal):
-        if not value.is_finite():
-            raise FloatNotAllowedError("unit-price rate must be finite")
-        return value
-    if isinstance(value, int):
-        return Decimal(value)
-    raise FloatNotAllowedError(
-        f"unit-price rate must be Decimal or int, got {type(value).__name__}"
+    return coerce_decimal(
+        value, "unit-price rate", float_error=FloatNotAllowedError, require_finite=True
     )
 
 

--- a/common/unit_price/wire.py
+++ b/common/unit_price/wire.py
@@ -8,61 +8,30 @@ their canonical string codes.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 
+from common.decimal_scalar import WireCodec
+from common.decimal_scalar import decimal_to_wire as _decimal_to_wire
 from common.unit_price.errors import FloatNotAllowedError, InvalidUnitPricePayloadError
 from common.unit_price.unit_price import UnitPrice
 
 UnitPriceWire = dict[str, str]
 UnitPriceDbFields = dict[str, Decimal | str]
 
-
-def _decimal_to_wire(value: Decimal) -> str:
-    text = format(value, "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    if text in {"", "-0"}:
-        return "0"
-    return text
+# The shared scalar codec bound to unit-price's typed errors (parse / mapping / field).
+_CODEC = WireCodec(FloatNotAllowedError, InvalidUnitPricePayloadError)
 
 
 def _decimal_from_wire(value: object, what: str = "unit-price rate") -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError(f"bool is not a valid {what}")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(
-            f"float is not allowed for {what}; use a decimal string"
-        )
-    if not isinstance(value, str):
-        raise FloatNotAllowedError(
-            f"{what} must be encoded as a decimal string, got {type(value).__name__}"
-        )
-    try:
-        parsed = Decimal(value)
-    except (InvalidOperation, ValueError) as exc:
-        raise InvalidUnitPricePayloadError(
-            f"{what} is not a valid decimal string"
-        ) from exc
-    if not parsed.is_finite():
-        raise FloatNotAllowedError(f"{what} must be finite")
-    return parsed
+    return _CODEC.parse(value, what)
 
 
 def _payload_mapping(payload: object) -> Mapping[str, object]:
-    if not isinstance(payload, Mapping):
-        raise InvalidUnitPricePayloadError(
-            f"UnitPrice payload must be an object, got {type(payload).__name__}"
-        )
-    return payload
+    return _CODEC.mapping(payload, "UnitPrice")
 
 
 def _field(payload: Mapping[str, object], key: str) -> object:
-    try:
-        return payload[key]
-    except KeyError as exc:
-        raise InvalidUnitPricePayloadError(
-            f"UnitPrice payload missing {key!r}"
-        ) from exc
+    return _CODEC.field(payload, key, "UnitPrice")
 
 
 def unit_price_to_wire(unit_price: UnitPrice) -> UnitPriceWire:

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -555,6 +555,22 @@ other models/services follow incrementally.
 | AC12.35.2 | Investment accounting updates position state through the typed accessors (`position.cost_basis_money`/`realized_pnl_money`/`quantity_qty`) with `Money`/`Quantity` arithmetic instead of re-wrapping raw `Decimal` columns; writes back `.amount`/`.value` only at the storage edge {tier:PC} | `test_AC12_35_2_investment_accounting_reads_position_via_accessors` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
 | AC12.35.3 | The FX boundary is Money-native: `fx.convert_money(money, target) -> Money` wraps `convert_amount`, and portfolio holdings valuation flows as `Money` end-to-end (`UnitPrice(price) * position.quantity_qty` → `fx.convert_money` → `Money` P&L), collapsing the `if currency != base` Decimal branch {tier:PC} | `test_AC12_35_3_portfolio_holdings_value_flows_as_money` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
 
+### AC12.36: Shared Decimal-scalar codec — one SSOT per layer ([#1253](https://github.com/wangzitian0/finance_report/issues/1253))
+
+The raw-`Decimal` boundary codec required by `base-packages.md` §3 was re-implemented
+in every base package — a byte-identical `_decimal_to_wire`, a `_decimal_from_wire` /
+`_payload_mapping` / `_field` triad, and a construction-time `_coerce` — differing only
+by which typed error it raised. That codec is now factored once into a single
+`decimal_scalar` module per layer (`decimal_to_wire` / `coerce_decimal` / `WireCodec`);
+each package supplies its own error classes, so the per-domain error hierarchy is
+preserved while the duplicated bodies disappear. The module is dependency-light (it
+imports no base package, so the family stays bounded — not a fifth base package).
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC12.36.1 | The four `common/` base-package codecs route raw-`Decimal` conversion through one shared `common.decimal_scalar` module (`decimal_to_wire` / `coerce_decimal` / `WireCodec`); no base package re-defines the `_decimal_to_wire` / `_decimal_from_wire` / `_payload_mapping` / `_field` bodies or the construction-time `_coerce` body locally, and the canonical codec logic (`rstrip`, `IEEE-754` rejection, decimal-string parse) lives only in `decimal_scalar` {tier:PC} | `test_AC12_36_1_common_base_packages_share_one_scalar_codec` | `tests/tooling/test_decimal_scalar_ssot.py` | P1 |
+| AC12.36.2 | The backend self-contained mirror likewise routes every base-package `Decimal` boundary through one shared `src.decimal_scalar` module, keeping the backend end conformant without re-duplicating the codec per package {tier:PC} | `test_AC12_36_2_backend_base_packages_share_one_scalar_codec` | `tests/tooling/test_decimal_scalar_ssot.py` | P1 |
+
 ---
 
 *Planning snapshot captured: January 2026*

--- a/docs/ssot/base-packages.md
+++ b/docs/ssot/base-packages.md
@@ -112,6 +112,15 @@ return exact `Decimal` storage fields plus their semantic key (`currency` or
 errors (`Invalid*PayloadError` or `FloatNotAllowedError`), giving application
 code one place to audit and translate failures.
 
+The Decimal-scalar mechanics shared by every package's codec — the canonical
+wire string form (`decimal_to_wire`), the construction-time coercion
+(`coerce_decimal`), and the wire-parse / mapping / field triad (`WireCodec`) —
+live once in a single `decimal_scalar` module per layer (`common/decimal_scalar.py`
+and its `apps/backend/src` mirror), parameterized by each package's typed errors.
+It is dependency-light substrate, not a fifth base package, so the family stays
+bounded (§2). Routing every package through it is enforced by AC12.36, so the
+per-package codec bodies cannot silently re-duplicate.
+
 Runtime service code should keep the owning value type alive once a raw storage
 field crosses into business logic. For example, backend services should turn a
 quantity DB `Decimal` into `Quantity(value, unit).quantize()`, call methods such

--- a/tests/tooling/test_decimal_scalar_ssot.py
+++ b/tests/tooling/test_decimal_scalar_ssot.py
@@ -1,0 +1,157 @@
+"""Shared Decimal-scalar codec is one SSOT per layer (EPIC-012 AC12.36).
+
+These guards ratchet the dedup: each base package's wire/core modules must route
+their raw-``Decimal`` conversion through the shared ``decimal_scalar`` codec, and
+the canonical codec logic must live *only* there — so the per-package duplication
+(``_decimal_to_wire`` / ``_decimal_from_wire`` / ``_payload_mapping`` / ``_field``
+bodies + a construction-time ``_coerce`` body) cannot silently come back.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from common.decimal_scalar import WireCodec, coerce_decimal, decimal_to_wire
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Markers of the canonical codec bodies that must exist ONLY in decimal_scalar.
+_CODEC_BODY_MARKERS = (
+    'rstrip("0").rstrip(".")',  # decimal_to_wire body
+    "IEEE-754 precision loss",  # coerce_decimal float-rejection body
+    "is not a valid decimal string",  # WireCodec.parse body
+    "must be encoded as a decimal string",  # WireCodec.parse body
+)
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+def _assert_layer_shares_one_codec(layer_root: str, import_prefix: str) -> None:
+    """Every base package under ``layer_root`` routes through ``import_prefix.decimal_scalar``."""
+    wire_modules = {
+        "money": f"{layer_root}/money/wire.py",
+        "quantity": f"{layer_root}/quantity/wire.py",
+        "ratio": f"{layer_root}/ratio/wire.py",
+        "unit_price": f"{layer_root}/unit_price/wire.py",
+    }
+    core_modules = {
+        "money": f"{layer_root}/money/money.py",
+        "quantity": f"{layer_root}/quantity/quantity.py",
+        "ratio": f"{layer_root}/ratio/ratio.py",
+        "unit_price": f"{layer_root}/unit_price/unit_price.py",
+    }
+
+    for pkg, rel in wire_modules.items():
+        src = _read(rel)
+        assert f"from {import_prefix}.decimal_scalar import" in src, (
+            f"{rel} must import the shared codec"
+        )
+        assert "WireCodec(" in src, f"{rel} must bind a WireCodec to its typed errors"
+        for marker in _CODEC_BODY_MARKERS:
+            assert marker not in src, (
+                f"{rel} still inlines codec body {marker!r} (route through decimal_scalar)"
+            )
+
+    for pkg, rel in core_modules.items():
+        src = _read(rel)
+        assert "coerce_decimal" in src, f"{rel} must coerce via the shared codec"
+        assert "IEEE-754 precision loss" not in src, (
+            f"{rel} still inlines the _coerce float-rejection body"
+        )
+
+    # The canonical logic lives only in the shared module.
+    codec_src = _read(f"{layer_root}/decimal_scalar.py")
+    assert "def decimal_to_wire(" in codec_src
+    assert "def coerce_decimal(" in codec_src
+    assert "class WireCodec" in codec_src
+    for marker in _CODEC_BODY_MARKERS:
+        assert marker in codec_src, (
+            f"{layer_root}/decimal_scalar.py is missing canonical body {marker!r}"
+        )
+
+
+@ac_proof(
+    proof_id="test_common_base_packages_share_one_scalar_codec",
+    ac_ids=["AC12.36.1"],
+    ci_tier="pr_ci",
+)
+def test_AC12_36_1_common_base_packages_share_one_scalar_codec():
+    """AC12.36.1: the four common base packages share one decimal_scalar codec."""
+    _assert_layer_shares_one_codec("common", "common")
+
+
+@ac_proof(
+    proof_id="test_backend_base_packages_share_one_scalar_codec",
+    ac_ids=["AC12.36.2"],
+    ci_tier="pr_ci",
+)
+def test_AC12_36_2_backend_base_packages_share_one_scalar_codec():
+    """AC12.36.2: the backend mirror shares one src.decimal_scalar codec."""
+    _assert_layer_shares_one_codec("apps/backend/src", "src")
+
+
+# ── behavioural coverage of the shared codec (common layer) ──────────────────
+
+
+class _FloatError(TypeError):
+    pass
+
+
+class _PayloadError(ValueError):
+    pass
+
+
+def test_decimal_to_wire_trims_and_normalizes_zero():
+    assert decimal_to_wire(Decimal("10.5000")) == "10.5"
+    assert decimal_to_wire(Decimal("3")) == "3"
+    assert decimal_to_wire(Decimal("-0")) == "0"
+    assert decimal_to_wire(Decimal("0.00")) == "0"
+
+
+def test_coerce_decimal_accepts_decimal_and_int():
+    assert coerce_decimal(Decimal("1.25"), "x", float_error=_FloatError) == Decimal(
+        "1.25"
+    )
+    assert coerce_decimal(7, "x", float_error=_FloatError) == Decimal("7")
+
+
+def test_coerce_decimal_rejects_bool_float_and_other_types():
+    for bad in (True, 1.5, "1.5", None):
+        with pytest.raises(_FloatError):
+            coerce_decimal(bad, "x", float_error=_FloatError)
+
+
+def test_coerce_decimal_require_finite_rejects_nan_infinity():
+    # Non-finite is allowed when require_finite is off, rejected when on.
+    assert coerce_decimal(Decimal("NaN"), "x", float_error=_FloatError).is_nan()
+    for bad in (Decimal("NaN"), Decimal("Infinity")):
+        with pytest.raises(_FloatError):
+            coerce_decimal(bad, "x", float_error=_FloatError, require_finite=True)
+
+
+def test_wire_codec_parse_decodes_and_validates():
+    codec = WireCodec(_FloatError, _PayloadError)
+    assert codec.parse("1.50", "x") == Decimal("1.50")
+    for bad in (True, 1.5, b"1"):
+        with pytest.raises(_FloatError):
+            codec.parse(bad, "x")
+    with pytest.raises(_PayloadError):
+        codec.parse("not-a-number", "x")
+    with pytest.raises(_FloatError):
+        codec.parse("NaN", "x")
+
+
+def test_wire_codec_mapping_and_field():
+    codec = WireCodec(_FloatError, _PayloadError)
+    assert codec.mapping({"a": "1"}, "X") == {"a": "1"}
+    with pytest.raises(_PayloadError):
+        codec.mapping(["not", "a", "map"], "X")
+    assert codec.field({"a": "1"}, "a", "X") == "1"
+    with pytest.raises(_PayloadError):
+        codec.field({"a": "1"}, "missing", "X")


### PR DESCRIPTION
## Why

The four base packages (`money`/`quantity`/`ratio`/`unit_price`) each re-implemented the raw-`Decimal` boundary codec that `base-packages.md` §3 requires — a **byte-identical** `_decimal_to_wire`, a `_decimal_from_wire` / `_payload_mapping` / `_field` triad, and a construction-time `_coerce` — differing only by which typed error they raised. Same flow, different parameters: exactly the redundancy the review flagged.

## What

Extract that codec **once** into a single dependency-light `decimal_scalar` module **per layer**:

- `common/decimal_scalar.py` (reference) + `apps/backend/src/decimal_scalar.py` (the backend's self-contained mirror, per the #1167 narrow-waist design — backend does not import `common` at runtime).
- API: `decimal_to_wire(value)`, `coerce_decimal(value, what, *, float_error, require_finite)`, and `WireCodec(float_error, payload_error)` with `.parse` / `.mapping` / `.field`.
- Each package binds the shared codec to **its own** error classes, so the per-domain error hierarchy (`Invalid*PayloadError` / `FloatNotAllowedError`) is preserved.

It is substrate, **not** a fifth base package — the family stays bounded (§2).

## Invariants preserved (no behavior change)

- Field names (`amount`/`value`/`rate`), denominations, public API (`*_to_wire` / `*_from_wire` / `*_to_db_fields` …), and `__all__` are untouched.
- Per-package `_coerce` semantics kept exactly (money/ratio do **not** finite-check; quantity/unit_price do — via `require_finite`).
- money/unit_price float-rejection messages are now templated by `{what}` (was an irregular plural); no test/vector pins the text, and it is more consistent.

## SSOT ratchet

New **AC12.36.1/.2** (EPIC-012) + `test_decimal_scalar_ssot.py` assert every package routes through `decimal_scalar` and that the canonical codec bodies live **only** there — so the duplication cannot silently come back. SSOT doc (`base-packages.md` §3) updated.

## Verification (local)

- Pinned ruff 0.14.11 (CI's): `ruff check src tests` ✅, `ruff format --check` ✅
- Backend VO + codec suite: **88 passed**; common VO + SSOT suite: **118 passed**; full `tests/tooling/`: **1823 passed**
- Gates: `check_ac_index` (Gate A+B) ✅, `generate_ac_registry --check` ✅, `check_ac_proof_kind` ✅, `check_package_contract` ✅, `lint_doc_consistency` ✅, narrow-waist guard + decimal-boundary-policy ✅
- New modules: **100% coverage**

Note: the pre-commit `mypy` hook (local-only; CI does not run mypy) reports **pre-existing** `Currency | str` dataclass-coercion errors on the touched files — confirmed identical on unchanged `HEAD` — so not introduced here. Also modernizes one pre-existing `UP038` isinstance-tuple in `quantity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)