### PR TITLE
[finance_report_ui] Add readme.md + todo.md to value packages (package-model parity)

### DIFF
--- a/common/money/readme.md
+++ b/common/money/readme.md
@@ -1,0 +1,58 @@
+# `money` — Decimal money value language (platform package)
+
+> The money/currency/FX value type. Model spec:
+> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`contract.py`](./contract.py). Language-neutral interface + conformance:
+> [`contract/money.contract.md`](./contract/money.contract.md) +
+> [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
+> [`todo.md`](./todo.md).
+>
+> A **kernel-style value language**, but classed **`platform`** because it imports
+> the `ratio` kernel package (`MoneyTolerance` is a `Ratio`) — so it sits one
+> layer above `ratio` in the dependency DAG.
+
+## Why
+
+Money is never a `float` (the #1 red line). This package makes correct money the
+*only representable* money: a `Money` is an exact `Decimal` amount bound to a
+validated ISO-4217 `Currency`, rounded with banker's `HALF_EVEN` to the currency's
+minor unit. Cross-currency math must go through an explicit `ExchangeRate`; you
+cannot add two different currencies by accident.
+
+## Ubiquitous language
+
+- **`Money`** — an exact `Decimal` amount + a `Currency`. Float construction is
+  unrepresentable (`FloatNotAllowedError`); a mismatched-currency operation raises
+  `CurrencyMismatchError`.
+- **`Currency`** — a validated ISO-4217 code (`ISO_4217_CODES`); an invalid code
+  is unrepresentable (`InvalidCurrencyError`). `MONEY_QUANTUM` is the rounding step.
+- **`ExchangeRate`** — a directed, validated rate; `convert()` applies it and
+  rounds deterministically (`InvalidExchangeRateError` guards bad rates).
+- **`CurrencyBalances` / `CurrencyBalance`** — a multi-currency balance bag.
+- **`MoneyTolerance`** — an absolute+relative band (a `Ratio`) for "are these two
+  amounts close enough" in matching/reconciliation.
+- **wire/db adapters** — `money_{to,from}_{wire,db_fields}`,
+  `exchange_rate_{to,from}_{wire,db_fields}`, `to_money` convert at the boundary.
+
+## Public vs internal
+
+**Public** (`__all__` == `contract.interface`, 24 symbols): the types above +
+`MoneyError` and the typed errors + `convert` + the wire/db adapters. Everything
+else (`guard.py`, `rounding.py` internals) is implementation detail.
+
+## Three ends, one spec
+
+`common/money/` is the canonical value language; the runtime mirrors at
+`apps/backend/src/money` (`implementations["be"]`) and
+`apps/frontend/src/lib/money` (`implementations["fe"]`) must render the *same*
+behaviour. Drift is prevented by the shared `conformance/vectors.json` — both ends
+prove themselves against the same vectors.
+
+## Governance
+
+[`contract.py`](./contract.py) is validated by `tools/check_package_contract.py`:
+`interface` == the BE `__all__`, every invariant pins to a conformance test, and
+no upward/sideways import edge. The money ACs (`AC2.19.x` / `AC2.20.x`) are still
+owned by the EPIC-002 table; moving that AC ownership into the contract `roadmap`
+(so the contract is the single source) is a tracked follow-up — see
+[`todo.md`](./todo.md).

--- a/common/money/todo.md
+++ b/common/money/todo.md
@@ -1,0 +1,23 @@
+# `money` — todo
+
+The package-local worklist. Cross-package migration lives in
+[`../todo.md`](../todo.md).
+
+## Done
+
+- [x] Decimal-only money/currency/FX value language with banker's rounding and
+      explicit `ExchangeRate` conversion.
+- [x] Three-end parity (`common/` canonical + BE/FE mirrors) enforced by
+      `conformance/vectors.json`.
+- [x] Migrated to the package model: ships `contract.py`, governed by
+      `check_package_contract` (interface == `__all__`, DAG, invariants).
+
+## Next
+
+- [ ] Move the money ACs (`AC2.19.x` / `AC2.20.x`) out of the EPIC-002 table into
+      the contract `roadmap`, so the contract is the single AC source (the model
+      forbids mirroring an AC into both an EPIC and a roadmap).
+- [ ] Resolve the class question with the package-model owners: `money` is classed
+      `platform` because it imports `ratio`; either accept that or remove the
+      `ratio` dependency to make it a true `kernel` leaf (and fix the
+      `governance/readme.md` "kernel: money, ratio, quantity" example).

--- a/common/quantity/readme.md
+++ b/common/quantity/readme.md
@@ -1,0 +1,48 @@
+# `quantity` — Decimal quantity + unit value language (platform package)
+
+> The quantity/unit value type. Model spec:
+> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`contract.py`](./contract.py). Language-neutral interface + conformance:
+> [`contract/quantity.contract.md`](./contract/quantity.contract.md) +
+> [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
+> [`todo.md`](./todo.md).
+>
+> Classed **`platform`** because it imports the `ratio` kernel package (a `Ratio`
+> can scale a `Quantity`), so it sits one layer above `ratio`.
+
+## Why
+
+A holding of "10.5 shares" or "3 units" is an exact `Decimal` amount bound to a
+`Unit` — never a float, and never silently mixing incompatible units. `Quantity`
+makes that the only representable form, with one standard quantization
+(`QUANTITY_DP` / `QUANTITY_QUANTUM` / `QUANTITY_ROUNDING`).
+
+## Ubiquitous language
+
+- **`Quantity`** — an exact `Decimal` amount + a `Unit`. Float construction is
+  unrepresentable (`FloatNotAllowedError`).
+- **`Unit`** — the validated unit of measure; an invalid unit is unrepresentable
+  (`InvalidUnitError`), and combining mismatched units raises `UnitMismatchError`.
+- **scaling** — applying a `Ratio` to a `Quantity` rounds deterministically.
+- **wire/db adapters** — `quantity_{to,from}_{wire,db_fields}` convert at the
+  boundary.
+
+## Public vs internal
+
+**Public** (`__all__` == `contract.interface`, 14 symbols): `Quantity`, `Unit`,
+the constants (`QUANTITY_DP` / `QUANTITY_QUANTUM` / `QUANTITY_ROUNDING`), the
+errors (`QuantityError`, `FloatNotAllowedError`, `InvalidQuantityPayloadError`,
+`InvalidUnitError`, `UnitMismatchError`), and the wire/db adapters.
+
+## Three ends, one spec
+
+`common/quantity/` is canonical; `apps/backend/src/quantity` and
+`apps/frontend/src/lib/quantity` mirror it, kept in sync by
+`conformance/vectors.json`.
+
+## Governance
+
+[`contract.py`](./contract.py) is validated by `tools/check_package_contract.py`
+(interface == BE `__all__`, invariants pin to conformance tests, no forbidden
+import edge). The quantity ACs (`AC12.30.x`) are still owned by EPIC-012; moving
+them into the contract `roadmap` is a tracked follow-up — see [`todo.md`](./todo.md).

--- a/common/quantity/todo.md
+++ b/common/quantity/todo.md
@@ -1,0 +1,17 @@
+# `quantity` — todo
+
+The package-local worklist. Cross-package migration lives in
+[`../todo.md`](../todo.md).
+
+## Done
+
+- [x] Decimal-only quantity + unit value language with one standard quantization.
+- [x] Three-end parity (`common/` canonical + BE/FE mirrors) enforced by
+      `conformance/vectors.json`.
+- [x] Migrated to the package model: ships `contract.py`, governed by
+      `check_package_contract`. Classed `platform` (imports `ratio`).
+
+## Next
+
+- [ ] Move the quantity ACs (`AC12.30.x`) out of the EPIC-012 table into the
+      contract `roadmap`, so the contract is the single AC source.

--- a/common/ratio/readme.md
+++ b/common/ratio/readme.md
@@ -1,0 +1,46 @@
+# `ratio` — Decimal ratio / percentage value language (kernel package)
+
+> The ratio/percentage value type. Model spec:
+> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`contract.py`](./contract.py). Language-neutral interface + conformance:
+> [`contract/ratio.contract.md`](./contract/ratio.contract.md) +
+> [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
+> [`todo.md`](./todo.md).
+>
+> A **`kernel` leaf** — it depends on nothing in the app, and is reused by
+> `money` and `quantity`.
+
+## Why
+
+Percentages drift into floats and lose precision. `Ratio` makes a proportion an
+exact `Decimal` value with one standard rendering (`PERCENT_DP` decimal places,
+`PERCENT_ROUNDING`), so "1.5%", "apply 1.5% to a base", and round-tripping a
+stored percentage are all deterministic and identical across BE and FE.
+
+## Ubiquitous language
+
+- **`Ratio`** — an exact `Decimal` proportion. Float construction is
+  unrepresentable (`FloatNotAllowedError`); an undefined ratio (e.g. divide-by-zero
+  origin) raises `UndefinedRatioError`.
+- **percent rendering** — `to_percent()` / `from_percent()` use `PERCENT_DP` +
+  `PERCENT_ROUNDING` so a percentage round-trips within the standard precision.
+- **wire/db adapters** — `ratio_{to,from}_{wire,db_value}` convert at the boundary.
+
+## Public vs internal
+
+**Public** (`__all__` == `contract.interface`, 11 symbols): `Ratio`, the constants
+`PERCENT_DP` / `PERCENT_ROUNDING`, the errors (`RatioError`, `FloatNotAllowedError`,
+`InvalidRatioPayloadError`, `UndefinedRatioError`), and the wire/db adapters.
+
+## Three ends, one spec
+
+`common/ratio/` is canonical; `apps/backend/src/ratio` and
+`apps/frontend/src/lib/ratio` mirror it. The shared `conformance/vectors.json`
+keeps the two ends from drifting.
+
+## Governance
+
+[`contract.py`](./contract.py) is validated by `tools/check_package_contract.py`
+(interface == BE `__all__`, invariants pin to conformance tests, no forbidden
+import edge). The ratio ACs (`AC12.9.x`) are still owned by EPIC-012; moving them
+into the contract `roadmap` is a tracked follow-up — see [`todo.md`](./todo.md).

--- a/common/ratio/todo.md
+++ b/common/ratio/todo.md
@@ -1,0 +1,18 @@
+# `ratio` — todo
+
+The package-local worklist. Cross-package migration lives in
+[`../todo.md`](../todo.md).
+
+## Done
+
+- [x] Decimal-only ratio/percentage value language with one standard rendering
+      (`PERCENT_DP` / `PERCENT_ROUNDING`).
+- [x] Three-end parity (`common/` canonical + BE/FE mirrors) enforced by
+      `conformance/vectors.json`.
+- [x] Migrated to the package model: ships `contract.py`, governed by
+      `check_package_contract`. Classed `kernel` (a true leaf — depends on nothing).
+
+## Next
+
+- [ ] Move the ratio ACs (`AC12.9.x`) out of the EPIC-012 table into the contract
+      `roadmap`, so the contract is the single AC source.

--- a/common/unit_price/readme.md
+++ b/common/unit_price/readme.md
@@ -23,7 +23,7 @@ checked — not a float multiply that loses precision or silently mixes currenci
   unit, quantized by `UNIT_PRICE_DP` / `UNIT_PRICE_QUANTUM` / `UNIT_PRICE_ROUNDING`.
   Float construction is unrepresentable (`FloatNotAllowedError`).
 - **product** — `UnitPrice` × `Quantity` → `Money`, rounded deterministically;
-  a currency clash raises `CurrencyMismatchError` and a unit clash
+  a currency clash raises `CurrencyMismatchError` and a unit clash raises
   `UnitMismatchError`.
 - **undefined** — an undefined unit price raises `UndefinedUnitPriceError`.
 - **wire/db adapters** — `unit_price_{to,from}_{wire,db_fields}` convert at the

--- a/common/unit_price/readme.md
+++ b/common/unit_price/readme.md
@@ -1,0 +1,52 @@
+# `unit_price` — money-per-unit value language (core package)
+
+> The unit-price value type. Model spec:
+> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`contract.py`](./contract.py). Language-neutral interface + conformance:
+> [`contract/unit_price.contract.md`](./contract/unit_price.contract.md) +
+> [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
+> [`todo.md`](./todo.md).
+>
+> Classed **`core`** because it imports the `money` and `quantity` platform
+> packages — a `UnitPrice` is money per unit, so it sits above both.
+
+## Why
+
+A price is "money per unit" (e.g. `12.34 SGD / share`). Multiplying a `UnitPrice`
+by a `Quantity` must yield `Money` deterministically, with the currency and unit
+checked — not a float multiply that loses precision or silently mixes currencies.
+`UnitPrice` makes that the only representable form.
+
+## Ubiquitous language
+
+- **`UnitPrice`** — an exact `Decimal` money-per-unit bound to a currency and a
+  unit, quantized by `UNIT_PRICE_DP` / `UNIT_PRICE_QUANTUM` / `UNIT_PRICE_ROUNDING`.
+  Float construction is unrepresentable (`FloatNotAllowedError`).
+- **product** — `UnitPrice` × `Quantity` → `Money`, rounded deterministically;
+  a currency clash raises `CurrencyMismatchError` and a unit clash
+  `UnitMismatchError`.
+- **undefined** — an undefined unit price raises `UndefinedUnitPriceError`.
+- **wire/db adapters** — `unit_price_{to,from}_{wire,db_fields}` convert at the
+  boundary.
+
+## Public vs internal
+
+**Public** (`__all__` == `contract.interface`, 14 symbols): `UnitPrice`, the
+constants, the errors (`UnitPriceError`, `FloatNotAllowedError`,
+`InvalidUnitPricePayloadError`, `UndefinedUnitPriceError`, `CurrencyMismatchError`,
+`UnitMismatchError`), and the wire/db adapters.
+
+## Ends
+
+`common/unit_price/` is canonical and mirrored at `apps/backend/src/unit_price`
+(`implementations["be"]`), kept honest by `conformance/vectors.json`. There is no
+frontend implementation yet, so `implementations["fe"]` is `None`.
+
+## Governance
+
+[`contract.py`](./contract.py) is validated by `tools/check_package_contract.py`
+(interface == BE `__all__`, invariants pin to conformance tests, no forbidden
+import edge — it may import the lower-class `money` and `quantity` packages,
+declared in `depends_on`). The unit_price ACs (`AC12.32.x`) are still owned by
+EPIC-012; moving them into the contract `roadmap` is a tracked follow-up — see
+[`todo.md`](./todo.md).

--- a/common/unit_price/todo.md
+++ b/common/unit_price/todo.md
@@ -1,0 +1,20 @@
+# `unit_price` — todo
+
+The package-local worklist. Cross-package migration lives in
+[`../todo.md`](../todo.md).
+
+## Done
+
+- [x] Decimal-only money-per-unit value language; `UnitPrice` × `Quantity` → `Money`
+      with currency/unit checks.
+- [x] Backend parity (`common/` canonical + BE mirror) enforced by
+      `conformance/vectors.json`.
+- [x] Migrated to the package model: ships `contract.py`, governed by
+      `check_package_contract`. Classed `core` (imports `money` + `quantity`).
+
+## Next
+
+- [ ] Move the unit_price ACs (`AC12.32.x`) out of the EPIC-012 table into the
+      contract `roadmap`, so the contract is the single AC source.
+- [ ] Add a frontend implementation (`apps/frontend/src/lib/unit_price`) and set
+      `implementations["fe"]`, with FE conformance against the shared vectors.


### PR DESCRIPTION
Convention-parity follow-up to the PackageContract migration (#1374): the four value packages now match the full package shape (counter = `__init__.py` + `contract.py` + `readme.md` + `todo.md`).

## What
- Adds `readme.md` to money/ratio/quantity/unit_price — why, ubiquitous language, public surface (`__all__`), the three-end parity pattern (canonical `common/` + BE/FE mirrors kept in sync by `conformance/vectors.json`), and governance.
- Adds `todo.md` to each — records the migration done + the substantive follow-up: **move the value-type ACs (`AC2.x`/`AC12.x`) out of the EPIC-002/012 tables into the contract `roadmap`s** (the model forbids mirroring an AC into both).

## Not in scope (intentional)
- No code, `contract.py`, `.contract.md`, EPIC, or MANIFEST changes — docs only.
- Role subdirs (`types/ops/store/api`) are **not** added: a pure value type has no store/api; its flat module + conformance-vectors layout is the correct value-type shape.

## Open decision (carried from #1374)
`money`/`quantity` are classed `platform` (they import `ratio`); the `governance/readme.md` "kernel: money, ratio, quantity" example is now inaccurate. Each `todo.md` notes it. Accept money-as-platform, or refactor money off ratio to keep it a true kernel leaf.
