### PR TITLE
[finance_report_test_and_doc] ci(lint): fast-fail SSOT/contract gates before uv sync + npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,51 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      # Fast-fail (left-move): these SSOT/contract gates are app-independent
+      # (`uv run --with pyyaml`, no backend sync / npm) and are the drift classes
+      # behind most CI failures. Running them BEFORE the expensive `uv sync` +
+      # `npm ci` means a drift fails in ~20s instead of after ~50s of setup. Same
+      # checks, no coverage change; ordering only.
+      - name: SSOT Manifest Check
+        run: |
+          uv run --with pyyaml python tools/check_manifest.py
+      - name: SSOT Governance Exceptions Check
+        run: |
+          uv run --with pyyaml python tools/check_governance_exceptions.py
+      - name: SSOT Governance Report
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          base_sha="${BASE_SHA:-}"
+          head_sha="${HEAD_SHA:-}"
+
+          if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git rev-parse "${head_sha}^" 2>/dev/null || git rev-parse HEAD^)"
+          fi
+
+          if ! git diff --name-only "$base_sha...$head_sha" > "$RUNNER_TEMP/ssot-changed-files.txt"; then
+            git diff --name-only "$base_sha" "$head_sha" > "$RUNNER_TEMP/ssot-changed-files.txt"
+          fi
+
+          uv run --with pyyaml python tools/report_ssot_governance.py \
+            --changed-files "$RUNNER_TEMP/ssot-changed-files.txt" \
+            --base-ref "$base_sha" \
+            --fail-on-gate \
+            --json-out "$RUNNER_TEMP/ssot-governance-report.json" \
+            --markdown-out "$RUNNER_TEMP/SSOT-GOVERNANCE-REPORT.md"
+          cat "$RUNNER_TEMP/SSOT-GOVERNANCE-REPORT.md" >> "$GITHUB_STEP_SUMMARY"
+      - name: Migration Risk Contract Check
+        run: |
+          uv run --with pyyaml python tools/check_migration_risk.py
+      - name: CI Metrics Contract Check
+        run: |
+          uv run --with pyyaml python tools/check_ci_metrics_contract.py
+      - name: Workflow Contract Check
+        run: |
+          uv run --with pyyaml python tools/check_workflow_contract.py
       - name: Cache Python venv
         uses: actions/cache@v5
         with:
@@ -254,46 +299,6 @@ jobs:
       - name: SSOT Ownership Lint
         run: |
           python tools/check_ssot_ownership.py --verbose
-      - name: SSOT Manifest Check
-        run: |
-          uv run --with pyyaml python tools/check_manifest.py
-      - name: SSOT Governance Exceptions Check
-        run: |
-          uv run --with pyyaml python tools/check_governance_exceptions.py
-      - name: SSOT Governance Report
-        env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: |
-          set -euo pipefail
-
-          base_sha="${BASE_SHA:-}"
-          head_sha="${HEAD_SHA:-}"
-
-          if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
-            base_sha="$(git rev-parse "${head_sha}^" 2>/dev/null || git rev-parse HEAD^)"
-          fi
-
-          if ! git diff --name-only "$base_sha...$head_sha" > "$RUNNER_TEMP/ssot-changed-files.txt"; then
-            git diff --name-only "$base_sha" "$head_sha" > "$RUNNER_TEMP/ssot-changed-files.txt"
-          fi
-
-          uv run --with pyyaml python tools/report_ssot_governance.py \
-            --changed-files "$RUNNER_TEMP/ssot-changed-files.txt" \
-            --base-ref "$base_sha" \
-            --fail-on-gate \
-            --json-out "$RUNNER_TEMP/ssot-governance-report.json" \
-            --markdown-out "$RUNNER_TEMP/SSOT-GOVERNANCE-REPORT.md"
-          cat "$RUNNER_TEMP/SSOT-GOVERNANCE-REPORT.md" >> "$GITHUB_STEP_SUMMARY"
-      - name: Migration Risk Contract Check
-        run: |
-          uv run --with pyyaml python tools/check_migration_risk.py
-      - name: CI Metrics Contract Check
-        run: |
-          uv run python tools/check_ci_metrics_contract.py
-      - name: Workflow Contract Check
-        run: |
-          uv run --with pyyaml python tools/check_workflow_contract.py
       - name: PR Review Thread Merge Gate
         # Issue #755 (scope 2a): block merge while an unresolved P0/P1 (or
         # unresolved Copilot-authored) review thread is open. Skips cleanly on


### PR DESCRIPTION
Left-move (fast-fail) within the `lint` job — no coverage change, no skip.

## What
The SSOT manifest, governance-exceptions, governance-report, migration-risk, ci-metrics, and workflow-contract checks are app-independent (`uv run --with pyyaml`, no backend sync / npm) and are the **drift classes behind most CI failures**. They previously ran near the **end** of `lint`, after ~50s of `uv sync` + `npm ci`. Moved as one block to right after Python setup, so a drift **fails in ~20s instead of ~72s**.

Ordering only — same checks, same job, no behavior/coverage change. `CI Metrics` now uses `--with pyyaml` since it no longer runs after the backend sync.

## On cleanup (向下)
I looked for safe dead code to remove. The one candidate, `tools/migrate_proof_index_storage.py`, turned out **not** to be dead — `.gitattributes` documents it as a re-runnable utility to re-sort/normalise the merge-union `ac-score-baseline.jsonl`. Kept. The other findings (deprecated-endpoint doc refs, strikethrough AC rows, `ci-gate-inventory` resolved entries) are either still-live logic, AC-registry-tracked, or kept-by-policy audit trail — none safe to delete casually. So this PR is fast-fail only.

## Why not the resource skips
Per your steer: a package change should fan its full downstream E2E, not get skipped. So I dropped the right-move/skip items (R1/R3) — this reorder reduces nothing and skips nothing.

## Verification
`ci.yml` parses; lint step set unchanged (32 steps, no dups); moved checks precede `Install dependencies`; workflow-contract / ci-metrics / manifest gates + 35 tooling tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)