### PR TITLE
[finance_report_ui] fix(e2e): vision-hard-gate must use the CSV-kind uploader, not statement

### DIFF
--- a/apps/frontend/src/__tests__/StatementUploader.test.tsx
+++ b/apps/frontend/src/__tests__/StatementUploader.test.tsx
@@ -372,6 +372,37 @@ describe("AC3.5.3 StatementUploader model selection", () => {
     expect(apiUpload).not.toHaveBeenCalled();
   });
 
+  it("AC19.15.3 statement uploader rejects csv and csv uploader rejects non-csv, each enforcing its own kind's extensions", async () => {
+    vi.mocked(fetchAiModels).mockResolvedValue({
+      default_model: "google/gemini-3-flash-preview",
+      fallback_models: [],
+      models: baseModels,
+    });
+
+    const { unmount } = render(<StatementUploader kind="statement" />);
+    fireEvent.change(screen.getByTestId("uploader-file-statement"), {
+      target: { files: [new File(["a,b"], "data.csv", { type: "text/csv" })] },
+    });
+    expect(
+      await screen.findByText("Invalid file type: .csv. Allowed: PDF, PNG, or JPG"),
+    ).toBeInTheDocument();
+    unmount();
+
+    render(<StatementUploader kind="csv" />);
+    const csvInput = screen.getByTestId("uploader-file-csv");
+    fireEvent.change(csvInput, {
+      target: { files: [new File(["data"], "statement.pdf", { type: "application/pdf" })] },
+    });
+    expect(
+      await screen.findByText("Invalid file type: .pdf. Allowed: CSV"),
+    ).toBeInTheDocument();
+
+    fireEvent.change(csvInput, {
+      target: { files: [new File(["a,b"], "data.csv", { type: "text/csv" })] },
+    });
+    expect(await screen.findByText("data.csv")).toBeInTheDocument();
+  });
+
   it("AC8.4.1 requires a file and calls completion callback after successful upload", async () => {
     vi.mocked(fetchAiModels).mockResolvedValue({
       default_model: "google/gemini-3-flash-preview",

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -488,8 +488,14 @@ independently by AC13.12 over `docs/ssot/source-coverage-matrix.yaml`.
 |---|---|---|---|
 | AC19.15.1 | The Upload page exposes exactly three intake entries — one primary statement uploader (the AI identifies the type; the user never pre-classifies), one CSV import, and one Manual records entry — with no per-source-class checklist | `AC19.15.1 exposes exactly three intake entries: one statement uploader plus CSV and Manual` | P1 |
 | AC19.15.2 | The CSV import and Manual records entries are folded (collapsed) by default so they stay passive, the retired per-source-class checklist does not return, and the page does not fetch report readiness merely to render intake | `AC19.15.2 keeps secondary intake passive: CSV and Manual folded, no per-class checklist, no readiness fetch` | P1 |
+| AC19.15.3 {tier:CODE-ONLY} | The primary statement uploader (`kind="statement"`) rejects `.csv` files by extension before setting a selected file, and the CSV import uploader (`kind="csv"`) rejects non-csv files and accepts `.csv` — each intake entry enforces its own kind's file-extension restriction, independent of the shared `all`-kind default | `AC19.15.3 statement uploader rejects csv and csv uploader rejects non-csv, each enforcing its own kind's extensions` | P1 |
 
 Traceability note: AC19.15 is tracked in this EPIC-local product UI table.
+AC19.15.3 backfills coverage the [finance_report_ui] fix(e2e) #1542 gap exposed:
+`StatementUploader.test.tsx` only ever rendered the default `kind="all"`, and
+`statementsPage.test.tsx` mocks `StatementUploader` out entirely, so the
+per-kind extension contract that Tier-3 E2E depends on had no unit/component-tier
+test — a Tier-3-only regression had to hit a real staging deploy to be caught.
 
 ## How To Build It
 

--- a/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
+++ b/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
@@ -158,28 +158,20 @@ async def test_statement_upload_to_dashboard_vision_hard_gate(
 
     await _goto_ready(page, "/statements")
 
-    await page.locator('[data-testid="uploader-institution-statement"]').fill(
+    # The fixture is a CSV, but the primary "statement" uploader (EPIC-019 AC19.15
+    # three-entry intake) only accepts pdf/png/jpg — a csv there is rejected by
+    # validateAndSetFile's extension check and never sets `file`, so the filename
+    # never renders. CSV import is the folded secondary entry: expand it and scope
+    # all interactions to it, since both entries share the same button label.
+    csv_section = page.locator("details").filter(has_text="CSV import")
+    await csv_section.locator("summary").click()
+    await csv_section.locator('[data-testid="uploader-institution-csv"]').fill(
         INSTITUTION_LABEL
     )
-    # The CSV path renders no AI-model dropdown, so unlike the PDF upload E2E specs
-    # there is no incidental async wait to absorb client-side hydration time before
-    # this is the first interaction on the page. Against a real staging deploy
-    # (JS bundle fetched over the network, unlike an instant localhost load), the
-    # file input's onChange handler can still be attaching when set_input_files
-    # dispatches the change event, dropping it silently. Retry the selection
-    # (each attempt re-dispatches the event) rather than widening the timeout,
-    # which would only mask the race.
-    filename_locator = page.locator("p.font-medium", has_text=fixture_path.name)
-    for attempt in range(3):
-        await page.set_input_files(
-            '[data-testid="uploader-file-statement"]', str(fixture_path)
-        )
-        try:
-            await expect(filename_locator).to_be_visible(timeout=5_000)
-            break
-        except AssertionError:
-            if attempt == 2:
-                raise
+    await page.set_input_files('[data-testid="uploader-file-csv"]', str(fixture_path))
+    await expect(
+        csv_section.locator("p.font-medium", has_text=fixture_path.name)
+    ).to_be_visible(timeout=5_000)
 
     upload_resp = None
     upload_body_text = ""
@@ -188,7 +180,9 @@ async def test_statement_upload_to_dashboard_vision_hard_gate(
         async with page.expect_response(
             lambda r: "/api/statements/upload" in r.url, timeout=30_000
         ) as upload_info:
-            await page.get_by_role("button", name="Upload & Parse Statement").click()
+            await csv_section.get_by_role(
+                "button", name="Upload & Parse Statement"
+            ).click()
         upload_resp = await upload_info.value
         upload_body_text = await upload_resp.text()
         if upload_resp.status in (200, 201, 202):

--- a/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
+++ b/tests/e2e/test_vision_upload_to_dashboard_hard_gate.py
@@ -161,17 +161,31 @@ async def test_statement_upload_to_dashboard_vision_hard_gate(
     # The fixture is a CSV, but the primary "statement" uploader (EPIC-019 AC19.15
     # three-entry intake) only accepts pdf/png/jpg — a csv there is rejected by
     # validateAndSetFile's extension check and never sets `file`, so the filename
-    # never renders. CSV import is the folded secondary entry: expand it and scope
-    # all interactions to it, since both entries share the same button label.
+    # never renders (confirmed root cause: two live staging runs still failed here
+    # with a hydration-race retry loop in place, ruling out timing as the cause —
+    # see AC19.15.3 for the unit-tier regression test that now locks this contract
+    # down). CSV import is the folded secondary entry: expand it and scope all
+    # interactions to it, since both entries share the same button label.
     csv_section = page.locator("details").filter(has_text="CSV import")
     await csv_section.locator("summary").click()
     await csv_section.locator('[data-testid="uploader-institution-csv"]').fill(
         INSTITUTION_LABEL
     )
-    await page.set_input_files('[data-testid="uploader-file-csv"]', str(fixture_path))
-    await expect(
-        csv_section.locator("p.font-medium", has_text=fixture_path.name)
-    ).to_be_visible(timeout=5_000)
+    # Belt-and-suspenders per this file's existing staging-environment tolerance
+    # convention (#944): retry the selection in case hydration is still slow on a
+    # freshly rolled-out container, even though the wrong-kind mismatch above was
+    # the actual, deterministic cause of both prior failures.
+    filename_locator = csv_section.locator("p.font-medium", has_text=fixture_path.name)
+    for attempt in range(3):
+        await page.set_input_files(
+            '[data-testid="uploader-file-csv"]', str(fixture_path)
+        )
+        try:
+            await expect(filename_locator).to_be_visible(timeout=5_000)
+            break
+        except AssertionError:
+            if attempt == 2:
+                raise
 
     upload_resp = None
     upload_body_text = ""


### PR DESCRIPTION
## Why
v0.1.30's staging deploy failed on the exact same assertion as v0.1.29, even after #1540's retry-loop fix — because that fix targeted the wrong hypothesis (hydration timing). The real bug: this test's fixture (`vision_hard_gate_statement.csv`) is a CSV, but the test fills/selects it through the **primary "statement" uploader** (`data-testid="uploader-institution-statement"` / `uploader-file-statement`).

Per EPIC-019 AC19.15's three-entry intake redesign, the primary "statement" uploader only accepts `pdf/png/jpg`:
```ts
statement: { extensions: ["pdf", "png", "jpg", "jpeg"], ... }
csv: { extensions: ["csv"], ... }
```
`validateAndSetFile`'s extension check rejects the `.csv` file there with an inline error and never calls `setFile(f)` — so the filename `<p className="font-medium">` never renders. No amount of retrying or waiting for hydration fixes a file aimed at an input that structurally rejects its extension.

CSV import lives in a separate, folded-by-default `<details>` section on `/upload` (`kind="csv"`) with its own `uploader-institution-csv` / `uploader-file-csv` test-ids.

## What
- Expand the "CSV import" `<details>` section before interacting.
- Scope the institution fill, filename assertion, and upload-button click to that section's locator — both uploader instances render an identically-labelled "Upload & Parse Statement" button, so an unscoped `get_by_role` click would be ambiguous once the CSV section is open.

## Gates (local)
- `py_compile`, `ruff check`, `ruff format --check` all clean
- pre-commit hooks passed

## Verification
This test tier is `post_merge_environment` — only verifiable by re-running the staging deploy gate. Recommend cutting a new version and re-triggering `Deploy Staging` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)