### PR TITLE
[finance_report_test_and_doc] chore(deploy): re-pin repo submodule to published infra2 v1.1.18

### DIFF
--- a/tests/tooling/test_dokploy_redaction.py
+++ b/tests/tooling/test_dokploy_redaction.py
@@ -19,7 +19,7 @@ def run_bash(script: str) -> subprocess.CompletedProcess[str]:
 
 
 def test_AC8_13_72_common_dokploy_call_redacts_non_200_body() -> None:
-    script = r'''
+    script = r"""
       source common/shell/common.sh
       DOKPLOY_API_URL="https://dokploy.example/api"
       DOKPLOY_API_KEY="api-secret"
@@ -40,7 +40,7 @@ JSON
       }
       output_file="$(mktemp)"
       dokploy_api_call "POST" "compose.update" '{"composeId":"cmp"}' "$output_file" "Environment update"
-    '''
+    """
 
     result = run_bash(script)
 
@@ -57,7 +57,7 @@ JSON
 
 
 def test_AC8_13_72_deploy_v2_updates_allowlisted_env_only() -> None:
-    primitive = (ROOT / "repo/tools/deploy_primitive.py").read_text()
+    primitive = (ROOT / "repo/libs/deploy/promote.py").read_text()
     common_shell = (ROOT / "common/shell/common.sh").read_text()
 
     assert "env_vars = {" in primitive
@@ -79,13 +79,13 @@ def test_AC8_13_72_deploy_v2_updates_allowlisted_env_only() -> None:
     assert '-d "$data"' not in common_shell
     assert "--connect-timeout" in common_shell
     assert "--max-time" in common_shell
-    assert "--config \"$curl_config_file\"" in common_shell
-    assert "--data-binary \"@$data_file\"" in common_shell
+    assert '--config "$curl_config_file"' in common_shell
+    assert '--data-binary "@$data_file"' in common_shell
 
 
 def test_AC8_13_72_deploy_v2_dokploy_client_does_not_log_raw_response_bodies() -> None:
     dokploy_client = (ROOT / "repo/libs/dokploy.py").read_text()
-    primitive = (ROOT / "repo/tools/deploy_primitive.py").read_text()
+    primitive = (ROOT / "repo/libs/deploy/promote.py").read_text()
 
     request_block = dokploy_client.split("def _request(", 1)[1].split(
         "    # Project endpoints", 1

--- a/tests/tooling/test_issue_575_effective_env_verify.py
+++ b/tests/tooling/test_issue_575_effective_env_verify.py
@@ -20,7 +20,7 @@ def read(path: str) -> str:
 
 def test_AC7_14_1_verify_runs_after_rollout_and_before_health() -> None:
     """AC7.14.1 AC7.14.4: effective-config verification gates fixed-env deploy success."""
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
     staging = read(".github/workflows/deploy.yml")
     production = read(".github/workflows/release.yml")
     primitive_tests = read("repo/libs/tests/test_deploy_primitive.py")
@@ -59,7 +59,7 @@ def test_AC7_14_1_verify_runs_after_rollout_and_before_health() -> None:
 
 def test_AC7_14_2_stale_effective_config_fails_fast_without_secret_echo() -> None:
     """AC7.14.2: stale effective config raises a named failure, not a late health 404."""
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
     dokploy_client = read("repo/libs/dokploy.py")
     primitive_tests = read("repo/libs/tests/test_deploy_primitive.py")
 
@@ -83,7 +83,7 @@ def test_AC7_14_2_stale_effective_config_fails_fast_without_secret_echo() -> Non
 
 def test_AC7_14_3_no_force_recreate_escape_hatch_remains() -> None:
     """AC7.14.3: stale effective config is fail-closed; reruns use deploy_v2."""
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
     production = read(".github/workflows/deploy.yml")
     deployment_doc = read("docs/ssot/deployment.md")
 
@@ -98,7 +98,7 @@ def test_AC7_14_3_no_force_recreate_escape_hatch_remains() -> None:
 
 def test_AC7_14_6_rollout_baseline_is_snapshotted_before_mutation() -> None:
     """AC7.14.6: rollout wait compares against the pre-mutation deployment ids."""
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
     primitive_tests = read("repo/libs/tests/test_deploy_primitive.py")
 
     baseline = "before_ids = ("

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -490,7 +490,7 @@ def test_AC8_13_11_health_check_diagnoses_staging_api_route_404() -> None:
 
 def test_AC8_13_11_deploy_preflights_vault_token_before_redeploy() -> None:
     """AC8.13.11: deploy_v2 fails before rollout on invalid legacy Vault tokens."""
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
     deploy_v2 = read("repo/tools/deploy_v2.py")
     staging_workflow = read(".github/workflows/deploy.yml")
     production_workflow = read(".github/workflows/deploy.yml")
@@ -1960,7 +1960,7 @@ def test_AC8_13_67_production_release_preserves_version_metadata() -> None:
     workflow = read(".github/workflows/release.yml")
     # Tag promotion (imagetools create x2) stays in deploy.yml's promote job.
     release_images = read(".github/workflows/deploy.yml")
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
     app_compose = read("repo/finance_report/finance_report/10.app/compose.yaml")
 
     # In the promote-not-rebuild pattern, deploy.yml promotes the retained tag once.
@@ -2057,7 +2057,7 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     brokerage = read("tests/e2e/test_brokerage_upload_to_portfolio_value.py")
     four_asset = read("tests/e2e/test_four_asset_net_worth_golden_path.py")
     upload = read("tests/e2e/test_statement_upload_e2e.py")
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
     preview_lifecycle = read("tools/_lib/dev/pr_preview_lifecycle")
 
     assert "post-merge-train-turn:" not in workflow
@@ -3072,7 +3072,7 @@ def test_AC8_13_72_staging_deploy_proves_health_sha_after_dokploy_trigger() -> N
     """AC8.13.72 AC8.13.106: staging proof checks health git_sha, not just Dokploy trigger."""
     workflow = read(".github/workflows/deploy.yml")
     deploy_v2 = read("repo/tools/deploy_v2.py")
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
     health_check = read("tools/_lib/shell/health_check.sh")
 
     deploy_block = workflow.split("- name: Deploy to Staging", 1)[1].split(
@@ -3123,7 +3123,7 @@ def test_AC8_13_72_staging_deploy_proves_health_sha_after_dokploy_trigger() -> N
 def test_AC8_13_72_staging_dokploy_rollout_parsing_is_typed_and_fail_fast() -> None:
     """AC8.13.72: staging rollout parsing handles Dokploy shape drift clearly."""
     dokploy_client = read("repo/libs/dokploy.py")
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
 
     assert (
         "def get_compose_deployments(self, compose_id: str) -> list[dict]"
@@ -3153,7 +3153,7 @@ def test_AC8_13_72_staging_dokploy_rollout_parsing_is_typed_and_fail_fast() -> N
 
 def test_AC8_13_72_staging_dokploy_noop_after_redeploy_fails_before_health() -> None:
     """AC8.13.72: staging fails when Dokploy accepts deploys without rollout records."""
-    primitive = read("repo/tools/deploy_primitive.py")
+    primitive = read("repo/libs/deploy/promote.py")
     workflow = read(".github/workflows/deploy.yml")
     ci_cd = read("docs/ssot/ci-cd.md")
 


### PR DESCRIPTION
## What

Re-pin `repo/` submodule: `18f4c88` → `27025da` (infra2 **v1.1.18**, published on origin/main).

## Why

main pinned `repo/` at `18f4c88` — an infra2 commit tagged `v1.1.15` **locally but never pushed to infra2 origin**. Result: `deploy_v2` staging/prod failed the *"iac_ref must be a published release tag"* gate (`resolve_release_coordinate.py`), and the commit isn't even fetchable from infra2 origin — main was **non-deployable**.

`27025da` = infra2 **v1.1.18** (published, on origin/main) carries the `libs/deploy` relocation (#447) + iac-runner 404 tolerance + reconcile preview-GC (#449/#450). infra2 v1.1.18 is already released (reconcile green).

## Effect

Unblocks the finance_report staging/prod release line. Pre-commit `Check repo/ submodule points to latest infra2 main` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)