### PR TITLE
[finance_report_hacker] fix(reports): best-effort market-data freshness must not 500 reports (#1388)

### DIFF
--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -109,13 +109,27 @@ async def _ensure_report_market_data_fresh(
     end_date: date,
 ) -> None:
     has_report_subjects = await db.scalar(select(Account.id).where(Account.user_id == user_id).limit(1))
-    await ensure_market_data_fresh(
-        db,
-        user_id=user_id,
-        end_date=end_date,
-        include_default_fx=False,
-        extra_fx_pairs=_target_currency_pair(currency) if has_report_subjects is not None else [],
-    )
+    try:
+        await ensure_market_data_fresh(
+            db,
+            user_id=user_id,
+            end_date=end_date,
+            include_default_fx=False,
+            extra_fx_pairs=_target_currency_pair(currency) if has_report_subjects is not None else [],
+        )
+    except Exception as exc:  # noqa: BLE001 - freshness is best-effort enrichment
+        # #1388: a failed market-data/FX refresh (provider error, unresolvable
+        # symbol, malformed FX pair, network blip) must not turn report
+        # generation into a 500. The report endpoints only catch ReportError, so
+        # any other exception escaping here surfaced as an unhandled 500 the
+        # moment an account held a position. Fall back to already-stored data
+        # (possibly stale) and let the report render.
+        logger.warning(
+            "Market-data freshness sync failed; rendering report with stored data",
+            error=str(exc),
+            user_id=str(user_id),
+            end_date=str(end_date),
+        )
 
 
 @router.get("/currencies", response_model=list[str])

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import csv
 import json
 from copy import deepcopy
@@ -117,18 +118,24 @@ async def _ensure_report_market_data_fresh(
             include_default_fx=False,
             extra_fx_pairs=_target_currency_pair(currency) if has_report_subjects is not None else [],
         )
+    except asyncio.CancelledError:
+        # Never swallow cancellation (request disconnect / shutdown): let it
+        # propagate so FastAPI can unwind the request properly.
+        raise
     except Exception as exc:  # noqa: BLE001 - freshness is best-effort enrichment
         # #1388: a failed market-data/FX refresh (provider error, unresolvable
         # symbol, malformed FX pair, network blip) must not turn report
         # generation into a 500. The report endpoints only catch ReportError, so
         # any other exception escaping here surfaced as an unhandled 500 the
         # moment an account held a position. Fall back to already-stored data
-        # (possibly stale) and let the report render.
+        # (possibly stale) and let the report render. Keep the traceback
+        # (exc_info) since these failures can be hard to reproduce.
         logger.warning(
             "Market-data freshness sync failed; rendering report with stored data",
             error=str(exc),
             user_id=str(user_id),
             end_date=str(end_date),
+            exc_info=True,
         )
 
 

--- a/apps/backend/tests/repro/test_reports_500_market_data.py
+++ b/apps/backend/tests/repro/test_reports_500_market_data.py
@@ -1,0 +1,62 @@
+"""Repro for #1388 — report endpoints 500 when the market-data freshness sync raises.
+
+Synthetic data only. Found during real-machine testing of staging v0.1.19:
+every money-aggregating report returned HTTP 500 as soon as the account held a
+position, while an empty account returned 200. Root cause: the report endpoints
+call `_ensure_report_market_data_fresh` -> `ensure_market_data_fresh` (a live
+market-data/FX sync) inside a `try` that catches only `ReportError`, so any
+other failure from the sync surfaces as a 500.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture
+async def account_with_subject(db: AsyncSession, test_user):
+    """A single asset account so `_ensure_report_market_data_fresh` actually runs."""
+    from src.models.account import Account, AccountType
+
+    account = Account(
+        user_id=test_user.id,
+        name="Synthetic Brokerage",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add(account)
+    await db.commit()
+    return account
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/reports/balance-sheet",
+        "/reports/income-statement?start_date=2025-01-01&end_date=2025-12-31",
+        "/reports/cash-flow?start_date=2025-01-01&end_date=2025-12-31",
+        "/reports/net-worth/allocation",
+        "/reports/net-worth/timeseries?from=2025-01-01&to=2025-12-31",
+    ],
+)
+async def test_reports_do_not_500_when_market_data_sync_raises(
+    client: AsyncClient, account_with_subject, monkeypatch, url: str
+):
+    import src.routers.reports as reports_router
+
+    async def _raise(*args, **kwargs):
+        # Mirror a live freshness sync failing on an unresolvable ticker /
+        # malformed FX pair with something that is NOT a ReportError.
+        raise ValueError("simulated market-data sync failure (unresolvable symbol)")
+
+    monkeypatch.setattr(reports_router, "ensure_market_data_fresh", _raise)
+
+    resp = await client.get(url)
+    assert resp.status_code != 500, (
+        f"{url} returned 500 when the market-data freshness sync raised a "
+        "non-ReportError exception; freshness is best-effort and must not crash "
+        "report generation"
+    )

--- a/apps/backend/tests/repro/test_reports_500_market_data.py
+++ b/apps/backend/tests/repro/test_reports_500_market_data.py
@@ -55,8 +55,8 @@ async def test_reports_do_not_500_when_market_data_sync_raises(
     monkeypatch.setattr(reports_router, "ensure_market_data_fresh", _raise)
 
     resp = await client.get(url)
-    assert resp.status_code != 500, (
-        f"{url} returned 500 when the market-data freshness sync raised a "
-        "non-ReportError exception; freshness is best-effort and must not crash "
-        "report generation"
+    assert resp.status_code < 500, (
+        f"{url} returned {resp.status_code} when the market-data freshness sync "
+        "raised a non-ReportError exception; freshness is best-effort and must "
+        "not crash report generation with any 5xx"
     )

--- a/docs/analysis/traceability-exceptions.md
+++ b/docs/analysis/traceability-exceptions.md
@@ -160,6 +160,15 @@ router, or generated-fixture flows.
 | `tools/_lib/pdf_fixtures/generators/base_generator.py` | EPIC-009 fixture infrastructure covered by `tests/tooling/test_pdf_fixture_epic009_behavior.py` |
 | `tools/_lib/pdf_fixtures/generators/font_utils.py` | EPIC-009 fixture infrastructure covered by `tests/tooling/test_pdf_fixture_tooling_coverage.py` |
 
+### Staging Bug Regression Repros
+
+Regression guards for production bugs found during real-machine testing. They
+pin a specific fix rather than owning an EPIC acceptance criterion.
+
+| Path | Owner |
+|---|---|
+| `apps/backend/tests/repro/test_reports_500_market_data.py` | Issue #1388 (reports must not 500 on best-effort market-data sync failure) |
+
 ## Rule
 
 New tests for user-visible behavior must include an AC reference. New helper,

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -13,8 +13,8 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `POST` | `` | `chat_message` | apps/backend/src/routers/chat.py:37 |
 | `DELETE` | `/session/{session_id}` | `delete_session` | apps/backend/src/routers/chat.py:212 |
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:154 |
-| `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:505 |
-| `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:785 |
+| `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:512 |
+| `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:792 |
 | `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:546 |
 | `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:684 |
 | `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:104 |

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -13,8 +13,8 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `POST` | `` | `chat_message` | apps/backend/src/routers/chat.py:37 |
 | `DELETE` | `/session/{session_id}` | `delete_session` | apps/backend/src/routers/chat.py:212 |
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:154 |
-| `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:491 |
-| `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:771 |
+| `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:505 |
+| `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:785 |
 | `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:546 |
 | `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:684 |
 | `DELETE` | `/{user_id}` | `delete_user` | apps/backend/src/routers/users.py:104 |


### PR DESCRIPTION
Closes #1388.

## Problem
Every money-aggregating report (`/reports/balance-sheet`, `/income-statement`, `/cash-flow`, `/net-worth/timeseries`, `/net-worth/allocation`) returned **HTTP 500** as soon as the account held a position; an empty account returned 200. Found during real-machine testing of staging v0.1.19.

## Root cause
Each report endpoint wraps work in `try/except ReportError`, but `_ensure_report_market_data_fresh` → `ensure_market_data_fresh` (a live market-data/FX sync) can raise **non-`ReportError`** exceptions (provider error, unresolvable symbol — see #1389 — malformed FX pair, network blip). Those escaped uncaught and became a 500. The sync only runs when the user has report subjects, which is exactly why empty accounts never 500.

## Fix
Make the freshness sync best-effort in `_ensure_report_market_data_fresh`: log and fall back to already-stored (possibly stale) data instead of crashing report generation.

## Tests (TDD)
- `tests/repro/test_reports_500_market_data.py` — parametrized over all five endpoints; forces the freshness sync to raise a non-`ReportError` and asserts the endpoint does not 500. RED before the fix, GREEN after.
- Reporting regression suite: 262 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)