### PR TITLE
[finance_report_audit] refactor(frontend): reuse LoadingState/EmptyState components (DRY)

### DIFF
--- a/apps/frontend/src/app/(main)/journal/page.tsx
+++ b/apps/frontend/src/app/(main)/journal/page.tsx
@@ -6,6 +6,7 @@ import JournalEntryForm from "@/components/journal/JournalEntryForm";
 import JournalEntryDetailsModal from "@/components/journal/JournalEntryDetailsModal";
 import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import ConfidenceBadge from "@/components/ui/ConfidenceBadge";
+import { EmptyState, LoadingState } from "@/components/ui";
 import { useToast } from "@/components/ui/Toast";
 import { apiFetch } from "@/lib/api";
 import { formatCurrencyLocale, sumAmounts } from "@/lib/money";
@@ -170,10 +171,7 @@ export default function JournalPage() {
 
             {/* Content */}
             {loading ? (
-                <div className="card p-8 text-center text-muted">
-                    <div className="inline-block w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin mb-2" />
-                    <p className="text-sm">Loading entries...</p>
-                </div>
+                <LoadingState label="Loading entries" />
             ) : error ? (
                 <div className="card p-8 text-center" role="alert" aria-live="polite">
                     <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--error-muted)] text-[var(--error)] mb-4">
@@ -192,10 +190,10 @@ export default function JournalPage() {
                     </button>
                 </div>
             ) : entries.length === 0 ? (
-                <div className="card p-8 text-center">
-                    <p className="text-muted mb-4">No journal entries yet</p>
-                    <button onClick={() => setIsFormOpen(true)} className="btn-primary">Create First Entry</button>
-                </div>
+                <EmptyState
+                    title="No journal entries yet"
+                    action={<button onClick={() => setIsFormOpen(true)} className="btn-primary">Create First Entry</button>}
+                />
             ) : (
                 <div className="card">
                     <div className="divide-y divide-[var(--border)]">

--- a/apps/frontend/src/app/(main)/portfolio/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/page.tsx
@@ -8,6 +8,7 @@ import { CalendarDays, X } from "lucide-react";
 import { apiFetch } from "@/lib/api";
 import { PortfolioHolding, PortfolioSummaryResponse } from "@/lib/types";
 import { PerformanceCard } from "@/components/portfolio/PerformanceCard";
+import { LoadingState } from "@/components/ui";
 import { HoldingsTable } from "@/components/portfolio/HoldingsTable";
 import { AllocationChart } from "@/components/portfolio/AllocationChart";
 import { InvestmentPerformanceSchedule } from "@/components/portfolio/InvestmentPerformanceSchedule";
@@ -446,10 +447,7 @@ export default function PortfolioPage() {
       </div>
 
       {isLoading ? (
-        <div className="card p-8 text-center text-muted">
-          <div className="inline-block w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin mb-2" />
-          <p className="text-sm">Loading holdings...</p>
-        </div>
+        <LoadingState label="Loading holdings" />
       ) : error ? (
         <div className="card p-8 text-center" role="alert" aria-live="polite">
           <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--error-muted)] text-[var(--error)] mb-4">

--- a/apps/frontend/src/app/(main)/processing/page.tsx
+++ b/apps/frontend/src/app/(main)/processing/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle } from "lucide-react";
 import { BackLink } from "@/components/ui/BackLink";
+import { LoadingState } from "@/components/ui";
 import { apiFetch } from "@/lib/api";
 import { ProcessingPendingItem, ProcessingPendingListResponse } from "@/lib/types";
 import { formatDateDisplay } from "@/lib/date";
@@ -39,10 +40,7 @@ export default function ProcessingPage() {
       </div>
 
       {loading ? (
-        <div className="card p-8 text-center text-muted">
-          <div className="inline-block w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin mb-2" />
-          <p className="text-sm">Loading transfers...</p>
-        </div>
+        <LoadingState label="Loading transfers" />
       ) : error ? (
         <div className="card p-8 text-center text-[var(--error)] border-[var(--error)]/30">
           <p>{error}</p>

--- a/apps/frontend/src/app/(main)/statements/[id]/page.tsx
+++ b/apps/frontend/src/app/(main)/statements/[id]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 
 import { useToast } from "@/components/ui/Toast";
+import { LoadingState } from "@/components/ui";
 import { FlowStepBanner } from "@/components/workflow/FlowStepBanner";
 import { apiFetch } from "@/lib/api";
 import { BankStatement, BrokerageImportResponse } from "@/lib/types";
@@ -157,10 +158,7 @@ export default function StatementDetailPage() {
     if (loading) {
         return (
             <div className="p-6">
-                <div className="card p-8 text-center text-muted">
-                    <div className="inline-block w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin mb-2" />
-                    <p className="text-sm">Loading statement...</p>
-                </div>
+                <LoadingState label="Loading statement" />
             </div>
         );
     }


### PR DESCRIPTION
DRY sweep PR 3 (ROI #1 of the remaining set — lowest risk, highest reach). Several pages re-inlined the exact spinner/empty cards that shared components already render.

## What

Replaced inline markup with the existing `LoadingState` / `EmptyState` components (already used by attention / confidence / accounts / upload):

| Page | Swap |
|------|------|
| journal | loading → `LoadingState`, empty → `EmptyState` |
| processing | loading → `LoadingState` |
| portfolio | loading → `LoadingState` |
| statements/[id] | loading → `LoadingState` |

## Pixel-identical

`LoadingState` *is* the verbatim `card p-8 text-center text-muted` + `animate-spin` markup (it appends the `...`, so labels drop the dots). `EmptyState` renders `card p-8 text-center` + `<p className="text-muted mb-4">{title}</p>` + action — exactly the inlined journal empty card.

## Intentionally left

- **Error-state cards** — they carry a distinct error icon + `role="alert"` not in `EmptyState`; folding them in would change the visuals. A shared `ErrorState` is a separate (additive) change.
- **Small inline `w-4`/`w-5` button/banner spinners** (assets reconcile button, statements parsing banner) — inline indicators, not the full-card loading pattern.

## Verification

- `eslint` + `tsc --noEmit` clean.
- **1008** frontend vitest tests pass (incl. coverage-baseline test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)