### PR TITLE
[finance_report_test_and_doc] feat(runtime): scaffold the runtime package — app↔external-world dependency boundary (draft)

### DIFF
--- a/common/runtime/__init__.py
+++ b/common/runtime/__init__.py
@@ -1,0 +1,7 @@
+"""``runtime`` — the app↔external-world dependency boundary (draft).
+
+Spec-only for now: this package owns the *contract* for how the application
+depends on external backends (object storage, the LLM provider, cache, telemetry,
+…), how each environment substitutes them, and how their presence is asserted.
+No curated symbol language yet (``contract.interface == []``); see ``readme.md``.
+"""

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -1,0 +1,32 @@
+"""The ``runtime`` package's machine-checkable :class:`PackageContract`.
+
+``runtime`` is the app↔external-world dependency boundary: it owns the *contract*
+for the external backends the application depends on (object storage, the LLM
+provider, cache, telemetry, …), how each of the six environments substitutes
+them, and the invariant that a *declared* dependency must be *asserted present*
+(no silent ``skipped``/``warning``/fallback).
+
+It is a ``kernel`` leaf (``depends_on=[]``) and currently ``draft`` — still being
+designed. It ships no implementation units and no curated published language yet
+(``interface=[]``), so the prose contract (ubiquitous language, invariants, the
+roadmap of ACs) lives in ``readme.md`` + ``todo.md`` until each AC lands with a
+real test. Roadmap entries move here (each pinned to its test) as they are built.
+"""
+
+from __future__ import annotations
+
+from common.meta.package_contract import PackageContract
+
+CONTRACT = PackageContract(
+    name="runtime",
+    klass="kernel",
+    status="draft",
+    tier="CODE-ONLY",
+    depends_on=[],
+    roles=[],
+    implementations={"be": "common/runtime", "fe": None},
+    interface=[],
+    events=[],
+    invariants=[],
+    roadmap=[],
+)

--- a/common/runtime/readme.md
+++ b/common/runtime/readme.md
@@ -1,0 +1,89 @@
+# `runtime` — the app↔external-world dependency boundary
+
+> **Status: draft.** The model below is the contract we are committing to; the
+> implementation (ports, manifest, gate wiring) lands incrementally, each AC with
+> a real test, moving from [`todo.md`](./todo.md) into [`contract.py`](./contract.py).
+> Model spec: [`../meta/readme.md`](../meta/readme.md).
+
+## Why this package exists
+
+The application depends on external backends — object storage (S3), the LLM
+provider, cache (Redis), telemetry (OTel), analytics (OpenPanel), the database.
+Today that boundary is **homeless**: `ServiceStatus` + `_check_*` float in
+`apps/backend/src/boot.py`, env keys live in `config`, the smoke test is a shell
+script, and the six-environment tiering lives in `environments.md`. Nobody owns
+the *contract* across them — which is exactly why dependencies **degrade
+silently** (`_check_ai_provider` returns `"skipped"` when unconfigured; S3 is
+treated as "optional" and only `warning`s when down).
+
+`runtime` is the bounded context that owns that boundary: **what we depend on,
+how each environment provides or substitutes it, and the guarantee that a
+declared dependency is proven present — or the build/smoke fails.**
+
+## Ubiquitous language
+
+- **Dependency** — an external backend the app talks to across a process edge.
+- **Kind** — how a dependency must be tested:
+  - **code-dominant** (e.g. S3, Redis): deterministic; a light substitute behaves
+    identically to the real backend, so it is behaviourally equivalent everywhere.
+  - **model-dominant** (e.g. the LLM): non-deterministic; output depends on the
+    real service. *Input changes ⇒ result changes* — so CI uses an **input-keyed
+    recording**, and the real behaviour is validated only against staging.
+- **Substitute** — the per-environment stand-in for a dependency. A *backend* may
+  differ per environment (in-memory ≠ minio ≠ real S3); that is expected and fine.
+- **Env tier** — one of the six environments (Local Dev / Local CI / GitHub CI /
+  PR Preview / Staging / Production). CI and Preview use **light substitutes**
+  (Preview = same as CI but persistent); Staging and Production use **real**
+  backends.
+- **Declared vs present** — each env *declares* its required dependencies (via env
+  vars, owned with `config`); a dependency is either **present** or **absent** —
+  there is no `skipped`.
+
+## Invariants (the contract)
+
+1. **Declared ⇒ asserted.** Every dependency an environment declares as required
+   has a check, a substitute, and a smoke assertion.
+2. **Absent ⇒ fail.** A declared dependency that is missing/unreachable fails
+   `/health` and the smoke test. No silent `skipped` / `warning` / fallback.
+3. **Substitute by tier.** CI/Preview run light substitutes; Staging/Production
+   run real backends. The *backend* may differ per env; the *presence* must not.
+4. **code-dominant ⇒ real adapter runs in CI.** The substitute fakes the
+   *backend* (in-memory), never the app's own adapter — so the real adapter code
+   executes in CI (no wrapper-stub like `DummyStorage`).
+5. **model-dominant ⇒ recorded in CI, real on staging.** CI replays an
+   input-keyed recording (changed input ⇒ recording miss); the real provider is
+   exercised only by the staging gate (which does **not** read recordings).
+6. **Smoke ↔ declaration parity.** The smoke test asserts exactly the declared set
+   for its tier (count == declared count); a release tag promotes only after the
+   **staging** smoke (real backends, real LLM) passes.
+
+## Shape (port / adapter, per the `base`/`extension`/`data` model)
+
+- **base** — the `DependencyCheck` port (the `ServiceStatus`/check protocol) + the
+  **DependencyManifest** (declared required dependencies per env tier) + the value
+  language (`Kind`, `EnvTier`, presence status — no `skipped`).
+- **extension** — the per-dependency check/substitute adapters (db, s3, llm,
+  redis, telemetry). Each implements the port; an adapter may instead live in its
+  own domain package and implement this port (dependency inversion).
+- **api** — `boot.validate` and the smoke test become this package's boundary:
+  they run the declared checks and enforce invariants 2 and 6.
+
+## Boundaries with neighbouring packages
+
+- **`config`** — owns the env-key *plumbing* (the three-layer
+  `secrets.ctmpl` ↔ `config.py` ↔ `.env.example` consistency). `runtime` owns the
+  *dependency semantics* on top: which keys denote a dependency, its kind, its
+  per-tier substitute, and the presence assertion.
+- **`testing`** — owns proof *provenance* (`deterministic` / `golden_fixture` /
+  `live_llm`); `runtime`'s `Kind` maps onto it (code-dominant → deterministic,
+  model-dominant → live on staging).
+- **`platform`** — the *in-process* middleware substrate (event bus, rate limiter).
+  `runtime` is the complementary *outbound* substrate (the edges to the external
+  world). Distinct concerns; sibling kernels.
+- **`observability`** — telemetry is itself a dependency `runtime` declares/asserts,
+  but its own emit/query logic stays in `observability`.
+
+## Public vs internal
+
+Draft: no published symbol language yet (`contract.interface == []`). Consumers do
+not import `runtime` today; the package currently owns the *model* (this file).

--- a/common/runtime/todo.md
+++ b/common/runtime/todo.md
@@ -1,0 +1,37 @@
+# `runtime` — todo
+
+The package-local worklist. Cross-package migration lives in
+[`../todo.md`](../todo.md). Each item below becomes a `roadmap` AC in
+[`contract.py`](./contract.py) — pinned to a real test — when it lands (TDD: a
+failing test first).
+
+## Done
+
+- [x] Package created on the model: ships `readme.md` + `contract.py` + `todo.md`,
+      governed by `check_package_contract` as a `draft` `kernel` leaf
+      (`depends_on=[]`, `interface=[]`).
+
+## Next (the dependency-boundary contract, in order)
+
+- [ ] **Manifest (base).** Define `DependencyManifest`: per env tier, the declared
+      required dependencies + each one's `Kind`. First filled from a full audit of
+      `config.py` (S3, LLM, Postgres, Redis, Prefect, OTel, OpenPanel, market-data).
+- [ ] **Port (base).** Lift `ServiceStatus` + the `_check_*` methods out of
+      `boot.py` into a `DependencyCheck` port + per-dependency adapters
+      (extension). Drop the `"skipped"` status (invariant 2).
+- [ ] **Assert + fail (api).** `boot.validate` + `smoke_test` assert the declared
+      set for their tier; a declared-but-absent dependency fails (no `warning`).
+      Proof: dropping a declared dependency's config makes the smoke FAIL.
+- [ ] **Smoke ↔ declaration parity.** Extend the smoke meta-guard to
+      `checks == declared count`; wire the tag→staging smoke as the prod-promote
+      gate.
+- [ ] **code-dominant substitutes.** S3 → in-memory (moto) so the real
+      `StorageService` runs in CI (retire `DummyStorage`); the upload→store→load→
+      parse pipeline test. Redis → fakeredis or document the in-memory path.
+      Market-data → transport-layer record/replay (not a blanket disable).
+- [ ] **model-dominant recording.** Pin the LLM recording as input-keyed (changed
+      input ⇒ miss); the staging gate (real provider) stays recording-free.
+- [ ] **Guardrail.** A contract test: adding an external dependency to `config.py`
+      without (kind + per-tier declaration + substitute + smoke assertion) fails CI.
+- [ ] Promote `status` `draft` → `active` once the manifest + port + assert
+      invariants have landing tests.

--- a/docs/ssot/draft-package-baseline.json
+++ b/docs/ssot/draft-package-baseline.json
@@ -1,4 +1,6 @@
 {
   "_comment": "Registered draft packages (tools/check_draft_packages.py). A draft package leaves its authority tier undecided; listing it here makes adding one a reviewed act. Resolve drafts to active over time.",
-  "draft_packages": []
+  "draft_packages": [
+    "runtime"
+  ]
 }


### PR DESCRIPTION
## Why
The app's boundary to external backends (S3, LLM provider, Redis, OTel, OpenPanel, DB) is **homeless**: `ServiceStatus` + `_check_*` float in `boot.py`, env keys live in `config`, smoke is a shell script, env tiering in `environments.md`. That homelessness is the **root cause of silent dependency degradation** — `_check_ai_provider` returns `"skipped"` when unconfigured, S3 is treated as "optional" and only `warning`s when down. So a dependency can be entirely absent while CI/smoke stays green.

Per the DDD package model, this boundary qualifies as its own bounded context. Giving it a package gives the invariant an **owner + a gate-checked contract**.

## What
`common/runtime/` — a **draft `kernel`** package:
- **readme.md** — ubiquitous language (dependency, kind = code-dominant / model-dominant, substitute, env-tier, declared-vs-present), the **6 invariants** (declared⇒asserted; absent⇒fail; substitute-by-tier; code-dominant⇒real-adapter-runs-in-CI; model-dominant⇒recorded-in-CI+real-on-staging; smoke↔declaration parity), the port/adapter shape, and boundaries with `config`/`testing`/`platform`/`observability`.
- **contract.py** — `PackageContract` (draft, kernel, `interface=[]`, no units/roadmap yet).
- **todo.md** — the worklist (manifest → port → assert+fail → substitutes → guardrail), each to become a roadmap AC pinned to a real test (TDD), promoting draft → active.
- **__init__.py**.

## Verify
- `tools/check_package_contract.py` → **PASSED** (`runtime (class kernel): 0 interface, 0 invariant, 0 roadmap — OK`).
- ruff clean; no new test failures (the 4 local `*_converges_by_layer` / epic-status failures reproduce **without** this change — pre-existing/local-env).

## Scope
Spec-only scaffold. No behaviour change. The implementation (lift `ServiceStatus`/`_check_*` into a `DependencyCheck` port, the dependency manifest, the assert+fail wiring, S3→moto, smoke↔declaration parity) lands incrementally per todo.md.

Context: this is the foundation for the dependency-testing strategy worked out in #1520 (which becomes `runtime`'s roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)