### PR TITLE
[finance_report_test_and_doc] fix(tests): stub Bootloader._check_s3 in autouse mock (kills the 26s /health floor)

### DIFF
--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -83,16 +83,27 @@ def ac_evidence(record_property):
 
 
 # --- Bootloader Mock ---
-# Prevent Bootloader from creating its own engine (causes event loop conflicts)
+# Prevent Bootloader dependency checks from making real network/engine calls.
+# Covers BOTH checks symmetrically: _check_database (its own engine causes event
+# loop conflicts) and _check_s3 (uses aioboto3 — without a stub it hits a dead S3
+# endpoint and burns ~8s on connect-timeout+retries per /health call, the real
+# cost behind the slow /health tests). Tests that assert specific S3/DB health
+# behaviour monkeypatch these again, which overrides the defaults set here.
 @pytest.fixture(autouse=True)
-def mock_bootloader_db_check():
-    """Mock Bootloader._check_database to avoid event loop conflicts in tests."""
+def mock_bootloader_checks():
+    """Stub Bootloader dependency checks (DB + S3) so /health is fast by default."""
     from src.boot import ServiceStatus
 
-    async def mock_check():
+    async def ok_database():
         return ServiceStatus("database", "ok", "Mocked for tests", 0.0)
 
-    with patch("src.boot.Bootloader._check_database", new=mock_check):
+    async def ok_s3():
+        return ServiceStatus("s3", "ok", "Mocked for tests", 0.0)
+
+    with (
+        patch("src.boot.Bootloader._check_database", new=ok_database),
+        patch("src.boot.Bootloader._check_s3", new=ok_s3),
+    ):
         yield
 
 
@@ -263,7 +274,7 @@ async def ensure_database(db_url: str):
             else:
                 print(f"Test database {db_name} already exists")
     except (SQLAlchemyError, Exception) as e:
-        if isinstance(e, (SQLAlchemyError,)):
+        if isinstance(e, SQLAlchemyError):
             logger.error(
                 f"Test database setup failed: {type(e).__name__}: {e}",
                 extra={"database": db_name, "error_type": type(e).__name__},

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -9,8 +9,26 @@ import pytest
 from src.boot import Bootloader, Bootloader as BootloaderClass, BootMode, ServiceStatus
 
 _ORIGINAL_CHECK_DATABASE = BootloaderClass._check_database
+_ORIGINAL_CHECK_S3 = BootloaderClass._check_s3
 ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
 pytestmark = pytest.mark.no_db
+
+
+@pytest.fixture(autouse=True)
+def restore_original_s3_check():
+    """Restore the real _check_s3 for this module.
+
+    conftest autouse-stubs ``Bootloader._check_s3`` so ``/health`` is fast in the
+    rest of the suite; the Bootloader tests here exercise the real implementation,
+    so undo that stub. Tests that want it mocked (e.g. ``mock_minio_check``) re-patch
+    it, which overrides this restore.
+    """
+    if isinstance(_ORIGINAL_CHECK_S3, types.FunctionType):
+        BootloaderClass._check_s3 = staticmethod(_ORIGINAL_CHECK_S3)
+    else:
+        BootloaderClass._check_s3 = _ORIGINAL_CHECK_S3
+    yield
+    BootloaderClass._check_s3 = _ORIGINAL_CHECK_S3
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why
The autouse Bootloader fixture mocked `_check_database` but **not** `_check_s3`. So any test hitting `/health` without its own S3 mock ran the real `Bootloader._check_s3()` → aioboto3 `head_bucket` against `127.0.0.1:9000` (no MinIO in unit shards) → **~8s on connect_timeout+retries per /health call**.

Worst offenders (from a clean CI junit):
- `test_global_rate_limit_middleware_exempts_health`: **26.1s** (hits /health 3×)
- `test_health_endpoint_structure`: 8.8s
- `test_health_returns_503_on_database_failure`: 6.7s (mocked DB, not S3)

This was the real cost behind the slow backend tests — **not** the duration seed (#1509). It's an omission: the global Bootloader stub only covered DB, not its S3 sibling.

## What
Stub `_check_s3` → ok by default in the **same autouse fixture**, symmetric with the DB stub. Tests that assert specific S3 health behaviour (`test_health_returns_503_on_s3_failure`, `test_health_when_all_services_healthy`) `monkeypatch` `_check_s3` themselves → that overrides this default, behaviour unchanged. (Also fixes a pre-existing UP038 lint nit in the same file, surfaced by the changed-file hook.)

## Verify
Local (Postgres up, no S3): the 26.1s test drops to a **0.05s** call; all 34 tests in `test_main.py` + `test_rate_limit.py` pass. This PR's CI shard times should drop (the 26s single-test floor is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)