### PR TITLE
[finance_report_audit] close out value→audit fold (#1419 step 3/3)

### DIFF
--- a/.opencode/skills/domain/accounting/SKILL.md
+++ b/.opencode/skills/domain/accounting/SKILL.md
@@ -21,11 +21,12 @@ Assets = Liabilities + Equity + (Income - Expenses)
 - **Decimal only** — NEVER use `float` to store, calculate, or transfer money.
 - **Rule A2 — canonical rounding**: currency amounts are quantized to **2 dp with
   banker's rounding (`ROUND_HALF_EVEN`)**. Always round through the one helper
-  `apps/backend/src/utils/money.py::to_money()` (exposed as `src.utils.to_money`).
-  Do NOT hand-roll `quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)` for money.
+  `apps/backend/src/audit/money/rounding.py::to_money()` (exposed as
+  `src.audit.money.to_money`). Do NOT hand-roll
+  `quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)` for money.
   Out of scope (keep their own quantization): FX rates & security prices (6 dp),
   share quantities (6 dp), percentages/ratios (XIRR, TWR, MWR, allocation %).
-  Guardrail: `apps/backend/tests/money/test_money.py`.
+  Guardrail: `apps/backend/tests/audit/money/test_money.py`.
 
 ## Multi-Currency Journal Balance
 


### PR DESCRIPTION
## Summary
- PR3 (final step) of the 3-PR sequence in #1419, following #1539 (physical fold) and #1548 (AC migration).
- Ran an exhaustive repo-wide scan (paths, dotted module refs, MANIFEST entries, EPIC-025/026, other SSOT docs) for anything left pointing at the pre-fold `money`/`ratio`/`quantity`/`unit_price` layout.
- Found exactly one leftover: `.opencode/skills/domain/accounting/SKILL.md`'s Rule A2 guardrail still referenced `apps/backend/tests/money/test_money.py` (pre-fold path). Same paragraph also still referenced the long-retired `src/utils/money.py` shim (retired years ago in #1191, unrelated to this fold, but same sentence) instead of the current `src.audit.money.to_money` — fixed both together since leaving one half-fixed would read worse than fixing the whole paragraph.
- Confirmed **nothing else needs changing**: `docs/ssot/MANIFEST.yaml`'s `money_value_type` and `base_packages` entries are legitimately distinct (different families/owners, not redundant); `EPIC-025`/`EPIC-026` (mentioned in #1419's original body as a possible AC source) have no money/ratio/quantity/unit_price-related rows; no other doc, skill, or code file anywhere references the old paths.

This closes out issue #1419.

## Test plan
- [x] Repo-wide grep sweep (path fragments + dotted module forms across `.opencode`, `.github`, `docs`, `AGENTS.md`, `README.md`, `vision.md`) — zero remaining hits after this fix
- [x] Manual verification: `apps/backend/src/audit/money/rounding.py::to_money` and `apps/backend/tests/audit/money/test_money.py` both exist at the corrected paths