### PR TITLE
[finance_report_hacker] fix(cr): address Copilot review follow-ups (currency normalization auto-post gap + robustness)

### DIFF
--- a/apps/backend/migrations/versions/0052_signed_positions.py
+++ b/apps/backend/migrations/versions/0052_signed_positions.py
@@ -30,6 +30,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Precondition: no short positions exist. Re-imposing these CHECK constraints
+    # fails if any atomic_positions.market_value or managed_positions.cost_basis is
+    # already negative (CR on #1448) — which is expected, since you cannot downgrade
+    # a database that has used the feature this migration enables. Purge/clamp those
+    # rows out-of-band before downgrading; we do NOT delete financial data here.
     op.create_check_constraint(
         "ck_atomic_positions_market_value_non_negative",
         "atomic_positions",

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -23,6 +23,7 @@ from src.models.layer3 import (
     PositionStatus,
 )
 from src.money import Money, to_money
+from src.money.currency import normalize_currency_code
 from src.quantity import Quantity
 from src.schemas.provenance import DataProvenance
 
@@ -634,7 +635,7 @@ class AssetService:
                 user_id=user_id,
                 name=broker_name,
                 type=AccountType.ASSET,
-                currency=(currency or "").strip().upper() or "USD",
+                currency=normalize_currency_code(currency) or "USD",
                 code="AUTO-ASSET",
             )
             db.add(account)

--- a/apps/backend/src/services/assets.py
+++ b/apps/backend/src/services/assets.py
@@ -634,7 +634,7 @@ class AssetService:
                 user_id=user_id,
                 name=broker_name,
                 type=AccountType.ASSET,
-                currency=(currency or "USD").strip().upper(),
+                currency=(currency or "").strip().upper() or "USD",
                 code="AUTO-ASSET",
             )
             db.add(account)

--- a/apps/backend/src/services/extraction/service.py
+++ b/apps/backend/src/services/extraction/service.py
@@ -17,6 +17,7 @@ from src.models.layer1 import DocumentType
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.statement_enums import BankStatementStatus, Stage1Status
 from src.models.statement_summary import StatementSummary
+from src.money.currency import normalize_currency_code
 from src.prompts import get_parsing_prompt
 from src.services.ai_streaming import (
     AIStreamError,
@@ -103,7 +104,7 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
         account. The account is a fact (the money lives here); category
         classification of each transaction is a separate, user-adjustable layer.
         """
-        currency = (currency or "").strip().upper() or "SGD"
+        currency = normalize_currency_code(currency) or settings.base_currency
         name = f"{institution} ••{account_last4}"
         existing = (
             await db.execute(
@@ -205,7 +206,7 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
             # agree on a canonical ISO code. A non-normalized extraction ("sgd"/"SGD ")
             # would otherwise mismatch `normalize_currency_code(statement.currency)` in
             # the posting path and silently block auto-post (CR on #1467).
-            statement_currency = (raw_statement_currency or "SGD").strip().upper() or "SGD"
+            statement_currency = normalize_currency_code(raw_statement_currency) or settings.base_currency
             # A bank statement requires a period; resolve it tolerantly (a missing
             # bound falls back to the transaction-date range, then the other bound)
             # so a single missing ``period_start`` no longer hard-fails an

--- a/apps/backend/src/services/extraction/service.py
+++ b/apps/backend/src/services/extraction/service.py
@@ -103,6 +103,7 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
         account. The account is a fact (the money lives here); category
         classification of each transaction is a separate, user-adjustable layer.
         """
+        currency = (currency or "").strip().upper() or "SGD"
         name = f"{institution} ••{account_last4}"
         existing = (
             await db.execute(
@@ -199,7 +200,12 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
             # ingest-boundary resolution (AC12.40) so a genuinely-missing currency is
             # flagged for review rather than masked by the StatementSummary default.
             raw_statement_currency = extracted.get("currency")
-            statement_currency = raw_statement_currency or "SGD"
+            # Normalize the envelope currency (strip/upper) so the StatementSummary,
+            # the auto-created bank account, and the posting-account currency check all
+            # agree on a canonical ISO code. A non-normalized extraction ("sgd"/"SGD ")
+            # would otherwise mismatch `normalize_currency_code(statement.currency)` in
+            # the posting path and silently block auto-post (CR on #1467).
+            statement_currency = (raw_statement_currency or "SGD").strip().upper() or "SGD"
             # A bank statement requires a period; resolve it tolerantly (a missing
             # bound falls back to the transaction-date range, then the other bound)
             # so a single missing ``period_start`` no longer hard-fails an

--- a/apps/backend/src/services/market_data/_util.py
+++ b/apps/backend/src/services/market_data/_util.py
@@ -124,16 +124,17 @@ def _normalize_utc(value: datetime) -> datetime:
 
 
 def _hk_numeric_code(symbol: str) -> str | None:
-    """Return the zero-padded 4-digit Hong Kong board-lot code, or ``None``.
+    """Return the Hong Kong board-lot code (left-zero-padded to ≥4 digits), or ``None``.
 
     Brokerages store Hong Kong equities by their numeric exchange code (e.g.
-    Xiaomi ``"01810"``, Tencent ``"00700"``). Market-data providers expect the
-    ``"<4-digit>.HK"`` form, so callers must translate before issuing a request;
-    sent verbatim, the numeric code 404s. US tickers are alphabetic and never
-    match here, so they are left untouched.
+    Xiaomi ``"01810"`` → ``"1810"``, Tencent ``"00700"`` → ``"0700"``). HKEX codes
+    are 4–5 digits, so a 5-digit code is preserved (``"10000"`` → ``"10000"``).
+    Market-data providers expect the ``"<code>.HK"`` form; sent verbatim the raw
+    numeric 404s. An all-zero / zero-valued code is not a real ticker and returns
+    ``None`` (CR on #1453); US tickers are alphabetic and never match here.
     """
     candidate = symbol.strip()
-    if candidate.isdigit() and 1 <= len(candidate) <= 5:
+    if candidate.isdigit() and 1 <= len(candidate) <= 5 and int(candidate) != 0:
         return f"{int(candidate):04d}"
     return None
 

--- a/apps/backend/tests/integration/test_bank_statement_auto_account_post.py
+++ b/apps/backend/tests/integration/test_bank_statement_auto_account_post.py
@@ -23,10 +23,13 @@ from src.services.statement_posting import try_auto_approve_high_confidence_stat
 
 
 def _balanced_bank_payload() -> dict:
+    # CR on #1467: a non-normalized extraction currency ("sgd") must still produce a
+    # canonical account currency so the posting-account currency check matches and
+    # auto-post is not silently blocked.
     return {
         "institution": "MariBank",
         "account_last4": "8497",
-        "currency": "SGD",
+        "currency": "sgd",
         "period_start": "2026-05-01",
         "period_end": "2026-05-31",
         "opening_balance": "1000.00",
@@ -37,7 +40,7 @@ def _balanced_bank_payload() -> dict:
                 "description": "Interest",
                 "amount": "90.00",
                 "direction": "IN",
-                "currency": "SGD",
+                "currency": "sgd",
                 "balance_after": "1090.00",
             },
         ],
@@ -65,6 +68,7 @@ async def test_AC8_15_2_bank_statement_auto_creates_account_and_posts_without_ma
     assert account is not None
     assert account.type == AccountType.ASSET
     assert account.is_active is True
+    assert account.currency == "SGD"  # normalized from the lowercase extraction currency
     assert statement.status == BankStatementStatus.APPROVED
 
     # And it auto-posts to the ledger (so reports would reflect it).

--- a/apps/backend/tests/market_data/test_provider_parsers.py
+++ b/apps/backend/tests/market_data/test_provider_parsers.py
@@ -45,6 +45,13 @@ def test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes() -> None:
     assert market_data._yahoo_stock_symbol("AAPL") == "AAPL"
     assert market_data._yahoo_stock_symbol("brk.b") == "BRK.B"
     assert market_data._yahoo_stock_symbol("1810.HK") == "1810.HK"
+    # CR on #1453: a 5-digit HKEX code is preserved (not truncated to 4)...
+    assert market_data._yahoo_stock_symbol("10000") == "10000.HK"
+    assert market_data._hk_numeric_code("10000") == "10000"
+    # ...and an all-zero / zero-valued "code" is not a real ticker (no "0000.HK").
+    assert market_data._hk_numeric_code("0") is None
+    assert market_data._hk_numeric_code("00000") is None
+    assert market_data._yahoo_stock_symbol("00000") == "00000"
 
 
 def test_AC17_33_2_stooq_stock_symbol_maps_hk_numeric_codes() -> None:

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -17,6 +17,7 @@ from src.models.layer3 import ManagedPosition
 from src.models.statement_enums import BankStatementStatus
 from src.models.statement_summary import StatementSummary
 from src.schemas.portfolio import BrokerageImportRequest, BrokerageImportResponse
+from src.services.assets import AssetService
 from src.services.brokerage_positions import (
     BrokeragePositionImportService,
     _asset_type,
@@ -895,3 +896,16 @@ def test_brokerage_payload_from_statement_preserves_outflows_and_empty_metadata(
             "raw_text": "Platform fee",
         }
     ]
+
+
+async def test_AC17_33_3_broker_account_currency_is_normalized_with_usd_fallback(db, test_user):
+    """AC17.33.3 (CR on #1453): an auto-created broker account normalizes the snapshot
+    currency (strip/upper) and falls back to USD for a blank one — never persisting a
+    non-canonical or empty currency code."""
+    service = AssetService()
+    lower = await service._get_or_create_broker_account(db, test_user.id, "Lower Broker", "hkd ")
+    blank = await service._get_or_create_broker_account(db, test_user.id, "Blank Broker", "   ")
+    await db.commit()
+
+    assert lower.currency == "HKD"
+    assert blank.currency == "USD"

--- a/apps/backend/tests/unit/llm/test_client.py
+++ b/apps/backend/tests/unit/llm/test_client.py
@@ -366,10 +366,12 @@ def test_AC23_9_1_litellm_aiohttp_transport_disabled_prevents_session_leak():
     on every acompletion (#1442). Routing through the httpx transport litellm
     manages itself avoids the leak. ``src.llm.client`` is imported at module top,
     so the hardening has already run.
+
+    Asserts only the public, documented ``litellm.disable_aiohttp_transport`` flag
+    (litellm's opt-out contract) — not any private transport-selection internal,
+    which is brittle across litellm versions (CR on #1462).
     """
     import litellm
-    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
     assert client_mod.litellm.disable_aiohttp_transport is True
     assert litellm.disable_aiohttp_transport is True
-    assert AsyncHTTPHandler._should_use_aiohttp_transport() is False


### PR DESCRIPTION
## What & why

Self-review of the five merged QA-fix PRs (#1453/#1458/#1462/#1467/#1468) found unresolved Copilot review comments. One is a real **goal gap**, the rest are correctness/robustness. This follow-up addresses them.

| Source PR | Finding | Fix |
|---|---|---|
| **#1467** (goal gap) | `_get_or_create_bank_account` used the **raw** extraction currency. A non-canonical code (`"sgd"`/`"SGD "`) then mismatches `normalize_currency_code(statement.currency)` in `resolve_statement_posting_account` → **auto-post silently blocked** (defeats #1444). | Normalize the envelope currency (strip/upper) at the source + defensively in the helper. |
| **#1453** | broker-account `(currency or "USD").strip().upper()` stores `""` for a whitespace currency | `(currency or "").strip().upper() or "USD"` |
| **#1453** | `_hk_numeric_code` mapped `"0"`/`"00000"` → `"0000"` (garbage `.HK`) | reject all-zero; keep valid 4–5 digit codes (documented) |
| **#1462** | test asserted a litellm **private** internal (`_should_use_aiohttp_transport`), brittle across versions | assert only the public `disable_aiohttp_transport` flag |
| **#1468** | migration `downgrade()` fails if short rows exist | document the precondition (no negative rows) |

## Tests
- **AC8.15.2** now uses a lowercase extraction currency (`"sgd"`) and asserts the auto-created account normalizes to `"SGD"` — a regression test for the goal-gap.
- **AC17.33.1** extended: all-zero codes return `None` (no `0000.HK`); 5-digit codes preserved.
- **AC17.33.3** new: broker account currency normalizes + falls back to `USD` for blank.
- **AC23.9.1** asserts only the public flag.

Targeted tests pass (5/5). No test asserts a lowercase statement currency, so the normalization is safe. Broad local regression was unreliable under concurrent-session shared-test-DB contention (connection-reset cascades, not logic) — CI shards run in isolated DBs and are authoritative here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
