### PR TITLE
[finance_report_audit] migrate EPIC-002 AC2.13-2.23 → AC-ledger.* (final AC batch) — slice 3c-iii of #1420

### DIFF
--- a/apps/backend/src/schemas/account.py
+++ b/apps/backend/src/schemas/account.py
@@ -35,7 +35,7 @@ class OpeningBalanceRequest(BaseModel):
 
 
 class OpeningBalanceReadinessResponse(BaseModel):
-    """Whether the user should be nudged to record opening balances (#949 / AC2.16.1).
+    """Whether the user should be nudged to record opening balances (#949 / AC-ledger.16.1).
 
     ``needs_opening_balance`` is true when the user has posted activity but no
     opening-balance entry on or before the earliest such activity, so a cumulative

--- a/apps/backend/src/services/accounting.py
+++ b/apps/backend/src/services/accounting.py
@@ -146,7 +146,7 @@ async def post_opening_balance_entry(
 
 
 async def get_opening_balance_readiness(db: AsyncSession, user_id: UUID) -> dict:
-    """Detect whether a user's balance sheet may be silently incomplete (#949 / AC2.16.1).
+    """Detect whether a user's balance sheet may be silently incomplete (#949 / AC-ledger.16.1).
 
     The everyday-user persona who already owns assets/liabilities on day one will,
     without recording opening balances, get a balance sheet that looks right but

--- a/apps/backend/tests/api/test_users_router.py
+++ b/apps/backend/tests/api/test_users_router.py
@@ -56,7 +56,7 @@ async def test_delete_user_with_immutable_entries_returns_409(
     client: AsyncClient,
     test_user: User,
 ) -> None:
-    """AC2.14.6: when the cascade is blocked by the ledger immutability invariant
+    """AC-ledger.14.6: when the cascade is blocked by the ledger immutability invariant
     (posted/reconciled entries), account deletion returns a clean 409, not a leaked 500.
 
     The invariant is a DB trigger present only on the migrated database, not the

--- a/apps/backend/tests/ledger/test_accounting_integration.py
+++ b/apps/backend/tests/ledger/test_accounting_integration.py
@@ -194,7 +194,7 @@ async def test_AC2_13_1_create_journal_entry_rejects_cross_user_account(
     salary_account,
     test_user_id,
 ):
-    """AC2.13.1: Manual journal creation rejects lines using another user's account."""
+    """AC-ledger.13.1: Manual journal creation rejects lines using another user's account."""
     other_user_id = (await UserFactory.create_async(db)).id
     other_account = Account(
         user_id=other_user_id,
@@ -223,7 +223,7 @@ async def test_AC2_13_1_line_account_ownership_accepts_empty_line_set(
     db: AsyncSession,
     test_user_id,
 ):
-    """AC2.13.1: Empty line account sets short-circuit without a database lookup."""
+    """AC-ledger.13.1: Empty line account sets short-circuit without a database lookup."""
     accounts = await validate_line_account_ownership(db, test_user_id, set())
 
     assert accounts == {}
@@ -233,7 +233,7 @@ async def test_AC2_13_1_line_account_ownership_rejects_missing_account(
     db: AsyncSession,
     test_user_id,
 ):
-    """AC2.13.1: Journal lines cannot reference nonexistent accounts."""
+    """AC-ledger.13.1: Journal lines cannot reference nonexistent accounts."""
     missing_account_id = uuid4()
 
     with pytest.raises(ValidationError, match=f"Account {missing_account_id} not found"):
@@ -246,7 +246,7 @@ async def test_AC2_13_2_journal_lines_reject_cross_user_account_at_db_boundary(
     salary_account,
     test_user_id,
 ):
-    """AC2.13.2: Database invariants reject line accounts outside the entry owner."""
+    """AC-ledger.13.2: Database invariants reject line accounts outside the entry owner."""
     other_user_id = (await UserFactory.create_async(db)).id
     other_account = Account(
         user_id=other_user_id,
@@ -293,7 +293,7 @@ async def test_AC2_13_2_journal_lines_reject_cross_user_account_at_db_boundary(
 async def test_AC2_13_2_posting_invariants_reject_line_with_missing_account_relationship(
     test_user_id,
 ):
-    """AC2.13.2: Posting invariants require every line to resolve to an account."""
+    """AC-ledger.13.2: Posting invariants require every line to resolve to an account."""
     missing_account_id = uuid4()
     entry = JournalEntry(
         user_id=test_user_id,
@@ -329,7 +329,7 @@ async def test_AC2_13_3_balance_queries_ignore_cross_user_entry_headers(
     salary_account,
     test_user_id,
 ):
-    """AC2.13.3: Balance aggregation requires account and entry ownership to match."""
+    """AC-ledger.13.3: Balance aggregation requires account and entry ownership to match."""
     other_user_id = (await UserFactory.create_async(db)).id
     other_account = Account(
         user_id=other_user_id,

--- a/apps/backend/tests/ledger/test_ledger_schema_invariants.py
+++ b/apps/backend/tests/ledger/test_ledger_schema_invariants.py
@@ -58,7 +58,7 @@ async def _valid_posted_entry(
 
 
 async def test_AC2_14_1_posted_entry_requires_two_lines_at_database_boundary(db: AsyncSession, test_user):
-    """AC2.14.1: Posted/reconciled entries need at least two lines at the database boundary."""
+    """AC-ledger.14.1: Posted/reconciled entries need at least two lines at the database boundary."""
     cash = await _account(db, test_user.id, "cash", AccountType.ASSET)
     entry = JournalEntry(
         user_id=test_user.id,
@@ -84,7 +84,7 @@ async def test_AC2_14_1_posted_entry_requires_two_lines_at_database_boundary(db:
 
 
 async def test_AC2_14_2_posted_entry_must_balance_in_base_currency(db: AsyncSession, test_user):
-    """AC2.14.2: Posted/reconciled entries balance debit and credit totals in base currency."""
+    """AC-ledger.14.2: Posted/reconciled entries balance debit and credit totals in base currency."""
     cash = await _account(db, test_user.id, "cash", AccountType.ASSET)
     income = await _account(db, test_user.id, "income", AccountType.INCOME)
     entry = JournalEntry(
@@ -120,7 +120,7 @@ async def test_AC2_14_2_posted_entry_must_balance_in_base_currency(db: AsyncSess
 
 
 async def test_AC2_14_3_non_base_posted_lines_require_positive_fx_rate(db: AsyncSession, test_user):
-    """AC2.14.3: Non-base posted/reconciled lines require positive FX rates."""
+    """AC-ledger.14.3: Non-base posted/reconciled lines require positive FX rates."""
     cash = await _account(db, test_user.id, "hkd cash", AccountType.ASSET)
     income = await _account(db, test_user.id, "sgd income", AccountType.INCOME)
     entry = JournalEntry(
@@ -157,7 +157,7 @@ async def test_AC2_14_3_non_base_posted_lines_require_positive_fx_rate(db: Async
 
 
 async def test_AC2_14_4_posted_entries_and_lines_are_immutable_but_drafts_are_editable(db: AsyncSession, test_user):
-    """AC2.14.4: Posted/reconciled ledger facts block direct mutation; drafts remain editable."""
+    """AC-ledger.14.4: Posted/reconciled ledger facts block direct mutation; drafts remain editable."""
     user_id = test_user.id
     entry, debit, _credit = await _valid_posted_entry(db, user_id)
     entry_id = entry.id
@@ -242,7 +242,7 @@ async def test_AC2_14_4_posted_entries_and_lines_are_immutable_but_drafts_are_ed
 
 
 async def test_AC2_14_5_void_transition_requires_reversal_relationship(db: AsyncSession, test_user):
-    """AC2.14.5: Voiding preserves a non-null immutable reversal relationship."""
+    """AC-ledger.14.5: Voiding preserves a non-null immutable reversal relationship."""
     user_id = test_user.id
     entry, _debit, _credit = await _valid_posted_entry(db, user_id, memo="original")
     entry_id = entry.id

--- a/apps/backend/tests/ledger/test_opening_balance.py
+++ b/apps/backend/tests/ledger/test_opening_balance.py
@@ -21,7 +21,7 @@ async def _account(client: AsyncClient, name: str, account_type: str) -> str:
 async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet(
     client: AsyncClient, ac_evidence
 ) -> None:
-    """AC2.15.1: a guided opening-balance request posts a balanced entry and the
+    """AC-ledger.15.1: a guided opening-balance request posts a balanced entry and the
     as-of balance sheet reflects the starting position with the equation intact."""
     bank = await _account(client, "Bank", "ASSET")
     mortgage = await _account(client, "Mortgage", "LIABILITY")
@@ -48,7 +48,7 @@ async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sh
     # Behavioral evidence: 10000 asset offset by 5000 liability nets 5000 into equity,
     # the entry balances at 10000.00, and the equation delta is exactly 0.00.
     ac_evidence(
-        ac_id="AC2.15.1",
+        ac_id="AC-ledger.15.1",
         score=1.0,
         metric="opening_balance_golden_totals_match",
         comment="balanced 10000.00; total_assets 10000.00, total_equity 5000.00, equation_delta 0.00",
@@ -57,7 +57,7 @@ async def test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sh
 
 
 async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client: AsyncClient, ac_evidence) -> None:
-    """AC2.15.2: a single asset opening balance is offset entirely into Opening
+    """AC-ledger.15.2: a single asset opening balance is offset entirely into Opening
     Balance Equity, keeping the entry balanced."""
     savings = await _account(client, "Savings", "ASSET")
     resp = await client.post(
@@ -74,7 +74,7 @@ async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client:
     # Behavioral evidence: a single 8000 asset is offset entirely into equity, so
     # total_assets == total_equity == 8000.00 with the equation kept intact.
     ac_evidence(
-        ac_id="AC2.15.2",
+        ac_id="AC-ledger.15.2",
         score=1.0,
         metric="single_asset_opening_offsets_into_equity",
         comment="total_assets 8000.00 == total_equity 8000.00 (single asset offset to equity)",
@@ -83,7 +83,7 @@ async def test_AC2_15_2_single_asset_opening_balance_offsets_into_equity(client:
 
 
 async def test_AC2_15_3_unknown_account_is_rejected(client: AsyncClient) -> None:
-    """AC2.15.3: an opening balance for a non-owned/unknown account is rejected."""
+    """AC-ledger.15.3: an opening balance for a non-owned/unknown account is rejected."""
     resp = await client.post(
         "/accounts/opening-balances",
         json={"entry_date": "2026-01-01", "balances": {str(uuid4()): "100.00"}},
@@ -92,7 +92,7 @@ async def test_AC2_15_3_unknown_account_is_rejected(client: AsyncClient) -> None
 
 
 async def test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists(client: AsyncClient) -> None:
-    """AC2.15.4: an opening balance establishes a starting position, not a delta,
+    """AC-ledger.15.4: an opening balance establishes a starting position, not a delta,
     so it is rejected when an affected account already has posted activity before
     the opening date."""
     bank = await _account(client, "Bank", "ASSET")
@@ -110,7 +110,7 @@ async def test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists(clie
 
 
 async def test_AC2_15_5_non_base_currency_is_rejected(client: AsyncClient) -> None:
-    """AC2.15.5: opening balances are accepted only in the base currency (MVP),
+    """AC-ledger.15.5: opening balances are accepted only in the base currency (MVP),
     with a clear error rather than a confusing FX-rate failure."""
     bank = await _account(client, "Bank", "ASSET")
     resp = await client.post(
@@ -121,7 +121,7 @@ async def test_AC2_15_5_non_base_currency_is_rejected(client: AsyncClient) -> No
 
 
 async def test_AC2_15_6_account_currency_mismatch_is_rejected(client: AsyncClient) -> None:
-    """AC2.15.6: an opening balance into an account whose currency differs from the
+    """AC-ledger.15.6: an opening balance into an account whose currency differs from the
     request (base) currency is rejected, so journal lines cannot be mis-stamped."""
     resp_acc = await client.post("/accounts", json={"name": "USD Bank", "type": "ASSET", "currency": "USD"})
     assert resp_acc.status_code == 201, resp_acc.text
@@ -135,7 +135,7 @@ async def test_AC2_15_6_account_currency_mismatch_is_rejected(client: AsyncClien
 
 
 async def test_AC2_15_7_system_account_target_is_rejected(client: AsyncClient, db, test_user) -> None:
-    """AC2.15.7: opening balances may only target user-managed accounts; a system
+    """AC-ledger.15.7: opening balances may only target user-managed accounts; a system
     account (e.g. Processing) cannot be set via this endpoint."""
     from src.models.account import Account, AccountType
 

--- a/apps/backend/tests/ledger/test_opening_balance_readiness.py
+++ b/apps/backend/tests/ledger/test_opening_balance_readiness.py
@@ -24,7 +24,7 @@ async def _asset(db: AsyncSession, user_id, name: str = "Bank") -> Account:
 
 
 async def test_AC2_16_1_no_activity_does_not_need_opening_balance(db: AsyncSession, test_user) -> None:
-    """AC2.16.1: a user with no posted activity is not nudged — there is nothing
+    """AC-ledger.16.1: a user with no posted activity is not nudged — there is nothing
     to be incomplete about yet."""
     readiness = await get_opening_balance_readiness(db, test_user.id)
     assert readiness["needs_opening_balance"] is False
@@ -33,7 +33,7 @@ async def test_AC2_16_1_no_activity_does_not_need_opening_balance(db: AsyncSessi
 
 
 async def test_AC2_16_1_activity_without_opening_entry_needs_opening_balance(db: AsyncSession, test_user) -> None:
-    """AC2.16.1: posted activity with no opening-balance entry flags the gap."""
+    """AC-ledger.16.1: posted activity with no opening-balance entry flags the gap."""
     await create_valid_posted_entry(db, test_user.id, entry_date=date(2026, 3, 1))
 
     readiness = await get_opening_balance_readiness(db, test_user.id)
@@ -44,7 +44,7 @@ async def test_AC2_16_1_activity_without_opening_entry_needs_opening_balance(db:
 
 
 async def test_AC2_16_1_opening_entry_before_activity_clears_the_nudge(db: AsyncSession, test_user) -> None:
-    """AC2.16.1: an opening-balance entry on/before the earliest activity clears it."""
+    """AC-ledger.16.1: an opening-balance entry on/before the earliest activity clears it."""
     asset = await _asset(db, test_user.id)
     await create_valid_posted_entry(db, test_user.id, entry_date=date(2026, 3, 1))
     await post_opening_balance_entry(
@@ -63,7 +63,7 @@ async def test_AC2_16_1_opening_entry_before_activity_clears_the_nudge(db: Async
 
 
 async def test_AC2_16_1_opening_entry_after_activity_still_needs(db: AsyncSession, test_user) -> None:
-    """AC2.16.1: an opening entry dated *after* the earliest activity leaves the
+    """AC-ledger.16.1: an opening entry dated *after* the earliest activity leaves the
     early period uncovered, so the nudge stays on."""
     asset = await _asset(db, test_user.id)
     await create_valid_posted_entry(db, test_user.id, entry_date=date(2026, 1, 1))
@@ -83,7 +83,7 @@ async def test_AC2_16_1_opening_entry_after_activity_still_needs(db: AsyncSessio
 
 
 async def test_AC2_16_2_readiness_endpoint_returns_status(client: AsyncClient) -> None:
-    """AC2.16.2: the endpoint exposes the readiness signal to the UI."""
+    """AC-ledger.16.2: the endpoint exposes the readiness signal to the UI."""
     resp = await client.get("/accounts/opening-balance-readiness")
     assert resp.status_code == 200, resp.text
     body = resp.json()

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -6205,7 +6205,7 @@
         "type": "object"
       },
       "OpeningBalanceReadinessResponse": {
-        "description": "Whether the user should be nudged to record opening balances (#949 / AC2.16.1).\n\n``needs_opening_balance`` is true when the user has posted activity but no\nopening-balance entry on or before the earliest such activity, so a cumulative\nbalance sheet would silently omit the starting position.",
+        "description": "Whether the user should be nudged to record opening balances (#949 / AC-ledger.16.1).\n\n``needs_opening_balance`` is true when the user has posted activity but no\nopening-balance entry on or before the earliest such activity, so a cumulative\nbalance sheet would silently omit the starting position.",
         "properties": {
           "earliest_activity_date": {
             "anyOf": [

--- a/apps/frontend/src/lib/api-types.ts
+++ b/apps/frontend/src/lib/api-types.ts
@@ -5180,7 +5180,7 @@ export interface components {
         };
         /**
          * OpeningBalanceReadinessResponse
-         * @description Whether the user should be nudged to record opening balances (#949 / AC2.16.1).
+         * @description Whether the user should be nudged to record opening balances (#949 / AC-ledger.16.1).
          *
          *     ``needs_opening_balance`` is true when the user has posted activity but no
          *     opening-balance entry on or before the earliest such activity, so a cumulative

--- a/common/ledger/contract.py
+++ b/common/ledger/contract.py
@@ -22,26 +22,42 @@ event (Decision B — one transaction per domain).
 
 The package's ACs migrate into ``roadmap`` across the slice-3c sub-slices of the
 cutover (#1420). **Slice 3c-i homed the EPIC-015 processing-account ACs** as
-``AC-ledger.71.* … AC-ledger.76.*``. **Slice 3c-ii (this change) homes the first
-half of the EPIC-002 double-entry core** — groups ``AC2.1``…``AC2.12`` → groups
+``AC-ledger.71.* … AC-ledger.76.*``. **Slice 3c-ii homed the first half of the
+EPIC-002 double-entry core** — groups ``AC2.1``…``AC2.12`` → groups
 ``AC-ledger.1.*``…``AC-ledger.12.*`` (the leading "2" is dropped; seq preserved).
-In each case the package now owns the ACs; the source EPIC backend tables are
-deleted and replaced with a disclaimer that lists the new ids (mirroring how
-identity emptied EPIC-001). The remaining EPIC-002 groups ``AC2.13``…``AC2.23``
-land in slice 3c-iii under groups ``AC-ledger.13.*``…``AC-ledger.23.*``.
+**Slice 3c-iii (this change, the final AC batch) homes the genuine double-entry
+ACs of the second half** — ``AC2.13``…``AC2.16`` → groups
+``AC-ledger.13.*``…``AC-ledger.16.*`` (same drop-the-"2", seq-preserved rule). It
+deliberately does **not** drag the non-double-entry rows of that range into the
+ledger roadmap (the #1517 mis-file lesson — validate each AC, never blanket
+rename): the frontend UI ACs ``AC2.15.8``/``AC2.16.3``/``AC2.17.1`` stay in
+EPIC-002 (ledger is ``fe=None``), the reporting tier-degrade ``AC2.16.4`` is a
+report-layer property not a posting one, the framework-boundary contract
+``AC2.18.1`` is a cross-EPIC doc-assertion test (not double-entry behaviour), and
+the entire Money value-type extension ``AC2.19.*``–``AC2.23.*`` belongs to the
+``money`` kernel, not ledger. Those rows remain defined in EPIC-002.
+In each case the package now owns the migrated ACs; the source EPIC backend
+tables are deleted and replaced with a disclaimer that lists the new ids
+(mirroring how identity emptied EPIC-001).
 
 **Group-number reservation (ledger-local).** The first dotted segment of an
 ``AC-ledger.<group>.<seq>`` id is a bare uniqueness key (no gate reads semantics
 from it), so the package reserves disjoint blocks to keep the namespace
 collision-free as later slices add ACs without re-reading this file:
 
-- **groups 1–12** — the EPIC-002 double-entry core, first half, this slice
+- **groups 1–12** — the EPIC-002 double-entry core, first half (slice 3c-ii)
   (1=account-mgmt, 2=entry-creation, 3=posting/voiding, 4=balance, 5=equation,
   6=boundary, 7=router/errors, 8=decimal-safety, 9=data-model, 10=endpoints,
   11=must-have-traceability, 12=multi-currency), each mirroring its source
   ``AC2.<g>`` group;
-- **groups 13–70** — the rest of the EPIC-002/012 double-entry core (slice
-  3c-iii, not yet homed);
+- **groups 13–16** — the genuine double-entry ACs of the EPIC-002 second half
+  (slice 3c-iii, this change): 13=user-scoped ledger integrity,
+  14=database invariant floor, 15=guided opening balances,
+  16=opening-balance readiness, each mirroring its source ``AC2.<g>`` group (only
+  the backend double-entry rows; the frontend/reporting/framework/money rows of
+  ``AC2.15``–``AC2.23`` stay in EPIC-002 as noted above);
+- **groups 17–70** — reserved for any later EPIC-002/012 double-entry ACs (not
+  yet homed);
 - **groups 71–76** — the EPIC-015 processing (in-transit) account, slice 3c-i
   (71=creation, 72=transfer-entry, 73=integrity, 74=detection, 75=scoring,
   76=reconciliation integration), each mirroring its source ``AC15.<g>`` group.
@@ -54,9 +70,9 @@ identity — already uses.) The EPIC-015 **frontend** UI-gap ACs (``AC15.7.*``)
 stay in EPIC-015: ledger is a backend-only package (``fe=None``), exactly as the
 identity migration left EPIC-001's frontend rows in place. ``roadmap`` carries the
 homed backend ACs (the 23 EPIC-015 processing ACs + the 61 EPIC-002 first-half
-ACs of this slice); the structural invariants of the cutover stay in
-``invariants`` (no tier, not matrix-constrained). Decision A — standard-preserving
-move, no bar lowered.
+ACs + the 18 EPIC-002 second-half double-entry ACs of slice 3c-iii); the
+structural invariants of the cutover stay in ``invariants`` (no tier, not
+matrix-constrained). Decision A — standard-preserving move, no bar lowered.
 """
 
 from __future__ import annotations
@@ -985,6 +1001,271 @@ CONTRACT = PackageContract(
                 "::test_validate_balance_mismatch"
             ),
             priority="P0",
+            status="done",
+        ),
+        # ── EPIC-002 double-entry core (slice 3c-iii of #1420): groups 13–16 ──
+        # (the second half of EPIC-002; was AC2.13.* … AC2.16.*, leading "2"
+        # dropped, sequence preserved. The non-double-entry AC2.* rows — the
+        # frontend UI ACs AC2.15.8/2.16.3/2.17.1, the reporting tier-degrade
+        # AC2.16.4, the framework-boundary doc-contract AC2.18.1, and the whole
+        # Money-extension block AC2.19.*–AC2.23.* — are NOT double-entry and stay
+        # defined in EPIC-002.)
+        # ── group 13: User-scoped ledger integrity (was EPIC-002 AC2.13.*) ──
+        ACRecord(
+            id="AC-ledger.13.1",
+            statement=(
+                "Manual journal creation rejects lines using another user's "
+                "account. Was EPIC-002 AC2.13.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_accounting_integration.py"
+                "::test_AC2_13_1_create_journal_entry_rejects_cross_user_account"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.13.2",
+            statement=(
+                "Posting validates that every line account belongs to the entry "
+                "owner. Was EPIC-002 AC2.13.2."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_accounting_integration.py"
+                "::test_AC2_13_2_journal_lines_reject_cross_user_account_at_db_boundary"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.13.3",
+            statement=(
+                "Balance aggregation requires account and entry ownership to "
+                "match. Was EPIC-002 AC2.13.3."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_accounting_integration.py"
+                "::test_AC2_13_3_balance_queries_ignore_cross_user_entry_headers"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group 14: Database ledger invariant floor (was EPIC-002 AC2.14.*) ──
+        ACRecord(
+            id="AC-ledger.14.1",
+            statement=(
+                "PostgreSQL rejects posted/reconciled entries with fewer than two "
+                "lines even when service validation is bypassed. Was EPIC-002 "
+                "AC2.14.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_ledger_schema_invariants.py"
+                "::test_AC2_14_1_posted_entry_requires_two_lines_at_database_boundary"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.14.2",
+            statement=(
+                "PostgreSQL rejects posted/reconciled entries whose debits and "
+                "credits do not balance after base-currency conversion. Was "
+                "EPIC-002 AC2.14.2."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_ledger_schema_invariants.py"
+                "::test_AC2_14_2_posted_entry_must_balance_in_base_currency"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.14.3",
+            statement=(
+                "PostgreSQL rejects posted/reconciled non-base-currency lines "
+                "without a positive FX rate. Was EPIC-002 AC2.14.3."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_ledger_schema_invariants.py"
+                "::test_AC2_14_3_non_base_posted_lines_require_positive_fx_rate"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.14.4",
+            statement=(
+                "PostgreSQL blocks direct update/delete of posted/reconciled "
+                "entries and lines while draft entries remain editable. Was "
+                "EPIC-002 AC2.14.4."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_ledger_schema_invariants.py"
+                "::test_AC2_14_4_posted_entries_and_lines_are_immutable_but_drafts_are_editable"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.14.5",
+            statement=(
+                "Voiding a posted entry preserves a non-null immutable reversal "
+                "relationship instead of deleting or editing posted lines. Was "
+                "EPIC-002 AC2.14.5."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_ledger_schema_invariants.py"
+                "::test_AC2_14_5_void_transition_requires_reversal_relationship"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.14.6",
+            statement=(
+                "Account deletion blocked by the immutability invariant "
+                "(posted/reconciled entries) returns a clean HTTP 409, not a "
+                "leaked 500. Was EPIC-002 AC2.14.6."
+            ),
+            test=(
+                "apps/backend/tests/api/test_users_router.py"
+                "::test_delete_user_with_immutable_entries_returns_409"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group 15: Guided opening balances (was EPIC-002 AC2.15.*) ──
+        # (AC2.15.8 is the frontend OpeningBalanceModal test — fe=None, so it
+        # stays defined in EPIC-002, like the EPIC-015 AC15.7.* frontend block.)
+        ACRecord(
+            id="AC-ledger.15.1",
+            statement=(
+                "POST /api/accounts/opening-balances posts one balanced entry that "
+                "increases each account to its opening balance on its normal side "
+                "and offsets the net into a system Opening Balance Equity account; "
+                "the as-of balance sheet reflects the starting position with the "
+                "accounting equation intact. Was EPIC-002 AC2.15.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_opening_balance.py"
+                "::test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.15.2",
+            statement=(
+                "A single asset opening balance offsets entirely into Opening "
+                "Balance Equity, keeping the entry balanced. Was EPIC-002 AC2.15.2."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_opening_balance.py"
+                "::test_AC2_15_2_single_asset_opening_balance_offsets_into_equity"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.15.3",
+            statement=(
+                "An opening balance for a non-owned or unknown account is "
+                "rejected. Was EPIC-002 AC2.15.3."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_opening_balance.py"
+                "::test_AC2_15_3_unknown_account_is_rejected"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.15.4",
+            statement=(
+                "An opening balance establishes a starting position, not a delta: "
+                "it is rejected when an affected account already has posted "
+                "activity before the opening date. Was EPIC-002 AC2.15.4."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_opening_balance.py"
+                "::test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.15.5",
+            statement=(
+                "Opening balances are accepted only in the base currency, with a "
+                "clear error rather than a confusing FX-rate failure. Was EPIC-002 "
+                "AC2.15.5."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_opening_balance.py"
+                "::test_AC2_15_5_non_base_currency_is_rejected"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.15.6",
+            statement=(
+                "An opening balance into an account whose currency differs from "
+                "the request currency is rejected, so journal lines cannot be "
+                "mis-stamped. Was EPIC-002 AC2.15.6."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_opening_balance.py"
+                "::test_AC2_15_6_account_currency_mismatch_is_rejected"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.15.7",
+            statement=(
+                "Opening balances may only target user-managed accounts; a system "
+                "account (e.g. Processing) cannot be set via this endpoint even "
+                "though the entry is SYSTEM-typed. Was EPIC-002 AC2.15.7."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_opening_balance.py"
+                "::test_AC2_15_7_system_account_target_is_rejected"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group 16: Opening-balance readiness nudge (was EPIC-002 AC2.16.*) ──
+        # (Only the backend ledger-activity detection ACs migrate. AC2.16.3 is the
+        # frontend nudge test — fe=None — and AC2.16.4 is a reporting-layer
+        # tier-degrade test, not double-entry posting; both stay in EPIC-002.)
+        ACRecord(
+            id="AC-ledger.16.1",
+            statement=(
+                "get_opening_balance_readiness reports needs_opening_balance=True "
+                "only when the user has posted activity and no opening-balance "
+                "entry on or before its earliest date (no activity, an opening "
+                "entry before activity, or a mis-dated opening entry after "
+                "activity are all distinguished). Was EPIC-002 AC2.16.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_opening_balance_readiness.py"
+                "::test_AC2_16_1_activity_without_opening_entry_needs_opening_balance"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.16.2",
+            statement=(
+                "GET /api/accounts/opening-balance-readiness exposes the readiness "
+                "signal to the UI. Was EPIC-002 AC2.16.2."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_opening_balance_readiness.py"
+                "::test_AC2_16_2_readiness_endpoint_returns_status"
+            ),
+            priority="P1",
             status="done",
         ),
         # ── group 71: Processing account creation (was EPIC-015 AC15.1.*) ──

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -90,21 +90,25 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 
 ## 🧪 Test Cases
 
-> **The EPIC-002 double-entry backend ACs in groups AC2.1–AC2.12 are no longer
-> defined here.** They migrated into the `ledger` package (#1420 slice 3c-ii) and
-> are owned by, and sourced directly from,
+> **The EPIC-002 double-entry backend ACs in groups AC2.1–AC2.12 and the genuine
+> double-entry rows of AC2.13–AC2.16 are no longer defined here.** They migrated
+> into the `ledger` package (#1420 slices 3c-ii and 3c-iii) and are owned by, and
+> sourced directly from,
 > [`common/ledger/contract.py`](../../common/ledger/contract.py)'s `roadmap` under
 > the package-scoped numeric `AC-ledger.<group>.<seq>` id scheme (the leading "2"
 > is dropped and the sequence preserved, so `AC2.<g>.<s>` becomes
-> `AC-ledger.<g>.<s>`; groups 1–12 are this slice, 71–76 are the EPIC-015
-> processing block from slice 3c-i).
+> `AC-ledger.<g>.<s>`; groups 1–12 are slice 3c-ii, 13–16 are slice 3c-iii, and
+> 71–76 are the EPIC-015 processing block from slice 3c-i).
 > `common/ssot/generate_ac_registry.py` reads package-contract roadmaps additively,
 > so the AC index counts them without an EPIC-table mirror. This note references
 > the new ids (keeping the registry↔EPIC link intact) but defines none of them —
-> the contract is the single definition source. The remaining double-entry groups
-> AC2.13–AC2.23 (user-scoped integrity, DB invariant floor, opening balances,
-> framework boundary, and the Money value-type extension) **remain defined below**;
-> the AC2.13–AC2.23 backend core lands in slice 3c-iii.
+> the contract is the single definition source. The **non-double-entry** rows of
+> the AC2.13–AC2.23 range stay defined below, because they are not ledger ACs: the
+> frontend UI ACs `AC2.15.8` / `AC2.16.3` / `AC2.17.1` (the ledger package is
+> `fe=None`), the reporting-layer tier-degrade `AC2.16.4`, the cross-EPIC
+> framework-boundary doc-contract `AC2.18.1`, and the whole Money value-type
+> extension `AC2.19.*`–`AC2.23.*` (owned by the `money` kernel). Slice 3c-iii is
+> the final AC batch of the #1420 cutover.
 >
 > **Account management** (was AC2.1.*):
 > `AC-ledger.1.1` · `AC-ledger.1.2` · `AC-ledger.1.3` · `AC-ledger.1.4` · `AC-ledger.1.5` · `AC-ledger.1.6`
@@ -141,6 +145,18 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 >
 > **Multi-currency ledger integrity** (was AC2.12.*):
 > `AC-ledger.12.1` · `AC-ledger.12.2` · `AC-ledger.12.6`
+>
+> **User-scoped ledger integrity** (was AC2.13.*):
+> `AC-ledger.13.1` · `AC-ledger.13.2` · `AC-ledger.13.3`
+>
+> **Database ledger invariant floor** (was AC2.14.*):
+> `AC-ledger.14.1` · `AC-ledger.14.2` · `AC-ledger.14.3` · `AC-ledger.14.4` · `AC-ledger.14.5` · `AC-ledger.14.6`
+>
+> **Guided opening balances — backend** (was the AC2.15.* backend rows; the frontend `AC2.15.8` stays in EPIC-002):
+> `AC-ledger.15.1` · `AC-ledger.15.2` · `AC-ledger.15.3` · `AC-ledger.15.4` · `AC-ledger.15.5` · `AC-ledger.15.6` · `AC-ledger.15.7`
+>
+> **Opening-balance readiness — backend** (was the AC2.16.* backend detection rows; the frontend `AC2.16.3` and reporting `AC2.16.4` stay in EPIC-002):
+> `AC-ledger.16.1` · `AC-ledger.16.2`
 
 ### AC2.17: Account Management UI Responsiveness
 
@@ -169,51 +185,40 @@ pending a proper re-home to a storage/observability package.
 |----|-----------|---------------|------|----------|
 | AC2.12.5 | Stream redactor accumulates small chunks in buffer | `test_stream_redactor_small_chunks` | `infra/test_infra_edge_cases.py` | P1 |
 
-### AC2.13: User-Scoped Ledger Integrity
+> **AC2.13 (User-Scoped Ledger Integrity) and AC2.14 (Database Ledger Invariant
+> Floor)** were genuine double-entry groups and migrated wholesale into the
+> `ledger` package as `AC-ledger.13.*` and `AC-ledger.14.*` (#1420 slice 3c-iii);
+> see the disclaimer above. No EPIC-002 row remains for them.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC2.13.1 | Manual journal creation rejects lines using another user's account | `test_AC2_13_1_create_journal_entry_rejects_cross_user_account()` | `accounting/test_accounting_integration.py` | P0 |
-| AC2.13.2 | Posting validates that every line account belongs to the entry owner | `test_AC2_13_2_post_journal_entry_rejects_cross_user_account()` | `accounting/test_accounting_integration.py` | P0 |
-| AC2.13.3 | Balance aggregation requires account and entry ownership to match | `test_AC2_13_3_balance_queries_ignore_cross_user_entry_headers()` | `accounting/test_accounting_integration.py` | P0 |
-
-### AC2.14: Database Ledger Invariant Floor
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC2.14.1 | PostgreSQL rejects posted/reconciled entries with fewer than two lines even when service validation is bypassed | `test_AC2_14_1_posted_entry_requires_two_lines_at_database_boundary()` | `accounting/test_ledger_schema_invariants.py` | P0 |
-| AC2.14.2 | PostgreSQL rejects posted/reconciled entries whose debits and credits do not balance after base-currency conversion | `test_AC2_14_2_posted_entry_must_balance_in_base_currency()` | `accounting/test_ledger_schema_invariants.py` | P0 |
-| AC2.14.3 | PostgreSQL rejects posted/reconciled non-base-currency lines without a positive FX rate | `test_AC2_14_3_non_base_posted_lines_require_positive_fx_rate()` | `accounting/test_ledger_schema_invariants.py` | P0 |
-| AC2.14.4 | PostgreSQL blocks direct update/delete of posted/reconciled entries and lines while draft entries remain editable | `test_AC2_14_4_posted_entries_and_lines_are_immutable_but_drafts_are_editable()` | `accounting/test_ledger_schema_invariants.py` | P0 |
-| AC2.14.5 | Voiding a posted entry preserves a non-null immutable reversal relationship instead of deleting or editing posted lines | `test_AC2_14_5_void_transition_requires_reversal_relationship()` | `accounting/test_ledger_schema_invariants.py` | P0 |
-| AC2.14.6 | Account deletion blocked by the immutability invariant (posted/reconciled entries) returns a clean HTTP 409, not a leaked 500 | `test_delete_user_with_immutable_entries_returns_409()` | `apps/backend/tests/api/test_users_router.py` | P1 |
-
-### AC2.15: Guided Opening Balances ([#949](https://github.com/wangzitian0/finance_report/issues/949))
+### AC2.15: Guided Opening Balances ([#949](https://github.com/wangzitian0/finance_report/issues/949)) — frontend AC only
 
 A user with pre-existing assets/liabilities can establish year-start balances via one guided request, so a cross-year balance sheet is complete from the start instead of silently omitting the opening position.
 
+> The backend opening-balance ACs in the `AC2.15.*` range (which post and validate
+> the balanced double-entry) migrated into the `ledger` package as
+> `AC-ledger.15.*` (#1420 slice 3c-iii). Only the **frontend** guided-flow AC
+> `AC2.15.8` stays here, because the ledger package is `fe=None` (the same rule
+> that kept EPIC-015's `AC15.7.*` frontend rows in their EPIC).
+
 | AC ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC2.15.1 | `POST /api/accounts/opening-balances` posts one balanced entry that increases each account to its opening balance on its normal side and offsets the net into a system Opening Balance Equity account; the as-of balance sheet reflects the starting position with the accounting equation intact | `test_AC2_15_1_opening_balances_post_balanced_and_reflect_in_balance_sheet` | `accounting/test_opening_balance.py` | P0 |
-| AC2.15.2 | A single asset opening balance offsets entirely into Opening Balance Equity, keeping the entry balanced | `test_AC2_15_2_single_asset_opening_balance_offsets_into_equity` | `accounting/test_opening_balance.py` | P0 |
-| AC2.15.3 | An opening balance for a non-owned or unknown account is rejected | `test_AC2_15_3_unknown_account_is_rejected` | `accounting/test_opening_balance.py` | P0 |
-| AC2.15.4 | An opening balance establishes a starting position, not a delta: it is rejected when an affected account already has posted activity before the opening date | `test_AC2_15_4_opening_balance_rejected_when_prior_activity_exists` | `accounting/test_opening_balance.py` | P0 |
-| AC2.15.5 | Opening balances are accepted only in the base currency, with a clear error rather than a confusing FX-rate failure | `test_AC2_15_5_non_base_currency_is_rejected` | `accounting/test_opening_balance.py` | P0 |
-| AC2.15.6 | An opening balance into an account whose currency differs from the request currency is rejected, so journal lines cannot be mis-stamped | `test_AC2_15_6_account_currency_mismatch_is_rejected` | `accounting/test_opening_balance.py` | P0 |
-| AC2.15.7 | Opening balances may only target user-managed accounts; a system account (e.g. Processing) cannot be set via this endpoint even though the entry is SYSTEM-typed | `test_AC2_15_7_system_account_target_is_rejected` | `accounting/test_opening_balance.py` | P0 |
 | AC2.15.8 | The Accounts page offers a guided opening-balance flow: a non-accountant enters an as-of date and a starting balance per eligible (active, non-income/expense) account, and the UI posts the balances map to `POST /api/accounts/opening-balances` — never hand-written journal lines — validating positive two-decimal amounts and surfacing backend errors instead of silently closing | `AC2.15.8 lists only eligible accounts and hides income/expense and inactive ones`, `AC2.15.8 posts a balances map without requiring hand-written journal lines`, `AC2.15.8 blocks submission until at least one positive balance is entered`, `AC2.15.8 rejects non-positive or over-precise amounts before calling the API`, `AC2.15.8 surfaces a backend error instead of closing` | `apps/frontend/src/__tests__/openingBalanceModal.test.tsx` | P1 |
 
-### AC2.16: Opening-Balance Readiness Nudge ([#949](https://github.com/wangzitian0/finance_report/issues/949))
+### AC2.16: Opening-Balance Readiness Nudge ([#949](https://github.com/wangzitian0/finance_report/issues/949)) — frontend & reporting ACs only
 
 The everyday-user persona who already owns assets/liabilities on day one can post
 real activity without ever recording a starting position, yielding a balance
 sheet that looks right but silently omits the opening balances. These ACs surface
 that gap before the numbers are trusted.
 
+> The backend ledger-activity detection ACs in the `AC2.16.*` range migrated into
+> the `ledger` package as `AC-ledger.16.*` (#1420 slice 3c-iii). The **frontend**
+> nudge `AC2.16.3` (ledger is `fe=None`) and the **reporting-layer** tier-degrade
+> `AC2.16.4` (a report-assembly property, not a double-entry posting one) stay
+> defined here.
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC2.16.1 | `get_opening_balance_readiness` reports `needs_opening_balance=True` only when the user has posted activity and no opening-balance entry on or before its earliest date (no activity, an opening entry before activity, or a mis-dated opening entry after activity are all distinguished) | `test_AC2_16_1_no_activity_does_not_need_opening_balance`, `test_AC2_16_1_activity_without_opening_entry_needs_opening_balance`, `test_AC2_16_1_opening_entry_before_activity_clears_the_nudge`, `test_AC2_16_1_opening_entry_after_activity_still_needs` | `apps/backend/tests/accounting/test_opening_balance_readiness.py` | P1 |
-| AC2.16.2 | `GET /api/accounts/opening-balance-readiness` exposes the readiness signal to the UI | `test_AC2_16_2_readiness_endpoint_returns_status` | `apps/backend/tests/accounting/test_opening_balance_readiness.py` | P1 |
 | AC2.16.3 | The Accounts page shows a warning nudge (with a CTA that opens the guided flow) when opening balances are missing, and hides it once they are recorded | `AC2.16.3 shows a readiness nudge and opens the modal when opening balances are missing`, `AC2.16.3 hides the readiness nudge when opening balances are already recorded` | `apps/frontend/src/__tests__/accountsPage.test.tsx` | P1 |
 | AC2.16.4 {tier:CODE-ONLY} | The balance sheet and net-worth allocation degrade their aggregate confidence tier to `LOW` and emit an `opening_balance_warnings` entry when the user needs an opening balance, so a structurally-incomplete total is never presented as trusted (HIGH); once an opening balance is recorded the degrade and warning clear | `test_AC2_16_4_balance_sheet_degrades_tier_and_warns_when_opening_balance_missing`, `test_AC2_16_4_balance_sheet_clears_warning_once_opening_balance_recorded`, `test_AC2_16_4_net_worth_allocation_surfaces_opening_balance_warning` | `apps/backend/tests/reporting/test_balance_sheet_opening_balance_gate.py` | P1 |
 
@@ -382,8 +387,9 @@ disclosure decisions must not be embedded into posting logic.
 
 ### AC2.18: Framework-Neutral Ledger Boundary
 
-> Renumbered from a second `AC2.13` group whose `AC2.13.1` collided with AC2.13.1
-> (User-Scoped Ledger Integrity); the registry kept the user-scoped row and
+> Renumbered from a second `AC2.13` group whose first row collided with the
+> original User-Scoped Ledger Integrity `AC2.13.*` group (since migrated to
+> `AC-ledger.13.*`, #1420 slice 3c-iii); the registry kept the user-scoped row and
 > silently dropped this framework-neutral one until the IDs were made unique.
 
 | ID | Test Case | Test Function | File | Priority |

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -155,21 +155,21 @@ Semantics (the contract the balance sheet relies on):
   journal entry that increases each supplied account to its opening balance on
   its normal side (assets/expenses debited, liabilities/equity/income credited).
   The net is offset into a **system Opening Balance Equity account** so the entry
-  balances and the accounting equation holds (AC2.15.1, AC2.15.2). Opening Balance
+  balances and the accounting equation holds (AC-ledger.15.1, AC-ledger.15.2). Opening Balance
   Equity surfaces inside the balance sheet's `EQUITY` section, not as an asset or
   liability.
 - **A starting position, not a delta.** An opening balance is rejected when an
   affected account already has posted activity *before* the opening date, so the
-  posted amount can never stack on top of an existing balance (AC2.15.4). It
+  posted amount can never stack on top of an existing balance (AC-ledger.15.4). It
   establishes where the account *was*, then statement imports take over.
 - **Base currency only.** Opening balances are accepted only in the report base
   currency, with a clear error instead of a confusing downstream FX-rate failure
-  (AC2.15.5); a referenced account whose currency differs from the request is
-  rejected so journal lines cannot be mis-stamped (AC2.15.6).
+  (AC-ledger.15.5); a referenced account whose currency differs from the request is
+  rejected so journal lines cannot be mis-stamped (AC-ledger.15.6).
 - **User-managed accounts only.** Even though the entry is SYSTEM-typed (it
   touches the system equity account), the request may only target user-managed
   accounts — a system account such as Processing cannot be seeded this way
-  (AC2.15.3, AC2.15.7).
+  (AC-ledger.15.3, AC-ledger.15.7).
 
 Because opening balances are ordinary posted journal entries, every downstream
 report (net-worth time-series, cash-flow opening position) reads them through the

--- a/tests/tooling/test_generate_ac_registry.py
+++ b/tests/tooling/test_generate_ac_registry.py
@@ -652,11 +652,11 @@ class TestFindAcCollisions:
         epic_dir = self._write_epic(
             tmp_path,
             "EPIC-002.double-entry-core.md",
-            "| AC2.13.1 | User-scoped rule |\n"
-            "| AC2.13.1 | A different framework rule sharing the id |\n",
+            "| AC2.91.1 | User-scoped rule |\n"
+            "| AC2.91.1 | A different framework rule sharing the id |\n",
         )
         dup_defs, _ = gar.find_ac_collisions(epic_dir=epic_dir)
-        assert "AC2.13.1" in dup_defs
+        assert "AC2.91.1" in dup_defs
 
     def test_checklist_bullet_is_not_a_competing_definition(self, tmp_path):
         """A bullet that restates an AC must not be treated as a duplicate row."""
@@ -682,7 +682,7 @@ class TestFindAcCollisions:
         epic_dir = self._write_epic(
             tmp_path,
             "EPIC-002.double-entry-core.md",
-            "| AC2.13.1 | one |\n| AC2.13.1 | two |\n",
+            "| AC2.91.1 | one |\n| AC2.91.1 | two |\n",
         )
         monkeypatch.setattr(gar, "EPIC_DIR", str(epic_dir))
         assert gar.main(["--check"]) == 1


### PR DESCRIPTION
## Slice 3c-iii (FINAL AC batch) of the ledger cutover #1420

Homes the **genuine double-entry** ACs of the EPIC-002 second half into `common/ledger/contract.py`'s `roadmap`, completing the AC migration of #1420 (after 3c-i `#1512` processing ACs and 3c-ii `#1517` AC2.1-2.12). 18 ACs migrate as `AC-ledger.13.*`…`AC-ledger.16.*` (leading "2" dropped, sequence preserved, package CODE-ONLY tier inherited). **ADDED** to the existing roadmap; groups 1-12 + 71-76 and all invariants untouched. ledger roadmap: 83 → **101** ACs.

### Migrated (AC2 → AC-ledger), each validated as genuine double-entry with a real proving anchor
| was | now | subject | anchor |
|-----|-----|---------|--------|
| AC2.13.1-.3 | AC-ledger.13.1-.3 | user-scoped ledger integrity (cross-user account rejection in create/post/balance) | `tests/ledger/test_accounting_integration.py` |
| AC2.14.1-.6 | AC-ledger.14.1-.6 | DB ledger invariant floor (two-line, balance, FX, immutability, reversal, clean-409) | `tests/ledger/test_ledger_schema_invariants.py`, `tests/api/test_users_router.py` |
| AC2.15.1-.7 | AC-ledger.15.1-.7 | guided opening balances — backend posting & validation | `tests/ledger/test_opening_balance.py` |
| AC2.16.1-.2 | AC-ledger.16.1-.2 | opening-balance readiness — backend ledger-activity detection | `tests/ledger/test_opening_balance_readiness.py` |

### LEFT in EPIC-002 (NOT double-entry — the #1517 mis-file lesson: validate each AC, never blanket-rename)
- **`AC2.15.8` / `AC2.16.3` / `AC2.17.1`** — frontend UI tests; ledger is `fe=None` (the `AC15.7.*` precedent keeps frontend ACs in their EPIC).
- **`AC2.16.4`** — reporting-layer confidence-tier degrade; a report-assembly property proven by `tests/reporting/`, not a posting one.
- **`AC2.18.1`** — "framework-neutral ledger boundary": its anchor is a cross-EPIC **doc-contract** test that asserts EPIC-002.md prose (alongside AC3.10.1/AC5.14.1/AC17.13.1), not double-entry behaviour.
- **`AC2.19.*` – `AC2.23.*`** — the entire Money value-type extension (value types, `convert` FX primitive, per-currency container, materiality adoption, narrow-waist `float` guard). Belongs to the **money** kernel, not ledger (`AC2.23.1`/`AC2.22.3` per the brief).

### Reference repointing (same PR)
Function names keep the `test_AC2_x_y_` form (they don't match the dotted traceability regex; the roadmap `test=` references them verbatim, mirroring 3c-ii). Repointed every **dotted** `AC2.13-2.16` ref → `AC-ledger.*`: test docstrings + `ac_evidence(ac_id=…)` in the four migrated ledger tests + `test_users_router.py`; the illustrative SSOT refs in `docs/ssot/reporting.md`; source-prose + its generated mirrors (`src/schemas/account.py`, `src/services/accounting.py`, `openapi.json`, `api-types.ts`). Deleted the EPIC-002 AC2.13/AC2.14 tables, trimmed AC2.15/AC2.16 to their retained non-ledger rows, extended the migrated-disclaimer id list, and repointed the pre-existing AC2.18 renumber note. The synthetic collision-test literals in `tests/tooling/test_generate_ac_registry.py` were swapped to a placeholder (`AC2.91.1`) — they are fake-EPIC fixture data, not real refs — preserving the duplicate-detection semantics without dragging a real id.

Decision A — standard-preserving move: every migrated AC reappears with the same proof/priority/status; nothing dropped, non-migrated ACs stay defined in EPIC-002.

### Gates (all green locally)
`check_package_contract` (ledger 101 ACs) · `generate_ac_registry --check` · `check_epic_package_dual` · `lint_doc_consistency` · `check_ac_tier_baseline` (shrink-only; migrated ids tagged via package tier, stale baseline ids resolved) · `check_ac_proof_kind` · `check_tier_ast_literal` · `check_ac_index` (no per-type/mirror regression) · `check_authority_reconcile` · `check_draft_packages` · `check_tier_imports` · `check_ac_traceability` · `check_e2e_epic_traceability`. uv-pinned `ruff check`/`format` clean on src+tests; backend `pytest --collect-only` = 2818 tests, 0 collection errors. Straggler grep: 0 live `AC2.13-2.16` dotted refs (only `Was EPIC-002 AC2.x.y` provenance + retained `ac-tier-baseline.json` ids remain); `AC-ledger.13-16` in 0 non-ledger test dirs. (`check_manifest` `repo/` cross-ref failures are pre-existing environmental.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)