### PR TITLE
[finance_report_ui] L2→L1 reporting-line coverage: map BOND/OTHER + completeness gate (#1342)

### DIFF
--- a/apps/backend/src/services/framework_policy.py
+++ b/apps/backend/src/services/framework_policy.py
@@ -218,7 +218,7 @@ def get_framework_policy_matrix(framework_id: PersonalReportingFrameworkId) -> F
     if framework_id == PersonalReportingFrameworkId.US_GAAP_LIKE:
         listed_security = _rule(
             domain=PolicyFactDomain.LISTED_SECURITY,
-            supported_instrument_types=["listed_equity", "listed_security", "etf", "fixture"],
+            supported_instrument_types=["listed_equity", "listed_security", "etf", "bond", "fixture"],
             recognition="Recognize listed securities when brokerage evidence confirms trade or holding ownership.",
             measurement="Measure at quoted fair value when market data is fresh; preserve cost basis and unrealized gain evidence.",
             classification="Marketable investment asset.",
@@ -233,7 +233,7 @@ def get_framework_policy_matrix(framework_id: PersonalReportingFrameworkId) -> F
     else:
         listed_security = _rule(
             domain=PolicyFactDomain.LISTED_SECURITY,
-            supported_instrument_types=["listed_equity", "listed_security", "etf", "fixture"],
+            supported_instrument_types=["listed_equity", "listed_security", "etf", "bond", "fixture"],
             recognition="Recognize listed securities when brokerage evidence confirms trade or holding ownership.",
             measurement="Measure at quoted fair value when market data is fresh; preserve cost basis and fair-value movement evidence.",
             classification="Financial asset measured with HK-like fair-value presentation.",
@@ -336,6 +336,12 @@ def _position_domain_and_instrument(position: AtomicPosition) -> tuple[PolicyFac
         return PolicyFactDomain.CASH, "cash"
     if position.asset_type == AssetType.PROPERTY:
         return PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "property"
+    if position.asset_type == AssetType.BOND:
+        # A bond is a marketable financial asset -> the listed-security line.
+        return PolicyFactDomain.LISTED_SECURITY, "bond"
+    if position.asset_type == AssetType.OTHER:
+        # Unclassified holdings land in the manual/private asset line, not a gap.
+        return PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "manual_asset"
     return (
         PolicyFactDomain.UNSUPPORTED,
         position.asset_type.value if position.asset_type is not None else "unknown_asset",

--- a/apps/backend/src/services/framework_policy.py
+++ b/apps/backend/src/services/framework_policy.py
@@ -340,8 +340,10 @@ def _position_domain_and_instrument(position: AtomicPosition) -> tuple[PolicyFac
         # A bond is a marketable financial asset -> the listed-security line.
         return PolicyFactDomain.LISTED_SECURITY, "bond"
     if position.asset_type == AssetType.OTHER:
-        # Unclassified holdings land in the manual/private asset line, not a gap.
-        return PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "manual_asset"
+        # An unclassified *position* (brokerage evidence) lands in the private-asset
+        # line; "private_asset" (not "manual_asset", which implies manual-valuation
+        # provenance) keeps the instrument type's source semantics honest.
+        return PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "private_asset"
     return (
         PolicyFactDomain.UNSUPPORTED,
         position.asset_type.value if position.asset_type is not None else "unknown_asset",

--- a/apps/backend/tests/reporting/test_framework_package_integration.py
+++ b/apps/backend/tests/reporting/test_framework_package_integration.py
@@ -185,7 +185,9 @@ async def test_AC19_7_1_readiness_consumes_framework_specific_evidence_blockers(
         quantity=Decimal("1"),
         market_value=Decimal("500.00"),
         currency="SGD",
-        asset_type=AssetType.OTHER,
+        # asset_type=None is genuinely unclassifiable -> UNSUPPORTED/gap. (OTHER is
+        # now a mapped category since #1342, so it no longer produces a policy gap.)
+        asset_type=None,
         dedup_hash=f"framework-token-{uuid4()}",
         source_documents={"documents": [{"doc_id": "token-doc", "doc_type": "brokerage_statement"}]},
     )
@@ -494,8 +496,8 @@ def test_AC20_5_1_atomic_position_asset_types_map_to_policy_domains() -> None:
         (AssetType.MUTUAL_FUND, PolicyFactDomain.FUND, "fund"),
         (AssetType.CASH, PolicyFactDomain.CASH, "cash"),
         (AssetType.PROPERTY, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "property"),
-        (AssetType.BOND, PolicyFactDomain.UNSUPPORTED, "bond"),
-        (AssetType.OTHER, PolicyFactDomain.UNSUPPORTED, "other"),
+        (AssetType.BOND, PolicyFactDomain.LISTED_SECURITY, "bond"),
+        (AssetType.OTHER, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "manual_asset"),
         (None, PolicyFactDomain.UNSUPPORTED, "unknown_asset"),
     ]
 

--- a/apps/backend/tests/reporting/test_framework_package_integration.py
+++ b/apps/backend/tests/reporting/test_framework_package_integration.py
@@ -497,7 +497,7 @@ def test_AC20_5_1_atomic_position_asset_types_map_to_policy_domains() -> None:
         (AssetType.CASH, PolicyFactDomain.CASH, "cash"),
         (AssetType.PROPERTY, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "property"),
         (AssetType.BOND, PolicyFactDomain.LISTED_SECURITY, "bond"),
-        (AssetType.OTHER, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "manual_asset"),
+        (AssetType.OTHER, PolicyFactDomain.PROPERTY_MORTGAGE_PRIVATE, "private_asset"),
         (None, PolicyFactDomain.UNSUPPORTED, "unknown_asset"),
     ]
 

--- a/apps/backend/tests/reporting/test_framework_policy_coverage.py
+++ b/apps/backend/tests/reporting/test_framework_policy_coverage.py
@@ -37,7 +37,10 @@ def _resolves(domain: PolicyFactDomain, instrument: str, framework: PersonalRepo
         return False
     matrix = get_framework_policy_matrix(framework)
     fact = SimpleNamespace(domain=domain, instrument_type=instrument)
-    return _find_rule(matrix, fact) is not None
+    rule = _find_rule(matrix, fact)
+    # "Concrete L1 line": a matching rule is not enough — it must carry a non-empty
+    # line_mappings (otherwise the category resolves but still has no report line).
+    return rule is not None and bool(rule.line_mappings)
 
 
 @pytest.mark.parametrize("framework", _FRAMEWORKS)

--- a/apps/backend/tests/reporting/test_framework_policy_coverage.py
+++ b/apps/backend/tests/reporting/test_framework_policy_coverage.py
@@ -1,0 +1,71 @@
+"""L2 -> L1 reporting-line coverage gate (EPIC-020 AC20.8 / issue #1342).
+
+Every known L2 category — each ``AssetType`` and each
+``ManualValuationComponentType`` — MUST resolve to a concrete L1 report line via
+the framework policy matrix, in BOTH ``personal_us_gaap_like`` and
+``personal_hkfrs_like``. A category that lands in ``UNSUPPORTED``/the gap path
+(instead of a real line) fails here — this is the "no creative reports"
+completeness guard: report assembly never has to improvise a line for a known
+category.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.models.layer2 import AssetType
+from src.models.layer3 import ManualValuationComponentType
+from src.schemas.reporting import PersonalReportingFrameworkId, PolicyFactDomain
+from src.services.framework_policy import (
+    _find_rule,
+    _manual_domain_and_instrument,
+    _position_domain_and_instrument,
+    get_framework_policy_matrix,
+)
+
+_FRAMEWORKS = [
+    PersonalReportingFrameworkId.US_GAAP_LIKE,
+    PersonalReportingFrameworkId.HKFRS_LIKE,
+]
+
+
+def _resolves(domain: PolicyFactDomain, instrument: str, framework: PersonalReportingFrameworkId) -> bool:
+    """True iff (domain, instrument) maps to a concrete matrix rule (not a gap)."""
+    if domain == PolicyFactDomain.UNSUPPORTED:
+        return False
+    matrix = get_framework_policy_matrix(framework)
+    fact = SimpleNamespace(domain=domain, instrument_type=instrument)
+    return _find_rule(matrix, fact) is not None
+
+
+@pytest.mark.parametrize("framework", _FRAMEWORKS)
+def test_AC20_8_1_every_asset_type_maps_to_an_l1_line(framework: PersonalReportingFrameworkId) -> None:
+    """AC20.8.1: every AssetType resolves to an L1 report line in this framework."""
+    unmapped = []
+    for asset_type in AssetType:
+        domain, instrument = _position_domain_and_instrument(SimpleNamespace(asset_type=asset_type))
+        if not _resolves(domain, instrument, framework):
+            unmapped.append(f"{asset_type.value} -> ({domain}, {instrument})")
+    assert unmapped == [], f"AssetType values with no L1 line in {framework.value}: {unmapped}"
+
+
+@pytest.mark.parametrize("framework", _FRAMEWORKS)
+def test_AC20_8_1_every_manual_component_maps_to_an_l1_line(framework: PersonalReportingFrameworkId) -> None:
+    """AC20.8.1: every ManualValuationComponentType resolves to an L1 report line."""
+    unmapped = []
+    for component_type in ManualValuationComponentType:
+        domain, instrument = _manual_domain_and_instrument(SimpleNamespace(component_type=component_type))
+        if not _resolves(domain, instrument, framework):
+            unmapped.append(f"{component_type.value} -> ({domain}, {instrument})")
+    assert unmapped == [], f"ManualValuationComponentType values with no L1 line in {framework.value}: {unmapped}"
+
+
+def test_AC20_8_1_bond_and_other_are_mapped_not_gaps() -> None:
+    """AC20.8.1 regression: BOND and OTHER (previously UNSUPPORTED) now map to a line."""
+    for asset_type in (AssetType.BOND, AssetType.OTHER):
+        domain, instrument = _position_domain_and_instrument(SimpleNamespace(asset_type=asset_type))
+        assert domain != PolicyFactDomain.UNSUPPORTED, f"{asset_type.value} still falls to the gap path"
+        assert _resolves(domain, instrument, PersonalReportingFrameworkId.US_GAAP_LIKE)
+        assert _resolves(domain, instrument, PersonalReportingFrameworkId.HKFRS_LIKE)

--- a/docs/project/EPIC-020.framework-aware-personal-reporting.md
+++ b/docs/project/EPIC-020.framework-aware-personal-reporting.md
@@ -110,6 +110,12 @@ Not owned here:
 |----|-----------|---------------|------|----------|
 | AC20.7.1 | The same settlement and portfolio fixture must be able to produce US-like and HK-like personal report packages with framework-specific line mappings, notes, source anchors, export metadata, and readiness blockers | `test_AC20_7_1_same_fixture_must_drive_framework_differentiated_reports`, `test_AC20_7_1_same_settlement_fixture_drives_us_hk_report_policy_outputs`, `AC20.6.1 AC20.7.1 loads readiness and policy result with the selected framework` | `tests/tooling/test_framework_reporting_epic_contract.py`, `reporting/test_framework_policy.py`, `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
 
+### AC20.8: L2→L1 Line-Mapping Completeness
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC20.8.1 | Every L2 category — each `AssetType` and each `ManualValuationComponentType` — resolves to a concrete L1 report line via the framework policy matrix in both `personal_us_gaap_like` and `personal_hkfrs_like`; a known category landing in the `UNSUPPORTED`/gap path fails the gate, so report assembly never improvises a line for a known category (`BOND`/`OTHER` regression covered) {tier:PC}{proof:property} | `test_AC20_8_1_every_asset_type_maps_to_an_l1_line`, `test_AC20_8_1_every_manual_component_maps_to_an_l1_line`, `test_AC20_8_1_bond_and_other_are_mapped_not_gaps` | `reporting/test_framework_policy_coverage.py` | P0 |
+
 ## Implementation Order
 
 1. Define the framework policy result schema and SSOT contract.


### PR DESCRIPTION
Closes #1342 (EPIC-020 AC20.8.1).

## What
- **BOND/OTHER mapped**: `framework_policy._position_domain_and_instrument` now maps `AssetType.BOND` → LISTED_SECURITY (`assets.marketable_securities`) and `AssetType.OTHER` → PROPERTY_MORTGAGE_PRIVATE (`assets.manual_private_assets`). They previously fell to `UNSUPPORTED`/gap.
- **ManualValuationComponentType**: verified already fully mapped (ESOP/RSU/options→restricted_compensation, mortgage/tax_payable/other_liability→liability, rest→property/manual) — no change needed, now covered by the gate.
- **Completeness gate** (`tests/reporting/test_framework_policy_coverage.py`): asserts every `AssetType` + every `ManualValuationComponentType` resolves to a concrete L1 line in **both** `personal_us_gaap_like` and `personal_hkfrs_like`. A known category in the gap path fails CI → report assembly never improvises a line. Runs in the normal backend suite (not a bespoke shard step → no AC-aggregator interaction).
- EPIC-020 **AC20.8.1** `{tier:PC}{proof:property}`.

## Out of scope (issue stretch)
Current/non-current split + US-PP&E-vs-IFRS-investment-property (IAS 40) — separate follow-up.

## Data hygiene
Stub-based test (no real data).