### PR TITLE
[finance_report_hacker] fix(reports): seed report filters from URL query params (deep-link regression)

### DIFF
--- a/apps/frontend/src/__tests__/cashFlowPage.test.tsx
+++ b/apps/frontend/src/__tests__/cashFlowPage.test.tsx
@@ -9,6 +9,10 @@ vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: ReactNode }) => <a href={href}>{children}</a>,
 }))
 
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+}))
+
 vi.mock("@/components/charts/SankeyChart", () => ({
   SankeyChart: () => <div>SankeyChartMock</div>,
 }))

--- a/apps/frontend/src/__tests__/incomeStatementPage.test.tsx
+++ b/apps/frontend/src/__tests__/incomeStatementPage.test.tsx
@@ -9,6 +9,10 @@ vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: ReactNode }) => <a href={href}>{children}</a>,
 }))
 
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+}))
+
 vi.mock("@/components/charts/BarChart", () => ({
   BarChart: () => <div>BarChartMock</div>,
 }))

--- a/apps/frontend/src/__tests__/useReportFilters.test.ts
+++ b/apps/frontend/src/__tests__/useReportFilters.test.ts
@@ -1,9 +1,26 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useReportFilters } from "@/hooks/useReportFilters";
 
+// Mock next/navigation so the hook can seed its initial state from the URL
+// query params (the AC5.34.6 deep-link contract). Tests set `urlParams` and the
+// mocked `useSearchParams().get()` reads from it.
+let urlParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: (key: string) => urlParams.get(key) }),
+}));
+
 describe("useReportFilters", () => {
+  beforeEach(() => {
+    urlParams = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("AC5.34.3 builds query string from filter state", () => {
     const { result } = renderHook(() =>
       useReportFilters({
@@ -53,5 +70,55 @@ describe("useReportFilters", () => {
     });
 
     expect(new URLSearchParams(result.current.queryString).get("currency")).toBe("EUR");
+  });
+
+  it("AC5.34.6 seeds initial filter state from URL query params", () => {
+    urlParams = new URLSearchParams({
+      as_of_date: "2026-05-31",
+      start_date: "2026-04-01",
+      end_date: "2026-05-31",
+      currency: "USD",
+    });
+
+    const { result } = renderHook(() =>
+      useReportFilters({ reportType: "balance-sheet" }),
+    );
+
+    expect(result.current.asOfDate).toBe("2026-05-31");
+    expect(result.current.startDate).toBe("2026-04-01");
+    expect(result.current.endDate).toBe("2026-05-31");
+    expect(result.current.currency).toBe("USD");
+
+    const params = new URLSearchParams(result.current.queryString);
+    expect(params.get("as_of_date")).toBe("2026-05-31");
+    expect(params.get("currency")).toBe("USD");
+  });
+
+  it("AC5.34.6 lets an explicit option override the URL query param", () => {
+    urlParams = new URLSearchParams({
+      as_of_date: "2026-05-31",
+      currency: "USD",
+    });
+
+    const { result } = renderHook(() =>
+      useReportFilters({
+        reportType: "balance-sheet",
+        initialAsOfDate: "2026-01-15",
+        initialCurrency: "SGD",
+      }),
+    );
+
+    expect(result.current.asOfDate).toBe("2026-01-15");
+    expect(result.current.currency).toBe("SGD");
+  });
+
+  it("AC5.34.6 falls back to defaults when neither option nor URL is present", () => {
+    const { result } = renderHook(() =>
+      useReportFilters({ reportType: "balance-sheet" }),
+    );
+
+    // No URL param and no option: as-of date defaults to today, currency to SGD.
+    expect(result.current.asOfDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.current.currency).toBe("SGD");
   });
 });

--- a/apps/frontend/src/hooks/useReportFilters.ts
+++ b/apps/frontend/src/hooks/useReportFilters.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 
 import { formatDateInput } from "@/lib/date";
@@ -50,10 +51,27 @@ export function useReportFilters(
   const { reportType } = options;
   const isPointInTime = reportType === "balance-sheet";
 
-  const [asOfDate, setAsOfDate] = useState(options.initialAsOfDate ?? today());
-  const [startDate, setStartDate] = useState(options.initialStartDate ?? today());
-  const [endDate, setEndDate] = useState(options.initialEndDate ?? today());
-  const [currency, setCurrency] = useState(options.initialCurrency ?? "SGD");
+  // Seed initial filter state with precedence:
+  //   explicit option ?? URL query param ?? existing default.
+  // This restores deep-link support (e.g. ?as_of_date=2026-05-31&currency=SGD)
+  // that was dropped when filters were centralized into this hook (Slice 3 of
+  // #751). `useSearchParams` is read once; the values only seed `useState`
+  // initial expressions (evaluated on mount), so they never fight user edits and
+  // no URL round-trip / router.replace is performed here.
+  const searchParams = useSearchParams();
+  const initialAsOfDate =
+    options.initialAsOfDate ?? searchParams.get("as_of_date") ?? today();
+  const initialStartDate =
+    options.initialStartDate ?? searchParams.get("start_date") ?? today();
+  const initialEndDate =
+    options.initialEndDate ?? searchParams.get("end_date") ?? today();
+  const initialCurrency =
+    options.initialCurrency ?? searchParams.get("currency") ?? "SGD";
+
+  const [asOfDate, setAsOfDate] = useState(initialAsOfDate);
+  const [startDate, setStartDate] = useState(initialStartDate);
+  const [endDate, setEndDate] = useState(initialEndDate);
+  const [currency, setCurrency] = useState(initialCurrency);
 
   const queryString = useMemo(() => {
     const params = new URLSearchParams();

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -380,6 +380,7 @@ page-level intent.
 | AC5.34.3 | `useReportFilters` builds a query string from its date and currency state | `AC5.34.3 builds query string from filter state` | `apps/frontend/src/__tests__/useReportFilters.test.ts` | P1 |
 | AC5.34.4 | `useReportFilters` derives the CSV export path for the given report type | `AC5.34.4 derives csv export path for report type` | `apps/frontend/src/__tests__/useReportFilters.test.ts` | P1 |
 | AC5.34.5 | `useReportFilters` updates the query string when the currency changes | `AC5.34.5 updates query string when currency changes` | `apps/frontend/src/__tests__/useReportFilters.test.ts` | P1 |
+| AC5.34.6 {tier:PC} | `useReportFilters` seeds its initial date/currency state from the URL query params (`as_of_date`/`start_date`/`end_date`/`currency`) with precedence explicit option > URL param > default, so report routes honour deep links | `AC5.34.6 seeds initial filter state from URL query params` | `apps/frontend/src/__tests__/useReportFilters.test.ts` | P1 |
 
 ### AC5.35: Dashboard Aggregation Moved Into Hook Layer ([#751](https://github.com/wangzitian0/finance_report/issues/751))
 


### PR DESCRIPTION
## Root cause

`apps/frontend/src/hooks/useReportFilters.ts` ignored the URL entirely: it never called `useSearchParams`, seeding `asOfDate`/`startDate`/`endDate` to `today()` and `currency` to `"SGD"`. So `/reports/balance-sheet`, `/reports/income-statement`, and `/reports/cash-flow` ignored their deep-link query params (`as_of_date`/`start_date`/`end_date`/`currency`) and always rendered "today". This was introduced by the report-shell refactor (Slice 3 of #751 / #1092) that centralized filters into the hook but dropped the URL-param init.

## Impact

- Breaks report deep-linking (shared links / bookmarks render the wrong period).
- Reds the staging vision hard gate `tests/e2e/test_vision_upload_to_dashboard_hard_gate.py`: it deep-links `/reports/balance-sheet?as_of_date=2026-05-31&currency=SGD`, the page renders for today instead → data mismatch → error alert → the `Balance Sheet` heading is not found (line 451).

## Fix (minimal, low-risk)

Read `useSearchParams()` in the (`"use client"`) hook and seed each `useState` initial expression with precedence **explicit option ?? URL param ?? existing default**:

- `asOfDate`  = `options.initialAsOfDate ?? sp.get("as_of_date") ?? today()`
- `startDate` = `options.initialStartDate ?? sp.get("start_date") ?? today()`
- `endDate`   = `options.initialEndDate ?? sp.get("end_date") ?? today()`
- `currency`  = `options.initialCurrency ?? sp.get("currency") ?? "SGD"`

The URL is read once on mount to seed state only — no effects, no `router.replace` / URL sync — so user edits are never fought, and an explicit option still wins. The three report pages need no changes (they all go through the hook).

## Tests

- Extends `apps/frontend/src/__tests__/useReportFilters.test.ts` with **AC5.34.6** (mocks `useSearchParams`): asserts initial `asOfDate`/`startDate`/`endDate`/`currency` and the derived `queryString` reflect the URL; that an explicit option overrides the URL; and that defaults still apply when neither is present. Red before the fix, green after.
- Adds the same `next/navigation` mock (already used by the balance-sheet page test) to the income-statement and cash-flow page tests, which now exercise the hook's `useSearchParams` call.
- New AC `AC5.34.6 {tier:PC}` added to EPIC-005 in the existing AC5.34 family, restoring the deep-link contract. AC index + tier-baseline + proof-kind gates pass locally.

## Scope

Does **not** touch the backend or #1327. Frontend-only seeding change.