### PR TITLE
[finance_report_hacker] test(#1232): make AC8.13.159 audit-replay subtraction test non-vacuous

### DIFF
--- a/tests/tooling/test_staging_ai_ocr_gate_contract.py
+++ b/tests/tooling/test_staging_ai_ocr_gate_contract.py
@@ -164,14 +164,20 @@ def test_AC8_13_159_blocking_path_excludes_heavy_audit_journeys() -> None:
     # (subtraction), so a new heavy journey can never silently block production.
     import tools.staging_ai_ocr_gate_contract as live
 
+    # Use a genuinely NEW path (absent from both the real gate corpus and the
+    # canary list) so the subtraction is actually exercised — unioning in an
+    # existing CANARY_FILE would be a no-op and assert nothing.
+    new_heavy = "tests/e2e/test_hypothetical_new_heavy_proof.py"
+    assert new_heavy not in set(live.gate_files())
+    assert new_heavy not in set(live.canary_files())
+
     original_gate_files = live.gate_files
     try:
         live.gate_files = lambda: sorted(  # type: ignore[assignment]
-            set(original_gate_files()) | {CANARY_FILE}
+            set(original_gate_files()) | {new_heavy}
         )
-        assert CANARY_FILE not in set(live.audit_replay_files())
-        # A brand-new heavy file (not in CANARY_FILES) lands in audit-replay.
-        new_heavy = "tests/e2e/test_statement_full_journey.py"
+        # Derived by subtraction (gate_files - canary), so the brand-new heavy
+        # file lands in audit-replay and never in the blocking canary.
         assert new_heavy in set(live.audit_replay_files())
         assert new_heavy not in set(live.canary_files())
     finally:


### PR DESCRIPTION
## Forward-fix for a Copilot finding that merged before its fix landed

#1401 (the #1232 canary split) was merged at commit `d298a9b2` **before** the Copilot-CR fix commit was pushed, so the fix was orphaned on the branch and `main` still carries the flawed test.

**The flaw (Copilot CR on #1401):** `test_AC8_13_159_blocking_path_excludes_heavy_audit_journeys` monkeypatched `gate_files()` to union in `CANARY_FILE` — but `CANARY_FILE` is already in the canary set, so the `audit_replay = gate_files − canary` subtraction was a **no-op**. The "a newly-added heavy file defaults to audit-replay" case the test claims to cover was never actually exercised, and `new_heavy` only passed because it was already a real gate file.

**Fix:** union in a synthetic path (`test_hypothetical_new_heavy_proof.py`) absent from both `gate_files()` and the canary, and assert up front that it's genuinely new — so the subtraction is really exercised.

Verified: the test passes, ruff clean. Anchors EPIC-008 AC8.13.159 (unchanged AC; this strengthens its proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)