### PR TITLE
[finance_report_ui] fix(e2e): retry vision-hard-gate file selection to close hydration race

### DIFF
--- a/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
+++ b/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
@@ -161,12 +161,25 @@ async def test_statement_upload_to_dashboard_vision_hard_gate(
     await page.locator('[data-testid="uploader-institution-statement"]').fill(
         INSTITUTION_LABEL
     )
-    await page.set_input_files(
-        '[data-testid="uploader-file-statement"]', str(fixture_path)
-    )
-    await expect(
-        page.locator("p.font-medium", has_text=fixture_path.name)
-    ).to_be_visible(timeout=5_000)
+    # The CSV path renders no AI-model dropdown, so unlike the PDF upload E2E specs
+    # there is no incidental async wait to absorb client-side hydration time before
+    # this is the first interaction on the page. Against a real staging deploy
+    # (JS bundle fetched over the network, unlike an instant localhost load), the
+    # file input's onChange handler can still be attaching when set_input_files
+    # dispatches the change event, dropping it silently. Retry the selection
+    # (each attempt re-dispatches the event) rather than widening the timeout,
+    # which would only mask the race.
+    filename_locator = page.locator("p.font-medium", has_text=fixture_path.name)
+    for attempt in range(3):
+        await page.set_input_files(
+            '[data-testid="uploader-file-statement"]', str(fixture_path)
+        )
+        try:
+            await expect(filename_locator).to_be_visible(timeout=5_000)
+            break
+        except AssertionError:
+            if attempt == 2:
+                raise
 
     upload_resp = None
     upload_body_text = ""


### PR DESCRIPTION
## Why
Two consecutive attempts to deploy v0.1.29 to staging (runs 28451530688 and 28510550880) failed on the same assertion in `test_vision_upload_to_dashboard_hard_gate.py:167`: after `set_input_files`, the selected filename never rendered within the 5s timeout.

Root cause: this test's CSV fixture skips the AI-model dropdown (CSV parses directly, no model selection needed), so unlike the sibling PDF-upload E2E specs — which incidentally buffer client-side hydration time while waiting up to 15s for the model dropdown to populate from an API call — this test interacts with the file input as its very first action after navigation. Against a real staging deploy (JS bundle fetched over the network, not an instant localhost load), React's `onChange` handler can still be attaching when Playwright dispatches the file input's `change` event, so it's silently dropped and the filename never renders.

`networkidle` was considered but ruled out: `/upload` polls statement status via `setInterval` every 3s, so the network never truly idles — that wait would just introduce a different timeout risk.

## What
Retry the file selection (each attempt re-dispatches the `change` event) instead of widening the 5s timeout, which would only make the race harder to lose without closing it.

## Gates (local)
- `py_compile` clean
- `ruff check` + `ruff format --check` clean
- pre-commit hooks passed

## Verification
Only verifiable by re-running the staging deploy gate (this test tier is `post_merge_environment` — it only runs against a real deployed environment). Recommend re-triggering `Deploy Staging v0.1.29` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)