### PR TITLE
[finance_report_audit] refactor(routers): shared get_owned_or_404 + paginate query helpers (DRY)

### DIFF
--- a/apps/backend/src/routers/chat.py
+++ b/apps/backend/src/routers/chat.py
@@ -26,7 +26,7 @@ from src.schemas.chat import (
 )
 from src.schemas.streaming import ChatStreamEnvelope
 from src.services.ai_advisor import AIAdvisorError, AIAdvisorService, detect_language
-from src.utils import raise_bad_request, raise_not_found, raise_service_unavailable
+from src.utils import get_owned_or_404, raise_bad_request, raise_not_found, raise_service_unavailable
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 logger = get_logger(__name__)
@@ -215,12 +215,7 @@ async def delete_session(
     user_id: CurrentUserId = None,
 ) -> None:
     """Soft-delete a chat session."""
-    result = await db.execute(
-        select(ChatSession).where(ChatSession.id == session_id).where(ChatSession.user_id == user_id)
-    )
-    session = result.scalar_one_or_none()
-    if not session:
-        raise_not_found("Chat session")
+    session = await get_owned_or_404(db, ChatSession, session_id, user_id, name="Chat session")
     session.status = ChatSessionStatus.DELETED
     await db.commit()
 

--- a/apps/backend/src/routers/journal.py
+++ b/apps/backend/src/routers/journal.py
@@ -2,7 +2,7 @@ from datetime import date as date_type
 from uuid import UUID
 
 from fastapi import APIRouter, Query, status
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from src.deps import CurrentUserId, DbSession
@@ -21,7 +21,7 @@ from src.services import (
     post_journal_entry,
     void_journal_entry,
 )
-from src.utils import raise_bad_request, raise_not_found
+from src.utils import get_owned_or_404, paginate, raise_bad_request
 
 router = APIRouter(prefix="/journal-entries", tags=["journal-entries"])
 logger = get_logger(__name__)
@@ -71,21 +71,14 @@ async def list_journal_entries(
     if end_date:
         query = query.where(JournalEntry.entry_date <= end_date)
 
-    # Get total count efficiently without loading data
-    count_query = select(func.count()).select_from(query.subquery())
-    count_result = await db.execute(count_query)
-    total = count_result.scalar() or 0
-
-    # Apply pagination and eager load lines
-    query = (
-        query.options(selectinload(JournalEntry.lines))
-        .order_by(JournalEntry.entry_date.desc(), JournalEntry.created_at.desc())
-        .offset(offset)
-        .limit(limit)
+    entries, total = await paginate(
+        db,
+        query,
+        limit=limit,
+        offset=offset,
+        options=[selectinload(JournalEntry.lines)],
+        order_by=[JournalEntry.entry_date.desc(), JournalEntry.created_at.desc()],
     )
-
-    result = await db.execute(query)
-    entries = result.scalars().all()
 
     items = [JournalEntryResponse.model_validate(e) for e in entries]
     return JournalEntryListResponse(items=items, total=total)
@@ -97,17 +90,14 @@ async def get_journal_entry(
     db: DbSession = None,
     user_id: CurrentUserId = None,
 ) -> JournalEntryResponse:
-    result = await db.execute(
-        select(JournalEntry)
-        .where(JournalEntry.id == entry_id)
-        .where(JournalEntry.user_id == user_id)
-        .options(selectinload(JournalEntry.lines))
+    entry = await get_owned_or_404(
+        db,
+        JournalEntry,
+        entry_id,
+        user_id,
+        name="Journal entry",
+        options=[selectinload(JournalEntry.lines)],
     )
-    entry = result.scalar_one_or_none()
-
-    if not entry:
-        raise_not_found("Journal entry")
-
     return JournalEntryResponse.model_validate(entry)
 
 
@@ -166,13 +156,7 @@ async def delete_journal_entry(
     db: DbSession = None,
     user_id: CurrentUserId = None,
 ) -> None:
-    result = await db.execute(
-        select(JournalEntry).where(JournalEntry.id == entry_id).where(JournalEntry.user_id == user_id)
-    )
-    entry = result.scalar_one_or_none()
-
-    if not entry:
-        raise_not_found("Journal entry")
+    entry = await get_owned_or_404(db, JournalEntry, entry_id, user_id, name="Journal entry")
 
     if entry.status != JournalEntryStatus.DRAFT:
         raise_bad_request("Only draft entries can be deleted")

--- a/apps/backend/src/routers/llm.py
+++ b/apps/backend/src/routers/llm.py
@@ -36,7 +36,7 @@ from src.schemas.llm import (
     LlmScenesResponse,
     LlmScenesUpdate,
 )
-from src.utils import raise_bad_request, raise_conflict, raise_not_found, raise_service_unavailable
+from src.utils import get_owned_or_404, raise_bad_request, raise_conflict, raise_not_found, raise_service_unavailable
 
 logger = get_logger(__name__)
 
@@ -116,11 +116,7 @@ async def delete_provider(provider_id: str, db: DbSession, user_id: CurrentUserI
     except (ValueError, TypeError):
         # A non-UUID path param is a not-found, not a 500 from the UUID column cast.
         raise_not_found("Provider")
-    row = (
-        await db.execute(select(LlmProvider).where(LlmProvider.id == pid, LlmProvider.user_id == user_id))
-    ).scalar_one_or_none()
-    if row is None:
-        raise_not_found("Provider")
+    row = await get_owned_or_404(db, LlmProvider, pid, user_id, name="Provider")
     deleted_id = row.id
     await db.delete(row)
     await db.commit()

--- a/apps/backend/src/routers/reconciliation.py
+++ b/apps/backend/src/routers/reconciliation.py
@@ -44,7 +44,7 @@ from src.services.review_queue import (
     reject_match as reject_match_service,
 )
 from src.services.source_type_priority import STATEMENT_SOURCE_TYPES
-from src.utils import raise_bad_request, raise_not_found
+from src.utils import get_owned_or_404, raise_bad_request, raise_not_found
 
 router = APIRouter(prefix="/reconciliation", tags=["reconciliation"])
 logger = get_logger(__name__)
@@ -565,12 +565,7 @@ async def list_anomalies(
     user_id: CurrentUserId,
     pagination: Pagination,
 ) -> list[AnomalyResponse]:
-    result = await db.execute(
-        select(AtomicTransaction).where(AtomicTransaction.id == txn_id).where(AtomicTransaction.user_id == user_id)
-    )
-    txn = result.scalar_one_or_none()
-    if not txn:
-        raise_not_found("Transaction")
+    txn = await get_owned_or_404(db, AtomicTransaction, txn_id, user_id, name="Transaction")
     anomalies = await detect_anomalies(db, txn, user_id=user_id)
     page = anomalies[pagination.offset : pagination.offset + pagination.limit]
     return [AnomalyResponse(**anomaly.__dict__) for anomaly in page]

--- a/apps/backend/src/routers/review.py
+++ b/apps/backend/src/routers/review.py
@@ -45,7 +45,7 @@ from src.services.currency_resolution import resolve_transaction_currency
 from src.services.review_queue import accept_match as accept_match_service, get_stage2_queue
 from src.services.source_type_priority import STATEMENT_SOURCE_TYPES
 from src.services.statement_validation import resolve_statement_conflicts, resolve_statement_transactions
-from src.utils import raise_conflict, raise_not_found
+from src.utils import get_owned_or_404, raise_conflict
 
 logger = get_logger(__name__)
 
@@ -60,12 +60,7 @@ async def get_review_conflicts(
     user_id: CurrentUserId,
 ) -> ReviewConflictsResponse:
     """Return duplicate and transfer-pair candidates for a statement."""
-    statement_result = await db.execute(
-        select(StatementSummary).where(StatementSummary.id == statement_id).where(StatementSummary.user_id == user_id)
-    )
-    statement = statement_result.scalar_one_or_none()
-    if not statement:
-        raise_not_found("Statement")
+    statement = await get_owned_or_404(db, StatementSummary, statement_id, user_id, name="Statement")
 
     transactions = await resolve_statement_transactions(db, statement)
 
@@ -220,12 +215,8 @@ async def run_stage2_checks(
     user_id: CurrentUserId,
 ) -> ConsistencyCheckListResponse:
     """Run consistency checks for a statement."""
-    result = await db.execute(
-        select(StatementSummary).where(StatementSummary.id == statement_id).where(StatementSummary.user_id == user_id)
-    )
-    statement = result.scalar_one_or_none()
-    if not statement:
-        raise_not_found("Statement")
+    # Existence/ownership guard (404); the checks below key off statement_id.
+    await get_owned_or_404(db, StatementSummary, statement_id, user_id, name="Statement")
 
     checks = await run_all_consistency_checks(db, user_id, statement_id)
     await db.commit()

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -63,6 +63,7 @@ from src.services.statement_validation import (
 )
 from src.services.statement_workflow import approve_statement_workflow, reject_statement_workflow
 from src.utils import (
+    get_owned_or_404,
     raise_bad_request,
     raise_internal_error,
     raise_not_found,
@@ -138,13 +139,7 @@ async def _get_statement_or_404(
     statement_id: UUID,
     user_id: UUID,
 ) -> StatementSummary:
-    result = await db.execute(
-        select(StatementSummary).where(StatementSummary.id == statement_id).where(StatementSummary.user_id == user_id)
-    )
-    statement = result.scalar_one_or_none()
-    if not statement:
-        raise_not_found("Statement")
-    return statement
+    return await get_owned_or_404(db, StatementSummary, statement_id, user_id, name="Statement")
 
 
 async def _queue_statement_reparse(

--- a/apps/backend/src/utils/__init__.py
+++ b/apps/backend/src/utils/__init__.py
@@ -13,9 +13,12 @@ from .exceptions import (
     raise_too_many_requests,
     raise_unauthorized,
 )
+from .queries import get_owned_or_404, paginate
 
 __all__ = [
     "MONEY_QUANTUM",
+    "get_owned_or_404",
+    "paginate",
     "raise_bad_request",
     "raise_conflict",
     "raise_gateway_timeout",

--- a/apps/backend/src/utils/queries.py
+++ b/apps/backend/src/utils/queries.py
@@ -1,0 +1,72 @@
+"""Shared query helpers for router handlers.
+
+Two patterns were re-implemented inline across the routers:
+
+- "load a user-owned row by id, or 404" — ``select(...).where(id).where(user_id)``
+  → ``scalar_one_or_none()`` → ``raise_not_found(...)``;
+- "paginate a filtered query" — count the full set via a ``func.count`` subquery,
+  then apply eager-load options / ordering / offset / limit and materialise rows.
+
+Centralising them keeps the 404 contract and the count-then-page contract in one
+place so they cannot drift between endpoints.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Select
+from sqlalchemy.sql.base import ExecutableOption
+
+from src.utils.exceptions import raise_not_found
+
+
+async def get_owned_or_404[M](
+    db: AsyncSession,
+    model: type[M],
+    entity_id: Any,
+    user_id: Any,
+    *,
+    name: str,
+    options: Sequence[ExecutableOption] = (),
+) -> M:
+    """Return the ``model`` row owned by ``user_id`` with ``entity_id``, or raise 404.
+
+    ``name`` is the human resource label passed to :func:`raise_not_found`.
+    ``options`` are eager-load options (e.g. ``selectinload(...)``).
+    """
+    stmt = select(model).where(model.id == entity_id).where(model.user_id == user_id)
+    if options:
+        stmt = stmt.options(*options)
+    obj = (await db.execute(stmt)).scalar_one_or_none()
+    if obj is None:
+        raise_not_found(name)
+    return obj
+
+
+async def paginate(
+    db: AsyncSession,
+    query: Select[Any],
+    *,
+    limit: int,
+    offset: int,
+    options: Sequence[ExecutableOption] = (),
+    order_by: Sequence[Any] = (),
+) -> tuple[list[Any], int]:
+    """Return ``(rows, total)`` for a filtered base ``query``.
+
+    ``total`` is the count of the full filtered set (before paging), computed via a
+    ``func.count`` subquery so it is independent of ``limit``/``offset``. Eager-load
+    ``options`` and ``order_by`` are applied before slicing.
+    """
+    total = (await db.execute(select(func.count()).select_from(query.subquery()))).scalar() or 0
+    paged = query
+    if options:
+        paged = paged.options(*options)
+    if order_by:
+        paged = paged.order_by(*order_by)
+    rows = (await db.execute(paged.offset(offset).limit(limit))).scalars().all()
+    return list(rows), total

--- a/apps/backend/src/utils/queries.py
+++ b/apps/backend/src/utils/queries.py
@@ -61,8 +61,13 @@ async def paginate(
     ``total`` is the count of the full filtered set (before paging), computed via a
     ``func.count`` subquery so it is independent of ``limit``/``offset``. Eager-load
     ``options`` and ``order_by`` are applied before slicing.
+
+    Any ``ORDER BY`` / ``LIMIT`` / ``OFFSET`` already on the incoming ``query`` is
+    stripped before counting, so a pre-sliced or pre-ordered query still yields the
+    true total rather than a clamped/paged count.
     """
-    total = (await db.execute(select(func.count()).select_from(query.subquery()))).scalar() or 0
+    count_source = query.order_by(None).limit(None).offset(None).subquery()
+    total = (await db.execute(select(func.count()).select_from(count_source))).scalar() or 0
     paged = query
     if options:
         paged = paged.options(*options)

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -12,9 +12,9 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/valuation-snapshots/{snapshot_id}` | `delete_valuation_snapshot` | apps/backend/src/routers/assets.py:186 |
 | `POST` | `` | `chat_message` | apps/backend/src/routers/chat.py:37 |
 | `DELETE` | `/session/{session_id}` | `delete_session` | apps/backend/src/routers/chat.py:212 |
-| `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:164 |
+| `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:154 |
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:491 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:771 |
-| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:551 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:689 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:546 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:684 |
 | `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:104 |


### PR DESCRIPTION
DRY sweep PR 2 of the multi-PR series. Two query patterns were re-implemented inline across routers.

## What

New `src/utils/queries.py` (re-exported from `src.utils` next to the `raise_*` helpers):

- **`get_owned_or_404(db, Model, id, user_id, *, name, options=())`** — `select().where(id).where(user_id)` → `scalar_one_or_none()` → `raise_not_found(name)`, returning the typed row.
- **`paginate(db, query, *, limit, offset, options=(), order_by=())`** — counts the full filtered set via a `func.count` subquery, then applies eager-load options / ordering / slice; returns `(rows, total)`.

## Adopted at the clean sites

- `paginate`: journal list endpoint.
- `get_owned_or_404`: journal (get + delete), chat (`delete_session`), review (×2), reconciliation (anomalies-by-txn), llm (`delete_provider`), statements (`_get_statement`).

## Deliberately not migrated

- The reconciliation site holding a `.with_for_update()` row lock — the helper takes **loader** options, not execution options; folding it in would silently drop the lock.
- Service-layer list/get endpoints (e.g. accounts) that already delegate pagination/404 to their service.
- Existence/duplicate `if scalar_one_or_none():` checks — not the get-or-404 shape.

## Notes

Behaviour-preserving (identical 404 + count-then-page contracts). `get_owned_or_404` uses **PEP 695 type parameters** (`def get_owned_or_404[M]`) so the returned row stays typed — required by the repo's `UP047` lint.

## Verification

- **548** journal/statements/reconciliation/review/chat/llm tests pass.
- Pinned `ruff check` + `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)