### PR TITLE
[finance_report_audit] Establish transaction currency at ingest with human review (Phase E, #1341)

### DIFF
--- a/apps/backend/migrations/versions/0050_add_currency_unresolved.py
+++ b/apps/backend/migrations/versions/0050_add_currency_unresolved.py
@@ -1,0 +1,62 @@
+"""add currency_unresolved flag to atomic_transactions (EPIC-012 AC12.40)
+
+Phase E of the currency strong-type invariant (#1341). A transaction's currency
+must be established at the ingest boundary: attached explicitly when determinable,
+otherwise flagged for human review and blocked from promotion to a JournalLine.
+
+This adds the ``currency_unresolved`` boolean flag plus the resolution-audit
+columns ``currency_resolved_by`` / ``currency_resolved_at`` (who/when). The flag
+defaults to ``false`` so every existing row is treated as resolved (their currency
+was already persisted by the legacy ingest path); only newly-ingested rows whose
+currency could not be determined are flagged ``true``.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0050_add_currency_unresolved"
+down_revision = "0049_add_outbox"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "atomic_transactions",
+        sa.Column(
+            "currency_unresolved",
+            sa.Boolean(),
+            server_default=sa.false(),
+            nullable=False,
+            comment=(
+                "EPIC-012 AC12.40: True when the ingest boundary could NOT determine the "
+                "transaction currency (no statement/account metadata). The currency column then "
+                "holds a non-authoritative placeholder and the row MUST NOT be promoted to a "
+                "JournalLine until a reviewer specifies the currency. Never silent-default."
+            ),
+        ),
+    )
+    op.add_column(
+        "atomic_transactions",
+        sa.Column(
+            "currency_resolved_by",
+            sa.UUID(),
+            nullable=True,
+            comment="EPIC-012 AC12.40.3: user_id of the reviewer who specified the currency (audit: who).",
+        ),
+    )
+    op.add_column(
+        "atomic_transactions",
+        sa.Column(
+            "currency_resolved_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="EPIC-012 AC12.40.3: timestamp the currency was specified by a reviewer (audit: when).",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("atomic_transactions", "currency_resolved_at")
+    op.drop_column("atomic_transactions", "currency_resolved_by")
+    op.drop_column("atomic_transactions", "currency_unresolved")

--- a/apps/backend/migrations/versions/0051_add_currency_unresolved.py
+++ b/apps/backend/migrations/versions/0051_add_currency_unresolved.py
@@ -14,8 +14,8 @@ currency could not be determined are flagged ``true``.
 import sqlalchemy as sa
 from alembic import op
 
-revision = "0050_add_currency_unresolved"
-down_revision = "0049_add_outbox"
+revision = "0051_add_currency_unresolved"
+down_revision = "0050_add_app_config"
 branch_labels = None
 depends_on = None
 

--- a/apps/backend/migrations/versions/0051_add_currency_unresolved.py
+++ b/apps/backend/migrations/versions/0051_add_currency_unresolved.py
@@ -41,6 +41,7 @@ def upgrade() -> None:
         sa.Column(
             "currency_resolved_by",
             sa.UUID(),
+            sa.ForeignKey("users.id"),
             nullable=True,
             comment="EPIC-012 AC12.40.3: user_id of the reviewer who specified the currency (audit: who).",
         ),

--- a/apps/backend/src/models/layer2.py
+++ b/apps/backend/src/models/layer2.py
@@ -96,6 +96,7 @@ class AtomicTransaction(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     )
     currency_resolved_by: Mapped[UUID | None] = mapped_column(
         PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
         nullable=True,
         comment="EPIC-012 AC12.40.3: user_id of the reviewer who specified the currency (audit: who).",
     )

--- a/apps/backend/src/models/layer2.py
+++ b/apps/backend/src/models/layer2.py
@@ -1,13 +1,15 @@
 """Layer 2: Atomic Records - Immutable, deduplicated transaction and position records."""
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
 from uuid import UUID
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     Date,
+    DateTime,
     Enum as SQLEnum,
     ForeignKey,
     Index,
@@ -16,6 +18,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    false as sa_false,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -79,6 +82,28 @@ class AtomicTransaction(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):
     description: Mapped[str] = mapped_column(Text, nullable=False)
     reference: Mapped[str | None] = mapped_column(String(100), nullable=True)
     currency: Mapped[str] = mapped_column(String(3), nullable=False, comment="ISO currency code")
+    currency_unresolved: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=sa_false(),
+        default=False,
+        comment=(
+            "EPIC-012 AC12.40: True when the ingest boundary could NOT determine the "
+            "transaction currency (no statement/account metadata). The currency column then "
+            "holds a non-authoritative placeholder and the row MUST NOT be promoted to a "
+            "JournalLine until a reviewer specifies the currency. Never silent-default."
+        ),
+    )
+    currency_resolved_by: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        nullable=True,
+        comment="EPIC-012 AC12.40.3: user_id of the reviewer who specified the currency (audit: who).",
+    )
+    currency_resolved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="EPIC-012 AC12.40.3: timestamp the currency was specified by a reviewer (audit: when).",
+    )
     balance_after: Mapped[Decimal | None] = mapped_column(
         Numeric(18, 2),
         nullable=True,

--- a/apps/backend/src/routers/review.py
+++ b/apps/backend/src/routers/review.py
@@ -15,6 +15,7 @@ from src.models import (
 from src.models.consistency_check import CheckStatus, CheckType
 from src.models.layer2 import AtomicTransaction
 from src.models.reconciliation import ReconciliationMatch, ReconciliationStatus
+from src.money import InvalidCurrencyError
 from src.schemas.review import (
     BatchApproveRequest,
     BatchApproveResponse,
@@ -24,6 +25,8 @@ from src.schemas.review import (
     ConsistencyCheckResponse,
     ResolveCheckRequest,
     ResolveConflictsRequest,
+    ResolveCurrencyRequest,
+    ResolveCurrencyResponse,
     ReviewConflictCandidate,
     ReviewConflictsResolveResponse,
     ReviewConflictsResponse,
@@ -38,6 +41,7 @@ from src.services.consistency_checks import (
     resolve_check,
     run_all_consistency_checks,
 )
+from src.services.currency_resolution import resolve_transaction_currency
 from src.services.review_queue import accept_match as accept_match_service, get_stage2_queue
 from src.services.source_type_priority import STATEMENT_SOURCE_TYPES
 from src.services.statement_validation import resolve_statement_conflicts, resolve_statement_transactions
@@ -133,6 +137,47 @@ async def resolve_review_conflicts(
         note=request.note,
     )
     return ReviewConflictsResolveResponse(resolved=True, resolved_at=resolved_at)
+
+
+@conflicts_router.post(
+    "/transactions/{transaction_id}/currency",
+    response_model=ResolveCurrencyResponse,
+)
+async def resolve_transaction_currency_endpoint(
+    transaction_id: UUID,
+    request: ResolveCurrencyRequest,
+    db: DbSession,
+    user_id: CurrentUserId,
+) -> ResolveCurrencyResponse:
+    """Reviewer specifies the currency for a ``currency_unresolved`` transaction (AC12.40.3).
+
+    Validates the chosen code as ISO-4217 (``src.money.Currency``), clears the
+    unresolved flag, and records the resolution audit (who/when). Only after this
+    can the transaction be promoted to a journal entry (AC12.40.4).
+    """
+    try:
+        txn = await resolve_transaction_currency(
+            db,
+            transaction_id,
+            user_id=user_id,
+            currency=request.currency,
+        )
+    except InvalidCurrencyError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    response = ResolveCurrencyResponse(
+        transaction_id=txn.id,
+        currency=txn.currency,
+        currency_unresolved=txn.currency_unresolved,
+        resolved_by=txn.currency_resolved_by,
+        resolved_at=txn.currency_resolved_at,
+    )
+    await db.commit()
+    return response
 
 
 @router.get("/stage2/queue", response_model=Stage2ReviewQueueResponse)

--- a/apps/backend/src/schemas/review.py
+++ b/apps/backend/src/schemas/review.py
@@ -125,6 +125,22 @@ class ResolveCheckRequest(BaseModel):
     note: str | None = None
 
 
+class ResolveCurrencyRequest(BaseModel):
+    """Reviewer-specified currency for a ``currency_unresolved`` transaction (AC12.40.3)."""
+
+    currency: str = Field(..., description="ISO-4217 alphabetic currency code, e.g. 'USD'")
+
+
+class ResolveCurrencyResponse(BaseModel):
+    """Result of resolving a transaction's currency."""
+
+    transaction_id: UUID
+    currency: str
+    currency_unresolved: bool
+    resolved_by: UUID | None = None
+    resolved_at: datetime | None = None
+
+
 class BatchApproveRequest(BaseModel):
     match_ids: list[UUID] = Field(default_factory=list)
     run_id: str | None = None

--- a/apps/backend/src/services/currency_resolution.py
+++ b/apps/backend/src/services/currency_resolution.py
@@ -1,0 +1,137 @@
+"""Ingest-boundary currency resolution (EPIC-012 AC12.40, #1341).
+
+Phase E of the currency strong-type invariant. A transaction's currency must be
+established **at the ingest boundary**, never silent-defaulted:
+
+* **AC12.40.1** — when the currency is determinable (statement metadata / linked
+  account), attach it explicitly.
+* **AC12.40.2** — when it is unknown/ambiguous, flag the row ``currency_unresolved``
+  and route it to human review; it cannot be promoted to a ``JournalLine``.
+* **AC12.40.3** — a reviewer specifies the currency (ISO-4217 validated via
+  ``src.money.Currency``); the resolution is audited (who / when / chosen value).
+* **AC12.40.4** — the promotion gate blocks ``currency_unresolved`` items (enforced
+  in ``review_queue.create_entry_from_txn``).
+
+This module owns the *decision*: it is dependency-light (kernel ``src.money`` +
+models only) so both the ingest path (``deduplication``) and the review path
+(``review_queue`` / routers) reuse the same rule without an import cycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logger import get_logger
+from src.models.layer2 import AtomicTransaction
+from src.money import Currency, InvalidCurrencyError
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "UNRESOLVED_PLACEHOLDER",
+    "CurrencyUnresolvedError",
+    "ResolvedCurrency",
+    "resolve_ingest_currency",
+    "resolve_transaction_currency",
+]
+
+
+class CurrencyUnresolvedError(ValueError):
+    """A transaction whose currency was never human-confirmed was promoted.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` promotion callers
+    surface it as a 400 without special-casing, while callers that care can catch
+    the specific type.
+    """
+
+
+@dataclass(frozen=True)
+class ResolvedCurrency:
+    """Outcome of resolving a transaction's currency at the ingest boundary.
+
+    ``code`` is always a stored placeholder; when ``unresolved`` is True it is a
+    non-authoritative fallback that MUST NOT be trusted until a reviewer specifies
+    the real currency.
+    """
+
+    code: str
+    unresolved: bool
+
+
+# Non-authoritative placeholder stored in the ``currency`` NOT NULL column while a
+# row is flagged ``currency_unresolved``. It is never trusted: the flag gates
+# promotion, and a reviewer overwrites this on resolution. ``XXX`` is the ISO-4217
+# code for "no currency" and is deliberately NOT in this project's active currency
+# set, so ``Currency("XXX")`` raises — a placeholder can never masquerade as a
+# real, resolved currency.
+UNRESOLVED_PLACEHOLDER = "XXX"
+
+
+def resolve_ingest_currency(
+    *candidates: str | None,
+) -> ResolvedCurrency:
+    """Decide a transaction's currency from ingest-boundary candidates, in priority order.
+
+    Returns the first candidate that is a valid ISO-4217 code (e.g. the parsed
+    transaction currency, then the linked statement currency). When no candidate is
+    a valid code, returns the ``XXX`` placeholder flagged ``unresolved`` instead of
+    silently defaulting to the base currency — the row is then routed to human
+    review (AC12.40.2).
+    """
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            return ResolvedCurrency(code=Currency.of(candidate).code, unresolved=False)
+        except InvalidCurrencyError:
+            continue
+    return ResolvedCurrency(code=UNRESOLVED_PLACEHOLDER, unresolved=True)
+
+
+async def resolve_transaction_currency(
+    db: AsyncSession,
+    txn_id: UUID,
+    *,
+    user_id: UUID,
+    currency: str,
+) -> AtomicTransaction:
+    """Reviewer specifies the currency for a ``currency_unresolved`` transaction (AC12.40.3).
+
+    Validates ``currency`` as an ISO-4217 code via ``src.money.Currency``, writes it
+    to the row, clears the ``currency_unresolved`` flag, and records the resolution
+    audit (who / when). After this the promotion gate (AC12.40.4) lets the row
+    become a ``JournalLine``.
+
+    Raises:
+        ValueError: the transaction does not exist / belong to the user.
+        InvalidCurrencyError: ``currency`` is not a valid ISO-4217 code.
+    """
+    result = await db.execute(
+        select(AtomicTransaction).where(AtomicTransaction.id == txn_id).where(AtomicTransaction.user_id == user_id)
+    )
+    txn = result.scalar_one_or_none()
+    if txn is None:
+        raise ValueError("Transaction not found")
+
+    # ISO-4217 validation is the single gate; an invalid code raises and nothing is written.
+    resolved = Currency.of(currency).code
+
+    txn.currency = resolved
+    txn.currency_unresolved = False
+    txn.currency_resolved_by = user_id
+    txn.currency_resolved_at = datetime.now(UTC)
+    await db.flush()
+
+    logger.info(
+        "currency.resolved",
+        audit_event="currency.resolved",
+        atomic_txn_id=str(txn.id),
+        resolved_currency=resolved,
+        resolved_by=str(user_id),
+    )
+    return txn

--- a/apps/backend/src/services/currency_resolution.py
+++ b/apps/backend/src/services/currency_resolution.py
@@ -29,6 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.logger import get_logger
 from src.models.layer2 import AtomicTransaction
 from src.money import Currency, InvalidCurrencyError
+from src.utils.exceptions import BaseAppException
 
 logger = get_logger(__name__)
 
@@ -41,13 +42,16 @@ __all__ = [
 ]
 
 
-class CurrencyUnresolvedError(ValueError):
+class CurrencyUnresolvedError(BaseAppException, ValueError):
     """A transaction whose currency was never human-confirmed was promoted.
 
-    Subclasses ``ValueError`` so existing ``except ValueError`` promotion callers
-    surface it as a 400 without special-casing, while callers that care can catch
-    the specific type.
+    Subclasses ``BaseAppException`` so the global handler returns a structured 409
+    to API callers (the promotion routers don't catch ``ValueError``), and
+    ``ValueError`` so existing ``except ValueError`` callers still match.
     """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(error_id="currency_unresolved", message=message, status_code=409)
 
 
 @dataclass(frozen=True)

--- a/apps/backend/src/services/deduplication.py
+++ b/apps/backend/src/services/deduplication.py
@@ -18,6 +18,7 @@ from src.models.layer2 import (
     TransactionDirection,
 )
 from src.models.statement_summary import StatementSummary
+from src.services.currency_resolution import resolve_ingest_currency
 
 logger = get_logger(__name__)
 
@@ -133,11 +134,17 @@ class DeduplicationService:
         reference: str | None = None,
         balance_after: Decimal | None = None,
         occurrence_index: int = 0,
+        currency_unresolved: bool = False,
     ) -> AtomicTransaction:
         """Upsert atomic transaction with deduplication.
 
         If dedup_hash exists -> Append to source_documents array
         If dedup_hash new -> Insert new record
+
+        ``currency_unresolved`` (EPIC-012 AC12.40.2) flags a new row whose currency
+        could not be determined at the ingest boundary; ``currency`` then holds a
+        non-authoritative placeholder and the row is blocked from promotion until a
+        reviewer specifies the currency.
         """
         dedup_hash = self.calculate_transaction_hash(
             user_id, txn_date, amount, direction, description, reference, balance_after, occurrence_index
@@ -199,6 +206,7 @@ class DeduplicationService:
             description=description,
             reference=reference,
             currency=currency,
+            currency_unresolved=currency_unresolved,
             balance_after=balance_after,
             dedup_hash=dedup_hash,
             source_documents=[source_doc],
@@ -531,6 +539,19 @@ async def dual_write_layer2(
 
         layer2_count = 0
         for txn in transactions:
+            # EPIC-012 AC12.40.1/.2: the currency is decided once at the ingest boundary
+            # in ``ExtractionService.parse_document`` via ``resolve_ingest_currency`` and
+            # stashed on ``txn._currency_unresolved`` (alongside the resolved/placeholder
+            # code already on ``txn.currency``). Callers that build transactions outside
+            # that path fall back to a fresh resolution over the model + statement fields
+            # so this stays the single DB-write boundary and never silent-defaults.
+            if hasattr(txn, "_currency_unresolved"):
+                resolved_code = txn.currency
+                currency_unresolved = bool(txn._currency_unresolved)
+            else:
+                resolved = resolve_ingest_currency(txn.currency, statement.currency)
+                resolved_code = resolved.code
+                currency_unresolved = resolved.unresolved
             upserted_txn = await dedup_service.upsert_atomic_transaction(
                 db=db,
                 user_id=user_id,
@@ -538,7 +559,8 @@ async def dual_write_layer2(
                 amount=txn.amount,
                 direction=txn.direction,
                 description=txn.description,
-                currency=txn.currency or statement.currency or "SGD",
+                currency=resolved_code,
+                currency_unresolved=currency_unresolved,
                 source_doc_id=uploaded_doc.id,
                 source_doc_type=doc_type,
                 reference=txn.reference,

--- a/apps/backend/src/services/extraction/service.py
+++ b/apps/backend/src/services/extraction/service.py
@@ -27,6 +27,7 @@ from src.services.brokerage_positions import (
     looks_like_brokerage_payload,
 )
 from src.services.chain_repair import RegionReExtractor, repair_under_extraction
+from src.services.currency_resolution import resolve_ingest_currency
 from src.services.deduplication import DeduplicationService, _decimal_key, dual_write_layer2
 from src.services.extraction._base import (
     CSV_INFERRED_BALANCE_REVIEW_NOTE,
@@ -152,7 +153,11 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
             )
 
             resolved_file_hash = file_hash or hashlib.sha256(file_content or b"").hexdigest()
-            statement_currency = extracted.get("currency", "SGD")
+            # Raw extracted statement currency (no fallback) — feeds the per-transaction
+            # ingest-boundary resolution (AC12.40) so a genuinely-missing currency is
+            # flagged for review rather than masked by the StatementSummary default.
+            raw_statement_currency = extracted.get("currency")
+            statement_currency = raw_statement_currency or "SGD"
             statement = StatementSummary(
                 user_id=user_id,
                 account_id=account_id,
@@ -318,7 +323,12 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
                 else:
                     net_transactions -= amount
 
-                txn_currency = txn.get("currency") or statement_currency or "SGD"
+                # EPIC-012 AC12.40.1/.2: establish the currency at the ingest boundary from
+                # the parsed transaction then the statement's RAW extracted currency. When
+                # neither is a valid ISO-4217 code, flag the row ``currency_unresolved`` so it
+                # is routed to human review instead of silently defaulting to the base currency.
+                resolved_currency = resolve_ingest_currency(txn.get("currency"), raw_statement_currency)
+                txn_currency = resolved_currency.code
                 txn_balance_after = self._safe_decimal(txn.get("balance_after"))
                 txn_direction = TransactionDirection.IN if direction == "IN" else TransactionDirection.OUT
                 txn_description = txn.get("description", "Unknown")
@@ -370,6 +380,8 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
                 )
                 transaction._extracted_balance_after = txn_balance_after
                 transaction._occurrence_index = occurrence_index
+                # AC12.40.2: carry the ingest-boundary resolution decision to dual_write_layer2.
+                transaction._currency_unresolved = resolved_currency.unresolved
                 transactions.append(transaction)
 
             # Within-document dedup-collapse signal (EPIC-026 AC26.8.1; #1254 class).

--- a/apps/backend/src/services/review_queue.py
+++ b/apps/backend/src/services/review_queue.py
@@ -26,6 +26,7 @@ from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.layer3 import ClassificationStatus, TransactionClassification
 from src.models.statement_summary import StatementSummary
 from src.services.accounting import ValidationError, validate_journal_balance, validate_journal_posting_invariants
+from src.services.currency_resolution import CurrencyUnresolvedError
 from src.services.fx import FxRateError, get_exchange_rate
 from src.services.reconciliation import entry_total_amount, sync_reconciliation_match_journal_entry_links
 from src.services.source_type_priority import (
@@ -342,6 +343,16 @@ async def create_entry_from_txn(
     # Validate transaction belongs to user and resolve owning statement summary.
     if txn.user_id != user_id:
         raise ValueError("Transaction does not belong to user")
+
+    # Promotion-gate (EPIC-012 AC12.40.4): a transaction whose currency could not be
+    # established at the ingest boundary is non-authoritative. It cannot become a
+    # JournalLine until a reviewer specifies the currency (see resolve_transaction_currency).
+    # This is the load-bearing guard that makes JournalLine.currency human-confirmed.
+    if getattr(txn, "currency_unresolved", False):
+        raise CurrencyUnresolvedError(
+            f"Transaction {txn.id} has an unresolved currency and cannot be promoted to a "
+            "journal entry. A reviewer must specify its currency first."
+        )
 
     statement = preloaded_statement
     if statement is not None:

--- a/apps/backend/src/services/review_queue.py
+++ b/apps/backend/src/services/review_queue.py
@@ -362,7 +362,10 @@ async def create_entry_from_txn(
     else:
         statement = await _resolve_statement_summary(db, txn, user_id=user_id)
 
-    currency = ((statement.currency if statement else None) or txn.currency or "SGD").upper()
+    # The transaction's own (human-confirmed at this point) currency is authoritative
+    # per AC12.40; the statement currency is only a fallback, then the base SSOT. This
+    # preserves a transaction-specific currency in multi-currency statements.
+    currency = (txn.currency or (statement.currency if statement else None) or settings.base_currency).upper()
     base_currency = settings.base_currency.upper()
     line_fx_rate: Decimal | None = None
     if currency != base_currency:

--- a/apps/backend/tests/services/test_currency_resolution.py
+++ b/apps/backend/tests/services/test_currency_resolution.py
@@ -1,0 +1,203 @@
+"""Ingest-boundary currency resolution + promotion gate (EPIC-012 AC12.40, #1341).
+
+Phase E of the currency strong-type invariant: a transaction's currency is
+established AT INGEST (attached when determinable, otherwise flagged
+``currency_unresolved`` and routed to human review), a reviewer specifies it with
+an ISO-4217-validated value (audited who/when), and the promotion gate refuses to
+turn an unresolved transaction into a JournalLine.
+
+These proofs are DB-free: they exercise the decision logic and the promotion-gate
+guard directly, so they run in PR CI without a database.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.money import InvalidCurrencyError
+from src.services.currency_resolution import (
+    UNRESOLVED_PLACEHOLDER,
+    CurrencyUnresolvedError,
+    resolve_ingest_currency,
+    resolve_transaction_currency,
+)
+from src.services.review_queue import create_entry_from_txn
+
+pytestmark = pytest.mark.no_db
+
+
+# --- AC12.40.1: attach an explicit currency when determinable -----------------
+
+
+@ac_proof(proof_id="test_ingest_attaches_explicit_currency", ac_ids=["AC12.40.1"], ci_tier="pr_ci", issue="#1341")
+@pytest.mark.parametrize(
+    ("candidates", "expected"),
+    [
+        (("USD",), "USD"),
+        (("usd ",), "USD"),  # normalized (strip + upper) by Currency
+        ((None, "SGD"), "SGD"),  # fall through to the statement currency
+        (("ZZZ", "EUR"), "EUR"),  # skip an invalid code, take the next valid one
+    ],
+)
+def test_AC12_40_1_attaches_explicit_currency(candidates, expected):
+    """AC12.40.1: the first valid ISO-4217 candidate is attached, normalized."""
+    resolved = resolve_ingest_currency(*candidates)
+    assert resolved.code == expected
+    assert resolved.unresolved is False
+
+
+# --- AC12.40.2: unknown/ambiguous -> flagged currency_unresolved --------------
+
+
+@ac_proof(proof_id="test_ingest_flags_unresolved", ac_ids=["AC12.40.2"], ci_tier="pr_ci", issue="#1341")
+@pytest.mark.parametrize(
+    "candidates",
+    [
+        (),  # no candidates at all
+        (None,),  # missing transaction currency
+        (None, None),  # missing transaction + statement currency
+        ("ZZZ",),  # not an ISO-4217 code
+        ("US", ""),  # too short / empty -> neither is valid
+    ],
+)
+def test_AC12_40_2_flags_unresolved_instead_of_silent_default(candidates):
+    """AC12.40.2: no valid currency -> flagged unresolved with a non-trusted placeholder.
+
+    Critically it must NOT silently default to a base currency like SGD.
+    """
+    resolved = resolve_ingest_currency(*candidates)
+    assert resolved.unresolved is True
+    assert resolved.code == UNRESOLVED_PLACEHOLDER
+    assert resolved.code != "SGD"
+
+
+@ac_proof(proof_id="test_unresolved_placeholder_is_not_valid", ac_ids=["AC12.40.2"], ci_tier="pr_ci", issue="#1341")
+def test_AC12_40_2_placeholder_cannot_masquerade_as_real_currency():
+    """AC12.40.2: the placeholder is rejected by Currency(), so it can never look resolved."""
+    from src.money import Currency
+
+    with pytest.raises(InvalidCurrencyError):
+        Currency(UNRESOLVED_PLACEHOLDER)
+
+
+# --- AC12.40.4: promotion gate blocks currency_unresolved items ----------------
+
+
+@ac_proof(proof_id="test_promotion_gate_blocks_unresolved", ac_ids=["AC12.40.4"], ci_tier="pr_ci", issue="#1341")
+async def test_AC12_40_4_promotion_gate_blocks_unresolved_currency():
+    """AC12.40.4: an unresolved transaction cannot be promoted to a JournalLine.
+
+    The guard fires before any DB access, so ``db=None`` is sufficient to prove the
+    block: if the guard were absent the call would instead fail trying to use the DB.
+    """
+    user_id = uuid4()
+    txn = SimpleNamespace(
+        id=uuid4(),
+        user_id=user_id,
+        currency_unresolved=True,
+        currency=UNRESOLVED_PLACEHOLDER,
+        txn_date=date(2024, 1, 1),
+    )
+
+    with pytest.raises(CurrencyUnresolvedError):
+        await create_entry_from_txn(None, txn, user_id=user_id)  # type: ignore[arg-type]
+
+
+@ac_proof(proof_id="test_promotion_gate_allows_resolved", ac_ids=["AC12.40.4"], ci_tier="pr_ci", issue="#1341")
+async def test_AC12_40_4_promotion_gate_passes_guard_when_resolved():
+    """AC12.40.4: a resolved transaction passes the currency guard (it then proceeds to DB work).
+
+    With ``currency_unresolved=False`` the guard must NOT raise; the call moves past
+    the guard and only then needs the DB, so we assert it does not raise the
+    currency error specifically.
+    """
+    user_id = uuid4()
+    txn = SimpleNamespace(
+        id=uuid4(),
+        user_id=user_id,
+        currency_unresolved=False,
+        currency="USD",
+        txn_date=date(2024, 1, 1),
+        source_documents=[],
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await create_entry_from_txn(None, txn, user_id=user_id)  # type: ignore[arg-type]
+    # It must fail for a reason OTHER than the currency guard (the guard was passed).
+    assert not isinstance(exc_info.value, CurrencyUnresolvedError)
+
+
+# --- AC12.40.3: reviewer specifies currency, audited (who/when/value) ----------
+
+
+class _FakeResult:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def scalar_one_or_none(self):
+        return self._obj
+
+
+class _FakeSession:
+    """Minimal async session that returns a preset transaction and records flush()."""
+
+    def __init__(self, txn):
+        self._txn = txn
+        self.flushed = False
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._txn)
+
+    async def flush(self):
+        self.flushed = True
+
+
+@ac_proof(proof_id="test_reviewer_resolves_currency_audited", ac_ids=["AC12.40.3"], ci_tier="pr_ci", issue="#1341")
+async def test_AC12_40_3_reviewer_resolves_currency_with_audit():
+    """AC12.40.3: a reviewer sets an ISO-4217 currency; who/when/value are recorded."""
+    user_id = uuid4()
+    txn = SimpleNamespace(
+        id=uuid4(),
+        user_id=user_id,
+        currency=UNRESOLVED_PLACEHOLDER,
+        currency_unresolved=True,
+        currency_resolved_by=None,
+        currency_resolved_at=None,
+    )
+    session = _FakeSession(txn)
+
+    result = await resolve_transaction_currency(session, txn.id, user_id=user_id, currency="usd ")
+
+    assert result.currency == "USD"  # validated + normalized via Currency
+    assert result.currency_unresolved is False
+    assert result.currency_resolved_by == user_id  # who
+    assert result.currency_resolved_at is not None  # when
+    assert session.flushed is True
+
+
+@ac_proof(proof_id="test_reviewer_rejects_bad_currency", ac_ids=["AC12.40.3"], ci_tier="pr_ci", issue="#1341")
+async def test_AC12_40_3_reviewer_currency_must_be_iso_4217():
+    """AC12.40.3: an invalid code is rejected and nothing is written (still unresolved)."""
+    user_id = uuid4()
+    txn = SimpleNamespace(
+        id=uuid4(),
+        user_id=user_id,
+        currency=UNRESOLVED_PLACEHOLDER,
+        currency_unresolved=True,
+        currency_resolved_by=None,
+        currency_resolved_at=None,
+    )
+    session = _FakeSession(txn)
+
+    with pytest.raises(InvalidCurrencyError):
+        await resolve_transaction_currency(session, txn.id, user_id=user_id, currency="ZZZ")
+
+    # Nothing mutated: the row is still flagged unresolved and un-audited.
+    assert txn.currency_unresolved is True
+    assert txn.currency_resolved_by is None
+    assert txn.currency_resolved_at is None

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -8302,6 +8302,70 @@
         "title": "ResolveConflictsRequest",
         "type": "object"
       },
+      "ResolveCurrencyRequest": {
+        "description": "Reviewer-specified currency for a ``currency_unresolved`` transaction (AC12.40.3).",
+        "properties": {
+          "currency": {
+            "description": "ISO-4217 alphabetic currency code, e.g. 'USD'",
+            "title": "Currency",
+            "type": "string"
+          }
+        },
+        "required": [
+          "currency"
+        ],
+        "title": "ResolveCurrencyRequest",
+        "type": "object"
+      },
+      "ResolveCurrencyResponse": {
+        "description": "Result of resolving a transaction's currency.",
+        "properties": {
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "currency_unresolved": {
+            "title": "Currency Unresolved",
+            "type": "boolean"
+          },
+          "resolved_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved At"
+          },
+          "resolved_by": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved By"
+          },
+          "transaction_id": {
+            "format": "uuid",
+            "title": "Transaction Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "transaction_id",
+          "currency",
+          "currency_unresolved"
+        ],
+        "title": "ResolveCurrencyResponse",
+        "type": "object"
+      },
       "RestrictedHoldingResponse": {
         "description": "Restricted equity or locked holding surfaced for dashboard visibility.",
         "properties": {
@@ -23332,6 +23396,135 @@
           }
         ],
         "summary": "Resolve Review Conflicts",
+        "tags": [
+          "review"
+        ]
+      }
+    },
+    "/review/transactions/{transaction_id}/currency": {
+      "post": {
+        "description": "Reviewer specifies the currency for a ``currency_unresolved`` transaction (AC12.40.3).\n\nValidates the chosen code as ISO-4217 (``src.money.Currency``), clears the\nunresolved flag, and records the resolution audit (who/when). Only after this\ncan the transaction be promoted to a journal entry (AC12.40.4).",
+        "operationId": "resolve_transaction_currency_endpoint_review_transactions__transaction_id__currency_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Transaction Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveCurrencyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolveCurrencyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Too many requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Resolve Transaction Currency Endpoint",
         "tags": [
           "review"
         ]

--- a/apps/frontend/src/lib/api-types.ts
+++ b/apps/frontend/src/lib/api-types.ts
@@ -1890,6 +1890,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/review/transactions/{transaction_id}/currency": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resolve Transaction Currency Endpoint
+         * @description Reviewer specifies the currency for a ``currency_unresolved`` transaction (AC12.40.3).
+         *
+         *     Validates the chosen code as ISO-4217 (``src.money.Currency``), clears the
+         *     unresolved flag, and records the resolution audit (who/when). Only after this
+         *     can the transaction be promoted to a journal entry (AC12.40.4).
+         */
+        post: operations["resolve_transaction_currency_endpoint_review_transactions__transaction_id__currency_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/statements": {
         parameters: {
             query?: never;
@@ -6113,6 +6137,36 @@ export interface components {
             action: "confirm_distinct" | "link_transfer";
             /** Note */
             note?: string | null;
+        };
+        /**
+         * ResolveCurrencyRequest
+         * @description Reviewer-specified currency for a ``currency_unresolved`` transaction (AC12.40.3).
+         */
+        ResolveCurrencyRequest: {
+            /**
+             * Currency
+             * @description ISO-4217 alphabetic currency code, e.g. 'USD'
+             */
+            currency: string;
+        };
+        /**
+         * ResolveCurrencyResponse
+         * @description Result of resolving a transaction's currency.
+         */
+        ResolveCurrencyResponse: {
+            /** Currency */
+            currency: string;
+            /** Currency Unresolved */
+            currency_unresolved: boolean;
+            /** Resolved At */
+            resolved_at?: string | null;
+            /** Resolved By */
+            resolved_by?: string | null;
+            /**
+             * Transaction Id
+             * Format: uuid
+             */
+            transaction_id: string;
         };
         /**
          * RestrictedHoldingResponse
@@ -16359,6 +16413,104 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ReviewConflictsResolveResponse"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Too many requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    resolve_transaction_currency_endpoint_review_transactions__transaction_id__currency_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                transaction_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResolveCurrencyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResolveCurrencyResponse"];
                 };
             };
             /** @description Bad request */

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -608,6 +608,23 @@ Currency was resolved ad-hoc in ≥3 divergent ways (`or "SGD"`, `or settings.ba
 | AC12.39.3 | The frontend General Settings page exposes a "Base currency" control that reads + updates the effective value via `lib/api.ts` (`fetchBaseCurrency`/`updateBaseCurrency`, never raw `fetch`) {tier:PC} | `AC12.39.3 renders the effective base currency`, `AC12.39.3 submits the edited currency via updateBaseCurrency` | `apps/frontend/src/__tests__/generalSettingsPage.test.tsx` | P1 |
 | AC12.39.4 | Updating the base currency persists the override and the effective accessor returns the new value on a subsequent read {tier:PC} | `test_AC12_39_4_update_persists_and_effective_accessor_returns_new_value` | `apps/backend/tests/api/test_app_config_router.py` | P1 |
 
+### AC12.40: Currency established at ingest, never silent-defaulted — Phase E ([#1341](https://github.com/wangzitian0/finance_report/issues/1341))
+
+A transaction's currency must be established **at the ingest boundary**: attached
+explicitly when determinable, and otherwise flagged `currency_unresolved` and routed
+to human review rather than silently defaulted to a base currency. An unresolved
+transaction cannot be promoted to a `JournalLine` until a reviewer specifies an
+ISO-4217 currency (validated via `src.money.Currency`), with the resolution audited
+(who/when/value). This makes the downstream `JournalLine.currency` human-confirmed by
+construction — closing the input-selection seam where currency was previously assumed.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC12.40.1 | Ingest resolution attaches the first valid ISO-4217 candidate (parsed transaction currency, then statement currency), normalized, when the currency is determinable {tier:PC} | `test_AC12_40_1_attaches_explicit_currency` | `tests/services/test_currency_resolution.py` | P0 |
+| AC12.40.2 | When no candidate is a valid ISO-4217 code the row is flagged `currency_unresolved` with a non-trusted placeholder and is NOT silently defaulted to a base currency {tier:PC} | `test_AC12_40_2_flags_unresolved_instead_of_silent_default` | `tests/services/test_currency_resolution.py` | P0 |
+| AC12.40.3 | A reviewer specifies the currency (ISO-4217 validated via `src.money.Currency`; an invalid code is rejected and nothing is written); the resolution records who/when/value {tier:PC} | `test_AC12_40_3_reviewer_resolves_currency_with_audit` | `tests/services/test_currency_resolution.py` | P0 |
+| AC12.40.4 | The promotion gate (`create_entry_from_txn`) blocks a `currency_unresolved` transaction from becoming a `JournalLine` {tier:PC} | `test_AC12_40_4_promotion_gate_blocks_unresolved_currency` | `tests/services/test_currency_resolution.py` | P0 |
+
 ---
 
 *Planning snapshot captured: January 2026*

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -620,10 +620,10 @@ construction — closing the input-selection seam where currency was previously 
 
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC12.40.1 | Ingest resolution attaches the first valid ISO-4217 candidate (parsed transaction currency, then statement currency), normalized, when the currency is determinable {tier:PC} | `test_AC12_40_1_attaches_explicit_currency` | `tests/services/test_currency_resolution.py` | P0 |
-| AC12.40.2 | When no candidate is a valid ISO-4217 code the row is flagged `currency_unresolved` with a non-trusted placeholder and is NOT silently defaulted to a base currency {tier:PC} | `test_AC12_40_2_flags_unresolved_instead_of_silent_default` | `tests/services/test_currency_resolution.py` | P0 |
-| AC12.40.3 | A reviewer specifies the currency (ISO-4217 validated via `src.money.Currency`; an invalid code is rejected and nothing is written); the resolution records who/when/value {tier:PC} | `test_AC12_40_3_reviewer_resolves_currency_with_audit` | `tests/services/test_currency_resolution.py` | P0 |
-| AC12.40.4 | The promotion gate (`create_entry_from_txn`) blocks a `currency_unresolved` transaction from becoming a `JournalLine` {tier:PC} | `test_AC12_40_4_promotion_gate_blocks_unresolved_currency` | `tests/services/test_currency_resolution.py` | P0 |
+| AC12.40.1 | Ingest resolution attaches the first valid ISO-4217 candidate (parsed transaction currency, then statement currency), normalized, when the currency is determinable {tier:PC} | `test_AC12_40_1_attaches_explicit_currency` | `apps/backend/tests/services/test_currency_resolution.py` | P0 |
+| AC12.40.2 | When no candidate is a valid ISO-4217 code the row is flagged `currency_unresolved` with a non-trusted placeholder and is NOT silently defaulted to a base currency {tier:PC} | `test_AC12_40_2_flags_unresolved_instead_of_silent_default` | `apps/backend/tests/services/test_currency_resolution.py` | P0 |
+| AC12.40.3 | A reviewer specifies the currency (ISO-4217 validated via `src.money.Currency`; an invalid code is rejected and nothing is written); the resolution records who/when/value {tier:PC} | `test_AC12_40_3_reviewer_resolves_currency_with_audit` | `apps/backend/tests/services/test_currency_resolution.py` | P0 |
+| AC12.40.4 | The promotion gate (`create_entry_from_txn`) blocks a `currency_unresolved` transaction from becoming a `JournalLine` {tier:PC} | `test_AC12_40_4_promotion_gate_blocks_unresolved_currency` | `apps/backend/tests/services/test_currency_resolution.py` | P0 |
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,8 +5,8 @@
 
 - API title: `Finance Report API`
 - API version: `0.1.0`
-- Endpoint count: `136`
-- Schema count: `244`
+- Endpoint count: `137`
+- Schema count: `246`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 
@@ -31,7 +31,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `portfolio` | 13 |
 | `reconciliation` | 11 |
 | `reports` | 21 |
-| `review` | 8 |
+| `review` | 9 |
 | `statements` | 14 |
 | `untagged` | 3 |
 | `user-settings` | 2 |
@@ -232,6 +232,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 |---|---|---|---|---|---|---|
 | `GET` | `/review/conflicts/{statement_id}` | yes | `statement_id`* (path) | - | `200` `ReviewConflictsResponse` | Get Review Conflicts |
 | `POST` | `/review/conflicts/{statement_id}/resolve` | yes | `statement_id`* (path) | `ResolveConflictsRequest` | `200` `ReviewConflictsResolveResponse` | Resolve Review Conflicts |
+| `POST` | `/review/transactions/{transaction_id}/currency` | yes | `transaction_id`* (path) | `ResolveCurrencyRequest` | `200` `ResolveCurrencyResponse` | Resolve Transaction Currency Endpoint |
 | `POST` | `/statements/batch-approve-matches` | yes | - | `BatchApproveRequest` | `200` `BatchApproveResponse` | Batch Approve Matches |
 | `POST` | `/statements/batch-reject-matches` | yes | - | `BatchRejectRequest` | `200` `BatchRejectResponse` | Batch Reject Matches |
 | `GET` | `/statements/consistency-checks/list` | yes | `status` (query), `check_type` (query), `run_id` (query), `limit` (query), `offset` (query) | - | `200` `ConsistencyCheckListResponse` | List Consistency Checks |


### PR DESCRIPTION
## Summary

Phase E (#1341) of the **currency strong-type invariant** EPIC (EPIC-012). A transaction's currency is now established **at the ingest boundary** and is **never silent-defaulted** to a base currency. When the currency is unknown/ambiguous, the row is flagged `currency_unresolved`, routed to human review, and **cannot be promoted to a `JournalLine`** until a reviewer specifies an ISO-4217 currency. This guarantees every `JournalLine.currency` is human-confirmed by construction.

## Acceptance Criteria (AC12.40.x)

- **AC12.40.1** — `resolve_ingest_currency` attaches the first valid ISO-4217 candidate (parsed transaction currency, then statement currency), normalized via `src.money.Currency`.
- **AC12.40.2** — when no candidate is a valid code, the row is flagged `currency_unresolved` with a non-trusted `XXX` placeholder (itself rejected by `Currency()`), instead of defaulting to SGD.
- **AC12.40.3** — `resolve_transaction_currency` + `POST /review/transactions/{id}/currency` let a reviewer specify an ISO-4217 currency; the resolution is audited (who/when/value) on new `currency_resolved_by` / `currency_resolved_at` columns.
- **AC12.40.4** — the promotion gate `create_entry_from_txn` blocks `currency_unresolved` transactions from becoming `JournalLines` (proven by test).

## Changes

- `services/currency_resolution.py` (new) — dependency-light decision module (`src.money` + models only), reused by the ingest path (`deduplication` / `extraction`) and the review path (`review_queue` / router).
- `models/layer2.py` + migration `0050_add_currency_unresolved` — new `currency_unresolved` flag + audit columns on `atomic_transactions` (down_revision `0049_add_outbox`).
- `services/extraction/service.py` + `services/deduplication.py` — resolve currency once at the ingest boundary; remove the `or "SGD"` silent default.
- `services/review_queue.py` — promotion-gate guard.
- `routers/review.py` + `schemas/review.py` — reviewer resolve endpoint (422 on invalid ISO-4217, 404 on unknown txn).
- `docs/project/EPIC-012.foundation-libs.md` — AC12.40 table (rows tagged `{tier:PC}`); AC registry regenerated, tier baseline non-increasing.

## Tests

`apps/backend/tests/services/test_currency_resolution.py` — 14 DB-free `@ac_proof` proofs covering AC12.40.1–.4 (ingest resolution, unresolved-flagging vs silent-default, placeholder rejection, reviewer resolution + audit, ISO-4217 validation, promotion-gate block/pass). All green.

## Deferred scope

The **frontend reviewer UX** for entering the currency is intentionally not included. The backend resolve endpoint is shipped and the invariant is enforced **end-to-end** (ingest flag -> review queue -> resolve -> promotion gate). Frontend wiring is a clean follow-up.

Closes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)