### PR TITLE
[finance_report_test_and_doc] fix(pipeline): fail-soft when managed Prefect is unavailable (EPIC-019)

### DIFF
--- a/apps/backend/src/services/statement_pipeline.py
+++ b/apps/backend/src/services/statement_pipeline.py
@@ -68,53 +68,71 @@ async def submit_parse_pipeline(
     P1 optimization deferred until the worker lands; in P0 (fallback only) the
     content is needed in-process anyway.
     """
+
+    def _run_in_process() -> asyncio.Task[None]:
+        task = asyncio.create_task(
+            run_with_async_parse_tracking(
+                parse_statement_background(
+                    statement_id=statement_id,
+                    filename=filename,
+                    institution=institution,
+                    user_id=user_id,
+                    account_id=account_id,
+                    file_hash=file_hash,
+                    storage_key=storage_key,
+                    content=content,
+                    model=model,
+                    session_maker=create_session_maker_from_db(db),
+                    request_id=request_id,
+                ),
+                statement_id=statement_id,
+                request_id=request_id,
+            )
+        )
+        task.add_done_callback(_consume_background_task_exception)
+        return task
+
     if settings.prefect_api_url:
         # Remote durable execution. Only serializable params cross the boundary
         # (no raw bytes, no session maker): the worker re-fetches ``content``
         # from storage and builds its own DB session.
-        from prefect.deployments import run_deployment  # lazy: fallback never imports prefect
+        try:
+            from prefect.deployments import run_deployment  # lazy: fallback never imports prefect
 
-        await run_deployment(
-            name=PARSE_DEPLOYMENT,
-            parameters={
-                "statement_id": str(statement_id),
-                "filename": filename,
-                "institution": institution,
-                "user_id": str(user_id),
-                "account_id": str(account_id) if account_id is not None else None,
-                "file_hash": file_hash,
-                "storage_key": storage_key,
-                "model": model,
-                "request_id": request_id,
-            },
-            timeout=0,  # fire-and-submit: do not block the upload request on completion
-        )
-        logger.info(
-            "statement.parse.submitted_to_prefect",
-            statement_id=str(statement_id),
-            deployment=PARSE_DEPLOYMENT,
-            request_id=request_id,
-        )
-        return None
-
-    task = asyncio.create_task(
-        run_with_async_parse_tracking(
-            parse_statement_background(
-                statement_id=statement_id,
-                filename=filename,
-                institution=institution,
-                user_id=user_id,
-                account_id=account_id,
-                file_hash=file_hash,
-                storage_key=storage_key,
-                content=content,
-                model=model,
-                session_maker=create_session_maker_from_db(db),
+            await run_deployment(
+                name=PARSE_DEPLOYMENT,
+                parameters={
+                    "statement_id": str(statement_id),
+                    "filename": filename,
+                    "institution": institution,
+                    "user_id": str(user_id),
+                    "account_id": str(account_id) if account_id is not None else None,
+                    "file_hash": file_hash,
+                    "storage_key": storage_key,
+                    "model": model,
+                    "request_id": request_id,
+                },
+                timeout=0,  # fire-and-submit: do not block the upload request on completion
+            )
+            logger.info(
+                "statement.parse.submitted_to_prefect",
+                statement_id=str(statement_id),
+                deployment=PARSE_DEPLOYMENT,
                 request_id=request_id,
-            ),
-            statement_id=statement_id,
-            request_id=request_id,
-        )
-    )
-    task.add_done_callback(_consume_background_task_exception)
-    return task
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001
+            # Fail-soft: the managed Prefect is opt-in durability, never a hard
+            # dependency. If the client isn't installed (ImportError on the base
+            # image) or the server is unreachable / the submit fails, degrade to
+            # in-process so an upload NEVER 500s on a Prefect issue. The work still
+            # runs; only the durable-handoff is skipped (logged loudly for ops).
+            logger.warning(
+                "statement.parse.prefect_unavailable_fallback_in_process",
+                statement_id=str(statement_id),
+                error=str(exc),
+                request_id=request_id,
+            )
+            return _run_in_process()
+
+    return _run_in_process()

--- a/apps/backend/tests/api/test_statement_pipeline.py
+++ b/apps/backend/tests/api/test_statement_pipeline.py
@@ -118,3 +118,50 @@ async def test_AC19_13_2_dispatch_submits_serializable_params_to_prefect(monkeyp
     assert "session_maker" not in params
     assert params["statement_id"] == str(kwargs["statement_id"])
     assert params["storage_key"] == "uploads/stmt.pdf"
+
+
+async def test_AC19_13_1_dispatch_falls_back_when_prefect_client_absent(monkeypatch):
+    """AC19.13.1 (fail-soft): PREFECT_API_URL set but the prefect client isn't installed
+    (base image) → degrade to in-process. An upload must NEVER 500 on Prefect absence."""
+    monkeypatch.setattr(statement_pipeline.settings, "prefect_api_url", "http://prefect:4200/api")
+    # Force `from prefect.deployments import run_deployment` to raise ImportError.
+    monkeypatch.setitem(sys.modules, "prefect.deployments", None)
+    seen: dict = {}
+
+    async def fake_background(**kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr(statement_pipeline, "parse_statement_background", fake_background)
+    monkeypatch.setattr(statement_pipeline, "create_session_maker_from_db", lambda db: "session-maker")
+
+    task = await statement_pipeline.submit_parse_pipeline(**_dispatch_kwargs())
+
+    assert isinstance(task, asyncio.Task)  # degraded to in-process, no raise
+    await task
+    assert seen["content"] == b"file-bytes"  # in-process keeps the raw content
+    assert seen["session_maker"] == "session-maker"
+
+
+async def test_AC19_13_1_dispatch_falls_back_when_prefect_submit_fails(monkeypatch):
+    """AC19.13.1 (fail-soft): Prefect installed but the submit fails (server unreachable)
+    → degrade to in-process rather than failing the upload."""
+    monkeypatch.setattr(statement_pipeline.settings, "prefect_api_url", "http://prefect:4200/api")
+    run_deployment = AsyncMock(side_effect=ConnectionError("prefect server unreachable"))
+    fake_deployments = types.ModuleType("prefect.deployments")
+    fake_deployments.run_deployment = run_deployment
+    monkeypatch.setitem(sys.modules, "prefect", types.ModuleType("prefect"))
+    monkeypatch.setitem(sys.modules, "prefect.deployments", fake_deployments)
+    seen: dict = {}
+
+    async def fake_background(**kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr(statement_pipeline, "parse_statement_background", fake_background)
+    monkeypatch.setattr(statement_pipeline, "create_session_maker_from_db", lambda db: "session-maker")
+
+    task = await statement_pipeline.submit_parse_pipeline(**_dispatch_kwargs())
+
+    assert isinstance(task, asyncio.Task)  # degraded after the submit raised
+    await task
+    run_deployment.assert_awaited_once()  # it tried Prefect first, then fell back
+    assert seen["content"] == b"file-bytes"


### PR DESCRIPTION
## What
Make the upload→report Prefect handoff **fail-soft**: if the managed Prefect can't be used (client not installed → `ImportError`, or server unreachable → submit fails), degrade to the in-process path + log a loud warning. **Uploads never 500 on a Prefect issue.**

## Why
v0.1.23 staging deploy failed the vision upload hard-gate E2E:
```
POST /api/statements/upload → 500   (ModuleNotFoundError: No module named 'prefect')
```
`statement_pipeline` took the Prefect path whenever `PREFECT_API_URL` is set, but the base/staging image doesn't install the `prefect` extra → the lazy `from prefect.deployments import run_deployment` raised → every upload 500'd.

## The contract (per the agreed app↔infra split)
- **App (this PR):** managed Prefect is *opt-in durability, never a hard dependency*. Reachable → delegate (durable). Not reachable → run in-process. The app is always self-runnable.
- **infra2 (separate, long-term):** provide a usable managed Prefect service + a worker running this backend image with the `prefect` extra.

This unblocks the release **without** an image change or waiting on infra: the current image simply falls back in-process.

## Tests
Two AC19.13.1 fail-soft cases added — prefect client absent (ImportError) and submit failure both degrade to in-process (return an in-process task, no raise). `5 passed`; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)