### PR TITLE
[finance_report_vision_1482] fix(portfolio): unify per-holding currency contract across endpoints (#1482)

### DIFF
--- a/apps/backend/src/schemas/assets.py
+++ b/apps/backend/src/schemas/assets.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from src.models.layer3 import (
     ManualValuationBasis,
@@ -43,6 +43,24 @@ class ManagedPositionResponse(BaseResponse):
 
     # Denormalized fields from related Account (optional)
     account_name: str | None = None
+
+    # #1482: the bare `currency`/`cost_basis` are this endpoint's NATIVE view,
+    # but /portfolio/holdings uses the same names for its REPORTING view — so a
+    # client reading `currency` gets a different meaning per endpoint. Expose the
+    # native view under the same explicit names both endpoints share
+    # (`native_currency`/`native_cost_basis`), so clients never depend on the
+    # endpoint-local meaning of the bare field. Pure aliases of the native fields.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def native_currency(self) -> str:
+        """Explicit native-currency alias of `currency` (identical across endpoints)."""
+        return self.currency
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def native_cost_basis(self) -> MoneyAmount:
+        """Explicit native cost-basis alias of `cost_basis`."""
+        return self.cost_basis
 
 
 class ReconcilePositionsResponse(BaseModel):

--- a/apps/backend/src/schemas/portfolio.py
+++ b/apps/backend/src/schemas/portfolio.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 from src.models.layer3 import CostBasisMethod, PositionStatus
 from src.schemas.base import BaseResponse, ListResponse, MoneyAmount, NonNegativeMoneyAmount, Percent, Quantity
@@ -48,6 +48,24 @@ class HoldingResponse(BaseResponse):
         default=None,
         description="Normalized source provenance when known; null when not safely derivable.",
     )
+
+    # #1482: the bare `currency`/`cost_basis` are this endpoint's REPORTING view,
+    # but /assets/positions uses the same names for its NATIVE view. Expose the
+    # reporting view under the same explicit names both endpoints share
+    # (`reporting_currency`/`reporting_cost_basis`), so native vs reporting is
+    # identically named everywhere and clients never depend on the endpoint-local
+    # meaning of the bare field. Pure aliases of the reporting fields.
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def reporting_currency(self) -> str:
+        """Explicit reporting-currency alias of `currency` (identical across endpoints)."""
+        return self.currency
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def reporting_cost_basis(self) -> MoneyAmount:
+        """Explicit reporting cost-basis alias of `cost_basis`."""
+        return self.cost_basis
 
 
 class RealizedPnLResponse(BaseModel):

--- a/apps/backend/tests/portfolio/test_position_valuation_consistency.py
+++ b/apps/backend/tests/portfolio/test_position_valuation_consistency.py
@@ -151,3 +151,35 @@ async def test_ac3_missing_fx_rate_does_not_500(client, db, test_user):
     single = single_resp.json()
     assert single["reporting_cost_basis"] is None
     assert single["reporting_currency"] is None
+
+
+async def test_native_and_reporting_currency_fields_are_identically_named_across_endpoints(client, db, test_user):
+    """#1482: both endpoints expose the SAME explicit currency fields
+    (`native_currency`, `reporting_currency`) with identical meaning, so a client
+    never has to read the endpoint-local bare `currency` — which means NATIVE on
+    /assets/positions but REPORTING on /portfolio/holdings."""
+    position = await _seed_position(db, test_user, with_fx_rate=True)
+
+    positions_resp = await client.get("/assets/positions")
+    assert positions_resp.status_code == 200
+    item = next(i for i in positions_resp.json()["items"] if i["id"] == str(position.id))
+
+    holdings_resp = await client.get("/portfolio/holdings")
+    assert holdings_resp.status_code == 200
+    holding = _find_holding(holdings_resp.json(), str(position.id))
+
+    # Both endpoints now carry BOTH explicit, identically-named currency fields.
+    assert item["native_currency"] == holding["native_currency"] == "HKD"
+    assert item["reporting_currency"] == holding["reporting_currency"] == "SGD"
+    # Cost-basis aliases line up the same way.
+    assert Decimal(str(item["native_cost_basis"])) == Decimal(str(holding["native_cost_basis"])) == _NATIVE_COST
+    assert (
+        Decimal(str(item["reporting_cost_basis"]))
+        == Decimal(str(holding["reporting_cost_basis"]))
+        == _EXPECTED_BASE_COST
+    )
+    # The explicit fields are pure aliases of each endpoint's legacy bare field,
+    # not newly-computed values: native on the native endpoint, reporting on the
+    # reporting endpoint.
+    assert item["native_currency"] == item["currency"]
+    assert holding["reporting_currency"] == holding["currency"]


### PR DESCRIPTION
## What & why

Fixes #1482 (high) — the residual **part C** of #1441 (A and B already fixed). The same holding reported a different value under the **identically-named `currency` field** depending on the endpoint:

- `GET /assets/positions` → `currency` = **native** (e.g. HKD)
- `GET /portfolio/holdings` → `currency` = **reporting/base** (e.g. SGD) for the same position

A client reading `currency` could not tell which currency it was getting — undermining explainability and any cross-endpoint consolidation (vision: auditable/explainable; Good Taste #1 "kill the special case").

## Root cause

#1098 already cross-exposed both views, but **asymmetrically**: positions carried `currency`(native) + `reporting_currency`; holdings carried `currency`(reporting) + `native_currency`. So the *native* view lived under a different field name on each endpoint, and likewise reporting — the bare `currency` still flipped meaning.

## Change

Add the missing same-named aliases so **both** endpoints expose `native_currency` + `reporting_currency` (and `native_cost_basis` + `reporting_cost_basis`) with identical meaning, as pure `computed_field` aliases of each endpoint's existing native/reporting values:

- `ManagedPositionResponse` (+`native_currency`, +`native_cost_basis`)
- `HoldingResponse` (+`reporting_currency`, +`reporting_cost_basis`)

The bare `currency`/`cost_basis` fields are **unchanged** (backward-compatible — Good Taste #2). Clients should read the explicit, identically-named fields and never depend on the endpoint-local meaning of the bare field. Fully renaming/removing the bare `currency` is a breaking change deferred; the frontend counterpart that consumes the explicit fields is #1487.

## Tests

Extends the #1098 `test_position_valuation_consistency.py` suite (the same native+base reconciliation lineage; AC-exempt behavioral repro per `docs/project/traceability-exceptions.md`) with a cross-endpoint contract test asserting `native_currency`/`reporting_currency` and the cost-basis aliases are **equal** across `/assets/positions` and `/portfolio/holdings`, and that each explicit field is a pure alias of its endpoint's legacy bare field.

## Verification
- `tests/portfolio/` + `tests/assets/` green (222 passed); API contract sweep (`tests/api/test_typed_contract_sweep.py`, `test_api_surface_consistency.py`) green (16 passed) — additive computed fields don't break the surface contract.
- `ruff check` / `ruff format` clean; `docs/reference/api.md` regenerates with no diff.

## Scope / follow-ups
- Backend contract only. Frontend (display native + reporting, drop hardcoded base/USD fallbacks) is #1487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)