### PR TITLE
[finance_report_hacker] feat(#1307): cassette graded LLM eval + drift ratchet

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,8 @@
 # conflict. Re-run `tools/migrate_proof_index_storage.py` to re-sort/normalise
 # after a union merge if line order drifts.
 docs/ssot/ac-score-baseline.jsonl merge=union
+
+# docs/ssot/cassette-eval-baseline.jsonl is the cassette graded-eval ratchet floor
+# (EPIC-023 AC23.8), stored as sorted JSONL (one case per line). Same rationale:
+# PRs ratcheting DIFFERENT cases auto-merge by union; only same-case edits conflict.
+docs/ssot/cassette-eval-baseline.jsonl merge=union

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,16 @@ jobs:
           # extraction fails here. Pure Python (no key/network/DB), so it runs in
           # lint without touching the AC behavioral-score aggregator.
           python tools/check_llm_cassettes.py
+      - name: LLM Cassette Graded Eval (field-accuracy drift ratchet)
+        run: |
+          # EPIC-023 AC23.8 / #1307: GRADED field-accuracy eval over committed
+          # cassettes. AC23.7 above gates CONSISTENCY (the chain reconciles); this
+          # gates ACCURACY — each cassette is scored per-field against a synthetic
+          # ground truth and ratcheted against a per-case floor that only goes UP.
+          # Fails when a refreshed cassette regresses below floor (incl. "balance
+          # passes but a field is wrong"). Pure Python (no key/network/DB), so it
+          # runs in lint without touching the AC behavioral-score aggregator.
+          python tools/check_cassette_graded_eval.py
       - name: SSOT Ownership Lint
         run: |
           python tools/check_ssot_ownership.py --verbose

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ test:
 #   make llm-record ARGS='tests/extraction/test_extraction_cassette_replay.py -m needs_real_cassette'
 # then remove the `needs_real_cassette` module skip so the dedicated replay CI
 # step runs them with no key.
+#
+# After re-recording a statement cassette, raise the GRADED field-accuracy floor
+# (EPIC-023 AC23.8) so the ratchet adopts the new (>=) scores; commit cassettes +
+# baseline together:
+#   python tools/check_cassette_graded_eval.py --update
 llm-record:
 	cd apps/backend && LLM_CASSETTE_MODE=record uv run pytest tests/unit/llm/test_cassette.py tests/unit/llm/test_streaming_cassette.py --llm-record $(ARGS)
 

--- a/apps/backend/tests/fixtures/llm_cassettes/ground_truth/cb5dd1f714784190dab3356c17d635a0e09b8f9fca78abb6023218ca29efcbab.truth.json
+++ b/apps/backend/tests/fixtures/llm_cassettes/ground_truth/cb5dd1f714784190dab3356c17d635a0e09b8f9fca78abb6023218ca29efcbab.truth.json
@@ -1,0 +1,16 @@
+{
+  "synthetic": true,
+  "modality": "text",
+  "institution_class": "generic",
+  "edge_condition": "duplicate_rows",
+  "note": "SYNTHETIC anonymised statement — no real financial data. #1254-class case: two genuine same-date same-amount deposits must BOTH be present. Known-correct field values for the matching text cassette (glm-5.2).",
+  "expected": {
+    "opening_balance": "1000.00",
+    "closing_balance": "1490.00",
+    "transactions": [
+      {"date": "2026-02-01", "description": "Deposit ABC", "amount": "250.00"},
+      {"date": "2026-02-01", "description": "Deposit ABC", "amount": "250.00"},
+      {"date": "2026-02-03", "description": "Service fee", "amount": "-10.00"}
+    ]
+  }
+}

--- a/apps/backend/tests/fixtures/llm_cassettes/ground_truth/d2bef919d2918989d2a6dbc8bbf019bd6bd2107d97f2e1bd85c91185c36e4fd0.truth.json
+++ b/apps/backend/tests/fixtures/llm_cassettes/ground_truth/d2bef919d2918989d2a6dbc8bbf019bd6bd2107d97f2e1bd85c91185c36e4fd0.truth.json
@@ -1,0 +1,16 @@
+{
+  "synthetic": true,
+  "modality": "vision",
+  "institution_class": "named_bank",
+  "edge_condition": "happy_path",
+  "note": "SYNTHETIC anonymised statement — no real financial data. Vision/OCR cassette (glm-4.6v) reads magnitude amounts plus an IN/OUT direction. Known-correct field values for the matching vision cassette.",
+  "expected": {
+    "opening_balance": "100.00",
+    "closing_balance": "130.00",
+    "transactions": [
+      {"date": "2026-01-02", "description": "Coffee shop", "amount": "5.00"},
+      {"date": "2026-01-05", "description": "Salary credit", "amount": "50.00"},
+      {"date": "2026-01-09", "description": "Groceries", "amount": "15.00"}
+    ]
+  }
+}

--- a/apps/backend/tests/fixtures/llm_cassettes/ground_truth/d69fbafcecb481e614651b1178a5fb9d9e3724718ef7bf623502120bcd27db30.truth.json
+++ b/apps/backend/tests/fixtures/llm_cassettes/ground_truth/d69fbafcecb481e614651b1178a5fb9d9e3724718ef7bf623502120bcd27db30.truth.json
@@ -1,0 +1,16 @@
+{
+  "synthetic": true,
+  "modality": "text",
+  "institution_class": "generic",
+  "edge_condition": "happy_path",
+  "note": "SYNTHETIC anonymised statement — no real financial data. Known-correct field values for the matching text cassette (glm-5.2). Amounts signed (debit negative).",
+  "expected": {
+    "opening_balance": "100.00",
+    "closing_balance": "130.00",
+    "transactions": [
+      {"date": "2026-01-02", "description": "Coffee shop", "amount": "-5.00"},
+      {"date": "2026-01-05", "description": "Salary credit", "amount": "50.00"},
+      {"date": "2026-01-09", "description": "Groceries", "amount": "-15.00"}
+    ]
+  }
+}

--- a/common/ssot/cassette_eval_baseline.py
+++ b/common/ssot/cassette_eval_baseline.py
@@ -1,0 +1,113 @@
+"""Conflict-free storage for the cassette graded-eval ratchet baseline.
+
+EPIC-023 AC23.8 / issue #1307. This mirrors
+:mod:`common.ssot.ac_score_baseline_format`: the per-case score FLOOR is stored
+as **sorted, line-oriented JSONL** (one JSON object per case, one per line,
+sorted by ``case_id``). Paired with a ``merge=union`` ``.gitattributes`` rule,
+two PRs that ratchet DIFFERENT cases auto-merge by union concatenation; only two
+PRs editing the SAME case produce a (legitimate, semantic) conflict.
+
+This is a STORAGE module only. The baseline is a PERSISTED ratchet floor — it is
+never regenerated from current scores (that would erase the floor). The ratchet
+semantics live in :mod:`common.ssot.cassette_graded_eval`; this module only
+loads/normalises/writes the on-disk form into the in-memory shape
+``{"version": 1, "cases": {case_id: {...}}}``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_BASELINE = REPO_ROOT / "docs" / "ssot" / "cassette-eval-baseline.jsonl"
+
+BASELINE_VERSION = 1
+
+# Fields persisted per case line, in a stable key order for deterministic output.
+_LINE_KEY_ORDER = ("case_id", "score", "metric", "provenance")
+
+
+def _normalize_record(case_id: str, record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "score": round(float(record.get("score", 0.0)), 6),
+        "metric": record.get("metric", ""),
+        "provenance": record.get("provenance", ""),
+    }
+
+
+def _ordered_line(record: dict[str, Any]) -> dict[str, Any]:
+    ordered = {key: record[key] for key in _LINE_KEY_ORDER if key in record}
+    for key, value in record.items():
+        if key not in ordered:
+            ordered[key] = value
+    return ordered
+
+
+def cases_to_lines(cases: dict[str, dict[str, Any]]) -> list[str]:
+    """Render the per-case mapping as sorted, deterministic JSONL lines."""
+    lines: list[str] = []
+    for case_id in sorted(cases):
+        record = _ordered_line(_normalize_record(case_id, cases[case_id]))
+        lines.append(json.dumps(record, sort_keys=False, ensure_ascii=False))
+    return lines
+
+
+def render_jsonl(payload: dict[str, Any]) -> str:
+    """Render a ``{"version", "cases"}`` payload as the canonical JSONL text."""
+    cases = payload.get("cases", {})
+    if not isinstance(cases, dict):
+        cases = {}
+    body = "\n".join(cases_to_lines(cases))
+    return (body + "\n") if body else ""
+
+
+def load_jsonl(path: Path) -> dict[str, Any]:
+    """Load a JSONL baseline into the in-memory ``{"version", "cases"}`` shape.
+
+    Blank lines are ignored (union merges can leave them). A duplicate ``case_id``
+    is a real same-case conflict that git's union merge surfaces by keeping both
+    lines; we fail loudly rather than silently picking one floor.
+    """
+    if not path.exists():
+        return {"version": BASELINE_VERSION, "cases": {}}
+    cases: dict[str, dict[str, Any]] = {}
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path}:{lineno}: invalid JSONL line: {exc}") from exc
+        if not isinstance(record, dict) or "case_id" not in record:
+            raise ValueError(
+                f"{path}:{lineno}: each line must be a JSON object with a 'case_id'"
+            )
+        case_id = str(record["case_id"])
+        if case_id in cases:
+            raise ValueError(
+                f"{path}:{lineno}: duplicate case_id {case_id!r} — resolve the "
+                "same-case ratchet conflict (keep the higher floor)"
+            )
+        cases[case_id] = {
+            "score": round(float(record.get("score", 0.0)), 6),
+            "metric": record.get("metric", ""),
+            "provenance": record.get("provenance", ""),
+        }
+    return {"version": BASELINE_VERSION, "cases": cases}
+
+
+def write_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    """Write the payload as canonical, sorted JSONL (deterministic order)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_jsonl(payload), encoding="utf-8")
+
+
+def normalize_file(path: Path) -> dict[str, Any]:
+    """Re-sort and re-normalise an on-disk JSONL baseline in place."""
+    payload = load_jsonl(path)
+    write_jsonl(path, payload)
+    return payload

--- a/common/ssot/cassette_graded_eval.py
+++ b/common/ssot/cassette_graded_eval.py
@@ -1,0 +1,284 @@
+"""Cassette GRADED field-accuracy eval + drift ratchet.
+
+EPIC-023 AC23.8 / issue #1307. The balance-chain gate
+(:mod:`common.ssot.check_llm_cassettes`, AC23.7) catches INCONSISTENCY, not
+INACCURACY: an LLM that reads ``50`` as ``150`` still passes as long as the chain
+balances. This module scores each committed statement cassette PER FIELD against
+a sibling SYNTHETIC ground-truth artifact (``<fingerprint>.truth.json``), yields
+a numeric ``[0,1]`` score per case, and ratchets a persisted per-case floor that
+may only go UP. The gate FAILS when a refreshed cassette regresses a case below
+its floor — including the "balance passes but a field is now wrong" case the
+AC23.7 gate cannot see.
+
+Pure Python: no network, no API key, no DB. Scoring is deterministic on committed
+fixtures; refresh is the local ``make llm-record`` path.
+
+**Scope (anti-overclaim):** drift-detection power is bounded by the eval-set
+breadth documented in ``docs/ssot/cassette-graded-eval.md`` — CI green is NOT a
+correctness guarantee on an unseen statement (the staging ``-m llm`` gate's job).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from common.ssot.cassette_eval_baseline import DEFAULT_BASELINE, load_jsonl
+from common.ssot.check_llm_cassettes import CASSETTE_DIR, _response_text
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GROUND_TRUTH_DIR = CASSETTE_DIR / "ground_truth"
+
+# Floating-point slack so an identical re-measurement never trips the ratchet.
+EPSILON = 1e-6
+
+# The documented coverage matrix this eval set must satisfy (AC23.8.1). Keeping
+# the required axes in code lets the test assert breadth and the doc state it.
+REQUIRED_MODALITIES = {"text", "vision"}
+REQUIRED_EDGE_CONDITIONS = {"happy_path", "duplicate_rows"}
+MIN_CASES = 3
+
+# Transaction fields scored per row (exact/normalised match against truth).
+_TXN_FIELDS = ("date", "description", "amount")
+
+
+# --------------------------------------------------------------------------- #
+# Normalisers — exact/normalised match per field type.
+# --------------------------------------------------------------------------- #
+def normalize_amount(value: object) -> Decimal:
+    """Money as ``Decimal`` (never float): ``"5.00"``, ``5``, ``5.0`` all == ``5``."""
+    try:
+        return Decimal(str(value)).normalize()
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        raise ValueError(f"unparseable amount: {value!r}") from exc
+
+
+def normalize_date(value: object, *, dayfirst: bool = False) -> str:
+    """Dates to ISO ``YYYY-MM-DD``. Accepts ISO directly or ``DD/MM/YYYY`` /
+    ``MM/DD/YYYY`` (``dayfirst`` selects the slash-form interpretation)."""
+    text = str(value).strip()
+    if "/" in text:
+        parts = text.split("/")
+        if len(parts) == 3:
+            a, b, y = (p.zfill(2) for p in parts)
+            day, month = (a, b) if dayfirst else (b, a)
+            return f"{y}-{month}-{day}"
+    return text
+
+
+def normalize_description(value: object) -> str:
+    """Descriptions: case-fold and collapse internal whitespace."""
+    return " ".join(str(value).split()).casefold()
+
+
+# --------------------------------------------------------------------------- #
+# Per-field scoring.
+# --------------------------------------------------------------------------- #
+def _field_matches(field_name: str, got: object, want: object) -> bool:
+    try:
+        if field_name == "amount" or field_name in ("opening_balance", "closing_balance"):
+            return normalize_amount(got) == normalize_amount(want)
+        if field_name == "date":
+            return normalize_date(got) == normalize_date(want)
+        return normalize_description(got) == normalize_description(want)
+    except ValueError:
+        return False
+
+
+def case_score(extracted: dict[str, Any], truth: dict[str, Any]) -> tuple[float, dict[str, int]]:
+    """Score one extraction against ground truth: fraction of fields matched.
+
+    Scored fields: ``opening_balance``, ``closing_balance``, and per transaction
+    its ``date`` / ``description`` / ``amount``. A missing or extra transaction
+    row counts against the score (each expected row contributes its fields; an
+    extracted row beyond the truth length is penalised as fully wrong).
+    """
+    matched = 0
+    total = 0
+
+    for balance_field in ("opening_balance", "closing_balance"):
+        if balance_field in truth:
+            total += 1
+            if balance_field in extracted and _field_matches(
+                balance_field, extracted[balance_field], truth[balance_field]
+            ):
+                matched += 1
+
+    truth_txns = truth.get("transactions", []) or []
+    got_txns = extracted.get("transactions", []) or []
+    for i, want in enumerate(truth_txns):
+        got = got_txns[i] if i < len(got_txns) else {}
+        for fname in _TXN_FIELDS:
+            if fname in want:
+                total += 1
+                if isinstance(got, dict) and fname in got and _field_matches(
+                    fname, got[fname], want[fname]
+                ):
+                    matched += 1
+    # Penalise invented extra rows: each extra extracted row beyond truth is wrong.
+    extra = max(0, len(got_txns) - len(truth_txns))
+    total += extra * len(_TXN_FIELDS)
+
+    score = (matched / total) if total else 1.0
+    return score, {"matched": matched, "total": total}
+
+
+def reliability_score(samples: list[dict[str, Any]], truth: dict[str, Any]) -> float:
+    """Mean per-field score over N recordings of the same case (AC23.8.7).
+
+    One recording yields a single point estimate, NOT a reliability measure — the
+    limitation is documented in ``docs/ssot/cassette-graded-eval.md``. With N>=2
+    samples the case score is the mean, smoothing per-run nondeterminism.
+    """
+    if not samples:
+        return 1.0
+    scores = [case_score(s, truth)[0] for s in samples]
+    return sum(scores) / len(scores)
+
+
+# --------------------------------------------------------------------------- #
+# Loading cassettes + ground truth into scored cases.
+# --------------------------------------------------------------------------- #
+@dataclass
+class EvalCase:
+    """One eval case: a committed cassette paired with its ground truth."""
+
+    case_id: str
+    modality: str
+    institution_class: str
+    edge_condition: str
+    extracted: dict[str, Any]
+    truth: dict[str, Any]
+    samples: list[dict[str, Any]] = field(default_factory=list)
+
+    def score(self) -> float:
+        if self.samples:
+            return reliability_score(self.samples, self.truth)
+        return case_score(self.extracted, self.truth)[0]
+
+
+def _parse_extraction(cassette_path: Path) -> dict[str, Any] | None:
+    """Return the parsed JSON extraction from a cassette response, or None."""
+    try:
+        cassette = json.loads(cassette_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    text = _response_text(cassette.get("response"))
+    if not text:
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def load_cases(
+    ground_truth_dir: Path = GROUND_TRUTH_DIR,
+    cassette_dir: Path = CASSETTE_DIR,
+) -> list[EvalCase]:
+    """Load every cassette that has a sibling ``<id>.truth.json`` ground truth.
+
+    The ground-truth file is the case manifest: it carries the coverage-matrix
+    metadata (modality / institution_class / edge_condition), the synthetic flag,
+    and the known-correct ``expected`` fields. The matching cassette
+    (``<id>.json``) supplies the LLM's frozen extraction to score.
+    """
+    cases: list[EvalCase] = []
+    for truth_path in sorted(ground_truth_dir.glob("*.truth.json")):
+        case_id = truth_path.name[: -len(".truth.json")]
+        truth_doc = json.loads(truth_path.read_text(encoding="utf-8"))
+        extracted = _parse_extraction(cassette_dir / f"{case_id}.json")
+        if extracted is None:
+            raise ValueError(
+                f"ground truth {truth_path.name} has no scorable cassette "
+                f"{case_id}.json (extraction unreadable)"
+            )
+        cases.append(
+            EvalCase(
+                case_id=case_id,
+                modality=truth_doc["modality"],
+                institution_class=truth_doc["institution_class"],
+                edge_condition=truth_doc["edge_condition"],
+                extracted=extracted,
+                truth=truth_doc["expected"],
+            )
+        )
+    return cases
+
+
+# --------------------------------------------------------------------------- #
+# Ratchet evaluation.
+# --------------------------------------------------------------------------- #
+def ratcheted_baseline(
+    baseline: dict[str, Any], current: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    """Raise-only merge: new floor = max(old, current) per case, plus new cases."""
+    cases = dict(baseline.get("cases", {}))
+    for case_id, cur in current.items():
+        cur_score = float(cur.get("score", 0.0))
+        prev = cases.get(case_id)
+        if prev is None or cur_score >= float(prev.get("score", 0.0)):
+            cases[case_id] = {
+                "score": round(cur_score, 6),
+                "metric": cur.get("metric", "field-accuracy"),
+                "provenance": cur.get("provenance", ""),
+            }
+    return {"version": 1, "cases": dict(sorted(cases.items()))}
+
+
+def evaluate(
+    *,
+    baseline_path: Path = DEFAULT_BASELINE,
+    ground_truth_dir: Path = GROUND_TRUTH_DIR,
+    cassette_dir: Path = CASSETTE_DIR,
+    overrides: dict[str, list[dict[str, Any]]] | None = None,
+) -> dict[str, list[str]]:
+    """Compare current per-case scores to the persisted floors.
+
+    ``overrides`` maps ``case_id`` -> a list of substitute extractions (used by
+    the reverse-proof tests to inject a regression without mutating committed
+    fixtures); when given, that case is scored from the override samples.
+    """
+    baseline = load_jsonl(baseline_path)
+    base_cases = baseline.get("cases", {})
+    cases = load_cases(ground_truth_dir, cassette_dir)
+    overrides = overrides or {}
+
+    regressions: list[str] = []
+    missing: list[str] = []
+    new_cases: list[str] = []
+    current: dict[str, dict[str, Any]] = {}
+
+    seen: set[str] = set()
+    for case in cases:
+        seen.add(case.case_id)
+        if case.case_id in overrides:
+            cur_score = reliability_score(overrides[case.case_id], case.truth)
+        else:
+            cur_score = case.score()
+        current[case.case_id] = {"score": cur_score}
+        floor = base_cases.get(case.case_id)
+        if floor is None:
+            new_cases.append(f"{case.case_id}: new eval case (adopt via --update)")
+            continue
+        floor_score = float(floor.get("score", 0.0))
+        if cur_score < floor_score - EPSILON:
+            regressions.append(
+                f"{case.case_id}: score {cur_score:.4f} < floor {floor_score:.4f} "
+                f"(delta {cur_score - floor_score:+.4f})"
+            )
+
+    for case_id in base_cases:
+        if case_id not in seen:
+            missing.append(f"{case_id}: baselined case has no cassette/ground-truth in this run")
+
+    return {
+        "regressions": regressions,
+        "missing": missing,
+        "new": new_cases,
+        "_current": current,  # type: ignore[dict-item]
+    }

--- a/common/ssot/cassette_graded_eval.py
+++ b/common/ssot/cassette_graded_eval.py
@@ -29,7 +29,6 @@ from typing import Any
 from common.ssot.cassette_eval_baseline import DEFAULT_BASELINE, load_jsonl
 from common.ssot.check_llm_cassettes import CASSETTE_DIR, _response_text
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
 GROUND_TRUTH_DIR = CASSETTE_DIR / "ground_truth"
 
 # Floating-point slack so an identical re-measurement never trips the ratchet.

--- a/common/ssot/check_cassette_graded_eval.py
+++ b/common/ssot/check_cassette_graded_eval.py
@@ -32,7 +32,7 @@ def render(findings: dict[str, list[str]]) -> str:
     for title, key in (
         ("Regressions", "regressions"),
         ("Missing ground truth", "missing"),
-        ("New (informational)", "new"),
+        ("Unbaselined cases (need a floor)", "new"),
     ):
         items = findings.get(key, [])
         lines.append(f"  {title}: {len(items)}")
@@ -59,11 +59,17 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     findings = evaluate(baseline_path=args.baseline)
-    blocking = findings["regressions"] + findings["missing"]
+    # A regressed score or a vanished baseline line blocks BOTH paths. An
+    # unbaselined ("new") case blocks the GATE path too — otherwise adding a case
+    # (or accidentally deleting its floor) would leave the ratchet silently
+    # disabled for that case while CI stays green. `--update` is the sanctioned way
+    # to adopt new cases, so it does NOT treat "new" as blocking.
+    blocking_update = findings["regressions"] + findings["missing"]
+    blocking_gate = blocking_update + findings["new"]
 
     if args.update:
-        if blocking:
-            for item in blocking:
+        if blocking_update:
+            for item in blocking_update:
                 print(
                     f"::error title=Cassette graded eval::refusing --update: {item}",
                     file=sys.stderr,
@@ -86,17 +92,22 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     print(render(findings))
-    if blocking:
-        for item in blocking:
+    if blocking_gate:
+        for item in blocking_gate:
             print(f"::error title=Cassette graded eval::{item}", file=sys.stderr)
         print(
             "[CASSETTE-EVAL] FAILED: a committed cassette regressed below its "
-            "field-accuracy floor (re-record correctly via make llm-record, or fix "
-            "the ground truth if the statement legitimately changed).",
+            "field-accuracy floor, lost its baselined floor, or has no floor yet. "
+            "Re-record correctly via `make llm-record`, fix the ground truth if the "
+            "statement legitimately changed, or adopt a new case's floor with "
+            "`python tools/check_cassette_graded_eval.py --update`.",
             file=sys.stderr,
         )
         return 1
-    print("[CASSETTE-EVAL] PASSED: every committed cassette meets its field-accuracy floor.")
+    print(
+        "[CASSETTE-EVAL] PASSED: every committed cassette is baselined and meets "
+        "its field-accuracy floor."
+    )
     return 0
 
 

--- a/common/ssot/check_cassette_graded_eval.py
+++ b/common/ssot/check_cassette_graded_eval.py
@@ -1,0 +1,104 @@
+"""Cassette graded field-accuracy eval gate (EPIC-023 AC23.8 / issue #1307).
+
+Scores each committed statement cassette per-field against its SYNTHETIC ground
+truth and ratchets a persisted per-case floor that may only go UP. The gate FAILS
+when a refreshed cassette regresses below its floor — catching the "balance chain
+still reconciles but a field is now wrong" drift the AC23.7 balance gate cannot
+see.
+
+Pure Python (no key/network/DB): runs in the lint job alongside
+``check_llm_cassettes`` so it never perturbs the AC behavioral-score aggregator.
+``--update`` raises the floor to the current scores (never lowers, refuses to
+cement a regressed run) and is the local ``make llm-record`` companion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from common.ssot.cassette_eval_baseline import DEFAULT_BASELINE, load_jsonl, write_jsonl
+from common.ssot.cassette_graded_eval import (
+    GROUND_TRUTH_DIR,
+    evaluate,
+    load_cases,
+    ratcheted_baseline,
+)
+
+
+def render(findings: dict[str, list[str]]) -> str:
+    lines = ["Cassette graded eval ratchet"]
+    for title, key in (
+        ("Regressions", "regressions"),
+        ("Missing ground truth", "missing"),
+        ("New (informational)", "new"),
+    ):
+        items = findings.get(key, [])
+        lines.append(f"  {title}: {len(items)}")
+        lines.extend(f"    - {item}" for item in items)
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Cassette graded field-accuracy ratchet.")
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Raise the per-case floor to the current scores (never lowers).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not GROUND_TRUTH_DIR.exists() or not any(GROUND_TRUTH_DIR.glob("*.truth.json")):
+        print("[CASSETTE-EVAL] no ground-truth artifacts; nothing to grade.")
+        return 0
+
+    findings = evaluate(baseline_path=args.baseline)
+    blocking = findings["regressions"] + findings["missing"]
+
+    if args.update:
+        if blocking:
+            for item in blocking:
+                print(
+                    f"::error title=Cassette graded eval::refusing --update: {item}",
+                    file=sys.stderr,
+                )
+            return 1
+        baseline = load_jsonl(args.baseline)
+        current = findings["_current"]  # type: ignore[assignment]
+        updated = ratcheted_baseline(baseline, current)  # type: ignore[arg-type]
+        # Carry provenance from the cases for new floors.
+        provenance = {
+            c.case_id: f"{c.modality}/{c.institution_class}/{c.edge_condition}"
+            for c in load_cases()
+        }
+        for case_id, record in updated["cases"].items():
+            if not record.get("provenance"):
+                record["provenance"] = provenance.get(case_id, "")
+            record.setdefault("metric", "field-accuracy")
+        write_jsonl(args.baseline, updated)
+        print(f"Updated cassette-eval baseline: {args.baseline} ({len(updated['cases'])} case(s))")
+        return 0
+
+    print(render(findings))
+    if blocking:
+        for item in blocking:
+            print(f"::error title=Cassette graded eval::{item}", file=sys.stderr)
+        print(
+            "[CASSETTE-EVAL] FAILED: a committed cassette regressed below its "
+            "field-accuracy floor (re-record correctly via make llm-record, or fix "
+            "the ground truth if the statement legitimately changed).",
+            file=sys.stderr,
+        )
+        return 1
+    print("[CASSETTE-EVAL] PASSED: every committed cassette meets its field-accuracy floor.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/docs/project/EPIC-023.llm-provider-abstraction.md
+++ b/docs/project/EPIC-023.llm-provider-abstraction.md
@@ -176,3 +176,30 @@ parallel once PR1 merges.
 | AC23.6.4 | `off` mode is an EXACT passthrough of the live (mocked) stream — deltas arrive unchanged (not collapsed), no cassette is written, and a provider failure is normalised to `LLMError` exactly as before — so prod/staging keep running the live `-m llm` path real {tier:CODE-ONLY}{proof:property} | `apps/backend/tests/unit/llm/test_streaming_cassette.py` | P1 |
 | AC23.6.5 | The fingerprint role is derived from the messages (any image part → `vision`, else `text`), so text and vision get **different** keys, while the same semantic request under a different model id resolves the **same** cassette (model-id-agnostic) {tier:CODE-ONLY}{proof:property} | `apps/backend/tests/unit/llm/test_streaming_cassette.py` | P1 |
 | AC23.7.1 | The LLM cassette integrity gate (`tools/check_llm_cassettes.py`, lint job) fails when any committed statement-extraction cassette breaks the balance-chain invariant `opening + Σ amounts ≈ closing` (Decimal) — detectable drift for a re-recorded/inconsistent cassette; pure Python, no key/network/DB, so it never perturbs the AC behavioral-score aggregator {tier:CODE-ONLY}{proof:property} | `tests/tooling/test_llm_cassette_integrity.py` | P1 |
+
+### AC23.8 — Cassette GRADED field-accuracy eval + drift ratchet
+> AC23.7 gates cassette *consistency* (the balance chain reconciles), not
+> *accuracy*: an LLM that misreads `50` as `150` still passes as long as the chain
+> still balances. This slice adds a GRADED field-accuracy eval over the committed
+> statement cassettes — each case is scored per-field (exact/normalised match:
+> amounts as `Decimal`, dates ISO, descriptions normalised) against a sibling
+> SYNTHETIC ground-truth artifact (`*.truth.json`, anonymised; no real financial
+> data). A per-case score FLOOR is persisted as a ratcheted JSONL baseline
+> (`docs/ssot/cassette-eval-baseline.jsonl`, `merge=union`, floor only goes UP),
+> and the lint-job gate FAILS when a refreshed cassette regresses a case below its
+> floor — catching "invariant passes but a field is now wrong", which AC23.7 cannot
+> see. Pure Python, no key/network/DB, deterministic on committed cassettes;
+> refresh is the local `make llm-record` path. **Scope (anti-overclaim):**
+> drift-detection power is bounded by the eval-set breadth documented in the
+> coverage matrix — CI green ≠ accurate on an unseen statement (that remains the
+> staging `-m llm` gate's job). {tier:LLM-LED}{proof:eval}
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC23.8.1 | The eval set covers a documented **modality × institution-class × edge-condition** matrix (text & vision modalities; generic & named-institution classes; happy-path & duplicate-row/#1254 edge conditions) to a stated minimum case count, and the doc explicitly states drift-detection power is bounded by that breadth (no overclaiming) {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |
+| AC23.8.2 | Each case scores **per-field accuracy** (exact/normalised match: amounts as `Decimal`, dates ISO-normalised, descriptions case/space-normalised) against the case's known-correct ground-truth values, producing a numeric `[0,1]` score {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |
+| AC23.8.3 | A per-case score floor is persisted in a ratcheted JSONL baseline and may only go **UP** (`--update` raises, never lowers; refuses to cement a regressed run); the gate FAILS when any case scores below its floor {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |
+| AC23.8.4 | A deliberately-regressed cassette (a field flipped so its score drops below floor) is CAUGHT and fails the gate — proven by a test that injects the regression and asserts the gate returns a violation {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |
+| AC23.8.5 | The graded eval distinguishes "balance invariant passes but field-accuracy regressed" from "invariant fails": a cassette whose chain still reconciles but whose amount no longer matches ground truth is flagged by the graded gate while the AC23.7 balance gate stays green {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |
+| AC23.8.6 | The eval runs deterministically in CI on committed cassettes with **NO network and NO API key**; the refresh path is the local `make llm-record` target (documented), never CI {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |
+| AC23.8.7 | Reliability scoring aggregates over **N≥2 samples** per case when multiple recordings of the same case exist (mean score), and the single-sample limitation (one recording ⇒ point estimate, not a reliability measure) is documented {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -829,3 +829,17 @@ concepts:
       - apps/backend/tests/unit/llm/test_secrets.py
       - apps/backend/tests/unit/llm/test_types.py
       - apps/backend/tests/unit/llm/test_cassette.py
+
+  cassette_graded_eval:
+    owner: docs/ssot/cassette-graded-eval.md
+    family: llm
+    kind: concept
+    description: Graded per-field accuracy eval over committed cassettes with a ratcheted per-case score floor (EPIC-023 AC23.8) — the accuracy oracle complementing the AC23.7 balance-chain consistency gate.
+    cross_refs:
+      - docs/ssot/llm.md
+      - docs/project/EPIC-023.llm-provider-abstraction.md
+      - common/ssot/cassette_graded_eval.py
+      - common/ssot/check_cassette_graded_eval.py
+      - docs/ssot/cassette-eval-baseline.jsonl
+    proofs:
+      - tests/tooling/test_cassette_graded_eval.py

--- a/docs/ssot/cassette-eval-baseline.jsonl
+++ b/docs/ssot/cassette-eval-baseline.jsonl
@@ -1,0 +1,3 @@
+{"case_id": "cb5dd1f714784190dab3356c17d635a0e09b8f9fca78abb6023218ca29efcbab", "score": 1.0, "metric": "field-accuracy", "provenance": "text/generic/duplicate_rows"}
+{"case_id": "d2bef919d2918989d2a6dbc8bbf019bd6bd2107d97f2e1bd85c91185c36e4fd0", "score": 1.0, "metric": "field-accuracy", "provenance": "vision/named_bank/happy_path"}
+{"case_id": "d69fbafcecb481e614651b1178a5fb9d9e3724718ef7bf623502120bcd27db30", "score": 1.0, "metric": "field-accuracy", "provenance": "text/generic/happy_path"}

--- a/docs/ssot/cassette-graded-eval.md
+++ b/docs/ssot/cassette-graded-eval.md
@@ -66,9 +66,13 @@ established AC behavioural-score ratchet (`docs/ssot/ac-score-baseline.jsonl`,
 `common/ssot/check_ac_score_baseline.py`):
 
 - **Gate:** `tools/check_cassette_graded_eval.py` fails if any case scores below
-  its floor (minus a tiny epsilon).
+  its floor (minus a tiny epsilon), if a baselined case lost its floor, **or if a
+  committed case has no floor at all** — so adding a case (or accidentally
+  deleting its baseline line) cannot silently disable the ratchet while CI stays
+  green.
 - **Raise only:** `--update` raises the floor to the current scores and never
-  lowers it; it refuses to cement a run that has a regression or missing case.
+  lowers it; it adopts new cases (the sanctioned way to baseline a freshly added
+  case) but refuses to cement a run that has a regression or missing case.
 - The baseline is a **persisted** floor — it is never regenerated from current
   scores (that would erase the floor).
 

--- a/docs/ssot/cassette-graded-eval.md
+++ b/docs/ssot/cassette-graded-eval.md
@@ -1,0 +1,121 @@
+# Cassette Graded Field-Accuracy Eval + Drift Ratchet
+
+> SSOT owner for the **graded LLM extraction eval** over committed cassettes
+> (EPIC-023 AC23.8, issue #1307). The balance-chain integrity gate
+> (`docs/ssot/llm.md#cassettes`, AC23.7) is the *consistency* oracle; this is the
+> *accuracy* oracle.
+
+## 1. Why a graded eval (what the balance gate cannot see)
+
+The committed record/replay cassettes are gated today by the **balance-chain
+invariant** `opening + Σ amounts ≈ closing` (`tools/check_llm_cassettes.py`,
+AC23.7). That catches an **inconsistent** re-recording, but it is blind to
+**inaccuracy**: an LLM that reads `50` as `150` — or swaps two transaction
+amounts so the net is unchanged — still satisfies the chain. Such a cassette is
+*plausible but wrong*.
+
+This graded eval scores each committed statement cassette **per field** against a
+known-correct **ground-truth** artifact, producing a numeric `[0, 1]` accuracy
+score per case, and ratchets a per-case **score floor** that may only go **UP**.
+The gate fails CI when a refreshed cassette regresses a case below its floor —
+including the "balance still reconciles but a field is now wrong" case.
+
+## 2. Ground-truth source (synthetic only)
+
+Each scored cassette `<fingerprint>.json` has a sibling ground-truth manifest
+`apps/backend/tests/fixtures/llm_cassettes/ground_truth/<fingerprint>.truth.json`:
+
+```json
+{
+  "synthetic": true,
+  "modality": "text",
+  "institution_class": "generic",
+  "edge_condition": "happy_path",
+  "expected": { "opening_balance": "...", "closing_balance": "...", "transactions": [ ... ] }
+}
+```
+
+- **Data hygiene (AC, enforced):** every ground-truth artifact MUST set
+  `"synthetic": true`. The inputs are **synthetic / anonymised** — never real
+  financial data. The test `test_AC23_8_6_ground_truth_artifacts_are_synthetic`
+  enforces the flag.
+- `expected` carries the known-correct field values; the matching cassette
+  supplies the LLM's frozen extraction to score against it.
+
+## 3. Scoring & normalisation
+
+A case score is the fraction of **scored fields** that match ground truth:
+
+| Field | Match rule |
+|-------|-----------|
+| `opening_balance`, `closing_balance` | Decimal equality (never float) |
+| transaction `amount` | Decimal equality (`"5.00" == 5 == 5.0`) |
+| transaction `date` | ISO `YYYY-MM-DD` (slash forms normalised) |
+| transaction `description` | case-folded, whitespace-collapsed |
+
+A missing expected transaction row scores its fields as wrong; an **invented**
+extra row is penalised as fully wrong. Money is compared as `Decimal`
+end-to-end so `0.10 × 3 == 0.30` holds exactly.
+
+## 4. Ratchet (floor only goes up)
+
+The per-case floor is persisted as sorted, line-oriented JSONL at
+`docs/ssot/cassette-eval-baseline.jsonl` (one case per line, `merge=union` in
+`.gitattributes` so PRs ratcheting different cases auto-merge). This mirrors the
+established AC behavioural-score ratchet (`docs/ssot/ac-score-baseline.jsonl`,
+`common/ssot/check_ac_score_baseline.py`):
+
+- **Gate:** `tools/check_cassette_graded_eval.py` fails if any case scores below
+  its floor (minus a tiny epsilon).
+- **Raise only:** `--update` raises the floor to the current scores and never
+  lowers it; it refuses to cement a run that has a regression or missing case.
+- The baseline is a **persisted** floor — it is never regenerated from current
+  scores (that would erase the floor).
+
+## 5. Coverage matrix (and its bounds)
+
+The eval set covers a **modality × institution-class × edge-condition** matrix:
+
+| Case (cassette) | Modality | Institution class | Edge condition |
+|-----------------|----------|-------------------|----------------|
+| `d69fbafc…` | text | generic | happy_path |
+| `cb5dd1f7…` | text | generic | duplicate_rows (#1254) |
+| `d2bef919…` | vision | named_bank | happy_path |
+
+Minimum case count: **3** (`MIN_CASES`). Required axes asserted by
+`test_AC23_8_1_eval_set_covers_documented_matrix_to_min_count`: both modalities
+(`text`, `vision`), ≥2 institution classes, and the `happy_path` +
+`duplicate_rows` edge conditions.
+
+**Drift-detection power is BOUNDED by this breadth (no overclaiming).** The gate
+only detects regressions on the modality / institution-class / edge-condition
+combinations present in the matrix above. **CI green is NOT a correctness
+guarantee on an UNSEEN statement** — a layout, institution, or edge condition not
+represented here is invisible to this gate. Live correctness on unseen documents
+remains the staging `-m llm` gate's job (`docs/ssot/llm.md`). Grow the matrix by
+recording new cassettes + ground truth and adopting their floors via `--update`.
+
+## 6. Reliability over N samples
+
+When a case has **N≥2** recordings (multiple cassettes of the same logical
+statement), its score is the **mean** over samples (`reliability_score`),
+smoothing per-run nondeterminism. **A single sample is a point estimate, NOT a
+reliability measure** — one recording cannot distinguish a stable extraction from
+a lucky one. To measure reliability for a case, record multiple samples; until
+then a single-sample case is scored as a point estimate and documented as such.
+
+## 7. Determinism & refresh
+
+The eval is **pure Python**: no network, no API key, no DB. It runs in the CI
+**lint** job alongside `check_llm_cassettes` so it never perturbs the AC
+behavioural-score aggregator. Scoring is deterministic on the committed fixtures.
+
+Refresh is a **local** operation (never CI): re-record the cassettes against a
+live provider with `make llm-record`, then raise the floors:
+
+```bash
+make llm-record                                   # re-record cassettes (needs a provider key)
+python tools/check_cassette_graded_eval.py --update   # raise the per-case floors
+```
+
+Commit the refreshed cassettes and the raised baseline together.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - Source Type Priority: ssot/source-type-priority.md
       - Workflow Events: ssot/workflow-events.md
       - LLM Provider Abstraction: ssot/llm.md
+      - Cassette Graded Eval: ssot/cassette-graded-eval.md
       - Evidence Lineage: ssot/evidence-lineage.md
       - Database Schema: ssot/schema.md
       - Observability: ssot/observability.md

--- a/tests/tooling/test_cassette_graded_eval.py
+++ b/tests/tooling/test_cassette_graded_eval.py
@@ -115,6 +115,20 @@ def test_AC23_8_3_committed_cassettes_meet_their_floors() -> None:
     assert findings["missing"] == [], findings["missing"]
 
 
+def test_AC23_8_3_unbaselined_case_blocks_the_gate(tmp_path: Path) -> None:
+    """AC23.8.3: an eval case with NO persisted floor blocks the gate (so a deleted
+    floor or an unguarded new case cannot silently disable the ratchet)."""
+    from common.ssot.check_cassette_graded_eval import main as gate_main
+
+    empty_baseline = tmp_path / "empty.jsonl"
+    empty_baseline.write_text("", encoding="utf-8")
+    # Every committed case is now "new" (no floor) -> gate must FAIL.
+    assert gate_main(["--baseline", str(empty_baseline)]) == 1
+    # But --update is the sanctioned adopt path -> succeeds and writes floors.
+    assert gate_main(["--baseline", str(empty_baseline), "--update"]) == 0
+    assert load_jsonl(empty_baseline)["cases"], "expected floors adopted by --update"
+
+
 def test_AC23_8_3_baseline_is_raise_only() -> None:
     """AC23.8.3: ratcheted_baseline keeps the higher floor and never lowers it."""
     baseline = {"version": 1, "cases": {"c1": {"score": 0.9, "metric": "x", "provenance": "y"}}}

--- a/tests/tooling/test_cassette_graded_eval.py
+++ b/tests/tooling/test_cassette_graded_eval.py
@@ -1,0 +1,280 @@
+"""Graded field-accuracy eval + drift ratchet over committed cassettes.
+
+EPIC-023 AC23.8 / issue #1307. AC23.7 (`check_llm_cassettes`) gates cassette
+*consistency* (the balance chain reconciles); it cannot see *accuracy* — an LLM
+that misreads ``50`` as ``150`` still balances. This graded eval scores each
+committed statement cassette per-field against a SYNTHETIC ground-truth artifact
+and ratchets a per-case score floor that only ever goes UP, so a refreshed
+cassette that regresses a field fails the lint-job gate.
+
+Pure Python: no network, no API key, no DB — runs in `tests/tooling/` (CI-required).
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+from common.ssot.cassette_graded_eval import (
+    GROUND_TRUTH_DIR,
+    REQUIRED_EDGE_CONDITIONS,
+    REQUIRED_MODALITIES,
+    MIN_CASES,
+    case_score,
+    evaluate,
+    load_cases,
+    normalize_amount,
+    normalize_date,
+    normalize_description,
+    ratcheted_baseline,
+)
+from common.ssot.cassette_eval_baseline import DEFAULT_BASELINE, load_jsonl
+
+
+# --------------------------------------------------------------------------- #
+# AC23.8.1 — coverage matrix (modality × institution-class × edge-condition)
+# --------------------------------------------------------------------------- #
+def test_AC23_8_1_eval_set_covers_documented_matrix_to_min_count() -> None:
+    """AC23.8.1: the committed eval set meets the documented coverage matrix and
+    minimum case count across modality / institution-class / edge-condition axes."""
+    cases = load_cases()
+    assert len(cases) >= MIN_CASES, f"need >= {MIN_CASES} eval cases, got {len(cases)}"
+
+    modalities = {c.modality for c in cases}
+    institution_classes = {c.institution_class for c in cases}
+    edge_conditions = {c.edge_condition for c in cases}
+
+    # Both modalities present (text + vision).
+    assert REQUIRED_MODALITIES <= modalities, f"missing modalities: {REQUIRED_MODALITIES - modalities}"
+    # At least a generic and a named institution class are represented.
+    assert len(institution_classes) >= 2, institution_classes
+    # The #1254-class duplicate-row edge condition and a happy path are present.
+    assert REQUIRED_EDGE_CONDITIONS <= edge_conditions, (
+        f"missing edge conditions: {REQUIRED_EDGE_CONDITIONS - edge_conditions}"
+    )
+
+
+def test_AC23_8_1_matrix_breadth_is_documented_not_overclaimed() -> None:
+    """AC23.8.1: the eval doc explicitly bounds drift-detection power by breadth."""
+    doc = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "ssot"
+        / "cassette-graded-eval.md"
+    )
+    text = doc.read_text(encoding="utf-8").lower()
+    # No overclaiming: the doc must say breadth bounds the power and CI green is
+    # not a correctness guarantee on unseen statements.
+    assert "bounded" in text or "bound" in text
+    assert "unseen" in text
+
+
+# --------------------------------------------------------------------------- #
+# AC23.8.2 — per-field scoring (exact / normalised match -> numeric score)
+# --------------------------------------------------------------------------- #
+def test_AC23_8_2_normalizers_are_exact_value_aware() -> None:
+    """AC23.8.2: amounts compare as Decimal, dates ISO, descriptions normalised."""
+    assert normalize_amount("5.00") == normalize_amount(5) == Decimal("5")
+    assert normalize_amount("-5.0") == Decimal("-5")
+    assert normalize_date("2026-01-02") == "2026-01-02"
+    assert normalize_date("02/01/2026", dayfirst=True) == "2026-01-02"
+    assert normalize_description("  Coffee   SHOP ") == normalize_description("coffee shop")
+
+
+def test_AC23_8_2_case_score_is_fraction_of_correct_fields() -> None:
+    """AC23.8.2: a perfect extraction scores 1.0; each wrong field lowers it."""
+    truth = {
+        "opening_balance": "100.00",
+        "closing_balance": "130.00",
+        "transactions": [
+            {"date": "2026-01-02", "description": "Coffee shop", "amount": "-5.00"},
+            {"date": "2026-01-05", "description": "Salary credit", "amount": "50.00"},
+        ],
+    }
+    perfect = json.loads(json.dumps(truth))
+    score, detail = case_score(perfect, truth)
+    assert score == 1.0
+    assert detail["matched"] == detail["total"]
+
+    # Flip one amount -> exactly one field wrong.
+    wrong = json.loads(json.dumps(truth))
+    wrong["transactions"][0]["amount"] = "-15.00"
+    score2, detail2 = case_score(wrong, truth)
+    assert 0.0 < score2 < 1.0
+    assert detail2["matched"] == detail2["total"] - 1
+
+
+# --------------------------------------------------------------------------- #
+# AC23.8.3 — ratchet floor only goes UP; gate fails on regression
+# --------------------------------------------------------------------------- #
+def test_AC23_8_3_committed_cassettes_meet_their_floors() -> None:
+    """AC23.8.3: every committed cassette scores at/above its persisted floor."""
+    findings = evaluate(baseline_path=DEFAULT_BASELINE)
+    assert findings["regressions"] == [], findings["regressions"]
+    assert findings["missing"] == [], findings["missing"]
+
+
+def test_AC23_8_3_baseline_is_raise_only() -> None:
+    """AC23.8.3: ratcheted_baseline keeps the higher floor and never lowers it."""
+    baseline = {"version": 1, "cases": {"c1": {"score": 0.9, "metric": "x", "provenance": "y"}}}
+    # A higher current score raises the floor.
+    raised = ratcheted_baseline(baseline, {"c1": {"score": 0.95}})
+    assert raised["cases"]["c1"]["score"] == 0.95
+    # A lower current score does NOT lower the floor.
+    kept = ratcheted_baseline(baseline, {"c1": {"score": 0.5}})
+    assert kept["cases"]["c1"]["score"] == 0.9
+    # A brand-new case is adopted.
+    added = ratcheted_baseline(baseline, {"c2": {"score": 0.7}})
+    assert added["cases"]["c2"]["score"] == 0.7
+
+
+# --------------------------------------------------------------------------- #
+# AC23.8.4 — reverse proof: an injected regression is CAUGHT
+# --------------------------------------------------------------------------- #
+def test_AC23_8_4_injected_regression_fails_the_gate(tmp_path: Path) -> None:
+    """AC23.8.4: a cassette field flipped below its floor is caught by the gate."""
+    cases = load_cases()
+    # Pick a statement case with at least one transaction amount to corrupt.
+    target = next(c for c in cases if c.extracted.get("transactions"))
+
+    # Build a baseline that records the case's CURRENT (correct) score as the floor.
+    correct_score, _ = case_score(target.extracted, target.truth)
+    baseline_file = tmp_path / "baseline.jsonl"
+    from common.ssot.cassette_eval_baseline import write_jsonl
+
+    write_jsonl(
+        baseline_file,
+        {"version": 1, "cases": {target.case_id: {"score": correct_score, "metric": "field-accuracy", "provenance": "test"}}},
+    )
+
+    # Inject a regression: corrupt one transaction amount so the case score drops.
+    corrupted = json.loads(json.dumps(target.extracted))
+    amt = Decimal(str(corrupted["transactions"][0]["amount"]))
+    corrupted["transactions"][0]["amount"] = str(amt + Decimal("999"))
+    regressed_score, _ = case_score(corrupted, target.truth)
+    assert regressed_score < correct_score  # sanity: the corruption lowered the score
+
+    findings = evaluate(
+        baseline_path=baseline_file,
+        overrides={target.case_id: [corrupted]},
+    )
+    assert any(target.case_id in r for r in findings["regressions"]), findings
+
+
+# --------------------------------------------------------------------------- #
+# AC23.8.5 — catches plausible-but-wrong (invariant passes, accuracy regresses)
+# --------------------------------------------------------------------------- #
+def test_AC23_8_5_balance_passes_but_field_accuracy_regresses(tmp_path: Path) -> None:
+    """AC23.8.5: a cassette whose balance chain still reconciles but whose amount
+    no longer matches ground truth is flagged by the graded gate (while AC23.7 stays green)."""
+    from common.ssot.check_llm_cassettes import balance_violation
+
+    def _same_direction(a: dict, b: dict) -> bool:
+        """True when two transactions move money the SAME way (so a compensating
+        +δ/−δ on their magnitudes keeps the net — and the balance chain — fixed)."""
+        da = str(a.get("direction") or "").strip().upper()
+        db = str(b.get("direction") or "").strip().upper()
+        if da or db:
+            return da == db
+        # No direction: same way ⇔ same sign of the signed amount.
+        return (Decimal(str(a["amount"])) < 0) == (Decimal(str(b["amount"])) < 0)
+
+    def _pick_pair(case) -> tuple[int, int] | None:
+        txns = case.extracted.get("transactions") or []
+        for i in range(len(txns)):
+            for j in range(i + 1, len(txns)):
+                if _same_direction(txns[i], txns[j]):
+                    return i, j
+        return None
+
+    cases = load_cases()
+    target, pair = next((c, p) for c in cases if (p := _pick_pair(c)) is not None)
+    i, j = pair
+
+    # Plausible-but-wrong: shift +1 onto txn i and −1 off txn j (same direction), so
+    # the NET is unchanged — the balance chain STILL reconciles — but two per-field
+    # amounts now mismatch truth. This is the drift AC23.7 cannot see.
+    plausible = json.loads(json.dumps(target.extracted))
+    ti, tj = plausible["transactions"][i], plausible["transactions"][j]
+    ti["amount"] = str(Decimal(str(ti["amount"])) + Decimal("1"))
+    tj["amount"] = str(Decimal(str(tj["amount"])) - Decimal("1"))
+
+    # AC23.7 balance gate: still GREEN (net preserved).
+    assert balance_violation(plausible) is None
+
+    # Graded gate: CAUGHT (per-field amounts regressed) given a floor at the
+    # correct score.
+    correct_score, _ = case_score(target.extracted, target.truth)
+    plausible_score, _ = case_score(plausible, target.truth)
+    assert plausible_score < correct_score
+
+    baseline_file = tmp_path / "baseline.jsonl"
+    from common.ssot.cassette_eval_baseline import write_jsonl
+
+    write_jsonl(
+        baseline_file,
+        {"version": 1, "cases": {target.case_id: {"score": correct_score, "metric": "field-accuracy", "provenance": "test"}}},
+    )
+    findings = evaluate(baseline_path=baseline_file, overrides={target.case_id: [plausible]})
+    assert any(target.case_id in r for r in findings["regressions"]), findings
+
+
+# --------------------------------------------------------------------------- #
+# AC23.8.6 — deterministic, no network / no key; baseline persisted
+# --------------------------------------------------------------------------- #
+def test_AC23_8_6_runs_on_committed_cassettes_without_network_or_key() -> None:
+    """AC23.8.6: the eval scores committed cassettes purely from disk (no I/O beyond
+    reading the fixtures); a persisted baseline floor exists for the committed cases."""
+    cases = load_cases()
+    assert cases, "expected committed eval cases"
+    # Scoring is pure: same input -> same score, no env/key dependence.
+    for case in cases:
+        s1, _ = case_score(case.extracted, case.truth)
+        s2, _ = case_score(case.extracted, case.truth)
+        assert s1 == s2
+
+    baseline = load_jsonl(DEFAULT_BASELINE)
+    for case in cases:
+        assert case.case_id in baseline["cases"], f"no persisted floor for {case.case_id}"
+
+
+def test_AC23_8_6_ground_truth_artifacts_are_synthetic() -> None:
+    """AC23.8.6 (data hygiene): every ground-truth artifact is flagged synthetic."""
+    for path in sorted(GROUND_TRUTH_DIR.glob("*.truth.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data.get("synthetic") is True, f"{path.name} not marked synthetic"
+
+
+# --------------------------------------------------------------------------- #
+# AC23.8.7 — reliability over N samples, single-sample limitation documented
+# --------------------------------------------------------------------------- #
+def test_AC23_8_7_reliability_aggregates_over_n_samples() -> None:
+    """AC23.8.7: a case with multiple recordings scores the MEAN over samples."""
+    truth = {
+        "opening_balance": "0.00",
+        "closing_balance": "0.00",
+        "transactions": [{"date": "2026-01-01", "description": "X", "amount": "0.00"}],
+    }
+    perfect = json.loads(json.dumps(truth))
+    wrong = json.loads(json.dumps(truth))
+    wrong["transactions"][0]["amount"] = "1.00"
+    s_perfect, _ = case_score(perfect, truth)
+    s_wrong, _ = case_score(wrong, truth)
+
+    from common.ssot.cassette_graded_eval import reliability_score
+
+    mean = reliability_score([perfect, wrong], truth)
+    assert mean == (s_perfect + s_wrong) / 2
+
+
+def test_AC23_8_7_single_sample_limitation_documented() -> None:
+    """AC23.8.7: the doc states a single recording is a point estimate, not reliability."""
+    doc = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "ssot"
+        / "cassette-graded-eval.md"
+    )
+    text = doc.read_text(encoding="utf-8").lower()
+    assert "single" in text and "sample" in text

--- a/tools/check_cassette_graded_eval.py
+++ b/tools/check_cassette_graded_eval.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Command wrapper for the cassette graded field-accuracy eval gate (EPIC-023 AC23.8)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.ssot.check_cassette_graded_eval import main  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

Adds a **GRADED field-accuracy eval + drift ratchet** over the committed LLM
cassettes (EPIC-023 **AC23.8**).

The only cassette gate today (AC23.7, `tools/check_llm_cassettes.py`) is the
balance-chain invariant — it catches **inconsistency**, not **inaccuracy**. An
LLM that misreads `50` as `150`, or swaps two amounts so the net is unchanged,
still passes. This PR adds a per-field accuracy score against synthetic ground
truth, with a ratcheted per-case floor that fails CI when a refreshed cassette
regresses.

## How

- `common/ssot/cassette_graded_eval.py` — per-field scorer (amounts `Decimal`,
  dates ISO, descriptions normalised) → numeric `[0,1]` case score; coverage-matrix
  loader; reliability mean over N≥2 samples; raise-only ratchet + `evaluate()`.
- `common/ssot/cassette_eval_baseline.py` — sorted JSONL floor storage, mirroring
  the AC-score baseline (`merge=union` for conflict-free ratcheting).
- `common/ssot/check_cassette_graded_eval.py` + `tools/` wrapper — lint-job gate;
  `--update` raises the floor (never lowers; refuses to cement a regressed run).
- Synthetic ground truth per case under
  `apps/backend/tests/fixtures/llm_cassettes/ground_truth/` (`*.truth.json`,
  `synthetic` flag enforced); seeded floors in `docs/ssot/cassette-eval-baseline.jsonl`.
- `docs/ssot/cassette-graded-eval.md` — coverage matrix + explicit **breadth bound
  (no overclaiming)**, single-sample limitation, deterministic / `make llm-record`
  refresh path.
- CI lint step, `.gitattributes merge=union`, mkdocs nav, MANIFEST concept, Makefile note.

## Acceptance criteria (AC23.8.1–.7, tier LLM-LED, proof:eval)

| AC | Covered by |
|----|-----------|
| AC23.8.1 coverage matrix + breadth bound | `test_AC23_8_1_*` + the doc |
| AC23.8.2 per-field scoring | `test_AC23_8_2_*` |
| AC23.8.3 raise-only ratchet | `test_AC23_8_3_*` |
| AC23.8.4 reverse proof (injected regression caught) | `test_AC23_8_4_injected_regression_fails_the_gate` |
| AC23.8.5 plausible-but-wrong (balance green, accuracy regressed) | `test_AC23_8_5_balance_passes_but_field_accuracy_regresses` |
| AC23.8.6 deterministic, no network/key + data hygiene | `test_AC23_8_6_*` |
| AC23.8.7 reliability over N samples + single-sample doc | `test_AC23_8_7_*` |

Pure Python — no key, no network, no DB. Synthetic / anonymised data only.

Parent: #1397
Closes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)