### PR TITLE
[finance_report_audit] Stage 0: align governance docs + contracts to the package model (#1459)

### DIFF
--- a/common/authority/readme.md
+++ b/common/authority/readme.md
@@ -28,14 +28,19 @@ The same four-tier scale is used by both views, which is why they cannot drift:
 - **detected** — the band `authority_classifier` measures from the shapes of the
   tests that prove a package's ACs (`BANDS` *is* `PACKAGE_TIERS`).
 
-## Layout (roles)
+## Structure (layers)
 
-- **matrix** (`authority_matrix.py`) — the value language: tier Literals, the
-  tier→proof matrix, the canonical tuples. stdlib-only (no pydantic).
-- **classifier** (`authority_classifier.py`) — the detected CODE/LLM band.
-- **gates** (run via `tools/<name>.py`): `check_ac_proof_kind` (tier→proof matrix),
-  `check_tier_ast_literal`, `check_tier_imports`, `check_ac_tier_baseline`,
-  `check_authority_reconcile` (declared vs detected at the enforceable ends).
+Like every package, the implementation converges by **layer** (base / extension /
+data), not by role:
+
+- **base** — the value language: `authority_matrix.py` (tier Literals, the
+  tier→proof matrix, the canonical tuples; stdlib-only, no pydantic) and
+  `authority_classifier.py` (the detected CODE/LLM band). Self-contained pure
+  definitions + logic, no I/O.
+- **extension** — the gates (run via `tools/<name>.py`): `check_ac_proof_kind`
+  (tier→proof matrix), `check_tier_ast_literal`, `check_tier_imports`,
+  `check_ac_tier_baseline`, `check_authority_reconcile` (declared vs detected at
+  the enforceable ends). The impure edges that read the repo and fail CI.
 
 ## Published language
 

--- a/common/authority/readme.md
+++ b/common/authority/readme.md
@@ -30,8 +30,12 @@ The same four-tier scale is used by both views, which is why they cannot drift:
 
 ## Structure (layers)
 
-Like every package, the implementation converges by **layer** (base / extension /
-data), not by role:
+The **target** model — like every migrated package — is to converge by **layer**
+(base / extension / data) rather than by role. `authority` is **not there yet**:
+its `contract.py` still declares legacy `roles=["matrix", "classifier", "gates"]`
+and the files are physically flat under `common/authority/`. The base/extension
+split below is therefore the **conceptual/intended** layering each file maps onto;
+the role-to-layer migration is still pending.
 
 - **base** — the value language: `authority_matrix.py` (tier Literals, the
   tier→proof matrix, the canonical tuples; stdlib-only, no pydantic) and

--- a/common/meta/migration-standard.md
+++ b/common/meta/migration-standard.md
@@ -221,11 +221,18 @@ An EPIC is horizontal and a package is vertical, so they do not map 1:1. The
    `roadmap[].test` resolves.
 5. **Consumers repointed** — importers use the package's published `interface`
    (`__all__`), not its submodules/internals.
-6. **Green** — `check_package_contract` + the package's own invariants pass.
+6. **Original removed** — the pre-migration modules / god-files are **deleted, not copied**: no leftover code, re-export shim, test, or import of the old path remains. The package is the **single home** (zero duplication). Enforced like `counter` (its package test asserts the retired modules are gone) + the no-old-path-import lint (#1461 generalized). **A lingering original means the package is NOT migrated.**
+7. **Green** — `check_package_contract` + the package's own invariants pass.
 
 Each package cutover is **one atomic PR** (never leave a single package half in
 both an EPIC and a roadmap). Different packages may be old-or-new during the
-overall migration; a single package is never half-migrated.
+overall migration; a single package is never half-migrated — and "migrated" means
+the old code is gone, not merely that a new copy exists.
+
+A cutover that spans more than one domain still obeys **one transaction per
+domain**: each domain's interface/event change lands as its own atomic step, never
+a single edit reaching across domain boundaries. The enforcement is owned by the
+cross-domain gate (issue #1460); this standard only states the rule.
 
 ## Anti-mud-ball guard
 

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -151,8 +151,8 @@ The recipe for moving a module (and its EPIC-table ACs) into the package model.
    satisfy the tier→proof matrix (LLM-LED/LLM-ONLY may never be `exact`).
 
 4. **Structural guarantees → `invariants`, NOT `roadmap`.** interface==`__all__`,
-   converges-by-role, layer purity, "passes its own gate" carry no tier and are
-   not matrix-constrained. (Keeping them out of `roadmap` is what lets an LLM-LED/LLM-ONLY
+   converges-by-layer (base/extension/data), layer purity, "passes its own gate"
+   carry no tier and are not matrix-constrained. (Keeping them out of `roadmap` is what lets an LLM-LED/LLM-ONLY
    package's structural `exact` tests stay valid — see counter's 7 invariants.)
 
 5. **Anchor every `test` to a real test.** Each `roadmap[].test` /

--- a/common/money/contract.py
+++ b/common/money/contract.py
@@ -27,9 +27,10 @@ CONTRACT = PackageContract(
     # Pure-Decimal value type, no LLM in the package: CODE-ONLY (0% LLM).
     tier="CODE-ONLY",
     depends_on=["ratio"],
-    roles=["types", "ops"],
     # The package's domain value objects (kind for the taxonomy; no module path —
-    # money still uses the types/ops layout, so the gate skips placement here).
+    # the BE implementation has not yet split into base/extension/data, so the gate
+    # skips placement here). `units` is the layer-converging taxonomy; the legacy
+    # `roles` kwarg is dropped (it defaults to empty and the gate accepts its absence).
     units=[
         Unit(name="Money", kind=Kind.VALUE_OBJECT),
         Unit(name="Currency", kind=Kind.VALUE_OBJECT),

--- a/common/quantity/contract.py
+++ b/common/quantity/contract.py
@@ -22,7 +22,6 @@ CONTRACT = PackageContract(
     status="active",
     tier="CODE-ONLY",
     depends_on=["ratio"],
-    roles=["types", "ops"],
     units=[
         Unit(name="Quantity", kind=Kind.VALUE_OBJECT),
         Unit(name="Unit", kind=Kind.VALUE_OBJECT),

--- a/common/ratio/contract.py
+++ b/common/ratio/contract.py
@@ -21,7 +21,6 @@ CONTRACT = PackageContract(
     status="active",
     tier="CODE-ONLY",
     depends_on=[],
-    roles=["types", "ops"],
     units=[Unit(name="Ratio", kind=Kind.VALUE_OBJECT)],
     implementations={
         "be": "apps/backend/src/ratio",

--- a/common/unit_price/contract.py
+++ b/common/unit_price/contract.py
@@ -22,7 +22,6 @@ CONTRACT = PackageContract(
     status="active",
     tier="CODE-ONLY",
     depends_on=["money", "quantity"],
-    roles=["types", "ops"],
     units=[Unit(name="UnitPrice", kind=Kind.VALUE_OBJECT)],
     implementations={"be": "apps/backend/src/unit_price", "fe": None},
     interface=[

--- a/docs/agents/orchestration.md
+++ b/docs/agents/orchestration.md
@@ -78,32 +78,46 @@ Use this cascade **before processing any task**:
 
 ## Development Work Order (TDD-First)
 
-**Mandatory sequence: MECE → EPIC → ACx.y.z → Test → Code → Doc**
+**The culture is `EPIC → AC → test`** (vision's north-star discipline: every
+behavior is anchored to a goal and proven by a test). The **mechanism** for
+*where an AC lives* is the **package contract**, not an EPIC table:
+
+**Mandatory sequence: MECE → AC (package `roadmap`) → Test → Code → Doc**
 
 0. **MECE**: Split the work into non-overlapping slices that collectively
    cover the stated goal; name dependencies and out-of-scope work before
    implementation.
-1. **EPIC**: Anchor task to a project EPIC in `docs/project/`
-2. **ACx.y.z**: Define acceptance criteria before writing code:
-   - Active feature ACs live in the owning EPIC and materialize through
-     `docs/ac_registry.yaml`
-   - Active infrastructure/tooling ACs live in the owning EPIC and materialize
-     through `docs/infra_registry.yaml`
-   - Historical, deprecated, or non-derived metadata is explicit in
-     `docs/ac_registry_overrides.yaml`
-3. **Test**: Write failing tests that reference the AC IDs (red phase).
+1. **AC home — the package `roadmap`**: For a **migrated** package, define the
+   acceptance criterion as `AC-<pkg>.<entity>.<seq>` in that package's
+   `contract.py` `roadmap`, conforming to `meta`'s schema
+   ([`common/meta/migration-standard.md`](../../common/meta/migration-standard.md)).
+   `meta`'s data layer aggregates these; **never mirror a package AC back into an
+   EPIC table.** Anchor the slice to a project EPIC in `docs/project/` as its
+   horizontal goal — but the AC is owned by the package once that package is
+   migrated.
+   - **Legacy (not-yet-migrated) modules only**: the AC still lives in the
+     owning EPIC and materializes through `docs/ac_registry.yaml` (feature) or
+     `docs/infra_registry.yaml` (infra), with historical/non-derived metadata in
+     `docs/ac_registry_overrides.yaml`. This EPIC-table source is being phased
+     out package by package; once a module becomes a package its ACs move into
+     the `roadmap`.
+2. **Test**: Write failing tests that reference the AC IDs (red phase).
    Regression fixtures and test data MUST be generated/anonymized, never
    derived from real user uploads or real statements — see the financial-data
    red line in [red-lines.md](./red-lines.md).
-4. **Code**: Write minimal code to make the tests pass (green phase)
-5. **Doc**: Update SSOT docs and README
+3. **Code**: Write minimal code to make the tests pass (green phase)
+4. **Doc**: Update the package `readme`/contract (or, for legacy modules, SSOT
+   docs and README)
 
 **Hard constraints**:
 - ❌ **NEVER** write code before the test exists
-- ❌ **NEVER** write a test without a registered AC number
-- ❌ **NEVER** ship without updating SSOT docs
+- ❌ **NEVER** write a test without a registered AC number (a package `roadmap`
+  AC for migrated packages; an EPIC/registry AC for legacy modules)
+- ❌ **NEVER** ship without updating the owning package's contract/readme (or
+  SSOT docs for legacy modules)
 
-Reference: [docs/ssot/tdd.md](../ssot/tdd.md)
+Reference: [docs/ssot/tdd.md](../ssot/tdd.md) ·
+[package migration standard](../../common/meta/migration-standard.md)
 
 ---
 

--- a/docs/agents/orchestration.md
+++ b/docs/agents/orchestration.md
@@ -88,7 +88,9 @@ behavior is anchored to a goal and proven by a test). The **mechanism** for
    cover the stated goal; name dependencies and out-of-scope work before
    implementation.
 1. **AC home — the package `roadmap`**: For a **migrated** package, define the
-   acceptance criterion as `AC-<pkg>.<entity>.<seq>` in that package's
+   acceptance criterion as `AC-<pkg>.<group>.<seq>` (the `<group>` segment is an
+   entity name **or** a numeric group, e.g. `AC-ledger.journal-entry.3` or
+   `AC-counter.1.1`) in that package's
    `contract.py` `roadmap`, conforming to `meta`'s schema
    ([`common/meta/migration-standard.md`](../../common/meta/migration-standard.md)).
    `meta`'s data layer aggregates these; **never mirror a package AC back into an

--- a/docs/ssot/authority-tiers.md
+++ b/docs/ssot/authority-tiers.md
@@ -76,8 +76,8 @@ AC:
 ### Structural assertions go in `invariants`, not `roadmap`
 
 A package's **structural / governance guarantees** — interface == `__all__`,
-"converges by role", layer-purity (types/ops never import the store/ORM),
-"passes its own `check_package_contract`" — are NOT domain ACs. They are
+"converges by **layer**" (base/extension/data), layer-purity (`base` never imports
+`extension`/`data`), "passes its own `check_package_contract`" — are NOT domain ACs. They are
 deterministic properties of *how the package is assembled*, so they belong in
 `PackageContract.invariants` (which carry no tier and are not constrained by the
 tier→proof matrix), and the `roadmap` holds only the package's **domain** ACs,
@@ -93,7 +93,7 @@ bespoke lint needed).
 
 `common/counter` is the worked example: its `roadmap` is pure domain (key
 validation, count, increment, query) while its structural guarantees
-(`converges-by-role`, `types-layer-pure`, `ops-layer-pure`,
+(`converges-by-layer`, `base-layer-pure`, `interface-equals-published-language`,
 `passes-own-governance-gate`) are `invariants`. A CODE-ONLY package like `counter` would
 not *fail* with structural ACs in its roadmap (CODE-ONLY permits `exact`), but it follows
 the convention so it is a correct template to copy for LLM-LED/LLM-ONLY packages.

--- a/docs/ssot/base-packages.md
+++ b/docs/ssot/base-packages.md
@@ -10,6 +10,15 @@ across every end (backend Python + frontend TypeScript). `money` (#1167) is the
 reference instance; this doc generalises it so the family stays uniform and
 bounded.
 
+In the package model this value family **is** the project's **Shared Kernel** —
+the canonical ubiquitous language (`money`/`ratio`/`quantity`/`unit_price`) that
+every package reuses, whose strategic role is "shared by everyone" and whose
+implementation therefore lives in `common/`. The family's structure, layering,
+and how each package migrates onto the model are owned by the package migration
+standard: [`common/meta/migration-standard.md`](../../common/meta/migration-standard.md)
+(see "Where files go" and "Completion state"). This doc owns the *membership rule*
+(what earns a Shared-Kernel value package) and the per-package value contract.
+
 ## 1. What qualifies (all five must hold)
 
 A domain earns a base package only if it is **all** of:

--- a/docs/ssot/tdd.md
+++ b/docs/ssot/tdd.md
@@ -26,7 +26,9 @@ prove with a test). The **mechanism** for *where an AC lives* depends on whether
 the owning module has migrated onto the package model:
 
 - **Migrated package** — the AC home is the package's `contract.py` `roadmap`,
-  keyed `AC-<pkg>.<entity>.<seq>` and conforming to `meta`'s schema (see
+  keyed `AC-<pkg>.<group>.<seq>` (the `<group>` segment is an entity name **or** a
+  numeric group, e.g. `AC-ledger.journal-entry.3` or `AC-counter.1.1`) and
+  conforming to `meta`'s schema (see
   [`common/meta/migration-standard.md`](../../common/meta/migration-standard.md)).
   `meta`'s data layer aggregates these into the computed index; a package AC is
   **never** mirrored into an EPIC table.
@@ -36,8 +38,10 @@ the owning module has migrated onto the package model:
 
 ## Acceptance Criteria
 
-Package-`roadmap` ACs use `AC-<pkg>.<entity>.<seq>` (e.g. `AC-ledger.journal-entry.3`)
-and hang off the package's **entities**, owned by `contract.py` and validated by
+Package-`roadmap` ACs use `AC-<pkg>.<group>.<seq>`, where the `<group>` segment is
+an **entity name** (e.g. `AC-ledger.journal-entry.3`) **or** a numeric group
+(e.g. `AC-counter.1.1`, `AC-authority.1.1`). They hang off the package's
+entities/groups, are owned by `contract.py`, and are validated by
 `check_package_contract`.
 
 Legacy EPIC-sourced AC IDs use `ACx.y.z`:

--- a/docs/ssot/tdd.md
+++ b/docs/ssot/tdd.md
@@ -21,9 +21,26 @@ README.md -> docs/project/EPIC-*.md -> docs/*_registry.yaml -> tests
 `vision.md` owns the product's north-star goal, culture, and decision filters —
 not a status or acceptance document.
 
+`EPIC → AC → test` is the **culture** (vision's discipline: anchor to a goal,
+prove with a test). The **mechanism** for *where an AC lives* depends on whether
+the owning module has migrated onto the package model:
+
+- **Migrated package** — the AC home is the package's `contract.py` `roadmap`,
+  keyed `AC-<pkg>.<entity>.<seq>` and conforming to `meta`'s schema (see
+  [`common/meta/migration-standard.md`](../../common/meta/migration-standard.md)).
+  `meta`'s data layer aggregates these into the computed index; a package AC is
+  **never** mirrored into an EPIC table.
+- **Legacy module (not yet a package)** — the AC still lives in the owning EPIC
+  and materializes through the generated registries below. This EPIC-table source
+  is being phased out one package at a time.
+
 ## Acceptance Criteria
 
-AC IDs use `ACx.y.z`:
+Package-`roadmap` ACs use `AC-<pkg>.<entity>.<seq>` (e.g. `AC-ledger.journal-entry.3`)
+and hang off the package's **entities**, owned by `contract.py` and validated by
+`check_package_contract`.
+
+Legacy EPIC-sourced AC IDs use `ACx.y.z`:
 
 | Part | Meaning |
 |---|---|


### PR DESCRIPTION
Closes #1459. **Stage 0 · Foundations** of the package-model migration (umbrella #1416). **Standard-raising only** (Decision A — never lowers a bar): it teaches the new standard so cutover PRs don't drift back to the old framing.

## What changed (only the files this PR owns)

1. **`common/meta/migration-standard.md`** — re-land the completion-state point that missed the #1456 merge. In "## Completion state (Definition of Done)", inserted point **6. Original removed** (pre-migration modules / god-files are **deleted, not copied** — no leftover code/shim/test/import of the old path; the package is the **single home**, zero duplication; enforced like `counter` + the no-old-path-import lint, #1461 generalized; *a lingering original means the package is NOT migrated*) and renumbered old "6. Green" → **7. Green**. Closing paragraph now adds that *"migrated" means the old code is gone, not merely that a new copy exists*. Added a brief paragraph: cross-domain cutovers obey **one transaction per domain** (interface/event), enforcement owned by the cross-domain gate (#1460).
2. **`docs/agents/orchestration.md`, `docs/ssot/tdd.md`** — the AC home is the package **`roadmap`** (`AC-<pkg>.<entity>.<seq>`, conforming to `meta`'s schema), not "EPIC → ACx.y.z" first. `EPIC → AC → test` kept as **culture**; EPIC tables described as the **legacy source being phased out** per package.
3. **`docs/ssot/authority-tiers.md`** — structural invariant is **"converges-by-layer"** (base/extension/data), not converges-by-role / types/ops/store/api; synced counter's actual invariant IDs (`converges-by-layer`, `base-layer-pure`, …).
4. **`common/authority/readme.md`** — `## Layout (roles)` → **`## Structure (layers)`** (base/extension language).
5. **`docs/ssot/base-packages.md`** — frame the value family as the **Shared Kernel** and link `common/meta/migration-standard.md`.
6. **`common/{money,ratio,quantity,unit_price}/contract.py`** — removed the redundant legacy `roles=[...]` kwarg (they already declare `units`; the gate accepts its absence). `config`/`authority`/`coverage`/`observability` (no units) left untouched.

## ⚠️ Owner action required — `CLAUDE.md`
`CLAUDE.md` (~line 81, "MECE → EPIC → ACx.y.z → Test → Code → Doc", and the "Mandatory Work Order" section) still teaches the **old order** with EPIC tables as the primary AC source. Per its own prohibition, **AI may not modify `CLAUDE.md` without explicit owner authorization** — this PR does not touch it. It needs an owner-authorized update to point the AC home at the package `roadmap`.

## Verification
- `apps/backend/.venv/bin/python tools/check_package_contract.py` → **PASSED** (all 11 packages OK).
- `apps/backend/.venv/bin/ruff check` on the 4 changed `contract.py` → **clean**.
- `tools/lint_doc_consistency.py` → **passed** (exit 0, no violations).
- `tests/tooling/test_check_manifest.py` → 39 passed, 1 failed; the one failure (`test_actual_manifest_passes`) is **pre-existing & environmental** — the `repo/` submodule is not populated in this worktree so infra cross-ref files (`repo/docs/ssot/ops.*`, `repo/finance_report/...`) are missing. Confirmed identical failure on a clean (stashed) tree; this PR's diff touches **no** MANIFEST entry. CI populates the submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)