### PR TITLE
[finance_report_vision] feat(EPIC-026): reconcile declared authority tier vs detected CODE/LLM band

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,11 @@ jobs:
           uv run --with pyyaml python tools/check_epic_package_dual.py
           # 1e: a draft package must carry no done ACs and must be registered.
           uv run --with pyyaml python tools/check_draft_packages.py
-      - name: Tier Import Guard (PC must not import the LLM layer)
+          # reconcile: a package's DECLARED tier must agree with its DETECTED
+          # CODE/LLM band at the enforceable ends (CODE-ONLY ⟹ no LLM test;
+          # LLM-ONLY ⟹ no deterministic test). Makes the declared tier checkable.
+          uv run --with pyyaml python tools/check_authority_reconcile.py
+      - name: Tier Import Guard (CODE-ONLY must not import the LLM layer)
         run: |
           # EPIC-026 phase 3: enforce the cross-tier STRUCTURAL MUST rule
           # (docs/ssot/authority-tiers.md, rule 2 "PC stays pure"). AST-based,

--- a/common/ssot/check_authority_reconcile.py
+++ b/common/ssot/check_authority_reconcile.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Gate: reconcile a package's DECLARED authority tier against its DETECTED band.
+
+The authority tier has two views over one CODE↔LLM spectrum
+(``common/ssot/authority_matrix.py``):
+
+- **declared** — ``PackageContract.tier`` (the package's authorial intent);
+- **detected** — the band the ``authority_classifier`` measures from the shapes
+  of the tests that prove the package's roadmap ACs (cassette/replay → LLM,
+  deterministic → CODE).
+
+Until now nothing tied the two together, so intent and reality could diverge
+silently — the exact gap that made "the declared tier can't be validated". This
+gate closes it by enforcing the two *enforceable ends* of the band scale (the
+ones ``authority_classifier`` itself marks enforceable); the middle bands
+(CODE-LED / LLM-LED) are measured, not hard-gated:
+
+- declared **CODE-ONLY** ⟹ NO roadmap-AC test may be an LLM test (share == 0);
+- declared **LLM-ONLY** ⟹ NO roadmap-AC test may be deterministic CODE (share == 100).
+
+Pure AST/text (no pydantic), so it runs in the CI lint env. ``draft`` packages
+(tier undecided) are skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from common.ssot.authority_classifier import band, build_test_index, classify_test_files
+from common.ssot.generate_ac_registry import package_contract_meta
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _detect(meta: dict, index: dict, cache: dict) -> tuple[int, int, float, str]:
+    """Return (code, llm, llm_share, detected_band) for a package's roadmap ACs."""
+    code = llm = 0
+    for ac in meta.get("roadmap", []):
+        test = ac.get("test")
+        if not test:
+            continue
+        verdict = classify_test_files([test.split("::")[0]], index, cache)
+        if verdict == "CODE":
+            code += 1
+        elif verdict == "LLM":
+            llm += 1
+    known = code + llm
+    share = round(100 * llm / known, 1) if known else 0.0
+    return code, llm, share, band(share)
+
+
+def reconcile(repo_root: Path) -> tuple[list[str], list[str]]:
+    """Return (violations, report_lines) comparing declared tier vs detected band."""
+    index = build_test_index(repo_root)
+    cache: dict = {}
+    violations: list[str] = []
+    report: list[str] = []
+    for path in sorted(repo_root.glob("common/*/contract.py")):
+        meta = package_contract_meta(path)
+        if not meta or not meta.get("tier"):  # draft / undecided → nothing to reconcile
+            continue
+        declared = meta["tier"]
+        code, llm, share, detected = _detect(meta, index, cache)
+        report.append(
+            f"  {meta.get('name') or path.parent.name:14} declared={declared:10} "
+            f"detected={detected:10} (code={code} llm={llm} share={share}%)"
+        )
+        if declared == "CODE-ONLY" and llm > 0:
+            violations.append(
+                f"package {meta.get('name')!r}: declared CODE-ONLY but {llm}/"
+                f"{code + llm} roadmap-AC test(s) are LLM tests (detected "
+                f"{detected}). A CODE-ONLY package permits no LLM — re-declare the "
+                "tier or drop the LLM test dependency."
+            )
+        elif declared == "LLM-ONLY" and code > 0:
+            violations.append(
+                f"package {meta.get('name')!r}: declared LLM-ONLY but {code}/"
+                f"{code + llm} roadmap-AC test(s) are deterministic CODE (detected "
+                f"{detected}). An LLM-ONLY package permits no hardcoded oracle."
+            )
+    return violations, report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reconcile declared authority tier vs detected CODE/LLM band."
+    )
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args([] if argv is None else argv)
+    violations, report = reconcile(args.repo_root.resolve())
+    for line in report:
+        print(line)
+    if violations:
+        for message in violations:
+            print(f"::error title=Authority reconcile::{message}", file=sys.stderr)
+        print(
+            f"[RECONCILE] FAILED: {len(violations)} package(s) whose declared tier "
+            "contradicts the detected CODE/LLM band at an enforceable end.",
+            file=sys.stderr,
+        )
+        return 1
+    print("[RECONCILE] PASSED: every shipped package's declared tier agrees with its detected band.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/common/ssot/generate_ac_registry.py
+++ b/common/ssot/generate_ac_registry.py
@@ -339,8 +339,8 @@ def package_contract_meta(contract_path: Path) -> dict | None:
 
     Returns ``{name, status, tier, roadmap}`` where ``tier``/``status``/``name``
     are the string literals on the ``PackageContract(...)`` call (``None`` if not
-    an AST-readable literal) and ``roadmap`` is a list of ``{id, status}`` per
-    ``ACRecord``. Returns ``None`` if the file has no ``PackageContract(...)``.
+    an AST-readable literal) and ``roadmap`` is a list of ``{id, status, test}``
+    per ``ACRecord``. Returns ``None`` if the file has no ``PackageContract(...)``.
 
     This is the AST view the registry generator and the migration-safety gates
     consume; it deliberately does NOT import the contract, so it runs in the
@@ -361,7 +361,11 @@ def package_contract_meta(contract_path: Path) -> dict | None:
                     ac_id = _ac_record_field(elt, "id")
                     if ac_id:
                         roadmap.append(
-                            {"id": ac_id, "status": _ac_record_field(elt, "status")}
+                            {
+                                "id": ac_id,
+                                "status": _ac_record_field(elt, "status"),
+                                "test": _ac_record_field(elt, "test"),
+                            }
                         )
         return {
             "name": _ac_record_field(node, "name"),

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -710,6 +710,8 @@ concepts:
       - common/ssot/check_tier_ast_literal.py
       - common/ssot/check_epic_package_dual.py
       - common/ssot/check_draft_packages.py
+      - common/ssot/authority_classifier.py
+      - common/ssot/check_authority_reconcile.py
 
   ac_tier_baseline:
     owner: docs/ssot/ac-tier-baseline.json

--- a/tests/tooling/test_migration_safety_gates.py
+++ b/tests/tooling/test_migration_safety_gates.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import pytest
 
+from common.ssot import check_authority_reconcile as g_reconcile
 from common.ssot import check_draft_packages as g_draft
 from common.ssot import check_epic_package_dual as g_dual
 from common.ssot import check_tier_ast_literal as g_tier
@@ -185,6 +186,48 @@ def test_1e_load_baseline_rejects_malformed(tmp_path: Path) -> None:
     bad.write_text('["wip"]', encoding="utf-8")  # a list, not an object
     with pytest.raises(ValueError):
         g_draft.load_baseline(bad)
+
+
+def _ac_pointing_at(test_file: str) -> str:
+    return (
+        f'ACRecord(id="AC-p.1.1", statement="s", test="{test_file}::t", '
+        'priority="P0", status="done"),'
+    )
+
+
+def test_reconcile_flags_llm_test_under_code_only(tmp_path: Path) -> None:
+    # A CODE-ONLY package whose AC test drives the cassette harness = a real
+    # declared-vs-detected contradiction.
+    (tmp_path / "cass_test.py").write_text(
+        "def t():\n    cassette.replay()  # cassette marker\n", encoding="utf-8"
+    )
+    _write_contract(
+        tmp_path, "p", _active("p", tier='"CODE-ONLY"', roadmap=_ac_pointing_at("cass_test.py"))
+    )
+    violations, _ = g_reconcile.reconcile(tmp_path)
+    assert any("declared CODE-ONLY but" in v for v in violations)
+
+
+def test_reconcile_passes_code_only_with_deterministic_test(tmp_path: Path) -> None:
+    (tmp_path / "det_test.py").write_text(
+        "def t():\n    assert 1 == 1\n", encoding="utf-8"
+    )
+    _write_contract(
+        tmp_path, "p", _active("p", tier='"CODE-ONLY"', roadmap=_ac_pointing_at("det_test.py"))
+    )
+    violations, _ = g_reconcile.reconcile(tmp_path)
+    assert violations == []
+
+
+def test_reconcile_flags_code_test_under_llm_only(tmp_path: Path) -> None:
+    (tmp_path / "det_test.py").write_text(
+        "def t():\n    assert 1 == 1\n", encoding="utf-8"
+    )
+    _write_contract(
+        tmp_path, "p", _active("p", tier='"LLM-ONLY"', roadmap=_ac_pointing_at("det_test.py"))
+    )
+    violations, _ = g_reconcile.reconcile(tmp_path)
+    assert any("declared LLM-ONLY but" in v for v in violations)
 
 
 def test_1e_passes_for_registered_draft_without_done(tmp_path: Path) -> None:

--- a/tools/check_authority_reconcile.py
+++ b/tools/check_authority_reconcile.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Command wrapper for common.ssot.check_authority_reconcile."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.ssot.check_authority_reconcile import main  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Makes the **declared** authority tier checkable against **reality** — the gap behind "authority_matrix can't be validated".

## What
The tier has two views over one CODE↔LLM spectrum: **declared** (`PackageContract.tier`) and **detected** (the band `authority_classifier` measures from each roadmap-AC test's shape). Nothing tied them — intent and reality could drift silently.

`common/ssot/check_authority_reconcile.py` reconciles them per package, enforcing the two **enforceable ends** the classifier itself marks (the middle bands are measured, not hard-gated):
- declared **CODE-ONLY** ⟹ no roadmap-AC test is an LLM test (share 0)
- declared **LLM-ONLY** ⟹ no roadmap-AC test is deterministic CODE (share 100)

Pure AST/text (no pydantic) → runs in the `uv run --with pyyaml` lint env, beside the other migration-safety gates.

Also: `package_contract_meta()` now exposes each AC's `test` ref (for per-package detection).

## Verification
- Current packages reconcile clean: counter (code=4/llm=0), platform (5/0), governance (0/0) → all CODE-ONLY↔CODE-ONLY.
- Tests cover pass + both fail ends; 1793 tooling tests pass; all gates green (reconcile/manifest/doc-consistency/proof-kind/package-contract); ruff clean.

## Follow-up (PR-B)
`common/authority` package consolidation (move the scattered `authority_*` into one bounded-context package) + delete the ungated `authority-distribution.json` snapshot (needs the governance-exceptions handling, grouped with PR-B's MANIFEST rework).

🤖 Generated with [Claude Code](https://claude.com/claude-code)