### PR TITLE
[finance_report_vision] feat(meta): add check_package_directory_coverage — close the additive-discovery blind spot

### DIFF
--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -154,6 +154,24 @@ CONTRACT = PackageContract(
             ),
             test="tests/tooling/test_meta_layering.py::test_meta_base_is_pure",
         ),
+        Invariant(
+            id="every-common-directory-is-governed-or-excepted",
+            statement=(
+                "check_package_contract discovers packages additively (globs "
+                "common/*/contract.py), so a directory with no contract.py is "
+                "invisible to it -- how common/ci, common/shell, and common/ssot "
+                "accumulated as undeclared junk drawers (#1564-#1568). "
+                "check_package_directory_coverage closes that gap from the other "
+                "direction: every directory directly under common/ must ship a "
+                "contract.py or be a documented, reasoned entry in "
+                "UNGOVERNED_EXCEPTIONS, so a new junk drawer cannot silently "
+                "recur."
+            ),
+            test=(
+                "tests/tooling/test_check_package_directory_coverage.py"
+                "::test_bare_directory_with_no_exception_is_rejected"
+            ),
+        ),
     ],
     roadmap=[
         # The governance gate's building-block behavior — meta's domain. Each AC

--- a/common/meta/extension/check_package_directory_coverage.py
+++ b/common/meta/extension/check_package_directory_coverage.py
@@ -1,0 +1,108 @@
+"""``check_package_directory_coverage`` — no directory under ``common/`` goes ungoverned.
+
+``check_package_contract`` discovers packages *additively*: it globs
+``common/*/contract.py`` and validates whatever it finds. That makes it easy to
+add a package, but it means a directory dropped into ``common/`` WITHOUT a
+``contract.py`` is invisible to it -- exactly how ``common/ci``, ``common/shell``,
+and ``common/ssot`` accumulated as undeclared "junk drawers" that this repo spent
+five PRs dissolving back into real packages (#1564-#1568).
+
+This gate closes that gap from the other direction: it enumerates every
+directory directly under ``common/`` and requires each one to either ship a
+``contract.py`` or be a documented, reasoned entry in
+:data:`UNGOVERNED_EXCEPTIONS` (a pending SSOT-only domain, or leftover files with
+no clean package fit yet). A brand-new directory with neither is rejected, so the
+junk-drawer pattern cannot silently recur.
+
+stdlib only (no pyyaml/pydantic) so the gate runs anywhere, including the
+lightweight CI lint environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# This module lives at common/meta/extension/check_package_directory_coverage.py,
+# so the repo root is three parents up (extension -> meta -> common -> repo).
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+IGNORED_DIR_NAMES = {"__pycache__"}
+
+# Directories under common/ that are deliberately, not accidentally, ungoverned
+# today. Each entry names the reason so the exception can be audited and
+# eventually retired (once the directory ships a contract.py or is dissolved).
+UNGOVERNED_EXCEPTIONS: dict[str, str] = {
+    "ssot": (
+        "Leftover from the common/ci + common/ssot dissolution (#1564-#1568): "
+        "houses three generator scripts with no clean package fit yet "
+        "(generate_api_reference.py, generate_db_schema_reference.py, "
+        "generate_openapi_spec.py) -- not a bounded context itself."
+    ),
+    "extraction": (
+        "Pending code cutover (#1421): SSOT-only today (readme.md + "
+        "audit-failed-cases.yaml); ships a contract.py once the conforming "
+        "implementation lands under apps/backend/src/services/extraction/."
+    ),
+    "llm": (
+        "Pending code cutover (#1426): SSOT-only today (readme.md); ships a "
+        "contract.py once the conforming implementation lands under "
+        "apps/backend/src/llm/."
+    ),
+}
+
+
+def discover_common_dirs(repo_root: Path) -> list[str]:
+    """Every directory directly under common/, excluding caches and dotdirs."""
+    common_dir = repo_root / "common"
+    return sorted(
+        p.name
+        for p in common_dir.iterdir()
+        if p.is_dir()
+        and p.name not in IGNORED_DIR_NAMES
+        and not p.name.startswith(".")
+    )
+
+
+def check_directory_coverage(repo_root: Path) -> list[str]:
+    """Every common/<dir> ships a contract.py or is a documented exception."""
+    errors: list[str] = []
+    for name in discover_common_dirs(repo_root):
+        contract_path = repo_root / "common" / name / "contract.py"
+        if contract_path.exists():
+            continue
+        if name in UNGOVERNED_EXCEPTIONS:
+            continue
+        errors.append(
+            f"common/{name}/ has no contract.py and is not a documented "
+            "exception in UNGOVERNED_EXCEPTIONS "
+            "(common/meta/extension/check_package_directory_coverage.py). Ship "
+            f"a PackageContract (common/{name}/contract.py) or add a reasoned "
+            "exception entry."
+        )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT),
+        help="Repository root to scan (default: this file's repo).",
+    )
+    args = parser.parse_args(argv)
+
+    errors = check_directory_coverage(Path(args.repo_root))
+    if errors:
+        print("[DIRECTORY COVERAGE] FAILED:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("[DIRECTORY COVERAGE] PASSED: every common/ directory is governed or excepted.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -101,6 +101,18 @@ about a package is *derived from its contract*:
 Because governance reads the contract, adding a package adds no central index to
 edit: a new package is governed the moment it ships a `common/<pkg>/contract.py`.
 
+That additive discovery has a blind spot: a directory with **no** `contract.py`
+is invisible to `check_package_contract`, not rejected — exactly how
+`common/ci`, `common/shell`, and `common/ssot` accumulated as undeclared junk
+drawers before being dissolved back into real packages (#1564-#1568).
+`tools/check_package_directory_coverage.py` (logic in
+[`extension/check_package_directory_coverage.py`](./extension/check_package_directory_coverage.py))
+closes that gap from the other direction: every directory directly under
+`common/` must ship a `contract.py` **or** be a documented, reasoned entry in
+`UNGOVERNED_EXCEPTIONS` (today: `ssot`, and the two pending-cutover SSOT-only
+domains `extraction` / `llm`) — so a new junk drawer fails the gate instead of
+silently accumulating.
+
 ## Examples
 
 - **`meta`** (`platform`, the meta-package) — self-hosts the model **and** is the
@@ -190,7 +202,8 @@ The recipe for moving a module (and its EPIC-table ACs) into the package model.
    [`traceability-exceptions.md`](../../docs/project/traceability-exceptions.md).
 
 9. **Run the gates locally before pushing:** `check_package_contract`,
-   `generate_ac_registry --check`, `check_ac_proof_kind`, `check_tier_ast_literal`,
-   `check_epic_package_dual`, `check_draft_packages`, `check_tier_imports`,
-   `check_authority_reconcile`, and `lint_doc_consistency`. The untagged-debt
-   ratchet shrinks automatically as the moved ACs leave the EPIC source.
+   `check_package_directory_coverage`, `generate_ac_registry --check`,
+   `check_ac_proof_kind`, `check_tier_ast_literal`, `check_epic_package_dual`,
+   `check_draft_packages`, `check_tier_imports`, `check_authority_reconcile`, and
+   `lint_doc_consistency`. The untagged-debt ratchet shrinks automatically as the
+   moved ACs leave the EPIC source.

--- a/common/meta/todo.md
+++ b/common/meta/todo.md
@@ -13,6 +13,11 @@ The meta package's own worklist. Cross-package migration lives in
       contracts at `common/*/contract.py`; resolve `interface` against
       `implementations["be"]`.
 - [x] Source ACs additively from package-contract `roadmap`s (no EPIC mirror).
+- [x] Close the additive-discovery blind spot: every `common/<dir>` must ship a
+      `contract.py` or be a documented exception
+      (`check_package_directory_coverage`), so a new undeclared junk drawer
+      (like the retired `common/ci`/`common/shell`/`common/ssot`) cannot
+      silently recur.
 
 ## Next
 

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -141,6 +141,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_check_env_keys.py` | `docs/ssot/development.md` |
 | `tests/tooling/test_check_manifest.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_check_package_contract.py` | `common/meta/readme.md` |
+| `tests/tooling/test_check_package_directory_coverage.py` | `common/meta/readme.md` |
 | `tests/tooling/test_check_ssot_ownership.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_counter_package.py` | `common/meta/readme.md` |
 | `tests/tooling/test_identity_package.py` | `common/meta/readme.md` |

--- a/tests/tooling/test_check_package_directory_coverage.py
+++ b/tests/tooling/test_check_package_directory_coverage.py
@@ -1,0 +1,78 @@
+"""AC-meta.dircov.1: every common/ directory is governed or a documented exception.
+
+``check_package_contract`` discovers packages additively (globs
+``common/*/contract.py``), so it never notices a directory with NO
+``contract.py`` -- exactly how ``common/ci``, ``common/shell``, and
+``common/ssot`` accumulated as undeclared junk drawers (#1564-#1568).
+``check_package_directory_coverage`` closes that gap: it enumerates every
+directory directly under ``common/`` and fails on one that ships neither a
+``contract.py`` nor a documented entry in ``UNGOVERNED_EXCEPTIONS``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from common.meta.extension import check_package_directory_coverage as gate
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _make_pkg_with_contract(root: Path, name: str) -> None:
+    pkg = root / "common" / name
+    pkg.mkdir(parents=True)
+    (pkg / "contract.py").write_text("CONTRACT = object()\n", encoding="utf-8")
+
+
+def _make_bare_dir(root: Path, name: str, *, with_file: bool = True) -> None:
+    pkg = root / "common" / name
+    pkg.mkdir(parents=True)
+    if with_file:
+        (pkg / "some_tool.py").write_text("# a stray script\n", encoding="utf-8")
+
+
+def test_real_repo_passes() -> None:
+    """The actual repository has no ungoverned, undocumented common/ directory."""
+    errors = gate.check_directory_coverage(REPO_ROOT)
+    assert errors == [], "\n".join(errors)
+
+
+def test_directory_with_contract_passes(tmp_path: Path) -> None:
+    """A directory shipping a contract.py is governed -- no error."""
+    _make_pkg_with_contract(tmp_path, "widgets")
+    assert gate.check_directory_coverage(tmp_path) == []
+
+
+def test_documented_exception_passes_without_contract(tmp_path: Path, monkeypatch) -> None:
+    """A directory named in UNGOVERNED_EXCEPTIONS passes even with no contract.py."""
+    _make_bare_dir(tmp_path, "wip_domain")
+    monkeypatch.setitem(
+        gate.UNGOVERNED_EXCEPTIONS, "wip_domain", "test-only documented exception"
+    )
+    assert gate.check_directory_coverage(tmp_path) == []
+
+
+def test_bare_directory_with_no_exception_is_rejected(tmp_path: Path) -> None:
+    """A new junk-drawer directory with no contract.py and no exception fails."""
+    _make_bare_dir(tmp_path, "random_junk")
+    errors = gate.check_directory_coverage(tmp_path)
+    assert len(errors) == 1
+    assert "common/random_junk/" in errors[0]
+    assert "contract.py" in errors[0]
+
+
+def test_pycache_is_ignored(tmp_path: Path) -> None:
+    """__pycache__ residue under common/ is never flagged."""
+    (tmp_path / "common" / "__pycache__").mkdir(parents=True)
+    assert gate.check_directory_coverage(tmp_path) == []
+
+
+def test_main_passes_quietly_on_real_repo(capsys) -> None:
+    assert gate.main(["--repo-root", str(REPO_ROOT)]) == 0
+    assert "PASSED" in capsys.readouterr().out
+
+
+def test_main_fails_and_reports_on_a_junk_drawer(tmp_path: Path, capsys) -> None:
+    _make_bare_dir(tmp_path, "another_junk_drawer")
+    assert gate.main(["--repo-root", str(tmp_path)]) == 1
+    assert "another_junk_drawer" in capsys.readouterr().err

--- a/tools/check_package_directory_coverage.py
+++ b/tools/check_package_directory_coverage.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Command wrapper for the common/ directory-coverage governance gate.
+
+Every directory directly under ``common/`` must either ship a ``contract.py``
+(a declared package, checked by ``check_package_contract.py``) or be a
+documented exception in ``UNGOVERNED_EXCEPTIONS``. See
+``common/meta/extension/check_package_directory_coverage.py`` and
+``common/meta/readme.md``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.meta.extension.check_package_directory_coverage import main  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Follow-up to the `common/ci`/`common/shell`/`common/ssot` dissolution
(#1564-#1568). While confirming those cleanups, we found that
`check_package_contract` discovers packages **additively**: it globs
`common/*/contract.py` and validates whatever it finds. That makes adding a
package easy, but a directory dropped into `common/` **without** a
`contract.py` is invisible to it -- not rejected -- which is exactly how
`common/ci`, `common/shell`, and `common/ssot` accumulated as undeclared junk
drawers in the first place. Nothing today stops the same pattern from
recurring.

This adds a gate from the other direction: every directory directly under
`common/` must ship a `contract.py` **or** be a documented, reasoned entry in
`UNGOVERNED_EXCEPTIONS`:
- `ssot` — the 3 no-clean-package-fit generators left behind by the
  dissolution (`generate_api_reference.py`, `generate_db_schema_reference.py`,
  `generate_openapi_spec.py`).
- `extraction` / `llm` — pending code cutovers (#1421 / #1426), SSOT-only
  today.

A brand-new junk-drawer directory with neither now fails the gate instead of
silently accumulating.

- `common/meta/extension/check_package_directory_coverage.py` — the gate
  (stdlib only, no pyyaml/pydantic, so it runs anywhere).
- `tools/check_package_directory_coverage.py` — the CLI wrapper.
- `tests/tooling/test_check_package_directory_coverage.py` — 7 tests.
- `common/meta/contract.py` — new invariant
  (`every-common-directory-is-governed-or-excepted`) pinned to the rejection
  test.
- `common/meta/readme.md`, `todo.md` — document the blind spot and the fix.
- `docs/project/traceability-exceptions.md` — classify the new test file
  (invariant-only, same pattern as `test_check_package_contract.py`).

## Test plan

- [x] `check_package_contract.py`, `check_package_directory_coverage.py`
      (itself), `check_authority_reconcile.py`, `check_ac_index.py`,
      `lint_doc_consistency.py`, `check_manifest.py`,
      `check_workflow_contract.py`, `generate_ac_registry.py --check` all pass
- [x] Full `tests/tooling/` suite: 1857 passed, 1 skipped
- [x] `ruff check` clean on every changed/new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)