### PR TITLE
[finance_report_audit] refactor(frontend): StatusBadge for status→variant badges (DRY)

### DIFF
--- a/apps/frontend/src/app/(main)/assets/page.tsx
+++ b/apps/frontend/src/app/(main)/assets/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { useToast } from "@/components/ui/Toast";
-import { TableSkeleton } from "@/components/ui";
+import { StatusBadge, TableSkeleton } from "@/components/ui";
 import { FilterTabs } from "@/components/ui/FilterTabs";
 import { apiFetch } from "@/lib/api";
 import { formatCurrencyLocale, parseAmount } from "@/lib/money";
@@ -467,9 +467,7 @@ export default function AssetsPage() {
                                             <div className="flex-1 min-w-0">
                                                 <div className="flex items-center gap-2">
                                                     <span className="font-medium font-mono">{position.asset_identifier}</span>
-                                                    <span className={`badge ${position.status === "active" ? "badge-success" : "badge-muted"}`}>
-                                                        {position.status}
-                                                    </span>
+                                                    <StatusBadge status={position.status} variants={{ active: "success" }} />
                                                 </div>
                                                 <div className="text-xs text-muted mt-0.5">
                                                     Acquired: {formatDateDisplay(position.acquisition_date)}

--- a/apps/frontend/src/app/(main)/journal/page.tsx
+++ b/apps/frontend/src/app/(main)/journal/page.tsx
@@ -8,7 +8,7 @@ import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { FilterTabs } from "@/components/ui/FilterTabs";
 import ConfidenceBadge from "@/components/ui/ConfidenceBadge";
-import { EmptyState, LoadingState } from "@/components/ui";
+import { EmptyState, LoadingState, StatusBadge } from "@/components/ui";
 import { useToast } from "@/components/ui/Toast";
 import { apiFetch } from "@/lib/api";
 import { formatCurrencyLocale, sumAmounts } from "@/lib/money";
@@ -163,13 +163,10 @@ export default function JournalPage() {
                                         <div className="flex-1 min-w-0">
                                             <div className="flex items-center gap-2 mb-1">
                                                 <span className="font-medium truncate">{entry.memo}</span>
-                                                <span className={`badge ${entry.status === "posted" ? "badge-success" :
-                                                    entry.status === "reconciled" ? "badge-primary" :
-                                                        entry.status === "void" ? "badge-error" :
-                                                            "badge-muted"
-                                                    }`}>
-                                                    {entry.status}
-                                                </span>
+                                                <StatusBadge
+                                                    status={entry.status}
+                                                    variants={{ posted: "success", reconciled: "primary", void: "error" }}
+                                                />
                                             </div>
                                             <div className="flex items-center gap-3 text-xs text-muted">
                                                 <span>{formatDateDisplay(entry.entry_date)}</span>

--- a/apps/frontend/src/app/(main)/statements/[id]/_components/StatementHeader.tsx
+++ b/apps/frontend/src/app/(main)/statements/[id]/_components/StatementHeader.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { BankStatement } from "@/lib/types";
+import { StatusBadge } from "@/components/ui";
 
 interface StatementHeaderProps {
     statement: BankStatement;
@@ -32,14 +33,10 @@ export function StatementHeader({
             <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-3 mb-2">
                     <h1 className="page-title truncate">{statement.original_filename}</h1>
-                    <span className={`badge ${
-                        statement.status === "approved" ? "badge-success" :
-                        statement.status === "rejected" ? "badge-error" :
-                        statement.status === "parsed" ? "badge-warning" :
-                        "badge-muted"
-                    }`}>
-                        {statement.status}
-                    </span>
+                    <StatusBadge
+                        status={statement.status}
+                        variants={{ approved: "success", rejected: "error", parsed: "warning" }}
+                    />
                 </div>
                 <p className="page-description">
                     {statement.institution} • {formatCode(statement.currency)} • {formatPeriod(statement.period_start, statement.period_end)}

--- a/apps/frontend/src/app/(main)/statements/[id]/_components/StatementTransactionsTable.tsx
+++ b/apps/frontend/src/app/(main)/statements/[id]/_components/StatementTransactionsTable.tsx
@@ -1,5 +1,6 @@
 import { BankStatement, BankStatementTransaction } from "@/lib/types";
 import { formatCurrencyLocale } from "@/lib/money";
+import { StatusBadge } from "@/components/ui";
 
 interface StatementTransactionsTableProps {
     statement: BankStatement;
@@ -52,22 +53,17 @@ export function StatementTransactionsTable({ statement }: StatementTransactionsT
                                     <td className="px-4 py-3 whitespace-nowrap text-sm text-[var(--foreground-muted)]">{txn.currency || "—"}</td>
                                     <td className="px-4 py-3 whitespace-nowrap text-sm text-[var(--foreground-muted)]">{txn.balance_after != null ? formatCurrencyLocale(txn.balance_after, (txn.currency ?? statement.currency) || "SGD") : "—"}</td>
                                     <td className="px-4 py-3 text-center">
-                                        <span className={`badge ${
-                                            txn.confidence === "high" ? "badge-success" :
-                                            txn.confidence === "medium" ? "badge-warning" :
-                                            "badge-error"
-                                        }`}>
-                                            {txn.confidence}
-                                        </span>
+                                        <StatusBadge
+                                            status={txn.confidence}
+                                            variants={{ high: "success", medium: "warning" }}
+                                            fallback="error"
+                                        />
                                     </td>
                                     <td className="px-4 py-3 text-center">
-                                        <span className={`badge ${
-                                            txn.status === "matched" ? "badge-success" :
-                                            txn.status === "unmatched" ? "badge-error" :
-                                            "badge-muted"
-                                        }`}>
-                                            {txn.status}
-                                        </span>
+                                        <StatusBadge
+                                            status={txn.status}
+                                            variants={{ matched: "success", unmatched: "error" }}
+                                        />
                                     </td>
                                 </tr>
                             ))}

--- a/apps/frontend/src/components/ui/index.tsx
+++ b/apps/frontend/src/components/ui/index.tsx
@@ -78,6 +78,28 @@ export function Badge({ variant = "muted", className, ...props }: BadgeProps) {
   return <span className={cx("badge", badgeClasses[variant], className)} {...props} />;
 }
 
+interface StatusBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  /** The status value to render (also the default label). */
+  status: string;
+  /** Maps a status value to a badge variant. */
+  variants: Record<string, BadgeVariant>;
+  /** Variant for a status not present in `variants` (default "muted"). */
+  fallback?: BadgeVariant;
+}
+
+/**
+ * A `Badge` whose variant is derived from a status value — replaces the
+ * `badge ${x === "a" ? "badge-success" : …}` ternary chains repeated across pages.
+ * Renders the status as the label unless `children` is provided.
+ */
+export function StatusBadge({ status, variants, fallback = "muted", children, ...props }: StatusBadgeProps) {
+  return (
+    <Badge variant={variants[status] ?? fallback} {...props}>
+      {children ?? status}
+    </Badge>
+  );
+}
+
 type AlertVariant = "error" | "success" | "warning" | "info";
 
 interface AlertProps extends HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
DRY sweep PR (#4 of the currency + small-UI batch). Five badge ternary chains mapped a status to a color inline.

## What

Added a thin **`StatusBadge`** (wraps the existing `Badge`) taking a `status` value + a `{value: variant}` map + `fallback`, replacing `<span className={`badge ${x === "a" ? "badge-success" : …}`}>` chains:

- journal entry status, statement status (`StatementHeader`), txn confidence + txn status (`StatementTransactionsTable`), position status (assets).

## Behaviour-preserving

`StatusBadge` renders the same `<span class="badge badge-X">` that `Badge` does; the status string stays the label. Each call site declares its own value→variant map (the part that legitimately differs per page).

## Verification

- `eslint` + `tsc --noEmit` clean.
- **1008** frontend vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)