### PR TITLE
[finance_report_test_and_doc] test(ci): guard container-images publishes on every main/release push

### DIFF
--- a/tests/tooling/test_workflow_contract.py
+++ b/tests/tooling/test_workflow_contract.py
@@ -62,6 +62,39 @@ def test_AC7_15_1_real_repo_passes_the_workflow_contract() -> None:
     assert contract.run_contract(ROOT) == 0
 
 
+def test_AC7_15_1_container_images_publishes_on_every_main_release_push() -> None:
+    """AC7.15.1: container-images must build+push :<sha> images on EVERY main/release
+    push, not only when image_build_required is true.
+
+    Regression guard for #1411 -> #1433. main/release push CI is the only path that
+    publishes :<sha> images to GHCR, and deploy_v2 is promote-not-rebuild (it pulls
+    images by exact SHA). #1411 right-moved container-images onto image_build_required
+    for ALL events, so source-only main pushes skipped the build and downstream
+    auto-deploy failed on a missing image. Right-moving for PR events is fine, but the
+    job `if` must keep an unconditional main/release-push (plus workflow_dispatch)
+    clause that does NOT depend on image_build_required.
+    """
+    import yaml
+
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    )
+    condition = workflow["jobs"]["container-images"]["if"]
+
+    # The publish-on-main/release clause and the dispatch clause must be present.
+    assert "github.event_name == 'push'" in condition, condition
+    assert "refs/heads/main" in condition, condition
+    assert "refs/heads/release/" in condition, condition
+    assert "workflow_dispatch" in condition, condition
+
+    # And that publish clause must sit BEFORE the image_build_required right-move, so
+    # the right-move can only narrow PR runs, never gate the main/release publish.
+    if "image_build_required" in condition:
+        assert condition.index("refs/heads/main") < condition.index(
+            "image_build_required"
+        ), condition
+
+
 def test_AC7_15_3_stale_ci_classifier_job_name_fails(tmp_path) -> None:
     """AC7.15.3: A stale `classify-changes` reference in ci-cd.md fails."""
     _copy_inputs(tmp_path)


### PR DESCRIPTION
防回归守卫(中文说明见下)。

Locks in the #1433 fix so the #1411 regression cannot recur: a test asserting that `container-images.if` keeps an unconditional **main/release push + workflow_dispatch** clause, with the `image_build_required` right-move only able to narrow **PR** runs (publish clause must precede it).

**Why:** main/release push is the only path that publishes `:<sha>` images to GHCR, and `deploy_v2` is promote-not-rebuild (pulls by exact SHA). #1411 gated container-images on `image_build_required` for all events → source-only main pushes skipped the build → auto-deploy failed on a missing image → Lark alerts.

**Verified:** passes on current ci.yml; fails if the condition reverts to the PR-only gate; `check_ac_index` + ruff clean. Reuses AC7.15.1 (no new AC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)