### PR TITLE
[finance_report_vision] fix(ci): adapt workflow contract to reorganized infra2 workflow set

### DIFF
--- a/common/ci/workflow_contract.py
+++ b/common/ci/workflow_contract.py
@@ -79,12 +79,16 @@ APP_WORKFLOW_FILES = (
 
 INFRA2_WORKFLOW_FILES = (
     ".github/workflows/apply-observability.yml",
+    ".github/workflows/deploy-guard-audit.yml",
+    ".github/workflows/deploy-platform.yml",
     ".github/workflows/deploy-report-main.yml",
+    ".github/workflows/deploy-v2-canary.yml",
     ".github/workflows/deploy.yml",
-    ".github/workflows/docs.yml",
+    ".github/workflows/docs-site.yml",
+    ".github/workflows/dokploy-route-canary.yml",
     ".github/workflows/infra-ci.yml",
-    ".github/workflows/ops-checks.yml",
-    ".github/workflows/reconcile-iac-inputs.yml",
+    ".github/workflows/out-of-band-watchdog.yml",
+    ".github/workflows/watchdog-weekly-digest.yml",
 )
 
 # Triggers a workflow must NOT declare. Staging auto-following `main` is the


### PR DESCRIPTION
## Problem
`check_workflow_contract` (Lint job + `test_workflow_contract.py::test_AC7_15_1`) fails with **"consolidated infra2 workflow set drifted"** — on `main` today and on any PR that triggers the Lint/Tooling jobs (e.g. #1358, #1360).

The infra2 submodule's `repo/.github/workflows/` was reorganized but `INFRA2_WORKFLOW_FILES` in `common/ci/workflow_contract.py` still listed the old 7-file set.

## Fix
Update `INFRA2_WORKFLOW_FILES` to the **11 files actually present** in the submodule (verified via `ls repo/.github/workflows/`):
- added: `deploy-guard-audit`, `deploy-platform`, `deploy-v2-canary`, `docs-site`, `dokploy-route-canary`, `out-of-band-watchdog`, `watchdog-weekly-digest`
- dropped: `docs.yml`, `ops-checks.yml`, `reconcile-iac-inputs.yml`

infra2 is validated by **file-set only** (the per-job/trigger `WORKFLOW_CONTRACT` dict is app-workflow-keyed), so nothing else changes.

## Verification
- `tools/check_workflow_contract.py` → exit 0 ("Workflow contract OK").
- `tests/tooling/test_workflow_contract.py` → 17 passed (was 3 failing).
- ruff clean.

Unblocks `main` and PRs #1358 / #1360 (which were red only on this pre-existing drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)