### PR TITLE
[finance_report_hacker] chore: finish authority-vocab cleanup (LP/PC/PL → LLM-LED/CODE-ONLY/LLM-ONLY)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,9 @@ jobs:
           # EPIC-026 phase 2: enforce the tier->valid-proof-kind matrix
           # (docs/ssot/authority-tiers.md) for ACs that carry a {tier:XX}.
           # Untagged legacy ACs have no proof_kind and are ignored (non-breaking).
-          # The rule with teeth: an LP AC's proof_kind MUST NOT be `exact`
+          # The rule with teeth: an LLM-LED AC's proof_kind MUST NOT be `exact`
           # (an LLM-emitted output cannot be proven by an exact golden assertion);
-          # HU must be `evidence`; PL must not be exact.
+          # HU must be `evidence`; LLM-ONLY must not be exact.
           uv run --with pyyaml python tools/check_ac_proof_kind.py
       - name: Package-Model Migration-Safety Gates
         run: |
@@ -222,8 +222,8 @@ jobs:
       - name: Tier Import Guard (CODE-ONLY must not import the LLM layer)
         run: |
           # EPIC-026 phase 3: enforce the cross-tier STRUCTURAL MUST rule
-          # (docs/ssot/authority-tiers.md, rule 2 "PC stays pure"). AST-based,
-          # direct-imports-only: a curated set of PC/financial-truth modules
+          # (docs/ssot/authority-tiers.md, rule 2 "CODE-ONLY stays pure"). AST-based,
+          # direct-imports-only: a curated set of CODE-ONLY/financial-truth modules
           # (money/**, ledger/**, journal model, deterministic services) must
           # not import the LLM layer (src.llm) or a raw provider SDK
           # (litellm/openrouter/anthropic/openai). GREEN on main today; this is a


### PR DESCRIPTION
## Finish the EPIC-026 authority-vocabulary migration

The vocabulary unification (#1373) retired the legacy tier codes. A repo-wide PCRE scan (`git grep -P '\b(LP|PC|CP|PL)\b'`) confirms docs + AC markers + most code are **already migrated**; the genuine remaining stale prose was:

1. **`.github/workflows/ci.yml`** comments (this PR) — `LP AC`→`LLM-LED AC`, `PL`→`LLM-ONLY`, rule 2 `"PC stays pure"`→`"CODE-ONLY stays pure"`, `PC/financial-truth`→`CODE-ONLY/financial-truth`. Comments only — no rule/logic change.
2. `apps/backend/tests/extraction/test_extraction_invariants.py` (11× `LP`) — **already fixed in #1402** (the #1352 PR).

### Mapping (authoritative — `common/authority/authority_matrix.py:20-21`)
`PC→CODE-ONLY · CP→CODE-LED · LP→LLM-LED · PL→LLM-ONLY · HU→draft/undecided`

### Deliberately NOT touched
- **`HU`** — the governed "undecided" legacy marker (`{tier:HU}`×3 in EPIC-003 + prose), still owned by the **#1357** ratchet; retired there, not here.
- **`common/authority/authority_matrix.py:20-21`** — the rename-record comment (historical mapping).
- **`.opencode/.../backend-mindset.md`** "CP"/"PC/EC" — that's the **CAP/PACELC theorem**, unrelated to authority tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)