### PR TITLE
[finance_report_ui_1486] fix(frontend): surface opening-balance gate + native currency on report/portfolio surfaces (#1486, #1487)

### DIFF
--- a/apps/frontend/src/__tests__/balanceSheetPage.test.tsx
+++ b/apps/frontend/src/__tests__/balanceSheetPage.test.tsx
@@ -206,4 +206,32 @@ describe("BalanceSheetPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "–" }))
     expect(screen.queryByText("Wallet")).not.toBeInTheDocument()
   })
+
+  it("#1486 surfaces the opening-balance warning and degraded confidence tier", async () => {
+    mockedApiFetch.mockResolvedValue({
+      as_of_date: "2026-02-01",
+      currency: "SGD",
+      assets: [{ account_id: "a-root", name: "Cash", type: "ASSET", parent_id: null, amount: "-500", provenance: "imported" }],
+      liabilities: [],
+      equity: [],
+      total_assets: "-500",
+      total_liabilities: "0",
+      total_equity: "0",
+      confidence_tier: "LOW",
+      opening_balance_warnings: [
+        { type: "missing_opening_balance", message: "Record opening balances to trust this total." },
+      ],
+      equation_delta: "0",
+      is_balanced: true,
+    })
+
+    render(<BalanceSheetPage />)
+
+    await waitFor(() => expect(screen.getByText("Balance Sheet")).toBeInTheDocument())
+    // Warning banner + CTA are shown on the report surface, not just /accounts.
+    expect(screen.getByText("Opening balances not recorded")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /set opening balances/i })).toHaveAttribute("href", "/accounts")
+    // The degraded aggregate tier is visible, so "✓ Balanced" is not the only signal.
+    expect(screen.getByText("LOW")).toBeInTheDocument()
+  })
 })

--- a/apps/frontend/src/__tests__/holdingsTable.test.tsx
+++ b/apps/frontend/src/__tests__/holdingsTable.test.tsx
@@ -138,4 +138,28 @@ describe("HoldingsTable", () => {
     expect(screen.getByText("Derived")).toHaveClass("badge-muted")
     expect(screen.queryByText("Unknown")).not.toBeInTheDocument()
   })
+
+  it("#1487 surfaces the native currency when it differs from the reporting currency", () => {
+    const foreign: PortfolioHolding = {
+      ...fractional,
+      id: "hk",
+      asset_identifier: "0700",
+      currency: "SGD",
+      native_currency: "HKD",
+    }
+    render(<HoldingsTable holdings={[foreign]} />)
+    expect(screen.getByText(/HKD-denominated/)).toBeInTheDocument()
+  })
+
+  it("#1487 omits the native-currency note when it matches the reporting currency", () => {
+    const local: PortfolioHolding = {
+      ...fractional,
+      id: "sg",
+      asset_identifier: "D05",
+      currency: "SGD",
+      native_currency: "SGD",
+    }
+    render(<HoldingsTable holdings={[local]} />)
+    expect(screen.queryByText(/denominated/)).not.toBeInTheDocument()
+  })
 })

--- a/apps/frontend/src/__tests__/openingBalanceWarningBanner.test.tsx
+++ b/apps/frontend/src/__tests__/openingBalanceWarningBanner.test.tsx
@@ -1,0 +1,40 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OpeningBalanceWarningBanner } from "@/components/reports/OpeningBalanceWarningBanner";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+describe("OpeningBalanceWarningBanner (#1486)", () => {
+  it("renders nothing when there are no warnings", () => {
+    const { container } = render(<OpeningBalanceWarningBanner warnings={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when warnings is undefined", () => {
+    const { container } = render(<OpeningBalanceWarningBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the backend message and a CTA to the guided opening-balance flow", () => {
+    render(
+      <OpeningBalanceWarningBanner
+        warnings={[{ type: "missing_opening_balance", message: "Record opening balances to trust this total." }]}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Record opening balances to trust this total.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /set opening balances/i })).toHaveAttribute("href", "/accounts");
+  });
+
+  it("falls back to a default message when the warning carries none", () => {
+    render(<OpeningBalanceWarningBanner warnings={[{ type: "missing_opening_balance" }]} />);
+
+    expect(screen.getByText(/reflect only/i)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/__tests__/useBaseCurrency.test.tsx
+++ b/apps/frontend/src/__tests__/useBaseCurrency.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { useBaseCurrency } from "../hooks/useBaseCurrency";
+import * as api from "../lib/api";
+
+vi.mock("../lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+describe("useBaseCurrency (#1487)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults to SGD while loading", () => {
+    vi.mocked(api.apiFetch).mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useBaseCurrency());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.baseCurrency).toBe("SGD");
+  });
+
+  it("returns the configured base currency from app config", async () => {
+    vi.mocked(api.apiFetch).mockResolvedValue({ base_currency: "HKD" });
+
+    const { result } = renderHook(() => useBaseCurrency());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.baseCurrency).toBe("HKD");
+  });
+
+  it("falls back to SGD on API error", async () => {
+    vi.mocked(api.apiFetch).mockRejectedValue(new Error("network error"));
+
+    const { result } = renderHook(() => useBaseCurrency());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.baseCurrency).toBe("SGD");
+  });
+});

--- a/apps/frontend/src/app/(main)/page.tsx
+++ b/apps/frontend/src/app/(main)/page.tsx
@@ -8,6 +8,7 @@ import { UploadToReportHomePanel } from "@/components/workflow/WorkflowNotificat
 import { AdvisorBrief } from "@/components/advisor/AdvisorBrief";
 import { TrustMeter } from "@/components/home/TrustMeter";
 import { InfoHint } from "@/components/ui/InfoHint";
+import { OpeningBalanceWarningBanner } from "@/components/reports/OpeningBalanceWarningBanner";
 
 import { formatDateDisplay, formatMonthLabel } from "@/lib/date";
 import {
@@ -304,6 +305,11 @@ export default function HomePage() {
                 <p className="text-xs text-muted mt-1">Obligations</p>
               </div>
             </div>
+            {/* #1486: surface the opening-balance gate here too — net worth can
+                render negative/incomplete until opening balances are recorded. */}
+            <OpeningBalanceWarningBanner
+              warnings={balanceSheet?.opening_balance_warnings}
+            />
             {/* Hero: Net Worth Banner (C2 + C3) */}
             {balanceSheet && (
               <div className="card p-6 mb-6 bg-gradient-to-r from-[var(--accent-muted)] to-[var(--background-card)] border border-[var(--accent)]/30">

--- a/apps/frontend/src/app/(main)/portfolio/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/page.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { CalendarDays, X } from "lucide-react";
 
 import { apiFetch } from "@/lib/api";
+import { useBaseCurrency } from "@/hooks/useBaseCurrency";
 import { PortfolioHolding, PortfolioSummaryResponse } from "@/lib/types";
 import { PerformanceCard } from "@/components/portfolio/PerformanceCard";
 import { LoadingState } from "@/components/ui";
@@ -26,8 +27,6 @@ import type {
   NetWorthAllocationResponse,
   NetWorthAllocationRow,
 } from "@/lib/types";
-
-const REPORT_CURRENCY = "SGD";
 
 function allocationBarWidth(percentage: string | null): string {
   return clampPercentWidthFromPercentValue(percentage);
@@ -56,6 +55,8 @@ function allocationBarClass(row: NetWorthAllocationRow): string {
 }
 
 export default function PortfolioPage() {
+  // #1487: derive the reporting currency from app config instead of hardcoding it.
+  const { baseCurrency: reportCurrency } = useBaseCurrency();
   const [showDisposed, setShowDisposed] = useState(false);
   const [asOfDate, setAsOfDate] = useState("");
   const [includeRestrictedAllocation, setIncludeRestrictedAllocation] =
@@ -63,14 +64,14 @@ export default function PortfolioPage() {
 
   const netWorthAllocationQueryString = useMemo(() => {
     const params = new URLSearchParams({
-      currency: REPORT_CURRENCY,
+      currency: reportCurrency,
       include_restricted: includeRestrictedAllocation ? "true" : "false",
     });
     if (asOfDate) {
       params.set("as_of_date", asOfDate);
     }
     return params.toString();
-  }, [asOfDate, includeRestrictedAllocation]);
+  }, [asOfDate, includeRestrictedAllocation, reportCurrency]);
 
   const {
     data: holdings,
@@ -140,7 +141,7 @@ export default function PortfolioPage() {
   const totalPortfolioValue = sumAmounts(
     activeHoldings.map((holding) => holding.market_value),
   );
-  const primaryCurrency = activeHoldings[0]?.currency ?? "USD";
+  const primaryCurrency = activeHoldings[0]?.currency ?? reportCurrency;
   const allocationRows = netWorthAllocation?.rows ?? [];
 
   return (
@@ -247,7 +248,7 @@ export default function PortfolioPage() {
             <div className="text-xs text-muted md:text-right">
               <p>
                 Report currency:{" "}
-                {netWorthAllocation?.currency ?? REPORT_CURRENCY}
+                {netWorthAllocation?.currency ?? reportCurrency}
               </p>
               <p>
                 As of {netWorthAllocation?.as_of_date ?? (asOfDate || "latest")}
@@ -351,7 +352,7 @@ export default function PortfolioPage() {
                 >
                   {formatCurrencyLocale(
                     row.value,
-                    netWorthAllocation?.currency ?? REPORT_CURRENCY,
+                    netWorthAllocation?.currency ?? reportCurrency,
                   )}
                 </p>
                 <p className="text-sm text-muted md:text-right">

--- a/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/balance-sheet/page.tsx
@@ -10,6 +10,8 @@ import { useCurrencies } from "@/hooks/useCurrencies";
 import { useApiQuery } from "@/hooks/useApiQuery";
 import { useReportFilters } from "@/hooks/useReportFilters";
 import { FxWarningBanner } from "@/components/reports/FxWarningBanner";
+import { OpeningBalanceWarningBanner } from "@/components/reports/OpeningBalanceWarningBanner";
+import ConfidenceBadge, { type ConfidenceTier } from "@/components/ui/ConfidenceBadge";
 import { AccountLineageDrawer, type AccountLineageTarget } from "@/components/reports/AccountLineageDrawer";
 import { ReportPageShell } from "@/components/reports/ReportPageShell";
 import { ReportToolbar } from "@/components/reports/ReportToolbar";
@@ -137,9 +139,15 @@ export default function BalanceSheetPage() {
           <span>Include restricted holdings</span>
         </label>
         <span className="self-end inline-flex items-center"><span className={`badge ${report?.is_balanced ? "badge-success" : "badge-warning"}`}>{report?.is_balanced ? "✓ Balanced" : "⚠ Drift"}</span><InfoHint term={report?.is_balanced ? "balanced" : "drift"} label={report?.is_balanced ? "Balanced" : "Drift"} /></span>
+        {report?.confidence_tier ? (
+          <span className="self-end inline-flex items-center" title="Aggregate confidence of these totals">
+            <ConfidenceBadge tier={report.confidence_tier as ConfidenceTier} />
+          </span>
+        ) : null}
       </div>
 
       <FxWarningBanner warnings={report?.fx_warnings} />
+      <OpeningBalanceWarningBanner warnings={report?.opening_balance_warnings} />
 
       <div className="flex flex-col gap-2 mb-6">
         <span className="text-xs text-muted uppercase">Quick filters</span>

--- a/apps/frontend/src/components/portfolio/HoldingsTable.tsx
+++ b/apps/frontend/src/components/portfolio/HoldingsTable.tsx
@@ -112,6 +112,14 @@ export function HoldingsTable({
                       <div className="text-xs text-muted mt-0.5">
                         {formatDateDisplay(h.acquisition_date)}
                         {h.sector && ` · ${h.sector}`}
+                        {/* #1487: a foreign holding's values below are shown in
+                            the reporting currency — surface its native currency
+                            so the denomination is never hidden. */}
+                        {h.native_currency && h.native_currency !== h.currency && (
+                          <span title={`Denominated in ${h.native_currency}; values shown in ${h.currency}`}>
+                            {` · ${h.native_currency}-denominated`}
+                          </span>
+                        )}
                       </div>
                     </td>
                     <td className="px-4 py-2 text-right font-mono">

--- a/apps/frontend/src/components/reports/OpeningBalanceWarningBanner.tsx
+++ b/apps/frontend/src/components/reports/OpeningBalanceWarningBanner.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+
+import type { FxWarning } from "@/lib/types";
+
+const DEFAULT_MESSAGE =
+  "Activity is recorded without an opening balance, so account totals reflect only " +
+  "period movement, not your actual starting balances. Record opening balances to trust these totals.";
+
+interface OpeningBalanceWarningBannerProps {
+  warnings?: FxWarning[];
+}
+
+/**
+ * #1481/#1486: surfaces the backend `opening_balance_warnings` on the reporting
+ * and dashboard surfaces (not just the Accounts page), so a structurally
+ * incomplete total is never presented as trusted with no guidance. The CTA opens
+ * the guided opening-balance flow on the Accounts page (#949).
+ */
+export function OpeningBalanceWarningBanner({ warnings }: OpeningBalanceWarningBannerProps) {
+  if (!warnings?.length) return null;
+  const message = warnings.find((warning) => warning.message)?.message ?? DEFAULT_MESSAGE;
+
+  return (
+    <div
+      role="alert"
+      className="mb-6 rounded-md border border-[var(--warning)]/40 bg-[var(--warning-muted)] p-4 text-sm"
+    >
+      <p className="font-medium text-[var(--warning)]">Opening balances not recorded</p>
+      <p className="mt-1 text-muted">{message}</p>
+      <Link
+        href="/accounts"
+        className="mt-2 inline-flex items-center gap-1 font-medium text-[var(--warning)] hover:underline"
+      >
+        Set opening balances →
+      </Link>
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/useBaseCurrency.ts
+++ b/apps/frontend/src/hooks/useBaseCurrency.ts
@@ -1,0 +1,21 @@
+import { useApiQuery } from "@/hooks/useApiQuery";
+
+import type { BaseCurrency } from "@/lib/types";
+
+// Sensible fallback while the effective base currency loads or if the request
+// fails — never a hardcoded assumption baked into report queries (#1487).
+const DEFAULT_BASE_CURRENCY = "SGD";
+
+type UseBaseCurrencyResult = {
+  baseCurrency: string;
+  loading: boolean;
+};
+
+/** The user's effective base/reporting currency (ISO 4217), from app config. */
+export function useBaseCurrency(): UseBaseCurrencyResult {
+  const query = useApiQuery<BaseCurrency>(["app-config", "base-currency"], "/api/app-config/base-currency");
+  return {
+    baseCurrency: query.data?.base_currency ?? DEFAULT_BASE_CURRENCY,
+    loading: query.isLoading,
+  };
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -145,6 +145,10 @@ export interface BalanceSheetResponse {
   unrealized_fx_gain_loss?: MoneyValue;
   net_worth_adjustment_gain_loss?: MoneyValue;
   fx_warnings?: FxWarning[];
+  // #1481/#1486: aggregate confidence tier (degraded to LOW while an opening
+  // balance is missing) and the matching opening-balance warning(s).
+  confidence_tier?: "TRUSTED" | "HIGH" | "MEDIUM" | "LOW" | null;
+  opening_balance_warnings?: FxWarning[];
   equation_delta: MoneyValue;
   is_balanced: boolean;
 }
@@ -474,6 +478,9 @@ export interface NetWorthAllocationResponse {
   total_liabilities: MoneyValue;
   net_worth: MoneyValue;
   rows: NetWorthAllocationRow[];
+  // #1481/#1486: same opening-balance gate as the balance sheet.
+  confidence_tier?: "TRUSTED" | "HIGH" | "MEDIUM" | "LOW" | null;
+  opening_balance_warnings?: FxWarning[];
 }
 
 export interface ReconciliationMatchResponse {
@@ -599,7 +606,15 @@ export interface PortfolioHolding {
   market_value: string;
   unrealized_pnl: string;
   unrealized_pnl_percent: string;
+  /** Reporting/base-currency view (same as `reporting_currency`). */
   currency: string;
+  // #1482/#1487: native vs reporting are identically-named on both
+  // /portfolio/holdings and /assets/positions, so the UI can show the native
+  // denomination instead of depending on the endpoint-local `currency`.
+  native_currency?: string;
+  reporting_currency?: string;
+  native_cost_basis?: string;
+  reporting_cost_basis?: string;
   acquisition_date: string;
   disposal_date?: string | null;
   status: "active" | "disposed";

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -120,6 +120,8 @@ explicit AC IDs for the behavior.
 | `apps/frontend/src/__tests__/sheetAndDetailDialogComponents.test.tsx` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/__tests__/theme.coverage.test.ts` | `docs/ssot/frontend-patterns.md` |
 | `apps/frontend/src/__tests__/types.test.ts` | `docs/ssot/frontend-patterns.md` |
+| `apps/frontend/src/__tests__/openingBalanceWarningBanner.test.tsx` | `docs/ssot/frontend-patterns.md` (#1486 opening-balance warning surface) |
+| `apps/frontend/src/__tests__/useBaseCurrency.test.tsx` | `docs/ssot/frontend-patterns.md` (#1487 base-currency hook) |
 | `apps/frontend/src/__tests__/useLlmConfigStatus.test.ts` | `docs/ssot/llm.md` |
 | `apps/frontend/src/components/__tests__/ProcessingSummaryCard.test.tsx` | `docs/ssot/processing_account.md` |
 | `apps/frontend/src/components/review/__tests__/ConflictResolutionDialog.keydown.test.tsx` | `docs/ssot/frontend-patterns.md` |


### PR DESCRIPTION
## What & why

Frontend counterparts of the now-merged backend fixes **#1481** (opening-balance gate) and **#1482** (per-holding currency contract). The backend now emits the trust signals; this PR makes them visible to the user — completing the user-facing value of both.

### #1486 — dashboard/report no longer presents a wrong total as trusted
The balance sheet and home dashboard rendered a structurally-wrong total (a negative net worth) with a green **"✓ Balanced"** badge and **no warning** — the opening-balance nudge lived only on the Accounts page (#949). Now both surfaces consume the backend `opening_balance_warnings` + degraded `confidence_tier`:
- new **`OpeningBalanceWarningBanner`** (message + CTA to the guided `/accounts` flow), rendered on the balance sheet and the home net-worth hero;
- the balance sheet shows the aggregate **`ConfidenceBadge`**, so "✓ Balanced" is no longer the only signal on an incomplete total.

### #1487 — portfolio shows native currency, no hardcoded base
The portfolio UI showed reporting-currency values only and hardcoded the base currency (`REPORT_CURRENCY = "SGD"`, `?? "USD"` fallback). Now:
- a **`useBaseCurrency`** hook derives the reporting currency from app config (`/api/app-config/base-currency`), replacing the hardcoded constant and the stray `"USD"` fallback;
- **`HoldingsTable`** surfaces a holding's **native currency** (from #1482's `native_currency`) when it differs from the reporting currency, so a foreign-denominated holding is never silently shown only in the base currency.

## Types
Add `confidence_tier` + `opening_balance_warnings` to `BalanceSheetResponse` and `NetWorthAllocationResponse`, and `native_currency`/`reporting_currency` (+ cost-basis aliases) to `PortfolioHolding` — matching the merged backend contracts.

## Tests
- New `openingBalanceWarningBanner` (4) and `useBaseCurrency` (3) suites.
- Extended `balanceSheetPage` (opening-balance warning + LOW tier badge) and `holdingsTable` (native-currency note present/absent) tests.
- `tsc --noEmit` clean, `eslint` clean, full `vitest run --coverage` meets the 98%/98%/84%/98% thresholds.

## Scope
Frontend only; backend contracts already merged (#1481, #1482). Closes #1486 and #1487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)