### PR TITLE
[finance_report_test_and_doc] chore(deps): bump echarts 6.0.0→6.1.0 (fix moderate XSS, unblock CI audit gate)

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -4784,13 +4784,13 @@
       }
     },
     "node_modules/echarts": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
-      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "6.0.0"
+        "zrender": "6.1.0"
       }
     },
     "node_modules/echarts-for-react": {
@@ -9856,9 +9856,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
-      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"


### PR DESCRIPTION
## Why
`npm audit` (the `Audit frontend production dependencies` Lint gate) now flags **echarts <6.1.0** for a moderate XSS advisory (**GHSA-fgmj-fm8m-jvvx**). Because npm audit queries the **live** advisory DB, this newly-published advisory trips the gate on **every new PR** (main passed earlier today, before it published) — a repo-wide block.

## What
Lockfile-only bump: **echarts + zrender 6.0.0 → 6.1.0**. The declared range (`^6.0.0`) already allows 6.1.0, so `package.json` is unchanged; 14 lines in `package-lock.json`, devDependencies untouched.

## Verify
`npm audit --omit=dev` → **found 0 vulnerabilities**.

Unblocks all open PRs (incl. the runtime migration #1536).