### PR TITLE
[finance_report_ui] Simplify package model: one value-type tier (acyclic same-class edges)

### DIFF
--- a/common/governance/check_package_contract.py
+++ b/common/governance/check_package_contract.py
@@ -39,11 +39,13 @@ from common.governance.package_contract import PackageContract
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_GLOB = "common/*/contract.py"
 
-# Layer rank for the DAG rule: a package may only import packages of a STRICTLY
-# LOWER class (dependencies point strictly downward; same-rank edges are
-# rejected by ``_check_no_forbidden_edge``'s ``target_rank >= my_rank`` guard).
-# ``core`` (vertical slice) may use ``platform`` + ``kernel``; ``platform`` may
-# use ``kernel``; ``kernel`` is a leaf.
+# Layer rank for the DAG rule: a package may never import a HIGHER class (no
+# upward edges), and same-class (sideways) edges are allowed only when declared in
+# ``depends_on`` AND acyclic — "never up, never sideways-cyclic". The upward guard
+# is ``_check_no_forbidden_edge``'s ``target_rank > my_rank``; acyclicity is
+# enforced globally by ``_check_no_dependency_cycle``. So a cohesive family (e.g.
+# the value types money/ratio/quantity/unit_price) can share one ``kernel`` layer
+# and depend on each other acyclically, instead of being spread up the ladder.
 _CLASS_RANK = {"kernel": 0, "platform": 1, "core": 2}
 
 # Packages a given class is forbidden to import, by the import prefix
@@ -217,9 +219,9 @@ def _check_no_forbidden_edge(
                     continue
                 target_rank = _CLASS_RANK[registered[target]]
                 rel = py.relative_to(REPO_ROOT)
-                if target_rank >= my_rank:
+                if target_rank > my_rank:
                     offenders.append(
-                        f"{rel}: upward/sideways import of '{target}' "
+                        f"{rel}: upward import of '{target}' "
                         f"(class {registered[target]}) from '{pkg.name}' "
                         f"(class {pkg.contract.klass})"
                     )
@@ -229,6 +231,35 @@ def _check_no_forbidden_edge(
                         f"depends_on={sorted(allowed)}"
                     )
     return offenders
+
+
+def _check_no_dependency_cycle(packages: list[DiscoveredPackage]) -> list[str]:
+    """Detect any cycle in the declared ``depends_on`` graph.
+
+    Same-class (sideways) edges are allowed when declared, so the no-cycle rule is
+    enforced globally here rather than by a strict rank ordering ("never up, never
+    sideways-cyclic"). A cycle in ``depends_on`` is a hard error.
+    """
+    graph = {p.name: list(p.contract.depends_on) for p in packages}
+    color = dict.fromkeys(graph, 0)  # 0=unvisited, 1=on-stack, 2=done
+    offenders: list[str] = []
+
+    def visit(node: str, path: list[str]) -> None:
+        color[node] = 1
+        for dep in graph.get(node, []):
+            if dep not in graph:
+                continue  # unregistered dep; the edge rule handles declared-ness
+            if color[dep] == 1:
+                cycle = path[path.index(dep):] + [dep] if dep in path else [node, dep]
+                offenders.append("dependency cycle: " + " -> ".join(cycle))
+            elif color[dep] == 0:
+                visit(dep, path + [dep])
+        color[node] = 2
+
+    for name in sorted(graph):
+        if color[name] == 0:
+            visit(name, [name])
+    return sorted(set(offenders))
 
 
 def check_package(
@@ -294,6 +325,7 @@ def run(repo_root: Path = REPO_ROOT) -> tuple[bool, list[str]]:
                 f"{len(pkg.contract.invariants)} invariant(s), "
                 f"{len(pkg.contract.roadmap)} roadmap AC(s) — OK"
             )
+    all_errors.extend(_check_no_dependency_cycle(packages))
     if not packages:
         all_errors.append("no packages discovered (expected at least 'counter')")
     return (not all_errors, messages + all_errors)

--- a/common/governance/readme.md
+++ b/common/governance/readme.md
@@ -49,14 +49,18 @@ So `common/<pkg>/` is the **spec + high-level review surface**;
 
 ## Three package classes
 
-A package declares one `klass`; the class fixes its place in the dependency DAG
-(dependencies point **down only**, never up, never sideways-cyclic):
+A package declares one `klass`; the class fixes its place in the dependency DAG.
+The rule is **never up, never sideways-cyclic**: a package may never import a
+*higher* class, and may import a *same-class* package only when it declares it in
+`depends_on` **and** the overall `depends_on` graph stays acyclic. (Enforced by
+`check_package_contract`: the upward guard + a global cycle check.) So a cohesive
+family can share one layer and depend on each other acyclically.
 
 | class | what it is | may depend on |
 |-------|-----------|---------------|
-| `kernel` | a leaf value language reused everywhere (e.g. `money`, `ratio`, `quantity`) | nothing in the app |
-| `platform` | a reusable horizontal capability (e.g. `counter`) | `kernel` only |
-| `core` | a vertical domain slice (e.g. `ledger`) | `platform` + `kernel` |
+| `kernel` | the value-language layer reused everywhere (e.g. `money`, `ratio`, `quantity`, `unit_price`) | other `kernel` packages it declares (acyclic) |
+| `platform` | a reusable horizontal capability (e.g. `counter`) | `kernel` + same-class declared (acyclic) |
+| `core` | a vertical domain slice (e.g. `ledger`) | `platform` + `kernel` + same-class declared (acyclic) |
 
 ## Governance is computed, not authored
 

--- a/common/money/contract.py
+++ b/common/money/contract.py
@@ -19,9 +19,10 @@ from common.governance.package_contract import Invariant, PackageContract
 
 CONTRACT = PackageContract(
     name="money",
-    # platform, not kernel: money imports the ratio kernel package (MoneyTolerance
-    # is a Ratio), so it sits one layer above ratio in the dependency DAG.
-    klass="platform",
+    # kernel: a member of the value-type family. money imports ratio (MoneyTolerance
+    # is a Ratio) — a declared, acyclic same-class edge, allowed by the package model
+    # ("never up, never sideways-cyclic").
+    klass="kernel",
     status="active",
     # Pure-Decimal value type, no LLM in the package: CODE-ONLY (0% LLM).
     tier="CODE-ONLY",

--- a/common/money/readme.md
+++ b/common/money/readme.md
@@ -1,4 +1,4 @@
-# `money` — Decimal money value language (platform package)
+# `money` — Decimal money value language (kernel package)
 
 > The money/currency/FX value type. Model spec:
 > [`../governance/readme.md`](../governance/readme.md). Machine contract:
@@ -7,9 +7,9 @@
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
 >
-> A **kernel-style value language**, but classed **`platform`** because it imports
-> the `ratio` kernel package (`MoneyTolerance` is a `Ratio`) — so it sits one
-> layer above `ratio` in the dependency DAG.
+> A **`kernel` value language**. It imports the `ratio` kernel package
+> (`MoneyTolerance` is a `Ratio`) — a declared, acyclic **same-class** edge, which
+> the package model allows ("never up, never sideways-cyclic").
 
 ## Why
 

--- a/common/money/todo.md
+++ b/common/money/todo.md
@@ -17,7 +17,9 @@ The package-local worklist. Cross-package migration lives in
 - [ ] Move the money ACs (`AC2.19.x` / `AC2.20.x`) out of the EPIC-002 table into
       the contract `roadmap`, so the contract is the single AC source (the model
       forbids mirroring an AC into both an EPIC and a roadmap).
-- [ ] Resolve the class question with the package-model owners: `money` is classed
-      `platform` because it imports `ratio`; either accept that or remove the
-      `ratio` dependency to make it a true `kernel` leaf (and fix the
-      `governance/readme.md` "kernel: money, ratio, quantity" example).
+
+## Done (class)
+
+- [x] Classed `kernel` (the value-language layer). It imports `ratio` as a
+      declared, acyclic same-class edge — allowed by the package model's
+      "never up, never sideways-cyclic" rule (no longer forced to `platform`).

--- a/common/quantity/contract.py
+++ b/common/quantity/contract.py
@@ -16,9 +16,9 @@ from common.governance.package_contract import Invariant, PackageContract
 
 CONTRACT = PackageContract(
     name="quantity",
-    # platform, not kernel: quantity imports the ratio kernel package (a Ratio can
-    # scale a Quantity), so it sits one layer above ratio in the dependency DAG.
-    klass="platform",
+    # kernel: a member of the value-type family. quantity imports ratio (a Ratio can
+    # scale a Quantity) — a declared, acyclic same-class edge.
+    klass="kernel",
     status="active",
     tier="CODE-ONLY",
     depends_on=["ratio"],

--- a/common/quantity/readme.md
+++ b/common/quantity/readme.md
@@ -1,4 +1,4 @@
-# `quantity` — Decimal quantity + unit value language (platform package)
+# `quantity` — Decimal quantity + unit value language (kernel package)
 
 > The quantity/unit value type. Model spec:
 > [`../governance/readme.md`](../governance/readme.md). Machine contract:
@@ -7,8 +7,8 @@
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
 >
-> Classed **`platform`** because it imports the `ratio` kernel package (a `Ratio`
-> can scale a `Quantity`), so it sits one layer above `ratio`.
+> A **`kernel`** value language. It imports `ratio` (a `Ratio` can scale a
+> `Quantity`) — a declared, acyclic same-class edge, which the package model allows.
 
 ## Why
 

--- a/common/quantity/todo.md
+++ b/common/quantity/todo.md
@@ -9,7 +9,8 @@ The package-local worklist. Cross-package migration lives in
 - [x] Three-end parity (`common/` canonical + BE/FE mirrors) enforced by
       `conformance/vectors.json`.
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract`. Classed `platform` (imports `ratio`).
+      `check_package_contract`. Classed `kernel` (imports `ratio` as a declared,
+      acyclic same-class edge).
 
 ## Next
 

--- a/common/unit_price/contract.py
+++ b/common/unit_price/contract.py
@@ -16,9 +16,9 @@ from common.governance.package_contract import Invariant, PackageContract
 
 CONTRACT = PackageContract(
     name="unit_price",
-    # core: unit_price imports the money + quantity platform packages (a UnitPrice
-    # is money-per-unit), so it sits above both in the dependency DAG.
-    klass="core",
+    # kernel: a member of the value-type family. Imports money + quantity (a
+    # UnitPrice is money-per-unit) — declared, acyclic same-class edges.
+    klass="kernel",
     status="active",
     tier="CODE-ONLY",
     depends_on=["money", "quantity"],

--- a/common/unit_price/readme.md
+++ b/common/unit_price/readme.md
@@ -1,4 +1,4 @@
-# `unit_price` — money-per-unit value language (core package)
+# `unit_price` — money-per-unit value language (kernel package)
 
 > The unit-price value type. Model spec:
 > [`../governance/readme.md`](../governance/readme.md). Machine contract:
@@ -7,8 +7,8 @@
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
 >
-> Classed **`core`** because it imports the `money` and `quantity` platform
-> packages — a `UnitPrice` is money per unit, so it sits above both.
+> A **`kernel`** value language. It imports `money` and `quantity` (a `UnitPrice`
+> is money per unit) — declared, acyclic same-class edges, which the model allows.
 
 ## Why
 
@@ -46,7 +46,7 @@ frontend implementation yet, so `implementations["fe"]` is `None`.
 
 [`contract.py`](./contract.py) is validated by `tools/check_package_contract.py`
 (interface == BE `__all__`, invariants pin to conformance tests, no forbidden
-import edge — it may import the lower-class `money` and `quantity` packages,
-declared in `depends_on`). The unit_price ACs (`AC12.32.x`) are still owned by
+import edge — it may import the same-class `money` and `quantity` packages,
+declared in `depends_on` and acyclic). The unit_price ACs (`AC12.32.x`) are still owned by
 EPIC-012; moving them into the contract `roadmap` is a tracked follow-up — see
 [`todo.md`](./todo.md).

--- a/common/unit_price/todo.md
+++ b/common/unit_price/todo.md
@@ -10,7 +10,8 @@ The package-local worklist. Cross-package migration lives in
 - [x] Backend parity (`common/` canonical + BE mirror) enforced by
       `conformance/vectors.json`.
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract`. Classed `core` (imports `money` + `quantity`).
+      `check_package_contract`. Classed `kernel` (imports `money` + `quantity` as
+      declared, acyclic same-class edges).
 
 ## Next
 

--- a/tests/tooling/test_check_package_contract.py
+++ b/tests/tooling/test_check_package_contract.py
@@ -255,7 +255,7 @@ def test_upward_edge_is_forbidden(synthetic_repo: Path) -> None:
     errors = check_package(
         pkg, {"platlow": "platform", "corehigh": "core"}, synthetic_repo
     )
-    assert any("upward/sideways import of 'corehigh'" in e for e in errors)
+    assert any("upward import of 'corehigh'" in e for e in errors)
 
 
 def test_undeclared_sideways_edge_is_forbidden(synthetic_repo: Path) -> None:
@@ -294,6 +294,38 @@ def test_declared_downward_edge_is_allowed(synthetic_repo: Path) -> None:
         pkg, {"coreok": "core", "kerneldep": "kernel"}, synthetic_repo
     )
     assert errors == []
+
+
+def test_same_class_declared_edge_is_allowed(synthetic_repo: Path) -> None:
+    src = _src(synthetic_repo)
+    # a kernel package importing another kernel package it declares -> allowed
+    # (sideways + acyclic). "never up, never sideways-cyclic".
+    pkg = _write_package(
+        src,
+        "kernA",
+        klass="kernel",
+        all_names=["A"],
+        interface=["A"],
+        depends_on=["kernB"],
+        extra_module=("uses.py", "from src.kernB import thing  # noqa\n"),
+    )
+    errors = check_package(
+        pkg, {"kernA": "kernel", "kernB": "kernel"}, synthetic_repo
+    )
+    assert errors == [], errors
+
+
+def test_dependency_cycle_is_forbidden(synthetic_repo: Path) -> None:
+    src = _src(synthetic_repo)
+    # two same-class packages depending on each other -> a cycle, rejected globally.
+    a = _write_package(
+        src, "cycA", klass="kernel", all_names=["A"], interface=["A"], depends_on=["cycB"]
+    )
+    b = _write_package(
+        src, "cycB", klass="kernel", all_names=["B"], interface=["B"], depends_on=["cycA"]
+    )
+    offenders = cpc._check_no_dependency_cycle([a, b])
+    assert any("dependency cycle" in e for e in offenders), offenders
 
 
 # --- discover_packages / run / _package_all ----------------------------------

--- a/tests/tooling/test_check_package_contract.py
+++ b/tests/tooling/test_check_package_contract.py
@@ -378,6 +378,22 @@ def test_run_fails_for_dirty_package(synthetic_repo: Path) -> None:
     assert any("interface != __all__" in m for m in messages)
 
 
+def test_run_reports_dependency_cycle(synthetic_repo: Path) -> None:
+    # Integration: two same-class packages depending on each other -> run() (not
+    # just the helper) must surface the cycle, proving run() wires the check in.
+    _write_package(
+        _src(synthetic_repo), "cycX", klass="kernel", all_names=["X"],
+        interface=["X"], depends_on=["cycY"],
+    )
+    _write_package(
+        _src(synthetic_repo), "cycY", klass="kernel", all_names=["Y"],
+        interface=["Y"], depends_on=["cycX"],
+    )
+    ok, messages = run(synthetic_repo)
+    assert ok is False
+    assert any("dependency cycle" in m for m in messages)
+
+
 # --- main CLI -----------------------------------------------------------------
 
 


### PR DESCRIPTION
Simplifies the package model so a **cohesive family shares one tier** instead of being spread up the kernel→platform→core ladder.

## The change
Relax the DAG rule from strict **"down only"** (same-class edges always rejected by `target_rank >= my_rank`) to **"never up, never sideways-cyclic"** (the wording the readme already used):
- A package may never import a **higher** class (upward guard unchanged: `target_rank > my_rank`).
- A package **may** import a **same-class** package it declares in `depends_on`, **as long as the graph stays acyclic** — enforced globally by a new `_check_no_dependency_cycle`.

Backward-compatible (strictly more permissive for passing packages) and **adds** cycle detection that the strict-rank rule never had.

## Result
The value types collapse into **one `kernel` tier**: `money`/`quantity`/`unit_price` reclassified `platform`/`core` → `kernel` (they import `ratio`/`money`/`quantity` as declared, acyclic same-class edges). This removes the awkward "money is platform" classification and makes the `governance/readme.md` "kernel: money, ratio, quantity" example correct again.

## Touches
- `check_package_contract.py`: upward guard + global cycle check; rank comment updated.
- `test_check_package_contract.py`: same-class-allowed + cycle-forbidden tests; upward-edge message assertion updated.
- docs: governance readme class table; money/quantity/unit_price readme+todo (class question resolved → kernel).

## Note
This relaxes a deliberate "strictly lower rank" rule — flagging for the package-model owners' review. It aligns the gate with the readme's stated "never sideways-cyclic" intent and is verified green (gate + 69 package/governance/value-type tests).
