### PR TITLE
[finance_report_hacker] fix(portfolio): non-US/multi-currency correctness — HK price symbols + broker account currency (#1441 A/C)

### DIFF
--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -535,7 +535,7 @@ class AssetService:
                     asset=snap.asset_identifier,
                 )
 
-            account = await self._get_or_create_broker_account(db, user_id, broker_name)
+            account = await self._get_or_create_broker_account(db, user_id, broker_name, snap.currency)
 
             pos_query = (
                 select(ManagedPosition)
@@ -609,8 +609,17 @@ class AssetService:
         )
         return result
 
-    async def _get_or_create_broker_account(self, db: AsyncSession, user_id: UUID, broker_name: str) -> Account:
-        """Find or create an asset account for the broker."""
+    async def _get_or_create_broker_account(
+        self, db: AsyncSession, user_id: UUID, broker_name: str, currency: str | None = None
+    ) -> Account:
+        """Find or create an asset account for the broker.
+
+        A newly created account adopts the currency of the holding that triggered
+        it (``currency``) rather than a hardcoded ``USD`` — a Hong Kong (HKD) or
+        Singapore (SGD) brokerage must not be stamped as a USD account. Existing
+        accounts keep their currency; ``USD`` remains the fallback when no
+        snapshot currency is available.
+        """
         query = (
             select(Account)
             .where(Account.user_id == user_id)
@@ -625,7 +634,7 @@ class AssetService:
                 user_id=user_id,
                 name=broker_name,
                 type=AccountType.ASSET,
-                currency="USD",
+                currency=(currency or "USD").strip().upper(),
                 code="AUTO-ASSET",
             )
             db.add(account)

--- a/apps/backend/src/services/market_data/__init__.py
+++ b/apps/backend/src/services/market_data/__init__.py
@@ -73,6 +73,7 @@ from src.services.market_data._util import (
     _date_to_epoch,
     _default_start_date,
     _fx_scope,
+    _hk_numeric_code,
     _incremental_start,
     _iter_dates,
     _looks_like_ticker,
@@ -91,6 +92,7 @@ from src.services.market_data._util import (
     _stock_scope,
     _stooq_fx_symbol,
     _stooq_stock_symbol,
+    _yahoo_stock_symbol,
 )
 from src.services.market_data.service import (
     _sync_market_observation_series,
@@ -138,6 +140,7 @@ __all__ = [
     "_fetch_yahoo_stock_price",
     "_fetch_yahoo_stock_price_series",
     "_fx_scope",
+    "_hk_numeric_code",
     "_incremental_start",
     "_is_sync_scope_fresh",
     "_iter_dates",
@@ -185,6 +188,7 @@ __all__ = [
     "_sync_scope_status",
     "_upsert_sync_state",
     "_yahoo_chart_params",
+    "_yahoo_stock_symbol",
     "ensure_market_data_fresh",
     "get_market_data_status",
     "resolve_missing_fx_rate",

--- a/apps/backend/src/services/market_data/_providers.py
+++ b/apps/backend/src/services/market_data/_providers.py
@@ -48,6 +48,7 @@ from src.services.market_data._util import (
     _stock_scope,
     _stooq_fx_symbol,
     _stooq_stock_symbol,
+    _yahoo_stock_symbol,
 )
 
 
@@ -407,7 +408,7 @@ async def _fetch_yahoo_stock_price_series(
             end_date=end_date.isoformat(),
         )
         return None
-    url = _YAHOO_STOCK_CHART_URL.format(symbol=quote(normalized, safe=".-"))
+    url = _YAHOO_STOCK_CHART_URL.format(symbol=quote(_yahoo_stock_symbol(normalized), safe=".-"))
     response = await _fetch_provider_response(
         url,
         _yahoo_chart_params(start_date, end_date),

--- a/apps/backend/src/services/market_data/_util.py
+++ b/apps/backend/src/services/market_data/_util.py
@@ -123,10 +123,44 @@ def _normalize_utc(value: datetime) -> datetime:
     return value.astimezone(UTC)
 
 
+def _hk_numeric_code(symbol: str) -> str | None:
+    """Return the zero-padded 4-digit Hong Kong board-lot code, or ``None``.
+
+    Brokerages store Hong Kong equities by their numeric exchange code (e.g.
+    Xiaomi ``"01810"``, Tencent ``"00700"``). Market-data providers expect the
+    ``"<4-digit>.HK"`` form, so callers must translate before issuing a request;
+    sent verbatim, the numeric code 404s. US tickers are alphabetic and never
+    match here, so they are left untouched.
+    """
+    candidate = symbol.strip()
+    if candidate.isdigit() and 1 <= len(candidate) <= 5:
+        return f"{int(candidate):04d}"
+    return None
+
+
+def _yahoo_stock_symbol(symbol: str) -> str:
+    """Map a stored asset identifier to the symbol Yahoo Finance expects.
+
+    Storage keeps the raw identifier (see ``_normalize_symbol``); only the
+    outbound provider symbol is exchange-qualified, so the stored scope and
+    dedup keys are unaffected.
+    """
+    normalized = _normalize_symbol(symbol)
+    if "." in normalized:
+        return normalized
+    hk_code = _hk_numeric_code(normalized)
+    if hk_code is not None:
+        return f"{hk_code}.HK"
+    return normalized
+
+
 def _stooq_stock_symbol(symbol: str) -> str:
     normalized = _normalize_symbol(symbol)
     if "." in normalized:
         return normalized.lower()
+    hk_code = _hk_numeric_code(normalized)
+    if hk_code is not None:
+        return f"{hk_code}.hk"
     return f"{normalized.lower()}.us"
 
 

--- a/apps/backend/tests/market_data/test_provider_parsers.py
+++ b/apps/backend/tests/market_data/test_provider_parsers.py
@@ -32,6 +32,29 @@ def test_market_data_helper_boundaries() -> None:
     assert market_data._normalize_utc(datetime(2026, 1, 5)).tzinfo == UTC
 
 
+def test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes() -> None:
+    """AC17.33.1: HK numeric exchange codes map to the Yahoo `<4-digit>.HK` symbol.
+
+    Brokerages store Hong Kong equities by their numeric board-lot code (e.g.
+    Xiaomi "01810"). Sent verbatim, Yahoo 404s; it expects "1810.HK". US
+    alphabetic tickers and already-suffixed symbols must pass through unchanged.
+    """
+    assert market_data._yahoo_stock_symbol("01810") == "1810.HK"
+    assert market_data._yahoo_stock_symbol("00700") == "0700.HK"
+    assert market_data._yahoo_stock_symbol("700") == "0700.HK"
+    assert market_data._yahoo_stock_symbol("AAPL") == "AAPL"
+    assert market_data._yahoo_stock_symbol("brk.b") == "BRK.B"
+    assert market_data._yahoo_stock_symbol("1810.HK") == "1810.HK"
+
+
+def test_AC17_33_2_stooq_stock_symbol_maps_hk_numeric_codes() -> None:
+    """AC17.33.2: HK numeric codes resolve to Stooq `<4-digit>.hk`; US tickers stay `.us`."""
+    assert market_data._stooq_stock_symbol("01810") == "1810.hk"
+    assert market_data._stooq_stock_symbol("00700") == "0700.hk"
+    assert market_data._stooq_stock_symbol("AAPL") == "aapl.us"
+    assert market_data._stooq_stock_symbol("0700.HK") == "0700.hk"
+
+
 def test_select_validated_observation_paths() -> None:
     """AC11.10.4: Provider selection accepts fallback data and blocks disagreements."""
     observed_date = date(2026, 1, 5)

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models import BankStatementStatus
+from src.models.account import Account, AccountType
 from src.models.layer1 import DocumentType, UploadedDocument
 from src.models.layer2 import AssetType, AtomicPosition, AtomicTransaction, TransactionDirection
 from src.models.layer3 import ManagedPosition
@@ -412,6 +413,33 @@ async def test_import_interactive_brokers_positions_idempotently_reconciles(db, 
     assert len(managed_rows) == 1
     assert managed_rows[0].asset_identifier == "AAPL"
     assert managed_rows[0].quantity == Decimal("10")
+
+
+async def test_AC17_33_3_broker_account_uses_snapshot_currency_not_hardcoded_usd(db, test_user):
+    """AC17.33.3: an auto-created broker account adopts the holding's currency, not a hardcoded USD."""
+    service = BrokeragePositionImportService()
+    payload = {
+        "institution": "Futu",
+        "statement": {"period_end": "2026-05-18", "currency": "HKD"},
+        "positions": [
+            {
+                "symbol": "01810",
+                "quantity": "100",
+                "market_value": "5500.00",
+                "currency": "HKD",
+                "asset_type": "stock",
+                "geography": "HK",
+            }
+        ],
+    }
+
+    await service.import_positions(db, user_id=test_user.id, payload=payload, source_document_id="doc-futu-hkd")
+    await db.commit()
+
+    account = (
+        await db.execute(select(Account).where(Account.user_id == test_user.id, Account.type == AccountType.ASSET))
+    ).scalar_one()
+    assert account.currency == "HKD"
 
 
 async def test_AC17_4_8_brokerage_import_survives_concurrent_auto_and_manual_import(db_engine, test_user):

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -455,3 +455,20 @@ unchanged for non-brokerage schemas.
 | AC17.32.1 | Brokerage positions CSV is mapped into a `positions` payload (not a bank parse failure) so it reaches the brokerage import path | `test_AC17_32_1_brokerage_positions_csv_produces_positions_payload` | `extraction/test_brokerage_csv_routing.py` | P1 |
 | AC17.32.2 | Brokerage trade-history CSV raises an actionable unsupported-document error, not the generic bank "No valid transactions" failure | `test_AC17_32_2_brokerage_trade_history_csv_raises_actionable_error` | `extraction/test_brokerage_csv_routing.py` | P1 |
 | AC17.32.3 | Bank transaction CSV parsing is unaffected by brokerage CSV detection (no regression) | `test_AC17_32_3_bank_csv_unaffected_by_brokerage_detection` | `extraction/test_brokerage_csv_routing.py` | P1 |
+
+### AC17.33: Non-US / multi-currency correctness ([#1441](https://github.com/wangzitian0/finance_report/issues/1441))
+
+The system implicitly assumed a US-market / USD world. Hong Kong equities are
+stored by their numeric exchange code (e.g. "01810"); sent verbatim to Yahoo /
+Stooq they 404, so non-US holdings got no live or historical price and the
+net-worth trend flat-lined at cost basis. Separately, an auto-created brokerage
+account was stamped with a hardcoded `USD` currency regardless of the holding's
+actual currency. The outbound provider symbol is now exchange-qualified
+(`<4-digit>.HK`) without changing the stored symbol scope, and a new broker
+account adopts the currency of the holding that created it.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC17.33.1 | HK numeric exchange codes map to the Yahoo `<4-digit>.HK` symbol while US tickers and already-suffixed symbols pass through unchanged | `test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes` | `market_data/test_provider_parsers.py` | P1 |
+| AC17.33.2 | HK numeric codes resolve to the Stooq `<4-digit>.hk` symbol while US tickers stay `.us` | `test_AC17_33_2_stooq_stock_symbol_maps_hk_numeric_codes` | `market_data/test_provider_parsers.py` | P1 |
+| AC17.33.3 | An auto-created broker account adopts the holding's currency instead of a hardcoded USD | `test_AC17_33_3_broker_account_uses_snapshot_currency_not_hardcoded_usd` | `portfolio/test_brokerage_position_parsing.py` | P1 |

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -469,6 +469,6 @@ account adopts the currency of the holding that created it.
 
 | AC ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC17.33.1 | HK numeric exchange codes map to the Yahoo `<4-digit>.HK` symbol while US tickers and already-suffixed symbols pass through unchanged | `test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes` | `market_data/test_provider_parsers.py` | P1 |
-| AC17.33.2 | HK numeric codes resolve to the Stooq `<4-digit>.hk` symbol while US tickers stay `.us` | `test_AC17_33_2_stooq_stock_symbol_maps_hk_numeric_codes` | `market_data/test_provider_parsers.py` | P1 |
-| AC17.33.3 | An auto-created broker account adopts the holding's currency instead of a hardcoded USD | `test_AC17_33_3_broker_account_uses_snapshot_currency_not_hardcoded_usd` | `portfolio/test_brokerage_position_parsing.py` | P1 |
+| AC17.33.1 | HK numeric exchange codes map to the Yahoo `<4-digit>.HK` symbol while US tickers and already-suffixed symbols pass through unchanged {tier:CODE-ONLY} | `test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes` | `market_data/test_provider_parsers.py` | P1 |
+| AC17.33.2 | HK numeric codes resolve to the Stooq `<4-digit>.hk` symbol while US tickers stay `.us` {tier:CODE-ONLY} | `test_AC17_33_2_stooq_stock_symbol_maps_hk_numeric_codes` | `market_data/test_provider_parsers.py` | P1 |
+| AC17.33.3 | An auto-created broker account adopts the holding's currency instead of a hardcoded USD {tier:CODE-ONLY} | `test_AC17_33_3_broker_account_uses_snapshot_currency_not_hardcoded_usd` | `portfolio/test_brokerage_position_parsing.py` | P1 |


### PR DESCRIPTION
## What & why

Fixes the two same-root, backend-only parts of #1441 — the system implicitly assumed a **US-market / USD** world, so a Hong Kong holding broke pricing and was stamped with the wrong account currency. Found via live staging QA (ground truth omitted here — personal financial data).

### A — HK price symbols (AC17.33.1 / AC17.33.2)
Brokerages store HK equities by their numeric exchange code (e.g. `01810`). Sent verbatim, Yahoo/Stooq 404 on every lookup → no live/historical price → net-worth trend flat-lines at cost basis.

`_normalize_symbol` only upper-cased; now a dedicated `_yahoo_stock_symbol` / updated `_stooq_stock_symbol` map a numeric code to the exchange-qualified form (`1810.HK` / `1810.hk`). **Only the outbound provider symbol changes** — the stored symbol scope and dedup keys are untouched, so there is no storage migration or regression. US alphabetic tickers and already-suffixed symbols pass through unchanged.

### C — broker account currency (AC17.33.3)
`assets._get_or_create_broker_account` hardcoded `currency="USD"`. It now receives the snapshot currency at the call site (already available) and a new account adopts the holding's currency; `USD` stays as the no-currency fallback. Existing accounts are unchanged.

## Tests (TDD, 🔴→🟢)
- `AC17.33.1` `test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes`
- `AC17.33.2` `test_AC17_33_2_stooq_stock_symbol_maps_hk_numeric_codes`
- `AC17.33.3` `test_AC17_33_3_broker_account_uses_snapshot_currency_not_hardcoded_usd`

Confirmed red before the fix, green after. Full `test_provider_parsers.py` + `test_brokerage_position_parsing.py` pass (44); `ruff check`/`format` clean; `generate_api_reference.py --check` clean (no schema change); `check_ac_index.py` PASSED with AC17.33 registered.

## Out of scope (tracked on #1441)
- **D** — `portfolio/holdings` `currency` field reports the base/reporting currency under a name that reads as native; fixing it is an additive API-contract change (api.md + frontend) and lands separately.
- **Non-HK exchanges** (e.g. SGX) need their own symbol mapping; this PR covers the HK case from the report.

Closes part of #1441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
