### PR TITLE
[finance_report_vision] feat(eval): HF extraction oracle — raw LLM output + code-guaranteed layer (Axiom D)

### DIFF
--- a/apps/backend/tests/extraction/hf_oracle_codec.py
+++ b/apps/backend/tests/extraction/hf_oracle_codec.py
@@ -39,9 +39,7 @@ def parse_page(raw_text: str) -> dict[str, Any]:
 
 def _normalize_txn(txn: dict[str, Any]) -> dict[str, Any]:
     try:
-        amount, direction = normalize_amount_direction(
-            Decimal(str(txn.get("amount", "0"))), txn.get("direction")
-        )
+        amount, direction = normalize_amount_direction(Decimal(str(txn.get("amount", "0"))), txn.get("direction"))
     except (InvalidOperation, ValueError, TypeError):
         amount, direction = Decimal("0"), "OUT"
     bal = txn.get("balance_after")

--- a/apps/backend/tests/extraction/hf_oracle_codec.py
+++ b/apps/backend/tests/extraction/hf_oracle_codec.py
@@ -1,0 +1,122 @@
+"""Deterministic CODE layer for the HF extraction oracle (Axiom D boundary).
+
+The cassette persists the LLM's RAW output (LLM-LED, replayed). Everything here
+is the CODE half that must stay code-guaranteed: parse the raw page text,
+normalise to the production transaction schema, merge pages, and run the
+deterministic self-checks. It REUSES the production validators
+(``src.services.validation``) so this exercises the real code, not a parallel
+copy. No LLM, no network — replayable in CI without a key.
+
+    raw page outputs (LLM) --parse--> pages --merge--> statement --validate--> checks
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from src.services.validation import (
+    detect_balance_chain_break,
+    normalize_amount_direction,
+    validate_balance,
+)
+
+_SCORED_TXN_FIELDS = ("date", "description", "amount", "direction", "balance_after")
+
+
+def parse_page(raw_text: str) -> dict[str, Any]:
+    """One page's RAW LLM output -> dict (tolerant of a ```json fence)."""
+    text = (raw_text or "").strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[-1].rsplit("```", 1)[0]
+    try:
+        obj = json.loads(text)
+    except ValueError:
+        return {}
+    return obj if isinstance(obj, dict) else {}
+
+
+def _normalize_txn(txn: dict[str, Any]) -> dict[str, Any]:
+    try:
+        amount, direction = normalize_amount_direction(
+            Decimal(str(txn.get("amount", "0"))), txn.get("direction")
+        )
+    except (InvalidOperation, ValueError, TypeError):
+        amount, direction = Decimal("0"), "OUT"
+    bal = txn.get("balance_after")
+    return {
+        "date": str(txn.get("date", "")).strip(),
+        "description": str(txn.get("description", "")).strip(),
+        "amount": str(amount),
+        "direction": direction,
+        "balance_after": str(bal) if bal not in (None, "") else None,
+    }
+
+
+def merge_pages(pages: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge per-page dicts into one statement (opening from first page that has
+    it, closing from the last, transactions concatenated in order)."""
+    txns: list[dict[str, Any]] = []
+    opening = closing = None
+    for pg in pages:
+        if opening is None and pg.get("opening_balance") not in (None, ""):
+            opening = pg["opening_balance"]
+        if pg.get("closing_balance") not in (None, ""):
+            closing = pg["closing_balance"]
+        for t in pg.get("transactions") or []:
+            txns.append(_normalize_txn(t))
+    return {"opening_balance": opening, "closing_balance": closing, "transactions": txns}
+
+
+def reconstruct(raw_pages: list[str]) -> dict[str, Any]:
+    """RAW per-page LLM outputs -> one normalised statement (pure code)."""
+    return merge_pages([parse_page(r) for r in raw_pages])
+
+
+def self_checks(statement: dict[str, Any]) -> dict[str, Any]:
+    """The code-guaranteed confidence signals on OUR extraction (no truth needed):
+    opening+Σ≈closing, and the running-balance chain (row i validates row i-1)."""
+    bal = validate_balance(statement)
+    opening = statement.get("opening_balance")
+    try:
+        opening_dec = Decimal(str(opening)) if opening not in (None, "") else None
+    except (InvalidOperation, ValueError, TypeError):
+        opening_dec = None
+    chain = detect_balance_chain_break(statement.get("transactions", []), opening_balance=opening_dec)
+    return {
+        "balance_valid": bool(bal["balance_valid"]),
+        "balance_computable": bool(bal.get("balance_computable", True)),
+        "chain_break_index": chain.index if chain else None,
+    }
+
+
+def _field_eq(name: str, got: object, want: object) -> bool:
+    if want is None:
+        return got is None
+    if name in ("amount", "balance_after"):
+        try:
+            return Decimal(str(got)) == Decimal(str(want))
+        except (InvalidOperation, ValueError, TypeError):
+            return False
+    if name == "description":
+        return " ".join(str(got).split()).casefold() == " ".join(str(want).split()).casefold()
+    return str(got).strip() == str(want).strip()
+
+
+def field_score(extraction: dict[str, Any], truth: dict[str, Any]) -> tuple[float, dict[str, int]]:
+    """Fraction of scored fields matching truth (per-row over the 5 fields +
+    opening/closing). A missing/extra row scores its fields wrong."""
+    got_txns = extraction.get("transactions", [])
+    want_txns = truth.get("transactions", [])
+    total = matched = 0
+    for field in ("opening_balance", "closing_balance"):
+        total += 1
+        matched += _field_eq("amount", extraction.get(field), truth.get(field))
+    for i in range(max(len(got_txns), len(want_txns))):
+        g = got_txns[i] if i < len(got_txns) else {}
+        w = want_txns[i] if i < len(want_txns) else {}
+        for field in _SCORED_TXN_FIELDS:
+            total += 1
+            matched += _field_eq(field, g.get(field), w.get(field)) if w else 0
+    return (matched / total if total else 0.0), {"total": total, "matched": matched}

--- a/apps/backend/tests/extraction/test_hf_oracle_codec.py
+++ b/apps/backend/tests/extraction/test_hf_oracle_codec.py
@@ -1,0 +1,86 @@
+"""HF extraction oracle: the CODE layer + committed-example replay.
+
+Exercises the deterministic code (parse RAW LLM output -> normalise -> merge ->
+validate, reusing the production validators) and replays the committed raw
+examples through it (no LLM, no key). The cassette holds only the LLM's RAW
+output; everything asserted here is code-guaranteed (Axiom D).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.extraction.hf_oracle_codec import (
+    field_score,
+    parse_page,
+    reconstruct,
+    self_checks,
+)
+
+ROOT = Path(__file__).resolve().parents[4]  # repo root (apps/backend/tests/extraction/<file>)
+sys.path.insert(0, str(ROOT / "tools" / "_lib" / "pdf_fixtures"))
+from hf_oracle_truth import build_truth  # noqa: E402
+
+EXAMPLES = sorted((Path(__file__).resolve().parents[1] / "fixtures" / "hf_oracle").glob("*.json"))
+
+
+def test_parse_page_tolerates_fence() -> None:
+    assert parse_page('```json\n{"transactions": []}\n```') == {"transactions": []}
+    assert parse_page("not json at all") == {}
+
+
+def test_reconstruct_merges_pages_into_production_schema() -> None:
+    pages = [
+        '{"opening_balance":"100","transactions":[{"date":"2026-01-02",'
+        '"description":"Coffee","amount":"5","direction":"OUT","balance_after":"95"}]}',
+        '{"closing_balance":"145","transactions":[{"date":"2026-01-05",'
+        '"description":"Salary","amount":"50","direction":"IN","balance_after":"145"}]}',
+    ]
+    st = reconstruct(pages)
+    assert st["opening_balance"] == "100" and st["closing_balance"] == "145"
+    assert [t["direction"] for t in st["transactions"]] == ["OUT", "IN"]
+    assert st["transactions"][0]["balance_after"] == "95"
+
+
+def test_self_checks_pass_a_balanced_chain_and_flag_a_break() -> None:
+    good = reconstruct([
+        '{"opening_balance":"100","closing_balance":"145","transactions":['
+        '{"date":"d","description":"a","amount":"5","direction":"OUT","balance_after":"95"},'
+        '{"date":"d","description":"b","amount":"50","direction":"IN","balance_after":"145"}]}'
+    ])
+    checks = self_checks(good)
+    assert checks["balance_valid"] is True and checks["chain_break_index"] is None
+
+    broken = reconstruct([
+        '{"opening_balance":"100","closing_balance":"145","transactions":['
+        '{"date":"d","description":"a","amount":"5","direction":"OUT","balance_after":"999"}]}'
+    ])
+    assert self_checks(broken)["chain_break_index"] == 0  # row's running balance is impossible
+
+
+def test_mapped_truth_chain_validates() -> None:
+    """The mapped truth is internally consistent under the production validator —
+    a free quality check that the label's running-balance chain holds."""
+    hf = {"opening_balance": 100.0, "closing_balance": 145.0, "transactions": [
+        {"date": "d", "description": "a", "debit": 5.0, "credit": None, "balance": 95.0},
+        {"date": "d", "description": "b", "debit": None, "credit": 50.0, "balance": 145.0}]}
+    truth = build_truth(hf, dirname="India_Bank_Statement_Scanned_Type1")["expected"]
+    assert self_checks(truth)["chain_break_index"] is None
+
+
+@pytest.mark.skipif(not EXAMPLES, reason="no recorded HF examples committed yet")
+@pytest.mark.parametrize("path", EXAMPLES, ids=lambda p: p.stem)
+def test_recorded_example_replays_through_codec(path: Path) -> None:
+    """A committed raw example: RAW LLM output -> codec -> scored vs truth, no key."""
+    rec = json.loads(path.read_text(encoding="utf-8"))
+    assert rec["synthetic"] is True
+    assert isinstance(rec["raw_pages"], list) and rec["raw_pages"], "no raw LLM pages persisted"
+    statement = reconstruct(rec["raw_pages"])
+    assert statement["transactions"], "codec produced no transactions from the raw output"
+    score, breakdown = field_score(statement, rec["truth"])
+    assert 0.0 <= score <= 1.0 and breakdown["total"] > 0
+    self_checks(statement)  # the code self-checks run without error

--- a/apps/backend/tests/extraction/test_hf_oracle_codec.py
+++ b/apps/backend/tests/extraction/test_hf_oracle_codec.py
@@ -47,27 +47,36 @@ def test_reconstruct_merges_pages_into_production_schema() -> None:
 
 
 def test_self_checks_pass_a_balanced_chain_and_flag_a_break() -> None:
-    good = reconstruct([
-        '{"opening_balance":"100","closing_balance":"145","transactions":['
-        '{"date":"d","description":"a","amount":"5","direction":"OUT","balance_after":"95"},'
-        '{"date":"d","description":"b","amount":"50","direction":"IN","balance_after":"145"}]}'
-    ])
+    good = reconstruct(
+        [
+            '{"opening_balance":"100","closing_balance":"145","transactions":['
+            '{"date":"d","description":"a","amount":"5","direction":"OUT","balance_after":"95"},'
+            '{"date":"d","description":"b","amount":"50","direction":"IN","balance_after":"145"}]}'
+        ]
+    )
     checks = self_checks(good)
     assert checks["balance_valid"] is True and checks["chain_break_index"] is None
 
-    broken = reconstruct([
-        '{"opening_balance":"100","closing_balance":"145","transactions":['
-        '{"date":"d","description":"a","amount":"5","direction":"OUT","balance_after":"999"}]}'
-    ])
+    broken = reconstruct(
+        [
+            '{"opening_balance":"100","closing_balance":"145","transactions":['
+            '{"date":"d","description":"a","amount":"5","direction":"OUT","balance_after":"999"}]}'
+        ]
+    )
     assert self_checks(broken)["chain_break_index"] == 0  # row's running balance is impossible
 
 
 def test_mapped_truth_chain_validates() -> None:
     """The mapped truth is internally consistent under the production validator —
     a free quality check that the label's running-balance chain holds."""
-    hf = {"opening_balance": 100.0, "closing_balance": 145.0, "transactions": [
-        {"date": "d", "description": "a", "debit": 5.0, "credit": None, "balance": 95.0},
-        {"date": "d", "description": "b", "debit": None, "credit": 50.0, "balance": 145.0}]}
+    hf = {
+        "opening_balance": 100.0,
+        "closing_balance": 145.0,
+        "transactions": [
+            {"date": "d", "description": "a", "debit": 5.0, "credit": None, "balance": 95.0},
+            {"date": "d", "description": "b", "debit": None, "credit": 50.0, "balance": 145.0},
+        ],
+    }
     truth = build_truth(hf, dirname="India_Bank_Statement_Scanned_Type1")["expected"]
     assert self_checks(truth)["chain_break_index"] is None
 

--- a/apps/backend/tests/fixtures/hf_oracle/India_Bank_Statement_Digital_Type1__00001.json
+++ b/apps/backend/tests/fixtures/hf_oracle/India_Bank_Statement_Digital_Type1__00001.json
@@ -1,0 +1,1156 @@
+{
+  "source": "India_Bank_Statement_Digital_Type1/00001.pdf",
+  "model": "glm-4.6v",
+  "prompt": "Extract this bank-statement page as strict JSON only (no prose, no markdown fence): {opening_balance, closing_balance, transactions:[{date, description, amount, direction, balance_after}]}. amount = absolute value; direction = \"IN\" for credits / \"OUT\" for debits; balance_after = the running balance printed on that row. Omit opening_balance/closing_balance if not on this page.",
+  "synthetic": true,
+  "modality": "text",
+  "pages": 6,
+  "raw_pages": [
+    "{\"opening_balance\": \"Rs. 59,131.72\", \"closing_balance\": \"Rs. 21,661.82\", \"transactions\": [{\"date\": \"01-01-2024\", \"description\": \"NEFT Cr-210968206613-ICIC0SF0002-CLOTHING INDUSTRIES LTD--\", \"amount\": \"6,086.63\", \"direction\": \"IN\", \"balance_after\": \"Rs. 65,218.35\"}, {\"date\": \"02-01-2024\", \"description\": \"Chq Paid-MICR Inward Clearing-KAUSHIK SAHA-HDFC BANK LTD.\", \"amount\": \"23,702.04\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 41,516.31\"}, {\"date\": \"03-01-2024\", \"description\": \"RTGS Dr-CNBRB929510940342-HDFC0004171-BIPLAB CHATTERJEE/NONE\", \"amount\": \"9,055.89\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 32,460.42\"}, {\"date\": \"04-01-2024\", \"description\": \"IMPS Dr-670498159700-SHREYA SENGUPTA\", \"amount\": \"2,177.93\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 30,282.49\"}, {\"date\": \"04-01-2024\", \"description\": \"CASH-BNA-SELF-PAYEL SAHA\", \"amount\": \"661.06\", \"direction\": \"IN\", \"balance_after\": \"Rs. 30,943.55\"}, {\"date\": \"04-01-2024\", \"description\": \"CASH-BNA-SELF-ANANYA CHAKRABORTY\", \"amount\": \"1,789.08\", \"direction\": \"IN\", \"balance_after\": \"Rs. 32,732.63\"}, {\"date\": \"05-01-2024\", \"description\": \"IMPS BRN SALARY TRF BY-VITALITY MEDICINES LTD\", \"amount\": \"4,795.06\", \"direction\": \"IN\", \"balance_after\": \"Rs. 37,527.69\"}, {\"date\": \"05-01-2024\", \"description\": \"UPI/DR/956616604066/PRIYANKA SENGUPTA/UPI-TRANSFER TO 9097052564\", \"amount\": \"652.28\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 36,875.41\"}, {\"date\": \"05-01-2024\", \"description\": \"IMPS BRN SALARY TRF BY-FOUNDATION PROJECTS LTD\", \"amount\": \"1,212.22\", \"direction\": \"IN\", \"balance_after\": \"Rs. 38,087.63\"}, {\"date\": \"05-01-2024\", \"description\": \"IMPS Dr-446289662468-SONALI BOSE\", \"amount\": \"407.72\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 37,679.91\"}, {\"date\": \"06-01-2024\", \"description\": \"RTGS Dr-CNBRB368742409288-HDFC0004171-ABHIJIT DAS/NONE\", \"amount\": \"20,253.80\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 17,426.11\"}, {\"date\": \"06-01-2024\", \"description\": \"IMPS BRN SALARY TRF BY-CREDIT SERVICES LTD\", \"amount\": \"2,574.63\", \"direction\": \"IN\", \"balance_after\": \"Rs. 20,000.74\"}, {\"date\": \"06-01-2024\", \"description\": \"UPI/DR/447951602541/DEBASHIS CHAKRABORTY/UPI-TRANSFER TO 7333183915\", \"amount\": \"571.24\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 19,429.50\"}]}",
+    "{\"transactions\":[{\"date\":\"08-01-2024\",\"description\":\"UPI/DR/728341737715/PAYEL BHATTACHARYA/TRANSFER TO 8557940363\",\"amount\":513.47,\"direction\":\"OUT\",\"balance_after\":18916.03},{\"date\":\"08-01-2024\",\"description\":\"IMPS Dr-336203076056-TANMAY GANGULY\",\"amount\":2287.52,\"direction\":\"OUT\",\"balance_after\":16628.51},{\"date\":\"08-01-2024\",\"description\":\"NEFT Cr-947749222922-ICICOSF0002-SOFTWARE TECHNOLOGIES--\",\"amount\":7675.95,\"direction\":\"IN\",\"balance_after\":24304.46},{\"date\":\"08-01-2024\",\"description\":\"NEFT Cr-85101820366-ICICOSF0002-DAILY NEEDS LIMITED--\",\"amount\":3180.55,\"direction\":\"IN\",\"balance_after\":27485.01},{\"date\":\"08-01-2024\",\"description\":\"By Cig.DEL ACCTS-CITI BANK N.A.(CIT), TECHVISION SYSTEMS\",\"amount\":3206.08,\"direction\":\"IN\",\"balance_after\":30691.09},{\"date\":\"08-01-2024\",\"description\":\"Cash Withdrawal-BIPLAB DUTTA\",\"amount\":742.40,\"direction\":\"OUT\",\"balance_after\":29948.69},{\"date\":\"09-01-2024\",\"description\":\"NEFT Dr-863017303564-UTILITY PAYMENT\",\"amount\":1347.60,\"direction\":\"OUT\",\"balance_after\":20386.59},{\"date\":\"11-01-2024\",\"description\":\"NEFT Cr-623097695825-ICICOSF0002-COMMERCIAL PROPERTIES INDIA\",\"amount\":3103.69,\"direction\":\"IN\",\"balance_after\":33052.38},{\"date\":\"11-01-2024\",\"description\":\"CASH-BNA-SELF-BIPLAB BHATTACHARYA\",\"amount\":1376.45,\"direction\":\"IN\",\"balance_after\":34428.83},{\"date\":\"11-01-2024\",\"description\":\"NEFT Dr-349487998528-HDFC0009038-SOURAV DASGUPTA\",\"amount\":5267.64,\"direction\":\"OUT\",\"balance_after\":29161.19},{\"date\":\"12-01-2024\",\"description\":\"NEFT Dr-857406851540-HDFC0009038-ARIJIT SEN\",\"amount\":6725.28,\"direction\":\"OUT\",\"balance_after\":22435.91},{\"date\":\"12-01-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-RAHUL CHAKRABORTY-HDFC BANK LTD.\",\"amount\":6233.58,\"direction\":\"OUT\",\"balance_after\":16202.33},{\"date\":\"12-01-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-ANANYA MAJUMDAR-HDFC BANK LTD.\",\"amount\":6513.72,\"direction\":\"OUT\",\"balance_after\":9688.61},{\"date\":\"12-01-2024\",\"description\":\"NEFT Dr-245974395610-HDFC0009038-SUBRATA BOSE\",\"amount\":3329.88,\"direction\":\"OUT\",\"balance_after\":6358.73},{\"date\":\"13-01-2024\",\"description\":\"IMPS Dr-550685841633-RAJIB CHAKRABORTY\",\"amount\":523.74,\"direction\":\"OUT\",\"balance_after\":5834.99},{\"date\":\"13-01-2024\",\"description\":\"By Cig.DEL ACCTS-CITI BANK N.A.(CIT), CREDIT SERVICES LTD\",\"amount\":312.87,\"direction\":\"IN\",\"balance_after\":6147.86},{\"date\":\"13-01-2024\",\"description\":\"NEFT Cr-977213384724-ICICOSF0002-INFOCORE TECHNOLOGIES--\",\"amount\":1554.17,\"direction\":\"IN\",\"balance_after\":7702.03},{\"date\":\"15-01-2024\",\"description\":\"By Cig.DEL ACCTS-CITI BANK N.A.(CIT), CAPITAL VENTURES INDIA\",\"amount\":1828.18,\"direction\":\"IN\",\"balance_after\":9530.21},{\"date\":\"16-01-2024\",\"description\":\"NEFT Cr-533294388600-ICICOSF0002-INDUSTRIAL WORKS INDIA--\",\"amount\":4328.08,\"direction\":\"IN\",\"balance_after\":13858.29},{\"date\":\"17-01-2024\",\"description\":\"CASH-BNA-SELF-RAHUL SARKAR\",\"amount\":1152.35,\"direction\":\"OUT\",\"balance_after\":15010.64},{\"date\":\"17-01-2024\",\"description\":\"CASH-BNA-SELF-SONALI BISWAS\",\"amount\":1279.23,\"direction\":\"OUT\",\"balance_after\":16289.87},{\"date\":\"18-01-2024\",\"description\":\"IMPS BRN SALARY TRF BY-PHARMACY PRODUCTS LTD\",\"amount\":2864.65,\"direction\":\"IN\",\"balance_after\":19154.52},{\"date\":\"18-01-2024\",\"description\":\"RTGS Dr-CNBRB793975948062-HDFC0004171-PAYEL GHOSH/NONE\",\"amount\":8256.49,\"direction\":\"OUT\",\"balance_after\":10898.03},{\"date\":\"18-01-2024\",\"description\":\"CASH-BNA-SELF-TAPAS PAUL\",\"amount\":216.21,\"direction\":\"IN\",\"balance_after\":11114.24},{\"date\":\"19-01-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-DEBASHIS DASGUPTA-HDFC BANK LTD.\",\"amount\":2677.73,\"direction\":\"OUT\",\"balance_after\":8436.51},{\"date\":\"19-01-2024\",\"description\":\"NEFT Dr-590187733891-HDFC0009038-AMIT SENGUPTA\",\"amount\":866.79,\"direction\":\"OUT\",\"balance_after\":7569.72},{\"date\":\"20-01-2024\",\"description\":\"NEFT Dr-270635188773-HDFC0009038-RIYA GHOSH\",\"amount\":1087.71,\"direction\":\"OUT\",\"balance_after\":6482.01},{\"date\":\"20-01-2024\",\"description\":\"RTGS Dr-CNBRB16351280044-HDFC0004171-RITAM DAS/NONE\",\"amount\":5009.85,\"direction\":\"OUT\",\"balance_after\":1472.16},{\"date\":\"20-01-2024\",\"description\":\"NEFT Dr-455142811587-GST PAYMENT-GSTIN 54A8955\",\"amount\":10476.71,\"direction\":\"OUT\",\"balance_after\":9909.88},{\"date\":\"20-01-2024\",\"description\":\"NEFT Cr-379809553812-ICICOSF0002-CURE PHARMACEUTICALS--\",\"amount\":979.59,\"direction\":\"IN\",\"balance_after\":2451.75},{\"date\":\"22-01-2024\",\"description\":\"IMPS BRN SALARY TRF BY-ROADWAY INFRATECH\",\"amount\":785.55,\"direction\":\"IN\",\"balance_after\":3237.30},{\"date\":\"23-01-2024\",\"description\":\"By Cig.DEL ACCTS-CITI BANK N.A.(CIT), DAIRY PRODUCTS INDIA\",\"amount\":326.25,\"direction\":\"IN\",\"balance_after\":3563.55},{\"date\":\"24-01-2024\",\"description\":\"IMPS BRN SALARY TRF BY-CODEBASE SOLUTIONS\",\"amount\":712.07,\"direction\":\"IN\",\"balance_after\":4275.62}]}",
+    "{\"transactions\":[{\"date\":\"24-01-2024\",\"description\":\"NEFT Cr-457834252605-ICICOSF0002-BRIDGE ENGINEERING CO-\",\"amount\":935.48,\"direction\":\"IN\",\"balance_after\":5211.10},{\"date\":\"24-01-2024\",\"description\":\"By CIG.DEL ACCTS-CITI BANK N.A.(CIT), HOUSING DEVELOPERS LTD\",\"amount\":487.33,\"direction\":\"IN\",\"balance_after\":5698.43},{\"date\":\"24-01-2024\",\"description\":\"RTGS Cr-ICICR356849853581-ICIC0000011-NETFORG E TECHNOLOGIES--URGENT/\",\"amount\":7836.93,\"direction\":\"IN\",\"balance_after\":13535.36},{\"date\":\"24-01-2024\",\"description\":\"NEFT Dr-827913570929-HDFC0009038-SWAGATA GUPTA\",\"amount\":2731.48,\"direction\":\"OUT\",\"balance_after\":10803.88},{\"date\":\"25-01-2024\",\"description\":\"IMPS BRN SALARY TRF BY-CYBERCRAFT SYSTEMS\",\"amount\":161.94,\"direction\":\"IN\",\"balance_after\":10965.82},{\"date\":\"25-01-2024\",\"description\":\"By CIG.DEL ACCTS-CITI BANK N.A.(CIT), AUTOMOTIVE PARTS CORP\",\"amount\":1083.23,\"direction\":\"IN\",\"balance_after\":12049.05},{\"date\":\"25-01-2024\",\"description\":\"RTGS Dr-CNBRBR273427857612-HDFC0004171-PRIYA NKA CHOWDHURY-NONE\",\"amount\":4231.14,\"direction\":\"OUT\",\"balance_after\":7817.91},{\"date\":\"25-01-2024\",\"description\":\"UPI/CR/650834173112/SHREYA DUTTA/SENT-TRANSFER FROM 8522417469\",\"amount\":297.82,\"direction\":\"IN\",\"balance_after\":8115.73},{\"date\":\"27-01-2024\",\"description\":\"NEFT Cr-328504307889-ICICOSF0002-VITALITY MEDICINES LTD--\",\"amount\":2947.62,\"direction\":\"IN\",\"balance_after\":11063.35},{\"date\":\"29-01-2024\",\"description\":\"UPI/CR/544906412821/TANMAY GUPTA/SENT-TRANSFER FROM 8845256710\",\"amount\":353.70,\"direction\":\"IN\",\"balance_after\":11417.05},{\"date\":\"29-01-2024\",\"description\":\"NEFT Cr-123815374689-ICICOSF0002-WELLNESS BRANDS INDIA--\",\"amount\":3226.77,\"direction\":\"IN\",\"balance_after\":14643.82},{\"date\":\"30-01-2024\",\"description\":\"IMPS BRN SALARY TRF BY-DAIRY PRODUCTS INDIA\",\"amount\":2056.48,\"direction\":\"IN\",\"balance_after\":16700.30},{\"date\":\"30-01-2024\",\"description\":\"UPI/CR/775180999565/AMIT SAHA/SENT-TRANSFER FROM 8731919656\",\"amount\":401.24,\"direction\":\"IN\",\"balance_after\":17101.54},{\"date\":\"30-01-2024\",\"description\":\"CASH-BNA-SELF-SWAGATA BANERJEE\",\"amount\":819.21,\"direction\":\"IN\",\"balance_after\":17920.75},{\"date\":\"31-01-2024\",\"description\":\"REVERSAL-UPI/CR/544906412821/TANMAY GUPTA/SENT-TRANSFER FRO\",\"amount\":353.70,\"direction\":\"OUT\",\"balance_after\":17567.05},{\"date\":\"31-01-2024\",\"description\":\"UPI/DR/503125953079/KAUSHIK ROY/UPI-TRANSFER TO 9790400869\",\"amount\":396.36,\"direction\":\"OUT\",\"balance_after\":17170.69},{\"date\":\"31-01-2024\",\"description\":\"IMPS BRN SALARY TRF BY-CODEBASE SOLUTIONS\",\"amount\":2246.64,\"direction\":\"IN\",\"balance_after\":19417.33},{\"date\":\"01-02-2024\",\"description\":\"IMPS Dr-942009840782-RITAM GANGULY\",\"amount\":1288.87,\"direction\":\"OUT\",\"balance_after\":18128.46},{\"date\":\"02-02-2024\",\"description\":\"ATM WDL-ATM CASH 65498\",\"amount\":9482.92,\"direction\":\"OUT\",\"balance_after\":8645.54},{\"date\":\"03-02-2024\",\"description\":\"By CIG.DEL ACCTS-CITI BANK N.A.(CIT), DIGITAL SOLUTIONS INDIA\",\"amount\":1520.04,\"direction\":\"IN\",\"balance_after\":10165.58},{\"date\":\"03-02-2024\",\"description\":\"RTGS Cr-ICICR75113612926-ICIC0000011-NETPULS E SYSTEMS--/URGENT/\",\"amount\":20416.63,\"direction\":\"IN\",\"balance_after\":30682.21},{\"date\":\"03-02-2024\",\"description\":\"ATM WDL-ATM CASH 76619\",\"amount\":12427.35,\"direction\":\"OUT\",\"balance_after\":18254.86},{\"date\":\"05-02-2024\",\"description\":\"UPI/CR/213102212480/ARPITA CHATTERJEE/SENT-TRANSFER FROM 7788799544\",\"amount\":378.91,\"direction\":\"IN\",\"balance_after\":18633.77},{\"date\":\"05-02-2024\",\"description\":\"IMPS Dr-744362921769-BIPLAB BANERJEE\",\"amount\":2523.73,\"direction\":\"OUT\",\"balance_after\":16110.04},{\"date\":\"05-02-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-RAHUL CHOWDHURY-HDFC BANK LTD.\",\"amount\":7465.74,\"direction\":\"OUT\",\"balance_after\":8644.30},{\"date\":\"05-02-2024\",\"description\":\"By CIG.DEL ACCTS-CITI BANK N.A.(CIT), FINANCE SOLUTIONS INDIA\",\"amount\":583.89,\"direction\":\"IN\",\"balance_after\":9228.19},{\"date\":\"07-02-2024\",\"description\":\"RTGS Dr-CNBRBA469171147220-HDFC0004171-SUBRA TA SARKAR-NONE\",\"amount\":6944.61,\"direction\":\"OUT\",\"balance_after\":2283.58},{\"date\":\"08-02-2024\",\"description\":\"NEFT Cr-901235775423-ICICOSF0002-COMMERCIAL PROPERTIES INDIA--\",\"amount\":302.74,\"direction\":\"IN\",\"balance_after\":2586.32},{\"date\":\"09-02-2024\",\"description\":\"NEFT Dr-731359724204-UTILITY PAYMENT\",\"amount\":3352.68,\"direction\":\"OUT\",\"balance_after\":-766.36},{\"date\":\"09-02-2024\",\"description\":\"By CIG.DEL ACCTS-CITI BANK N.A.(CIT), BUILDING SOLUTIONS LTD\",\"amount\":432.09,\"direction\":\"IN\",\"balance_after\":-334.27},{\"date\":\"10-02-2024\",\"description\":\"By CIG.DEL ACCTS-CITI BANK N.A.(CIT), CONCRETE STRUCTURES LTD\",\"amount\":853.56,\"direction\":\"IN\",\"balance_after\":519.29},{\"date\":\"10-02-2024\",\"description\":\"By CIG.DEL ACCTS-CITI BANK N.A.(CIT), NETFORGE TECHNOLOGIES\",\"amount\":451.25,\"direction\":\"IN\",\"balance_after\":970.54},{\"date\":\"10-02-2024\",\"description\":\"NEFT Cr-929831790524-ICICOSF0002-COMMERCIAL VEHICLES LTD--\",\"amount\":1785.19,\"direction\":\"IN\",\"balance_after\":2755.73}]}",
+    "{\"transactions\":[{\"date\":\"10-02-2024\",\"description\":\"UPI/CR/460987990432/SUJIT SAHA/SENT-TRANSFER FROM 91985559983\",\"amount\":929.96,\"direction\":\"IN\",\"balance_after\":7292.07},{\"date\":\"13-02-2024\",\"description\":\"By CIG/DEL ACCTS-CITI BANK N.A.(CIT), EXPRESS LOGISTICS INDIA\",\"amount\":712.98,\"direction\":\"IN\",\"balance_after\":8005.05},{\"date\":\"13-02-2024\",\"description\":\"REVERSAL-UPI/CR/460987990432/SUJIT SAHA/SENT-TRANSFER FROM\",\"amount\":929.96,\"direction\":\"OUT\",\"balance_after\":20378.16},{\"date\":\"14-02-2024\",\"description\":\"NEFT Dr-126276538173-HDFC0009038-SOURAV DASGUPTA\",\"amount\":1830.56,\"direction\":\"OUT\",\"balance_after\":6174.49},{\"date\":\"14-02-2024\",\"description\":\"RTGS Dr-CNBRB443420225559-HDFC0004171-SREYA DASGUPTA-NONE\",\"amount\":1310.51,\"direction\":\"OUT\",\"balance_after\":4863.98},{\"date\":\"15-02-2024\",\"description\":\"RTGS Cr-ICICR371910036764-ICIC0000011-AUTOMOTIVE PARTS CORP-/URGENT-\",\"amount\":6440.36,\"direction\":\"IN\",\"balance_after\":11304.34},{\"date\":\"15-02-2024\",\"description\":\"NEFT Cr-213285328597-ICIC0SF0002-CITYSCAPE DEVELOPERS-\",\"amount\":5451.92,\"direction\":\"IN\",\"balance_after\":16756.26},{\"date\":\"15-02-2024\",\"description\":\"CASH-BNA-SELF-SUSMITA BHATTACHARYA\",\"amount\":962.42,\"direction\":\"IN\",\"balance_after\":17718.68},{\"date\":\"17-02-2024\",\"description\":\"RTGS Cr-ICICR258761652534-ICIC0000011-BIOCARE INDUSTRIES-/URGENT-\",\"amount\":19038.22,\"direction\":\"IN\",\"balance_after\":36756.9},{\"date\":\"17-02-2024\",\"description\":\"Cash Withdrawal-RIYA DUTTA\",\"amount\":1832.42,\"direction\":\"OUT\",\"balance_after\":34924.48},{\"date\":\"17-02-2024\",\"description\":\"NEFT Cr-285336525867-ICIC0SF0002-COTTON MILLS CORP-.\",\"amount\":2325.53,\"direction\":\"IN\",\"balance_after\":37250.01},{\"date\":\"17-02-2024\",\"description\":\"RTGS Cr-ICICR211281778829-ICIC0000011-PRECISION ENGINEERING WORKS-/URGENT-\",\"amount\":43436.34,\"direction\":\"IN\",\"balance_after\":80686.35},{\"date\":\"17-02-2024\",\"description\":\"NEFT Cr-199658371324-ICIC0SF0002-FABRIC PRODUCTS CORP-.\",\"amount\":14590.37,\"direction\":\"IN\",\"balance_after\":95276.72},{\"date\":\"19-02-2024\",\"description\":\"IMPS Dr-644134271355-SUBRATA SEN\",\"amount\":8657.47,\"direction\":\"OUT\",\"balance_after\":86619.28},{\"date\":\"19-02-2024\",\"description\":\"NEFT Dr-541034268128-HDFC0009038-ARPITA GHOSH\",\"amount\":5067.47,\"direction\":\"OUT\",\"balance_after\":81551.81},{\"date\":\"20-02-2024\",\"description\":\"NEFT Cr-357213517799-ICIC0SF0002-RETAIL BRANDS CORP-\",\"amount\":22264.98,\"direction\":\"IN\",\"balance_after\":103816.79},{\"date\":\"20-02-2024\",\"description\":\"NEFT Dr-769161930088-GST PAYMENT-GSTIN 71C4171\",\"amount\":10476.71,\"direction\":\"OUT\",\"balance_after\":-3919.51},{\"date\":\"21-02-2024\",\"description\":\"UPI/CR/478426056369-RIYA CHOWDHURY/SENT-TRANSFER FROM 7289768879\",\"amount\":106.68,\"direction\":\"IN\",\"balance_after\":103923.47},{\"date\":\"22-02-2024\",\"description\":\"Cash Withdrawal-RAJIB MITRA\",\"amount\":5170.28,\"direction\":\"OUT\",\"balance_after\":98753.19},{\"date\":\"22-02-2024\",\"description\":\"By CIG/DEL ACCTS-CITI BANK N.A.(CIT), MINDWAVE CONSULTING\",\"amount\":14081.58,\"direction\":\"IN\",\"balance_after\":112834.77},{\"date\":\"23-02-2024\",\"description\":\"By CIG/DEL ACCTS-CITI BANK N.A.(CIT), FOUNDATION PROJECTS LTD\",\"amount\":14029.17,\"direction\":\"IN\",\"balance_after\":126863.94},{\"date\":\"24-02-2024\",\"description\":\"NEFT Cr-472014442250-ICIC0SF0002-DISTRIBUTION NETWORKS INDIA-\",\"amount\":49027.87,\"direction\":\"IN\",\"balance_after\":175891.81},{\"date\":\"24-02-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-ANINDYA BANERJEE-HDFC BANK LTD.\",\"amount\":71993.52,\"direction\":\"OUT\",\"balance_after\":103898.29},{\"date\":\"24-02-2024\",\"description\":\"RTGS Cr-ICICR993498752371-ICIC0000011-APPAREL MAKERS INDIA-/URGENT-\",\"amount\":37177.04,\"direction\":\"IN\",\"balance_after\":141075.33},{\"date\":\"24-02-2024\",\"description\":\"NEFT Cr-537071536149-ICIC0SF0002-FINANCIAL PARTNERS INDIA-\",\"amount\":33889.33,\"direction\":\"IN\",\"balance_after\":174964.66},{\"date\":\"24-02-2024\",\"description\":\"By CIG/DEL ACCTS-CITI BANK N.A.(CIT), SHIPPING SERVICES INDIA\",\"amount\":51788.93,\"direction\":\"IN\",\"balance_after\":226753.59},{\"date\":\"26-02-2024\",\"description\":\"NEFT Dr-362713973481-SOFTWARE SUBSCRIPTION\",\"amount\":1759.58,\"direction\":\"OUT\",\"balance_after\":-5679.09},{\"date\":\"26-02-2024\",\"description\":\"RTGS Dr-CNBRB165377554004-HDFC0004171-SHREY A SAHA-NONE\",\"amount\":6198.68,\"direction\":\"OUT\",\"balance_after\":165554.91},{\"date\":\"27-02-2024\",\"description\":\"UPI/DR/410866848656-RITAM SENGUPTA/UPI-TRANSFER TO 6249183902\",\"amount\":1622.9,\"direction\":\"OUT\",\"balance_after\":163932.01},{\"date\":\"27-02-2024\",\"description\":\"IMPS BRN SALARY TRF BY-BUILDING SOLUTIONS LTD\",\"amount\":9271.67,\"direction\":\"IN\",\"balance_after\":173203.68},{\"date\":\"27-02-2024\",\"description\":\"IMPS BRN SALARY TRF BY-FOUNDATION PROJECTS LTD\",\"amount\":25697.34,\"direction\":\"IN\",\"balance_after\":198901.02},{\"date\":\"27-02-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-MITALI SENGUPTA-HDFC BANK LTD.\",\"amount\":99036.48,\"direction\":\"OUT\",\"balance_after\":99864.54},{\"date\":\"27-02-2024\",\"description\":\"NEFT Dr-600630105173-HDFC0009038-TAPAS DUTTA\",\"amount\":33492.48,\"direction\":\"OUT\",\"balance_after\":66372.06}]}",
+    "{\"transactions\":[{\"date\":\"27-02-2024\",\"description\":\"RTGS Dr-CNBRB118549177807-HDFC0004171-SHREY A BISWAS-NONE\",\"amount\":14033.52,\"direction\":\"OUT\",\"balance_after\":52338.54},{\"date\":\"28-02-2024\",\"description\":\"UPICR/931674830862/SANJAY CHATTERJEE/SENT-TRANSFER FROM 6601393596\",\"amount\":2163.29,\"direction\":\"IN\",\"balance_after\":54501.83},{\"date\":\"28-02-2024\",\"description\":\"By Cig/DEL ACCTS-CITI BANK N.A.(CIT), DATABRIDGE INFOTECH\",\"amount\":6835.45,\"direction\":\"IN\",\"balance_after\":61337.28},{\"date\":\"28-02-2024\",\"description\":\"Service Charges-Demat Account AMC\",\"amount\":337.27,\"direction\":\"OUT\",\"balance_after\":-6016.36},{\"date\":\"28-02-2024\",\"description\":\"Service Charges-Online Banking Charges\",\"amount\":206.83,\"direction\":\"OUT\",\"balance_after\":-6223.19},{\"date\":\"28-02-2024\",\"description\":\"Service Charges-SMS Alert Charges\",\"amount\":90.75,\"direction\":\"OUT\",\"balance_after\":-6313.94},{\"date\":\"29-02-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-ARPITA DASGUPTA-HDFC BANK LTD.\",\"amount\":26979.32,\"direction\":\"OUT\",\"balance_after\":34357.96},{\"date\":\"29-02-2024\",\"description\":\"RTGS Dr-CNRRB678992061478-HDFC0004171-SONAL I DUTTA-NONE\",\"amount\":22061.03,\"direction\":\"OUT\",\"balance_after\":12296.93},{\"date\":\"01-03-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-AMIT DASGUPTA-HDFC BANK LTD.\",\"amount\":6091.77,\"direction\":\"OUT\",\"balance_after\":6205.16},{\"date\":\"01-03-2024\",\"description\":\"Cash Withdrawal-TANMAY BOSE\",\"amount\":823.12,\"direction\":\"OUT\",\"balance_after\":5382.04},{\"date\":\"02-03-2024\",\"description\":\"RTGS Cr-ICICR844226908288-ICIC0000011-CREDIT SERVICES LTD--URGENT/\",\"amount\":6595.41,\"direction\":\"IN\",\"balance_after\":11977.45},{\"date\":\"04-03-2024\",\"description\":\"IMPS BRN SALARY TRF BY-SHIPPING SERVICES INDIA\",\"amount\":503.00,\"direction\":\"IN\",\"balance_after\":12480.45},{\"date\":\"05-03-2024\",\"description\":\"IMPS Dr-915641514403-RAJIB MUKHERJEE\",\"amount\":1097.33,\"direction\":\"OUT\",\"balance_after\":11383.12},{\"date\":\"05-03-2024\",\"description\":\"IMPS Dr-534754213825-PAYEL DUTTA\",\"amount\":1560.02,\"direction\":\"OUT\",\"balance_after\":9823.10},{\"date\":\"06-03-2024\",\"description\":\"By Cig/DEL ACCTS-CITI BANK N.A.(CIT), GATEWAY PROJECTS LTD\",\"amount\":787.87,\"direction\":\"IN\",\"balance_after\":10610.97},{\"date\":\"06-03-2024\",\"description\":\"By Cig/DEL ACCTS-CITI BANK N.A.(CIT), RETAIL COMMERCE INDIA\",\"amount\":1935.68,\"direction\":\"IN\",\"balance_after\":12546.65},{\"date\":\"06-03-2024\",\"description\":\"RTGS Cr-ICICR345775995432-ICIC0000011-CAPITAL VENTURES INDIA--/URGENT/\",\"amount\":17289.40,\"direction\":\"IN\",\"balance_after\":29836.05},{\"date\":\"06-03-2024\",\"description\":\"NEFT Cr-959332621698-ICIC0SF0002-APEX HEAVY INDUSTRIES-\",\"amount\":14338.29,\"direction\":\"IN\",\"balance_after\":44174.34},{\"date\":\"07-03-2024\",\"description\":\"NEFT Cr-182093576973-ICIC0SF0002-PRECISION ENGINEERING WORKS-\",\"amount\":3170.94,\"direction\":\"IN\",\"balance_after\":47345.28},{\"date\":\"12-03-2024\",\"description\":\"NEFT Dr-867251037460-HDFC0009038-SUSMITA SENGUPTA\",\"amount\":3236.48,\"direction\":\"OUT\",\"balance_after\":44108.80},{\"date\":\"13-03-2024\",\"description\":\"NEFT Cr-675084101912-ICIC0SF0002-DAILY NEEDS LIMITED--\",\"amount\":20750.49,\"direction\":\"IN\",\"balance_after\":64859.29},{\"date\":\"14-03-2024\",\"description\":\"RTGS Dr-CNBRB219239255472-HDFC0004171-SANJA Y SARKAR-NONE\",\"amount\":41602.44,\"direction\":\"OUT\",\"balance_after\":23256.85},{\"date\":\"14-03-2024\",\"description\":\"NEFT Cr-259069608854-ICIC0SF0002-SUPPLY CHAIN CORP-\",\"amount\":5733.73,\"direction\":\"IN\",\"balance_after\":28990.58},{\"date\":\"15-03-2024\",\"description\":\"Dividend Cr-AUTOMOTIVE PARTS CORP-EQUITY SHARES\",\"amount\":1356.03,\"direction\":\"IN\",\"balance_after\":21734.19},{\"date\":\"15-03-2024\",\"description\":\"UPI/CR/394566296733-RAHUL SENGUPTA/SENT-TRANSFER FROM 9841874124\",\"amount\":743.12,\"direction\":\"IN\",\"balance_after\":29733.70},{\"date\":\"15-03-2024\",\"description\":\"UPI/DR/936536138846/BIPABL SEN/UPI-TRANSFER TO 8745951918\",\"amount\":361.52,\"direction\":\"OUT\",\"balance_after\":29372.18},{\"date\":\"16-03-2024\",\"description\":\"NEFT Cr-439738889875-ICIC0SF0002-CONSUMER ESSENTIALS INDIA-\",\"amount\":11491.98,\"direction\":\"IN\",\"balance_after\":40864.16},{\"date\":\"18-03-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-MITALI DUTTA-HDFC BANK LTD.\",\"amount\":10836.25,\"direction\":\"OUT\",\"balance_after\":30027.91},{\"date\":\"18-03-2024\",\"description\":\"CASH-BNA-SELF-RITAM DUTTA\",\"amount\":745.26,\"direction\":\"IN\",\"balance_after\":30773.17},{\"date\":\"18-03-2024\",\"description\":\"By Cig/DEL ACCTS-CITI BANK N.A.(CIT), METROPOLITAN BUILDERS\",\"amount\":5003.83,\"direction\":\"IN\",\"balance_after\":35777.00},{\"date\":\"19-03-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-SOURAV CHATTERJEE-HDFC BANK LTD.\",\"amount\":13018.88,\"direction\":\"OUT\",\"balance_after\":22758.12},{\"date\":\"20-03-2024\",\"description\":\"Chq Paid-MICR Inward Clearing-TAPAS MUKHERJEE-HDFC BANK LTD.\",\"amount\":10937.03,\"direction\":\"OUT\",\"balance_after\":11821.09},{\"date\":\"20-03-2024\",\"description\":\"IMPS BRN SALARY TRF BY-PHARMACY PRODUCTS LTD\",\"amount\":1873.07,\"direction\":\"IN\",\"balance_after\":13694.16}]}",
+    "{\"transactions\":[{\"date\":\"21-03-2024 07:32:53\",\"description\":\"Chq Paid-MICR Inward Clearing-SOURAV GANGULY-HDFC BANK LTD.\",\"amount\":2868.01,\"direction\":\"OUT\",\"balance_after\":10826.15},{\"date\":\"21-03-2024 12:36:45\",\"description\":\"Cash Withdrawal-TAPAS BHATTACHARYA\",\"amount\":147.31,\"direction\":\"OUT\",\"balance_after\":10678.84},{\"date\":\"22-03-2024 06:58:40\",\"description\":\"NEFT Cr-998034591743-ICICOSF0002-PERSONAL CARE LTD-\",\"amount\":3664.61,\"direction\":\"IN\",\"balance_after\":14343.45},{\"date\":\"22-03-2024 21:54:44\",\"description\":\"UPI/CR/341412834258/SONALI CHATTERJEE/SENT-TRANSFER FROM 8444366180\",\"amount\":585.87,\"direction\":\"IN\",\"balance_after\":14929.32},{\"date\":\"23-03-2024 10:18:42\",\"description\":\"Chq Paid-MICR Inward Clearing-SUJIT SEN-HDFC BANK LTD.\",\"amount\":6836.90,\"direction\":\"OUT\",\"balance_after\":8092.42},{\"date\":\"26-03-2024 06:11:18\",\"description\":\"NEFT Cr-754481424204-ICICOSF0002-TEXTILE SOLUTIONS INDIA-\",\"amount\":775.81,\"direction\":\"IN\",\"balance_after\":8868.23},{\"date\":\"26-03-2024 06:35:03\",\"description\":\"NEFT Cr-818376489476-ICICOSF0002-RESIDENTIAL PROJECTS LTD-\",\"amount\":3255.94,\"direction\":\"IN\",\"balance_after\":12124.17},{\"date\":\"26-03-2024 20:28:17\",\"description\":\"NEFT Dr-639820282851-HDFC0009038-ARJIT CHATTERJEE\",\"amount\":885.56,\"direction\":\"OUT\",\"balance_after\":11238.61},{\"date\":\"27-03-2024 14:29:07\",\"description\":\"NEFT Cr-633101275754-ICICOSF0002-FASHION TEXTILES LTD-\",\"amount\":4367.43,\"direction\":\"IN\",\"balance_after\":15606.04},{\"date\":\"27-03-2024 16:34:50\",\"description\":\"IMPS BRN SALARY TRF BY-RESIDENTIAL PROJECTS LTD\",\"amount\":365.78,\"direction\":\"IN\",\"balance_after\":15971.82},{\"date\":\"28-03-2024 10:19:33\",\"description\":\"By Clg/DEL ACCTS-CITI BANK N.A.(CIT), POWER SYSTEMS CORP\",\"amount\":1134.45,\"direction\":\"IN\",\"balance_after\":17106.27},{\"date\":\"28-03-2024 11:53:22\",\"description\":\"RTGS Cr-ICICR983555220673-ICIC0000011-COTTON MILLS CORP-URGENT/\",\"amount\":22753.12,\"direction\":\"IN\",\"balance_after\":39859.39},{\"date\":\"28-03-2024 12:15:34\",\"description\":\"NEFT Cr-397197036503-ICICOSF0002-INDUSTRIAL COMPONENTS INDIA-\",\"amount\":16031.10,\"direction\":\"IN\",\"balance_after\":55890.49},{\"date\":\"28-03-2024 23:59:00\",\"description\":\"Service Charges-NEFT/RTGS Charges\",\"amount\":11.97,\"direction\":\"OUT\",\"balance_after\":6325.91},{\"date\":\"30-03-2024 12:59:54\",\"description\":\"NEFT Dr-107800254021-HDFC0009038-BIPLAB BANERJEE\",\"amount\":21205.89,\"direction\":\"OUT\",\"balance_after\":34684.60},{\"date\":\"30-03-2024 15:11:53\",\"description\":\"NEFT Dr-929459255429-HDFC0009038-SOURAV CHAKRABORTY\",\"amount\":13771.73,\"direction\":\"OUT\",\"balance_after\":20912.87},{\"date\":\"30-03-2024 15:37:44\",\"description\":\"UPI/CR/48432226569/ARJIT CHOWDHURY/SENT-TRANSFER FROM 6174365174\",\"amount\":748.95,\"direction\":\"IN\",\"balance_after\":21661.82}],\"closing_balance\":21661.82}"
+  ],
+  "truth": {
+    "opening_balance": "59131.72",
+    "closing_balance": "21661.82",
+    "transactions": [
+      {
+        "date": "2024-01-01",
+        "description": "NEFT Cr-210968206613-ICIC0SF0002-CLOTHING INDUSTRIES LTD--",
+        "amount": "6086.63",
+        "direction": "IN",
+        "balance_after": "65218.35"
+      },
+      {
+        "date": "2024-01-02",
+        "description": "Chq Paid-MICR Inward Clearing-KAUSHIK SAHA-HDFC BANK LTD.",
+        "amount": "23702.04",
+        "direction": "OUT",
+        "balance_after": "41516.31"
+      },
+      {
+        "date": "2024-01-03",
+        "description": "RTGS Dr-CNRBR929510940342-HDFC0004171-BIPLAB CHATTERJEE-/NONE",
+        "amount": "9055.89",
+        "direction": "OUT",
+        "balance_after": "32460.42"
+      },
+      {
+        "date": "2024-01-04",
+        "description": "IMPS Dr-670498159700-SHREYA SENGUPTA",
+        "amount": "2177.93",
+        "direction": "OUT",
+        "balance_after": "30282.49"
+      },
+      {
+        "date": "2024-01-04",
+        "description": "CASH-BNA-SELF-PAYEL SAHA",
+        "amount": "661.06",
+        "direction": "IN",
+        "balance_after": "30943.55"
+      },
+      {
+        "date": "2024-01-04",
+        "description": "CASH-BNA-SELF-ANANYA CHAKRABORTY",
+        "amount": "1789.08",
+        "direction": "IN",
+        "balance_after": "32732.63"
+      },
+      {
+        "date": "2024-01-05",
+        "description": "IMPS BRN SALARY TRF BY-VITALITY MEDICINES LTD",
+        "amount": "4795.06",
+        "direction": "IN",
+        "balance_after": "37527.69"
+      },
+      {
+        "date": "2024-01-05",
+        "description": "UPI/DR/956616604066/PRIYANKA SENGUPTA/UPI-TRANSFER TO 9097052564",
+        "amount": "652.28",
+        "direction": "OUT",
+        "balance_after": "36875.41"
+      },
+      {
+        "date": "2024-01-05",
+        "description": "IMPS BRN SALARY TRF BY-FOUNDATION PROJECTS LTD",
+        "amount": "1212.22",
+        "direction": "IN",
+        "balance_after": "38087.63"
+      },
+      {
+        "date": "2024-01-05",
+        "description": "IMPS Dr-446289662468-SONALI BOSE",
+        "amount": "407.72",
+        "direction": "OUT",
+        "balance_after": "37679.91"
+      },
+      {
+        "date": "2024-01-06",
+        "description": "RTGS Dr-CNRBR368742409288-HDFC0004171-ABHIJIT DAS-/NONE",
+        "amount": "20253.8",
+        "direction": "OUT",
+        "balance_after": "17426.11"
+      },
+      {
+        "date": "2024-01-06",
+        "description": "IMPS BRN SALARY TRF BY-CREDIT SERVICES LTD",
+        "amount": "2574.63",
+        "direction": "IN",
+        "balance_after": "20000.74"
+      },
+      {
+        "date": "2024-01-06",
+        "description": "UPI/DR/447951602541/DEBASHIS CHAKRABORTY/UPI-TRANSFER TO 7333183915",
+        "amount": "571.24",
+        "direction": "OUT",
+        "balance_after": "19429.5"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "UPI/DR/728341737715/PAYEL BHATTACHARYA/UPI-TRANSFER TO 8557940363",
+        "amount": "513.47",
+        "direction": "OUT",
+        "balance_after": "18916.03"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "IMPS Dr-336203076056-TANMAY GANGULY",
+        "amount": "2287.52",
+        "direction": "OUT",
+        "balance_after": "16628.51"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "NEFT Cr-947749222922-ICIC0SF0002-SOFTWAVE TECHNOLOGIES--",
+        "amount": "7675.95",
+        "direction": "IN",
+        "balance_after": "24304.46"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "NEFT Cr-851018220366-ICIC0SF0002-DAILY NEEDS LIMITED--",
+        "amount": "3180.55",
+        "direction": "IN",
+        "balance_after": "27485.01"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), TECHVISION SYSTEMS",
+        "amount": "3206.08",
+        "direction": "IN",
+        "balance_after": "30691.09"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "Cash Withdrawal-BIPLAB DUTTA",
+        "amount": "742.4",
+        "direction": "OUT",
+        "balance_after": "29948.69"
+      },
+      {
+        "date": "2024-01-09",
+        "description": "NEFT Dr-863017303564-UTILITY PAYMENT",
+        "amount": "1347.6",
+        "direction": "OUT",
+        "balance_after": "20386.59"
+      },
+      {
+        "date": "2024-01-11",
+        "description": "NEFT Cr-623097695825-ICIC0SF0002-COMMERCIAL PROPERTIES INDIA--",
+        "amount": "3103.69",
+        "direction": "IN",
+        "balance_after": "33052.38"
+      },
+      {
+        "date": "2024-01-11",
+        "description": "CASH-BNA-SELF-BIPLAB BHATTACHARYA",
+        "amount": "1376.45",
+        "direction": "IN",
+        "balance_after": "34428.83"
+      },
+      {
+        "date": "2024-01-11",
+        "description": "NEFT Dr-349487998528-HDFC0009038-SOURAV DASGUPTA",
+        "amount": "5267.64",
+        "direction": "OUT",
+        "balance_after": "29161.19"
+      },
+      {
+        "date": "2024-01-12",
+        "description": "NEFT Dr-857406851540-HDFC0009038-ARIJIT SEN",
+        "amount": "6725.28",
+        "direction": "OUT",
+        "balance_after": "22435.91"
+      },
+      {
+        "date": "2024-01-12",
+        "description": "Chq Paid-MICR Inward Clearing-RAHUL CHAKRABORTY-HDFC BANK LTD.",
+        "amount": "6233.58",
+        "direction": "OUT",
+        "balance_after": "16202.33"
+      },
+      {
+        "date": "2024-01-12",
+        "description": "Chq Paid-MICR Inward Clearing-ANANYA MAJUMDAR-HDFC BANK LTD.",
+        "amount": "6513.72",
+        "direction": "OUT",
+        "balance_after": "9688.61"
+      },
+      {
+        "date": "2024-01-12",
+        "description": "NEFT Dr-245974395610-HDFC0009038-SUBRATA BOSE",
+        "amount": "3329.88",
+        "direction": "OUT",
+        "balance_after": "6358.73"
+      },
+      {
+        "date": "2024-01-13",
+        "description": "IMPS Dr-550685841633-RAJIB CHAKRABORTY",
+        "amount": "523.74",
+        "direction": "OUT",
+        "balance_after": "5834.99"
+      },
+      {
+        "date": "2024-01-13",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), CREDIT SERVICES LTD",
+        "amount": "312.87",
+        "direction": "IN",
+        "balance_after": "6147.86"
+      },
+      {
+        "date": "2024-01-13",
+        "description": "NEFT Cr-977213384724-ICIC0SF0002-INFOCORE TECHNOLOGIES--",
+        "amount": "1554.17",
+        "direction": "IN",
+        "balance_after": "7702.03"
+      },
+      {
+        "date": "2024-01-15",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), CAPITAL VENTURES INDIA",
+        "amount": "1828.18",
+        "direction": "IN",
+        "balance_after": "9530.21"
+      },
+      {
+        "date": "2024-01-16",
+        "description": "NEFT Cr-533294388600-ICIC0SF0002-INDUSTRIAL WORKS INDIA--",
+        "amount": "4328.08",
+        "direction": "IN",
+        "balance_after": "13858.29"
+      },
+      {
+        "date": "2024-01-17",
+        "description": "CASH-BNA-SELF-RAHUL SARKAR",
+        "amount": "1152.35",
+        "direction": "IN",
+        "balance_after": "15010.64"
+      },
+      {
+        "date": "2024-01-17",
+        "description": "CASH-BNA-SELF-SONALI BISWAS",
+        "amount": "1279.23",
+        "direction": "IN",
+        "balance_after": "16289.87"
+      },
+      {
+        "date": "2024-01-18",
+        "description": "IMPS BRN SALARY TRF BY-PHARMACY PRODUCTS LTD",
+        "amount": "2864.65",
+        "direction": "IN",
+        "balance_after": "19154.52"
+      },
+      {
+        "date": "2024-01-18",
+        "description": "RTGS Dr-CNRBR793975948062-HDFC0004171-PAYEL GHOSH-/NONE",
+        "amount": "8256.49",
+        "direction": "OUT",
+        "balance_after": "10898.03"
+      },
+      {
+        "date": "2024-01-18",
+        "description": "CASH-BNA-SELF-TAPAS PAUL",
+        "amount": "216.21",
+        "direction": "IN",
+        "balance_after": "11114.24"
+      },
+      {
+        "date": "2024-01-19",
+        "description": "Chq Paid-MICR Inward Clearing-DEBASHIS DASGUPTA-HDFC BANK LTD.",
+        "amount": "2677.73",
+        "direction": "OUT",
+        "balance_after": "8436.51"
+      },
+      {
+        "date": "2024-01-19",
+        "description": "NEFT Dr-590187733891-HDFC0009038-AMIT SENGUPTA",
+        "amount": "866.79",
+        "direction": "OUT",
+        "balance_after": "7569.72"
+      },
+      {
+        "date": "2024-01-20",
+        "description": "NEFT Dr-270635188773-HDFC0009038-RIYA GHOSH",
+        "amount": "1087.71",
+        "direction": "OUT",
+        "balance_after": "6482.01"
+      },
+      {
+        "date": "2024-01-20",
+        "description": "RTGS Dr-CNRBR163512820044-HDFC0004171-RITAM DAS-/NONE",
+        "amount": "5009.85",
+        "direction": "OUT",
+        "balance_after": "1472.16"
+      },
+      {
+        "date": "2024-01-20",
+        "description": "NEFT Dr-455142811587-GST PAYMENT-GSTIN 54A8955",
+        "amount": "10476.71",
+        "direction": "OUT",
+        "balance_after": "9909.88"
+      },
+      {
+        "date": "2024-01-20",
+        "description": "NEFT Cr-379809553812-ICIC0SF0002-CURE PHARMACEUTICALS--",
+        "amount": "979.59",
+        "direction": "IN",
+        "balance_after": "2451.75"
+      },
+      {
+        "date": "2024-01-22",
+        "description": "IMPS BRN SALARY TRF BY-ROADWAY INFRATECH",
+        "amount": "785.55",
+        "direction": "IN",
+        "balance_after": "3237.3"
+      },
+      {
+        "date": "2024-01-23",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), DAIRY PRODUCTS INDIA",
+        "amount": "326.25",
+        "direction": "IN",
+        "balance_after": "3563.55"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "IMPS BRN SALARY TRF BY-CODEBASE SOLUTIONS",
+        "amount": "712.07",
+        "direction": "IN",
+        "balance_after": "4275.62"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "NEFT Cr-457834252605-ICIC0SF0002-BRIDGE ENGINEERING CO--",
+        "amount": "935.48",
+        "direction": "IN",
+        "balance_after": "5211.1"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), HOUSING DEVELOPERS CORP",
+        "amount": "487.33",
+        "direction": "IN",
+        "balance_after": "5698.43"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "RTGS Cr-ICICR356849853581-ICIC0000011-NETFORGE TECHNOLOGIES--/URGENT/",
+        "amount": "7836.93",
+        "direction": "IN",
+        "balance_after": "13535.36"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "NEFT Dr-827913570929-HDFC0009038-SWAGATA GUPTA",
+        "amount": "2731.48",
+        "direction": "OUT",
+        "balance_after": "10803.88"
+      },
+      {
+        "date": "2024-01-25",
+        "description": "IMPS BRN SALARY TRF BY-CYBERCRAFT SYSTEMS",
+        "amount": "161.94",
+        "direction": "IN",
+        "balance_after": "10965.82"
+      },
+      {
+        "date": "2024-01-25",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), AUTOMOTIVE PARTS CORP",
+        "amount": "1083.23",
+        "direction": "IN",
+        "balance_after": "12049.05"
+      },
+      {
+        "date": "2024-01-25",
+        "description": "RTGS Dr-CNRBR273427875612-HDFC0004171-PRIYANKA CHOWDHURY-/NONE",
+        "amount": "4231.14",
+        "direction": "OUT",
+        "balance_after": "7817.91"
+      },
+      {
+        "date": "2024-01-25",
+        "description": "UPI/CR/650834173112/SHREYA DUTTA/SENT-TRANSFER FROM 8522417469",
+        "amount": "297.82",
+        "direction": "IN",
+        "balance_after": "8115.73"
+      },
+      {
+        "date": "2024-01-27",
+        "description": "NEFT Cr-328504307889-ICIC0SF0002-VITALITY MEDICINES LTD--",
+        "amount": "2947.62",
+        "direction": "IN",
+        "balance_after": "11063.35"
+      },
+      {
+        "date": "2024-01-29",
+        "description": "UPI/CR/544906412821/TANMAY GUPTA/SENT-TRANSFER FROM 8845256710",
+        "amount": "353.7",
+        "direction": "IN",
+        "balance_after": "11417.05"
+      },
+      {
+        "date": "2024-01-29",
+        "description": "NEFT Cr-123815374689-ICIC0SF0002-WELLNESS BRANDS INDIA--",
+        "amount": "3226.77",
+        "direction": "IN",
+        "balance_after": "14643.82"
+      },
+      {
+        "date": "2024-01-30",
+        "description": "IMPS BRN SALARY TRF BY-DAIRY PRODUCTS INDIA",
+        "amount": "2056.48",
+        "direction": "IN",
+        "balance_after": "16700.3"
+      },
+      {
+        "date": "2024-01-30",
+        "description": "UPI/CR/775180999565/AMIT SAHA/SENT-TRANSFER FROM 8731919656",
+        "amount": "401.24",
+        "direction": "IN",
+        "balance_after": "17101.54"
+      },
+      {
+        "date": "2024-01-30",
+        "description": "CASH-BNA-SELF-SWAGATA BANERJEE",
+        "amount": "819.21",
+        "direction": "IN",
+        "balance_after": "17920.75"
+      },
+      {
+        "date": "2024-01-31",
+        "description": "REVERSAL-UPI/CR/544906412821/TANMAY GUPTA/SENT-TRANSFER FRO",
+        "amount": "353.7",
+        "direction": "OUT",
+        "balance_after": "21308.12"
+      },
+      {
+        "date": "2024-01-31",
+        "description": "UPI/DR/503125953079/KAUSHIK ROY/UPI-TRANSFER TO 9790400869",
+        "amount": "396.36",
+        "direction": "OUT",
+        "balance_after": "17524.39"
+      },
+      {
+        "date": "2024-01-31",
+        "description": "IMPS BRN SALARY TRF BY-CODEBASE SOLUTIONS",
+        "amount": "2246.64",
+        "direction": "IN",
+        "balance_after": "19771.03"
+      },
+      {
+        "date": "2024-02-01",
+        "description": "IMPS Dr-942009840782-RITAM GANGULY",
+        "amount": "1288.87",
+        "direction": "OUT",
+        "balance_after": "18482.16"
+      },
+      {
+        "date": "2024-02-02",
+        "description": "ATM WDL-ATM CASH 65498",
+        "amount": "9482.92",
+        "direction": "OUT",
+        "balance_after": "8999.24"
+      },
+      {
+        "date": "2024-02-03",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), DIGITAL SOLUTIONS INDIA",
+        "amount": "1520.04",
+        "direction": "IN",
+        "balance_after": "10519.28"
+      },
+      {
+        "date": "2024-02-03",
+        "description": "RTGS Cr-ICICR751136129026-ICIC0000011-NETPULSE SYSTEMS--/URGENT/",
+        "amount": "20416.63",
+        "direction": "IN",
+        "balance_after": "30935.91"
+      },
+      {
+        "date": "2024-02-03",
+        "description": "ATM WDL-ATM CASH 76619",
+        "amount": "12427.35",
+        "direction": "OUT",
+        "balance_after": "18508.56"
+      },
+      {
+        "date": "2024-02-05",
+        "description": "UPI/CR/213102212480/ARPITA CHATTERJEE/SENT-TRANSFER FROM 7768799544",
+        "amount": "378.91",
+        "direction": "IN",
+        "balance_after": "18887.47"
+      },
+      {
+        "date": "2024-02-05",
+        "description": "IMPS Dr-744362921769-BIPLAB BANERJEE",
+        "amount": "2523.73",
+        "direction": "OUT",
+        "balance_after": "16363.74"
+      },
+      {
+        "date": "2024-02-05",
+        "description": "Chq Paid-MICR Inward Clearing-RAHUL CHOWDHURY-HDFC BANK LTD.",
+        "amount": "7465.74",
+        "direction": "OUT",
+        "balance_after": "8898.0"
+      },
+      {
+        "date": "2024-02-05",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), FINANCE SOLUTIONS INDIA",
+        "amount": "583.89",
+        "direction": "IN",
+        "balance_after": "9481.89"
+      },
+      {
+        "date": "2024-02-07",
+        "description": "RTGS Dr-CNRBR469171147220-HDFC0004171-SUBRATA SARKAR-/NONE",
+        "amount": "6944.61",
+        "direction": "OUT",
+        "balance_after": "2537.28"
+      },
+      {
+        "date": "2024-02-08",
+        "description": "NEFT Cr-901235775423-ICIC0SF0002-COMMERCIAL PROPERTIES INDIA--",
+        "amount": "302.74",
+        "direction": "IN",
+        "balance_after": "2840.02"
+      },
+      {
+        "date": "2024-02-09",
+        "description": "NEFT Dr-731359724204-UTILITY PAYMENT",
+        "amount": "3352.68",
+        "direction": "OUT",
+        "balance_after": "6557.2"
+      },
+      {
+        "date": "2024-02-09",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), BUILDING SOLUTIONS LTD",
+        "amount": "432.09",
+        "direction": "IN",
+        "balance_after": "3272.11"
+      },
+      {
+        "date": "2024-02-10",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), CONCRETE STRUCTURES LTD",
+        "amount": "853.56",
+        "direction": "IN",
+        "balance_after": "4125.67"
+      },
+      {
+        "date": "2024-02-10",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), NETFORGE TECHNOLOGIES",
+        "amount": "451.25",
+        "direction": "IN",
+        "balance_after": "4576.92"
+      },
+      {
+        "date": "2024-02-10",
+        "description": "NEFT Cr-929831790524-ICIC0SF0002-COMMERCIAL VEHICLES LTD--",
+        "amount": "1785.19",
+        "direction": "IN",
+        "balance_after": "6362.11"
+      },
+      {
+        "date": "2024-02-10",
+        "description": "UPI/CR/460987990432/SUJIT SAHA/SENT-TRANSFER FROM 9198559983",
+        "amount": "929.96",
+        "direction": "IN",
+        "balance_after": "7292.07"
+      },
+      {
+        "date": "2024-02-13",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), EXPRESS LOGISTICS INDIA",
+        "amount": "712.98",
+        "direction": "IN",
+        "balance_after": "8005.05"
+      },
+      {
+        "date": "2024-02-13",
+        "description": "REVERSAL-UPI/CR/460987990432/SUJIT SAHA/SENT-TRANSFER FROM",
+        "amount": "929.96",
+        "direction": "OUT",
+        "balance_after": "20378.16"
+      },
+      {
+        "date": "2024-02-14",
+        "description": "NEFT Dr-126276538173-HDFC0009038-SOURAV DASGUPTA",
+        "amount": "1830.56",
+        "direction": "OUT",
+        "balance_after": "6174.49"
+      },
+      {
+        "date": "2024-02-14",
+        "description": "RTGS Dr-CNRBR443420225559-HDFC0004171-SREYA DASGUPTA-/NONE",
+        "amount": "1310.51",
+        "direction": "OUT",
+        "balance_after": "4863.98"
+      },
+      {
+        "date": "2024-02-15",
+        "description": "RTGS Cr-ICICR371910036764-ICIC0000011-AUTOMOTIVE PARTS CORP--/URGENT/",
+        "amount": "6440.36",
+        "direction": "IN",
+        "balance_after": "11304.34"
+      },
+      {
+        "date": "2024-02-15",
+        "description": "NEFT Cr-213285328597-ICIC0SF0002-CITYSCAPE DEVELOPERS--",
+        "amount": "5451.92",
+        "direction": "IN",
+        "balance_after": "16756.26"
+      },
+      {
+        "date": "2024-02-15",
+        "description": "CASH-BNA-SELF-SUSMITA BHATTACHARYA",
+        "amount": "962.42",
+        "direction": "IN",
+        "balance_after": "17718.68"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "RTGS Cr-ICICR256761652534-ICIC0000011-BIOCARE INDUSTRIES--/URGENT/",
+        "amount": "19038.22",
+        "direction": "IN",
+        "balance_after": "36756.9"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "Cash Withdrawal-RIYA DUTTA",
+        "amount": "1832.42",
+        "direction": "OUT",
+        "balance_after": "34924.48"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "NEFT Cr-285336525867-ICIC0SF0002-COTTON MILLS CORP--",
+        "amount": "2325.53",
+        "direction": "IN",
+        "balance_after": "37250.01"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "RTGS Cr-ICICR211281778829-ICIC0000011-PRECISION ENGINEERING WORKS--/URGENT/",
+        "amount": "43436.34",
+        "direction": "IN",
+        "balance_after": "80686.35"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "NEFT Cr-199658371324-ICIC0SF0002-FABRIC PRODUCTS CORP--",
+        "amount": "14590.37",
+        "direction": "IN",
+        "balance_after": "95276.72"
+      },
+      {
+        "date": "2024-02-19",
+        "description": "IMPS Dr-644134271355-SUBRATA SEN",
+        "amount": "8657.44",
+        "direction": "OUT",
+        "balance_after": "86619.28"
+      },
+      {
+        "date": "2024-02-19",
+        "description": "NEFT Dr-541034268128-HDFC0009038-ARPITA GHOSH",
+        "amount": "5067.47",
+        "direction": "OUT",
+        "balance_after": "81551.81"
+      },
+      {
+        "date": "2024-02-20",
+        "description": "NEFT Cr-357213517799-ICIC0SF0002-RETAIL BRANDS CORP--",
+        "amount": "22264.98",
+        "direction": "IN",
+        "balance_after": "103816.79"
+      },
+      {
+        "date": "2024-02-20",
+        "description": "NEFT Dr-769161930088-GST PAYMENT-GSTIN 71C4171",
+        "amount": "10476.71",
+        "direction": "OUT",
+        "balance_after": "-3919.51"
+      },
+      {
+        "date": "2024-02-21",
+        "description": "UPI/CR/478426056369/RIYA CHOWDHURY/SENT-TRANSFER FROM 7289768879",
+        "amount": "106.68",
+        "direction": "IN",
+        "balance_after": "103923.47"
+      },
+      {
+        "date": "2024-02-22",
+        "description": "Cash Withdrawal-RAJIB MITRA",
+        "amount": "5170.28",
+        "direction": "OUT",
+        "balance_after": "98753.19"
+      },
+      {
+        "date": "2024-02-22",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), MINDWAVE CONSULTING",
+        "amount": "14081.58",
+        "direction": "IN",
+        "balance_after": "112834.77"
+      },
+      {
+        "date": "2024-02-23",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), FOUNDATION PROJECTS LTD",
+        "amount": "14029.17",
+        "direction": "IN",
+        "balance_after": "126863.94"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "NEFT Cr-472014442250-ICIC0SF0002-DISTRIBUTION NETWORKS INDIA--",
+        "amount": "49027.87",
+        "direction": "IN",
+        "balance_after": "175891.81"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "Chq Paid-MICR Inward Clearing-ANINDYA BANERJEE-HDFC BANK LTD.",
+        "amount": "71993.52",
+        "direction": "OUT",
+        "balance_after": "103898.29"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "RTGS Cr-ICICR993498752371-ICIC0000011-APPAREL MAKERS INDIA--/URGENT/",
+        "amount": "37177.04",
+        "direction": "IN",
+        "balance_after": "141075.33"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "NEFT Cr-537071536149-ICIC0SF0002-FINANCIAL PARTNERS INDIA--",
+        "amount": "33889.33",
+        "direction": "IN",
+        "balance_after": "174964.66"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), SHIPPING SERVICES INDIA",
+        "amount": "51788.93",
+        "direction": "IN",
+        "balance_after": "226753.59"
+      },
+      {
+        "date": "2024-02-26",
+        "description": "NEFT Dr-362713973481-SOFTWARE SUBSCRIPTION",
+        "amount": "1759.58",
+        "direction": "OUT",
+        "balance_after": "-5679.09"
+      },
+      {
+        "date": "2024-02-26",
+        "description": "RTGS Dr-CNRBR165377554004-HDFC0004171-SHREYA SAHA-/NONE",
+        "amount": "61198.68",
+        "direction": "OUT",
+        "balance_after": "165554.91"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "UPI/DR/410866848656/RITAM SENGUPTA/UPI-TRANSFER TO 6249183902",
+        "amount": "1622.9",
+        "direction": "OUT",
+        "balance_after": "163932.01"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "IMPS BRN SALARY TRF BY-BUILDING SOLUTIONS LTD",
+        "amount": "9271.67",
+        "direction": "IN",
+        "balance_after": "173203.68"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "IMPS BRN SALARY TRF BY-FOUNDATION PROJECTS LTD",
+        "amount": "25697.34",
+        "direction": "IN",
+        "balance_after": "198901.02"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "Chq Paid-MICR Inward Clearing-MITALI SENGUPTA-HDFC BANK LTD.",
+        "amount": "99036.48",
+        "direction": "OUT",
+        "balance_after": "99864.54"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "NEFT Dr-600630105173-HDFC0009038-TAPAS DUTTA",
+        "amount": "33492.48",
+        "direction": "OUT",
+        "balance_after": "66372.06"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "RTGS Dr-CNRBR118549177807-HDFC0004171-SHREYA BISWAS-/NONE",
+        "amount": "14033.52",
+        "direction": "OUT",
+        "balance_after": "52338.54"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "UPI/CR/931674830862/SANJAY CHATTERJEE/SENT-TRANSFER FROM 6601393596",
+        "amount": "2163.29",
+        "direction": "IN",
+        "balance_after": "54501.83"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), DATABRIDGE INFOTECH",
+        "amount": "6835.45",
+        "direction": "IN",
+        "balance_after": "61337.28"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "Service Charges-Demat Account AMC",
+        "amount": "337.27",
+        "direction": "OUT",
+        "balance_after": "-6016.36"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "Service Charges-Online Banking Charges",
+        "amount": "206.83",
+        "direction": "OUT",
+        "balance_after": "-6223.19"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "Service Charges-SMS Alert Charges",
+        "amount": "90.75",
+        "direction": "OUT",
+        "balance_after": "-6313.94"
+      },
+      {
+        "date": "2024-02-29",
+        "description": "Chq Paid-MICR Inward Clearing-ARPITA DASGUPTA-HDFC BANK LTD.",
+        "amount": "26979.32",
+        "direction": "OUT",
+        "balance_after": "34357.96"
+      },
+      {
+        "date": "2024-02-29",
+        "description": "RTGS Dr-CNRBR678992061478-HDFC0004171-SONALI DUTTA-/NONE",
+        "amount": "22061.03",
+        "direction": "OUT",
+        "balance_after": "12296.93"
+      },
+      {
+        "date": "2024-03-01",
+        "description": "Chq Paid-MICR Inward Clearing-AMIT DASGUPTA-HDFC BANK LTD.",
+        "amount": "6091.77",
+        "direction": "OUT",
+        "balance_after": "6205.16"
+      },
+      {
+        "date": "2024-03-01",
+        "description": "Cash Withdrawal-TANMAY BOSE",
+        "amount": "823.12",
+        "direction": "OUT",
+        "balance_after": "5382.04"
+      },
+      {
+        "date": "2024-03-02",
+        "description": "RTGS Cr-ICICR844226908288-ICIC0000011-CREDIT SERVICES LTD--/URGENT/",
+        "amount": "6595.41",
+        "direction": "IN",
+        "balance_after": "11977.45"
+      },
+      {
+        "date": "2024-03-04",
+        "description": "IMPS BRN SALARY TRF BY-SHIPPING SERVICES INDIA",
+        "amount": "503.0",
+        "direction": "IN",
+        "balance_after": "12480.45"
+      },
+      {
+        "date": "2024-03-05",
+        "description": "IMPS Dr-915641514403-RAJIB MUKHERJEE",
+        "amount": "1097.33",
+        "direction": "OUT",
+        "balance_after": "11383.12"
+      },
+      {
+        "date": "2024-03-05",
+        "description": "IMPS Dr-534754213825-PAYEL DUTTA",
+        "amount": "1560.02",
+        "direction": "OUT",
+        "balance_after": "9823.1"
+      },
+      {
+        "date": "2024-03-06",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), GATEWAY PROJECTS LTD",
+        "amount": "787.87",
+        "direction": "IN",
+        "balance_after": "10610.97"
+      },
+      {
+        "date": "2024-03-06",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), RETAIL COMMERCE INDIA",
+        "amount": "1935.68",
+        "direction": "IN",
+        "balance_after": "12546.65"
+      },
+      {
+        "date": "2024-03-06",
+        "description": "RTGS Cr-ICICR345775995432-ICIC0000011-CAPITAL VENTURES INDIA--/URGENT/",
+        "amount": "17289.4",
+        "direction": "IN",
+        "balance_after": "29836.05"
+      },
+      {
+        "date": "2024-03-06",
+        "description": "NEFT Cr-959332621698-ICIC0SF0002-APEX HEAVY INDUSTRIES--",
+        "amount": "14338.29",
+        "direction": "IN",
+        "balance_after": "44174.34"
+      },
+      {
+        "date": "2024-03-07",
+        "description": "NEFT Cr-182093576973-ICIC0SF0002-PRECISION ENGINEERING WORKS--",
+        "amount": "3170.94",
+        "direction": "IN",
+        "balance_after": "47345.28"
+      },
+      {
+        "date": "2024-03-12",
+        "description": "NEFT Dr-867251037460-HDFC0009038-SUSMITA SENGUPTA",
+        "amount": "3236.48",
+        "direction": "OUT",
+        "balance_after": "44108.8"
+      },
+      {
+        "date": "2024-03-13",
+        "description": "NEFT Cr-675084101912-ICIC0SF0002-DAILY NEEDS LIMITED--",
+        "amount": "20750.49",
+        "direction": "IN",
+        "balance_after": "64859.29"
+      },
+      {
+        "date": "2024-03-14",
+        "description": "RTGS Dr-CNRBR219239255472-HDFC0004171-SANJAY SARKAR-/NONE",
+        "amount": "41602.44",
+        "direction": "OUT",
+        "balance_after": "23256.85"
+      },
+      {
+        "date": "2024-03-14",
+        "description": "NEFT Cr-259069608854-ICIC0SF0002-SUPPLY CHAIN CORP--",
+        "amount": "5733.73",
+        "direction": "IN",
+        "balance_after": "28990.58"
+      },
+      {
+        "date": "2024-03-15",
+        "description": "Dividend Cr-AUTOMOTIVE PARTS CORP-EQUITY SHARES",
+        "amount": "1356.03",
+        "direction": "IN",
+        "balance_after": "21734.19"
+      },
+      {
+        "date": "2024-03-15",
+        "description": "UPI/CR/394566296733/RAHUL SENGUPTA/SENT-TRANSFER FROM 9841874124",
+        "amount": "743.12",
+        "direction": "IN",
+        "balance_after": "29733.7"
+      },
+      {
+        "date": "2024-03-15",
+        "description": "UPI/DR/936536138846/BIPLAB SEN/UPI-TRANSFER TO 8745951918",
+        "amount": "361.52",
+        "direction": "OUT",
+        "balance_after": "29372.18"
+      },
+      {
+        "date": "2024-03-16",
+        "description": "NEFT Cr-439738889875-ICIC0SF0002-CONSUMER ESSENTIALS INDIA--",
+        "amount": "11491.98",
+        "direction": "IN",
+        "balance_after": "40864.16"
+      },
+      {
+        "date": "2024-03-18",
+        "description": "Chq Paid-MICR Inward Clearing-MITALI DUTTA-HDFC BANK LTD.",
+        "amount": "10836.25",
+        "direction": "OUT",
+        "balance_after": "30027.91"
+      },
+      {
+        "date": "2024-03-18",
+        "description": "CASH-BNA-SELF-RITAM DUTTA",
+        "amount": "745.26",
+        "direction": "IN",
+        "balance_after": "30773.17"
+      },
+      {
+        "date": "2024-03-18",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), METROPOLITAN BUILDERS",
+        "amount": "5003.83",
+        "direction": "IN",
+        "balance_after": "35777.0"
+      },
+      {
+        "date": "2024-03-19",
+        "description": "Chq Paid-MICR Inward Clearing-SOURAV CHATTERJEE-HDFC BANK LTD.",
+        "amount": "13018.88",
+        "direction": "OUT",
+        "balance_after": "22758.12"
+      },
+      {
+        "date": "2024-03-20",
+        "description": "Chq Paid-MICR Inward Clearing-TAPAS MUKHERJEE-HDFC BANK LTD.",
+        "amount": "10937.03",
+        "direction": "OUT",
+        "balance_after": "11821.09"
+      },
+      {
+        "date": "2024-03-20",
+        "description": "IMPS BRN SALARY TRF BY-PHARMACY PRODUCTS LTD",
+        "amount": "1873.07",
+        "direction": "IN",
+        "balance_after": "13694.16"
+      },
+      {
+        "date": "2024-03-21",
+        "description": "Chq Paid-MICR Inward Clearing-SOURAV GANGULY-HDFC BANK LTD.",
+        "amount": "2868.01",
+        "direction": "OUT",
+        "balance_after": "10826.15"
+      },
+      {
+        "date": "2024-03-21",
+        "description": "Cash Withdrawal-TAPAS BHATTACHARYA",
+        "amount": "147.31",
+        "direction": "OUT",
+        "balance_after": "10678.84"
+      },
+      {
+        "date": "2024-03-22",
+        "description": "NEFT Cr-998034591743-ICIC0SF0002-PERSONAL CARE LTD--",
+        "amount": "3664.61",
+        "direction": "IN",
+        "balance_after": "14343.45"
+      },
+      {
+        "date": "2024-03-22",
+        "description": "UPI/CR/341412834258/SONALI CHATTERJEE/SENT-TRANSFER FROM 8444366180",
+        "amount": "585.87",
+        "direction": "IN",
+        "balance_after": "14929.32"
+      },
+      {
+        "date": "2024-03-23",
+        "description": "Chq Paid-MICR Inward Clearing-SUJIT SEN-HDFC BANK LTD.",
+        "amount": "6836.9",
+        "direction": "OUT",
+        "balance_after": "8092.42"
+      },
+      {
+        "date": "2024-03-26",
+        "description": "NEFT Cr-754481424204-ICIC0SF0002-TEXTILE SOLUTIONS INDIA--",
+        "amount": "775.81",
+        "direction": "IN",
+        "balance_after": "8868.23"
+      },
+      {
+        "date": "2024-03-26",
+        "description": "NEFT Cr-818376489476-ICIC0SF0002-RESIDENTIAL PROJECTS LTD--",
+        "amount": "3255.94",
+        "direction": "IN",
+        "balance_after": "12124.17"
+      },
+      {
+        "date": "2024-03-26",
+        "description": "NEFT Dr-639820282851-HDFC0009038-ARIJIT CHATTERJEE",
+        "amount": "885.56",
+        "direction": "OUT",
+        "balance_after": "11238.61"
+      },
+      {
+        "date": "2024-03-27",
+        "description": "NEFT Cr-633101275754-ICIC0SF0002-FASHION TEXTILES LTD--",
+        "amount": "4367.43",
+        "direction": "IN",
+        "balance_after": "15606.04"
+      },
+      {
+        "date": "2024-03-27",
+        "description": "IMPS BRN SALARY TRF BY-RESIDENTIAL PROJECTS LTD",
+        "amount": "365.78",
+        "direction": "IN",
+        "balance_after": "15971.82"
+      },
+      {
+        "date": "2024-03-28",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), POWER SYSTEMS CORP",
+        "amount": "1134.45",
+        "direction": "IN",
+        "balance_after": "17106.27"
+      },
+      {
+        "date": "2024-03-28",
+        "description": "RTGS Cr-ICICR983555220673-ICIC0000011-COTTON MILLS CORP--/URGENT/",
+        "amount": "22753.12",
+        "direction": "IN",
+        "balance_after": "39859.39"
+      },
+      {
+        "date": "2024-03-28",
+        "description": "NEFT Cr-397197036503-ICIC0SF0002-INDUSTRIAL COMPONENTS INDIA--",
+        "amount": "16031.1",
+        "direction": "IN",
+        "balance_after": "55890.49"
+      },
+      {
+        "date": "2024-03-28",
+        "description": "Service Charges-NEFT/RTGS Charges",
+        "amount": "11.97",
+        "direction": "OUT",
+        "balance_after": "-6325.91"
+      },
+      {
+        "date": "2024-03-30",
+        "description": "NEFT Dr-107800254021-HDFC0009038-BIPLAB BANERJEE",
+        "amount": "21205.89",
+        "direction": "OUT",
+        "balance_after": "34684.6"
+      },
+      {
+        "date": "2024-03-30",
+        "description": "NEFT Dr-929459255429-HDFC0009038-SOURAV CHAKRABORTY",
+        "amount": "13771.73",
+        "direction": "OUT",
+        "balance_after": "20912.87"
+      },
+      {
+        "date": "2024-03-30",
+        "description": "UPI/CR/484432226569/ARIJIT CHOWDHURY/SENT-TRANSFER FROM 6174365174",
+        "amount": "748.95",
+        "direction": "IN",
+        "balance_after": "21661.82"
+      }
+    ]
+  }
+}

--- a/apps/backend/tests/fixtures/hf_oracle/India_Bank_Statement_Digital_Type2__00001.json
+++ b/apps/backend/tests/fixtures/hf_oracle/India_Bank_Statement_Digital_Type2__00001.json
@@ -1,0 +1,1149 @@
+{
+  "source": "India_Bank_Statement_Digital_Type2/00001.pdf",
+  "model": "glm-4.6v",
+  "prompt": "Extract this bank-statement page as strict JSON only (no prose, no markdown fence): {opening_balance, closing_balance, transactions:[{date, description, amount, direction, balance_after}]}. amount = absolute value; direction = \"IN\" for credits / \"OUT\" for debits; balance_after = the running balance printed on that row. Omit opening_balance/closing_balance if not on this page.",
+  "synthetic": true,
+  "modality": "text",
+  "pages": 6,
+  "raw_pages": [
+    "{\"opening_balance\": 1279072.17, \"closing_balance\": 110110.37, \"transactions\": [{\"date\": \"01/01/2024\", \"description\": \"RTGS-ICICR510742914335-Lakshmi Naidu\", \"amount\": 475617.41, \"direction\": \"OUT\", \"balance_after\": 803454.76}, {\"date\": \"02/01/2024\", \"description\": \"IMPS-212190484533-HEALTHCARE PRODUCTS LTD\", \"amount\": 101795.99, \"direction\": \"IN\", \"balance_after\": 905250.75}, {\"date\": \"02/01/2024\", \"description\": \"IMPS-597987779248-DATABRIDGE INFOTECH\", \"amount\": 60198.25, \"direction\": \"IN\", \"balance_after\": 965449.00}, {\"date\": \"02/01/2024\", \"description\": \"UPI/CR/586134526249-Priya Krishnan/6788808567@pay\", \"amount\": 46334.23, \"direction\": \"IN\", \"balance_after\": 1011783.23}, {\"date\": \"02/01/2024\", \"description\": \"UPI/DR/700203118416-Ramesh Reddy/7124029087@pay\", \"amount\": 9371.77, \"direction\": \"OUT\", \"balance_after\": 1002411.46}, {\"date\": \"04/01/2024\", \"description\": \"SERVICE CHARGES-Foreign Currency Markup\", \"amount\": 139.96, \"direction\": \"OUT\", \"balance_after\": 100271.50}, {\"date\": \"04/01/2024\", \"description\": \"NEFT-403681166106-Ganesh Pillai\", \"amount\": 266844.11, \"direction\": \"OUT\", \"balance_after\": 735427.39}, {\"date\": \"05/01/2024\", \"description\": \"IMPS-414202795937-DAILY NEEDS LIMITED\", \"amount\": 125251.78, \"direction\": \"IN\", \"balance_after\": 860679.17}, {\"date\": \"05/01/2024\", \"description\": \"NEFT-524813805872-GST PAYMENT-GSTIN\", \"amount\": 81089.25, \"direction\": \"OUT\", \"balance_after\": 779589.92}, {\"date\": \"06/01/2024\", \"description\": \"NEFT-644951640158-DIGITAL SOLUTIONS INDIA\", \"amount\": 313988.86, \"direction\": \"IN\", \"balance_after\": 1093578.78}, {\"date\": \"06/01/2024\", \"description\": \"NEFT-727523724896-HEALTHPLUS PHARMA LTD\", \"amount\": 111752.00, \"direction\": \"IN\", \"balance_after\": 1205330.78}, {\"date\": \"06/01/2024\", \"description\": \"ATM WDL-84393\", \"amount\": 13657.59, \"direction\": \"OUT\", \"balance_after\": 1191673.19}, {\"date\": \"06/01/2024\", \"description\": \"IMPS-290319105487-HEALTHCARE PRODUCTS LTD\", \"amount\": 108535.03, \"direction\": \"IN\", \"balance_after\": 1300208.22}, {\"date\": \"08/01/2024\", \"description\": \"RTGS-ICICR419518253429-Venkatesh Rao\", \"amount\": 849452.05, \"direction\": \"OUT\", \"balance_after\": 450756.17}, {\"date\": \"08/01/2024\", \"description\": \"CHQ PAID-Subramaniam Rao-MICR\", \"amount\": 217613.90, \"direction\": \"OUT\", \"balance_after\": 233142.27}]}",
+    "{\"transactions\":[{\"date\":\"09/01/2024\",\"description\":\"NEFT-278734715387-PRECISION ENGINEERING WORKS\",\"amount\":104999.07,\"direction\":\"IN\",\"balance_after\":338141.34},{\"date\":\"10/01/2024\",\"description\":\"UPICR/725645555690/Srinivas Reddy/8497226062@pay\",\"amount\":1301.27,\"direction\":\"IN\",\"balance_after\":339442.61},{\"date\":\"10/01/2024\",\"description\":\"NEFT-618421866089-PERSONAL CARE LTD\",\"amount\":57376.44,\"direction\":\"IN\",\"balance_after\":396819.05},{\"date\":\"10/01/2024\",\"description\":\"CASH DEPOSIT-Srinivas Nair\",\"amount\":11484.19,\"direction\":\"IN\",\"balance_after\":408303.24},{\"date\":\"11/01/2024\",\"description\":\"SERVICE CHARGES-Cheque Book Charges\",\"amount\":333.31,\"direction\":\"OUT\",\"balance_after\":407969.93},{\"date\":\"11/01/2024\",\"description\":\"RTGS-ICICR297944257075-APEX HEAVY INDUSTRIES\",\"amount\":252626.61,\"direction\":\"IN\",\"balance_after\":660596.54},{\"date\":\"11/01/2024\",\"description\":\"IMPS-815957436362-DAILY NEEDS LIMITED\",\"amount\":94672.33,\"direction\":\"IN\",\"balance_after\":755268.87},{\"date\":\"12/01/2024\",\"description\":\"REVERSAL-RTGS-ICICR297944257075-A PEX HEAVY INDUSTRIES\",\"amount\":252626.61,\"direction\":\"OUT\",\"balance_after\":549436.79},{\"date\":\"13/01/2024\",\"description\":\"IMPS-569297862727-URBAN ESTATES INDIA\",\"amount\":97998.35,\"direction\":\"IN\",\"balance_after\":853267.22},{\"date\":\"13/01/2024\",\"description\":\"UPI/DR/338919637684/Anitha Nair/963593174@pay\",\"amount\":24552.36,\"direction\":\"OUT\",\"balance_after\":828714.86},{\"date\":\"13/01/2024\",\"description\":\"IMPS-697830964902-Karthik Iyer\",\"amount\":62367.24,\"direction\":\"OUT\",\"balance_after\":766347.62},{\"date\":\"13/01/2024\",\"description\":\"IMPS-992983448493-Venkatesh Rao\",\"amount\":86410.98,\"direction\":\"OUT\",\"balance_after\":679936.64},{\"date\":\"15/01/2024\",\"description\":\"CHO PAID-Srinivas Menon-MICR\",\"amount\":163924.72,\"direction\":\"OUT\",\"balance_after\":516011.92},{\"date\":\"16/01/2024\",\"description\":\"UPICR/612430383276/Subramaniam Krishnan/7232360624@pay\",\"amount\":23080.18,\"direction\":\"IN\",\"balance_after\":539092.10},{\"date\":\"16/01/2024\",\"description\":\"NEFT-889583341413-PRECISION ENGINEERING WORKS\",\"amount\":230424.72,\"direction\":\"IN\",\"balance_after\":769516.82},{\"date\":\"18/01/2024\",\"description\":\"NEFT-519719438810-Priya Menon\",\"amount\":201434.60,\"direction\":\"OUT\",\"balance_after\":568082.22},{\"date\":\"19/01/2024\",\"description\":\"UPI/DR/857223273927/Ganesh Pillai/7683434104@pay\",\"amount\":16841.22,\"direction\":\"OUT\",\"balance_after\":551241.00},{\"date\":\"19/01/2024\",\"description\":\"CHO PAID-Venkatesh Pillai-MICR\",\"amount\":251230.73,\"direction\":\"OUT\",\"balance_after\":300010.27},{\"date\":\"19/01/2024\",\"description\":\"RTGS-ICICR182066605377-NETFORGE TECHNOLOGIES\",\"amount\":465711.54,\"direction\":\"IN\",\"balance_after\":765721.81},{\"date\":\"19/01/2024\",\"description\":\"UPI/DR/279751944022/Srinivas Murthy/7758605814@pay\",\"amount\":10024.28,\"direction\":\"OUT\",\"balance_after\":755697.53},{\"date\":\"20/01/2024\",\"description\":\"CASH DEPOSIT-Lakshmi Naidu\",\"amount\":8896.84,\"direction\":\"IN\",\"balance_after\":764594.37},{\"date\":\"20/01/2024\",\"description\":\"CHO PAID-Subramaniam Nair-MICR\",\"amount\":172001.87,\"direction\":\"OUT\",\"balance_after\":592592.50},{\"date\":\"20/01/2024\",\"description\":\"NEFT-Dr-894100359246-GST PAYMENT-GSTIN 28C8742\",\"amount\":119321.88,\"direction\":\"OUT\",\"balance_after\":430114.91},{\"date\":\"22/01/2024\",\"description\":\"CHO PAID-Anitha Naidu-MICR\",\"amount\":164067.25,\"direction\":\"OUT\",\"balance_after\":428525.25},{\"date\":\"22/01/2024\",\"description\":\"CLG-FINANCE SOLUTIONS INDIA\",\"amount\":106531.19,\"direction\":\"IN\",\"balance_after\":535056.44},{\"date\":\"22/01/2024\",\"description\":\"IMPS-198513905699-THERMAL SYSTEMS LTD\",\"amount\":85227.86,\"direction\":\"IN\",\"balance_after\":620284.30},{\"date\":\"22/01/2024\",\"description\":\"IMPS-376925559056-Priya Naidu\",\"amount\":84875.78,\"direction\":\"OUT\",\"balance_after\":535408.52},{\"date\":\"23/01/2024\",\"description\":\"ATM WDL-78867\",\"amount\":10606.39,\"direction\":\"OUT\",\"balance_after\":524802.13},{\"date\":\"23/01/2024\",\"description\":\"UPICR/671379523877/Subramaniam Menon/7451082689@pay\",\"amount\":13462.86,\"direction\":\"IN\",\"balance_after\":538264.99},{\"date\":\"24/01/2024\",\"description\":\"ATM WDL-69028\",\"amount\":15351.04,\"direction\":\"OUT\",\"balance_after\":522913.95},{\"date\":\"25/01/2024\",\"description\":\"NEFT-856429506970-MEDCARE LABORATORIES\",\"amount\":192586.16,\"direction\":\"IN\",\"balance_after\":715500.11},{\"date\":\"29/01/2024\",\"description\":\"CASH DEPOSIT-Venkatesh Murthy\",\"amount\":32456.03,\"direction\":\"IN\",\"balance_after\":747956.14},{\"date\":\"29/01/2024\",\"description\":\"NEFT-384430462240-Subramaniam Rao\",\"amount\":209997.66,\"direction\":\"OUT\",\"balance_after\":537958.48},{\"date\":\"29/01/2024\",\"description\":\"UPICR/323017461830/Ramesh Reddy/8241426919@pay\",\"amount\":2899.67,\"direction\":\"IN\",\"balance_after\":540858.15}]}",
+    "{\"transactions\":[{\"date\":\"29/01/2024\",\"description\":\"ATM WDL-88835\",\"amount\":4336.12,\"direction\":\"OUT\",\"balance_after\":536522.03},{\"date\":\"30/01/2024\",\"description\":\"NEFT-378435985055-CARGO SOLUTIONS LTD\",\"amount\":82409.13,\"direction\":\"IN\",\"balance_after\":618931.16},{\"date\":\"30/01/2024\",\"description\":\"NEFT-704756068064-GATEWAY PROJECTS LTD\",\"amount\":89402.31,\"direction\":\"IN\",\"balance_after\":708333.47},{\"date\":\"31/01/2024\",\"description\":\"NEFT-514556788419-DAILY NEEDS LIMITED\",\"amount\":185770.02,\"direction\":\"IN\",\"balance_after\":894103.49},{\"date\":\"31/01/2024\",\"description\":\"CLG-LIFELINE PHARMACEUTICAL\",\"amount\":211854.07,\"direction\":\"IN\",\"balance_after\":1105957.56},{\"date\":\"01/02/2024\",\"description\":\"NEFT-442611102554-CYBERCRAFT SYSTEMS\",\"amount\":282784.18,\"direction\":\"IN\",\"balance_after\":1388741.74},{\"date\":\"02/02/2024\",\"description\":\"RTGS-ICICR923815251247-CONSTRUCTION SOLUTIONS LTD\",\"amount\":2038434.65,\"direction\":\"IN\",\"balance_after\":3427176.39},{\"date\":\"05/02/2024\",\"description\":\"CLG-GATEWAY PROJECTS LTD\",\"amount\":562315.15,\"direction\":\"IN\",\"balance_after\":3989491.54},{\"date\":\"05/02/2024\",\"description\":\"UPI/CR/319177823601-Subramaniam Murthy/8974815900@pay\",\"amount\":88371.45,\"direction\":\"IN\",\"balance_after\":4077862.99},{\"date\":\"06/02/2024\",\"description\":\"ATM WDL-33865\",\"amount\":4246.28,\"direction\":\"OUT\",\"balance_after\":4073616.71},{\"date\":\"07/02/2024\",\"description\":\"NEFT-644348138246-Lakshmi Reddy\",\"amount\":279052.83,\"direction\":\"OUT\",\"balance_after\":3794563.88},{\"date\":\"07/02/2024\",\"description\":\"NEFT-686611365349-Karthik Naidu\",\"amount\":367866.95,\"direction\":\"OUT\",\"balance_after\":3426969.93},{\"date\":\"08/02/2024\",\"description\":\"IMPS-915898137500-Ramesh Iyer\",\"amount\":408515.58,\"direction\":\"OUT\",\"balance_after\":3018181.35},{\"date\":\"08/02/2024\",\"description\":\"IMPS-483565397419-CAPITAL VENTURES INDIA\",\"amount\":94704.24,\"direction\":\"IN\",\"balance_after\":3112885.59},{\"date\":\"08/02/2024\",\"description\":\"FAILED-INSUFFICIENT FUNDS-CASH WITHDRAWAL-Karthik Menon\",\"amount\":902370.06,\"direction\":\"OUT\",\"balance_after\":3112885.59},{\"date\":\"08/02/2024\",\"description\":\"NEFT-269717509281-Subramaniam Naidu\",\"amount\":902370.06,\"direction\":\"OUT\",\"balance_after\":2210515.53},{\"date\":\"09/02/2024\",\"description\":\"CLG-NETPULSE SYSTEMS\",\"amount\":443328.71,\"direction\":\"IN\",\"balance_after\":2653844.24},{\"date\":\"10/02/2024\",\"description\":\"ATM WDL-24242\",\"amount\":10322.49,\"direction\":\"OUT\",\"balance_after\":2643521.75},{\"date\":\"10/02/2024\",\"description\":\"IMPS-573077013494-HEALTHCARE PRODUCTS LTD\",\"amount\":171184.22,\"direction\":\"IN\",\"balance_after\":2814705.97},{\"date\":\"10/02/2024\",\"description\":\"CLG-CONSUMER PRODUCTS INDIA\",\"amount\":164290.39,\"direction\":\"IN\",\"balance_after\":2978996.36},{\"date\":\"12/02/2024\",\"description\":\"CASH WITHDRAWAL-Ramesh Menon\",\"amount\":136618.45,\"direction\":\"OUT\",\"balance_after\":2842377.91},{\"date\":\"12/02/2024\",\"description\":\"NEFT-122697498898-Srinivas Nair\",\"amount\":724777.73,\"direction\":\"OUT\",\"balance_after\":2117600.18},{\"date\":\"12/02/2024\",\"description\":\"SERVICE CHARGES-Foreign Currency Markup\",\"amount\":142.09,\"direction\":\"OUT\",\"balance_after\":2117458.09},{\"date\":\"13/02/2024\",\"description\":\"UPI/CR/614495410263/Venkatesh Reddy/7054374447@pay\",\"amount\":16601.42,\"direction\":\"IN\",\"balance_after\":2134059.51},{\"date\":\"13/02/2024\",\"description\":\"CLG-PRECISION ENGINEERING WORKS\",\"amount\":273267.77,\"direction\":\"IN\",\"balance_after\":2407327.28},{\"date\":\"14/02/2024\",\"description\":\"UPI/CR/486813495244/Venkatesh Reddy/8072645452@pay\",\"amount\":74802.82,\"direction\":\"IN\",\"balance_after\":2482130.1},{\"date\":\"14/02/2024\",\"description\":\"CHO PAID-Ganesh Murthy-MICR\",\"amount\":218474.18,\"direction\":\"OUT\",\"balance_after\":2263655.92},{\"date\":\"15/02/2024\",\"description\":\"CHO PAID-Subramaniam Reddy-MICR\",\"amount\":924596.53,\"direction\":\"OUT\",\"balance_after\":1339059.39},{\"date\":\"15/02/2024\",\"description\":\"IMPS-358436224492-CYBERCRAFT SYSTEMS\",\"amount\":30226.83,\"direction\":\"IN\",\"balance_after\":1369286.22},{\"date\":\"16/02/2024\",\"description\":\"CLG-URBAN CONSTRUCTIONS\",\"amount\":323842.44,\"direction\":\"IN\",\"balance_after\":1693128.66},{\"date\":\"16/02/2024\",\"description\":\"UPI/DR/357054274902/Venkatesh Reddy/9510290650@pay\",\"amount\":6789.58,\"direction\":\"OUT\",\"balance_after\":1686339.08},{\"date\":\"16/02/2024\",\"description\":\"NEFT-103474279499-Subramaniam Menon\",\"amount\":657104.35,\"direction\":\"OUT\",\"balance_after\":1029234.73},{\"date\":\"17/02/2024\",\"description\":\"UPI/CR/75301697690-Ganesh Pillai/6800851015@pay\",\"amount\":23158.94,\"direction\":\"IN\",\"balance_after\":1052393.67},{\"date\":\"19/02/2024\",\"description\":\"CASH DEPOSIT-Ramesh Rao\",\"amount\":84290.99,\"direction\":\"IN\",\"balance_after\":1136684.66},{\"date\":\"19/02/2024\",\"description\":\"IMPS-660367155471-CODEBASE SOLUTIONS\",\"amount\":163939.15,\"direction\":\"IN\",\"balance_after\":1300623.81}]}",
+    "{\"transactions\":[{\"date\":\"20/02/2024\",\"description\":\"NEFT-666763858122-DIGITAL SOLUTIONS INDIA\",\"amount\":456429.85,\"direction\":\"IN\",\"balance_after\":1757053.66},{\"date\":\"20/02/2024\",\"description\":\"CASH WITHDRAWAL-Karthik Nair\",\"amount\":82556.53,\"direction\":\"OUT\",\"balance_after\":1674497.13},{\"date\":\"20/02/2024\",\"description\":\"NEFT Dr-771669702522-GST PAYMENT-GSTIN 76A7387\",\"amount\":170450.39,\"direction\":\"OUT\",\"balance_after\":259664.52},{\"date\":\"21/02/2024\",\"description\":\"ATM WDL-27889\",\"amount\":14051.51,\"direction\":\"OUT\",\"balance_after\":1660445.62},{\"date\":\"21/02/2024\",\"description\":\"RTGS-ICICR315191603794-CONSTRUCTION SOLUTIONS LTD\",\"amount\":1447999.43,\"direction\":\"IN\",\"balance_after\":3108445.05},{\"date\":\"22/02/2024\",\"description\":\"IMPS-920714945814-CARGO SOLUTIONS LTD\",\"amount\":435369.14,\"direction\":\"IN\",\"balance_after\":3543814.19},{\"date\":\"24/02/2024\",\"description\":\"NEFT-782537817783-LIFELINE PHARMACEUTICAL\",\"amount\":287912.27,\"direction\":\"IN\",\"balance_after\":3831726.46},{\"date\":\"24/02/2024\",\"description\":\"CLG-DIGITAL SOLUTIONS INDIA\",\"amount\":992992.44,\"direction\":\"IN\",\"balance_after\":4824718.90},{\"date\":\"24/02/2024\",\"description\":\"ATM WDL-29978\",\"amount\":8041.84,\"direction\":\"OUT\",\"balance_after\":4816677.06},{\"date\":\"26/02/2024\",\"description\":\"IMPS-941817641209-FOOD INDUSTRIES CORP\",\"amount\":252924.01,\"direction\":\"IN\",\"balance_after\":5069601.07},{\"date\":\"26/02/2024\",\"description\":\"RTGS-ICICR488557855256-Karthik Menon\",\"amount\":1328679.63,\"direction\":\"OUT\",\"balance_after\":3740921.44},{\"date\":\"26/02/2024\",\"description\":\"NEFT-143632038001-Ganesh Pillai\",\"amount\":237872.29,\"direction\":\"OUT\",\"balance_after\":3503049.15},{\"date\":\"27/02/2024\",\"description\":\"NEFT-873415776261-PREMIUM INFRASTRUCTURE\",\"amount\":1059971.57,\"direction\":\"IN\",\"balance_after\":4563020.72},{\"date\":\"28/02/2024\",\"description\":\"UPI/CR-867703494263/Srinivas Iyer/7352098555@pay\",\"amount\":225484.01,\"direction\":\"IN\",\"balance_after\":4788504.73},{\"date\":\"28/02/2024\",\"description\":\"NEFT-559266103550-Kavitha Rao\",\"amount\":1538995.13,\"direction\":\"OUT\",\"balance_after\":3249509.60},{\"date\":\"28/02/2024\",\"description\":\"NEFT-541542497892-GST PAYMENT-GSTIN\",\"amount\":351150.76,\"direction\":\"OUT\",\"balance_after\":2898358.84},{\"date\":\"28/02/2024\",\"description\":\"Service Charges-Online Banking Charges\",\"amount\":159.60,\"direction\":\"OUT\",\"balance_after\":259430.12},{\"date\":\"28/02/2024\",\"description\":\"Service Charges-SMS Alert Charges\",\"amount\":74.80,\"direction\":\"OUT\",\"balance_after\":259589.72},{\"date\":\"28/02/2024\",\"description\":\"Service Charges-Demat Account AMC\",\"amount\":374.21,\"direction\":\"OUT\",\"balance_after\":259055.91},{\"date\":\"29/02/2024\",\"description\":\"IMPS-169315319731-CREDIT SERVICES LTD\",\"amount\":73863.21,\"direction\":\"IN\",\"balance_after\":2972222.05},{\"date\":\"29/02/2024\",\"description\":\"IMPS-662944833911-CONSTRUCTION SOLUTIONS INDIA\",\"amount\":430157.81,\"direction\":\"IN\",\"balance_after\":3402379.86},{\"date\":\"29/02/2024\",\"description\":\"CLG-CAPITAL VENTURES INDIA\",\"amount\":942328.27,\"direction\":\"IN\",\"balance_after\":4344708.13},{\"date\":\"01/03/2024\",\"description\":\"ATM WDL-35072\",\"amount\":18486.39,\"direction\":\"OUT\",\"balance_after\":4326221.74},{\"date\":\"02/03/2024\",\"description\":\"NEFT-622296553551-FASHION TEXTILES LTD\",\"amount\":574203.65,\"direction\":\"IN\",\"balance_after\":4900425.39},{\"date\":\"02/03/2024\",\"description\":\"CASH WITHDRAWAL-Ramesh Pillai\",\"amount\":235387.97,\"direction\":\"OUT\",\"balance_after\":4665037.42},{\"date\":\"02/03/2024\",\"description\":\"NEFT-744561237829-GST PAYMENT-GSTIN\",\"amount\":447177.84,\"direction\":\"OUT\",\"balance_after\":4217859.58},{\"date\":\"02/03/2024\",\"description\":\"ATM WDL-73339\",\"amount\":10619.65,\"direction\":\"OUT\",\"balance_after\":4207239.93},{\"date\":\"04/03/2024\",\"description\":\"REVERSAL-IMPS-169315319731-CREDIT SERVICES LTD\",\"amount\":73863.21,\"direction\":\"OUT\",\"balance_after\":802063.40},{\"date\":\"04/03/2024\",\"description\":\"ATM WDL-46274\",\"amount\":6849.91,\"direction\":\"OUT\",\"balance_after\":4200390.02},{\"date\":\"04/03/2024\",\"description\":\"IMPS-329944215729-HOUSING DEVELOPERS CORP\",\"amount\":553635.66,\"direction\":\"IN\",\"balance_after\":4754025.68},{\"date\":\"05/03/2024\",\"description\":\"NEFT-622432549701-Subramaniam Naidu\",\"amount\":453510.13,\"direction\":\"OUT\",\"balance_after\":4300515.55},{\"date\":\"05/03/2024\",\"description\":\"IMPS-634649383399-WELLNESS BRANDS INDIA\",\"amount\":632004.20,\"direction\":\"IN\",\"balance_after\":4932519.75},{\"date\":\"05/03/2024\",\"description\":\"ATM WDL-28536\",\"amount\":17977.69,\"direction\":\"OUT\",\"balance_after\":4914542.06},{\"date\":\"05/03/2024\",\"description\":\"NEFT-524687515636-Lakshmi Naidu\",\"amount\":1931369.10,\"direction\":\"OUT\",\"balance_after\":2983172.96},{\"date\":\"05/03/2024\",\"description\":\"CHQ PAID-Venkatesh Menon-MICR\",\"amount\":1122810.81,\"direction\":\"OUT\",\"balance_after\":1860362.15}]}",
+    "{\"transactions\":[{\"date\":\"06/03/2024\",\"description\":\"NEFT-817429369883-FASHION TEXTILES LTD\",\"amount\":598741.62,\"direction\":\"IN\",\"balance_after\":2459103.77},{\"date\":\"06/03/2024\",\"description\":\"NEFT-959233854874-URBAN CONSTRUCTIONS\",\"amount\":188619.16,\"direction\":\"IN\",\"balance_after\":2647722.93},{\"date\":\"06/03/2024\",\"description\":\"NEFT-568955747384-Venkatesh Nair\",\"amount\":434962.10,\"direction\":\"OUT\",\"balance_after\":2212760.83},{\"date\":\"07/03/2024\",\"description\":\"NEFT-140033889662-Ganesh Rao\",\"amount\":489299.24,\"direction\":\"OUT\",\"balance_after\":1723461.59},{\"date\":\"09/03/2024\",\"description\":\"NEFT-719460649751-APEX HEAVY INDUSTRIES\",\"amount\":474006.27,\"direction\":\"IN\",\"balance_after\":2197467.86},{\"date\":\"11/03/2024\",\"description\":\"NEFT-900078848401-Subramaniam Menon\",\"amount\":59865.76,\"direction\":\"OUT\",\"balance_after\":1598602.10},{\"date\":\"11/03/2024\",\"description\":\"IMPS-517854169377-APEX HEAVY INDUSTRIES\",\"amount\":131448.68,\"direction\":\"IN\",\"balance_after\":1730050.78},{\"date\":\"12/03/2024\",\"description\":\"RTGS-ICICR9080705654981-FASHION TEXTILES LTD\",\"amount\":3105234.88,\"direction\":\"IN\",\"balance_after\":4835285.66},{\"date\":\"12/03/2024\",\"description\":\"RTGS-ICICR803745188189-Venkatesh Naidu\",\"amount\":1701379.66,\"direction\":\"OUT\",\"balance_after\":3133906.00},{\"date\":\"13/03/2024\",\"description\":\"ATM WDL-83870\",\"amount\":14637.19,\"direction\":\"OUT\",\"balance_after\":3119268.81},{\"date\":\"13/03/2024\",\"description\":\"SERVICE CHARGES-SMS Alert Charges\",\"amount\":291.19,\"direction\":\"OUT\",\"balance_after\":3118977.62},{\"date\":\"13/03/2024\",\"description\":\"RTGS-ICICR539516527079-EXPRESS LOGISTICS INDIA\",\"amount\":4045927.09,\"direction\":\"IN\",\"balance_after\":7164904.71},{\"date\":\"13/03/2024\",\"description\":\"CLG-REALTY VENTURES LTD\",\"amount\":420527.16,\"direction\":\"IN\",\"balance_after\":7585431.87},{\"date\":\"14/03/2024\",\"description\":\"NEFT-628242640309-Anitha Reddy\",\"amount\":2194293.83,\"direction\":\"OUT\",\"balance_after\":5391138.04},{\"date\":\"14/03/2024\",\"description\":\"NEFT-321947659087-FABRIC INDUSTRIES INDIA\",\"amount\":2049286.83,\"direction\":\"IN\",\"balance_after\":7440424.87},{\"date\":\"15/03/2024\",\"description\":\"NEFT-829567684854-DATABRIDGE INFOTECH\",\"amount\":3667970.18,\"direction\":\"IN\",\"balance_after\":11108395.05},{\"date\":\"15/03/2024\",\"description\":\"CASH WITHDRAWAL-Ganesh Pillai\",\"amount\":177643.99,\"direction\":\"OUT\",\"balance_after\":10930751.06},{\"date\":\"16/03/2024\",\"description\":\"ATM WDL-20035\",\"amount\":9151.54,\"direction\":\"OUT\",\"balance_after\":10921599.52},{\"date\":\"16/03/2024\",\"description\":\"CASH WITHDRAWAL-Karthik Rao\",\"amount\":169960.47,\"direction\":\"OUT\",\"balance_after\":10751639.05},{\"date\":\"18/03/2024\",\"description\":\"CHO PAID-Venkatesh Krishnan-MICR\",\"amount\":731999.84,\"direction\":\"OUT\",\"balance_after\":10019639.21},{\"date\":\"20/03/2024\",\"description\":\"RTGS-ICICR644959518406-Srinivas Krishnan\",\"amount\":2136377.76,\"direction\":\"OUT\",\"balance_after\":7883261.45},{\"date\":\"20/03/2024\",\"description\":\"CHO PAID-Karthik Reddy-MICR\",\"amount\":2064242.22,\"direction\":\"OUT\",\"balance_after\":5819019.23},{\"date\":\"20/03/2024\",\"description\":\"NEFT-Dr-424861610036-GST PAYMENT-GSTIN 54B9990\",\"amount\":148805.74,\"direction\":\"OUT\",\"balance_after\":110250.17},{\"date\":\"20/03/2024\",\"description\":\"CHQ PAID-Anitha Menon-MICR\",\"amount\":968184.51,\"direction\":\"OUT\",\"balance_after\":4850834.72},{\"date\":\"21/03/2024\",\"description\":\"CASH WITHDRAWAL-Kavitha Rao\",\"amount\":100799.67,\"direction\":\"OUT\",\"balance_after\":4750035.05},{\"date\":\"22/03/2024\",\"description\":\"IMPS-575296122794-Ramesh Nair\",\"amount\":332737.59,\"direction\":\"OUT\",\"balance_after\":4417297.46},{\"date\":\"23/03/2024\",\"description\":\"CLG-URBAN CONSTRUCTIONS\",\"amount\":1213013.24,\"direction\":\"IN\",\"balance_after\":5630310.70},{\"date\":\"23/03/2024\",\"description\":\"RTGS-ICICR740133104054-Karthik Murthy\",\"amount\":4286494.50,\"direction\":\"OUT\",\"balance_after\":1343816.20},{\"date\":\"26/03/2024\",\"description\":\"NEFT-457658204692-REALTY VENTURES LTD\",\"amount\":635006.27,\"direction\":\"IN\",\"balance_after\":1978822.47},{\"date\":\"26/03/2024\",\"description\":\"NEFT-638268505310-CODEBASE SOLUTIONS\",\"amount\":912366.57,\"direction\":\"IN\",\"balance_after\":2891189.04},{\"date\":\"26/03/2024\",\"description\":\"ATM WDL-19152\",\"amount\":10873.96,\"direction\":\"OUT\",\"balance_after\":2880315.08},{\"date\":\"27/03/2024\",\"description\":\"SERVICE CHARGES-Demat Account AMC\",\"amount\":68.61,\"direction\":\"OUT\",\"balance_after\":2880246.47},{\"date\":\"27/03/2024\",\"description\":\"RTGS-ICICR450592146984-Subramaniam Murthy\",\"amount\":1679704.76,\"direction\":\"OUT\",\"balance_after\":1200541.71},{\"date\":\"27/03/2024\",\"description\":\"IMPS-435521586165-CREDIT SERVICES LTD\",\"amount\":20923.38,\"direction\":\"IN\",\"balance_after\":1221465.09},{\"date\":\"28/03/2024\",\"description\":\"ATM WDL-54345\",\"amount\":12542.36,\"direction\":\"OUT\",\"balance_after\":1208922.73}]}",
+    "{\"transactions\":[{\"date\":\"28/03/2024\",\"description\":\"Dividend Cr-INVESTMENT SERVICES INDIA-EQUITY SHARES\",\"amount\":12062.90,\"direction\":\"IN\",\"balance_after\":1220985.63},{\"date\":\"28/03/2024\",\"description\":\"SERVICE CHARGES-SMS Alert Charges\",\"amount\":150.79,\"direction\":\"OUT\",\"balance_after\":1220834.84},{\"date\":\"28/03/2024\",\"description\":\"CLG-MOTOR INDUSTRIES LTD\",\"amount\":278543.39,\"direction\":\"IN\",\"balance_after\":1499378.23},{\"date\":\"28/03/2024\",\"description\":\"CHQ PAID-Anitha Krishnan-MICR\",\"amount\":623451.62,\"direction\":\"OUT\",\"balance_after\":875926.61},{\"date\":\"28/03/2024\",\"description\":\"Service Charges-Demat Account AMC\",\"amount\":582.41,\"direction\":\"OUT\",\"balance_after\":109527.96},{\"date\":\"28/03/2024\",\"description\":\"Service Charges-Online Banking Charges\",\"amount\":233.88,\"direction\":\"OUT\",\"balance_after\":109294.08},{\"date\":\"28/03/2024\",\"description\":\"Service Charges-Statement Charges\",\"amount\":139.80,\"direction\":\"OUT\",\"balance_after\":110110.37}]}"
+  ],
+  "truth": {
+    "opening_balance": "1279072.17",
+    "closing_balance": "110110.37",
+    "transactions": [
+      {
+        "date": "01/01/2024",
+        "description": "RTGS-ICICR510742914335-Lakshmi Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/01/2024",
+        "description": "IMPS-212190484533-HEALTHCARE PRODUCTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/01/2024",
+        "description": "IMPS-597987779248-DATABRIDGE INFOTECH",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/01/2024",
+        "description": "UPI/CR/586134526249/Priya Krishnan/6788808567@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/01/2024",
+        "description": "UPI/DR/700203118416/Ramesh Reddy/7124029087@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/01/2024",
+        "description": "SERVICE CHARGES-Foreign Currency Markup",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/01/2024",
+        "description": "NEFT-403681166106-Ganesh Pillai",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/01/2024",
+        "description": "IMPS-414202795937-DAILY NEEDS LIMITED",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/01/2024",
+        "description": "NEFT-524813805872-GST PAYMENT-GSTIN",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/01/2024",
+        "description": "NEFT-644951640158-DIGITAL SOLUTIONS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/01/2024",
+        "description": "NEFT-727523724896-HEALTHPLUS PHARMA LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/01/2024",
+        "description": "ATM WDL-84393",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/01/2024",
+        "description": "IMPS-290319105487-HEALTHCARE PRODUCTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/01/2024",
+        "description": "RTGS-ICICR419518253429-Venkatesh Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/01/2024",
+        "description": "CHQ PAID-Subramaniam Rao-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "09/01/2024",
+        "description": "NEFT-287837415387-PRECISION ENGINEERING WORKS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/01/2024",
+        "description": "UPI/CR/725664555690/Srinivas Reddy/8497226062@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/01/2024",
+        "description": "NEFT-618421866089-PERSONAL CARE LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/01/2024",
+        "description": "CASH DEPOSIT-Srinivas Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/01/2024",
+        "description": "SERVICE CHARGES-Cheque Book Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/01/2024",
+        "description": "RTGS-ICICR297944257075-APEX HEAVY INDUSTRIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/01/2024",
+        "description": "IMPS-815957436362-DAILY NEEDS LIMITED",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/01/2024",
+        "description": "REVERSAL-RTGS-ICICR297944257075-APEX HEAVY INDUSTRIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/01/2024",
+        "description": "IMPS-569297862727-URBAN ESTATES INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/01/2024",
+        "description": "UPI/DR/338919637684/Anitha Nair/9635953174@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/01/2024",
+        "description": "IMPS-697830964902-Karthik Iyer",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/01/2024",
+        "description": "IMPS-992983448493-Venkatesh Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/01/2024",
+        "description": "CHQ PAID-Srinivas Menon-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/01/2024",
+        "description": "UPI/CR/612430383276/Subramaniam Krishnan/7232360624@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/01/2024",
+        "description": "NEFT-889583341413-PRECISION ENGINEERING WORKS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "18/01/2024",
+        "description": "NEFT-519719438810-Priya Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "UPI/DR/857223273927/Ganesh Pillai/7683434104@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "CHQ PAID-Venkatesh Pillai-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "RTGS-ICICR182066605377-NETFORGE TECHNOLOGIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "UPI/DR/279751944022/Srinivas Murthy/7758605812@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "CASH DEPOSIT-Lakshmi Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/01/2024",
+        "description": "CHQ PAID-Subramaniam Nair-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/01/2024",
+        "description": "NEFT Dr-894100359246-GST PAYMENT-GSTIN 28C8742",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/01/2024",
+        "description": "CHQ PAID-Anitha Naidu-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/01/2024",
+        "description": "CLG-FINANCE SOLUTIONS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/01/2024",
+        "description": "IMPS-198513905699-THERMAL SYSTEMS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/01/2024",
+        "description": "IMPS-376925559056-Priya Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "23/01/2024",
+        "description": "ATM WDL-78867",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "23/01/2024",
+        "description": "UPI/CR/671379523877/Subramaniam Menon/7451082689@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "24/01/2024",
+        "description": "ATM WDL-69028",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "25/01/2024",
+        "description": "NEFT-856429560970-MEDCARE LABORATORIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/01/2024",
+        "description": "CASH DEPOSIT-Venkatesh Murthy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/01/2024",
+        "description": "NEFT-384430462240-Subramaniam Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/01/2024",
+        "description": "UPI/CR/323017461830/Ramesh Reddy/8241426919@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/01/2024",
+        "description": "ATM WDL-88835",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "30/01/2024",
+        "description": "NEFT-378435985055-CARGO SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "30/01/2024",
+        "description": "NEFT-704756068064-GATEWAY PROJECTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "31/01/2024",
+        "description": "NEFT-514556788419-DAILY NEEDS LIMITED",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "31/01/2024",
+        "description": "CLG-LIFELINE PHARMACEUTICAL",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "01/02/2024",
+        "description": "NEFT-442611102554-CYBERCRAFT SYSTEMS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/02/2024",
+        "description": "RTGS-ICICR923815251247-CONSTRUCTION SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/02/2024",
+        "description": "CLG-GATEWAY PROJECTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/02/2024",
+        "description": "UPI/CR/319177823601/Subramaniam Murthy/8974815900@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/02/2024",
+        "description": "ATM WDL-33865",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "07/02/2024",
+        "description": "NEFT-644348138246-Lakshmi Reddy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "07/02/2024",
+        "description": "NEFT-686611365349-Karthik Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/02/2024",
+        "description": "IMPS-915898137500-Ramesh Iyer",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/02/2024",
+        "description": "IMPS-483565397419-CAPITAL VENTURES INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/02/2024",
+        "description": "FAILED-INSUFFICIENT FUNDS-CASH WITHDRAWAL-Karthik Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/02/2024",
+        "description": "NEFT-269717509281-Subramaniam Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "09/02/2024",
+        "description": "CLG-NETPULSE SYSTEMS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/02/2024",
+        "description": "ATM WDL-24242",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/02/2024",
+        "description": "IMPS-573077013494-HEALTHCARE PRODUCTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/02/2024",
+        "description": "CLG-CONSUMER PRODUCTS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/02/2024",
+        "description": "CASH WITHDRAWAL-Ramesh Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/02/2024",
+        "description": "NEFT-122697498898-Srinivas Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/02/2024",
+        "description": "SERVICE CHARGES-Foreign Currency Markup",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/02/2024",
+        "description": "UPI/CR/614495410263/Venkatesh Reddy/7054374447@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/02/2024",
+        "description": "CLG-PRECISION ENGINEERING WORKS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "14/02/2024",
+        "description": "UPI/CR/486813495244/Venkatesh Reddy/8072645452@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "14/02/2024",
+        "description": "CHQ PAID-Ganesh Murthy-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/02/2024",
+        "description": "CHQ PAID-Subramaniam Reddy-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/02/2024",
+        "description": "IMPS-358436224492-CYBERCRAFT SYSTEMS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/02/2024",
+        "description": "CLG-URBAN CONSTRUCTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/02/2024",
+        "description": "UPI/DR/357054274902/Venkatesh Reddy/9510290650@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/02/2024",
+        "description": "NEFT-103474729499-Subramaniam Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "17/02/2024",
+        "description": "UPI/CR/753016976960/Ganesh Pillai/6800851015@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/02/2024",
+        "description": "CASH DEPOSIT-Ramesh Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/02/2024",
+        "description": "IMPS-660367155471-CODEBASE SOLUTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/02/2024",
+        "description": "NEFT-666763858122-DIGITAL SOLUTIONS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/02/2024",
+        "description": "CASH WITHDRAWAL-Karthik Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/02/2024",
+        "description": "NEFT Dr-771669702522-GST PAYMENT-GSTIN 76A7387",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "21/02/2024",
+        "description": "ATM WDL-27889",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "21/02/2024",
+        "description": "RTGS-ICICR315191603794-CONSTRUCTION SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/02/2024",
+        "description": "IMPS-920714945814-CARGO SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "24/02/2024",
+        "description": "NEFT-782537817783-LIFELINE PHARMACEUTICAL",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "24/02/2024",
+        "description": "CLG-DIGITAL SOLUTIONS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "24/02/2024",
+        "description": "ATM WDL-29978",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/02/2024",
+        "description": "IMPS-941817641209-FOOD INDUSTRIES CORP",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/02/2024",
+        "description": "RTGS-ICICR488557855256-Karthik Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/02/2024",
+        "description": "NEFT-143632038001-Ganesh Pillai",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "27/02/2024",
+        "description": "NEFT-873415776261-PREMIUM INFRASTRUCTURE",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "UPI/CR/867703494263/Srinivas Iyer/7352098555@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "NEFT-559266103550-Kavitha Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "NEFT-541542497892-GST PAYMENT-GSTIN",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "Service Charges-Online Banking Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "Service Charges-SMS Alert Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "Service Charges-Demat Account AMC",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/02/2024",
+        "description": "IMPS-169315319731-CREDIT SERVICES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/02/2024",
+        "description": "IMPS-662944833911-CONSTRUCTION SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/02/2024",
+        "description": "CLG-CAPITAL VENTURES INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "01/03/2024",
+        "description": "ATM WDL-35072",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/03/2024",
+        "description": "NEFT-622296553551-FASHION TEXTILES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/03/2024",
+        "description": "CASH WITHDRAWAL-Ramesh Pillai",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/03/2024",
+        "description": "NEFT-744561237829-GST PAYMENT-GSTIN",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/03/2024",
+        "description": "ATM WDL-73339",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/03/2024",
+        "description": "REVERSAL-IMPS-169315319731-CREDIT SERVICES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/03/2024",
+        "description": "ATM WDL-46274",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/03/2024",
+        "description": "IMPS-329944215729-HOUSING DEVELOPERS CORP",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "NEFT-622432549701-Subramaniam Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "IMPS-634649383399-WELLNESS BRANDS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "ATM WDL-28536",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "NEFT-524687515636-Lakshmi Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "CHQ PAID-Venkatesh Menon-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/03/2024",
+        "description": "NEFT-817429369883-FASHION TEXTILES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/03/2024",
+        "description": "NEFT-959233854874-URBAN CONSTRUCTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/03/2024",
+        "description": "NEFT-568955747384-Venkatesh Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "07/03/2024",
+        "description": "NEFT-140033896962-Ganesh Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "09/03/2024",
+        "description": "NEFT-719460649751-APEX HEAVY INDUSTRIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/03/2024",
+        "description": "NEFT-900078848401-Subramaniam Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/03/2024",
+        "description": "IMPS-517854169377-APEX HEAVY INDUSTRIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/03/2024",
+        "description": "RTGS-ICICR908705654981-FASHION TEXTILES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/03/2024",
+        "description": "RTGS-ICICR803745188189-Venkatesh Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/03/2024",
+        "description": "ATM WDL-83870",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/03/2024",
+        "description": "SERVICE CHARGES-SMS Alert Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/03/2024",
+        "description": "RTGS-ICICR539516527079-EXPRESS LOGISTICS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/03/2024",
+        "description": "CLG-REALTY VENTURES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "14/03/2024",
+        "description": "NEFT-628242640309-Anitha Reddy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "14/03/2024",
+        "description": "NEFT-321947659087-FABRIC INDUSTRIES INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/03/2024",
+        "description": "NEFT-829567684854-DATABRIDGE INFOTECH",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/03/2024",
+        "description": "CASH WITHDRAWAL-Ganesh Pillai",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/03/2024",
+        "description": "ATM WDL-20035",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/03/2024",
+        "description": "CASH WITHDRAWAL-Karthik Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "18/03/2024",
+        "description": "CHQ PAID-Venkatesh Krishnan-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/03/2024",
+        "description": "RTGS-ICICR644959518406-Srinivas Krishnan",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/03/2024",
+        "description": "CHQ PAID-Karthik Reddy-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/03/2024",
+        "description": "NEFT Dr-424861610036-GST PAYMENT-GSTIN 54B9990",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/03/2024",
+        "description": "CHQ PAID-Anitha Menon-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "21/03/2024",
+        "description": "CASH WITHDRAWAL-Kavitha Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/03/2024",
+        "description": "IMPS-575296122794-Ramesh Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "23/03/2024",
+        "description": "CLG-URBAN CONSTRUCTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "23/03/2024",
+        "description": "RTGS-ICICR740133104054-Karthik Murthy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/03/2024",
+        "description": "NEFT-457658204692-REALTY VENTURES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/03/2024",
+        "description": "NEFT-638268505310-CODEBASE SOLUTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/03/2024",
+        "description": "ATM WDL-19152",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "27/03/2024",
+        "description": "SERVICE CHARGES-Demat Account AMC",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "27/03/2024",
+        "description": "RTGS-ICICR450592146984-Subramaniam Murthy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "27/03/2024",
+        "description": "IMPS-435521586165-CREDIT SERVICES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "ATM WDL-54345",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "Dividend Cr-INVESTMENT SERVICES INDIA-EQUITY SHARES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "SERVICE CHARGES-SMS Alert Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "CLG-MOTOR INDUSTRIES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "CHQ PAID-Anitha Krishnan-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "Service Charges-Demat Account AMC",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "Service Charges-Online Banking Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "Service Charges-Statement Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      }
+    ]
+  }
+}

--- a/apps/backend/tests/fixtures/hf_oracle/India_Bank_Statement_Scanned_Type1__00001.json
+++ b/apps/backend/tests/fixtures/hf_oracle/India_Bank_Statement_Scanned_Type1__00001.json
@@ -1,0 +1,1156 @@
+{
+  "source": "India_Bank_Statement_Scanned_Type1/00001.pdf",
+  "model": "glm-4.6v",
+  "prompt": "Extract this bank-statement page as strict JSON only (no prose, no markdown fence): {opening_balance, closing_balance, transactions:[{date, description, amount, direction, balance_after}]}. amount = absolute value; direction = \"IN\" for credits / \"OUT\" for debits; balance_after = the running balance printed on that row. Omit opening_balance/closing_balance if not on this page.",
+  "synthetic": true,
+  "modality": "vision",
+  "pages": 6,
+  "raw_pages": [
+    "{\"opening_balance\": \"Rs. 59,131.72\", \"closing_balance\": \"Rs. 21,661.82\", \"transactions\": [{\"date\": \"01-01-2024\", \"description\": \"NEFT Cr-210968206613-ICIC0SF0002-CLOTHING INDUSTRIES LTD--\", \"amount\": \"6,086.63\", \"direction\": \"IN\", \"balance_after\": \"Rs. 65,218.35\"}, {\"date\": \"02-01-2024\", \"description\": \"Chq Paid-MICR Inward Clearing-KAUSHIK SAHA-HDFC BANK LTD.\", \"amount\": \"23,702.04\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 41,516.31\"}, {\"date\": \"03-01-2024\", \"description\": \"RTGS Dr-CNRBR929510940342-HDFC0004171-BIPLAB CHATTERJEE-/NONE\", \"amount\": \"9,055.89\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 32,460.42\"}, {\"date\": \"04-01-2024\", \"description\": \"IMPS Dr-670498159700-SHREYA SENGUPTA\", \"amount\": \"2,177.93\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 30,282.49\"}, {\"date\": \"04-01-2024\", \"description\": \"CASH-BNA-SELF-PAYEL SAHA\", \"amount\": \"661.06\", \"direction\": \"IN\", \"balance_after\": \"Rs. 30,943.55\"}, {\"date\": \"04-01-2024\", \"description\": \"CASH-BNA-SELF-ANANYA CHAKRABORTY\", \"amount\": \"1,789.08\", \"direction\": \"IN\", \"balance_after\": \"Rs. 32,732.63\"}, {\"date\": \"05-01-2024\", \"description\": \"IMPS BRN SALARY TRF BY-VITALITY MEDICINES LTD\", \"amount\": \"4,795.06\", \"direction\": \"IN\", \"balance_after\": \"Rs. 37,527.69\"}, {\"date\": \"05-01-2024\", \"description\": \"UPI/DR/956616604066/PRIYANKA SENGUPTA/UPI-TRANSFER TO 9097052564\", \"amount\": \"652.28\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 36,875.41\"}, {\"date\": \"05-01-2024\", \"description\": \"IMPS BRN SALARY TRF BY-FOUNDATION PROJECTS LTD\", \"amount\": \"1,212.22\", \"direction\": \"IN\", \"balance_after\": \"Rs. 38,087.63\"}, {\"date\": \"05-01-2024\", \"description\": \"IMPS Dr-446289662468-SONALI BOSE\", \"amount\": \"407.72\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 37,679.91\"}, {\"date\": \"06-01-2024\", \"description\": \"RTGS Dr-CNRBR368742409288-HDFC0004171-ABHIJI T DAS-/NONE\", \"amount\": \"20,253.80\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 17,426.11\"}, {\"date\": \"06-01-2024\", \"description\": \"IMPS BRN SALARY TRF BY-CREDIT SERVICES LTD\", \"amount\": \"2,574.63\", \"direction\": \"IN\", \"balance_after\": \"Rs. 20,000.74\"}, {\"date\": \"06-01-2024\", \"description\": \"UPI/DR/447951602541/DEBASHIS CHAKRABORTY/UPI-TRANSFER TO 7333183915\", \"amount\": \"571.24\", \"direction\": \"OUT\", \"balance_after\": \"Rs. 19,429.50\"}]}",
+    "{\"transactions\":[{\"date\":\"08-01-2024 14:52:45\",\"description\":\"UPI/DR/728341737715/PAYEL BHATTACHARYA/UPI-TRANSFER TO 8557940363\",\"amount\":513.47,\"direction\":\"OUT\",\"balance_after\":\"Rs. 18,916.03\"},{\"date\":\"08-01-2024 15:53:04\",\"description\":\"IMPS Dr-336203076056-TANMAY GANGULY\",\"amount\":2287.52,\"direction\":\"OUT\",\"balance_after\":\"Rs. 16,628.51\"},{\"date\":\"08-01-2024 16:52:30\",\"description\":\"NEFT Cr-947749222922-ICIC0SF0002-SOFTWARE TECHNOLOGIES--\",\"amount\":7675.95,\"direction\":\"IN\",\"balance_after\":\"Rs. 24,304.46\"},{\"date\":\"08-01-2024 17:07:06\",\"description\":\"NEFT Cr-851018220366-ICIC0SF0002-DAILY NEEDS LIMITED--\",\"amount\":3180.55,\"direction\":\"IN\",\"balance_after\":\"Rs. 27,485.01\"},{\"date\":\"08-01-2024 21:51:37\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), TECHVISION SYSTEMS\",\"amount\":3206.08,\"direction\":\"IN\",\"balance_after\":\"Rs. 30,691.09\"},{\"date\":\"08-01-2024 21:59:48\",\"description\":\"Cash Withdrawal-BIPLAB DUTTA\",\"amount\":742.40,\"direction\":\"OUT\",\"balance_after\":\"Rs. 29,948.69\"},{\"date\":\"09-01-2024 09:30:00\",\"description\":\"NEFT Dr-863017303564-UTILITY PAYMENT\",\"amount\":1347.60,\"direction\":\"OUT\",\"balance_after\":\"Rs. 20,386.59\"},{\"date\":\"11-01-2024 15:09:37\",\"description\":\"NEFT Cr-623097695825-ICIC0SF0002-COMMERCIAL PROPERTIES INDIA--\",\"amount\":3103.69,\"direction\":\"IN\",\"balance_after\":\"Rs. 33,052.38\"},{\"date\":\"11-01-2024 15:58:15\",\"description\":\"CASH-BNA-SELF-BIPLAB BHATTACHARYA\",\"amount\":1376.45,\"direction\":\"IN\",\"balance_after\":\"Rs. 34,428.83\"},{\"date\":\"11-01-2024 16:07:21\",\"description\":\"NEFT Dr-349487998528-HDFC0009038-SOURAV DASGUPTA\",\"amount\":5267.64,\"direction\":\"OUT\",\"balance_after\":\"Rs. 29,161.19\"},{\"date\":\"12-01-2024 09:49:08\",\"description\":\"NEFT Dr-857406851540-HDFC0009038-ARIJIT SEN\",\"amount\":6725.28,\"direction\":\"OUT\",\"balance_after\":\"Rs. 22,435.91\"},{\"date\":\"12-01-2024 12:44:59\",\"description\":\"Chq Paid-MICR Inward Clearing-RAHUL CHAKRABORTY-HDFC BANK LTD.\",\"amount\":6233.58,\"direction\":\"OUT\",\"balance_after\":\"Rs. 16,202.33\"},{\"date\":\"12-01-2024 15:08:59\",\"description\":\"Chq Paid-MICR Inward Clearing-ANANYA MAJUMDAR-HDFC BANK LTD.\",\"amount\":6513.72,\"direction\":\"OUT\",\"balance_after\":\"Rs. 9,688.61\"},{\"date\":\"12-01-2024 15:56:25\",\"description\":\"NEFT Dr-245974395610-HDFC0009038-SUBRATA BOSE\",\"amount\":3329.88,\"direction\":\"OUT\",\"balance_after\":\"Rs. 6,358.73\"},{\"date\":\"13-01-2024 11:11:43\",\"description\":\"IMPS Dr-550685841633-RAJIB CHAKRABORTY\",\"amount\":523.74,\"direction\":\"OUT\",\"balance_after\":\"Rs. 5,834.99\"},{\"date\":\"13-01-2024 13:13:09\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), CREDIT SERVICES LTD\",\"amount\":312.87,\"direction\":\"IN\",\"balance_after\":\"Rs. 6,147.86\"},{\"date\":\"13-01-2024 15:12:10\",\"description\":\"NEFT Cr-977213384724-ICIC0SF0002-INFOCORE TECHNOLOGIES--\",\"amount\":1554.17,\"direction\":\"IN\",\"balance_after\":\"Rs. 7,702.03\"},{\"date\":\"15-01-2024 13:11:15\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), CAPITAL VENTURES INDIA\",\"amount\":1828.18,\"direction\":\"IN\",\"balance_after\":\"Rs. 9,530.21\"},{\"date\":\"16-01-2024 15:13:30\",\"description\":\"NEFT Cr-533294388600-ICIC0SF0002-INDUSTRIAL WORKS INDIA--\",\"amount\":4328.08,\"direction\":\"IN\",\"balance_after\":\"Rs. 13,858.29\"},{\"date\":\"17-01-2024 17:48:30\",\"description\":\"CASH-BNA-SELF-RAHUL SARKAR\",\"amount\":1152.35,\"direction\":\"IN\",\"balance_after\":\"Rs. 15,010.64\"},{\"date\":\"17-01-2024 21:11:24\",\"description\":\"CASH-BNA-SELF-SONALI BISWAS\",\"amount\":1279.23,\"direction\":\"IN\",\"balance_after\":\"Rs. 16,289.87\"},{\"date\":\"18-01-2024 10:53:12\",\"description\":\"IMPS BRN SALARY TRF BY-PHARMACY PRODUCTS LTD\",\"amount\":2864.65,\"direction\":\"IN\",\"balance_after\":\"Rs. 19,154.52\"},{\"date\":\"18-01-2024 11:58:27\",\"description\":\"RTGS Dr-CNRBR793975948062-HDFC0004171-PAYEL GHOSH-/NONE\",\"amount\":8256.49,\"direction\":\"OUT\",\"balance_after\":\"Rs. 10,898.03\"},{\"date\":\"18-01-2024 16:47:30\",\"description\":\"CASH-BNA-SELF-TAPAS PAUL\",\"amount\":216.21,\"direction\":\"IN\",\"balance_after\":\"Rs. 11,114.24\"},{\"date\":\"19-01-2024 10:02:14\",\"description\":\"Chq Paid-MICR Inward Clearing-DEBASHIS DASGUPTA-HDFC BANK LTD.\",\"amount\":2677.73,\"direction\":\"OUT\",\"balance_after\":\"Rs. 8,436.51\"},{\"date\":\"19-01-2024 12:14:02\",\"description\":\"NEFT Dr-590187733891-HDFC0009038-AMIT SENGUPTA\",\"amount\":866.79,\"direction\":\"OUT\",\"balance_after\":\"Rs. 7,569.72\"},{\"date\":\"20-01-2024 12:01:12\",\"description\":\"NEFT Dr-270635188773-HDFC0009038-RIYA GHOSH\",\"amount\":1087.71,\"direction\":\"OUT\",\"balance_after\":\"Rs. 6,482.01\"},{\"date\":\"20-01-2024 14:18:42\",\"description\":\"RTGS Dr-CNRBR16351280044-HDFC0004171-RITAM DAS-/NONE\",\"amount\":5009.85,\"direction\":\"OUT\",\"balance_after\":\"Rs. 1,472.16\"},{\"date\":\"20-01-2024 15:30:00\",\"description\":\"NEFT Dr-455142811587-GST PAYMENT-GSTIN 54A8955\",\"amount\":10476.71,\"direction\":\"OUT\",\"balance_after\":\"Rs. 9,909.88\"},{\"date\":\"20-01-2024 19:18:07\",\"description\":\"NEFT Cr-379809553812-ICIC0SF0002-CURE PHARMACEUTICALS--\",\"amount\":979.59,\"direction\":\"IN\",\"balance_after\":\"Rs. 2,451.75\"},{\"date\":\"22-01-2024 13:28:50\",\"description\":\"IMPS BRN SALARY TRF BY-ROADWAY INFRATECH\",\"amount\":785.55,\"direction\":\"IN\",\"balance_after\":\"Rs. 3,237.30\"},{\"date\":\"23-01-2024 17:39:58\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), DAIRY PRODUCTS INDIA\",\"amount\":326.25,\"direction\":\"IN\",\"balance_after\":\"Rs. 3,563.55\"},{\"date\":\"24-01-2024 07:55:58\",\"description\":\"IMPS BRN SALARY TRF BY-CODEBASE SOLUTIONS\",\"amount\":712.07,\"direction\":\"IN\",\"balance_after\":\"Rs. 4,275.62\"}]}",
+    "{\"transactions\":[{\"date\":\"24-01-2024 10:51:40\",\"description\":\"NEFT Cr-457834252605-ICIC0SF0002-BRIDGE ENGINEERING CO--\",\"amount\":935.48,\"direction\":\"IN\",\"balance_after\":5211.10},{\"date\":\"24-01-2024 12:39:48\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), HOUSING DEVELOPERS CORP\",\"amount\":487.33,\"direction\":\"IN\",\"balance_after\":5698.43},{\"date\":\"24-01-2024 14:02:05\",\"description\":\"RTGS Cr-ICICR356849853581-ICIC0000011-NETFORG E TECHNOLOGIES--/URGENT/\",\"amount\":7836.93,\"direction\":\"IN\",\"balance_after\":13535.36},{\"date\":\"24-01-2024 14:23:59\",\"description\":\"NEFT Dr-827913570929-HDFC0009038-SWAGATA GUPTA\",\"amount\":2731.48,\"direction\":\"OUT\",\"balance_after\":10803.88},{\"date\":\"25-01-2024 10:19:32\",\"description\":\"IMPS BRN SALARY TRF BY-CYBERCRAFT SYSTEMS\",\"amount\":161.94,\"direction\":\"IN\",\"balance_after\":10965.82},{\"date\":\"25-01-2024 11:09:39\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), AUTOMOTIVE PARTS CORP\",\"amount\":1083.23,\"direction\":\"IN\",\"balance_after\":12049.05},{\"date\":\"25-01-2024 12:52:21\",\"description\":\"RTGS Dr-CNRBR273427875612-HDFC0004171-PRIYA NKA CHOWDHURY-/NONE\",\"amount\":4231.14,\"direction\":\"OUT\",\"balance_after\":7817.91},{\"date\":\"25-01-2024 13:06:48\",\"description\":\"UPI/CR/650834173112/SHREYA DUTTA/SENT-TRANSFER FROM 8522417469\",\"amount\":297.82,\"direction\":\"IN\",\"balance_after\":8115.73},{\"date\":\"27-01-2024 16:59:54\",\"description\":\"NEFT Cr-328504307889-ICIC0SF0002-VITALITY MEDICINES LTD--\",\"amount\":2947.62,\"direction\":\"IN\",\"balance_after\":11063.35},{\"date\":\"29-01-2024 10:16:19\",\"description\":\"UPI/CR/544906412821/TANMAY GUPTA/SENT-TRANSFER FROM 8845256710\",\"amount\":353.70,\"direction\":\"IN\",\"balance_after\":11417.05},{\"date\":\"29-01-2024 19:49:53\",\"description\":\"NEFT Cr-123815374689-ICIC0SF0002-WELLNESS BRANDS INDIA--\",\"amount\":3226.77,\"direction\":\"IN\",\"balance_after\":14643.82},{\"date\":\"30-01-2024 14:57:24\",\"description\":\"IMPS BRN SALARY TRF BY-DAIRY PRODUCTS INDIA\",\"amount\":2056.48,\"direction\":\"IN\",\"balance_after\":16700.30},{\"date\":\"30-01-2024 18:52:00\",\"description\":\"UPI/CR/775180999565/AMIT SAHA/SENT-TRANSFER FROM 8731919656\",\"amount\":401.24,\"direction\":\"IN\",\"balance_after\":17101.54},{\"date\":\"30-01-2024 19:31:54\",\"description\":\"CASH-BNA-SELF-SWAGATA BANERJEE\",\"amount\":819.21,\"direction\":\"IN\",\"balance_after\":17920.75},{\"date\":\"31-01-2024 10:16:19\",\"description\":\"REVERSAL-UPI/CR/544906412821/TANMAY GUPTA/SENT-TRANSFER FRO\",\"amount\":353.70,\"direction\":\"OUT\",\"balance_after\":21308.12},{\"date\":\"31-01-2024 10:31:48\",\"description\":\"UPI/DR/503125953079/KAUSHIK ROY/UPI-TRANSFER TO 9790400869\",\"amount\":396.36,\"direction\":\"OUT\",\"balance_after\":17524.39},{\"date\":\"31-01-2024 21:00:29\",\"description\":\"IMPS BRN SALARY TRF BY-CODEBASE SOLUTIONS\",\"amount\":2246.64,\"direction\":\"IN\",\"balance_after\":19771.03},{\"date\":\"01-02-2024 11:30:23\",\"description\":\"IMPS Dr-942009840782-RITAM GANGULY\",\"amount\":1288.87,\"direction\":\"OUT\",\"balance_after\":18482.16},{\"date\":\"02-02-2024 12:05:41\",\"description\":\"ATM WDL-ATM CASH 65498\",\"amount\":9482.92,\"direction\":\"OUT\",\"balance_after\":8999.24},{\"date\":\"03-02-2024 11:39:07\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), DIGITAL SOLUTIONS INDIA\",\"amount\":1520.04,\"direction\":\"IN\",\"balance_after\":10519.28},{\"date\":\"03-02-2024 12:43:03\",\"description\":\"RTGS Cr-ICICR751136129026-ICIC0000011-NETPULS E SYSTEMS--/URGENT/\",\"amount\":20416.63,\"direction\":\"IN\",\"balance_after\":30935.91},{\"date\":\"03-02-2024 16:34:37\",\"description\":\"ATM WDL-ATM CASH 76619\",\"amount\":12427.35,\"direction\":\"OUT\",\"balance_after\":18508.56},{\"date\":\"05-02-2024 16:02:16\",\"description\":\"UPI/CR/213102212480/ARPITA CHATTERJEE/SENT-TRANSFER FROM 7768799544\",\"amount\":378.91,\"direction\":\"IN\",\"balance_after\":18887.47},{\"date\":\"05-02-2024 16:13:02\",\"description\":\"IMPS Dr-744362921769-BIPLAB BANERJEE\",\"amount\":2523.73,\"direction\":\"OUT\",\"balance_after\":16363.74},{\"date\":\"05-02-2024 17:38:51\",\"description\":\"Chq Paid-MICR Inward Clearing-RAHUL CHOWDHURY-HDFC BANK LTD.\",\"amount\":7465.74,\"direction\":\"OUT\",\"balance_after\":8898.00},{\"date\":\"05-02-2024 21:02:07\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), FINANCE SOLUTIONS INDIA\",\"amount\":583.89,\"direction\":\"IN\",\"balance_after\":9481.89},{\"date\":\"07-02-2024 14:48:32\",\"description\":\"RTGS Dr-CNRBR469171147220-HDFC0004171-SUBRA TA SARKAR-/NONE\",\"amount\":6944.61,\"direction\":\"OUT\",\"balance_after\":2537.28},{\"date\":\"08-02-2024 15:26:03\",\"description\":\"NEFT Cr-901235775423-ICIC0SF0002-COMMERCIAL PROPERTIES INDIA--\",\"amount\":302.74,\"direction\":\"IN\",\"balance_after\":2840.02},{\"date\":\"09-02-2024 09:30:00\",\"description\":\"NEFT Dr-731359724204-UTILITY PAYMENT\",\"amount\":3352.68,\"direction\":\"OUT\",\"balance_after\":6557.20},{\"date\":\"09-02-2024 21:11:45\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), BUILDING SOLUTIONS LTD\",\"amount\":432.09,\"direction\":\"IN\",\"balance_after\":3272.11},{\"date\":\"10-02-2024 13:24:24\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), CONCRETE STRUCTURES LTD\",\"amount\":853.56,\"direction\":\"IN\",\"balance_after\":4125.67},{\"date\":\"10-02-2024 16:05:05\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), NETFORGE TECHNOLOGIES\",\"amount\":451.25,\"direction\":\"IN\",\"balance_after\":4576.92},{\"date\":\"10-02-2024 18:05:14\",\"description\":\"NEFT Cr-929831790524-ICIC0SF0002-COMMERCIAL VEHICLES LTD--\",\"amount\":1785.19,\"direction\":\"IN\",\"balance_after\":6362.11}]}",
+    "{\"transactions\":[{\"date\":\"10-02-2024 19:44:14\",\"description\":\"UPI/CR/460987990432/SUJIT SAHA/SENT-TRANSFER FROM 9198559983\",\"amount\":929.96,\"direction\":\"IN\",\"balance_after\":7292.07},{\"date\":\"13-02-2024 09:59:23\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), EXPRESS LOGISTICS INDIA\",\"amount\":712.98,\"direction\":\"IN\",\"balance_after\":8005.05},{\"date\":\"13-02-2024 19:44:14\",\"description\":\"REVERSAL-UPI/CR/460987990432/SUJIT SAHA/SENT-TRANSFER FROM\",\"amount\":929.96,\"direction\":\"OUT\",\"balance_after\":20378.16},{\"date\":\"14-02-2024 09:42:54\",\"description\":\"NEFT Dr-126276538173-HDFC0009038-SOURAV DASGUPTA\",\"amount\":1830.56,\"direction\":\"OUT\",\"balance_after\":6174.49},{\"date\":\"14-02-2024 13:18:37\",\"description\":\"RTGS Dr-CNRBR443420225559-HDFC0004171-SREYA DASGUPTA-/NONE\",\"amount\":1310.51,\"direction\":\"OUT\",\"balance_after\":4863.98},{\"date\":\"15-02-2024 06:46:33\",\"description\":\"RTGS Cr-ICICR371910036764-ICIC0000011-AUTOMOTIVE PARTS CORP--/URGENT/\",\"amount\":6440.36,\"direction\":\"IN\",\"balance_after\":11304.34},{\"date\":\"15-02-2024 13:42:23\",\"description\":\"NEFT Cr-213285328597-ICIC0SF0002-CITYSCAPE DEVELOPERS--\",\"amount\":5451.92,\"direction\":\"IN\",\"balance_after\":16756.26},{\"date\":\"15-02-2024 17:16:34\",\"description\":\"CASH-BNA-SELF-SUSMITA BHATTACHARYA\",\"amount\":962.42,\"direction\":\"IN\",\"balance_after\":17718.68},{\"date\":\"17-02-2024 11:02:24\",\"description\":\"RTGS Cr-ICICR256761652534-ICIC0000011-BIOCARE INDUSTRIES--/URGENT/\",\"amount\":19038.22,\"direction\":\"IN\",\"balance_after\":36756.9},{\"date\":\"17-02-2024 12:29:30\",\"description\":\"Cash Withdrawal-RIYA DUTTA\",\"amount\":1832.42,\"direction\":\"OUT\",\"balance_after\":34924.48},{\"date\":\"17-02-2024 16:16:56\",\"description\":\"NEFT Cr-285336525867-ICIC0SF0002-COTTON MILLS CORP--\",\"amount\":2325.53,\"direction\":\"IN\",\"balance_after\":37250.01},{\"date\":\"17-02-2024 16:23:16\",\"description\":\"RTGS Cr-ICICR211281778829-ICIC0000011-PRECISION ENGINEERING WORKS--/URGENT/\",\"amount\":43436.34,\"direction\":\"IN\",\"balance_after\":80686.35},{\"date\":\"17-02-2024 16:24:45\",\"description\":\"NEFT Cr-199658371324-ICIC0SF0002-FABRIC PRODUCTS CORP--\",\"amount\":14590.37,\"direction\":\"IN\",\"balance_after\":95276.72},{\"date\":\"19-02-2024 11:37:30\",\"description\":\"IMPS Dr-644134271355-SUBRATA SEN\",\"amount\":8657.44,\"direction\":\"OUT\",\"balance_after\":86619.28},{\"date\":\"19-02-2024 14:17:37\",\"description\":\"NEFT Dr-541034268128-HDFC0009038-ARPITA GHOSH\",\"amount\":5067.47,\"direction\":\"OUT\",\"balance_after\":81551.81},{\"date\":\"20-02-2024 11:02:38\",\"description\":\"NEFT Cr-357213517799-ICIC0SF0002-RETAIL BRANDS CORP--\",\"amount\":22264.98,\"direction\":\"IN\",\"balance_after\":103816.79},{\"date\":\"20-02-2024 15:30:00\",\"description\":\"NEFT Dr-769161930088-GST PAYMENT-GSTIN 71C4171\",\"amount\":10476.71,\"direction\":\"OUT\",\"balance_after\":-3919.51},{\"date\":\"21-02-2024 13:02:18\",\"description\":\"UPI/CR/478426056369/RIYA CHOWDHURY/SENT-TRANSFER FROM 7289768879\",\"amount\":106.68,\"direction\":\"IN\",\"balance_after\":103923.47},{\"date\":\"22-02-2024 09:26:33\",\"description\":\"Cash Withdrawal-RAJIB MITRA\",\"amount\":5170.28,\"direction\":\"OUT\",\"balance_after\":98753.19},{\"date\":\"22-02-2024 09:57:48\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), MINDWAVE CONSULTING\",\"amount\":14081.58,\"direction\":\"IN\",\"balance_after\":112834.77},{\"date\":\"23-02-2024 16:49:43\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), FOUNDATION PROJECTS LTD\",\"amount\":14029.17,\"direction\":\"IN\",\"balance_after\":126863.94},{\"date\":\"24-02-2024 06:00:59\",\"description\":\"NEFT Cr-472014442250-ICIC0SF0002-DISTRIBUTION NETWORKS INDIA--\",\"amount\":49027.87,\"direction\":\"IN\",\"balance_after\":175891.81},{\"date\":\"24-02-2024 09:16:44\",\"description\":\"Chq Paid-MICR Inward Clearing-ANINDYA BANERJEE-HDFC BANK LTD.\",\"amount\":71993.52,\"direction\":\"OUT\",\"balance_after\":103898.29},{\"date\":\"24-02-2024 12:59:29\",\"description\":\"RTGS Cr-ICICR993498752371-ICIC0000011-APPAREL MAKERS INDIA--/URGENT/\",\"amount\":37177.04,\"direction\":\"IN\",\"balance_after\":141075.33},{\"date\":\"24-02-2024 16:49:19\",\"description\":\"NEFT Cr-537071536149-ICIC0SF0002-FINANCIAL PARTNERS INDIA--\",\"amount\":33889.33,\"direction\":\"IN\",\"balance_after\":174964.66},{\"date\":\"24-02-2024 21:43:43\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), SHIPPING SERVICES INDIA\",\"amount\":51788.93,\"direction\":\"IN\",\"balance_after\":226753.59},{\"date\":\"26-02-2024 09:30:00\",\"description\":\"NEFT Dr-362713973481-SOFTWARE SUBSCRIPTION\",\"amount\":1759.58,\"direction\":\"OUT\",\"balance_after\":-5679.09},{\"date\":\"26-02-2024 17:52:12\",\"description\":\"RTGS Dr-CNRBR165377554004-HDFC0004171-SHREYA SAHA-/NONE\",\"amount\":61198.68,\"direction\":\"OUT\",\"balance_after\":165554.91},{\"date\":\"27-02-2024 06:25:15\",\"description\":\"UPI/DR/410866848656/RITAM SENGUPTA/UPI-TRANSFER TO 6249183902\",\"amount\":1622.9,\"direction\":\"OUT\",\"balance_after\":163932.01},{\"date\":\"27-02-2024 06:42:14\",\"description\":\"IMPS BRN SALARY TRF BY-BUILDING SOLUTIONS LTD\",\"amount\":9271.67,\"direction\":\"IN\",\"balance_after\":173203.68},{\"date\":\"27-02-2024 10:48:23\",\"description\":\"IMPS BRN SALARY TRF BY-FOUNDATION PROJECTS LTD\",\"amount\":25697.34,\"direction\":\"IN\",\"balance_after\":198901.02},{\"date\":\"27-02-2024 12:11:06\",\"description\":\"Chq Paid-MICR Inward Clearing-MITALI SENGUPTA-HDFC BANK LTD.\",\"amount\":99036.48,\"direction\":\"OUT\",\"balance_after\":99864.54},{\"date\":\"27-02-2024 14:41:57\",\"description\":\"NEFT Dr-600630105173-HDFC0009038-TAPAS DUTTA\",\"amount\":33492.48,\"direction\":\"OUT\",\"balance_after\":66372.06}]}",
+    "{\"transactions\":[{\"date\":\"27-02-2024 16:09:42\",\"description\":\"RTGS Dr-CNRBR118549177807-HDFC0004171-SHREY A BISWAS-/NONE\",\"amount\":14033.52,\"direction\":\"OUT\",\"balance_after\":52338.54},{\"date\":\"28-02-2024 11:31:57\",\"description\":\"UPI/CR/931674830862/SANJAY CHATTERJEE/SENT-TRANSFER FROM 6601393596\",\"amount\":2163.29,\"direction\":\"IN\",\"balance_after\":54501.83},{\"date\":\"28-02-2024 17:18:44\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), DATABRIDGE INFOTECH\",\"amount\":6835.45,\"direction\":\"IN\",\"balance_after\":61337.28},{\"date\":\"28-02-2024 23:59:00\",\"description\":\"Service Charges-Demat Account AMC\",\"amount\":337.27,\"direction\":\"OUT\",\"balance_after\":-6016.36},{\"date\":\"28-02-2024 23:59:00\",\"description\":\"Service Charges-Online Banking Charges\",\"amount\":206.83,\"direction\":\"OUT\",\"balance_after\":-6223.19},{\"date\":\"28-02-2024 23:59:00\",\"description\":\"Service Charges-SMS Alert Charges\",\"amount\":90.75,\"direction\":\"OUT\",\"balance_after\":-6313.94},{\"date\":\"29-02-2024 15:02:49\",\"description\":\"Chq Paid-MICR Inward Clearing-ARPITA DASGUPTA-HDFC BANK LTD.\",\"amount\":26979.32,\"direction\":\"OUT\",\"balance_after\":34357.96},{\"date\":\"29-02-2024 16:23:10\",\"description\":\"RTGS Dr-CNRBR678992061478-HDFC0004171-SONAL I DUTTA-/NONE\",\"amount\":22061.03,\"direction\":\"OUT\",\"balance_after\":12296.93},{\"date\":\"01-03-2024 16:28:48\",\"description\":\"Chq Paid-MICR Inward Clearing-AMIT DASGUPTA-HDFC BANK LTD.\",\"amount\":6091.77,\"direction\":\"OUT\",\"balance_after\":6205.16},{\"date\":\"01-03-2024 16:34:54\",\"description\":\"Cash Withdrawal-TANMAY BOSE\",\"amount\":823.12,\"direction\":\"OUT\",\"balance_after\":5382.04},{\"date\":\"02-03-2024 12:16:20\",\"description\":\"RTGS Cr-ICICR844226908288-ICIC0000011-CREDIT SERVICES LTD--/URGENT/\",\"amount\":6595.41,\"direction\":\"IN\",\"balance_after\":11977.45},{\"date\":\"04-03-2024 09:28:05\",\"description\":\"IMPS BRN SALARY TRF BY-SHIPPING SERVICES INDIA\",\"amount\":503.00,\"direction\":\"IN\",\"balance_after\":12480.45},{\"date\":\"05-03-2024 12:24:14\",\"description\":\"IMPS Dr-915641514403-RAJIB MUKHERJEE\",\"amount\":1097.33,\"direction\":\"OUT\",\"balance_after\":11383.12},{\"date\":\"05-03-2024 21:32:27\",\"description\":\"IMPS Dr-534754213825-PAYEL DUTTA\",\"amount\":1560.02,\"direction\":\"OUT\",\"balance_after\":9823.10},{\"date\":\"06-03-2024 13:53:55\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), GATEWAY PROJECTS LTD\",\"amount\":787.87,\"direction\":\"IN\",\"balance_after\":10610.97},{\"date\":\"06-03-2024 14:22:58\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), RETAIL COMMERCE INDIA\",\"amount\":1935.68,\"direction\":\"IN\",\"balance_after\":12546.65},{\"date\":\"06-03-2024 17:03:21\",\"description\":\"RTGS Cr-ICICR345775995432-ICIC0000011-CAPITAL VENTURES INDIA--/URGENT/\",\"amount\":17289.40,\"direction\":\"IN\",\"balance_after\":29836.05},{\"date\":\"06-03-2024 18:23:40\",\"description\":\"NEFT Cr-959332621698-ICIC0SF0002-APEX HEAVY INDUSTRIES--\",\"amount\":14338.29,\"direction\":\"IN\",\"balance_after\":44174.34},{\"date\":\"07-03-2024 06:17:57\",\"description\":\"NEFT Cr-182093576973-ICIC0SF0002-PRECISION ENGINEERING WORKS--\",\"amount\":3170.94,\"direction\":\"IN\",\"balance_after\":47345.28},{\"date\":\"12-03-2024 19:32:29\",\"description\":\"NEFT Dr-867251037460-HDFC0009038-SUSMITA SENGUPTA\",\"amount\":3236.48,\"direction\":\"OUT\",\"balance_after\":44108.80},{\"date\":\"13-03-2024 13:23:51\",\"description\":\"NEFT Cr-675084101912-ICIC0SF0002-DAILY NEEDS LIMITED--\",\"amount\":20750.49,\"direction\":\"IN\",\"balance_after\":64859.29},{\"date\":\"14-03-2024 11:24:48\",\"description\":\"RTGS Dr-CNRBR219239255472-HDFC0004171-SANJA Y SARKAR-/NONE\",\"amount\":41602.44,\"direction\":\"OUT\",\"balance_after\":23256.85},{\"date\":\"14-03-2024 13:39:48\",\"description\":\"NEFT Cr-259069608854-ICIC0SF0002-SUPPLY CHAIN CORP--\",\"amount\":5733.73,\"direction\":\"IN\",\"balance_after\":28990.58},{\"date\":\"15-03-2024 14:00:00\",\"description\":\"Dividend Cr-AUTOMOTIVE PARTS CORP-EQUITY SHARES\",\"amount\":1356.03,\"direction\":\"IN\",\"balance_after\":21734.19},{\"date\":\"15-03-2024 15:52:42\",\"description\":\"UPI/CR/394566296733/RAHUL SENGUPTA/SENT-TRANSFER FROM 9841874124\",\"amount\":743.12,\"direction\":\"IN\",\"balance_after\":29733.70},{\"date\":\"15-03-2024 20:22:24\",\"description\":\"UPI/DR/936536138846/BIPLAB SEN/UPI-TRANSFER TO 8745951918\",\"amount\":361.52,\"direction\":\"OUT\",\"balance_after\":29372.18},{\"date\":\"16-03-2024 06:43:36\",\"description\":\"NEFT Cr-439738889875-ICIC0SF0002-CONSUMER ESSENTIALS INDIA--\",\"amount\":11491.98,\"direction\":\"IN\",\"balance_after\":40864.16},{\"date\":\"18-03-2024 09:00:00\",\"description\":\"Chq Paid-MICR Inward Clearing-MITALI DUTTA-HDFC BANK LTD.\",\"amount\":10836.25,\"direction\":\"OUT\",\"balance_after\":30027.91},{\"date\":\"18-03-2024 10:23:08\",\"description\":\"CASH-BNA-SELF-RITAM DUTTA\",\"amount\":745.26,\"direction\":\"IN\",\"balance_after\":30773.17},{\"date\":\"18-03-2024 11:24:36\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), METROPOLITAN BUILDERS\",\"amount\":5003.83,\"direction\":\"IN\",\"balance_after\":35777.00},{\"date\":\"19-03-2024 16:23:13\",\"description\":\"Chq Paid-MICR Inward Clearing-SOURAV CHATTERJEE-HDFC BANK LTD.\",\"amount\":13018.88,\"direction\":\"OUT\",\"balance_after\":22758.12},{\"date\":\"20-03-2024 11:02:10\",\"description\":\"Chq Paid-MICR Inward Clearing-TAPAS MUKHERJEE-HDFC BANK LTD.\",\"amount\":10937.03,\"direction\":\"OUT\",\"balance_after\":11821.09},{\"date\":\"20-03-2024 14:41:39\",\"description\":\"IMPS BRN SALARY TRF BY-PHARMACY PRODUCTS LTD\",\"amount\":1873.07,\"direction\":\"IN\",\"balance_after\":13694.16}]}",
+    "{\"transactions\":[{\"date\":\"21-03-2024 07:32:53\",\"description\":\"Chq Paid-MICR Inward Clearing-SOURAV GANGULY-HDFC BANK LTD.\",\"amount\":2868.01,\"direction\":\"OUT\",\"balance_after\":10826.15},{\"date\":\"21-03-2024 12:36:45\",\"description\":\"Cash Withdrawal-TAPAS BHATTACHARYA\",\"amount\":147.31,\"direction\":\"OUT\",\"balance_after\":10678.84},{\"date\":\"22-03-2024 06:58:40\",\"description\":\"NEFT Cr-998034591743-ICIC0SF0002-PERSONAL CARE LTD--\",\"amount\":3664.61,\"direction\":\"IN\",\"balance_after\":14343.45},{\"date\":\"22-03-2024 21:54:44\",\"description\":\"UPI/CR/341412834258/SONALI CHATTERJEE/SENT-TRANSFER FROM 8444366180\",\"amount\":585.87,\"direction\":\"IN\",\"balance_after\":14929.32},{\"date\":\"23-03-2024 10:18:42\",\"description\":\"Chq Paid-MICR Inward Clearing-SUJIT SEN-HDFC BANK LTD.\",\"amount\":6836.90,\"direction\":\"OUT\",\"balance_after\":8092.42},{\"date\":\"26-03-2024 06:11:18\",\"description\":\"NEFT Cr-754481424204-ICIC0SF0002-TEXTILE SOLUTIONS INDIA--\",\"amount\":775.81,\"direction\":\"IN\",\"balance_after\":8868.23},{\"date\":\"26-03-2024 06:35:03\",\"description\":\"NEFT Cr-818376489476-ICIC0SF0002-RESIDENTIAL PROJECTS LTD--\",\"amount\":3255.94,\"direction\":\"IN\",\"balance_after\":12124.17},{\"date\":\"26-03-2024 20:28:17\",\"description\":\"NEFT Dr-639820282851-HDFC0009038-ARIJIT CHATTERJEE\",\"amount\":885.56,\"direction\":\"OUT\",\"balance_after\":11238.61},{\"date\":\"27-03-2024 14:29:07\",\"description\":\"NEFT Cr-633101275754-ICIC0SF0002-FASHION TEXTILES LTD--\",\"amount\":4367.43,\"direction\":\"IN\",\"balance_after\":15606.04},{\"date\":\"27-03-2024 16:34:50\",\"description\":\"IMPS BRN SALARY TRF BY-RESIDENTIAL PROJECTS LTD\",\"amount\":365.78,\"direction\":\"IN\",\"balance_after\":15971.82},{\"date\":\"28-03-2024 10:19:33\",\"description\":\"By Clg:DEL ACCTS-CITI BANK N.A.(CIT), POWER SYSTEMS CORP\",\"amount\":1134.45,\"direction\":\"IN\",\"balance_after\":17106.27},{\"date\":\"28-03-2024 11:53:22\",\"description\":\"RTGS Cr-ICICR983555220673-ICIC0000011-COTTON MILLS CORP--/URGENT/\",\"amount\":22753.12,\"direction\":\"IN\",\"balance_after\":39859.39},{\"date\":\"28-03-2024 12:15:34\",\"description\":\"NEFT Cr-397197036503-ICIC0SF0002-INDUSTRIAL COMPONENTS INDIA--\",\"amount\":16031.10,\"direction\":\"IN\",\"balance_after\":55890.49},{\"date\":\"28-03-2024 23:59:00\",\"description\":\"Service Charges-NEFT/RTGS Charges\",\"amount\":11.97,\"direction\":\"OUT\",\"balance_after\":6325.91},{\"date\":\"30-03-2024 12:59:54\",\"description\":\"NEFT Dr-107800254021-HDFC0009038-BIPLAB BANERJEE\",\"amount\":21205.89,\"direction\":\"OUT\",\"balance_after\":34684.60},{\"date\":\"30-03-2024 15:11:53\",\"description\":\"NEFT Dr-929459255429-HDFC0009038-SOURAV CHAKRABORTY\",\"amount\":13771.73,\"direction\":\"OUT\",\"balance_after\":20912.87},{\"date\":\"30-03-2024 15:37:44\",\"description\":\"UPI/CR/484432226569/ARIJIT CHOWDHURY/SENT-TRANSFER FROM 6174365174\",\"amount\":748.95,\"direction\":\"IN\",\"balance_after\":21661.82}]}"
+  ],
+  "truth": {
+    "opening_balance": "59131.72",
+    "closing_balance": "21661.82",
+    "transactions": [
+      {
+        "date": "2024-01-01",
+        "description": "NEFT Cr-210968206613-ICIC0SF0002-CLOTHING INDUSTRIES LTD--",
+        "amount": "6086.63",
+        "direction": "IN",
+        "balance_after": "65218.35"
+      },
+      {
+        "date": "2024-01-02",
+        "description": "Chq Paid-MICR Inward Clearing-KAUSHIK SAHA-HDFC BANK LTD.",
+        "amount": "23702.04",
+        "direction": "OUT",
+        "balance_after": "41516.31"
+      },
+      {
+        "date": "2024-01-03",
+        "description": "RTGS Dr-CNRBR929510940342-HDFC0004171-BIPLAB CHATTERJEE-/NONE",
+        "amount": "9055.89",
+        "direction": "OUT",
+        "balance_after": "32460.42"
+      },
+      {
+        "date": "2024-01-04",
+        "description": "IMPS Dr-670498159700-SHREYA SENGUPTA",
+        "amount": "2177.93",
+        "direction": "OUT",
+        "balance_after": "30282.49"
+      },
+      {
+        "date": "2024-01-04",
+        "description": "CASH-BNA-SELF-PAYEL SAHA",
+        "amount": "661.06",
+        "direction": "IN",
+        "balance_after": "30943.55"
+      },
+      {
+        "date": "2024-01-04",
+        "description": "CASH-BNA-SELF-ANANYA CHAKRABORTY",
+        "amount": "1789.08",
+        "direction": "IN",
+        "balance_after": "32732.63"
+      },
+      {
+        "date": "2024-01-05",
+        "description": "IMPS BRN SALARY TRF BY-VITALITY MEDICINES LTD",
+        "amount": "4795.06",
+        "direction": "IN",
+        "balance_after": "37527.69"
+      },
+      {
+        "date": "2024-01-05",
+        "description": "UPI/DR/956616604066/PRIYANKA SENGUPTA/UPI-TRANSFER TO 9097052564",
+        "amount": "652.28",
+        "direction": "OUT",
+        "balance_after": "36875.41"
+      },
+      {
+        "date": "2024-01-05",
+        "description": "IMPS BRN SALARY TRF BY-FOUNDATION PROJECTS LTD",
+        "amount": "1212.22",
+        "direction": "IN",
+        "balance_after": "38087.63"
+      },
+      {
+        "date": "2024-01-05",
+        "description": "IMPS Dr-446289662468-SONALI BOSE",
+        "amount": "407.72",
+        "direction": "OUT",
+        "balance_after": "37679.91"
+      },
+      {
+        "date": "2024-01-06",
+        "description": "RTGS Dr-CNRBR368742409288-HDFC0004171-ABHIJIT DAS-/NONE",
+        "amount": "20253.8",
+        "direction": "OUT",
+        "balance_after": "17426.11"
+      },
+      {
+        "date": "2024-01-06",
+        "description": "IMPS BRN SALARY TRF BY-CREDIT SERVICES LTD",
+        "amount": "2574.63",
+        "direction": "IN",
+        "balance_after": "20000.74"
+      },
+      {
+        "date": "2024-01-06",
+        "description": "UPI/DR/447951602541/DEBASHIS CHAKRABORTY/UPI-TRANSFER TO 7333183915",
+        "amount": "571.24",
+        "direction": "OUT",
+        "balance_after": "19429.5"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "UPI/DR/728341737715/PAYEL BHATTACHARYA/UPI-TRANSFER TO 8557940363",
+        "amount": "513.47",
+        "direction": "OUT",
+        "balance_after": "18916.03"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "IMPS Dr-336203076056-TANMAY GANGULY",
+        "amount": "2287.52",
+        "direction": "OUT",
+        "balance_after": "16628.51"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "NEFT Cr-947749222922-ICIC0SF0002-SOFTWAVE TECHNOLOGIES--",
+        "amount": "7675.95",
+        "direction": "IN",
+        "balance_after": "24304.46"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "NEFT Cr-851018220366-ICIC0SF0002-DAILY NEEDS LIMITED--",
+        "amount": "3180.55",
+        "direction": "IN",
+        "balance_after": "27485.01"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), TECHVISION SYSTEMS",
+        "amount": "3206.08",
+        "direction": "IN",
+        "balance_after": "30691.09"
+      },
+      {
+        "date": "2024-01-08",
+        "description": "Cash Withdrawal-BIPLAB DUTTA",
+        "amount": "742.4",
+        "direction": "OUT",
+        "balance_after": "29948.69"
+      },
+      {
+        "date": "2024-01-09",
+        "description": "NEFT Dr-863017303564-UTILITY PAYMENT",
+        "amount": "1347.6",
+        "direction": "OUT",
+        "balance_after": "20386.59"
+      },
+      {
+        "date": "2024-01-11",
+        "description": "NEFT Cr-623097695825-ICIC0SF0002-COMMERCIAL PROPERTIES INDIA--",
+        "amount": "3103.69",
+        "direction": "IN",
+        "balance_after": "33052.38"
+      },
+      {
+        "date": "2024-01-11",
+        "description": "CASH-BNA-SELF-BIPLAB BHATTACHARYA",
+        "amount": "1376.45",
+        "direction": "IN",
+        "balance_after": "34428.83"
+      },
+      {
+        "date": "2024-01-11",
+        "description": "NEFT Dr-349487998528-HDFC0009038-SOURAV DASGUPTA",
+        "amount": "5267.64",
+        "direction": "OUT",
+        "balance_after": "29161.19"
+      },
+      {
+        "date": "2024-01-12",
+        "description": "NEFT Dr-857406851540-HDFC0009038-ARIJIT SEN",
+        "amount": "6725.28",
+        "direction": "OUT",
+        "balance_after": "22435.91"
+      },
+      {
+        "date": "2024-01-12",
+        "description": "Chq Paid-MICR Inward Clearing-RAHUL CHAKRABORTY-HDFC BANK LTD.",
+        "amount": "6233.58",
+        "direction": "OUT",
+        "balance_after": "16202.33"
+      },
+      {
+        "date": "2024-01-12",
+        "description": "Chq Paid-MICR Inward Clearing-ANANYA MAJUMDAR-HDFC BANK LTD.",
+        "amount": "6513.72",
+        "direction": "OUT",
+        "balance_after": "9688.61"
+      },
+      {
+        "date": "2024-01-12",
+        "description": "NEFT Dr-245974395610-HDFC0009038-SUBRATA BOSE",
+        "amount": "3329.88",
+        "direction": "OUT",
+        "balance_after": "6358.73"
+      },
+      {
+        "date": "2024-01-13",
+        "description": "IMPS Dr-550685841633-RAJIB CHAKRABORTY",
+        "amount": "523.74",
+        "direction": "OUT",
+        "balance_after": "5834.99"
+      },
+      {
+        "date": "2024-01-13",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), CREDIT SERVICES LTD",
+        "amount": "312.87",
+        "direction": "IN",
+        "balance_after": "6147.86"
+      },
+      {
+        "date": "2024-01-13",
+        "description": "NEFT Cr-977213384724-ICIC0SF0002-INFOCORE TECHNOLOGIES--",
+        "amount": "1554.17",
+        "direction": "IN",
+        "balance_after": "7702.03"
+      },
+      {
+        "date": "2024-01-15",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), CAPITAL VENTURES INDIA",
+        "amount": "1828.18",
+        "direction": "IN",
+        "balance_after": "9530.21"
+      },
+      {
+        "date": "2024-01-16",
+        "description": "NEFT Cr-533294388600-ICIC0SF0002-INDUSTRIAL WORKS INDIA--",
+        "amount": "4328.08",
+        "direction": "IN",
+        "balance_after": "13858.29"
+      },
+      {
+        "date": "2024-01-17",
+        "description": "CASH-BNA-SELF-RAHUL SARKAR",
+        "amount": "1152.35",
+        "direction": "IN",
+        "balance_after": "15010.64"
+      },
+      {
+        "date": "2024-01-17",
+        "description": "CASH-BNA-SELF-SONALI BISWAS",
+        "amount": "1279.23",
+        "direction": "IN",
+        "balance_after": "16289.87"
+      },
+      {
+        "date": "2024-01-18",
+        "description": "IMPS BRN SALARY TRF BY-PHARMACY PRODUCTS LTD",
+        "amount": "2864.65",
+        "direction": "IN",
+        "balance_after": "19154.52"
+      },
+      {
+        "date": "2024-01-18",
+        "description": "RTGS Dr-CNRBR793975948062-HDFC0004171-PAYEL GHOSH-/NONE",
+        "amount": "8256.49",
+        "direction": "OUT",
+        "balance_after": "10898.03"
+      },
+      {
+        "date": "2024-01-18",
+        "description": "CASH-BNA-SELF-TAPAS PAUL",
+        "amount": "216.21",
+        "direction": "IN",
+        "balance_after": "11114.24"
+      },
+      {
+        "date": "2024-01-19",
+        "description": "Chq Paid-MICR Inward Clearing-DEBASHIS DASGUPTA-HDFC BANK LTD.",
+        "amount": "2677.73",
+        "direction": "OUT",
+        "balance_after": "8436.51"
+      },
+      {
+        "date": "2024-01-19",
+        "description": "NEFT Dr-590187733891-HDFC0009038-AMIT SENGUPTA",
+        "amount": "866.79",
+        "direction": "OUT",
+        "balance_after": "7569.72"
+      },
+      {
+        "date": "2024-01-20",
+        "description": "NEFT Dr-270635188773-HDFC0009038-RIYA GHOSH",
+        "amount": "1087.71",
+        "direction": "OUT",
+        "balance_after": "6482.01"
+      },
+      {
+        "date": "2024-01-20",
+        "description": "RTGS Dr-CNRBR163512820044-HDFC0004171-RITAM DAS-/NONE",
+        "amount": "5009.85",
+        "direction": "OUT",
+        "balance_after": "1472.16"
+      },
+      {
+        "date": "2024-01-20",
+        "description": "NEFT Dr-455142811587-GST PAYMENT-GSTIN 54A8955",
+        "amount": "10476.71",
+        "direction": "OUT",
+        "balance_after": "9909.88"
+      },
+      {
+        "date": "2024-01-20",
+        "description": "NEFT Cr-379809553812-ICIC0SF0002-CURE PHARMACEUTICALS--",
+        "amount": "979.59",
+        "direction": "IN",
+        "balance_after": "2451.75"
+      },
+      {
+        "date": "2024-01-22",
+        "description": "IMPS BRN SALARY TRF BY-ROADWAY INFRATECH",
+        "amount": "785.55",
+        "direction": "IN",
+        "balance_after": "3237.3"
+      },
+      {
+        "date": "2024-01-23",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), DAIRY PRODUCTS INDIA",
+        "amount": "326.25",
+        "direction": "IN",
+        "balance_after": "3563.55"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "IMPS BRN SALARY TRF BY-CODEBASE SOLUTIONS",
+        "amount": "712.07",
+        "direction": "IN",
+        "balance_after": "4275.62"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "NEFT Cr-457834252605-ICIC0SF0002-BRIDGE ENGINEERING CO--",
+        "amount": "935.48",
+        "direction": "IN",
+        "balance_after": "5211.1"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), HOUSING DEVELOPERS CORP",
+        "amount": "487.33",
+        "direction": "IN",
+        "balance_after": "5698.43"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "RTGS Cr-ICICR356849853581-ICIC0000011-NETFORGE TECHNOLOGIES--/URGENT/",
+        "amount": "7836.93",
+        "direction": "IN",
+        "balance_after": "13535.36"
+      },
+      {
+        "date": "2024-01-24",
+        "description": "NEFT Dr-827913570929-HDFC0009038-SWAGATA GUPTA",
+        "amount": "2731.48",
+        "direction": "OUT",
+        "balance_after": "10803.88"
+      },
+      {
+        "date": "2024-01-25",
+        "description": "IMPS BRN SALARY TRF BY-CYBERCRAFT SYSTEMS",
+        "amount": "161.94",
+        "direction": "IN",
+        "balance_after": "10965.82"
+      },
+      {
+        "date": "2024-01-25",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), AUTOMOTIVE PARTS CORP",
+        "amount": "1083.23",
+        "direction": "IN",
+        "balance_after": "12049.05"
+      },
+      {
+        "date": "2024-01-25",
+        "description": "RTGS Dr-CNRBR273427875612-HDFC0004171-PRIYANKA CHOWDHURY-/NONE",
+        "amount": "4231.14",
+        "direction": "OUT",
+        "balance_after": "7817.91"
+      },
+      {
+        "date": "2024-01-25",
+        "description": "UPI/CR/650834173112/SHREYA DUTTA/SENT-TRANSFER FROM 8522417469",
+        "amount": "297.82",
+        "direction": "IN",
+        "balance_after": "8115.73"
+      },
+      {
+        "date": "2024-01-27",
+        "description": "NEFT Cr-328504307889-ICIC0SF0002-VITALITY MEDICINES LTD--",
+        "amount": "2947.62",
+        "direction": "IN",
+        "balance_after": "11063.35"
+      },
+      {
+        "date": "2024-01-29",
+        "description": "UPI/CR/544906412821/TANMAY GUPTA/SENT-TRANSFER FROM 8845256710",
+        "amount": "353.7",
+        "direction": "IN",
+        "balance_after": "11417.05"
+      },
+      {
+        "date": "2024-01-29",
+        "description": "NEFT Cr-123815374689-ICIC0SF0002-WELLNESS BRANDS INDIA--",
+        "amount": "3226.77",
+        "direction": "IN",
+        "balance_after": "14643.82"
+      },
+      {
+        "date": "2024-01-30",
+        "description": "IMPS BRN SALARY TRF BY-DAIRY PRODUCTS INDIA",
+        "amount": "2056.48",
+        "direction": "IN",
+        "balance_after": "16700.3"
+      },
+      {
+        "date": "2024-01-30",
+        "description": "UPI/CR/775180999565/AMIT SAHA/SENT-TRANSFER FROM 8731919656",
+        "amount": "401.24",
+        "direction": "IN",
+        "balance_after": "17101.54"
+      },
+      {
+        "date": "2024-01-30",
+        "description": "CASH-BNA-SELF-SWAGATA BANERJEE",
+        "amount": "819.21",
+        "direction": "IN",
+        "balance_after": "17920.75"
+      },
+      {
+        "date": "2024-01-31",
+        "description": "REVERSAL-UPI/CR/544906412821/TANMAY GUPTA/SENT-TRANSFER FRO",
+        "amount": "353.7",
+        "direction": "OUT",
+        "balance_after": "21308.12"
+      },
+      {
+        "date": "2024-01-31",
+        "description": "UPI/DR/503125953079/KAUSHIK ROY/UPI-TRANSFER TO 9790400869",
+        "amount": "396.36",
+        "direction": "OUT",
+        "balance_after": "17524.39"
+      },
+      {
+        "date": "2024-01-31",
+        "description": "IMPS BRN SALARY TRF BY-CODEBASE SOLUTIONS",
+        "amount": "2246.64",
+        "direction": "IN",
+        "balance_after": "19771.03"
+      },
+      {
+        "date": "2024-02-01",
+        "description": "IMPS Dr-942009840782-RITAM GANGULY",
+        "amount": "1288.87",
+        "direction": "OUT",
+        "balance_after": "18482.16"
+      },
+      {
+        "date": "2024-02-02",
+        "description": "ATM WDL-ATM CASH 65498",
+        "amount": "9482.92",
+        "direction": "OUT",
+        "balance_after": "8999.24"
+      },
+      {
+        "date": "2024-02-03",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), DIGITAL SOLUTIONS INDIA",
+        "amount": "1520.04",
+        "direction": "IN",
+        "balance_after": "10519.28"
+      },
+      {
+        "date": "2024-02-03",
+        "description": "RTGS Cr-ICICR751136129026-ICIC0000011-NETPULSE SYSTEMS--/URGENT/",
+        "amount": "20416.63",
+        "direction": "IN",
+        "balance_after": "30935.91"
+      },
+      {
+        "date": "2024-02-03",
+        "description": "ATM WDL-ATM CASH 76619",
+        "amount": "12427.35",
+        "direction": "OUT",
+        "balance_after": "18508.56"
+      },
+      {
+        "date": "2024-02-05",
+        "description": "UPI/CR/213102212480/ARPITA CHATTERJEE/SENT-TRANSFER FROM 7768799544",
+        "amount": "378.91",
+        "direction": "IN",
+        "balance_after": "18887.47"
+      },
+      {
+        "date": "2024-02-05",
+        "description": "IMPS Dr-744362921769-BIPLAB BANERJEE",
+        "amount": "2523.73",
+        "direction": "OUT",
+        "balance_after": "16363.74"
+      },
+      {
+        "date": "2024-02-05",
+        "description": "Chq Paid-MICR Inward Clearing-RAHUL CHOWDHURY-HDFC BANK LTD.",
+        "amount": "7465.74",
+        "direction": "OUT",
+        "balance_after": "8898.0"
+      },
+      {
+        "date": "2024-02-05",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), FINANCE SOLUTIONS INDIA",
+        "amount": "583.89",
+        "direction": "IN",
+        "balance_after": "9481.89"
+      },
+      {
+        "date": "2024-02-07",
+        "description": "RTGS Dr-CNRBR469171147220-HDFC0004171-SUBRATA SARKAR-/NONE",
+        "amount": "6944.61",
+        "direction": "OUT",
+        "balance_after": "2537.28"
+      },
+      {
+        "date": "2024-02-08",
+        "description": "NEFT Cr-901235775423-ICIC0SF0002-COMMERCIAL PROPERTIES INDIA--",
+        "amount": "302.74",
+        "direction": "IN",
+        "balance_after": "2840.02"
+      },
+      {
+        "date": "2024-02-09",
+        "description": "NEFT Dr-731359724204-UTILITY PAYMENT",
+        "amount": "3352.68",
+        "direction": "OUT",
+        "balance_after": "6557.2"
+      },
+      {
+        "date": "2024-02-09",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), BUILDING SOLUTIONS LTD",
+        "amount": "432.09",
+        "direction": "IN",
+        "balance_after": "3272.11"
+      },
+      {
+        "date": "2024-02-10",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), CONCRETE STRUCTURES LTD",
+        "amount": "853.56",
+        "direction": "IN",
+        "balance_after": "4125.67"
+      },
+      {
+        "date": "2024-02-10",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), NETFORGE TECHNOLOGIES",
+        "amount": "451.25",
+        "direction": "IN",
+        "balance_after": "4576.92"
+      },
+      {
+        "date": "2024-02-10",
+        "description": "NEFT Cr-929831790524-ICIC0SF0002-COMMERCIAL VEHICLES LTD--",
+        "amount": "1785.19",
+        "direction": "IN",
+        "balance_after": "6362.11"
+      },
+      {
+        "date": "2024-02-10",
+        "description": "UPI/CR/460987990432/SUJIT SAHA/SENT-TRANSFER FROM 9198559983",
+        "amount": "929.96",
+        "direction": "IN",
+        "balance_after": "7292.07"
+      },
+      {
+        "date": "2024-02-13",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), EXPRESS LOGISTICS INDIA",
+        "amount": "712.98",
+        "direction": "IN",
+        "balance_after": "8005.05"
+      },
+      {
+        "date": "2024-02-13",
+        "description": "REVERSAL-UPI/CR/460987990432/SUJIT SAHA/SENT-TRANSFER FROM",
+        "amount": "929.96",
+        "direction": "OUT",
+        "balance_after": "20378.16"
+      },
+      {
+        "date": "2024-02-14",
+        "description": "NEFT Dr-126276538173-HDFC0009038-SOURAV DASGUPTA",
+        "amount": "1830.56",
+        "direction": "OUT",
+        "balance_after": "6174.49"
+      },
+      {
+        "date": "2024-02-14",
+        "description": "RTGS Dr-CNRBR443420225559-HDFC0004171-SREYA DASGUPTA-/NONE",
+        "amount": "1310.51",
+        "direction": "OUT",
+        "balance_after": "4863.98"
+      },
+      {
+        "date": "2024-02-15",
+        "description": "RTGS Cr-ICICR371910036764-ICIC0000011-AUTOMOTIVE PARTS CORP--/URGENT/",
+        "amount": "6440.36",
+        "direction": "IN",
+        "balance_after": "11304.34"
+      },
+      {
+        "date": "2024-02-15",
+        "description": "NEFT Cr-213285328597-ICIC0SF0002-CITYSCAPE DEVELOPERS--",
+        "amount": "5451.92",
+        "direction": "IN",
+        "balance_after": "16756.26"
+      },
+      {
+        "date": "2024-02-15",
+        "description": "CASH-BNA-SELF-SUSMITA BHATTACHARYA",
+        "amount": "962.42",
+        "direction": "IN",
+        "balance_after": "17718.68"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "RTGS Cr-ICICR256761652534-ICIC0000011-BIOCARE INDUSTRIES--/URGENT/",
+        "amount": "19038.22",
+        "direction": "IN",
+        "balance_after": "36756.9"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "Cash Withdrawal-RIYA DUTTA",
+        "amount": "1832.42",
+        "direction": "OUT",
+        "balance_after": "34924.48"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "NEFT Cr-285336525867-ICIC0SF0002-COTTON MILLS CORP--",
+        "amount": "2325.53",
+        "direction": "IN",
+        "balance_after": "37250.01"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "RTGS Cr-ICICR211281778829-ICIC0000011-PRECISION ENGINEERING WORKS--/URGENT/",
+        "amount": "43436.34",
+        "direction": "IN",
+        "balance_after": "80686.35"
+      },
+      {
+        "date": "2024-02-17",
+        "description": "NEFT Cr-199658371324-ICIC0SF0002-FABRIC PRODUCTS CORP--",
+        "amount": "14590.37",
+        "direction": "IN",
+        "balance_after": "95276.72"
+      },
+      {
+        "date": "2024-02-19",
+        "description": "IMPS Dr-644134271355-SUBRATA SEN",
+        "amount": "8657.44",
+        "direction": "OUT",
+        "balance_after": "86619.28"
+      },
+      {
+        "date": "2024-02-19",
+        "description": "NEFT Dr-541034268128-HDFC0009038-ARPITA GHOSH",
+        "amount": "5067.47",
+        "direction": "OUT",
+        "balance_after": "81551.81"
+      },
+      {
+        "date": "2024-02-20",
+        "description": "NEFT Cr-357213517799-ICIC0SF0002-RETAIL BRANDS CORP--",
+        "amount": "22264.98",
+        "direction": "IN",
+        "balance_after": "103816.79"
+      },
+      {
+        "date": "2024-02-20",
+        "description": "NEFT Dr-769161930088-GST PAYMENT-GSTIN 71C4171",
+        "amount": "10476.71",
+        "direction": "OUT",
+        "balance_after": "-3919.51"
+      },
+      {
+        "date": "2024-02-21",
+        "description": "UPI/CR/478426056369/RIYA CHOWDHURY/SENT-TRANSFER FROM 7289768879",
+        "amount": "106.68",
+        "direction": "IN",
+        "balance_after": "103923.47"
+      },
+      {
+        "date": "2024-02-22",
+        "description": "Cash Withdrawal-RAJIB MITRA",
+        "amount": "5170.28",
+        "direction": "OUT",
+        "balance_after": "98753.19"
+      },
+      {
+        "date": "2024-02-22",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), MINDWAVE CONSULTING",
+        "amount": "14081.58",
+        "direction": "IN",
+        "balance_after": "112834.77"
+      },
+      {
+        "date": "2024-02-23",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), FOUNDATION PROJECTS LTD",
+        "amount": "14029.17",
+        "direction": "IN",
+        "balance_after": "126863.94"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "NEFT Cr-472014442250-ICIC0SF0002-DISTRIBUTION NETWORKS INDIA--",
+        "amount": "49027.87",
+        "direction": "IN",
+        "balance_after": "175891.81"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "Chq Paid-MICR Inward Clearing-ANINDYA BANERJEE-HDFC BANK LTD.",
+        "amount": "71993.52",
+        "direction": "OUT",
+        "balance_after": "103898.29"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "RTGS Cr-ICICR993498752371-ICIC0000011-APPAREL MAKERS INDIA--/URGENT/",
+        "amount": "37177.04",
+        "direction": "IN",
+        "balance_after": "141075.33"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "NEFT Cr-537071536149-ICIC0SF0002-FINANCIAL PARTNERS INDIA--",
+        "amount": "33889.33",
+        "direction": "IN",
+        "balance_after": "174964.66"
+      },
+      {
+        "date": "2024-02-24",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), SHIPPING SERVICES INDIA",
+        "amount": "51788.93",
+        "direction": "IN",
+        "balance_after": "226753.59"
+      },
+      {
+        "date": "2024-02-26",
+        "description": "NEFT Dr-362713973481-SOFTWARE SUBSCRIPTION",
+        "amount": "1759.58",
+        "direction": "OUT",
+        "balance_after": "-5679.09"
+      },
+      {
+        "date": "2024-02-26",
+        "description": "RTGS Dr-CNRBR165377554004-HDFC0004171-SHREYA SAHA-/NONE",
+        "amount": "61198.68",
+        "direction": "OUT",
+        "balance_after": "165554.91"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "UPI/DR/410866848656/RITAM SENGUPTA/UPI-TRANSFER TO 6249183902",
+        "amount": "1622.9",
+        "direction": "OUT",
+        "balance_after": "163932.01"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "IMPS BRN SALARY TRF BY-BUILDING SOLUTIONS LTD",
+        "amount": "9271.67",
+        "direction": "IN",
+        "balance_after": "173203.68"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "IMPS BRN SALARY TRF BY-FOUNDATION PROJECTS LTD",
+        "amount": "25697.34",
+        "direction": "IN",
+        "balance_after": "198901.02"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "Chq Paid-MICR Inward Clearing-MITALI SENGUPTA-HDFC BANK LTD.",
+        "amount": "99036.48",
+        "direction": "OUT",
+        "balance_after": "99864.54"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "NEFT Dr-600630105173-HDFC0009038-TAPAS DUTTA",
+        "amount": "33492.48",
+        "direction": "OUT",
+        "balance_after": "66372.06"
+      },
+      {
+        "date": "2024-02-27",
+        "description": "RTGS Dr-CNRBR118549177807-HDFC0004171-SHREYA BISWAS-/NONE",
+        "amount": "14033.52",
+        "direction": "OUT",
+        "balance_after": "52338.54"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "UPI/CR/931674830862/SANJAY CHATTERJEE/SENT-TRANSFER FROM 6601393596",
+        "amount": "2163.29",
+        "direction": "IN",
+        "balance_after": "54501.83"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), DATABRIDGE INFOTECH",
+        "amount": "6835.45",
+        "direction": "IN",
+        "balance_after": "61337.28"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "Service Charges-Demat Account AMC",
+        "amount": "337.27",
+        "direction": "OUT",
+        "balance_after": "-6016.36"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "Service Charges-Online Banking Charges",
+        "amount": "206.83",
+        "direction": "OUT",
+        "balance_after": "-6223.19"
+      },
+      {
+        "date": "2024-02-28",
+        "description": "Service Charges-SMS Alert Charges",
+        "amount": "90.75",
+        "direction": "OUT",
+        "balance_after": "-6313.94"
+      },
+      {
+        "date": "2024-02-29",
+        "description": "Chq Paid-MICR Inward Clearing-ARPITA DASGUPTA-HDFC BANK LTD.",
+        "amount": "26979.32",
+        "direction": "OUT",
+        "balance_after": "34357.96"
+      },
+      {
+        "date": "2024-02-29",
+        "description": "RTGS Dr-CNRBR678992061478-HDFC0004171-SONALI DUTTA-/NONE",
+        "amount": "22061.03",
+        "direction": "OUT",
+        "balance_after": "12296.93"
+      },
+      {
+        "date": "2024-03-01",
+        "description": "Chq Paid-MICR Inward Clearing-AMIT DASGUPTA-HDFC BANK LTD.",
+        "amount": "6091.77",
+        "direction": "OUT",
+        "balance_after": "6205.16"
+      },
+      {
+        "date": "2024-03-01",
+        "description": "Cash Withdrawal-TANMAY BOSE",
+        "amount": "823.12",
+        "direction": "OUT",
+        "balance_after": "5382.04"
+      },
+      {
+        "date": "2024-03-02",
+        "description": "RTGS Cr-ICICR844226908288-ICIC0000011-CREDIT SERVICES LTD--/URGENT/",
+        "amount": "6595.41",
+        "direction": "IN",
+        "balance_after": "11977.45"
+      },
+      {
+        "date": "2024-03-04",
+        "description": "IMPS BRN SALARY TRF BY-SHIPPING SERVICES INDIA",
+        "amount": "503.0",
+        "direction": "IN",
+        "balance_after": "12480.45"
+      },
+      {
+        "date": "2024-03-05",
+        "description": "IMPS Dr-915641514403-RAJIB MUKHERJEE",
+        "amount": "1097.33",
+        "direction": "OUT",
+        "balance_after": "11383.12"
+      },
+      {
+        "date": "2024-03-05",
+        "description": "IMPS Dr-534754213825-PAYEL DUTTA",
+        "amount": "1560.02",
+        "direction": "OUT",
+        "balance_after": "9823.1"
+      },
+      {
+        "date": "2024-03-06",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), GATEWAY PROJECTS LTD",
+        "amount": "787.87",
+        "direction": "IN",
+        "balance_after": "10610.97"
+      },
+      {
+        "date": "2024-03-06",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), RETAIL COMMERCE INDIA",
+        "amount": "1935.68",
+        "direction": "IN",
+        "balance_after": "12546.65"
+      },
+      {
+        "date": "2024-03-06",
+        "description": "RTGS Cr-ICICR345775995432-ICIC0000011-CAPITAL VENTURES INDIA--/URGENT/",
+        "amount": "17289.4",
+        "direction": "IN",
+        "balance_after": "29836.05"
+      },
+      {
+        "date": "2024-03-06",
+        "description": "NEFT Cr-959332621698-ICIC0SF0002-APEX HEAVY INDUSTRIES--",
+        "amount": "14338.29",
+        "direction": "IN",
+        "balance_after": "44174.34"
+      },
+      {
+        "date": "2024-03-07",
+        "description": "NEFT Cr-182093576973-ICIC0SF0002-PRECISION ENGINEERING WORKS--",
+        "amount": "3170.94",
+        "direction": "IN",
+        "balance_after": "47345.28"
+      },
+      {
+        "date": "2024-03-12",
+        "description": "NEFT Dr-867251037460-HDFC0009038-SUSMITA SENGUPTA",
+        "amount": "3236.48",
+        "direction": "OUT",
+        "balance_after": "44108.8"
+      },
+      {
+        "date": "2024-03-13",
+        "description": "NEFT Cr-675084101912-ICIC0SF0002-DAILY NEEDS LIMITED--",
+        "amount": "20750.49",
+        "direction": "IN",
+        "balance_after": "64859.29"
+      },
+      {
+        "date": "2024-03-14",
+        "description": "RTGS Dr-CNRBR219239255472-HDFC0004171-SANJAY SARKAR-/NONE",
+        "amount": "41602.44",
+        "direction": "OUT",
+        "balance_after": "23256.85"
+      },
+      {
+        "date": "2024-03-14",
+        "description": "NEFT Cr-259069608854-ICIC0SF0002-SUPPLY CHAIN CORP--",
+        "amount": "5733.73",
+        "direction": "IN",
+        "balance_after": "28990.58"
+      },
+      {
+        "date": "2024-03-15",
+        "description": "Dividend Cr-AUTOMOTIVE PARTS CORP-EQUITY SHARES",
+        "amount": "1356.03",
+        "direction": "IN",
+        "balance_after": "21734.19"
+      },
+      {
+        "date": "2024-03-15",
+        "description": "UPI/CR/394566296733/RAHUL SENGUPTA/SENT-TRANSFER FROM 9841874124",
+        "amount": "743.12",
+        "direction": "IN",
+        "balance_after": "29733.7"
+      },
+      {
+        "date": "2024-03-15",
+        "description": "UPI/DR/936536138846/BIPLAB SEN/UPI-TRANSFER TO 8745951918",
+        "amount": "361.52",
+        "direction": "OUT",
+        "balance_after": "29372.18"
+      },
+      {
+        "date": "2024-03-16",
+        "description": "NEFT Cr-439738889875-ICIC0SF0002-CONSUMER ESSENTIALS INDIA--",
+        "amount": "11491.98",
+        "direction": "IN",
+        "balance_after": "40864.16"
+      },
+      {
+        "date": "2024-03-18",
+        "description": "Chq Paid-MICR Inward Clearing-MITALI DUTTA-HDFC BANK LTD.",
+        "amount": "10836.25",
+        "direction": "OUT",
+        "balance_after": "30027.91"
+      },
+      {
+        "date": "2024-03-18",
+        "description": "CASH-BNA-SELF-RITAM DUTTA",
+        "amount": "745.26",
+        "direction": "IN",
+        "balance_after": "30773.17"
+      },
+      {
+        "date": "2024-03-18",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), METROPOLITAN BUILDERS",
+        "amount": "5003.83",
+        "direction": "IN",
+        "balance_after": "35777.0"
+      },
+      {
+        "date": "2024-03-19",
+        "description": "Chq Paid-MICR Inward Clearing-SOURAV CHATTERJEE-HDFC BANK LTD.",
+        "amount": "13018.88",
+        "direction": "OUT",
+        "balance_after": "22758.12"
+      },
+      {
+        "date": "2024-03-20",
+        "description": "Chq Paid-MICR Inward Clearing-TAPAS MUKHERJEE-HDFC BANK LTD.",
+        "amount": "10937.03",
+        "direction": "OUT",
+        "balance_after": "11821.09"
+      },
+      {
+        "date": "2024-03-20",
+        "description": "IMPS BRN SALARY TRF BY-PHARMACY PRODUCTS LTD",
+        "amount": "1873.07",
+        "direction": "IN",
+        "balance_after": "13694.16"
+      },
+      {
+        "date": "2024-03-21",
+        "description": "Chq Paid-MICR Inward Clearing-SOURAV GANGULY-HDFC BANK LTD.",
+        "amount": "2868.01",
+        "direction": "OUT",
+        "balance_after": "10826.15"
+      },
+      {
+        "date": "2024-03-21",
+        "description": "Cash Withdrawal-TAPAS BHATTACHARYA",
+        "amount": "147.31",
+        "direction": "OUT",
+        "balance_after": "10678.84"
+      },
+      {
+        "date": "2024-03-22",
+        "description": "NEFT Cr-998034591743-ICIC0SF0002-PERSONAL CARE LTD--",
+        "amount": "3664.61",
+        "direction": "IN",
+        "balance_after": "14343.45"
+      },
+      {
+        "date": "2024-03-22",
+        "description": "UPI/CR/341412834258/SONALI CHATTERJEE/SENT-TRANSFER FROM 8444366180",
+        "amount": "585.87",
+        "direction": "IN",
+        "balance_after": "14929.32"
+      },
+      {
+        "date": "2024-03-23",
+        "description": "Chq Paid-MICR Inward Clearing-SUJIT SEN-HDFC BANK LTD.",
+        "amount": "6836.9",
+        "direction": "OUT",
+        "balance_after": "8092.42"
+      },
+      {
+        "date": "2024-03-26",
+        "description": "NEFT Cr-754481424204-ICIC0SF0002-TEXTILE SOLUTIONS INDIA--",
+        "amount": "775.81",
+        "direction": "IN",
+        "balance_after": "8868.23"
+      },
+      {
+        "date": "2024-03-26",
+        "description": "NEFT Cr-818376489476-ICIC0SF0002-RESIDENTIAL PROJECTS LTD--",
+        "amount": "3255.94",
+        "direction": "IN",
+        "balance_after": "12124.17"
+      },
+      {
+        "date": "2024-03-26",
+        "description": "NEFT Dr-639820282851-HDFC0009038-ARIJIT CHATTERJEE",
+        "amount": "885.56",
+        "direction": "OUT",
+        "balance_after": "11238.61"
+      },
+      {
+        "date": "2024-03-27",
+        "description": "NEFT Cr-633101275754-ICIC0SF0002-FASHION TEXTILES LTD--",
+        "amount": "4367.43",
+        "direction": "IN",
+        "balance_after": "15606.04"
+      },
+      {
+        "date": "2024-03-27",
+        "description": "IMPS BRN SALARY TRF BY-RESIDENTIAL PROJECTS LTD",
+        "amount": "365.78",
+        "direction": "IN",
+        "balance_after": "15971.82"
+      },
+      {
+        "date": "2024-03-28",
+        "description": "By Clg:DEL ACCTS-CITI BANK N.A.(CIT), POWER SYSTEMS CORP",
+        "amount": "1134.45",
+        "direction": "IN",
+        "balance_after": "17106.27"
+      },
+      {
+        "date": "2024-03-28",
+        "description": "RTGS Cr-ICICR983555220673-ICIC0000011-COTTON MILLS CORP--/URGENT/",
+        "amount": "22753.12",
+        "direction": "IN",
+        "balance_after": "39859.39"
+      },
+      {
+        "date": "2024-03-28",
+        "description": "NEFT Cr-397197036503-ICIC0SF0002-INDUSTRIAL COMPONENTS INDIA--",
+        "amount": "16031.1",
+        "direction": "IN",
+        "balance_after": "55890.49"
+      },
+      {
+        "date": "2024-03-28",
+        "description": "Service Charges-NEFT/RTGS Charges",
+        "amount": "11.97",
+        "direction": "OUT",
+        "balance_after": "-6325.91"
+      },
+      {
+        "date": "2024-03-30",
+        "description": "NEFT Dr-107800254021-HDFC0009038-BIPLAB BANERJEE",
+        "amount": "21205.89",
+        "direction": "OUT",
+        "balance_after": "34684.6"
+      },
+      {
+        "date": "2024-03-30",
+        "description": "NEFT Dr-929459255429-HDFC0009038-SOURAV CHAKRABORTY",
+        "amount": "13771.73",
+        "direction": "OUT",
+        "balance_after": "20912.87"
+      },
+      {
+        "date": "2024-03-30",
+        "description": "UPI/CR/484432226569/ARIJIT CHOWDHURY/SENT-TRANSFER FROM 6174365174",
+        "amount": "748.95",
+        "direction": "IN",
+        "balance_after": "21661.82"
+      }
+    ]
+  }
+}

--- a/apps/backend/tests/fixtures/hf_oracle/India_Bank_Statement_Scanned_Type2__00001.json
+++ b/apps/backend/tests/fixtures/hf_oracle/India_Bank_Statement_Scanned_Type2__00001.json
@@ -1,0 +1,1149 @@
+{
+  "source": "India_Bank_Statement_Scanned_Type2/00001.pdf",
+  "model": "glm-4.6v",
+  "prompt": "Extract this bank-statement page as strict JSON only (no prose, no markdown fence): {opening_balance, closing_balance, transactions:[{date, description, amount, direction, balance_after}]}. amount = absolute value; direction = \"IN\" for credits / \"OUT\" for debits; balance_after = the running balance printed on that row. Omit opening_balance/closing_balance if not on this page.",
+  "synthetic": true,
+  "modality": "vision",
+  "pages": 6,
+  "raw_pages": [
+    "{\"opening_balance\": 1279072.17, \"closing_balance\": 110110.37, \"transactions\": [{\"date\": \"01/01/2024\", \"description\": \"RTGS-ICICR510742914335-Lakshmi Naidu\", \"amount\": 475617.41, \"direction\": \"OUT\", \"balance_after\": 803454.76}, {\"date\": \"02/01/2024\", \"description\": \"IMPS-212190484533-HEALTHCARE PRODUCTS LTD\", \"amount\": 101795.99, \"direction\": \"IN\", \"balance_after\": 905250.75}, {\"date\": \"02/01/2024\", \"description\": \"IMPS-597987779248-DATABRIDGE INFOTECH\", \"amount\": 60198.25, \"direction\": \"IN\", \"balance_after\": 965449.00}, {\"date\": \"02/01/2024\", \"description\": \"UPI/CR/586134526249/Priya Krishnan/6788808567@pay\", \"amount\": 46334.23, \"direction\": \"IN\", \"balance_after\": 1011783.23}, {\"date\": \"02/01/2024\", \"description\": \"UPI/DR/700203118416/Ramesh Reddy/7124029087@pay\", \"amount\": 9371.77, \"direction\": \"OUT\", \"balance_after\": 1002411.46}, {\"date\": \"04/01/2024\", \"description\": \"SERVICE CHARGES-Foreign Currency Markup\", \"amount\": 139.96, \"direction\": \"OUT\", \"balance_after\": 1002271.50}, {\"date\": \"04/01/2024\", \"description\": \"NEFT-403681166106-Ganesh Pillai\", \"amount\": 266844.11, \"direction\": \"OUT\", \"balance_after\": 735427.39}, {\"date\": \"05/01/2024\", \"description\": \"IMPS-414202795937-DAILY NEEDS LIMITED\", \"amount\": 125251.78, \"direction\": \"IN\", \"balance_after\": 860679.17}, {\"date\": \"05/01/2024\", \"description\": \"NEFT-524813805872-GST PAYMENT-GSTIN\", \"amount\": 81089.25, \"direction\": \"OUT\", \"balance_after\": 779589.92}, {\"date\": \"06/01/2024\", \"description\": \"NEFT-644951640158-DIGITAL SOLUTIONS INDIA\", \"amount\": 313988.86, \"direction\": \"IN\", \"balance_after\": 1093578.78}, {\"date\": \"06/01/2024\", \"description\": \"NEFT-727523724896-HEALTHPLUS PHARMA LTD\", \"amount\": 111752.00, \"direction\": \"IN\", \"balance_after\": 1205330.78}, {\"date\": \"06/01/2024\", \"description\": \"ATM WDL-84393\", \"amount\": 13657.59, \"direction\": \"OUT\", \"balance_after\": 1191673.19}, {\"date\": \"06/01/2024\", \"description\": \"IMPS-290319105487-HEALTHCARE PRODUCTS LTD\", \"amount\": 108535.03, \"direction\": \"IN\", \"balance_after\": 1300208.22}, {\"date\": \"08/01/2024\", \"description\": \"RTGS-ICICR419518253429-Venkatesh Rao\", \"amount\": 849452.05, \"direction\": \"OUT\", \"balance_after\": 450756.17}, {\"date\": \"08/01/2024\", \"description\": \"CHQ PAID-Subramaniam Rao-MICR\", \"amount\": 217613.90, \"direction\": \"OUT\", \"balance_after\": 233142.27}]}",
+    "{\"transactions\":[{\"date\":\"09/01/2024\",\"description\":\"NEFT-287837415387-PRECISION ENGINEERING WORKS\",\"amount\":104999.07,\"direction\":\"IN\",\"balance_after\":338141.34},{\"date\":\"10/01/2024\",\"description\":\"UPI/CR/725664555690/Srinivas Reddy/8497226062@pay\",\"amount\":1301.27,\"direction\":\"IN\",\"balance_after\":339442.61},{\"date\":\"10/01/2024\",\"description\":\"NEFT-618421866089-PERSONAL CARE LTD\",\"amount\":57376.44,\"direction\":\"IN\",\"balance_after\":396819.05},{\"date\":\"10/01/2024\",\"description\":\"CASH DEPOSIT-Srinivas Nair\",\"amount\":11484.19,\"direction\":\"IN\",\"balance_after\":408303.24},{\"date\":\"11/01/2024\",\"description\":\"SERVICE CHARGES-Cheque Book Charges\",\"amount\":333.31,\"direction\":\"OUT\",\"balance_after\":407969.93},{\"date\":\"11/01/2024\",\"description\":\"RTGS-ICICR297944257075-APEX HEAVY INDUSTRIES\",\"amount\":252626.61,\"direction\":\"IN\",\"balance_after\":660596.54},{\"date\":\"11/01/2024\",\"description\":\"IMPS-815957436362-DAILY NEEDS LIMITED\",\"amount\":94672.33,\"direction\":\"IN\",\"balance_after\":755268.87},{\"date\":\"12/01/2024\",\"description\":\"REVERSAL-RTGS-ICICR297944257075-A PEX HEAVY INDUSTRIES\",\"amount\":252626.61,\"direction\":\"OUT\",\"balance_after\":549436.79},{\"date\":\"13/01/2024\",\"description\":\"IMPS-569297862727-URBAN ESTATES INDIA\",\"amount\":97998.35,\"direction\":\"IN\",\"balance_after\":853267.22},{\"date\":\"13/01/2024\",\"description\":\"UPI/DR/338919637684/Anitha Nair/9635953174@pay\",\"amount\":24552.36,\"direction\":\"OUT\",\"balance_after\":828714.86},{\"date\":\"13/01/2024\",\"description\":\"IMPS-697830964902-Karthik Iyer\",\"amount\":62367.24,\"direction\":\"OUT\",\"balance_after\":766347.62},{\"date\":\"13/01/2024\",\"description\":\"IMPS-992983448493-Venkatesh Rao\",\"amount\":86410.98,\"direction\":\"OUT\",\"balance_after\":679936.64},{\"date\":\"15/01/2024\",\"description\":\"CHQ PAID-Srinivas Menon-MICR\",\"amount\":163924.72,\"direction\":\"OUT\",\"balance_after\":516011.92},{\"date\":\"16/01/2024\",\"description\":\"UPI/CR/612430383276/Subramaniam Krishnan/7232360624@pay\",\"amount\":23080.18,\"direction\":\"IN\",\"balance_after\":539092.1},{\"date\":\"16/01/2024\",\"description\":\"NEFT-889583341413-PRECISION ENGINEERING WORKS\",\"amount\":230424.72,\"direction\":\"IN\",\"balance_after\":769516.82},{\"date\":\"18/01/2024\",\"description\":\"NEFT-519719438810-Priya Menon\",\"amount\":201434.6,\"direction\":\"OUT\",\"balance_after\":568082.22},{\"date\":\"19/01/2024\",\"description\":\"UPI/DR/857223273927/Ganesh Pillai/7683434104@pay\",\"amount\":16841.22,\"direction\":\"OUT\",\"balance_after\":551241.0},{\"date\":\"19/01/2024\",\"description\":\"CHQ PAID-Venkatesh Pillai-MICR\",\"amount\":251230.73,\"direction\":\"OUT\",\"balance_after\":300010.27},{\"date\":\"19/01/2024\",\"description\":\"RTGS-ICICR182066605377-NETFORGE TECHNOLOGIES\",\"amount\":465711.54,\"direction\":\"IN\",\"balance_after\":765721.81},{\"date\":\"19/01/2024\",\"description\":\"UPI/DR/279751944022/Srinivas Murthy/7758605812@pay\",\"amount\":10024.28,\"direction\":\"OUT\",\"balance_after\":755697.53},{\"date\":\"19/01/2024\",\"description\":\"CASH DEPOSIT-Lakshmi Naidu\",\"amount\":8896.84,\"direction\":\"IN\",\"balance_after\":764594.37},{\"date\":\"20/01/2024\",\"description\":\"CHQ PAID-Subramaniam Nair-MICR\",\"amount\":172001.87,\"direction\":\"OUT\",\"balance_after\":592592.5},{\"date\":\"20/01/2024\",\"description\":\"NEFT Dr-894100359246-GST PAYMENT-GSTIN 28C8742\",\"amount\":119321.88,\"direction\":\"OUT\",\"balance_after\":430114.91},{\"date\":\"22/01/2024\",\"description\":\"CHQ PAID-Anitha Naidu-MICR\",\"amount\":164067.25,\"direction\":\"OUT\",\"balance_after\":428525.25},{\"date\":\"22/01/2024\",\"description\":\"CLG-FINANCE SOLUTIONS INDIA\",\"amount\":106531.19,\"direction\":\"IN\",\"balance_after\":535056.44},{\"date\":\"22/01/2024\",\"description\":\"IMPS-198513905699-THERMAL SYSTEMS LTD\",\"amount\":85227.86,\"direction\":\"IN\",\"balance_after\":620284.3},{\"date\":\"22/01/2024\",\"description\":\"IMPS-376925559056-Priya Naidu\",\"amount\":84875.78,\"direction\":\"OUT\",\"balance_after\":535408.52},{\"date\":\"23/01/2024\",\"description\":\"ATM WDL-78867\",\"amount\":10606.39,\"direction\":\"OUT\",\"balance_after\":524802.13},{\"date\":\"23/01/2024\",\"description\":\"UPI/CR/671379523877/Subramaniam Menon/7451082689@pay\",\"amount\":13462.86,\"direction\":\"IN\",\"balance_after\":538264.99},{\"date\":\"24/01/2024\",\"description\":\"ATM WDL-69028\",\"amount\":15351.04,\"direction\":\"OUT\",\"balance_after\":522913.95},{\"date\":\"25/01/2024\",\"description\":\"NEFT-856429560970-MEDCARE LABORATORIES\",\"amount\":192586.16,\"direction\":\"IN\",\"balance_after\":715500.11},{\"date\":\"29/01/2024\",\"description\":\"CASH DEPOSIT-Venkatesh Murthy\",\"amount\":32456.03,\"direction\":\"IN\",\"balance_after\":747956.14},{\"date\":\"29/01/2024\",\"description\":\"NEFT-384430462240-Subramaniam Rao\",\"amount\":209997.66,\"direction\":\"OUT\",\"balance_after\":537958.48},{\"date\":\"29/01/2024\",\"description\":\"UPI/CR/323017461830/Ramesh Reddy/8241426919@pay\",\"amount\":2899.67,\"direction\":\"IN\",\"balance_after\":540858.15}]}",
+    "{\"transactions\":[{\"date\":\"29/01/2024\",\"description\":\"ATM WDL-88835\",\"amount\":4336.12,\"direction\":\"OUT\",\"balance_after\":536522.03},{\"date\":\"30/01/2024\",\"description\":\"NEFT-378435985055-CARGO SOLUTIONS LTD\",\"amount\":82409.13,\"direction\":\"IN\",\"balance_after\":618931.16},{\"date\":\"30/01/2024\",\"description\":\"NEFT-704756068064-GATEWAY PROJECTS LTD\",\"amount\":89402.31,\"direction\":\"IN\",\"balance_after\":708333.47},{\"date\":\"31/01/2024\",\"description\":\"NEFT-514556788419-DAILY NEEDS LIMITED\",\"amount\":185770.02,\"direction\":\"IN\",\"balance_after\":894103.49},{\"date\":\"31/01/2024\",\"description\":\"CLG-LIFELINE PHARMACEUTICAL\",\"amount\":211854.07,\"direction\":\"IN\",\"balance_after\":1105957.56},{\"date\":\"01/02/2024\",\"description\":\"NEFT-442611102554-CYBERCRAFT SYSTEMS\",\"amount\":282784.18,\"direction\":\"IN\",\"balance_after\":1388741.74},{\"date\":\"02/02/2024\",\"description\":\"RTGS-ICICR923815251247-CONSTRUCTION SOLUTIONS LTD\",\"amount\":2038434.65,\"direction\":\"IN\",\"balance_after\":3427176.39},{\"date\":\"05/02/2024\",\"description\":\"CLG-GATEWAY PROJECTS LTD\",\"amount\":562315.15,\"direction\":\"IN\",\"balance_after\":3989491.54},{\"date\":\"05/02/2024\",\"description\":\"UPI/CR/319177823601/Subramaniam Murthy/8974815900@pay\",\"amount\":88371.45,\"direction\":\"IN\",\"balance_after\":4077862.99},{\"date\":\"06/02/2024\",\"description\":\"ATM WDL-33865\",\"amount\":4246.28,\"direction\":\"OUT\",\"balance_after\":4073616.71},{\"date\":\"07/02/2024\",\"description\":\"NEFT-644348138246-Lakshmi Reddy\",\"amount\":279052.83,\"direction\":\"OUT\",\"balance_after\":3794563.88},{\"date\":\"07/02/2024\",\"description\":\"NEFT-686611365349-Karthik Naidu\",\"amount\":367866.95,\"direction\":\"OUT\",\"balance_after\":3426969.93},{\"date\":\"08/02/2024\",\"description\":\"IMPS-915898137500-Ramesh Iyer\",\"amount\":408515.58,\"direction\":\"OUT\",\"balance_after\":3018181.35},{\"date\":\"08/02/2024\",\"description\":\"IMPS-483565397419-CAPITAL VENTURES INDIA\",\"amount\":94704.24,\"direction\":\"IN\",\"balance_after\":3112885.59},{\"date\":\"08/02/2024\",\"description\":\"FAILED-INSUFFICIENT FUNDS-CASH WITHDRAWAL-Karthik Menon\",\"amount\":0,\"direction\":\"OUT\",\"balance_after\":3112885.59},{\"date\":\"08/02/2024\",\"description\":\"NEFT-269717509281-Subramaniam Naidu\",\"amount\":902370.06,\"direction\":\"OUT\",\"balance_after\":2210515.53},{\"date\":\"09/02/2024\",\"description\":\"CLG-NETPULSE SYSTEMS\",\"amount\":443328.71,\"direction\":\"IN\",\"balance_after\":2653844.24},{\"date\":\"10/02/2024\",\"description\":\"ATM WDL-24242\",\"amount\":10322.49,\"direction\":\"OUT\",\"balance_after\":2643521.75},{\"date\":\"10/02/2024\",\"description\":\"IMPS-573077013494-HEALTHCARE PRODUCTS LTD\",\"amount\":171184.22,\"direction\":\"IN\",\"balance_after\":2814705.97},{\"date\":\"10/02/2024\",\"description\":\"CLG-CONSUMER PRODUCTS INDIA\",\"amount\":164290.39,\"direction\":\"IN\",\"balance_after\":2978996.36},{\"date\":\"12/02/2024\",\"description\":\"CASH WITHDRAWAL-Ramesh Menon\",\"amount\":136618.45,\"direction\":\"OUT\",\"balance_after\":2842377.91},{\"date\":\"12/02/2024\",\"description\":\"NEFT-122697498898-Srinivas Nair\",\"amount\":724777.73,\"direction\":\"OUT\",\"balance_after\":2117600.18},{\"date\":\"12/02/2024\",\"description\":\"SERVICE CHARGES-Foreign Currency Markup\",\"amount\":142.09,\"direction\":\"OUT\",\"balance_after\":2117458.09},{\"date\":\"13/02/2024\",\"description\":\"UPI/CR/614495410263/Venkatesh Reddy/7054374447@pay\",\"amount\":16601.42,\"direction\":\"IN\",\"balance_after\":2134059.51},{\"date\":\"13/02/2024\",\"description\":\"CLG-PRECISION ENGINEERING WORKS\",\"amount\":273267.77,\"direction\":\"IN\",\"balance_after\":2407327.28},{\"date\":\"14/02/2024\",\"description\":\"UPI/CR/486813495244/Venkatesh Reddy/8072645452@pay\",\"amount\":74802.82,\"direction\":\"IN\",\"balance_after\":2482130.1},{\"date\":\"14/02/2024\",\"description\":\"CHQ PAID-Ganesh Murthy-MICR\",\"amount\":218474.18,\"direction\":\"OUT\",\"balance_after\":2263655.92},{\"date\":\"15/02/2024\",\"description\":\"CHQ PAID-Subramaniam Reddy-MICR\",\"amount\":924596.53,\"direction\":\"OUT\",\"balance_after\":1339059.39},{\"date\":\"15/02/2024\",\"description\":\"IMPS-358436224492-CYBERCRAFT SYSTEMS\",\"amount\":30226.83,\"direction\":\"IN\",\"balance_after\":1369286.22},{\"date\":\"16/02/2024\",\"description\":\"CLG-URBAN CONSTRUCTIONS\",\"amount\":323842.44,\"direction\":\"IN\",\"balance_after\":1693128.66},{\"date\":\"16/02/2024\",\"description\":\"UPI/DR/357054274902/Venkatesh Reddy/9510290650@pay\",\"amount\":6789.58,\"direction\":\"OUT\",\"balance_after\":1686339.08},{\"date\":\"16/02/2024\",\"description\":\"NEFT-103474729499-Subramaniam Menon\",\"amount\":657104.35,\"direction\":\"OUT\",\"balance_after\":1029234.73},{\"date\":\"17/02/2024\",\"description\":\"UPI/CR/753016976960/Ganesh Pillai/6800851015@pay\",\"amount\":23158.94,\"direction\":\"IN\",\"balance_after\":1052393.67},{\"date\":\"19/02/2024\",\"description\":\"CASH DEPOSIT-Ramesh Rao\",\"amount\":84290.99,\"direction\":\"IN\",\"balance_after\":1136684.66},{\"date\":\"19/02/2024\",\"description\":\"IMPS-660367155471-CODEBASE SOLUTIONS\",\"amount\":163939.15,\"direction\":\"IN\",\"balance_after\":1300623.81}]}",
+    "{\"transactions\":[{\"date\":\"20/02/2024\",\"description\":\"NEFT-666763858122-DIGITAL SOLUTIONS INDIA\",\"amount\":456429.85,\"direction\":\"IN\",\"balance_after\":1757053.66},{\"date\":\"20/02/2024\",\"description\":\"CASH WITHDRAWAL-Karthik Nair\",\"amount\":82556.53,\"direction\":\"OUT\",\"balance_after\":1674497.13},{\"date\":\"20/02/2024\",\"description\":\"NEFT Dr-771669702522-GST PAYMENT-GSTIN 76A7387\",\"amount\":170450.39,\"direction\":\"OUT\",\"balance_after\":259664.52},{\"date\":\"21/02/2024\",\"description\":\"ATM WDL-27889\",\"amount\":14051.51,\"direction\":\"OUT\",\"balance_after\":1660445.62},{\"date\":\"21/02/2024\",\"description\":\"RTGS-ICICR315191603794-CONSTRUCTI ON SOLUTIONS LTD\",\"amount\":1447999.43,\"direction\":\"IN\",\"balance_after\":3108445.05},{\"date\":\"22/02/2024\",\"description\":\"IMPS-920714945814-CARGO SOLUTIONS LTD\",\"amount\":435369.14,\"direction\":\"IN\",\"balance_after\":3543814.19},{\"date\":\"24/02/2024\",\"description\":\"NEFT-782537817783-LIFELINE PHARMACEUTICAL\",\"amount\":287912.27,\"direction\":\"IN\",\"balance_after\":3831726.46},{\"date\":\"24/02/2024\",\"description\":\"CLG-DIGITAL SOLUTIONS INDIA\",\"amount\":992992.44,\"direction\":\"IN\",\"balance_after\":4824718.90},{\"date\":\"24/02/2024\",\"description\":\"ATM WDL-29978\",\"amount\":8041.84,\"direction\":\"OUT\",\"balance_after\":4816677.06},{\"date\":\"26/02/2024\",\"description\":\"IMPS-941817641209-FOOD INDUSTRIES CORP\",\"amount\":252924.01,\"direction\":\"IN\",\"balance_after\":5069601.07},{\"date\":\"26/02/2024\",\"description\":\"RTGS-ICICR488557855256-Karthik Menon\",\"amount\":1328679.63,\"direction\":\"OUT\",\"balance_after\":3740921.44},{\"date\":\"26/02/2024\",\"description\":\"NEFT-143632038001-Ganesh Pillai\",\"amount\":237872.29,\"direction\":\"OUT\",\"balance_after\":3503049.15},{\"date\":\"27/02/2024\",\"description\":\"NEFT-873415776261-PREMIUM INFRASTRUCTURE\",\"amount\":1059971.57,\"direction\":\"IN\",\"balance_after\":4563020.72},{\"date\":\"28/02/2024\",\"description\":\"UPI/CR/867703494263/Srinivas Iyer/7352098555@pay\",\"amount\":225484.01,\"direction\":\"IN\",\"balance_after\":4788504.73},{\"date\":\"28/02/2024\",\"description\":\"NEFT-559266103550-Kavitha Rao\",\"amount\":1538995.13,\"direction\":\"OUT\",\"balance_after\":3249509.60},{\"date\":\"28/02/2024\",\"description\":\"NEFT-541542497892-GST PAYMENT-GSTIN\",\"amount\":351150.76,\"direction\":\"OUT\",\"balance_after\":2898358.84},{\"date\":\"28/02/2024\",\"description\":\"Service Charges-Online Banking Charges\",\"amount\":159.60,\"direction\":\"OUT\",\"balance_after\":259430.12},{\"date\":\"28/02/2024\",\"description\":\"Service Charges-SMS Alert Charges\",\"amount\":74.80,\"direction\":\"OUT\",\"balance_after\":259589.72},{\"date\":\"28/02/2024\",\"description\":\"Service Charges-Demat Account AMC\",\"amount\":374.21,\"direction\":\"OUT\",\"balance_after\":259055.91},{\"date\":\"29/02/2024\",\"description\":\"IMPS-169315319731-CREDIT SERVICES LTD\",\"amount\":73863.21,\"direction\":\"IN\",\"balance_after\":2972222.05},{\"date\":\"29/02/2024\",\"description\":\"IMPS-662944833911-CONSTRUCTION SOLUTIONS LTD\",\"amount\":430157.81,\"direction\":\"IN\",\"balance_after\":3402379.86},{\"date\":\"29/02/2024\",\"description\":\"CLG-CAPITAL VENTURES INDIA\",\"amount\":942328.27,\"direction\":\"IN\",\"balance_after\":4344708.13},{\"date\":\"01/03/2024\",\"description\":\"ATM WDL-35072\",\"amount\":18486.39,\"direction\":\"OUT\",\"balance_after\":4326221.74},{\"date\":\"02/03/2024\",\"description\":\"NEFT-622296553551-FASHION TEXTILES LTD\",\"amount\":574203.65,\"direction\":\"IN\",\"balance_after\":4900425.39},{\"date\":\"02/03/2024\",\"description\":\"CASH WITHDRAWAL-Ramesh Pillai\",\"amount\":235387.97,\"direction\":\"OUT\",\"balance_after\":4665037.42},{\"date\":\"02/03/2024\",\"description\":\"NEFT-744561237829-GST PAYMENT-GSTIN\",\"amount\":447177.84,\"direction\":\"OUT\",\"balance_after\":4217859.58},{\"date\":\"02/03/2024\",\"description\":\"ATM WDL-73339\",\"amount\":10619.65,\"direction\":\"OUT\",\"balance_after\":4207239.93},{\"date\":\"04/03/2024\",\"description\":\"REVERSAL-IMPS-169315319731-CREDIT SERVICES LTD\",\"amount\":73863.21,\"direction\":\"OUT\",\"balance_after\":802063.40},{\"date\":\"04/03/2024\",\"description\":\"ATM WDL-46274\",\"amount\":6849.91,\"direction\":\"OUT\",\"balance_after\":4200390.02},{\"date\":\"04/03/2024\",\"description\":\"IMPS-329944215729-HOUSING DEVELOPERS CORP\",\"amount\":553635.66,\"direction\":\"IN\",\"balance_after\":4754025.68},{\"date\":\"05/03/2024\",\"description\":\"NEFT-622432549701-Subramaniam Naidu\",\"amount\":453510.13,\"direction\":\"OUT\",\"balance_after\":4300515.55},{\"date\":\"05/03/2024\",\"description\":\"IMPS-634649383399-WELLNESS BRANDS INDIA\",\"amount\":632004.20,\"direction\":\"IN\",\"balance_after\":4932519.75},{\"date\":\"05/03/2024\",\"description\":\"ATM WDL-28536\",\"amount\":17977.69,\"direction\":\"OUT\",\"balance_after\":4914542.06},{\"date\":\"05/03/2024\",\"description\":\"NEFT-524687515636-Lakshmi Naidu\",\"amount\":1931369.10,\"direction\":\"OUT\",\"balance_after\":2983172.96},{\"date\":\"05/03/2024\",\"description\":\"CHQ PAID-Venkatesh Menon-MICR\",\"amount\":1122810.81,\"direction\":\"OUT\",\"balance_after\":1860362.15}]}",
+    "{\"transactions\":[{\"date\":\"06/03/2024\",\"description\":\"NEFT-817429369883-FASHION TEXTILES LTD\",\"amount\":598741.62,\"direction\":\"IN\",\"balance_after\":2459103.77},{\"date\":\"06/03/2024\",\"description\":\"NEFT-959233854874-URBAN CONSTRUCTIONS\",\"amount\":188619.16,\"direction\":\"IN\",\"balance_after\":2647722.93},{\"date\":\"06/03/2024\",\"description\":\"NEFT-568955747384-Venkatesh Nair\",\"amount\":434962.1,\"direction\":\"OUT\",\"balance_after\":2212760.83},{\"date\":\"07/03/2024\",\"description\":\"NEFT-140033896962-Ganesh Rao\",\"amount\":489299.24,\"direction\":\"OUT\",\"balance_after\":1723461.59},{\"date\":\"09/03/2024\",\"description\":\"NEFT-719460649751-APEX HEAVY INDUSTRIES\",\"amount\":474006.27,\"direction\":\"IN\",\"balance_after\":2197467.86},{\"date\":\"11/03/2024\",\"description\":\"NEFT-900078848401-Subramaniam Menon\",\"amount\":598865.76,\"direction\":\"OUT\",\"balance_after\":1598602.1},{\"date\":\"11/03/2024\",\"description\":\"IMPS-517854169377-APEX HEAVY INDUSTRIES\",\"amount\":131448.68,\"direction\":\"IN\",\"balance_after\":1730050.78},{\"date\":\"12/03/2024\",\"description\":\"RTGS-ICICR908705654981-FASHION TEXTILES LTD\",\"amount\":3105234.88,\"direction\":\"IN\",\"balance_after\":4835285.66},{\"date\":\"12/03/2024\",\"description\":\"RTGS-ICICR803745188189-Venkatesh Naidu\",\"amount\":1701379.66,\"direction\":\"OUT\",\"balance_after\":3133906.0},{\"date\":\"13/03/2024\",\"description\":\"ATM WDL-83870\",\"amount\":14637.19,\"direction\":\"OUT\",\"balance_after\":3119268.81},{\"date\":\"13/03/2024\",\"description\":\"SERVICE CHARGES-SMS Alert Charges\",\"amount\":291.19,\"direction\":\"OUT\",\"balance_after\":3118977.62},{\"date\":\"13/03/2024\",\"description\":\"RTGS-ICICR539516527079-EXPRESS LOGISTICS INDIA\",\"amount\":4045927.09,\"direction\":\"IN\",\"balance_after\":7164904.71},{\"date\":\"13/03/2024\",\"description\":\"CLG-REALTY VENTURES LTD\",\"amount\":420527.16,\"direction\":\"IN\",\"balance_after\":7585431.87},{\"date\":\"14/03/2024\",\"description\":\"NEFT-628242640309-Anitha Reddy\",\"amount\":2194293.83,\"direction\":\"OUT\",\"balance_after\":5391138.04},{\"date\":\"14/03/2024\",\"description\":\"NEFT-321947659087-FABRIC INDUSTRIES INDIA\",\"amount\":2049286.83,\"direction\":\"IN\",\"balance_after\":7440424.87},{\"date\":\"15/03/2024\",\"description\":\"NEFT-829567684854-DATABRIDGE INFOTECH\",\"amount\":3667970.18,\"direction\":\"IN\",\"balance_after\":11108395.05},{\"date\":\"15/03/2024\",\"description\":\"CASH WITHDRAWAL-Ganesh Pillai\",\"amount\":177643.99,\"direction\":\"OUT\",\"balance_after\":10930751.06},{\"date\":\"16/03/2024\",\"description\":\"ATM WDL-20035\",\"amount\":9151.54,\"direction\":\"OUT\",\"balance_after\":10921599.52},{\"date\":\"16/03/2024\",\"description\":\"CASH WITHDRAWAL-Karthik Rao\",\"amount\":169960.47,\"direction\":\"OUT\",\"balance_after\":10751639.05},{\"date\":\"18/03/2024\",\"description\":\"CHQ PAID-Venkatesh Krishnan-MICR\",\"amount\":731999.84,\"direction\":\"OUT\",\"balance_after\":10019639.21},{\"date\":\"20/03/2024\",\"description\":\"RTGS-ICICR644959518406-Srinivas Krishnan\",\"amount\":2136377.76,\"direction\":\"OUT\",\"balance_after\":7883261.45},{\"date\":\"20/03/2024\",\"description\":\"CHQ PAID-Karthik Reddy-MICR\",\"amount\":2064242.22,\"direction\":\"OUT\",\"balance_after\":5819019.23},{\"date\":\"20/03/2024\",\"description\":\"NEFT Dr-424861610036-GST PAYMENT-GSTIN 54B9990\",\"amount\":148805.74,\"direction\":\"OUT\",\"balance_after\":110250.17},{\"date\":\"20/03/2024\",\"description\":\"CHQ PAID-Anitha Menon-MICR\",\"amount\":968184.51,\"direction\":\"OUT\",\"balance_after\":4850834.72},{\"date\":\"21/03/2024\",\"description\":\"CASH WITHDRAWAL-Kavitha Rao\",\"amount\":100799.67,\"direction\":\"OUT\",\"balance_after\":4750035.05},{\"date\":\"22/03/2024\",\"description\":\"IMPS-575296122794-Ramesh Nair\",\"amount\":332737.59,\"direction\":\"OUT\",\"balance_after\":4417297.46},{\"date\":\"23/03/2024\",\"description\":\"CLG-URBAN CONSTRUCTIONS\",\"amount\":1213013.24,\"direction\":\"IN\",\"balance_after\":5630310.7},{\"date\":\"23/03/2024\",\"description\":\"RTGS-ICICR740133104054-Karthik Murthy\",\"amount\":4286494.5,\"direction\":\"OUT\",\"balance_after\":1343816.2},{\"date\":\"26/03/2024\",\"description\":\"NEFT-457658204692-REALTY VENTURES LTD\",\"amount\":635006.27,\"direction\":\"IN\",\"balance_after\":1978822.47},{\"date\":\"26/03/2024\",\"description\":\"NEFT-638268505310-CODEBASE SOLUTIONS\",\"amount\":912366.57,\"direction\":\"IN\",\"balance_after\":2891189.04},{\"date\":\"26/03/2024\",\"description\":\"ATM WDL-19152\",\"amount\":10873.96,\"direction\":\"OUT\",\"balance_after\":2880315.08},{\"date\":\"27/03/2024\",\"description\":\"SERVICE CHARGES-Demat Account AMC\",\"amount\":68.61,\"direction\":\"OUT\",\"balance_after\":2880246.47},{\"date\":\"27/03/2024\",\"description\":\"RTGS-ICICR450592146984-Subramaniam Murthy\",\"amount\":1679704.76,\"direction\":\"OUT\",\"balance_after\":1200541.71},{\"date\":\"27/03/2024\",\"description\":\"IMPS-435521586165-CREDIT SERVICES LTD\",\"amount\":20923.38,\"direction\":\"IN\",\"balance_after\":1221465.09},{\"date\":\"28/03/2024\",\"description\":\"ATM WDL-54345\",\"amount\":12542.36,\"direction\":\"OUT\",\"balance_after\":1208922.73}]}",
+    "{\"transactions\":[{\"date\":\"28/03/2024\",\"description\":\"Dividend Cr-INVESTMENT SERVICES INDIA-EQUITY SHARES\",\"amount\":12062.90,\"direction\":\"IN\",\"balance_after\":1220985.63},{\"date\":\"28/03/2024\",\"description\":\"SERVICE CHARGES-SMS Alert Charges\",\"amount\":150.79,\"direction\":\"OUT\",\"balance_after\":1220834.84},{\"date\":\"28/03/2024\",\"description\":\"CLG-MOTOR INDUSTRIES LTD\",\"amount\":278543.39,\"direction\":\"IN\",\"balance_after\":1499378.23},{\"date\":\"28/03/2024\",\"description\":\"CHQ PAID-Anitha Krishnan-MICR\",\"amount\":623451.62,\"direction\":\"OUT\",\"balance_after\":875926.61},{\"date\":\"28/03/2024\",\"description\":\"Service Charges-Demat Account AMC\",\"amount\":582.41,\"direction\":\"OUT\",\"balance_after\":109527.96},{\"date\":\"28/03/2024\",\"description\":\"Service Charges-Online Banking Charges\",\"amount\":233.88,\"direction\":\"OUT\",\"balance_after\":109294.08},{\"date\":\"28/03/2024\",\"description\":\"Service Charges-Statement Charges\",\"amount\":139.80,\"direction\":\"OUT\",\"balance_after\":110110.37}]}"
+  ],
+  "truth": {
+    "opening_balance": "1279072.17",
+    "closing_balance": "110110.37",
+    "transactions": [
+      {
+        "date": "01/01/2024",
+        "description": "RTGS-ICICR510742914335-Lakshmi Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/01/2024",
+        "description": "IMPS-212190484533-HEALTHCARE PRODUCTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/01/2024",
+        "description": "IMPS-597987779248-DATABRIDGE INFOTECH",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/01/2024",
+        "description": "UPI/CR/586134526249/Priya Krishnan/6788808567@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/01/2024",
+        "description": "UPI/DR/700203118416/Ramesh Reddy/7124029087@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/01/2024",
+        "description": "SERVICE CHARGES-Foreign Currency Markup",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/01/2024",
+        "description": "NEFT-403681166106-Ganesh Pillai",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/01/2024",
+        "description": "IMPS-414202795937-DAILY NEEDS LIMITED",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/01/2024",
+        "description": "NEFT-524813805872-GST PAYMENT-GSTIN",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/01/2024",
+        "description": "NEFT-644951640158-DIGITAL SOLUTIONS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/01/2024",
+        "description": "NEFT-727523724896-HEALTHPLUS PHARMA LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/01/2024",
+        "description": "ATM WDL-84393",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/01/2024",
+        "description": "IMPS-290319105487-HEALTHCARE PRODUCTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/01/2024",
+        "description": "RTGS-ICICR419518253429-Venkatesh Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/01/2024",
+        "description": "CHQ PAID-Subramaniam Rao-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "09/01/2024",
+        "description": "NEFT-287837415387-PRECISION ENGINEERING WORKS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/01/2024",
+        "description": "UPI/CR/725664555690/Srinivas Reddy/8497226062@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/01/2024",
+        "description": "NEFT-618421866089-PERSONAL CARE LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/01/2024",
+        "description": "CASH DEPOSIT-Srinivas Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/01/2024",
+        "description": "SERVICE CHARGES-Cheque Book Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/01/2024",
+        "description": "RTGS-ICICR297944257075-APEX HEAVY INDUSTRIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/01/2024",
+        "description": "IMPS-815957436362-DAILY NEEDS LIMITED",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/01/2024",
+        "description": "REVERSAL-RTGS-ICICR297944257075-APEX HEAVY INDUSTRIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/01/2024",
+        "description": "IMPS-569297862727-URBAN ESTATES INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/01/2024",
+        "description": "UPI/DR/338919637684/Anitha Nair/9635953174@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/01/2024",
+        "description": "IMPS-697830964902-Karthik Iyer",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/01/2024",
+        "description": "IMPS-992983448493-Venkatesh Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/01/2024",
+        "description": "CHQ PAID-Srinivas Menon-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/01/2024",
+        "description": "UPI/CR/612430383276/Subramaniam Krishnan/7232360624@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/01/2024",
+        "description": "NEFT-889583341413-PRECISION ENGINEERING WORKS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "18/01/2024",
+        "description": "NEFT-519719438810-Priya Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "UPI/DR/857223273927/Ganesh Pillai/7683434104@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "CHQ PAID-Venkatesh Pillai-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "RTGS-ICICR182066605377-NETFORGE TECHNOLOGIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "UPI/DR/279751944022/Srinivas Murthy/7758605812@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/01/2024",
+        "description": "CASH DEPOSIT-Lakshmi Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/01/2024",
+        "description": "CHQ PAID-Subramaniam Nair-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/01/2024",
+        "description": "NEFT Dr-894100359246-GST PAYMENT-GSTIN 28C8742",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/01/2024",
+        "description": "CHQ PAID-Anitha Naidu-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/01/2024",
+        "description": "CLG-FINANCE SOLUTIONS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/01/2024",
+        "description": "IMPS-198513905699-THERMAL SYSTEMS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/01/2024",
+        "description": "IMPS-376925559056-Priya Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "23/01/2024",
+        "description": "ATM WDL-78867",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "23/01/2024",
+        "description": "UPI/CR/671379523877/Subramaniam Menon/7451082689@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "24/01/2024",
+        "description": "ATM WDL-69028",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "25/01/2024",
+        "description": "NEFT-856429560970-MEDCARE LABORATORIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/01/2024",
+        "description": "CASH DEPOSIT-Venkatesh Murthy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/01/2024",
+        "description": "NEFT-384430462240-Subramaniam Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/01/2024",
+        "description": "UPI/CR/323017461830/Ramesh Reddy/8241426919@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/01/2024",
+        "description": "ATM WDL-88835",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "30/01/2024",
+        "description": "NEFT-378435985055-CARGO SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "30/01/2024",
+        "description": "NEFT-704756068064-GATEWAY PROJECTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "31/01/2024",
+        "description": "NEFT-514556788419-DAILY NEEDS LIMITED",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "31/01/2024",
+        "description": "CLG-LIFELINE PHARMACEUTICAL",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "01/02/2024",
+        "description": "NEFT-442611102554-CYBERCRAFT SYSTEMS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/02/2024",
+        "description": "RTGS-ICICR923815251247-CONSTRUCTION SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/02/2024",
+        "description": "CLG-GATEWAY PROJECTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/02/2024",
+        "description": "UPI/CR/319177823601/Subramaniam Murthy/8974815900@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/02/2024",
+        "description": "ATM WDL-33865",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "07/02/2024",
+        "description": "NEFT-644348138246-Lakshmi Reddy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "07/02/2024",
+        "description": "NEFT-686611365349-Karthik Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/02/2024",
+        "description": "IMPS-915898137500-Ramesh Iyer",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/02/2024",
+        "description": "IMPS-483565397419-CAPITAL VENTURES INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/02/2024",
+        "description": "FAILED-INSUFFICIENT FUNDS-CASH WITHDRAWAL-Karthik Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "08/02/2024",
+        "description": "NEFT-269717509281-Subramaniam Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "09/02/2024",
+        "description": "CLG-NETPULSE SYSTEMS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/02/2024",
+        "description": "ATM WDL-24242",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/02/2024",
+        "description": "IMPS-573077013494-HEALTHCARE PRODUCTS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "10/02/2024",
+        "description": "CLG-CONSUMER PRODUCTS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/02/2024",
+        "description": "CASH WITHDRAWAL-Ramesh Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/02/2024",
+        "description": "NEFT-122697498898-Srinivas Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/02/2024",
+        "description": "SERVICE CHARGES-Foreign Currency Markup",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/02/2024",
+        "description": "UPI/CR/614495410263/Venkatesh Reddy/7054374447@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/02/2024",
+        "description": "CLG-PRECISION ENGINEERING WORKS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "14/02/2024",
+        "description": "UPI/CR/486813495244/Venkatesh Reddy/8072645452@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "14/02/2024",
+        "description": "CHQ PAID-Ganesh Murthy-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/02/2024",
+        "description": "CHQ PAID-Subramaniam Reddy-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/02/2024",
+        "description": "IMPS-358436224492-CYBERCRAFT SYSTEMS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/02/2024",
+        "description": "CLG-URBAN CONSTRUCTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/02/2024",
+        "description": "UPI/DR/357054274902/Venkatesh Reddy/9510290650@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/02/2024",
+        "description": "NEFT-103474729499-Subramaniam Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "17/02/2024",
+        "description": "UPI/CR/753016976960/Ganesh Pillai/6800851015@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/02/2024",
+        "description": "CASH DEPOSIT-Ramesh Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "19/02/2024",
+        "description": "IMPS-660367155471-CODEBASE SOLUTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/02/2024",
+        "description": "NEFT-666763858122-DIGITAL SOLUTIONS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/02/2024",
+        "description": "CASH WITHDRAWAL-Karthik Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/02/2024",
+        "description": "NEFT Dr-771669702522-GST PAYMENT-GSTIN 76A7387",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "21/02/2024",
+        "description": "ATM WDL-27889",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "21/02/2024",
+        "description": "RTGS-ICICR315191603794-CONSTRUCTION SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/02/2024",
+        "description": "IMPS-920714945814-CARGO SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "24/02/2024",
+        "description": "NEFT-782537817783-LIFELINE PHARMACEUTICAL",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "24/02/2024",
+        "description": "CLG-DIGITAL SOLUTIONS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "24/02/2024",
+        "description": "ATM WDL-29978",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/02/2024",
+        "description": "IMPS-941817641209-FOOD INDUSTRIES CORP",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/02/2024",
+        "description": "RTGS-ICICR488557855256-Karthik Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/02/2024",
+        "description": "NEFT-143632038001-Ganesh Pillai",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "27/02/2024",
+        "description": "NEFT-873415776261-PREMIUM INFRASTRUCTURE",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "UPI/CR/867703494263/Srinivas Iyer/7352098555@pay",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "NEFT-559266103550-Kavitha Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "NEFT-541542497892-GST PAYMENT-GSTIN",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "Service Charges-Online Banking Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "Service Charges-SMS Alert Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/02/2024",
+        "description": "Service Charges-Demat Account AMC",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/02/2024",
+        "description": "IMPS-169315319731-CREDIT SERVICES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/02/2024",
+        "description": "IMPS-662944833911-CONSTRUCTION SOLUTIONS LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "29/02/2024",
+        "description": "CLG-CAPITAL VENTURES INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "01/03/2024",
+        "description": "ATM WDL-35072",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/03/2024",
+        "description": "NEFT-622296553551-FASHION TEXTILES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/03/2024",
+        "description": "CASH WITHDRAWAL-Ramesh Pillai",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/03/2024",
+        "description": "NEFT-744561237829-GST PAYMENT-GSTIN",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "02/03/2024",
+        "description": "ATM WDL-73339",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/03/2024",
+        "description": "REVERSAL-IMPS-169315319731-CREDIT SERVICES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/03/2024",
+        "description": "ATM WDL-46274",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "04/03/2024",
+        "description": "IMPS-329944215729-HOUSING DEVELOPERS CORP",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "NEFT-622432549701-Subramaniam Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "IMPS-634649383399-WELLNESS BRANDS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "ATM WDL-28536",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "NEFT-524687515636-Lakshmi Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "05/03/2024",
+        "description": "CHQ PAID-Venkatesh Menon-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/03/2024",
+        "description": "NEFT-817429369883-FASHION TEXTILES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/03/2024",
+        "description": "NEFT-959233854874-URBAN CONSTRUCTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "06/03/2024",
+        "description": "NEFT-568955747384-Venkatesh Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "07/03/2024",
+        "description": "NEFT-140033896962-Ganesh Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "09/03/2024",
+        "description": "NEFT-719460649751-APEX HEAVY INDUSTRIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/03/2024",
+        "description": "NEFT-900078848401-Subramaniam Menon",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "11/03/2024",
+        "description": "IMPS-517854169377-APEX HEAVY INDUSTRIES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/03/2024",
+        "description": "RTGS-ICICR908705654981-FASHION TEXTILES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "12/03/2024",
+        "description": "RTGS-ICICR803745188189-Venkatesh Naidu",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/03/2024",
+        "description": "ATM WDL-83870",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/03/2024",
+        "description": "SERVICE CHARGES-SMS Alert Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/03/2024",
+        "description": "RTGS-ICICR539516527079-EXPRESS LOGISTICS INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "13/03/2024",
+        "description": "CLG-REALTY VENTURES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "14/03/2024",
+        "description": "NEFT-628242640309-Anitha Reddy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "14/03/2024",
+        "description": "NEFT-321947659087-FABRIC INDUSTRIES INDIA",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/03/2024",
+        "description": "NEFT-829567684854-DATABRIDGE INFOTECH",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "15/03/2024",
+        "description": "CASH WITHDRAWAL-Ganesh Pillai",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/03/2024",
+        "description": "ATM WDL-20035",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "16/03/2024",
+        "description": "CASH WITHDRAWAL-Karthik Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "18/03/2024",
+        "description": "CHQ PAID-Venkatesh Krishnan-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/03/2024",
+        "description": "RTGS-ICICR644959518406-Srinivas Krishnan",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/03/2024",
+        "description": "CHQ PAID-Karthik Reddy-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/03/2024",
+        "description": "NEFT Dr-424861610036-GST PAYMENT-GSTIN 54B9990",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "20/03/2024",
+        "description": "CHQ PAID-Anitha Menon-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "21/03/2024",
+        "description": "CASH WITHDRAWAL-Kavitha Rao",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "22/03/2024",
+        "description": "IMPS-575296122794-Ramesh Nair",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "23/03/2024",
+        "description": "CLG-URBAN CONSTRUCTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "23/03/2024",
+        "description": "RTGS-ICICR740133104054-Karthik Murthy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/03/2024",
+        "description": "NEFT-457658204692-REALTY VENTURES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/03/2024",
+        "description": "NEFT-638268505310-CODEBASE SOLUTIONS",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "26/03/2024",
+        "description": "ATM WDL-19152",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "27/03/2024",
+        "description": "SERVICE CHARGES-Demat Account AMC",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "27/03/2024",
+        "description": "RTGS-ICICR450592146984-Subramaniam Murthy",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "27/03/2024",
+        "description": "IMPS-435521586165-CREDIT SERVICES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "ATM WDL-54345",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "Dividend Cr-INVESTMENT SERVICES INDIA-EQUITY SHARES",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "SERVICE CHARGES-SMS Alert Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "CLG-MOTOR INDUSTRIES LTD",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "CHQ PAID-Anitha Krishnan-MICR",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "Service Charges-Demat Account AMC",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "Service Charges-Online Banking Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      },
+      {
+        "date": "28/03/2024",
+        "description": "Service Charges-Statement Charges",
+        "amount": "0",
+        "direction": "OUT",
+        "balance_after": null
+      }
+    ]
+  }
+}

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -30,6 +30,7 @@ These files are test infrastructure, not behavior proof.
 | `apps/backend/tests/reconciliation/conftest.py` | EPIC-011 PR-B Layer-2 read bridge fixture |
 | `apps/backend/tests/e2e/conftest.py` | Shared E2E fixtures |
 | `apps/backend/tests/extraction/__init__.py` | Package marker |
+| `apps/backend/tests/extraction/hf_oracle_codec.py` | HF accuracy-oracle code layer (parse/normalise/merge/validate support; reuses production validators) |
 | `apps/backend/tests/factories.py` | Shared backend test factories |
 | `apps/backend/tests/infra/__init__.py` | Package marker |
 | `apps/backend/tests/locustfile.py` | Load-test harness, not AC proof |
@@ -61,6 +62,7 @@ explicit AC IDs for the behavior.
 | `apps/backend/tests/auth/test_auth_router_unit.py` | `docs/ssot/auth.md` |
 | `apps/backend/tests/extraction/test_account_last4_defense.py` | `docs/ssot/extraction.md` |
 | `apps/backend/tests/extraction/test_classification_service.py` | `docs/ssot/extraction.md` |
+| `apps/backend/tests/extraction/test_hf_oracle_codec.py` | `docs/ssot/cassette-graded-eval.md` |
 | `apps/backend/tests/extraction/test_extraction_cassette_replay.py` | `docs/ssot/llm.md` (EPIC-023 AC23.6 streaming-bridge scaffold; skipped via `needs_real_cassette` until real cassettes are recorded with `make llm-record`, then it becomes AC proof) |
 | `apps/backend/tests/extraction/test_dual_write_layer2.py` | `docs/ssot/extraction.md` |
 | `apps/backend/tests/extraction/test_extraction_logging.py` | `docs/ssot/extraction.md` |
@@ -138,6 +140,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_env_contract_boundary.py` | `docs/ssot/observability.md`, `docs/ssot/environments.md` |
 | `tests/tooling/test_generate_fixtures.py` | `docs/ssot/extraction.md` |
 | `tests/tooling/test_github_workflow_timing_summary.py` | `docs/ssot/ci-cd.md` |
+| `tests/tooling/test_hf_oracle_truth.py` | `docs/ssot/cassette-graded-eval.md` |
 | `tests/tooling/test_infra2_pin_is_release_tag.py` | `docs/ssot/deployment.md` |
 | `tests/tooling/test_merge_lcov.py` | `docs/ssot/coverage.md` |
 | `tests/tooling/test_preflight.py` | `docs/ssot/ci-cd.md` |

--- a/docs/ssot/cassette-graded-eval.md
+++ b/docs/ssot/cassette-graded-eval.md
@@ -72,6 +72,33 @@ dedup) — those stay the job of the deterministic downstream gates and a future
 benchmark. The **Scanned** cases carry the real accuracy signal; the Digital
 cases are clean renders (weak signal), kept only for modality coverage.
 
+### 2.2 Recorded HF dataset (separate from the balance-gated cassettes)
+
+The recorded HF data lives in its OWN dataset,
+`apps/backend/tests/fixtures/hf_oracle/*.json` — **not** the `llm_cassettes` dir —
+because real OCR has errors that do **not** satisfy the balance-chain invariant
+(`opening + Σ ≈ closing`, AC23.7); forcing them through that gate would reject the
+very imperfection an accuracy oracle exists to measure.
+
+**Axiom-D split — persist the LLM's RAW output; code guarantees the rest.** Each
+record holds only the model artifact: `{source, model, prompt, synthetic,
+modality, raw_pages, truth}`, where `raw_pages` is the **verbatim per-page model
+output** and `truth` is the independent HF label (production schema
+`{date, description, amount, direction, balance_after}`). Everything downstream —
+parse, normalise, merge pages, validate — is the deterministic CODE layer
+`apps/backend/tests/extraction/hf_oracle_codec.py`, which **reuses the production
+validators** (`validate_balance`, `detect_balance_chain_break`) so it exercises
+real code, and `field_score`/`self_checks` (incl. the running-balance chain: each
+row validates the previous). `test_hf_oracle_codec.py` replays the raw examples
+through the codec with **no key** (CI-safe); `test_hf_oracle_truth.py` gates the
+mapper.
+
+The recorder is `tools/_lib/pdf_fixtures/record_hf_oracle_raw.py` — per-page,
+parallel, non-streaming raw z.ai (the production streaming path is ~2× slower, the
+single all-pages call is output-token-bound, scanned pages need a render
+dimension cap, and the coding plan rate-limits hard). Source PDFs stay git-ignored
+under `tmp/input/hf_oracle/`; only the synthetic dataset is committed.
+
 ## 3. Scoring & normalisation
 
 A case score is the fraction of **scored fields** that match ground truth:

--- a/tests/tooling/test_hf_oracle_truth.py
+++ b/tests/tooling/test_hf_oracle_truth.py
@@ -15,15 +15,38 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "tools" / "_lib" / "pdf_fixtures"))
 
-from hf_oracle_truth import amount_direction, build_truth, label_to_expected, modality_for_dir  # noqa: E402
+from hf_oracle_truth import (  # noqa: E402
+    amount_direction,
+    build_truth,
+    label_to_expected,
+    modality_for_dir,
+)
 
 _HF = {
     "opening_balance": 100.0,
     "closing_balance": 130.0,
     "transactions": [
-        {"date": "2026-01-02 11:30:55", "description": " Coffee  shop ", "debit": 5.0, "credit": None, "balance": 95.0},
-        {"date": "2026-01-05 09:00:00", "description": "Salary", "debit": None, "credit": 50.0, "balance": 145.0},
-        {"date": "2026-01-09 18:00:00", "description": "Groceries", "debit": 15.0, "credit": None, "balance": 130.0},
+        {
+            "date": "2026-01-02 11:30:55",
+            "description": " Coffee  shop ",
+            "debit": 5.0,
+            "credit": None,
+            "balance": 95.0,
+        },
+        {
+            "date": "2026-01-05 09:00:00",
+            "description": "Salary",
+            "debit": None,
+            "credit": 50.0,
+            "balance": 145.0,
+        },
+        {
+            "date": "2026-01-09 18:00:00",
+            "description": "Groceries",
+            "debit": 15.0,
+            "credit": None,
+            "balance": 130.0,
+        },
     ],
 }
 
@@ -45,9 +68,13 @@ def test_label_to_expected_production_schema() -> None:
     assert Decimal(exp["opening_balance"]) == Decimal("100")
     first, second = exp["transactions"][0], exp["transactions"][1]
     assert first["date"] == "2026-01-02"  # datetime -> ISO date
-    assert Decimal(first["amount"]) == Decimal("5") and first["direction"] == "OUT"  # debit
+    assert (
+        Decimal(first["amount"]) == Decimal("5") and first["direction"] == "OUT"
+    )  # debit
     assert Decimal(first["balance_after"]) == Decimal("95")  # running balance preserved
-    assert Decimal(second["amount"]) == Decimal("50") and second["direction"] == "IN"  # credit
+    assert (
+        Decimal(second["amount"]) == Decimal("50") and second["direction"] == "IN"
+    )  # credit
 
 
 def test_build_truth_is_synthetic() -> None:

--- a/tests/tooling/test_hf_oracle_truth.py
+++ b/tests/tooling/test_hf_oracle_truth.py
@@ -1,8 +1,9 @@
-"""Tests for the HF extraction-oracle truth mapper (tools/_lib/pdf_fixtures).
+"""Tests for the HF oracle truth mapper (production transaction schema).
 
-Pure transform — no network, no LLM, no key. The decisive test feeds the mapper's
-output through the REAL graded-eval scorer to prove it is shape-compatible (a
-perfect extraction scores 1.0), so a recorded HF cassette can actually be graded.
+Pure transform — no LLM, no network. Asserts HF debit/credit -> amount+direction
+and that the running balance is preserved as `balance_after` (the field that
+powers the running-balance self-check). The chain-validity of the mapped truth is
+asserted in the backend codec test (it needs the production validators).
 """
 
 from __future__ import annotations
@@ -14,30 +15,24 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "tools" / "_lib" / "pdf_fixtures"))
 
-from hf_oracle_truth import (  # noqa: E402
-    build_truth,
-    label_to_expected,
-    modality_for_dir,
-    signed_amount,
-)
+from hf_oracle_truth import amount_direction, build_truth, label_to_expected, modality_for_dir  # noqa: E402
 
-# A minimal HF-shaped label (the dataset's per-statement schema): split
-# debit/credit columns, datetime strings, header balances.
-_HF_SAMPLE = {
+_HF = {
     "opening_balance": 100.0,
     "closing_balance": 130.0,
     "transactions": [
-        {"date": "2026-01-02 11:30:55", "description": " Coffee  shop ", "debit": 5.0, "credit": None},
-        {"date": "2026-01-05 09:00:00", "description": "Salary credit", "debit": None, "credit": 50.0},
-        {"date": "2026-01-09 18:00:00", "description": "Groceries", "debit": 15.0, "credit": None},
+        {"date": "2026-01-02 11:30:55", "description": " Coffee  shop ", "debit": 5.0, "credit": None, "balance": 95.0},
+        {"date": "2026-01-05 09:00:00", "description": "Salary", "debit": None, "credit": 50.0, "balance": 145.0},
+        {"date": "2026-01-09 18:00:00", "description": "Groceries", "debit": 15.0, "credit": None, "balance": 130.0},
     ],
 }
 
 
-def test_signed_amount_credit_positive_debit_negative() -> None:
-    assert Decimal(signed_amount({"credit": 50.0, "debit": None})) == Decimal("50")
-    assert Decimal(signed_amount({"credit": None, "debit": 5.0})) == Decimal("-5")
-    assert signed_amount({"credit": None, "debit": None}) == "0"
+def test_amount_direction_from_debit_credit() -> None:
+    amt, direction = amount_direction({"credit": 50.0, "debit": None})
+    assert Decimal(amt) == Decimal("50") and direction == "IN"
+    amt, direction = amount_direction({"credit": None, "debit": 5.0})
+    assert Decimal(amt) == Decimal("5") and direction == "OUT"
 
 
 def test_modality_from_layout() -> None:
@@ -45,27 +40,19 @@ def test_modality_from_layout() -> None:
     assert modality_for_dir("India_Bank_Statement_Digital_Type2") == "text"
 
 
-def test_label_to_expected_normalises_date_and_amount() -> None:
-    exp = label_to_expected(_HF_SAMPLE)
+def test_label_to_expected_production_schema() -> None:
+    exp = label_to_expected(_HF)
     assert Decimal(exp["opening_balance"]) == Decimal("100")
-    assert Decimal(exp["closing_balance"]) == Decimal("130")
-    first = exp["transactions"][0]
+    first, second = exp["transactions"][0], exp["transactions"][1]
     assert first["date"] == "2026-01-02"  # datetime -> ISO date
-    assert Decimal(first["amount"]) == Decimal("-5")  # debit -> negative
-    assert Decimal(exp["transactions"][1]["amount"]) == Decimal("50")  # credit -> positive
+    assert Decimal(first["amount"]) == Decimal("5") and first["direction"] == "OUT"  # debit
+    assert Decimal(first["balance_after"]) == Decimal("95")  # running balance preserved
+    assert Decimal(second["amount"]) == Decimal("50") and second["direction"] == "IN"  # credit
 
 
-def test_build_truth_is_synthetic_and_scorable_by_the_real_eval() -> None:
-    """The mapper output must be the exact shape the graded eval scores."""
-    truth = build_truth(_HF_SAMPLE, dirname="India_Bank_Statement_Scanned_Type1")
-    assert truth["synthetic"] is True  # AC23.8.6 hygiene flag
-    assert truth["modality"] == "vision"
-
-    sys.path.insert(0, str(ROOT))
-    from common.ssot.cassette_graded_eval import case_score
-
-    # A perfect extraction (== the truth) scores 1.0 — proves shape-compatibility
-    # with the scorer, and that a balance-failing field WOULD lower the score.
-    score, breakdown = case_score(truth["expected"], truth["expected"])
-    assert score == 1.0
-    assert breakdown["total"] > 0
+def test_build_truth_is_synthetic() -> None:
+    truth = build_truth(_HF, dirname="India_Bank_Statement_Scanned_Type1")
+    assert truth["synthetic"] is True and truth["modality"] == "vision"
+    assert {"date", "description", "amount", "direction", "balance_after"} <= set(
+        truth["expected"]["transactions"][0]
+    )

--- a/tools/_lib/pdf_fixtures/hf_oracle_truth.py
+++ b/tools/_lib/pdf_fixtures/hf_oracle_truth.py
@@ -1,25 +1,24 @@
 #!/usr/bin/env python
-"""Map a Hugging Face bank-statement label -> our graded-eval ground truth.
+"""Map a Hugging Face bank-statement label -> our PRODUCTION transaction schema.
 
-Pure transform (no LLM, no network). Turns the dataset's per-statement field
-label into the ``expected`` shape that ``common.ssot.cassette_graded_eval`` scores
-against (``docs/ssot/cassette-graded-eval.md`` §2). Used by ``record_hf_oracle.py``
-to write ``ground_truth/<fingerprint>.truth.json`` next to a freshly recorded
-cassette.
+Pure transform (no LLM, no network). The transaction schema mirrors what the
+extraction pipeline emits and what the deterministic validators consume
+(``validate_balance`` / ``detect_balance_chain_break`` in
+``apps/backend/src/services/validation.py``):
 
-Key choices:
-- **Signed amount.** The HF label splits ``debit`` / ``credit`` into two nullable
-  columns; our scored ``amount`` is a single signed Decimal-string (credit
-  positive, debit negative), matching the existing truth fixtures.
-- **No anonymisation.** This source is already synthetic (Apache-2.0, tagged
-  ``synthetic``; fabricated names/accounts), so there is no PII to strip — and the
-  scored fields (date / description / amount) MUST match the document the LLM
-  reads, so mangling them would make the case ungradeable. The desensitisation
-  policy applies to *real* statements (``tmp/input/*``), which have no label and
-  are consistency-only. ``synthetic: True`` is carried so the AC23.8.6 hygiene
-  gate stays satisfied.
-- **Modality from layout.** Scanned dirs -> ``vision`` (OCR of a degraded image,
-  the real accuracy signal); digital dirs -> ``text``.
+    transaction = {date, description, amount, direction, balance_after}
+    statement   = {opening_balance, closing_balance, transactions: [...]}
+
+- ``amount`` is the absolute magnitude (string, Decimal-safe); ``direction`` is
+  ``IN``/``OUT`` (the HF debit/credit columns), NOT a signed amount — that is the
+  shape ``normalize_amount_direction`` expects.
+- ``balance_after`` is the per-row RUNNING balance (HF ``balance``). It is the
+  field that powers the running-balance self-check (each row validates the
+  previous one): ``prev_balance + signed_amount == balance_after``. Dropping it
+  loses that confidence signal — so it is first-class here.
+
+No anonymisation: the source is synthetic (Apache-2.0, fabricated names), and the
+scored fields must match the document the LLM reads.
 """
 
 from __future__ import annotations
@@ -29,31 +28,32 @@ from typing import Any
 
 
 def _decimal_str(value: Any) -> str:
-    """Decimal-safe string (never float): ``59131.72`` / ``"5.00"`` -> canonical."""
     return str(Decimal(str(value)))
 
 
-def signed_amount(txn: dict[str, Any]) -> str:
-    """Single signed amount from the HF debit/credit columns (credit +, debit -)."""
+def amount_direction(txn: dict[str, Any]) -> tuple[str, str]:
+    """(absolute amount, IN/OUT) from the HF debit/credit columns."""
     credit, debit = txn.get("credit"), txn.get("debit")
     if credit not in (None, ""):
-        return _decimal_str(credit)
+        return _decimal_str(credit), "IN"
     if debit not in (None, ""):
-        return str(-Decimal(str(debit)))
-    return "0"
+        return _decimal_str(debit), "OUT"
+    return "0", "OUT"
 
 
 def label_to_expected(hf: dict[str, Any]) -> dict[str, Any]:
-    """HF statement label -> the scored ``expected`` block."""
-    transactions = [
-        {
-            # "2024-01-01 11:30:55" -> "2024-01-01"; the eval normalises ISO/slash.
-            "date": str(txn.get("date", "")).split(" ")[0],
+    """HF statement label -> the production-schema ``expected`` block."""
+    transactions = []
+    for txn in hf.get("transactions", []):
+        amount, direction = amount_direction(txn)
+        bal = txn.get("balance")
+        transactions.append({
+            "date": str(txn.get("date", "")).split(" ")[0],  # datetime -> ISO date
             "description": str(txn.get("description", "")).strip(),
-            "amount": signed_amount(txn),
-        }
-        for txn in hf.get("transactions", [])
-    ]
+            "amount": amount,
+            "direction": direction,
+            "balance_after": _decimal_str(bal) if bal not in (None, "") else None,
+        })
     return {
         "opening_balance": _decimal_str(hf["opening_balance"]),
         "closing_balance": _decimal_str(hf["closing_balance"]),
@@ -62,7 +62,6 @@ def label_to_expected(hf: dict[str, Any]) -> dict[str, Any]:
 
 
 def modality_for_dir(dirname: str) -> str:
-    """Scanned layouts are image OCR (``vision``); digital are text."""
     return "vision" if "Scanned" in dirname else "text"
 
 
@@ -73,7 +72,7 @@ def build_truth(
     institution_class: str = "generic_india",
     edge_condition: str = "happy_path",
 ) -> dict[str, Any]:
-    """Full ``<fingerprint>.truth.json`` manifest for one HF statement."""
+    """Full truth manifest for one HF statement (production transaction schema)."""
     return {
         "synthetic": True,
         "modality": modality_for_dir(dirname),
@@ -81,8 +80,7 @@ def build_truth(
         "edge_condition": edge_condition,
         "note": (
             "SYNTHETIC label from HF Akashved/Indian-Bank-Statements (Apache-2.0). "
-            "Independent per-statement field label; signed amounts (debit negative). "
-            "Per-file consolidated table — proves field accuracy, not page assembly."
+            "Production schema: amount+direction (IN/OUT) + running balance_after."
         ),
         "expected": label_to_expected(hf),
     }

--- a/tools/_lib/pdf_fixtures/hf_oracle_truth.py
+++ b/tools/_lib/pdf_fixtures/hf_oracle_truth.py
@@ -47,13 +47,15 @@ def label_to_expected(hf: dict[str, Any]) -> dict[str, Any]:
     for txn in hf.get("transactions", []):
         amount, direction = amount_direction(txn)
         bal = txn.get("balance")
-        transactions.append({
-            "date": str(txn.get("date", "")).split(" ")[0],  # datetime -> ISO date
-            "description": str(txn.get("description", "")).strip(),
-            "amount": amount,
-            "direction": direction,
-            "balance_after": _decimal_str(bal) if bal not in (None, "") else None,
-        })
+        transactions.append(
+            {
+                "date": str(txn.get("date", "")).split(" ")[0],  # datetime -> ISO date
+                "description": str(txn.get("description", "")).strip(),
+                "amount": amount,
+                "direction": direction,
+                "balance_after": _decimal_str(bal) if bal not in (None, "") else None,
+            }
+        )
     return {
         "opening_balance": _decimal_str(hf["opening_balance"]),
         "closing_balance": _decimal_str(hf["closing_balance"]),

--- a/tools/_lib/pdf_fixtures/record_hf_oracle_raw.py
+++ b/tools/_lib/pdf_fixtures/record_hf_oracle_raw.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+"""Record the HF oracle FAST: per-page, parallel, non-streaming raw z.ai.
+
+Why this exists (measured): our production extractor STREAMS a single
+all-pages-in-one-call request -> ~30s/page and ~290s for a 6-page/162-txn
+statement. A non-streaming raw call is ~14s/page, and a statement's pages are
+independent, so extracting them **in parallel** is ~14s/statement. With a global
+concurrency cap this records 40 statements in minutes.
+
+OPERATOR-ONLY, KEYED: needs a z.ai key in ``ZAI_API_KEY`` (or ``GLM_CODING_TOKEN``).
+Uses the coding endpoint + ``glm-4.6v`` by default (overridable). Persists one
+record per statement to ``apps/backend/tests/fixtures/hf_oracle/``: the LLM's
+**raw per-page output** (verbatim) + the HF ``truth`` label — nothing code-derived
+(Axiom D). Parsing/merging/validating/scoring is the CODE layer
+(``tests/extraction/hf_oracle_codec.py``). This dir is its OWN dataset —
+deliberately NOT the balance-gated ``llm_cassettes`` dir, since real OCR has
+errors that won't satisfy the balance-chain invariant (AC23.7).
+
+    cd <repo> && ZAI_API_KEY=$GLM_CODING_TOKEN \\
+        uv run --directory apps/backend python ../../tools/_lib/pdf_fixtures/record_hf_oracle_raw.py --per-dir 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CORPUS_DIR = REPO_ROOT / "tmp" / "input" / "hf_oracle"
+# Its OWN dataset dir — NOT the balance-gated llm_cassettes dir. Real OCR has
+# errors (won't satisfy opening+Σ≈closing), so it must not go through AC23.7's
+# balance-chain gate. Each entry is self-contained: our extraction + the truth + score.
+ORACLE_DIR = REPO_ROOT / "apps" / "backend" / "tests" / "fixtures" / "hf_oracle"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(REPO_ROOT))
+from hf_oracle_truth import build_truth  # noqa: E402
+
+ENDPOINT = os.environ.get("ZAI_BASE", "https://api.z.ai/api/coding/paas/v4") + "/chat/completions"
+MODEL = os.environ.get("HF_OCR_MODEL", "glm-4.6v")
+RENDER_SCALE = 1.6
+CONCURRENCY = int(os.environ.get("HF_CONCURRENCY", "10"))
+PROMPT = (
+    "Extract this bank-statement page as strict JSON only (no prose, no markdown "
+    "fence): {opening_balance, closing_balance, transactions:[{date, description, "
+    "amount, direction, balance_after}]}. amount = absolute value; direction = "
+    "\"IN\" for credits / \"OUT\" for debits; balance_after = the running balance "
+    "printed on that row. Omit opening_balance/closing_balance if not on this page."
+)
+
+
+async def _page_extract(client, key: str, png_b64: str, sem: asyncio.Semaphore) -> str:
+    """Return the RAW model output text (persisted verbatim — the LLM artifact).
+    Parsing/normalising is the CODE layer's job (hf_oracle_codec), kept out of here."""
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": [
+            {"type": "text", "text": PROMPT},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{png_b64}"}},
+        ]}],
+        "max_tokens": 8192, "temperature": 0, "thinking": {"type": "disabled"}, "stream": False,
+    }
+    async with sem:
+        for attempt in range(6):  # absorb the coding plan's tight rate limit
+            r = await client.post(ENDPOINT, headers={"Authorization": f"Bearer {key}"}, json=body, timeout=120)
+            if r.status_code == 429:
+                await asyncio.sleep(2 * (attempt + 1))
+                continue
+            break
+    r.raise_for_status()
+    return (r.json().get("choices") or [{}])[0].get("message", {}).get("content", "")
+
+
+MAX_DIM = int(os.environ.get("HF_MAX_DIM", "2200"))  # cap long side (px)
+
+
+def _render_pages(pdf: Path) -> list[str]:
+    """Render pages, capping the long side at MAX_DIM. Scanned PDFs embed huge
+    hi-res images (e.g. 3970x5613 -> 22MB -> z.ai '1261 Prompt too long'); capping
+    fixes the 400 AND cuts vision tokens (faster). Never upscales past RENDER_SCALE."""
+    import fitz
+
+    doc = fitz.open(pdf)
+    out = []
+    for i in range(len(doc)):
+        page = doc.load_page(i)
+        long_side = max(page.rect.width, page.rect.height) or 1
+        scale = min(RENDER_SCALE, MAX_DIM / long_side)
+        png = page.get_pixmap(matrix=fitz.Matrix(scale, scale), alpha=False).tobytes("png")
+        out.append(base64.b64encode(png).decode())
+    return out
+
+
+async def _record_statement(client, key, pdf: Path, sem: asyncio.Semaphore) -> dict:
+    hf = json.loads(pdf.with_suffix(".json").read_text(encoding="utf-8"))
+    truth = build_truth(hf, dirname=pdf.parent.name)
+    pages_b64 = _render_pages(pdf)
+    t = time.monotonic()
+    raw_pages = await asyncio.gather(*[_page_extract(client, key, b, sem) for b in pages_b64])
+    dt = time.monotonic() - t
+
+    out = {
+        "source": f"{pdf.parent.name}/{pdf.name}",
+        "model": MODEL,
+        "prompt": PROMPT,
+        "synthetic": True,  # HF dataset is synthetic (Apache-2.0); no real PII.
+        "modality": truth["modality"],
+        "pages": len(pages_b64),
+        "raw_pages": list(raw_pages),   # RAW LLM output per page — the persisted artifact
+        "truth": truth["expected"],     # independent HF label (production schema)
+    }
+    name = f"{pdf.parent.name}__{pdf.stem}.json"
+    (ORACLE_DIR / name).write_text(json.dumps(out, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return {"pdf": str(pdf.relative_to(CORPUS_DIR)), "pages": len(pages_b64), "sec": round(dt, 1)}
+
+
+async def _main(per_dir: int) -> int:
+    import httpx
+
+    key = os.environ.get("ZAI_API_KEY") or os.environ.get("GLM_CODING_TOKEN")
+    if not key:
+        print("Set ZAI_API_KEY (or GLM_CODING_TOKEN) — keyed record step.")
+        return 1
+    # Balanced: the first `per_dir` numbered files from EACH of the 4 folders.
+    pdfs: list[Path] = []
+    for d in sorted(p for p in CORPUS_DIR.iterdir() if p.is_dir() and not p.name.startswith("_")):
+        pdfs.extend(sorted(d.glob("[0-9]*.pdf"))[:per_dir])
+    if not pdfs:
+        print(f"No corpus under {CORPUS_DIR}; run fetch_hf_oracle.py first.")
+        return 1
+    ORACLE_DIR.mkdir(parents=True, exist_ok=True)
+    sem = asyncio.Semaphore(CONCURRENCY)
+    async with httpx.AsyncClient() as client:
+        results = await asyncio.gather(
+            *[_record_statement(client, key, p, sem) for p in pdfs], return_exceptions=True
+        )
+    ok = 0
+    for r in results:
+        if isinstance(r, Exception):
+            print(f"  FAIL: {type(r).__name__}: {str(r)[:70]}")
+        else:
+            ok += 1
+            print(f"  {r['pdf']}: {r['pages']} raw page(s) ({r['sec']}s)")
+    print(f"Recorded {ok}/{len(pdfs)} raw -> {ORACLE_DIR.relative_to(REPO_ROOT)} "
+          "(score via the codec test, not here)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--per-dir", type=int, default=5, help="files per folder (4 folders)")
+    return asyncio.run(_main(ap.parse_args(argv).per_dir))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/_lib/pdf_fixtures/record_hf_oracle_raw.py
+++ b/tools/_lib/pdf_fixtures/record_hf_oracle_raw.py
@@ -42,7 +42,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(REPO_ROOT))
 from hf_oracle_truth import build_truth  # noqa: E402
 
-ENDPOINT = os.environ.get("ZAI_BASE", "https://api.z.ai/api/coding/paas/v4") + "/chat/completions"
+ENDPOINT = (
+    os.environ.get("ZAI_BASE", "https://api.z.ai/api/coding/paas/v4")
+    + "/chat/completions"
+)
 MODEL = os.environ.get("HF_OCR_MODEL", "glm-4.6v")
 RENDER_SCALE = 1.6
 CONCURRENCY = int(os.environ.get("HF_CONCURRENCY", "10"))
@@ -50,7 +53,7 @@ PROMPT = (
     "Extract this bank-statement page as strict JSON only (no prose, no markdown "
     "fence): {opening_balance, closing_balance, transactions:[{date, description, "
     "amount, direction, balance_after}]}. amount = absolute value; direction = "
-    "\"IN\" for credits / \"OUT\" for debits; balance_after = the running balance "
+    '"IN" for credits / "OUT" for debits; balance_after = the running balance '
     "printed on that row. Omit opening_balance/closing_balance if not on this page."
 )
 
@@ -60,15 +63,31 @@ async def _page_extract(client, key: str, png_b64: str, sem: asyncio.Semaphore) 
     Parsing/normalising is the CODE layer's job (hf_oracle_codec), kept out of here."""
     body = {
         "model": MODEL,
-        "messages": [{"role": "user", "content": [
-            {"type": "text", "text": PROMPT},
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{png_b64}"}},
-        ]}],
-        "max_tokens": 8192, "temperature": 0, "thinking": {"type": "disabled"}, "stream": False,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": PROMPT},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{png_b64}"},
+                    },
+                ],
+            }
+        ],
+        "max_tokens": 8192,
+        "temperature": 0,
+        "thinking": {"type": "disabled"},
+        "stream": False,
     }
     async with sem:
         for attempt in range(6):  # absorb the coding plan's tight rate limit
-            r = await client.post(ENDPOINT, headers={"Authorization": f"Bearer {key}"}, json=body, timeout=120)
+            r = await client.post(
+                ENDPOINT,
+                headers={"Authorization": f"Bearer {key}"},
+                json=body,
+                timeout=120,
+            )
             if r.status_code == 429:
                 await asyncio.sleep(2 * (attempt + 1))
                 continue
@@ -92,7 +111,9 @@ def _render_pages(pdf: Path) -> list[str]:
         page = doc.load_page(i)
         long_side = max(page.rect.width, page.rect.height) or 1
         scale = min(RENDER_SCALE, MAX_DIM / long_side)
-        png = page.get_pixmap(matrix=fitz.Matrix(scale, scale), alpha=False).tobytes("png")
+        png = page.get_pixmap(matrix=fitz.Matrix(scale, scale), alpha=False).tobytes(
+            "png"
+        )
         out.append(base64.b64encode(png).decode())
     return out
 
@@ -102,7 +123,9 @@ async def _record_statement(client, key, pdf: Path, sem: asyncio.Semaphore) -> d
     truth = build_truth(hf, dirname=pdf.parent.name)
     pages_b64 = _render_pages(pdf)
     t = time.monotonic()
-    raw_pages = await asyncio.gather(*[_page_extract(client, key, b, sem) for b in pages_b64])
+    raw_pages = await asyncio.gather(
+        *[_page_extract(client, key, b, sem) for b in pages_b64]
+    )
     dt = time.monotonic() - t
 
     out = {
@@ -112,12 +135,20 @@ async def _record_statement(client, key, pdf: Path, sem: asyncio.Semaphore) -> d
         "synthetic": True,  # HF dataset is synthetic (Apache-2.0); no real PII.
         "modality": truth["modality"],
         "pages": len(pages_b64),
-        "raw_pages": list(raw_pages),   # RAW LLM output per page — the persisted artifact
-        "truth": truth["expected"],     # independent HF label (production schema)
+        "raw_pages": list(
+            raw_pages
+        ),  # RAW LLM output per page — the persisted artifact
+        "truth": truth["expected"],  # independent HF label (production schema)
     }
     name = f"{pdf.parent.name}__{pdf.stem}.json"
-    (ORACLE_DIR / name).write_text(json.dumps(out, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-    return {"pdf": str(pdf.relative_to(CORPUS_DIR)), "pages": len(pages_b64), "sec": round(dt, 1)}
+    (ORACLE_DIR / name).write_text(
+        json.dumps(out, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return {
+        "pdf": str(pdf.relative_to(CORPUS_DIR)),
+        "pages": len(pages_b64),
+        "sec": round(dt, 1),
+    }
 
 
 async def _main(per_dir: int) -> int:
@@ -129,7 +160,9 @@ async def _main(per_dir: int) -> int:
         return 1
     # Balanced: the first `per_dir` numbered files from EACH of the 4 folders.
     pdfs: list[Path] = []
-    for d in sorted(p for p in CORPUS_DIR.iterdir() if p.is_dir() and not p.name.startswith("_")):
+    for d in sorted(
+        p for p in CORPUS_DIR.iterdir() if p.is_dir() and not p.name.startswith("_")
+    ):
         pdfs.extend(sorted(d.glob("[0-9]*.pdf"))[:per_dir])
     if not pdfs:
         print(f"No corpus under {CORPUS_DIR}; run fetch_hf_oracle.py first.")
@@ -138,7 +171,8 @@ async def _main(per_dir: int) -> int:
     sem = asyncio.Semaphore(CONCURRENCY)
     async with httpx.AsyncClient() as client:
         results = await asyncio.gather(
-            *[_record_statement(client, key, p, sem) for p in pdfs], return_exceptions=True
+            *[_record_statement(client, key, p, sem) for p in pdfs],
+            return_exceptions=True,
         )
     ok = 0
     for r in results:
@@ -147,14 +181,18 @@ async def _main(per_dir: int) -> int:
         else:
             ok += 1
             print(f"  {r['pdf']}: {r['pages']} raw page(s) ({r['sec']}s)")
-    print(f"Recorded {ok}/{len(pdfs)} raw -> {ORACLE_DIR.relative_to(REPO_ROOT)} "
-          "(score via the codec test, not here)")
+    print(
+        f"Recorded {ok}/{len(pdfs)} raw -> {ORACLE_DIR.relative_to(REPO_ROOT)} "
+        "(score via the codec test, not here)"
+    )
     return 0
 
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--per-dir", type=int, default=5, help="files per folder (4 folders)")
+    ap.add_argument(
+        "--per-dir", type=int, default=5, help="files per folder (4 folders)"
+    )
     return asyncio.run(_main(ap.parse_args(argv).per_dir))
 
 


### PR DESCRIPTION
The HF extraction-accuracy oracle, done on the **Axiom-D split**: the cassette persists the LLM's **raw output**; every deterministic transform downstream is **code with its own tests**. (Supersedes the earlier signed-amount/derived-blob cut.)

## What's in it
- **Production transaction schema** `{date, description, amount, direction(IN/OUT), balance_after}` — the prior `{date,description,amount}` dropped `direction` + the running `balance_after`, the field that powers the **running-balance self-check** (each row validates the previous).
- **Persist RAW, not derived**: `apps/backend/tests/fixtures/hf_oracle/*.json` = `{source, model, prompt, synthetic, modality, raw_pages, truth}` — `raw_pages` is the verbatim per-page model output.
- **Code layer** `hf_oracle_codec.py`: parse → normalise → merge pages → validate, **reusing the production validators** (`validate_balance`, `detect_balance_chain_break`) so it exercises real code; `field_score` + `self_checks`.
- **CI-safe (no key)**: `test_hf_oracle_codec.py` replays the committed raw examples through the codec; `test_hf_oracle_truth.py` gates the mapper.
- **4 worked examples** (one per HF folder, Digital + Scanned): score 0.48–0.71, and the chain self-check correctly locates where OCR drifts (rows 19/5/60/22).

## Notes
- Separate dataset dir (not balance-gated `llm_cassettes/`): real OCR errors don't satisfy `opening+Σ≈closing` (AC23.7) — forcing them through it would reject the imperfection the oracle measures.
- Synthetic (Apache-2.0) only; source PDFs git-ignored. **Large-scale recording is a later step** (this lands the code + worked examples).
- Why per-page raw z.ai: production streaming ~2× slower, single all-pages call output-token-bound, scanned pages need a render dim-cap, coding plan rate-limits hard — all measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)