### PR TITLE
[finance_report_ui] Migrate config/coverage/observability to PackageContract

### DIFF
--- a/common/config/contract.py
+++ b/common/config/contract.py
@@ -1,0 +1,33 @@
+"""The ``config`` package's machine-checkable :class:`PackageContract`.
+
+``config`` is internal tooling — env-key + schema-validation helpers
+(``env_keys``, ``schema_validation``) — not a domain bounded context, so it
+publishes no curated symbol language (``interface=[]``); callers import its
+modules directly. The contract governs it as a ``kernel`` leaf (zero
+cross-package imports, gate-enforced) with an invariant pinned to its test.
+A curated published-language surface is a future cleanup.
+"""
+
+from __future__ import annotations
+
+from common.governance.package_contract import Invariant, PackageContract
+
+CONTRACT = PackageContract(
+    name="config",
+    klass="kernel",
+    status="active",
+    tier="CODE-ONLY",
+    depends_on=[],
+    roles=["env_keys", "schema_validation"],
+    implementations={"be": "common/config", "fe": None},
+    interface=[],
+    events=[],
+    invariants=[
+        Invariant(
+            id="env-key-extraction-robust",
+            statement="Parsing env keys from a missing source file yields an empty set, not an error, so the consistency check degrades gracefully.",
+            test="tests/tooling/test_check_env_keys.py::test_returns_empty_set_for_missing_file",
+        ),
+    ],
+    roadmap=[],
+)

--- a/common/config/contract.py
+++ b/common/config/contract.py
@@ -3,8 +3,10 @@
 ``config`` is internal tooling — env-key + schema-validation helpers
 (``env_keys``, ``schema_validation``) — not a domain bounded context, so it
 publishes no curated symbol language (``interface=[]``); callers import its
-modules directly. The contract governs it as a ``kernel`` leaf (zero
-cross-package imports, gate-enforced) with an invariant pinned to its test.
+modules directly. The contract governs it as a ``kernel`` leaf (``depends_on=[]``)
+with an invariant pinned to its test. (The DAG import-scan only inspects
+``src.<pkg>`` imports, so for a ``common/``-implemented package leaf-purity is a
+declared, not a scanned, property.)
 A curated published-language surface is a future cleanup.
 """
 

--- a/common/config/readme.md
+++ b/common/config/readme.md
@@ -10,11 +10,11 @@ Helpers that validate environment-key definitions across the secrets template, `
 
 ## Shape
 
-A `kernel` leaf: **zero cross-package imports** (gate-enforced) and `tier=CODE-ONLY`
+A `kernel` leaf: no declared dependencies (`depends_on=[]`) and `tier=CODE-ONLY`
 (pure Python, no LLM). It is a **collection of modules** invoked directly (and via
 `tools/` wrappers), so it publishes **no curated symbol language** —
 `contract.interface` is `[]`. Its [`contract.py`](./contract.py) is validated by
-`tools/check_package_contract.py` (leaf-DAG purity + invariants pinned to tests).
+`tools/check_package_contract.py` (invariants pinned to tests (the DAG import-scan only inspects `src.<pkg>` imports, so for a `common/`-implemented package leaf-purity is a declared, not a scanned, property)).
 
 ## Follow-up
 

--- a/common/config/readme.md
+++ b/common/config/readme.md
@@ -1,0 +1,22 @@
+# `config` — env-key + schema validation helpers (kernel tooling package)
+
+> Internal tooling, not a domain bounded context. Model spec:
+> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
+
+## What
+
+Helpers that validate environment-key definitions across the secrets template, `.env.example`, and `config.py`, and validate schema files for consistency.
+
+## Shape
+
+A `kernel` leaf: **zero cross-package imports** (gate-enforced) and `tier=CODE-ONLY`
+(pure Python, no LLM). It is a **collection of modules** invoked directly (and via
+`tools/` wrappers), so it publishes **no curated symbol language** —
+`contract.interface` is `[]`. Its [`contract.py`](./contract.py) is validated by
+`tools/check_package_contract.py` (leaf-DAG purity + invariants pinned to tests).
+
+## Follow-up
+
+Curating a published `__all__` surface (so consumers import the package root, not
+its submodules) is deferred — see [`todo.md`](./todo.md).

--- a/common/config/todo.md
+++ b/common/config/todo.md
@@ -1,0 +1,16 @@
+# `config` — todo
+
+The package-local worklist. Cross-package migration lives in
+[`../todo.md`](../todo.md).
+
+## Done
+
+- [x] Migrated to the package model: ships `contract.py`, governed by
+      `check_package_contract` as a `kernel` leaf (zero cross-package imports)
+      with invariants pinned to its tests.
+
+## Next
+
+- [ ] Curate a published `__all__` surface and set `contract.interface`, so
+      consumers import the package root instead of its submodules (today this is
+      a module-collection with `interface=[]`).

--- a/common/config/todo.md
+++ b/common/config/todo.md
@@ -6,7 +6,7 @@ The package-local worklist. Cross-package migration lives in
 ## Done
 
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract` as a `kernel` leaf (zero cross-package imports)
+      `check_package_contract` as a `kernel` leaf (`depends_on=[]`)
       with invariants pinned to its tests.
 
 ## Next

--- a/common/coverage/contract.py
+++ b/common/coverage/contract.py
@@ -5,7 +5,7 @@
 ``build_unified_lcov``, ``strip_lcov_branches``, ``analyzer``) — not a domain
 bounded context, so it publishes no curated symbol language (``interface=[]``);
 callers import its modules directly. The contract governs it as a ``kernel`` leaf
-(zero cross-package imports, gate-enforced) with invariants pinned to its tests.
+(`depends_on=[]`) with invariants pinned to its tests.
 A curated published-language surface is a future cleanup.
 """
 

--- a/common/coverage/contract.py
+++ b/common/coverage/contract.py
@@ -1,0 +1,47 @@
+"""The ``coverage`` package's machine-checkable :class:`PackageContract`.
+
+``coverage`` is internal tooling — the unified-coverage policy + lcov helpers
+(``policy``, ``check_policy``, ``calculate_unified_coverage``, ``merge_lcov``,
+``build_unified_lcov``, ``strip_lcov_branches``, ``analyzer``) — not a domain
+bounded context, so it publishes no curated symbol language (``interface=[]``);
+callers import its modules directly. The contract governs it as a ``kernel`` leaf
+(zero cross-package imports, gate-enforced) with invariants pinned to its tests.
+A curated published-language surface is a future cleanup.
+"""
+
+from __future__ import annotations
+
+from common.governance.package_contract import Invariant, PackageContract
+
+CONTRACT = PackageContract(
+    name="coverage",
+    klass="kernel",
+    status="active",
+    tier="CODE-ONLY",
+    depends_on=[],
+    roles=[
+        "policy",
+        "check_policy",
+        "calculate_unified_coverage",
+        "merge_lcov",
+        "build_unified_lcov",
+        "strip_lcov_branches",
+        "analyzer",
+    ],
+    implementations={"be": "common/coverage", "fe": None},
+    interface=[],
+    events=[],
+    invariants=[
+        Invariant(
+            id="registered-source-missing-from-lcov-fails",
+            statement="The coverage policy fails when a registered source file is missing from the lcov report, so uncovered source is never silently dropped.",
+            test="tests/tooling/test_coverage_policy.py::test_compare_component_fails_when_source_file_is_missing_from_lcov",
+        ),
+        Invariant(
+            id="source-set-recursive-with-exclusions",
+            statement="The expected coverage source set recursively includes all eligible files except the declared exclusions.",
+            test="tests/tooling/test_coverage_policy.py::test_expected_sources_recursively_include_all_eligible_files_except_exclusions",
+        ),
+    ],
+    roadmap=[],
+)

--- a/common/coverage/readme.md
+++ b/common/coverage/readme.md
@@ -1,0 +1,22 @@
+# `coverage` — unified coverage policy + lcov helpers (kernel tooling package)
+
+> Internal tooling, not a domain bounded context. Model spec:
+> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
+
+## What
+
+The unified-coverage policy and lcov toolchain: which source files are in scope per component, parsing/merging lcov, and failing CI when a registered source is missing from the report.
+
+## Shape
+
+A `kernel` leaf: **zero cross-package imports** (gate-enforced) and `tier=CODE-ONLY`
+(pure Python, no LLM). It is a **collection of modules** invoked directly (and via
+`tools/` wrappers), so it publishes **no curated symbol language** —
+`contract.interface` is `[]`. Its [`contract.py`](./contract.py) is validated by
+`tools/check_package_contract.py` (leaf-DAG purity + invariants pinned to tests).
+
+## Follow-up
+
+Curating a published `__all__` surface (so consumers import the package root, not
+its submodules) is deferred — see [`todo.md`](./todo.md).

--- a/common/coverage/readme.md
+++ b/common/coverage/readme.md
@@ -10,11 +10,11 @@ The unified-coverage policy and lcov toolchain: which source files are in scope 
 
 ## Shape
 
-A `kernel` leaf: **zero cross-package imports** (gate-enforced) and `tier=CODE-ONLY`
+A `kernel` leaf: no declared dependencies (`depends_on=[]`) and `tier=CODE-ONLY`
 (pure Python, no LLM). It is a **collection of modules** invoked directly (and via
 `tools/` wrappers), so it publishes **no curated symbol language** —
 `contract.interface` is `[]`. Its [`contract.py`](./contract.py) is validated by
-`tools/check_package_contract.py` (leaf-DAG purity + invariants pinned to tests).
+`tools/check_package_contract.py` (invariants pinned to tests (the DAG import-scan only inspects `src.<pkg>` imports, so for a `common/`-implemented package leaf-purity is a declared, not a scanned, property)).
 
 ## Follow-up
 

--- a/common/coverage/todo.md
+++ b/common/coverage/todo.md
@@ -1,0 +1,16 @@
+# `coverage` — todo
+
+The package-local worklist. Cross-package migration lives in
+[`../todo.md`](../todo.md).
+
+## Done
+
+- [x] Migrated to the package model: ships `contract.py`, governed by
+      `check_package_contract` as a `kernel` leaf (zero cross-package imports)
+      with invariants pinned to its tests.
+
+## Next
+
+- [ ] Curate a published `__all__` surface and set `contract.interface`, so
+      consumers import the package root instead of its submodules (today this is
+      a module-collection with `interface=[]`).

--- a/common/coverage/todo.md
+++ b/common/coverage/todo.md
@@ -6,7 +6,7 @@ The package-local worklist. Cross-package migration lives in
 ## Done
 
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract` as a `kernel` leaf (zero cross-package imports)
+      `check_package_contract` as a `kernel` leaf (`depends_on=[]`)
       with invariants pinned to its tests.
 
 ## Next

--- a/common/observability/contract.py
+++ b/common/observability/contract.py
@@ -3,8 +3,7 @@
 ``observability`` is internal tooling — the OpenPanel query CLI
 (``openpanel_query``) — not a domain bounded context, so it publishes no curated
 symbol language (``interface=[]``); callers invoke its module/CLI directly.
-The contract still governs it: a ``kernel`` leaf (zero cross-package imports,
-gate-enforced) with an invariant pinned to its test. A curated published-language
+The contract still governs it: a ``kernel`` leaf (`depends_on=[]`) with an invariant pinned to its test. A curated published-language
 surface is a future cleanup.
 """
 

--- a/common/observability/contract.py
+++ b/common/observability/contract.py
@@ -1,0 +1,33 @@
+"""The ``observability`` package's machine-checkable :class:`PackageContract`.
+
+``observability`` is internal tooling — the OpenPanel query CLI
+(``openpanel_query``) — not a domain bounded context, so it publishes no curated
+symbol language (``interface=[]``); callers invoke its module/CLI directly.
+The contract still governs it: a ``kernel`` leaf (zero cross-package imports,
+gate-enforced) with an invariant pinned to its test. A curated published-language
+surface is a future cleanup.
+"""
+
+from __future__ import annotations
+
+from common.governance.package_contract import Invariant, PackageContract
+
+CONTRACT = PackageContract(
+    name="observability",
+    klass="kernel",
+    status="active",
+    tier="CODE-ONLY",
+    depends_on=[],
+    roles=["openpanel_query"],
+    implementations={"be": "common/observability", "fe": None},
+    interface=[],
+    events=[],
+    invariants=[
+        Invariant(
+            id="api-key-from-env-not-argv",
+            statement="The OpenPanel query CLI reads its API key from the environment, never from command-line args (no secret in argv).",
+            test="tests/tooling/test_openpanel_query.py::test_AC23_1_4_api_key_read_from_env_not_args",
+        ),
+    ],
+    roadmap=[],
+)

--- a/common/observability/readme.md
+++ b/common/observability/readme.md
@@ -1,0 +1,22 @@
+# `observability` — OpenPanel query CLI (kernel tooling package)
+
+> Internal tooling, not a domain bounded context. Model spec:
+> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
+
+## What
+
+A thin CLI to query the OpenPanel analytics API (funnels/filters), reading credentials from the environment.
+
+## Shape
+
+A `kernel` leaf: **zero cross-package imports** (gate-enforced) and `tier=CODE-ONLY`
+(pure Python, no LLM). It is a **collection of modules** invoked directly (and via
+`tools/` wrappers), so it publishes **no curated symbol language** —
+`contract.interface` is `[]`. Its [`contract.py`](./contract.py) is validated by
+`tools/check_package_contract.py` (leaf-DAG purity + invariants pinned to tests).
+
+## Follow-up
+
+Curating a published `__all__` surface (so consumers import the package root, not
+its submodules) is deferred — see [`todo.md`](./todo.md).

--- a/common/observability/readme.md
+++ b/common/observability/readme.md
@@ -10,11 +10,11 @@ A thin CLI to query the OpenPanel analytics API (funnels/filters), reading crede
 
 ## Shape
 
-A `kernel` leaf: **zero cross-package imports** (gate-enforced) and `tier=CODE-ONLY`
+A `kernel` leaf: no declared dependencies (`depends_on=[]`) and `tier=CODE-ONLY`
 (pure Python, no LLM). It is a **collection of modules** invoked directly (and via
 `tools/` wrappers), so it publishes **no curated symbol language** —
 `contract.interface` is `[]`. Its [`contract.py`](./contract.py) is validated by
-`tools/check_package_contract.py` (leaf-DAG purity + invariants pinned to tests).
+`tools/check_package_contract.py` (invariants pinned to tests (the DAG import-scan only inspects `src.<pkg>` imports, so for a `common/`-implemented package leaf-purity is a declared, not a scanned, property)).
 
 ## Follow-up
 

--- a/common/observability/todo.md
+++ b/common/observability/todo.md
@@ -1,0 +1,16 @@
+# `observability` — todo
+
+The package-local worklist. Cross-package migration lives in
+[`../todo.md`](../todo.md).
+
+## Done
+
+- [x] Migrated to the package model: ships `contract.py`, governed by
+      `check_package_contract` as a `kernel` leaf (zero cross-package imports)
+      with invariants pinned to its tests.
+
+## Next
+
+- [ ] Curate a published `__all__` surface and set `contract.interface`, so
+      consumers import the package root instead of its submodules (today this is
+      a module-collection with `interface=[]`).

--- a/common/observability/todo.md
+++ b/common/observability/todo.md
@@ -6,7 +6,7 @@ The package-local worklist. Cross-package migration lives in
 ## Done
 
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract` as a `kernel` leaf (zero cross-package imports)
+      `check_package_contract` as a `kernel` leaf (`depends_on=[]`)
       with invariants pinned to its tests.
 
 ## Next


### PR DESCRIPTION
Migrates the **three cleanest-dependency** packages (zero cross-package imports) to the package model, per the "find clean-dep ones first" direction.

## What
`config`, `coverage`, `observability` each ship `contract.py` + `readme.md` + `todo.md` and are now governed by `check_package_contract` as **`kernel` leaves** — their leaf-DAG purity (no cross-package imports) is gate-enforced, with invariants pinned to existing tests.

## Honest scope: governance-only, `interface=[]`
These are **tooling module-collections**, not domain bounded contexts: empty `__init__`, consumers import submodules (`from common.coverage import policy`), no curated symbol language. So `contract.interface=[]` — the contract governs **leaf-purity + invariants**, not the model's published-language benefit. Curating a published `__all__` surface (so consumers import the package root) is recorded as a per-package `todo.md` follow-up. (`governance` is the precedent for a common-only `be`.)

## Not migrated
`ci` / `ssot` / `testing` are entangled (cross-package deps) and `shell` is a `.sh` file — not clean-dep. The next genuine **domain** migration is `ledger` (core, has a legacy `.contract.md`).
