### PR TITLE
[finance_report_hacker] fix(extraction): auto-create+link physical bank account so high-confidence statements auto-post (#1444)

### DIFF
--- a/apps/backend/src/services/extraction/service.py
+++ b/apps/backend/src/services/extraction/service.py
@@ -9,9 +9,10 @@ from typing import Any
 from uuid import UUID
 
 import httpx
+from sqlalchemy import select
 
 from src.config import settings
-from src.models import DocumentType
+from src.models import Account, AccountType, DocumentType
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
@@ -84,6 +85,45 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
         # deterministic chain-break detector still runs and logs, but no live model
         # is called. A real LLM-backed backend is wired separately.
         self.region_reextractor: RegionReExtractor | None = None
+
+    async def _get_or_create_bank_account(
+        self,
+        db: Any,
+        *,
+        user_id: UUID,
+        institution: str,
+        account_last4: str,
+        currency: str,
+    ) -> Account:
+        """Get-or-create the physical asset account for a bank statement (#1444).
+
+        Keyed on (user_id, institution, account_last4, currency) via a stable
+        display name so re-uploaded statements for the same account reuse one
+        account. The account is a fact (the money lives here); category
+        classification of each transaction is a separate, user-adjustable layer.
+        """
+        name = f"{institution} ••{account_last4}"
+        existing = (
+            await db.execute(
+                select(Account)
+                .where(Account.user_id == user_id)
+                .where(Account.name == name)
+                .where(Account.type == AccountType.ASSET)
+                .where(Account.currency == currency)
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            return existing
+        account = Account(
+            user_id=user_id,
+            name=name,
+            type=AccountType.ASSET,
+            currency=currency,
+            code="AUTO-BANK",
+        )
+        db.add(account)
+        await db.flush()
+        return account
 
     async def parse_document(
         self,
@@ -170,12 +210,39 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
                 resolved_period_end = self._safe_optional_date(extracted.get("period_end"))
             else:
                 resolved_period_start, resolved_period_end = self._resolve_required_period(extracted)
+
+            sanitized_account_last4 = self._sanitize_account_last4(extracted.get("account_last4"))
+            # Auto-create and link the physical bank account so a high-confidence,
+            # balance-validated statement can reach APPROVED and auto-post without
+            # the everyday user having to map an account first (#1444). The account
+            # is a *factual* asset account keyed on institution + last4 + currency
+            # (mirrors the brokerage auto-account path); category (counter-account)
+            # classification stays a separate, user-adjustable layer. Skipped for
+            # brokerage payloads (they own a broker account at import) and when no
+            # db, real institution, or last4 is available to key a stable account.
+            if (
+                account_id is None
+                and db is not None
+                and not is_brokerage_payload
+                and final_institution
+                and final_institution != "Unknown"
+                and sanitized_account_last4
+            ):
+                bank_account = await self._get_or_create_bank_account(
+                    db,
+                    user_id=user_id,
+                    institution=final_institution,
+                    account_last4=sanitized_account_last4,
+                    currency=statement_currency,
+                )
+                account_id = bank_account.id
+
             statement = StatementSummary(
                 user_id=user_id,
                 account_id=account_id,
                 file_hash=resolved_file_hash,
                 institution=final_institution,
-                account_last4=self._sanitize_account_last4(extracted.get("account_last4")),
+                account_last4=sanitized_account_last4,
                 currency=statement_currency,
                 period_start=resolved_period_start,
                 period_end=resolved_period_end,

--- a/apps/backend/tests/integration/test_bank_statement_auto_account_post.py
+++ b/apps/backend/tests/integration/test_bank_statement_auto_account_post.py
@@ -1,0 +1,85 @@
+"""AC8.15.2: a bank statement auto-creates+links its physical account (#1444).
+
+The everyday-user flow uploads a bank statement without picking an account. A
+high-confidence, balance-validated statement must therefore auto-create and link
+its physical asset account (by institution + account_last4 + currency) so it can
+reach APPROVED and auto-post to the ledger — instead of being stranded in review
+with empty reports. Category (counter-account) classification stays a separate,
+user-adjustable layer and is not exercised here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from sqlalchemy import select
+
+from src.models import Account, AccountType, JournalEntry, JournalEntryStatus
+from src.models.statement_enums import BankStatementStatus
+from src.services.extraction import ExtractionService
+from src.services.statement_posting import try_auto_approve_high_confidence_statement
+
+
+def _balanced_bank_payload() -> dict:
+    return {
+        "institution": "MariBank",
+        "account_last4": "8497",
+        "currency": "SGD",
+        "period_start": "2026-05-01",
+        "period_end": "2026-05-31",
+        "opening_balance": "1000.00",
+        "closing_balance": "1090.00",
+        "transactions": [
+            {
+                "date": "2026-05-10",
+                "description": "Interest",
+                "amount": "90.00",
+                "direction": "IN",
+                "currency": "SGD",
+                "balance_after": "1090.00",
+            },
+        ],
+    }
+
+
+async def test_AC8_15_2_bank_statement_auto_creates_account_and_posts_without_manual_mapping(db, test_user):
+    service = ExtractionService()
+    service.extract_financial_data = AsyncMock(return_value=_balanced_bank_payload())
+
+    # No account_id passed — the everyday-user upload path.
+    statement, _txns = await service.parse_document(
+        file_path=Path("mari-2605.pdf"),
+        institution="MariBank",
+        user_id=test_user.id,
+        file_content=b"%PDF-1.7",
+        file_hash="ac-8-15-2-auto-account",
+        db=db,
+    )
+    await db.flush()
+
+    # Physical account auto-created + linked; the high-confidence statement reaches APPROVED.
+    assert statement.account_id is not None
+    account = await db.get(Account, statement.account_id)
+    assert account is not None
+    assert account.type == AccountType.ASSET
+    assert account.is_active is True
+    assert statement.status == BankStatementStatus.APPROVED
+
+    # And it auto-posts to the ledger (so reports would reflect it).
+    posted = await try_auto_approve_high_confidence_statement(db, statement.id, test_user.id)
+    assert posted >= 1
+
+    posted_entries = (
+        (
+            await db.execute(
+                select(JournalEntry).where(
+                    JournalEntry.user_id == test_user.id,
+                    JournalEntry.status == JournalEntryStatus.POSTED,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(posted_entries) >= 1

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -450,6 +450,7 @@ Closing gate for the **Usable** milestone (G2∩G3, [#950](https://github.com/wa
 | AC ID | Test Case | Test Function | File | Priority |
 |---|---|---|---|---|
 | AC8.15.1 | Multi-month CSV statements parse, approve under the balance-chain guard, auto-post to the ledger, and the assembled period reports tie out end-to-end (income, expenses, net income, ending cash, total assets, and the accounting equation) | `test_AC8_15_1_full_year_statement_to_report_ties_out` | `apps/backend/tests/integration/test_full_year_statement_to_report_e2e.py` | P0 |
+| AC8.15.2 | A high-confidence, balance-validated bank statement with no pre-selected account auto-creates+links its physical asset account (by institution + account_last4 + currency), reaches APPROVED, and auto-posts to the ledger — the everyday-user upload→report path no longer dead-ends in review (#1444) {tier:CODE-ONLY} | `test_AC8_15_2_bank_statement_auto_creates_account_and_posts_without_manual_mapping` | `apps/backend/tests/integration/test_bank_statement_auto_account_post.py` | P1 |
 
 ### AC8.16: Augmentation-Layer Report Integrity
 


### PR DESCRIPTION
## What & why

Plan A (confidence-gated auto-posting of bank transactions into reports) was **already implemented but blocked upstream** — the everyday-user "upload → see reports" path dead-ended in review even for a confidence-100, fully-reconciled statement.

### Root cause
- A bank statement uploaded **without a pre-selected `account_id`** is forced to `PARSED` by `service.py` (`if status == APPROVED and account_id is None: status = PARSED`).
- `is_high_confidence_auto_approve_candidate` requires `status == APPROVED`, so `try_auto_approve_high_confidence_statement` returns 0 → no posting.
- Unlike the brokerage path (`assets._get_or_create_broker_account`), the **bank path never auto-creates/links an account**, so a first-time bank statement can never reach APPROVED. Parsed data sits in `pending_review`; reports read 0.00.

The balance-chain signal the design relies on already works (it drives `balance_validated` + `confidence_score`); the only missing piece was the physical account.

### Fix (AC8.15.2)
In `parse_document`, when a bank statement (not brokerage) has no `account_id` but a db, a real institution, and an `account_last4`, **get-or-create the physical asset account** (keyed on `institution + account_last4 + currency`, mirroring the brokerage auto-account) and link it. The existing routing then yields `APPROVED` for a high-confidence, balance-validated statement, and the existing `auto-approve → auto_create_posted_entries(auto_post=True)` chain posts to the ledger. A broken/unreconciled chain still fails balance validation → review (exactly the "if it doesn't chain, hold it" intent).

### Scope boundary (by design)
- **Physical account = fact → auto-created & auto-posted.**
- **Category (counter-account) classification = judgment → separate, user-adjustable layer** (the existing `TransactionClassification`-or-`Uncategorized` path, untouched). Re-categorization is non-destructive and evolves with user needs — tracked separately.

## Tests (TDD 🔴→🟢)
- `AC8.15.2` `test_AC8_15_2_bank_statement_auto_creates_account_and_posts_without_manual_mapping` — parse a high-confidence balanced bank statement with **no account_id**; assert an active ASSET account is auto-created+linked, status `APPROVED`, and entries auto-post (`POSTED`).

Failing first (account_id None / PARSED), then green. `{tier:CODE-ONLY}`. No regressions: `tests/extraction` (563 passed) + full-year e2e pass in isolation; ruff/format, tier-ratchet, ac-index, api.md all green.

Closes #1444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
