### PR TITLE
[finance_report_ui] feat(testing): workflow selection conformance + pr_ci evidence reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1415,6 +1415,11 @@ jobs:
           python tools/aggregate_ac_evidence.py $junit_files --output ac-evidence-current.json
           # L2 (pass-required) + L3 (score ratchet) against the checked-in baseline.
           python tools/check_ac_score_baseline.py ac-evidence-current.json
+          # ci_tier reconciliation (#1557): every behavioral pr_ci proof must
+          # actually appear in this PR's junit evidence — declared execution
+          # tier is a contract, not metadata.
+          # shellcheck disable=SC2086
+          python tools/check_pr_ci_evidence.py $junit_files
 
   finish:
     needs: [changes, schema-migrations, backend, backend-integration, backend-e2e-tier1, frontend-build, frontend-vitest, frontend-playwright, frontend-telemetry-e2e, container-images, lint, tooling-coverage, unified-coverage, ac-traceability, ac-behavioral-ratchet]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1417,7 +1417,9 @@ jobs:
           python tools/check_ac_score_baseline.py ac-evidence-current.json
           # ci_tier reconciliation (#1557): every behavioral pr_ci proof must
           # actually appear in this PR's junit evidence — declared execution
-          # tier is a contract, not metadata.
+          # tier is a contract, not metadata. The proof graph loads the AC
+          # registry, which needs PyYAML (this job is bare setup-python).
+          python -m pip install --quiet pyyaml
           # shellcheck disable=SC2086
           python tools/check_pr_ci_evidence.py $junit_files
 

--- a/common/testing/check_pr_ci_evidence.py
+++ b/common/testing/check_pr_ci_evidence.py
@@ -1,0 +1,118 @@
+"""Reconcile declared proof execution tiers against actual PR junit evidence.
+
+A behavioral ``@ac_proof`` declaring ``ci_tier="pr_ci"`` promises its test runs
+on every PR. Until issue #1557 that field was shape-validated but never checked
+against real execution — a proof could claim pr_ci and silently never run.
+
+This gate runs in the ``ac-behavioral-ratchet`` job after junit aggregation:
+every behavioral pr_ci proof whose file classifies (via the execution matrix)
+into a PR-evidence stage must appear as an executed testcase in the aggregated
+junit. Absent → hard fail. Present but skipped-only → warning for now (some
+suites skip conditionally; tightening tracked in #1558).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+from common.testing.matrix import PR_EVIDENCE_STAGES, classify_stage
+
+
+def _module_for(file: str) -> str:
+    """Map a repo-relative test file to its pytest junit classname module."""
+    path = file[:-3] if file.endswith(".py") else file
+    # Backend suites run with cwd=apps/backend, so junit classnames are
+    # rooted at tests.*
+    prefix = "apps/backend/"
+    if path.startswith(prefix):
+        path = path[len(prefix) :]
+    return path.replace("/", ".")
+
+
+def collect_executed(junit_paths: list[Path]) -> dict[tuple[str, str], bool]:
+    """Return {(classname_module, base_test_name): ran_non_skipped}."""
+    executed: dict[tuple[str, str], bool] = {}
+    for path in junit_paths:
+        if not path.exists():
+            continue
+        try:
+            tree = ElementTree.parse(path)
+        except ElementTree.ParseError:
+            continue
+        for case in tree.iter("testcase"):
+            classname = case.get("classname") or ""
+            name = (case.get("name") or "").split("[", 1)[0]
+            skipped = case.find("skipped") is not None
+            key = (classname, name)
+            executed[key] = executed.get(key, False) or not skipped
+    return executed
+
+
+def run_check(junit_paths: list[Path]) -> int:
+    from common.testing.ac_graph import build_proofs_only
+    from common.testing.generate_critical_proof_matrix import build_matrix_from_graph
+
+    proofs = build_matrix_from_graph(build_proofs_only()).get("proofs", [])
+    scoped = [
+        p
+        for p in proofs
+        if p.get("scope") == "behavioral"
+        and p.get("ci_tier") == "pr_ci"
+        and classify_stage(p.get("file", "")) in PR_EVIDENCE_STAGES
+    ]
+
+    executed = collect_executed(junit_paths)
+    by_class: dict[str, dict[str, bool]] = {}
+    for (classname, name), ran in executed.items():
+        by_class.setdefault(classname, {})
+        by_class[classname][name] = by_class[classname].get(name, False) or ran
+
+    missing: list[str] = []
+    skipped_only: list[str] = []
+    for proof in scoped:
+        module = _module_for(proof["file"])
+        test = proof["test"]
+        hit = None
+        for classname, names in by_class.items():
+            if classname == module or classname.startswith(module + "."):
+                if test in names:
+                    hit = names[test]
+                    break
+        label = f"{proof['id']}: {proof['file']}::{test}"
+        if hit is None:
+            missing.append(label)
+        elif hit is False:
+            skipped_only.append(label)
+
+    for label in skipped_only:
+        print(f"WARNING: pr_ci proof only ever skipped in PR evidence: {label}")
+    if missing:
+        print(
+            f"ERROR: {len(missing)} behavioral pr_ci proof(s) never executed in "
+            "PR junit evidence. Either the test does not run pre-merge (fix the "
+            "marker/stage so it does) or the proof's ci_tier is wrong "
+            "(declare post_merge_environment).",
+            file=sys.stderr,
+        )
+        for label in missing:
+            print(f"  - {label}", file=sys.stderr)
+        return 1
+    print(
+        f"pr_ci evidence reconciliation: {len(scoped)} proofs executed "
+        f"({len(skipped_only)} skipped-only warnings)."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if not args:
+        print("usage: check_pr_ci_evidence.py <junit-xml> [...]", file=sys.stderr)
+        return 2
+    return run_check([Path(a) for a in args])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/common/testing/matrix.py
+++ b/common/testing/matrix.py
@@ -348,6 +348,7 @@ WORKFLOW_PYTEST_CONTRACTS: tuple[WorkflowPytestContract, ...] = (
         stage=PR_PREVIEW_E2E_STAGE,
         workflow=".github/workflows/preview.yml",
         marker=None,  # runtime-derived: eval tools/test_selection.py --shell
+        paths=('"${PR_PREVIEW_E2E_TESTS[@]}"',),
         anchor='-m "$PR_PREVIEW_E2E_MARKER"',
     ),
     WorkflowPytestContract(

--- a/common/testing/matrix.py
+++ b/common/testing/matrix.py
@@ -69,6 +69,15 @@ PATH_RULES: tuple[PathRule, ...] = (
     PathRule("tests/e2e/", "deployment_e2e", True),
 )
 
+
+def classify_stage(path: str) -> str | None:
+    """Return the execution stage for a repo-relative test path (first match)."""
+    for rule in PATH_RULES:
+        if path.startswith(rule.path):
+            return rule.stage
+    return None
+
+
 GENERATED_MATRIX_HEADER = (
     "# GENERATED from common/testing/matrix.py — do not hand-edit.\n"
     "# Regenerate: python tools/test_selection.py --emit-matrix\n"
@@ -276,3 +285,114 @@ def emit_shell(stage: str) -> str:
             f"PR_PREVIEW_E2E_PARALLELISM={PR_PREVIEW_E2E_PARALLELISM}",
         ]
     )
+
+
+# ---------------------------------------------------------------------------
+# Workflow pytest contracts (issue #1557): every pytest invocation in
+# .github/workflows/*.yml is registered here with its marker expression and
+# explicit paths. tests/tooling/test_workflow_selection_conformance.py
+# enforces this registry FAIL-CLOSED in both directions — an unregistered
+# invocation in a workflow fails lint-tier CI, and a registered contract with
+# no live invocation fails too (a gate cannot be dropped by editing only the
+# workflow). Marker expressions live here ONCE; workflows keep the literal
+# text and the conformance gate proves equality.
+# ---------------------------------------------------------------------------
+
+BACKEND_CI_MARKER = "not slow and not e2e and not integration"
+BACKEND_INTEGRATION_MARKER = "integration"
+BACKEND_TIER1_MARKER = "e2e and not slow and not integration and not perf"
+# Staging post-deploy core E2E intentionally shares the preview expression.
+STAGING_CORE_E2E_MARKER = PR_PREVIEW_E2E_MARKER
+STAGING_AI_OCR_MARKER = "llm"
+STAGING_VERSION_CHECK_MARKER = "smoke"
+PRODUCTION_READONLY_MARKER = "prod_safe"
+
+
+@dataclass(frozen=True)
+class WorkflowPytestContract:
+    """One expected pytest invocation inside a GitHub workflow."""
+
+    stage: str
+    workflow: str
+    # The exact `-m` expression the invocation must carry; None means the
+    # marker is variable-driven (derived at runtime via tools/test_selection).
+    marker: str | None
+    # Explicit path/node arguments the invocation must carry (empty = none:
+    # the job's cwd/addopts scope the run).
+    paths: tuple[str, ...] = ()
+    # Substring identifying this invocation's line uniquely in the workflow.
+    anchor: str = ""
+
+
+WORKFLOW_PYTEST_CONTRACTS: tuple[WorkflowPytestContract, ...] = (
+    WorkflowPytestContract(
+        stage="backend_ci",
+        workflow=".github/workflows/ci.yml",
+        marker=BACKEND_CI_MARKER,
+        anchor="--splits 5",
+    ),
+    WorkflowPytestContract(
+        stage="backend_integration",
+        workflow=".github/workflows/ci.yml",
+        marker=BACKEND_INTEGRATION_MARKER,
+        anchor="--junit-xml=test-results/backend-integration.xml",
+    ),
+    WorkflowPytestContract(
+        stage="backend_tier1_api_e2e",
+        workflow=".github/workflows/ci.yml",
+        marker=BACKEND_TIER1_MARKER,
+        paths=("tests/e2e/test_core_journeys.py",),
+        anchor="--junit-xml=test-results/backend-tier1-e2e.xml",
+    ),
+    WorkflowPytestContract(
+        stage=PR_PREVIEW_E2E_STAGE,
+        workflow=".github/workflows/preview.yml",
+        marker=None,  # runtime-derived: eval tools/test_selection.py --shell
+        anchor='-m "$PR_PREVIEW_E2E_MARKER"',
+    ),
+    WorkflowPytestContract(
+        stage="staging_core_e2e",
+        workflow=".github/workflows/deploy.yml",
+        marker=STAGING_CORE_E2E_MARKER,
+        paths=("tests/e2e",),
+        anchor="--junit-xml=test-results/staging-core-e2e.xml",
+    ),
+    WorkflowPytestContract(
+        stage="staging_provider_connectivity",
+        workflow=".github/workflows/deploy.yml",
+        marker=STAGING_AI_OCR_MARKER,
+        paths=("tests/e2e/test_ai_provider_connectivity.py",),
+        anchor="--junit-xml=test-results/staging-provider-connectivity.xml",
+    ),
+    WorkflowPytestContract(
+        stage="staging_ai_ocr_version_check",
+        workflow=".github/workflows/staging-ai-ocr-gate.yml",
+        marker=STAGING_VERSION_CHECK_MARKER,
+        paths=("tests/e2e/test_version_check.py",),
+        anchor="--junit-xml=test-results/staging-ai-ocr-version.xml",
+    ),
+    WorkflowPytestContract(
+        stage="staging_ai_ocr_gate",
+        workflow=".github/workflows/staging-ai-ocr-gate.yml",
+        marker=STAGING_AI_OCR_MARKER,
+        # Corpus is derived from @ac_proof metadata by
+        # tools/staging_ai_ocr_gate_contract.py --shell (a view over the same
+        # AC graph); the invocation consumes the emitted array.
+        paths=('"${STAGING_AI_OCR_TESTS[@]}"',),
+        anchor="--junit-xml=test-results/staging-ai-ocr-gate.xml",
+    ),
+    WorkflowPytestContract(
+        stage="production_readonly_smoke",
+        workflow=".github/workflows/release.yml",
+        marker=PRODUCTION_READONLY_MARKER,
+        paths=("tests/e2e/test_production_readonly_smoke.py",),
+        anchor="--junit-xml=test-results/production-readonly-e2e.xml",
+    ),
+)
+
+# Stages whose junit-xml is aggregated by the ac-behavioral-ratchet job on
+# every PR. A behavioral @ac_proof declaring ci_tier="pr_ci" must surface in
+# this evidence — enforced by common/testing/check_pr_ci_evidence.py.
+PR_EVIDENCE_STAGES: frozenset[str] = frozenset(
+    {"backend_ci", "backend_integration", "backend_tier1_api_e2e", "frontend_vitest"}
+)

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -609,6 +609,22 @@ reconciliation), #1558 (package declaration rollout + mirror-assertion ratchet).
 | AC8.22.5 | The `--shell` emission is valid, shlex-round-trippable bash (test array, quoted marker expression, parallelism) matching the in-code selection exactly, and an unknown stage is rejected with an explicit error {tier:CODE-ONLY} | `test_AC8_22_5_shell_emission_round_trips` | `tests/tooling/test_execution_matrix_contract.py` | P1 |
 | AC8.22.6 | The testing-package governance charter (execution matrix, package declaration protocol, E2E extension layer, fast interception, responsibility table) exists in `common/testing/README.md`, and `docs/ssot/MANIFEST.yaml` records `common/testing/matrix.py` as the `test_execution_matrix` owner with the generated YAML as a cross-ref {tier:CODE-ONLY} | `test_AC8_22_6_charter_and_manifest_ownership` | `tests/tooling/test_execution_matrix_contract.py` | P1 |
 
+### AC8.23: Workflow Selection Conformance & Execution Reconciliation
+
+Follow-up to AC8.22 (issue #1557): marker expressions and test paths for every
+junit-emitting pytest invocation across `.github/workflows/*.yml` now live once
+in `common/testing/matrix.py` (`WORKFLOW_PYTEST_CONTRACTS`), enforced
+fail-closed by a central conformance gate; and a declared `ci_tier="pr_ci"` on
+an `@ac_proof` is reconciled against actual PR junit evidence in the
+`ac-behavioral-ratchet` job — execution tier becomes a contract, not metadata.
+
+| AC ID | Test Case | Test Function | File | Priority |
+|---|---|---|---|---|
+| AC8.23.1 | Every junit-emitting pytest invocation in any workflow is registered in the matrix contracts and every registered contract has exactly one live invocation — fail-closed in both directions, so a selection change is impossible without touching the SSOT {tier:CODE-ONLY} | `test_AC8_23_1_every_workflow_pytest_invocation_is_registered` | `tests/tooling/test_workflow_selection_conformance.py` | P0 |
+| AC8.23.2 | Each registered invocation's `-m` expression and explicit path arguments equal the matrix constants (backend shards, integration, tier-1, staging core/provider/AI-OCR/version, production readonly) — marker semantics have exactly one owner {tier:CODE-ONLY} | `test_AC8_23_2_registered_invocations_match_matrix_selection` | `tests/tooling/test_workflow_selection_conformance.py` | P0 |
+| AC8.23.3 | The staging AI/OCR corpus (derived from `@ac_proof` metadata) and the matrix llm rows describe the same provider-dependent spec set, with the connectivity probe as the only declared difference — the two derivations cannot drift silently {tier:CODE-ONLY} | `test_AC8_23_3_staging_ai_ocr_corpus_aligns_with_matrix_llm_rows` | `tests/tooling/test_workflow_selection_conformance.py` | P1 |
+| AC8.23.4 | A behavioral `pr_ci` proof absent from aggregated PR junit evidence fails the reconciliation gate (wired after the score ratchet in ci.yml); present proofs pass, skipped-only warns, and parametrized/class-nested junit ids are matched correctly {tier:CODE-ONLY} | `test_AC8_23_4_pr_ci_evidence_reconciliation_gate`, `test_AC8_23_4_junit_parsing_handles_params_and_classes` | `tests/tooling/test_workflow_selection_conformance.py` | P0 |
+
 ## 5. E2E Suite Ownership
 
 Current test counts and coverage percentages belong to generated reports and CI

--- a/tests/tooling/test_workflow_selection_conformance.py
+++ b/tests/tooling/test_workflow_selection_conformance.py
@@ -1,0 +1,179 @@
+"""Workflow pytest-selection conformance (EPIC-008 AC8.23, issue #1557).
+
+Every junit-emitting pytest invocation in .github/workflows/*.yml must be
+registered in matrix.WORKFLOW_PYTEST_CONTRACTS with its marker expression and
+explicit paths — fail-closed in both directions. Marker expressions live once
+in common/testing/matrix.py; workflows keep literal text proven equal here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from common.testing import matrix
+from common.testing.check_pr_ci_evidence import _module_for, collect_executed
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _joined_lines(text: str) -> list[str]:
+    """Join backslash-continued lines so one invocation is one string."""
+    lines: list[str] = []
+    buffer = ""
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if line.endswith("\\"):
+            buffer += line[:-1] + " "
+            continue
+        lines.append(buffer + line)
+        buffer = ""
+    if buffer:
+        lines.append(buffer)
+    return lines
+
+
+def _pytest_invocations() -> dict[str, list[str]]:
+    """All junit-emitting pytest invocation lines per workflow file."""
+    found: dict[str, list[str]] = {}
+    for wf in sorted(WORKFLOWS.glob("*.yml")):
+        rel = wf.relative_to(ROOT).as_posix()
+        for line in _joined_lines(wf.read_text(encoding="utf-8")):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if re.search(r"\bpytest\b", stripped) and "--junit-xml=" in stripped:
+                found.setdefault(rel, []).append(stripped)
+    return found
+
+
+def test_AC8_23_1_every_workflow_pytest_invocation_is_registered() -> None:
+    """AC8.23.1: fail-closed both ways — no unregistered invocation, no
+    contract without a live invocation."""
+    invocations = _pytest_invocations()
+    anchors = [(c, c.anchor) for c in matrix.WORKFLOW_PYTEST_CONTRACTS]
+
+    matched_lines: set[str] = set()
+    for contract, anchor in anchors:
+        lines = [
+            line for line in invocations.get(contract.workflow, []) if anchor in line
+        ]
+        assert len(lines) == 1, (
+            f"contract {contract.stage!r}: expected exactly one invocation with "
+            f"anchor {anchor!r} in {contract.workflow}, found {len(lines)}"
+        )
+        matched_lines.add(lines[0])
+
+    for workflow, lines in invocations.items():
+        for line in lines:
+            assert line in matched_lines, (
+                f"UNREGISTERED pytest invocation in {workflow}: {line!r}. "
+                "Register it in matrix.WORKFLOW_PYTEST_CONTRACTS (the selection "
+                "SSOT) before adding it to a workflow."
+            )
+
+
+def test_AC8_23_2_registered_invocations_match_matrix_selection() -> None:
+    """AC8.23.2: each invocation's -m expression and explicit paths equal the
+    matrix contract."""
+    invocations = _pytest_invocations()
+    for contract in matrix.WORKFLOW_PYTEST_CONTRACTS:
+        line = next(
+            line for line in invocations[contract.workflow] if contract.anchor in line
+        )
+        if contract.marker is not None:
+            assert f'-m "{contract.marker}"' in line, (
+                f"{contract.stage}: marker drifted from matrix constant.\n"
+                f'  expected: -m "{contract.marker}"\n  line: {line}'
+            )
+        for path in contract.paths:
+            assert path in line, (
+                f"{contract.stage}: expected path {path!r} in invocation: {line}"
+            )
+
+
+def test_AC8_23_3_staging_ai_ocr_corpus_aligns_with_matrix_llm_rows() -> None:
+    """AC8.23.3: the staging AI/OCR corpus (derived from @ac_proof metadata)
+    and the matrix llm rows describe the same set of provider-dependent
+    specs — the two derivations cannot drift apart silently."""
+    import sys
+
+    sys.path.insert(0, str(ROOT / "tools"))
+    try:
+        from staging_ai_ocr_gate_contract import gate_files
+    finally:
+        sys.path.pop(0)
+
+    corpus = set(gate_files())
+    llm_rows = {
+        row.file for row in matrix.E2E_ROWS if matrix.NEEDS_LLM_PROVIDER in row.needs
+    }
+    # The connectivity probe runs in deploy.yml's dedicated provider gate, not
+    # the corpus; everything else llm-dependent must be corpus-covered.
+    connectivity = {"tests/e2e/test_ai_provider_connectivity.py"}
+    assert corpus <= llm_rows, f"corpus files missing llm rows: {corpus - llm_rows}"
+    assert llm_rows - corpus == connectivity, (
+        "llm-marked matrix rows not covered by the staging corpus (and not the "
+        f"connectivity probe): {llm_rows - corpus - connectivity}"
+    )
+
+
+def test_AC8_23_4_pr_ci_evidence_reconciliation_gate(tmp_path: Path) -> None:
+    """AC8.23.4: a behavioral pr_ci proof absent from PR junit evidence fails
+    the reconciliation gate; present proofs pass; skipped-only warns."""
+    from common.testing.check_pr_ci_evidence import run_check
+
+    # Real reconciliation over a synthetic junit containing every scoped
+    # proof: build the junit from the proof graph itself, then drop one.
+    from common.testing.ac_graph import build_proofs_only
+    from common.testing.generate_critical_proof_matrix import build_matrix_from_graph
+
+    proofs = [
+        p
+        for p in build_matrix_from_graph(build_proofs_only()).get("proofs", [])
+        if p.get("scope") == "behavioral"
+        and p.get("ci_tier") == "pr_ci"
+        and matrix.classify_stage(p.get("file", "")) in matrix.PR_EVIDENCE_STAGES
+    ]
+    assert proofs, "expected at least one scoped pr_ci proof in the repo"
+
+    def junit_for(subset: list[dict]) -> Path:
+        cases = "".join(
+            f'<testcase classname="{_module_for(p["file"])}" name="{p["test"]}" time="0.1"/>'
+            for p in subset
+        )
+        path = tmp_path / f"junit-{len(subset)}.xml"
+        path.write_text(
+            f'<testsuite name="s" tests="{len(subset)}">{cases}</testsuite>',
+            encoding="utf-8",
+        )
+        return path
+
+    assert run_check([junit_for(proofs)]) == 0
+    assert run_check([junit_for(proofs[1:])]) == 1
+
+    # Skipped-only counts as present (warning), not missing — for now.
+    skipped = tmp_path / "skipped.xml"
+    first = proofs[0]
+    skipped.write_text(
+        f'<testsuite name="s" tests="1"><testcase classname="{_module_for(first["file"])}"'
+        f' name="{first["test"]}"><skipped/></testcase></testsuite>',
+        encoding="utf-8",
+    )
+    assert run_check([junit_for(proofs[1:]), skipped]) == 0
+
+
+def test_AC8_23_4_junit_parsing_handles_params_and_classes(tmp_path: Path) -> None:
+    """AC8.23.4: parametrized ids and class-nested testcases still count."""
+    junit = tmp_path / "j.xml"
+    junit.write_text(
+        '<testsuite name="s" tests="2">'
+        '<testcase classname="tests.x.test_mod.TestK" name="test_a[case-1]"/>'
+        '<testcase classname="tests.x.test_mod" name="test_b"/>'
+        "</testsuite>",
+        encoding="utf-8",
+    )
+    executed = collect_executed([junit])
+    assert ("tests.x.test_mod.TestK", "test_a") in executed
+    assert ("tests.x.test_mod", "test_b") in executed

--- a/tests/tooling/test_workflow_selection_conformance.py
+++ b/tests/tooling/test_workflow_selection_conformance.py
@@ -74,9 +74,22 @@ def test_AC8_23_1_every_workflow_pytest_invocation_is_registered() -> None:
             )
 
 
+def _selection_tokens(line: str) -> set[str]:
+    """Extract the test-selection tokens from a pytest invocation line:
+    literal test paths/nodes plus test-array shell expansions."""
+    tokens = set()
+    for token in line.split():
+        if token.startswith("tests/"):
+            tokens.add(token)
+        elif token.startswith('"${') and "TESTS" in token:
+            tokens.add(token)
+    return tokens
+
+
 def test_AC8_23_2_registered_invocations_match_matrix_selection() -> None:
-    """AC8.23.2: each invocation's -m expression and explicit paths equal the
-    matrix contract."""
+    """AC8.23.2: each invocation's -m expression and its FULL set of
+    selection tokens equal the matrix contract — an extra path argument
+    added to a workflow without updating the SSOT fails too."""
     invocations = _pytest_invocations()
     for contract in matrix.WORKFLOW_PYTEST_CONTRACTS:
         line = next(
@@ -87,10 +100,11 @@ def test_AC8_23_2_registered_invocations_match_matrix_selection() -> None:
                 f"{contract.stage}: marker drifted from matrix constant.\n"
                 f'  expected: -m "{contract.marker}"\n  line: {line}'
             )
-        for path in contract.paths:
-            assert path in line, (
-                f"{contract.stage}: expected path {path!r} in invocation: {line}"
-            )
+        assert _selection_tokens(line) == set(contract.paths), (
+            f"{contract.stage}: selection tokens drifted from the matrix "
+            f"contract.\n  expected: {sorted(contract.paths)}\n"
+            f"  found: {sorted(_selection_tokens(line))}\n  line: {line}"
+        )
 
 
 def test_AC8_23_3_staging_ai_ocr_corpus_aligns_with_matrix_llm_rows() -> None:
@@ -99,11 +113,12 @@ def test_AC8_23_3_staging_ai_ocr_corpus_aligns_with_matrix_llm_rows() -> None:
     specs — the two derivations cannot drift apart silently."""
     import sys
 
-    sys.path.insert(0, str(ROOT / "tools"))
+    tools_dir = str(ROOT / "tools")
+    sys.path.insert(0, tools_dir)
     try:
         from staging_ai_ocr_gate_contract import gate_files
     finally:
-        sys.path.pop(0)
+        sys.path.remove(tools_dir)
 
     corpus = set(gate_files())
     llm_rows = {

--- a/tools/check_pr_ci_evidence.py
+++ b/tools/check_pr_ci_evidence.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Thin wrapper for common.testing.check_pr_ci_evidence (issue #1557)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.testing.check_pr_ci_evidence import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR B (2/3) of the testing-package transformation — closes #1557 (series #1556 → this → #1558; prereq PR #1562 merged).

### What changed

- **`matrix.WORKFLOW_PYTEST_CONTRACTS`** (AC8.23.1/2): every junit-emitting pytest invocation in `.github/workflows/*.yml` is registered with its marker expression and explicit paths; `tests/tooling/test_workflow_selection_conformance.py` enforces the registry **fail-closed in both directions**. The five previously undefended markers (backend shards, integration, tier-1, staging version smoke, prod_safe) now have contract coverage; marker semantics live once in `common/testing/matrix.py`.
- **Corpus alignment** (AC8.23.3): the staging AI/OCR corpus (already derived from `@ac_proof` metadata) must equal the matrix llm rows modulo the declared connectivity probe — the two derivations cannot drift apart silently.
- **ci_tier ↔ JUnit reconciliation** (AC8.23.4): new `common/testing/check_pr_ci_evidence.py`, wired into the `ac-behavioral-ratchet` job after the score ratchet: a behavioral `ci_tier="pr_ci"` proof absent from aggregated PR junit evidence fails the job. Declared execution tier becomes a contract, not metadata. All 97 current pr_ci proofs pre-verified collected under the backend_ci marker scope; skipped-only occurrences warn (tightening tracked in #1558).

### Approach note

Workflows keep their literal marker text (no runtime substitution outside preview): the conformance gate proves workflow text == matrix constants at lint speed, which gives the same no-drift guarantee with zero runtime risk. Existing positive marker mirror assertions in `test_post_merge_e2e_gates.py` are now redundant with AC8.23.2 — their deletion rides with #1558's mirror-assertion ratchet (baseline lock + batch removal), keeping this PR's blast radius minimal.

### Test plan

- New conformance suite green (5 tests, incl. red-path fixture junit for the reconciliation gate); affected suites green locally; preflight ac-traceability/doc-consistency pass; tier ratchet + proof-kind + AC-index pass. Pre-existing local failures from the dirty `repo` submodule are unrelated (same set with this diff absent).
- The `ac-behavioral-ratchet` check on this PR is the live proof of the reconciliation gate.

Closes #1557. Part of #1556 (next: #1558).

🤖 Generated with [Claude Code](https://claude.com/claude-code)