### PR TITLE
[finance_report_audit] fix(guardrails): revive two red-line guards defanged by package cutovers

### DIFF
--- a/apps/backend/tests/infra/test_schema_guardrails.py
+++ b/apps/backend/tests/infra/test_schema_guardrails.py
@@ -1,20 +1,14 @@
 from pathlib import Path
 
-from sqlalchemy import inspect
 from sqlalchemy.types import Enum
 
-from src import models
+import src.models._registry  # noqa: F401 — registers every mapped class on Base
+from src.database import Base
 
 
 def get_all_models():
-    """Dynamically get all SQLAlchemy models from src.models."""
-    model_classes = set()  # Use set to avoid duplicates from aliases
-    for name in dir(models):
-        obj = getattr(models, name)
-        # Check if it looks like a model (has __tablename__)
-        if hasattr(obj, "__tablename__"):
-            model_classes.add(obj)
-    return list(model_classes)
+    """Every mapped class, from the registry (the src.models hub is empty, #1461)."""
+    return [mapper.class_ for mapper in Base.registry.mappers]
 
 
 def test_enums_have_explicit_names():
@@ -25,11 +19,13 @@ def test_enums_have_explicit_names():
     See: docs/ssot/schema.md
     """
     models_to_check = get_all_models()
+    # Anti-vacuity: the guardrail went silently green once when the models
+    # facade was emptied (#1461) and this collected zero classes.
+    assert len(models_to_check) > 5, "no mapped classes collected — the enum guardrail is scanning nothing"
     violations = []
 
     for model in models_to_check:
-        mapper = inspect(model)
-        for column in mapper.columns:
+        for column in model.__mapper__.columns:
             if isinstance(column.type, Enum):
                 # Check if name is explicitly set
                 if column.type.name is None:

--- a/apps/backend/tests/infra/test_schema_guardrails.py
+++ b/apps/backend/tests/infra/test_schema_guardrails.py
@@ -20,8 +20,11 @@ def test_enums_have_explicit_names():
     """
     models_to_check = get_all_models()
     # Anti-vacuity: the guardrail went silently green once when the models
-    # facade was emptied (#1461) and this collected zero classes.
-    assert len(models_to_check) > 5, "no mapped classes collected — the enum guardrail is scanning nothing"
+    # facade was emptied (#1461) and this collected zero classes. A known
+    # mapped class must be in the collection or the registry wasn't populated.
+    assert any(model.__name__ == "User" for model in models_to_check), (
+        "known mapped classes missing — the enum guardrail is scanning nothing"
+    )
     violations = []
 
     for model in models_to_check:

--- a/common/audit/money/guard.py
+++ b/common/audit/money/guard.py
@@ -1,12 +1,14 @@
-"""Narrow-waist guard — keep the money standard from eroding (#1167 / #1172).
+"""Narrow-waist guard — keep the value-type standard from eroding (#1167 / #1172).
 
-Two invariants this guard enforces so the money "narrow waist" cannot silently
-decay back into ad-hoc money handling:
+Two invariants this guard enforces so the audit value-type "narrow waist"
+(money/ratio/quantity/unit_price, folded into ``audit`` by #1419) cannot
+silently decay back into ad-hoc number handling:
 
-1. **No ``float`` in the money modules.** The whole point of the value types is
-   that ``float`` is unrepresentable for money. A ``float(...)`` cast or a
-   ``: float`` annotation inside the money modules would reopen the red line.
-   (``isinstance(x, float)`` — the *rejection* of float — is explicitly allowed.)
+1. **No ``float`` in the audit value modules.** The whole point of the value
+   types is that ``float`` is unrepresentable for money-shaped numbers. A
+   ``float(...)`` cast or a ``: float`` annotation inside these modules would
+   reopen the red line. (``isinstance(x, float)`` — the *rejection* of float —
+   is explicitly allowed.)
 
 2. **A conformance suite per stack.** The cross-language standard
    (``common/audit/money/conformance/vectors.json``) is only meaningful if every stack
@@ -77,7 +79,11 @@ MONEY_MODULE_ROOTS = (
 
 
 def python_money_module_paths(repo_root: Path = REPO_ROOT) -> list[Path]:
-    """Python files that make up the money narrow waist (the runtime impls).
+    """Python files of the audit value-type narrow waist (the runtime impls).
+
+    Named for its historical money-only scope; since the #1419 fold it covers
+    every audit value module (money/ratio/quantity/unit_price), which all share
+    the no-float red line.
 
     Raises if a scan root is missing — a vanished root means the guard would
     silently pass on nothing (exactly how it went dead once after the value→audit

--- a/common/audit/money/guard.py
+++ b/common/audit/money/guard.py
@@ -67,18 +67,37 @@ def scan_text_for_float(text: str) -> list[str]:
     return sorted(set(offending))
 
 
+# The value-type narrow waist after the #1419 fold: the whole audit package
+# (money/ratio/quantity/unit_price contracts + backend impls) shares the
+# no-float red line, so the guard scans all of it, not just money.
+MONEY_MODULE_ROOTS = (
+    Path("common") / "audit",
+    Path("apps") / "backend" / "src" / "audit",
+)
+
+
 def python_money_module_paths(repo_root: Path = REPO_ROOT) -> list[Path]:
-    """Python files that make up the money narrow waist (the runtime impls)."""
-    roots = [
-        repo_root / "common" / "money",
-        repo_root / "apps" / "backend" / "src" / "money",
-    ]
+    """Python files that make up the money narrow waist (the runtime impls).
+
+    Raises if a scan root is missing — a vanished root means the guard would
+    silently pass on nothing (exactly how it went dead once after the value→audit
+    fold moved the modules; #1419).
+    """
     files: list[Path] = []
-    for root in roots:
-        if root.exists():
-            files.extend(
-                sorted(p for p in root.rglob("*.py") if "conformance" not in p.parts)
+    for rel in MONEY_MODULE_ROOTS:
+        root = repo_root / rel
+        if not root.exists():
+            raise FileNotFoundError(
+                f"money-guard scan root missing: {rel.as_posix()} — "
+                "update MONEY_MODULE_ROOTS if the modules moved"
             )
+        files.extend(
+            sorted(
+                p
+                for p in root.rglob("*.py")
+                if "conformance" not in p.parts and "__pycache__" not in p.parts
+            )
+        )
     return files
 
 

--- a/common/ledger/todo.md
+++ b/common/ledger/todo.md
@@ -41,12 +41,16 @@ The package-local worklist. Cross-package migration lives in
       **71–76 = EPIC-015 processing**. The EPIC-015 frontend ACs (`AC15.7.*`) stay
       in EPIC-015 (ledger is backend-only).
 
+- [x] **slice 3c-ii — EPIC-002 AC migration** (shipped in #1517/#1522): the
+      double-entry ACs homed in the contract `roadmap` under the reserved
+      **groups 1–70** (`AC-ledger.<n>.<n>` numeric grammar), removed from the
+      EPIC-002 tables; the rows left in EPIC-002 are the non-ledger ones
+      (frontend, reporting, money value-types) per its disclaimer.
+
 ## Next
-- [ ] **slice 3c-ii/iii — EPIC-002 / EPIC-012 (AC12.34) AC migration**: move the
-      double-entry ACs into the contract `roadmap` under the reserved **groups 1–70**
-      (`AC-ledger.<n>.<n>`, the numeric grammar — not `AC-ledger.<entity>.<seq>`),
-      removed from the EPIC tables (atomic), deleting the EPIC rows when all their
-      ACs are distributed.
+- [ ] **slice 3c-iii — EPIC-012 `AC12.34.1–.6` migration**: move the remaining
+      double-entry-adjacent rows out of EPIC-012 into the `roadmap` (same numeric
+      grammar), deleting the EPIC rows when distributed.
 - [ ] Publish a typed read API for balances consumed by reporting, and consider an
       `EntryPosted` domain event (mechanism C) so reconciliation/reporting react by
       event with no compile edge.

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -113,7 +113,7 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 > The two Money *leftovers* whose anchor test proves a money-package statement — the
 > net-worth restatement via the `convert` primitive and the narrow-waist `float`-ban
 > guard — have since migrated into the `money` package roadmap, owned by and sourced
-> from [`common/audit/money/contract.py`](../../common/audit/money/contract.py); their EPIC-002
+> from [`common/audit/contract.py`](../../common/audit/contract.py); their EPIC-002
 > table rows are deleted.
 >
 > **Money leftovers** (net-worth restatement + narrow-waist `float`-ban guard, was
@@ -475,7 +475,7 @@ banker's-rounding-vs-`decimal.js`-HALF_UP divergence).
 ### AC2.22: Materiality adoption ([#1171](https://github.com/wangzitian0/finance_report/issues/1171))
 
 Route the highest-value call-sites through the value types, behaviour-preserving.
-The backend runs its own shippable `src/money` "end" (mirrors `common/audit/money`, kept
+The backend runs its own shippable `src/audit/money` "end" (mirrors `common/audit/money`, kept
 in lockstep by the shared conformance vectors + the #1172 guard), because the
 backend image does not ship `common/`.
 
@@ -494,8 +494,8 @@ and there is no regression on currencies outside the active ISO set.
 
 > **Migrated**: net-worth restatement via the `convert` primitive moved to the `money`
 > package roadmap — its proof is a money-package statement. Owned by, and sourced from,
-> [`common/audit/money/contract.py`](../../common/audit/money/contract.py)'s `roadmap`.
-> *(AC2.22.3 removed — canonical copy is `AC-money.22.3` in `common/audit/money/contract.py`)*
+> [`common/audit/contract.py`](../../common/audit/contract.py)'s `roadmap`.
+> *(AC2.22.3 removed — canonical copy is `AC-money.22.3` in `common/audit/contract.py`)*
 
 > The L2/L3 *score-baseline* promotion of the money invariants stays in #1103.
 > The existing reporting net-worth E2E tests (internal-transfer fee / FX ledger)
@@ -509,8 +509,8 @@ narrow waist cannot silently decay back into ad-hoc money handling.
 
 > **Migrated**: the narrow-waist `float`-ban guard over the money modules moved to the
 > `money` package roadmap — its proof is a money-package statement. Owned by, and
-> sourced from, [`common/audit/money/contract.py`](../../common/audit/money/contract.py)'s `roadmap`.
-> *(AC2.23.1 removed — canonical copy is `AC-money.23.1` in `common/audit/money/contract.py`)*
+> sourced from, [`common/audit/contract.py`](../../common/audit/contract.py)'s `roadmap`.
+> *(AC2.23.1 removed — canonical copy is `AC-money.23.1` in `common/audit/contract.py`)*
 
 ---
 

--- a/tests/tooling/test_money_api_parity.py
+++ b/tests/tooling/test_money_api_parity.py
@@ -67,4 +67,4 @@ def test_AC2_19_1_backend_exposes_shared_money_api():
 def test_AC2_19_1_frontend_exposes_shared_money_api():
     """AC-audit.19.1: the frontend money module exports the full shared value-type surface."""
     missing = SHARED_API - _frontend_exports()
-    assert not missing, f"frontend lib/money missing shared API: {sorted(missing)}"
+    assert not missing, f"frontend lib/audit/money missing shared API: {sorted(missing)}"

--- a/tests/tooling/test_money_narrow_waist_guard.py
+++ b/tests/tooling/test_money_narrow_waist_guard.py
@@ -8,9 +8,12 @@ bites — it flags an injected violation and passes on the real tree.
 
 from pathlib import Path
 
+import pytest
+
 from common.audit.money.guard import (
     float_violations,
     missing_conformance_suites,
+    python_money_module_paths,
     scan_text_for_float,
 )
 from common.testing.ac_proof import ac_proof
@@ -59,6 +62,12 @@ def test_AC2_23_1_guard_flags_injected_float_violation():
 )
 def test_AC2_23_1_money_modules_are_float_free():
     """AC-money.23.1: the real money modules contain no float in money type positions."""
+    scanned = python_money_module_paths()
+    # Anti-vacuity: an empty scan set means the guard is dead, not that the
+    # tree is clean (this happened once after the value→audit fold, #1419).
+    assert any(p.name == "money.py" for p in scanned), (
+        "money guard no longer scans the money module — fix MONEY_MODULE_ROOTS"
+    )
     assert float_violations() == []
 
 
@@ -81,8 +90,21 @@ def test_AC2_23_1_conformance_suite_present_in_every_stack():
 )
 def test_AC2_23_1_float_violations_reports_offending_path(tmp_path: Path):
     """AC-money.23.1: float_violations surfaces an offending money-module file by path."""
-    money_dir = tmp_path / "common" / "money"
+    money_dir = tmp_path / "common" / "audit" / "money"
     money_dir.mkdir(parents=True)
+    (tmp_path / "apps" / "backend" / "src" / "audit").mkdir(parents=True)
     (money_dir / "bad.py").write_text("def f(x: float) -> None:\n    return None\n")
     violations = float_violations(repo_root=tmp_path)
-    assert any("common/money/bad.py" in v for v in violations)
+    assert any("common/audit/money/bad.py" in v for v in violations)
+
+
+@ac_proof(
+    proof_id="test_money_guard_scan_roots_must_exist",
+    ac_ids=["AC-money.23.1"],
+    ci_tier="pr_ci",
+    issue="#1172",
+)
+def test_AC2_23_1_missing_scan_root_is_loud(tmp_path: Path):
+    """AC-money.23.1: a vanished scan root fails loudly instead of passing vacuously."""
+    with pytest.raises(FileNotFoundError, match="scan root missing"):
+        python_money_module_paths(repo_root=tmp_path)

--- a/tests/tooling/test_quantity_adoption.py
+++ b/tests/tooling/test_quantity_adoption.py
@@ -22,7 +22,7 @@ def _read(path: Path) -> str:
     ci_tier="pr_ci",
 )
 def test_AC12_30_4_frontend_quantity_formatting_is_not_exported_from_money():
-    """AC-audit.30.4: formatQuantity is public from lib/quantity, not lib/money."""
+    """AC-audit.30.4: formatQuantity is public from lib/audit/quantity, not lib/audit/money."""
     money_index = _read(Path("apps/frontend/src/lib/audit/money/index.ts"))
     quantity_index = _read(Path("apps/frontend/src/lib/audit/quantity/index.ts"))
     assert "formatQuantity" not in money_index
@@ -36,7 +36,7 @@ def test_AC12_30_4_frontend_quantity_formatting_is_not_exported_from_money():
     for path in call_sites:
         src = _read(path)
         assert "@/lib/audit/quantity" in src, (
-            f"{path} must import quantity formatting from lib/quantity"
+            f"{path} must import quantity formatting from lib/audit/quantity"
         )
         assert "formatQuantity" in src
 

--- a/tests/tooling/test_quantity_api_parity.py
+++ b/tests/tooling/test_quantity_api_parity.py
@@ -59,4 +59,4 @@ def test_AC12_30_2_backend_exposes_shared_quantity_api():
 def test_AC12_30_2_frontend_exposes_shared_quantity_api():
     """AC-audit.30.2: the frontend quantity module exports the full shared surface."""
     missing = SHARED_API - _frontend_exports()
-    assert not missing, f"frontend lib/quantity missing shared API: {sorted(missing)}"
+    assert not missing, f"frontend lib/audit/quantity missing shared API: {sorted(missing)}"

--- a/tests/tooling/test_ratio_api_parity.py
+++ b/tests/tooling/test_ratio_api_parity.py
@@ -65,4 +65,4 @@ def test_AC12_9_2_backend_exposes_shared_ratio_api():
 def test_AC12_9_2_frontend_exposes_shared_ratio_api():
     """AC-audit.9.2: the frontend ratio module exports the full shared surface."""
     missing = SHARED_API - _frontend_exports()
-    assert not missing, f"frontend lib/ratio missing shared API: {sorted(missing)}"
+    assert not missing, f"frontend lib/audit/ratio missing shared API: {sorted(missing)}"


### PR DESCRIPTION
## Why

Post-review of migration Stages 0–2 (umbrella #1416) found two red-line guardrails that the cutovers left **silently vacuous** — CI green while checking nothing. Same failure shape in both: the cutover deleted/moved the guard's scan target, and the guard's failure mode is an empty scan, which reads as "clean".

## What

**1. No-float money guard was dead (#1419 value→audit fold)**
- `common/audit/money/guard.py` still scanned the deleted `common/money` + `apps/backend/src/money`; `float_violations()` returned `[]` over zero files. The path-join spelling (`"common" / "money"`) is why the fold's repo-wide text scan (afebf5b8) missed it.
- Repointed the scan at the whole audit value layer (`common/audit` + `apps/backend/src/audit` — money/ratio/quantity/unit_price all share the no-float red line; verified float-free).
- A missing scan root now **raises** instead of passing; the gate test asserts the real scan includes `money.py` and adds a loud-failure test for a vanished root. The injection fixture moved to the new path.

**2. sa.Enum explicit-name guard was dead (#1461 models-facade dissolution)**
- `apps/backend/tests/infra/test_schema_guardrails.py` collected models via `dir(src.models)` — empty since the hub was dissolved — so the enum check ran over zero classes.
- Now collects via `Base.registry.mappers` after importing `src.models._registry` (facade-independent, covers models owned by any package), and asserts the collection is non-empty.

**3. Doc/message residue from the same cutovers**
- EPIC-002: `common/audit/money/contract.py` → `common/audit/contract.py` (folded in #1539); `src/money` → `src/audit/money`.
- Parity/adoption test messages: `lib/money` etc. → `lib/audit/money` etc. (messages only; logic already read the new paths).
- `common/ledger/todo.md`: slice 3c-ii (EPIC-002 AC migration) shipped in #1517/#1522 — moved to Done; 3c-iii (EPIC-012 `AC12.34.*`) stays in Next.

## Out of scope
- `report_readiness.py` hand-rolled processing-account lookup (soft seam, behavioral change — separate issue).
- infra2 submodule pin bump (pin must be a release tag; separate PR).

## Suggested DoD addition for the remaining cutovers (extraction #1421, llm #1426)
Add "every guard that scans a moved path still scans a **non-empty** set" to the cutover checklist — both regressions here were invisible because the guards' empty-scan mode is green.

## Verification
- `tests/tooling/` suite green locally (pre-existing local-env failures excluded: missing `pdfplumber`, submodule pin state).
- `apps/backend/tests/infra/test_schema_guardrails.py` green; enum guard now scans all mapped classes.
- Guard now genuinely bites: injected float at the new path is flagged; vanished root raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)