### PR TITLE
[finance_report_audit] Stage 1: relocate shared observability logging/redaction helpers into the observability package (prereq for #1428)

### DIFF
--- a/apps/backend/src/auth.py
+++ b/apps/backend/src/auth.py
@@ -11,10 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.database import get_db
 from src.logger import get_logger
 from src.models.user import User
-from src.observability_events import (
-    bind_authenticated_user_context,
-    log_security_warning,
-)
+from src.observability import log_security_warning
+from src.observability_events import bind_authenticated_user_context
 from src.security import decode_access_token
 
 AUTH_COOKIE_NAME = "finance_access_token"

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -30,9 +30,9 @@ from src.models.ping_state import PingState
 from src.observability import (
     get_observability_status,
     log_observability_startup,
+    log_security_warning,
     mark_fastapi_instrumentation_active,
 )
-from src.observability_events import log_security_warning
 from src.rate_limit import api_rate_limiter
 from src.routers import (
     accounts,

--- a/apps/backend/src/observability/__init__.py
+++ b/apps/backend/src/observability/__init__.py
@@ -1,0 +1,49 @@
+"""The ``observability`` package — the backend's published observability language.
+
+This is the registered ``observability`` package's BE implementation (its spec and
+the stdlib ``openpanel_query`` analytics CLI live in ``common/observability``). It
+publishes two cohesive surfaces:
+
+* :mod:`src.observability.runtime` — the vendor-neutral OpenTelemetry runtime
+  contract (status + startup readiness, FastAPI instrumentation state); and
+* :mod:`src.observability.audit` — the shared structured audit/security logging
+  helpers with PII and secret redaction.
+
+Identity's request-context binding (``bind_authenticated_user_context``) is kept in
+``src.observability_events`` and folded in by #1428.
+"""
+
+from __future__ import annotations
+
+import src.config
+from src.observability.audit import (
+    current_request_id,
+    log_financial_mutation,
+    log_security_warning,
+    safe_error_message,
+    safe_log_fields,
+)
+from src.observability.runtime import (
+    get_observability_status,
+    is_fastapi_instrumentation_active,
+    log_observability_startup,
+    mark_fastapi_instrumentation_active,
+)
+
+# The shared config singleton, surfaced at the package root so callers and tests
+# can read/patch it via ``observability.settings`` (mirroring the prior flat
+# module). Bound by assignment from the bare-root ``src.config`` import to respect
+# the package-model cross-domain rule; not part of the published ``interface``.
+settings = src.config.settings
+
+__all__ = [
+    "current_request_id",
+    "get_observability_status",
+    "is_fastapi_instrumentation_active",
+    "log_financial_mutation",
+    "log_observability_startup",
+    "log_security_warning",
+    "mark_fastapi_instrumentation_active",
+    "safe_error_message",
+    "safe_log_fields",
+]

--- a/apps/backend/src/observability/audit.py
+++ b/apps/backend/src/observability/audit.py
@@ -1,0 +1,127 @@
+"""Structured audit/security logging helpers with PII and secret redaction.
+
+The shared, non-identity logging surface of the ``observability`` package: bounded
+one-line error summaries, risky-field redaction, and stable audit-event emitters
+for financial mutations and security warnings. Identity's request-context binding
+(``bind_authenticated_user_context``) deliberately lives elsewhere
+(``src.observability_events``) and is folded in later by #1428.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+import structlog
+
+from src.services.pii_redaction import detect_pii
+
+RISKY_LOG_FIELD_NAMES = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "cookies",
+        "api_key",
+        "token",
+        "secret",
+        "password",
+        "prompt",
+        "raw_prompt",
+        "raw_response",
+        "response_body",
+        "error_body",
+        "provider_body",
+        "provider_response",
+    }
+)
+MAX_SAFE_ERROR_CHARS = 300
+
+
+def _redact_detected_pii(text: str) -> str:
+    matches = detect_pii(text)
+    if not matches:
+        return text
+
+    redacted = text
+    for match in sorted(matches, key=lambda item: item.start, reverse=True):
+        label = f"[{match.pii_type.value.upper()}]"
+        redacted = redacted[: match.start] + label + redacted[match.end :]
+    return redacted
+
+
+def current_request_id() -> str | None:
+    value = structlog.contextvars.get_contextvars().get("request_id")
+    return str(value) if value else None
+
+
+def safe_error_message(message: object, *, limit: int = MAX_SAFE_ERROR_CHARS) -> str:
+    """Return a one-line bounded error summary that is safe for logs."""
+    text = _redact_detected_pii(" ".join(str(message).split()))
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def safe_log_fields(fields: Mapping[str, Any]) -> dict[str, Any]:
+    """Return log fields with risky raw body/secret keys redacted."""
+    safe: dict[str, Any] = {}
+    for key, value in fields.items():
+        normalized = key.lower()
+        if normalized in RISKY_LOG_FIELD_NAMES:
+            safe[key] = "[REDACTED]"
+        elif isinstance(value, Mapping):
+            safe[key] = safe_log_fields(value)
+        else:
+            safe[key] = value
+    return safe
+
+
+def log_financial_mutation(
+    logger: Any,
+    event: str,
+    *,
+    user_id: UUID | str,
+    action: str,
+    resource_type: str,
+    resource_id: UUID | str,
+    **fields: Any,
+) -> None:
+    """Emit one financial mutation audit event with stable common fields."""
+    logger.info(
+        event,
+        **safe_log_fields(
+            {
+                "audit_event": event,
+                "user_id": str(user_id),
+                "request_id": current_request_id(),
+                "action": action,
+                "resource_type": resource_type,
+                "resource_id": str(resource_id),
+                **fields,
+            }
+        ),
+    )
+
+
+def log_security_warning(
+    logger: Any,
+    event: str,
+    *,
+    reason: str,
+    user_id: UUID | str | None = None,
+    client_ip: str | None = None,
+    **fields: Any,
+) -> None:
+    """Emit one security-relevant warning without raw credentials or payloads."""
+    payload: dict[str, Any] = {
+        "audit_event": event,
+        "request_id": current_request_id(),
+        "reason": reason,
+    }
+    if user_id is not None:
+        payload["user_id"] = str(user_id)
+    if client_ip is not None:
+        payload["client_ip"] = client_ip
+    payload.update(fields)
+    logger.warning(event, **safe_log_fields(payload))

--- a/apps/backend/src/observability/runtime.py
+++ b/apps/backend/src/observability/runtime.py
@@ -5,13 +5,18 @@ knows nothing about the observability *backend* (which collector/UI/alerting is
 behind the OTLP endpoint). Choosing the backend, wiring alert rules, and proving
 ingestion are infra2's concern, reached only through the vendor-neutral OTLP
 endpoint.
+
+``src.config`` is imported by its bare published root (the package-model
+cross-domain rule: reach another registered package only via ``import src.<pkg>``
+or a symbol in its ``__all__``); the config singleton is read at call time so a
+monkeypatched ``src.config.settings`` is always reflected.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from src.config import parse_key_value_pairs, settings
+import src.config
 
 # Runtime flag set by the app once FastAPI request instrumentation is actually
 # applied to the app instance. This is real init state, not configuration: a
@@ -32,7 +37,10 @@ def is_fastapi_instrumentation_active() -> bool:
 
 
 def _deployment_environment(resource_attributes: dict[str, str]) -> str:
-    return resource_attributes.get("deployment.environment") or settings.environment
+    return (
+        resource_attributes.get("deployment.environment")
+        or src.config.settings.environment
+    )
 
 
 def get_observability_status() -> dict[str, Any]:
@@ -41,7 +49,10 @@ def get_observability_status() -> dict[str, Any]:
     The payload is safe for `/health` and startup logs: it intentionally does not
     expose collector URLs, webhook URLs, API keys, or bot secrets.
     """
-    resource_attributes = parse_key_value_pairs(settings.otel_resource_attributes)
+    settings = src.config.settings
+    resource_attributes = src.config.parse_key_value_pairs(
+        settings.otel_resource_attributes
+    )
     exporter_configured = bool(settings.otel_exporter_otlp_endpoint)
     try:
         from src.telemetry_metrics import is_metrics_export_active

--- a/apps/backend/src/observability/runtime.py
+++ b/apps/backend/src/observability/runtime.py
@@ -37,10 +37,7 @@ def is_fastapi_instrumentation_active() -> bool:
 
 
 def _deployment_environment(resource_attributes: dict[str, str]) -> str:
-    return (
-        resource_attributes.get("deployment.environment")
-        or src.config.settings.environment
-    )
+    return resource_attributes.get("deployment.environment") or src.config.settings.environment
 
 
 def get_observability_status() -> dict[str, Any]:
@@ -50,9 +47,7 @@ def get_observability_status() -> dict[str, Any]:
     expose collector URLs, webhook URLs, API keys, or bot secrets.
     """
     settings = src.config.settings
-    resource_attributes = src.config.parse_key_value_pairs(
-        settings.otel_resource_attributes
-    )
+    resource_attributes = src.config.parse_key_value_pairs(settings.otel_resource_attributes)
     exporter_configured = bool(settings.otel_exporter_otlp_endpoint)
     try:
         from src.telemetry_metrics import is_metrics_export_active

--- a/apps/backend/src/observability_events.py
+++ b/apps/backend/src/observability_events.py
@@ -1,125 +1,18 @@
-"""Structured observability event helpers for audit and security logs."""
+"""Identity request-context binding for structlog (identity-owned; see #1428).
+
+The shared structured-logging/redaction helpers that used to live here have moved
+to the ``observability`` package (``src.observability``). Only identity's
+request-context binding remains, to be folded into identity by #1428 — at which
+point this module is deleted with zero residue.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
 from uuid import UUID
 
 import structlog
-
-from src.services.pii_redaction import detect_pii
-
-RISKY_LOG_FIELD_NAMES = frozenset(
-    {
-        "authorization",
-        "cookie",
-        "cookies",
-        "api_key",
-        "token",
-        "secret",
-        "password",
-        "prompt",
-        "raw_prompt",
-        "raw_response",
-        "response_body",
-        "error_body",
-        "provider_body",
-        "provider_response",
-    }
-)
-MAX_SAFE_ERROR_CHARS = 300
-
-
-def _redact_detected_pii(text: str) -> str:
-    matches = detect_pii(text)
-    if not matches:
-        return text
-
-    redacted = text
-    for match in sorted(matches, key=lambda item: item.start, reverse=True):
-        label = f"[{match.pii_type.value.upper()}]"
-        redacted = redacted[: match.start] + label + redacted[match.end :]
-    return redacted
 
 
 def bind_authenticated_user_context(user_id: UUID | str) -> None:
     """Bind the authenticated user id into structlog contextvars."""
     structlog.contextvars.bind_contextvars(user_id=str(user_id))
-
-
-def current_request_id() -> str | None:
-    value = structlog.contextvars.get_contextvars().get("request_id")
-    return str(value) if value else None
-
-
-def safe_error_message(message: object, *, limit: int = MAX_SAFE_ERROR_CHARS) -> str:
-    """Return a one-line bounded error summary that is safe for logs."""
-    text = _redact_detected_pii(" ".join(str(message).split()))
-    if len(text) <= limit:
-        return text
-    return text[: limit - 3].rstrip() + "..."
-
-
-def safe_log_fields(fields: Mapping[str, Any]) -> dict[str, Any]:
-    """Return log fields with risky raw body/secret keys redacted."""
-    safe: dict[str, Any] = {}
-    for key, value in fields.items():
-        normalized = key.lower()
-        if normalized in RISKY_LOG_FIELD_NAMES:
-            safe[key] = "[REDACTED]"
-        elif isinstance(value, Mapping):
-            safe[key] = safe_log_fields(value)
-        else:
-            safe[key] = value
-    return safe
-
-
-def log_financial_mutation(
-    logger: Any,
-    event: str,
-    *,
-    user_id: UUID | str,
-    action: str,
-    resource_type: str,
-    resource_id: UUID | str,
-    **fields: Any,
-) -> None:
-    """Emit one financial mutation audit event with stable common fields."""
-    logger.info(
-        event,
-        **safe_log_fields(
-            {
-                "audit_event": event,
-                "user_id": str(user_id),
-                "request_id": current_request_id(),
-                "action": action,
-                "resource_type": resource_type,
-                "resource_id": str(resource_id),
-                **fields,
-            }
-        ),
-    )
-
-
-def log_security_warning(
-    logger: Any,
-    event: str,
-    *,
-    reason: str,
-    user_id: UUID | str | None = None,
-    client_ip: str | None = None,
-    **fields: Any,
-) -> None:
-    """Emit one security-relevant warning without raw credentials or payloads."""
-    payload: dict[str, Any] = {
-        "audit_event": event,
-        "request_id": current_request_id(),
-        "reason": reason,
-    }
-    if user_id is not None:
-        payload["user_id"] = str(user_id)
-    if client_ip is not None:
-        payload["client_ip"] = client_ip
-    payload.update(fields)
-    logger.warning(event, **safe_log_fields(payload))

--- a/apps/backend/src/routers/auth.py
+++ b/apps/backend/src/routers/auth.py
@@ -12,7 +12,8 @@ from src.config import settings
 from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
 from src.models.user import User
-from src.observability_events import bind_authenticated_user_context, log_security_warning
+from src.observability import log_security_warning
+from src.observability_events import bind_authenticated_user_context
 from src.rate_limit import RateLimiter, auth_rate_limiter, register_rate_limiter
 from src.schemas.auth import AuthResponse, LoginRequest, RegisterRequest
 from src.security import create_access_token

--- a/apps/backend/src/routers/journal.py
+++ b/apps/backend/src/routers/journal.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import selectinload
 from src.deps import CurrentUserId, DbSession
 from src.logger import get_logger
 from src.models.journal import JournalEntry, JournalEntryStatus
-from src.observability_events import log_financial_mutation
+from src.observability import log_financial_mutation
 from src.schemas import (
     JournalEntryCreate,
     JournalEntryListResponse,

--- a/apps/backend/src/routers/reconciliation.py
+++ b/apps/backend/src/routers/reconciliation.py
@@ -15,7 +15,7 @@ from src.models.journal import Direction, JournalEntry
 from src.models.layer2 import AtomicTransaction
 from src.models.reconciliation import ReconciliationMatch, ReconciliationStatus
 from src.models.statement_summary import StatementSummary
-from src.observability_events import log_financial_mutation
+from src.observability import log_financial_mutation
 from src.schemas.reconciliation import (
     AnomalyResponse,
     BatchAcceptRequest,

--- a/apps/backend/src/services/extraction/_brokerage.py
+++ b/apps/backend/src/services/extraction/_brokerage.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from src.observability_events import safe_error_message
+from src.observability import safe_error_message
 from src.services.brokerage_positions import (
     _generated_brokerage_positions_payload_from_text,
     looks_like_brokerage_document,

--- a/apps/backend/src/services/extraction/_ocr.py
+++ b/apps/backend/src/services/extraction/_ocr.py
@@ -3,7 +3,7 @@
 import httpx
 
 from src.config import settings
-from src.observability_events import safe_error_message
+from src.observability import safe_error_message
 from src.services.extraction._base import (
     ExtractionError,
     logger,

--- a/apps/backend/tests/infra/test_observability_contract.py
+++ b/apps/backend/tests/infra/test_observability_contract.py
@@ -14,7 +14,6 @@ from pydantic import ValidationError
 from src import (
     logger as logger_module,
     observability as observability_module,
-    observability_events,
     telemetry_metrics as telemetry_metrics_module,
 )
 from src.config import Settings
@@ -238,7 +237,7 @@ def test_AC10_11_1_security_warning_redacts_credentials() -> None:
     """AC10.11.1: Security warning helper never emits raw credentials."""
     mock_logger = Mock()
 
-    observability_events.log_security_warning(
+    observability_module.log_security_warning(
         mock_logger,
         "auth.failure",
         reason="invalid_token",
@@ -264,7 +263,7 @@ def test_AC10_11_2_financial_mutation_audit_helpers_and_callsites() -> None:
     user_id = uuid4()
     entry_id = uuid4()
 
-    observability_events.log_financial_mutation(
+    observability_module.log_financial_mutation(
         mock_logger,
         "journal.entry.posted",
         user_id=user_id,
@@ -294,7 +293,7 @@ def test_AC10_11_2_financial_mutation_audit_helpers_and_callsites() -> None:
 
 def test_AC10_11_3_provider_error_body_logging_is_redacted() -> None:
     """AC10.11.3: Raw provider bodies are redacted or summarized before logging."""
-    safe = observability_events.safe_log_fields(
+    safe = observability_module.safe_log_fields(
         {
             "error_body": "provider raw response with prompt and account 123456789",
             "nested": {"provider_response": "raw JSON"},
@@ -304,10 +303,10 @@ def test_AC10_11_3_provider_error_body_logging_is_redacted() -> None:
     assert safe["nested"]["provider_response"] == "[REDACTED]"
 
     long_message = "x" * 500
-    assert observability_events.safe_error_message(long_message).endswith("...")
-    assert len(observability_events.safe_error_message(long_message)) <= 300
+    assert observability_module.safe_error_message(long_message).endswith("...")
+    assert len(observability_module.safe_error_message(long_message)) <= 300
 
-    pii_message = observability_events.safe_error_message("provider failed for alice@example.com and account 123456789")
+    pii_message = observability_module.safe_error_message("provider failed for alice@example.com and account 123456789")
     assert "alice@example.com" not in pii_message
     assert "123456789" not in pii_message
     assert "[EMAIL]" in pii_message

--- a/common/observability/contract.py
+++ b/common/observability/contract.py
@@ -1,10 +1,18 @@
 """The ``observability`` package's machine-checkable :class:`PackageContract`.
 
-``observability`` is internal tooling — the OpenPanel query CLI
-(``openpanel_query``) — not a domain bounded context, so it publishes no curated
-symbol language (``interface=[]``); callers invoke its module/CLI directly.
-The contract still governs it: a ``kernel`` leaf (`depends_on=[]`) with an invariant pinned to its test. A curated published-language
-surface is a future cleanup.
+``observability`` owns two cohesive surfaces. Its **BE implementation**
+(``apps/backend/src/observability``) publishes the backend's observability
+language: the vendor-neutral OpenTelemetry runtime contract plus the shared
+structured audit/security logging helpers (PII + secret redaction) — this is the
+home #1428 relocates the shared logging helpers into. The stdlib OpenPanel query
+CLI (``openpanel_query``) stays here in ``common/observability`` as a triage tool
+run via ``tools/`` wrappers (its invariant is pinned below).
+
+``depends_on=["config"]``: the OTEL runtime reads the backend config singleton via
+its bare published root (``import src.config``), the one registered-package edge it
+declares (a same-class ``kernel`` -> ``kernel`` edge, acyclic). Its other imports
+(``src.services.pii_redaction``, ``src.telemetry_metrics``) are unregistered backend
+infrastructure, so they are not governed cross-package edges.
 """
 
 from __future__ import annotations
@@ -16,10 +24,19 @@ CONTRACT = PackageContract(
     klass="kernel",
     status="active",
     tier="CODE-ONLY",
-    depends_on=[],
-    roles=["openpanel_query"],
-    implementations={"be": "common/observability", "fe": None},
-    interface=[],
+    depends_on=["config"],
+    implementations={"be": "apps/backend/src/observability", "fe": None},
+    interface=[
+        "current_request_id",
+        "get_observability_status",
+        "is_fastapi_instrumentation_active",
+        "log_financial_mutation",
+        "log_observability_startup",
+        "log_security_warning",
+        "mark_fastapi_instrumentation_active",
+        "safe_error_message",
+        "safe_log_fields",
+    ],
     events=[],
     invariants=[
         Invariant(

--- a/common/observability/readme.md
+++ b/common/observability/readme.md
@@ -1,22 +1,31 @@
-# `observability` — OpenPanel query CLI (kernel tooling package)
+# `observability` — OTEL runtime contract, audit logging + OpenPanel CLI (kernel)
 
-> Internal tooling, not a domain bounded context. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
-> [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
+> Model spec: [`../governance/readme.md`](../governance/readme.md). Machine
+> contract: [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
 
 ## What
 
-A thin CLI to query the OpenPanel analytics API (funnels/filters), reading credentials from the environment.
+Two cohesive surfaces under one `kernel` package:
+
+1. **Backend observability language** (BE implementation:
+   `apps/backend/src/observability`) — the vendor-neutral OpenTelemetry runtime
+   contract (`runtime.py`: status + startup readiness, FastAPI instrumentation
+   state) and the shared structured audit/security logging helpers (`audit.py`:
+   bounded safe error summaries, risky-field redaction, financial-mutation and
+   security-warning emitters). This is the home #1428 relocates the shared
+   logging helpers into (identity's `bind_authenticated_user_context` is folded
+   in later).
+2. **OpenPanel query CLI** (`openpanel_query.py`, here in `common/observability`)
+   — a stdlib-only triage wrapper over the OpenPanel analytics export API, run
+   via `tools/openpanel_query.py`, reading credentials from the environment.
 
 ## Shape
 
-A `kernel` leaf: no declared dependencies (`depends_on=[]`) and `tier=CODE-ONLY`
-(pure Python, no LLM). It is a **collection of modules** invoked directly (and via
-`tools/` wrappers), so it publishes **no curated symbol language** —
-`contract.interface` is `[]`. Its [`contract.py`](./contract.py) is validated by
-`tools/check_package_contract.py` (invariants pinned to tests (the DAG import-scan only inspects `src.<pkg>` imports, so for a `common/`-implemented package leaf-purity is a declared, not a scanned, property)).
-
-## Follow-up
-
-Curating a published `__all__` surface (so consumers import the package root, not
-its submodules) is deferred — see [`todo.md`](./todo.md).
+A `kernel` package, `tier=CODE-ONLY` (pure Python, no LLM). `depends_on=["config"]`:
+the OTEL runtime reads the backend config singleton via its bare published root
+(`import src.config`) — a same-class, acyclic `kernel` -> `kernel` edge. Its other
+imports (`src.services.pii_redaction`, `src.telemetry_metrics`) are unregistered
+backend infrastructure, not governed cross-package edges. Its published language —
+`contract.interface` — equals `apps/backend/src/observability/__init__.__all__`,
+validated by `tools/check_package_contract.py` (which also resolves the OpenPanel
+api-key invariant to its test).

--- a/common/observability/todo.md
+++ b/common/observability/todo.md
@@ -8,9 +8,12 @@ The package-local worklist. Cross-package migration lives in
 - [x] Migrated to the package model: ships `contract.py`, governed by
       `check_package_contract` as a `kernel` leaf (`depends_on=[]`)
       with invariants pinned to its tests.
+- [x] Curated a published `__all__` surface and set `contract.interface`: the BE
+      implementation (`apps/backend/src/observability`) now publishes the OTEL
+      runtime contract + the shared audit/security logging helpers, so consumers
+      import the package root (`from src.observability import ...`).
 
 ## Next
 
-- [ ] Curate a published `__all__` surface and set `contract.interface`, so
-      consumers import the package root instead of its submodules (today this is
-      a module-collection with `interface=[]`).
+- [ ] #1428: fold identity's `bind_authenticated_user_context` out of
+      `src.observability_events` so that module is deleted with zero residue.

--- a/common/observability/todo.md
+++ b/common/observability/todo.md
@@ -6,8 +6,9 @@ The package-local worklist. Cross-package migration lives in
 ## Done
 
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract` as a `kernel` leaf (`depends_on=[]`)
-      with invariants pinned to its tests.
+      `check_package_contract` as a `kernel` package (`depends_on=["config"]` —
+      the OTEL runtime reads the backend config singleton) with invariants pinned
+      to its tests.
 - [x] Curated a published `__all__` surface and set `contract.interface`: the BE
       implementation (`apps/backend/src/observability`) now publishes the OTEL
       runtime contract + the shared audit/security logging helpers, so consumers


### PR DESCRIPTION
## Why

**Prerequisite for the identity cutover (#1428).** Relocate the SHARED structured-logging/redaction helpers out of `apps/backend/src/observability_events.py` into the registered `observability` package, so identity can later delete `observability_events.py` with zero residue.

## What moved

Into the `observability` package's BE implementation, now `apps/backend/src/observability/`:

- `audit.py` — `log_security_warning`, `safe_log_fields`, `safe_error_message`, `log_financial_mutation`, `current_request_id`, `_redact_detected_pii` (+ `RISKY_LOG_FIELD_NAMES` / `MAX_SAFE_ERROR_CHARS`).
- `runtime.py` — the pre-existing OTEL runtime module `observability.py` (the flat module name had to yield so the package could own `src.observability`).

`bind_authenticated_user_context` **stays** in `observability_events.py` (identity's; handled by #1428). Only that helper remains there now — no residue of the shared helpers.

## Package model

- The `observability` contract's `implementations.be` now points at the backend package; `__init__.__all__` (9 symbols) **equals** `contract.interface`, so `check_package_contract` stays green. `openpanel_query` stays in `common/observability` (still the pinned test for the api-key invariant).
- The OTEL runtime reads the backend config singleton via its **bare published root** (`import src.config`), declared as `depends_on=["config"]` — the gate-sanctioned cross-domain form (same-class, acyclic `kernel`->`kernel` edge), not a deep internal import.

## Importers redirected

To the published interface (`from src.observability import ...`): `auth.py`, `main.py`, `routers/auth.py`, `routers/journal.py`, `routers/reconciliation.py`, `services/extraction/_ocr.py`, `services/extraction/_brokerage.py`. The observability contract test repoints its moved-helper assertions to the package.

## Verification

- `tools/check_package_contract.py` — **PASSED** (observability: 9 interface symbols).
- `python -c "import src.main"` — **OK**.
- `pytest --collect-only -q` — **0 import errors**.
- `ruff check` — **clean**.
- Observability/auth/extraction/telemetry + openpanel tests — pass (incl. all AC10.11.x moved-helper tests, AC10.9.x runtime, auth router).
- no-models-facade lint — passes.
- DB-backed tests not run locally (need Postgres) — left to CI.

> Note: 2 observability-contract tests (`test_vault_template_*`, `test_app_readme_and_compose_*`) read files from the infra2 `repo/` submodule that is not checked out in this worktree — pre-existing/environmental, unrelated to this change; they run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)