### PR TITLE
[finance_report_hacker] fix(deploy): iac_ref must be an infra2 release tag, not a submodule sha (#1435 W2/W4)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -263,8 +263,10 @@ jobs:
           # Staging deploys the release tag through the infra2 deploy_v2 front door
           # (deploy_primitive -> Dokploy compose). The :<tag> images were published by
           # deploy.yml on the tag push; deploy_v2 pulls them (promote-not-rebuild).
-          # --iac-ref is the pinned infra2 submodule sha so staging uses the same IaC the
-          # app was tested against (and that prod will promote on the same tag).
+          # --iac-ref is the pinned infra2 submodule's RELEASE TAG (resolved by
+          # release_coordinate.py via `git -C repo describe --exact-match`): deploy_v2
+          # requires a vX.Y.Z iac_ref for staging/prod, and pinning the submodule at a
+          # tagged infra2 commit makes staging use the same released IaC prod promotes.
           version_ref="${{ steps.release.outputs.version_ref }}"
           iac_ref="${{ steps.release.outputs.iac_ref }}"
           echo "Deploying staging via deploy_v2: type=staging version-ref=$version_ref iac-ref=$iac_ref"

--- a/common/ci/release_coordinate.py
+++ b/common/ci/release_coordinate.py
@@ -30,6 +30,42 @@ def write_github_output(values: dict[str, str]) -> None:
             print(f"{key}={value}", file=fh)
 
 
+def resolve_infra2_release_tag(repo_dir: str = "repo") -> str:
+    """Resolve the pinned infra2 submodule to its release TAG (the deploy_v2 iac_ref).
+
+    deploy_v2 staging/prod reject a raw sha: the iac_ref must be a `vX.Y.Z` release
+    tag — the immutable, reviewed coordinate that passed infra2's release ritual.
+    A git submodule pins by sha, so the app MUST pin its submodule at a tagged infra2
+    commit; this resolves that sha back to its exact tag and fails closed otherwise,
+    turning "pinned at an unreleased infra2 commit" into a clear error instead of a
+    deploy-time `got a 'sha' ref` rejection.
+    """
+    if not Path(repo_dir).exists():
+        raise RuntimeError(f"{repo_dir} submodule is required to resolve iac_ref")
+    iac_sha = _out("git", "-C", repo_dir, "rev-parse", "HEAD")
+    # Tags are not always present after a submodule checkout; fetch them best-effort.
+    subprocess.run(
+        ["git", "-C", repo_dir, "fetch", "--tags", "--quiet", "origin"],
+        check=False,
+    )
+    try:
+        iac_ref = _out(
+            "git", "-C", repo_dir, "describe", "--tags", "--exact-match", "HEAD"
+        )
+    except subprocess.CalledProcessError:
+        raise RuntimeError(
+            f"infra2 submodule is pinned at {iac_sha[:12]}, which is NOT a release "
+            "tag — deploy_v2 staging/prod require a vX.Y.Z iac_ref. Pin the submodule "
+            "at an infra2 release tag (git -C repo checkout vX.Y.Z)."
+        ) from None
+    if not _RELEASE_VERSION_REF_RE.fullmatch(iac_ref):
+        raise RuntimeError(
+            f"infra2 submodule tag {iac_ref!r} (at {iac_sha[:12]}) is not a vX.Y.Z "
+            "release tag; deploy_v2 requires a release-tag iac_ref."
+        )
+    return iac_ref
+
+
 def resolve(version_ref: str) -> dict[str, str]:
     if not _RELEASE_VERSION_REF_RE.fullmatch(version_ref):
         raise ValueError(
@@ -47,10 +83,7 @@ def resolve(version_ref: str) -> dict[str, str]:
     _run("git", "submodule", "update", "--init", "--recursive")
 
     full_sha = _out("git", "rev-parse", "HEAD")
-    repo_dir = Path("repo")
-    if not repo_dir.exists():
-        raise RuntimeError("repo submodule is required to resolve iac_ref")
-    iac_ref = _out("git", "-C", "repo", "rev-parse", "HEAD")
+    iac_ref = resolve_infra2_release_tag("repo")
     return {
         "version_ref": version_ref,
         "full_sha": full_sha,

--- a/common/ci/release_coordinate.py
+++ b/common/ci/release_coordinate.py
@@ -42,11 +42,19 @@ def resolve_infra2_release_tag(repo_dir: str = "repo") -> str:
     """
     if not Path(repo_dir).exists():
         raise RuntimeError(f"{repo_dir} submodule is required to resolve iac_ref")
-    iac_sha = _out("git", "-C", repo_dir, "rev-parse", "HEAD")
-    # Tags are not always present after a submodule checkout; fetch them best-effort.
+    try:
+        iac_sha = _out("git", "-C", repo_dir, "rev-parse", "HEAD")
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"{repo_dir} is not a readable git repository (cannot resolve iac_ref)"
+        ) from exc
+    # Tags are not always present after a submodule checkout; fetch them best-effort
+    # (silenced — a repo with no `origin` remote, e.g. in tests, is fine here).
     subprocess.run(
         ["git", "-C", repo_dir, "fetch", "--tags", "--quiet", "origin"],
         check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
     try:
         iac_ref = _out(
@@ -56,7 +64,7 @@ def resolve_infra2_release_tag(repo_dir: str = "repo") -> str:
         raise RuntimeError(
             f"infra2 submodule is pinned at {iac_sha[:12]}, which is NOT a release "
             "tag — deploy_v2 staging/prod require a vX.Y.Z iac_ref. Pin the submodule "
-            "at an infra2 release tag (git -C repo checkout vX.Y.Z)."
+            f"at an infra2 release tag (git -C {repo_dir} checkout vX.Y.Z)."
         ) from None
     if not _RELEASE_VERSION_REF_RE.fullmatch(iac_ref):
         raise RuntimeError(

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -138,6 +138,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_env_contract_boundary.py` | `docs/ssot/observability.md`, `docs/ssot/environments.md` |
 | `tests/tooling/test_generate_fixtures.py` | `docs/ssot/extraction.md` |
 | `tests/tooling/test_github_workflow_timing_summary.py` | `docs/ssot/ci-cd.md` |
+| `tests/tooling/test_infra2_pin_is_release_tag.py` | `docs/ssot/deployment.md` |
 | `tests/tooling/test_merge_lcov.py` | `docs/ssot/coverage.md` |
 | `tests/tooling/test_preflight.py` | `docs/ssot/ci-cd.md` |
 | `tests/tooling/test_sanitize_fixtures.py` | `docs/agents/red-lines.md` |

--- a/tests/tooling/test_infra2_pin_is_release_tag.py
+++ b/tests/tooling/test_infra2_pin_is_release_tag.py
@@ -1,0 +1,61 @@
+"""PR-time gate: the pinned infra2 submodule must be an infra2 RELEASE TAG.
+
+deploy_v2 staging/prod reject a raw sha as `iac_ref` — it must be a `vX.Y.Z`
+release tag (the immutable, reviewed coordinate that passed infra2's release
+ritual). A git submodule pins by sha, so it is possible to bump the app's infra2
+submodule to an *unreleased* infra2 commit; that produces an un-releasable app
+state that, without this gate, only blows up at deploy time
+(`deploy_v2 ... requires a release-tag iac_ref, got a 'sha' ref`).
+
+This gate fails the PR instead, so "pinned at an unreleased infra2 commit" is
+caught at merge. It asserts behaviour (the real pin resolves to a tag), not the
+text of any workflow.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from common.ci.release_coordinate import resolve_infra2_release_tag
+
+ROOT = Path(__file__).resolve().parents[2]
+REPO = ROOT / "repo"
+
+
+def test_infra2_submodule_is_pinned_at_a_release_tag() -> None:
+    """The app's infra2 submodule must point at a vX.Y.Z release tag (deploy_v2 iac_ref)."""
+    if not REPO.exists():
+        pytest.skip("infra2 submodule not checked out")
+    # Resolves the pinned sha back to its exact release tag, or raises RuntimeError
+    # with a clear message if the pin is not a release tag.
+    iac_ref = resolve_infra2_release_tag(str(REPO))
+    assert iac_ref.startswith("v"), iac_ref
+
+
+def test_untagged_pin_fails_closed(tmp_path: Path) -> None:
+    """A submodule pinned at a non-tag commit fails closed (the gate has teeth)."""
+    fake = tmp_path / "repo"
+    fake.mkdir()
+    subprocess.run(["git", "-C", str(fake), "init", "-q"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(fake),
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "no tag here",
+        ],
+        check=True,
+    )
+    with pytest.raises(RuntimeError, match="NOT a release tag|not a vX.Y.Z"):
+        resolve_infra2_release_tag(str(fake))

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -2257,10 +2257,16 @@ def test_AC8_13_22_staging_deploys_manually_dispatched_version_ref() -> None:
     assert "_RELEASE_VERSION_REF_RE" in resolver
     assert "version_ref must be a release tag" in resolver
     assert "version_ref.strip()" not in resolver
+    # The superproject release-tag fetch stays narrow (no --force, only the
+    # requested tag, --no-tags so it does not pull every app tag).
     assert '"--force"' not in resolver
-    assert '"--tags"' not in resolver
+    assert '"--no-tags"' in resolver
     assert '"refs/tags/*:refs/tags/*"' not in resolver
     assert 'f"refs/tags/{version_ref}:refs/tags/{version_ref}"' in resolver
+    # iac_ref is the infra2 submodule's RELEASE TAG (deploy_v2 rejects a sha):
+    # resolved by `git -C repo describe --exact-match`, fail-closed if not a tag.
+    assert "resolve_infra2_release_tag" in resolver
+    assert '"--exact-match"' in resolver
     # The shared resolver checks out the dispatched release tag before deploy_v2
     # consumes the already-published release images.
     assert "VERSION_REF: ${{ inputs.version_ref }}" in workflow
@@ -2308,9 +2314,17 @@ def test_AC8_13_22_release_coordinate_fetches_only_requested_tag(
         "_run",
         lambda *args: commands.append(args),
     )
-    monkeypatch.setattr(release_coordinate, "_out", lambda *_args: "a" * 40)
+    # iac_ref resolution does `describe --exact-match` → return a valid release tag
+    # for that call, a fake sha otherwise; and stub the best-effort submodule
+    # tag-fetch so the test stays offline.
+    monkeypatch.setattr(
+        release_coordinate,
+        "_out",
+        lambda *args: "v1.2.3" if "describe" in args else "a" * 40,
+    )
+    monkeypatch.setattr(release_coordinate.subprocess, "run", lambda *a, **k: None)
 
-    release_coordinate.resolve("v1.2.3")
+    coord = release_coordinate.resolve("v1.2.3")
 
     assert commands[0] == (
         "git",
@@ -2320,6 +2334,8 @@ def test_AC8_13_22_release_coordinate_fetches_only_requested_tag(
         "refs/tags/v1.2.3:refs/tags/v1.2.3",
     )
     assert not any("--force" in command for command in commands)
+    # iac_ref is the infra2 release tag, not a sha.
+    assert coord["iac_ref"] == "v1.2.3"
 
 
 def test_AC8_13_36_post_merge_reuses_sha_tagged_staging_images() -> None:


### PR DESCRIPTION
## The 3rd app↔infra2 drift this release surfaced (root #1435 W2)

`deploy_v2` staging/prod **reject a raw sha** as `iac_ref`:
```
deploy_v2 failed: deploy type 'staging' requires a release-tag iac_ref (vX.Y.Z), got a 'sha' ref
```
It must be an infra2 **release tag** (the immutable, reviewed coordinate that passed infra2's release ritual). But `release_coordinate.py` emitted the pinned submodule **HEAD sha**. A git submodule pins by sha → structural impedance mismatch → the v0.1.20 staging deploy failed.

## Fix
- **`release_coordinate.py`**: `iac_ref` is now resolved via `git -C repo describe --tags --exact-match HEAD`, **fail-closed** if the pinned infra2 is not a `vX.Y.Z` release tag (clear error instead of a deploy-time `'sha' ref` rejection).
- **`test_infra2_pin_is_release_tag.py`** (new, **W4 PR-gate**): the infra2 submodule must be pinned at a release tag — bumping to an *unreleased* infra2 commit now fails the **PR**, not the deploy. (#1409 bumping to an untagged commit is exactly what this would have caught.) Behavioural check, not a text mirror.
- deploy.yml comment + `test_post_merge_e2e_gates` AC8.13.22 assertions updated.
- registered the new no-AC contract test.

## Pairs with infra2 v1.1.11
infra2 was tagged **v1.1.11 @ d7cefdd** (the commit the app submodule pins), and reconciled to staging+prod. So the submodule now `describe`s as `v1.1.11`, the gate passes, and `iac_ref=v1.1.11` — unblocking the v0.1.20 release promote→staging.

Note: `test_counter_package::test_AC_counter_1_1` fails on clean `main` too (pre-existing, unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)