### PR TITLE
[finance_report_test_and_doc] chore(governance): remove the now-inert env_smoke_test.md deletion exception (#1554)

### DIFF
--- a/docs/ssot/governance-exceptions.yaml
+++ b/docs/ssot/governance-exceptions.yaml
@@ -220,16 +220,6 @@ exceptions:
       apps/backend/tests/fixtures/generated/); the MANIFEST pdf_fixtures owner
       now points there. Remove this exception once the deletion is merged.
 
-  - target: finance_report:docs/ssot/env_smoke_test.md
-    issue: https://github.com/wangzitian0/finance_report/issues/1554
-    reason: >-
-      env_smoke_test.md is retired — its Three-Gates environment-verification
-      SSOT is internalized into the runtime package
-      (common/runtime/readme.md#environment-verification-the-three-gates); the
-      MANIFEST env_smoke_test owner now points there. The deletion shows up as a
-      changed SSOT file with no owner; this temporary exception covers only that
-      deletion churn. Remove this exception once the deletion is merged.
-
 # ---------------------------------------------------------------------------
 # Temporary SSOT governance gate exceptions live in `exceptions` above.
 # Each exception must target a single gate finding and link a GitHub issue.


### PR DESCRIPTION
## What & why

Final housekeeping for the runtime migration (umbrella #1554). PR #1569 retired `docs/ssot/env_smoke_test.md` and internalized its Three-Gates SSOT into `common/runtime/readme.md`. That PR carried a **temporary** SSOT-governance exception for the deletion churn (`changed_ssot_file_without_owner`), whose own note said *"remove once the deletion is merged"*.

Now that #1569 is merged, the file is gone from `main` — no future diff carries it, so the finding cannot recur. This removes the inert exception.

## Change

- Delete the `finance_report:docs/ssot/env_smoke_test.md` entry from `docs/ssot/governance-exceptions.yaml`.

## Verification

- SSOT governance gate: **PASS** without the exception (env_smoke_test.md no longer appears in any diff vs `main`).
- `check_ssot_ownership`, `check_manifest`, `lint_doc_consistency`: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)