### PR TITLE
[finance_report_vision] feat(governance): package-scoped authority tiers + AC id scheme (EPIC-026)

### DIFF
--- a/apps/backend/tests/counter/test_count.py
+++ b/apps/backend/tests/counter/test_count.py
@@ -1,4 +1,4 @@
-"""Count value object — a non-negative tally (EPIC-025 AC25.6.2)."""
+"""Count value object — a non-negative tally (EPIC-025 AC-counter.1.2)."""
 
 import pytest
 from common.testing.ac_proof import ac_proof
@@ -8,18 +8,18 @@ from src.counter import Count, NegativeCountError
 pytestmark = pytest.mark.no_db
 
 
-@ac_proof(proof_id="test_count_non_negative_ok", ac_ids=["AC25.6.2"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_count_non_negative_ok", ac_ids=["AC-counter.1.2"], ci_tier="pr_ci")
 def test_count_accepts_zero_and_positive():
-    """AC25.6.2: zero and positive tallies construct and compare like ints."""
+    """AC-counter.1.2: zero and positive tallies construct and compare like ints."""
     assert int(Count(0)) == 0
     assert int(Count(7)) == 7
     assert Count(3) < Count(4)
     assert Count(5) == Count(5)
 
 
-@ac_proof(proof_id="test_count_non_negative_raises", ac_ids=["AC25.6.2"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_count_non_negative_raises", ac_ids=["AC-counter.1.2"], ci_tier="pr_ci")
 def test_count_rejects_negative():
-    """AC25.6.2: a negative count is unrepresentable (NegativeCountError)."""
+    """AC-counter.1.2: a negative count is unrepresentable (NegativeCountError)."""
     with pytest.raises(NegativeCountError):
         Count(-1)
     # a bool is not a valid tally either (guards int/bool confusion)

--- a/apps/backend/tests/counter/test_increment.py
+++ b/apps/backend/tests/counter/test_increment.py
@@ -1,4 +1,4 @@
-"""increment verb — per-user bump + Incremented event (EPIC-025 AC25.6.3)."""
+"""increment verb — per-user bump + Incremented event (EPIC-025 AC-counter.1.3)."""
 
 from uuid import uuid4
 
@@ -16,9 +16,9 @@ KEY = CounterKey("report.generated")
 OTHER = CounterKey("statement.uploaded")
 
 
-@ac_proof(proof_id="test_increment_per_user", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_increment_per_user", ac_ids=["AC-counter.1.3"], ci_tier="pr_ci")
 def test_increment_is_per_user():
-    """AC25.6.3: increment bumps THIS user's tally and returns the new Count."""
+    """AC-counter.1.3: increment bumps THIS user's tally and returns the new Count."""
     repo = InMemoryCounterRepository()
     u1, u2 = uuid4(), uuid4()
 
@@ -30,9 +30,9 @@ def test_increment_is_per_user():
     assert increment(repo, user_id=u1, key=OTHER) == Count(1)
 
 
-@ac_proof(proof_id="test_increment_emits_event", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_increment_emits_event", ac_ids=["AC-counter.1.3"], ci_tier="pr_ci")
 def test_increment_emits_incremented_event():
-    """AC25.6.3: increment publishes an Incremented domain event through the bus."""
+    """AC-counter.1.3: increment publishes an Incremented domain event through the bus."""
     repo = InMemoryCounterRepository()
     u1 = uuid4()
     bus = RecordingEventBus()
@@ -48,9 +48,9 @@ def test_increment_emits_incremented_event():
     assert event.occurred_at is not None
 
 
-@ac_proof(proof_id="test_keys_users_isolated", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_keys_users_isolated", ac_ids=["AC-counter.1.3"], ci_tier="pr_ci")
 def test_two_keys_two_users_do_not_interfere():
-    """AC25.6.3: (user, key) pairs are independent tallies."""
+    """AC-counter.1.3: (user, key) pairs are independent tallies."""
     repo = InMemoryCounterRepository()
     u1, u2 = uuid4(), uuid4()
     increment(repo, user_id=u1, key=KEY)

--- a/apps/backend/tests/counter/test_key.py
+++ b/apps/backend/tests/counter/test_key.py
@@ -1,4 +1,4 @@
-"""CounterKey validation — the package's self-owned SSOT term (EPIC-025 AC25.6.1)."""
+"""CounterKey validation — the package's self-owned SSOT term (EPIC-025 AC-counter.1.1)."""
 
 import pytest
 from common.testing.ac_proof import ac_proof
@@ -8,16 +8,16 @@ from src.counter import CounterKey, InvalidCounterKeyError
 pytestmark = pytest.mark.no_db
 
 
-@ac_proof(proof_id="test_counter_key_valid", ac_ids=["AC25.6.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_counter_key_valid", ac_ids=["AC-counter.1.1"], ci_tier="pr_ci")
 def test_counter_key_accepts_valid():
-    """AC25.6.1: valid lowercase dotted 'domain.action' keys construct."""
+    """AC-counter.1.1: valid lowercase dotted 'domain.action' keys construct."""
     for value in ("report.generated", "statement.uploaded", "a.b.c", "user.signed_in"):
         assert str(CounterKey(value)) == value
 
 
-@ac_proof(proof_id="test_counter_key_invalid", ac_ids=["AC25.6.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_counter_key_invalid", ac_ids=["AC-counter.1.1"], ci_tier="pr_ci")
 def test_counter_key_rejects_invalid():
-    """AC25.6.1: malformed keys are unrepresentable (InvalidCounterKeyError)."""
+    """AC-counter.1.1: malformed keys are unrepresentable (InvalidCounterKeyError)."""
     invalid = [
         "",  # empty
         "report",  # not dotted (no namespace)
@@ -34,9 +34,9 @@ def test_counter_key_rejects_invalid():
             CounterKey(value)
 
 
-@ac_proof(proof_id="test_counter_key_value_object", ac_ids=["AC25.6.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_counter_key_value_object", ac_ids=["AC-counter.1.1"], ci_tier="pr_ci")
 def test_counter_key_is_frozen_value_object():
-    """AC25.6.1: keys are equal/hashable by value and immutable."""
+    """AC-counter.1.1: keys are equal/hashable by value and immutable."""
     a, b = CounterKey("report.generated"), CounterKey("report.generated")
     assert a == b
     assert hash(a) == hash(b)

--- a/apps/backend/tests/counter/test_outbox_emit.py
+++ b/apps/backend/tests/counter/test_outbox_emit.py
@@ -1,4 +1,4 @@
-"""counter emits ``counter.Incremented`` through the outbox (AC25.7.5).
+"""counter emits ``counter.Incremented`` through the outbox (AC-platform.1.5).
 
 Proves the package wiring end to end against a real Postgres session: the async
 ``record_increment`` boundary bumps the per-(user, key) tally AND writes the
@@ -25,10 +25,10 @@ async def _outbox_rows(db):
     return (await db.execute(sa.select(Outbox).order_by(Outbox.id))).scalars().all()
 
 
-@ac_proof(proof_id="test_counter_emits_to_outbox", ac_ids=["AC25.7.5"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_counter_emits_to_outbox", ac_ids=["AC-platform.1.5"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_record_increment_writes_incremented_atomically(db):
-    """AC25.7.5: record_increment bumps the tally and enqueues counter.Incremented."""
+    """AC-platform.1.5: record_increment bumps the tally and enqueues counter.Incremented."""
     user_id = uuid4()
 
     count = await record_increment(db, user_id=user_id, key=KEY)
@@ -48,10 +48,10 @@ async def test_record_increment_writes_incremented_atomically(db):
     assert row.payload["count"] == 1
 
 
-@ac_proof(proof_id="test_counter_emit_rolls_back_with_tally", ac_ids=["AC25.7.5"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_counter_emit_rolls_back_with_tally", ac_ids=["AC-platform.1.5"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_rollback_leaves_neither_tally_nor_event(db):
-    """AC25.7.5: rollback ⇒ no tally bump AND no outbox row (one transaction)."""
+    """AC-platform.1.5: rollback ⇒ no tally bump AND no outbox row (one transaction)."""
     user_id = uuid4()
 
     await record_increment(db, user_id=user_id, key=KEY)
@@ -62,9 +62,9 @@ async def test_rollback_leaves_neither_tally_nor_event(db):
     assert len(await _outbox_rows(db)) == 0
 
 
-@ac_proof(proof_id="test_counter_increment_op_publishes_via_bus", ac_ids=["AC25.7.5"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_counter_increment_op_publishes_via_bus", ac_ids=["AC-platform.1.5"], ci_tier="pr_ci")
 def test_increment_op_publishes_through_bus_fake():
-    """AC25.7.5: the pure increment verb publishes Incremented through any EventBus."""
+    """AC-platform.1.5: the pure increment verb publishes Incremented through any EventBus."""
     from tests.counter._fake import InMemoryCounterRepository
 
     repo = InMemoryCounterRepository()

--- a/apps/backend/tests/counter/test_query.py
+++ b/apps/backend/tests/counter/test_query.py
@@ -1,4 +1,4 @@
-"""get_count verb — per-user vs global (EPIC-025 AC25.6.4)."""
+"""get_count verb — per-user vs global (EPIC-025 AC-counter.1.4)."""
 
 from uuid import uuid4
 
@@ -14,9 +14,9 @@ pytestmark = pytest.mark.no_db
 KEY = CounterKey("report.generated")
 
 
-@ac_proof(proof_id="test_global_vs_per_user", ac_ids=["AC25.6.4"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_global_vs_per_user", ac_ids=["AC-counter.1.4"], ci_tier="pr_ci")
 def test_global_vs_per_user_count():
-    """AC25.6.4: user_id=None yields the global sum; a user_id yields that user's."""
+    """AC-counter.1.4: user_id=None yields the global sum; a user_id yields that user's."""
     repo = InMemoryCounterRepository()
     u1, u2 = uuid4(), uuid4()
     # u1 increments twice, u2 once
@@ -31,9 +31,9 @@ def test_global_vs_per_user_count():
     assert get_count(repo, key=KEY, user_id=None) == Count(3)
 
 
-@ac_proof(proof_id="test_unknown_count_is_zero", ac_ids=["AC25.6.4"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_unknown_count_is_zero", ac_ids=["AC-counter.1.4"], ci_tier="pr_ci")
 def test_unknown_key_or_user_is_zero():
-    """AC25.6.4: never-incremented (user, key) reads as Count(0), not an error."""
+    """AC-counter.1.4: never-incremented (user, key) reads as Count(0), not an error."""
     repo = InMemoryCounterRepository()
     assert get_count(repo, key=KEY) == Count(0)
     assert get_count(repo, key=KEY, user_id=uuid4()) == Count(0)

--- a/apps/backend/tests/counter/test_sql_store.py
+++ b/apps/backend/tests/counter/test_sql_store.py
@@ -1,7 +1,7 @@
 """DB-backed SqlCounterRepository — atomic upsert + per-user/global reads.
 
 Exercises the only role that touches the ORM against the real ``counter_tally``
-table (EPIC-025 AC25.6.3 / AC25.6.4). The bump is an atomic upsert-increment, so
+table (EPIC-025 AC-counter.1.3 / AC-counter.1.4). The bump is an atomic upsert-increment, so
 the second bump of the same (user, key) returns 2 rather than colliding on the
 unique (user_id, key) primary key.
 """
@@ -18,10 +18,10 @@ from src.counter.store.sql import SqlCounterRepository
 KEY = CounterKey("report.generated")
 
 
-@ac_proof(proof_id="test_sql_counter_atomic", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_sql_counter_atomic", ac_ids=["AC-counter.1.3"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_sql_bump_is_atomic_and_per_user(db):
-    """AC25.6.3: repeated bumps increment the same (user, key) row atomically."""
+    """AC-counter.1.3: repeated bumps increment the same (user, key) row atomically."""
     repo = SqlCounterRepository(db)
     u1, u2 = uuid4(), uuid4()
 
@@ -34,10 +34,10 @@ async def test_sql_bump_is_atomic_and_per_user(db):
     assert await repo.for_user(u2, KEY) == 1
 
 
-@ac_proof(proof_id="test_sql_counter_global", ac_ids=["AC25.6.4"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_sql_counter_global", ac_ids=["AC-counter.1.4"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_sql_global_and_per_user_reads(db):
-    """AC25.6.4: total() sums across users; read_count bridges to a Count."""
+    """AC-counter.1.4: total() sums across users; read_count bridges to a Count."""
     repo = SqlCounterRepository(db)
     u1, u2 = uuid4(), uuid4()
     await repo.bump(u1, KEY)
@@ -53,10 +53,10 @@ async def test_sql_global_and_per_user_reads(db):
     assert int(await read_count(db, key=KEY, user_id=uuid4())) == 0
 
 
-@ac_proof(proof_id="test_sql_ops_port_parity", ac_ids=["AC25.6.4"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_sql_ops_port_parity", ac_ids=["AC-counter.1.4"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_sql_repo_satisfies_read_via_ops_after_sync_snapshot(db):
-    """AC25.6.4: ops over an in-memory snapshot of the SQL state agree with the DB."""
+    """AC-counter.1.4: ops over an in-memory snapshot of the SQL state agree with the DB."""
     from tests.counter._fake import InMemoryCounterRepository
 
     repo = SqlCounterRepository(db)

--- a/apps/backend/tests/platform/test_contract.py
+++ b/apps/backend/tests/platform/test_contract.py
@@ -1,4 +1,4 @@
-"""The ``platform`` package conforms to its ``PackageContract`` (AC25.7.4).
+"""The ``platform`` package conforms to its ``PackageContract`` (AC-platform.1.4).
 
 A lighter mirror of the governance gate, scoped to this package: it asserts the
 published language (``__all__``) equals ``contract.interface`` and that the
@@ -16,17 +16,17 @@ from common.platform.contract import CONTRACT
 from common.testing.ac_proof import ac_proof
 
 
-@ac_proof(proof_id="test_platform_interface_matches_all", ac_ids=["AC25.7.4"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_platform_interface_matches_all", ac_ids=["AC-platform.1.4"], ci_tier="pr_ci")
 def test_interface_equals_published_all():
-    """AC25.7.4: contract.interface equals the BE implementation's __all__."""
+    """AC-platform.1.4: contract.interface equals the BE implementation's __all__."""
     from src.platform import __all__ as published
 
     assert sorted(CONTRACT.interface) == sorted(published)
 
 
-@ac_proof(proof_id="test_platform_passes_contract_gate", ac_ids=["AC25.7.4"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_platform_passes_contract_gate", ac_ids=["AC-platform.1.4"], ci_tier="pr_ci")
 def test_platform_package_passes_governance_gate():
-    """AC25.7.4: check_package_contract validates platform with no violations."""
+    """AC-platform.1.4: check_package_contract validates platform with no violations."""
     packages = discover_packages(REPO_ROOT)
     registered = {p.name: p.contract.klass for p in packages}
     platform = next(p for p in packages if p.name == "platform")

--- a/apps/backend/tests/platform/test_outbox_atomicity.py
+++ b/apps/backend/tests/platform/test_outbox_atomicity.py
@@ -1,4 +1,4 @@
-"""DB-backed atomicity of the transactional outbox (AC25.7.1).
+"""DB-backed atomicity of the transactional outbox (AC-platform.1.1).
 
 The single invariant the pattern rests on: a domain event row is written in the
 SAME transaction as the domain state change. So a transaction that publishes an
@@ -27,10 +27,10 @@ async def _outbox_count(db) -> int:
     return int(result.scalar_one())
 
 
-@ac_proof(proof_id="test_outbox_commit_persists_row", ac_ids=["AC25.7.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_outbox_commit_persists_row", ac_ids=["AC-platform.1.1"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_commit_leaves_exactly_one_outbox_row(db):
-    """AC25.7.1: a committed publish leaves exactly one pending outbox row."""
+    """AC-platform.1.1: a committed publish leaves exactly one pending outbox row."""
     bus = OutboxEventBus(db, source_pkg="test")
     bus.publish(_event())
     await db.commit()
@@ -43,10 +43,10 @@ async def test_commit_leaves_exactly_one_outbox_row(db):
     assert row.published_at is None
 
 
-@ac_proof(proof_id="test_outbox_rollback_leaves_no_row", ac_ids=["AC25.7.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_outbox_rollback_leaves_no_row", ac_ids=["AC-platform.1.1"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_rollback_leaves_no_outbox_row(db):
-    """AC25.7.1: a rolled-back publish leaves NO outbox row (atomic)."""
+    """AC-platform.1.1: a rolled-back publish leaves NO outbox row (atomic)."""
     bus = OutboxEventBus(db, source_pkg="test")
     bus.publish(_event())
     await db.flush()  # row is in the transaction...

--- a/apps/backend/tests/platform/test_relay.py
+++ b/apps/backend/tests/platform/test_relay.py
@@ -1,4 +1,4 @@
-"""The relay drains committed pending rows post-commit (AC25.7.2 / AC25.7.3).
+"""The relay drains committed pending rows post-commit (AC-platform.1.2 / AC-platform.1.3).
 
 Proves the read half of the outbox: ``run_once`` dispatches each pending row to
 its subscribed handlers with the rehydrated event, marks the row published, and a
@@ -31,10 +31,10 @@ async def _seed(db, *, n=1, name="counter.Incremented"):
     await db.commit()
 
 
-@ac_proof(proof_id="test_relay_dispatches_pending", ac_ids=["AC25.7.2"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_relay_dispatches_pending", ac_ids=["AC-platform.1.2"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_run_once_dispatches_and_marks_published(db):
-    """AC25.7.2: run_once invokes the handler with the event, then marks published."""
+    """AC-platform.1.2: run_once invokes the handler with the event, then marks published."""
     registry = SubscriberRegistry()
     seen: list[dict] = []
     registry.subscribe("counter.Incremented", lambda e: seen.append(e.payload()))
@@ -50,10 +50,10 @@ async def test_run_once_dispatches_and_marks_published(db):
     assert all(r.status == STATUS_PUBLISHED and r.published_at is not None for r in rows)
 
 
-@ac_proof(proof_id="test_relay_no_redispatch", ac_ids=["AC25.7.3"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_relay_no_redispatch", ac_ids=["AC-platform.1.3"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_second_run_does_not_redispatch_published(db):
-    """AC25.7.3: a second run_once does NOT re-deliver already-published rows."""
+    """AC-platform.1.3: a second run_once does NOT re-deliver already-published rows."""
     registry = SubscriberRegistry()
     deliveries: list[str] = []
     registry.subscribe("counter.Incremented", lambda e: deliveries.append(e.event_type))
@@ -66,10 +66,10 @@ async def test_second_run_does_not_redispatch_published(db):
     assert deliveries == ["counter.Incremented"]  # delivered exactly once
 
 
-@ac_proof(proof_id="test_relay_redelivery_idempotent", ac_ids=["AC25.7.3"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_relay_redelivery_idempotent", ac_ids=["AC-platform.1.3"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_redelivery_of_pending_is_idempotent_safe(db):
-    """AC25.7.3: re-delivering a still-pending row twice is safe for an idempotent handler.
+    """AC-platform.1.3: re-delivering a still-pending row twice is safe for an idempotent handler.
 
     Models at-least-once: if a pass crashes before marking published, the next
     pass redelivers. An idempotent handler keyed by aggregate_id collapses the

--- a/common/counter/contract.py
+++ b/common/counter/contract.py
@@ -25,6 +25,9 @@ CONTRACT = PackageContract(
     name="counter",
     klass="platform",
     status="active",
+    # Deterministic tally + event emission, no LLM: a pure-code (PC) package.
+    # Every AC in the roadmap inherits this tier.
+    tier="PC",
     depends_on=["platform"],
     roles=["types", "ops", "store", "api"],
     implementations={"be": "apps/backend/src/counter", "fe": None},
@@ -63,7 +66,7 @@ CONTRACT = PackageContract(
     ],
     roadmap=[
         ACRecord(
-            id="AC25.6.1",
+            id="AC-counter.1.1",
             statement=(
                 "CounterKey validates the namespaced lowercase dotted "
                 "'domain.action' shape and rejects invalid keys with "
@@ -73,10 +76,9 @@ CONTRACT = PackageContract(
             test="apps/backend/tests/counter/test_key.py::test_counter_key_rejects_invalid",
             priority="P0",
             status="done",
-            tier="PC",
         ),
         ACRecord(
-            id="AC25.6.2",
+            id="AC-counter.1.2",
             statement=(
                 "Count is a non-negative tally; constructing a negative count "
                 "raises NegativeCountError; domain types never import the "
@@ -85,10 +87,9 @@ CONTRACT = PackageContract(
             test="apps/backend/tests/counter/test_count.py::test_count_rejects_negative",
             priority="P0",
             status="done",
-            tier="PC",
         ),
         ACRecord(
-            id="AC25.6.3",
+            id="AC-counter.1.3",
             statement=(
                 "increment bumps the per-(user, key) tally by one, returns the new "
                 "per-user Count, and publishes an Incremented domain event through "
@@ -98,10 +99,9 @@ CONTRACT = PackageContract(
             test="apps/backend/tests/counter/test_increment.py::test_increment_is_per_user",
             priority="P1",
             status="done",
-            tier="PC",
         ),
         ACRecord(
-            id="AC25.6.4",
+            id="AC-counter.1.4",
             statement=(
                 "get_count returns the per-user count for a concrete user_id and "
                 "the global count (sum across users) when user_id is None; "
@@ -111,7 +111,6 @@ CONTRACT = PackageContract(
             test="apps/backend/tests/counter/test_query.py::test_global_vs_per_user_count",
             priority="P1",
             status="done",
-            tier="PC",
         ),
     ],
 )

--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -103,7 +103,7 @@ concurrent increments cannot lose updates. Migration:
 
 ## Governance
 
-The package's ACs (`AC25.6.1`–`AC25.6.4`) live in [`contract.py`](./contract.py)'s
+The package's ACs (`AC-counter.1.1`–`AC-counter.1.4`) live in [`contract.py`](./contract.py)'s
 `roadmap` and are sourced **directly** from there into the AC registry (no EPIC
 mirror); its invariants pin to the tests that prove them.
 `tools/check_package_contract.py` validates the implementation against this

--- a/common/counter/todo.md
+++ b/common/counter/todo.md
@@ -10,7 +10,7 @@ The package-local worklist. Cross-package migration lives in
 - [x] Become the `common/`-centric template: spec (`readme.md` + `contract.py` +
       `todo.md`) under `common/counter/`, implementation under
       `apps/backend/src/counter`.
-- [x] ACs (`AC25.6.1`–`AC25.6.4`) sourced directly from the contract `roadmap`.
+- [x] ACs (`AC-counter.1.1`–`AC-counter.1.4`) sourced directly from the contract `roadmap`.
 
 ## Next
 

--- a/common/governance/contract.py
+++ b/common/governance/contract.py
@@ -23,6 +23,9 @@ CONTRACT = PackageContract(
     name="governance",
     klass="platform",
     status="active",
+    # The package-model gate is deterministic code (AST + set comparison), no
+    # LLM: a pure-code (PC) package. It also OWNS the authority-tier rules below.
+    tier="PC",
     depends_on=[],
     roles=["package_contract", "check_package_contract"],
     implementations={"be": "common/governance", "fe": None},
@@ -66,6 +69,36 @@ CONTRACT = PackageContract(
             test=(
                 "tests/tooling/test_check_package_contract.py"
                 "::test_upward_edge_is_forbidden"
+            ),
+        ),
+        Invariant(
+            id="active-package-has-a-decided-tier",
+            statement=(
+                "Authority tier is a module-design property declared once on the "
+                "PackageContract (docs/ssot/authority-tiers.md). An active/"
+                "deprecated package must have resolved its tier to one of "
+                "PC/CP/LP/PL; only a draft package may leave tier undecided (the "
+                "legacy 'HU' state), so a shipped untyped package is "
+                "unrepresentable."
+            ),
+            test=(
+                "tests/tooling/test_check_package_contract.py"
+                "::test_active_package_must_declare_a_tier"
+            ),
+        ),
+        Invariant(
+            id="ac-proof-kind-satisfies-package-tier-matrix",
+            statement=(
+                "Every roadmap AC's proof_kind must be valid for the package's "
+                "tier per the single machine matrix "
+                "(package_contract.TIER_VALID_PROOF_KINDS); PackageContract "
+                "enforces it at construction, so a contract that violates the "
+                "tier->proof matrix (e.g. an LP/PL package with an AC claiming an "
+                "exact golden proof) fails to import."
+            ),
+            test=(
+                "tests/tooling/test_check_package_contract.py"
+                "::test_package_proof_kind_must_satisfy_the_tier_matrix"
             ),
         ),
     ],

--- a/common/governance/package_contract.py
+++ b/common/governance/package_contract.py
@@ -8,14 +8,30 @@ ACs it owns). ``tools/check_package_contract.py`` validates the live package
 against this contract, so governance is *computed*, not hand-maintained.
 
 stdlib + pydantic only by design: importable from the governance gate and from a
-package's ``contract.py`` without pulling app/framework dependencies.
+package's ``contract.py`` without pulling app/framework dependencies. The
+authority-tier vocabulary and the tier->proof matrix come from the stdlib-only
+:mod:`common.ssot.authority_matrix` (the single machine source, also imported by
+the lightweight SSOT tooling that must NOT pull pydantic).
 """
 
 from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+
+# Re-exported (hence noqa) so existing imports like
+# `from common.governance.package_contract import TIER_VALID_PROOF_KINDS` keep
+# resolving; the single source of these definitions is common.ssot.authority_matrix.
+from common.ssot.authority_matrix import (  # noqa: F401
+    AC_PROOF_KINDS,
+    AC_TIERS,
+    ACProofKind,
+    ACTier,
+    PackageTier,
+    TIER_DEFAULT_PROOF_KIND,
+    TIER_VALID_PROOF_KINDS,
+)
 
 #: A package class. The three orthogonal kinds in the model:
 #: - ``kernel``   — leaf value-language reused everywhere (e.g. ``money``);
@@ -32,16 +48,10 @@ Priority = Literal["P0", "P1", "P2"]
 #: AC lifecycle status within a package roadmap.
 ACStatus = Literal["open", "done"]
 
-#: Package lifecycle status. ``active`` packages are governed and shipped;
-#: ``deprecated`` ones are on the way out (still checked, but flagged).
-PackageStatus = Literal["active", "deprecated"]
-
-#: Authority tier of a roadmap AC (SSOT: ``docs/ssot/authority-tiers.md``). The
-#: tier travels with the AC into the package-aware AC registry so the existing
-#: tier/proof-kind gates keep seeing the same tier they did when the AC lived in
-#: an EPIC table. ``None`` leaves the AC untagged (tracked by the tier ratchet).
-ACTier = Literal["PC", "CP", "HU", "LP", "PL"]
-
+#: Package lifecycle status. ``draft`` = still being designed (its authority
+#: tier may be undecided); ``active`` = governed and shipped (tier MUST be
+#: decided); ``deprecated`` = on the way out (still checked, but flagged).
+PackageStatus = Literal["draft", "active", "deprecated"]
 
 class Invariant(BaseModel):
     """A property the package guarantees, pinned to the test that proves it.
@@ -70,13 +80,14 @@ class ACRecord(BaseModel):
     test: str
     priority: Priority
     status: ACStatus
-    #: Authority tier (``docs/ssot/authority-tiers.md``); carried into the AC
-    #: registry so the tier/proof-kind gates see the same tier the EPIC table
-    #: declared. ``None`` = untagged (the tier ratchet tracks that debt).
-    tier: ACTier | None = None
-    #: Proof kind the AC's test provides. When ``None`` the AC registry derives
-    #: the tier's canonical kind, exactly as a tier-tagged EPIC row would.
-    proof_kind: str | None = None
+    #: Proof kind the AC's test provides. The AC inherits its authority tier from
+    #: the owning :class:`PackageContract` (tier is a module-design property, not a
+    #: per-AC one), so ``proof_kind`` is the only tier-related attribute an AC
+    #: carries. ``None`` resolves to the package tier's canonical kind
+    #: (:data:`TIER_DEFAULT_PROOF_KIND`); an explicit value MUST be valid for the
+    #: package tier per :data:`TIER_VALID_PROOF_KINDS` (e.g. under an LP/PL package
+    #: an AC can never be ``exact``). Enforced by the owning ``PackageContract``.
+    proof_kind: ACProofKind | None = None
 
 
 class PackageContract(BaseModel):
@@ -85,7 +96,9 @@ class PackageContract(BaseModel):
     Fields:
         name:            the package name (matches its ``common/<name>/`` dir).
         klass:           ``core`` / ``platform`` / ``kernel`` (the dependency tier).
-        status:          ``active`` / ``deprecated`` (package lifecycle).
+        status:          ``draft`` / ``active`` / ``deprecated`` (package lifecycle).
+        tier:            the package's permanent authority tier (:data:`PackageTier`);
+                         ``None`` = undecided, allowed only while ``status="draft"``.
         depends_on:      names of packages this one may import (down-only edges).
         roles:           the role folders the implementation converges into
                          (e.g. ``["types", "ops", "store", "api"]``).
@@ -108,5 +121,44 @@ class PackageContract(BaseModel):
     invariants: list[Invariant]
     roadmap: list[ACRecord]
     status: PackageStatus = "active"
+    #: The package's permanent authority tier. ``None`` means "undecided" and is
+    #: legal only for a ``draft`` package; an ``active``/``deprecated`` package
+    #: must have resolved its tier to a concrete :data:`PackageTier`.
+    tier: PackageTier | None = None
     roles: list[str] = []
     implementations: dict[str, str | None] = {}
+
+    @model_validator(mode="after")
+    def _tier_decided_and_proofs_match(self) -> PackageContract:
+        """Enforce the module-design tier rules at construction.
+
+        1. A shipped package has a decided tier: ``status != "draft"`` requires a
+           concrete :data:`PackageTier` (a ``draft`` may stay ``tier=None`` — the
+           "undecided" state that the legacy EPIC source spelled ``HU``).
+        2. Every roadmap AC's proof kind is valid for the package's tier per the
+           single matrix (:data:`TIER_VALID_PROOF_KINDS`); a missing kind resolves
+           to the tier's canonical default and is materialized on the record. An
+           undecided (``None``) tier skips the proof check — there is no tier to
+           validate against yet.
+        """
+        if self.tier is None:
+            if self.status != "draft":
+                raise ValueError(
+                    f"package {self.name!r}: status {self.status!r} requires a "
+                    "decided authority tier (one of PC/CP/LP/PL); only a 'draft' "
+                    "package may leave tier undecided (the legacy 'HU' state)."
+                )
+            return self
+
+        valid = TIER_VALID_PROOF_KINDS[self.tier]
+        for ac in self.roadmap:
+            kind = ac.proof_kind or TIER_DEFAULT_PROOF_KIND[self.tier]
+            if kind not in valid:
+                raise ValueError(
+                    f"package {self.name!r} AC {ac.id}: proof_kind {kind!r} is "
+                    f"not valid for the package tier {self.tier} "
+                    f"(valid: {sorted(valid)}). Under an LP/PL package an AC can "
+                    "never be proven by an exact golden assertion."
+                )
+            ac.proof_kind = kind
+        return self

--- a/common/governance/readme.md
+++ b/common/governance/readme.md
@@ -93,7 +93,7 @@ edit: a new package is governed the moment it ships a `common/<pkg>/contract.py`
   tallies for insight reports. `CounterKey`/`Count` value objects (`types`),
   `increment`/`get_count` verbs (`ops`) over a `CounterRepository` port (`store`),
   a thin async `read_count` boundary (`api`), and a `PackageContract` whose
-  `roadmap` owns `AC25.6.1`–`AC25.6.4`. See its
+  `roadmap` owns `AC-counter.1.1`–`AC-counter.1.4`. See its
   [`readme.md`](../counter/readme.md) and
   [`contract.py`](../counter/contract.py).
 - **`ledger`** (`core`) — the prototype vertical slice that introduced the

--- a/common/platform/contract.py
+++ b/common/platform/contract.py
@@ -34,6 +34,9 @@ CONTRACT = PackageContract(
     name="platform",
     klass="kernel",
     status="active",
+    # Deterministic event/outbox substrate, no LLM: a pure-code (PC) package.
+    # Every AC in the roadmap inherits this tier.
+    tier="PC",
     depends_on=[],
     roles=["events", "store"],
     implementations={"be": "apps/backend/src/platform", "fe": None},
@@ -76,7 +79,7 @@ CONTRACT = PackageContract(
     ],
     roadmap=[
         ACRecord(
-            id="AC25.7.1",
+            id="AC-platform.1.1",
             statement=(
                 "The OutboxEventBus writes a domain event into the shared outbox "
                 "table using the caller's AsyncSession; a rolled-back transaction "
@@ -89,10 +92,9 @@ CONTRACT = PackageContract(
             ),
             priority="P0",
             status="done",
-            tier="PC",
         ),
         ACRecord(
-            id="AC25.7.2",
+            id="AC-platform.1.2",
             statement=(
                 "OutboxRelay.run_once reads committed pending rows in enqueue "
                 "order, dispatches each to its subscribed handlers with the "
@@ -104,10 +106,9 @@ CONTRACT = PackageContract(
             ),
             priority="P0",
             status="done",
-            tier="PC",
         ),
         ACRecord(
-            id="AC25.7.3",
+            id="AC-platform.1.3",
             statement=(
                 "Dispatch is at-least-once: a second run_once does not re-deliver "
                 "published rows, and re-delivery of a still-pending row is safe "
@@ -119,10 +120,9 @@ CONTRACT = PackageContract(
             ),
             priority="P1",
             status="done",
-            tier="PC",
         ),
         ACRecord(
-            id="AC25.7.4",
+            id="AC-platform.1.4",
             statement=(
                 "The platform package converges by role and its published "
                 "language equals contract.interface; check_package_contract "
@@ -134,10 +134,9 @@ CONTRACT = PackageContract(
             ),
             priority="P1",
             status="done",
-            tier="PC",
         ),
         ACRecord(
-            id="AC25.7.5",
+            id="AC-platform.1.5",
             statement=(
                 "counter.record_increment bumps the per-(user, key) tally and "
                 "enqueues a counter.Incremented event into the shared outbox in "
@@ -149,7 +148,6 @@ CONTRACT = PackageContract(
             ),
             priority="P1",
             status="done",
-            tier="PC",
         ),
     ],
 )

--- a/common/platform/readme.md
+++ b/common/platform/readme.md
@@ -114,7 +114,7 @@ relay's "oldest pending, in order" drain. `status` is plain text (not a
 
 ## Governance
 
-The package's ACs (`AC25.7.1`–`AC25.7.5`) live in [`contract.py`](./contract.py)'s
+The package's ACs (`AC-platform.1.1`–`AC-platform.1.5`) live in [`contract.py`](./contract.py)'s
 `roadmap` (carrying `tier: PC`, EPIC-026's authority-tier model) and are sourced
 directly from there into the AC registry; its invariants pin to the DB-backed
 tests that prove atomicity and post-commit dispatch.

--- a/common/platform/todo.md
+++ b/common/platform/todo.md
@@ -14,7 +14,7 @@ The package-local worklist. Cross-package migration lives in
 - [x] Shared `outbox` table + migration `0049_add_outbox`.
 - [x] `counter` emits `counter.Incremented` through the outbox, atomic with the
       tally bump (`counter.api.record_increment`).
-- [x] ACs `AC25.7.1`–`AC25.7.5` sourced directly from the contract `roadmap`.
+- [x] ACs `AC-platform.1.1`–`AC-platform.1.5` sourced directly from the contract `roadmap`.
 
 ## Next
 

--- a/common/ssot/ac_registry_format.py
+++ b/common/ssot/ac_registry_format.py
@@ -10,14 +10,34 @@ from typing import Any, Iterable
 import yaml
 
 
+# Legacy EPIC-scoped id: ``AC{epic}.{scenario}.{case}`` (all numeric).
 AC_PATTERN = re.compile(r"^AC(?P<epic>\d+)\.(?P<scenario>\d+)\.(?P<case>\d+)$")
 
+# Package-scoped id: ``AC-{package}.{group}.{seq}`` — the package model's scheme,
+# where the key self-describes its owning package instead of an EPIC number.
+PKG_AC_PATTERN = re.compile(
+    r"^AC-(?P<package>[a-z][a-z0-9_]*)\.(?P<group>\d+)\.(?P<seq>\d+)$"
+)
 
-def sort_key(ac_id: str) -> list[int]:
-    return [int(p) for p in ac_id[2:].split(".")]
+
+def sort_key(ac_id: str) -> tuple:
+    """Total order over BOTH id grammars.
+
+    Legacy numeric ids sort first (leading ``0``) by (epic, scenario, case);
+    package ids sort after (leading ``1``) by (package, group, seq). The leading
+    discriminant means an ``int`` field is never compared against a ``str`` one.
+    """
+    pkg = PKG_AC_PATTERN.fullmatch(ac_id)
+    if pkg:
+        return (1, pkg.group("package"), int(pkg.group("group")), int(pkg.group("seq")))
+    return (0, "", *(int(p) for p in ac_id[2:].split(".")))
 
 
 def epic_group_key(ac_id: str) -> str:
+    """Top-level registry group: ``AC{epic}`` (legacy) or ``AC-{package}``."""
+    pkg = PKG_AC_PATTERN.fullmatch(ac_id)
+    if pkg:
+        return f"AC-{pkg.group('package')}"
     match = AC_PATTERN.fullmatch(ac_id)
     if not match:
         raise ValueError(f"Invalid AC ID: {ac_id}")
@@ -25,6 +45,10 @@ def epic_group_key(ac_id: str) -> str:
 
 
 def scenario_group_key(ac_id: str) -> str:
+    """Second-level group: ``AC{epic}.{scenario}`` or ``AC-{package}.{group}``."""
+    pkg = PKG_AC_PATTERN.fullmatch(ac_id)
+    if pkg:
+        return f"AC-{pkg.group('package')}.{pkg.group('group')}"
     match = AC_PATTERN.fullmatch(ac_id)
     if not match:
         raise ValueError(f"Invalid AC ID: {ac_id}")

--- a/common/ssot/ac_traceability_refs.py
+++ b/common/ssot/ac_traceability_refs.py
@@ -7,7 +7,9 @@ import re
 from pathlib import Path
 from typing import Literal
 
-AC_PATTERN = re.compile(r"\bAC\d+\.\d+\.\d+\b")
+# Matches both id grammars: legacy ``AC{epic}.{n}.{n}`` and package-scoped
+# ``AC-{package}.{n}.{n}``.
+AC_PATTERN = re.compile(r"\bAC(?:\d+|-[a-z][a-z0-9_]*)\.\d+\.\d+\b")
 
 ReferenceKind = Literal["real", "stub", "placeholder"]
 

--- a/common/ssot/authority_matrix.py
+++ b/common/ssot/authority_matrix.py
@@ -1,0 +1,50 @@
+"""Single machine source of the authority-tier vocabulary + tier->proof matrix.
+
+This is the canonical machine mirror of ``docs/ssot/authority-tiers.md``. It is
+**stdlib-only by design** (``typing`` only): importable by the lightweight SSOT
+tooling — the registry generator (``generate_ac_registry``) and the proof-kind
+gate (``check_ac_proof_kind``) — WITHOUT pulling ``pydantic``, so the CI lint
+env (``uv run --with pyyaml …``) keeps working. ``common.governance``'s
+pydantic ``PackageContract`` model re-uses these same definitions for its
+construction-time validation, so there is exactly one matrix and it cannot drift
+between the model and the gates.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, get_args
+
+#: The four permanent module-design authority tiers (SSOT: authority-tiers.md).
+PackageTier = Literal["PC", "CP", "LP", "PL"]
+
+#: Legacy per-AC tier vocabulary used only by the EPIC-table ``{tier:XX}`` marker
+#: source; still recognizes ``HU`` for the handful of pre-package ACs that carry
+#: it (in the package model "undecided" is a ``draft`` package with ``tier=None``).
+ACTier = Literal["PC", "CP", "HU", "LP", "PL"]
+
+#: Proof kind an AC's test provides.
+ACProofKind = Literal["property", "invariant", "eval", "exact", "evidence", "smoke"]
+
+#: tier -> the proof kinds the matrix accepts for that tier.
+TIER_VALID_PROOF_KINDS: dict[str, frozenset[str]] = {
+    "PC": frozenset({"exact", "property"}),
+    "CP": frozenset({"exact", "property"}),
+    "HU": frozenset({"evidence"}),
+    "LP": frozenset({"property", "invariant", "eval"}),
+    "PL": frozenset({"eval", "smoke"}),
+}
+
+#: tier -> canonical proof kind when an AC declares no explicit ``proof_kind``.
+#: Each default is a member of that tier's :data:`TIER_VALID_PROOF_KINDS`.
+TIER_DEFAULT_PROOF_KIND: dict[str, str] = {
+    "PC": "exact",
+    "CP": "exact",
+    "HU": "evidence",
+    "LP": "property",
+    "PL": "smoke",
+}
+
+#: Canonical vocabularies as tuples, derived from the Literals so the tuple form
+#: (used by the ssot tooling) cannot drift from the type form.
+AC_TIERS: tuple[str, ...] = get_args(ACTier)
+AC_PROOF_KINDS: tuple[str, ...] = get_args(ACProofKind)

--- a/common/ssot/build_ac_traceability.py
+++ b/common/ssot/build_ac_traceability.py
@@ -179,9 +179,11 @@ def collect_references(test_files: list[Path]) -> dict[str, ACReferenceStats]:
 # ---------------------------------------------------------------------------
 
 
-def _ac_sort_key(ac_id: str) -> tuple[int, ...]:
-    """Sort ACs numerically (AC1.2.10 after AC1.2.9)."""
-    return tuple(int(p) for p in ac_id[2:].split("."))
+def _ac_sort_key(ac_id: str) -> tuple:
+    """Sort ACs over both id grammars (AC1.2.10 after AC1.2.9; package ids last)."""
+    from common.ssot.ac_registry_format import sort_key
+
+    return sort_key(ac_id)
 
 
 _DEPRECATED_PATTERN = re.compile(r"^~~.+~~$", re.DOTALL)

--- a/common/ssot/check_ac_proof_kind.py
+++ b/common/ssot/check_ac_proof_kind.py
@@ -40,20 +40,17 @@ import sys
 from pathlib import Path
 
 from common.ssot.ac_registry_format import sort_key
+from common.ssot.authority_matrix import TIER_VALID_PROOF_KINDS
 from common.ssot.generate_ac_registry import AC_PROOF_KINDS, build_registry_entries
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# tier -> the set of proof kinds the SSOT matrix accepts for that tier. The
-# single source of truth for these rules is docs/ssot/authority-tiers.md; this
-# dict is the machine-checkable mirror.
-VALID_PROOF_KINDS: dict[str, frozenset[str]] = {
-    "PC": frozenset({"exact", "property"}),
-    "CP": frozenset({"exact", "property"}),
-    "HU": frozenset({"evidence"}),
-    "LP": frozenset({"property", "invariant", "eval"}),
-    "PL": frozenset({"eval", "smoke"}),
-}
+# tier -> the set of proof kinds the SSOT matrix accepts for that tier. The prose
+# source of truth is docs/ssot/authority-tiers.md; its single MACHINE mirror is
+# common/governance/package_contract.TIER_VALID_PROOF_KINDS (the same matrix the
+# ACRecord model validates against). Aliased here so this gate and the contract
+# model enforce one identical matrix — they cannot drift apart.
+VALID_PROOF_KINDS: dict[str, frozenset[str]] = TIER_VALID_PROOF_KINDS
 
 
 def proof_kind_violations(repo_root: Path) -> list[str]:

--- a/common/ssot/check_ac_proof_kind.py
+++ b/common/ssot/check_ac_proof_kind.py
@@ -47,9 +47,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # tier -> the set of proof kinds the SSOT matrix accepts for that tier. The prose
 # source of truth is docs/ssot/authority-tiers.md; its single MACHINE mirror is
-# common/governance/package_contract.TIER_VALID_PROOF_KINDS (the same matrix the
-# ACRecord model validates against). Aliased here so this gate and the contract
-# model enforce one identical matrix — they cannot drift apart.
+# common/ssot/authority_matrix.TIER_VALID_PROOF_KINDS (which package_contract also
+# re-exports for the PackageContract model). Aliased here so this gate and the
+# contract model enforce one identical matrix — they cannot drift apart.
 VALID_PROOF_KINDS: dict[str, frozenset[str]] = TIER_VALID_PROOF_KINDS
 
 

--- a/common/ssot/generate_ac_registry.py
+++ b/common/ssot/generate_ac_registry.py
@@ -6,7 +6,16 @@ import os
 import sys
 from pathlib import Path
 
+# Import the matrix from the stdlib-only source (NOT package_contract, which
+# pulls pydantic) so this generator stays importable in the lightweight CI lint
+# env (`uv run --with pyyaml ...`).
+from common.ssot.authority_matrix import (
+    AC_PROOF_KINDS as _AC_PROOF_KINDS,
+    AC_TIERS as _AC_TIERS,
+    TIER_DEFAULT_PROOF_KIND as _TIER_DEFAULT_PROOF_KIND,
+)
 from common.ssot.ac_registry_format import (
+    PKG_AC_PATTERN,
     epic_group_key,
     load_registry_entries,
     registry_validation_errors,
@@ -63,44 +72,35 @@ EPIC_NAMES: dict[int, str] = {
 
 AC_PATTERN = re.compile(r"\b(AC(\d+)\.(\d+)\.(\d+))\b")
 
-# Authority tier vocabulary (SSOT: docs/ssot/authority-tiers.md). One AC = one
-# tier; the tier dictates what KIND of proof is valid for the AC's behavior.
-AC_TIERS = ("PC", "CP", "HU", "LP", "PL")
+# Authority tier + proof-kind vocabulary and the tier->proof matrix all come from
+# the single machine source in common/governance/package_contract.py (the same
+# definitions the ACRecord model validates against), so the EPIC-table source and
+# the package-contract source can never disagree about the matrix.
+AC_TIERS = _AC_TIERS
+AC_PROOF_KINDS = _AC_PROOF_KINDS
 
 # Definition-site tier marker, e.g. ``{tier:PC}``. Declared next to the AC text
 # in the EPIC doc so the tier travels with the behavior it describes. The marker
 # is parsed out of the line and lifted into the registry value; it never leaks
 # into the AC description.
-_TIER_MARKER_RE = re.compile(r"\{tier:\s*(PC|CP|HU|LP|PL)\s*\}", re.IGNORECASE)
-
-# Proof-kind vocabulary (SSOT: docs/ssot/authority-tiers.md). The KIND of proof
-# an AC's tests provide; an AC's tier dictates which kinds are VALID for it (the
-# tier->proof matrix, enforced by tools/check_ac_proof_kind.py for tier-tagged
-# ACs). ``exact`` = deterministic exact/golden assertion; ``property`` /
-# ``invariant`` = an asserted invariant that holds across inputs (e.g. a balance
-# chain); ``eval`` = graded/quality eval; ``evidence`` = an evidence-chain
-# assertion (HU); ``smoke`` = guardrail/quality smoke (PL).
-AC_PROOF_KINDS = ("property", "invariant", "eval", "exact", "evidence", "smoke")
+_TIER_MARKER_RE = re.compile(
+    r"\{tier:\s*(" + "|".join(AC_TIERS) + r")\s*\}", re.IGNORECASE
+)
 
 # Definition-site proof-kind marker, e.g. ``{proof:property}``. Declared next to
 # the AC text the same way as ``{tier:XX}`` and lifted into the registry value as
-# ``proof_kind``; stripped from the description so it never leaks.
+# ``proof_kind``; stripped from the description so it never leaks. The alternation
+# is built from the canonical vocabulary so it cannot drift from it.
 _PROOF_MARKER_RE = re.compile(
-    r"\{proof:\s*(property|invariant|eval|exact|evidence|smoke)\s*\}",
+    r"\{proof:\s*(" + "|".join(AC_PROOF_KINDS) + r")\s*\}",
     re.IGNORECASE,
 )
 
 # When an AC declares a tier but no explicit ``{proof:KIND}`` marker, its
-# proof_kind defaults to the tier's CANONICAL valid kind, so the registry value
-# is always a kind the matrix accepts (never a sentinel the gate must reject).
-# Untagged ACs get no proof_kind key at all.
-_TIER_DEFAULT_PROOF = {
-    "PC": "exact",
-    "CP": "exact",
-    "HU": "evidence",
-    "LP": "property",
-    "PL": "smoke",
-}
+# proof_kind defaults to the tier's CANONICAL valid kind (single source:
+# package_contract.TIER_DEFAULT_PROOF_KIND), so the registry value is always a
+# kind the matrix accepts. Untagged ACs get no proof_kind key at all.
+_TIER_DEFAULT_PROOF = _TIER_DEFAULT_PROOF_KIND
 
 
 def _extract_tier(text: str) -> tuple[str, str | None]:
@@ -340,17 +340,20 @@ def _roadmap_acs_from_contract(contract_path: Path) -> list[dict]:
     Parses ``common/<pkg>/contract.py`` with :mod:`ast` (no import, so no
     pydantic/governance dependency — this runs in every tooling environment) and
     returns one dict per ``ACRecord`` in the ``roadmap=[...]`` list, with its
-    ``id``/``statement``/``tier``/``proof_kind`` literals.
+    ``id``/``statement``/``proof_kind`` literals plus the PACKAGE's ``tier``
+    (authority tier is a module-design property declared once on the
+    ``PackageContract``; every AC the package owns inherits it).
     """
     tree = ast.parse(contract_path.read_text(encoding="utf-8"))
     records: list[dict] = []
     for node in ast.walk(tree):
-        # The single ``CONTRACT = PackageContract(...)`` assignment; find its
-        # ``roadmap=[...]`` keyword and read each ``ACRecord(...)`` element.
+        # The single ``CONTRACT = PackageContract(...)`` assignment; read its
+        # package-level ``tier`` then each ``ACRecord(...)`` in ``roadmap=[...]``.
         if not (
             isinstance(node, ast.Call) and _call_name(node.func) == "PackageContract"
         ):
             continue
+        package_tier = _ac_record_field(node, "tier")
         for kw in node.keywords:
             if kw.arg != "roadmap" or not isinstance(kw.value, (ast.List, ast.Tuple)):
                 continue
@@ -366,7 +369,7 @@ def _roadmap_acs_from_contract(contract_path: Path) -> list[dict]:
                     {
                         "id": ac_id,
                         "statement": _ac_record_field(elt, "statement") or "",
-                        "tier": _ac_record_field(elt, "tier"),
+                        "tier": package_tier,
                         "proof_kind": _ac_record_field(elt, "proof_kind"),
                     }
                 )
@@ -401,16 +404,28 @@ def _package_roadmap_acs(source_dir: Path) -> dict[str, dict]:
     for contract_path in sorted(repo_root.glob("common/*/contract.py")):
         for record in _roadmap_acs_from_contract(contract_path):
             ac_id = record["id"]
-            match = AC_PATTERN.fullmatch(ac_id)
-            if not match:
-                continue
-            ac_epic = int(match.group(2))
-            entry: dict = {
-                "epic": ac_epic,
-                "epic_name": EPIC_NAMES.get(ac_epic, f"epic-{ac_epic:03d}"),
-                "description": _clean_description(record["statement"]),
-                "mandatory": True,
-            }
+            pkg_match = PKG_AC_PATTERN.fullmatch(ac_id)
+            if pkg_match:
+                # Package-scoped id (AC-{package}.{group}.{seq}): the key names its
+                # owner, so there is no EPIC number and no cross-package collision.
+                package = pkg_match.group("package")
+                entry = {
+                    "epic": 0,
+                    "epic_name": f"pkg-{package}",
+                    "description": _clean_description(record["statement"]),
+                    "mandatory": True,
+                }
+            else:
+                match = AC_PATTERN.fullmatch(ac_id)
+                if not match:
+                    continue
+                ac_epic = int(match.group(2))
+                entry = {
+                    "epic": ac_epic,
+                    "epic_name": EPIC_NAMES.get(ac_epic, f"epic-{ac_epic:03d}"),
+                    "description": _clean_description(record["statement"]),
+                    "mandatory": True,
+                }
             tier = record["tier"]
             if tier:
                 entry["tier"] = tier
@@ -492,6 +507,10 @@ def extract_acs(
 
 def classify_ac(ac_id: str, entry: dict) -> str:
     """Return 'feature' or 'infra' for a given AC entry."""
+    # Package-scoped ids carry their own grouping (AC-{package}.…) and no EPIC
+    # number; route them to the feature registry (the package model's default).
+    if PKG_AC_PATTERN.fullmatch(ac_id):
+        return "feature"
     epic = entry["epic"]
     if epic in INFRA_EPICS:
         return "infra"

--- a/common/ssot/generate_ac_registry.py
+++ b/common/ssot/generate_ac_registry.py
@@ -73,9 +73,9 @@ EPIC_NAMES: dict[int, str] = {
 AC_PATTERN = re.compile(r"\b(AC(\d+)\.(\d+)\.(\d+))\b")
 
 # Authority tier + proof-kind vocabulary and the tier->proof matrix all come from
-# the single machine source in common/governance/package_contract.py (the same
-# definitions the ACRecord model validates against), so the EPIC-table source and
-# the package-contract source can never disagree about the matrix.
+# the single machine source common/ssot/authority_matrix.py (stdlib-only;
+# package_contract re-exports the same definitions for its model validation), so
+# the EPIC-table source and the package-contract source can never disagree.
 AC_TIERS = _AC_TIERS
 AC_PROOF_KINDS = _AC_PROOF_KINDS
 

--- a/common/ssot/lint_doc_consistency/_base.py
+++ b/common/ssot/lint_doc_consistency/_base.py
@@ -76,9 +76,14 @@ TEST_FILE_SUFFIXES = (
     ".spec.tsx",
 )
 
-# Matches the canonical AC ID form used by common.ssot.ac_traceability_refs:
-# ``ACx.y.z`` (epic.major.minor).
-AC_PATTERN = re.compile(r"\bAC(\d+)\.(\d+)\.(\d+)\b")
+# Matches BOTH AC id grammars (mirrors common.ssot.ac_traceability_refs):
+# legacy ``AC{epic}.{n}.{n}`` and package-scoped ``AC-{package}.{n}.{n}``. The
+# ``epic`` group is set only for the legacy form (``pkg`` for the package form),
+# so consumers needing the EPIC number must check ``group("epic")`` is not None.
+AC_PATTERN = re.compile(
+    r"\bAC(?:(?P<epic>\d+)|-(?P<pkg>[a-z][a-z0-9_]*))"
+    r"\.(?P<scenario>\d+)\.(?P<case>\d+)\b"
+)
 
 # Lines in EPIC docs that document AC IDs as removed/duplicated/
 # canonicalised must NOT count as live references for check #4

--- a/common/ssot/lint_doc_consistency/_checks.py
+++ b/common/ssot/lint_doc_consistency/_checks.py
@@ -294,9 +294,11 @@ def check_test_id_epic_alignment(
         if ac_id in CHECK6_FIXTURE_EXCLUDE:
             continue
         match = AC_PATTERN.match(ac_id)
-        if not match:
+        if not match or match.group("epic") is None:
+            # Package-scoped ids (AC-{package}.…) carry no EPIC number to
+            # cross-check against the registry's epic field; skip them here.
             continue
-        expected_epic = int(match.group(1))
+        expected_epic = int(match.group("epic"))
         entry = registry_by_id.get(ac_id)
         if entry is None:
             # Missing registry entries are surfaced by check #4

--- a/docs/project/EPIC-025.dry-ssot-simplification.md
+++ b/docs/project/EPIC-025.dry-ssot-simplification.md
@@ -120,7 +120,7 @@ verifiable.
 |----|-------------|---------------|------|----------|
 | AC25.5.1 | No backend router module imports a symbol from another router (`from src.routers.<x> import ...` is absent across `apps/backend/src/routers`); the personal-report-package assembly calls `services.performance_report.build_investment_performance_report_schedule` directly instead of the portfolio router handler, preserving behavior | `test_AC25_5_1_no_router_imports_another_router` | `apps/backend/tests/api/test_router_boundary.py` | P1 |
 
-### AC25.6 — Package model: the `counter` worked example (a package = DDD bounded context)
+### AC-counter — Package model: the `counter` worked example (a package = DDD bounded context)
 
 > The package model (a package = a DDD bounded context: `readme.md` +
 > `PackageContract` + `types/ops/store/api` roles + `__all__` published language,
@@ -128,7 +128,7 @@ verifiable.
 > [../../common/governance/readme.md](../../common/governance/readme.md). The
 > `counter` platform package is its first worked example.
 >
-> **`AC25.6.1`, `AC25.6.2`, `AC25.6.3`, and `AC25.6.4` are NOT defined here.**
+> **`AC-counter.1.1`, `AC-counter.1.2`, `AC-counter.1.3`, and `AC-counter.1.4` are NOT defined here.**
 > They are owned by, and sourced directly from,
 > [`common/counter/contract.py`](../../common/counter/contract.py)'s `roadmap`;
 > `common/ssot/generate_ac_registry.py` reads package-contract roadmaps
@@ -137,7 +137,7 @@ verifiable.
 > defines none of them — the contract is the single definition source. This is
 > the precedent: a package's ACs live in its contract, never duplicated.
 
-### AC25.7 — Platform: domain EventBus via the transactional outbox (meta-layer capability #1)
+### AC-platform — Platform: domain EventBus via the transactional outbox (meta-layer capability #1)
 
 > The first *runtime* capability of the meta layer: a domain **EventBus
 > implemented with the transactional outbox pattern**, in the new
@@ -149,14 +149,14 @@ verifiable.
 > (at-least-once, so handlers must be idempotent). `counter` now emits its
 > `Incremented` event through this bus.
 >
-> **`AC25.7.1`, `AC25.7.2`, `AC25.7.3`, `AC25.7.4`, and `AC25.7.5` are NOT defined
+> **`AC-platform.1.1`, `AC-platform.1.2`, `AC-platform.1.3`, `AC-platform.1.4`, and `AC-platform.1.5` are NOT defined
 > here.** They are owned by, and sourced directly from,
 > [`common/platform/contract.py`](../../common/platform/contract.py)'s `roadmap`
-> (`AC25.7.5` is the cross-package one proving `counter` emits atomically through
+> (`AC-platform.1.5` is the cross-package one proving `counter` emits atomically through
 > the outbox); `common/ssot/generate_ac_registry.py` reads it additively, so the
 > AC index counts them without an EPIC-table mirror. This blockquote references
 > the IDs (keeping the registry-to-EPIC link intact) but defines none of them —
-> the contract is the single definition source, exactly as the `AC25.6`
+> the contract is the single definition source, exactly as the `AC-counter`
 > precedent.
 
 ---

--- a/docs/ssot/authority-tiers.md
+++ b/docs/ssot/authority-tiers.md
@@ -27,7 +27,7 @@ permanent tiers:
 
 | Code | Name (中文) | Produces the result | Reproducible? | Typical modules |
 |------|-------------|---------------------|---------------|-----------------|
-| **PC** | 纯代码 pure-code | **Code**, no LLM | Bit-level, fully reproducible (bit-level reproducible) | money/accounting, dedup, validation, persistence, reporting-calc, **recording a human decision/label** |
+| **PC** | 纯代码 pure-code | **Code**, no LLM | Bit-level, fully reproducible | money/accounting, dedup, validation, persistence, reporting-calc, **recording a human decision/label** |
 | **CP** | 代码为主·LLM辅助 code-primary | **Code**; the LLM only assists within strict code constraints on the I/O and decisions | Reproducible once the config/knobs are pinned | model/strategy selection feeding a deterministic parser; LLM-tuned thresholds with deterministic scoring |
 | **LP** | LLM为主·代码守门 LLM-primary | **The LLM**; code validates its format/invariants and may reject, never produces | Not reproducible but DETECTABLE | extraction, OCR, classification, brokerage CSV→canonical mapping |
 | **PL** | 纯LLM pure-LLM | **The LLM**, with no validation | Not required | advisor narrative, chat answer/suggestion text |

--- a/docs/ssot/authority-tiers.md
+++ b/docs/ssot/authority-tiers.md
@@ -2,90 +2,112 @@
 
 > **SSOT Key**: `authority_tiers`
 
-This document owns the **authority-tier** vocabulary: a single attribute on every
-acceptance criterion (AC) that records **who holds final decision authority over
-the behavior the AC describes** — deterministic code, a human, or an LLM. The
-tier is a property of the AC's *behavior*, not of any file or module: it travels
-with the intent, so the same source file can host PC and LP behaviors and each AC
-still carries its own tier.
+This document owns the **authority-tier** vocabulary: the attribute that records
+**how a module is built along one axis — who produces its result and how tightly
+code constrains the LLM**. The tier is a **module-design property**, declared once
+on a package's [`PackageContract`](../../common/governance/package_contract.py);
+every AC the package owns *inherits* it.
 
-The payoff is direct: **an AC's tier dictates what KIND of proof is valid for
-it.** Tying the testing strategy to authority stops us from demanding a
+> **A tier is NOT a per-record confidence.** "How confident are we in *this one*
+> extracted row?" is a runtime number on a result, handled by reconciliation /
+> review flows. "How is this *module* built?" is its tier. They are different
+> axes — do not conflate them.
+
+The payoff is direct: **a module's tier dictates what KIND of proof is valid for
+its ACs.** Tying the testing strategy to authority stops us from demanding a
 bit-exact golden assertion for an LLM-owned mapping (impossible) or accepting a
 smoke test for a money calculation (unsafe).
 
-This SSOT owns the *terms*. EPIC docs declare a tier per AC (the `{tier:XX}`
-marker at the AC's definition site); the registry generator lifts it into the AC
-value; the ratchet gate keeps new/changed ACs from skipping it. See
-[EPIC-026](../project/EPIC-026.ac-authority-tiers.md) for the horizontal goal and
-[tdd.md](./tdd.md) for the surrounding EPIC -> AC -> Test workflow.
+## The axis and the four permanent tiers
 
-## The five tiers
+There is **one axis**: how much of the result the LLM produces, and how tightly
+code boxes it in. Two binary cuts — *does code or the LLM produce the used
+result* (hard vs soft) × *how strong is the code discipline* — give four
+permanent tiers:
 
-| Code | Name (中文) | Authority | Reproducible? | Typical behaviors |
-|------|-------------|-----------|---------------|-------------------|
-| **PC** | 纯代码 pure-code | Code | Bit-level, fully reproducible, no LLM | money/accounting, dedup, validation, persistence, security, reporting-calc, types |
-| **CP** | 代码为主·LLM辅助 code-primary | **Code emits the output**; the LLM may only adjust *configuration* — thresholds, which profile/strategy to run, mapping hints | Reproducible once the config is pinned (the LLM only turned knobs) | model/strategy selection feeding a deterministic parser; LLM-tuned reconciliation thresholds with deterministic scoring |
-| **HU** | 人来判定 human-decides | A human adjudicates; system presents evidence + options | Decision NOT reproducible; the EVIDENCE CHAIN is | review queue, low-confidence corrections |
-| **LP** | LLM为主·代码守门 LLM-primary | **The LLM emits the output/content**; code does only format constraints + sanity / invariant checks — it can reject or flag, never produce | Not reproducible but DETECTABLE | extraction, OCR, classification, brokerage CSV→canonical mapping |
-| **PL** | 纯LLM pure-LLM | LLM output is the deliverable; low blast radius; no hard oracle | Not required | advisor narrative, chat answer/suggestion text |
+| Code | Name (中文) | Produces the result | Reproducible? | Typical modules |
+|------|-------------|---------------------|---------------|-----------------|
+| **PC** | 纯代码 pure-code | **Code**, no LLM | Bit-level, fully reproducible (bit-level reproducible) | money/accounting, dedup, validation, persistence, reporting-calc, **recording a human decision/label** |
+| **CP** | 代码为主·LLM辅助 code-primary | **Code**; the LLM only assists within strict code constraints on the I/O and decisions | Reproducible once the config/knobs are pinned | model/strategy selection feeding a deterministic parser; LLM-tuned thresholds with deterministic scoring |
+| **LP** | LLM为主·代码守门 LLM-primary | **The LLM**; code validates its format/invariants and may reject, never produces | Not reproducible but DETECTABLE | extraction, OCR, classification, brokerage CSV→canonical mapping |
+| **PL** | 纯LLM pure-LLM | **The LLM**, with no validation | Not required | advisor narrative, chat answer/suggestion text |
 
-The five tiers form one axis — **how much of the output the LLM controls, from 0
-(PC) to full (PL)** — with **HU as the orthogonal escape hatch** for when neither
-code nor LLM should hold authority. `CP` and `LP` are mirror images around a
-single question:
+The **hard/soft** cut (who produces the used artifact) falls between CP and LP —
+the same "who emits" test as before: code computes it and the LLM only turned
+knobs → **CP**; the LLM emits it and code only validates/constrains → **LP**.
 
-> **CP vs LP — the deciding test:** is the artifact that actually gets used
-> *computed by code* or *emitted by the LLM*? Code computes it and the LLM only
-> turned configuration knobs → **CP**. The LLM emits it and code only
-> validates / constrains it → **LP**. The line is **who emits**, not how much LLM
-> is involved.
+### HU is not a permanent tier — it is "undecided"
 
-## How a tier is assigned
+The legacy vocabulary had a fifth code, **HU** (人来判定). In the module-design
+model it is **not a peer tier**: it means *the module's tier has not been decided
+yet*. It is represented by a `draft` package with `tier=None` and **MUST resolve
+to one of PC/CP/LP/PL before the package goes `active`** (see the rule below).
 
-A tier is **bounded by the blast radius of an *undetected* error**, not by how
-much LLM happens to be in the loop. Walk this order and take the first match:
+There is deliberately **no permanent "human" tier**, because:
 
-1. The outcome is a human judgment with no automatable oracle → **HU**.
-2. A wrong automated output could **silently become financial truth** with no
-   deterministic oracle to catch it → it MUST be **PC / CP** (never LP/PL — the
-   LLM is not allowed to own an unverifiable money-affecting result).
-3. It maps messy input where a **deterministic invariant can catch errors and
-   recover** → **LP**.
-4. Code makes the final call; the LLM only tunes config / assists → **CP**.
-5. Pure narrative — touches no number and persists nothing → **PL**.
+- **Genuine human review is narrow and is an *input*.** The only place a person
+  truly adjudicates is where reconciliation does not match and a human decides or
+  labels. The matching engine is PC/CP (deterministic scoring); the human's
+  decision is an *input* to a PC module that records it — exactly like an
+  uploaded file or an FX rate is an input. The proof is a deterministic
+  assertion that the **evidence chain** is surfaced and the chosen label is
+  applied correctly — not an assertion of the human's outcome.
+- So "a human decides" never describes *how a module is built*; it describes a
+  runtime input the module consumes.
 
-Governance / scoping / architecture statements (no runtime decision authority)
-default to **PC**: they are deterministic assertions, not adjudicated behavior.
+## Tier is a module property — one package, one tier
+
+Because the tier describes construction, it lives on the **package**, not on each
+AC:
+
+- `PackageContract.tier` is the single declaration; ACs inherit it.
+- **One package = one tier.** A module that genuinely both *emits via the LLM*
+  and *computes deterministically* is two bounded contexts — split it into two
+  packages (LP's definition already includes the code-side validation gate, so a
+  well-formed LP package does not need a separate PC tier for its guard).
+
+### The shipped-package rule (replaces the per-AC ratchet for packages)
+
+> **`status="active"` (or `"deprecated"`) ⟹ `tier ∈ {PC, CP, LP, PL}`.**
+> Only a `draft` package may leave `tier=None` (the "undecided" / legacy `HU`
+> state). `PackageContract` enforces this at construction, so a *shipped untyped
+> package is unrepresentable*.
 
 ## tier -> valid proof type
 
-This matrix is the operative contract: it says which proof shape is *valid*
-evidence for an AC at each tier.
+This matrix is the operative contract: which proof shape is *valid* evidence for
+an AC under a package at each tier. Its single machine mirror is
+`TIER_VALID_PROOF_KINDS` in `common/governance/package_contract.py` (the same
+matrix `PackageContract` and `check_ac_proof_kind` both enforce).
 
 | Tier | Valid proof | NOT valid |
 |------|-------------|-----------|
 | **PC** | Deterministic exact-assertion / property test; bit-level reproducible | — |
 | **CP** | Test asserts the **code's final decision** is correct; the LLM suggestion may vary and is **not** asserted | Asserting the LLM suggestion text |
-| **HU** | Test asserts the **evidence chain** is present (evidence + options surfaced) | Asserting the human's outcome |
 | **LP** | Invariant/property test + graded eval + provenance | Exact "golden" assertions on the LLM output |
 | **PL** | Quality/smoke eval + guardrail assertions (must not touch numbers) | Reproducibility / exact-match requirements |
+| **HU** *(legacy/undecided)* | Test asserts the **evidence chain** is present (evidence + options surfaced) | Asserting the human's outcome |
+
+The rule with teeth: **an LP/PL behavior MUST NOT be proven by an exact golden
+assertion** — LLM-emitted output has no golden oracle. The `HU` row applies only
+to the handful of pre-package ACs still carrying the legacy marker; new packages
+do not use it.
 
 ## Cross-tier MUST rules
 
-These are hard rules an AC's tier must respect; they are the safety boundary
-between the deterministic core and the LLM surface.
+Hard rules a module's tier must respect — the safety boundary between the
+deterministic core and the LLM surface:
 
 1. **No LLM-sourced financial truth without a deterministic oracle.** LP/PL
    output MUST cross a PC oracle (validation/guard) before it is persisted as
    financial truth. An LLM never writes a ledger number unchecked.
-2. **PC stays pure.** A PC AC MUST NOT depend on an LLM client; its outcome is
-   produced and proven by deterministic code alone.
-3. **PL owns no money.** A PL AC MUST NOT source a number or persist financial
-   facts; its deliverable is narrative/UX text with low blast radius.
-4. **One AC = one tier.** An AC that spans tiers is too coarse and MUST be split.
-   If a behavior both extracts (LP) and validates-then-persists (PC), those are
-   two ACs.
+2. **PC stays pure.** A PC module MUST NOT depend on an LLM client; its outcome
+   is produced and proven by deterministic code alone.
+3. **PL owns no money.** A PL module MUST NOT source a number or persist
+   financial facts; its deliverable is narrative/UX text with low blast radius.
+4. **One package = one tier.** A package whose behaviors span tiers is too coarse
+   and MUST be split (e.g. an LLM extractor that also validates-then-persists is
+   an LP package whose guard is its code-side validation, not a PC package).
 
 ### Enforcing rule 2 structurally — the tier-import guard (phase 3)
 
@@ -121,81 +143,88 @@ cannot silently shrink as the tree evolves.
 
 ## How a tier is declared
 
-Declare the tier at the AC's **definition site** in the EPIC doc, inline in the
-requirement cell, with a `{tier:XX}` marker:
+**Primary (package model):** on the `PackageContract`, once per package:
+
+```python
+CONTRACT = PackageContract(
+    name="counter",
+    klass="platform",
+    status="active",
+    tier="PC",        # the whole package's authority tier; every AC inherits it
+    ...
+)
+```
+
+`common/ssot/generate_ac_registry.py` reads this package tier statically (AST) and
+stamps it onto every AC in the package's `roadmap`, so the registry value carries
+the inherited tier.
+
+**Legacy (EPIC-table source, being phased out):** a pre-package AC declares its
+tier inline at the definition site with a `{tier:XX}` marker, where `XX` is one of
+`PC | CP | HU | LP | PL`:
 
 ```text
 | AC3.1.1 | Parse DBS PDF {tier:LP} | `test_...` | `extraction/test_pdf_parsing.py` | P0 |
 | AC3.2.1 | Balance Validation (Pass) {tier:PC} | `test_balance_valid` | ... | P0 |
 ```
 
-`tools/generate_ac_registry.py` strips the marker from the description and lifts
-`tier: LP` (etc.) into the AC's registry value, so the tier is a first-class
-attribute of the generated AC entry. `XX` is one of `PC | CP | HU | LP | PL`.
+`tools/generate_ac_registry.py` strips the marker and lifts the tier into the AC's
+registry value. As modules become packages, their ACs move into the package
+`roadmap` and the marker (including any legacy `HU`) goes away.
 
 ## How a proof kind is declared (and enforced)
 
-The tier→proof matrix above is **enforced**, not merely descriptive, for every
-AC that carries a tier. Each AC declares the KIND of proof its tests provide with
-a second definition-site marker, parsed exactly like `{tier:XX}`:
-
-```text
-| AC3.1.1 | Parse DBS PDF {tier:LP} {proof:invariant} | `test_...` | ... | P0 |
-```
-
-`KIND` is one of `property | invariant | eval | exact | evidence | smoke`. The
-generator strips it from the description and lifts it into the registry as
-`proof_kind`. When a tier-tagged AC declares **no** `{proof:KIND}` marker, its
-`proof_kind` defaults to the tier's canonical valid kind, so the registry value
-is always a kind the matrix accepts (never a sentinel):
+Each AC declares the KIND of proof its tests provide with a `proof_kind` (on the
+`ACRecord`, or a `{proof:KIND}` marker in the legacy EPIC source). `KIND` is one
+of `property | invariant | eval | exact | evidence | smoke`. When an AC declares
+**no** proof kind, it defaults to its (package) tier's canonical valid kind, so
+the value is always a kind the matrix accepts:
 
 | Tier | Default proof kind |
 |------|--------------------|
 | PC | `exact` |
 | CP | `exact` |
-| HU | `evidence` |
 | LP | `property` |
 | PL | `smoke` |
+| HU *(legacy)* | `evidence` |
 
-`tools/check_ac_proof_kind.py` (impl `common/ssot/check_ac_proof_kind.py`) then
-asserts the declared/defaulted `proof_kind` is valid for the AC's tier per the
-matrix above. It runs **only for tier-tagged ACs** (untagged legacy ACs have no
-`proof_kind` and are ignored — non-breaking), and the rule with teeth is **an LP
-AC's proof_kind MUST NOT be `exact`** (likewise PL). The gate asserts the
-*declared* kind; statically verifying the referenced test's runtime shape (so a
-golden assertion mislabeled `property` is rejected) is a documented follow-up.
+`PackageContract` validates each roadmap AC's `proof_kind` against the package
+tier at construction (a violating contract fails to import);
+`tools/check_ac_proof_kind.py` enforces the same matrix for the legacy EPIC
+source. The rule with teeth is **an LP/PL AC's proof_kind MUST NOT be `exact`**.
+Statically verifying the referenced test's runtime *shape* (so a golden assertion
+mislabeled `property` is rejected) is a documented follow-up.
 
 `proof_kind` is a different axis from the critical-proof matrix's `trust_mode`
 (`deterministic_pr` / `llm_ocr_post_merge` / `hybrid`): `trust_mode` says which
 CI stage may be trusted to run a proof, while `proof_kind` says what SHAPE of
-proof is valid for the AC's authority tier. They are orthogonal and may both
-apply to one AC.
+proof is valid for the module's authority tier. They are orthogonal.
 
-## Ratchet gate (non-breaking adoption)
+## Adoption (non-breaking)
 
-~1830 ACs predate this attribute, so coverage is adopted via a **shrink-only
-debt ratchet**, mirroring the protection-floor / AC-score baselines:
-
-- The untagged debt lives in [`ac-tier-baseline.json`](./ac-tier-baseline.json).
-- `tools/check_ac_tier_baseline.py` is **id-based**: it fails only when an AC
-  whose id is **absent from the baseline** (i.e. a genuinely new AC) lacks a
-  tier. Already-untagged AC ids listed in the baseline are tolerated; the gate
-  does not detect edits to the text of an existing untagged AC.
-- The baseline may only **shrink** (`--update` drops newly-tagged ACs and refuses
-  to launder fresh debt), so the untagged count is monotonically non-increasing.
+- **Package model:** the shipped-package rule above is enforced at construction —
+  no ratchet needed, because an active package physically cannot omit its tier.
+- **Legacy EPIC source:** ~1830 ACs predate this attribute, adopted via a
+  **shrink-only debt ratchet** in [`ac-tier-baseline.json`](./ac-tier-baseline.json).
+  `tools/check_ac_tier_baseline.py` is id-based: it fails only when a genuinely
+  new AC (id absent from the baseline) lacks a tier; the baseline may only shrink.
+  Each module that becomes a package moves its ACs into the package `roadmap`,
+  which removes them from the untagged debt.
 
 ## Follow-ups (out of scope here)
 
-- Full backfill of the remaining untagged ACs (ratcheted over time).
-- A derived **module-level tier view** (aggregating AC tiers per module).
+- Migrating the remaining EPIC-table ACs into package `roadmap`s (the ratchet
+  shrinks as packages adopt them); retiring the `{tier:XX}` marker and the `HU`
+  code once no EPIC AC carries them.
+- A derived **module-level tier view** (already the natural unit now that tier is
+  per-package).
 - Upgrading the proof-kind gate from asserting the *declared* `proof_kind` to
   statically inspecting the referenced test's shape (e.g. rejecting an
-  exact-golden assertion mislabeled `property` on an LP AC, or a number-touching
-  assertion on a PL AC). Phase 2 enforces the declared kind; the test-shape
-  verification is the next ratchet.
+  exact-golden assertion mislabeled `property` on an LP AC).
 
 ## Related
 
 - [tdd.md](./tdd.md) — EPIC -> AC -> Test workflow that this attribute extends.
 - [EPIC-026](../project/EPIC-026.ac-authority-tiers.md) — the EPIC that introduces tiers.
-- [ai.md](./ai.md), [extraction.md](./extraction.md) — domains where LP/PL/HU/CP behaviors concentrate.
+- [ai.md](./ai.md), [extraction.md](./extraction.md) — domains where LP/PL behaviors concentrate.
+- [`common/governance/package_contract.py`](../../common/governance/package_contract.py) — the machine source of `PackageTier` and the proof matrix.

--- a/tests/tooling/test_build_ac_traceability.py
+++ b/tests/tooling/test_build_ac_traceability.py
@@ -200,7 +200,12 @@ class TestHelpers:
         assert bat._ac_sort_key("AC1.2.10") > bat._ac_sort_key("AC1.2.9")
 
     def test_ac_sort_key_basic(self):
-        assert bat._ac_sort_key("AC1.1.1") == (1, 1, 1)
+        # Delegates to the shared sort_key, which prefixes a grammar discriminant
+        # (0 = legacy numeric) so package-scoped ids can share one total order.
+        assert bat._ac_sort_key("AC1.1.1") == (0, "", 1, 1, 1)
+
+    def test_ac_sort_key_orders_package_ids_after_legacy(self):
+        assert bat._ac_sort_key("AC-counter.1.1") > bat._ac_sort_key("AC9.9.9")
 
     def test_is_manual_manual_verification(self):
         ac = bat.AC("AC1.1.1", 1, "x", "manual verification needed", True)

--- a/tests/tooling/test_check_package_contract.py
+++ b/tests/tooling/test_check_package_contract.py
@@ -29,7 +29,15 @@ from common.governance.check_package_contract import (
     main,
     run,
 )
-from common.governance.package_contract import ACRecord, Invariant, PackageContract
+from pydantic import ValidationError
+
+from common.governance.package_contract import (
+    TIER_DEFAULT_PROOF_KIND,
+    TIER_VALID_PROOF_KINDS,
+    ACRecord,
+    Invariant,
+    PackageContract,
+)
 
 
 def _write_package(
@@ -43,6 +51,7 @@ def _write_package(
     invariants: list[Invariant] | None = None,
     roadmap: list[ACRecord] | None = None,
     extra_module: tuple[str, str] | None = None,
+    tier: str = "PC",
 ) -> DiscoveredPackage:
     """Materialize a package in the package model: a ``common/<name>/contract.py``
     spec pointing at a BE implementation under ``apps/backend/src/<name>``.
@@ -65,6 +74,7 @@ def _write_package(
     contract = PackageContract(
         name=name,
         klass=klass,  # type: ignore[arg-type]
+        tier=tier,  # type: ignore[arg-type]
         depends_on=depends_on or [],
         interface=interface,
         events=[],
@@ -371,3 +381,69 @@ def test_main_fails_on_empty_repo(
     rc = main(["--repo-root", str(synthetic_repo)])
     assert rc == 1
     assert "no packages discovered" in capsys.readouterr().out
+
+
+def _ac(**overrides: object) -> ACRecord:
+    """Build a roadmap ACRecord with valid defaults, overriding per test."""
+    kwargs: dict[str, object] = {
+        "id": "AC1.1.1",
+        "statement": "s",
+        "test": "t::f",
+        "priority": "P0",
+        "status": "open",
+    }
+    kwargs.update(overrides)
+    return ACRecord(**kwargs)  # type: ignore[arg-type]
+
+
+def _pkg(**overrides: object) -> PackageContract:
+    """Build a minimal PackageContract with valid defaults, overriding per test."""
+    kwargs: dict[str, object] = {
+        "name": "p",
+        "klass": "kernel",
+        "depends_on": [],
+        "interface": [],
+        "events": [],
+        "invariants": [],
+        "roadmap": [],
+        "status": "active",
+        "tier": "PC",
+    }
+    kwargs.update(overrides)
+    return PackageContract(**kwargs)  # type: ignore[arg-type]
+
+
+def test_active_package_must_declare_a_tier() -> None:
+    """An active/deprecated package with an undecided tier cannot be constructed.
+
+    Authority tier is a module-design property: a shipped package must have
+    resolved it to one of PC/CP/LP/PL. The "undecided" state (the legacy ``HU``)
+    is legal only while the package is still a ``draft``.
+    """
+    for status in ("active", "deprecated"):
+        with pytest.raises(ValidationError):
+            _pkg(status=status, tier=None)
+    # A draft package may stay undecided (tier=None) — that is the HU state.
+    draft = _pkg(status="draft", tier=None)
+    assert draft.tier is None
+
+
+def test_package_proof_kind_must_satisfy_the_tier_matrix() -> None:
+    """A roadmap AC whose proof_kind is invalid for the PACKAGE tier is rejected.
+
+    Enforces the tier->proof matrix at construction, against the package's tier
+    (not a per-AC one): under an LP/PL package an AC can never claim ``exact``.
+    """
+    for tier in ("LP", "PL"):
+        with pytest.raises(ValidationError):
+            _pkg(tier=tier, roadmap=[_ac(proof_kind="exact")])
+
+
+def test_package_ac_proof_kind_defaults_to_the_tier_canonical_kind() -> None:
+    """Omitting an AC's proof_kind resolves to the package tier's canonical kind."""
+    for tier, expected in TIER_DEFAULT_PROOF_KIND.items():
+        if tier == "HU":  # not a permanent package tier
+            continue
+        pkg = _pkg(tier=tier, roadmap=[_ac()])
+        assert pkg.roadmap[0].proof_kind == expected
+        assert pkg.roadmap[0].proof_kind in TIER_VALID_PROOF_KINDS[tier]

--- a/tests/tooling/test_counter_package.py
+++ b/tests/tooling/test_counter_package.py
@@ -1,4 +1,4 @@
-"""counter package + package-model governance guards (EPIC-025 AC25.6.x).
+"""counter package + package-model governance guards (EPIC-025 AC-counter.1.x).
 
 The ``counter`` package is the first worked example of the package model. These
 guards keep its shape honest — roles converge (types/ops never reach down into
@@ -37,10 +37,10 @@ def _imported_modules(path: Path) -> set[str]:
 
 
 @ac_proof(
-    proof_id="test_counter_converges_by_role", ac_ids=["AC25.6.1"], ci_tier="pr_ci"
+    proof_id="test_counter_converges_by_role", ac_ids=["AC-counter.1.1"], ci_tier="pr_ci"
 )
 def test_AC25_6_1_counter_converges_by_role():
-    """AC25.6.1: counter exposes types (nouns/events), ops (verbs), store, api."""
+    """AC-counter.1.1: counter exposes types (nouns/events), ops (verbs), store, api."""
     assert (COUNTER / "types/key.py").exists()
     assert (COUNTER / "types/count.py").exists()
     assert (COUNTER / "types/events.py").exists()
@@ -53,9 +53,9 @@ def test_AC25_6_1_counter_converges_by_role():
         assert name in exports, f"counter must export {name}"
 
 
-@ac_proof(proof_id="test_counter_types_pure", ac_ids=["AC25.6.2"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_counter_types_pure", ac_ids=["AC-counter.1.2"], ci_tier="pr_ci")
 def test_AC25_6_2_types_never_import_store_api_or_orm():
-    """AC25.6.2: domain types depend on nothing below them (no store/api/ORM/session).
+    """AC-counter.1.2: domain types depend on nothing below them (no store/api/ORM/session).
 
     The value language must stay free of persistence and transport so it is a
     pure, reusable vocabulary (the DAG points down only).
@@ -76,9 +76,9 @@ def test_AC25_6_2_types_never_import_store_api_or_orm():
     assert not offenders, f"counter types reach below their layer: {offenders}"
 
 
-@ac_proof(proof_id="test_counter_ops_pure", ac_ids=["AC25.6.3"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_counter_ops_pure", ac_ids=["AC-counter.1.3"], ci_tier="pr_ci")
 def test_AC25_6_3_ops_never_import_the_orm_session_or_api():
-    """AC25.6.3: ops depend on the store *port* + types only — no ORM/session/api.
+    """AC-counter.1.3: ops depend on the store *port* + types only — no ORM/session/api.
 
     Verbs talk to the ``CounterRepository`` Protocol, never to ``store.sql`` /
     ``store.__init__`` concretes, the ORM, or the api boundary.
@@ -99,9 +99,9 @@ def test_AC25_6_3_ops_never_import_the_orm_session_or_api():
     assert not offenders, f"counter ops reach into ORM/concretes/api: {offenders}"
 
 
-@ac_proof(proof_id="test_counter_only_all_public", ac_ids=["AC25.6.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_counter_only_all_public", ac_ids=["AC-counter.1.1"], ci_tier="pr_ci")
 def test_AC25_6_1_only_all_is_the_published_language():
-    """AC25.6.1: the package's contract.interface equals its __init__.__all__."""
+    """AC-counter.1.1: the package's contract.interface equals its __init__.__all__."""
     import src.counter as counter_pkg
     from common.counter.contract import CONTRACT
 
@@ -113,11 +113,11 @@ def test_AC25_6_1_only_all_is_the_published_language():
 
 @ac_proof(
     proof_id="test_counter_contract_gate_passes",
-    ac_ids=["AC25.6.4"],
+    ac_ids=["AC-counter.1.4"],
     ci_tier="pr_ci",
 )
 def test_AC25_6_4_package_contract_gate_passes_for_counter():
-    """AC25.6.4: check_package_contract discovers and validates counter (green)."""
+    """AC-counter.1.4: check_package_contract discovers and validates counter (green)."""
     names = {p.name for p in discover_packages(REPO)}
     assert "counter" in names, f"counter not discovered; found {names}"
     ok, messages = run(REPO)

--- a/tests/tooling/test_counter_package.py
+++ b/tests/tooling/test_counter_package.py
@@ -39,7 +39,7 @@ def _imported_modules(path: Path) -> set[str]:
 @ac_proof(
     proof_id="test_counter_converges_by_role", ac_ids=["AC-counter.1.1"], ci_tier="pr_ci"
 )
-def test_AC25_6_1_counter_converges_by_role():
+def test_AC_counter_1_1_counter_converges_by_role():
     """AC-counter.1.1: counter exposes types (nouns/events), ops (verbs), store, api."""
     assert (COUNTER / "types/key.py").exists()
     assert (COUNTER / "types/count.py").exists()
@@ -54,7 +54,7 @@ def test_AC25_6_1_counter_converges_by_role():
 
 
 @ac_proof(proof_id="test_counter_types_pure", ac_ids=["AC-counter.1.2"], ci_tier="pr_ci")
-def test_AC25_6_2_types_never_import_store_api_or_orm():
+def test_AC_counter_1_2_types_never_import_store_api_or_orm():
     """AC-counter.1.2: domain types depend on nothing below them (no store/api/ORM/session).
 
     The value language must stay free of persistence and transport so it is a
@@ -77,7 +77,7 @@ def test_AC25_6_2_types_never_import_store_api_or_orm():
 
 
 @ac_proof(proof_id="test_counter_ops_pure", ac_ids=["AC-counter.1.3"], ci_tier="pr_ci")
-def test_AC25_6_3_ops_never_import_the_orm_session_or_api():
+def test_AC_counter_1_3_ops_never_import_the_orm_session_or_api():
     """AC-counter.1.3: ops depend on the store *port* + types only — no ORM/session/api.
 
     Verbs talk to the ``CounterRepository`` Protocol, never to ``store.sql`` /
@@ -100,7 +100,7 @@ def test_AC25_6_3_ops_never_import_the_orm_session_or_api():
 
 
 @ac_proof(proof_id="test_counter_only_all_public", ac_ids=["AC-counter.1.1"], ci_tier="pr_ci")
-def test_AC25_6_1_only_all_is_the_published_language():
+def test_AC_counter_1_1_only_all_is_the_published_language():
     """AC-counter.1.1: the package's contract.interface equals its __init__.__all__."""
     import src.counter as counter_pkg
     from common.counter.contract import CONTRACT
@@ -116,7 +116,7 @@ def test_AC25_6_1_only_all_is_the_published_language():
     ac_ids=["AC-counter.1.4"],
     ci_tier="pr_ci",
 )
-def test_AC25_6_4_package_contract_gate_passes_for_counter():
+def test_AC_counter_1_4_package_contract_gate_passes_for_counter():
     """AC-counter.1.4: check_package_contract discovers and validates counter (green)."""
     names = {p.name for p in discover_packages(REPO)}
     assert "counter" in names, f"counter not discovered; found {names}"

--- a/tests/tooling/test_generate_ac_registry.py
+++ b/tests/tooling/test_generate_ac_registry.py
@@ -10,13 +10,18 @@ from common.ssot.ac_registry_format import load_registry_entries
 
 
 class TestSortKey:
-    """sort_key converts AC IDs to numeric tuples for correct ordering."""
+    """sort_key totally orders BOTH id grammars.
+
+    Legacy numeric ids carry a leading ``0`` discriminant, package-scoped ids a
+    leading ``1`` (so they sort after, and an int field is never compared to a
+    str one). The contract that matters is the ORDERING, asserted below.
+    """
 
     def test_simple_ac(self):
-        assert gar.sort_key("AC1.2.3") == [1, 2, 3]
+        assert gar.sort_key("AC1.2.3") == (0, "", 1, 2, 3)
 
     def test_double_digit_epic(self):
-        assert gar.sort_key("AC16.3.1") == [16, 3, 1]
+        assert gar.sort_key("AC16.3.1") == (0, "", 16, 3, 1)
 
     def test_ordering_correctness(self):
         ids = ["AC10.1.1", "AC2.1.1", "AC1.99.1"]
@@ -24,9 +29,22 @@ class TestSortKey:
         assert sorted_ids == ["AC1.99.1", "AC2.1.1", "AC10.1.1"]
 
     def test_three_digit_sort_stability(self):
-        assert gar.sort_key("AC1.1.10") == [1, 1, 10]
-        assert gar.sort_key("AC1.1.9") == [1, 1, 9]
+        assert gar.sort_key("AC1.1.10") == (0, "", 1, 1, 10)
+        assert gar.sort_key("AC1.1.9") == (0, "", 1, 1, 9)
         assert gar.sort_key("AC1.1.10") > gar.sort_key("AC1.1.9")
+
+    def test_package_ids_sort_after_legacy_and_by_package(self):
+        assert gar.sort_key("AC-counter.1.1") == (1, "counter", 1, 1)
+        # Package ids sort after every legacy numeric id...
+        assert gar.sort_key("AC-counter.1.1") > gar.sort_key("AC999.9.9")
+        # ...then by (package, group, seq).
+        ids = ["AC-platform.1.2", "AC-counter.2.1", "AC-counter.1.1", "AC1.1.1"]
+        assert sorted(ids, key=gar.sort_key) == [
+            "AC1.1.1",
+            "AC-counter.1.1",
+            "AC-counter.2.1",
+            "AC-platform.1.2",
+        ]
 
 
 class TestExtractAcs:


### PR DESCRIPTION
## What

Makes the **authority tier a module-design property owned by the package**, corrects the conceptual model in the SSOT, and gives package ACs a self-describing id `AC-{package}.{group}.{seq}`.

### Model (`common/governance/package_contract.py`)
- `tier` moves from per-`ACRecord` to `PackageContract` (`PackageTier` = PC/CP/LP/PL), **required for active/deprecated** packages; a `draft` package may leave it undecided (the former "HU"). ACs inherit the package tier.
- `proof_kind` stays per-AC, validated against the package tier matrix at construction (LP/PL can never be `exact`).
- **HU is no longer a permanent tier**; genuine human review is modeled as an *input* to a PC module, and per-record confidence is a separate runtime concern (Axiom B), not a tier (Axiom D).

### Single matrix source (`common/ssot/authority_matrix.py`, new)
- stdlib-only module holds the tier vocabulary + tier→proof matrix. `package_contract` (pydantic) re-exports it; the SSOT tooling imports it **without pulling pydantic**, so the `uv run --with pyyaml` CI lint env keeps working.

### Package-scoped AC ids
- Taught to the shared parser, registry generator, traceability refs/sort, and doc-consistency lint. Legacy `AC{epic}.x.y` ids keep working; package names in the key make **package↔package id collisions structurally impossible**.
- `counter`/`platform` renumbered (`AC25.6.x`→`AC-counter.1.x`, `AC25.7.x`→`AC-platform.1.x`) across contracts, `@ac_proof` refs, docstrings, readmes.

### Doc
- `docs/ssot/authority-tiers.md` rewritten to the module-design model.

## Verification (local)
- 1828 tooling + backend counter/platform tests pass; ruff clean on all changed files.
- Gates green: registry-complete, proof-kind, tier-ratchet, package-contract, doc-consistency, manifest, tier-imports.
- Exact CI lint command (`uv run --with pyyaml python tools/lint_doc_consistency.py`) passes without pydantic.

## Follow-ups (not in this PR)
- Cross-source key-uniqueness gates (EPIC↔package, AST↔model tier agreement) — Phase 1 hardening before mass migration.
- Structural-AC → `invariants` split (entangled with the critical-proof-matrix subsystem; first real LP package exercises it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)