### PR TITLE
[finance_report_audit] refactor(frontend): FilterTabs + useConfirmDialog + useSettingsForm (DRY)

### DIFF
--- a/apps/frontend/src/app/(main)/accounts/page.tsx
+++ b/apps/frontend/src/app/(main)/accounts/page.tsx
@@ -5,9 +5,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Pencil, Plus, Scale, Trash2 } from "lucide-react";
 
 import AccountFormModal from "@/components/accounts/AccountFormModal";
+import { FilterTabs } from "@/components/ui/FilterTabs";
 import OpeningBalanceModal from "@/components/accounts/OpeningBalanceModal";
 import AccountDetailsSidebar from "@/components/accounts/AccountDetailsSidebar";
 import ConfirmDialog from "@/components/ui/ConfirmDialog";
+import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { useToast } from "@/components/ui/Toast";
 import { Alert, Badge, Button, EmptyState, IconButton, LoadingState, PageHeader } from "@/components/ui";
 import { apiFetch } from "@/lib/api";
@@ -23,8 +25,6 @@ export default function AccountsPage() {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isOpeningBalanceOpen, setIsOpeningBalanceOpen] = useState(false);
     const [editingAccount, setEditingAccount] = useState<Account | null>(null);
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-    const [deletingAccountId, setDeletingAccountId] = useState<string | null>(null);
     const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
 
     const { data, isLoading, error, refetch } = useQuery({
@@ -53,22 +53,13 @@ export default function AccountsPage() {
         },
     });
 
-    const handleDeleteAccount = (accountId: string) => {
-        setDeletingAccountId(accountId);
-        setDeleteDialogOpen(true);
-    };
-
-    const handleDeleteConfirm = async () => {
-        if (!deletingAccountId) return;
+    const deleteDialog = useConfirmDialog(async (accountId) => {
         try {
-            await deleteMutation.mutateAsync(deletingAccountId);
+            await deleteMutation.mutateAsync(accountId);
         } catch {
-            // onError handler already shows the toast
-        } finally {
-            setDeleteDialogOpen(false);
-            setDeletingAccountId(null);
+            // onError handler already shows the toast; close the dialog regardless.
         }
-    };
+    });
 
     const handleModalSuccess = () => {
         queryClient.invalidateQueries({ queryKey: ["accounts"] });
@@ -130,20 +121,12 @@ export default function AccountsPage() {
             )}
 
             {/* Tabs */}
-            <div className="mb-6 flex w-full flex-wrap gap-1 rounded-lg bg-[var(--background-muted)] p-1 sm:w-fit">
-                {ACCOUNT_TYPES.map((type) => (
-                    <button
-                        key={type}
-                        onClick={() => setActiveFilter(type)}
-                        className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${activeFilter === type
-                            ? "bg-[var(--background-card)] text-[var(--foreground)]"
-                            : "text-muted hover:text-[var(--foreground)]"
-                            }`}
-                    >
-                        {type}
-                    </button>
-                ))}
-            </div>
+            <FilterTabs
+                options={ACCOUNT_TYPES}
+                value={activeFilter}
+                onChange={setActiveFilter}
+                className="mb-6 flex w-full flex-wrap gap-1 rounded-lg bg-[var(--background-muted)] p-1 sm:w-fit"
+            />
 
             {/* Error */}
             {error && (
@@ -214,7 +197,7 @@ export default function AccountsPage() {
                                                 <IconButton
                                                     icon={Trash2}
                                                     label="Delete Account"
-                                                    onClick={(e) => { e.stopPropagation(); handleDeleteAccount(account.id); }}
+                                                    onClick={(e) => { e.stopPropagation(); deleteDialog.open(account.id); }}
                                                     className="text-muted hover:text-[var(--error)]"
                                                     disabled={deleteMutation.isPending}
                                                 />
@@ -247,9 +230,9 @@ export default function AccountsPage() {
             />
 
             <ConfirmDialog
-                isOpen={deleteDialogOpen}
-                onCancel={() => { setDeleteDialogOpen(false); setDeletingAccountId(null); }}
-                onConfirm={handleDeleteConfirm}
+                isOpen={deleteDialog.isOpen}
+                onCancel={deleteDialog.cancel}
+                onConfirm={() => deleteDialog.confirm()}
                 title="Delete Account"
                 message="Are you sure you want to delete this account? This will only work if there are no transactions."
                 confirmLabel="Delete Account"

--- a/apps/frontend/src/app/(main)/assets/page.tsx
+++ b/apps/frontend/src/app/(main)/assets/page.tsx
@@ -6,6 +6,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { useToast } from "@/components/ui/Toast";
 import { TableSkeleton } from "@/components/ui";
+import { FilterTabs } from "@/components/ui/FilterTabs";
 import { apiFetch } from "@/lib/api";
 import { formatCurrencyLocale, parseAmount } from "@/lib/money";
 import { formatQuantity } from "@/lib/quantity";
@@ -377,23 +378,13 @@ export default function AssetsPage() {
 
 
             <div className="flex items-center justify-between mb-6">
-                <div role="tablist" aria-label="Asset status filter" className="flex gap-1 bg-[var(--background-muted)] p-1 rounded-lg w-fit">
-                    {STATUS_FILTERS.map((status) => (
-                        <button
-                            key={status}
-                            role="tab"
-                            aria-selected={activeFilter === status}
-                            onClick={() => setActiveFilter(status)}
-                            className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors capitalize ${
-                                activeFilter === status
-                                    ? "bg-[var(--background-card)] text-[var(--foreground)]"
-                                    : "text-muted hover:text-[var(--foreground)]"
-                            }`}
-                        >
-                            {status}
-                        </button>
-                    ))}
-                </div>
+                <FilterTabs
+                    options={STATUS_FILTERS}
+                    value={activeFilter}
+                    onChange={setActiveFilter}
+                    capitalize
+                    ariaLabel="Asset status filter"
+                />
 
                 {!isLoading && !error && positions.length > 0 && (
                     <div className="text-sm text-muted">

--- a/apps/frontend/src/app/(main)/journal/page.tsx
+++ b/apps/frontend/src/app/(main)/journal/page.tsx
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useState } from "react";
 import JournalEntryForm from "@/components/journal/JournalEntryForm";
 import JournalEntryDetailsModal from "@/components/journal/JournalEntryDetailsModal";
 import ConfirmDialog from "@/components/ui/ConfirmDialog";
+import { useConfirmDialog } from "@/hooks/useConfirmDialog";
+import { FilterTabs } from "@/components/ui/FilterTabs";
 import ConfidenceBadge from "@/components/ui/ConfidenceBadge";
 import { EmptyState, LoadingState } from "@/components/ui";
 import { useToast } from "@/components/ui/Toast";
@@ -23,14 +25,6 @@ export default function JournalPage() {
     const [activeFilter, setActiveFilter] = useState<string>("All");
     const [isFormOpen, setIsFormOpen] = useState(false);
     
-    // Void dialog state
-    const [voidDialogOpen, setVoidDialogOpen] = useState(false);
-    const [voidingEntryId, setVoidingEntryId] = useState<string | null>(null);
-    const [voidLoading, setVoidLoading] = useState(false);
-    // Delete dialog state
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-    const [deletingEntryId, setDeletingEntryId] = useState<string | null>(null);
-    const [deleteLoading, setDeleteLoading] = useState(false);
     const [selectedEntry, setSelectedEntry] = useState<JournalEntry | null>(null);
 
     const fetchEntries = useCallback(async () => {
@@ -68,67 +62,34 @@ export default function JournalPage() {
         }
     };
 
-    const openDeleteDialog = (entryId: string) => {
-        setDeletingEntryId(entryId);
-        setDeleteDialogOpen(true);
-    };
-
-    const handleDeleteConfirm = async () => {
-        if (!deletingEntryId) return;
-        setDeleteLoading(true);
+    const deleteDialog = useConfirmDialog(async (entryId) => {
         try {
-            await apiFetch(`/api/journal-entries/${deletingEntryId}`, { method: "DELETE" });
+            await apiFetch(`/api/journal-entries/${entryId}`, { method: "DELETE" });
             showToast("Draft entry deleted successfully", "success");
-            setDeleteDialogOpen(false);
-            setDeletingEntryId(null);
             fetchEntries();
         } catch (err) {
             const message = err instanceof Error ? err.message : "Failed to delete entry";
             showToast(message, "error");
             setError(message);
-        } finally {
-            setDeleteLoading(false);
+            throw err;
         }
-    };
+    });
 
-    const handleDeleteCancel = () => {
-        if (deleteLoading) return;
-        setDeleteDialogOpen(false);
-        setDeletingEntryId(null);
-    };
-
-    const openVoidDialog = (entryId: string) => {
-        setVoidingEntryId(entryId);
-        setVoidDialogOpen(true);
-    };
-
-    const handleVoidConfirm = async (reason: string) => {
-        if (!voidingEntryId) return;
-        
-        setVoidLoading(true);
+    const voidDialog = useConfirmDialog<[string]>(async (entryId, reason) => {
         try {
-            await apiFetch(`/api/journal-entries/${voidingEntryId}/voidings`, {
+            await apiFetch(`/api/journal-entries/${entryId}/voidings`, {
                 method: "POST",
                 body: JSON.stringify({ reason }),
             });
             showToast("Entry voided successfully. Reversal entry created.", "success");
-            setVoidDialogOpen(false);
-            setVoidingEntryId(null);
             fetchEntries();
         } catch (err) {
             const message = err instanceof Error ? err.message : "Failed to void entry";
             showToast(message, "error");
             setError(message);
-        } finally {
-            setVoidLoading(false);
+            throw err;
         }
-    };
-
-    const handleVoidCancel = () => {
-        if (voidLoading) return;
-        setVoidDialogOpen(false);
-        setVoidingEntryId(null);
-    };
+    });
 
     return (
         <div className="p-6">
@@ -147,20 +108,13 @@ export default function JournalPage() {
             </div>
 
             {/* Tabs */}
-            <div className="flex gap-1 mb-6 bg-[var(--background-muted)] p-1 rounded-lg w-fit">
-                {STATUS_FILTERS.map((status) => (
-                    <button
-                        key={status}
-                        onClick={() => setActiveFilter(status)}
-                        className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors capitalize ${activeFilter === status
-                            ? "bg-[var(--background-card)] text-[var(--foreground)]"
-                            : "text-muted hover:text-[var(--foreground)]"
-                            }`}
-                    >
-                        {status}
-                    </button>
-                ))}
-            </div>
+            <FilterTabs
+                options={STATUS_FILTERS}
+                value={activeFilter}
+                onChange={setActiveFilter}
+                capitalize
+                className="flex gap-1 mb-6 bg-[var(--background-muted)] p-1 rounded-lg w-fit"
+            />
 
             {/* Error */}
             {error && (
@@ -239,7 +193,7 @@ export default function JournalPage() {
                                             {entry.status === "draft" && (
                                                 <div className="flex gap-2">
                                                     <button
-                                                        onClick={(e) => { e.stopPropagation(); openDeleteDialog(entry.id); }}
+                                                        onClick={(e) => { e.stopPropagation(); deleteDialog.open(entry.id); }}
                                                         className="btn-secondary text-xs py-1 px-2 text-[var(--error)] border-[var(--error)]/30 hover:bg-[var(--error-muted)]"
                                                     >
                                                         Delete
@@ -254,7 +208,7 @@ export default function JournalPage() {
                                             )}
                                             {(entry.status === "posted" || entry.status === "reconciled") && (
                                                 <button 
-                                                    onClick={(e) => { e.stopPropagation(); openVoidDialog(entry.id); }} 
+                                                    onClick={(e) => { e.stopPropagation(); voidDialog.open(entry.id); }} 
                                                     className="btn-secondary text-xs py-1 px-2 text-[var(--error)] border-[var(--error)]/30 hover:bg-[var(--error-muted)]"
                                                 >
                                                     Void
@@ -273,9 +227,9 @@ export default function JournalPage() {
             <JournalEntryForm isOpen={isFormOpen} onClose={() => setIsFormOpen(false)} onSuccess={fetchEntries} />
             
             <ConfirmDialog
-                isOpen={voidDialogOpen}
-                onCancel={handleVoidCancel}
-                onConfirm={(reason) => handleVoidConfirm(reason!)}
+                isOpen={voidDialog.isOpen}
+                onCancel={voidDialog.cancel}
+                onConfirm={(reason) => voidDialog.confirm(reason!)}
                 title="Void Journal Entry"
                 message="Are you sure you want to void this journal entry? A reversal entry will be created automatically."
                 confirmLabel="Void Entry"
@@ -284,18 +238,18 @@ export default function JournalPage() {
                 inputLabel="Void Reason"
                 inputPlaceholder="Enter reason for voiding this entry..."
                 inputRequired
-                loading={voidLoading}
+                loading={voidDialog.isLoading}
             />
 
             <ConfirmDialog
-                isOpen={deleteDialogOpen}
-                onCancel={handleDeleteCancel}
-                onConfirm={() => handleDeleteConfirm()}
+                isOpen={deleteDialog.isOpen}
+                onCancel={deleteDialog.cancel}
+                onConfirm={() => deleteDialog.confirm()}
                 title="Delete Journal Entry"
                 message="Are you sure you want to delete this journal entry? This action cannot be undone."
                 confirmLabel="Delete Entry"
                 confirmVariant="danger"
-                loading={deleteLoading}
+                loading={deleteDialog.isLoading}
             />
 
             <JournalEntryDetailsModal

--- a/apps/frontend/src/app/(main)/settings/ai/page.tsx
+++ b/apps/frontend/src/app/(main)/settings/ai/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useToast } from "@/components/ui/Toast";
 import { fetchUserSettings, patchUserSettings } from "@/lib/api";
+import { useSettingsForm } from "@/hooks/useSettingsForm";
 import type { UserAiSettings } from "@/lib/types";
 
 const DEFAULT_SETTINGS: UserAiSettings = {
@@ -16,62 +16,24 @@ export default function AiSettingsPage() {
   const { showToast } = useToast();
   // `saved` is the last value persisted by the backend; `draft` is the
   // in-progress edit. A dirty form is any divergence between the two.
-  const [saved, setSaved] = useState<UserAiSettings | null>(null);
-  const [draft, setDraft] = useState<UserAiSettings | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const loadSettings = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await fetchUserSettings();
-      setSaved(data);
-      setDraft(data);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load AI settings");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    loadSettings();
-  }, [loadSettings]);
-
-  const isDirty = useMemo(() => {
-    if (!saved || !draft) return false;
-    return (
-      saved.enable_ai_reconciliation !== draft.enable_ai_reconciliation ||
-      saved.enable_ai_classification !== draft.enable_ai_classification
-    );
-  }, [saved, draft]);
+  const { draft, setDraft, loading, submitting, error, isDirty, submit, reset } = useSettingsForm<UserAiSettings>({
+    load: fetchUserSettings,
+    save: patchUserSettings,
+    isEqual: (a, b) =>
+      a.enable_ai_reconciliation === b.enable_ai_reconciliation &&
+      a.enable_ai_classification === b.enable_ai_classification,
+    loadErrorMessage: "Failed to load AI settings",
+    saveErrorMessage: "Failed to save AI settings",
+  });
 
   const setField = (key: keyof UserAiSettings, value: boolean) => {
     setDraft((prev) => ({ ...(prev ?? DEFAULT_SETTINGS), [key]: value }));
   };
 
-  const handleReset = () => {
-    if (saved) setDraft(saved);
-    setError(null);
-  };
-
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!draft || submitting) return;
-    setSubmitting(true);
-    setError(null);
-    try {
-      const updated = await patchUserSettings(draft);
-      setSaved(updated);
-      setDraft(updated);
-      showToast("AI settings saved", "success");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save AI settings");
-    } finally {
-      setSubmitting(false);
-    }
+    const updated = await submit();
+    if (updated !== null) showToast("AI settings saved", "success");
   };
 
   if (loading) {
@@ -150,7 +112,7 @@ export default function AiSettingsPage() {
           <button
             type="button"
             className="btn-secondary"
-            onClick={handleReset}
+            onClick={reset}
             disabled={!isDirty || submitting}
           >
             Reset

--- a/apps/frontend/src/app/(main)/settings/general/page.tsx
+++ b/apps/frontend/src/app/(main)/settings/general/page.tsx
@@ -1,56 +1,25 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-
 import { useToast } from "@/components/ui/Toast";
 import { fetchBaseCurrency, updateBaseCurrency } from "@/lib/api";
+import { useSettingsForm } from "@/hooks/useSettingsForm";
 
 // EPIC-012 AC12.39 / #1340: edit the effective base reporting currency.
 // The backend validates the ISO 4217 code (HTTP 422 on invalid), so this
 // control stays minimal — a text input normalized to upper-case.
 export default function GeneralSettingsPage() {
   const { showToast } = useToast();
-  const [saved, setSaved] = useState<string | null>(null);
-  const [draft, setDraft] = useState<string>("");
-  const [loading, setLoading] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const loadBaseCurrency = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await fetchBaseCurrency();
-      setSaved(data.base_currency);
-      setDraft(data.base_currency);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load base currency");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    loadBaseCurrency();
-  }, [loadBaseCurrency]);
-
-  const isDirty = useMemo(() => saved !== null && draft !== saved, [saved, draft]);
+  const { draft, setDraft, loading, submitting, error, isDirty, submit, reset } = useSettingsForm<string>({
+    load: async () => (await fetchBaseCurrency()).base_currency,
+    save: async (next) => (await updateBaseCurrency(next)).base_currency,
+    loadErrorMessage: "Failed to load base currency",
+    saveErrorMessage: "Failed to save base currency",
+  });
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (submitting || !isDirty) return;
-    setSubmitting(true);
-    setError(null);
-    try {
-      const updated = await updateBaseCurrency(draft);
-      setSaved(updated.base_currency);
-      setDraft(updated.base_currency);
-      showToast("Base currency saved", "success");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save base currency");
-    } finally {
-      setSubmitting(false);
-    }
+    const updated = await submit();
+    if (updated !== null) showToast("Base currency saved", "success");
   };
 
   if (loading) {
@@ -86,7 +55,7 @@ export default function GeneralSettingsPage() {
             id="base-currency"
             aria-label="Base currency"
             type="text"
-            value={draft}
+            value={draft ?? ""}
             disabled={submitting}
             maxLength={3}
             onChange={(event) => setDraft(event.target.value.toUpperCase())}
@@ -101,10 +70,7 @@ export default function GeneralSettingsPage() {
           <button
             type="button"
             className="btn-secondary"
-            onClick={() => {
-              if (saved !== null) setDraft(saved);
-              setError(null);
-            }}
+            onClick={reset}
             disabled={!isDirty || submitting}
           >
             Reset

--- a/apps/frontend/src/components/ui/FilterTabs.tsx
+++ b/apps/frontend/src/components/ui/FilterTabs.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+interface FilterTabsProps {
+  /** The selectable filter values (rendered verbatim as the button labels). */
+  options: readonly string[];
+  /** The currently-active value. */
+  value: string;
+  onChange: (value: string) => void;
+  /** Capitalize the label (matches the journal/assets `capitalize` styling). */
+  capitalize?: boolean;
+  /** When set, renders `role="tablist"`/`role="tab"`/`aria-selected` (accessible tabs). */
+  ariaLabel?: string;
+  /** Container className override. Defaults to the shared pill-bar styling. */
+  className?: string;
+}
+
+const CONTAINER_DEFAULT = "flex gap-1 bg-[var(--background-muted)] p-1 rounded-lg w-fit";
+
+/**
+ * The segmented filter pill-bar repeated across journal / accounts / assets:
+ * a row of buttons where the active one gets the card background. Only the
+ * button markup (and its active/inactive className) was duplicated; the
+ * container styling and a11y wrapper vary per page, so they stay props.
+ */
+export function FilterTabs({
+  options,
+  value,
+  onChange,
+  capitalize = false,
+  ariaLabel,
+  className,
+}: FilterTabsProps) {
+  return (
+    <div className={className ?? CONTAINER_DEFAULT} {...(ariaLabel ? { role: "tablist", "aria-label": ariaLabel } : {})}>
+      {options.map((option) => (
+        <button
+          key={option}
+          {...(ariaLabel ? { role: "tab", "aria-selected": value === option } : {})}
+          onClick={() => onChange(option)}
+          className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${capitalize ? "capitalize " : ""}${
+            value === option
+              ? "bg-[var(--background-card)] text-[var(--foreground)]"
+              : "text-muted hover:text-[var(--foreground)]"
+          }`}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ui/FilterTabs.tsx
+++ b/apps/frontend/src/components/ui/FilterTabs.tsx
@@ -35,6 +35,7 @@ export function FilterTabs({
       {options.map((option) => (
         <button
           key={option}
+          type="button"
           {...(ariaLabel ? { role: "tab", "aria-selected": value === option } : {})}
           onClick={() => onChange(option)}
           className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${capitalize ? "capitalize " : ""}${

--- a/apps/frontend/src/hooks/useConfirmDialog.ts
+++ b/apps/frontend/src/hooks/useConfirmDialog.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/**
+ * State machine for a confirm/delete/void dialog, repeated verbatim across pages:
+ * `{open, id, loading}` plus `open(id)` / `cancel()` / `confirm(...)` handlers.
+ *
+ * `onConfirm` does the page-specific work (API call + toast + refetch). The dialog
+ * closes and resets only when `onConfirm` resolves; if it throws, the dialog stays
+ * open (so `onConfirm` should surface its own error and rethrow to keep it open).
+ * `cancel()` is a no-op while a confirm is in flight.
+ */
+export function useConfirmDialog<A extends unknown[] = []>(onConfirm: (id: string, ...args: A) => Promise<void>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [id, setId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const open = useCallback((targetId: string) => {
+    setId(targetId);
+    setIsOpen(true);
+  }, []);
+
+  const cancel = useCallback(() => {
+    if (isLoading) return;
+    setIsOpen(false);
+    setId(null);
+  }, [isLoading]);
+
+  const confirm = useCallback(
+    async (...args: A) => {
+      if (id === null) return;
+      setIsLoading(true);
+      try {
+        await onConfirm(id, ...args);
+        setIsOpen(false);
+        setId(null);
+      } catch {
+        // Keep the dialog open; onConfirm is responsible for surfacing the error.
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [id, onConfirm],
+  );
+
+  return { isOpen, id, isLoading, open, cancel, confirm };
+}

--- a/apps/frontend/src/hooks/useSettingsForm.ts
+++ b/apps/frontend/src/hooks/useSettingsForm.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+interface UseSettingsFormOptions<T> {
+  /** Load the persisted value (on mount and on `reload`). */
+  load: () => Promise<T>;
+  /** Persist the current draft; returns the new persisted value. */
+  save: (draft: T) => Promise<T>;
+  /** Dirty comparison; defaults to identity (`saved !== draft`). */
+  isEqual?: (saved: T, draft: T) => boolean;
+  loadErrorMessage?: string;
+  saveErrorMessage?: string;
+}
+
+/**
+ * The saved/draft settings form state machine repeated across the settings pages:
+ * load → keep a `saved` baseline + an editable `draft`, expose `isDirty`, and a
+ * `submit` that persists and re-baselines. State only — the page owns rendering and
+ * any success toast (it can branch on `submit()`'s return: the new value, or `null`
+ * if it no-opped/failed).
+ */
+export function useSettingsForm<T>({
+  load,
+  save,
+  isEqual,
+  loadErrorMessage = "Failed to load",
+  saveErrorMessage = "Failed to save",
+}: UseSettingsFormOptions<T>) {
+  const [saved, setSaved] = useState<T | null>(null);
+  const [draft, setDraft] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Hold the load/save callbacks in refs so the hook's own callbacks stay stable
+  // even when the caller passes inline (non-memoized) `load`/`save` — otherwise the
+  // mount effect would re-run on every render.
+  const loadRef = useRef(load);
+  loadRef.current = load;
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await loadRef.current();
+      setSaved(data);
+      setDraft(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : loadErrorMessage);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadErrorMessage]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const isDirty = useMemo(() => {
+    if (saved === null || draft === null) return false;
+    return isEqual ? !isEqual(saved, draft) : saved !== draft;
+  }, [saved, draft, isEqual]);
+
+  const submit = useCallback(async (): Promise<T | null> => {
+    if (submitting || !isDirty || draft === null) return null;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const updated = await saveRef.current(draft);
+      setSaved(updated);
+      setDraft(updated);
+      return updated;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : saveErrorMessage);
+      return null;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [submitting, isDirty, draft, saveErrorMessage]);
+
+  const reset = useCallback(() => {
+    setDraft(saved);
+    setError(null);
+  }, [saved]);
+
+  return { saved, draft, setDraft, loading, submitting, error, isDirty, submit, reset, reload };
+}


### PR DESCRIPTION
DRY sweep PR (frontend interaction-hook batch). Three duplicated interaction patterns extracted into shared abstractions.

## What

| Abstraction | Replaces | Adopted in |
|-------------|----------|------------|
| **`FilterTabs`** (`components/ui`) | the segmented filter pill-bar's duplicated active/inactive button markup | journal, accounts, assets |
| **`useConfirmDialog`** (`hooks`) | `{open,id,loading}` + open/cancel/confirm dialog state machine | journal (delete + void), accounts (delete) |
| **`useSettingsForm`** (`hooks`) | saved/draft/isDirty/loading/submitting/error machine | settings/general, settings/ai |

`FilterTabs` keeps per-page container className / `capitalize` / aria roles as props (only the repeated button is shared). `useConfirmDialog`'s `onConfirm` does the page-specific work; the dialog closes on success and stays open on error where the page wants that. `useSettingsForm` is state-only — the page keeps its success toast and branches on `submit()`'s return.

## Notable

- **`useSettingsForm` holds `load`/`save` in refs** so inline (non-memoized) callbacks don't retrigger the mount effect — a unit test caught the infinite-reload bug before this stabilization; all green now.
- Minor intentional tightening: `useConfirmDialog.cancel()` is a no-op while a confirm is in-flight (accounts previously allowed cancel mid-delete).
- **settings/llm deliberately deferred** — it has extra providers/catalog state + custom merge logic; its own follow-up.

## Impact

~219 lines of duplicated per-page machinery removed; net page LOC drops (the 3 reusable abstractions add ~189).

## Verification

- `eslint` + `tsc --noEmit` clean.
- **1008** frontend vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)