### PR TITLE
[finance_report_hacker] fix(extraction/llm): litellm aiohttp session leak + non-vacuous balance_validated (#1442 #1443)

### DIFF
--- a/apps/backend/src/llm/client.py
+++ b/apps/backend/src/llm/client.py
@@ -53,7 +53,23 @@ def _harden_litellm_logging() -> None:
             pass
 
 
+def _disable_litellm_aiohttp_transport() -> None:
+    """Route litellm through its httpx transport instead of the default aiohttp one.
+
+    litellm's aiohttp transport lazily creates an ``aiohttp.ClientSession`` per
+    request handler and never closes it (no shared ``litellm.aclient_session``),
+    so every ``acompletion`` leaks an "Unclosed client session" — an ERROR-level
+    log plus a real socket/fd leak that accumulates under sustained parsing
+    (#1442). The httpx transport litellm manages itself does not leak. Guarded so
+    a future litellm rename can never break import."""
+    try:
+        litellm.disable_aiohttp_transport = True
+    except Exception:  # noqa: BLE001 - transport hardening is never fatal
+        pass
+
+
 _harden_litellm_logging()
+_disable_litellm_aiohttp_transport()
 
 # litellm exception names that represent transient conditions worth retrying.
 _RETRYABLE_EXC = frozenset(

--- a/apps/backend/src/services/extraction/service.py
+++ b/apps/backend/src/services/extraction/service.py
@@ -480,7 +480,16 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
             # the array is the authoritative multi-currency evidence (#1160 CR1).
             if per_currency_invalid_note is not None:
                 is_valid = False
-            statement.balance_validated = is_valid
+            # Only assert a balance verdict when the chain was actually evaluable.
+            # A brokerage/no-balance statement has no opening+closing to check, so
+            # `validate_balance_explicit` returns a vacuous `0 == 0` True — report
+            # `None` (not-applicable) instead, so the UI never shows a green
+            # "validated" badge for something that was never validated (#1443). A
+            # real failure signal (per-currency NAV mismatch) still records False.
+            if not balance_evaluable and per_currency_invalid_note is None:
+                statement.balance_validated = None
+            else:
+                statement.balance_validated = is_valid
             if has_inferred_csv_balances:
                 statement.validation_error = CSV_INFERRED_BALANCE_REVIEW_NOTE
             elif per_currency_invalid_note is not None:

--- a/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
+++ b/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
@@ -662,3 +662,31 @@ async def test_parse_statement_background_routes_brokerage_to_review_without_imp
     assert refreshed.stage1_status == Stage1Status.PENDING_REVIEW
     assert refreshed.validation_error == "existing parser note"
     assert len(atomic_rows) == 0
+
+
+async def test_AC3_12_1_brokerage_without_balances_reports_balance_validated_none_not_vacuous_true():
+    """AC3.12.1: a brokerage holdings statement with no opening/closing balances reports
+    balance_validated=None (not-applicable), not a vacuous 0==0 True (#1443)."""
+    service = ExtractionService()
+    service.extract_financial_data = AsyncMock(
+        return_value={
+            "institution": "Futu",
+            "currency": "HKD",
+            "positions": [
+                {"symbol": "01810", "quantity": "100", "market_value": "5500.00", "currency": "HKD"},
+            ],
+        }
+    )
+
+    statement, _txns = await service.parse_document(
+        file_path=Path("futu-positions.pdf"),
+        institution="Futu",
+        user_id=uuid4(),
+        file_content=b"%PDF-1.7",
+        file_hash="ac-3-12-1-no-balances",
+        original_filename="futu-positions.pdf",
+    )
+
+    assert statement.opening_balance is None
+    assert statement.closing_balance is None
+    assert statement.balance_validated is None

--- a/apps/backend/tests/unit/llm/test_client.py
+++ b/apps/backend/tests/unit/llm/test_client.py
@@ -356,3 +356,20 @@ async def test_AC23_5_4_cassette_completion_passes_through_llmerror(monkeypatch,
             recorder=CassetteRecorder(store, mode=CassetteMode.RECORD),
         )
     assert ei.value.retryable is True
+
+
+def test_AC23_9_1_litellm_aiohttp_transport_disabled_prevents_session_leak():
+    """AC23.9.1: importing the litellm client disables litellm's aiohttp transport.
+
+    litellm's aiohttp transport lazily creates an aiohttp ClientSession per
+    request handler and never closes it, leaking an "Unclosed client session"
+    on every acompletion (#1442). Routing through the httpx transport litellm
+    manages itself avoids the leak. ``src.llm.client`` is imported at module top,
+    so the hardening has already run.
+    """
+    import litellm
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+    assert client_mod.litellm.disable_aiohttp_transport is True
+    assert litellm.disable_aiohttp_transport is True
+    assert AsyncHTTPHandler._should_use_aiohttp_transport() is False

--- a/docs/project/EPIC-003.statement-parsing.md
+++ b/docs/project/EPIC-003.statement-parsing.md
@@ -247,6 +247,14 @@ The model occasionally omits `period_start` (or `period_end`) for a bank stateme
 | AC3.11.2 | With no period bounds, the statement period is derived from the transaction-date range {tier:CODE-ONLY} | `test_AC3_11_2_period_derived_from_transaction_dates` | `extraction/test_extraction.py` | P1 |
 | AC3.11.3 | A statement with no period and no transaction dates still rejects (no silent zero-date) {tier:CODE-ONLY} | `test_AC3_11_3_no_resolvable_date_still_raises` | `extraction/test_extraction.py` | P1 |
 
+### AC3.12: Balance verdict is not-applicable when unevaluable ([#1443](https://github.com/wangzitian0/finance_report/issues/1443))
+
+When a statement carries no opening+closing balance to check (e.g. a brokerage holdings statement with zero transactions), `validate_balance_explicit` substitutes `0.00` and a zero-chain vacuously "passes", so the persisted `balance_validated` became `true` and the UI showed a green "validated" badge for something that was never validated. The verdict is now `None` (not-applicable) when the balance chain is not evaluable; a real failure signal (per-currency NAV mismatch) still records `false`.
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC3.12.1 | A brokerage holdings statement with no opening/closing balances persists `balance_validated=None` (not a vacuous `0==0` true) {tier:CODE-ONLY} | `test_AC3_12_1_brokerage_without_balances_reports_balance_validated_none_not_vacuous_true` | `extraction/test_statement_brokerage_import_bridge.py` | P1 |
+
 ## 📏 Acceptance Criteria
 
 ### 🟢 Must Have

--- a/docs/project/EPIC-023.llm-provider-abstraction.md
+++ b/docs/project/EPIC-023.llm-provider-abstraction.md
@@ -203,3 +203,11 @@ parallel once PR1 merges.
 | AC23.8.5 | The graded eval distinguishes "balance invariant passes but field-accuracy regressed" from "invariant fails": a cassette whose chain still reconciles but whose amount no longer matches ground truth is flagged by the graded gate while the AC23.7 balance gate stays green {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |
 | AC23.8.6 | The eval runs deterministically in CI on committed cassettes with **NO network and NO API key**; the refresh path is the local `make llm-record` target (documented), never CI {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |
 | AC23.8.7 | Reliability scoring aggregates over **N≥2 samples** per case when multiple recordings of the same case exist (mean score), and the single-sample limitation (one recording ⇒ point estimate, not a reliability measure) is documented {tier:LLM-LED}{proof:eval} | `tests/tooling/test_cassette_graded_eval.py` | P1 |
+
+### AC23.9 — litellm transport hygiene ([#1442](https://github.com/wangzitian0/finance_report/issues/1442))
+
+litellm's default aiohttp transport lazily creates an `aiohttp.ClientSession` per request handler and never closes it (no shared `litellm.aclient_session`), leaking an ERROR-level "Unclosed client session" on every `acompletion` — a real socket/fd leak that accumulates under sustained parsing. The single litellm chokepoint (`src/llm/client.py`) disables the aiohttp transport so litellm uses the httpx transport it manages itself.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
+| AC23.9.1 | Importing the litellm client disables litellm's aiohttp transport (so no per-`acompletion` unclosed-session leak); the transport resolver returns httpx {tier:CODE-ONLY} | `test_AC23_9_1_litellm_aiohttp_transport_disabled_prevents_session_leak` | `unit/llm/test_client.py` | P1 |


### PR DESCRIPTION
## What & why

The two cleanly-fixable remaining QA findings, in one PR (per request; #1444 and #1448 set aside).

### #1442 — litellm aiohttp ClientSession leak (AC23.9.1)
litellm's default aiohttp transport lazily creates an `aiohttp.ClientSession` per request handler and never closes it (no shared `litellm.aclient_session`). Every `acompletion` therefore leaks an ERROR-level `Unclosed client session` — a real socket/fd leak that accumulates under sustained parsing and pollutes the error-log → alerting pipeline. Root-caused to litellm internals (`http_handler._create_aiohttp_transport`), not our code. Fix: disable the aiohttp transport at the single litellm chokepoint (`src/llm/client.py`, beside the existing logging hardening) — litellm falls back to the httpx transport it manages itself. This is litellm's documented opt-out (`disable_aiohttp_transport`).

### #1443 — vacuous `balance_validated: true` (AC3.12.1)
A statement with no opening+closing balance (e.g. a brokerage holdings statement with zero transactions) had `balance_validated` set to a vacuous `0 == 0` True, so the UI showed a green "validated" badge for something that was never validated. Fix (`service.py`): persist `None` (not-applicable) when the balance chain is not evaluable; a real per-currency NAV failure still records `False`, and bank statements (which require opening+closing) are unaffected.

## Tests (TDD)
- `AC23.9.1` `test_AC23_9_1_litellm_aiohttp_transport_disabled_prevents_session_leak`
- `AC3.12.1` `test_AC3_12_1_brokerage_without_balances_reports_balance_validated_none_not_vacuous_true`

New ACs tagged `{tier:CODE-ONLY}`. No regressions: `tests/extraction` (562 passed) + `tests/unit/llm` + `tests/ai` (205 passed) green; `ruff`/`format`, `check_ac_tier_baseline.py`, `check_ac_index.py`, `generate_api_reference.py --check` all pass.

## Note on remaining #1441 work
- **#1441-D is already satisfied**: `/portfolio/holdings` already exposes `native_currency` (`schemas/portfolio.py`) alongside the reporting `currency`, so native (e.g. HKD) vs display (base) is already distinguishable — recommend closing the D sub-item.
- Non-HK (e.g. SGX) symbol mapping is deferred: SGX codes are alphanumeric and indistinguishable from US tickers by shape, so they need the holding's currency/market threaded through the market-data pipeline — a larger change, and there is no SGX-listed holding in the test data to validate against.

Closes #1442. Closes #1443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
