### PR TITLE
[finance_report_vision] feat(llm): add Google Gemini extraction provider (native-PDF, fixes big/scanned truncation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,9 +59,10 @@ PRIMARY_MODEL=glm-5.1
 VISION_FALLBACK_MODELS=glm-4.5v
 # Vision AI model id.
 VISION_MODEL=glm-4.6v
-# AI provider API key (empty key = AI features disabled). ZAI_API_KEY is preferred for the default Z.AI provider; AI_API_KEY is a provider-neutral alias. [VAULT]
+# AI provider API key (empty key = AI features disabled). ZAI_API_KEY is preferred for the default Z.AI provider; GEMINI_API_KEY for AI_PROVIDER=gemini; AI_API_KEY is a provider-neutral alias. [VAULT]
 ZAI_API_KEY=
 AI_API_KEY=
+GEMINI_API_KEY=
 
 # === S3 / MinIO Storage ===
 # S3 / MinIO access key. [VAULT]

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -199,7 +199,7 @@ class Settings(BaseSettings):
     ai_api_key: str = Field(
         default="",
         validation_alias=AliasChoices(
-            "ZAI_API_KEY", "GLM_API_KEY", "AI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"
+            "ZAI_API_KEY", "GLM_API_KEY", "AI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"
         ),
         description=(
             "AI provider API key (empty key = AI features disabled). ZAI_API_KEY is "

--- a/apps/backend/src/config.py
+++ b/apps/backend/src/config.py
@@ -198,16 +198,18 @@ class Settings(BaseSettings):
     )
     ai_api_key: str = Field(
         default="",
-        validation_alias=AliasChoices("ZAI_API_KEY", "GLM_API_KEY", "AI_API_KEY", "OPENROUTER_API_KEY"),
+        validation_alias=AliasChoices(
+            "ZAI_API_KEY", "GLM_API_KEY", "AI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"
+        ),
         description=(
             "AI provider API key (empty key = AI features disabled). ZAI_API_KEY is "
-            "preferred for the default Z.AI provider; AI_API_KEY is a provider-neutral "
-            "alias."
+            "preferred for the default Z.AI provider; GEMINI_API_KEY for AI_PROVIDER=gemini; "
+            "AI_API_KEY is a provider-neutral alias."
         ),
         json_schema_extra={
             "group": "AI Provider",
             "vault": True,
-            "extra_keys": ["AI_API_KEY"],
+            "extra_keys": ["AI_API_KEY", "GEMINI_API_KEY"],
         },
     )
 

--- a/apps/backend/src/llm/common/types.py
+++ b/apps/backend/src/llm/common/types.py
@@ -22,12 +22,17 @@ class ProtocolFamily(StrEnum):
     """Axis 1 — the wire protocol a provider speaks.
 
     Concrete vendors map onto exactly one family; e.g. Z.AI/GLM and DeepSeek are
-    ``OPENAI_COMPATIBLE`` (custom ``api_base``), Claude is ``ANTHROPIC_COMPATIBLE``.
+    ``OPENAI_COMPATIBLE`` (custom ``api_base``), Claude is ``ANTHROPIC_COMPATIBLE``,
+    and Google Gemini (AI Studio / Vertex) is ``GOOGLE_GEMINI`` — its native API
+    accepts a whole PDF as one ``file`` part (no per-page image rendering) and has
+    a high output ceiling, which is why it is the provider of choice for extracting
+    large or scanned statements.
     """
 
     OPENAI_COMPATIBLE = "openai-compatible"
     ANTHROPIC_COMPATIBLE = "anthropic-compatible"
     OPENROUTER_COMPATIBLE = "openrouter-compatible"
+    GOOGLE_GEMINI = "google-gemini"
 
 
 class Scene(StrEnum):

--- a/apps/backend/src/llm/env_config.py
+++ b/apps/backend/src/llm/env_config.py
@@ -15,12 +15,14 @@ from src.llm.common import ProtocolFamily, ProviderRef, Scene, SceneBinding
 _PROVIDER_ENV_ID = "env"
 
 # Map the loosely-typed AI_PROVIDER value onto a protocol family. Anything that
-# is not OpenRouter or Anthropic is treated as OpenAI-compatible (Z.AI/GLM,
+# is not OpenRouter, Anthropic or Gemini is treated as OpenAI-compatible (Z.AI/GLM,
 # DeepSeek, a local vLLM, …) — they all ride the OpenAI wire format.
 _FAMILY_BY_PROVIDER: dict[str, ProtocolFamily] = {
     "openrouter": ProtocolFamily.OPENROUTER_COMPATIBLE,
     "anthropic": ProtocolFamily.ANTHROPIC_COMPATIBLE,
     "claude": ProtocolFamily.ANTHROPIC_COMPATIBLE,
+    "gemini": ProtocolFamily.GOOGLE_GEMINI,
+    "google": ProtocolFamily.GOOGLE_GEMINI,
 }
 
 

--- a/apps/backend/src/llm/env_config.py
+++ b/apps/backend/src/llm/env_config.py
@@ -22,7 +22,6 @@ _FAMILY_BY_PROVIDER: dict[str, ProtocolFamily] = {
     "anthropic": ProtocolFamily.ANTHROPIC_COMPATIBLE,
     "claude": ProtocolFamily.ANTHROPIC_COMPATIBLE,
     "gemini": ProtocolFamily.GOOGLE_GEMINI,
-    "google": ProtocolFamily.GOOGLE_GEMINI,
 }
 
 

--- a/apps/backend/src/llm/routing.py
+++ b/apps/backend/src/llm/routing.py
@@ -19,7 +19,12 @@ _FAMILY_PREFIX: dict[ProtocolFamily, str] = {
     ProtocolFamily.OPENAI_COMPATIBLE: "openai",
     ProtocolFamily.ANTHROPIC_COMPATIBLE: "anthropic",
     ProtocolFamily.OPENROUTER_COMPATIBLE: "openrouter",
+    ProtocolFamily.GOOGLE_GEMINI: "gemini",
 }
+
+# Families whose litellm route is the vendor's native endpoint — they must NOT be
+# given a custom OpenAI-style ``api_base`` (it would point litellm at the wrong host).
+_NATIVE_ENDPOINT_FAMILIES = frozenset({ProtocolFamily.ANTHROPIC_COMPATIBLE, ProtocolFamily.GOOGLE_GEMINI})
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,9 +68,9 @@ def build_call(provider: ProviderRef, model_id: str) -> LitellmCall:
             "X-Title": "Finance Report Backend",
         }
 
-    # Anthropic native uses its own endpoint; only custom OpenAI-compatible and
-    # OpenRouter endpoints need an explicit api_base.
-    api_base = provider.api_base if provider.protocol is not ProtocolFamily.ANTHROPIC_COMPATIBLE else None
+    # Native-endpoint families (Anthropic, Gemini) use the vendor's own host; only
+    # custom OpenAI-compatible and OpenRouter endpoints need an explicit api_base.
+    api_base = None if provider.protocol in _NATIVE_ENDPOINT_FAMILIES else provider.api_base
 
     return LitellmCall(
         model=litellm_model,

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -368,6 +368,33 @@ def test_build_vision_media_payloads_rejects_non_url_pdf_input(monkeypatch):
             )
 
 
+def test_build_vision_media_payloads_gemini_sends_native_pdf_not_rendered_images(monkeypatch):
+    """Gemini extracts the whole PDF natively: a PDF with file content yields a single
+    `file` payload (base64 PDF), NOT per-page rendered `image_url` images. This is what
+    lets Gemini handle large/scanned statements the z.ai image-render path truncates."""
+    from src.config import settings
+
+    monkeypatch.setattr(settings, "ai_provider", "gemini")
+    service = ExtractionService()
+
+    # If this path ever tried to render images for Gemini, the test would catch it.
+    with patch.object(
+        service,
+        "_render_pdf_pages_as_image_payloads",
+        side_effect=AssertionError("Gemini must not render PDF pages to images"),
+    ):
+        payloads = service._build_vision_media_payloads(
+            file_content=b"%PDF-1.4 fake pdf bytes",
+            file_url=None,
+            file_type="pdf",
+            mime_type="application/pdf",
+        )
+
+    assert len(payloads) == 1
+    assert payloads[0]["type"] == "file"
+    assert payloads[0]["file"]["file_data"].startswith("data:application/pdf;base64,")
+
+
 def test_build_vision_media_payloads_reraises_render_error_without_external_url(monkeypatch):
     """AC8.12.6: Render failures without a safe external URL do not silently continue."""
     from src.config import settings

--- a/apps/backend/tests/unit/llm/test_env_config.py
+++ b/apps/backend/tests/unit/llm/test_env_config.py
@@ -47,6 +47,8 @@ async def test_AC23_2_4_openrouter_and_anthropic_families(monkeypatch):
     assert (await EnvConfigSource().list_providers())[0].protocol is ProtocolFamily.OPENROUTER_COMPATIBLE
     monkeypatch.setattr(settings, "ai_provider", "anthropic", raising=False)
     assert (await EnvConfigSource().list_providers())[0].protocol is ProtocolFamily.ANTHROPIC_COMPATIBLE
+    monkeypatch.setattr(settings, "ai_provider", "gemini", raising=False)
+    assert (await EnvConfigSource().list_providers())[0].protocol is ProtocolFamily.GOOGLE_GEMINI
 
 
 async def test_AC23_2_4_get_provider_by_id(configured):

--- a/apps/backend/tests/unit/llm/test_routing.py
+++ b/apps/backend/tests/unit/llm/test_routing.py
@@ -34,6 +34,18 @@ def test_AC23_2_1_anthropic_is_native_without_api_base():
     assert call.api_base is None
 
 
+def test_AC23_2_1_gemini_is_native_and_drops_inherited_api_base():
+    """AC23.2.1: google-gemini -> gemini/ prefix on litellm's native endpoint; any
+    inherited OpenAI-style api_base (e.g. the default Z.AI base url) is dropped so
+    litellm does not point Gemini at the wrong host."""
+    call = build_call(
+        _provider(ProtocolFamily.GOOGLE_GEMINI, "https://api.z.ai/api/coding/paas/v4"),
+        "gemini-3-flash-preview",
+    )
+    assert call.model == "gemini/gemini-3-flash-preview"
+    assert call.api_base is None
+
+
 def test_AC23_2_1_avoids_double_family_prefix():
     """AC23.2.1: a model already carrying the litellm family token is not double-prefixed."""
     call = build_call(_provider(ProtocolFamily.OPENAI_COMPATIBLE, "https://x"), "openai/glm-5.1")

--- a/apps/backend/tests/unit/llm/test_types.py
+++ b/apps/backend/tests/unit/llm/test_types.py
@@ -16,12 +16,15 @@ from src.llm.common import (
 )
 
 
-def test_AC23_1_1_protocol_family_enumerates_exactly_three_universal_families():
-    """AC23.1.1: axis 1 is exactly the three universally-compatible protocol families."""
+def test_AC23_1_1_protocol_family_enumerates_the_supported_families():
+    """AC23.1.1: axis 1 is the fixed set of supported wire protocols. Google Gemini
+    is its own family (native endpoint + whole-PDF ``file`` input) rather than an
+    openai-compatible base-url variant."""
     assert {f.value for f in ProtocolFamily} == {
         "openai-compatible",
         "anthropic-compatible",
         "openrouter-compatible",
+        "google-gemini",
     }
 
 

--- a/docs/ssot/env-reference.generated.md
+++ b/docs/ssot/env-reference.generated.md
@@ -37,8 +37,9 @@ Where a field's `.env.example` value intentionally differs from its code default
 | `PRIMARY_MODEL` | `glm-5.1` |  |  | AI Provider | Primary AI model id. |
 | `VISION_FALLBACK_MODELS` |  | `glm-4.5v` |  | AI Provider | Comma-separated fallback AI model ids for the vision/OCR path. These must be vision-capable because the vision request carries image content; the text-only FALLBACK_MODELS are not reused here (#1034). |
 | `VISION_MODEL` | `glm-4.6v` |  |  | AI Provider | Vision AI model id. |
-| `ZAI_API_KEY` |  |  | yes | AI Provider | AI provider API key (empty key = AI features disabled). ZAI_API_KEY is preferred for the default Z.AI provider; AI_API_KEY is a provider-neutral alias. |
+| `ZAI_API_KEY` |  |  | yes | AI Provider | AI provider API key (empty key = AI features disabled). ZAI_API_KEY is preferred for the default Z.AI provider; GEMINI_API_KEY for AI_PROVIDER=gemini; AI_API_KEY is a provider-neutral alias. |
 | `AI_API_KEY` |  |  | yes | AI Provider | Alias of `ZAI_API_KEY`. |
+| `GEMINI_API_KEY` |  |  | yes | AI Provider | Alias of `ZAI_API_KEY`. |
 | `S3_ACCESS_KEY` | `minio` |  | yes | S3 / MinIO Storage | S3 / MinIO access key. |
 | `S3_BUCKET` | `statements` |  | yes | S3 / MinIO Storage | S3 / MinIO bucket name for uploaded statements. |
 | `S3_ENDPOINT` | `http://127.0.0.1:9000` | `http://localhost:9000` | yes | S3 / MinIO Storage | S3 / MinIO endpoint used for storing uploaded statement files. |

--- a/docs/ssot/llm.md
+++ b/docs/ssot/llm.md
@@ -40,6 +40,7 @@ protocols. Every concrete vendor maps onto one of them:
 | `openai-compatible` | OpenAI, Z.AI/GLM, DeepSeek, a local vLLM (custom `api_base`) |
 | `anthropic-compatible` | Claude (native Messages API) |
 | `openrouter-compatible` | OpenRouter (adds `:free` tier, provider routing, extra headers) |
+| `google-gemini` | Google Gemini (AI Studio / Vertex; native endpoint, accepts a whole PDF as one `file` part — no per-page image rendering — and a high output ceiling, so it extracts large/scanned statements that the image-render path truncates). Enable with `AI_PROVIDER=gemini` + `GEMINI_API_KEY`. DB-stored Gemini providers need an `llm_protocol_family_enum` migration; the env path works today. |
 
 A *provider instance* is `(protocol_family, api_base?, api_key, label)`. The
 litellm client turns it into a `provider/model` call string.


### PR DESCRIPTION
## Problem (this is a latent **production** gap, not just a fixtures issue)
`extract_financial_data` is single-shot, inlines base64 page images, and caps output at `AI_JSON_MAX_TOKENS=8192`. On the z.ai coding plan that means:
- **Large statements truncate** — the coding plan caps model output at ~5.5k tokens (below our 8192), cutting the JSON mid-string → 0 txns parsed.
- **Scanned PDFs** can't be OCR'd without a paid balance (`layout_parsing`/GLM-OCR → 429); inlining a 22MB rendered image overflows the context (`1261 prompt too long`).

## Fix — Gemini as a first-class extraction provider (opt-in)
Gemini's native API takes a **whole PDF as one `file` part** (no per-page rendering), with a high output ceiling and built-in OCR. **Verified end-to-end** on a scanned 162-txn statement: one request, `finish=stop`, **162/162 txns, no truncation**, balance chain identical to ground truth.

- `ProtocolFamily.GOOGLE_GEMINI` → litellm `gemini/` prefix on the native endpoint (any inherited z.ai `api_base` dropped).
- `AI_PROVIDER=gemini` + `GEMINI_API_KEY` (config alias; `.env.example`/env-reference regenerated).
- **`_media.py` unchanged**: non-z.ai PDFs already build a native `file` payload (base64 PDF) which litellm routes to Gemini `inline_data` — confirmed against the repo's litellm.

## Safety / scope
- **Opt-in: default stays `zai`** → the 7 existing cassettes, replay tests, and CI are untouched.
- Tests (no network): routing (`gemini → gemini/…`, api_base dropped), env_config (`gemini → GOOGLE_GEMINI`), the family set, and a behavioral guard that `AI_PROVIDER=gemini` produces a native-PDF `file` payload **not** rendered images.
- SSOT `llm.md` updated.

## Verification
174 affected tests pass; doc-consistency + manifest green; ruff clean.

## Deferred (each its own PR)
- Flip the default provider to Gemini + re-record the affected (vision) cassettes.
- Record the HF synthetic corpus via Gemini as cassette-replay fixtures.
- DB-stored Gemini providers need an `llm_protocol_family_enum` migration (env path works now).
- Own **real** statements stay on **local OCR** (no cloud — AI Studio free tier trains on data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)