### PR TITLE
[finance_report_audit] meta: encode the DDD building-block table into the package model

### DIFF
--- a/apps/backend/tests/platform/test_contract.py
+++ b/apps/backend/tests/platform/test_contract.py
@@ -7,7 +7,7 @@ heavy gate runs in CI over every package; this anchors the AC to an executable
 proof in the backend suite.
 """
 
-from common.meta.check_package_contract import (
+from common.meta.extension.check_package_contract import (
     REPO_ROOT,
     check_package,
     discover_packages,

--- a/common/counter/contract.py
+++ b/common/counter/contract.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     Invariant,
+    Kind,
     PackageContract,
+    Unit,
 )
 
 CONTRACT = PackageContract(
@@ -30,6 +32,20 @@ CONTRACT = PackageContract(
     tier="CODE-ONLY",
     depends_on=["platform"],
     roles=["base", "extension"],
+    units=[
+        # base — pure value objects + the domain event type.
+        Unit(name="CounterKey", kind=Kind.VALUE_OBJECT, module="base/types/key.py"),
+        Unit(name="Count", kind=Kind.VALUE_OBJECT, module="base/types/count.py"),
+        Unit(name="Incremented", kind=Kind.DOMAIN_EVENT, module="base/types/events.py"),
+        # repository — the one split block: the abstract port lives in base/, the
+        # SQL adapter in extension/ (dependency inversion, mechanism B).
+        Unit(
+            name="CounterRepository",
+            kind=Kind.REPOSITORY,
+            module="base/repository.py",
+            impl="extension/sql.py",
+        ),
+    ],
     implementations={"be": "apps/backend/src/counter", "fe": None},
     interface=[
         "Count",

--- a/common/meta/__init__.py
+++ b/common/meta/__init__.py
@@ -3,8 +3,18 @@
 A *package* in this repo is a DDD bounded context: a ``readme.md`` (prose /
 ubiquitous language) + a :class:`PackageContract` (the machine-checkable
 contract in ``contract.py``) + a ``todo.md`` + conforming implementations whose
-files converge by role (``types/ops/store/api``) and whose published language is
-declared via ``__all__``.
+files converge by layer (``base`` / ``extension`` / ``data``) and whose published
+language is declared via ``__all__``.
+
+The meta package now follows the very layout it governs (the Layout-3 exemplar):
+
+* ``base``      — :mod:`common.meta.base.package_contract`: the ``PackageContract``
+  aggregate root, its value objects, and the ``Kind`` / ``KIND_LAYER``
+  building-block taxonomy (pure model);
+* ``extension`` — :mod:`common.meta.extension.check_package_contract`: the
+  governance gate (the impure edge that walks the tree and validates);
+* ``data``      — :mod:`common.meta.data.projection`: ``contract_index``, the
+  computed meta-index (the read-model / projection).
 
 Governance is *computed from contracts*, not hand-maintained: every package
 declares a :class:`PackageContract` in ``common/<pkg>/contract.py`` and
@@ -19,14 +29,20 @@ first worked example.
 
 from __future__ import annotations
 
-from common.meta.package_contract import (
+from common.meta.base.package_contract import (
     ACRecord,
     Invariant,
+    Kind,
     PackageContract,
+    Unit,
 )
+from common.meta.data.projection import contract_index
 
 __all__ = [
     "ACRecord",
     "Invariant",
+    "Kind",
     "PackageContract",
+    "Unit",
+    "contract_index",
 ]

--- a/common/meta/base/__init__.py
+++ b/common/meta/base/__init__.py
@@ -1,0 +1,8 @@
+"""``common.meta.base`` — the meta package's pure model layer.
+
+Holds :mod:`common.meta.base.package_contract`: the :class:`PackageContract`
+aggregate root plus its value objects (``ACRecord``, ``Invariant``, ``Unit``) and
+the building-block taxonomy (``Kind`` / ``KIND_LAYER``). Pure, stdlib + pydantic
+only — the downward-DAG core the gate (``extension``) and the projection
+(``data``) build on. ``base`` never imports ``extension`` or ``data``.
+"""

--- a/common/meta/base/package_contract.py
+++ b/common/meta/base/package_contract.py
@@ -1,0 +1,293 @@
+"""``PackageContract`` — the machine-checkable contract a package publishes.
+
+A package = bounded context declares one :class:`PackageContract` instance in its
+``contract.py``. The contract is the single source of truth for the package's
+*published language* (``interface`` mirrors ``__init__.__all__``), its emitted
+domain ``events``, the ``invariants`` it guarantees, its ``roadmap`` (the
+ACs it owns), and — for a package modelled with DDD building blocks — its
+``units`` (each tactical building block and the layer it lives in).
+``check_package_contract`` validates the live package against this contract, so
+governance is *computed*, not hand-maintained.
+
+This module is the meta package's ``base`` layer: pure model, stdlib + pydantic
+only by design (importable from the governance gate and from a package's
+``contract.py`` without pulling app/framework dependencies). The authority-tier
+vocabulary and the tier->proof matrix come from the stdlib-only
+:mod:`common.authority.authority_matrix` (the single machine source, also imported
+by the lightweight SSOT tooling that must NOT pull pydantic).
+
+DDD building-block taxonomy
+---------------------------
+The eight DDD tactical building blocks each map to one canonical layer, and the
+layering keeps the dependency graph acyclic via three mechanisms (A/B/C). That
+mapping is the single source of truth in :data:`KIND_LAYER`:
+
+==================  ====================  ============================
+Building block      Layer                 Cycle-breaking mechanism
+==================  ====================  ============================
+Value Object        base                  A (leaf, only depended-on)
+Entity              base                  A (composes VOs, one-way)
+Aggregate Root      base                  A + C (refer by id)
+Factory (pure)      base                  A
+Domain Event        base                  C (both sides depend on the event type)
+Repository          port=base/impl=ext    B (dependency inversion)
+Domain Service      extension             A (extension -> base, one-way)
+Event Bus           extension             C (runtime registry, no compile edge)
+Projection          data                  read-model, leaf sink
+==================  ====================  ============================
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, model_validator
+
+# The tier vocabulary + matrix live in one source: common.authority.authority_matrix.
+# Import only what this model uses (the field types + the validator's matrix).
+from common.authority.authority_matrix import (
+    ACProofKind,
+    PackageTier,
+    TIER_DEFAULT_PROOF_KIND,
+    TIER_VALID_PROOF_KINDS,
+)
+
+#: A package class. The three orthogonal kinds in the model:
+#: - ``kernel``   — leaf value-language reused everywhere (e.g. ``money``);
+#:                  depends on nothing in the app.
+#: - ``platform`` — a reusable horizontal capability (e.g. ``counter``);
+#:                  depends only on kernels.
+#: - ``core``     — a vertical domain slice (e.g. ``ledger``);
+#:                  may depend on platform + kernel packages.
+PackageClass = Literal["core", "platform", "kernel"]
+
+#: AC priority, mirroring the EPIC AC tables (P0 highest).
+Priority = Literal["P0", "P1", "P2"]
+
+#: AC lifecycle status within a package roadmap.
+ACStatus = Literal["open", "done"]
+
+#: Package lifecycle status. ``draft`` = still being designed (its authority
+#: tier may be undecided); ``active`` = governed and shipped (tier MUST be
+#: decided); ``deprecated`` = on the way out (still checked, but flagged).
+PackageStatus = Literal["draft", "active", "deprecated"]
+
+#: The three internal layers a package converges into (the universal purity
+#: axis, applied to every package — domain or tooling):
+#: - ``base``      — pure, self-contained core; no I/O, no cross-package edges;
+#:                   imports only other packages' ``base`` (a downward DAG).
+#: - ``extension`` — the impure edges: cross-package wiring, I/O, ORM, bus.
+#: - ``data``      — the read-model / projection: a leaf sink computed FROM the
+#:                   write side; nothing in ``base``/``extension`` imports it.
+Layer = Literal["base", "extension", "data"]
+
+
+class Kind(str, Enum):
+    """The eight DDD tactical building blocks (+ ``projection``, the read-model).
+
+    A :class:`Unit`'s ``kind`` decides which :data:`Layer` it must live in via
+    :data:`KIND_LAYER` — that mapping is the executable form of the building-block
+    table. ``str`` mixin so the value is a plain string in dumps / AST views.
+    """
+
+    VALUE_OBJECT = "value-object"
+    ENTITY = "entity"
+    AGGREGATE_ROOT = "aggregate-root"
+    FACTORY = "factory"
+    DOMAIN_EVENT = "domain-event"
+    REPOSITORY = "repository"
+    DOMAIN_SERVICE = "domain-service"
+    EVENT_BUS = "event-bus"
+    PROJECTION = "projection"
+
+
+#: ``"split"`` marks the one building block (``REPOSITORY``) that straddles two
+#: layers: its port (the abstract interface) lives in ``base`` and its adapter
+#: (the concrete impl) lives in ``extension`` — dependency inversion (mechanism
+#: B). Every other kind resolves to a single :data:`Layer`.
+SPLIT = "split"
+
+#: The building-block table, as code: each :class:`Kind` -> its canonical layer.
+#: The governance gate enforces unit placement against this single map, so the
+#: table can never drift from what is checked.
+KIND_LAYER: dict[Kind, str] = {
+    Kind.VALUE_OBJECT: "base",
+    Kind.ENTITY: "base",
+    Kind.AGGREGATE_ROOT: "base",
+    Kind.FACTORY: "base",
+    Kind.DOMAIN_EVENT: "base",
+    Kind.REPOSITORY: SPLIT,
+    Kind.DOMAIN_SERVICE: "extension",
+    Kind.EVENT_BUS: "extension",
+    Kind.PROJECTION: "data",
+}
+
+
+class Unit(BaseModel):
+    """One DDD building block a package owns, pinned to where its code lives.
+
+    ``kind`` decides the canonical layer via :data:`KIND_LAYER`; ``module`` is the
+    unit's file path **relative to the BE implementation dir** (e.g.
+    ``"base/types/key.py"``) so the gate can check it sits in the right layer.
+    ``module`` is optional: a package that has not adopted the physical
+    ``base/extension/`` split (e.g. a value-type package still using
+    ``types/ops``) may declare its units' kinds for the taxonomy without a path,
+    and the gate skips placement for it (additive).
+
+    A ``REPOSITORY`` unit is the one split block: ``module`` is its port (in
+    ``base``) and ``impl`` is its adapter (in ``extension``) — mechanism B. ``impl``
+    is meaningful only for a repository.
+    """
+
+    name: str
+    kind: Kind
+    module: str | None = None
+    impl: str | None = None
+
+    @property
+    def layer(self) -> str:
+        """The canonical layer for this unit's kind (``"split"`` for repository)."""
+        return KIND_LAYER[self.kind]
+
+    @model_validator(mode="after")
+    def _impl_only_for_repository(self) -> Unit:
+        """``impl`` (the extension adapter) is a repository-only concept.
+
+        A non-repository unit lives in exactly one layer, so an ``impl`` second
+        path is meaningless and almost certainly a mis-declaration. A repository
+        that pins its port (``module``) must also pin its adapter (``impl``) — the
+        split is the whole point of the kind.
+        """
+        if self.kind != Kind.REPOSITORY and self.impl is not None:
+            raise ValueError(
+                f"unit {self.name!r}: 'impl' is only valid for a repository unit "
+                f"(kind={self.kind.value!r} resolves to layer {self.layer!r})."
+            )
+        if (
+            self.kind == Kind.REPOSITORY
+            and self.module is not None
+            and self.impl is None
+        ):
+            raise ValueError(
+                f"repository unit {self.name!r}: a pinned port ('module') requires "
+                "a pinned adapter ('impl') — a repository is a base port + an "
+                "extension adapter (dependency inversion)."
+            )
+        return self
+
+
+class Invariant(BaseModel):
+    """A property the package guarantees, pinned to the test that proves it.
+
+    ``test`` is a ``"path::func"`` reference (pytest node-id style, module path
+    relative to the repo root) so the governance gate can resolve it to a real
+    test function — an invariant with no executable proof is not an invariant.
+    """
+
+    id: str
+    statement: str
+    test: str
+
+
+class ACRecord(BaseModel):
+    """One acceptance criterion the package owns, in the package-model registry.
+
+    The package roadmap is the *new* home for a package's ACs (the model where
+    governance is computed from contracts). ``test`` is a ``"path::func"``
+    reference, exactly like :class:`Invariant.test`, so each AC resolves to the
+    test that anchors it.
+    """
+
+    id: str
+    statement: str
+    test: str
+    priority: Priority
+    status: ACStatus
+    #: Proof kind the AC's test provides. The AC inherits its authority tier from
+    #: the owning :class:`PackageContract` (tier is a module-design property, not a
+    #: per-AC one), so ``proof_kind`` is the only tier-related attribute an AC
+    #: carries. ``None`` resolves to the package tier's canonical kind
+    #: (:data:`TIER_DEFAULT_PROOF_KIND`); an explicit value MUST be valid for the
+    #: package tier per :data:`TIER_VALID_PROOF_KINDS` (e.g. under an LLM-LED/LLM-ONLY package
+    #: an AC can never be ``exact``). Enforced by the owning ``PackageContract``.
+    proof_kind: ACProofKind | None = None
+
+
+class PackageContract(BaseModel):
+    """The contract a package publishes — the unit the governance gate checks.
+
+    Fields:
+        name:            the package name (matches its ``common/<name>/`` dir).
+        klass:           ``core`` / ``platform`` / ``kernel`` (the dependency tier).
+        status:          ``draft`` / ``active`` / ``deprecated`` (package lifecycle).
+        tier:            the package's permanent authority tier (:data:`PackageTier`);
+                         ``None`` = undecided, allowed only while ``status="draft"``.
+        depends_on:      names of packages this one may import (down-only edges).
+        roles:           (legacy) the role folders the implementation converges into
+                         (e.g. ``["types", "ops", "store", "api"]``). Superseded by
+                         ``units`` but still accepted during migration.
+        units:           the DDD building blocks this package owns, each carrying its
+                         kind (hence layer) and, when the physical base/extension
+                         split is adopted, the path it lives at.
+        implementations: where each implementation lives, by surface key
+                         (``"be"`` / ``"fe"``); ``None`` means "no implementation
+                         on that surface yet". The governance gate resolves
+                         ``__all__`` against ``implementations["be"]``.
+        interface:       the published language — must equal the BE
+                         implementation's ``__init__.__all__``.
+        events:          domain event type names this package publishes.
+        invariants:      guaranteed properties, each pinned to a proving test.
+        roadmap:         the ACs this package owns (the package-model AC registry).
+    """
+
+    name: str
+    klass: PackageClass
+    depends_on: list[str]
+    interface: list[str]
+    events: list[str]
+    invariants: list[Invariant]
+    roadmap: list[ACRecord]
+    status: PackageStatus = "active"
+    #: The package's permanent authority tier. ``None`` means "undecided" and is
+    #: legal only for a ``draft`` package; an ``active``/``deprecated`` package
+    #: must have resolved its tier to a concrete :data:`PackageTier`.
+    tier: PackageTier | None = None
+    roles: list[str] = []
+    units: list[Unit] = []
+    implementations: dict[str, str | None] = {}
+
+    @model_validator(mode="after")
+    def _tier_decided_and_proofs_match(self) -> PackageContract:
+        """Enforce the module-design tier rules at construction.
+
+        1. A shipped package has a decided tier: ``status != "draft"`` requires a
+           concrete :data:`PackageTier` (a ``draft`` may stay ``tier=None`` — the
+           "undecided" state that the legacy EPIC source spelled ``HU``).
+        2. Every roadmap AC's proof kind is valid for the package's tier per the
+           single matrix (:data:`TIER_VALID_PROOF_KINDS`); a missing kind resolves
+           to the tier's canonical default and is materialized on the record. An
+           undecided (``None``) tier skips the proof check — there is no tier to
+           validate against yet.
+        """
+        if self.tier is None:
+            if self.status != "draft":
+                raise ValueError(
+                    f"package {self.name!r}: status {self.status!r} requires a "
+                    "decided authority tier (one of CODE-ONLY/CODE-LED/LLM-LED/LLM-ONLY); only a 'draft' "
+                    "package may leave tier undecided (the legacy 'HU' state)."
+                )
+            return self
+
+        valid = TIER_VALID_PROOF_KINDS[self.tier]
+        for ac in self.roadmap:
+            kind = ac.proof_kind or TIER_DEFAULT_PROOF_KIND[self.tier]
+            if kind not in valid:
+                raise ValueError(
+                    f"package {self.name!r} AC {ac.id}: proof_kind {kind!r} is "
+                    f"not valid for the package tier {self.tier} "
+                    f"(valid: {sorted(valid)}). Under an LLM-LED/LLM-ONLY package an AC can "
+                    "never be proven by an exact golden assertion."
+                )
+            ac.proof_kind = kind
+        return self

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -1,22 +1,27 @@
 """The ``meta`` package's own :class:`PackageContract`.
 
 The package model self-hosts: the meta package that *defines* what a package is
-(``PackageContract`` / ``ACRecord`` / ``Invariant`` and the
+(``PackageContract`` / ``ACRecord`` / ``Invariant`` / ``Unit`` / ``Kind`` and the
 ``check_package_contract`` gate) is itself a package, with a ``readme.md`` (the
 package-model spec), this ``contract.py``, and a ``todo.md``. It is discovered
 and validated by the very gate it ships, so the model proves itself.
 
-Its BE implementation is ``common/meta`` (the same directory): the
-published language is ``common/meta/__init__.py``'s ``__all__``. The gate
-resolves ``interface`` against that, and pins each invariant/roadmap AC to a real
-governance test.
+meta is also the Layout-3 exemplar: it converges into the ``base`` / ``extension``
+/ ``data`` layers it governs, and declares its DDD building-block ``units`` (the
+``PackageContract`` aggregate root + its value objects in ``base``, the gate as a
+``domain-service`` in ``extension``, and ``contract_index`` as a ``projection`` in
+``data``). Its BE implementation is ``common/meta`` (the same directory): the
+published language is ``common/meta/__init__.py``'s ``__all__``.
 """
 
 from __future__ import annotations
 
 from common.meta.package_contract import (
+    ACRecord,
     Invariant,
+    Kind,
     PackageContract,
+    Unit,
 )
 
 CONTRACT = PackageContract(
@@ -27,12 +32,41 @@ CONTRACT = PackageContract(
     # LLM: a pure-code (CODE-ONLY) package. It also OWNS the authority-tier rules below.
     tier="CODE-ONLY",
     depends_on=["authority"],
-    roles=["package_contract", "check_package_contract"],
+    roles=["base", "extension", "data"],
+    units=[
+        # base — the pure model: the PackageContract aggregate root + its value
+        # objects, and the building-block taxonomy. All live in base/package_contract.py.
+        Unit(
+            name="PackageContract",
+            kind=Kind.AGGREGATE_ROOT,
+            module="base/package_contract.py",
+        ),
+        Unit(
+            name="ACRecord", kind=Kind.VALUE_OBJECT, module="base/package_contract.py"
+        ),
+        Unit(
+            name="Invariant", kind=Kind.VALUE_OBJECT, module="base/package_contract.py"
+        ),
+        Unit(name="Unit", kind=Kind.VALUE_OBJECT, module="base/package_contract.py"),
+        Unit(name="Kind", kind=Kind.VALUE_OBJECT, module="base/package_contract.py"),
+        # extension — the impure edge: the governance gate (a domain service that
+        # walks the tree and validates every package against its contract).
+        Unit(
+            name="check_package_contract",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/check_package_contract.py",
+        ),
+        # data — the read-model: the computed meta-index over all contracts.
+        Unit(name="contract_index", kind=Kind.PROJECTION, module="data/projection.py"),
+    ],
     implementations={"be": "common/meta", "fe": None},
     interface=[
         "ACRecord",
         "Invariant",
+        "Kind",
         "PackageContract",
+        "Unit",
+        "contract_index",
     ],
     events=[],
     invariants=[
@@ -101,6 +135,99 @@ CONTRACT = PackageContract(
                 "::test_package_proof_kind_must_satisfy_the_tier_matrix"
             ),
         ),
+        # Structural guarantees about meta ITSELF as the Layout-3 exemplar (no
+        # authority tier, not matrix-constrained — see docs/ssot/authority-tiers.md).
+        Invariant(
+            id="meta-converges-by-layer",
+            statement=(
+                "The meta package converges into base/ (the pure model) + "
+                "extension/ (the gate) + data/ (the projection) — the layout it "
+                "governs."
+            ),
+            test=("tests/tooling/test_meta_layering.py::test_meta_converges_by_layer"),
+        ),
+        Invariant(
+            id="meta-base-is-pure",
+            statement=(
+                "The meta base/ layer never imports its own extension/ or data/ — "
+                "the model is the pure, downward-only core."
+            ),
+            test="tests/tooling/test_meta_layering.py::test_meta_base_is_pure",
+        ),
     ],
-    roadmap=[],
+    roadmap=[
+        # The governance gate's building-block behavior — meta's domain. Each AC
+        # is proven by a negative test driving the gate against a synthetic
+        # package that violates the rule.
+        ACRecord(
+            id="AC-meta.kind.1",
+            statement=(
+                "A declared unit must live in the layer its kind dictates "
+                "(KIND_LAYER); a unit whose module sits in the wrong layer is "
+                "rejected (mechanism A)."
+            ),
+            test=(
+                "tests/tooling/test_meta_layering.py"
+                "::test_AC_meta_kind_1_unit_misplacement_is_rejected"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.kind.2",
+            statement=(
+                "A repository unit must split into a base port + an extension "
+                "adapter; a port outside base/ or an adapter outside extension/ is "
+                "rejected (mechanism B, dependency inversion)."
+            ),
+            test=(
+                "tests/tooling/test_meta_layering.py"
+                "::test_AC_meta_kind_2_repository_requires_port_and_adapter"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.kind.3",
+            statement=(
+                "The data/ layer is a sink: nothing in base/ or extension/ may "
+                "import the package's own data/, so the read-model never feeds back "
+                "into the write side."
+            ),
+            test=(
+                "tests/tooling/test_meta_layering.py"
+                "::test_AC_meta_kind_3_data_layer_is_a_sink"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.projection.1",
+            statement=(
+                "contract_index is a pure projection over the contracts it is "
+                "handed: registry, AC index, reverse-dependency consumers, and "
+                "per-package units-by-layer, with no I/O of its own."
+            ),
+            test=(
+                "tests/tooling/test_meta_layering.py"
+                "::test_AC_meta_projection_1_contract_index_is_pure"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.kind.4",
+            statement=(
+                "A value-type package may declare value-object units for the "
+                "taxonomy without the physical base/extension split; the gate "
+                "accepts it (additive) and still passes."
+            ),
+            test=(
+                "tests/tooling/test_meta_layering.py"
+                "::test_AC_meta_kind_4_value_type_packages_pass"
+            ),
+            priority="P2",
+            status="done",
+        ),
+    ],
 )

--- a/common/meta/data/__init__.py
+++ b/common/meta/data/__init__.py
@@ -1,9 +1,10 @@
 """``common.meta.data`` — the meta package's read-model / projection layer.
 
 Holds :mod:`common.meta.data.projection`: :func:`contract_index`, a pure
-projection that folds a set of :class:`~common.meta.base.package_contract.PackageContract`
-s into the computed meta-index (registry, AC index, reverse-dependency consumers,
-and per-package unit fan-out by layer).
+projection that folds a set of package contracts (see
+:class:`~common.meta.base.package_contract.PackageContract`) into the computed
+meta-index (registry, AC index, reverse-dependency consumers, and per-package unit
+fan-out by layer).
 
 ``data`` is a **sink**: it imports only ``base`` (the model) and is imported by no
 other layer — nothing in ``base`` or ``extension`` may depend on the read model.

--- a/common/meta/data/__init__.py
+++ b/common/meta/data/__init__.py
@@ -1,0 +1,11 @@
+"""``common.meta.data`` — the meta package's read-model / projection layer.
+
+Holds :mod:`common.meta.data.projection`: :func:`contract_index`, a pure
+projection that folds a set of :class:`~common.meta.base.package_contract.PackageContract`
+s into the computed meta-index (registry, AC index, reverse-dependency consumers,
+and per-package unit fan-out by layer).
+
+``data`` is a **sink**: it imports only ``base`` (the model) and is imported by no
+other layer — nothing in ``base`` or ``extension`` may depend on the read model.
+That one-way edge is what the governance gate's ``_check_data_is_sink`` enforces.
+"""

--- a/common/meta/data/projection.py
+++ b/common/meta/data/projection.py
@@ -1,0 +1,72 @@
+"""``contract_index`` — the computed meta-index over package contracts.
+
+This is the meta package's ``data`` layer: a CQRS-style **read model** derived
+from the write side (the :class:`~common.meta.base.package_contract.PackageContract`
+aggregates). It is a pure projection — a function of the contracts it is handed,
+with no I/O and no discovery of its own. Discovery (walking the filesystem) is an
+``extension`` concern; the caller passes the already-loaded contracts in, so this
+layer depends only on ``base`` and stays a leaf sink.
+
+The index answers the questions the standard's ``data`` layer is meant to:
+
+* **registry** — name -> class / tier / status, the at-a-glance package table;
+* **ac_index** — every roadmap AC id -> the package that owns it (no AC is owned
+  twice);
+* **consumers** — reverse dependencies (who depends on each package), the
+  blast-radius view;
+* **units_by_layer** — per package, how many DDD building-block units land in
+  ``base`` / ``extension`` / ``data`` (the extension fan-out / anti-mud-ball
+  metric: a package whose ``extension`` count balloons is drifting toward a mud
+  ball).
+"""
+
+from __future__ import annotations
+
+from common.meta.base.package_contract import KIND_LAYER, SPLIT, PackageContract
+
+
+def contract_index(contracts: list[PackageContract]) -> dict[str, dict]:
+    """Project a set of package contracts into the computed meta-index.
+
+    Pure: the result is a function of ``contracts`` alone. ``consumers`` and
+    ``ac_index`` only reference packages within the given set, so the projection
+    is well-defined over any subset (e.g. a single package in a test).
+    """
+    by_name = {c.name: c for c in contracts}
+
+    registry: dict[str, dict] = {
+        c.name: {"klass": c.klass, "tier": c.tier, "status": c.status}
+        for c in contracts
+    }
+
+    ac_index: dict[str, str] = {}
+    for c in contracts:
+        for ac in c.roadmap:
+            ac_index[ac.id] = c.name
+
+    consumers: dict[str, list[str]] = {name: [] for name in by_name}
+    for c in contracts:
+        for dep in c.depends_on:
+            if dep in consumers:
+                consumers[dep].append(c.name)
+    consumers = {name: sorted(deps) for name, deps in consumers.items()}
+
+    units_by_layer: dict[str, dict[str, int]] = {}
+    for c in contracts:
+        counts = {"base": 0, "extension": 0, "data": 0}
+        for unit in c.units:
+            layer = KIND_LAYER[unit.kind]
+            if layer == SPLIT:
+                # a repository spans both sides of the dependency inversion.
+                counts["base"] += 1
+                counts["extension"] += 1
+            else:
+                counts[layer] += 1
+        units_by_layer[c.name] = counts
+
+    return {
+        "registry": registry,
+        "ac_index": ac_index,
+        "consumers": consumers,
+        "units_by_layer": units_by_layer,
+    }

--- a/common/meta/data/projection.py
+++ b/common/meta/data/projection.py
@@ -42,6 +42,14 @@ def contract_index(contracts: list[PackageContract]) -> dict[str, dict]:
     ac_index: dict[str, str] = {}
     for c in contracts:
         for ac in c.roadmap:
+            owner = ac_index.get(ac.id)
+            if owner is not None and owner != c.name:
+                # No AC is owned twice. A duplicate id across packages is a
+                # contract-integrity violation; surface it instead of silently
+                # overwriting the owner mapping.
+                raise ValueError(
+                    f"AC {ac.id!r} is claimed by two packages: {owner!r} and {c.name!r}"
+                )
             ac_index[ac.id] = c.name
 
     consumers: dict[str, list[str]] = {name: [] for name in by_name}

--- a/common/meta/extension/__init__.py
+++ b/common/meta/extension/__init__.py
@@ -1,0 +1,8 @@
+"""``common.meta.extension`` — the meta package's edge layer.
+
+Holds :mod:`common.meta.extension.check_package_contract`: the governance gate
+(a domain service) that walks the filesystem, parses contracts and ``__all__``,
+and validates every package against its :class:`~common.meta.base.package_contract.PackageContract`.
+It imports ``base`` (the model) — never the other way round (``extension -> base``,
+one-way), and never ``data``.
+"""

--- a/common/meta/extension/check_package_contract.py
+++ b/common/meta/extension/check_package_contract.py
@@ -4,9 +4,9 @@ Governance in the package model is *computed from contracts*, not hand-kept. The
 authoritative spec for each package lives in ``common/<pkg>/`` (its ``readme.md``
 + ``contract.py``); the running code lives in the *implementations* the contract
 points at. ``implementations["be"]`` is a **repo-relative** path — usually
-``apps/backend/src/<pkg>``, but not required (the meta package ``governance``
-points its BE implementation at ``common/meta`` itself). For every
-registered package this gate asserts:
+``apps/backend/src/<pkg>``, but not required (the meta package points its BE
+implementation at ``common/meta`` itself). For every registered package this gate
+asserts:
 
   (a) ``contract.interface`` equals the BE implementation's ``__init__.__all__``
       (the published language and the contract agree);
@@ -14,7 +14,16 @@ registered package this gate asserts:
       resolves to a real test function in the repo;
   (c) ``depends_on`` introduces no forbidden edge — a ``platform``/``kernel``
       package's implementation modules must not import a higher layer (mirrors
-      the spirit of ``tests/tooling/test_ledger_module.py``: down only).
+      the spirit of ``tests/tooling/test_ledger_module.py``: down only);
+  (d) the building-block layering holds for any package that adopts the
+      ``base/extension/`` split — base stays pure (mechanism A), each declared
+      ``unit`` sits in the layer its ``kind`` dictates (``KIND_LAYER``), a
+      ``repository`` unit splits into a base port + an extension adapter
+      (mechanism B), and ``data`` is a sink nothing else imports (the read-model).
+
+This module is the meta package's ``extension`` layer (the impure edge: it walks
+the filesystem and parses ASTs). It imports the ``base`` model
+(:mod:`common.meta.base.package_contract`) — never ``data``.
 
 Packages are discovered by scanning ``common/*/contract.py`` for a module-level
 ``CONTRACT = PackageContract(...)``; that single registry keeps the gate additive
@@ -34,9 +43,11 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from common.meta.package_contract import PackageContract
+from common.meta.base.package_contract import KIND_LAYER, SPLIT, PackageContract, Unit
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+# This module lives at common/meta/extension/check_package_contract.py, so the
+# repo root is four parents up (extension -> meta -> common -> repo).
+REPO_ROOT = Path(__file__).resolve().parents[3]
 PACKAGE_GLOB = "common/*/contract.py"
 
 # Layer rank for the DAG rule: a package may never import a HIGHER class (no
@@ -95,6 +106,27 @@ def _contained_impl_dir(be_rel: str | None, repo_root: Path) -> Path | None:
     if resolved != root and root not in resolved.parents:
         return None
     return resolved
+
+
+def _impl_module_prefix(impl_dir: Path, repo_root: Path) -> str:
+    """The dotted import prefix the implementation dir is importable under.
+
+    The gate's layering checks need to recognise a package's *own* layer imports
+    (``...extension`` / ``...data``) by their absolute module path. That path
+    depends on which ``sys.path`` root contains the implementation:
+    ``apps/backend/src/counter`` is importable as ``src.counter`` (``apps/backend``
+    is on the path), while ``common/meta`` is importable as ``common.meta`` (the
+    repo root is on the path). We derive the prefix from the dir location instead
+    of assuming ``src.<name>``, so meta self-hosts correctly.
+    """
+    backend = (repo_root / "apps" / "backend").resolve()
+    impl = impl_dir.resolve()
+    root = repo_root.resolve()
+    if impl == backend or backend in impl.parents:
+        rel = impl.relative_to(backend)
+    else:
+        rel = impl.relative_to(root)
+    return ".".join(rel.parts)
 
 
 def discover_packages(repo_root: Path = REPO_ROOT) -> list[DiscoveredPackage]:
@@ -250,7 +282,7 @@ def _check_no_dependency_cycle(packages: list[DiscoveredPackage]) -> list[str]:
             if dep not in graph:
                 continue  # unregistered dep; the edge rule handles declared-ness
             if color[dep] == 1:
-                cycle = path[path.index(dep):] + [dep] if dep in path else [node, dep]
+                cycle = path[path.index(dep) :] + [dep] if dep in path else [node, dep]
                 offenders.append("dependency cycle: " + " -> ".join(cycle))
             elif color[dep] == 0:
                 visit(dep, path + [dep])
@@ -262,10 +294,60 @@ def _check_no_dependency_cycle(packages: list[DiscoveredPackage]) -> list[str]:
     return sorted(set(offenders))
 
 
+def _sibling_import_hit(node: ast.AST, prefix: str, sibling: str) -> str | None:
+    """If ``node`` imports the package's own ``<sibling>`` layer, describe it.
+
+    Recognises the package's own sibling-layer import in every form — relative
+    (``from ..<sibling> import x`` / ``from .. import <sibling>``) and absolute
+    (``from <prefix>.<sibling>... import x`` / ``from <prefix> import <sibling>`` /
+    ``import <prefix>.<sibling>...``). ``prefix`` is the implementation's dotted
+    import path (see :func:`_impl_module_prefix`). Returns ``None`` when the node
+    does not reach the sibling layer.
+    """
+    own = f"{prefix}.{sibling}"
+    if isinstance(node, ast.ImportFrom):
+        mod = node.module or ""
+        names = node.names
+        if node.level and (
+            mod.split(".")[0] == sibling
+            or any(a.name == sibling or a.name.startswith(f"{sibling}.") for a in names)
+        ):
+            return (
+                f"(relative level {node.level}) "
+                f"{mod or '.'.join(a.name for a in names)}"
+            )
+        if mod.startswith(own):
+            return mod
+        if mod == prefix and any(
+            a.name == sibling or a.name.startswith(f"{sibling}.") for a in names
+        ):
+            return f"{mod}.{sibling}"
+    elif isinstance(node, ast.Import):
+        for a in node.names:
+            if a.name.startswith(own):
+                return a.name
+    return None
+
+
+def _layer_imports(
+    layer_dir: Path, prefix: str, sibling: str
+) -> list[tuple[Path, str]]:
+    """Every ``.py`` under ``layer_dir`` that imports the own ``<sibling>`` layer."""
+    hits: list[tuple[Path, str]] = []
+    for py in sorted(layer_dir.rglob("*.py")):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            hit = _sibling_import_hit(node, prefix, sibling)
+            if hit:
+                hits.append((py, hit))
+    return hits
+
+
 def _check_layer_purity(pkg: DiscoveredPackage) -> list[str]:
     """If a package's implementation uses ``base/`` + ``extension/`` layers, the
     ``base/`` layer must not import the package's own ``extension/`` — base is the
-    pure, downward-only core; the edges live in extension (base↓ / extension↑).
+    pure, downward-only core; the edges live in extension (base down / extension
+    up). This is mechanism A applied within the package.
 
     Additive: a package that does not use the two-layer split is skipped, so the
     role-folder packages keep passing unchanged.
@@ -276,37 +358,105 @@ def _check_layer_purity(pkg: DiscoveredPackage) -> list[str]:
     base_dir, ext_dir = pkg.impl_dir / "base", pkg.impl_dir / "extension"
     if not (base_dir.exists() and ext_dir.exists()):
         return offenders
-    own_extension = f"src.{pkg.name}.extension"
-    own_pkg = f"src.{pkg.name}"
-    for py in sorted(base_dir.rglob("*.py")):
-        tree = ast.parse(py.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            hit: str | None = None
-            if isinstance(node, ast.ImportFrom):
-                mod = node.module or ""
-                if node.level and (
-                    mod.split(".")[0] == "extension"
-                    or any(a.name == "extension" or a.name.startswith("extension.") for a in node.names)
-                ):
-                    # relative: from ..extension import X / from .. import extension
-                    hit = f"(relative level {node.level}) {mod or '.'.join(a.name for a in node.names)}"
-                elif mod.startswith(own_extension):
-                    # absolute: from src.<pkg>.extension... import X
-                    hit = mod
-                elif mod == own_pkg and any(
-                    a.name == "extension" or a.name.startswith("extension.") for a in node.names
-                ):
-                    # absolute: from src.<pkg> import extension
-                    hit = f"{mod}.extension"
-            elif isinstance(node, ast.Import):
-                for a in node.names:
-                    if a.name.startswith(own_extension):
-                        hit = a.name
-            if hit:
-                offenders.append(
-                    f"{py.relative_to(REPO_ROOT)}: base/ imports the package's own "
-                    f"extension/ ('{hit}') — base must stay pure"
-                )
+    prefix = _impl_module_prefix(pkg.impl_dir, REPO_ROOT)
+    for py, hit in _layer_imports(base_dir, prefix, "extension"):
+        offenders.append(
+            f"{py.relative_to(REPO_ROOT)}: base/ imports the package's own "
+            f"extension/ ('{hit}') — base must stay pure"
+        )
+    return offenders
+
+
+def _check_data_is_sink(pkg: DiscoveredPackage) -> list[str]:
+    """If a package has a ``data/`` layer, nothing in ``base/`` or ``extension/``
+    may import it — ``data`` is the read-model / projection, a leaf sink computed
+    FROM the write side. Keeping it a sink is what makes the projection safe: the
+    write side never depends on its own read model.
+
+    Additive: a package without a ``data/`` layer is skipped.
+    """
+    offenders: list[str] = []
+    if pkg.impl_dir is None or not pkg.impl_dir.exists():
+        return offenders
+    if not (pkg.impl_dir / "data").exists():
+        return offenders
+    prefix = _impl_module_prefix(pkg.impl_dir, REPO_ROOT)
+    for layer in ("base", "extension"):
+        layer_dir = pkg.impl_dir / layer
+        if not layer_dir.exists():
+            continue
+        for py, hit in _layer_imports(layer_dir, prefix, "data"):
+            offenders.append(
+                f"{py.relative_to(REPO_ROOT)}: {layer}/ imports the package's own "
+                f"data/ ('{hit}') — data is a read-model sink; nothing may import it"
+            )
+    return offenders
+
+
+def _check_repository_unit(pkg: DiscoveredPackage, unit: Unit) -> list[str]:
+    """A ``repository`` unit must split: port in ``base/``, adapter in ``extension/``.
+
+    This is mechanism B (dependency inversion) made checkable: the abstract port
+    the pure core depends on lives in ``base``; the concrete adapter that touches
+    I/O lives in ``extension`` and depends back on the port.
+    """
+    offenders: list[str] = []
+    port, impl = unit.module, unit.impl
+    if port is not None and port.split("/")[0] != "base":
+        offenders.append(
+            f"repository unit {unit.name!r}: port {port!r} must live in 'base/' "
+            "(the abstract port the pure core depends on)"
+        )
+    if impl is not None and impl.split("/")[0] != "extension":
+        offenders.append(
+            f"repository unit {unit.name!r}: adapter {impl!r} must live in "
+            "'extension/' (the concrete I/O adapter — dependency inversion)"
+        )
+    for path in (port, impl):
+        if path is not None and not (pkg.impl_dir / path).exists():
+            offenders.append(
+                f"repository unit {unit.name!r}: declared path {path!r} does not exist"
+            )
+    return offenders
+
+
+def _check_kind_placement(pkg: DiscoveredPackage) -> list[str]:
+    """Each declared ``unit`` must live in the layer its ``kind`` dictates.
+
+    The building-block table is :data:`KIND_LAYER`; this check enforces it. A
+    value-object/entity/aggregate/factory/domain-event belongs in ``base``, a
+    domain-service/event-bus in ``extension``, a projection in ``data``, and a
+    repository splits across ``base`` + ``extension`` (see
+    :func:`_check_repository_unit`).
+
+    Additive on two axes: a package that has not adopted the physical
+    ``base/extension/`` split is skipped entirely, and within an adopted package a
+    unit with no ``module`` path (kind declared for the taxonomy only) is skipped.
+    """
+    offenders: list[str] = []
+    if pkg.impl_dir is None or not pkg.impl_dir.exists():
+        return offenders
+    base_dir, ext_dir = pkg.impl_dir / "base", pkg.impl_dir / "extension"
+    if not (base_dir.exists() and ext_dir.exists()):
+        return offenders
+    for unit in pkg.contract.units:
+        expected = KIND_LAYER[unit.kind]
+        if expected == SPLIT:
+            offenders.extend(_check_repository_unit(pkg, unit))
+            continue
+        if unit.module is None:
+            continue
+        top = unit.module.split("/")[0]
+        if top != expected:
+            offenders.append(
+                f"unit {unit.name!r} (kind {unit.kind.value!r}) declares module "
+                f"{unit.module!r} but its kind belongs in '{expected}/'"
+            )
+            continue
+        if not (pkg.impl_dir / unit.module).exists():
+            offenders.append(
+                f"unit {unit.name!r}: declared module {unit.module!r} does not exist"
+            )
     return offenders
 
 
@@ -353,8 +503,12 @@ def check_package(
         f"[{pkg.name}] {e}" for e in _check_no_forbidden_edge(pkg, registered)
     )
 
-    # (d) layer purity: base/ must not import the package's own extension/ (additive)
+    # (d) building-block layering (additive — only for packages using the split):
+    #     base stays pure (A), each unit sits in its kind's layer + repository
+    #     splits (B), and data is a read-model sink nothing imports.
     errors.extend(f"[{pkg.name}] {e}" for e in _check_layer_purity(pkg))
+    errors.extend(f"[{pkg.name}] {e}" for e in _check_kind_placement(pkg))
+    errors.extend(f"[{pkg.name}] {e}" for e in _check_data_is_sink(pkg))
 
     return errors
 

--- a/common/meta/migration-standard.md
+++ b/common/meta/migration-standard.md
@@ -51,14 +51,52 @@ Every package is, in implementation, three sub-layers — a **menu**, not a mand
   bus, transport/LLM adapters. Its own import surface; forms its own DAG (typically
   the **transpose/upward** direction). Separate from base, so `A.base → B.base`
   and `B.extension → A.extension` coexist **without a cycle**.
-- **data** — metadata only: consumers (reverse deps) + governance tasks (roadmap
-  ACs, invariants). Free (no code-import constraint), because declarations can't
-  form import cycles.
+- **data** — the **read-model / projection** (CQRS sense): the computed view over
+  the write side — consumers (reverse deps) + governance tasks (roadmap ACs,
+  invariants) + the meta-index. A **leaf sink**: it imports `base`, and nothing in
+  `base`/`extension` imports it, so the write side never depends on its own read
+  model.
+
+### The DDD building blocks → layer (the `units` taxonomy)
+
+The layer is the **universal purity axis** (every package, domain or tooling). For
+a *domain* package, each unit is additionally one of the eight DDD tactical
+building blocks, and its `kind` decides its layer. That mapping is **code**
+(`common/meta/base/package_contract.py` → `KIND_LAYER`), so the table can never
+drift from what the gate checks:
+
+| Building block | Layer | Cycle-breaking mechanism |
+|---|---|---|
+| Value Object | base | A — leaf, only depended-on |
+| Entity | base | A — composes VOs, one-way |
+| Aggregate Root | base | A + C — refer to other aggregates **by id** |
+| Factory (pure) | base | A |
+| Domain Event (record) | base | C — publisher & subscriber depend only on the event type |
+| **Repository** | **port=base / impl=extension** | **B** — dependency inversion |
+| Domain Service (cross-aggregate) | extension | A — `extension → base`, one-way |
+| Event publish / Bus | extension | C — runtime registry, no compile edge |
+| Projection | data | read-model, leaf sink |
+
+The acyclicity is held by three mechanisms (the gate enforces A and B statically;
+C is a convention with a partial static guard):
+
+- **A — layer split / transpose.** No import of a higher layer; `base` never
+  imports `extension`/`data`; cross-package edges flip to the transpose direction
+  (`A.base → B.base` with `B.extension → A.extension`).
+- **B — dependency inversion (repository).** A repository's abstract **port** lives
+  in `base` (what the pure core depends on); its concrete **adapter** lives in
+  `extension`. The gate requires the split.
+- **C — id-reference + events.** Aggregates reference each other **by id**, not by
+  object, and cross-aggregate effects go through a **Domain Event** on the bus
+  (a runtime registry) — so there is no compile-time edge between aggregates or
+  between publisher and subscriber. (Convention; the gate guards the data-sink and
+  layer-purity halves of it, not the id-reference itself.)
 
 Rule enforced by `check_package_contract`: **never up, never sideways-cyclic** —
 no import of a higher layer; same-layer edges allowed when declared **and** the
-graph stays acyclic (a global cycle check, per layer). "10 packages" is really
-~30 governed units (10 × 3 layers).
+graph stays acyclic (a global cycle check, per layer); each declared `unit` sits in
+its kind's layer; a repository splits port/adapter; `data` stays a sink. "10
+packages" is really ~30 governed units (10 × 3 layers).
 
 ## Acceptance criteria: `AC-<package>.<entity>.<seq>`
 
@@ -87,7 +125,7 @@ Spec in `common/`, code in `apps/`. `data` is metadata in `contract.py`, not a d
 ```
 common/<pkg>/                         spec + review surface
   __init__.py                         re-exports CONTRACT
-  contract.py                         interface · roles=[base,extension] · invariants · roadmap(ACs)
+  contract.py                         interface · units=[Unit(kind=…)] · invariants · roadmap(ACs)
   readme.md  todo.md                  prose (absorbs the package's SSOT) + worklist
 apps/backend/src/<pkg>/               BE implementation  (implementations["be"])
   __init__.py                         __all__ == contract.interface
@@ -134,9 +172,13 @@ common/meta/
 - cross-runtime leaf value language (BE + FE + conformance vectors) → **layout 2**.
 - the governing `meta` package → **layout 3** (common-only).
 
-Layout 1 is live in `counter`; the value types already use layout 2; `meta` is
-still flat and adopts layout 3 as it is refactored. New packages MUST match one
-of these — the gate (`check_package_contract`) owns the `base↓ / extension↑` rule.
+Layout 1 is live in `counter`; the value types already use layout 2; `meta` is the
+live **layout-3 exemplar** — it converges into `base/` (the `PackageContract`
+aggregate + its value objects), `extension/` (the gate, a domain service), and
+`data/` (`contract_index`, the projection), and declares its own `units`. New
+packages MUST match one of these — the gate (`check_package_contract`) owns the
+`base↓ / extension↑` rule, the `kind → layer` placement, the repository port/adapter
+split, and the data-sink rule.
 
 ## Completion state (Definition of Done) — the migration unit is the AC
 

--- a/common/meta/package_contract.py
+++ b/common/meta/package_contract.py
@@ -1,160 +1,50 @@
-"""``PackageContract`` — the machine-checkable contract a package publishes.
+"""Compatibility re-export of the meta model (now in ``common.meta.base``).
 
-A package = bounded context declares one :class:`PackageContract` instance in its
-``contract.py``. The contract is the single source of truth for the package's
-*published language* (``interface`` mirrors ``__init__.__all__``), its emitted
-domain ``events``, the ``invariants`` it guarantees, and its ``roadmap`` (the
-ACs it owns). ``tools/check_package_contract.py`` validates the live package
-against this contract, so governance is *computed*, not hand-maintained.
-
-stdlib + pydantic only by design: importable from the governance gate and from a
-package's ``contract.py`` without pulling app/framework dependencies. The
-authority-tier vocabulary and the tier->proof matrix come from the stdlib-only
-:mod:`common.authority.authority_matrix` (the single machine source, also imported by
-the lightweight SSOT tooling that must NOT pull pydantic).
+The :class:`PackageContract` model moved into the meta package's ``base`` layer
+(``common.meta.base.package_contract``) when the meta package adopted the
+``base/extension/data`` layout it governs. This module is a thin, stable
+re-export so existing imports — every ``common/<pkg>/contract.py`` and the
+governance tests that do ``from common.meta.package_contract import ...`` — keep
+working unchanged. Prefer importing from :mod:`common.meta.base.package_contract`
+(or ``common.meta``) in new code.
 """
 
 from __future__ import annotations
 
-from typing import Literal
-
-from pydantic import BaseModel, model_validator
-
-# The tier vocabulary + matrix live in one source: common.authority.authority_matrix.
-# Import only what this model uses (the field types + the validator's matrix).
-from common.authority.authority_matrix import (
+from common.meta.base.package_contract import (  # noqa: F401
     ACProofKind,
+    ACRecord,
+    ACStatus,
+    Invariant,
+    KIND_LAYER,
+    Kind,
+    Layer,
+    PackageClass,
+    PackageContract,
+    PackageStatus,
     PackageTier,
+    Priority,
+    SPLIT,
     TIER_DEFAULT_PROOF_KIND,
     TIER_VALID_PROOF_KINDS,
+    Unit,
 )
 
-#: A package class. The three orthogonal kinds in the model:
-#: - ``kernel``   — leaf value-language reused everywhere (e.g. ``money``);
-#:                  depends on nothing in the app.
-#: - ``platform`` — a reusable horizontal capability (e.g. ``counter``);
-#:                  depends only on kernels.
-#: - ``core``     — a vertical domain slice (e.g. ``ledger``);
-#:                  may depend on platform + kernel packages.
-PackageClass = Literal["core", "platform", "kernel"]
-
-#: AC priority, mirroring the EPIC AC tables (P0 highest).
-Priority = Literal["P0", "P1", "P2"]
-
-#: AC lifecycle status within a package roadmap.
-ACStatus = Literal["open", "done"]
-
-#: Package lifecycle status. ``draft`` = still being designed (its authority
-#: tier may be undecided); ``active`` = governed and shipped (tier MUST be
-#: decided); ``deprecated`` = on the way out (still checked, but flagged).
-PackageStatus = Literal["draft", "active", "deprecated"]
-
-class Invariant(BaseModel):
-    """A property the package guarantees, pinned to the test that proves it.
-
-    ``test`` is a ``"path::func"`` reference (pytest node-id style, module path
-    relative to the repo root) so the governance gate can resolve it to a real
-    test function — an invariant with no executable proof is not an invariant.
-    """
-
-    id: str
-    statement: str
-    test: str
-
-
-class ACRecord(BaseModel):
-    """One acceptance criterion the package owns, in the package-model registry.
-
-    The package roadmap is the *new* home for a package's ACs (the model where
-    governance is computed from contracts). ``test`` is a ``"path::func"``
-    reference, exactly like :class:`Invariant.test`, so each AC resolves to the
-    test that anchors it.
-    """
-
-    id: str
-    statement: str
-    test: str
-    priority: Priority
-    status: ACStatus
-    #: Proof kind the AC's test provides. The AC inherits its authority tier from
-    #: the owning :class:`PackageContract` (tier is a module-design property, not a
-    #: per-AC one), so ``proof_kind`` is the only tier-related attribute an AC
-    #: carries. ``None`` resolves to the package tier's canonical kind
-    #: (:data:`TIER_DEFAULT_PROOF_KIND`); an explicit value MUST be valid for the
-    #: package tier per :data:`TIER_VALID_PROOF_KINDS` (e.g. under an LLM-LED/LLM-ONLY package
-    #: an AC can never be ``exact``). Enforced by the owning ``PackageContract``.
-    proof_kind: ACProofKind | None = None
-
-
-class PackageContract(BaseModel):
-    """The contract a package publishes — the unit the governance gate checks.
-
-    Fields:
-        name:            the package name (matches its ``common/<name>/`` dir).
-        klass:           ``core`` / ``platform`` / ``kernel`` (the dependency tier).
-        status:          ``draft`` / ``active`` / ``deprecated`` (package lifecycle).
-        tier:            the package's permanent authority tier (:data:`PackageTier`);
-                         ``None`` = undecided, allowed only while ``status="draft"``.
-        depends_on:      names of packages this one may import (down-only edges).
-        roles:           the role folders the implementation converges into
-                         (e.g. ``["types", "ops", "store", "api"]``).
-        implementations: where each implementation lives, by surface key
-                         (``"be"`` / ``"fe"``); ``None`` means "no implementation
-                         on that surface yet". The governance gate resolves
-                         ``__all__`` against ``implementations["be"]``.
-        interface:       the published language — must equal the BE
-                         implementation's ``__init__.__all__``.
-        events:          domain event type names this package publishes.
-        invariants:      guaranteed properties, each pinned to a proving test.
-        roadmap:         the ACs this package owns (the package-model AC registry).
-    """
-
-    name: str
-    klass: PackageClass
-    depends_on: list[str]
-    interface: list[str]
-    events: list[str]
-    invariants: list[Invariant]
-    roadmap: list[ACRecord]
-    status: PackageStatus = "active"
-    #: The package's permanent authority tier. ``None`` means "undecided" and is
-    #: legal only for a ``draft`` package; an ``active``/``deprecated`` package
-    #: must have resolved its tier to a concrete :data:`PackageTier`.
-    tier: PackageTier | None = None
-    roles: list[str] = []
-    implementations: dict[str, str | None] = {}
-
-    @model_validator(mode="after")
-    def _tier_decided_and_proofs_match(self) -> PackageContract:
-        """Enforce the module-design tier rules at construction.
-
-        1. A shipped package has a decided tier: ``status != "draft"`` requires a
-           concrete :data:`PackageTier` (a ``draft`` may stay ``tier=None`` — the
-           "undecided" state that the legacy EPIC source spelled ``HU``).
-        2. Every roadmap AC's proof kind is valid for the package's tier per the
-           single matrix (:data:`TIER_VALID_PROOF_KINDS`); a missing kind resolves
-           to the tier's canonical default and is materialized on the record. An
-           undecided (``None``) tier skips the proof check — there is no tier to
-           validate against yet.
-        """
-        if self.tier is None:
-            if self.status != "draft":
-                raise ValueError(
-                    f"package {self.name!r}: status {self.status!r} requires a "
-                    "decided authority tier (one of CODE-ONLY/CODE-LED/LLM-LED/LLM-ONLY); only a 'draft' "
-                    "package may leave tier undecided (the legacy 'HU' state)."
-                )
-            return self
-
-        valid = TIER_VALID_PROOF_KINDS[self.tier]
-        for ac in self.roadmap:
-            kind = ac.proof_kind or TIER_DEFAULT_PROOF_KIND[self.tier]
-            if kind not in valid:
-                raise ValueError(
-                    f"package {self.name!r} AC {ac.id}: proof_kind {kind!r} is "
-                    f"not valid for the package tier {self.tier} "
-                    f"(valid: {sorted(valid)}). Under an LLM-LED/LLM-ONLY package an AC can "
-                    "never be proven by an exact golden assertion."
-                )
-            ac.proof_kind = kind
-        return self
+__all__ = [
+    "ACProofKind",
+    "ACRecord",
+    "ACStatus",
+    "Invariant",
+    "KIND_LAYER",
+    "Kind",
+    "Layer",
+    "PackageClass",
+    "PackageContract",
+    "PackageStatus",
+    "PackageTier",
+    "Priority",
+    "SPLIT",
+    "TIER_DEFAULT_PROOF_KIND",
+    "TIER_VALID_PROOF_KINDS",
+    "Unit",
+]

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -27,8 +27,9 @@ these parts:
    review surface.)
 2. **`contract.py`** (`common/<pkg>/contract.py`) — a machine-checkable
    `PackageContract` (a pydantic model): the package's `status`, `klass`,
-   `roles`, `implementations`, published `interface`, emitted `events`, the
-   `invariants` it guarantees, and its `roadmap` (the ACs it owns).
+   `units` (its DDD building blocks, each carrying its `kind` → layer; `roles` is
+   the legacy form), `implementations`, published `interface`, emitted `events`,
+   the `invariants` it guarantees, and its `roadmap` (the ACs it owns).
 3. **`todo.md`** (`common/<pkg>/todo.md`) — the package's own worklist.
 4. **Implementations** — the conforming code under `apps/backend/src/<pkg>`
    (`implementations["be"]`) and/or `apps/frontend/src/lib/<pkg>`
@@ -42,6 +43,14 @@ these parts:
 5. **Published language** — the implementation's `__init__.__all__` is the
    *entire* public surface; everything else is internal. `contract.interface`
    must equal that `__all__`.
+
+The role folders above are the legacy convergence. The forward model converges by
+the **DDD building block → layer** table (`base` / `extension` / `data`): each
+`unit`'s `kind` decides its layer (`KIND_LAYER`), a repository splits into a base
+port + an extension adapter, and `data` is the read-model sink. See
+[`migration-standard.md`](./migration-standard.md#internal-layering-replaces-kernelplatformcore-and-typesopsstoreapi)
+for the full table and the three cycle-breaking mechanisms; `meta` itself is the
+live exemplar.
 
 So `common/<pkg>/` is the **spec + high-level review surface**;
 `apps/backend/src/<pkg>` and `apps/frontend/src/lib/<pkg>` are conforming
@@ -68,8 +77,8 @@ The only **authored horizontal doc is `vision.md`** (the "why"). Everything else
 about a package is *derived from its contract*:
 
 - `tools/check_package_contract.py` (logic in
-  [`check_package_contract.py`](./check_package_contract.py)) discovers every
-  package by scanning `common/*/contract.py` for a
+  [`extension/check_package_contract.py`](./extension/check_package_contract.py))
+  discovers every package by scanning `common/*/contract.py` for a
   `CONTRACT = PackageContract(...)` and asserts, per package:
   - **(a)** `contract.interface == __init__.__all__` of the BE implementation
     (`implementations["be"]`) — contract and published language agree;
@@ -78,7 +87,11 @@ about a package is *derived from its contract*:
     invariant);
   - **(c)** no implementation module imports a **higher-class** registered
     package or an undeclared dependency (the DAG rule, mirroring
-    `tests/tooling/test_ledger_module.py`).
+    `tests/tooling/test_ledger_module.py`);
+  - **(d)** for a package that adopts the `base/extension/` split: `base` stays
+    pure (A), each declared `unit` sits in its `kind`'s layer + a repository splits
+    port/adapter (B), and `data` is a sink nothing imports — additive, so legacy
+    role-folder packages keep passing.
 - The AC registry sources a package's ACs **directly from its `roadmap`**:
   `common/ssot/generate_ac_registry.py` reads `common/*/contract.py` roadmaps
   additively (alongside the EPIC tables), so a package's ACs live in its contract
@@ -89,10 +102,14 @@ edit: a new package is governed the moment it ships a `common/<pkg>/contract.py`
 
 ## Examples
 
-- **`meta`** (`platform`, the meta-package) — self-hosts the model. Its
+- **`meta`** (`platform`, the meta-package) — self-hosts the model **and** is the
+  live layout-3 exemplar of the building-block layering it governs. Its
   [`contract.py`](./contract.py) publishes `PackageContract` / `ACRecord` /
-  `Invariant`, and its invariants pin to the governance-gate failure-path tests,
-  so the model proves itself.
+  `Invariant` / `Kind` / `Unit` / `contract_index`, declares its `units` (the
+  `PackageContract` aggregate + value objects in `base/`, the gate as a
+  `domain-service` in `extension/`, `contract_index` as a `projection` in
+  `data/`), and its invariants + `AC-meta.*` roadmap pin to the governance-gate
+  tests, so the model proves itself.
 - **`counter`** (`platform`) — the first full worked example: per-(user, key)
   tallies for insight reports. `CounterKey`/`Count` value objects (`types`),
   `increment`/`get_count` verbs (`ops`) over a `CounterRepository` port (`store`),
@@ -121,10 +138,10 @@ The recipe for moving a module (and its EPIC-table ACs) into the package model.
    behavior is two packages.
 
 2. **Write `contract.py`.** One `PackageContract(...)` with `name`, `klass`,
-   `status`, `tier`, `depends_on` (down-only edges), `roles`
-   (`types`/`ops`/`store`/`api`), `implementations` (`be`/`fe` paths),
-   `interface` (must equal the BE `__init__.__all__`), `events`, `invariants`,
-   `roadmap`.
+   `status`, `tier`, `depends_on` (down-only edges), `units` (the DDD building
+   blocks, each `Unit(kind=…, module=…)`; `roles` is the legacy form),
+   `implementations` (`be`/`fe` paths), `interface` (must equal the BE
+   `__init__.__all__`), `events`, `invariants`, `roadmap`.
 
 3. **Domain ACs → `roadmap`.** Each `ACRecord(id, statement, test, priority,
    status)` with a **package-scoped id `AC-{package}.{group}.{seq}`** (e.g.

--- a/common/money/contract.py
+++ b/common/money/contract.py
@@ -15,7 +15,7 @@ and an EPIC. Moving that AC ownership into the roadmap is a tracked follow-up.
 
 from __future__ import annotations
 
-from common.meta.package_contract import Invariant, PackageContract
+from common.meta.package_contract import Invariant, Kind, PackageContract, Unit
 
 CONTRACT = PackageContract(
     name="money",
@@ -28,8 +28,46 @@ CONTRACT = PackageContract(
     tier="CODE-ONLY",
     depends_on=["ratio"],
     roles=["types", "ops"],
-    implementations={"be": "apps/backend/src/money", "fe": "apps/frontend/src/lib/money"},
-    interface=["ISO_4217_CODES", "MONEY_QUANTUM", "Currency", "CurrencyBalance", "CurrencyBalances", "CurrencyMismatchError", "ExchangeRate", "FloatNotAllowedError", "InvalidExchangeRateError", "InvalidCurrencyError", "InvalidMoneyPayloadError", "Money", "MoneyError", "MoneyTolerance", "convert", "exchange_rate_from_db_fields", "exchange_rate_from_wire", "exchange_rate_to_db_fields", "exchange_rate_to_wire", "money_from_db_fields", "money_from_wire", "money_to_db_fields", "money_to_wire", "to_money"],
+    # The package's domain value objects (kind for the taxonomy; no module path —
+    # money still uses the types/ops layout, so the gate skips placement here).
+    units=[
+        Unit(name="Money", kind=Kind.VALUE_OBJECT),
+        Unit(name="Currency", kind=Kind.VALUE_OBJECT),
+        Unit(name="ExchangeRate", kind=Kind.VALUE_OBJECT),
+        Unit(name="MoneyTolerance", kind=Kind.VALUE_OBJECT),
+        Unit(name="CurrencyBalance", kind=Kind.VALUE_OBJECT),
+        Unit(name="CurrencyBalances", kind=Kind.VALUE_OBJECT),
+    ],
+    implementations={
+        "be": "apps/backend/src/money",
+        "fe": "apps/frontend/src/lib/money",
+    },
+    interface=[
+        "ISO_4217_CODES",
+        "MONEY_QUANTUM",
+        "Currency",
+        "CurrencyBalance",
+        "CurrencyBalances",
+        "CurrencyMismatchError",
+        "ExchangeRate",
+        "FloatNotAllowedError",
+        "InvalidExchangeRateError",
+        "InvalidCurrencyError",
+        "InvalidMoneyPayloadError",
+        "Money",
+        "MoneyError",
+        "MoneyTolerance",
+        "convert",
+        "exchange_rate_from_db_fields",
+        "exchange_rate_from_wire",
+        "exchange_rate_to_db_fields",
+        "exchange_rate_to_wire",
+        "money_from_db_fields",
+        "money_from_wire",
+        "money_to_db_fields",
+        "money_to_wire",
+        "to_money",
+    ],
     events=[],
     invariants=[
         Invariant(

--- a/common/quantity/contract.py
+++ b/common/quantity/contract.py
@@ -12,7 +12,7 @@ table; moving that ownership into the roadmap is a tracked follow-up.
 
 from __future__ import annotations
 
-from common.meta.package_contract import Invariant, PackageContract
+from common.meta.package_contract import Invariant, Kind, PackageContract, Unit
 
 CONTRACT = PackageContract(
     name="quantity",
@@ -23,8 +23,30 @@ CONTRACT = PackageContract(
     tier="CODE-ONLY",
     depends_on=["ratio"],
     roles=["types", "ops"],
-    implementations={"be": "apps/backend/src/quantity", "fe": "apps/frontend/src/lib/quantity"},
-    interface=["QUANTITY_DP", "QUANTITY_QUANTUM", "QUANTITY_ROUNDING", "FloatNotAllowedError", "InvalidQuantityPayloadError", "InvalidUnitError", "Quantity", "QuantityError", "Unit", "UnitMismatchError", "quantity_from_db_fields", "quantity_from_wire", "quantity_to_db_fields", "quantity_to_wire"],
+    units=[
+        Unit(name="Quantity", kind=Kind.VALUE_OBJECT),
+        Unit(name="Unit", kind=Kind.VALUE_OBJECT),
+    ],
+    implementations={
+        "be": "apps/backend/src/quantity",
+        "fe": "apps/frontend/src/lib/quantity",
+    },
+    interface=[
+        "QUANTITY_DP",
+        "QUANTITY_QUANTUM",
+        "QUANTITY_ROUNDING",
+        "FloatNotAllowedError",
+        "InvalidQuantityPayloadError",
+        "InvalidUnitError",
+        "Quantity",
+        "QuantityError",
+        "Unit",
+        "UnitMismatchError",
+        "quantity_from_db_fields",
+        "quantity_from_wire",
+        "quantity_to_db_fields",
+        "quantity_to_wire",
+    ],
     events=[],
     invariants=[
         Invariant(

--- a/common/ratio/contract.py
+++ b/common/ratio/contract.py
@@ -13,7 +13,7 @@ mirrored into both a roadmap and an EPIC).
 
 from __future__ import annotations
 
-from common.meta.package_contract import Invariant, PackageContract
+from common.meta.package_contract import Invariant, Kind, PackageContract, Unit
 
 CONTRACT = PackageContract(
     name="ratio",
@@ -22,8 +22,24 @@ CONTRACT = PackageContract(
     tier="CODE-ONLY",
     depends_on=[],
     roles=["types", "ops"],
-    implementations={"be": "apps/backend/src/ratio", "fe": "apps/frontend/src/lib/ratio"},
-    interface=["PERCENT_DP", "PERCENT_ROUNDING", "FloatNotAllowedError", "InvalidRatioPayloadError", "Ratio", "RatioError", "UndefinedRatioError", "ratio_from_db_value", "ratio_from_wire", "ratio_to_db_value", "ratio_to_wire"],
+    units=[Unit(name="Ratio", kind=Kind.VALUE_OBJECT)],
+    implementations={
+        "be": "apps/backend/src/ratio",
+        "fe": "apps/frontend/src/lib/ratio",
+    },
+    interface=[
+        "PERCENT_DP",
+        "PERCENT_ROUNDING",
+        "FloatNotAllowedError",
+        "InvalidRatioPayloadError",
+        "Ratio",
+        "RatioError",
+        "UndefinedRatioError",
+        "ratio_from_db_value",
+        "ratio_from_wire",
+        "ratio_to_db_value",
+        "ratio_to_wire",
+    ],
     events=[],
     invariants=[
         Invariant(

--- a/common/unit_price/contract.py
+++ b/common/unit_price/contract.py
@@ -12,7 +12,7 @@ EPIC-012 table; moving that ownership into the roadmap is a tracked follow-up.
 
 from __future__ import annotations
 
-from common.meta.package_contract import Invariant, PackageContract
+from common.meta.package_contract import Invariant, Kind, PackageContract, Unit
 
 CONTRACT = PackageContract(
     name="unit_price",
@@ -23,8 +23,24 @@ CONTRACT = PackageContract(
     tier="CODE-ONLY",
     depends_on=["money", "quantity"],
     roles=["types", "ops"],
+    units=[Unit(name="UnitPrice", kind=Kind.VALUE_OBJECT)],
     implementations={"be": "apps/backend/src/unit_price", "fe": None},
-    interface=["UNIT_PRICE_DP", "UNIT_PRICE_QUANTUM", "UNIT_PRICE_ROUNDING", "CurrencyMismatchError", "FloatNotAllowedError", "InvalidUnitPricePayloadError", "UndefinedUnitPriceError", "UnitMismatchError", "UnitPrice", "UnitPriceError", "unit_price_from_db_fields", "unit_price_from_wire", "unit_price_to_db_fields", "unit_price_to_wire"],
+    interface=[
+        "UNIT_PRICE_DP",
+        "UNIT_PRICE_QUANTUM",
+        "UNIT_PRICE_ROUNDING",
+        "CurrencyMismatchError",
+        "FloatNotAllowedError",
+        "InvalidUnitPricePayloadError",
+        "UndefinedUnitPriceError",
+        "UnitMismatchError",
+        "UnitPrice",
+        "UnitPriceError",
+        "unit_price_from_db_fields",
+        "unit_price_from_wire",
+        "unit_price_to_db_fields",
+        "unit_price_to_wire",
+    ],
     events=[],
     invariants=[
         Invariant(

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -79,13 +79,14 @@ concepts:
 
   package_model:
     owner: common/meta/readme.md#package-model
-    description: A package = a DDD bounded context (readme.md + PackageContract + types/ops/store/api roles + __all__ published language); three classes core/platform/kernel; governance is computed from contracts by check_package_contract. The model self-hosts in the common/meta package.
+    description: A package = a DDD bounded context (readme.md + PackageContract + base/extension/data layers carrying DDD building-block units + __all__ published language); three classes core/platform/kernel; governance is computed from contracts by check_package_contract. The model self-hosts in the common/meta package (base = model, extension = gate, data = projection).
     family: platform
     kind: concept
     authority: documented_contract
     cross_refs:
-      - common/meta/package_contract.py
-      - common/meta/check_package_contract.py
+      - common/meta/base/package_contract.py
+      - common/meta/extension/check_package_contract.py
+      - common/meta/data/projection.py
       - common/meta/contract.py
       - common/counter/readme.md
       - common/counter/contract.py

--- a/tests/tooling/test_check_package_contract.py
+++ b/tests/tooling/test_check_package_contract.py
@@ -1,4 +1,4 @@
-"""Failure-path coverage for ``common.meta.check_package_contract``.
+"""Failure-path coverage for ``common.meta.extension.check_package_contract``.
 
 ``test_counter_package.py`` proves the gate is GREEN for the live ``counter``
 package (the happy path). This module drives the gate's *negative* branches —
@@ -19,8 +19,8 @@ from pathlib import Path
 
 import pytest
 
-import common.meta.check_package_contract as cpc
-from common.meta.check_package_contract import (
+import common.meta.extension.check_package_contract as cpc
+from common.meta.extension.check_package_contract import (
     DiscoveredPackage,
     _package_all,
     _resolve_test,

--- a/tests/tooling/test_counter_package.py
+++ b/tests/tooling/test_counter_package.py
@@ -14,7 +14,7 @@ import ast
 import sys
 from pathlib import Path
 
-from common.meta.check_package_contract import discover_packages, run
+from common.meta.extension.check_package_contract import discover_packages, run
 
 REPO = Path(__file__).resolve().parents[2]
 COUNTER = REPO / "apps/backend/src/counter"

--- a/tests/tooling/test_meta_layering.py
+++ b/tests/tooling/test_meta_layering.py
@@ -1,0 +1,261 @@
+"""meta package — the DDD building-block layering, proven.
+
+These tests anchor the meta package's structural invariants (it converges into
+``base`` / ``extension`` / ``data`` and its base stays pure) and its roadmap ACs
+(the governance gate enforces the building-block table: kind -> layer placement,
+the repository port/adapter split, and the data-as-sink rule), plus the purity of
+the ``data`` projection.
+
+They drive the gate (``common.meta.extension.check_package_contract``) against
+synthetic packages built in a tmp dir, exactly like
+``test_check_package_contract.py``, so the rules are proven to FAIL loudly when a
+contract violates them — and to stay additive (skipped) for packages that have not
+adopted the physical split.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import common.meta.extension.check_package_contract as cpc
+from common.meta import (
+    ACRecord,
+    Kind,
+    PackageContract,
+    Unit,
+    contract_index,
+)
+from common.meta.extension.check_package_contract import DiscoveredPackage
+
+REPO = Path(__file__).resolve().parents[2]
+META = REPO / "common/meta"
+
+
+def _imported_modules(path: Path) -> set[str]:
+    mods: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            mods.add(node.module)
+        elif isinstance(node, ast.Import):
+            mods.update(a.name for a in node.names)
+    return mods
+
+
+def _contract(name: str, **overrides: object) -> PackageContract:
+    kwargs: dict[str, object] = {
+        "name": name,
+        "klass": "kernel",
+        "tier": "CODE-ONLY",
+        "depends_on": [],
+        "interface": [],
+        "events": [],
+        "invariants": [],
+        "roadmap": [],
+        "units": [],
+    }
+    kwargs.update(overrides)
+    return PackageContract(**kwargs)  # type: ignore[arg-type]
+
+
+def _make_pkg(
+    tmp: Path,
+    name: str,
+    *,
+    units: list[Unit],
+    layered: bool = True,
+    extra_files: dict[str, str] | None = None,
+) -> DiscoveredPackage:
+    """Materialize a synthetic package at ``apps/backend/src/<name>`` (importable
+    as ``src.<name>``) with optional ``base/``+``extension/`` layers and units."""
+    impl = tmp / "apps/backend/src" / name
+    impl.mkdir(parents=True)
+    (impl / "__init__.py").write_text("__all__ = []\n", encoding="utf-8")
+    if layered:
+        for layer in ("base", "extension"):
+            (impl / layer).mkdir()
+            (impl / layer / "__init__.py").write_text("", encoding="utf-8")
+    for rel, content in (extra_files or {}).items():
+        path = impl / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    contract = _contract(
+        name,
+        units=units,
+        implementations={"be": f"apps/backend/src/{name}", "fe": None},
+    )
+    return DiscoveredPackage(
+        name=name, spec_dir=tmp / "common" / name, impl_dir=impl, contract=contract
+    )
+
+
+# --- structural invariants about meta itself ---------------------------------
+
+
+def test_meta_converges_by_layer():
+    """Invariant meta-converges-by-layer: base/ (model) + extension/ (gate) + data/ (projection)."""
+    assert (META / "base/package_contract.py").exists()
+    assert (META / "extension/check_package_contract.py").exists()
+    assert (META / "data/projection.py").exists()
+    exports = (META / "__init__.py").read_text(encoding="utf-8")
+    for name in ("PackageContract", "Kind", "Unit", "contract_index"):
+        assert name in exports, f"meta must export {name}"
+
+
+def test_meta_base_is_pure():
+    """Invariant meta-base-is-pure: base/ never imports its own extension/ or data/."""
+    offenders: dict[str, set[str]] = {}
+    for path in sorted((META / "base").rglob("*.py")):
+        bad = {
+            m
+            for m in _imported_modules(path)
+            if m.startswith("common.meta.extension")
+            or m.startswith("common.meta.data")
+            or "sqlalchemy" in m
+        }
+        if bad:
+            offenders[str(path.relative_to(META))] = bad
+    assert not offenders, f"meta base/ reaches into extension/data/ORM: {offenders}"
+
+
+# --- gate behavior: the building-block table (roadmap ACs) --------------------
+
+
+def test_AC_meta_kind_1_unit_misplacement_is_rejected(tmp_path: Path):
+    """AC-meta.kind.1: a unit whose module sits in the wrong layer is rejected (A)."""
+    bad = _make_pkg(
+        tmp_path,
+        "misplaced",
+        units=[Unit(name="V", kind=Kind.VALUE_OBJECT, module="extension/v.py")],
+        extra_files={"extension/v.py": "V = 1\n"},
+    )
+    offenders = cpc._check_kind_placement(bad)
+    assert any("belongs in 'base/'" in o for o in offenders), offenders
+    # a right-layer unit whose declared module file is missing is also reported.
+    missing = _make_pkg(
+        tmp_path,
+        "missingmod",
+        units=[Unit(name="V", kind=Kind.VALUE_OBJECT, module="base/ghost.py")],
+    )
+    assert any("does not exist" in o for o in cpc._check_kind_placement(missing))
+    # correct placement passes; a unit with no module (taxonomy only) is skipped.
+    ok = _make_pkg(
+        tmp_path,
+        "placed",
+        units=[
+            Unit(name="V", kind=Kind.VALUE_OBJECT, module="base/v.py"),
+            Unit(name="Taxonomy", kind=Kind.VALUE_OBJECT),  # no module -> skipped
+        ],
+        extra_files={"base/v.py": "V = 1\n"},
+    )
+    assert cpc._check_kind_placement(ok) == []
+
+
+def test_AC_meta_kind_2_repository_requires_port_and_adapter(tmp_path: Path):
+    """AC-meta.kind.2: a repository unit must split base port + extension adapter (B)."""
+    bad = _make_pkg(
+        tmp_path,
+        "badrepo",
+        units=[
+            Unit(
+                name="R",
+                kind=Kind.REPOSITORY,
+                module="base/port.py",
+                impl="base/adapter.py",  # adapter must be in extension/
+            )
+        ],
+        extra_files={"base/port.py": "P = 1\n", "base/adapter.py": "A = 1\n"},
+    )
+    offenders = cpc._check_kind_placement(bad)
+    assert any("must live in 'extension/'" in o for o in offenders), offenders
+    # a proper port/adapter split passes.
+    ok = _make_pkg(
+        tmp_path,
+        "okrepo",
+        units=[
+            Unit(
+                name="R",
+                kind=Kind.REPOSITORY,
+                module="base/port.py",
+                impl="extension/sql.py",
+            )
+        ],
+        extra_files={"base/port.py": "P = 1\n", "extension/sql.py": "A = 1\n"},
+    )
+    assert cpc._check_kind_placement(ok) == []
+
+
+def test_AC_meta_kind_3_data_layer_is_a_sink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """AC-meta.kind.3: nothing in base/ or extension/ may import the package's own data/."""
+    monkeypatch.setattr(cpc, "REPO_ROOT", tmp_path)
+    bad = _make_pkg(
+        tmp_path,
+        "sinky",
+        units=[],
+        extra_files={
+            "data/projection.py": "X = 1\n",
+            "base/reader.py": "from src.sinky.data.projection import X  # noqa\n",
+        },
+    )
+    offenders = cpc._check_data_is_sink(bad)
+    assert any("data is a read-model sink" in o for o in offenders), offenders
+    # a package whose write side does not import data/ passes.
+    clean = _make_pkg(
+        tmp_path, "cleansink", units=[], extra_files={"data/projection.py": "X = 1\n"}
+    )
+    assert cpc._check_data_is_sink(clean) == []
+
+
+def test_AC_meta_projection_1_contract_index_is_pure(tmp_path: Path):
+    """AC-meta.projection.1: contract_index is a pure projection over its inputs."""
+    a = _contract(
+        "a", units=[Unit(name="V", kind=Kind.VALUE_OBJECT, module="base/v.py")]
+    )
+    b = _contract(
+        "b",
+        klass="platform",
+        depends_on=["a"],
+        roadmap=[
+            ACRecord(
+                id="AC-b.1.1", statement="s", test="t::f", priority="P0", status="done"
+            )
+        ],
+        units=[
+            Unit(
+                name="R",
+                kind=Kind.REPOSITORY,
+                module="base/p.py",
+                impl="extension/s.py",
+            )
+        ],
+    )
+    idx = contract_index([a, b])
+    assert idx["registry"]["a"]["klass"] == "kernel"
+    assert idx["consumers"]["a"] == ["b"]
+    assert idx["ac_index"]["AC-b.1.1"] == "b"
+    assert idx["units_by_layer"]["a"] == {"base": 1, "extension": 0, "data": 0}
+    # a repository spans both sides of the dependency inversion.
+    assert idx["units_by_layer"]["b"] == {"base": 1, "extension": 1, "data": 0}
+    # pure: identical inputs -> identical output, no I/O.
+    assert contract_index([a, b]) == idx
+
+
+def test_AC_meta_kind_4_value_type_packages_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """AC-meta.kind.4: a value-type package may declare value-object units with no
+    physical split; the gate accepts it (additive) and passes."""
+    monkeypatch.setattr(cpc, "REPO_ROOT", tmp_path)
+    pkg = _make_pkg(
+        tmp_path,
+        "valpkg",
+        layered=False,
+        units=[Unit(name="V", kind=Kind.VALUE_OBJECT)],  # no module path
+    )
+    # no base/extension dirs -> placement is skipped, not failed.
+    assert cpc._check_kind_placement(pkg) == []
+    assert cpc.check_package(pkg, {"valpkg": "kernel"}, tmp_path) == []

--- a/tests/tooling/test_meta_layering.py
+++ b/tests/tooling/test_meta_layering.py
@@ -244,6 +244,17 @@ def test_AC_meta_projection_1_contract_index_is_pure(tmp_path: Path):
     assert contract_index([a, b]) == idx
 
 
+def test_contract_index_rejects_duplicate_ac_id():
+    """contract_index surfaces an AC id claimed by two packages, never overwrites."""
+    dup = ACRecord(
+        id="AC-dup.1.1", statement="s", test="t::f", priority="P0", status="done"
+    )
+    a = _contract("a", roadmap=[dup])
+    b = _contract("b", roadmap=[dup])
+    with pytest.raises(ValueError, match="claimed by two packages"):
+        contract_index([a, b])
+
+
 def test_AC_meta_kind_4_value_type_packages_pass(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tools/check_package_contract.py
+++ b/tools/check_package_contract.py
@@ -4,8 +4,8 @@
 Validates every package's ``common/<pkg>/contract.py`` (a ``PackageContract``)
 against its BE implementation: published language (``interface`` == the
 implementation's ``__all__``), every invariant/roadmap test resolves, and no
-forbidden dependency edge. See ``common/meta/check_package_contract.py``
-and ``common/meta/readme.md``.
+forbidden dependency edge. See
+``common/meta/extension/check_package_contract.py`` and ``common/meta/readme.md``.
 """
 
 from __future__ import annotations
@@ -17,7 +17,7 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from common.meta.check_package_contract import main  # noqa: E402
+from common.meta.extension.check_package_contract import main  # noqa: E402
 
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Context

We converged on a model where the eight DDD tactical building blocks each map to one canonical **layer** (`base`/`extension`/`data`), kept acyclic by three **mechanisms** (A/B/C). This PR makes that table the *executable* spec and turns the `meta` package into the live `base/extension/data` exemplar of the layout it governs (it was flat, preaching a layout it didn't follow).

| Building block | Layer | Mechanism |
|---|---|---|
| Value Object / Entity / Aggregate Root / Factory / Domain Event | base | A (+ C for aggregate id-refs / events) |
| **Repository** | **port=base / impl=extension** | **B** (dependency inversion) |
| Domain Service / Event Bus | extension | A / C |
| Projection | data | read-model, leaf sink |

Mechanisms: **A** = no-up / base↛extension purity · **B** = repository port/adapter split · **C** = id-reference + events via a runtime bus (no compile edge).

## What changed

- **model** `common/meta/base/package_contract.py`: `Kind` enum + `KIND_LAYER` map (the table, as code) + `Unit`; `PackageContract.units` alongside the legacy `roles`.
- **gate** `common/meta/extension/check_package_contract.py`: layer-purity generalized to any impl prefix (so meta self-hosts under `common.meta`, not just `src.*`); enforces kind→layer placement (A), the repository split (B), and `data`-as-sink.
- **projection** `common/meta/data/projection.py`: `contract_index`, a pure read-model over contracts (registry · AC index · consumers · units-by-layer).
- **meta** restructured into `base/extension/data` (a re-export shim stays at the old `package_contract.py` path; the gate's 4 importers repointed).
- **contracts**: `counter` declares units (value objects, domain event, repository port/adapter split); `money/ratio/quantity/unit_price` declare value-object units (additive, no dir moves).
- **docs**: `migration-standard.md` + `readme.md` encode the table, the A/B/C mechanisms, and the `data` = projection (read-model) naming.

## Scope / additivity

Additive on purpose — legacy `roles` is still accepted, and the 6 tooling packages (`authority/config/coverage/observability/platform`) are untouched. Building-block `kind` is a domain-package refinement *inside* the layer, not a replacement for it.

## Verification

- `python tools/check_package_contract.py` → **PASSED**, all 11 packages green; meta self-hosts (6 interface, 7 invariants, 5 roadmap ACs).
- `pytest tests/tooling/{test_meta_layering,test_check_package_contract,test_counter_package,test_migration_safety_gates}.py` → 52 passed; `apps/backend/tests/platform/test_contract.py` → 2 passed.
- `ruff check` + `ruff format --check` clean; `generate_ac_registry.py` → no diff (package-roadmap ACs aren't mirrored into the YAML registries).
- New `AC-meta.*` ACs + 2 invariants pinned to `tests/tooling/test_meta_layering.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)