### PR TITLE
[finance_report_vision] feat(eval): HF independent-label extraction-accuracy oracle harness

### DIFF
--- a/docs/ssot/cassette-graded-eval.md
+++ b/docs/ssot/cassette-graded-eval.md
@@ -42,6 +42,36 @@ Each scored cassette `<fingerprint>.json` has a sibling ground-truth manifest
 - `expected` carries the known-correct field values; the matching cassette
   supplies the LLM's frozen extraction to score against it.
 
+### 2.1 Independently-labelled corpus (HF oracle)
+
+Hand-authored truth fixtures prove the scorer; they do not exercise the real
+failure mode (a messy **scanned** statement). The HF oracle supplies an
+*independent* label that we did not write:
+[`Akashved/Indian-Bank-Statements`](https://huggingface.co/datasets/Akashved/Indian-Bank-Statements)
+(Apache-2.0, tagged `synthetic` — synthetic Indian business current-account
+statements, no real PII), in **Digital** (clean render) and **Scanned** (degraded
+image) layouts.
+
+Build pipeline (the source PDFs stay git-ignored under `tmp/input/hf_oracle/`;
+only the recorded cassette + truth are committed):
+
+1. `tools/_lib/pdf_fixtures/fetch_hf_oracle.py` — fetch a **scanned-weighted**
+   sample (default ~10 pairs; `--per-dir 25` for the full 100).
+2. `tools/_lib/pdf_fixtures/record_hf_oracle.py` — **operator-only, keyed**: runs
+   the production extractor in `record` mode (real provider call) → cassette;
+   writes `ground_truth/<fingerprint>.truth.json` from the HF label via
+   `hf_oracle_truth.py` (HF debit/credit columns → one signed Decimal `amount`;
+   Scanned → `vision`, Digital → `text`). No anonymisation: the source is already
+   synthetic, and the scored fields must match the document the LLM reads.
+3. `tools/check_cassette_graded_eval.py --update` — adopt the new cases' floor.
+
+**Honest boundary.** The HF label is a *per-file consolidated* table, so it
+proves **field accuracy** (did we read each amount/date/description right),
+**not** page assembly (multi-page stitching, carried-forward balances, in-doc
+dedup) — those stay the job of the deterministic downstream gates and a future
+benchmark. The **Scanned** cases carry the real accuracy signal; the Digital
+cases are clean renders (weak signal), kept only for modality coverage.
+
 ## 3. Scoring & normalisation
 
 A case score is the fraction of **scored fields** that match ground truth:

--- a/tests/tooling/test_hf_oracle_truth.py
+++ b/tests/tooling/test_hf_oracle_truth.py
@@ -1,0 +1,71 @@
+"""Tests for the HF extraction-oracle truth mapper (tools/_lib/pdf_fixtures).
+
+Pure transform — no network, no LLM, no key. The decisive test feeds the mapper's
+output through the REAL graded-eval scorer to prove it is shape-compatible (a
+perfect extraction scores 1.0), so a recorded HF cassette can actually be graded.
+"""
+
+from __future__ import annotations
+
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "_lib" / "pdf_fixtures"))
+
+from hf_oracle_truth import (  # noqa: E402
+    build_truth,
+    label_to_expected,
+    modality_for_dir,
+    signed_amount,
+)
+
+# A minimal HF-shaped label (the dataset's per-statement schema): split
+# debit/credit columns, datetime strings, header balances.
+_HF_SAMPLE = {
+    "opening_balance": 100.0,
+    "closing_balance": 130.0,
+    "transactions": [
+        {"date": "2026-01-02 11:30:55", "description": " Coffee  shop ", "debit": 5.0, "credit": None},
+        {"date": "2026-01-05 09:00:00", "description": "Salary credit", "debit": None, "credit": 50.0},
+        {"date": "2026-01-09 18:00:00", "description": "Groceries", "debit": 15.0, "credit": None},
+    ],
+}
+
+
+def test_signed_amount_credit_positive_debit_negative() -> None:
+    assert Decimal(signed_amount({"credit": 50.0, "debit": None})) == Decimal("50")
+    assert Decimal(signed_amount({"credit": None, "debit": 5.0})) == Decimal("-5")
+    assert signed_amount({"credit": None, "debit": None}) == "0"
+
+
+def test_modality_from_layout() -> None:
+    assert modality_for_dir("India_Bank_Statement_Scanned_Type1") == "vision"
+    assert modality_for_dir("India_Bank_Statement_Digital_Type2") == "text"
+
+
+def test_label_to_expected_normalises_date_and_amount() -> None:
+    exp = label_to_expected(_HF_SAMPLE)
+    assert Decimal(exp["opening_balance"]) == Decimal("100")
+    assert Decimal(exp["closing_balance"]) == Decimal("130")
+    first = exp["transactions"][0]
+    assert first["date"] == "2026-01-02"  # datetime -> ISO date
+    assert Decimal(first["amount"]) == Decimal("-5")  # debit -> negative
+    assert Decimal(exp["transactions"][1]["amount"]) == Decimal("50")  # credit -> positive
+
+
+def test_build_truth_is_synthetic_and_scorable_by_the_real_eval() -> None:
+    """The mapper output must be the exact shape the graded eval scores."""
+    truth = build_truth(_HF_SAMPLE, dirname="India_Bank_Statement_Scanned_Type1")
+    assert truth["synthetic"] is True  # AC23.8.6 hygiene flag
+    assert truth["modality"] == "vision"
+
+    sys.path.insert(0, str(ROOT))
+    from common.ssot.cassette_graded_eval import case_score
+
+    # A perfect extraction (== the truth) scores 1.0 — proves shape-compatibility
+    # with the scorer, and that a balance-failing field WOULD lower the score.
+    score, breakdown = case_score(truth["expected"], truth["expected"])
+    assert score == 1.0
+    assert breakdown["total"] > 0

--- a/tools/_lib/pdf_fixtures/fetch_hf_oracle.py
+++ b/tools/_lib/pdf_fixtures/fetch_hf_oracle.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""Fetch a small labelled bank-statement corpus from Hugging Face as an
+extraction **accuracy oracle** (PDF/image -> structured table).
+
+Unlike our generated fixtures (whose "truth" is the render source — circular for
+accuracy), this dataset ships a document + an *independent* field label, and —
+crucially — **scanned** variants. Recovering the label from a degraded scan is a
+genuine accuracy test of the first hop (document -> structured table), not just
+"read back a clean render".
+
+The corpus lands under ``tmp/input/hf_oracle/`` (git-ignored). It is the INPUT to
+the record step (``record_hf_oracle.py``), which runs our extractor in record
+mode to produce a cassette and writes the sibling ground-truth manifest. Nothing
+here calls an LLM or needs a key.
+
+Dataset: https://huggingface.co/datasets/Akashved/Indian-Bank-Statements
+(Apache-2.0, tagged ``synthetic`` — synthetic Indian business current-account
+statements; no real PII). Digital + Scanned, two layouts each.
+
+Usage:
+    # default: scanned-weighted ~10 pairs (the real failure mode)
+    python tools/_lib/pdf_fixtures/fetch_hf_oracle.py
+
+    # the full 25-per-dir / 100-pair corpus
+    python tools/_lib/pdf_fixtures/fetch_hf_oracle.py --per-dir 25
+
+Requires: huggingface_hub
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+REPO_ID = "Akashved/Indian-Bank-Statements"
+REPO_TYPE = "dataset"
+
+# The four corpus directories. Scanned is weighted higher in the default mix:
+# it exercises the messy real-world failure mode (OCR of a degraded image),
+# where the field label is a genuine accuracy target — the digital variants are
+# clean renders, so their accuracy signal is weak (see cassette-graded-eval.md).
+DIRS = (
+    "India_Bank_Statement_Scanned_Type1",
+    "India_Bank_Statement_Scanned_Type2",
+    "India_Bank_Statement_Digital_Type1",
+    "India_Bank_Statement_Digital_Type2",
+)
+DEFAULT_MIX = {  # scanned-weighted ~10-pair smoke corpus
+    "India_Bank_Statement_Scanned_Type1": 3,
+    "India_Bank_Statement_Scanned_Type2": 3,
+    "India_Bank_Statement_Digital_Type1": 2,
+    "India_Bank_Statement_Digital_Type2": 2,
+}
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OUT_DIR = REPO_ROOT / "tmp" / "input" / "hf_oracle"
+
+
+def _pair_ids(dirname: str, count: int) -> list[str]:
+    """The first ``count`` zero-padded pair ids (``00001`` ...) in a directory."""
+    return [f"{i:05d}" for i in range(1, count + 1)]
+
+
+def fetch(per_dir: int | None, out_dir: Path = OUT_DIR) -> list[Path]:
+    """Download ``<id>.pdf`` + ``<id>.json`` pairs into ``out_dir/<dir>/``.
+
+    Returns the list of downloaded file paths. ``per_dir=None`` uses the
+    scanned-weighted default mix; an int fetches that many from every directory.
+    """
+    from huggingface_hub import hf_hub_download
+
+    mix = {d: per_dir for d in DIRS} if per_dir is not None else DEFAULT_MIX
+    downloaded: list[Path] = []
+    for dirname, count in mix.items():
+        dest = out_dir / dirname
+        dest.mkdir(parents=True, exist_ok=True)
+        for pid in _pair_ids(dirname, count):
+            for ext in ("pdf", "json"):
+                rel = f"train/{dirname}/{pid}.{ext}"
+                local = hf_hub_download(
+                    repo_id=REPO_ID,
+                    repo_type=REPO_TYPE,
+                    filename=rel,
+                    local_dir=str(out_dir / "_hf"),
+                )
+                target = dest / f"{pid}.{ext}"
+                target.write_bytes(Path(local).read_bytes())
+                downloaded.append(target)
+            print(f"  {dirname}/{pid}  (pdf+json)")
+    return downloaded
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--per-dir",
+        type=int,
+        default=None,
+        help="pairs to fetch from EACH of the 4 dirs (default: scanned-weighted ~10 total)",
+    )
+    parser.add_argument("--out-dir", type=Path, default=OUT_DIR)
+    args = parser.parse_args(argv)
+
+    print(f"Fetching {REPO_ID} -> {args.out_dir}")
+    paths = fetch(args.per_dir, args.out_dir)
+    pairs = len(paths) // 2
+    print(f"Done: {pairs} pair(s) across {len(DIRS)} dirs under {args.out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/_lib/pdf_fixtures/hf_oracle_truth.py
+++ b/tools/_lib/pdf_fixtures/hf_oracle_truth.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+"""Map a Hugging Face bank-statement label -> our graded-eval ground truth.
+
+Pure transform (no LLM, no network). Turns the dataset's per-statement field
+label into the ``expected`` shape that ``common.ssot.cassette_graded_eval`` scores
+against (``docs/ssot/cassette-graded-eval.md`` §2). Used by ``record_hf_oracle.py``
+to write ``ground_truth/<fingerprint>.truth.json`` next to a freshly recorded
+cassette.
+
+Key choices:
+- **Signed amount.** The HF label splits ``debit`` / ``credit`` into two nullable
+  columns; our scored ``amount`` is a single signed Decimal-string (credit
+  positive, debit negative), matching the existing truth fixtures.
+- **No anonymisation.** This source is already synthetic (Apache-2.0, tagged
+  ``synthetic``; fabricated names/accounts), so there is no PII to strip — and the
+  scored fields (date / description / amount) MUST match the document the LLM
+  reads, so mangling them would make the case ungradeable. The desensitisation
+  policy applies to *real* statements (``tmp/input/*``), which have no label and
+  are consistency-only. ``synthetic: True`` is carried so the AC23.8.6 hygiene
+  gate stays satisfied.
+- **Modality from layout.** Scanned dirs -> ``vision`` (OCR of a degraded image,
+  the real accuracy signal); digital dirs -> ``text``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+
+def _decimal_str(value: Any) -> str:
+    """Decimal-safe string (never float): ``59131.72`` / ``"5.00"`` -> canonical."""
+    return str(Decimal(str(value)))
+
+
+def signed_amount(txn: dict[str, Any]) -> str:
+    """Single signed amount from the HF debit/credit columns (credit +, debit -)."""
+    credit, debit = txn.get("credit"), txn.get("debit")
+    if credit not in (None, ""):
+        return _decimal_str(credit)
+    if debit not in (None, ""):
+        return str(-Decimal(str(debit)))
+    return "0"
+
+
+def label_to_expected(hf: dict[str, Any]) -> dict[str, Any]:
+    """HF statement label -> the scored ``expected`` block."""
+    transactions = [
+        {
+            # "2024-01-01 11:30:55" -> "2024-01-01"; the eval normalises ISO/slash.
+            "date": str(txn.get("date", "")).split(" ")[0],
+            "description": str(txn.get("description", "")).strip(),
+            "amount": signed_amount(txn),
+        }
+        for txn in hf.get("transactions", [])
+    ]
+    return {
+        "opening_balance": _decimal_str(hf["opening_balance"]),
+        "closing_balance": _decimal_str(hf["closing_balance"]),
+        "transactions": transactions,
+    }
+
+
+def modality_for_dir(dirname: str) -> str:
+    """Scanned layouts are image OCR (``vision``); digital are text."""
+    return "vision" if "Scanned" in dirname else "text"
+
+
+def build_truth(
+    hf: dict[str, Any],
+    *,
+    dirname: str,
+    institution_class: str = "generic_india",
+    edge_condition: str = "happy_path",
+) -> dict[str, Any]:
+    """Full ``<fingerprint>.truth.json`` manifest for one HF statement."""
+    return {
+        "synthetic": True,
+        "modality": modality_for_dir(dirname),
+        "institution_class": institution_class,
+        "edge_condition": edge_condition,
+        "note": (
+            "SYNTHETIC label from HF Akashved/Indian-Bank-Statements (Apache-2.0). "
+            "Independent per-statement field label; signed amounts (debit negative). "
+            "Per-file consolidated table — proves field accuracy, not page assembly."
+        ),
+        "expected": label_to_expected(hf),
+    }

--- a/tools/_lib/pdf_fixtures/record_hf_oracle.py
+++ b/tools/_lib/pdf_fixtures/record_hf_oracle.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+"""Record HF-oracle extraction cassettes + write their sibling ground truth.
+
+OPERATOR-ONLY, KEYED LOCAL STEP — record mode does a REAL provider call (there is
+no key in CI). Mirrors the vision path of
+``apps/backend/tests/extraction/test_extraction_cassette_replay.py``: it runs the
+PRODUCTION extractor (``ExtractionService.extract_financial_data``) over each
+fetched HF statement in ``record`` mode, which freezes the response as a cassette
+keyed by the request fingerprint (rendered-image bytes + prompt). For each new
+cassette it then writes ``ground_truth/<fingerprint>.truth.json`` from the HF
+label (via :mod:`hf_oracle_truth`), so the graded eval can score the frozen
+extraction against an independent label.
+
+Pipeline: ``fetch_hf_oracle.py`` (corpus) -> THIS (record + truth) ->
+``tools/check_cassette_graded_eval.py --update`` (raise the per-case floor).
+
+Run from the repo root with a provider key (GLM coding plan shown):
+
+    cd apps/backend && \\
+    AI_PROVIDER=zai AI_BASE_URL=https://api.z.ai/api/coding/paas/v4 \\
+    AI_API_KEY=$GLM_CODING_TOKEN PRIMARY_MODEL=glm-5.2 \\
+    OCR_MODEL=glm-4.6v VISION_MODEL=glm-4.6v LLM_CASSETTE_MODE=record \\
+        uv run python ../../tools/_lib/pdf_fixtures/record_hf_oracle.py
+
+The recorded cassettes + truth manifests are committed (synthetic, Apache-2.0);
+the source PDFs stay under git-ignored ``tmp/input/hf_oracle/``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CORPUS_DIR = REPO_ROOT / "tmp" / "input" / "hf_oracle"
+
+# Importable both as the HF label mapper (this dir) and the backend src tree.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(REPO_ROOT / "apps" / "backend"))
+
+from hf_oracle_truth import build_truth  # noqa: E402
+
+
+async def _record_pair(pdf: Path, dirname: str, cassette_dir: Path, truth_dir: Path) -> list[str]:
+    """Record one statement; write truth for each new cassette. Returns fingerprints."""
+    from src.services.extraction.service import ExtractionService
+
+    hf_label = json.loads(pdf.with_suffix(".json").read_text(encoding="utf-8"))
+    truth = build_truth(hf_label, dirname=dirname)
+
+    before = {p.name for p in cassette_dir.glob("*.json")}
+    service = ExtractionService()
+    service.api_key = service.api_key or "replay"  # record uses the real env key
+    await service.extract_financial_data(
+        file_content=pdf.read_bytes(),
+        institution="HF-IN",
+        file_type="pdf",
+        filename=pdf.name,
+    )
+    new = sorted({p.name for p in cassette_dir.glob("*.json")} - before)
+
+    fingerprints = []
+    for name in new:
+        fp = name[: -len(".json")]
+        (truth_dir / f"{fp}.truth.json").write_text(
+            json.dumps(truth, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+        fingerprints.append(fp)
+    return fingerprints
+
+
+def main(argv: list[str] | None = None) -> int:
+    from src.llm.cassette import CassetteMode, current_mode
+
+    if current_mode() is CassetteMode.OFF:
+        print(
+            "LLM_CASSETTE_MODE is off — this is the keyed record step. "
+            "Set LLM_CASSETTE_MODE=record + a provider key (see module docstring)."
+        )
+        return 1
+
+    from common.ssot.check_llm_cassettes import CASSETTE_DIR
+
+    truth_dir = CASSETTE_DIR / "ground_truth"
+    truth_dir.mkdir(parents=True, exist_ok=True)
+
+    pdfs = sorted(p for p in CORPUS_DIR.glob("*/[0-9]*.pdf"))
+    if not pdfs:
+        print(f"No corpus under {CORPUS_DIR}; run fetch_hf_oracle.py first.")
+        return 1
+
+    total = 0
+    for pdf in pdfs:
+        fps = asyncio.run(_record_pair(pdf, pdf.parent.name, CASSETTE_DIR, truth_dir))
+        total += len(fps)
+        rel = pdf.relative_to(CORPUS_DIR)
+        print(f"  {rel}: {', '.join(f[:12] + '…' for f in fps) or 'no new cassette'}")
+    print(f"Recorded {total} cassette(s) + truth. Now: python tools/check_cassette_graded_eval.py --update")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/_lib/pdf_fixtures/record_hf_oracle.py
+++ b/tools/_lib/pdf_fixtures/record_hf_oracle.py
@@ -36,33 +36,49 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CORPUS_DIR = REPO_ROOT / "tmp" / "input" / "hf_oracle"
 
-# Importable both as the HF label mapper (this dir) and the backend src tree.
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+# Resolve imports regardless of CWD: this dir (hf_oracle_truth), the backend src
+# tree (src.*), and the repo root (common.*).
+sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "apps" / "backend"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from hf_oracle_truth import build_truth  # noqa: E402
 
 
-async def _record_pair(pdf: Path, dirname: str, cassette_dir: Path, truth_dir: Path) -> list[str]:
-    """Record one statement; write truth for each new cassette. Returns fingerprints."""
-    from src.services.extraction.service import ExtractionService
+def _is_statement_cassette(path: Path) -> bool:
+    """True only for an extraction cassette whose response parses to a statement
+    dict (``transactions``). A single extract may also record non-statement
+    intermediate cassettes; writing truth for those would create unscorable
+    ground truth that breaks the graded-eval gate."""
+    from common.ssot.check_llm_cassettes import _response_text
 
+    try:
+        text = _response_text(json.loads(path.read_text(encoding="utf-8"))).strip()
+        if text.startswith("```"):
+            text = text.split("\n", 1)[-1].rsplit("```", 1)[0]
+        obj = json.loads(text)
+    except (ValueError, KeyError, OSError):
+        return False
+    return isinstance(obj, dict) and "transactions" in obj
+
+
+async def _record_pair(
+    pdf: Path, dirname: str, service: object, cassette_dir: Path, truth_dir: Path
+) -> list[str]:
+    """Record one statement; write truth ONLY for new statement-shaped cassettes."""
     hf_label = json.loads(pdf.with_suffix(".json").read_text(encoding="utf-8"))
     truth = build_truth(hf_label, dirname=dirname)
 
     before = {p.name for p in cassette_dir.glob("*.json")}
-    service = ExtractionService()
-    service.api_key = service.api_key or "replay"  # record uses the real env key
-    await service.extract_financial_data(
-        file_content=pdf.read_bytes(),
-        institution="HF-IN",
-        file_type="pdf",
-        filename=pdf.name,
+    await service.extract_financial_data(  # type: ignore[attr-defined]
+        file_content=pdf.read_bytes(), institution="HF-IN", file_type="pdf", filename=pdf.name
     )
     new = sorted({p.name for p in cassette_dir.glob("*.json")} - before)
 
     fingerprints = []
     for name in new:
+        if not _is_statement_cassette(cassette_dir / name):
+            continue  # skip non-statement intermediate cassettes
         fp = name[: -len(".json")]
         (truth_dir / f"{fp}.truth.json").write_text(
             json.dumps(truth, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
@@ -73,11 +89,23 @@ async def _record_pair(pdf: Path, dirname: str, cassette_dir: Path, truth_dir: P
 
 def main(argv: list[str] | None = None) -> int:
     from src.llm.cassette import CassetteMode, current_mode
+    from src.services.extraction.service import ExtractionService
 
-    if current_mode() is CassetteMode.OFF:
+    # Keyed RECORD step: require record mode explicitly (replay/off would miss or
+    # silently no-op, masking operator error).
+    if current_mode() is not CassetteMode.RECORD:
         print(
-            "LLM_CASSETTE_MODE is off — this is the keyed record step. "
-            "Set LLM_CASSETTE_MODE=record + a provider key (see module docstring)."
+            "This is the keyed RECORD step — set LLM_CASSETTE_MODE=record + a "
+            "provider key (see module docstring). Refusing to run in "
+            f"{current_mode().value!r} mode."
+        )
+        return 1
+
+    service = ExtractionService()
+    if not service.api_key:
+        print(
+            "No provider key configured (AI_API_KEY). Record mode does a REAL call; "
+            "set the provider env (see module docstring) and retry."
         )
         return 1
 
@@ -93,10 +121,10 @@ def main(argv: list[str] | None = None) -> int:
 
     total = 0
     for pdf in pdfs:
-        fps = asyncio.run(_record_pair(pdf, pdf.parent.name, CASSETTE_DIR, truth_dir))
+        fps = asyncio.run(_record_pair(pdf, pdf.parent.name, service, CASSETTE_DIR, truth_dir))
         total += len(fps)
         rel = pdf.relative_to(CORPUS_DIR)
-        print(f"  {rel}: {', '.join(f[:12] + '…' for f in fps) or 'no new cassette'}")
+        print(f"  {rel}: {', '.join(f[:12] + '…' for f in fps) or 'no statement cassette'}")
     print(f"Recorded {total} cassette(s) + truth. Now: python tools/check_cassette_graded_eval.py --update")
     return 0
 


### PR DESCRIPTION
Builds the reproducible harness for an **independent** extraction accuracy oracle (PDF/image → structured table), feeding the existing #1400 graded-eval rails. Attacks the root gap: today the eval grades against truth we generated ourselves (circular) on clean synthetic docs — this adds an external label + **scanned** documents (the real failure mode).

## What lands (P1+P2+P3, one PR — the harness)
- **P1 fetch** (`tools/_lib/pdf_fixtures/fetch_hf_oracle.py`): scanned-weighted pull from HF `Akashved/Indian-Bank-Statements` (Apache-2.0, `synthetic`; Digital + Scanned) → git-ignored `tmp/input/hf_oracle/`. Verified on 10 real pairs.
- **P2 mapper** (`hf_oracle_truth.py`): pure transform HF label → our truth `expected` (debit/credit → one signed Decimal `amount`; Scanned→`vision`, Digital→`text`; `synthetic:true`). Unit-tested — incl. the decisive test that the output is **scorable by the real `cassette_graded_eval`** (perfect extraction → 1.0).
- **P3 record** (`record_hf_oracle.py`): **operator-only KEYED step** (record mode = real provider call; none in CI — matches "本地录制一次"). Runs the production extractor → cassette, writes the sibling `ground_truth/<fp>.truth.json`. Mirrors the verified vision path in `test_extraction_cassette_replay.py`.
- **SSOT** `docs/ssot/cassette-graded-eval.md` §2.1: source, pipeline, and the **honest boundary** — the per-file label proves *field accuracy*, not page assembly (multi-page/dedup stay the deterministic gates' + a future benchmark's job); Scanned = real signal, Digital = clean-render (weak).

## Why a harness, not the recorded corpus
The cassette↔truth pair is keyed by `sha256(prompt + image-bytes)` and recording needs a live provider key — so the corpus is populated by the local keyed `record` step. This PR is the reproducible builder.

## Verification
mapper tests pass (incl. real-eval scorability); existing graded-eval gate, doc-consistency, manifest, ruff all green; `git status` shows only the 5 intended files (corpus gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)