### PR TITLE
[finance_report_audit] feat(audit): register the number-governor package + declare the Shared-Kernel value language (#1419 Stage 1)

### DIFF
--- a/common/audit/__init__.py
+++ b/common/audit/__init__.py
@@ -1,0 +1,22 @@
+"""``common.audit`` — the spec + review surface for the ``audit`` package.
+
+This package directory holds the *authoritative* form of ``audit`` (the **number
+governor**, the parallel peer to ``meta`` the *form* governor) — its
+ubiquitous-language prose ([`readme.md`](./readme.md)), its machine-checkable
+:class:`~common.meta.package_contract.PackageContract`
+([`contract.py`](./contract.py)), and its worklist ([`todo.md`](./todo.md)).
+
+``audit`` has no implementation of its own yet: the value language it governs
+(``Money`` / ``Ratio`` / ``Quantity`` / ``UnitPrice`` and friends) runs in the
+Shared-Kernel value packages' cross-runtime mirrors (``common/<pkg>`` +
+``apps/backend/src/<pkg>`` + ``apps/frontend/src/lib/<pkg>``). This is a *spec
+surface*: the only thing it re-exports is the package's own ``CONTRACT`` (so
+tooling can ``from common.audit import CONTRACT``). See ``common/meta/readme.md``
+and ``common/meta/migration-standard.md`` for the model and the value→audit fold.
+"""
+
+from __future__ import annotations
+
+from common.audit.contract import CONTRACT
+
+__all__ = ["CONTRACT"]

--- a/common/audit/contract.py
+++ b/common/audit/contract.py
@@ -1,0 +1,162 @@
+"""The ``audit`` package's machine-checkable :class:`PackageContract`.
+
+``audit`` is the **number governor** — the parallel peer to ``meta`` (the *form*
+governor) in the package migration standard
+([`common/meta/migration-standard.md`](../meta/migration-standard.md), the
+"meta / audit symmetry"). Where ``meta.base`` is the package model that everyone's
+structure conforms to, ``audit.base`` is the **value language** that everyone's
+numbers are expressed in: the cross-runtime Shared-Kernel value types
+(``Money`` / ``Currency`` / ``ExchangeRate`` / ``MoneyTolerance`` /
+``CurrencyBalances`` / ``Ratio`` / ``Quantity`` / ``Unit`` / ``UnitPrice``), plus
+— in a later fold — audit's own base value objects (financial invariants,
+confidence / provenance, trace records). ``audit.extension`` will then reach the
+financial flow (``ledger`` / ``extraction`` / ``portfolio`` / ``reporting``) to
+assert global numeric correctness (issue #1419, umbrella #1416; closeout #1429).
+
+Scope of THIS contract (the low-risk first fold — see ``readme.md`` §Migration
+state):
+
+* **Declares the Shared Kernel as audit's value-object ``units``.** The four value
+  packages (``money`` / ``ratio`` / ``quantity`` / ``unit_price``) remain the
+  canonical cross-runtime reference (``common/<pkg>`` + BE/FE mirrors +
+  ``conformance/vectors.json``) — their code is **not** physically relocated, which
+  is the correct model: they ARE the Shared-Kernel reference (see
+  ``common/meta/migration-standard.md`` "project-level contract"). ``audit``
+  declares them as the value language it governs.
+* **Pins the number-governor invariants to the existing conformance tests.** Each
+  ``invariants[].test`` resolves to a real, already-green conformance/guard test,
+  so the gate proves audit's numeric guarantees against the SAME vectors that keep
+  the BE/FE mirrors honest — without duplicating or weakening any proof.
+
+Deliberately deferred (a separate atomic transaction — see ``readme.md`` and
+``todo.md``): transferring AC *ownership* (``AC2.19/2.20`` in EPIC-002,
+``AC12.9/12.30/12.32/12.33/12.36`` in EPIC-012) into audit's ``roadmap``. Those
+ACs are registry-tracked and wired into ``@ac_proof`` edges, the per-type
+PROTECTION count floor (``docs/ssot/protection-floor.json``), the tier baseline,
+and the BE/FE traceability references; re-homing them must rename every such
+reference atomically to avoid lowering the protection floor — so it is its own
+cutover, not bundled here. ``roadmap`` is therefore empty for now, exactly as the
+``money`` contract documents for the same reason (no AC may live in both an EPIC
+table and a package roadmap; ``check_epic_package_dual`` enforces it).
+
+This file is the machine contract the governance gate
+(``tools/check_package_contract.py``) validates: ``interface`` == the BE
+implementation's ``__all__`` (audit has no BE implementation yet, so its interface
+is empty), and every ``invariants[].test`` resolves to a real test function.
+"""
+
+from __future__ import annotations
+
+from common.meta.package_contract import Invariant, Kind, PackageContract, Unit
+
+CONTRACT = PackageContract(
+    name="audit",
+    # platform: the number governor, a governing peer to ``meta`` (also platform).
+    # It declares the value language as its units but imports none of it (its base
+    # depends on nothing, per the migration-standard package table), so depends_on
+    # is empty and no dependency edge or cycle is introduced.
+    klass="platform",
+    status="active",
+    # The number governor is deterministic value-language + invariant checking, no
+    # LLM: a pure-code (CODE-ONLY) package, like ``meta`` and the value packages.
+    tier="CODE-ONLY",
+    depends_on=[],
+    # The Shared Kernel value language audit governs, declared as value-object
+    # units (the taxonomy; no module path — audit has no physical base/extension
+    # split of its own yet, and the canonical code lives in the value packages'
+    # cross-runtime reference, so the gate skips placement). audit's OWN base value
+    # objects (financial invariants, confidence/provenance, trace records) arrive
+    # in a later fold and are tracked in readme.md/todo.md, not declared as vapor
+    # units here.
+    units=[
+        Unit(name="Money", kind=Kind.VALUE_OBJECT),
+        Unit(name="Currency", kind=Kind.VALUE_OBJECT),
+        Unit(name="ExchangeRate", kind=Kind.VALUE_OBJECT),
+        Unit(name="MoneyTolerance", kind=Kind.VALUE_OBJECT),
+        Unit(name="CurrencyBalance", kind=Kind.VALUE_OBJECT),
+        Unit(name="CurrencyBalances", kind=Kind.VALUE_OBJECT),
+        Unit(name="Ratio", kind=Kind.VALUE_OBJECT),
+        Unit(name="Quantity", kind=Kind.VALUE_OBJECT),
+        Unit(name="Unit", kind=Kind.VALUE_OBJECT),
+        Unit(name="UnitPrice", kind=Kind.VALUE_OBJECT),
+    ],
+    # No BE/FE implementation of its own yet: audit is governance-only at this
+    # stage (the value language runs in the value packages' mirrors). An empty
+    # interface against a missing BE implementation is accepted by the gate.
+    implementations={"be": None, "fe": None},
+    interface=[],
+    events=[],
+    # The number-governor guarantees, each pinned to an existing, already-green
+    # conformance/guard test (the SAME vectors that keep the BE/FE value mirrors in
+    # lockstep). No new test, no duplicated proof: audit asserts numeric
+    # correctness over the canonical Shared-Kernel suites.
+    invariants=[
+        Invariant(
+            id="money-rounds-half-even",
+            statement=(
+                "Money quantizes to its currency's minor unit with banker's "
+                "HALF_EVEN rounding, matching the money conformance vectors."
+            ),
+            test=(
+                "tests/tooling/test_money_conformance.py"
+                "::test_AC2_20_1_conformance_rounding"
+            ),
+        ),
+        Invariant(
+            id="fx-convert-is-deterministic",
+            statement=(
+                "convert() applies a typed ExchangeRate and rounds the result "
+                "deterministically, matching the money conformance vectors."
+            ),
+            test=(
+                "tests/tooling/test_money_conformance.py"
+                "::test_AC2_20_1_conformance_convert"
+            ),
+        ),
+        Invariant(
+            id="ratio-percent-policy",
+            statement=(
+                "Ratio percent rendering/application matches its conformance "
+                "vectors (canonical 2 dp / ROUND_HALF_UP)."
+            ),
+            test=(
+                "tests/tooling/test_ratio_conformance.py"
+                "::test_AC12_9_2_to_percent_matches_standard"
+            ),
+        ),
+        Invariant(
+            id="quantity-quantizes",
+            statement=(
+                "Quantity quantizes to 6 dp / ROUND_HALF_UP, matching its "
+                "conformance vectors."
+            ),
+            test=(
+                "tests/tooling/test_quantity_conformance.py"
+                "::test_AC12_30_2_quantity_quantize_matches_standard"
+            ),
+        ),
+        Invariant(
+            id="unit-price-times-quantity-is-money",
+            statement=(
+                "UnitPrice applied to a same-unit Quantity yields Money, matching "
+                "the unit_price conformance vectors (currency/unit checked)."
+            ),
+            test=(
+                "tests/tooling/test_unit_price_conformance.py"
+                "::test_AC12_32_2_unit_price_product_matches_standard"
+            ),
+        ),
+        Invariant(
+            id="no-float-in-money-narrow-waist",
+            statement=(
+                "Monetary values never use float in the money narrow waist; the "
+                "no-float guard reports any injected float violation."
+            ),
+            test=(
+                "tests/tooling/test_money_narrow_waist_guard.py"
+                "::test_AC2_23_1_money_modules_are_float_free"
+            ),
+        ),
+    ],
+    roadmap=[],
+)

--- a/common/audit/readme.md
+++ b/common/audit/readme.md
@@ -1,0 +1,84 @@
+# `audit` — the number governor
+
+> The **number** governor, the parallel peer to [`meta`](../meta/readme.md) the
+> **form** governor. `meta.base` is the package model everyone's *structure*
+> conforms to; `audit.base` is the **value language** everyone's *numbers* are
+> expressed in. Both are foundational *and* governing — one for form, one for
+> number (the "meta / audit symmetry" in
+> [`../meta/migration-standard.md`](../meta/migration-standard.md)).
+
+## What audit governs
+
+- **`audit.base`** — the value language: the cross-runtime Shared-Kernel value
+  types (`Money` / `Currency` / `ExchangeRate` / `MoneyTolerance` /
+  `CurrencyBalances` / `Ratio` / `Quantity` / `Unit` / `UnitPrice`), plus audit's
+  own base value objects (financial invariants, confidence / provenance, trace
+  records — the "governs number" core, a later fold).
+- **`audit.extension`** — reaches the financial flow (`ledger` / `extraction` /
+  `portfolio` / `reporting`) to assert global numeric correctness and end-to-end
+  traceability (a later fold; closeout #1429).
+- **`audit.data`** — confidence / provenance rollups and the trace-record index
+  (a later fold).
+
+Everyone's `base` ultimately depends on `audit.base` (the value types), so
+`audit.extension` reaching the whole flow is what lets audit govern the numbers —
+the symmetric mirror of `meta.extension` reaching every package to govern
+structure.
+
+## The Shared Kernel stays where it is
+
+The four value packages (`money` / `ratio` / `quantity` / `unit_price`) are a
+cross-runtime **Shared Kernel**: a language-neutral standard
+(`common/<pkg>/contract/*.contract.md` + `conformance/vectors.json`) with a
+canonical Python reference in `common/<pkg>` and per-end mirrors in
+`apps/backend/src/<pkg>` and `apps/frontend/src/lib/<pkg>`, kept in lockstep by
+the conformance vectors. That is exactly what `common/` is for — code whose
+strategic role is "shared by everyone" (see
+[`../meta/migration-standard.md`](../meta/migration-standard.md) "Where files
+go"). The value→audit fold therefore **declares** these types as audit's value
+language (its `units`) and **homes audit's numeric invariants against the same
+conformance suites**; it does **not** relocate the value-package code, and it does
+**not** touch the conformance vectors or the BE/FE parity. Backward compatibility
+of those contracts is sacred.
+
+The membership rule for what earns a Shared-Kernel value package, and the
+per-package value contract, stay in the base-packages SSOT.
+See: docs/ssot/base-packages.md
+
+Monetary values are `Decimal`-backed and never use `float`; money rounds with
+banker's `HALF_EVEN`. audit's `no-float-in-money-narrow-waist` invariant pins this
+to the existing narrow-waist guard test. See: docs/ssot/accounting.md#decimal-rule
+
+## Migration state (this fold)
+
+This first, low-risk fold (issue #1419, Stage 1 of umbrella #1416):
+
+- **Done here** — `audit` is registered as a package (this `contract.py`),
+  declares the Shared Kernel as its value-object `units`, and pins six
+  number-governor `invariants` to the existing, already-green conformance/guard
+  tests (`test_{money,ratio,quantity,unit_price}_conformance.py` +
+  `test_money_narrow_waist_guard.py`). The gate
+  (`tools/check_package_contract.py`) validates audit alongside every other
+  package.
+- **Deferred (separate atomic cutover)** — transferring AC *ownership* of the
+  value-language ACs (`AC2.19`/`AC2.20` in EPIC-002, `AC12.9`/`AC12.30`/`AC12.32`/
+  `AC12.33`/`AC12.36` in EPIC-012) into audit's `roadmap`. Those ACs are
+  registry-tracked and wired into `@ac_proof` edges, the per-type PROTECTION count
+  floor, the tier baseline, and the BE/FE traceability references; re-homing them
+  must atomically rename every such reference so the protection floor never drops.
+  That is its own transaction (one per domain), tracked in [`todo.md`](./todo.md).
+  `roadmap` stays empty until then — no AC may live in both an EPIC table and a
+  package roadmap (`check_epic_package_dual` enforces it), exactly as the `money`
+  contract documents today.
+- **Also deferred** — audit's own base value objects (invariants / confidence /
+  provenance / trace) and the `extension` reach into the financial flow.
+
+## See also
+
+- [`../meta/readme.md`](../meta/readme.md) — the form governor and the package
+  model audit conforms to.
+- [`../meta/migration-standard.md`](../meta/migration-standard.md) — the target
+  architecture and the value→audit fold (meta / audit symmetry).
+- `contract.py` — audit's machine-checkable `PackageContract`.
+- [`../../vision.md`](../../vision.md) — the north star (Good Taste: backward
+  compatibility of the value contracts is sacred).

--- a/common/audit/todo.md
+++ b/common/audit/todo.md
@@ -1,0 +1,38 @@
+# `audit` — worklist
+
+The number-governor fold lands in waves (issue #1419, umbrella #1416). This file
+tracks what remains after the first, low-risk fold (registering `audit`, declaring
+the Shared-Kernel `units`, pinning the number-governor invariants).
+
+## Next: AC ownership transfer (its own atomic cutover)
+
+Move the value-language ACs from their EPIC tables into audit's `roadmap` as
+`AC-audit.*`, deleting the EPIC rows (DoD: a single home; no AC in both an EPIC
+table and a roadmap). This is deferred because the value ACs are wired into more
+than the EPIC table, and all references must move atomically or the per-type
+PROTECTION count floor regresses:
+
+- EPIC-002: `AC2.19.1`, `AC2.19.2`, `AC2.20.1` (Money / Currency / FX convert).
+- EPIC-012: `AC12.9.*` (Ratio), `AC12.30.*` (Quantity + ExchangeRate),
+  `AC12.32.*` (UnitPrice), `AC12.33.*` (composite ops), `AC12.36.*` (decimal
+  scalar codec).
+- Each move must also rename: every `@ac_proof(ac_ids=[...])` edge, the
+  traceability docstring references in the BE *and* FE tests, and the tier
+  baseline (`docs/ssot/ac-tier-baseline.json`) — keeping registry-eligible
+  numeric ids (`AC-audit.<n>.<n>`) so `has_real_ref` / `has_proof` counts stay at
+  or above `docs/ssot/protection-floor.json`.
+- Edit only the audit/value rows: EPIC-012 is shared with middleware (leave its
+  rows); EPIC-001 is identity's.
+
+## Later: audit's own base + extension + data
+
+- `base` — audit's own value objects: financial invariants, confidence /
+  provenance, trace records (the "governs number" core).
+- `extension` — reach into `ledger` / `extraction` / `portfolio` / `reporting`
+  to assert global numeric correctness + end-to-end traceability (closeout #1429).
+- `data` — confidence / provenance rollups + the trace-record index (projection).
+
+## Will not do here
+
+- Relocate the value-package code or touch the conformance vectors / BE-FE parity
+  — the value packages ARE the Shared-Kernel cross-runtime reference and stay put.


### PR DESCRIPTION
## What

Closes part of #1419 (Stage 1 of umbrella #1416): the **value → audit fold**, scoped to its lowest-risk first wave.

Creates `common/audit` as the **number governor** — the parallel peer to `meta` (the *form* governor) per the meta/audit symmetry in `common/meta/migration-standard.md`. `meta.base` is the package model everyone's structure conforms to; `audit.base` is the **value language** everyone's numbers are expressed in.

### Done here
- Register `audit` as a package: `contract.py` + `__init__.py` + `readme.md` + `todo.md`. It is discovered and validated by `check_package_contract` alongside every other package (`platform` class, `CODE-ONLY` tier, `depends_on=[]` — its base depends on nothing, per the migration-standard package table).
- Declare the cross-runtime **Shared Kernel** (`Money`/`Currency`/`ExchangeRate`/`MoneyTolerance`/`CurrencyBalance(s)`/`Ratio`/`Quantity`/`Unit`/`UnitPrice`) as audit's value-object `units` — the value language it governs.
- Pin six number-governor `invariants` (money HALF_EVEN, FX convert, ratio percent, quantity quantize, unit_price product, no-float guard) to the **existing, already-green** conformance/guard tests. No new test, no duplicated or weakened proof.

### Deliberately NOT done (each its own atomic cutover — see `common/audit/todo.md`)
- The four value packages' **code is not relocated** and the **conformance vectors / BE-FE parity are untouched** — they ARE the Shared-Kernel cross-runtime reference and correctly stay in `common/<pkg>` + BE/FE mirrors. Backward compatibility of those contracts is sacred (vision Good Taste).
- **AC ownership transfer** (`AC2.19/2.20` in EPIC-002; `AC12.9/12.30/12.32/12.33/12.36` in EPIC-012) into audit's `roadmap` is deferred. Those ACs are wired into `@ac_proof` edges, the per-type PROTECTION count floor (`docs/ssot/protection-floor.json`), the tier baseline, and BE *and* FE traceability references; re-homing them must rename every such reference atomically or the protection floor regresses. `roadmap` stays empty (no AC may live in both an EPIC table and a package roadmap — `check_epic_package_dual` enforces it), mirroring the `money` contract's documented stance.

This is the "Pick the lowest-risk interpretation that still advances the goal" path: audit is established as the number governor and owns the value language as `units` + invariants, without breaking the money standard or shipping a half-migration of the registry/proof graph.

## Gates (run locally)
- `check_package_contract.py` — **PASSED**, incl. new `audit` (6 invariants, 0 roadmap ACs).
- Value conformance + guard suites — **60 passed** (`test_{money,ratio,quantity,unit_price}_conformance.py` + `test_money_narrow_waist_guard.py`).
- `generate_ac_registry.py --check`, `check_epic_package_dual`, `check_ssot_ownership`, `check_draft_packages` — **green**.
- `check_ac_index.py` — INTEGRITY + PROTECTION **green**, no count regression (`has_real_ref` 1916/1642, `has_proof` 96/45, `has_mirror` 33/33).
- `ruff check` / `ruff format --check` — **clean**.
- Package-model tests (`test_check_package_contract.py`, `test_counter_package.py`, `test_meta_layering.py`) — **43 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)