### PR TITLE
[finance_report_infra_rollback] fix(release): restore prod auto-rollback — clear PYTHONPATH so deploy_v2 resolves repo/tools

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -258,6 +258,10 @@ jobs:
           DEPLOY_PRIMARY_MODEL_OVERRIDE: ${{ env.STAGING_E2E_PRIMARY_MODEL }}
           DEPLOY_OCR_MODEL_OVERRIDE: ${{ env.STAGING_E2E_OCR_MODEL }}
           DEPLOY_VISION_MODEL_OVERRIDE: ${{ env.STAGING_E2E_VISION_MODEL }}
+          # Empty PYTHONPATH so `python -m tools.deploy_v2` resolves repo/tools (infra2)
+          # rather than the app's tools/ package, which a later E2E step's
+          # PYTHONPATH=<repo root> export would otherwise shadow (see release.yml).
+          PYTHONPATH: ""
         run: |
           set -euo pipefail
           # Staging deploys the release tag through the infra2 deploy_v2 front door

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,6 +365,12 @@ jobs:
         working-directory: repo
         env:
           DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          # `python -m tools.deploy_v2` MUST resolve to repo/tools (infra2), not the
+          # app's own tools/ package. The E2E setup step exports PYTHONPATH=<repo root>
+          # into GITHUB_ENV, and finance_report/tools/__init__.py makes `tools` a
+          # regular package that shadows repo/tools when that root is on the path —
+          # so an empty PYTHONPATH keeps deploy_v2 importable regardless of step order.
+          PYTHONPATH: ""
         run: |
           set -euo pipefail
           version_ref="${{ steps.release.outputs.version_ref }}"
@@ -422,6 +428,12 @@ jobs:
         working-directory: repo
         env:
           DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          # Empty PYTHONPATH so `python -m tools.deploy_v2` resolves repo/tools, not
+          # the app's tools/ package. This step runs AFTER the E2E setup exported
+          # PYTHONPATH=<repo root> into GITHUB_ENV, which previously shadowed
+          # repo/tools and crashed the rollback with "No module named tools.deploy_v2"
+          # — leaving production un-rolled-back on a failed deploy (the safety net).
+          PYTHONPATH: ""
         run: |
           set -euo pipefail
           rollback_ref="${{ steps.production_before.outputs.rollback_ref }}"


### PR DESCRIPTION
## Incident

During today's **v0.1.26 production release**, a post-deploy read-only smoke flaked (a cold-start client-side redirect timing on a non-existent `/dashboard` route) and triggered the **auto-rollback** — which then **failed**:

```
Rolling back production via deploy_v2 to v0.1.25 with iac_ref=v1.1.14
/home/runner/.../.venv/bin/python: No module named tools.deploy_v2
```

So the safety net silently broke: production was **left on the smoke-failing release** instead of rolling back. (Prod turned out functionally healthy and a re-run went green, but the rollback path must work.)

## Root cause (proven locally)

The `Setup E2E Tests` step exports `PYTHONPATH=<repo root>` into `GITHUB_ENV` for all later steps. The app ships `finance_report/tools/__init__.py`, making `tools` a **regular package** that **shadows** the infra2 submodule's `repo/tools` once the repo root is on `PYTHONPATH`:

- `Deploy with deploy_v2` runs **before** the E2E setup → resolves `repo/tools/deploy_v2.py` from `working-directory: repo` → works.
- `Roll back …` runs **after** it → inherits the polluted `PYTHONPATH` → `python -m tools.deploy_v2` finds the app's `tools/` (no `deploy_v2`) → crash.

Reproduced deterministically:
```
cd repo && PYTHONPATH=<root>  python -m tools.deploy_v2 --help  →  No module named tools.deploy_v2
cd repo && PYTHONPATH=        python -m tools.deploy_v2 --help  →  usage: deploy_v2.py ...
```

## Fix

Set `PYTHONPATH: ""` on **every** `deploy_v2` invocation so the infra2 module always resolves from `working-directory: repo`, independent of step ordering:
- `release.yml`: `Deploy with deploy_v2` + `Roll back production after post-deploy failure`
- `deploy.yml`: staging `deploy_v2` (defensive — same latent fragility)

## Verification
- Local reproduction above proves the fix (module resolves with empty `PYTHONPATH`).
- YAML valid; `tools/check_workflow_contract.py` → OK; doc-consistency → OK.

Note: the smoke flakiness itself (cold-start redirect within a 15s window) is a separate, lower-severity follow-up; this PR fixes the broken **rollback safety net**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)