### PR TITLE
[finance_report_vision] fix(llm): make Gemini extraction work — drop GLM-only knobs + disable default thinking

### DIFF
--- a/apps/backend/src/llm/client.py
+++ b/apps/backend/src/llm/client.py
@@ -33,6 +33,7 @@ from src.llm.common import (
     LLMConfigError,
     LLMError,
     Message,
+    ProtocolFamily,
     ProviderRef,
     ReasoningEffort,
 )
@@ -111,6 +112,14 @@ def _base_kwargs(
         kwargs["temperature"] = temperature
     if reasoning is not None and reasoning is not ReasoningEffort.NONE:
         kwargs["reasoning_effort"] = reasoning.value
+    elif provider.protocol is ProtocolFamily.GOOGLE_GEMINI:
+        # Gemini 2.5+ "thinks" by default and those thinking tokens are charged
+        # against max_output_tokens, so a verbose extraction (raw_text + category
+        # per row) hits finish="length" and truncates mid-JSON -> 0 parsed rows.
+        # Disable thinking when no reasoning is requested. Live-call kwarg ONLY —
+        # deliberately NOT mirrored into the cassette fingerprint decode params, so
+        # a Gemini-recorded cassette still replays under any default provider.
+        kwargs["reasoning_effort"] = "disable"
     if seed is not None:
         # Native param so drop_params can strip it for models that reject seed.
         kwargs["seed"] = seed

--- a/apps/backend/src/services/ai_streaming.py
+++ b/apps/backend/src/services/ai_streaming.py
@@ -17,7 +17,7 @@ from uuid import UUID
 from src.config import settings
 from src.llm.cassette import CassetteMode, current_mode
 from src.llm.client import litellm_stream, resolve_provider_and_model
-from src.llm.common import LLMConfigError, LLMError, ProviderRef, ReasoningEffort
+from src.llm.common import LLMConfigError, LLMError, ProtocolFamily, ProviderRef, ReasoningEffort
 from src.llm.env_config import _protocol_for
 from src.llm.factory import get_config_source, get_usage_meter
 from src.llm.usage import estimate_tokens, estimate_tokens_from_chars
@@ -141,11 +141,15 @@ async def _stream_ai_base(
     else:
         provider = await _resolve_provider(api_key, base_url, user_id)
 
+    # do_sample/thinking are Z.AI/GLM (OpenAI-compatible) extra_body knobs. Other
+    # families (Gemini, Anthropic) reject unknown request fields with a 400, so
+    # only forward them to OpenAI-compatible providers.
     extra_body: dict[str, Any] = {}
-    if do_sample is not None:
-        extra_body["do_sample"] = do_sample
-    if thinking is not None:
-        extra_body["thinking"] = thinking
+    if provider.protocol is ProtocolFamily.OPENAI_COMPATIBLE:
+        if do_sample is not None:
+            extra_body["do_sample"] = do_sample
+        if thinking is not None:
+            extra_body["thinking"] = thinking
 
     completion_chars = 0
     # AC10.10.4: time the provider call and emit a latency+outcome metric on

--- a/apps/backend/tests/ai/test_ai_streaming.py
+++ b/apps/backend/tests/ai/test_ai_streaming.py
@@ -91,6 +91,28 @@ async def test_stream_ai_json_forwards_zai_knobs_and_seed(litellm_stub, monkeypa
     assert kw["temperature"] == 0.0
 
 
+async def test_stream_ai_json_drops_glm_knobs_for_gemini(litellm_stub, monkeypatch):
+    """do_sample/thinking are Z.AI/GLM extra_body knobs; Gemini rejects unknown request
+    fields with HTTP 400. For a Gemini provider they must NOT be forwarded, and the live
+    call instead carries reasoning_effort="disable" (Gemini 2.5+ thinks by default and the
+    thinking tokens otherwise eat the output budget, truncating a verbose extraction)."""
+    monkeypatch.setattr(settings, "ai_provider", "gemini", raising=False)
+    await accumulate_stream(
+        stream_ai_json(
+            [{"role": "user", "content": "x"}],
+            "gemini-3-flash-preview",
+            api_key="k",
+            do_sample=False,
+            thinking={"type": "disabled"},
+            temperature=0.0,
+        )
+    )
+    kw = litellm_stub["kwargs"]
+    assert "extra_body" not in kw  # GLM knobs not forwarded to Gemini
+    assert kw.get("reasoning_effort") == "disable"
+    assert kw["model"] == "gemini/gemini-3-flash-preview"
+
+
 async def test_stream_resolves_default_provider_from_config(litellm_stub, monkeypatch):
     """With no explicit key, the configured default provider is resolved."""
 

--- a/apps/backend/tests/llm/test_client.py
+++ b/apps/backend/tests/llm/test_client.py
@@ -101,6 +101,30 @@ async def test_AC23_2_4_reasoning_max_tokens_temperature_passthrough(captured):
     assert kw["reasoning_effort"] == "medium"
 
 
+def _gemini_provider() -> ProviderRef:
+    return ProviderRef(id="env", label="gemini", protocol=ProtocolFamily.GOOGLE_GEMINI, api_key="k")
+
+
+async def test_gemini_disables_thinking_when_no_reasoning_requested(captured):
+    """Gemini 2.5+ thinks by default and those thinking tokens are charged against the
+    output budget, truncating a verbose extraction mid-JSON. With no reasoning requested,
+    the live call must carry reasoning_effort="disable" — and only for Gemini."""
+    async for _ in litellm_stream(
+        [{"role": "user", "content": "hi"}], provider=_gemini_provider(), model_id="gemini-3-flash-preview"
+    ):
+        pass
+    assert captured["kwargs"]["reasoning_effort"] == "disable"
+    assert captured["kwargs"]["model"] == "gemini/gemini-3-flash-preview"
+    assert captured["kwargs"].get("api_base") is None
+
+
+async def test_non_gemini_no_reasoning_omits_reasoning_effort(captured):
+    """The disable is Gemini-only: Z.AI/GLM with no reasoning sends no reasoning_effort."""
+    async for _ in litellm_stream([{"role": "user", "content": "hi"}], provider=_provider(), model_id="glm-5.1"):
+        pass
+    assert "reasoning_effort" not in captured["kwargs"]
+
+
 async def test_AC23_2_3_provider_error_is_normalised_to_llmerror(monkeypatch):
     """AC23.2.3: a transient provider failure becomes a retryable LLMError."""
 


### PR DESCRIPTION
## Why
#1472 added Gemini *routing*, but live Gemini extraction still failed because the request carried Z.AI/GLM-only fields:
1. **`do_sample`/`thinking`** in `extra_body` → Gemini `400 "Unknown name … Cannot find field"`.
2. **Gemini 2.5+ "thinks" by default**, and those thinking tokens are charged against `max_output_tokens`. A verbose statement extraction (raw_text + category per row) then hits `finish="length"` and **truncates mid-JSON → 0 rows parsed**. (Disabling thinking: same call returns the full 162 txns, `finish=stop`.)

## Change (opt-in; production default stays GLM)
- `ai_streaming.py`: forward `do_sample`/`thinking` **only to `OPENAI_COMPATIBLE`** providers (Gemini/Anthropic reject unknown fields).
- `client.py`: Gemini family + no reasoning requested → `reasoning_effort="disable"`. **Live-call kwarg only** — deliberately *not* mirrored into the cassette fingerprint decode-params, so a Gemini-recorded cassette still replays under any default provider.

Default remains `AI_PROVIDER=zai` → **production GLM behaviour unchanged**; this only activates when `AI_PROVIDER=gemini` (used for local cassette recording).

## Tests
- `test_client`: Gemini + no reasoning → `reasoning_effort="disable"` (+ native endpoint, no api_base); non-Gemini omits it.
- `test_ai_streaming`: Gemini drops the GLM `extra_body` knobs and sets `disable`; Z.AI still forwards them.
- 101 affected tests pass; ruff clean.

Prerequisite for the next PR (HF real-statement cassette corpus recorded locally via Gemini).

🤖 Generated with [Claude Code](https://claude.com/claude-code)