### PR TITLE
[finance_report_audit] feat(currency): editable DB-backed base currency (Phase D, AC12.39, #1340)

### DIFF
--- a/apps/backend/migrations/versions/0050_add_app_config.py
+++ b/apps/backend/migrations/versions/0050_add_app_config.py
@@ -1,0 +1,36 @@
+"""add the app_config table for runtime app-level settings (#1340, Phase D)
+
+Creates a single key/value ``app_config`` table so app-level settings (starting
+with the base reporting currency) can be overridden at runtime instead of being
+env-only. ``key`` is unique so each setting has exactly one row; the effective
+value is "persisted row else ``settings.base_currency``" (see
+``src.services.app_config.get_effective_base_currency``).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+
+revision = "0050_add_app_config"
+down_revision = "0049_add_outbox"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_config",
+        sa.Column("id", PGUUID(as_uuid=True), nullable=False),
+        sa.Column("key", sa.String(length=64), nullable=False),
+        sa.Column("value", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_app_config"),
+        sa.UniqueConstraint("key", name="uq_app_config_key"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("app_config")

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -33,6 +33,7 @@ from src.rate_limit import api_rate_limiter
 from src.routers import (
     accounts,
     ai_feedback,
+    app_config,
     assets,
     audit,
     auth,
@@ -362,6 +363,7 @@ app.add_middleware(
 _router_kwargs = {"responses": COMMON_ERROR_RESPONSES}
 app.include_router(auth.router, **_router_kwargs)
 app.include_router(accounts.router, **_router_kwargs)
+app.include_router(app_config.router, **_router_kwargs)
 app.include_router(ai_feedback.router, **_router_kwargs)
 app.include_router(audit.router, **_router_kwargs)
 app.include_router(assets.router, **_router_kwargs)

--- a/apps/backend/src/models/__init__.py
+++ b/apps/backend/src/models/__init__.py
@@ -1,6 +1,7 @@
 """SQLAlchemy models package."""
 
 from src.models.account import Account, AccountType
+from src.models.app_config import BASE_CURRENCY_KEY, AppConfig
 from src.models.chat import ChatMessage, ChatMessageRole, ChatSession, ChatSessionStatus
 from src.models.consistency_check import CheckStatus, CheckType, ConsistencyCheck
 from src.models.correction import CorrectionLog
@@ -62,9 +63,11 @@ from src.models.workflow import (
 )
 
 __all__ = [
+    "BASE_CURRENCY_KEY",
     "Account",
     "AccountType",
     "AiFeedback",
+    "AppConfig",
     "AtomicPosition",
     "AtomicPositionSourceDocument",
     "AtomicTransaction",

--- a/apps/backend/src/models/app_config.py
+++ b/apps/backend/src/models/app_config.py
@@ -1,0 +1,32 @@
+"""Application-level configuration persisted in the database.
+
+Phase D of the currency strong-type EPIC (#1340) makes the base reporting
+currency editable at runtime. ``settings.base_currency`` (``src.config``) is an
+env-only default; this single-row, key/value ``app_config`` table lets an
+operator override app-level settings (starting with the base currency) without
+redeploying. The effective value is "persisted row else env default" — see
+``src.services.app_config.get_effective_base_currency``.
+
+The table is a generic ``key -> value`` store (text columns) so future app-level
+settings reuse the same row shape; ``key`` is unique so each setting has exactly
+one row.
+"""
+
+from sqlalchemy import String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.database import Base
+from src.models.base import TimestampMixin, UUIDMixin
+
+# Stable key for the base reporting currency row.
+BASE_CURRENCY_KEY = "base_currency"
+
+
+class AppConfig(Base, UUIDMixin, TimestampMixin):
+    """A single app-level configuration entry (``key`` -> ``value``)."""
+
+    __tablename__ = "app_config"
+    __table_args__ = (UniqueConstraint("key", name="uq_app_config_key"),)
+
+    key: Mapped[str] = mapped_column(String(64), nullable=False)
+    value: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/apps/backend/src/routers/app_config.py
+++ b/apps/backend/src/routers/app_config.py
@@ -32,4 +32,5 @@ async def update_base_currency(
 ) -> BaseCurrencyResponse:
     """Persist a new effective base currency. Invalid ISO 4217 code -> HTTP 422."""
     stored = await set_base_currency(db, payload.base_currency)
+    await db.commit()  # router owns the transaction boundary
     return BaseCurrencyResponse(base_currency=stored)

--- a/apps/backend/src/routers/app_config.py
+++ b/apps/backend/src/routers/app_config.py
@@ -1,0 +1,35 @@
+"""App-level configuration endpoints (#1340, Phase D).
+
+Exposes the effective base reporting currency for reading and updating. The
+update validates the code against ISO 4217 (via the request schema, which reuses
+``src.money.Currency``) so an invalid code returns HTTP 422 and is never
+persisted.
+"""
+
+from fastapi import APIRouter
+
+from src.deps import CurrentUserId, DbSession
+from src.schemas.app_config import BaseCurrencyResponse, BaseCurrencyUpdate
+from src.services.app_config import get_effective_base_currency, set_base_currency
+
+router = APIRouter(prefix="/app-config", tags=["app-config"])
+
+
+@router.get("/base-currency", response_model=BaseCurrencyResponse)
+async def get_base_currency(
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> BaseCurrencyResponse:
+    """Return the effective base currency (persisted override else env default)."""
+    return BaseCurrencyResponse(base_currency=await get_effective_base_currency(db))
+
+
+@router.put("/base-currency", response_model=BaseCurrencyResponse)
+async def update_base_currency(
+    payload: BaseCurrencyUpdate,
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> BaseCurrencyResponse:
+    """Persist a new effective base currency. Invalid ISO 4217 code -> HTTP 422."""
+    stored = await set_base_currency(db, payload.base_currency)
+    return BaseCurrencyResponse(base_currency=stored)

--- a/apps/backend/src/schemas/app_config.py
+++ b/apps/backend/src/schemas/app_config.py
@@ -1,0 +1,31 @@
+"""Pydantic schemas for app-level configuration (#1340, Phase D)."""
+
+from pydantic import BaseModel, field_validator
+
+from src.money import Currency, InvalidCurrencyError
+
+
+class BaseCurrencyResponse(BaseModel):
+    """The effective base reporting currency (persisted override else env default)."""
+
+    base_currency: str
+
+
+class BaseCurrencyUpdate(BaseModel):
+    """Request body to set the effective base reporting currency.
+
+    The code is validated against ISO 4217 via ``src.money.Currency`` so an
+    invalid code is rejected at the request boundary (HTTP 422) and never
+    persisted; the stored value is the normalized (upper-cased) code.
+    """
+
+    base_currency: str
+
+    @field_validator("base_currency")
+    @classmethod
+    def validate_iso_4217(cls, value: str) -> str:
+        """Reuse the Currency value type to validate + normalize the code."""
+        try:
+            return Currency(value).code
+        except InvalidCurrencyError as exc:
+            raise ValueError(str(exc)) from exc

--- a/apps/backend/src/services/app_config.py
+++ b/apps/backend/src/services/app_config.py
@@ -42,5 +42,6 @@ async def set_base_currency(db: AsyncSession, code: str) -> str:
         db.add(AppConfig(key=BASE_CURRENCY_KEY, value=normalized))
     else:
         row.value = normalized
-    await db.commit()
+    # Service flushes; the router owns the commit (transaction-boundary policy).
+    await db.flush()
     return normalized

--- a/apps/backend/src/services/app_config.py
+++ b/apps/backend/src/services/app_config.py
@@ -1,0 +1,46 @@
+"""App-level configuration accessors (#1340, Phase D).
+
+The base reporting currency is normally the env-only ``settings.base_currency``
+default. Phase D persists an optional override in the ``app_config`` table so an
+operator can change it at runtime. ``get_effective_base_currency`` is the single
+accessor every caller should use: it returns the persisted override if present,
+otherwise falls back to ``settings.base_currency``.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.models.app_config import BASE_CURRENCY_KEY, AppConfig
+from src.money import Currency
+
+
+async def get_effective_base_currency(db: AsyncSession) -> str:
+    """Return the effective base currency: persisted override else env default.
+
+    The persisted value is written pre-validated/normalized, so it is returned
+    as-is; the env default is normalized through ``Currency`` for consistency.
+    """
+    result = await db.execute(select(AppConfig.value).where(AppConfig.key == BASE_CURRENCY_KEY))
+    persisted = result.scalar_one_or_none()
+    if persisted is not None:
+        return persisted
+    return Currency(settings.base_currency).code
+
+
+async def set_base_currency(db: AsyncSession, code: str) -> str:
+    """Persist (upsert) the base-currency override and return the stored value.
+
+    ``code`` must already be a valid, normalized ISO 4217 code (the request
+    schema validates it). The single ``app_config`` row keyed by
+    ``BASE_CURRENCY_KEY`` is created or updated in place.
+    """
+    normalized = Currency(code).code
+    result = await db.execute(select(AppConfig).where(AppConfig.key == BASE_CURRENCY_KEY))
+    row = result.scalar_one_or_none()
+    if row is None:
+        db.add(AppConfig(key=BASE_CURRENCY_KEY, value=normalized))
+    else:
+        row.value = normalized
+    await db.commit()
+    return normalized

--- a/apps/backend/tests/api/test_app_config_router.py
+++ b/apps/backend/tests/api/test_app_config_router.py
@@ -1,0 +1,64 @@
+"""App-config base-currency endpoint + effective-accessor tests (#1340, Phase D).
+
+Covers EPIC-012 AC12.39: GET/update of the effective base currency, ISO 4217
+validation (invalid -> 422), DB persistence, and the single effective accessor
+returning the persisted value (else the env default).
+"""
+
+import pytest
+from common.testing.ac_proof import ac_proof
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.money import Currency
+from src.services.app_config import get_effective_base_currency
+
+pytestmark = pytest.mark.asyncio
+
+
+@ac_proof(proof_id="test_app_config_base_currency_default", ac_ids=["AC12.39.2"], ci_tier="pr_ci", issue="#1340")
+async def test_AC12_39_2_effective_accessor_falls_back_to_env_default(db: AsyncSession) -> None:
+    """AC12.39.2: with no persisted row the accessor returns settings.base_currency."""
+    assert await get_effective_base_currency(db) == Currency(settings.base_currency).code
+
+
+@ac_proof(proof_id="test_app_config_get_default", ac_ids=["AC12.39.1"], ci_tier="pr_ci", issue="#1340")
+async def test_AC12_39_1_get_returns_env_default_when_unset(client: AsyncClient) -> None:
+    """AC12.39.1: GET returns the env-default base currency when nothing is persisted."""
+    response = await client.get("/app-config/base-currency")
+    assert response.status_code == 200
+    assert response.json() == {"base_currency": Currency(settings.base_currency).code}
+
+
+@ac_proof(proof_id="test_app_config_persist_and_effective", ac_ids=["AC12.39.4"], ci_tier="pr_ci", issue="#1340")
+async def test_AC12_39_4_update_persists_and_effective_accessor_returns_new_value(
+    client: AsyncClient,
+    db: AsyncSession,
+) -> None:
+    """AC12.39.4: PUT persists the override and the effective accessor returns it."""
+    target = "EUR" if Currency(settings.base_currency).code != "EUR" else "USD"
+
+    response = await client.put("/app-config/base-currency", json={"base_currency": target.lower()})
+    assert response.status_code == 200
+    assert response.json() == {"base_currency": target}
+
+    # The effective accessor (read on a fresh session) now returns the persisted value.
+    assert await get_effective_base_currency(db) == target
+
+    # And GET reflects it too.
+    get_response = await client.get("/app-config/base-currency")
+    assert get_response.json() == {"base_currency": target}
+
+
+@ac_proof(proof_id="test_app_config_invalid_rejected", ac_ids=["AC12.39.1"], ci_tier="pr_ci", issue="#1340")
+async def test_AC12_39_1_invalid_currency_returns_422_and_is_not_persisted(
+    client: AsyncClient,
+    db: AsyncSession,
+) -> None:
+    """AC12.39.1: a non-ISO-4217 code is rejected with 422 and never persisted."""
+    response = await client.put("/app-config/base-currency", json={"base_currency": "XYZ"})
+    assert response.status_code == 422
+
+    # Nothing was persisted: effective value stays the env default.
+    assert await get_effective_base_currency(db) == Currency(settings.base_currency).code

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -1821,6 +1821,34 @@
         "title": "BankTransactionSummary",
         "type": "object"
       },
+      "BaseCurrencyResponse": {
+        "description": "The effective base reporting currency (persisted override else env default).",
+        "properties": {
+          "base_currency": {
+            "title": "Base Currency",
+            "type": "string"
+          }
+        },
+        "required": [
+          "base_currency"
+        ],
+        "title": "BaseCurrencyResponse",
+        "type": "object"
+      },
+      "BaseCurrencyUpdate": {
+        "description": "Request body to set the effective base reporting currency.\n\nThe code is validated against ISO 4217 via ``src.money.Currency`` so an\ninvalid code is rejected at the request boundary (HTTP 422) and never\npersisted; the stored value is the normalized (upper-cased) code.",
+        "properties": {
+          "base_currency": {
+            "title": "Base Currency",
+            "type": "string"
+          }
+        },
+        "required": [
+          "base_currency"
+        ],
+        "title": "BaseCurrencyUpdate",
+        "type": "object"
+      },
       "BatchAcceptRequest": {
         "description": "Request body for batch accept.",
         "properties": {
@@ -11328,6 +11356,218 @@
         "summary": "List Ai Suggestions",
         "tags": [
           "ai-feedback"
+        ]
+      }
+    },
+    "/app-config/base-currency": {
+      "get": {
+        "description": "Return the effective base currency (persisted override else env default).",
+        "operationId": "get_base_currency_app_config_base_currency_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseCurrencyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Too many requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Base Currency",
+        "tags": [
+          "app-config"
+        ]
+      },
+      "put": {
+        "description": "Persist a new effective base currency. Invalid ISO 4217 code -> HTTP 422.",
+        "operationId": "update_base_currency_app_config_base_currency_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BaseCurrencyUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseCurrencyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Too many requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Base Currency",
+        "tags": [
+          "app-config"
         ]
       }
     },

--- a/apps/frontend/src/__tests__/apiFunctions.test.ts
+++ b/apps/frontend/src/__tests__/apiFunctions.test.ts
@@ -556,3 +556,44 @@ describe('apiDownload', () => {
     expect(window.location.href).toBe('/login');
   });
 });
+
+describe('base currency app-config api (EPIC-012 AC12.39)', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.unstubAllGlobals();
+    vi.stubGlobal('localStorage', localStorageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubGlobal('localStorage', localStorageMock);
+  });
+
+  it('AC12.39 fetchBaseCurrency GETs the effective base currency', async () => {
+    const fetchMock = makeFetchMock(200, { base_currency: 'SGD' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchBaseCurrency } = await import('../lib/api');
+    const result = await fetchBaseCurrency();
+
+    expect(result).toEqual({ base_currency: 'SGD' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/app-config/base-currency'),
+      expect.objectContaining({ credentials: 'include' })
+    );
+  });
+
+  it('AC12.39 updateBaseCurrency PUTs the new ISO code', async () => {
+    const fetchMock = makeFetchMock(200, { base_currency: 'USD' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { updateBaseCurrency } = await import('../lib/api');
+    const result = await updateBaseCurrency('USD');
+
+    expect(result).toEqual({ base_currency: 'USD' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/app-config/base-currency'),
+      expect.objectContaining({ method: 'PUT', body: JSON.stringify({ base_currency: 'USD' }) })
+    );
+  });
+});

--- a/apps/frontend/src/__tests__/generalSettingsPage.test.tsx
+++ b/apps/frontend/src/__tests__/generalSettingsPage.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import GeneralSettingsPage from "@/app/(main)/settings/general/page"
+import { fetchBaseCurrency, updateBaseCurrency } from "@/lib/api"
+
+vi.mock("@/lib/api", () => ({
+  fetchBaseCurrency: vi.fn(),
+  updateBaseCurrency: vi.fn(),
+}))
+
+const showToast = vi.fn()
+vi.mock("@/components/ui/Toast", () => ({
+  useToast: () => ({ showToast }),
+}))
+
+const mockedFetch = vi.mocked(fetchBaseCurrency)
+const mockedUpdate = vi.mocked(updateBaseCurrency)
+
+beforeEach(() => {
+  showToast.mockReset()
+  mockedFetch.mockReset()
+  mockedUpdate.mockReset()
+  mockedFetch.mockResolvedValue({ base_currency: "SGD" })
+})
+
+describe("GeneralSettingsPage (EPIC-012 AC12.39.3)", () => {
+  it("AC12.39.3 renders the effective base currency and keeps Save disabled until edited", async () => {
+    render(<GeneralSettingsPage />)
+    await waitFor(() => expect(screen.getByText("General Settings")).toBeInTheDocument())
+
+    expect(screen.getByLabelText("Base currency")).toHaveValue("SGD")
+    expect(screen.getByRole("button", { name: /Save changes/i })).toBeDisabled()
+  })
+
+  it("AC12.39.3 submits the edited currency via updateBaseCurrency and shows success", async () => {
+    mockedUpdate.mockResolvedValue({ base_currency: "EUR" })
+    render(<GeneralSettingsPage />)
+    await waitFor(() => expect(screen.getByText("General Settings")).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText("Base currency"), { target: { value: "eur" } })
+    const save = screen.getByRole("button", { name: /Save changes/i })
+    expect(save).toBeEnabled()
+    fireEvent.click(save)
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledWith("EUR"))
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith("Base currency saved", "success"))
+    await waitFor(() => expect(screen.getByRole("button", { name: /Save changes/i })).toBeDisabled())
+  })
+
+  it("AC12.39.3 surfaces an error and keeps the draft when the update fails", async () => {
+    mockedUpdate.mockRejectedValue(new Error("not an ISO-4217 currency code"))
+    render(<GeneralSettingsPage />)
+    await waitFor(() => expect(screen.getByText("General Settings")).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText("Base currency"), { target: { value: "XYZ" } })
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }))
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("not an ISO-4217 currency code"))
+    expect(screen.getByLabelText("Base currency")).toHaveValue("XYZ")
+    expect(showToast).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/__tests__/generalSettingsPage.test.tsx
+++ b/apps/frontend/src/__tests__/generalSettingsPage.test.tsx
@@ -60,4 +60,25 @@ describe("GeneralSettingsPage (EPIC-012 AC12.39.3)", () => {
     expect(screen.getByLabelText("Base currency")).toHaveValue("XYZ")
     expect(showToast).not.toHaveBeenCalled()
   })
+
+  it("AC12.39.3 surfaces a load error when fetching the base currency fails", async () => {
+    mockedFetch.mockReset()
+    mockedFetch.mockRejectedValueOnce(new Error("Network Error"))
+    render(<GeneralSettingsPage />)
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Network Error"))
+  })
+
+  it("AC12.39.3 Reset restores the saved value and clears the dirty state", async () => {
+    render(<GeneralSettingsPage />)
+    await waitFor(() => expect(screen.getByText("General Settings")).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText("Base currency"), { target: { value: "usd" } })
+    expect(screen.getByLabelText("Base currency")).toHaveValue("USD")
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: /Reset/i }))
+    expect(screen.getByLabelText("Base currency")).toHaveValue("SGD")
+    expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument()
+    expect(mockedUpdate).not.toHaveBeenCalled()
+  })
 })

--- a/apps/frontend/src/__tests__/navigation.test.ts
+++ b/apps/frontend/src/__tests__/navigation.test.ts
@@ -36,6 +36,7 @@ describe("navigation metadata", () => {
       "Reconciliation",
       "Processing",
       "Confidence Trend",
+      "General Settings",
       "AI Settings",
       "LLM Models",
     ]);

--- a/apps/frontend/src/app/(main)/settings/general/page.tsx
+++ b/apps/frontend/src/app/(main)/settings/general/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useToast } from "@/components/ui/Toast";
+import { fetchBaseCurrency, updateBaseCurrency } from "@/lib/api";
+
+// EPIC-012 AC12.39 / #1340: edit the effective base reporting currency.
+// The backend validates the ISO 4217 code (HTTP 422 on invalid), so this
+// control stays minimal — a text input normalized to upper-case.
+export default function GeneralSettingsPage() {
+  const { showToast } = useToast();
+  const [saved, setSaved] = useState<string | null>(null);
+  const [draft, setDraft] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadBaseCurrency = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchBaseCurrency();
+      setSaved(data.base_currency);
+      setDraft(data.base_currency);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load base currency");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadBaseCurrency();
+  }, [loadBaseCurrency]);
+
+  const isDirty = useMemo(() => saved !== null && draft !== saved, [saved, draft]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (submitting || !isDirty) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const updated = await updateBaseCurrency(draft);
+      setSaved(updated.base_currency);
+      setDraft(updated.base_currency);
+      showToast("Base currency saved", "success");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save base currency");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6">
+        <div className="card p-8 text-center text-muted">Loading general settings...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-3xl">
+      <div className="page-header">
+        <h1 className="page-title">General Settings</h1>
+        <p className="page-description">App-level settings shared across reports.</p>
+      </div>
+
+      {error && (
+        <div role="alert" className="mb-4 alert-error">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <div className="card p-5">
+          <label htmlFor="base-currency" className="block font-medium">
+            Base currency
+          </label>
+          <p className="text-sm text-muted">
+            The reporting currency all statements consolidate into (ISO 4217, e.g. SGD, USD, EUR).
+          </p>
+          <input
+            id="base-currency"
+            aria-label="Base currency"
+            type="text"
+            value={draft}
+            disabled={submitting}
+            maxLength={3}
+            onChange={(event) => setDraft(event.target.value.toUpperCase())}
+            className="input mt-3 w-32 uppercase"
+          />
+        </div>
+
+        <div className="mt-4 flex items-center gap-3">
+          <button type="submit" className="btn-primary" disabled={!isDirty || submitting}>
+            {submitting ? "Saving..." : "Save changes"}
+          </button>
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => {
+              if (saved !== null) setDraft(saved);
+              setError(null);
+            }}
+            disabled={!isDirty || submitting}
+          >
+            Reset
+          </button>
+          {isDirty && !submitting && <span className="text-sm text-muted">Unsaved changes</span>}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/navigation.ts
+++ b/apps/frontend/src/components/navigation.ts
@@ -2,6 +2,7 @@ import {
     BarChart3,
     Bell,
     BookOpen,
+    Coins,
     Cpu,
     ClipboardCheck,
     Clock,
@@ -46,6 +47,7 @@ export const advancedNavItems: NavItem[] = [
     { icon: Link2, label: "Reconciliation", href: "/reconciliation", protected: true },
     { icon: Clock, label: "Processing", href: "/processing", protected: true },
     { icon: TrendingDown, label: "Confidence Trend", href: "/confidence", protected: true },
+    { icon: Coins, label: "General Settings", href: "/settings/general", protected: true },
     { icon: SlidersHorizontal, label: "AI Settings", href: "/settings/ai", protected: true },
     { icon: Cpu, label: "LLM Models", href: "/settings/llm", protected: true },
 ];
@@ -81,6 +83,7 @@ export const ROUTE_CONFIG: Record<string, RouteConfig> = {
     "/processing": { label: "Processing", Icon: Clock },
     "/confidence": { label: "Confidence Trend", Icon: TrendingDown },
     "/chat": { label: "Chat", Icon: MessageSquare },
+    "/settings/general": { label: "General Settings", Icon: Coins },
     "/settings/ai": { label: "AI Settings", Icon: SlidersHorizontal },
     "/settings/llm": { label: "LLM Models", Icon: Cpu },
     "/ping-pong": { label: "Ping-Pong", Icon: Zap },

--- a/apps/frontend/src/lib/api-types.ts
+++ b/apps/frontend/src/lib/api-types.ts
@@ -188,6 +188,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/app-config/base-currency": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Base Currency
+         * @description Return the effective base currency (persisted override else env default).
+         */
+        get: operations["get_base_currency_app_config_base_currency_get"];
+        /**
+         * Update Base Currency
+         * @description Persist a new effective base currency. Invalid ISO 4217 code -> HTTP 422.
+         */
+        put: operations["update_base_currency_app_config_base_currency_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/assets/positions": {
         parameters: {
             query?: never;
@@ -3223,6 +3247,26 @@ export interface components {
              * Format: date
              */
             txn_date: string;
+        };
+        /**
+         * BaseCurrencyResponse
+         * @description The effective base reporting currency (persisted override else env default).
+         */
+        BaseCurrencyResponse: {
+            /** Base Currency */
+            base_currency: string;
+        };
+        /**
+         * BaseCurrencyUpdate
+         * @description Request body to set the effective base reporting currency.
+         *
+         *     The code is validated against ISO 4217 via ``src.money.Currency`` so an
+         *     invalid code is rejected at the request boundary (HTTP 422) and never
+         *     persisted; the stored value is the normalized (upper-cased) code.
+         */
+        BaseCurrencyUpdate: {
+            /** Base Currency */
+            base_currency: string;
         };
         /**
          * BatchAcceptRequest
@@ -7752,6 +7796,185 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AiSuggestionListResponse"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Too many requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_base_currency_app_config_base_currency_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseCurrencyResponse"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Too many requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    update_base_currency_app_config_base_currency_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BaseCurrencyUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BaseCurrencyResponse"];
                 };
             };
             /** @description Bad request */

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { getAccessToken } from "./auth";
 import type {
+  BaseCurrency,
   ConfidenceNorthStarResponse,
   CorrectionLoopReplayResponse,
   CurrentUser,
@@ -400,6 +401,23 @@ export async function patchUserSettings(
   return apiFetch<UserAiSettings>("/api/users/me/settings", {
     method: "PATCH",
     body: JSON.stringify(update),
+  });
+}
+
+// ── App-level base currency (EPIC-012 AC12.39 / #1340) ─────────────────────
+
+/** The effective base reporting currency (persisted override else env default). */
+export async function fetchBaseCurrency(): Promise<BaseCurrency> {
+  return apiFetch<BaseCurrency>("/api/app-config/base-currency");
+}
+
+/** Persist a new effective base reporting currency (ISO 4217). */
+export async function updateBaseCurrency(
+  baseCurrency: string
+): Promise<BaseCurrency> {
+  return apiFetch<BaseCurrency>("/api/app-config/base-currency", {
+    method: "PUT",
+    body: JSON.stringify({ base_currency: baseCurrency }),
   });
 }
 

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -748,6 +748,12 @@ export interface UserAiSettings {
 
 export type UserAiSettingsUpdate = Schemas["UserAiSettingsUpdate"];
 
+// Mirrors backend `BaseCurrencyResponse` / `BaseCurrencyUpdate`
+// (apps/backend/src/schemas/app_config.py) — EPIC-012 AC12.39 / #1340.
+export interface BaseCurrency {
+  base_currency: string;
+}
+
 /**
  * Identity returned by `GET /api/auth/me`, consumed by `useSessionBootstrap`.
  *

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -597,6 +597,17 @@ Currency was resolved ad-hoc in ≥3 divergent ways (`or "SGD"`, `or settings.ba
 | AC12.38.3 | Annualized-income (and the fx-revaluation + processing-account balance sums) read `line.money` / sum via `Money.sum`, dropping the per-site `or account.currency or target` currency fallback (only the impossible currency-`None` path differs; the column is non-null) {tier:PC} | `test_AC12_38_3_annualized_income_reads_line_money` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
 | AC12.38.4 | Ratchet: no service/ledger code sums journal-line amounts raw (`sum(line.amount …)` / `line.amount for …`); currency-blind addition must use `Money.sum`. Manual fast-path rate multiplies and single-value serialization reads are not sums and stay raw {tier:PC} | `test_AC12_38_4_no_currency_blind_line_amount_sum` | `tests/tooling/test_orm_value_type_boundary.py` | P1 |
 
+### AC12.39: Editable base reporting currency — DB-backed app config (Phase D) ([#1340](https://github.com/wangzitian0/finance_report/issues/1340))
+
+`settings.base_currency` was env-only (default `"SGD"`), so the base reporting currency could only change via a redeploy. Phase D persists an app-level override in a single key/value `app_config` table and reads it dynamically through one accessor, so an operator can edit the base currency at runtime on the config page. The override is ISO 4217 validated (reusing the `src.money.Currency` value type) at the request boundary, so an invalid code returns HTTP 422 and is never persisted.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC12.39.1 | The backend exposes `GET`/`PUT /app-config/base-currency` to read and update the effective base currency; the code is ISO 4217 validated via `src.money.Currency` and persisted in the DB-backed `app_config` row, and an invalid code returns HTTP 422 without persisting {tier:PC} | `test_AC12_39_1_get_returns_env_default_when_unset`, `test_AC12_39_1_invalid_currency_returns_422_and_is_not_persisted` | `apps/backend/tests/api/test_app_config_router.py` | P1 |
+| AC12.39.2 | A single accessor `get_effective_base_currency` returns the effective base currency — the persisted `app_config` override if present, else `settings.base_currency` {tier:PC} | `test_AC12_39_2_effective_accessor_falls_back_to_env_default` | `apps/backend/tests/api/test_app_config_router.py` | P1 |
+| AC12.39.3 | The frontend General Settings page exposes a "Base currency" control that reads + updates the effective value via `lib/api.ts` (`fetchBaseCurrency`/`updateBaseCurrency`, never raw `fetch`) {tier:PC} | `AC12.39.3 renders the effective base currency`, `AC12.39.3 submits the edited currency via updateBaseCurrency` | `apps/frontend/src/__tests__/generalSettingsPage.test.tsx` | P1 |
+| AC12.39.4 | Updating the base currency persists the override and the effective accessor returns the new value on a subsequent read {tier:PC} | `test_AC12_39_4_update_persists_and_effective_accessor_returns_new_value` | `apps/backend/tests/api/test_app_config_router.py` | P1 |
+
 ---
 
 *Planning snapshot captured: January 2026*

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,8 +5,8 @@
 
 - API title: `Finance Report API`
 - API version: `0.1.0`
-- Endpoint count: `134`
-- Schema count: `242`
+- Endpoint count: `136`
+- Schema count: `244`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 
@@ -16,6 +16,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 |---|---:|
 | `accounts` | 10 |
 | `ai-feedback` | 2 |
+| `app-config` | 2 |
 | `assets` | 11 |
 | `audit` | 1 |
 | `auth` | 3 |
@@ -60,6 +61,13 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 |---|---|---|---|---|---|---|
 | `POST` | `/ai/feedback` | yes | - | `AiFeedbackRequest` | `201` `AiFeedbackResponse` | Create Ai Feedback |
 | `GET` | `/ai/suggestions` | yes | `limit` (query), `offset` (query) | - | `200` `AiSuggestionListResponse` | List Ai Suggestions |
+
+### app-config
+
+| Method | Path | Auth | Params | Request | Success responses | Summary |
+|---|---|---|---|---|---|---|
+| `GET` | `/app-config/base-currency` | yes | - | - | `200` `BaseCurrencyResponse` | Get Base Currency |
+| `PUT` | `/app-config/base-currency` | yes | - | `BaseCurrencyUpdate` | `200` `BaseCurrencyResponse` | Update Base Currency |
 
 ### assets
 


### PR DESCRIPTION
## Phase D — editable base reporting currency (#1340)

Makes the base reporting currency editable at runtime. `settings.base_currency` was env-only (default `SGD`); Phase D persists an app-level override in a DB-backed `app_config` row, read dynamically via one accessor that overrides the env default.

### Acceptance Criteria (AC12.39.x)
- **AC12.39.1** — `GET`/`PUT /app-config/base-currency` read + update the effective base currency; ISO 4217 validated by reusing `src.money.Currency`; persisted in the `app_config` row; invalid code → HTTP 422 (never persisted).
- **AC12.39.2** — single accessor `get_effective_base_currency(db)` returns the persisted override else `settings.base_currency`.
- **AC12.39.3** — FE General Settings page exposes a "Base currency" control via `lib/api.ts` (`fetchBaseCurrency`/`updateBaseCurrency`, never raw `fetch`) + a nav entry.
- **AC12.39.4** — backend test covers persist + effective-accessor returns the new value.

### Changes
- New `app_config` key/value table: `AppConfig` model + migration `0050_add_app_config` (down_revision `0049_add_outbox`).
- `src/services/app_config.py` accessor + upsert; `src/routers/app_config.py` endpoints; `src/schemas/app_config.py` request/response (validator → 422).
- FE: `app/(main)/settings/general/page.tsx`, `lib/api.ts` + `lib/types.ts` additions, nav entry.
- EPIC-012 AC12.39 table + AC registry regenerated; tier baseline non-increasing.

### Tests
- Backend: `apps/backend/tests/api/test_app_config_router.py` (4 passing) — default GET, persist+effective, 422 invalid, accessor fallback.
- Frontend: `apps/frontend/src/__tests__/generalSettingsPage.test.tsx` (3 passing).

### Notes
- Scope is the accessor + endpoint + FE control + tests (per ACs). Rewiring the ~80 existing synchronous `settings.base_currency` call sites to the async DB accessor is intentionally **out of scope** for this PR.
- Local tooling guard suite passes except pre-existing infra/deployment tests that require the un-checked-out `repo`/`infra2` submodule (FileNotFoundError on `repo/...`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)