### PR TITLE
[finance_report_test_and_doc] docs(readme): fix stale authority-tier names left by the #1373 rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ registries, and generated reports rather than duplicated here.
 | [EPIC-023](docs/project/EPIC-023.llm-provider-abstraction.md) | LLM provider abstraction (litellm) |
 | [EPIC-024](docs/project/EPIC-024.frontend-observability.md) | Frontend browser observability |
 | [EPIC-025](docs/project/EPIC-025.dry-ssot-simplification.md) | DRY/SSOT simplification (reporting, statements, FE contracts, tests) |
-| [EPIC-026](docs/project/EPIC-026.ac-authority-tiers.md) | AC authority tiers (PC/CP/HU/LP/PL) and the tier-to-valid-proof matrix |
+| [EPIC-026](docs/project/EPIC-026.ac-authority-tiers.md) | AC authority tiers (CODE-ONLY/CODE-LED/HU/LLM-LED/LLM-ONLY) and the tier-to-valid-proof matrix |
 
 ## EPIC Status (Generated)
 


### PR DESCRIPTION
## Context

You asked whether the PC/CP/LP/PL → CODE-ONLY/CODE-LED/LLM-LED/LLM-ONLY work (#1373 rename, #1375 reconcile) left any **residue** to clean up.

I audited current `main`. The rename was thorough — **one** spot was missed.

## The residue

`README.md:112` (the EPIC index) still listed the **old** names:

```
- AC authority tiers (PC/CP/HU/LP/PL) and the tier-to-valid-proof matrix
+ AC authority tiers (CODE-ONLY/CODE-LED/HU/LLM-LED/LLM-ONLY) and the tier-to-valid-proof matrix
```

Every other reference (`docs/ssot/README.md:79`, `authority-tiers.md`, the gates, the EPIC tables) was already on the new vocabulary; this lone line was the only stale one.

## What I deliberately did **not** touch

- **`HU`** — not residue. It is the live "undecided / human-decision" code, still declared by `AC3.3.2` / `AC3.5.10` / `AC3.6.4` and mapped to `evidence` in the proof matrix.
- **`common/ssot/authority_matrix.py:20`** — the `"Renamed from the legacy PC/CP/LP/PL on 2026-06-24"` line is an intentional dated changelog of the rename, not stale residue.

Docs-only, one line, no code/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)