### PR TITLE
[finance_report_audit] migrate EPIC-015 ACs → AC-ledger.processing.* — slice 3c-i of #1420; EPIC-002=3c-ii/iii

### DIFF
--- a/apps/backend/tests/ledger/test_processing_account.py
+++ b/apps/backend/tests/ledger/test_processing_account.py
@@ -19,7 +19,7 @@ class TestProcessingAccountCreation:
     """Test Processing account creation and properties."""
 
     async def test_processing_account_created_on_first_call(self, db: AsyncSession, test_user):
-        """AC15.1.1 · Processing account is auto-created on first get_or_create call."""
+        """AC-ledger.71.1 · Processing account is auto-created on first get_or_create call."""
         user_id = test_user.id
         processing = await get_or_create_processing_account(db, user_id)
 
@@ -31,7 +31,7 @@ class TestProcessingAccountCreation:
         assert processing.user_id == user_id
 
     async def test_processing_account_idempotent(self, db: AsyncSession, test_user):
-        """AC15.1.2 · Multiple calls return the same Processing account."""
+        """AC-ledger.71.2 · Multiple calls return the same Processing account."""
         user_id = test_user.id
         processing1 = await get_or_create_processing_account(db, user_id)
         processing2 = await get_or_create_processing_account(db, user_id)
@@ -39,7 +39,7 @@ class TestProcessingAccountCreation:
         assert processing1.id == processing2.id
 
     async def test_processing_account_hidden_from_list(self, db: AsyncSession, test_user):
-        """AC15.1.3 · Processing account is hidden from list_accounts."""
+        """AC-ledger.71.3 · Processing account is hidden from list_accounts."""
         user_id = test_user.id
         from src.services.account_service import list_accounts
 
@@ -65,7 +65,7 @@ class TestProcessingAccountCreation:
         assert all(not acc.is_system for acc in accounts)
 
     async def test_processing_account_per_user(self, db: AsyncSession):
-        """AC15.1.4 · Each user gets their own Processing account."""
+        """AC-ledger.71.4 · Each user gets their own Processing account."""
         user1 = (await UserFactory.create_async(db)).id
         user2 = (await UserFactory.create_async(db)).id
 
@@ -81,7 +81,7 @@ class TestProcessingAccountTransfers:
     """Test transfer IN/OUT entries to Processing account."""
 
     async def test_transfer_out_to_processing(self, db: AsyncSession, test_user):
-        """AC15.2.1 · Transfer OUT: Debit Processing, Credit source account."""
+        """AC-ledger.72.1 · Transfer OUT: Debit Processing, Credit source account."""
         user_id = test_user.id
         # Setup: Cash account
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -123,7 +123,7 @@ class TestProcessingAccountTransfers:
         assert balance == Decimal("100.00")
 
     async def test_transfer_in_from_processing(self, db: AsyncSession, test_user):
-        """AC15.2.2 · Transfer IN: Debit destination account, Credit Processing."""
+        """AC-ledger.72.2 · Transfer IN: Debit destination account, Credit Processing."""
         user_id = test_user.id
         # Setup: Checking account
         checking = Account(user_id=user_id, name="Checking", code="1002", type=AccountType.ASSET, currency="SGD")
@@ -168,7 +168,7 @@ class TestProcessingAccountTransfers:
         assert balance == Decimal("-100.00")
 
     async def test_paired_transfers_zero_balance(self, db: AsyncSession, test_user):
-        """AC15.2.3 · Paired transfer OUT + IN results in Processing balance = 0."""
+        """AC-ledger.72.3 · Paired transfer OUT + IN results in Processing balance = 0."""
         user_id = test_user.id
         # Setup: Cash and Checking accounts
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -254,7 +254,7 @@ class TestProcessingAccountIntegrity:
     """Test accounting integrity with Processing account."""
 
     async def test_unpaired_transfer_visible_in_processing_balance(self, db: AsyncSession, test_user):
-        """AC15.3.1 · Unpaired transfer OUT shows as non-zero Processing balance."""
+        """AC-ledger.73.1 · Unpaired transfer OUT shows as non-zero Processing balance."""
         user_id = test_user.id
         # Setup: Cash account
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -293,7 +293,7 @@ class TestProcessingAccountIntegrity:
         assert balance != Decimal("0.00")  # Non-zero indicates unpaired transfer
 
     async def test_accounting_equation_holds_with_processing(self, db: AsyncSession, test_user):
-        """AC15.3.2 · Accounting equation holds after transfers involving Processing account."""
+        """AC-ledger.73.2 · Accounting equation holds after transfers involving Processing account."""
         user_id = test_user.id
         # Setup: Cash, Checking accounts
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -403,7 +403,7 @@ class TestProcessingAccountValidation:
     """Test validation rules for Processing account (Anti-pattern A)."""
 
     async def test_reject_manual_processing_entry(self, db: AsyncSession, test_user):
-        """AC15.4.A · Manual journal entries cannot use Processing account (SSOT Anti-pattern A)."""
+        """AC-ledger.74.A · Manual journal entries cannot use Processing account (SSOT Anti-pattern A)."""
         user_id = test_user.id
         processing = await get_or_create_processing_account(db, user_id)
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -440,7 +440,7 @@ class TestProcessingAccountValidation:
             await post_journal_entry(db, entry.id, user_id)
 
     async def test_system_entry_can_use_processing(self, db: AsyncSession, test_user):
-        """AC15.4.A · System-generated entries (source_type=SYSTEM) CAN use Processing account."""
+        """AC-ledger.74.A · System-generated entries (source_type=SYSTEM) CAN use Processing account."""
         user_id = test_user.id
         processing = await get_or_create_processing_account(db, user_id)
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -481,7 +481,7 @@ class TestTransferDetection:
     """Test transfer pattern detection and auto-pairing."""
 
     async def test_detect_transfer_keywords(self, db: AsyncSession, test_user):
-        """AC15.4.1 · detect_transfer_pattern identifies transfer keywords in descriptions."""
+        """AC-ledger.74.1 · detect_transfer_pattern identifies transfer keywords in descriptions."""
         from src.ledger import detect_transfer_pattern
         from tests.factories import AtomicTransactionFactory, UploadedDocumentFactory
 
@@ -534,7 +534,7 @@ class TestTransferDetection:
         assert detect_transfer_pattern(non_transfer.description) is False
 
     async def test_detect_transfer_no_description(self, db: AsyncSession, test_user):
-        """AC15.4.2 · detect_transfer_pattern returns False for None/empty description."""
+        """AC-ledger.74.2 · detect_transfer_pattern returns False for None/empty description."""
         from src.ledger import detect_transfer_pattern
         from tests.factories import AtomicTransactionFactory, UploadedDocumentFactory
 
@@ -555,7 +555,7 @@ class TestTransferDetection:
         assert detect_transfer_pattern(txn_empty.description) is False
 
     async def test_auto_pair_transfers_above_threshold(self, db: AsyncSession, test_user):
-        """AC15.4.3 · find_transfer_pairs auto-pairs transfers with confidence >= 85."""
+        """AC-ledger.74.3 · find_transfer_pairs auto-pairs transfers with confidence >= 85."""
         from src.ledger import (
             create_transfer_in_entry,
             create_transfer_out_entry,
@@ -599,7 +599,7 @@ class TestTransferScoringFunctions:
     """Test scoring functions for transfer pairing."""
 
     def test_amount_exact_match(self):
-        """AC15.5.1 · Exact amount match within 1 cent returns 100."""
+        """AC-ledger.75.1 · Exact amount match within 1 cent returns 100."""
         from src.ledger.base.processing import _score_amount_match
 
         score = _score_amount_match(Decimal("100.00"), Decimal("100.01"))
@@ -609,7 +609,7 @@ class TestTransferScoringFunctions:
         assert score == 100.0
 
     def test_amount_very_close_match(self):
-        """AC15.5.2 · Amount within 10 cents returns 95."""
+        """AC-ledger.75.2 · Amount within 10 cents returns 95."""
         from src.ledger.base.processing import _score_amount_match
 
         score = _score_amount_match(Decimal("100.00"), Decimal("100.05"))
@@ -619,7 +619,7 @@ class TestTransferScoringFunctions:
         assert score == 95.0
 
     def test_amount_close_match(self):
-        """AC15.5.2 · Amount within 1 SGD returns 85."""
+        """AC-ledger.75.2 · Amount within 1 SGD returns 85."""
         from src.ledger.base.processing import _score_amount_match
 
         score = _score_amount_match(Decimal("100.00"), Decimal("100.50"))
@@ -629,7 +629,7 @@ class TestTransferScoringFunctions:
         assert score == 85.0
 
     def test_amount_moderate_match(self):
-        """AC15.5.2 · Amount within 5 SGD returns 70."""
+        """AC-ledger.75.2 · Amount within 5 SGD returns 70."""
         from src.ledger.base.processing import _score_amount_match
 
         score = _score_amount_match(Decimal("100.00"), Decimal("103.00"))
@@ -639,42 +639,42 @@ class TestTransferScoringFunctions:
         assert score == 70.0
 
     def test_amount_zero_base(self):
-        """AC15.5.2 · Zero base amount returns 0."""
+        """AC-ledger.75.2 · Zero base amount returns 0."""
         from src.ledger.base.processing import _score_amount_match
 
         score = _score_amount_match(Decimal("0"), Decimal("100.00"))
         assert score == 0.0
 
     def test_amount_large_diff(self):
-        """AC15.5.2 · Large amount difference returns proportional score."""
+        """AC-ledger.75.2 · Large amount difference returns proportional score."""
         from src.ledger.base.processing import _score_amount_match
 
         score = _score_amount_match(Decimal("100.00"), Decimal("110.00"))
         assert score == 90.0  # 10 SGD diff on 100 = 90% match
 
     def test_description_exact_match(self):
-        """AC15.5.3 · Exact description match returns 100."""
+        """AC-ledger.75.3 · Exact description match returns 100."""
         from src.ledger.base.processing import _score_description_match
 
         score = _score_description_match("Transfer to Bank B", "Transfer to Bank B")
         assert score == 100.0
 
     def test_description_case_insensitive(self):
-        """AC15.5.3 · Description matching is case-insensitive."""
+        """AC-ledger.75.3 · Description matching is case-insensitive."""
         from src.ledger.base.processing import _score_description_match
 
         score = _score_description_match("TRANSFER TO BANK B", "transfer to bank b")
         assert score == 100.0
 
     def test_description_partial_match(self):
-        """AC15.5.3 · Partial description match returns proportional score."""
+        """AC-ledger.75.3 · Partial description match returns proportional score."""
         from src.ledger.base.processing import _score_description_match
 
         score = _score_description_match("Transfer to Bank B", "Transfer to Bank A")
         assert 50 < score < 100
 
     def test_description_none_values(self):
-        """AC15.5.3 · None descriptions return 0 score."""
+        """AC-ledger.75.3 · None descriptions return 0 score."""
         from src.ledger.base.processing import _score_description_match
 
         score = _score_description_match(None, "Transfer")
@@ -687,7 +687,7 @@ class TestTransferScoringFunctions:
         assert score == 0.0
 
     def test_date_same_day(self):
-        """AC15.5.4 · Same day transfer returns 100."""
+        """AC-ledger.75.4 · Same day transfer returns 100."""
         from src.ledger.base.processing import _score_date_proximity
 
         same_date = date(2025, 1, 15)
@@ -695,7 +695,7 @@ class TestTransferScoringFunctions:
         assert score == 100.0
 
     def test_date_one_day_diff(self):
-        """AC15.5.4 · 1 day difference returns 95."""
+        """AC-ledger.75.4 · 1 day difference returns 95."""
         from src.ledger.base.processing import _score_date_proximity
 
         d1 = date(2025, 1, 15)
@@ -704,7 +704,7 @@ class TestTransferScoringFunctions:
         assert score == 95.0
 
     def test_date_three_day_diff(self):
-        """AC15.5.4 · 3 day difference returns 85."""
+        """AC-ledger.75.4 · 3 day difference returns 85."""
         from src.ledger.base.processing import _score_date_proximity
 
         d1 = date(2025, 1, 15)
@@ -713,7 +713,7 @@ class TestTransferScoringFunctions:
         assert score == 85.0
 
     def test_date_seven_day_diff(self):
-        """AC15.5.4 · 7 day difference returns 70."""
+        """AC-ledger.75.4 · 7 day difference returns 70."""
         from src.ledger.base.processing import _score_date_proximity
 
         d1 = date(2025, 1, 15)
@@ -722,7 +722,7 @@ class TestTransferScoringFunctions:
         assert score == 70.0
 
     def test_date_far_apart(self):
-        """AC15.5.4 · Dates >7 days apart return 0."""
+        """AC-ledger.75.4 · Dates >7 days apart return 0."""
         from src.ledger.base.processing import _score_date_proximity
 
         d1 = date(2025, 1, 15)
@@ -735,7 +735,7 @@ class TestUnpairedTransferDetection:
     """Test detection of unpaired transfers."""
 
     async def test_get_unpaired_transfers_empty(self, db: AsyncSession, test_user):
-        """AC15.3.1 · No unpaired transfers when Processing balance is zero."""
+        """AC-ledger.73.1 · No unpaired transfers when Processing balance is zero."""
         from src.ledger import get_unpaired_transfers
 
         user_id = test_user.id
@@ -744,7 +744,7 @@ class TestUnpairedTransferDetection:
         assert unpaired == []
 
     async def test_get_unpaired_transfers_with_balance(self, db: AsyncSession, test_user):
-        """AC15.3.1 · Unpaired transfers detected when Processing balance ≠ 0."""
+        """AC-ledger.73.1 · Unpaired transfers detected when Processing balance ≠ 0."""
         from src.ledger import (
             create_transfer_out_entry,
             get_unpaired_transfers,
@@ -776,7 +776,7 @@ class TestProcessingBalanceQuery:
     """Test Processing account balance query."""
 
     async def test_get_processing_balance_zero(self, db: AsyncSession, test_user):
-        """AC15.3.2 · Processing balance is zero when no transfers exist."""
+        """AC-ledger.73.2 · Processing balance is zero when no transfers exist."""
         from src.ledger import get_processing_balance
 
         user_id = test_user.id
@@ -785,7 +785,7 @@ class TestProcessingBalanceQuery:
         assert balance == Decimal("0")
 
     async def test_get_processing_balance_with_transfers(self, db: AsyncSession, test_user):
-        """AC15.3.2 · Processing balance reflects unpaired transfers."""
+        """AC-ledger.73.2 · Processing balance reflects unpaired transfers."""
         from src.ledger import (
             create_transfer_out_entry,
             get_processing_balance,
@@ -815,7 +815,7 @@ class TestTransferEntryValidation:
     """Test input validation for create_transfer_out_entry and create_transfer_in_entry."""
 
     async def test_transfer_out_rejects_zero_amount(self, db: AsyncSession, test_user):
-        """AC15.2.1 · create_transfer_out_entry rejects amount <= 0."""
+        """AC-ledger.72.1 · create_transfer_out_entry rejects amount <= 0."""
         from src.ledger import create_transfer_out_entry
 
         user_id = test_user.id
@@ -834,7 +834,7 @@ class TestTransferEntryValidation:
             )
 
     async def test_transfer_out_rejects_negative_amount(self, db: AsyncSession, test_user):
-        """AC15.2.1 · create_transfer_out_entry rejects negative amount."""
+        """AC-ledger.72.1 · create_transfer_out_entry rejects negative amount."""
         from src.ledger import create_transfer_out_entry
 
         user_id = test_user.id
@@ -853,7 +853,7 @@ class TestTransferEntryValidation:
             )
 
     async def test_transfer_out_rejects_empty_description(self, db: AsyncSession, test_user):
-        """AC15.2.1 · create_transfer_out_entry rejects empty description."""
+        """AC-ledger.72.1 · create_transfer_out_entry rejects empty description."""
         from src.ledger import create_transfer_out_entry
 
         user_id = test_user.id
@@ -872,7 +872,7 @@ class TestTransferEntryValidation:
             )
 
     async def test_transfer_out_rejects_whitespace_description(self, db: AsyncSession, test_user):
-        """AC15.2.1 · create_transfer_out_entry rejects whitespace-only description."""
+        """AC-ledger.72.1 · create_transfer_out_entry rejects whitespace-only description."""
         from src.ledger import create_transfer_out_entry
 
         user_id = test_user.id
@@ -891,7 +891,7 @@ class TestTransferEntryValidation:
             )
 
     async def test_transfer_in_rejects_zero_amount(self, db: AsyncSession, test_user):
-        """AC15.2.2 · create_transfer_in_entry rejects amount <= 0."""
+        """AC-ledger.72.2 · create_transfer_in_entry rejects amount <= 0."""
         from src.ledger import create_transfer_in_entry
 
         user_id = test_user.id
@@ -910,7 +910,7 @@ class TestTransferEntryValidation:
             )
 
     async def test_transfer_in_rejects_empty_description(self, db: AsyncSession, test_user):
-        """AC15.2.2 · create_transfer_in_entry rejects empty description."""
+        """AC-ledger.72.2 · create_transfer_in_entry rejects empty description."""
         from src.ledger import create_transfer_in_entry
 
         user_id = test_user.id
@@ -933,7 +933,7 @@ class TestDescriptionScoringEdgeCases:
     """Test edge cases in description scoring."""
 
     def test_description_whitespace_only(self):
-        """AC15.5.3 · Whitespace-only descriptions return 0 score."""
+        """AC-ledger.75.3 · Whitespace-only descriptions return 0 score."""
         from src.ledger.base.processing import _score_description_match
 
         score = _score_description_match("   ", "Transfer")

--- a/apps/backend/tests/reconciliation/test_transfer_idempotency.py
+++ b/apps/backend/tests/reconciliation/test_transfer_idempotency.py
@@ -80,7 +80,7 @@ class TestTransferDetectionIdempotency:
         return summary, txn
 
     async def test_transfer_out_duplicate_detection_skipped(self, db: AsyncSession, test_user):
-        """AC15.6.7 · Running matching twice for transfer-OUT should not create a second match."""
+        """AC-ledger.76.7 · Running matching twice for transfer-OUT should not create a second match."""
         user_id = test_user.id
         _, txn = await self._setup(db, user_id, direction="OUT", file_hash_suffix="idem_out")
 
@@ -109,7 +109,7 @@ class TestTransferDetectionIdempotency:
         )
 
     async def test_transfer_in_duplicate_detection_skipped(self, db: AsyncSession, test_user):
-        """AC15.6.7 · Running matching twice for transfer-IN should not create a second match."""
+        """AC-ledger.76.7 · Running matching twice for transfer-IN should not create a second match."""
         user_id = test_user.id
         _, txn = await self._setup(db, user_id, direction="IN", file_hash_suffix="idem_in")
 

--- a/apps/backend/tests/reconciliation/test_transfer_integration.py
+++ b/apps/backend/tests/reconciliation/test_transfer_integration.py
@@ -93,7 +93,7 @@ class TestTransferDetectionDuringReconciliation:
     """Test Phase 1: Transfer detection with Processing account during reconciliation."""
 
     async def test_transfer_detected_creates_processing_entry(self, db: AsyncSession, test_user):
-        """AC15.6.1 · Transfer detection creates Processing account entry with linked account."""
+        """AC-ledger.76.1 · Transfer detection creates Processing account entry with linked account."""
         user_id = test_user.id
 
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -147,7 +147,7 @@ class TestTransferDetectionDuringReconciliation:
         await db.refresh(txn)
 
     async def test_transfer_detection_skips_when_no_account_linked(self, db: AsyncSession, test_user):
-        """AC15.6.2 · Transfer detection logs warning and skips when statement has no linked account."""
+        """AC-ledger.76.2 · Transfer detection logs warning and skips when statement has no linked account."""
         user_id = test_user.id
 
         doc = await _seed_statement(db, user_id, account_id=None, file_hash="test_hash_no_account")
@@ -171,7 +171,7 @@ class TestTransferDetectionDuringReconciliation:
         assert len(lines) == 0
 
     async def test_transfer_in_creates_correct_processing_entry(self, db: AsyncSession, test_user):
-        """AC15.6.3 · Transfer IN creates: DEBIT destination account, CREDIT Processing."""
+        """AC-ledger.76.3 · Transfer IN creates: DEBIT destination account, CREDIT Processing."""
         user_id = test_user.id
 
         checking = Account(user_id=user_id, name="Checking", code="1002", type=AccountType.ASSET, currency="SGD")
@@ -223,7 +223,7 @@ class TestTransferAutoPairingPhase:
     """Test Phase 3: Auto-pairing of transfers after all matching completes."""
 
     async def test_auto_pair_transfers_same_amount_same_date(self, db: AsyncSession, test_user):
-        """AC15.6.4 · Paired transfers (same amount, same date) are auto-paired, Processing balance = 0."""
+        """AC-ledger.76.4 · Paired transfers (same amount, same date) are auto-paired, Processing balance = 0."""
         user_id = test_user.id
 
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -261,7 +261,7 @@ class TestTransferAutoPairingPhase:
         assert balance == Decimal("0.00")
 
     async def test_unpaired_transfer_leaves_processing_nonzero(self, db: AsyncSession, test_user):
-        """AC15.6.5 · Unpaired transfer leaves Processing balance ≠ 0."""
+        """AC-ledger.76.5 · Unpaired transfer leaves Processing balance ≠ 0."""
         user_id = test_user.id
 
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -292,7 +292,7 @@ class TestNormalMatchingPhaseIntegration:
     """Test Phase 2: Normal matching still works when transfers are present."""
 
     async def test_non_transfer_transaction_proceeds_to_normal_matching(self, db: AsyncSession, test_user):
-        """AC15.6.6 · Non-transfer transactions skip Phase 1 and proceed to Phase 2 (normal matching)."""
+        """AC-ledger.76.6 · Non-transfer transactions skip Phase 1 and proceed to Phase 2 (normal matching)."""
         user_id = test_user.id
 
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")
@@ -351,7 +351,7 @@ class TestNormalMatchingPhaseIntegration:
         assert len(lines) == 0
 
     async def test_mixed_transactions_both_phases_execute(self, db: AsyncSession, test_user):
-        """AC15.6.6 · AC11.17.2 · Mix of transfer and non-transfer transactions: Phase 1 and Phase 2 both execute."""
+        """AC-ledger.76.6 · AC11.17.2 · Mix of transfer and non-transfer transactions: Phase 1 and Phase 2 both execute."""
         user_id = test_user.id
 
         cash = Account(user_id=user_id, name="Cash", code="1001", type=AccountType.ASSET, currency="SGD")

--- a/common/ledger/contract.py
+++ b/common/ledger/contract.py
@@ -20,16 +20,40 @@ project / ``find_transfer_pairs``) in ``extension/processing.py`` — the origin
 reporting consume it only through the published ``src.ledger`` interface, by id/
 event (Decision B — one transaction per domain).
 
-Its ACs (the EPIC-002/012/015 double-entry + processing-account ACs) migrate into
-``roadmap`` in a later slice of the cutover (#1420 slice 3c); for now the contract
-declares only the **structural invariants** of the cutover, each pinned to a real
-test. ``roadmap=[]`` is standard-preserving (Decision A — deferring the AC
-migration lowers no bar).
+The package's ACs migrate into ``roadmap`` across the slice-3c sub-slices of the
+cutover (#1420). **Slice 3c-i (this change) homes the EPIC-015 processing-account
+ACs** as ``AC-ledger.71.* … AC-ledger.76.*`` — the package now owns them; the
+EPIC-015 backend tables are deleted and replaced with a disclaimer that lists the
+new ids (mirroring how identity emptied EPIC-001). The EPIC-002 double-entry ACs
+(slice 3c-ii/iii) land later under the **lower** group numbers.
+
+**Group-number reservation (ledger-local).** The first dotted segment of an
+``AC-ledger.<group>.<seq>`` id is a bare uniqueness key (no gate reads semantics
+from it), so the package reserves disjoint blocks to keep the namespace
+collision-free as later slices add ACs without re-reading this file:
+
+- **groups 1–70** — the EPIC-002/012 double-entry core (slices 3c-ii/iii, not yet
+  homed);
+- **groups 71–76** — the EPIC-015 processing (in-transit) account, this slice
+  (71=creation, 72=transfer-entry, 73=integrity, 74=detection, 75=scoring,
+  76=reconciliation integration), each mirroring its source ``AC15.<g>`` group.
+
+(The aspirational ``AC-ledger.<entity>.<seq>`` form some docs advertise is not
+adopted: the live traceability regex in
+``common/ssot/ac_traceability_refs.py`` accepts only the numeric
+``AC-<pkg>.<n>.<n>`` grammar that every shipped package — counter/authority/
+identity — already uses.) The EPIC-015 **frontend** UI-gap ACs (``AC15.7.*``)
+stay in EPIC-015: ledger is a backend-only package (``fe=None``), exactly as the
+identity migration left EPIC-001's frontend rows in place. ``roadmap`` carries the
+23 backend ACs; the structural invariants of the cutover stay in ``invariants``
+(no tier, not matrix-constrained). Decision A — standard-preserving move, no bar
+lowered.
 """
 
 from __future__ import annotations
 
 from common.meta.package_contract import (
+    ACRecord,
     Invariant,
     Kind,
     PackageContract,
@@ -185,5 +209,316 @@ CONTRACT = PackageContract(
             ),
         ),
     ],
-    roadmap=[],
+    roadmap=[
+        # ── group 71: Processing account creation (was EPIC-015 AC15.1.*) ──
+        ACRecord(
+            id="AC-ledger.71.1",
+            statement=(
+                "The Processing (in-transit) account is auto-created on the first "
+                "get_or_create call for a user. Was EPIC-015 AC15.1.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_processing_account_created_on_first_call"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.71.2",
+            statement=(
+                "Processing-account creation is idempotent: repeated get_or_create "
+                "calls return the same account. Was EPIC-015 AC15.1.2."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_processing_account_idempotent"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.71.3",
+            statement=(
+                "The Processing account is a system account hidden from "
+                "list_accounts (is_system=true). Was EPIC-015 AC15.1.3."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_processing_account_hidden_from_list"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.71.4",
+            statement=(
+                "Each user gets their own isolated Processing account. Was "
+                "EPIC-015 AC15.1.4."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_processing_account_per_user"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group 72: Transfer entry creation (was EPIC-015 AC15.2.*) ──
+        ACRecord(
+            id="AC-ledger.72.1",
+            statement=(
+                "A transfer-OUT entry debits Processing and credits the source "
+                "account (balanced double-entry); non-positive amounts and "
+                "empty/whitespace descriptions are rejected. Was EPIC-015 AC15.2.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_transfer_out_to_processing"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.72.2",
+            statement=(
+                "A transfer-IN entry debits the destination account and credits "
+                "Processing (balanced double-entry); non-positive amounts and empty "
+                "descriptions are rejected. Was EPIC-015 AC15.2.2."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_transfer_in_from_processing"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.72.3",
+            statement=(
+                "A paired transfer OUT + IN nets the Processing balance to zero. "
+                "Was EPIC-015 AC15.2.3."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_paired_transfers_zero_balance"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group 73: Accounting integrity (was EPIC-015 AC15.3.*) ──
+        ACRecord(
+            id="AC-ledger.73.1",
+            statement=(
+                "An unpaired transfer leaves a non-zero Processing balance, keeping "
+                "in-transit funds visible (get_unpaired_transfers + balance query). "
+                "Was EPIC-015 AC15.3.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_unpaired_transfer_visible_in_processing_balance"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.73.2",
+            statement=(
+                "The accounting equation holds after transfers through Processing "
+                "(sum(accounts) + Processing is conserved). Was EPIC-015 AC15.3.2."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_accounting_equation_holds_with_processing"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group 74: Transfer detection (was EPIC-015 AC15.4.*) ──
+        ACRecord(
+            id="AC-ledger.74.1",
+            statement=(
+                "detect_transfer_pattern identifies transfer keywords in a "
+                "description (SOP-001). Was EPIC-015 AC15.4.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_detect_transfer_keywords"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.74.2",
+            statement=(
+                "detect_transfer_pattern returns False for a None/empty "
+                "description (no false positive). Was EPIC-015 AC15.4.2."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_detect_transfer_no_description"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.74.3",
+            statement=(
+                "find_transfer_pairs auto-pairs transfers whose confidence is at or "
+                "above the threshold (>= 85). Was EPIC-015 AC15.4.3."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_auto_pair_transfers_above_threshold"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group 75: Pairing scoring functions (was EPIC-015 AC15.5.*) ──
+        ACRecord(
+            id="AC-ledger.75.1",
+            statement=(
+                "Amount scoring returns 100 for an exact match within one cent. "
+                "Was EPIC-015 AC15.5.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_amount_exact_match"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.75.2",
+            statement=(
+                "Amount scoring degrades by tier as the gap widens (exact/close/"
+                "moderate bands), e.g. within 1 SGD scores 85. Was EPIC-015 AC15.5.2."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_amount_close_match"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.75.3",
+            statement=(
+                "Description scoring returns a proportional score for a partial "
+                "match (SequenceMatcher + token overlap). Was EPIC-015 AC15.5.3."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_description_partial_match"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.75.4",
+            statement=(
+                "Date-proximity scoring degrades over a 7-day window (same day 100, "
+                "3 days 85, >7 days 0). Was EPIC-015 AC15.5.4."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_processing_account.py"
+                "::test_date_three_day_diff"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group 76: Reconciliation integration (was EPIC-015 AC15.6.*) ──
+        ACRecord(
+            id="AC-ledger.76.1",
+            statement=(
+                "During reconciliation, a detected transfer creates a Processing "
+                "entry for the linked account (Phase 1). Was EPIC-015 AC15.6.1."
+            ),
+            test=(
+                "apps/backend/tests/reconciliation/test_transfer_integration.py"
+                "::test_transfer_detected_creates_processing_entry"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.76.2",
+            statement=(
+                "Transfer detection logs a warning and skips when the statement has "
+                "no linked account. Was EPIC-015 AC15.6.2."
+            ),
+            test=(
+                "apps/backend/tests/reconciliation/test_transfer_integration.py"
+                "::test_transfer_detection_skips_when_no_account_linked"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.76.3",
+            statement=(
+                "A detected transfer-IN creates the correct Processing entry "
+                "(debit destination, credit Processing). Was EPIC-015 AC15.6.3."
+            ),
+            test=(
+                "apps/backend/tests/reconciliation/test_transfer_integration.py"
+                "::test_transfer_in_creates_correct_processing_entry"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.76.4",
+            statement=(
+                "The auto-pairing phase pairs transfers with the same amount and "
+                "date, netting the Processing balance to zero (Phase 3). Was "
+                "EPIC-015 AC15.6.4."
+            ),
+            test=(
+                "apps/backend/tests/reconciliation/test_transfer_integration.py"
+                "::test_auto_pair_transfers_same_amount_same_date"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.76.5",
+            statement=(
+                "An unpaired transfer leaves a non-zero Processing balance after "
+                "reconciliation. Was EPIC-015 AC15.6.5."
+            ),
+            test=(
+                "apps/backend/tests/reconciliation/test_transfer_integration.py"
+                "::test_unpaired_transfer_leaves_processing_nonzero"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.76.6",
+            statement=(
+                "Non-transfer transactions skip Phase 1 and proceed to normal "
+                "matching (Phase 2), preserving existing reconciliation. Was "
+                "EPIC-015 AC15.6.6."
+            ),
+            test=(
+                "apps/backend/tests/reconciliation/test_transfer_integration.py"
+                "::test_non_transfer_transaction_proceeds_to_normal_matching"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.76.7",
+            statement=(
+                "Transfer detection is idempotent: re-running matching does not "
+                "create a duplicate Processing entry/match. Was EPIC-015 AC15.6.7."
+            ),
+            test=(
+                "apps/backend/tests/reconciliation/test_transfer_idempotency.py"
+                "::test_transfer_out_duplicate_detection_skipped"
+            ),
+            priority="P0",
+            status="done",
+        ),
+    ],
 )

--- a/common/ledger/todo.md
+++ b/common/ledger/todo.md
@@ -28,11 +28,25 @@ The package-local worklist. Cross-package migration lives in
       Processing cross-domain by id (Decision B). `src/services/processing_account.py`
       deleted (zero residue, no shim); tests moved to `apps/backend/tests/ledger/`.
 
+- [x] **slice 3c-i — EPIC-015 AC migration**: the 23 processing-account backend ACs
+      (was `AC15.1.1`…`AC15.6.7`) homed in the contract `roadmap` as
+      `AC-ledger.71.*`…`AC-ledger.76.*`; the EPIC-015 backend tables deleted and
+      replaced with a disclaimer listing the new ids; the `AC15.<1-6>.*` test
+      docstrings repointed to the new ids. The id form is the numeric
+      `AC-ledger.<n>.<n>` grammar the live traceability regex
+      (`common/ssot/ac_traceability_refs.py`) accepts — **not** the aspirational
+      `AC-ledger.<entity>.<seq>` form some docs advertise (that form fails the regex
+      and is invisible to `check_registry_to_tests`). Group blocks are reserved
+      ledger-locally: **1–70 = EPIC-002/012 double-entry** (slices 3c-ii/iii),
+      **71–76 = EPIC-015 processing**. The EPIC-015 frontend ACs (`AC15.7.*`) stay
+      in EPIC-015 (ledger is backend-only).
+
 ## Next
-- [ ] **slice 3c — AC migration**: move the EPIC-002 / EPIC-012 (AC12.34) /
-      EPIC-015 double-entry ACs into the contract `roadmap` as
-      `AC-ledger.<entity>.<seq>`, removed from the EPIC tables (atomic), and delete
-      the EPIC rows when all their ACs are distributed.
+- [ ] **slice 3c-ii/iii — EPIC-002 / EPIC-012 (AC12.34) AC migration**: move the
+      double-entry ACs into the contract `roadmap` under the reserved **groups 1–70**
+      (`AC-ledger.<n>.<n>`, the numeric grammar — not `AC-ledger.<entity>.<seq>`),
+      removed from the EPIC tables (atomic), deleting the EPIC rows when all their
+      ACs are distributed.
 - [ ] Publish a typed read API for balances consumed by reporting, and consider an
       `EntryPosted` domain event (mechanism C) so reconciliation/reporting react by
       event with no compile edge.

--- a/docs/project/EPIC-015.processing-account.md
+++ b/docs/project/EPIC-015.processing-account.md
@@ -84,61 +84,47 @@ Balance ≠ 0  → Pending Review ⚠️
 
 ## 🧪 Test Cases
 
-> **Test Organization**: Tests organized by feature blocks using ACx.y.z numbering.
-> **Coverage**: See `apps/backend/tests/accounting/test_processing_account.py` and `apps/backend/tests/reconciliation/test_transfer_integration.py`
-
-### AC15.1: Processing Account Creation
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC15.1.1 | Processing Account Created | `test_create_processing_account_once` | `accounting/test_processing_account.py` | P0 |
-| AC15.1.2 | Idempotent Creation | `test_processing_account_idempotent` | `accounting/test_processing_account.py` | P0 |
-| AC15.1.3 | Hidden from User Accounts | `test_processing_account_hidden_from_list` | `accounting/test_processing_account.py` | P0 |
-| AC15.1.4 | Per-User Isolation | `test_processing_account_per_user` | `accounting/test_processing_account.py` | P0 |
-
-### AC15.2: Transfer Entry Creation
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC15.2.1 | Transfer OUT Entry | `test_transfer_out_debits_processing` | `accounting/test_processing_account.py` | P0 |
-| AC15.2.2 | Transfer IN Entry | `test_transfer_in_credits_processing` | `accounting/test_processing_account.py` | P0 |
-| AC15.2.3 | Paired Transfers Zero Balance | `test_paired_transfers_zero_processing_balance` | `accounting/test_processing_account.py` | P0 |
-
-### AC15.3: Accounting Integrity
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC15.3.1 | Unpaired Transfer Visible | `test_unpaired_transfer_shows_in_balance` | `accounting/test_processing_account.py` | P0 |
-| AC15.3.2 | Accounting Equation Holds | `test_processing_account_maintains_equation` | `accounting/test_processing_account.py` | P0 |
-
-### AC15.4: Transfer Detection
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC15.4.1 | Keyword Detection | `test_detect_transfer_keywords` | `accounting/test_processing_account.py` | P0 |
-| AC15.4.2 | Non-Transfer Detection | `test_detect_no_description` | `accounting/test_processing_account.py` | P0 |
-| AC15.4.3 | Auto-Pairing Above Threshold | `test_find_transfer_pairs_above_threshold` | `accounting/test_processing_account.py` | P0 |
-
-### AC15.5: Scoring Functions
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC15.5.1 | Amount Scoring (Exact) | `test_score_amount_exact_match` | `accounting/test_processing_account.py` | P0 |
-| AC15.5.2 | Amount Scoring (Tiers) | `test_score_amount_*` (9 tests) | `accounting/test_processing_account.py` | P0 |
-| AC15.5.3 | Description Scoring | `test_score_description_*` (4 tests) | `accounting/test_processing_account.py` | P1 |
-| AC15.5.4 | Date Scoring | `test_score_date_*` (5 tests) | `accounting/test_processing_account.py` | P1 |
-
-### AC15.6: Reconciliation Integration
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC15.6.1 | Transfer Detection During Reconciliation | `test_transfer_out_detected_creates_processing_entry` | `reconciliation/test_transfer_integration.py` | P0 |
-| AC15.6.2 | Transfer Detection Skips (No Account) | `test_transfer_detection_skips_when_no_account_linked` | `reconciliation/test_transfer_integration.py` | P0 |
-| AC15.6.3 | Transfer IN Detection | `test_transfer_in_detected_creates_processing_entry` | `reconciliation/test_transfer_integration.py` | P0 |
-| AC15.6.4 | Auto-Pairing Phase | `test_auto_pair_matching_transfer_same_amount` | `reconciliation/test_transfer_integration.py` | P0 |
-| AC15.6.5 | Unpaired Transfer Balance | `test_unpaired_transfer_leaves_nonzero_balance` | `reconciliation/test_transfer_integration.py` | P0 |
-| AC15.6.6 | Normal Matching Preserved | `test_non_transfer_proceeds_to_normal_matching` | `reconciliation/test_transfer_integration.py` | P0 |
-| AC15.6.7 | Idempotent Transfer Detection | `test_transfer_out_duplicate_detection_skipped`, `test_transfer_in_duplicate_detection_skipped` | `reconciliation/test_transfer_idempotency.py` | P0 |
+> **The processing-account backend ACs (the former AC15.1–AC15.6 tables) are no
+> longer defined here.** They migrated into the `ledger` package (#1420 slice 3c-i)
+> and are owned by, and sourced directly from,
+> [`common/ledger/contract.py`](../../common/ledger/contract.py)'s `roadmap` under
+> the package-scoped `AC-ledger.<group>.<seq>` id scheme (groups 71–76 are the
+> reserved processing block; groups 1–70 are held for the EPIC-002/012 double-entry
+> ACs that land in slices 3c-ii/iii). `common/ssot/generate_ac_registry.py` reads
+> package-contract roadmaps additively, so the AC index counts them without an
+> EPIC-table mirror. This note references the new ids (keeping the registry↔EPIC
+> link intact) but defines none of them — the contract is the single definition
+> source.
+>
+> **Processing Account Creation**:
+> `AC-ledger.71.1` · `AC-ledger.71.2` ·
+> `AC-ledger.71.3` · `AC-ledger.71.4`
+>
+> **Transfer Entry Creation**:
+> `AC-ledger.72.1` · `AC-ledger.72.2` ·
+> `AC-ledger.72.3`
+>
+> **Accounting Integrity**:
+> `AC-ledger.73.1` · `AC-ledger.73.2`
+>
+> **Transfer Detection**:
+> `AC-ledger.74.1` · `AC-ledger.74.2` ·
+> `AC-ledger.74.3`
+>
+> **Scoring Functions**:
+> `AC-ledger.75.1` · `AC-ledger.75.2` ·
+> `AC-ledger.75.3` · `AC-ledger.75.4`
+>
+> **Reconciliation Integration**:
+> `AC-ledger.76.1` · `AC-ledger.76.2` ·
+> `AC-ledger.76.3` · `AC-ledger.76.4` ·
+> `AC-ledger.76.5` · `AC-ledger.76.6` ·
+> `AC-ledger.76.7`
+>
+> The **frontend** UI-gap ACs (AC15.7.*, the Processing-visibility surface) remain
+> defined below — `ledger` is a backend-only package, so its roadmap does not home
+> them (mirroring how EPIC-001 kept its frontend rows when the `identity` backend
+> ACs migrated).
 
 ## 📏 Acceptance Criteria
 

--- a/tests/tooling/test_processing_account_service_unit.py
+++ b/tests/tooling/test_processing_account_service_unit.py
@@ -102,7 +102,7 @@ def _make_transfer_entry(
 
 @pytest.mark.asyncio
 async def test_find_transfer_pairs_delayed_transfer_auto_pairs() -> None:
-    """AC15.6.4 · Delayed transfers within three days still auto-pair through Processing."""
+    """AC-ledger.76.4 · Delayed transfers within three days still auto-pair through Processing."""
     user_id = uuid4()
     processing_account = SimpleNamespace(id=uuid4(), currency="SGD")
     out_entry = _make_transfer_entry(
@@ -143,7 +143,7 @@ async def test_find_transfer_pairs_delayed_transfer_auto_pairs() -> None:
 
 @pytest.mark.asyncio
 async def test_find_transfer_pairs_keeps_partial_match_in_review_band() -> None:
-    """AC15.4.3 · Partial transfer matches stay visible for review instead of auto-pairing."""
+    """AC-ledger.74.3 · Partial transfer matches stay visible for review instead of auto-pairing."""
     user_id = uuid4()
     processing_account = SimpleNamespace(id=uuid4(), currency="SGD")
     out_entry = _make_transfer_entry(
@@ -190,7 +190,7 @@ async def test_find_transfer_pairs_keeps_partial_match_in_review_band() -> None:
 
 @pytest.mark.asyncio
 async def test_find_transfer_pairs_rejects_unmatched_pair() -> None:
-    """AC15.6.5 · Clearly unmatched transfers stay unpaired and visible in Processing."""
+    """AC-ledger.76.5 · Clearly unmatched transfers stay unpaired and visible in Processing."""
     user_id = uuid4()
     processing_account = SimpleNamespace(id=uuid4(), currency="SGD")
     out_entry = _make_transfer_entry(
@@ -235,7 +235,7 @@ async def test_find_transfer_pairs_rejects_unmatched_pair() -> None:
 
 @pytest.mark.asyncio
 async def test_processing_balance_uses_decimal_net_balance() -> None:
-    """AC15.3.1 · Processing balance keeps unpaired funds visible as a Decimal net balance."""
+    """AC-ledger.73.1 · Processing balance keeps unpaired funds visible as a Decimal net balance."""
     processing_account = SimpleNamespace(id=uuid4(), currency="SGD")
     # balance now reads the typed `line.money` accessor (Phase C / AC12.38)
     debit_line = SimpleNamespace(


### PR DESCRIPTION
## What

Slice **3c-i** of the ledger cutover (#1420). Homes the **23 EPIC-015 processing-account backend ACs** (`AC15.1.1`…`AC15.6.7`) into `common/ledger/contract.py`'s `roadmap` as package-scoped `ACRecord`s `AC-ledger.71.*`…`AC-ledger.76.*`. **AC migration only — no code moves** (the ledger code/SSOT/processing_account landed in slices 1/2/3a/3b).

Mirrors the `identity` / EPIC-001 worked precedent (migration-standard steps 6–8).

## AC15 → AC-ledger mapping

Group blocks reserved ledger-locally: **1–70** = EPIC-002/012 double-entry (slices 3c-ii/iii), **71–76** = EPIC-015 processing. Each group mirrors its source `AC15.<g>`.

| was | now | proof (path::func) |
|-----|-----|------|
| AC15.1.1 | AC-ledger.71.1 | ledger/test_processing_account.py::test_processing_account_created_on_first_call |
| AC15.1.2 | AC-ledger.71.2 | ::test_processing_account_idempotent |
| AC15.1.3 | AC-ledger.71.3 | ::test_processing_account_hidden_from_list |
| AC15.1.4 | AC-ledger.71.4 | ::test_processing_account_per_user |
| AC15.2.1 | AC-ledger.72.1 | ::test_transfer_out_to_processing |
| AC15.2.2 | AC-ledger.72.2 | ::test_transfer_in_from_processing |
| AC15.2.3 | AC-ledger.72.3 | ::test_paired_transfers_zero_balance |
| AC15.3.1 | AC-ledger.73.1 | ::test_unpaired_transfer_visible_in_processing_balance |
| AC15.3.2 | AC-ledger.73.2 | ::test_accounting_equation_holds_with_processing |
| AC15.4.1 | AC-ledger.74.1 | ::test_detect_transfer_keywords |
| AC15.4.2 | AC-ledger.74.2 | ::test_detect_transfer_no_description |
| AC15.4.3 | AC-ledger.74.3 | ::test_auto_pair_transfers_above_threshold |
| AC15.5.1 | AC-ledger.75.1 | ::test_amount_exact_match |
| AC15.5.2 | AC-ledger.75.2 | ::test_amount_close_match |
| AC15.5.3 | AC-ledger.75.3 | ::test_description_partial_match |
| AC15.5.4 | AC-ledger.75.4 | ::test_date_three_day_diff |
| AC15.6.1 | AC-ledger.76.1 | reconciliation/test_transfer_integration.py::test_transfer_detected_creates_processing_entry |
| AC15.6.2 | AC-ledger.76.2 | ::test_transfer_detection_skips_when_no_account_linked |
| AC15.6.3 | AC-ledger.76.3 | ::test_transfer_in_creates_correct_processing_entry |
| AC15.6.4 | AC-ledger.76.4 | ::test_auto_pair_transfers_same_amount_same_date |
| AC15.6.5 | AC-ledger.76.5 | ::test_unpaired_transfer_leaves_processing_nonzero |
| AC15.6.6 | AC-ledger.76.6 | ::test_non_transfer_transaction_proceeds_to_normal_matching |
| AC15.6.7 | AC-ledger.76.7 | reconciliation/test_transfer_idempotency.py::test_transfer_out_duplicate_detection_skipped |

## How (migration-standard 6–8)

- **roadmap**: 23 `ACRecord`s added; the structural `invariants` kept as-is.
- **EPIC-015**: the `AC15.1`–`AC15.6` definition tables deleted, replaced with a disclaimer that lists every new `AC-ledger.7x.y` id (registry↔EPIC link kept via prose; no table row, so `check_epic_package_dual` stays green).
- **test refs**: every `AC15.<1-6>.y` test docstring repointed to its new id so `check_registry_to_tests` (check5) resolves them.
- **id form**: numeric `AC-ledger.<n>.<n>` — the grammar the live traceability regex (`common/ssot/ac_traceability_refs.py`) accepts. The aspirational `AC-ledger.<entity>.<seq>` form some docs advertise fails that regex; flagged in `ledger/todo.md` as a follow-up doc-drift for the EPIC-002 author.

## Decision A — standard only rises

Standard-preserving move: every AC15 reappears with the same proof/priority/status. **No AC, proof, or floor entry dropped.** The EPIC-015 **frontend** UI-gap ACs (`AC15.7.*`) stay in EPIC-015 — `ledger` is backend-only (`fe=None`) and the BE roadmap gate (`_resolve_test`) cannot resolve their TypeScript tests; this mirrors EPIC-001 keeping its frontend rows (`AC1.10.3/.4`) when the `identity` backend ACs migrated.

## DEFER

EPIC-002's 93 ACs → slices 3c-ii/iii (reserved groups 1–70).

## Gates (local, all green)

`check_package_contract` (ledger: 23 roadmap ACs OK) · `generate_ac_registry --check` · `check_epic_package_dual` · `lint_doc_consistency` · `check_ac_proof_kind` · `check_tier_ast_literal` · `check_ac_tier_baseline` (shrink-only: 31 newly tagged, debt 1645→1622) · `check_ac_index` (no floor regression) · `check_e2e_epic_traceability` · `check_draft_packages` · `check_tier_imports` · `ruff check` + `ruff format --check`. `pytest --collect-only` 0 errors; 43 processing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)