### PR TITLE
[finance_report_vision] chore(counter): drop stale @ac_proof anchors left by the invariants split

### DIFF
--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -130,6 +130,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_check_manifest.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_check_package_contract.py` | `common/governance/readme.md` |
 | `tests/tooling/test_check_ssot_ownership.py` | `docs/ssot/MANIFEST.yaml` |
+| `tests/tooling/test_counter_package.py` | `common/governance/readme.md` |
 | `tests/tooling/test_coverage_analyzer.py` | `docs/ssot/coverage.md` |
 | `tests/tooling/test_migration_safety_gates.py` | `docs/ssot/authority-tiers.md` |
 | `tests/tooling/test_delivery_gates_contract.py` | `docs/ssot/delivery-gates.yaml` |

--- a/tests/tooling/test_counter_package.py
+++ b/tests/tooling/test_counter_package.py
@@ -1,10 +1,13 @@
-"""counter package + package-model governance guards (EPIC-025 AC-counter.1.x).
+"""counter package — package-model structural invariant guards.
 
 The ``counter`` package is the first worked example of the package model. These
-guards keep its shape honest — roles converge (types/ops never reach down into
-the ORM/session or up into store/api wiring), only ``__all__`` is public — and
-assert that the computed governance gate (``check_package_contract``) passes for
-counter, so the contract and the live package can never silently drift.
+tests prove its **structural invariants** (declared in
+``common/counter/contract.py`` ``invariants`` and resolved by
+``check_package_contract`` via ``invariants[].test``): roles converge, the
+layers stay pure (types/ops never reach the ORM/session or up into store/api),
+the published language equals ``__all__``, and the governance gate passes. They
+are invariant proofs, NOT AC critical-proofs, so they carry no ``@ac_proof``
+(the domain ACs are proven by the tests under ``apps/backend/tests/counter/``).
 """
 
 import ast
@@ -12,7 +15,6 @@ import sys
 from pathlib import Path
 
 from common.governance.check_package_contract import discover_packages, run
-from common.testing.ac_proof import ac_proof
 
 REPO = Path(__file__).resolve().parents[2]
 COUNTER = REPO / "apps/backend/src/counter"
@@ -36,11 +38,8 @@ def _imported_modules(path: Path) -> set[str]:
     return mods
 
 
-@ac_proof(
-    proof_id="test_counter_converges_by_role", ac_ids=["AC-counter.1.1"], ci_tier="pr_ci"
-)
 def test_AC_counter_1_1_counter_converges_by_role():
-    """AC-counter.1.1: counter exposes types (nouns/events), ops (verbs), store, api."""
+    """Invariant converges-by-role: counter exposes types (nouns/events), ops, store, api."""
     assert (COUNTER / "types/key.py").exists()
     assert (COUNTER / "types/count.py").exists()
     assert (COUNTER / "types/events.py").exists()
@@ -53,9 +52,8 @@ def test_AC_counter_1_1_counter_converges_by_role():
         assert name in exports, f"counter must export {name}"
 
 
-@ac_proof(proof_id="test_counter_types_pure", ac_ids=["AC-counter.1.2"], ci_tier="pr_ci")
 def test_AC_counter_1_2_types_never_import_store_api_or_orm():
-    """AC-counter.1.2: domain types depend on nothing below them (no store/api/ORM/session).
+    """Invariant types-layer-pure: domain types depend on nothing below them (no store/api/ORM).
 
     The value language must stay free of persistence and transport so it is a
     pure, reusable vocabulary (the DAG points down only).
@@ -76,9 +74,8 @@ def test_AC_counter_1_2_types_never_import_store_api_or_orm():
     assert not offenders, f"counter types reach below their layer: {offenders}"
 
 
-@ac_proof(proof_id="test_counter_ops_pure", ac_ids=["AC-counter.1.3"], ci_tier="pr_ci")
 def test_AC_counter_1_3_ops_never_import_the_orm_session_or_api():
-    """AC-counter.1.3: ops depend on the store *port* + types only — no ORM/session/api.
+    """Invariant ops-layer-pure: ops depend on the store *port* + types only — no ORM/session/api.
 
     Verbs talk to the ``CounterRepository`` Protocol, never to ``store.sql`` /
     ``store.__init__`` concretes, the ORM, or the api boundary.
@@ -99,9 +96,8 @@ def test_AC_counter_1_3_ops_never_import_the_orm_session_or_api():
     assert not offenders, f"counter ops reach into ORM/concretes/api: {offenders}"
 
 
-@ac_proof(proof_id="test_counter_only_all_public", ac_ids=["AC-counter.1.1"], ci_tier="pr_ci")
 def test_AC_counter_1_1_only_all_is_the_published_language():
-    """AC-counter.1.1: the package's contract.interface equals its __init__.__all__."""
+    """Invariant interface-equals-published-language: contract.interface == __init__.__all__."""
     import src.counter as counter_pkg
     from common.counter.contract import CONTRACT
 
@@ -111,13 +107,8 @@ def test_AC_counter_1_1_only_all_is_the_published_language():
     assert CONTRACT.implementations["be"] == "apps/backend/src/counter"
 
 
-@ac_proof(
-    proof_id="test_counter_contract_gate_passes",
-    ac_ids=["AC-counter.1.4"],
-    ci_tier="pr_ci",
-)
 def test_AC_counter_1_4_package_contract_gate_passes_for_counter():
-    """AC-counter.1.4: check_package_contract discovers and validates counter (green)."""
+    """Invariant passes-own-governance-gate: check_package_contract validates counter (green)."""
     names = {p.name for p in discover_packages(REPO)}
     assert "counter" in names, f"counter not discovered; found {names}"
     ok, messages = run(REPO)


### PR DESCRIPTION
Answers "after counter's migration, is there nothing to delete?" — **yes, there was**: the #1360 structural→invariants split left stale anchors.

## What was stale
After #1360 moved counter's structural guarantees into `PackageContract.invariants`, the 5 structural tests in `test_counter_package.py` still carried `@ac_proof(ac_ids=["AC-counter.1.x"])` anchoring them to **domain** ACs whose statements no longer match what the test proves — e.g. the *types-purity* test was tagged `AC-counter.1.2` (= "Count is non-negative"). They are now **invariant** proofs (resolved via `invariants[].test`), not AC critical-proofs.

## Cleanup
- Remove the 5 `@ac_proof` decorators + the now-unused import; docstrings rewritten to name the invariant each proves.
- Domain ACs keep their critical-proofs under `apps/backend/tests/counter/` (unchanged) → no AC loses coverage. `AC-counter.x` aren't floor-tracked → critical-proof matrix doesn't regress.
- Classify `test_counter_package.py` in `traceability-exceptions.md` (no longer carries AC refs).

Note: counter itself had **no EPIC-table rows to delete** — it was authored directly in the package model (EPIC-025 only *disclaims* its ACs). This PR removes the only leftover. The migration recipe (#1366) is updated so future migrations don't repeat it.

## Verification
- `test_counter_package.py` 5 tests pass; `check_package_contract` green (invariant refs resolve — function names unchanged); `check_ac_index`, `check_ac_proof_kind`, `lint_doc_consistency` green; ruff clean; full `tests/tooling` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)