### PR TITLE
[finance_report_test_and_doc] build(pre-commit): pre-push drift gates + ci-cd SSOT local guardrail tiers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,15 @@
 # 1. Ruff lint errors (auto-fixed locally)
 # 2. Environment variable sync issues (caught before push)
 # 3. Trailing whitespace / merge conflicts
+# 4. SSOT/contract/generated-doc drift (caught at push, see pre-push block below)
+
+# Wire both git hook types so `pre-commit install` (run by tools/bootstrap.sh)
+# also installs the pre-push hook. `default_stages: [pre-commit]` keeps every
+# existing hook commit-only -- adding the pre-push hook type does NOT pull ruff,
+# mypy, gitleaks, etc. into `git push`; only hooks that opt in with
+# `stages: [pre-push]` run there.
+default_install_hook_types: [pre-commit, pre-push]
+default_stages: [pre-commit]
 
 repos:
   # Ruff - Fast Python linter & formatter (replaces flake8, isort, black)
@@ -50,16 +59,22 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
+      # These three declare push in their upstream stages, so default_stages does
+      # not hold them to commit; pin them explicitly. Auto-fixers must not mutate
+      # the tree mid-`git push`. Commit behavior is unchanged.
       - id: trailing-whitespace
         exclude: ^(.*\.md|.*\.snap)$
+        stages: [pre-commit]
       - id: end-of-file-fixer
         exclude: ^(.*\.md|.*\.snap)$
+        stages: [pre-commit]
       - id: check-yaml
         args: [--unsafe]  # Allow custom tags in GitHub Actions
       - id: check-json
       - id: check-merge-conflict
       - id: check-added-large-files
         args: [--maxkb=1000]
+        stages: [pre-commit]
       - id: no-commit-to-branch
         args: [--branch, main]
 
@@ -104,7 +119,65 @@ repos:
         language: system
         pass_filenames: false
         always_run: true  # Check on every commit
+
+  # ---------------------------------------------------------------------------
+  # Pre-push drift gates (local==CI parity).
+  #
+  # These mirror the CI `lint` job's SSOT/contract/generated-doc checks, which
+  # account for the bulk of recent CI failures: a refactor moves a symbol/file
+  # but the coupled manifest, workflow contract, or generated reference is not
+  # synced. Each is a fast standalone script (~0.1s, except the API-reference
+  # check which imports the FastAPI app, ~4s), so they run at PUSH (infrequent)
+  # rather than on every commit. They are always-run because they assert global
+  # contracts that many different file changes can break -- file-scoping them
+  # would let a triggering edit slip through. Commands are copied verbatim from
+  # .github/workflows/ci.yml so local and CI cannot diverge.
+  - repo: local
+    hooks:
+      - id: ssot-manifest-check
+        name: SSOT manifest check (CI parity)
+        entry: uv run --with pyyaml python tools/check_manifest.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      - id: governance-exceptions-check
+        name: SSOT governance exceptions registry check (CI parity)
+        entry: uv run --with pyyaml python tools/check_governance_exceptions.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      - id: workflow-contract-check
+        name: Workflow contract check (CI parity)
+        entry: uv run --with pyyaml python tools/check_workflow_contract.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+      - id: generated-api-reference-check
+        name: Generated API reference freshness (CI parity)
+        # Mirrors CI exactly: the generator imports the FastAPI app, so `uv run`
+        # must resolve the backend project -- hence the cd into apps/backend.
+        entry: bash -c 'cd apps/backend && uv run python ../../tools/generate_api_reference.py --check'
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
 ci:
   autofix_prs: true
   autofix_commit_msg: "style: auto-fix from pre-commit hooks"
   autoupdate_schedule: monthly
+  # The pre-push drift gates need `uv` and the backend project, which the hosted
+  # pre-commit.ci runner does not provide. They are pre-push stage so pre-commit.ci
+  # (pre-commit stage) skips them anyway; listed here to make that explicit. The
+  # same checks run authoritatively in the GitHub Actions `lint` job.
+  skip:
+    - ssot-manifest-check
+    - governance-exceptions-check
+    - workflow-contract-check
+    - generated-api-reference-check

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -502,11 +502,12 @@ concepts:
   # ── CI / CD ────────────────────────────────────────────────────────────
   ci_workflow:
     owner: docs/ssot/ci-cd.md#ci-job-structure
-    description: CI job structure (lint → backend shards → frontend → coverage).
+    description: CI job structure (lint → backend shards → frontend → coverage) and the local guardrail tiers (pre-commit → pre-push → CI) that left-move its cheap drift gates.
     cross_refs:
       - docs/ssot/development.md
       - docs/ssot/coverage.md
       - .github/workflows/ci.yml
+      - .pre-commit-config.yaml
 
   pr_review_thread_merge_gate:
     owner: docs/ssot/ci-cd.md#pr-review-thread-merge-gate

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -179,6 +179,52 @@ Valid proof task categories:
 | `critical_behavioral` | Co-located critical product proof edge. |
 | `manual_evidence` | Manual gate evidence record. |
 
+### Local Guardrail Tiers and Latency Budget
+
+Pre-merge protection is layered by latency budget. Each tier is bounded so that it
+stays fast enough that contributors never learn to bypass it, and the cheapest tier
+that can catch a class of failure should also run it for the earliest feedback
+(left-move). Cost rises with each tier. **The local tiers are advisory
+(`local.advisory` proof stage); only CI is merge authority.**
+`.pre-commit-config.yaml` is the source of truth for the two local tiers, but every
+check a local tier runs is independently re-run by CI — the table's checks are a
+strict *mirror subset* of CI, never a delegation of it.
+
+| Tier | Trigger | Budget | Scope | Runs (all re-run by CI) | Must NOT do |
+|---|---|---|---|---|---|
+| `pre-commit` | every `git commit`, staged files | ≤ ~2s | file-scoped fast static + auto-fix | ruff lint/format, gitleaks (staged content), mypy (staged backend), env-key / Pydantic-schema sync, file hygiene | run repo-wide suites or import the app graph; auto-fixers stay commit-only (`stages: [pre-commit]`) so they never mutate the tree mid-push |
+| `pre-push` | every `git push`, whole repo | ≤ ~10s | cheap repo-wide contract / drift gates mirroring the CI `lint` job | SSOT manifest, governance-exceptions registry, workflow contract, generated API-reference freshness — the drift classes behind most CI `lint` / `tooling-coverage` failures | run full pytest, backend shards, coverage, or browser tests (minutes-scale → CI only) |
+| `CI` (`lint` + `changes` first) | PR / push on the GitHub runner | minutes; first gate ~1 min | full deterministic merge authority | everything in [Job Details](#job-details), re-run from a clean checkout with no assumption that any local tier ran | omit or weaken a check because a local tier also runs it |
+
+Tier rules:
+
+- **Local results are never trusted; they raise the hit rate, they do not gate
+  merge.** A hook can be uninstalled, bypassed with `--no-verify`, skipped under a
+  set `core.hooksPath`, or simply never have existed on the submitter's machine, so
+  CI assumes nothing local ran and re-runs every check independently from a clean
+  checkout. A check is therefore **never removed from or weakened in CI because a
+  local tier also performs it** — `pre-push` is a strict mirror-subset of CI gates
+  for early, cheap feedback, not an authority CI may lean on. The payoff of the
+  local tiers is fewer wasted CI cycles and faster author feedback, not a smaller CI.
+- **The budget is a contract, not a target.** A `pre-commit` hook that creeps past
+  ~2s, or a `pre-push` gate past ~10s, trains `--no-verify`, which silently disables
+  every gate behind it. When a check outgrows its budget, move it down a tier
+  (commit → push, or push → CI) rather than letting the tier slow down.
+- **CI parity is one-directional: local mirrors CI, not the reverse.** `pre-push`
+  gate commands are copied verbatim from `.github/workflows/ci.yml` so a local pass
+  predicts the CI result, but CI never shrinks to match local. The hosted
+  pre-commit.ci runner has no `uv`/backend and `ci.skip`s those gates; GitHub
+  Actions stays authoritative.
+- **No coverage or behavior proof at push.** Coverage, the AC behavioral ratchet,
+  and full test suites need artifacts and minutes; they stay in CI (see
+  [Stage Matrix and Left-Move Guidance](#stage-matrix-and-left-move-guidance)).
+  `pre-push` proves only cheap, deterministic contracts. A repo-wide pytest pre-push
+  hook is explicitly out of budget and is not the project guardrail.
+- **One install path.** `tools/bootstrap.sh` runs `pre-commit install`;
+  `default_install_hook_types: [pre-commit, pre-push]` wires both stages with no
+  extra step, so the two local tiers are managed by one framework rather than a
+  hand-placed native hook.
+
 ### Path Risk to Local Gate Matrix
 
 Default local verification starts with affected fast tests such as


### PR DESCRIPTION
## Why

A scan of the 30 most recent CI failures showed ~2/3 are **SSOT / contract / generated-doc drift**: a refactor moves a symbol or file but the coupled manifest, workflow contract, governance registry, or generated API reference is not synced. These are fast standalone scripts in the CI `lint` job — so catch them locally, before they burn CI minutes, and write the layered model into SSOT.

## What

**1. Pre-push drift gates (`.pre-commit-config.yaml`)** — 4 hooks at `stages: [pre-push]`, commands copied verbatim from `.github/workflows/ci.yml`:
- `check_manifest` · `check_governance_exceptions` · `check_workflow_contract` · `generate_api_reference --check`
- ~5–6s total (dominated by the API-reference check, which imports the FastAPI app).
- `default_install_hook_types: [pre-commit, pre-push]` wires both stages via the existing `pre-commit install` (no bootstrap change).
- `default_stages: [pre-commit]` plus explicit pins keep every existing hook — including the three auto-fixers — commit-only, so **commit-stage behavior is unchanged** and fixers never mutate the tree mid-push.
- `ci.skip` the uv-dependent gates (hosted pre-commit.ci has no uv/backend).

**2. SSOT: local guardrail tiers + latency budget (`docs/ssot/ci-cd.md`)** — new subsection beside the existing job inventory / Path-Risk matrix / Left-Move guidance:

| Tier | Budget | Role |
|------|--------|------|
| `pre-commit` | ≤ ~2s | file-scoped fast static + auto-fix |
| `pre-push` | ≤ ~10s | cheap repo-wide drift gates mirroring CI `lint` |
| `CI` | minutes (first gate ~1 min) | full merge authority |

Lead principle — **local results are never trusted**: hooks can be uninstalled, `--no-verify`'d, skipped under a set `core.hooksPath`, or never have existed on the submitter's machine, so CI re-runs every check from a clean checkout. A check is **never removed from or weakened in CI** because a local tier also runs it. `pre-push` is a strict *mirror-subset* of CI for early feedback; CI parity is one-directional (local mirrors CI, CI never shrinks to match local). Budget is a contract — an over-budget hook trains `--no-verify` and disables every gate behind it. Repo-wide pytest is explicitly out of pre-push budget.

`ci_workflow` concept in `MANIFEST.yaml` now cross-refs `.pre-commit-config.yaml`.

## Verification

Local gates run: `check_manifest`, `lint_doc_consistency`, `check_workflow_contract`, `check_ci_metrics_contract`, `check_governance_exceptions` → all exit 0; 164 tooling tests pass. Pre-push stage runs exactly the 4 gates; commit stage unchanged.

## Notes

- No CI job was added, removed, or weakened — this only adds local mirror gates and documents the tier model.
- An untracked, hand-placed native `.git/hooks/pre-push` (full pytest) exists on one machine and is exactly the unreliable local gate the new SSOT names; the intended end-state is to retire it in favor of the pre-commit-managed tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)