### PR TITLE
[finance_report_infra] chore(prefect): update repo submodule to pull prefect health probe and spelling fixes

### DIFF
--- a/common/ci/workflow_contract.py
+++ b/common/ci/workflow_contract.py
@@ -102,6 +102,7 @@ APP_WORKFLOW_FILES = (
 
 INFRA2_WORKFLOW_FILES = (
     ".github/workflows/apply-observability.yml",
+    ".github/workflows/config-drift-report.yml",
     ".github/workflows/deploy-report-main.yml",
     ".github/workflows/deploy.yml",
     ".github/workflows/dns-drift-report.yml",


### PR DESCRIPTION
Updates the infra2 submodule pointer to include the fix for the Prefect status check and route spelling fixes (closes #171 on infra2, which supports #813).