### PR TITLE
[finance_report] fix(smoke): meta-guard — refuse green on a silently-empty smoke

### DIFF
--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -60,6 +60,7 @@ explicit AC IDs for the behavior.
 
 | Path | Owner |
 |---|---|
+| `tests/tooling/test_smoke_min_checks.py` | `docs/ssot/env_smoke_test.md` |
 | `apps/backend/tests/money/test_money.py` | `common/ledger/readme.md` |
 | `apps/backend/tests/accounting/test_processing_account_endpoints.py` | `common/ledger/readme.md` |
 | `apps/backend/tests/api/test_ai_feedback_router_extra.py` | `docs/ssot/ai.md` |

--- a/tests/tooling/test_smoke_min_checks.py
+++ b/tests/tooling/test_smoke_min_checks.py
@@ -1,0 +1,47 @@
+"""Smoke meta-guard: a silently-empty smoke (0 / too-few checks) must not report green.
+
+This is the connectivity-layer guard for CF-C ("smoke runs 0 checks and exits 0") and the
+CF-B tail ("checks deleted/commented down to nothing"). Business-correctness belongs to
+e2e, not here (see finance_report#1505) — this only ensures the smoke can't *silently
+pass while empty*.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SMOKE = ROOT / "tools/_lib/shell/smoke_test.sh"
+DEFAULT_MIN_CHECKS = 12  # must match the MIN_CHECKS default in smoke_test.sh
+
+
+def _real_check_calls() -> int:
+    text = SMOKE.read_text(encoding="utf-8")
+    return len(re.findall(r'^\s*(?:check_endpoint|wait_for_endpoint)\s+"', text, re.M))
+
+
+def test_smoke_has_at_least_the_default_minimum_checks() -> None:
+    # Guards two things at once: the default MIN_CHECKS can't exceed the real check count
+    # (so a healthy smoke never false-positives), and nobody can delete/comment checks down
+    # below the floor without this test going red.
+    assert _real_check_calls() >= DEFAULT_MIN_CHECKS, (
+        f"only {_real_check_calls()} real smoke checks; add checks or lower MIN_CHECKS"
+    )
+
+
+def test_undersized_smoke_refuses_to_report_green() -> None:
+    # Behavioral counterfactual: force MIN_CHECKS above the real count -> smoke must exit
+    # non-zero with the silently-empty message. The count guard runs before the FAILED
+    # check, so this fires even though the URL is unreachable (proves the guard itself works,
+    # not just that an unreachable URL fails).
+    result = subprocess.run(
+        ["bash", str(SMOKE), "http://127.0.0.1:1", "staging"],
+        env={**os.environ, "MIN_CHECKS": "999", "SMOKE_READY_ATTEMPTS": "1", "SMOKE_READY_SLEEP_SECONDS": "0"},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0
+    assert "silently-empty" in (result.stdout + result.stderr)

--- a/tests/tooling/test_smoke_min_checks.py
+++ b/tests/tooling/test_smoke_min_checks.py
@@ -19,15 +19,19 @@ DEFAULT_MIN_CHECKS = 12  # must match the MIN_CHECKS default in smoke_test.sh
 
 def _real_check_calls() -> int:
     text = SMOKE.read_text(encoding="utf-8")
-    return len(re.findall(r'^\s*(?:check_endpoint|wait_for_endpoint)\s+"', text, re.M))
+    # A call is the command name followed by whitespace + an argument (any quote style /
+    # variable). The definition line `name() {` has `(` immediately after the name (no
+    # whitespace), so it's excluded — no dependence on the first arg being double-quoted.
+    return len(re.findall(r'^\s*(?:check_endpoint|wait_for_endpoint)\s+\S', text, re.M))
 
 
 def test_smoke_has_at_least_the_default_minimum_checks() -> None:
     # Guards two things at once: the default MIN_CHECKS can't exceed the real check count
     # (so a healthy smoke never false-positives), and nobody can delete/comment checks down
     # below the floor without this test going red.
-    assert _real_check_calls() >= DEFAULT_MIN_CHECKS, (
-        f"only {_real_check_calls()} real smoke checks; add checks or lower MIN_CHECKS"
+    count = _real_check_calls()
+    assert count >= DEFAULT_MIN_CHECKS, (
+        f"only {count} real smoke checks; add checks or lower MIN_CHECKS"
     )
 
 

--- a/tools/_lib/shell/smoke_test.sh
+++ b/tools/_lib/shell/smoke_test.sh
@@ -112,6 +112,12 @@ FAILED=0
 # low-water mark, not the exact total — overridable for reproduction (MIN_CHECKS=999 ...).
 CHECK_COUNT=0
 MIN_CHECKS="${MIN_CHECKS:-12}"
+case "$MIN_CHECKS" in
+    ''|*[!0-9]*)
+        echo "✗ MIN_CHECKS must be a non-negative integer, got '$MIN_CHECKS'"
+        exit 2
+        ;;
+esac
 
 # --- Readiness Check ---
 echo "--- Readiness Check ---"
@@ -227,9 +233,9 @@ else
 fi
 
 echo "========================================"
-echo "Ran $CHECK_COUNT checks (minimum $MIN_CHECKS)"
+echo "Ran $CHECK_COUNT endpoint checks (check_endpoint/wait_for_endpoint; minimum $MIN_CHECKS)"
 if [ "$CHECK_COUNT" -lt "$MIN_CHECKS" ]; then
-    echo "✗ smoke ran only $CHECK_COUNT checks (< $MIN_CHECKS) — refusing to report green (silently-empty smoke)"
+    echo "✗ smoke ran only $CHECK_COUNT endpoint checks (< $MIN_CHECKS) — refusing to report green (silently-empty smoke)"
     exit 1
 fi
 if [ "$FAILED" -eq 0 ]; then

--- a/tools/_lib/shell/smoke_test.sh
+++ b/tools/_lib/shell/smoke_test.sh
@@ -20,6 +20,7 @@ echo "========================================"
 
 # Helper function
 check_endpoint() {
+    CHECK_COUNT=$((CHECK_COUNT + 1))
     local name="$1"
     local url="$2"
     local expected="${3:-}"
@@ -80,6 +81,7 @@ check_endpoint() {
 
 # Wait for app/API to become reachable before running checks
 wait_for_endpoint() {
+    CHECK_COUNT=$((CHECK_COUNT + 1))
     local name="$1"
     local url="$2"
     local max_attempts="${SMOKE_READY_ATTEMPTS:-30}"
@@ -104,6 +106,12 @@ wait_for_endpoint() {
 
 # Run tests
 FAILED=0
+# Meta-guard against a silently-empty smoke (CF-C): count every check_endpoint /
+# wait_for_endpoint call and refuse to report green if fewer than MIN_CHECKS ran (e.g. the
+# check block got short-circuited, BASE_URL was empty, or checks were commented out). A
+# low-water mark, not the exact total — overridable for reproduction (MIN_CHECKS=999 ...).
+CHECK_COUNT=0
+MIN_CHECKS="${MIN_CHECKS:-12}"
 
 # --- Readiness Check ---
 echo "--- Readiness Check ---"
@@ -219,6 +227,11 @@ else
 fi
 
 echo "========================================"
+echo "Ran $CHECK_COUNT checks (minimum $MIN_CHECKS)"
+if [ "$CHECK_COUNT" -lt "$MIN_CHECKS" ]; then
+    echo "✗ smoke ran only $CHECK_COUNT checks (< $MIN_CHECKS) — refusing to report green (silently-empty smoke)"
+    exit 1
+fi
 if [ "$FAILED" -eq 0 ]; then
     echo "All smoke tests passed!"
     exit 0


### PR DESCRIPTION
Infra-owned hardening of the **smoke (connectivity) layer**: stop smoke from silently passing while empty.

## Problem (CF-C)
`smoke_test.sh` starts `FAILED=0`; if the check block is short-circuited / `BASE_URL` empty / checks commented out, **0 checks still exits 0**. No minimum-check floor.

## Fix
- Count every `check_endpoint`/`wait_for_endpoint` call; refuse green if `CHECK_COUNT < MIN_CHECKS` (default 12, env-overridable). Guard runs **before** the FAILED check.

## Proof it works (not a no-op guard)
- **No false-positive:** real check count = **14** ≥ default 12 (test).
- **Behavioral counterfactual:** `MIN_CHECKS=999 bash smoke_test.sh …` → exit 1 + `refusing to report green (silently-empty smoke)` (test). The guard truly reds when undersized — including the 0-checks case.

## Layer boundary
This is the **connectivity** guard only. "200 but the business value is wrong" is **e2e**'s job, not smoke's — filed for app as #1505. (Concept correction: smoke = is-it-connected; e2e = is-the-result-right.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)