### PR TITLE
[finance_report_ui] fix(e2e): stable uploader test-ids — unblock v0.1.28 staging deploy

### DIFF
--- a/apps/frontend/src/components/statements/StatementUploader.tsx
+++ b/apps/frontend/src/components/statements/StatementUploader.tsx
@@ -269,6 +269,7 @@ export default function StatementUploader({
                     onChange={handleFileChange}
                     className="hidden"
                     id={fileInputId}
+                    data-testid={`uploader-file-${kind}`}
                 />
                 <label htmlFor={fileInputId} className="cursor-pointer block">
                     <div className="flex flex-col items-center">
@@ -306,6 +307,7 @@ export default function StatementUploader({
                 <input
                     type="text"
                     id={institutionId}
+                    data-testid={`uploader-institution-${kind}`}
                     value={institution}
                     onChange={(e) => setInstitution(e.target.value)}
                     placeholder="Auto-detected from document, or enter manually"
@@ -346,6 +348,7 @@ export default function StatementUploader({
                     </label>
                     <select
                         id={aiModelId}
+                        data-testid={`uploader-model-${kind}`}
                         className="input"
                         value={selectedModel}
                         onChange={(e) => {

--- a/tests/e2e/test_statement_full_journey.py
+++ b/tests/e2e/test_statement_full_journey.py
@@ -150,7 +150,9 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
             f"Redirected to /login despite authenticated_page fixture. URL: {page.url}"
         )
 
-    await page.locator("#institution").fill(INSTITUTION_LABEL)
+    await page.locator('[data-testid="uploader-institution-statement"]').fill(
+        INSTITUTION_LABEL
+    )
     # Fetch the default model from the backend API and select it explicitly.
     # Selecting by value ensures we always use the backend-configured OCR model.
     models_resp = await page.evaluate(
@@ -159,11 +161,11 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
     default_model: str = (
         models_resp.get("default_model") or models_resp["models"][0]["id"]
     )
-    model_select = page.locator("select#ai-model")
+    model_select = page.locator('[data-testid="uploader-model-statement"]')
     await expect(model_select).to_be_visible(timeout=15_000)
     await expect(model_select).not_to_have_value("", timeout=15_000)
     await model_select.select_option(value=default_model)
-    await page.set_input_files("#file-upload", str(pdf_path))
+    await page.set_input_files('[data-testid="uploader-file-statement"]', str(pdf_path))
     await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(
         timeout=5_000
     )

--- a/tests/e2e/test_statement_upload_e2e.py
+++ b/tests/e2e/test_statement_upload_e2e.py
@@ -111,14 +111,18 @@ async def test_statement_upload_full_flow(authenticated_page_unique: Page) -> No
     page = authenticated_page_unique
     await page.goto(_get_url("/statements"))
     await page.wait_for_load_state("domcontentloaded")
-    await page.locator("#institution").fill("E2E Upload Test Bank")
+    await page.locator('[data-testid="uploader-institution-statement"]').fill(
+        "E2E Upload Test Bank"
+    )
     # Wait for AI model dropdown options to load, then explicitly select one.
-    model_select = page.locator("select#ai-model")
+    model_select = page.locator('[data-testid="uploader-model-statement"]')
     await expect(model_select).to_be_visible(timeout=15_000)
     await expect(model_select).not_to_have_value("", timeout=15_000)
     await model_select.select_option(index=0)
-    await page.set_input_files("#file-upload", str(pdf_path))
-    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(timeout=5_000)
+    await page.set_input_files('[data-testid="uploader-file-statement"]', str(pdf_path))
+    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(
+        timeout=5_000
+    )
 
     async with page.expect_response(
         lambda r: "/api/statements/upload" in r.url,
@@ -134,7 +138,9 @@ async def test_statement_upload_full_flow(authenticated_page_unique: Page) -> No
     statement_id = upload_body.get("id")
     assert statement_id, f"Upload response missing 'id' field: {upload_body}"
     # Statement row appears in the list with the institution name we provided.
-    await expect(_statement_row(page, "E2E Upload Test Bank")).to_be_visible(timeout=15_000)
+    await expect(_statement_row(page, "E2E Upload Test Bank")).to_be_visible(
+        timeout=15_000
+    )
     # Verify the statement is immediately accessible via the API. Playwright's
     # context request shares the browser cookie jar used by the page.
     api_resp = await page.request.get(_get_url(f"/api/statements/{statement_id}"))
@@ -168,13 +174,17 @@ async def test_model_selection_and_upload(authenticated_page_unique: Page) -> No
     await page.goto(_get_url("/statements"))
     await page.wait_for_load_state("domcontentloaded")
 
-    model_select = page.locator("select#ai-model")
+    model_select = page.locator('[data-testid="uploader-model-statement"]')
     await expect(model_select).to_be_visible(timeout=5_000)
     await model_select.select_option(index=0)
 
-    await page.locator("#institution").fill("E2E Model Test Bank")
-    await page.set_input_files("#file-upload", str(pdf_path))
-    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(timeout=5_000)
+    await page.locator('[data-testid="uploader-institution-statement"]').fill(
+        "E2E Model Test Bank"
+    )
+    await page.set_input_files('[data-testid="uploader-file-statement"]', str(pdf_path))
+    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(
+        timeout=5_000
+    )
 
     async with page.expect_response(
         lambda r: "/api/statements/upload" in r.url,
@@ -190,7 +200,9 @@ async def test_model_selection_and_upload(authenticated_page_unique: Page) -> No
     statement_id = upload_body.get("id")
     assert statement_id, f"Upload response missing 'id' field: {upload_body}"
 
-    await expect(_statement_row(page, "E2E Model Test Bank")).to_be_visible(timeout=15_000)
+    await expect(_statement_row(page, "E2E Model Test Bank")).to_be_visible(
+        timeout=15_000
+    )
     statement = await _find_statement_by_institution(page, "E2E Model Test Bank")
     assert statement and statement.get("id") == statement_id
 
@@ -205,7 +217,9 @@ async def test_stale_model_id_auto_cleanup(authenticated_page_unique: Page) -> N
     _skip_if_no_url()
     page = authenticated_page_unique
     await page.goto(_get_url("/statements"), wait_until="domcontentloaded")
-    await expect(page.locator("select#ai-model")).to_be_visible(timeout=15_000)
+    await expect(
+        page.locator('[data-testid="uploader-model-statement"]')
+    ).to_be_visible(timeout=15_000)
 
     # Use a guaranteed-nonexistent model ID so the test is catalog-independent.
     # Real model IDs are provider-configured and may change over time; using
@@ -213,11 +227,17 @@ async def test_stale_model_id_auto_cleanup(authenticated_page_unique: Page) -> N
     stale_id = "test/nonexistent-model-for-stale-cleanup-test"
     await page.evaluate(f'localStorage.setItem("statement_model_v1", "{stale_id}")')
     await page.reload(wait_until="domcontentloaded")
-    await expect(page.locator("select#ai-model")).to_be_visible(timeout=15_000)
+    await expect(
+        page.locator('[data-testid="uploader-model-statement"]')
+    ).to_be_visible(timeout=15_000)
     await page.wait_for_function(
         "(staleId) => localStorage.getItem('statement_model_v1') !== staleId",
         arg=stale_id,
         timeout=15_000,
     )
-    stored_model: str | None = await page.evaluate('localStorage.getItem("statement_model_v1")')
-    assert stored_model != stale_id, f"Stale model ID '{stale_id}' was not cleared from localStorage after reload"
+    stored_model: str | None = await page.evaluate(
+        'localStorage.getItem("statement_model_v1")'
+    )
+    assert stored_model != stale_id, (
+        f"Stale model ID '{stale_id}' was not cleared from localStorage after reload"
+    )

--- a/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
+++ b/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
@@ -158,8 +158,12 @@ async def test_statement_upload_to_dashboard_vision_hard_gate(
 
     await _goto_ready(page, "/statements")
 
-    await page.locator("#institution").fill(INSTITUTION_LABEL)
-    await page.set_input_files("#file-upload", str(fixture_path))
+    await page.locator('[data-testid="uploader-institution-statement"]').fill(
+        INSTITUTION_LABEL
+    )
+    await page.set_input_files(
+        '[data-testid="uploader-file-statement"]', str(fixture_path)
+    )
     await expect(
         page.locator("p.font-medium", has_text=fixture_path.name)
     ).to_be_visible(timeout=5_000)


### PR DESCRIPTION
## Why
The **v0.1.28 staging deploy failed** its E2E gate (`test_statement_upload_e2e::test_stale_model_id_auto_cleanup` and the vision upload hard gate). Root cause: PR #1521 switched `StatementUploader` to `useId()`-derived element ids (needed to avoid duplicate ids when the statement + CSV uploaders co-render on `/upload`), so the hard-coded `#file-upload` / `#institution` / `select#ai-model` selectors in the staging upload E2E no longer match. v0.1.28 is the first release to ship that change, so the gate caught it now.

**The app itself is fine** — labels associate correctly and uploads work for real users; only the test selectors were stale. The staging gate correctly blocked promotion to prod.

## What
- Add stable, kind-scoped `data-testid`s to the uploader inputs: `uploader-file-{kind}`, `uploader-institution-{kind}`, `uploader-model-{kind}` (unique across the statement + CSV instances).
- Point the three upload E2E specs (`test_statement_upload_e2e`, `test_vision_upload_to_dashboard_hard_gate`, `test_statement_full_journey`) at those test-ids.
- Unit tests already use label/role queries → unaffected.

## Gates (local)
- StatementUploader/addSheet/statementsPage vitest: 34 pass; tsc + eslint clean.
- e2e files: `py_compile` + `ruff` clean.

After merge: re-cut the release tag and re-run the staging deploy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)