### PR TITLE
[finance_report_test_and_doc] feat(runtime): migrate smoke/health ACs → package roadmap; draft→active (#1554 Step 2)

### DIFF
--- a/apps/backend/tests/e2e/test_core_journeys.py
+++ b/apps/backend/tests/e2e/test_core_journeys.py
@@ -62,7 +62,7 @@ async def _post_balanced_entry(client, *, debit_id, credit_id, amount, entry_dat
 @pytest.mark.e2e
 async def test_api_health_check(client):
     """
-    EPIC-001 EPIC-007 EPIC-010 EPIC-012 / AC8.1.1: Health endpoint reachable
+    EPIC-001 EPIC-007 EPIC-010 EPIC-012 / AC-runtime.1.1: Health endpoint reachable
     AC8.8.1: Core journey — health check
     GIVEN the API is running
     WHEN requesting health endpoint
@@ -744,7 +744,7 @@ async def test_register_and_login_flow(public_client):
 @pytest.mark.e2e
 async def test_backend_service_reachable(client):
     """
-    EPIC-001 EPIC-007 EPIC-010 EPIC-012 / AC8.1.2: Backend service returns structured health JSON
+    EPIC-001 EPIC-007 EPIC-010 EPIC-012 / AC-runtime.1.2: Backend service returns structured health JSON
     GIVEN the backend API is running
     WHEN requesting the health endpoint
     THEN it should return JSON with status information
@@ -758,7 +758,7 @@ async def test_backend_service_reachable(client):
 @pytest.mark.e2e
 async def test_frontend_api_proxy_reachable(client):
     """
-    EPIC-001 EPIC-007 EPIC-012 / AC8.1.3: OpenAPI docs endpoint reachable (proxy validates API availability)
+    EPIC-001 EPIC-007 EPIC-012 / AC-runtime.1.3: OpenAPI docs endpoint reachable (proxy validates API availability)
     GIVEN the backend API is running
     WHEN requesting the OpenAPI schema endpoint
     THEN it should return 200 with a valid OpenAPI JSON document
@@ -773,7 +773,7 @@ async def test_frontend_api_proxy_reachable(client):
 @pytest.mark.e2e
 async def test_database_connectivity(client, test_user):
     """
-    EPIC-001 EPIC-002 EPIC-012 / AC8.1.4: Database connectivity proven via create+read cycle
+    EPIC-001 EPIC-002 EPIC-012 / AC-runtime.1.4: Database connectivity proven via create+read cycle
     GIVEN the database is connected
     WHEN creating and then reading back an account
     THEN both operations succeed, proving DB write+read connectivity

--- a/apps/backend/tests/infra/test_main.py
+++ b/apps/backend/tests/infra/test_main.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 
 
 async def test_health_when_all_services_healthy(client: AsyncClient, monkeypatch) -> None:
-    """AC7.7.1: Health endpoint returns 200 when all services healthy."""
+    """AC-runtime.7.1: Health endpoint returns 200 when all services healthy."""
     from src.boot import Bootloader, ServiceStatus
 
     monkeypatch.setattr(
@@ -24,7 +24,7 @@ async def test_health_when_all_services_healthy(client: AsyncClient, monkeypatch
 
 
 async def test_health_endpoint_structure(client: AsyncClient) -> None:
-    """AC7.7.1: Health endpoint returns proper structure with checks."""
+    """AC-runtime.7.1: Health endpoint returns proper structure with checks."""
     response = await client.get("/health")
     assert response.status_code in [200, 503]
     data = response.json()
@@ -42,7 +42,7 @@ async def test_health_endpoint_structure(client: AsyncClient) -> None:
 
 
 async def test_health_returns_503_on_database_failure(public_client: AsyncClient, monkeypatch) -> None:
-    """AC7.7.2: Health returns 503 when database check fails."""
+    """AC-runtime.7.2: Health returns 503 when database check fails."""
     # The health check uses the db dependency directly.
     # To mock its failure, we can mock the execute method of the session.
     # However, it's easier to mock get_db to yield a session that fails.
@@ -70,7 +70,7 @@ async def test_health_returns_503_on_database_failure(public_client: AsyncClient
 
 
 async def test_health_returns_503_on_s3_failure(public_client: AsyncClient, monkeypatch) -> None:
-    """AC7.7.2: Health returns 503 when S3 check fails."""
+    """AC-runtime.7.2: Health returns 503 when S3 check fails."""
     from src.boot import Bootloader, ServiceStatus
 
     monkeypatch.setattr(

--- a/apps/backend/tests/unit/infra/test_test_lifecycle.py
+++ b/apps/backend/tests/unit/infra/test_test_lifecycle.py
@@ -23,7 +23,7 @@ def patch_cache_file(tmp_path):
 
 
 def test_sanitize_namespace():
-    """AC8.1.1: Verify namespace sanitization replaces invalid characters."""
+    """Namespace sanitization replaces invalid characters (test-isolation helper)."""
     assert test_lifecycle._sanitize_namespace("feat/cleanup") == "feat_cleanup"
     assert test_lifecycle._sanitize_namespace("WS-123") == "ws_123"
     assert test_lifecycle._sanitize_namespace("space name") == "spacename"
@@ -33,7 +33,7 @@ def test_sanitize_namespace():
 
 
 def test_long_namespace_resource_names_are_bounded():
-    """AC8.1.1: Long branch namespaces remain valid for Postgres and S3."""
+    """Long branch namespaces stay valid for Postgres and S3 (test-isolation helper)."""
     namespace = "codex_issue_490_testing_strategy_ac_coverage_0bb5607e"
 
     db_name = test_lifecycle.get_test_db_name(namespace)
@@ -94,7 +94,7 @@ def test_test_database_persistence(
     # branch name containing "down" (e.g. ".../cashflow-drilldown") would leak
     # into the string and create a false positive (#884).
     down_calls = [
-        c for c in mock_run.call_args_list if c.args and isinstance(c.args[0], (list, tuple)) and "down" in c.args[0]
+        c for c in mock_run.call_args_list if c.args and isinstance(c.args[0], list | tuple) and "down" in c.args[0]
     ]
     assert len(down_calls) == 0
 
@@ -184,7 +184,7 @@ def test_test_database_ephemeral(
     down_calls = [
         c
         for c in mock_run.call_args_list
-        if c.args and isinstance(c.args[0], (list, tuple)) and "down" in c.args[0] and "-v" in c.args[0]
+        if c.args and isinstance(c.args[0], list | tuple) and "down" in c.args[0] and "-v" in c.args[0]
     ]
     assert len(down_calls) == 1
     mock_unregister.assert_called_once()

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -6,27 +6,29 @@ provider, cache, telemetry, …), how each of the six environments substitutes
 them, and the invariant that a *declared* dependency must be *asserted present*
 (no silent ``skipped``/``warning``/fallback).
 
-It is a ``kernel`` leaf (``depends_on=[]``) and currently ``draft`` — still being
-designed. The *construct* phase shipped the ``base`` value language + dependency
-manifest + the ``DependencyCheck`` port; the *switch* phase adds the
-``extension`` probe adapters (``DatabaseCheck`` / ``ObjectStorageCheck`` /
-``LlmCheck``, published below) that ``boot.Bootloader`` now delegates to. The
-*cleanup* phase dropped the silent ``skipped`` status: an absent declared
-dependency is an ``error`` (runtime invariant 2). Remaining as a future feature
-(not the migration): manifest-driven ``validate`` for *all* declared dependencies
-per env tier + smoke↔declaration parity — see ``todo.md``. Roadmap ACs (each
-pinned to a real test) are added when those enforcement invariants land; the
-prose contract lives in ``readme.md`` + ``todo.md`` until then.
+A ``kernel`` leaf (``depends_on=[]``), now ``active``. The *construct* phase
+shipped the ``base`` value language + dependency manifest + the
+``DependencyCheck`` port; the *switch* phase added the ``extension`` probe
+adapters (``DatabaseCheck`` / ``ObjectStorageCheck`` / ``LlmCheck``, published
+below) that ``boot.Bootloader`` delegates to; the *cleanup* phase dropped the
+silent ``skipped`` status. The *migrate* phase homes the smoke-test / health
+ACs here: EPIC-008 AC8.1.1–.3 → ``AC-runtime.1.*`` (smoke / service reachability)
+and EPIC-007 AC7.7.1–.2 → ``AC-runtime.7.*`` (``/health`` dependency-presence),
+each ``test=`` resolving to its existing proof; the package tier (CODE-ONLY)
+gives ``proof_kind=exact``. The env-smoke-test SSOT prose is absorbed into
+``readme.md``. Remaining as a future feature (not this migration): manifest-driven
+``validate`` for *all* declared dependencies per env tier + smoke↔declaration
+parity — see ``todo.md``.
 """
 
 from __future__ import annotations
 
-from common.meta.package_contract import PackageContract
+from common.meta.package_contract import ACRecord, PackageContract
 
 CONTRACT = PackageContract(
     name="runtime",
     klass="kernel",
-    status="draft",
+    status="active",
     tier="CODE-ONLY",
     depends_on=[],
     roles=[],
@@ -48,5 +50,50 @@ CONTRACT = PackageContract(
     ],
     events=[],
     invariants=[],
-    roadmap=[],
+    roadmap=[
+        # ── Smoke tests / service reachability (was EPIC-008 AC8.1.1–.3) ──
+        ACRecord(
+            id="AC-runtime.1.1",
+            statement="The API health endpoint is reachable and returns 200. Was EPIC-008 AC8.1.1.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_api_health_check",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.1.2",
+            statement="The backend service is reachable and returns a structured health JSON. Was EPIC-008 AC8.1.2.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_backend_service_reachable",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.1.3",
+            statement="The frontend API proxy is reachable, validating API availability through the proxy. Was EPIC-008 AC8.1.3.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_frontend_api_proxy_reachable",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.1.4",
+            statement="Database connectivity is proven through a create+read cycle. Was EPIC-008 AC8.1.4.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_database_connectivity",
+            priority="P0",
+            status="done",
+        ),
+        # ── /health dependency-presence (was EPIC-007 AC7.7.1–.2) ──
+        ACRecord(
+            id="AC-runtime.7.1",
+            statement="/health returns 200 when all declared dependencies are present. Was EPIC-007 AC7.7.1.",
+            test="apps/backend/tests/infra/test_main.py::test_health_when_all_services_healthy",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.7.2",
+            statement="/health returns 503 when a declared dependency is absent (invariant 2). Was EPIC-007 AC7.7.2.",
+            test="apps/backend/tests/infra/test_main.py::test_health_returns_503_on_database_failure",
+            priority="P0",
+            status="done",
+        ),
+    ],
 )

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -12,11 +12,12 @@ shipped the ``base`` value language + dependency manifest + the
 adapters (``DatabaseCheck`` / ``ObjectStorageCheck`` / ``LlmCheck``, published
 below) that ``boot.Bootloader`` delegates to; the *cleanup* phase dropped the
 silent ``skipped`` status. The *migrate* phase homes the smoke-test / health
-ACs here: EPIC-008 AC8.1.1–.3 → ``AC-runtime.1.*`` (smoke / service reachability)
-and EPIC-007 AC7.7.1–.2 → ``AC-runtime.7.*`` (``/health`` dependency-presence),
-each ``test=`` resolving to its existing proof; the package tier (CODE-ONLY)
-gives ``proof_kind=exact``. The env-smoke-test SSOT prose is absorbed into
-``readme.md``. Remaining as a future feature (not this migration): manifest-driven
+ACs here: EPIC-008 AC8.1.1–.4 → ``AC-runtime.1.*`` (smoke / service reachability /
+DB connectivity) and EPIC-007 AC7.7.1–.2 → ``AC-runtime.7.*`` (``/health``
+dependency-presence), each ``test=`` resolving to its existing proof; the package
+tier (CODE-ONLY) gives ``proof_kind=exact``. (Step 3 / cleanup absorbs the
+env-smoke-test SSOT prose into ``readme.md`` and retires the doc.) Remaining as a
+future feature (not this migration): manifest-driven
 ``validate`` for *all* declared dependencies per env tier + smoke↔declaration
 parity — see ``todo.md``.
 """
@@ -51,7 +52,7 @@ CONTRACT = PackageContract(
     events=[],
     invariants=[],
     roadmap=[
-        # ── Smoke tests / service reachability (was EPIC-008 AC8.1.1–.3) ──
+        # ── Smoke tests / service reachability (was EPIC-008 AC8.1.1–.4) ──
         ACRecord(
             id="AC-runtime.1.1",
             statement="The API health endpoint is reachable and returns 200. Was EPIC-008 AC8.1.1.",

--- a/common/runtime/readme.md
+++ b/common/runtime/readme.md
@@ -1,8 +1,9 @@
 # `runtime` — the app↔external-world dependency boundary
 
-> **Status: draft.** The model below is the contract we are committing to; the
-> implementation (ports, manifest, gate wiring) lands incrementally, each AC with
-> a real test, moving from [`todo.md`](./todo.md) into [`contract.py`](./contract.py).
+> **Status: active.** The boundary — value language, manifest, `DependencyCheck`
+> port + adapters — is shipped, and the smoke/health ACs are homed in
+> [`contract.py`](./contract.py)'s roadmap. Remaining work (manifest-driven
+> enforcement, substitutes) is tracked in [`todo.md`](./todo.md).
 > Model spec: [`../meta/readme.md`](../meta/readme.md).
 
 ## Why this package exists
@@ -92,9 +93,10 @@ declared dependency is proven present — or the build/smoke fails.**
 
 ## Public vs internal
 
-Draft. The **construct** phase publishes the `base` value language + manifest +
-port (`contract.interface`): `DependencyKind`, `EnvTier` (+ `APP_OWNED_TIERS` /
-`VPS_TIERS`), `Dependency` / `DependencyManifest` / `DEPENDENCY_MANIFEST`, and the
-`DependencyCheck` port (+ `DependencyStatus`). No consumer routes through it yet —
-the switch phase points `boot.validate` and the smoke test at the manifest; the
-adapters and the compose/lifecycle relocation follow. See [`todo.md`](./todo.md).
+The package publishes (`contract.interface`) the `base` value language + manifest
++ port and the `extension` adapters: `DependencyKind`, `EnvTier`
+(+ `APP_OWNED_TIERS` / `VPS_TIERS`), `Dependency` / `DependencyManifest` /
+`DEPENDENCY_MANIFEST`, the `DependencyCheck` port (+ `DependencyStatus` /
+`ProbeResult`), and `DatabaseCheck` / `ObjectStorageCheck` / `LlmCheck`.
+`boot.Bootloader` delegates its checks to the adapters. See [`todo.md`](./todo.md)
+for the remaining enforcement work.

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -180,12 +180,14 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 | AC7.6.1 | Config syncs with .env.example | `TestConfigContract.test_config_sync_with_env_example` | `infra/test_config_contract.py` | P0 |
 | AC7.6.2 | Required secrets documented | Manual verification | `.env.example` | P0 |
 
-### AC7.7: Health Checks
+### AC7.7: Health Checks — migrated to the `runtime` package
 
-| ID | Requirement | Test Function | File | Priority |
-|----|-------------|---------------|------|----------|
-| AC7.7.1 | Health endpoint returns 200 | `test_health_when_all_services_healthy()` | `infra/test_main.py` | P0 |
-| AC7.7.2 | Health check with services down | `test_health_returns_503_on_database_failure()`, `test_health_fails_when_redis_configured_but_unavailable()`, `test_health_returns_503_on_s3_failure()` | `infra/test_main.py` | P0 |
+> The `/health` dependency-presence ACs (were `AC7.7.*`) moved into the
+> `runtime` package roadmap (`common/runtime/contract.py`) as
+> `AC-runtime.7.1` · `AC-runtime.7.2` — `/health` returning 200 when all declared
+> dependencies are present and 503 when one is absent is `runtime`'s invariant 2.
+> (Deployment-topology / manual-status ACs, e.g. `AC7.9.*`, stay in this EPIC —
+> that is infra2's domain.)
 
 ### AC7.8: Docker & CI Configuration
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -156,14 +156,15 @@ job inventories or scenario counts into this EPIC.
 >
 > ℹ️ **Non-contiguous AC numbering**: Gaps in `AC8.x.y` numbers reflect deprecated or merged ACs preserved for historical traceability through generated registry indexes plus explicit overrides. Do **not** renumber. New active ACs append to the next available index in the owning EPIC block.
 
-### AC8.1: Smoke Tests (Health Checks)
+### AC8.1: Smoke Tests (Health Checks) — migrated to the `runtime` package
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC8.1.1 | API health check | `test_api_health_check()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.1.2 | Backend service reachable | `test_backend_service_reachable()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.1.3 | Frontend service reachable | `test_frontend_api_proxy_reachable()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.1.4 | Database connectivity | `test_database_connectivity()` | `e2e/test_core_journeys.py` | P0 |
+> The smoke-test / health-check ACs (were `AC8.1.*`) moved into the
+> `runtime` package roadmap (`common/runtime/contract.py`) under the
+> package-scoped `AC-runtime.<group>.<seq>` id scheme —
+> `generate_ac_registry.py` reads package-contract roadmaps. Migrated ids
+> (homed in the package roadmap): `AC-runtime.1.1` · `AC-runtime.1.2` ·
+> `AC-runtime.1.3` · `AC-runtime.1.4`. `runtime` owns the environment smoke test
+> (`common/runtime/readme.md`).
 
 ### AC8.2: Phase 1 - Onboarding & Account Structure
 

--- a/docs/ssot/draft-package-baseline.json
+++ b/docs/ssot/draft-package-baseline.json
@@ -1,6 +1,4 @@
 {
   "_comment": "Registered draft packages (tools/check_draft_packages.py). A draft package leaves its authority tier undecided; listing it here makes adding one a reviewed act. Resolve drafts to active over time.",
-  "draft_packages": [
-    "runtime"
-  ]
+  "draft_packages": []
 }

--- a/tests/e2e/test_core_journeys.py
+++ b/tests/e2e/test_core_journeys.py
@@ -72,7 +72,7 @@ async def test_api_health_check(app_url):
 
 @pytest.mark.smoke
 async def test_homepage_loads(app_url):
-    """AC-runtime.1.3: Verify the homepage is accessible (frontend reachability)."""
+    """EPIC-007 / AC-runtime.1.3: Verify the homepage is accessible (frontend reachability)."""
     async with httpx.AsyncClient(verify=False, timeout=API_TIMEOUT) as client:
         response = await client.get(f"{app_url}/")
         assert response.status_code < 400, f"Homepage returned {response.status_code}"

--- a/tests/e2e/test_core_journeys.py
+++ b/tests/e2e/test_core_journeys.py
@@ -72,7 +72,7 @@ async def test_api_health_check(app_url):
 
 @pytest.mark.smoke
 async def test_homepage_loads(app_url):
-    """EPIC-001 EPIC-007 / AC8.1.3: Verify the homepage is accessible."""
+    """AC-runtime.1.3: Verify the homepage is accessible (frontend reachability)."""
     async with httpx.AsyncClient(verify=False, timeout=API_TIMEOUT) as client:
         response = await client.get(f"{app_url}/")
         assert response.status_code < 400, f"Homepage returned {response.status_code}"


### PR DESCRIPTION
**Step 2 (migrate)** of the runtime package refactor (#1554), per `common/meta/migration-standard.md`: EPIC ACs for this concern are absorbed into the package; a lingering mirror = NOT migrated.

## What
- **Home the smoke/health ACs** into `common/runtime/contract.py` roadmap:
  - EPIC-008 AC8.1.1–.4 → `AC-runtime.1.*` (smoke / service reachability / DB connectivity)
  - EPIC-007 AC7.7.1–.2 → `AC-runtime.7.*` (`/health` dependency-presence)
  - each `test=` resolves to its existing proof; CODE-ONLY ⇒ `proof_kind=exact`.
- **Delete the migrated EPIC rows**; replace each section with a "migrated to the runtime package" disclaimer referencing the new ids.
- **Retag** the anchoring tests' docstrings to the package ids (so registry→tests traceability resolves).
- **Promote `runtime` draft → active** (has units + roadmap); remove from `draft-package-baseline.json`.

## Verify (all local gates green)
`check_package_contract` (6 roadmap ACs resolve), `generate_ac_registry --check`, `build_ac_traceability --check`, `lint_doc_consistency`, `check_epic_package_dual`, `check_authority_reconcile` (CODE-ONLY, code=6 llm=0), `check_draft_packages`. 43 runtime/boot tests pass; ruff + mypy clean.

## Next
**Step 3 (cleanup)**: internalize `env_smoke_test.md` prose → `common/runtime/readme.md`, **delete** the doc + retire its MANIFEST entry, and add a guard test asserting zero runtime-exclusive content remains in EPIC/SSOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)