### PR TITLE
[finance_report_audit] feat(orm): JournalLine.money accessor + reconciliation sums via Money.sum (AC12.37)

### DIFF
--- a/apps/backend/src/models/journal.py
+++ b/apps/backend/src/models/journal.py
@@ -174,10 +174,12 @@ class JournalLine(Base, UUIDMixin, TimestampMixin):
 
         Lines are immutable (amount > 0); the raw amount/currency columns remain
         the storage boundary while business code reads this typed value. ``currency``
-        has a DB default of "SGD" (nullable=False) that only materializes on insert,
-        so mirror it for in-memory rows not yet flushed.
+        is non-nullable with a SQLAlchemy column default of "SGD" that only
+        materializes on insert, so mirror it ONLY for ``None`` on in-memory rows not
+        yet flushed — an empty/invalid present value still surfaces via Money.
         """
-        return Money(self.amount, self.currency or "SGD")
+        currency = self.currency if self.currency is not None else "SGD"
+        return Money(self.amount, currency)
 
     def __repr__(self) -> str:
         return f"<JournalLine {self.direction.value} {self.amount} {self.currency}>"

--- a/apps/backend/src/models/journal.py
+++ b/apps/backend/src/models/journal.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
 from src.models.base import TimestampMixin, UserOwnedMixin, UUIDMixin
+from src.money import Money
 
 if TYPE_CHECKING:
     from src.models.account import Account
@@ -166,6 +167,17 @@ class JournalLine(Base, UUIDMixin, TimestampMixin):
 
     journal_entry: Mapped[JournalEntry] = relationship("JournalEntry", back_populates="lines")
     account: Mapped[Account] = relationship("Account", back_populates="journal_lines")
+
+    @property
+    def money(self) -> Money:
+        """Line amount as a typed Money (read accessor, #3 boundary push).
+
+        Lines are immutable (amount > 0); the raw amount/currency columns remain
+        the storage boundary while business code reads this typed value. ``currency``
+        has a DB default of "SGD" (nullable=False) that only materializes on insert,
+        so mirror it for in-memory rows not yet flushed.
+        """
+        return Money(self.amount, self.currency or "SGD")
 
     def __repr__(self) -> str:
         return f"<JournalLine {self.direction.value} {self.amount} {self.currency}>"

--- a/apps/backend/src/services/reconciliation_config.py
+++ b/apps/backend/src/services/reconciliation_config.py
@@ -13,6 +13,7 @@ from src.models import (
     Direction,
     JournalEntry,
 )
+from src.money import Money
 from src.services.accounting import ValidationError, validate_journal_balance
 from src.services.promotion_gate import RECONCILIATION_AUTO_ACCEPT_SCORE, RECONCILIATION_REVIEW_SCORE
 from src.services.source_type_priority import source_type_rank
@@ -79,7 +80,8 @@ def _candidate_is_better(
 
 def entry_total_amount(entry: JournalEntry) -> Decimal:
     """Return total debit amount for matching."""
-    return sum(line.amount for line in entry.lines if line.direction == Direction.DEBIT)
+    debits = [line.money for line in entry.lines if line.direction == Direction.DEBIT]
+    return Money.sum(debits).amount if debits else Decimal("0.00")
 
 
 def entry_bank_side_amount(entry: JournalEntry, transaction_direction: str | None) -> Decimal:
@@ -89,12 +91,12 @@ def entry_bank_side_amount(entry: JournalEntry, transaction_direction: str | Non
     direction = transaction_direction.upper()
     bank_line_direction = Direction.DEBIT if direction == "IN" else Direction.CREDIT
     bank_lines = [
-        line.amount
+        line.money
         for line in entry.lines
         if line.direction == bank_line_direction and line.account and line.account.type == AccountType.ASSET
     ]
     if bank_lines:
-        return sum(bank_lines, Decimal("0.00"))
+        return Money.sum(bank_lines).amount
     return entry_total_amount(entry)
 
 

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -572,6 +572,19 @@ imports no base package, so the family stays bounded — not a fifth base packag
 | AC12.36.1 | The four `common/` base-package codecs route raw-`Decimal` conversion through one shared `common.decimal_scalar` module (`decimal_to_wire` / `coerce_decimal` / `WireCodec`); no base package re-defines the `_decimal_to_wire` / `_decimal_from_wire` / `_payload_mapping` / `_field` bodies or the construction-time `_coerce` body locally, and the canonical codec logic (`rstrip`, `IEEE-754` rejection, decimal-string parse) lives only in `decimal_scalar` {tier:PC} | `test_AC12_36_1_common_base_packages_share_one_scalar_codec` | `tests/tooling/test_decimal_scalar_ssot.py` | P1 |
 | AC12.36.2 | The backend self-contained mirror likewise routes every base-package `Decimal` boundary through one shared `src.decimal_scalar` module, keeping the backend end conformant without re-duplicating the codec per package {tier:PC} | `test_AC12_36_2_backend_base_packages_share_one_scalar_codec` | `tests/tooling/test_decimal_scalar_ssot.py` | P1 |
 
+### AC12.37: `JournalLine.money` accessor — boundary push Phase 2 ([#1253](https://github.com/wangzitian0/finance_report/issues/1253))
+
+After the `ManagedPosition` pilot (AC12.35), the next-largest raw-`Decimal` read
+surface is `JournalLine.amount` (~40 service reads). Journal lines are immutable
+(`amount > 0`), so a read-only `money` accessor is the boundary; business sums/reads
+lines as `Money` (currency-checked) instead of raw currency-blind `Decimal`. Migrated
+incrementally by area; the forbid-ratchet follows once the surface is covered.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC12.37.1 | `JournalLine` exposes a typed `money` read accessor (`Money(amount, currency)`, currency mirroring the column's "SGD" default for unflushed rows) at the ORM boundary; the raw `amount`/`currency` columns remain the storage edge {tier:PC} | `test_AC12_37_1_journal_line_exposes_money_accessor` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
+| AC12.37.2 | The reconciliation entry-amount helpers (`entry_total_amount`/`entry_bank_side_amount`) sum journal lines via `line.money` + `Money.sum` (currency-checked) instead of a raw currency-blind `sum(line.amount)` {tier:PC} | `test_AC12_37_2_reconciliation_config_sums_lines_as_money` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
+
 ---
 
 *Planning snapshot captured: January 2026*

--- a/tests/tooling/test_orm_value_type_boundary.py
+++ b/tests/tooling/test_orm_value_type_boundary.py
@@ -115,3 +115,31 @@ def test_AC12_35_4_no_raw_managed_position_money_reads_in_migrated_files():
     assert not offenders, (
         f"raw ManagedPosition money reads must use accessors: {offenders}"
     )
+
+
+@ac_proof(
+    proof_id="test_journal_line_money_accessor",
+    ac_ids=["AC12.37.1"],
+    ci_tier="pr_ci",
+)
+def test_AC12_37_1_journal_line_exposes_money_accessor():
+    """AC12.37.1: JournalLine exposes a typed `money` read accessor at the ORM
+    boundary (lines are immutable; amount/currency columns stay storage)."""
+    src = _read("apps/backend/src/models/journal.py")
+    assert "from src.money import Money" in src
+    assert "def money(self) -> Money" in src
+
+
+@ac_proof(
+    proof_id="test_reconciliation_config_sums_money",
+    ac_ids=["AC12.37.2"],
+    ci_tier="pr_ci",
+)
+def test_AC12_37_2_reconciliation_config_sums_lines_as_money():
+    """AC12.37.2: reconciliation entry-amount helpers sum journal lines via the
+    typed `line.money` accessor + `Money.sum` (currency-checked), not a raw
+    currency-blind `sum(line.amount)`."""
+    src = _read("apps/backend/src/services/reconciliation_config.py")
+    assert "line.money" in src
+    assert "Money.sum(" in src
+    assert "sum(line.amount" not in src


### PR DESCRIPTION
**Phase 2 of #3 (boundary push)** begins — the next-largest raw-`Decimal` read surface is `JournalLine.amount` (~40 service reads). This PR adds the accessor and migrates the first cohesive slice.

## What

- **`JournalLine.money`** → `Money(amount, currency)`. Lines are immutable (`amount > 0`), so it's a read-only accessor. `currency` mirrors the column's `"SGD"` default for in-memory (pre-flush) rows where the DB default hasn't materialized yet.
- **`reconciliation_config`** `entry_total_amount` / `entry_bank_side_amount` now sum lines via `line.money` + `Money.sum` (**currency-checked**) instead of currency-blind `sum(line.amount)`. Returns `.amount` (Decimal) so callers are unchanged; empty debit set → `Decimal("0.00")`.

This is a real `Money.sum` adoption (the composite op that's been waiting) and makes cross-currency line sums *unrepresentable* in the matching path.

## Scope

First slice only. `JournalLine` has ~40 reads across many files (reporting, fx_*, evidence graph, processing_account, …) — migrated by area across the next PRs. The **forbid-ratchet** (like AC12.35.4) follows once the surface is covered.

## Verification

- **676** reconciliation/accounting/journal tests pass (behaviour-preserving).
- Full tooling guard suite (**1648**) + `ruff` green — run locally before push.
- Fixed a `None`-currency crash for unflushed test rows via the column-default mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)