### PR TITLE
[finance_report_audit] refactor(currency): one canonical normalize_currency_code (DRY)

### DIFF
--- a/apps/backend/src/money/__init__.py
+++ b/apps/backend/src/money/__init__.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from src.money.balances import CurrencyBalance, CurrencyBalances
 from src.money.convert import convert
-from src.money.currency import ISO_4217_CODES, Currency
+from src.money.currency import ISO_4217_CODES, Currency, normalize_currency_code
 from src.money.errors import (
     CurrencyMismatchError,
     FloatNotAllowedError,
@@ -54,6 +54,7 @@ __all__ = [
     "MoneyError",
     "MoneyTolerance",
     "convert",
+    "normalize_currency_code",
     "exchange_rate_from_db_fields",
     "exchange_rate_from_wire",
     "exchange_rate_to_db_fields",

--- a/apps/backend/src/money/__init__.py
+++ b/apps/backend/src/money/__init__.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from src.money.balances import CurrencyBalance, CurrencyBalances
 from src.money.convert import convert
-from src.money.currency import ISO_4217_CODES, Currency, normalize_currency_code
+from src.money.currency import ISO_4217_CODES, Currency
 from src.money.errors import (
     CurrencyMismatchError,
     FloatNotAllowedError,
@@ -54,7 +54,6 @@ __all__ = [
     "MoneyError",
     "MoneyTolerance",
     "convert",
-    "normalize_currency_code",
     "exchange_rate_from_db_fields",
     "exchange_rate_from_wire",
     "exchange_rate_to_db_fields",

--- a/apps/backend/src/money/currency.py
+++ b/apps/backend/src/money/currency.py
@@ -3,15 +3,37 @@
 Construction normalizes (``strip().upper()``) and then rejects anything that is
 not an active ISO-4217 alphabetic code, so ``Currency`` cannot hold ``"US"``,
 ``"usd "`` (un-normalized), ``"XYZ"``, or ``"EURO"``. The soft
-``normalize_currency_code`` used at the Pydantic boundary only enforces length;
-this type adds the membership check the issue (#1167) requires.
+``normalize_currency_code`` below only normalizes (``strip().upper()``); this type
+adds the ISO-4217 membership check the issue (#1167) requires.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, overload
 
 from src.money.errors import InvalidCurrencyError
+
+
+@overload
+def normalize_currency_code(value: str) -> str: ...
+
+
+@overload
+def normalize_currency_code(value: Any) -> Any: ...
+
+
+def normalize_currency_code(value: Any) -> Any:
+    """Canonical soft normalization of an ISO-4217 code: ``strip().upper()``.
+
+    Single source of truth for the ``str`` normalization that was duplicated as
+    inline ``.strip().upper()`` across services/routers and re-defined in
+    ``schemas.base`` and ``fx``. Non-``str`` values pass through unchanged so
+    downstream validation (Pydantic, :class:`Currency`) raises its own type error.
+    This is the *soft* form (no membership check); :class:`Currency` adds that.
+    """
+    return value.strip().upper() if isinstance(value, str) else value
+
 
 # Active ISO-4217 alphabetic codes. Deliberately a static, dependency-light set
 # (no network / no third-party package) so the backend money module stays importable

--- a/apps/backend/src/schemas/base.py
+++ b/apps/backend/src/schemas/base.py
@@ -1,31 +1,16 @@
 """Base schema classes and generic types."""
 
 from decimal import Decimal
-from typing import Annotated, Any, Generic, TypeVar, overload
+from typing import Annotated, Generic, TypeVar
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
+# Canonical currency normalizer lives in the money layer; re-exported here so
+# existing ``from src.schemas.base import normalize_currency_code`` callers and the
+# ``CurrencyCode`` BeforeValidator keep working off the single source of truth.
+from src.money.currency import normalize_currency_code
+
 T = TypeVar("T")
-
-
-@overload
-def normalize_currency_code(value: str) -> str: ...
-
-
-@overload
-def normalize_currency_code(value: Any) -> Any: ...
-
-
-def normalize_currency_code(value: Any) -> Any:
-    """Normalize an ISO-4217 currency code to its canonical upper-case form.
-
-    Single source of truth for the soft ``.strip().upper()`` currency
-    normalization that was previously duplicated across routers/services.
-    Used as a Pydantic ``BeforeValidator``, so it must accept arbitrary input:
-    non-``str`` values are passed through unchanged so Pydantic raises its own
-    type error. The ``str`` overload keeps direct callers typed as ``str``.
-    """
-    return value.strip().upper() if isinstance(value, str) else value
 
 
 # Reusable typed ISO-4217 currency code: a 3-letter, upper-cased ``str``.

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -240,13 +240,13 @@ async def post_opening_balance_entry(
     # Imported lazily so importing this module stays free of the FastAPI/util
     # dependency graph (tooling tests import accounting without those installed).
     from src.ledger import Entry, Leg
-    from src.money import Money, to_money
+    from src.money import Money, normalize_currency_code, to_money
     from src.services.account_service import get_or_create_opening_balance_equity_account
 
     if not balances:
         raise ValidationError("At least one opening balance is required")
 
-    normalized_currency = currency.strip().upper()
+    normalized_currency = normalize_currency_code(currency)
     account_ids = list(balances.keys())
     result = await db.execute(select(Account).where(Account.id.in_(account_ids), Account.user_id == user_id))
     accounts = {account.id: account for account in result.scalars().all()}
@@ -261,7 +261,7 @@ async def post_opening_balance_entry(
     if system_targets:
         raise ValidationError(f"Opening balances cannot target system accounts: {system_targets}")
 
-    base_currency = settings.base_currency.strip().upper()
+    base_currency = normalize_currency_code(settings.base_currency)
     if normalized_currency != base_currency:
         raise ValidationError(
             f"Opening balances are supported only in the base currency ({base_currency}); got {normalized_currency}."
@@ -293,7 +293,7 @@ async def post_opening_balance_entry(
         if amount <= Decimal("0"):
             raise ValidationError("Opening balance amounts must be positive")
         account = accounts[account_id]
-        if (account.currency or "").strip().upper() != normalized_currency:
+        if normalize_currency_code(account.currency or "") != normalized_currency:
             raise ValidationError(
                 f"Opening balance currency {normalized_currency} does not match the currency "
                 f"of account {account_id} ({account.currency}); lines must not be mis-stamped."

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -240,7 +240,8 @@ async def post_opening_balance_entry(
     # Imported lazily so importing this module stays free of the FastAPI/util
     # dependency graph (tooling tests import accounting without those installed).
     from src.ledger import Entry, Leg
-    from src.money import Money, normalize_currency_code, to_money
+    from src.money import Money, to_money
+    from src.money.currency import normalize_currency_code
     from src.services.account_service import get_or_create_opening_balance_equity_account
 
     if not balances:

--- a/apps/backend/src/services/annualized_income.py
+++ b/apps/backend/src/services/annualized_income.py
@@ -20,7 +20,8 @@ from src.models.layer3 import (
     ManualValuationLiquidityClass,
     ManualValuationSnapshot,
 )
-from src.money import normalize_currency_code, to_money
+from src.money import to_money
+from src.money.currency import normalize_currency_code
 from src.schemas import (
     AnnualizedIncomeScheduleHolding,
     AnnualizedIncomeScheduleIncome,

--- a/apps/backend/src/services/annualized_income.py
+++ b/apps/backend/src/services/annualized_income.py
@@ -20,7 +20,7 @@ from src.models.layer3 import (
     ManualValuationLiquidityClass,
     ManualValuationSnapshot,
 )
-from src.money import to_money
+from src.money import normalize_currency_code, to_money
 from src.schemas import (
     AnnualizedIncomeScheduleHolding,
     AnnualizedIncomeScheduleIncome,
@@ -58,7 +58,7 @@ async def generate_annualized_income_schedule(
         "dividend": Decimal("0.00"),
         "total": Decimal("0.00"),
     }
-    currency = settings.base_currency.strip().upper()
+    currency = normalize_currency_code(settings.base_currency)
     for line, account in income_result.all():
         # Currency is the line's own, resolved via the single base-currency SSOT
         # (the previous per-site account/target fallback chain is dropped — only the

--- a/apps/backend/src/services/fx.py
+++ b/apps/backend/src/services/fx.py
@@ -12,7 +12,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.config import settings
 from src.logger import get_logger
 from src.models import FxRate
-from src.money import ExchangeRate, Money, MoneyError, convert as _money_convert, normalize_currency_code
+from src.money import ExchangeRate, Money, MoneyError, convert as _money_convert
+from src.money.currency import normalize_currency_code
 
 logger = get_logger(__name__)
 

--- a/apps/backend/src/services/fx.py
+++ b/apps/backend/src/services/fx.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.config import settings
 from src.logger import get_logger
 from src.models import FxRate
-from src.money import ExchangeRate, Money, MoneyError, convert as _money_convert
+from src.money import ExchangeRate, Money, MoneyError, convert as _money_convert, normalize_currency_code
 
 logger = get_logger(__name__)
 
@@ -78,10 +78,6 @@ def clear_fx_cache() -> None:
     _cache._store.clear()
 
 
-def _normalize_currency(code: str) -> str:
-    return code.strip().upper()
-
-
 def _append_fx_warning(fx_warnings: list[FxWarning] | None, warning: FxWarning) -> None:
     if fx_warnings is not None and warning not in fx_warnings:
         fx_warnings.append(warning)
@@ -103,8 +99,8 @@ async def get_exchange_rate(
     lazy_load: bool = False,
 ) -> Decimal:
     """Get FX rate for a given date, falling back to the most recent prior rate."""
-    base = _normalize_currency(base_currency)
-    quote = _normalize_currency(quote_currency)
+    base = normalize_currency_code(base_currency)
+    quote = normalize_currency_code(quote_currency)
 
     if base == quote:
         return Decimal("1")
@@ -151,8 +147,8 @@ async def get_average_rate(
     lazy_load: bool = False,
 ) -> Decimal:
     """Get average FX rate over a period, falling back to period-end rate."""
-    base = _normalize_currency(base_currency)
-    quote = _normalize_currency(quote_currency)
+    base = normalize_currency_code(base_currency)
+    quote = normalize_currency_code(quote_currency)
 
     if base == quote:
         return Decimal("1")
@@ -218,8 +214,8 @@ async def convert_amount(
     lazy_load: bool = False,
 ) -> Decimal:
     """Convert an amount into the target currency using FX rates."""
-    source = _normalize_currency(currency)
-    target = _normalize_currency(target_currency)
+    source = normalize_currency_code(currency)
+    target = normalize_currency_code(target_currency)
 
     if source == target:
         return amount
@@ -304,8 +300,8 @@ class PrefetchedFxRates:
         average_start: date | None = None,
         average_end: date | None = None,
     ) -> Decimal | None:
-        base = _normalize_currency(base)
-        quote = _normalize_currency(quote)
+        base = normalize_currency_code(base)
+        quote = normalize_currency_code(quote)
         if base == quote:
             return Decimal("1")
 
@@ -324,8 +320,8 @@ class PrefetchedFxRates:
         average_start: date | None = None,
         average_end: date | None = None,
     ) -> None:
-        base = _normalize_currency(base)
-        quote = _normalize_currency(quote)
+        base = normalize_currency_code(base)
+        quote = normalize_currency_code(quote)
         if average_start and average_end:
             key = f"avg:{base}:{quote}:{average_start.isoformat()}:{average_end.isoformat()}"
         else:

--- a/apps/backend/src/services/report_package.py
+++ b/apps/backend/src/services/report_package.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from src.config import settings
 from src.models.layer4 import ReportSnapshot
-from src.money import normalize_currency_code
+from src.money.currency import normalize_currency_code
 from src.schemas import (
     PersonalReportPackageSnapshotResponse,
     PersonalReportPackageSnapshotStatus,

--- a/apps/backend/src/services/report_package.py
+++ b/apps/backend/src/services/report_package.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 from src.config import settings
 from src.models.layer4 import ReportSnapshot
+from src.money import normalize_currency_code
 from src.schemas import (
     PersonalReportPackageSnapshotResponse,
     PersonalReportPackageSnapshotStatus,
@@ -56,7 +57,7 @@ def package_dates(
 
 
 def package_currency(currency: str | None) -> str:
-    return (currency or settings.base_currency).strip().upper()
+    return normalize_currency_code(currency or settings.base_currency)
 
 
 def package_snapshot_status(readiness: dict[str, Any]) -> PersonalReportPackageSnapshotStatus:

--- a/apps/backend/src/services/statement_posting.py
+++ b/apps/backend/src/services/statement_posting.py
@@ -23,7 +23,7 @@ from src.models import (
 )
 from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
-from src.money import normalize_currency_code
+from src.money.currency import normalize_currency_code
 from src.services.review_queue import create_entry_from_txn
 from src.services.source_type_priority import STATEMENT_SOURCE_TYPES, promote_entry_source_type
 from src.services.statement_validation import approve_statement, resolve_statement_transactions

--- a/apps/backend/src/services/statement_posting.py
+++ b/apps/backend/src/services/statement_posting.py
@@ -23,6 +23,7 @@ from src.models import (
 )
 from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
+from src.money import normalize_currency_code
 from src.services.review_queue import create_entry_from_txn
 from src.services.source_type_priority import STATEMENT_SOURCE_TYPES, promote_entry_source_type
 from src.services.statement_validation import approve_statement, resolve_statement_transactions
@@ -104,7 +105,7 @@ async def resolve_statement_posting_account(
     user_id: UUID,
 ) -> Account:
     """Resolve the asset account for automatic posting without generic fallback."""
-    currency = (statement.currency or "").strip().upper()
+    currency = normalize_currency_code(statement.currency or "")
     if not currency:
         raise ValueError("Statement currency required before posting. Confirm the source currency before posting.")
 
@@ -179,7 +180,7 @@ async def validate_statement_period_unique(
     if statement.period_start > statement.period_end:
         raise ValueError("Statement period is invalid. Confirm the source date range before posting.")
 
-    currency = (statement.currency or "").strip().upper()
+    currency = normalize_currency_code(statement.currency or "")
     if not currency:
         raise ValueError("Statement currency required before posting. Confirm the source currency before posting.")
 


### PR DESCRIPTION
DRY sweep PR (#2 of the currency + small-UI batch). The soft ISO-4217 string normalization (`strip().upper()`) had **three** independent definitions plus scattered inline copies.

## What

Established one canonical `normalize_currency_code` in the money layer (`src/money/currency.py`, re-exported from `src.money`), and pointed everything at it:

- **`schemas/base`** re-exports it (the `CurrencyCode` BeforeValidator and `from src.schemas.base import normalize_currency_code` callers keep working).
- **`fx`** drops its private `_normalize_currency` wrapper for the shared one (10 call sites).
- Verified currency sites in **accounting** (3), **annualized_income** (1), **statement_posting** (2), **report_package** (1) call it instead of inline `.strip().upper()`.

## Behaviour-preserving

The canonical fn is exactly `value.strip().upper() if isinstance(value, str) else value` — identical to every definition it replaces.

## Scoped to currency only

Asset-identifier / symbol `.strip().upper()` (framework_policy, report_readiness `asset_identifiers`, brokerage `… or "*"`, validation) are a **different concept** and deliberately left untouched — the agent's raw "41 sites" conflated currency with symbols.

## Verification

- **704** accounting/reporting/services + **271** fx/currency/money tests pass.
- Pinned `ruff check` clean.
- Note: preflight's `schema-validate` (98 missing-`description` warnings) and `backend-format` (PATH-ruff version skew) are **pre-existing — identical count on `main`**, not from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)