### PR TITLE
[finance_report_test_and_doc] docs(vision): add Good Taste section feeding the Decision Filter

### DIFF
--- a/vision.md
+++ b/vision.md
@@ -154,7 +154,7 @@ trade-off rules say *what* to choose; these say whether the thing is built well.
    user's data, we do not re-educate it. (Axiom A, pointed at our users.)
 3. **Pragmatism over purity.** Solve the real problem in front of us, not a
    hypothetical one; reject the elegant-on-paper design that is complex in
-   practice. Code serves reality, not a paper.
+   practice. Code serves reality, not a research paper.
 4. **Simplicity is the standard.** One function, one thing, done well and
    short; past three levels of nesting, fix the function, not the symptom.
    Over-specified complexity is a defect, not rigor. (Axiom D.)

--- a/vision.md
+++ b/vision.md
@@ -140,6 +140,28 @@ When two goods conflict, the higher rule wins.
 If a choice still feels balanced after these rules, run the Decision Filter and
 take the smaller step that improves proof quality.
 
+## Good Taste
+
+Culture for *how* we build — the craft counterpart to the axioms. The
+trade-off rules say *what* to choose; these say whether the thing is built well.
+
+1. **Good taste — kill the special case.** Re-see the problem so the edge case
+   becomes the normal path; deleting a branch beats guarding it. Taste is
+   earned by experience, not won by argument.
+2. **Never break the user's trust.** Breaking a working report, a stored fact,
+   or a published contract is a bug — however "theoretically correct."
+   Backward compatibility of trusted data and contracts is sacred; we serve the
+   user's data, we do not re-educate it. (Axiom A, pointed at our users.)
+3. **Pragmatism over purity.** Solve the real problem in front of us, not a
+   hypothetical one; reject the elegant-on-paper design that is complex in
+   practice. Code serves reality, not a paper.
+4. **Simplicity is the standard.** One function, one thing, done well and
+   short; past three levels of nesting, fix the function, not the symptom.
+   Over-specified complexity is a defect, not rigor. (Axiom D.)
+
+These govern *how* a change is built; when they still leave the choice
+ambiguous, run the Decision Filter.
+
 <a id="decision-filter-accuracy-auditability"></a>
 
 ## Decision Filter


### PR DESCRIPTION
## What

Adds a **Good Taste** section to `vision.md` — a short culture layer for *how* we build, the craft counterpart to the axioms. Four bets, distilled into the project's voice and domain:

1. **Good taste — kill the special case.** Re-see the problem so the edge case becomes the normal path; deleting a branch beats guarding it.
2. **Never break the user's trust.** Breaking a working report, a stored fact, or a published contract is a bug, however "theoretically correct" — backward compatibility of trusted data is sacred. (Axiom A, pointed at our users.)
3. **Pragmatism over purity.** Solve the real problem, not a hypothetical one; reject the elegant-on-paper, complex-in-practice design.
4. **Simplicity is the standard.** One function, one thing; past three levels of nesting, fix the function. Over-specified complexity is a defect, not rigor. (Axiom D.)

It hands off to the **Decision Filter**, mirroring the existing `axioms → trade-off rules → filter` chain.

## Why it's safe / aligned

- `vision.md` is explicitly *"culture, not specification"* — this is exactly the kind of content it owns.
- The new section is **prose only, no `<a id="...">` anchor**, so it adds **no vision-proof-matrix node** and demands no owner EPIC/AC. Verified: AC-index still reports **9 vision items** (unchanged); the vision-proof matrix builds (9 nodes).
- English-only per repo rules.

## Local verification
- `tools/check_ac_index.py`: INTEGRITY + PROTECTION PASSED (9 vision items, no dangling links)
- `generate_vision_proof_matrix --check`: OK (9 nodes)
- `tools/preflight.py`: doc-consistency gate **ok**
- `pytest` vision-structure suites (matrix / governance-report / doc-consistency): 123 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)