### PR TITLE
[finance_report_hacker] feat(classify): wire import → income statement onto the classify node (Migrate 2/3, #1545)

### DIFF
--- a/apps/backend/src/services/reporting/income_statement.py
+++ b/apps/backend/src/services/reporting/income_statement.py
@@ -21,7 +21,13 @@ from src.services.fx import (
     PrefetchedFxRates,
     convert_money,
 )
-from src.services.reporting._core import _REPORT_STATUSES, _build_account_lines, _line_total, _load_accounts
+from src.services.reporting._core import (
+    _REPORT_STATUSES,
+    _aggregate_account_confidence_tiers,
+    _build_account_lines,
+    _line_total,
+    _load_accounts,
+)
 from src.services.reporting.balance_sheet import generate_balance_sheet
 from src.services.reporting.internal_transfer import _internal_transfer_adjustment
 from src.services.reporting_calc import (
@@ -217,16 +223,29 @@ async def generate_income_statement(
         account_id: _combine_provenance(provenance_values)
         for account_id, provenance_values in provenance_inputs_by_account.items()
     }
+    # Per-line confidence tiers (#1483/#1545): derived from the contributing
+    # entries' source_type over the reporting window, same as the balance sheet.
+    # Income-statement lines previously always carried confidence_tier=None
+    # because the tier aggregation was never wired here.
+    tiers = await _aggregate_account_confidence_tiers(
+        db,
+        user_id,
+        (AccountType.INCOME, AccountType.EXPENSE),
+        end_date,
+        start_date=start_date,
+    )
     income_lines = _build_account_lines(
         accounts,
         balances,
         AccountType.INCOME,
+        tiers=tiers,
         provenance_by_account=provenance_by_account,
     )
     expense_lines = _build_account_lines(
         accounts,
         balances,
         AccountType.EXPENSE,
+        tiers=tiers,
         provenance_by_account=provenance_by_account,
     )
 

--- a/apps/backend/src/services/statement_posting.py
+++ b/apps/backend/src/services/statement_posting.py
@@ -21,7 +21,7 @@ from src.models.statement_summary import StatementSummary
 from src.services.review_queue import create_entry_from_txn
 from src.services.source_type_priority import STATEMENT_SOURCE_TYPES, promote_entry_source_type
 from src.services.statement_validation import approve_statement, resolve_statement_transactions
-from src.services.transaction_classification import ClassificationPolicy, classify_transactions, policy_for
+from src.services.transaction_classification import classify_by_effective_policy
 
 HIGH_CONFIDENCE_AUTO_APPROVE_THRESHOLD = 85
 
@@ -82,19 +82,11 @@ async def auto_create_posted_entries_for_statement(
 
     # Classify BEFORE posting (#1545): ``create_entry_from_txn`` picks the
     # counter-account from an APPLIED classification, so a categorized txn posts to
-    # its real category account instead of the Uncategorized bucket. The pass is
-    # flag-gated inside ``classify_transactions`` (no-op when off => today's
-    # behaviour), and the classification basis is effective-dated: each txn
-    # classifies under the policy in effect on its OWN txn_date, so publishing a
-    # new basis version never restates already-covered periods (prospective).
-    by_version: dict[int, list] = {}
-    policies: dict[int, ClassificationPolicy] = {}
-    for txn in txns_to_post:
-        policy = policy_for(txn.txn_date)
-        policies[policy.version] = policy
-        by_version.setdefault(policy.version, []).append(txn)
-    for version in sorted(by_version):
-        await classify_transactions(db, user_id, by_version[version], policy=policies[version])
+    # its real category account instead of the Uncategorized bucket. The seam is
+    # flag-gated FIRST (no policy evaluation when off => today's behaviour exactly)
+    # and effective-dated per txn_date, so publishing a new basis version never
+    # restates already-covered periods; uncovered dates are skipped, never fatal.
+    await classify_by_effective_policy(db, user_id, txns_to_post)
 
     for txn in txns_to_post:
         # ``create_entry_from_txn`` consumes the Layer-2 ``AtomicTransaction``.

--- a/apps/backend/src/services/statement_posting.py
+++ b/apps/backend/src/services/statement_posting.py
@@ -21,6 +21,7 @@ from src.models.statement_summary import StatementSummary
 from src.services.review_queue import create_entry_from_txn
 from src.services.source_type_priority import STATEMENT_SOURCE_TYPES, promote_entry_source_type
 from src.services.statement_validation import approve_statement, resolve_statement_transactions
+from src.services.transaction_classification import ClassificationPolicy, classify_transactions, policy_for
 
 HIGH_CONFIDENCE_AUTO_APPROVE_THRESHOLD = 85
 
@@ -78,6 +79,22 @@ async def auto_create_posted_entries_for_statement(
 
     preloaded_bank_account = await resolve_statement_posting_account(db, statement, user_id)
     await validate_statement_period_unique(db, statement, user_id, preloaded_bank_account.id)
+
+    # Classify BEFORE posting (#1545): ``create_entry_from_txn`` picks the
+    # counter-account from an APPLIED classification, so a categorized txn posts to
+    # its real category account instead of the Uncategorized bucket. The pass is
+    # flag-gated inside ``classify_transactions`` (no-op when off => today's
+    # behaviour), and the classification basis is effective-dated: each txn
+    # classifies under the policy in effect on its OWN txn_date, so publishing a
+    # new basis version never restates already-covered periods (prospective).
+    by_version: dict[int, list] = {}
+    policies: dict[int, ClassificationPolicy] = {}
+    for txn in txns_to_post:
+        policy = policy_for(txn.txn_date)
+        policies[policy.version] = policy
+        by_version.setdefault(policy.version, []).append(txn)
+    for version in sorted(by_version):
+        await classify_transactions(db, user_id, by_version[version], policy=policies[version])
 
     for txn in txns_to_post:
         # ``create_entry_from_txn`` consumes the Layer-2 ``AtomicTransaction``.

--- a/apps/backend/src/services/transaction_classification.py
+++ b/apps/backend/src/services/transaction_classification.py
@@ -116,7 +116,9 @@ class ClassificationPolicy(BaseModel):
 POLICY_VERSIONS: tuple[ClassificationPolicy, ...] = (
     ClassificationPolicy(
         version=1,
-        effective_from=date(2020, 1, 1),
+        # The INITIAL basis covers all prior history (pre-2020 statements are
+        # normal); only later versions carry a meaningful cutover date.
+        effective_from=date.min,
         catalog=tuple(TransactionCategory),
         model_version="v1",
     ),
@@ -487,3 +489,43 @@ async def backfill_classifications(db: AsyncSession, user_id: UUID) -> dict:
         summaries.append({"policy_version": version, **summarize_outcomes(outcomes)})
 
     return {"classified": written, "candidates": len(candidates), "runs": summaries}
+
+
+async def classify_by_effective_policy(
+    db: AsyncSession,
+    user_id: UUID,
+    transactions: Sequence[AtomicTransaction],
+) -> list[ClassificationOutcome]:
+    """The production posting seam (#1545): classify each transaction under the
+    policy in effect on its OWN txn_date.
+
+    Contract (CR #1555): the flag gate comes FIRST — with classification disabled
+    this returns immediately without evaluating any policy, so posting behaves
+    exactly as before this EPIC. A transaction whose date no policy covers is
+    SKIPPED (it stays in the Uncategorized tail) rather than crashing the posting
+    path.
+    """
+    if not transactions or not await _classification_enabled(db, user_id):
+        return []
+
+    by_version: dict[int, list[AtomicTransaction]] = {}
+    policies: dict[int, ClassificationPolicy] = {}
+    skipped = 0
+    for txn in transactions:
+        try:
+            policy = policy_for(txn.txn_date)
+        except ValueError:
+            skipped += 1
+            continue
+        policies[policy.version] = policy
+        by_version.setdefault(policy.version, []).append(txn)
+    if skipped:
+        logger.warning(
+            "transactions predate every classification policy; left unclassified",
+            skipped=skipped,
+        )
+
+    outcomes: list[ClassificationOutcome] = []
+    for version in sorted(by_version):
+        outcomes.extend(await classify_transactions(db, user_id, by_version[version], policy=policies[version]))
+    return outcomes

--- a/apps/backend/src/services/transaction_classification.py
+++ b/apps/backend/src/services/transaction_classification.py
@@ -123,8 +123,14 @@ POLICY_VERSIONS: tuple[ClassificationPolicy, ...] = (
 )
 
 
-def policy_for(as_of: date, *, registry: Sequence[ClassificationPolicy] = POLICY_VERSIONS) -> ClassificationPolicy:
-    """Head-select the policy in effect on ``as_of`` (latest effective_from <= as_of)."""
+def policy_for(as_of: date, *, registry: Sequence[ClassificationPolicy] | None = None) -> ClassificationPolicy:
+    """Head-select the policy in effect on ``as_of`` (latest effective_from <= as_of).
+
+    The default registry is resolved at call time so a newly published version is
+    visible without rebinding call sites.
+    """
+    if registry is None:
+        registry = POLICY_VERSIONS
     effective = [p for p in registry if p.effective_from <= as_of]
     if not effective:
         raise ValueError(f"no classification policy effective on {as_of.isoformat()}")
@@ -434,3 +440,50 @@ async def classify_transactions(
         **summarize_outcomes(outcomes),
     )
     return outcomes
+
+
+async def backfill_classifications(db: AsyncSession, user_id: UUID) -> dict:
+    """One-time (#1545) backfill: classify a user's not-yet-classified transactions
+    under each transaction's OWN effective policy (``policy_for(txn_date)``).
+
+    Idempotent and append-only by construction: only transactions with no
+    classification row at all are candidates, so a re-run is a no-op — existing
+    rows are never rewritten. This is a temporary migration aid, not a permanent
+    adapter; #1546 removes it once the backfill has run.
+    """
+    if not await _classification_enabled(db, user_id):
+        return {"classified": 0, "candidates": 0}
+
+    classified_txn_ids = select(TransactionClassification.atomic_txn_id)
+    candidates = (
+        (
+            await db.execute(
+                select(AtomicTransaction)
+                .where(AtomicTransaction.user_id == user_id)
+                .where(~AtomicTransaction.id.in_(classified_txn_ids))
+                .order_by(AtomicTransaction.txn_date)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not candidates:
+        return {"classified": 0, "candidates": 0}
+
+    # Effective-dated basis: group by the policy in effect on each txn's date, so a
+    # later-published version never touches already-covered periods (prospective).
+    by_version: dict[int, list[AtomicTransaction]] = {}
+    policies: dict[int, ClassificationPolicy] = {}
+    for txn in candidates:
+        policy = policy_for(txn.txn_date)
+        policies[policy.version] = policy
+        by_version.setdefault(policy.version, []).append(txn)
+
+    written = 0
+    summaries = []
+    for version, txns in sorted(by_version.items()):
+        outcomes = await classify_transactions(db, user_id, txns, policy=policies[version])
+        written += sum(1 for o in outcomes if o.disposition in ("applied", "review"))
+        summaries.append({"policy_version": version, **summarize_outcomes(outcomes)})
+
+    return {"classified": written, "candidates": len(candidates), "runs": summaries}

--- a/apps/backend/tests/services/test_classification_migration.py
+++ b/apps/backend/tests/services/test_classification_migration.py
@@ -266,3 +266,70 @@ async def test_AC18_16_5_reclassification_never_rewrites_posted_entries(db, test
     entries = (await db.execute(select(JournalEntry))).scalars().all()
     lines = (await db.execute(select(JournalLine))).scalars().all()
     assert _snapshot(entries, lines) == before
+
+
+# --- AC18.16.3/.6 (CR #1555): the posting seam must never raise from policy lookup ---
+
+
+@pytest.mark.asyncio
+async def test_AC18_16_3_flag_off_never_evaluates_policy_even_for_pre_epoch_txns(db, test_user, monkeypatch):
+    """CR #1555: with the flag off, posting a statement whose transactions predate
+    every policy's effective_from must NOT raise — the flag gate comes before any
+    policy evaluation (flag off = today's behaviour, unconditionally)."""
+    import src.services.transaction_classification as tc
+    from src.config import settings
+
+    monkeypatch.setattr(settings, "enable_ai_classification", False)
+    # a registry that covers nothing before 2030 — policy_for would raise for 2026
+    narrow = ClassificationPolicy(
+        version=1,
+        effective_from=date(2030, 1, 1),
+        catalog=tuple(TransactionCategory),
+        model_version="v1",
+    )
+    monkeypatch.setattr(tc, "POLICY_VERSIONS", (narrow,))
+
+    bank = await _bank(db, test_user.id)
+    created = await _ingest_month(db, test_user.id, bank, "2026-06", opening=Decimal("0.00"), closing=SALARY - RENT)
+
+    assert created == 2  # posting succeeded; no policy lookup ever ran
+    count = len((await db.execute(select(TransactionClassification))).scalars().all())
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_AC18_16_6_uncovered_txn_dates_skip_classification_not_crash_posting(
+    db, test_user, enabled_flag, stub_proposer, monkeypatch
+):
+    """CR #1555: flag ON, a transaction dated before every policy's effective_from
+    is SKIPPED (stays in the Uncategorized tail) — it must never crash posting."""
+    import src.services.transaction_classification as tc
+
+    narrow = ClassificationPolicy(
+        version=1,
+        effective_from=date(2026, 7, 1),  # June txns are uncovered, July covered
+        catalog=tuple(TransactionCategory),
+        model_version="v1",
+    )
+    monkeypatch.setattr(tc, "POLICY_VERSIONS", (narrow,))
+
+    bank = await _bank(db, test_user.id)
+    created_june = await _ingest_month(
+        db, test_user.id, bank, "2026-06", opening=Decimal("0.00"), closing=SALARY - RENT
+    )
+    created_july = await _ingest_month(
+        db, test_user.id, bank, "2026-07", opening=SALARY - RENT, closing=2 * (SALARY - RENT)
+    )
+
+    assert created_june == 2  # uncovered => skipped, not crashed
+    assert created_july == 2
+    rows = (await db.execute(select(TransactionClassification))).scalars().all()
+    assert len(rows) == 2  # only July's two txns classified
+
+
+def test_AC18_16_6_initial_policy_covers_all_history():
+    """CR #1555: the DEFAULT initial basis covers all prior history (pre-2020
+    statements are normal), so real imports never hit the uncovered edge."""
+    from src.services.transaction_classification import policy_for
+
+    assert policy_for(date(1999, 1, 1)).version == 1

--- a/apps/backend/tests/services/test_classification_migration.py
+++ b/apps/backend/tests/services/test_classification_migration.py
@@ -1,0 +1,268 @@
+"""EPIC-018 AC18.16 (#1545 Migrate): the import → income-statement path reads the
+classify node under the period's effective policy.
+
+Real path under test: CSV statement parse -> Stage-1 approval -> flag-gated
+classification -> auto-posted ledger entries -> income statement. Headline
+invariant: publishing a new policy version NEVER changes an already-covered
+period's as-reported figures (prospective from its effective_from cutoff).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.account import Account, AccountType
+from src.models.journal import JournalEntry, JournalLine
+from src.models.layer3 import TransactionClassification
+from src.services.extraction import ExtractionService
+from src.services.reporting import generate_income_statement
+from src.services.statement_posting import auto_create_posted_entries_for_statement
+from src.services.statement_validation import approve_statement
+from src.services.transaction_classification import (
+    POLICY_VERSIONS,
+    CategoryProposal,
+    ClassificationPolicy,
+    TransactionCategory,
+    backfill_classifications,
+)
+
+SALARY = Decimal("5000.00")
+RENT = Decimal("1500.00")
+
+_STUB_PROPOSALS = {
+    "Salary": CategoryProposal(category=TransactionCategory.SALARY.value, confidence=95),
+    "Rent": CategoryProposal(category=TransactionCategory.HOUSING.value, confidence=95),
+}
+
+
+@pytest.fixture
+def enabled_flag(monkeypatch):
+    from src.config import settings
+
+    monkeypatch.setattr(settings, "enable_ai_classification", True)
+
+
+@pytest.fixture
+def stub_proposer(monkeypatch):
+    """Deterministic stand-in for the LLM boundary on the production call path."""
+
+    async def proposer(transactions, policy):
+        return [_STUB_PROPOSALS.get(t.description) for t in transactions]
+
+    monkeypatch.setattr("src.services.transaction_classification.propose_categories", proposer)
+    return proposer
+
+
+def _month_csv(year_month: str) -> bytes:
+    # DBS column layout => rule-based CSV parser, no AI parsing fallback.
+    return (
+        f"Date,Description,Debit Amount,Credit Amount\n{year_month}-05,Salary,,{SALARY}\n{year_month}-20,Rent,{RENT},\n"
+    ).encode()
+
+
+async def _bank(db: AsyncSession, user_id: UUID) -> Account:
+    bank = Account(user_id=user_id, name="DBS Cash", code="1001", type=AccountType.ASSET, currency="SGD")
+    db.add(bank)
+    await db.flush()
+    return bank
+
+
+async def _ingest_month(
+    db: AsyncSession,
+    user_id: UUID,
+    bank: Account,
+    year_month: str,
+    *,
+    opening: Decimal,
+    closing: Decimal,
+) -> int:
+    statement, _txns = await ExtractionService().parse_document(
+        file_path=Path(f"{year_month}.csv"),
+        institution="DBS",
+        user_id=user_id,
+        file_type="csv",
+        file_content=_month_csv(year_month),
+        db=db,
+    )
+    statement.account_id = bank.id
+    statement.opening_balance = opening
+    statement.closing_balance = closing
+    await db.flush()
+    approved = await approve_statement(db, statement.id, user_id)
+    return await auto_create_posted_entries_for_statement(db, approved, user_id)
+
+
+def _leaf_names(report_lines: list[dict]) -> set[str]:
+    return {line["name"] for line in report_lines}
+
+
+async def _june_report(db: AsyncSession, user_id: UUID) -> dict:
+    report = await generate_income_statement(
+        db, user_id, start_date=date(2026, 6, 1), end_date=date(2026, 6, 30), currency="SGD"
+    )
+    # normalize to a comparable projection (drop nothing — as-reported means as-reported)
+    return report
+
+
+# --- AC18.16.2: the #1483 symptom, fixed and locked -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_AC18_16_2_import_produces_categorized_income_statement(db, test_user, enabled_flag, stub_proposer):
+    """AC18.16.2: after a real statement import with the flag on, the income statement
+    has categorized leaf lines beyond the two Uncategorized buckets, with non-null
+    confidence tiers — the exact #1483 QA symptom, now a permanent regression lock."""
+    bank = await _bank(db, test_user.id)
+    created = await _ingest_month(db, test_user.id, bank, "2026-06", opening=Decimal("0.00"), closing=SALARY - RENT)
+    assert created == 2
+
+    report = await _june_report(db, test_user.id)
+    income_names = _leaf_names(report["income"])
+    expense_names = _leaf_names(report["expenses"])
+
+    assert "Income - Salary" in income_names
+    assert "Expense - Housing" in expense_names
+    assert "Income - Uncategorized" not in income_names
+    assert "Expense - Uncategorized" not in expense_names
+
+    categorized = [
+        line
+        for line in report["income"] + report["expenses"]
+        if line["name"] in ("Income - Salary", "Expense - Housing") and line["amount"]
+    ]
+    assert categorized and all(line["confidence_tier"] is not None for line in categorized)
+
+
+# --- AC18.16.1 (headline): a new policy version never restates covered periods ----
+
+
+@pytest.mark.asyncio
+async def test_AC18_16_1_new_policy_version_never_restates_covered_periods(
+    db, test_user, enabled_flag, stub_proposer, monkeypatch
+):
+    """AC18.16.1: publishing policy v2 (effective 2026-07-01) leaves June's
+    as-reported income statement byte-identical; only July classifies under v2."""
+    import src.services.transaction_classification as tc
+
+    bank = await _bank(db, test_user.id)
+    await _ingest_month(db, test_user.id, bank, "2026-06", opening=Decimal("0.00"), closing=SALARY - RENT)
+    june_before = await _june_report(db, test_user.id)
+
+    # publish v2 with a July 1 cutoff (prospective by default)
+    v2 = ClassificationPolicy(
+        version=2,
+        effective_from=date(2026, 7, 1),
+        catalog=tuple(TransactionCategory),
+        model_version="v2",
+    )
+    monkeypatch.setattr(tc, "POLICY_VERSIONS", (*POLICY_VERSIONS, v2))
+
+    # July activity classifies under v2...
+    await _ingest_month(db, test_user.id, bank, "2026-07", opening=SALARY - RENT, closing=2 * (SALARY - RENT))
+    # ...and a full recompute over everything must still be prospective
+    await backfill_classifications(db, test_user.id)
+
+    june_after = await _june_report(db, test_user.id)
+    assert june_after == june_before  # as-reported June figures are untouched
+
+    # provenance: June rows anchored to policy v1, July rows to policy v2
+    rows = (
+        (
+            await db.execute(
+                select(TransactionClassification).join(
+                    tc.ClassificationRule,
+                    TransactionClassification.rule_version_id == tc.ClassificationRule.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows
+    versions = set()
+    for row in rows:
+        rule = (
+            await db.execute(select(tc.ClassificationRule).where(tc.ClassificationRule.id == row.rule_version_id))
+        ).scalar_one()
+        versions.add(rule.version_number)
+    assert versions == {1, 2}
+
+
+# --- AC18.16.3: flag OFF is byte-identical to today --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_AC18_16_3_flag_off_is_byte_identical_to_today(db, test_user, stub_proposer, monkeypatch):
+    """AC18.16.3: with the flag off (the default), the import path behaves exactly
+    as before this EPIC: two Uncategorized buckets, zero classification rows."""
+    from src.config import settings
+
+    monkeypatch.setattr(settings, "enable_ai_classification", False)
+    bank = await _bank(db, test_user.id)
+    await _ingest_month(db, test_user.id, bank, "2026-06", opening=Decimal("0.00"), closing=SALARY - RENT)
+
+    report = await _june_report(db, test_user.id)
+    assert _leaf_names(report["income"]) == {"Income - Uncategorized"}
+    assert _leaf_names(report["expenses"]) == {"Expense - Uncategorized"}
+    count = len((await db.execute(select(TransactionClassification))).scalars().all())
+    assert count == 0
+
+
+# --- AC18.16.4: backfill is idempotent, dated, append-only -------------------------
+
+
+@pytest.mark.asyncio
+async def test_AC18_16_4_backfill_is_idempotent_dated_append_only(db, test_user, enabled_flag, stub_proposer):
+    """AC18.16.4: backfilling historical transactions classifies once under the
+    effective policy; a second run is a no-op (append-only, never rewrites)."""
+    from tests.factories import AtomicTransactionFactory
+
+    for desc in ("Salary", "Rent"):
+        await AtomicTransactionFactory.create_async(
+            db, user_id=test_user.id, description=desc, txn_date=date(2026, 5, 10)
+        )
+
+    first = await backfill_classifications(db, test_user.id)
+    rows_first = (await db.execute(select(TransactionClassification))).scalars().all()
+    assert first["classified"] == 2
+    assert len(rows_first) == 2
+    assert all(r.created_at is not None for r in rows_first)  # dated
+
+    second = await backfill_classifications(db, test_user.id)
+    rows_second = (await db.execute(select(TransactionClassification))).scalars().all()
+    assert second["classified"] == 0  # idempotent no-op
+    assert {r.id for r in rows_second} == {r.id for r in rows_first}  # append-only, kept
+
+
+# --- AC18.16.5: re-classification never rewrites posted ledger entries -------------
+
+
+@pytest.mark.asyncio
+async def test_AC18_16_5_reclassification_never_rewrites_posted_entries(db, test_user, enabled_flag, stub_proposer):
+    """AC18.16.5: the immutable ledger is stable across classification re-runs —
+    category is a projection, journal entries are not silently rewritten."""
+    bank = await _bank(db, test_user.id)
+    await _ingest_month(db, test_user.id, bank, "2026-06", opening=Decimal("0.00"), closing=SALARY - RENT)
+
+    def _snapshot(entries, lines):
+        return (
+            sorted((e.id, e.status.value, e.entry_date) for e in entries),
+            sorted((ln.id, ln.account_id, str(ln.amount), ln.direction.value) for ln in lines),
+        )
+
+    entries = (await db.execute(select(JournalEntry))).scalars().all()
+    lines = (await db.execute(select(JournalLine))).scalars().all()
+    before = _snapshot(entries, lines)
+
+    await backfill_classifications(db, test_user.id)  # recompute pass
+
+    entries = (await db.execute(select(JournalEntry))).scalars().all()
+    lines = (await db.execute(select(JournalLine))).scalars().all()
+    assert _snapshot(entries, lines) == before

--- a/apps/backend/tests/services/test_transaction_classification.py
+++ b/apps/backend/tests/services/test_transaction_classification.py
@@ -302,9 +302,10 @@ async def test_AC18_15_8_flag_off_is_a_noop(db, test_user, monkeypatch):
     assert await _count(db, TransactionClassification) == 0
 
 
-def test_AC18_15_8_construct_only_no_production_consumer():
-    """AC18.15.8: pre-Migrate, no production module imports the classify node —
-    the exact 'wired' flip is #1545's job, asserted there in reverse."""
+def test_AC18_15_8_sole_production_consumer_is_statement_posting():
+    """AC18.15.8 (flipped by #1545 as planned): the statement-posting seam is the
+    ONLY production consumer of the classify node — no other module may grow a
+    side-door into classification."""
     src_root = Path("src")
     importers = []
     for path in src_root.rglob("*.py"):
@@ -316,7 +317,7 @@ def test_AC18_15_8_construct_only_no_production_consumer():
                 importers.append(str(path))
             elif isinstance(node, ast.Import) and any("transaction_classification" in a.name for a in node.names):
                 importers.append(str(path))
-    assert importers == []
+    assert importers == ["src/services/statement_posting.py"]
 
 
 # --- AC18.15.3 (LLM boundary contract): prompt-driven JSON, parsed + clamped by code ---

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -466,7 +466,22 @@ production consumes the node yet — #1545 (Migrate) flips that.
 | AC18.15.5 | Red line | The model never touches money: proposals cannot express an amount, the node imports no posting primitives, and transaction Decimal amounts pass through classification untouched {tier:CODE-LED} {proof:property} | `test_AC18_15_5_model_never_touches_money()` | `services/test_transaction_classification.py` | P0 |
 | AC18.15.6 | Pro-forma | `commit_basis=False` computes verdicts under a candidate policy without writing the basis-of-record: no classifications, no policy rules, no accounts {tier:CODE-LED} {proof:property} | `test_AC18_15_6_pro_forma_writes_nothing()` | `services/test_transaction_classification.py` | P1 |
 | AC18.15.7 | Rules | A user's deterministic rule wins before the model is consulted, and having no rules is a no-op pre-pass, not an error {tier:CODE-LED} {proof:property} | `test_AC18_15_7_user_rule_prepass_wins_over_model()`, `test_AC18_15_7_no_rules_is_a_noop_prepass_not_an_error()` | `services/test_transaction_classification.py` | P1 |
-| AC18.15.8 | Construct-only | The node is inert with `enable_ai_classification` off (the default), and pre-Migrate no production module imports it (the wired flip is #1545's job) {tier:CODE-LED} {proof:property} | `test_AC18_15_8_flag_off_is_a_noop()`, `test_AC18_15_8_construct_only_no_production_consumer()` | `services/test_transaction_classification.py` | P1 |
+| AC18.15.8 | Consumer seam | The node is inert with `enable_ai_classification` off (the default), and the statement-posting seam is the ONLY production consumer (wired by #1545; no other module may grow a side-door into classification) {tier:CODE-LED} {proof:property} | `test_AC18_15_8_flag_off_is_a_noop()`, `test_AC18_15_8_sole_production_consumer_is_statement_posting()` | `services/test_transaction_classification.py` | P1 |
+
+### AC18.16: Transaction Classification — Migrate (#1545)
+
+The import → income-statement path reads the classify node under the period's
+effective policy (#1483 EPIC, Migrate stage). Headline invariant: publishing a new
+classification-basis version NEVER changes an already-covered period's as-reported
+figures — a basis change is prospective from its `effective_from` cutoff.
+
+| AC | Group | Description | Test Functions | Test File | Priority |
+|----|-------|-------------|----------------|-----------|----------|
+| AC18.16.1 | Comparability | Publishing a new policy version leaves every already-covered period's as-reported income statement byte-identical: each transaction classifies under the policy in effect on its own txn_date, and a full recompute after publishing stays prospective (covered rows keep their original policy anchor) {tier:CODE-LED} {proof:property} | `test_AC18_16_1_new_policy_version_never_restates_covered_periods()` | `services/test_classification_migration.py` | P0 |
+| AC18.16.2 | Symptom | After a real statement import with the flag on, the income statement has categorized leaf lines beyond the two Uncategorized buckets, each with a non-null confidence tier (the exact #1483 QA symptom, locked as a regression test; the per-line tier aggregation is now wired into the income statement) {tier:CODE-LED} {proof:property} | `test_AC18_16_2_import_produces_categorized_income_statement()` | `services/test_classification_migration.py` | P0 |
+| AC18.16.3 | Flag off | With `enable_ai_classification` off (the default), the import path behaves exactly as before this EPIC: only the two Uncategorized buckets, zero classification rows {tier:CODE-LED} {proof:property} | `test_AC18_16_3_flag_off_is_byte_identical_to_today()` | `services/test_classification_migration.py` | P1 |
+| AC18.16.4 | Backfill | The one-time backfill classifies each not-yet-classified transaction once under its own effective policy; a re-run is a no-op (idempotent, dated, append-only) — a temporary migration aid removed by #1546, not a permanent adapter {tier:CODE-LED} {proof:property} | `test_AC18_16_4_backfill_is_idempotent_dated_append_only()` | `services/test_classification_migration.py` | P1 |
+| AC18.16.5 | Ledger stability | Re-running classification never rewrites posted journal entries or lines — the category is a projection over the immutable ledger, not an edit of it {tier:CODE-LED} {proof:property} | `test_AC18_16_5_reclassification_never_rewrites_posted_entries()` | `services/test_classification_migration.py` | P0 |
 
 ---
 


### PR DESCRIPTION
## What (EPIC #1483, stage 2 of 3: Construct → **Migrate** → Cleanup)

Closes #1545. Builds on merged #1551 (Construct).

The statement-posting path now runs the classify node **under the period's effective policy** before posting, so imported transactions post to real category accounts — the income statement finally answers "how much did I earn and spend" with a breakdown instead of two `Uncategorized` totals (the #1483 staging-QA symptom, locked as a P0 regression test).

## Headline invariant (AC18.16.1, P0)
**Publishing a new classification-basis version never changes an already-covered period's as-reported figures.** Each transaction classifies under the policy in effect on its *own* `txn_date` (prospective from the `effective_from` cutoff); a full recompute after publishing v2 leaves June byte-identical while July anchors to v2 — proven with policy-version provenance on the rows.

## Changes
- **`statement_posting`**: classify `txns_to_post` (grouped per-txn by `policy_for(txn_date)`) before `create_entry_from_txn`. Flag-gated inside the pass ⇒ **flag off = today's behaviour exactly** (AC18.16.3).
- **`income_statement`**: wire per-line confidence tiers via the existing `_aggregate_account_confidence_tiers` — income-statement lines previously **always** had `confidence_tier: null` (the aggregation existed for the balance sheet but was never plumbed here; the other half of the #1483 symptom).
- **`backfill_classifications`** (temporary, removed by #1546): classify not-yet-classified transactions once, each under its own effective policy; **idempotent + append-only by construction** (AC18.16.4).
- **AC18.15.8 flipped as planned**: `statement_posting` is now the **sole** production consumer (AST-asserted) — no side-doors into classification.

## Acceptance criteria → tests (EPIC-018 §AC18.16, real-path: CSV parse → approval → classify → auto-post → report)
| AC | Invariant | P |
|---|---|---|
| .1 | new policy version never restates covered periods (+ per-version provenance) | **P0** |
| .2 | import ⇒ categorized leaf lines + non-null confidence tiers (#1483 symptom lock) | **P0** |
| .3 | flag off ⇒ two Uncategorized buckets, zero classification rows (today's baseline) | P1 |
| .4 | backfill idempotent, dated, append-only | P1 |
| .5 | re-classification never rewrites posted entries/lines (ledger = immutable; category = projection) | **P0** |

## Proof
- 5/5 Migrate + 13/13 Construct tests green; blast radius (reporting + integration + statement suites) **291 passed**; tooling **1842 passed**; ac-traceability / tier-ratchet / proof-kind / doc-consistency gates pass (backend-format flags only the documented PATH-vs-pinned ruff drift — pinned/CI ruff passes clean).
- No migration; flag default off ⇒ the only always-on change is the income-statement confidence-tier fix.

## Rollout note (AC #1545.7 — observe-then-tune)
After merge: enable `enable_ai_classification` on **staging**, import real statements, review the emitted confidence/category distributions (`summarize_outcomes` logs), tune thresholds/catalog via a **new policy version**, then default the flag on. That step is operational, not code, and stays open on #1545 until done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)