### PR TITLE
[finance_report_test_and_doc] feat(runtime): drop silent `skipped` — absent dependency is an error (PR3/3, final)

### DIFF
--- a/apps/backend/src/boot.py
+++ b/apps/backend/src/boot.py
@@ -44,7 +44,7 @@ class BootMode(str, Enum):
 @dataclass
 class ServiceStatus:
     service: str
-    status: str  # 'ok', 'warning', 'error', 'skipped'
+    status: str  # 'ok', 'warning', 'error'
     message: str
     duration_ms: float = 0.0
 
@@ -237,10 +237,11 @@ class Bootloader:
         """Report the configured AI provider (the model catalogue is local — see
         ``src/llm/catalog.py`` — so there is no remote ``/models`` probe).
 
-        Delegates to the runtime `LlmCheck` adapter. The AI provider is treated as
-        optional here, so an absent (unconfigured) provider maps to `skipped`
-        rather than `error` — preserved from the pre-runtime behaviour; the switch
-        to declared-required enforcement lands with the manifest cutover.
+        Delegates to the runtime `LlmCheck` adapter. A declared dependency that is
+        absent is an `error`, not a silent `skipped` (runtime invariant 2). This
+        check only runs in FULL (smoke) mode, which runs against a real deployed
+        environment where the provider is configured; the app's own startup
+        (CRITICAL) checks only the database.
         """
         result = await LlmCheck(
             api_key=getattr(settings, "ai_api_key", None),
@@ -248,9 +249,8 @@ class Bootloader:
             primary_model=settings.primary_model,
             ocr_model=settings.ocr_model,
         ).probe()
-        if result.status is DependencyStatus.PRESENT:
-            return ServiceStatus("ai_provider", "ok", result.detail)
-        return ServiceStatus("ai_provider", "skipped", result.detail)
+        status = "ok" if result.status is DependencyStatus.PRESENT else "error"
+        return ServiceStatus("ai_provider", status, result.detail)
 
     _check_openrouter = _check_ai_provider
 

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -424,12 +424,14 @@ class TestBootloaderS3:
 
 
 class TestBootloaderOpenrouter:
-    async def test_check_openrouter_skipped(self, mock_settings):
+    async def test_check_openrouter_absent_is_error_not_skipped(self, mock_settings):
+        # runtime invariant 2: a declared dependency that is absent is an error,
+        # not a silent `skipped`.
         mock_settings.ai_api_key = None
 
         status = await Bootloader._check_openrouter()
 
-        assert status.status == "skipped"
+        assert status.status == "error"
         assert status.service == "ai_provider"
 
     async def test_check_openrouter_success(self, mock_settings):

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -10,11 +10,13 @@ It is a ``kernel`` leaf (``depends_on=[]``) and currently ``draft`` — still be
 designed. The *construct* phase shipped the ``base`` value language + dependency
 manifest + the ``DependencyCheck`` port; the *switch* phase adds the
 ``extension`` probe adapters (``DatabaseCheck`` / ``ObjectStorageCheck`` /
-``LlmCheck``, published below) that ``boot.Bootloader`` now delegates to. Still to
-come in *cleanup*: the "declared ⇒ asserted present" enforcement (drop
-``skipped``) and the compose/lifecycle relocation. Roadmap ACs (each pinned to a
-real test) are added when the enforcement invariants land; the prose contract
-lives in ``readme.md`` + ``todo.md`` until then.
+``LlmCheck``, published below) that ``boot.Bootloader`` now delegates to. The
+*cleanup* phase dropped the silent ``skipped`` status: an absent declared
+dependency is an ``error`` (runtime invariant 2). Remaining as a future feature
+(not the migration): manifest-driven ``validate`` for *all* declared dependencies
+per env tier + smoke↔declaration parity — see ``todo.md``. Roadmap ACs (each
+pinned to a real test) are added when those enforcement invariants land; the
+prose contract lives in ``readme.md`` + ``todo.md`` until then.
 """
 
 from __future__ import annotations

--- a/common/runtime/todo.md
+++ b/common/runtime/todo.md
@@ -1,37 +1,40 @@
 # `runtime` — todo
 
 The package-local worklist. Cross-package migration lives in
-[`../todo.md`](../todo.md). Each item below becomes a `roadmap` AC in
-[`contract.py`](./contract.py) — pinned to a real test — when it lands (TDD: a
-failing test first).
+[`../todo.md`](../todo.md). Each item becomes a `roadmap` AC in
+[`contract.py`](./contract.py) — pinned to a real test — when the enforcement
+invariants land (TDD).
 
-## Done
+## Done (the construct → switch → cleanup migration)
 
-- [x] Package created on the model: ships `readme.md` + `contract.py` + `todo.md`,
-      governed by `check_package_contract` as a `draft` `kernel` leaf
-      (`depends_on=[]`, `interface=[]`).
+- [x] Package created on the model: `readme.md` + `contract.py` + `todo.md`,
+      governed by `check_package_contract` as a `draft` `kernel` leaf.
+- [x] **Manifest (base)** — `DependencyManifest` declares the external
+      dependencies (database, object_storage, llm, cache, workflow_engine,
+      telemetry, analytics, market_data) with their `Kind` and required tiers.
+- [x] **Port + adapters** — `DependencyCheck` port + `ProbeResult`; the
+      `DatabaseCheck` / `ObjectStorageCheck` / `LlmCheck` adapters own the probe
+      logic; `boot.Bootloader` delegates to them.
+- [x] **Drop `skipped`** — an absent declared dependency is now an `error`, not a
+      silent `skipped` (runtime invariant 2), starting with the AI provider.
 
-## Next (the dependency-boundary contract, in order)
+## Next (declared-required enforcement — a future feature, not the migration)
 
-- [ ] **Manifest (base).** Define `DependencyManifest`: per env tier, the declared
-      required dependencies + each one's `Kind`. First filled from a full audit of
-      `config.py` (S3, LLM, Postgres, Redis, Prefect, OTel, OpenPanel, market-data).
-- [ ] **Port (base).** Lift `ServiceStatus` + the `_check_*` methods out of
-      `boot.py` into a `DependencyCheck` port + per-dependency adapters
-      (extension). Drop the `"skipped"` status (invariant 2).
-- [ ] **Assert + fail (api).** `boot.validate` + `smoke_test` assert the declared
-      set for their tier; a declared-but-absent dependency fails (no `warning`).
-      Proof: dropping a declared dependency's config makes the smoke FAIL.
-- [ ] **Smoke ↔ declaration parity.** Extend the smoke meta-guard to
-      `checks == declared count`; wire the tag→staging smoke as the prod-promote
-      gate.
-- [ ] **code-dominant substitutes.** S3 → in-memory (moto) so the real
-      `StorageService` runs in CI (retire `DummyStorage`); the upload→store→load→
-      parse pipeline test. Redis → fakeredis or document the in-memory path.
-      Market-data → transport-layer record/replay (not a blanket disable).
-- [ ] **model-dominant recording.** Pin the LLM recording as input-keyed (changed
-      input ⇒ miss); the staging gate (real provider) stays recording-free.
-- [ ] **Guardrail.** A contract test: adding an external dependency to `config.py`
-      without (kind + per-tier declaration + substitute + smoke assertion) fails CI.
-- [ ] Promote `status` `draft` → `active` once the manifest + port + assert
-      invariants have landing tests.
+- [ ] **Env tier + manifest-driven validate.** Resolve the running `EnvTier`;
+      `boot.validate` / the smoke test iterate `DEPENDENCY_MANIFEST.required_for`
+      and fail on any declared-required dependency that is absent (invariant 2 for
+      all deps, not just the AI provider).
+- [ ] **Smoke ↔ declaration parity** (invariant 6) + the tag→staging-smoke gate.
+- [ ] **Substitutes** (invariants 4/5): S3 → in-memory (moto), the real
+      `StorageService` runs in CI (see #1520); LLM recording input-keyed.
+- [ ] **Guardrail**: a new external dependency in `config.py` without a manifest
+      entry fails CI.
+- [ ] Promote `status` `draft` → `active` once the enforcement invariants land
+      with tests, and add their roadmap ACs.
+
+## Notes
+
+- The compose files (`docker-compose*.yml`), `tools/infra.sh`, and the dev
+  lifecycle stay at their functional locations (where docker compose / CI expect
+  them); `runtime` owns them *conceptually* via the manifest, not by a physical
+  move into the Python package.


### PR DESCRIPTION
**PR 3 of 3 (final)** for the runtime migration (construct → switch → **cleanup**). Removes the last piece of old logic: the silent-degradation `skipped`.

## What
`Bootloader._check_ai_provider` mapped an absent (unconfigured) AI provider to `skipped` — a non-error that let `boot.validate` FULL (smoke) pass while a **declared dependency was absent**. That is exactly the false-positive the `runtime` package exists to kill (invariant 2). It now maps **absent → `error`**. `skipped` had no other emitter, so it's dropped from the `ServiceStatus` value language too.

**Low-risk:** the AI check runs only in FULL/smoke mode, which targets a real deployed environment where the provider is configured; app startup (CRITICAL) checks only the database.

## Migration complete
| PR | phase |
|---|---|
| #1536 | construct — manifest + port |
| #1543 | switch — boot delegates to adapters |
| **this** | **cleanup — drop `skipped`** |

## Scope (deliberate, per the discussion — no PR4)
- The **manifest-driven `validate` for all declared deps per env tier** + smoke↔declaration parity + substitutes (moto, #1520) are a **future enforcement feature**, not part of this migration. Tracked in `common/runtime/todo.md`.
- The compose/infra files **stay at their functional locations** (docker compose / CI expect them there); `runtime` owns them conceptually via the manifest, not by a physical move into a Python package.

## Verify
- absent AI provider → `error` (new test `test_check_openrouter_absent_is_error_not_skipped`); no other test depended on `skipped`.
- 66 backend tests pass (boot/health/manifest); package-contract (13 symbols) + draft + migration-safety gates OK; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)