### PR TITLE
[finance_report_test_and_doc] perf(ci): run backend test Postgres on tmpfs (ramdisk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
           --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
@@ -415,6 +416,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
           --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
@@ -523,6 +525,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
           --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
@@ -607,6 +610,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
           --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s


### PR DESCRIPTION
## Why
Backend CI's parallelism is already maxed — 5-way `pytest-split` (duration-balanced) + xdist `-n auto` + `--dist worksteal` + per-worker DBs + session-scoped schema + per-test TRUNCATE. The remaining lever is the **per-test fixed cost**, not more parallelism (5 shards is enough).

The 4 backend test jobs (unit shards, integration, e2e, schema-migration) each run a Postgres service with **default durability (fsync on)**. With per-test `TRUNCATE` + frequent commits, every DB-bound test eats disk-fsync latency.

## What
Mount the Postgres data dir on **tmpfs (RAM)**:
```yaml
options: >-
  --mount type=tmpfs,destination=/var/lib/postgresql/data
  --health-cmd ...
```
All DB I/O is now in RAM. The test DB is ephemeral → zero durability need, **no correctness risk**. Applied to all 4 Postgres services. Typical **10–30%** on DB-heavy suites.

## Verify
This PR's own CI run is the measurement — compare `Backend Tests (Shard N/5)` duration vs the ~4:00 baseline.

---
Context (from a CI speed review, not in this PR):
- **#3 slow tests**: the seed's 26.8s `test_rate_limit` etc. are stale outliers (trivial mocked tests), not real — they mis-balance pytest-split. Fix = regenerate `ci/backend-test-durations.json` (last updated 06-21). Separate change.
- **#2 coverage gate**: confirmed *not* a second test run — `Calculate Unified Coverage` merges per-job lcov; tests run once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)