### PR TITLE
[finance_report_ui] fix(ia): post-merge review — hydration/CSV/a11y bugs + cross-EPIC nav drift cleanup

### DIFF
--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -138,21 +138,23 @@ def test_AC19_4_1_upload_first_home_ssot_documents_dashboard_contract() -> None:
     assert "must not block upload, event, or report readiness actions" in normalized_epic
 
 
-def test_AC19_6_1_workflow_navigation_ssot_documents_primary_and_advanced_groups() -> None:
-    """AC19.6.1: workflow navigation IA is documented in SSOT and EPIC."""
+def test_AC19_6_1_workflow_navigation_ia_owned_by_epic022_with_attention_contract() -> None:
+    """AC19.6.1: navigation IA is owned by EPIC-022 (bottom-tab); workflow-events
+    SSOT only keeps the workflow-attention contract, not a primary/advanced split."""
     ssot = (ROOT_DIR / "docs" / "ssot" / "workflow-events.md").read_text(encoding="utf-8")
     epic = (ROOT_DIR / "docs" / "project" / "EPIC-019.event-driven-upload-to-report-ux.md").read_text(encoding="utf-8")
 
     for phrase in (
-        "Primary navigation:",
-        "Upload Pipeline -> /dashboard",
-        "AI -> /chat",
-        "Advanced navigation:",
-        "Statements -> /statements",
-        "AI Settings -> /settings/ai",
+        "owned by EPIC-022",
+        "bottom tab bar",
+        "superseded by EPIC-022 AC22.21",
         "Navigation attention indicators must use `GET /api/workflow/status` through",
     ):
         assert phrase in ssot
+
+    # The superseded primary/advanced model must no longer be documented here.
+    assert "Primary navigation:" not in ssot
+    assert "Advanced navigation:" not in ssot
 
     assert "AC19.6.1" in epic
     assert "AC19.6.7" in epic

--- a/apps/frontend/src/__tests__/addSheet.test.tsx
+++ b/apps/frontend/src/__tests__/addSheet.test.tsx
@@ -27,7 +27,7 @@ describe("AddSheet (EPIC-022 AC22.21.2)", () => {
         expect(screen.getByText("Manual entry")).toBeInTheDocument();
 
         fireEvent.click(screen.getByText("Upload statement"));
-        expect(screen.getByTestId("uploader")).toHaveTextContent("UploaderMock-statement");
+        expect(screen.getByTestId("uploader")).toHaveTextContent("UploaderMock-all");
     });
 
     it("reveals the guided evidence form for manual entry", () => {

--- a/apps/frontend/src/__tests__/auditHub.test.tsx
+++ b/apps/frontend/src/__tests__/auditHub.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import AuditPage from "@/app/(main)/audit/page";
 
 describe("Audit hub (EPIC-022 AC22.21.3)", () => {
-    it("aggregates the verify-on-demand machinery as deep-linking cards", () => {
+    it("AC15.7.6 aggregates the verify-on-demand machinery (incl. Processing) as deep-linking cards", () => {
         render(<AuditPage />);
 
         expect(screen.getByRole("heading", { name: "Audit" })).toBeInTheDocument();

--- a/apps/frontend/src/__tests__/settingsPage.test.tsx
+++ b/apps/frontend/src/__tests__/settingsPage.test.tsx
@@ -49,6 +49,7 @@ describe("Merged Settings page (EPIC-022 AC22.21.4)", () => {
         const tablist = screen.getByRole("tablist", { name: "Settings sections" });
         fireEvent.keyDown(tablist, { key: "ArrowRight" });
         expect(screen.getByRole("tab", { name: "AI" })).toHaveAttribute("aria-selected", "true");
+        expect(screen.getByRole("tab", { name: "AI" })).toHaveFocus();
         expect(replaceMock).toHaveBeenCalledWith("/settings?tab=ai", { scroll: false });
         fireEvent.keyDown(tablist, { key: "ArrowLeft" });
         expect(screen.getByRole("tab", { name: "General" })).toHaveAttribute("aria-selected", "true");

--- a/apps/frontend/src/__tests__/settingsPage.test.tsx
+++ b/apps/frontend/src/__tests__/settingsPage.test.tsx
@@ -44,6 +44,24 @@ describe("Merged Settings page (EPIC-022 AC22.21.4)", () => {
         expect(replaceMock).toHaveBeenCalledWith("/settings?tab=llm", { scroll: false });
     });
 
+    it("moves between tabs with the arrow keys (WAI-ARIA tabs pattern)", () => {
+        render(<SettingsPage />);
+        const tablist = screen.getByRole("tablist", { name: "Settings sections" });
+        fireEvent.keyDown(tablist, { key: "ArrowRight" });
+        expect(screen.getByRole("tab", { name: "AI" })).toHaveAttribute("aria-selected", "true");
+        expect(replaceMock).toHaveBeenCalledWith("/settings?tab=ai", { scroll: false });
+        fireEvent.keyDown(tablist, { key: "ArrowLeft" });
+        expect(screen.getByRole("tab", { name: "General" })).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("wires each tab to its panel via aria-controls/labelledby", () => {
+        render(<SettingsPage />);
+        const tab = screen.getByRole("tab", { name: "General" });
+        const panel = screen.getByRole("tabpanel");
+        expect(tab).toHaveAttribute("aria-controls", "settings-panel-general");
+        expect(panel).toHaveAttribute("aria-labelledby", "settings-tab-general");
+    });
+
     it("opens the tab named by the ?tab= query (e.g. /settings/ai → ?tab=ai)", () => {
         navigationState.searchParams = new URLSearchParams("tab=ai");
         render(<SettingsPage />);

--- a/apps/frontend/src/app/(main)/settings/page.tsx
+++ b/apps/frontend/src/app/(main)/settings/page.tsx
@@ -40,15 +40,32 @@ export default function SettingsPage() {
         router.replace(`/settings?tab=${id}`, { scroll: false });
     };
 
+    // WAI-ARIA tabs keyboard pattern: Arrow keys move (and activate) the tab.
+    const onTablistKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+        e.preventDefault();
+        const i = TABS.findIndex((t) => t.id === tab);
+        const next = e.key === "ArrowRight" ? (i + 1) % TABS.length : (i - 1 + TABS.length) % TABS.length;
+        selectTab(TABS[next].id);
+    };
+
     return (
         <div className="p-6">
-            <div role="tablist" aria-label="Settings sections" className="flex gap-1 border-b border-[var(--border)]">
+            <div
+                role="tablist"
+                aria-label="Settings sections"
+                onKeyDown={onTablistKeyDown}
+                className="flex gap-1 border-b border-[var(--border)]"
+            >
                 {TABS.map((t) => (
                     <button
                         key={t.id}
                         type="button"
                         role="tab"
+                        id={`settings-tab-${t.id}`}
+                        aria-controls={`settings-panel-${t.id}`}
                         aria-selected={tab === t.id}
+                        tabIndex={tab === t.id ? 0 : -1}
                         onClick={() => selectTab(t.id)}
                         className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
                             tab === t.id
@@ -61,7 +78,13 @@ export default function SettingsPage() {
                 ))}
             </div>
 
-            <div className="mt-2">
+            <div
+                role="tabpanel"
+                id={`settings-panel-${tab}`}
+                aria-labelledby={`settings-tab-${tab}`}
+                tabIndex={0}
+                className="mt-2"
+            >
                 {tab === "general" && <GeneralSettingsPage />}
                 {tab === "ai" && <AiSettingsPage />}
                 {tab === "llm" && <LlmSettingsPage />}

--- a/apps/frontend/src/app/(main)/settings/page.tsx
+++ b/apps/frontend/src/app/(main)/settings/page.tsx
@@ -40,13 +40,16 @@ export default function SettingsPage() {
         router.replace(`/settings?tab=${id}`, { scroll: false });
     };
 
-    // WAI-ARIA tabs keyboard pattern: Arrow keys move (and activate) the tab.
+    // WAI-ARIA tabs keyboard pattern: Arrow keys move (and activate) the tab, and
+    // focus follows to the newly active tab (required with roving tabindex).
     const onTablistKeyDown = (e: React.KeyboardEvent) => {
         if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
         e.preventDefault();
         const i = TABS.findIndex((t) => t.id === tab);
         const next = e.key === "ArrowRight" ? (i + 1) % TABS.length : (i - 1 + TABS.length) % TABS.length;
-        selectTab(TABS[next].id);
+        const nextId = TABS[next].id;
+        selectTab(nextId);
+        document.getElementById(`settings-tab-${nextId}`)?.focus();
     };
 
     return (

--- a/apps/frontend/src/components/Sidebar.tsx
+++ b/apps/frontend/src/components/Sidebar.tsx
@@ -39,7 +39,6 @@ export function Sidebar() {
 
     const [home, chat, audit, more] = bottomTabItems;
     const AddIcon = ADD_ACTION.icon;
-    const visibleTabs: NavItem[] = isAuth ? [home, chat, audit, more] : [home];
 
     const renderNavLink = (item: NavItem) => {
         const active = isActive(pathname, item.href);
@@ -130,8 +129,6 @@ export function Sidebar() {
                 )}
                 {isAuth && renderNavLink(audit)}
                 {isAuth && renderNavLink(more)}
-                {/* visibleTabs retained for parity with the bottom bar's auth gating */}
-                <span className="sr-only">{visibleTabs.length} navigation targets</span>
             </nav>
 
             {/* Bottom Section */}

--- a/apps/frontend/src/components/shell/AddSheet.tsx
+++ b/apps/frontend/src/components/shell/AddSheet.tsx
@@ -67,7 +67,7 @@ export default function AddSheet({ isOpen, onClose, onUploadComplete }: AddSheet
 
             {mode === "upload" && (
                 <StatementUploader
-                    kind="statement"
+                    kind="all"
                     onUploadComplete={() => {
                         onUploadComplete?.();
                         close();

--- a/apps/frontend/src/components/shell/BottomTabBar.tsx
+++ b/apps/frontend/src/components/shell/BottomTabBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 
@@ -21,7 +21,14 @@ export function BottomTabBar() {
     const pathname = usePathname();
     const router = useRouter();
     const [addOpen, setAddOpen] = useState(false);
-    const authed = isAuthenticated();
+    // Read auth in an effect, not during render: isAuthenticated() returns false
+    // on the server (no localStorage) but true on the client, which would render
+    // a different tab set on each side and trip a hydration mismatch. Mirror the
+    // Sidebar's pattern so SSR and the first client render agree.
+    const [authed, setAuthed] = useState(false);
+    useEffect(() => {
+        setAuthed(isAuthenticated());
+    }, [pathname]);
 
     const renderTab = (item: NavItem) => {
         const Icon = item.icon;

--- a/docs/project/EPIC-015.processing-account.md
+++ b/docs/project/EPIC-015.processing-account.md
@@ -311,14 +311,19 @@ assert abs(assets - liabilities_equity) < Decimal("0.01")  # ✅ PASSED
 - [x] **AC15.7.3** Card click-through navigates to `/processing` listing pending transfers (existing or new page) with line items `{from_account, to_account, amount, initiated_date, days_outstanding}`
 - [x] **AC15.7.4** Pending entries older than 7 days render a warning badge on the listing row
 - [x] **AC15.7.5** Frontend test mounts ProcessingSummaryCard and asserts `pending_count` + `pending_total` labels render
-- [x] **AC15.7.6** Sidebar navigation exposes a Processing entry between Reconciliation and AI Settings
-- [x] **AC15.7.7** Sidebar Processing entry shows a warning indicator when Processing Account current balance is non-zero
+- [x] **AC15.7.6** Processing is discoverable as a card in the Audit hub at `/audit` (superseded the old sidebar entry per EPIC-022 AC22.21.3)
+- [x] **AC15.7.7** The Processing Account non-zero-balance warning surfaces on the Home Processing card (AC15.7.8) and the attention inbox; the old sidebar badge was removed with the Advanced drawer (EPIC-022 AC22.21)
 - [x] **AC15.7.8** Dashboard Processing card shows the signed current balance and a non-zero balance warning
+
+> **AC15.7.6/AC15.7.7 superseded by EPIC-022 AC22.21**: the Advanced sidebar drawer
+> was removed, so Processing discoverability moved to the `/audit` hub and its
+> balance warning is carried by the Home Processing card (AC15.7.8) and the
+> attention inbox. Rows kept for history with Verification updated to current tests.
 
 | AC ID | Description | Test | Path | Priority |
 |-------|-------------|------|------|----------|
-| AC15.7.6 | Sidebar navigation exposes a Processing entry between Reconciliation and AI Settings | `AC15.7.6 AC19.6.3 shows Processing between Reconciliation and AI Settings in Advanced` | `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx` | P1 |
-| AC15.7.7 | Sidebar Processing entry shows a warning indicator when Processing Account current balance is non-zero | `AC15.7.7 shows a sidebar warning when Processing Account balance is non-zero` | `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx` | P1 |
+| AC15.7.6 | Processing is discoverable as a card in the Audit hub (`/audit`), superseding the old sidebar entry | `AC15.7.6 aggregates the verify-on-demand machinery (incl. Processing) as deep-linking cards` | `apps/frontend/src/__tests__/auditHub.test.tsx` | P1 |
+| AC15.7.7 | The sidebar Processing badge was removed with the Advanced drawer; the non-zero-balance warning is carried by the Home Processing card and attention inbox | `AC15.7.7 AC16.19.12 AC19.6.3 AC19.6.4 AC19.6.5 AC22.21.1 keeps the accounting machinery, sidebar badges and settings out of the sidebar (supersedes the Advanced drawer)` | `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx` | P1 |
 | AC15.7.8 | Dashboard Processing card shows the signed current balance and a non-zero balance warning | `shows the current Processing Account balance when transfers are unresolved` | `apps/frontend/src/components/__tests__/ProcessingSummaryCard.test.tsx` | P1 |
 
 **Priority**: P0-quick-win — small UI surface; backend already exposes processing-account state.

--- a/docs/project/EPIC-016.two-stage-review-ui.md
+++ b/docs/project/EPIC-016.two-stage-review-ui.md
@@ -486,8 +486,8 @@ The April 2026 FE/UI audit snapshot was removed from this EPIC. Current review U
 - [x] **AC16.23.2** TransactionTable supports inline edit of `amount`, `description`, `date` with optimistic update + server confirm; failed write reverts row and shows error toast
 - [x] **AC16.23.3** Conflict resolution dialog `<ConflictResolutionDialog />` opens when backend returns duplicate or transfer-pair candidates; user can pick canonical row or link the pair
 - [x] **AC16.23.4** Stage 2 listing exposes severity filter, check-type filter, and score-range slider; filters persist in URL query string
-- [x] **AC16.23.5** Mobile navigation drawer (`<MobileNav />`) renders below 768 px with links to Dashboard / Review / Processing / Portfolio; existing desktop sidebar hidden on mobile
-- [x] **AC16.23.6** Frontend tests mount each new component (PdfPreviewPane, TransactionTable, ConflictResolutionDialog, MobileNav) and assert primary affordance renders
+- [x] **AC16.23.5** Mobile navigation renders below 768 px (originally the `<MobileNav />` drawer; replaced by the `<BottomTabBar />` bottom tab bar per EPIC-022 AC22.21); the desktop sidebar is hidden on mobile
+- [x] **AC16.23.6** Frontend tests mount each new component (PdfPreviewPane, TransactionTable, ConflictResolutionDialog, BottomTabBar) and assert primary affordance renders
 
 ### Acceptance Criteria — Feature (group 24, run-level Stage 2)
 

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -368,12 +368,20 @@ workflow state exists.
 
 ### AC19.6 — Navigation Folding And Advanced Drill-Down
 
+> **Superseded by EPIC-022 AC22.21.** AC19.6.1–AC19.6.7 below describe the
+> original primary/advanced navigation model (Upload Pipeline / Reports / AI /
+> Advanced + mobile drawer). EPIC-022 PR12 replaced it with a mobile/PWA bottom
+> tab bar (Home · Chat · Add · Audit · More); navigation IA is now owned by
+> EPIC-022 and `docs/ssot/frontend-patterns.md` §9. These rows are kept for
+> history with their Verification updated to the current tests; the live
+> navigation contract is AC22.21.x. Deep-link reachability (AC19.6.6) still holds.
+
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
-| AC19.6.1 | EPIC-019 and workflow-events SSOT define the canonical primary/advanced navigation IA and document `/dashboard` as the Upload Pipeline primary entry | `test_AC19_6_1_workflow_navigation_ssot_documents_primary_and_advanced_groups` | P0 |
+| AC19.6.1 | The workflow-events SSOT cedes navigation-IA ownership to EPIC-022 (bottom-tab) and keeps only the workflow-attention contract; the superseded primary/advanced split is no longer documented there | `test_AC19_6_1_workflow_navigation_ia_owned_by_epic022_with_attention_contract` | P0 |
 | AC19.6.2 | Frontend navigation exports separate primary workflow nav and advanced nav groups while preserving route config for all existing advanced deep links | `navigation.test.ts` | P0 |
 | AC19.6.3 | Desktop sidebar renders Upload Pipeline, Reports, AI, and Advanced as the primary surface; advanced child links remain accessible and active-state aware | `sidebarAndTabs.test.tsx` | P0 |
-| AC19.6.4 | Mobile nav renders the same primary/advanced grouping, supports advanced route selection, closes the drawer on navigation, and avoids overflow | `mobileNav.coverage.test.tsx`, `workflow-navigation.spec.ts` | P0 |
+| AC19.6.4 | Mobile navigation (now the bottom tab bar, per AC22.21) exposes the workflow surfaces and avoids overflow | `bottomTabBar.test.tsx`, `workflow-navigation.spec.ts` | P0 |
 | AC19.6.5 | Sidebar attention indicators are derived from `/api/workflow/status` through `lib/api.ts`; direct `/api/statements/pending-review` and stage2 queue polling are removed from Sidebar | `sidebarAndTabs.test.tsx` | P0 |
 | AC19.6.6 | Workflow event action links and workspace route labels continue to deep-link into advanced review/reconciliation/processing/report destinations | `workflowSurfaces.test.tsx`, `sidebarAndTabs.test.tsx`, `workflowActionRoutes.test.tsx` | P0 |
 | AC19.6.7 | Desktop and mobile Playwright smoke covers the folded navigation and Advanced access without horizontal overflow | `workflow-navigation.spec.ts` | P0 |
@@ -392,7 +400,7 @@ workflow state exists.
 | AC19.8.2 | Backend model and migration define `workflow_sessions`, explicit `workflow_session_status_enum`, and nullable legacy-safe `workflow_events.session_id` with session timeline indexes | `test_AC19_8_2_workflow_session_model_contract` | P0 |
 | AC19.8.3 | `GET /workflow/status` returns active session summary and `GET /workflow/events` returns session-scoped event timeline metadata | `test_AC19_8_3_workflow_status_and_events_expose_session_timeline` | P0 |
 | AC19.8.4 | Notification drawer and Events page group timestamped events by workflow session, while Upload Pipeline shows only active-session latest state plus recent timeline preview | `workflowSurfaces.test.tsx`, `workflow-notifications.spec.ts`, `upload-first-dashboard.spec.ts` | P0 |
-| AC19.8.5 | Primary IA is Upload Pipeline, Reports, AI, Advanced; Events and Portfolio are Advanced drill-downs; AI Settings points to `/settings/ai` | `navigation.test.ts`, `sidebarAndTabs.test.tsx`, `mobileNav.coverage.test.tsx`, `workflow-navigation.spec.ts` | P0 |
+| AC19.8.5 | Navigation IA (superseded by EPIC-022 AC22.21): the bottom tab bar is Home, Chat, Add, Audit, More; the accounting machinery and settings are reached via the Audit hub and More, not a primary/advanced split | `navigation.test.ts`, `sidebarAndTabs.test.tsx`, `bottomTabBar.test.tsx`, `workflow-navigation.spec.ts` | P0 |
 | AC19.8.6 | `/chat` is a simple AI utility page with model selector, active conversation, and session-list drawer; it is not labeled AI Settings | `chatPanelComponent.test.tsx`, `ChatPageClient.test.tsx` | P1 |
 | AC19.8.7 | Report readiness has route-level Playwright smoke coverage before package output | `report-readiness.spec.ts` | P1 |
 | AC19.8.8 | CR cleanup fixes mixed-currency investment schedule fallback, missing Processing FX readiness blocker coverage, stale SSOT paths, and stale navigation docs | `test_AC19_8_8_investment_schedule_fallback_holding_cost_basis_converts_currency`, `test_AC19_8_8_package_readiness_blocks_when_processing_fx_conversion_fails`, `report-readiness.spec.ts` | P0 |

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -21,7 +21,7 @@
 | Compact status/events API | `apps/backend/src/routers/workflow.py` |
 | Report package readiness fact source | `GET /api/reports/package/readiness` in `apps/backend/src/services/report_readiness.py` |
 | Header badge, Event inbox, Status feed | `apps/frontend/src/components/workflow/WorkflowNotifications.tsx` |
-| Upload-to-Report home | `apps/frontend/src/app/(main)/dashboard/page.tsx` |
+| Upload-to-Report home | `apps/frontend/src/app/(main)/page.tsx` (the `/dashboard` route redirects here) |
 | Events page | `apps/frontend/src/app/(main)/events/page.tsx` advanced session history surface |
 | Workflow navigation IA | `apps/frontend/src/components/navigation.ts` |
 | Desktop workflow navigation | `apps/frontend/src/components/Sidebar.tsx` |

--- a/docs/ssot/workflow-events.md
+++ b/docs/ssot/workflow-events.md
@@ -25,9 +25,9 @@
 | Events page | `apps/frontend/src/app/(main)/events/page.tsx` advanced session history surface |
 | Workflow navigation IA | `apps/frontend/src/components/navigation.ts` |
 | Desktop workflow navigation | `apps/frontend/src/components/Sidebar.tsx` |
-| Mobile workflow navigation | `apps/frontend/src/components/MobileNav.tsx` |
+| Mobile workflow navigation | `apps/frontend/src/components/shell/BottomTabBar.tsx` |
 | Database migrations | `apps/backend/migrations/versions/0021_add_workflow_events.py`, `apps/backend/migrations/versions/0022_harden_workflow_contract.py`, `apps/backend/migrations/versions/0024_add_workflow_sessions.py` |
-| Contract tests | `apps/backend/tests/workflow/test_workflow_events.py`, `apps/backend/tests/api/test_workflow_router.py`, `apps/frontend/src/__tests__/navigation.test.ts`, `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx`, `apps/frontend/src/__tests__/mobileNav.coverage.test.tsx`, `apps/frontend/src/__tests__/workflowApi.test.ts`, `apps/frontend/src/__tests__/workflowSurfaces.test.tsx`, `apps/frontend/playwright/workflow-notifications.spec.ts`, `apps/frontend/playwright/workflow-navigation.spec.ts`, `apps/frontend/playwright/report-readiness.spec.ts` |
+| Contract tests | `apps/backend/tests/workflow/test_workflow_events.py`, `apps/backend/tests/api/test_workflow_router.py`, `apps/frontend/src/__tests__/navigation.test.ts`, `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx`, `apps/frontend/src/__tests__/bottomTabBar.test.tsx`, `apps/frontend/src/__tests__/workflowApi.test.ts`, `apps/frontend/src/__tests__/workflowSurfaces.test.tsx`, `apps/frontend/playwright/workflow-notifications.spec.ts`, `apps/frontend/playwright/workflow-navigation.spec.ts`, `apps/frontend/playwright/report-readiness.spec.ts` |
 
 ---
 
@@ -398,50 +398,24 @@ Upload-to-Report home rules:
 
 ## 11. Workflow Navigation
 
-EPIC-019 owns the product-level navigation model for the upload-to-report
-journey. The primary navigation must express the workflow, not the internal
-accounting pipeline.
+The product navigation IA is owned by EPIC-022 and `docs/ssot/frontend-patterns.md`
+§9 (the mobile/PWA bottom tab bar — Home, Chat, Add, Audit, More). EPIC-019 no
+longer defines a primary/advanced navigation split; the earlier "Upload Pipeline
+/ Reports / AI / Advanced" model was superseded by EPIC-022 AC22.21. This section
+only records the workflow-events constraints the shell must honour, regardless of
+its form factor:
 
-Primary navigation:
-
-```text
-Upload Pipeline -> /dashboard
-Reports -> /reports
-AI -> /chat
-Advanced
-```
-
-Advanced navigation:
-
-```text
-Events -> /events
-Portfolio -> /portfolio
-Statements -> /statements
-Review -> /review
-Accounts -> /accounts
-Journal -> /journal
-Reconciliation -> /reconciliation
-Processing -> /processing
-AI Settings -> /settings/ai
-```
-
-Rules:
-
-- `/dashboard` remains the authenticated upload-to-report home and is labeled
-  as Upload Pipeline in primary navigation.
-- `/events` is an Advanced session-history surface, not a primary navigation
-  entry.
-- `/chat` is labeled AI and is an auxiliary utility, not workflow domain state.
-- `/settings/ai` is the AI Settings route.
-- Advanced is a navigation group, not a new backend workflow concept.
-- Advanced pages are not removed. Direct routes and event `action_href` links
-  into review, reconciliation, processing, statements, reports, and package
-  readiness must continue to work.
-- Desktop and mobile navigation must expose the same primary and advanced
-  groups.
 - Navigation attention indicators must use `GET /api/workflow/status` through
-  `lib/api.ts`. Sidebar-local review queue polling must not calculate separate
-  review badge semantics.
+  `lib/api.ts`. The shell must not calculate separate review-badge semantics with
+  bespoke sidebar polling.
+- Workflow attention is surfaced through the notification bell plus the
+  `/attention` inbox; the accounting machinery (journal, reconciliation,
+  processing, statements, reports, package readiness) is reachable on demand via
+  the Audit hub and event `action_href` deep links.
+- Direct routes and event `action_href` links into review, reconciliation,
+  processing, statements, reports, and package readiness must continue to work.
+- Legacy routes must keep resolving: `/dashboard` redirects to `/` (the
+  authenticated Home) and `/events` redirects to `/notifications`.
 
 ---
 


### PR DESCRIPTION
Follow-up to #1527 (bottom-tab IA). A post-merge review round (code-review agent + doc-drift sweep) surfaced real bugs the PR introduced and documentation drift it left behind.

## Code fixes
- **Hydration mismatch** — `BottomTabBar` read `isAuthenticated()` during render (false on server, true on client → different tab sets). Now reads auth in a `useEffect`, mirroring `Sidebar`.
- **CSV rejected from Add** — the "Upload statement" action used `kind="statement"` (rejects `.csv`) while the copy promised "PDF, CSV or image". Switched to `kind="all"` so CSV is actually accepted from the central Add affordance.
- **Settings tabs a11y** — completed the WAI-ARIA tabs pattern: `role="tabpanel"` + `aria-controls`/`aria-labelledby` wiring + roving `tabindex` + Arrow-key navigation.
- **Sidebar wart** — removed a leftover `sr-only` span that announced an ungrammatical "1 navigation targets".

## Cross-EPIC navigation drift
The new IA left the *old* primary/advanced model documented as canonical elsewhere, with dead references to the deleted `MobileNav`:
- **workflow-events.md §11** now cedes navigation-IA ownership to EPIC-022 / `frontend-patterns.md §9` and keeps only the workflow-attention contract; component-map rows fixed (`MobileNav`→`BottomTabBar`, `mobileNav.coverage`→`bottomTabBar`). Backend `test_AC19_6_1` updated to assert the new contract (and that the old model is gone).
- **EPIC-019** AC19.6.x / AC19.8.5, **EPIC-016** AC16.23.5/.6, **EPIC-015** AC15.7.6/.7: supersession notes + Verification re-pointed at current tests (the sidebar-Processing entry/badge moved to the Audit hub + Home Processing card).

## Gates (local)
- vitest+coverage: 148 files / 1031 tests pass, all-files **98.00% ≥ 98%**.
- `test_AC19_6_1` (backend) passes against the rewritten SSOT.
- Green: doc-consistency, ac-index, tier-baseline (no new untagged), ac-registry --check, eslint, tsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)