### PR TITLE
[finance_report_test_and_doc] feat(runtime): consolidate dependency env-vars + own the smoke test

### DIFF
--- a/apps/backend/src/runtime/base/manifest.py
+++ b/apps/backend/src/runtime/base/manifest.py
@@ -29,6 +29,7 @@ class Dependency:
     name: str
     kind: DependencyKind
     required_in: frozenset[EnvTier]
+    env_vars: frozenset[str]
     summary: str
 
     def __post_init__(self) -> None:
@@ -38,6 +39,11 @@ class Dependency:
             raise ValueError(
                 f"dependency {self.name!r} is required in no tier; a dependency "
                 "must be required somewhere (no silent-optional dependencies)"
+            )
+        if not self.env_vars:
+            raise ValueError(
+                f"dependency {self.name!r} declares no env vars; runtime is the "
+                "SSOT for which env vars configure each external dependency"
             )
 
 
@@ -74,18 +80,21 @@ DEPENDENCY_MANIFEST = DependencyManifest(
     (
         Dependency(
             name="database",
+            env_vars=frozenset({"DATABASE_URL"}),
             kind=DependencyKind.CODE_DOMINANT,
             required_in=_ALL,
             summary="Postgres — the system of record (DATABASE_URL).",
         ),
         Dependency(
             name="object_storage",
+            env_vars=frozenset({"S3_ENDPOINT", "S3_ACCESS_KEY", "S3_SECRET_KEY", "S3_BUCKET", "S3_REGION"}),
             kind=DependencyKind.CODE_DOMINANT,
             required_in=_ALL,
             summary="S3-compatible object storage for uploaded statements (S3_*).",
         ),
         Dependency(
             name="llm",
+            env_vars=frozenset({"AI_API_KEY", "AI_PROVIDER", "AI_BASE_URL"}),
             kind=DependencyKind.MODEL_DOMINANT,
             required_in=_ALL,
             summary="The AI provider used for statement extraction (AI_*); "
@@ -93,30 +102,35 @@ DEPENDENCY_MANIFEST = DependencyManifest(
         ),
         Dependency(
             name="cache",
+            env_vars=frozenset({"REDIS_URL"}),
             kind=DependencyKind.CODE_DOMINANT,
             required_in=_VPS,
             summary="Redis (REDIS_URL) — optional in the app-owned tiers.",
         ),
         Dependency(
             name="workflow_engine",
+            env_vars=frozenset({"PREFECT_API_URL"}),
             kind=DependencyKind.CODE_DOMINANT,
             required_in=frozenset({EnvTier.STAGING, EnvTier.PRODUCTION}),
             summary="Prefect (PREFECT_API_URL) — durable flows; in-process fallback in the app-owned tiers.",
         ),
         Dependency(
             name="telemetry",
+            env_vars=frozenset({"OTEL_EXPORTER_OTLP_ENDPOINT"}),
             kind=DependencyKind.CODE_DOMINANT,
             required_in=_VPS,
             summary="OTel exporter (OTEL_EXPORTER_OTLP_ENDPOINT).",
         ),
         Dependency(
             name="analytics",
+            env_vars=frozenset({"OPENPANEL_API_URL", "OPENPANEL_CLIENT_ID"}),
             kind=DependencyKind.CODE_DOMINANT,
             required_in=frozenset({EnvTier.STAGING, EnvTier.PRODUCTION}),
             summary="OpenPanel product analytics (OPENPANEL_API_URL).",
         ),
         Dependency(
             name="market_data",
+            env_vars=frozenset({"MARKET_DATA_YAHOO_TIMEOUT_SECONDS"}),
             kind=DependencyKind.CODE_DOMINANT,
             required_in=frozenset({EnvTier.PRODUCTION}),
             summary="Yahoo Finance market-data fetch for report-side FX.",

--- a/apps/backend/tests/runtime/test_manifest.py
+++ b/apps/backend/tests/runtime/test_manifest.py
@@ -46,12 +46,30 @@ def test_every_dependency_is_backed_by_a_real_config_setting() -> None:
         assert hasattr(settings, attr), f"{name}: settings.{attr} missing"
 
 
+def test_runtime_owns_the_dependency_env_vars_bound_to_config() -> None:
+    # runtime is the SSOT for *which* env vars configure each external dependency;
+    # config owns the mechanism (Settings reads them). Every declared env var maps
+    # to a real Settings field (env-var name -> snake_case attribute).
+    for dep in DEPENDENCY_MANIFEST:
+        assert dep.env_vars, dep.name
+        for env_var in dep.env_vars:
+            assert env_var.isupper(), f"{dep.name}: env var {env_var!r} should be UPPER_SNAKE"
+            attr = env_var.lower()
+            assert hasattr(settings, attr), f"{dep.name}: settings.{attr} missing for {env_var}"
+
+
 def test_every_dependency_is_required_somewhere_no_silent_optional() -> None:
     # A dependency required in no tier is meaningless; `Dependency` forbids it.
     for dep in DEPENDENCY_MANIFEST:
         assert dep.required_in, dep.name
     with pytest.raises(ValueError):
-        Dependency(name="x", kind=DependencyKind.CODE_DOMINANT, required_in=frozenset(), summary="s")
+        Dependency(
+            name="x",
+            kind=DependencyKind.CODE_DOMINANT,
+            required_in=frozenset(),
+            env_vars=frozenset({"X"}),
+            summary="s",
+        )
 
 
 def test_llm_is_the_only_model_dominant_dependency() -> None:

--- a/common/runtime/readme.md
+++ b/common/runtime/readme.md
@@ -65,15 +65,22 @@ declared dependency is proven present — or the build/smoke fails.**
 - **extension** — the per-dependency check/substitute adapters (db, s3, llm,
   redis, telemetry). Each implements the port; an adapter may instead live in its
   own domain package and implement this port (dependency inversion).
-- **api** — `boot.validate` and the smoke test become this package's boundary:
-  they run the declared checks and enforce invariants 2 and 6.
+- **api** — `boot.validate` and the **environment smoke test**
+  (`docs/ssot/env_smoke_test.md`, `tools/smoke_test.sh`) are this package's
+  boundary: `runtime` **owns** the smoke test — the deployed-environment
+  verification that every declared dependency is present (invariants 2 and 6),
+  plus the version-integrity / routing / functional checks it composes.
 
 ## Boundaries with neighbouring packages
 
-- **`config`** — owns the env-key *plumbing* (the three-layer
-  `secrets.ctmpl` ↔ `config.py` ↔ `.env.example` consistency). `runtime` owns the
-  *dependency semantics* on top: which keys denote a dependency, its kind, its
-  per-tier substitute, and the presence assertion.
+- **`config`** — owns the env-var *mechanism*: the three-layer SSOT
+  (`secrets.ctmpl` ↔ `config.py` ↔ `.env.example`), the pydantic `Settings`
+  reader, and schema validation — shared by every package. `runtime` owns the
+  *dependency layer* on top: the **manifest is the SSOT for which env vars are
+  external-dependency env vars** (`Dependency.env_vars`, bound to `Settings`),
+  each dependency's kind, its per-tier substitute, and the presence assertion.
+  (Only dependency env vars consolidate here — feature/security/domain env vars
+  stay with `config` and their domain packages.)
 - **`testing`** — owns proof *provenance* (`deterministic` / `golden_fixture` /
   `live_llm`); `runtime`'s `Kind` maps onto it (code-dominant → deterministic,
   model-dominant → live on staging).

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -62,7 +62,7 @@ explicit AC IDs for the behavior.
 
 | Path | Owner |
 |---|---|
-| `tests/tooling/test_smoke_min_checks.py` | `docs/ssot/env_smoke_test.md` |
+| `tests/tooling/test_smoke_min_checks.py` | `common/runtime/readme.md` (env_smoke_test owned by the runtime package) |
 | `apps/backend/tests/audit/money/test_money.py` | `common/ledger/readme.md` |
 | `apps/backend/tests/ledger/test_processing_account_endpoints.py` | `common/ledger/readme.md` |
 | `apps/backend/tests/api/test_ai_feedback_router_extra.py` | `docs/ssot/ai.md` |

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -827,9 +827,12 @@ concepts:
   # ── Environment smoke test ────────────────────────────────────────────
   env_smoke_test:
     owner: docs/ssot/env_smoke_test.md
-    description: Environment smoke testing via real boot operations.
+    description: Environment smoke testing via real boot operations. Owned by the
+      runtime package (common/runtime/readme.md) — it is runtime's deployed-env
+      dependency-presence verification; env_smoke_test.md is its SSOT doc.
     cross_refs:
       - docs/ssot/development.md
+      - common/runtime/readme.md
     proofs:
       - tests/tooling/test_runtime_incident_response_ssot.py
 


### PR DESCRIPTION
Per the boundary decision, `runtime` takes over two ownerships.

## 1. Dependency env vars → runtime is the SSOT
`Dependency` now carries **`env_vars`** — the UPPER_SNAKE env var names that configure each external dependency (`DATABASE_URL`, `S3_*`, `AI_*`, `REDIS_URL`, `PREFECT_API_URL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OPENPANEL_*`, `MARKET_DATA_YAHOO_TIMEOUT_SECONDS`). The manifest is now the **single source of truth for which env vars are external-dependency vars**; a new test binds each to a real `Settings` field.

`config` keeps the **mechanism** (three-layer SSOT + the pydantic reader); **feature/security/domain env vars stay with `config` and their domain packages** (only dependency env vars consolidate here).

## 2. Smoke test → runtime owns it
The environment smoke test (`docs/ssot/env_smoke_test.md`, `tools/smoke_test.sh`) is runtime's deployed-env dependency-presence verification (invariants 2 & 6) plus the version/routing/functional checks it composes. Updated: readme `api` section, the MANIFEST `env_smoke_test` entry (cross_ref), and `test_smoke_min_checks.py`'s classification → `common/runtime/readme.md`.

## Interpretation note
"收口 = ownership + declaration SSOT", not a physical move of `tools/smoke_test.sh` / the pydantic `Settings` fields into the Python package (that would be architecturally wrong). `Settings` still reads the env vars; the manifest declares which are dependencies.

## Verify
package-contract (13 symbols) + draft + migration-safety + doc-consistency + SSOT-manifest gates pass; 43 runtime/boot tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)