### PR TITLE
[finance_report_audit] Stage 0: gate enforces one-transaction-per-domain (#1460)

### DIFF
--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -229,5 +229,59 @@ CONTRACT = PackageContract(
             priority="P2",
             status="done",
         ),
+        # One-transaction-per-domain (issue #1460, Decision B made executable):
+        # one DB transaction belongs to exactly one domain; cross-domain changes
+        # go through a published interface or an id + a domain event — never a
+        # shared cross-domain transaction or a cross-domain FK. AC-meta.event.1
+        # (outbox atomicity) is a runtime property left to the platform package's
+        # own tests, not this structural gate, so it is intentionally not listed.
+        ACRecord(
+            id="AC-meta.txn.1",
+            statement=(
+                "A base unit reaching into another registered domain's unpublished "
+                "object (an internal entity/aggregate, not a symbol in that "
+                "package's __all__) is rejected; a cross-domain reference goes "
+                "through the published interface (root import or a published "
+                "symbol) or by id."
+            ),
+            test=(
+                "tests/tooling/test_meta_layering.py"
+                "::test_AC_meta_txn_1_base_deep_import_of_other_domain_object_is_rejected"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.txn.2",
+            statement=(
+                "A domain's extension reaching into another domain's ORM/models (an "
+                "unpublished internal) is rejected: a cross-domain effect must be a "
+                "published domain event, not another domain's tables written in the "
+                "same transaction. A plain deep 'import src.<other>.<sub>' is "
+                "rejected too (it names no published symbol)."
+            ),
+            test=(
+                "tests/tooling/test_meta_layering.py"
+                "::test_AC_meta_txn_2_extension_writing_other_domain_orm_is_rejected"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.txn.3",
+            statement=(
+                "A SQLAlchemy ForeignKey/relationship whose target table or model "
+                "belongs to another registered domain is rejected; a cross-domain "
+                "reference must be an id column resolved via the interface/event, "
+                "not a database FK. Detection is AST-only/best-effort on the "
+                "string-target forms (documented in the gate)."
+            ),
+            test=(
+                "tests/tooling/test_meta_layering.py"
+                "::test_AC_meta_txn_3_cross_domain_fk_is_rejected"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/meta/extension/check_package_contract.py
+++ b/common/meta/extension/check_package_contract.py
@@ -19,7 +19,30 @@ asserts:
       ``base/extension/`` split — base stays pure (mechanism A), each declared
       ``unit`` sits in the layer its ``kind`` dictates (``KIND_LAYER``), a
       ``repository`` unit splits into a base port + an extension adapter
-      (mechanism B), and ``data`` is a sink nothing else imports (the read-model).
+      (mechanism B), and ``data`` is a sink nothing else imports (the read-model);
+  (e) one transaction belongs to exactly one domain (issue #1460, Decision B): a
+      cross-domain reference goes through the *published* interface or by id + a
+      domain event — never a shared cross-domain transaction. Two static edges are
+      enforced. The **import edge** (``_check_cross_domain_deep_import``,
+      AC-meta.txn.1/.2): an impl module may reach another registered package only
+      via its published root (``from src.<other> import X`` / ``import
+      src.<other>``) or a symbol in that package's ``__all__``; a deep import of an
+      *unpublished* internal (another aggregate's object, or another domain's
+      ORM/models written in-transaction) is rejected. The **FK edge**
+      (``_check_cross_domain_fk``, AC-meta.txn.3): a ``ForeignKey`` /
+      ``relationship`` whose target table/model is owned by another registered
+      package is rejected — the reference must be an id column resolved via the
+      interface/event. The runtime atomicity of the outbox (AC-meta.event.1) is a
+      behavioural property proven by the platform package's own tests, not by this
+      structural gate.
+
+      *Port-exception decision (counter):* counter imports the platform bus port
+      ``from src.platform.events.bus import OutboxEventBus`` — a deep path, but
+      ``OutboxEventBus`` is in ``platform.__all__``, so the import resolves to a
+      *published* symbol and is allowed (the same exception lets ``unit_price``
+      import the published ``Money`` / ``Quantity`` value types from their defining
+      modules). The rule rejects deep imports of *unpublished* internals, not deep
+      paths to published symbols — so no current package regresses.
 
 This module is the meta package's ``extension`` layer (the impure edge: it walks
 the filesystem and parses ASTs). It imports the ``base`` model
@@ -265,6 +288,205 @@ def _check_no_forbidden_edge(
     return offenders
 
 
+def _check_cross_domain_deep_import(
+    pkg: DiscoveredPackage,
+    registered: dict[str, str],
+    published: dict[str, list[str]],
+) -> list[str]:
+    """One-transaction-per-domain, the import edge (AC-meta.txn.1 / .2).
+
+    A package's implementation may reference another *registered* package only
+    through that package's **published interface** — either its package root
+    (``from src.<other> import X`` / ``import src.<other>``) or a symbol the target
+    publishes in its ``__all__`` (``published[<other>]``). A deep import that
+    reaches an **unpublished internal** of another domain is rejected: cross-domain
+    references go through the published language (or by id + a domain event), never
+    by reaching into another aggregate's internals (txn.1) or writing another
+    domain's ORM/models in the same transaction (txn.2).
+
+    The *port-exception* that keeps the live packages green: a deep import is
+    allowed when the imported name IS in the target's ``__all__`` (the symbol is
+    published; only its physical defining module is deep). This is how ``counter``
+    imports the platform bus port (``from src.platform.events.bus import
+    OutboxEventBus`` — ``OutboxEventBus`` ∈ ``platform.__all__``) and how
+    ``unit_price`` imports the published ``Money`` / ``Quantity`` value types from
+    their defining modules. A plain ``import src.<other>.<sub>`` names no symbol and
+    so can never be a published reference — it is always rejected.
+
+    ``published`` maps package name -> its ``__all__`` (computed once by
+    :func:`run`). Imports of *unregistered* modules (shared infra such as
+    ``src.database``) are out of scope — only edges between registered packages are
+    governed.
+    """
+    offenders: list[str] = []
+    if pkg.impl_dir is None or not pkg.impl_dir.exists():
+        return offenders
+    for py in sorted(pkg.impl_dir.rglob("*.py")):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                parts = node.module.split(".")
+                if len(parts) < 2 or parts[0] != "src":
+                    continue
+                target = parts[1]
+                if target == pkg.name or target not in registered:
+                    continue
+                if len(parts) == 2:
+                    continue  # published root: `from src.<other> import X` — allowed
+                pub = set(published.get(target, []))
+                rel = py.relative_to(REPO_ROOT)
+                for alias in node.names:
+                    if alias.name == "*" or alias.name not in pub:
+                        offenders.append(
+                            f"{rel}: deep cross-domain import "
+                            f"'from {node.module} import {alias.name}' reaches an "
+                            f"unpublished internal of package '{target}'. A "
+                            f"cross-domain reference must go through the published "
+                            f"interface ('from src.{target} import ...' / a symbol "
+                            f"in its __all__) or by id + a domain event."
+                        )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    parts = alias.name.split(".")
+                    if len(parts) < 2 or parts[0] != "src":
+                        continue
+                    target = parts[1]
+                    if target == pkg.name or target not in registered:
+                        continue
+                    if len(parts) > 2:
+                        rel = py.relative_to(REPO_ROOT)
+                        offenders.append(
+                            f"{rel}: deep cross-domain import 'import {alias.name}' "
+                            f"targets a submodule of package '{target}'. Import the "
+                            f"package root ('import src.{target}') and use its "
+                            f"published interface, or reference by id + a domain event."
+                        )
+    return offenders
+
+
+def _classdef_tablename(node: ast.ClassDef) -> str | None:
+    """The ``__tablename__`` string literal a SQLAlchemy model class declares, if any."""
+    for stmt in node.body:
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(stmt, ast.Assign):
+            targets, value = stmt.targets, stmt.value
+        elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+            targets, value = [stmt.target], stmt.value
+        for t in targets:
+            if (
+                isinstance(t, ast.Name)
+                and t.id == "__tablename__"
+                and isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+            ):
+                return value.value
+    return None
+
+
+def _collect_orm_ownership(
+    packages: list[DiscoveredPackage],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Map every ORM table name and model class name to its owning package.
+
+    A package owns a table/model when one of its implementation modules declares a
+    class with ``__tablename__ = "<table>"``. The two maps (table name -> package,
+    model class name -> package) let :func:`_check_cross_domain_fk` decide whether a
+    ``ForeignKey`` string or a ``relationship`` target crosses a domain boundary.
+    First declaration wins (``setdefault``) so the maps are deterministic.
+    """
+    table_owner: dict[str, str] = {}
+    model_owner: dict[str, str] = {}
+    for pkg in packages:
+        if pkg.impl_dir is None or not pkg.impl_dir.exists():
+            continue
+        for py in sorted(pkg.impl_dir.rglob("*.py")):
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    table = _classdef_tablename(node)
+                    if table is not None:
+                        table_owner.setdefault(table, pkg.name)
+                        model_owner.setdefault(node.name, pkg.name)
+    return table_owner, model_owner
+
+
+def _call_func_name(func: ast.expr) -> str | None:
+    """The bare callable name of a call target (``ForeignKey`` / ``sa.ForeignKey``)."""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _check_cross_domain_fk(
+    pkg: DiscoveredPackage,
+    registered: dict[str, str],
+    table_owner: dict[str, str],
+    model_owner: dict[str, str],
+) -> list[str]:
+    """One-transaction-per-domain, the FK edge (AC-meta.txn.3).
+
+    A SQLAlchemy ``ForeignKey("<table>.<col>")`` or ``relationship(...)`` whose
+    target table/model belongs to **another** registered package is rejected — a
+    cross-domain reference must become an id column resolved via the interface/event,
+    never a database-enforced FK that ties two domains into one transaction.
+
+    Detection is **AST-only and best-effort**, scoped to the reliably-decidable
+    forms:
+      * ``ForeignKey("<table>.<col>")`` — the target table is read from the string
+        literal's first segment (the load-bearing, reliable case).
+      * ``relationship("<ClassName>")`` / ``relationship(<ClassName>)`` — the target
+        model class name is read from a string or bare ``Name`` argument.
+
+    It deliberately does NOT resolve dynamic targets (a ``ForeignKey`` whose table
+    comes from a variable/callable, or a ``relationship`` given an imported alias or
+    an expression) — those are left to runtime/migration review rather than flagged
+    here, to avoid false positives. ``table_owner`` / ``model_owner`` come from
+    :func:`_collect_orm_ownership`.
+    """
+    offenders: list[str] = []
+    if pkg.impl_dir is None or not pkg.impl_dir.exists():
+        return offenders
+    for py in sorted(pkg.impl_dir.rglob("*.py")):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = _call_func_name(node.func)
+            if name == "ForeignKey" and node.args:
+                arg = node.args[0]
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    table = arg.value.split(".")[0]
+                    owner = table_owner.get(table)
+                    if owner and owner in registered and owner != pkg.name:
+                        rel = py.relative_to(REPO_ROOT)
+                        offenders.append(
+                            f"{rel}: cross-domain ForeignKey('{arg.value}') targets "
+                            f"table '{table}' owned by package '{owner}'. A "
+                            f"cross-domain reference must be an id column resolved "
+                            f"via the interface/event, not a database FK."
+                        )
+            elif name == "relationship" and node.args:
+                arg = node.args[0]
+                cls: str | None = None
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    cls = arg.value
+                elif isinstance(arg, ast.Name):
+                    cls = arg.id
+                owner = model_owner.get(cls) if cls else None
+                if owner and owner in registered and owner != pkg.name:
+                    rel = py.relative_to(REPO_ROOT)
+                    offenders.append(
+                        f"{rel}: cross-domain relationship('{cls}') targets a model "
+                        f"owned by package '{owner}'. A cross-domain reference must "
+                        f"be an id column resolved via the interface/event, not an "
+                        f"ORM relationship."
+                    )
+    return offenders
+
+
 def _check_no_dependency_cycle(packages: list[DiscoveredPackage]) -> list[str]:
     """Detect any cycle in the declared ``depends_on`` graph.
 
@@ -461,9 +683,21 @@ def _check_kind_placement(pkg: DiscoveredPackage) -> list[str]:
 
 
 def check_package(
-    pkg: DiscoveredPackage, registered: dict[str, str], repo_root: Path = REPO_ROOT
+    pkg: DiscoveredPackage,
+    registered: dict[str, str],
+    repo_root: Path = REPO_ROOT,
+    *,
+    published: dict[str, list[str]] | None = None,
+    table_owner: dict[str, str] | None = None,
+    model_owner: dict[str, str] | None = None,
 ) -> list[str]:
-    """Return the list of contract violations for one package (empty == OK)."""
+    """Return the list of contract violations for one package (empty == OK).
+
+    The one-transaction-per-domain checks (e) need cross-package maps and so are
+    additive on their inputs: they run only when :func:`run` supplies ``published``
+    (the import edge) / ``table_owner`` (the FK edge). A direct ``check_package``
+    call without them skips those checks, exactly as before.
+    """
     errors: list[str] = []
 
     # (a) interface == the BE implementation's __init__.__all__
@@ -510,6 +744,23 @@ def check_package(
     errors.extend(f"[{pkg.name}] {e}" for e in _check_kind_placement(pkg))
     errors.extend(f"[{pkg.name}] {e}" for e in _check_data_is_sink(pkg))
 
+    # (e) one-transaction-per-domain (issue #1460): a cross-domain reference goes
+    #     through the published interface or by id + event — never a deep reach
+    #     into another domain's internals (txn.1/.2) or a cross-domain FK (txn.3).
+    #     Additive: each sub-check runs only when run() supplies its cross-package map.
+    if published is not None:
+        errors.extend(
+            f"[{pkg.name}] {e}"
+            for e in _check_cross_domain_deep_import(pkg, registered, published)
+        )
+    if table_owner is not None:
+        errors.extend(
+            f"[{pkg.name}] {e}"
+            for e in _check_cross_domain_fk(
+                pkg, registered, table_owner, model_owner or {}
+            )
+        )
+
     return errors
 
 
@@ -517,10 +768,26 @@ def run(repo_root: Path = REPO_ROOT) -> tuple[bool, list[str]]:
     """Validate every discovered package; return (ok, messages)."""
     packages = discover_packages(repo_root)
     registered = {p.name: p.contract.klass for p in packages}
+    # Cross-package maps for the one-transaction-per-domain checks (issue #1460):
+    # each package's published __all__ (the import edge) and the ORM table/model
+    # ownership (the FK edge).
+    published = {
+        p.name: _package_all(p.impl_dir)
+        for p in packages
+        if p.impl_dir is not None and (p.impl_dir / "__init__.py").exists()
+    }
+    table_owner, model_owner = _collect_orm_ownership(packages)
     messages: list[str] = []
     all_errors: list[str] = []
     for pkg in packages:
-        errs = check_package(pkg, registered, repo_root)
+        errs = check_package(
+            pkg,
+            registered,
+            repo_root,
+            published=published,
+            table_owner=table_owner,
+            model_owner=model_owner,
+        )
         if errs:
             all_errors.extend(errs)
         else:

--- a/common/meta/extension/check_package_contract.py
+++ b/common/meta/extension/check_package_contract.py
@@ -25,10 +25,11 @@ asserts:
       domain event — never a shared cross-domain transaction. Two static edges are
       enforced. The **import edge** (``_check_cross_domain_deep_import``,
       AC-meta.txn.1/.2): an impl module may reach another registered package only
-      via its published root (``from src.<other> import X`` / ``import
-      src.<other>``) or a symbol in that package's ``__all__``; a deep import of an
-      *unpublished* internal (another aggregate's object, or another domain's
-      ORM/models written in-transaction) is rejected. The **FK edge**
+      via its bare published root (``import src.<other>``) or a symbol in that
+      package's ``__all__`` (``from src.<other>... import <published name>``); an
+      import of an *unpublished* internal (a submodule, another aggregate's object,
+      or another domain's ORM/models written in-transaction) is rejected — whether
+      the module path is the package root or a deep submodule. The **FK edge**
       (``_check_cross_domain_fk``, AC-meta.txn.3): a ``ForeignKey`` /
       ``relationship`` whose target table/model is owned by another registered
       package is rejected — the reference must be an id column resolved via the
@@ -41,8 +42,10 @@ asserts:
       ``OutboxEventBus`` is in ``platform.__all__``, so the import resolves to a
       *published* symbol and is allowed (the same exception lets ``unit_price``
       import the published ``Money`` / ``Quantity`` value types from their defining
-      modules). The rule rejects deep imports of *unpublished* internals, not deep
-      paths to published symbols — so no current package regresses.
+      modules, and how ``money`` / ``quantity`` import the published ``Ratio`` via
+      its root ``from src.ratio import Ratio``). The rule rejects imports of
+      *unpublished* internals (including a root import of a submodule), not paths to
+      published symbols — so no current package regresses.
 
 This module is the meta package's ``extension`` layer (the impure edge: it walks
 the filesystem and parses ASTs). It imports the ``base`` model
@@ -296,22 +299,25 @@ def _check_cross_domain_deep_import(
     """One-transaction-per-domain, the import edge (AC-meta.txn.1 / .2).
 
     A package's implementation may reference another *registered* package only
-    through that package's **published interface** — either its package root
-    (``from src.<other> import X`` / ``import src.<other>``) or a symbol the target
-    publishes in its ``__all__`` (``published[<other>]``). A deep import that
-    reaches an **unpublished internal** of another domain is rejected: cross-domain
-    references go through the published language (or by id + a domain event), never
-    by reaching into another aggregate's internals (txn.1) or writing another
-    domain's ORM/models in the same transaction (txn.2).
+    through that package's **published interface** — either the bare package root
+    (``import src.<other>``) or a symbol the target publishes in its ``__all__``
+    (``published[<other>]``). Every name in a ``from src.<other>... import N1,
+    N2, ...`` must itself be in the target's ``__all__``; an import that reaches an
+    **unpublished internal** of another domain is rejected: cross-domain references
+    go through the published language (or by id + a domain event), never by reaching
+    into another aggregate's internals (txn.1) or writing another domain's
+    ORM/models in the same transaction (txn.2).
 
-    The *port-exception* that keeps the live packages green: a deep import is
-    allowed when the imported name IS in the target's ``__all__`` (the symbol is
-    published; only its physical defining module is deep). This is how ``counter``
-    imports the platform bus port (``from src.platform.events.bus import
-    OutboxEventBus`` — ``OutboxEventBus`` ∈ ``platform.__all__``) and how
-    ``unit_price`` imports the published ``Money`` / ``Quantity`` value types from
-    their defining modules. A plain ``import src.<other>.<sub>`` names no symbol and
-    so can never be a published reference — it is always rejected.
+    The published-symbol rule is uniform across the module path: a ``from`` import
+    is allowed iff each imported name is in the target's ``__all__``, whether the
+    module is the package root or a deep submodule. This is how ``counter`` imports
+    the platform bus port (``from src.platform.events.bus import OutboxEventBus`` —
+    ``OutboxEventBus`` ∈ ``platform.__all__``) and how ``unit_price`` imports the
+    published ``Money`` / ``Quantity`` value types from their defining modules — and
+    why a *root* import of an unpublished name (``from src.<other> import
+    <submodule>``) is rejected just like a deep reach. A plain ``import
+    src.<other>.<sub>`` names no symbol and so can never be a published reference —
+    it is always rejected; only the bare ``import src.<other>`` root is allowed.
 
     ``published`` maps package name -> its ``__all__`` (computed once by
     :func:`run`). Imports of *unregistered* modules (shared infra such as
@@ -331,19 +337,24 @@ def _check_cross_domain_deep_import(
                 target = parts[1]
                 if target == pkg.name or target not in registered:
                     continue
-                if len(parts) == 2:
-                    continue  # published root: `from src.<other> import X` — allowed
+                # Every name in a `from src.<other> import N1, N2, ...` must be a
+                # symbol the target publishes in its __all__ — whether the module is
+                # the package root (`from src.<other> import N`) or a deep path
+                # (`from src.<other>.<mod> import N`). A root import is NOT waved
+                # through: `from src.<other> import <submodule>` or an unpublished
+                # name bypasses the published interface just as a deep reach does.
                 pub = set(published.get(target, []))
                 rel = py.relative_to(REPO_ROOT)
                 for alias in node.names:
                     if alias.name == "*" or alias.name not in pub:
                         offenders.append(
-                            f"{rel}: deep cross-domain import "
+                            f"{rel}: cross-domain import "
                             f"'from {node.module} import {alias.name}' reaches an "
-                            f"unpublished internal of package '{target}'. A "
-                            f"cross-domain reference must go through the published "
-                            f"interface ('from src.{target} import ...' / a symbol "
-                            f"in its __all__) or by id + a domain event."
+                            f"unpublished internal of package '{target}' (a name not "
+                            f"in its __all__ — a submodule or another aggregate's "
+                            f"object). A cross-domain reference must go through the "
+                            f"published interface ('from src.{target} import <symbol "
+                            f"in __all__>') or by id + a domain event."
                         )
             elif isinstance(node, ast.Import):
                 for alias in node.names:

--- a/tests/tooling/test_meta_layering.py
+++ b/tests/tooling/test_meta_layering.py
@@ -322,7 +322,7 @@ def test_AC_meta_txn_1_base_deep_import_of_other_domain_object_is_rejected(
         == []
     )
 
-    # importing via the published root is always allowed.
+    # importing a *published* symbol via the package root is allowed (PubVO ∈ __all__).
     ok_root = _make_pkg(
         tmp_path,
         "consumer_root_ok",
@@ -336,7 +336,23 @@ def test_AC_meta_txn_1_base_deep_import_of_other_domain_object_is_rejected(
         == []
     )
 
-    # an import of an UNregistered module (e.g. shared infra) is out of scope.
+    # a ROOT import of an *unpublished* name (a submodule or unexported internal)
+    # bypasses the published interface just like a deep reach — it must be rejected.
+    # 'extension' is a submodule of domainx, not a symbol in its __all__.
+    bad_root = _make_pkg(
+        tmp_path,
+        "consumer_root_bad",
+        units=[],
+        extra_files={"base/use.py": "from src.domainx import extension  # noqa\n"},
+    )
+    offenders = cpc._check_cross_domain_deep_import(
+        bad_root, {"consumer_root_bad": "core", "domainx": "core"}, published
+    )
+    assert any("unpublished internal" in o and "domainx" in o for o in offenders), (
+        offenders
+    )
+
+    # an import of an unregistered module (e.g. shared infra) is out of scope.
     infra = _make_pkg(
         tmp_path,
         "consumer_infra_ok",

--- a/tests/tooling/test_meta_layering.py
+++ b/tests/tooling/test_meta_layering.py
@@ -270,3 +270,206 @@ def test_AC_meta_kind_4_value_type_packages_pass(
     # no base/extension dirs -> placement is skipped, not failed.
     assert cpc._check_kind_placement(pkg) == []
     assert cpc.check_package(pkg, {"valpkg": "kernel"}, tmp_path) == []
+
+
+# --- one-transaction-per-domain (Stage 0, issue #1460) ------------------------
+#
+# Decision B made executable: one DB transaction belongs to exactly one domain;
+# cross-domain references go through the *published* interface (a symbol in the
+# target's __all__) or by id + an event — never a deep reach into another
+# domain's internals, and never a cross-domain FK. The gate enforces the static,
+# checkable edges (AC-meta.txn.1/.2 = the import edge, AC-meta.txn.3 = the FK
+# edge); the runtime atomicity of the outbox (AC-meta.event.1) is proven by the
+# platform package's own tests, not by this structural gate.
+
+
+def test_AC_meta_txn_1_base_deep_import_of_other_domain_object_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """AC-meta.txn.1: a base unit reaching into another domain's *unpublished*
+    object (an internal entity/aggregate, not a published value-object/id) is
+    rejected; the published interface — root import or a published symbol — is
+    allowed (the cross-domain reference goes through the contract, or by id)."""
+    monkeypatch.setattr(cpc, "REPO_ROOT", tmp_path)
+    published = {"domainx": ["PubVO"]}  # 'Account' is an internal, not published
+
+    bad = _make_pkg(
+        tmp_path,
+        "consumer",
+        units=[],
+        extra_files={
+            "base/use.py": "from src.domainx.base.aggregate import Account  # noqa\n"
+        },
+    )
+    offenders = cpc._check_cross_domain_deep_import(
+        bad, {"consumer": "core", "domainx": "core"}, published
+    )
+    assert any("unpublished internal" in o and "domainx" in o for o in offenders), (
+        offenders
+    )
+
+    # a published symbol reached via its defining module is allowed (port-exception).
+    ok_deep = _make_pkg(
+        tmp_path,
+        "consumer_deep_ok",
+        units=[],
+        extra_files={"base/use.py": "from src.domainx.base.vo import PubVO  # noqa\n"},
+    )
+    assert (
+        cpc._check_cross_domain_deep_import(
+            ok_deep, {"consumer_deep_ok": "core", "domainx": "core"}, published
+        )
+        == []
+    )
+
+    # importing via the published root is always allowed.
+    ok_root = _make_pkg(
+        tmp_path,
+        "consumer_root_ok",
+        units=[],
+        extra_files={"base/use.py": "from src.domainx import PubVO  # noqa\n"},
+    )
+    assert (
+        cpc._check_cross_domain_deep_import(
+            ok_root, {"consumer_root_ok": "core", "domainx": "core"}, published
+        )
+        == []
+    )
+
+    # an import of an UNregistered module (e.g. shared infra) is out of scope.
+    infra = _make_pkg(
+        tmp_path,
+        "consumer_infra_ok",
+        units=[],
+        extra_files={"base/use.py": "from src.database import Base  # noqa\n"},
+    )
+    assert (
+        cpc._check_cross_domain_deep_import(
+            infra, {"consumer_infra_ok": "core", "domainx": "core"}, published
+        )
+        == []
+    )
+
+
+def test_AC_meta_txn_2_extension_writing_other_domain_orm_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """AC-meta.txn.2: a domain's extension reaching into another domain's
+    ORM/models (an unpublished internal) is rejected — a cross-domain effect must
+    be emitted as a published domain event, not by writing another domain's
+    tables in the same transaction. A plain deep ``import`` is rejected too."""
+    monkeypatch.setattr(cpc, "REPO_ROOT", tmp_path)
+    published = {"domainy": ["LedgerEvent"]}  # the ORM row is internal
+
+    bad = _make_pkg(
+        tmp_path,
+        "writer",
+        units=[],
+        extra_files={
+            "extension/effect.py": (
+                "from src.domainy.extension.models import LedgerRow  # noqa\n"
+            )
+        },
+    )
+    offenders = cpc._check_cross_domain_deep_import(
+        bad, {"writer": "core", "domainy": "core"}, published
+    )
+    assert any("unpublished internal" in o and "domainy" in o for o in offenders), (
+        offenders
+    )
+
+    # a plain deep `import src.<other>.<sub>` cannot reference a published symbol.
+    bad_plain = _make_pkg(
+        tmp_path,
+        "writer_plain",
+        units=[],
+        extra_files={"extension/effect.py": "import src.domainy.extension.models\n"},
+    )
+    assert any(
+        "deep cross-domain import" in o
+        for o in cpc._check_cross_domain_deep_import(
+            bad_plain, {"writer_plain": "core", "domainy": "core"}, published
+        )
+    )
+
+    # emitting the published event type instead is allowed.
+    via_event = _make_pkg(
+        tmp_path,
+        "writer_ok",
+        units=[],
+        extra_files={
+            "extension/effect.py": (
+                "from src.domainy.base.events import LedgerEvent  # noqa\n"
+            )
+        },
+    )
+    assert (
+        cpc._check_cross_domain_deep_import(
+            via_event, {"writer_ok": "core", "domainy": "core"}, published
+        )
+        == []
+    )
+
+
+def test_AC_meta_txn_3_cross_domain_fk_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """AC-meta.txn.3: a SQLAlchemy ForeignKey/relationship whose target belongs to
+    another registered domain's tables is rejected; a cross-domain reference must
+    be an id column resolved via the interface/event. A FK to the package's own
+    table is fine."""
+    monkeypatch.setattr(cpc, "REPO_ROOT", tmp_path)
+    owner = _make_pkg(
+        tmp_path,
+        "ownerdom",
+        units=[],
+        extra_files={
+            "extension/models.py": ("class Account:\n    __tablename__ = 'accounts'\n")
+        },
+    )
+    consumer = _make_pkg(
+        tmp_path,
+        "consumerdom",
+        units=[],
+        extra_files={
+            "extension/models.py": (
+                "from sqlalchemy import ForeignKey\n"
+                "from sqlalchemy.orm import mapped_column, relationship\n"
+                "class Entry:\n"
+                "    __tablename__ = 'entries'\n"
+                "    account_id = mapped_column(ForeignKey('accounts.id'))\n"
+                "    account = relationship('Account')\n"
+            )
+        },
+    )
+    table_owner, model_owner = cpc._collect_orm_ownership([owner, consumer])
+    assert table_owner.get("accounts") == "ownerdom"
+    assert model_owner.get("Account") == "ownerdom"
+
+    registered = {"ownerdom": "core", "consumerdom": "core"}
+    offenders = cpc._check_cross_domain_fk(
+        consumer, registered, table_owner, model_owner
+    )
+    assert any("ForeignKey" in o and "accounts" in o for o in offenders), offenders
+    assert any("relationship" in o and "Account" in o for o in offenders), offenders
+
+    # a FK to the package's OWN table is allowed.
+    selfdom = _make_pkg(
+        tmp_path,
+        "selfdom",
+        units=[],
+        extra_files={
+            "extension/models.py": (
+                "from sqlalchemy import ForeignKey\n"
+                "from sqlalchemy.orm import mapped_column\n"
+                "class A:\n    __tablename__ = 'a_tbl'\n"
+                "class B:\n"
+                "    __tablename__ = 'b_tbl'\n"
+                "    a_id = mapped_column(ForeignKey('a_tbl.id'))\n"
+            )
+        },
+    )
+    to_self, mo_self = cpc._collect_orm_ownership([selfdom])
+    assert (
+        cpc._check_cross_domain_fk(selfdom, {"selfdom": "core"}, to_self, mo_self) == []
+    )


### PR DESCRIPTION
Closes #1460.

## What

Stage 0 / Decision B made executable in the package-contract gate
(`common/meta/extension/check_package_contract.py`): **one DB transaction belongs to exactly one domain; cross-domain references go through the published interface or by id + a domain event — never a deep reach into another domain's internals or a cross-domain FK.** This is standard-raising and additive — the rules fire only on declared cross-domain edges and **no current package regresses** (all 11 stay green).

## Rules added (wired into `check_package` via maps `run()` computes)

- **`_check_cross_domain_deep_import` (AC-meta.txn.1 / .2)** — the import edge. An impl module may reach another *registered* package only via its published root (`from src.<other> import X` / `import src.<other>`) or a symbol in that package's `__all__`. A deep import of an **unpublished internal** (another aggregate's object — txn.1; another domain's ORM/models written in-transaction — txn.2) is rejected. A plain deep `import src.<other>.<sub>` names no symbol and is always rejected.
- **`_check_cross_domain_fk` (AC-meta.txn.3)** — the FK edge. A SQLAlchemy `ForeignKey("<table>.<col>")` / `relationship(...)` whose target table/model is owned by another registered package is rejected. Detection is **AST-only / best-effort** on the string-target forms (documented in the gate docstring); dynamic targets are left to runtime/migration review to avoid false positives.

`AC-meta.event.1` (outbox atomicity) is a *runtime* property and is intentionally left to the platform package's own tests, not this structural gate.

## counter port-exception decision

counter imports the platform bus port `from src.platform.events.bus import OutboxEventBus` — a deep path, but `OutboxEventBus ∈ platform.__all__`, so it resolves to a **published** symbol and is **allowed**. The rule rejects deep imports of *unpublished* internals, not deep paths to published symbols. The same principled exception (no hard-coded allowlist) keeps `unit_price` green, which deep-imports the published `Money` / `Currency` / `Quantity` / `Unit` value types from their defining modules. This is more general and self-maintaining than an allowlist: as soon as a symbol leaves a package's `__all__`, deep imports of it start failing.

## Tests (TDD — failing synthetic-package tests first)

Added to `tests/tooling/test_meta_layering.py`, each pinned from the meta roadmap in `common/meta/contract.py`:
- `test_AC_meta_txn_1_base_deep_import_of_other_domain_object_is_rejected`
- `test_AC_meta_txn_2_extension_writing_other_domain_orm_is_rejected`
- `test_AC_meta_txn_3_cross_domain_fk_is_rejected`

## Verification

- Live gate: `tools/check_package_contract.py` → **PASSED** (11 packages; meta now 8 roadmap ACs).
- `pytest tests/tooling/test_meta_layering.py tests/tooling/test_check_package_contract.py -q` → **39 passed**.
- `ruff check` clean on all three changed files.

Files owned per the issue split: only the gate module + its tests + `common/meta/contract.py`. `migration-standard.md` (docs PR) and `apps/backend/src/models/` (facade PR) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
