### PR TITLE
[finance_report_test_and_doc] feat(runtime): construct dependency-boundary base — manifest + check port (PR1/3)

### DIFF
--- a/apps/backend/src/runtime/__init__.py
+++ b/apps/backend/src/runtime/__init__.py
@@ -1,0 +1,31 @@
+"""``runtime`` — the app↔external-world dependency boundary (BE implementation).
+
+`PackageContract.implementations["be"]` for the `runtime` package; the spec
+(ubiquitous language, invariants, roadmap) lives in `common/runtime/`. Draft:
+this ships the `base` value language + manifest + the `DependencyCheck` port. The
+adapters, the assert-present enforcement, and the compose/lifecycle relocation
+land in the switch/cleanup phases (see `common/runtime/todo.md`).
+"""
+
+from __future__ import annotations
+
+from src.runtime.base.check import DependencyCheck, DependencyStatus
+from src.runtime.base.kind import DependencyKind
+from src.runtime.base.manifest import (
+    DEPENDENCY_MANIFEST,
+    Dependency,
+    DependencyManifest,
+)
+from src.runtime.base.tiers import APP_OWNED_TIERS, VPS_TIERS, EnvTier
+
+__all__ = [
+    "APP_OWNED_TIERS",
+    "DEPENDENCY_MANIFEST",
+    "VPS_TIERS",
+    "Dependency",
+    "DependencyCheck",
+    "DependencyKind",
+    "DependencyManifest",
+    "DependencyStatus",
+    "EnvTier",
+]

--- a/apps/backend/src/runtime/base/__init__.py
+++ b/apps/backend/src/runtime/base/__init__.py
@@ -1,0 +1,1 @@
+"""`runtime.base` — the value language + ports of the dependency boundary."""

--- a/apps/backend/src/runtime/base/check.py
+++ b/apps/backend/src/runtime/base/check.py
@@ -1,0 +1,35 @@
+"""`DependencyCheck` — the port a dependency's presence probe implements.
+
+Formalises the ad-hoc `ServiceStatus` + `_check_*` methods in
+`apps/backend/src/boot.py`. A dependency is either **present** or **absent**;
+there is no `skipped` (a declared dependency that cannot be reached is `ABSENT`
+and must fail — invariant 2 in `common/runtime/readme.md`). Adapters that
+implement this port are wired in the *switch* phase; this module only defines the
+port + its result value language.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+
+class DependencyStatus(str, Enum):
+    """The outcome of probing a dependency. Deliberately binary — no `skipped`."""
+
+    PRESENT = "present"
+    ABSENT = "absent"
+
+
+@runtime_checkable
+class DependencyCheck(Protocol):
+    """A probe that reports whether one declared dependency is reachable.
+
+    `name` matches the dependency's name in the `DependencyManifest`; `probe`
+    returns `PRESENT`/`ABSENT` and never raises for an ordinary outage (an
+    unreachable dependency is `ABSENT`, not an exception).
+    """
+
+    name: str
+
+    async def probe(self) -> DependencyStatus: ...

--- a/apps/backend/src/runtime/base/kind.py
+++ b/apps/backend/src/runtime/base/kind.py
@@ -1,0 +1,19 @@
+"""`DependencyKind` — how an external dependency must be tested.
+
+The two kinds decide the substitute strategy (see `common/runtime/readme.md`):
+`CODE_DOMINANT` is deterministic (a light in-process backend behaves identically
+to the real one, so it is behaviourally equivalent in every environment);
+`MODEL_DOMINANT` is non-deterministic (output depends on the real service, so CI
+replays an input-keyed recording and the real behaviour is proven on staging).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class DependencyKind(str, Enum):
+    """The testing character of an external dependency."""
+
+    CODE_DOMINANT = "code_dominant"
+    MODEL_DOMINANT = "model_dominant"

--- a/apps/backend/src/runtime/base/manifest.py
+++ b/apps/backend/src/runtime/base/manifest.py
@@ -1,0 +1,125 @@
+"""`DependencyManifest` — the declared external dependencies of the app.
+
+This is the single source of truth for *what the runtime depends on*: each
+external backend, its `DependencyKind`, and the `EnvTier`s that require it to be
+present. It is pure data (no imports of `config`/`boot`); the parity test binds
+it to `config.py`, and later phases (switch/cleanup) route `boot.validate` and
+the smoke test through it so a *declared* dependency that is *absent* fails
+(invariant 2). Kept deliberately declarative here — no I/O, no probing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.runtime.base.kind import DependencyKind
+from src.runtime.base.tiers import EnvTier
+
+
+@dataclass(frozen=True)
+class Dependency:
+    """One external backend the app depends on.
+
+    `required_in` is the set of tiers where the dependency MUST be present; it is
+    never empty (a dependency the app never requires anywhere does not belong in
+    the manifest). The *backend* behind it may differ per tier (in-memory vs real)
+    — the manifest declares the requirement, not the implementation.
+    """
+
+    name: str
+    kind: DependencyKind
+    required_in: frozenset[EnvTier]
+    summary: str
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Dependency.name must be non-empty")
+        if not self.required_in:
+            raise ValueError(
+                f"dependency {self.name!r} is required in no tier; a dependency "
+                "must be required somewhere (no silent-optional dependencies)"
+            )
+
+
+class DependencyManifest:
+    """The frozen set of declared dependencies, with tier/name lookups."""
+
+    def __init__(self, dependencies: tuple[Dependency, ...]) -> None:
+        names = [d.name for d in dependencies]
+        if len(names) != len(set(names)):
+            raise ValueError("duplicate dependency name in manifest")
+        self._by_name: dict[str, Dependency] = {d.name: d for d in dependencies}
+
+    def __iter__(self):
+        return iter(self._by_name.values())
+
+    def names(self) -> frozenset[str]:
+        return frozenset(self._by_name)
+
+    def get(self, name: str) -> Dependency:
+        return self._by_name[name]
+
+    def required_for(self, tier: EnvTier) -> frozenset[str]:
+        """Names of the dependencies that must be present in `tier`."""
+        return frozenset(d.name for d in self._by_name.values() if tier in d.required_in)
+
+
+_ALL = frozenset(EnvTier)
+_VPS = frozenset({EnvTier.PREVIEW, EnvTier.STAGING, EnvTier.PRODUCTION})
+
+#: The app's declared external dependencies. `required_in` values are a starting
+#: declaration refined as the switch phase wires enforcement; the *kind* is the
+#: stable contract (it decides the substitute strategy).
+DEPENDENCY_MANIFEST = DependencyManifest(
+    (
+        Dependency(
+            name="database",
+            kind=DependencyKind.CODE_DOMINANT,
+            required_in=_ALL,
+            summary="Postgres — the system of record (DATABASE_URL).",
+        ),
+        Dependency(
+            name="object_storage",
+            kind=DependencyKind.CODE_DOMINANT,
+            required_in=_ALL,
+            summary="S3-compatible object storage for uploaded statements (S3_*).",
+        ),
+        Dependency(
+            name="llm",
+            kind=DependencyKind.MODEL_DOMINANT,
+            required_in=_ALL,
+            summary="The AI provider used for statement extraction (AI_*); "
+            "recorded in CI/preview, real on staging/prod.",
+        ),
+        Dependency(
+            name="cache",
+            kind=DependencyKind.CODE_DOMINANT,
+            required_in=_VPS,
+            summary="Redis (REDIS_URL) — optional in the app-owned tiers.",
+        ),
+        Dependency(
+            name="workflow_engine",
+            kind=DependencyKind.CODE_DOMINANT,
+            required_in=frozenset({EnvTier.STAGING, EnvTier.PRODUCTION}),
+            summary="Prefect (PREFECT_API_URL) — durable flows; in-process fallback in the app-owned tiers.",
+        ),
+        Dependency(
+            name="telemetry",
+            kind=DependencyKind.CODE_DOMINANT,
+            required_in=_VPS,
+            summary="OTel exporter (OTEL_EXPORTER_OTLP_ENDPOINT).",
+        ),
+        Dependency(
+            name="analytics",
+            kind=DependencyKind.CODE_DOMINANT,
+            required_in=frozenset({EnvTier.STAGING, EnvTier.PRODUCTION}),
+            summary="OpenPanel product analytics (OPENPANEL_API_URL).",
+        ),
+        Dependency(
+            name="market_data",
+            kind=DependencyKind.CODE_DOMINANT,
+            required_in=frozenset({EnvTier.PRODUCTION}),
+            summary="Yahoo Finance market-data fetch for report-side FX.",
+        ),
+    )
+)

--- a/apps/backend/src/runtime/base/tiers.py
+++ b/apps/backend/src/runtime/base/tiers.py
@@ -1,0 +1,30 @@
+"""`EnvTier` — the six environments a dependency can be declared for.
+
+Mirrors `docs/ssot/environments.md#environment-overview` (the `six_environments`
+SSOT). CI and Preview run light substitutes (Preview = same as CI but
+persistent); Staging and Production run real backends. Local Dev / Local CI /
+GitHub CI are the app-owned tiers (self-hosted via docker compose); Preview /
+Staging / Production live on the VPS (implemented by infra2).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnvTier(str, Enum):
+    """One of the six environments."""
+
+    LOCAL_DEV = "local_dev"
+    LOCAL_CI = "local_ci"
+    GITHUB_CI = "github_ci"
+    PREVIEW = "preview"
+    STAGING = "staging"
+    PRODUCTION = "production"
+
+
+#: The app-owned tiers — brought up in-place by the app itself (docker compose).
+APP_OWNED_TIERS: frozenset[EnvTier] = frozenset({EnvTier.LOCAL_DEV, EnvTier.LOCAL_CI, EnvTier.GITHUB_CI})
+
+#: The VPS tiers — provisioned by infra2.
+VPS_TIERS: frozenset[EnvTier] = frozenset({EnvTier.PREVIEW, EnvTier.STAGING, EnvTier.PRODUCTION})

--- a/apps/backend/tests/runtime/test_manifest.py
+++ b/apps/backend/tests/runtime/test_manifest.py
@@ -1,0 +1,77 @@
+"""`runtime` dependency-manifest tests (draft: value language + config parity).
+
+These anchor the construct phase: the manifest is well-formed, binds to real
+`config.py` settings, and encodes the substitute-kind contract. Enforcement of
+"declared ⇒ asserted present" (routing `boot.validate`/smoke through the manifest)
+lands in the switch phase and gets its own roadmap AC then.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.config import settings
+from src.runtime import (
+    APP_OWNED_TIERS,
+    DEPENDENCY_MANIFEST,
+    Dependency,
+    DependencyKind,
+    DependencyStatus,
+    EnvTier,
+)
+
+pytestmark = pytest.mark.no_db
+
+# Each declared dependency is backed by a real Settings field (the manifest is
+# grounded in config.py, not free-floating).
+_CONFIG_BACKING = {
+    "database": "database_url",
+    "object_storage": "s3_endpoint",
+    "llm": "ai_base_url",
+    "cache": "redis_url",
+    "workflow_engine": "prefect_api_url",
+    "telemetry": "otel_exporter_otlp_endpoint",
+    "analytics": "openpanel_api_url",
+    "market_data": "market_data_yahoo_timeout_seconds",
+}
+
+
+def test_manifest_declares_the_known_external_dependencies() -> None:
+    assert DEPENDENCY_MANIFEST.names() == frozenset(_CONFIG_BACKING)
+
+
+def test_every_dependency_is_backed_by_a_real_config_setting() -> None:
+    for name, attr in _CONFIG_BACKING.items():
+        assert name in DEPENDENCY_MANIFEST.names()
+        assert hasattr(settings, attr), f"{name}: settings.{attr} missing"
+
+
+def test_every_dependency_is_required_somewhere_no_silent_optional() -> None:
+    # A dependency required in no tier is meaningless; `Dependency` forbids it.
+    for dep in DEPENDENCY_MANIFEST:
+        assert dep.required_in, dep.name
+    with pytest.raises(ValueError):
+        Dependency(name="x", kind=DependencyKind.CODE_DOMINANT, required_in=frozenset(), summary="s")
+
+
+def test_llm_is_the_only_model_dominant_dependency() -> None:
+    model = {d.name for d in DEPENDENCY_MANIFEST if d.kind is DependencyKind.MODEL_DOMINANT}
+    assert model == {"llm"}
+
+
+def test_required_for_tier_returns_the_declared_subset() -> None:
+    # database + object_storage + llm are required in every tier.
+    for tier in EnvTier:
+        required = DEPENDENCY_MANIFEST.required_for(tier)
+        assert {"database", "object_storage", "llm"} <= required
+    # market_data is production-only.
+    assert "market_data" in DEPENDENCY_MANIFEST.required_for(EnvTier.PRODUCTION)
+    assert "market_data" not in DEPENDENCY_MANIFEST.required_for(EnvTier.GITHUB_CI)
+
+
+def test_app_owned_tiers_are_the_compose_hostable_three() -> None:
+    assert APP_OWNED_TIERS == frozenset({EnvTier.LOCAL_DEV, EnvTier.LOCAL_CI, EnvTier.GITHUB_CI})
+
+
+def test_status_is_binary_no_skipped() -> None:
+    assert {s.value for s in DependencyStatus} == {"present", "absent"}

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -7,10 +7,12 @@ them, and the invariant that a *declared* dependency must be *asserted present*
 (no silent ``skipped``/``warning``/fallback).
 
 It is a ``kernel`` leaf (``depends_on=[]``) and currently ``draft`` — still being
-designed. It ships no implementation units and no curated published language yet
-(``interface=[]``), so the prose contract (ubiquitous language, invariants, the
-roadmap of ACs) lives in ``readme.md`` + ``todo.md`` until each AC lands with a
-real test. Roadmap entries move here (each pinned to its test) as they are built.
+designed. The *construct* phase ships the ``base`` value language + the dependency
+manifest + the ``DependencyCheck`` port (published below); the adapters, the
+"declared ⇒ asserted present" enforcement, and the compose/lifecycle relocation
+land in the switch/cleanup phases. Roadmap ACs (each pinned to a real test) are
+added when the enforcement invariants land; the prose contract lives in
+``readme.md`` + ``todo.md`` until then.
 """
 
 from __future__ import annotations
@@ -24,8 +26,18 @@ CONTRACT = PackageContract(
     tier="CODE-ONLY",
     depends_on=[],
     roles=[],
-    implementations={"be": "common/runtime", "fe": None},
-    interface=[],
+    implementations={"be": "apps/backend/src/runtime", "fe": None},
+    interface=[
+        "APP_OWNED_TIERS",
+        "DEPENDENCY_MANIFEST",
+        "VPS_TIERS",
+        "Dependency",
+        "DependencyCheck",
+        "DependencyKind",
+        "DependencyManifest",
+        "DependencyStatus",
+        "EnvTier",
+    ],
     events=[],
     invariants=[],
     roadmap=[],

--- a/common/runtime/readme.md
+++ b/common/runtime/readme.md
@@ -85,5 +85,9 @@ declared dependency is proven present — or the build/smoke fails.**
 
 ## Public vs internal
 
-Draft: no published symbol language yet (`contract.interface == []`). Consumers do
-not import `runtime` today; the package currently owns the *model* (this file).
+Draft. The **construct** phase publishes the `base` value language + manifest +
+port (`contract.interface`): `DependencyKind`, `EnvTier` (+ `APP_OWNED_TIERS` /
+`VPS_TIERS`), `Dependency` / `DependencyManifest` / `DEPENDENCY_MANIFEST`, and the
+`DependencyCheck` port (+ `DependencyStatus`). No consumer routes through it yet —
+the switch phase points `boot.validate` and the smoke test at the manifest; the
+adapters and the compose/lifecycle relocation follow. See [`todo.md`](./todo.md).

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -68,6 +68,7 @@ explicit AC IDs for the behavior.
 | `apps/backend/tests/api/test_ai_feedback_router_extra.py` | `docs/ssot/ai.md` |
 | `apps/backend/tests/assets/test_assets_positions_and_depreciation.py` | `docs/ssot/assets.md` |
 | `apps/backend/tests/identity/test_auth_router_unit.py` | `common/identity/readme.md` |
+| `apps/backend/tests/runtime/test_manifest.py` | `common/runtime/readme.md` |
 | `apps/backend/tests/extraction/test_account_last4_defense.py` | `common/extraction/readme.md` |
 | `apps/backend/tests/extraction/test_classification_service.py` | `common/extraction/readme.md` |
 | `apps/backend/tests/extraction/test_extraction_cassette_replay.py` | `common/llm/readme.md` (EPIC-023 AC23.6 streaming-bridge scaffold; skipped via `needs_real_cassette` until real cassettes are recorded with `make llm-record`, then it becomes AC proof) |


### PR DESCRIPTION
**PR 1 of 3** for the runtime migration: **construct → switch → cleanup** (expand/migrate/contract). This PR is pure additive construction — **nothing consumes it yet, zero behaviour change**.

## What
`apps/backend/src/runtime/base` — the value language + declaration of the app↔external-world boundary:
- `DependencyKind` — **code-dominant** (deterministic; light substitute ≡ real) vs **model-dominant** (non-deterministic; recorded in CI, real on staging). The substitute-strategy axis.
- `EnvTier` (six environments) + `APP_OWNED_TIERS` (local dev / local CI / GitHub CI — compose-hostable, app self-implements) vs `VPS_TIERS` (preview / staging / prod — infra2 implements).
- `Dependency` / `DependencyManifest` / `DEPENDENCY_MANIFEST` — the single declaration of what the app depends on (database, object_storage, llm, cache, workflow_engine, telemetry, analytics, market_data), each with its kind + the tiers that require it. **A dependency required in no tier is rejected** (no silent-optional).
- `DependencyCheck` port + `DependencyStatus` (**present / absent — no `skipped`**), formalising the ad-hoc `ServiceStatus` / `_check_*` scattered in `boot.py`.

## Verify
- `check_package_contract` → PASSED (`runtime (kernel): 9 interface, 0 invariant, 0 roadmap — OK`); draft-baseline + migration-safety gates pass.
- 7 new tests: manifest ↔ `config.py` parity, kind contract, no-silent-optional, tier lookups, binary status. ruff + mypy clean.

## Next (this migration)
- **PR2 switch**: route `boot.validate` + the smoke test through the manifest (declared ⇒ asserted present; drop `skipped`/optional-warning); `git mv` compose + `infra.sh` + `test_lifecycle` into runtime.
- **PR3 cleanup**: delete the superseded `_check_*` / old compose; hand the preview/Dokploy orchestration back to infra2 (de-dupe with `repo/libs/deploy/`).

Design context: `common/runtime/readme.md` (the 6 invariants) + the boundary discussion; #1531 scaffolded the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)