### PR TITLE
[finance_report_hacker] fix(portfolio): don't auto-import brokerage positions before review (#1408)

### DIFF
--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -18,7 +18,7 @@ from src.models.layer1 import DocumentStatus, DocumentType, UploadedDocument
 from src.models.statement_enums import Stage1Status
 from src.models.statement_summary import StatementSummary
 from src.services import ExtractionError, ExtractionService, StorageError, StorageService
-from src.services.brokerage_positions import BrokeragePositionImportService, looks_like_brokerage_payload
+from src.services.brokerage_positions import looks_like_brokerage_payload
 from src.services.statement_posting import try_auto_approve_high_confidence_statement
 from src.telemetry_metrics import record_statement_parse_outcome
 
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     pass
 
 logger = get_logger(__name__)
-_brokerage_import_service = BrokeragePositionImportService()
 
 
 def _safe_error_message(message: str | None) -> str | None:
@@ -55,7 +54,7 @@ def _append_validation_note(existing: str | None, note: str) -> str:
     return combined[:500]
 
 
-async def import_brokerage_payload_if_present(
+async def route_brokerage_for_review_if_present(
     *,
     summary: StatementSummary,
     db: AsyncSession,
@@ -66,7 +65,19 @@ async def import_brokerage_payload_if_present(
     request_id: str | None = None,
     model_to_use: str | None = None,
 ) -> None:
-    """Import parsed brokerage positions after statement parsing succeeds."""
+    """Route a detected brokerage statement to Stage-1 review WITHOUT importing positions (#1408).
+
+    Brokerage positions used to be auto-imported into AtomicPosition (L2) + ManagedPosition
+    (L3) during parse, before any human review, so a still-``pending_review`` brokerage
+    statement immediately inflated ``/portfolio/holdings``, ``/portfolio/summary``, and
+    ``/reports/net-worth/*`` (#1408). Positions must instead be created only by the explicit,
+    user-initiated ``POST /statements/{statement_id}/brokerage/import`` endpoint.
+
+    So at parse we ONLY surface the statement for review: a detected brokerage payload moves the
+    statement into ``Stage1Status.PENDING_REVIEW`` (when ``PARSED`` and not already approved) so a
+    human can trigger the explicit import. No ``AtomicPosition`` / ``ManagedPosition`` rows are
+    created here. ``user_id`` is retained for signature parity with the explicit import path.
+    """
     if not looks_like_brokerage_payload(payload, filename=filename, institution=institution or summary.institution):
         return
 
@@ -78,61 +89,49 @@ async def import_brokerage_payload_if_present(
             broker = payload["statement"].get("institution")
     broker = broker or institution or summary.institution
     parsed_positions = _count_brokerage_positions(payload)
-    source_document_id = str(summary.uploaded_document_id or summary.id)
     logger.info(
-        "statement.brokerage_import.started",
-        audit_event="statement.brokerage_import.started",
+        "statement.brokerage_review_routing.started",
+        audit_event="statement.brokerage_review_routing.started",
         request_id=request_id,
         statement_id=str(summary.id),
-        phase="brokerage_import_started",
+        phase="brokerage_review_routing_started",
         model_to_use=model_to_use,
         broker=broker,
         parsed_positions=parsed_positions,
     )
 
     try:
-        result = await _brokerage_import_service.import_positions(
-            db,
-            user_id=user_id,
-            payload=payload or {},
-            filename=filename,
-            source_document_id=source_document_id,
-        )
-        if result.parsed_positions == 0:
-            # AC-B5 (#1139): a brokerage document that yields zero positions is a
-            # surfaced REVIEW FLAG, not a buried string. Routing it to the Stage-1
-            # pending-review queue (in addition to the validation_error note) makes
-            # the empty-holdings case visible to a human instead of letting a
-            # brokerage upload silently auto-settle with no imported holdings.
+        if parsed_positions == 0:
+            # AC6 (#1408, formerly AC-B5/#1139): a brokerage document that yields zero
+            # positions is a surfaced REVIEW FLAG, not a buried string — keep the
+            # human-readable validation note in addition to the pending-review routing.
             summary.validation_error = _append_validation_note(
                 summary.validation_error,
                 "Brokerage import skipped: no positions detected in parsed brokerage payload",
             )
-            if summary.status == BankStatementStatus.PARSED:
-                summary.stage1_status = Stage1Status.PENDING_REVIEW
+        # #1408: do NOT import positions at parse. Only surface the brokerage statement in
+        # the Stage-1 review queue so the user can trigger the explicit import endpoint,
+        # which remains the sole path that creates AtomicPosition/ManagedPosition rows.
+        if summary.status == BankStatementStatus.PARSED and summary.stage1_status != Stage1Status.APPROVED:
+            summary.stage1_status = Stage1Status.PENDING_REVIEW
         await db.commit()
         logger.info(
-            "statement.brokerage_import.completed",
-            audit_event="statement.brokerage_import.completed",
+            "statement.brokerage_review_routing.completed",
+            audit_event="statement.brokerage_review_routing.completed",
             request_id=request_id,
             statement_id=str(summary.id),
-            phase="brokerage_import_completed",
+            phase="brokerage_review_routing_completed",
             model_to_use=model_to_use,
-            broker=result.broker,
-            parsed_positions=result.parsed_positions,
-            created_atomic_positions=result.created_atomic_positions,
-            existing_atomic_positions=result.existing_atomic_positions,
-            reconcile_created=result.reconcile_created,
-            reconcile_updated=result.reconcile_updated,
-            reconcile_disposed=result.reconcile_disposed,
+            broker=broker,
+            parsed_positions=parsed_positions,
         )
     except Exception as exc:
         logger.exception(
-            "statement.brokerage_import.failed",
-            audit_event="statement.brokerage_import.failed",
+            "statement.brokerage_review_routing.failed",
+            audit_event="statement.brokerage_review_routing.failed",
             request_id=request_id,
             statement_id=str(summary.id),
-            phase="brokerage_import_failed",
+            phase="brokerage_review_routing_failed",
             model_to_use=model_to_use,
             error_type=type(exc).__name__,
             safe_error_message=_safe_error_message(str(exc)),
@@ -143,7 +142,7 @@ async def import_brokerage_payload_if_present(
             return
         refreshed.validation_error = _append_validation_note(
             refreshed.validation_error,
-            "Brokerage import failed: parsed statement was saved but positions were not imported",
+            "Brokerage review routing failed: parsed statement was saved but was not routed for review",
         )
         await db.commit()
 
@@ -561,7 +560,11 @@ async def parse_statement_background(
             checkpoint("statement_persisted")
             auto_posted_count = await try_auto_approve_high_confidence_statement(session, statement.id, user_id)
             await session.commit()
-            await import_brokerage_payload_if_present(
+            # #1408: detect a brokerage statement and route it to Stage-1 review WITHOUT
+            # importing positions. Positions are created only by the explicit, user-initiated
+            # POST /statements/{id}/brokerage/import endpoint, so a pending-review brokerage
+            # statement never inflates holdings/summary/net-worth before human review.
+            await route_brokerage_for_review_if_present(
                 summary=statement,
                 db=session,
                 user_id=user_id,

--- a/apps/backend/tests/extraction/test_brokerage_position_extraction_wiring.py
+++ b/apps/backend/tests/extraction/test_brokerage_position_extraction_wiring.py
@@ -25,6 +25,7 @@ from sqlalchemy import select
 
 from src.database import create_session_maker_from_db
 from src.models import BankStatementStatus
+from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AtomicPosition
 from src.models.statement_enums import Stage1Status
 from src.models.statement_summary import StatementSummary
@@ -36,7 +37,7 @@ from src.services.brokerage_positions import (
     parse_brokerage_positions,
 )
 from src.services.extraction import ExtractionService
-from src.services.statement_parsing import import_brokerage_payload_if_present, parse_statement_background
+from src.services.statement_parsing import parse_statement_background, route_brokerage_for_review_if_present
 from tests.factories import StatementSummaryFactory
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -166,7 +167,7 @@ async def test_AC_B5_zero_position_brokerage_doc_raises_visible_review_flag(db, 
     db.add(statement)
     await db.commit()
 
-    await import_brokerage_payload_if_present(
+    await route_brokerage_for_review_if_present(
         summary=statement,
         db=db,
         user_id=test_user.id,
@@ -220,6 +221,19 @@ async def test_AC_B4_AC_B6_moomoo_positions_table_extracts_and_imports(client, d
         summary.status = BankStatementStatus.PARSED
         summary.confidence_score = 90
         summary.balance_validated = True
+        # The real parse_document persists the OCR payload; the explicit import endpoint
+        # (#1408) recovers positions from extraction_metadata.
+        summary.extraction_metadata = {"extraction_payload": fixture}
+        doc = UploadedDocument(
+            user_id=user_id,
+            file_path="statements/moomoo-positions.pdf",
+            file_hash=file_hash,
+            original_filename="moomoo-positions-2506.pdf",
+            document_type=DocumentType.BANK_STATEMENT,
+        )
+        session.add(doc)
+        await session.flush()
+        summary.uploaded_document_id = doc.id
         await session.flush()
         summary._extracted_payload = fixture
         return summary, []
@@ -244,6 +258,21 @@ async def test_AC_B4_AC_B6_moomoo_positions_table_extracts_and_imports(client, d
     )
 
     db.expire_all()
+    # #1408: parse routes the brokerage statement to review WITHOUT importing positions.
+    atomic_rows = (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == user_id))).scalars().all()
+    assert len(atomic_rows) == 0
+    refreshed = await db.get(StatementSummary, statement_id)
+    assert refreshed is not None
+    assert refreshed.status == BankStatementStatus.PARSED
+    assert refreshed.stage1_status == Stage1Status.PENDING_REVIEW
+    # Positions exist (no zero-position review flag), so no validation note is added.
+    assert refreshed.validation_error is None
+
+    # #1408: the explicit import endpoint is the only path that creates positions.
+    import_response = await client.post(f"/statements/{statement_id}/brokerage/import")
+    assert import_response.status_code == 200, import_response.text
+
+    db.expire_all()
     atomic_rows = (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == user_id))).scalars().all()
 
     # AtomicPosition rows == holdings-table rows.
@@ -259,12 +288,6 @@ async def test_AC_B4_AC_B6_moomoo_positions_table_extracts_and_imports(client, d
         assert row.quantity == Decimal(spec["quantity"])
         assert row.currency == spec["currency"]
         assert row.snapshot_date == date(2026, 6, 30)
-
-    refreshed = await db.get(StatementSummary, statement_id)
-    assert refreshed is not None
-    assert refreshed.status == BankStatementStatus.PARSED
-    # Positions were imported, so no zero-position review flag.
-    assert refreshed.validation_error is None
 
 
 async def test_AC_B6_positions_payload_imports_via_service(db, test_user):

--- a/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
+++ b/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
@@ -3,7 +3,6 @@
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -11,8 +10,10 @@ from sqlalchemy import select
 
 from src.database import create_session_maker_from_db
 from src.models import BankStatementStatus
+from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition
+from src.models.statement_enums import Stage1Status
 from src.models.statement_summary import StatementSummary
 from src.services import statement_parsing
 from src.services.brokerage_positions import looks_like_brokerage_payload, parse_brokerage_positions
@@ -20,8 +21,8 @@ from src.services.extraction import ExtractionService
 from src.services.statement_parsing import (
     _count_brokerage_positions,
     _filter_failure_handler_kwargs,
-    import_brokerage_payload_if_present,
     parse_statement_background,
+    route_brokerage_for_review_if_present,
 )
 from tests.factories import StatementSummaryFactory
 
@@ -79,6 +80,13 @@ def _brokerage_payload() -> dict:
             }
         ],
     }
+
+
+def _brokerage_payload_json_safe() -> dict:
+    """JSON-serializable variant for persisting to extraction_metadata (string snapshot_date)."""
+    payload = _brokerage_payload()
+    payload["positions"][0]["snapshot_date"] = "2026-05-18"
+    return payload
 
 
 def test_looks_like_brokerage_payload_detection_paths():
@@ -344,16 +352,12 @@ async def test_parse_document_routes_brokerage_balance_mismatch_to_parsed():
     assert statement._extracted_payload["positions"][0]["market_value"] == "1250.50"
 
 
-async def test_import_brokerage_payload_if_present_ignores_bank_payload(db, test_user, monkeypatch):
-    """AC17.4.7: Bank statement payloads do not call brokerage import."""
+async def test_route_brokerage_for_review_ignores_bank_payload(db, test_user):
+    """AC17.4.7/#1408: Bank statement payloads are not routed for brokerage review."""
     statement = _parsed_statement(test_user.id, "bank-hash")
+    statement.stage1_status = None
 
-    async def fail_if_called(*args, **kwargs):
-        raise AssertionError("brokerage import should not be called for bank payloads")
-
-    monkeypatch.setattr("src.services.statement_parsing._brokerage_import_service.import_positions", fail_if_called)
-
-    await import_brokerage_payload_if_present(
+    await route_brokerage_for_review_if_present(
         summary=statement,
         db=db,
         user_id=test_user.id,
@@ -363,22 +367,25 @@ async def test_import_brokerage_payload_if_present_ignores_bank_payload(db, test
     )
 
     assert statement.validation_error is None
+    # A bank payload must not be moved into the brokerage review queue.
+    assert statement.stage1_status is None
 
 
-async def test_import_brokerage_payload_if_present_records_zero_position_payload(db, test_user):
-    """AC17.4.7: Recognized brokerage payloads with no positions remain visible."""
+async def test_route_brokerage_for_review_records_zero_position_payload(db, test_user):
+    """AC17.4.7/#1408: Recognized brokerage payloads with no positions stay visible and route to review."""
     statement_id = uuid4()
     statement = StatementSummaryFactory.build(
         id=statement_id,
         user_id=test_user.id,
         status=BankStatementStatus.PARSED,
+        stage1_status=None,
         file_hash="futu-empty-hash",
         institution="Futu",
     )
     db.add(statement)
     await db.commit()
 
-    await import_brokerage_payload_if_present(
+    await route_brokerage_for_review_if_present(
         summary=statement,
         db=db,
         user_id=test_user.id,
@@ -393,31 +400,23 @@ async def test_import_brokerage_payload_if_present_records_zero_position_payload
     assert refreshed is not None
     assert refreshed.validation_error is not None
     assert "no positions detected" in refreshed.validation_error
+    # #1408: surfaced as a Stage-1 review flag, not auto-settled.
+    assert refreshed.stage1_status == Stage1Status.PENDING_REVIEW
 
 
-async def test_import_brokerage_payload_if_present_uses_nested_statement_institution(db, test_user, monkeypatch):
-    """AC17.4.7: Brokerage import reads broker identity from nested statement metadata."""
+async def test_route_brokerage_for_review_uses_nested_statement_institution(db, test_user, monkeypatch):
+    """AC17.4.7/#1408: Review routing reads broker identity from nested statement metadata."""
     statement = _parsed_statement(test_user.id, "nested-broker-hash")
+    db.add(statement)
+    await db.commit()
     info_events = []
-
-    async def fake_import_positions(*_args, **_kwargs):
-        return SimpleNamespace(
-            broker="Interactive Brokers",
-            parsed_positions=1,
-            created_atomic_positions=0,
-            existing_atomic_positions=0,
-            reconcile_created=0,
-            reconcile_updated=0,
-            reconcile_disposed=0,
-        )
 
     def capture_info(event_name, **kwargs):
         info_events.append((event_name, kwargs))
 
-    monkeypatch.setattr(statement_parsing._brokerage_import_service, "import_positions", fake_import_positions)
     monkeypatch.setattr(statement_parsing.logger, "info", capture_info)
 
-    await import_brokerage_payload_if_present(
+    await route_brokerage_for_review_if_present(
         summary=statement,
         db=db,
         user_id=test_user.id,
@@ -432,13 +431,19 @@ async def test_import_brokerage_payload_if_present_uses_nested_statement_institu
     )
 
     started_events = [
-        kwargs for event_name, kwargs in info_events if event_name == "statement.brokerage_import.started"
+        kwargs for event_name, kwargs in info_events if event_name == "statement.brokerage_review_routing.started"
     ]
     assert started_events[0]["broker"] == "Interactive Brokers"
+    # #1408: routing surfaces the statement for review without importing positions.
+    assert statement.stage1_status == Stage1Status.PENDING_REVIEW
 
 
-async def test_import_brokerage_payload_if_present_stops_when_failed_statement_is_missing(monkeypatch):
-    """AC17.4.7: Brokerage import failure handling tolerates deleted statements."""
+async def test_route_brokerage_for_review_stops_when_failed_statement_is_missing():
+    """AC17.4.7/#1408: Review-routing failure handling tolerates deleted statements.
+
+    If the routing commit raises, the function rolls back and tries to attach a
+    validation note to a re-fetched row; when that row is gone it must exit cleanly.
+    """
     statement_id = uuid4()
     statement = StatementSummaryFactory.build(
         id=statement_id,
@@ -452,6 +457,14 @@ async def test_import_brokerage_payload_if_present_stops_when_failed_statement_i
         def __init__(self):
             self.rolled_back = False
             self.lookup = None
+            self._commits = 0
+
+        async def commit(self):
+            # First commit (the routing write) fails; a second commit (post-rollback
+            # note) would only run if the re-fetched row exists, which it does not.
+            self._commits += 1
+            if self._commits == 1:
+                raise RuntimeError("forced commit failure")
 
         async def rollback(self):
             self.rolled_back = True
@@ -460,13 +473,9 @@ async def test_import_brokerage_payload_if_present_stops_when_failed_statement_i
             self.lookup = (model, lookup_id)
             return None
 
-    async def fail_import_positions(*_args, **_kwargs):
-        raise RuntimeError("forced import failure")
-
     db = MissingStatementDb()
-    monkeypatch.setattr(statement_parsing._brokerage_import_service, "import_positions", fail_import_positions)
 
-    await import_brokerage_payload_if_present(
+    await route_brokerage_for_review_if_present(
         summary=statement,
         db=db,
         user_id=statement.user_id,
@@ -498,6 +507,20 @@ async def test_parse_statement_background_imports_brokerage_positions(client, db
         session = kwargs["db"]
         summary = await session.get(StatementSummary, statement_id)
         _apply_parsed_envelope(summary)
+        # The real parse_document persists the OCR payload here; the explicit import
+        # endpoint (#1408) recovers positions from extraction_metadata.
+        summary.extraction_metadata = {"extraction_payload": _brokerage_payload_json_safe()}
+        # Link an ODS document so the explicit import resolves a source filename.
+        doc = UploadedDocument(
+            user_id=user_id,
+            file_path="statements/moomoo.pdf",
+            file_hash=file_hash,
+            original_filename="moomoo-positions.pdf",
+            document_type=DocumentType.BANK_STATEMENT,
+        )
+        session.add(doc)
+        await session.flush()
+        summary.uploaded_document_id = doc.id
         await session.flush()
         summary._extracted_payload = _brokerage_payload()
         return summary, []
@@ -531,9 +554,25 @@ async def test_parse_statement_background_imports_brokerage_positions(client, db
     assert refreshed.confidence_score == 90
     assert refreshed.balance_validated is True
     assert refreshed.validation_error is None
+    # #1408: parse does NOT auto-import positions; the statement is only routed to review.
+    assert refreshed.stage1_status == Stage1Status.PENDING_REVIEW
+    assert len(atomic_rows) == 0
+    assert len(managed_rows) == 0
+
+    # Holdings stay empty until the user triggers the explicit import endpoint.
+    pre_import_holdings = await client.get("/portfolio/holdings", params={"as_of_date": "2026-05-18"})
+    assert pre_import_holdings.status_code == 200
+    assert pre_import_holdings.json() == []
+
+    # #1408: the explicit, user-initiated endpoint is the only path that creates positions.
+    import_response = await client.post(f"/statements/{statement_id}/brokerage/import")
+    assert import_response.status_code == 200, import_response.text
+
+    db.expire_all()
+    atomic_rows = (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == user_id))).scalars().all()
+    managed_rows = (await db.execute(select(ManagedPosition).where(ManagedPosition.user_id == user_id))).scalars().all()
     assert len(atomic_rows) == 1
     assert atomic_rows[0].asset_identifier == _BRIDGE_ASSET_IDENTIFIER
-    assert atomic_rows[0].source_documents["documents"][0]["doc_id"] == str(statement_id)
     assert len(managed_rows) == 1
     assert managed_rows[0].asset_identifier == _BRIDGE_ASSET_IDENTIFIER
     assert managed_rows[0].quantity == Decimal("10")
@@ -570,11 +609,12 @@ async def test_parse_statement_background_imports_brokerage_positions(client, db
     )
 
 
-async def test_parse_statement_background_persists_brokerage_import_failure(db, test_user, monkeypatch):
-    """AC17.4.7: Brokerage import failures are visible on the parsed statement."""
+async def test_parse_statement_background_routes_brokerage_to_review_without_importing(db, test_user, monkeypatch):
+    """#1408: parse routes a brokerage statement to Stage-1 review and imports no positions,
+    preserving any existing parser validation note."""
     statement_id = uuid4()
     user_id = test_user.id
-    file_hash = "brokerage-failure-hash"
+    file_hash = "brokerage-review-routing-hash"
     statement = StatementSummaryFactory.build(
         id=statement_id,
         user_id=user_id,
@@ -593,24 +633,20 @@ async def test_parse_statement_background_persists_brokerage_import_failure(db, 
         summary._extracted_payload = _brokerage_payload()
         return summary, []
 
-    async def fail_import(*args, **kwargs):
-        raise RuntimeError("forced import failure")
-
     monkeypatch.setattr("src.services.statement_parsing.ExtractionService.parse_document", fake_parse_document)
     monkeypatch.setattr(
         "src.services.statement_parsing.StorageService.generate_presigned_url",
-        lambda *args, **kwargs: "https://example.com/moomoo-fail.pdf",
+        lambda *args, **kwargs: "https://example.com/moomoo-review.pdf",
     )
-    monkeypatch.setattr("src.services.statement_parsing._brokerage_import_service.import_positions", fail_import)
 
     await parse_statement_background(
         statement_id=statement_id,
-        filename="moomoo-fail.pdf",
+        filename="moomoo-review.pdf",
         institution="Moomoo",
         user_id=user_id,
         account_id=None,
         file_hash=file_hash,
-        storage_key="statements/moomoo-fail.pdf",
+        storage_key="statements/moomoo-review.pdf",
         content=b"%PDF-1.7",
         model=None,
         session_maker=create_session_maker_from_db(db),
@@ -618,10 +654,11 @@ async def test_parse_statement_background_persists_brokerage_import_failure(db, 
 
     db.expire_all()
     refreshed = await db.get(StatementSummary, statement_id)
+    atomic_rows = (await db.execute(select(AtomicPosition).where(AtomicPosition.user_id == user_id))).scalars().all()
 
     assert refreshed is not None
     assert refreshed.status == BankStatementStatus.PARSED
-    assert refreshed.validation_error is not None
-    assert refreshed.validation_error.startswith("existing parser note; ")
-    assert "Brokerage import failed" in refreshed.validation_error
-    assert "forced import failure" not in refreshed.validation_error
+    # #1408: routed to review, no positions imported, existing parser note preserved.
+    assert refreshed.stage1_status == Stage1Status.PENDING_REVIEW
+    assert refreshed.validation_error == "existing parser note"
+    assert len(atomic_rows) == 0

--- a/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
+++ b/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -13,7 +12,7 @@ from src.models import BankStatementStatus
 from src.models.statement_summary import StatementSummary
 from src.services import statement_parsing
 from src.services.extraction import ExtractionError
-from src.services.statement_parsing import import_brokerage_payload_if_present, parse_statement_background
+from src.services.statement_parsing import parse_statement_background, route_brokerage_for_review_if_present
 from tests.factories import StatementSummaryFactory
 
 
@@ -136,33 +135,26 @@ async def test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured(db, te
     assert "secret source bytes" not in failed["safe_error_message"]
 
 
-async def test_AC10_8_3_brokerage_import_audit_checkpoints(db, test_user, monkeypatch):
-    """AC10.8.3: Brokerage import logs start/completion/failure replay context."""
+async def test_AC10_8_3_brokerage_review_routing_audit_checkpoints(db, test_user, monkeypatch):
+    """AC10.8.3/#1408: Brokerage review-routing logs start/completion/failure replay context.
+
+    Parse no longer imports positions (#1408); it routes a detected brokerage statement to
+    Stage-1 review, so the replay events are the routing start/complete/failure events.
+    """
     statement = await _create_statement(db, test_user.id, file_hash="brokerage-audit-hash")
+    statement.status = BankStatementStatus.PARSED
+    await db.commit()
     payload = {
         "institution": "Moomoo",
         "positions": [{"symbol": "AAPL", "quantity": "10"}],
     }
-    result = SimpleNamespace(
-        broker="Moomoo",
-        parsed_positions=1,
-        created_atomic_positions=1,
-        existing_atomic_positions=0,
-        reconcile_created=1,
-        reconcile_updated=0,
-        reconcile_disposed=0,
-    )
     mock_info = MagicMock()
     mock_exception = MagicMock()
 
-    async def fake_import_positions(*_args, **_kwargs):
-        return result
-
     monkeypatch.setattr(statement_parsing.logger, "info", mock_info)
     monkeypatch.setattr(statement_parsing.logger, "exception", mock_exception)
-    monkeypatch.setattr(statement_parsing._brokerage_import_service, "import_positions", fake_import_positions)
 
-    await import_brokerage_payload_if_present(
+    await route_brokerage_for_review_if_present(
         summary=statement,
         db=db,
         user_id=test_user.id,
@@ -174,34 +166,46 @@ async def test_AC10_8_3_brokerage_import_audit_checkpoints(db, test_user, monkey
     )
 
     calls = [(call.args[0], call.kwargs) for call in mock_info.call_args_list]
-    started = next(kwargs for event, kwargs in calls if event == "statement.brokerage_import.started")
-    completed = next(kwargs for event, kwargs in calls if event == "statement.brokerage_import.completed")
+    started = next(kwargs for event, kwargs in calls if event == "statement.brokerage_review_routing.started")
+    completed = next(kwargs for event, kwargs in calls if event == "statement.brokerage_review_routing.completed")
 
-    assert started["audit_event"] == "statement.brokerage_import.started"
+    assert started["audit_event"] == "statement.brokerage_review_routing.started"
     assert started["statement_id"] == str(statement.id)
     assert started["request_id"] == "req-brokerage"
-    assert started["phase"] == "brokerage_import_started"
+    assert started["phase"] == "brokerage_review_routing_started"
     assert started["model_to_use"] == "glm-5.1"
     assert started["broker"] == "Moomoo"
     assert started["parsed_positions"] == 1
 
-    assert completed["audit_event"] == "statement.brokerage_import.completed"
+    assert completed["audit_event"] == "statement.brokerage_review_routing.completed"
     assert completed["statement_id"] == str(statement.id)
-    assert completed["phase"] == "brokerage_import_completed"
+    assert completed["phase"] == "brokerage_review_routing_completed"
     assert completed["model_to_use"] == "glm-5.1"
     assert completed["broker"] == "Moomoo"
-    assert completed["created_atomic_positions"] == 1
-    assert completed["existing_atomic_positions"] == 0
-    assert completed["reconcile_created"] == 1
+    assert completed["parsed_positions"] == 1
 
+    # Failure path: the routing commit raises -> a replayable failure event is emitted.
     failure_statement = await _create_statement(db, test_user.id, file_hash="brokerage-failure-audit-hash")
+    failure_statement.status = BankStatementStatus.PARSED
+    await db.commit()
 
-    async def fail_import_positions(*_args, **_kwargs):
-        raise RuntimeError("provider payload had no positions and raw text is omitted")
+    commit_calls = {"count": 0}
+    real_commit = db.commit
 
-    monkeypatch.setattr(statement_parsing._brokerage_import_service, "import_positions", fail_import_positions)
+    async def flaky_commit(*args, **kwargs):
+        commit_calls["count"] += 1
+        if commit_calls["count"] == 1:
+            raise RuntimeError("forced routing commit failure")
+        return await real_commit(*args, **kwargs)
 
-    await import_brokerage_payload_if_present(
+    async def missing_statement(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(db, "commit", flaky_commit)
+    monkeypatch.setattr(db, "rollback", missing_statement)
+    monkeypatch.setattr(db, "get", missing_statement)
+
+    await route_brokerage_for_review_if_present(
         summary=failure_statement,
         db=db,
         user_id=test_user.id,
@@ -213,15 +217,17 @@ async def test_AC10_8_3_brokerage_import_audit_checkpoints(db, test_user, monkey
     )
 
     failed = next(
-        call.kwargs for call in mock_exception.call_args_list if call.args[0] == "statement.brokerage_import.failed"
+        call.kwargs
+        for call in mock_exception.call_args_list
+        if call.args[0] == "statement.brokerage_review_routing.failed"
     )
-    assert failed["audit_event"] == "statement.brokerage_import.failed"
+    assert failed["audit_event"] == "statement.brokerage_review_routing.failed"
     assert failed["statement_id"] == str(failure_statement.id)
     assert failed["request_id"] == "req-brokerage-failed"
-    assert failed["phase"] == "brokerage_import_failed"
+    assert failed["phase"] == "brokerage_review_routing_failed"
     assert failed["model_to_use"] == "glm-5.1"
     assert failed["error_type"] == "RuntimeError"
-    assert failed["safe_error_message"] == "provider payload had no positions and raw text is omitted"
+    assert failed["safe_error_message"] == "forced routing commit failure"
 
 
 async def test_AC10_10_4_parse_outcome_metric_emitted(db, test_user, monkeypatch):

--- a/apps/backend/tests/infra/test_transaction_boundaries.py
+++ b/apps/backend/tests/infra/test_transaction_boundaries.py
@@ -22,7 +22,7 @@ ALLOWED_SERVICE_COMMIT_BOUNDARIES = {
     ("ai_advisor/service.py", "AIAdvisorService._stream_and_store"),
     ("market_data_scheduler.py", "run_daily_market_data_sync"),
     ("statement_parsing.py", "handle_parse_failure"),
-    ("statement_parsing.py", "import_brokerage_payload_if_present"),
+    ("statement_parsing.py", "route_brokerage_for_review_if_present"),
     ("statement_parsing.py", "parse_statement_background"),
     ("statement_parsing.py", "parse_statement_background.update_progress"),
     ("statement_parsing_supervisor.py", "reset_stale_parsing_jobs"),

--- a/apps/backend/tests/portfolio/test_brokerage_import_gated_on_review.py
+++ b/apps/backend/tests/portfolio/test_brokerage_import_gated_on_review.py
@@ -1,0 +1,166 @@
+"""#1408: brokerage positions must not be auto-imported at parse.
+
+Synthetic data only. Brokerage positions used to be auto-imported into AtomicPosition
+(L2) + ManagedPosition (L3) DURING parse, before any human review, so a still-
+``pending_review`` brokerage statement immediately inflated the live portfolio
+(``/portfolio/holdings``, ``/portfolio/summary``, ``/reports/net-worth/*``).
+
+The fix does NOT import at parse: a detected brokerage payload is only routed to the
+Stage-1 review queue (``pending_review``). Positions are created only by the explicit,
+user-initiated ``POST /statements/{statement_id}/brokerage/import`` endpoint, which
+recovers the payload from ``extraction_metadata``.
+
+Brokerage statements canNOT go through ``/review/approve`` (the DB check
+``ck_statement_summaries_approved_complete`` requires opening/closing balances brokerage
+statements do not have), so the gate is "no auto-import at parse -> explicit import
+endpoint", NOT "import on approval".
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.layer1 import DocumentType, UploadedDocument
+from src.models.layer2 import AtomicPosition
+from src.models.statement_enums import BankStatementStatus, Stage1Status
+from src.models.statement_summary import StatementSummary
+from src.services.statement_parsing import route_brokerage_for_review_if_present
+
+_ASSET = "GATED_TEST_STOCK"
+
+
+def _payload(*, with_positions: bool = True) -> dict:
+    positions = (
+        [
+            {
+                "symbol": _ASSET,
+                "snapshot_date": "2026-05-18",
+                "quantity": "10",
+                "market_value": "1900.25",
+                "currency": "SGD",
+                "asset_type": "stock",
+            }
+        ]
+        if with_positions
+        else []
+    )
+    return {
+        "institution": "Moomoo",
+        "statement": {"period_end": "2026-05-18", "currency": "SGD"},
+        "positions": positions,
+    }
+
+
+async def _make_brokerage_statement(
+    db: AsyncSession,
+    user_id,
+    *,
+    status: BankStatementStatus,
+    stage1: Stage1Status | None,
+    with_positions: bool = True,
+) -> StatementSummary:
+    stmt = StatementSummary(
+        user_id=user_id,
+        file_hash=uuid4().hex,
+        institution="Moomoo",
+        account_last4="1234",
+        currency="SGD",
+        period_start=date(2026, 5, 1),
+        period_end=date(2026, 5, 18),
+        status=status,
+        stage1_status=stage1,
+        confidence_score=60,
+        extraction_metadata=_payload(with_positions=with_positions),
+    )
+    db.add(stmt)
+    await db.flush()
+    doc = UploadedDocument(
+        user_id=user_id,
+        file_path="moomoo.pdf",
+        file_hash=stmt.file_hash,
+        original_filename="moomoo.pdf",
+        document_type=DocumentType.BANK_STATEMENT,
+    )
+    db.add(doc)
+    await db.flush()
+    stmt.uploaded_document_id = doc.id
+    await db.commit()
+    await db.refresh(stmt)
+    return stmt
+
+
+async def _position_count(db: AsyncSession, user_id) -> int:
+    return await db.scalar(select(func.count()).select_from(AtomicPosition).where(AtomicPosition.user_id == user_id))
+
+
+@pytest.mark.asyncio
+async def test_AC1_parse_routing_imports_no_positions_and_marks_pending_review(db: AsyncSession, test_user):
+    """AC1: parse routing of a brokerage payload imports no positions and marks pending_review."""
+    stmt = await _make_brokerage_statement(db, test_user.id, status=BankStatementStatus.PARSED, stage1=None)
+
+    await route_brokerage_for_review_if_present(
+        summary=stmt,
+        db=db,
+        user_id=test_user.id,
+        filename="moomoo.pdf",
+        institution="Moomoo",
+        payload=_payload(),
+    )
+
+    assert await _position_count(db, test_user.id) == 0, (
+        "brokerage positions were imported at parse before any human review"
+    )
+    await db.refresh(stmt)
+    assert stmt.stage1_status == Stage1Status.PENDING_REVIEW
+
+
+@pytest.mark.asyncio
+async def test_AC1_AC2_pending_review_absent_from_holdings_until_explicit_import(
+    client: AsyncClient, db: AsyncSession, test_user
+):
+    """AC1 + AC2 end-to-end: pending-review brokerage is absent from holdings; the explicit
+    import endpoint is the only path that surfaces the positions."""
+    stmt = await _make_brokerage_statement(
+        db, test_user.id, status=BankStatementStatus.PARSED, stage1=Stage1Status.PENDING_REVIEW
+    )
+
+    before = await client.get("/portfolio/holdings")
+    assert before.status_code == 200
+    assert before.json() == [], "pending-review brokerage positions must not appear in holdings"
+
+    imported = await client.post(f"/statements/{stmt.id}/brokerage/import")
+    assert imported.status_code == 200, imported.text
+
+    after = await client.get("/portfolio/holdings")
+    assert after.status_code == 200
+    identifiers = {h.get("asset_identifier") or h.get("ticker") for h in after.json()}
+    assert _ASSET in identifiers, "explicit brokerage import should surface the positions in holdings"
+
+
+@pytest.mark.asyncio
+async def test_AC6_zero_position_brokerage_payload_still_routes_to_pending_review(db: AsyncSession, test_user):
+    """AC6: a brokerage payload with 0 positions still routes to pending_review (with a note)."""
+    stmt = await _make_brokerage_statement(
+        db, test_user.id, status=BankStatementStatus.PARSED, stage1=None, with_positions=False
+    )
+
+    await route_brokerage_for_review_if_present(
+        summary=stmt,
+        db=db,
+        user_id=test_user.id,
+        filename="moomoo.pdf",
+        institution="Moomoo",
+        payload=_payload(with_positions=False),
+    )
+
+    assert await _position_count(db, test_user.id) == 0
+    await db.refresh(stmt)
+    assert stmt.stage1_status == Stage1Status.PENDING_REVIEW
+    assert stmt.validation_error is not None
+    assert "no positions detected" in stmt.validation_error

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -171,6 +171,7 @@ pin a specific fix rather than owning an EPIC acceptance criterion.
 | `apps/backend/tests/repro/test_brokerage_identifier.py` | Issue #1389 (brokerage position identifier must prefer ticker over company name) |
 | `apps/backend/tests/repro/test_balance_validation_vacuous.py` | Issue #1390 (balance validation must not pass vacuously with no closing balance) |
 | `apps/backend/tests/repro/test_review_document_url.py` | Issue #1391 (Stage-1 review PDF URL must use the public endpoint) |
+| `apps/backend/tests/portfolio/test_brokerage_import_gated_on_review.py` | Issue #1408 (brokerage positions must not count toward holdings/net-worth before review) |
 
 ## Rule
 


### PR DESCRIPTION
Closes #1408.

## Problem
Brokerage positions were auto-imported (L2 `AtomicPosition` + L3 `ManagedPosition`) **during parse**, so a still-`pending_review` statement immediately inflated `/portfolio/holdings`, `/portfolio/summary`, and `/reports/net-worth/*`. Found on staging v0.1.19: a fresh user who only *uploaded* (never reviewed) brokerage statements saw ~15 positions / ~1.26M SGD net worth while every statement was `pending_review` with 0 posted journal entries. Live manifestation of #1098.

## Fix
Parse no longer imports positions. `import_brokerage_payload_if_present` → renamed `route_brokerage_for_review_if_present`: it only routes the brokerage statement to Stage-1 **pending-review** (keeping the "0 positions detected" note). Positions are created **only** by the explicit, user-initiated `POST /statements/{id}/brokerage/import` endpoint (unchanged), which recovers the payload from `extraction_metadata`.

### Why not "import on /review/approve"
Brokerage statements **cannot** be approved via `/review/approve` — the `ck_statement_summaries_approved_complete` DB constraint and `_raise_if_approved_envelope_incomplete` require opening/closing balances brokerage statements don't have. The explicit `/brokerage/import` action **is** the review gate.

## Acceptance criteria
- **AC1** parse routes a brokerage statement to `pending_review` and imports **0** positions → absent from holdings/summary/net-worth.
- **AC2** explicit `POST /statements/{id}/brokerage/import` imports them → they appear in holdings.
- **AC6** a 0-position brokerage payload still routes to `pending_review` (no silent auto-settle).

## Tests (TDD)
- New `tests/portfolio/test_brokerage_import_gated_on_review.py` (AC1 unit + AC1/AC2 end-to-end via client + AC6). RED→GREEN.
- Updated the brokerage/parse suites that encoded the old auto-import-at-parse behavior.
- Local: `tests/extraction tests/portfolio tests/api/test_statements_router.py tests/infra/test_transaction_boundaries.py` → 809 passed / 3 pre-existing skips; ruff clean.

## Out of scope
- Currency divergence `/assets/positions` (native) vs `/portfolio/holdings` (base-converted) — #1098.
- `/statements/{id}/document` 502 — separate UX issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)