### PR TITLE
[finance_report_audit] feat(orm): income-statement FX is Money-native via convert_money (AC12.37.3)

### DIFF
--- a/apps/backend/src/services/reporting/income_statement.py
+++ b/apps/backend/src/services/reporting/income_statement.py
@@ -23,7 +23,7 @@ from src.services.fx import (
     FxRateError,
     FxWarning,
     PrefetchedFxRates,
-    convert_amount,
+    convert_money,
 )
 from src.services.reporting._core import _REPORT_STATUSES, _build_account_lines, _load_accounts
 from src.services.reporting.balance_sheet import generate_balance_sheet
@@ -147,17 +147,18 @@ async def generate_income_statement(
             if rate_total is None:
                 # Fallback to slow path if not pre-fetched (should be rare)
                 try:
-                    converted_total = await convert_amount(
-                        db,
-                        amount=line.amount,
-                        currency=line.currency,
-                        target_currency=target_currency,
-                        rate_date=end_date,
-                        average_start=start_date,
-                        average_end=end_date,
-                        fx_warnings=fx_warnings,
-                        lazy_load=True,
-                    )
+                    converted_total = (
+                        await convert_money(
+                            db,
+                            line.money,
+                            target_currency,
+                            end_date,
+                            average_start=start_date,
+                            average_end=end_date,
+                            fx_warnings=fx_warnings,
+                            lazy_load=True,
+                        )
+                    ).amount
                 except FxRateError as exc:
                     logger.warning(
                         "Average FX rate unavailable, falling back to spot",
@@ -170,14 +171,15 @@ async def generate_income_statement(
                     )
                     # Fallback to spot rate at end_date
                     try:
-                        converted_total = await convert_amount(
-                            db,
-                            amount=line.amount,
-                            currency=line.currency,
-                            target_currency=target_currency,
-                            rate_date=end_date,
-                            lazy_load=True,
-                        )
+                        converted_total = (
+                            await convert_money(
+                                db,
+                                line.money,
+                                target_currency,
+                                end_date,
+                                lazy_load=True,
+                            )
+                        ).amount
                     except FxRateError as final_exc:
                         logger.error(
                             "All FX rate fallbacks failed for income statement",

--- a/apps/backend/tests/reporting/test_reporting_fx_fallbacks.py
+++ b/apps/backend/tests/reporting/test_reporting_fx_fallbacks.py
@@ -17,6 +17,7 @@ from src.models import (
     JournalEntryStatus,
     JournalLine,
 )
+from src.money import Money
 from src.services.reporting import (
     ReportError,
     _aggregate_balances_sql,
@@ -398,12 +399,12 @@ async def test_income_statement_fx_average_to_spot_fallback(db: AsyncSession, ac
         mock_instance.get_rate = mock_get_rate
         MockPrefetched.return_value = mock_instance
 
-        async def mock_convert(db, amount, currency, target_currency, rate_date, **kwargs):
+        async def mock_convert(db, money, target_currency, rate_date, **kwargs):
             if kwargs.get("average_start") is not None:
                 raise FxRateError("No average rate available")
-            return amount * Decimal("1.35")
+            return Money(money.amount * Decimal("1.35"), target_currency)
 
-        with patch("src.services.reporting.income_statement.convert_amount", side_effect=mock_convert):
+        with patch("src.services.reporting.income_statement.convert_money", side_effect=mock_convert):
             report = await generate_income_statement(
                 db, user_id, start_date=date(2025, 1, 1), end_date=date(2025, 1, 31), currency="SGD"
             )
@@ -465,10 +466,10 @@ async def test_income_statement_fx_all_fallbacks_fail(db: AsyncSession, accounts
         mock_instance.get_rate = lambda *args, **kwargs: None
         MockPrefetched.return_value = mock_instance
 
-        async def mock_convert_fail(db, amount, currency, target_currency, rate_date, **kwargs):
+        async def mock_convert_fail(db, money, target_currency, rate_date, **kwargs):
             raise FxRateError("No rate available at all")
 
-        with patch("src.services.reporting.income_statement.convert_amount", side_effect=mock_convert_fail):
+        with patch("src.services.reporting.income_statement.convert_money", side_effect=mock_convert_fail):
             with pytest.raises(ReportError, match="FX conversion failed"):
                 await generate_income_statement(
                     db, user_id, start_date=date(2025, 1, 1), end_date=date(2025, 1, 31), currency="SGD"

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -584,6 +584,7 @@ incrementally by area; the forbid-ratchet follows once the surface is covered.
 |----|-----------|---------------|------|----------|
 | AC12.37.1 | `JournalLine` exposes a typed `money` read accessor (`Money(amount, currency)`, currency mirroring the column's "SGD" default for unflushed rows) at the ORM boundary; the raw `amount`/`currency` columns remain the storage edge {tier:PC} | `test_AC12_37_1_journal_line_exposes_money_accessor` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
 | AC12.37.2 | The reconciliation entry-amount helpers (`entry_total_amount`/`entry_bank_side_amount`) sum journal lines via `line.money` + `Money.sum` (currency-checked) instead of a raw currency-blind `sum(line.amount)` {tier:PC} | `test_AC12_37_2_reconciliation_config_sums_lines_as_money` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
+| AC12.37.3 | The income-statement slow-path FX converts journal lines through the Money-native `convert_money(line.money, …)` (incl. average-rate + spot fallbacks) instead of raw `convert_amount(line.amount, line.currency, …)`. (The pre-fetched-rate fast path stays a raw `Decimal` multiply by design; serialization edges and the balance core legitimately read raw columns) {tier:PC} | `test_AC12_37_3_income_statement_fx_is_money_native` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
 
 ---
 

--- a/tests/tooling/test_orm_value_type_boundary.py
+++ b/tests/tooling/test_orm_value_type_boundary.py
@@ -143,3 +143,17 @@ def test_AC12_37_2_reconciliation_config_sums_lines_as_money():
     assert "line.money" in src
     assert "Money.sum(" in src
     assert "sum(line.amount" not in src
+
+
+@ac_proof(
+    proof_id="test_income_statement_converts_money_native",
+    ac_ids=["AC12.37.3"],
+    ci_tier="pr_ci",
+)
+def test_AC12_37_3_income_statement_fx_is_money_native():
+    """AC12.37.3: the income-statement slow-path FX converts journal lines via the
+    Money-native `convert_money(line.money, ...)`, not raw `convert_amount(line.amount)`."""
+    src = _read("apps/backend/src/services/reporting/income_statement.py")
+    assert "convert_money(" in src
+    assert "line.money" in src
+    assert "amount=line.amount" not in src

--- a/tests/tooling/test_orm_value_type_boundary.py
+++ b/tests/tooling/test_orm_value_type_boundary.py
@@ -156,4 +156,7 @@ def test_AC12_37_3_income_statement_fx_is_money_native():
     src = _read("apps/backend/src/services/reporting/income_statement.py")
     assert "convert_money(" in src
     assert "line.money" in src
-    assert "amount=line.amount" not in src
+    # robust: income_statement no longer references raw convert_amount at all
+    # (import or call) — catches positional / intermediate-variable regressions
+    # that an `amount=line.amount` substring check would miss.
+    assert "convert_amount" not in src


### PR DESCRIPTION
**Phase 2 of #3 (JournalLine), second slice.** The income-statement slow-path FX (average-rate + spot fallback) now converts journal lines through the Money-native `convert_money(line.money, …)` instead of raw `convert_amount(line.amount, line.currency, …)`. Lines come from a flushed query, so `currency` is always set.

## Honest scope (important)

Reviewing the full `JournalLine` surface showed it is **not** cleanly "migrate every `line.amount`" like `ManagedPosition` was:
- **Serialization edges** (response dicts in report_traceability / lineage / evidence_graph) flatten `amount`+`currency` into a flat response — that's the read-edge; raw is correct.
- **The balance core** (`_line_base_amount`) resolves `None`→**base** currency, while the accessor resolves `None`→"SGD" — using `line.money` there would be a currency-default bug.
- **Context-currency sites** (annualized_income uses `line.currency or account.currency or base`) can't use the simple accessor.
- The **pre-fetched-rate fast path** stays a raw `Decimal` multiply by design (perf).

So `JournalLine` adoption targets **genuine money computation** (reconciliation `Money.sum` in #1335, this FX), not 100% column coverage — and a blanket forbid-ratchet is **not** appropriate here.

## Verification

- **279** reporting/income/fx-fallback tests pass (behaviour-preserving; tests updated to mock `convert_money`).
- AC12.37.3 + guard; full tooling guard suite (**1650**) + `ruff` green — run locally before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)