### PR TITLE
[finance_report_hacker] chore(classify): delete the dead pre-#1483 ML-signal matching path + orphaned schema

### DIFF
--- a/apps/backend/src/schemas/__init__.py
+++ b/apps/backend/src/schemas/__init__.py
@@ -147,7 +147,6 @@ from .extraction import (
     ParsedStatementPreview,
     RetryParsingRequest,
     StatementDecisionRequest,
-    TransactionUpdateRequest,
     compose_statement_response,
 )
 
@@ -257,7 +256,6 @@ __all__ = [
     "RetryParsingRequest",
     "StatementDecisionRequest",
     "Stage2ReviewQueueResponse",
-    "TransactionUpdateRequest",
     "TrendPeriod",
     "UnmatchedTransactionsResponse",
     "UserCreate",

--- a/apps/backend/src/schemas/extraction.py
+++ b/apps/backend/src/schemas/extraction.py
@@ -69,19 +69,6 @@ class RetryParsingRequest(BaseModel):
     model: str | None = Field(None, description="Optional model override (e.g. gpt-4o)")
 
 
-class TransactionUpdateRequest(BaseModel):
-    """Request to manually correct a transaction."""
-
-    txn_date: date | None = None
-    description: str | None = None
-    amount: Decimal | None = None
-    direction: str | None = None
-    reference: str | None = None
-    currency: str | None = None
-    balance_after: Decimal | None = None
-    suggested_category: str | None = None
-    category_confidence: Decimal | None = None
-
 
 # --- Response Schemas ---
 

--- a/apps/backend/src/schemas/extraction.py
+++ b/apps/backend/src/schemas/extraction.py
@@ -69,7 +69,6 @@ class RetryParsingRequest(BaseModel):
     model: str | None = Field(None, description="Optional model override (e.g. gpt-4o)")
 
 
-
 # --- Response Schemas ---
 
 

--- a/apps/backend/src/services/classification.py
+++ b/apps/backend/src/services/classification.py
@@ -1,7 +1,6 @@
 """Layer 3: Classification Service."""
 
 import re
-from decimal import Decimal
 from uuid import UUID
 
 from sqlalchemy import select
@@ -25,7 +24,6 @@ class ClassificationService:
     _RULE_PRIORITY: dict[RuleType, int] = {
         RuleType.KEYWORD_MATCH: 0,
         RuleType.REGEX_MATCH: 1,
-        RuleType.ML_MODEL: 2,
     }
 
     async def get_active_rules(self, db: AsyncSession, user_id: UUID) -> list[ClassificationRule]:
@@ -61,74 +59,16 @@ class ClassificationService:
                 logger.warning(f"Invalid regex pattern in rule {rule.id}: {e}")
                 return False
 
-        elif rule.rule_type == RuleType.ML_MODEL:
-            source = str(config.get("source", "extraction_ai"))
-            if source != "extraction_ai":
-                return False
-
-            confidence, category = self._extract_ai_signals(transaction)
-            if confidence is None:
-                return False
-
-            threshold_raw = config.get("confidence_threshold", "0.70")
-            try:
-                confidence_threshold = Decimal(str(threshold_raw))
-            except Exception:
-                logger.warning(f"Invalid ML confidence threshold in rule {rule.id}: {threshold_raw}")
-                return False
-
-            expected_category = config.get("suggested_category")
-            if expected_category and category:
-                return (
-                    category.strip().lower() == str(expected_category).strip().lower()
-                    and confidence >= confidence_threshold
-                )
-
-            return confidence >= confidence_threshold
+        # RuleType.ML_MODEL matching was retired (EPIC #1483 cleanup): it read AI
+        # signals no producer ever wrote, and no rule CRUD exists. The model path
+        # is the transaction classify node; ML_MODEL rows remain only as the
+        # classification-policy anchors (is_active=False), which never match.
 
         return False
 
-    def _extract_ai_signals(self, transaction: AtomicTransaction) -> tuple[Decimal | None, str | None]:
-        sources = transaction.source_documents
-
-        items: list[dict] = []
-        if isinstance(sources, dict):
-            items = [sources]
-        elif isinstance(sources, list):
-            items = [item for item in sources if isinstance(item, dict)]
-
-        for item in items:
-            confidence_raw = item.get("category_confidence")
-            if confidence_raw is None:
-                confidence_raw = item.get("ai_confidence")
-
-            if confidence_raw is None:
-                continue
-
-            try:
-                confidence = Decimal(str(confidence_raw))
-            except Exception:
-                continue
-
-            category_raw = item.get("suggested_category")
-            if category_raw is None:
-                category_raw = item.get("category")
-
-            category = str(category_raw) if category_raw is not None else None
-            return confidence, category
-
-        return None, None
-
     def _confidence_score_for_rule(self, transaction: AtomicTransaction, rule: ClassificationRule) -> int:
-        if rule.rule_type != RuleType.ML_MODEL:
-            return 100
-
-        confidence, _ = self._extract_ai_signals(transaction)
-        if confidence is None:
-            return 70
-
-        score = int((confidence * Decimal("100")).to_integral_value())
-        return max(0, min(score, 100))
+        # Deterministic rules (keyword/regex) are user intent: full confidence.
+        return 100
 
     def _sort_rules_by_priority(self, rules: list[ClassificationRule]) -> list[ClassificationRule]:
         return sorted(

--- a/apps/backend/tests/extraction/test_classification_service.py
+++ b/apps/backend/tests/extraction/test_classification_service.py
@@ -1,18 +1,20 @@
 """Tests for Classification Service.
 
-AC18.1.3 AC18.1.4: ML model classification threshold and rule priority coverage.
+AC18.1.4 AC11.12.2: deterministic rule matching and priority coverage (ML matching retired, EPIC #1483 cleanup).
 """
 
 from datetime import date
 from decimal import Decimal
 from unittest.mock import patch
 
+import pytest
 from sqlalchemy import select
 
 from src.models.account import Account, AccountType
 from src.models.layer2 import AtomicTransaction, TransactionDirection
 from src.models.layer3 import ClassificationRule, RuleType, TransactionClassification
 from src.services.classification import ClassificationService
+from tests.factories import AtomicTransactionFactory
 
 
 class TestClassificationService:
@@ -528,96 +530,8 @@ class TestClassificationService:
 
         assert len(results) == 0
 
-    async def test_apply_ml_model_rule_matches_on_confidence_threshold(self, db, test_user):
-        service = ClassificationService()
-
-        account = Account(
-            user_id=test_user.id,
-            name="AI Category Account",
-            type=AccountType.EXPENSE,
-            currency="SGD",
-            code="6810",
-        )
-        db.add(account)
-        await db.flush()
-
-        ml_rule = ClassificationRule(
-            user_id=test_user.id,
-            version_number=1,
-            effective_date=date(2024, 1, 1),
-            rule_name="ML Category Rule",
-            rule_type=RuleType.ML_MODEL,
-            rule_config={"source": "extraction_ai", "confidence_threshold": "0.70"},
-            default_account_id=account.id,
-            created_by=test_user.id,
-        )
-        db.add(ml_rule)
-        await db.flush()
-
-        txn = AtomicTransaction(
-            user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            amount=Decimal("22.00"),
-            direction=TransactionDirection.OUT,
-            description="Grocery purchase",
-            currency="SGD",
-            dedup_hash="hash_ml_high",
-            source_documents=[{"category_confidence": "0.82", "suggested_category": "Food & Dining"}],
-        )
-        db.add(txn)
-        await db.flush()
-
-        results = await service.apply_rules(db, test_user.id, [txn])
-
-        assert len(results) == 1
-        assert results[0].atomic_txn_id == txn.id
-        assert results[0].confidence_score == 82
-
-    async def test_apply_ml_model_rule_rejects_low_confidence(self, db, test_user):
-        service = ClassificationService()
-
-        account = Account(
-            user_id=test_user.id,
-            name="AI Low Confidence",
-            type=AccountType.EXPENSE,
-            currency="SGD",
-            code="6811",
-        )
-        db.add(account)
-        await db.flush()
-
-        ml_rule = ClassificationRule(
-            user_id=test_user.id,
-            version_number=1,
-            effective_date=date(2024, 1, 1),
-            rule_name="ML Low Confidence Rule",
-            rule_type=RuleType.ML_MODEL,
-            rule_config={"source": "extraction_ai", "confidence_threshold": "0.70"},
-            default_account_id=account.id,
-            created_by=test_user.id,
-        )
-        db.add(ml_rule)
-        await db.flush()
-
-        txn = AtomicTransaction(
-            user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            amount=Decimal("12.00"),
-            direction=TransactionDirection.OUT,
-            description="Random merchant",
-            currency="SGD",
-            dedup_hash="hash_ml_low",
-            source_documents=[{"category_confidence": "0.40", "suggested_category": "Shopping"}],
-        )
-        db.add(txn)
-        await db.flush()
-
-        results = await service.apply_rules(db, test_user.id, [txn])
-
-        assert len(results) == 0
-
-    async def test_classification_priority_keyword_over_regex_over_ml(self, db, test_user):
-        """AC18.1.4 AC11.12.2: Rule type priority beats lower-priority AI/regex matches."""
+    async def test_classification_priority_keyword_over_regex(self, db, test_user):
+        """AC18.1.4 AC11.12.2: Rule type priority: KEYWORD beats REGEX (ML tier retired)."""
         service = ClassificationService()
 
         keyword_account = Account(
@@ -634,14 +548,7 @@ class TestClassificationService:
             currency="SGD",
             code="6813",
         )
-        ml_account = Account(
-            user_id=test_user.id,
-            name="ML Account",
-            type=AccountType.EXPENSE,
-            currency="SGD",
-            code="6814",
-        )
-        db.add_all([keyword_account, regex_account, ml_account])
+        db.add_all([keyword_account, regex_account])
         await db.flush()
 
         keyword_rule = ClassificationRule(
@@ -664,17 +571,7 @@ class TestClassificationService:
             default_account_id=regex_account.id,
             created_by=test_user.id,
         )
-        ml_rule = ClassificationRule(
-            user_id=test_user.id,
-            version_number=1,
-            effective_date=date(2024, 1, 1),
-            rule_name="ML Priority",
-            rule_type=RuleType.ML_MODEL,
-            rule_config={"source": "extraction_ai", "confidence_threshold": "0.70"},
-            default_account_id=ml_account.id,
-            created_by=test_user.id,
-        )
-        db.add_all([keyword_rule, regex_rule, ml_rule])
+        db.add_all([keyword_rule, regex_rule])
         await db.flush()
 
         txn = AtomicTransaction(
@@ -810,216 +707,26 @@ class TestClassificationService:
         classifications = classification_result.scalars().all()
         assert len(classifications) == 1
 
-    async def test_ml_model_rule_ignores_non_extraction_source(self, db, test_user):
-        service = ClassificationService()
 
-        account = Account(
-            user_id=test_user.id,
-            name="ML Non Extraction",
-            type=AccountType.EXPENSE,
-            currency="SGD",
-            code="6815",
-        )
-        db.add(account)
-        await db.flush()
+@pytest.mark.asyncio
+async def test_AC18_1_3_ml_rule_matching_is_retired(db, test_user):
+    """AC18.1.3: ML_MODEL rule matching is RETIRED (EPIC #1483 cleanup) — even an
+    active ML_MODEL rule never matches (the model path is the classify node), and
+    the dead AI-signal reader is gone from the service."""
+    service = ClassificationService()
+    assert not hasattr(service, "_extract_ai_signals")
 
-        ml_rule = ClassificationRule(
-            user_id=test_user.id,
-            version_number=1,
-            effective_date=date(2024, 1, 1),
-            rule_name="ML Non Extraction Rule",
-            rule_type=RuleType.ML_MODEL,
-            rule_config={"source": "other", "confidence_threshold": "0.70"},
-            default_account_id=account.id,
-            created_by=test_user.id,
-        )
-        db.add(ml_rule)
-        await db.flush()
+    rule = ClassificationRule(
+        user_id=test_user.id,
+        version_number=1,
+        effective_date=date(2024, 1, 1),
+        rule_name="legacy-ml-rule",
+        rule_type=RuleType.ML_MODEL,
+        rule_config={"source": "extraction_ai", "confidence_threshold": "0.1"},
+        created_by=test_user.id,
+    )
+    db.add(rule)
+    await db.flush()
+    txn = await AtomicTransactionFactory.create_async(db, user_id=test_user.id, description="anything")
 
-        txn = AtomicTransaction(
-            user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            amount=Decimal("20.00"),
-            direction=TransactionDirection.OUT,
-            description="Food",
-            currency="SGD",
-            dedup_hash="hash_ml_non_extraction",
-            source_documents=[{"category_confidence": "0.99", "suggested_category": "Food & Dining"}],
-        )
-        db.add(txn)
-        await db.flush()
-
-        results = await service.apply_rules(db, test_user.id, [txn])
-        assert len(results) == 0
-
-    async def test_ml_model_rule_handles_invalid_threshold(self, db, test_user):
-        service = ClassificationService()
-
-        account = Account(
-            user_id=test_user.id,
-            name="ML Invalid Threshold",
-            type=AccountType.EXPENSE,
-            currency="SGD",
-            code="6816",
-        )
-        db.add(account)
-        await db.flush()
-
-        ml_rule = ClassificationRule(
-            user_id=test_user.id,
-            version_number=1,
-            effective_date=date(2024, 1, 1),
-            rule_name="ML Invalid Threshold Rule",
-            rule_type=RuleType.ML_MODEL,
-            rule_config={"source": "extraction_ai", "confidence_threshold": "bad"},
-            default_account_id=account.id,
-            created_by=test_user.id,
-        )
-        db.add(ml_rule)
-        await db.flush()
-
-        txn = AtomicTransaction(
-            user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            amount=Decimal("20.00"),
-            direction=TransactionDirection.OUT,
-            description="Food",
-            currency="SGD",
-            dedup_hash="hash_ml_invalid_threshold",
-            source_documents=[{"category_confidence": "0.99", "suggested_category": "Food & Dining"}],
-        )
-        db.add(txn)
-        await db.flush()
-
-        with patch("src.services.classification.logger") as mock_logger:
-            results = await service.apply_rules(db, test_user.id, [txn])
-        assert len(results) == 0
-        mock_logger.warning.assert_called_once()
-
-    async def test_ml_model_rule_category_constraint(self, db, test_user):
-        service = ClassificationService()
-
-        account = Account(
-            user_id=test_user.id,
-            name="ML Category Constraint",
-            type=AccountType.EXPENSE,
-            currency="SGD",
-            code="6817",
-        )
-        db.add(account)
-        await db.flush()
-
-        ml_rule = ClassificationRule(
-            user_id=test_user.id,
-            version_number=1,
-            effective_date=date(2024, 1, 1),
-            rule_name="ML Category Constraint Rule",
-            rule_type=RuleType.ML_MODEL,
-            rule_config={
-                "source": "extraction_ai",
-                "confidence_threshold": "0.70",
-                "suggested_category": "Transport",
-            },
-            default_account_id=account.id,
-            created_by=test_user.id,
-        )
-        db.add(ml_rule)
-        await db.flush()
-
-        txn_mismatch = AtomicTransaction(
-            user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            amount=Decimal("9.00"),
-            direction=TransactionDirection.OUT,
-            description="Taxi",
-            currency="SGD",
-            dedup_hash="hash_ml_category_mismatch",
-            source_documents=[{"category_confidence": "0.95", "suggested_category": "Food & Dining"}],
-        )
-        txn_match = AtomicTransaction(
-            user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            amount=Decimal("11.00"),
-            direction=TransactionDirection.OUT,
-            description="MRT",
-            currency="SGD",
-            dedup_hash="hash_ml_category_match",
-            source_documents=[{"category_confidence": "0.95", "suggested_category": "Transport"}],
-        )
-        db.add_all([txn_mismatch, txn_match])
-        await db.flush()
-
-        results = await service.apply_rules(db, test_user.id, [txn_mismatch, txn_match])
-
-        assert len(results) == 1
-        assert results[0].atomic_txn_id == txn_match.id
-
-    async def test_extract_ai_signals_supports_dict_and_fallback_keys(self, db, test_user):
-        service = ClassificationService()
-
-        txn = AtomicTransaction(
-            user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            amount=Decimal("8.00"),
-            direction=TransactionDirection.OUT,
-            description="Fallback keys",
-            currency="SGD",
-            dedup_hash="hash_ai_signal_dict",
-            source_documents={"ai_confidence": "0.88", "category": "Utilities"},
-        )
-        db.add(txn)
-        await db.flush()
-
-        confidence, category = service._extract_ai_signals(txn)
-        assert confidence == Decimal("0.88")
-        assert category == "Utilities"
-
-    async def test_extract_ai_signals_handles_invalid_values_and_empty(self, db, test_user):
-        service = ClassificationService()
-
-        txn_invalid = AtomicTransaction(
-            user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            amount=Decimal("8.00"),
-            direction=TransactionDirection.OUT,
-            description="Invalid ai confidence",
-            currency="SGD",
-            dedup_hash="hash_ai_signal_invalid",
-            source_documents=[{"category_confidence": "not-a-decimal"}, {"foo": "bar"}],
-        )
-        db.add(txn_invalid)
-        await db.flush()
-
-        confidence, category = service._extract_ai_signals(txn_invalid)
-        assert confidence is None
-        assert category is None
-
-    async def test_confidence_score_for_ml_defaults_to_70_without_signal(self, db, test_user):
-        service = ClassificationService()
-
-        ml_rule = ClassificationRule(
-            user_id=test_user.id,
-            version_number=1,
-            effective_date=date(2024, 1, 1),
-            rule_name="ML score fallback",
-            rule_type=RuleType.ML_MODEL,
-            rule_config={"source": "extraction_ai", "confidence_threshold": "0.70"},
-            created_by=test_user.id,
-        )
-        db.add(ml_rule)
-        await db.flush()
-
-        txn = AtomicTransaction(
-            user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            amount=Decimal("8.00"),
-            direction=TransactionDirection.OUT,
-            description="No ai signal",
-            currency="SGD",
-            dedup_hash="hash_ml_conf_fallback",
-            source_documents=[],
-        )
-        db.add(txn)
-        await db.flush()
-
-        assert service._confidence_score_for_rule(txn, ml_rule) == 70
+    assert await service.apply_rules(db, test_user.id, [txn]) == []

--- a/apps/backend/tests/extraction/test_classification_service.py
+++ b/apps/backend/tests/extraction/test_classification_service.py
@@ -7,7 +7,6 @@ from datetime import date
 from decimal import Decimal
 from unittest.mock import patch
 
-import pytest
 from sqlalchemy import select
 
 from src.models.account import Account, AccountType
@@ -708,7 +707,6 @@ class TestClassificationService:
         assert len(classifications) == 1
 
 
-@pytest.mark.asyncio
 async def test_AC18_1_3_ml_rule_matching_is_retired(db, test_user):
     """AC18.1.3: ML_MODEL rule matching is RETIRED (EPIC #1483 cleanup) — even an
     active ML_MODEL rule never matches (the model path is the classify node), and

--- a/apps/backend/tests/infra/test_main.py
+++ b/apps/backend/tests/infra/test_main.py
@@ -179,16 +179,6 @@ class TestSchemas:
         assert BankStatementStatusEnum.PARSED.value == "parsed"
         assert BankStatementStatusEnum.APPROVED.value == "approved"
 
-    def test_event_update_request(self):
-        """Test EventUpdateRequest partial update."""
-        from decimal import Decimal
-
-        from src.schemas.extraction import TransactionUpdateRequest
-
-        update = TransactionUpdateRequest(amount=Decimal("100.00"))
-        assert update.amount == Decimal("100.00")
-        assert update.description is None
-
 
 class TestDatabase:
     """Tests for database module."""

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -14078,7 +14078,7 @@
     },
     "/classifications/backfill": {
       "post": {
-        "description": "Classify the caller's not-yet-classified transactions (idempotent).",
+        "description": "Classify the caller's not-yet-classified transactions (duplicate-free; the tail is re-attempted).",
         "operationId": "backfill_transaction_classifications_classifications_backfill_post",
         "responses": {
           "200": {

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -415,4 +415,4 @@ representative fixture expansion needed before the overall
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC11.12.1 | Re-applying the same rule version to the same atomic transaction is idempotent and returns the existing classification without inserting duplicates | `test_apply_rules_is_idempotent_for_existing_transaction_rule_version` | `extraction/test_classification_service.py` | P0 |
-| AC11.12.2 | Classification priority is deterministic across rule type and descending rule version | `test_classification_priority_keyword_over_regex_over_ml`, `test_same_type_rules_prefer_newer_version` | `extraction/test_classification_service.py` | P0 |
+| AC11.12.2 | Classification priority is deterministic across rule type and descending rule version {tier:CODE-LED} {proof:property} | `test_classification_priority_keyword_over_regex`, `test_same_type_rules_prefer_newer_version` | `extraction/test_classification_service.py` | P0 |

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -255,8 +255,8 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
 |-------|-------|-------------|
 | AC18.1.1 | 1 | Extraction prompt returns `suggested_category` and `category_confidence` |
 | AC18.1.2 | 1 | `BankStatementTransaction` has `suggested_category` and `category_confidence` columns |
-| AC18.1.3 | 1 | `RuleType.ML_MODEL` evaluates AI suggestion with confidence threshold ≥ 0.7 |
-| AC18.1.4 | 1 | Classification priority: KEYWORD > REGEX > ML_MODEL > Uncategorized |
+| AC18.1.3 | 1 | RETIRED (EPIC #1483 cleanup): `RuleType.ML_MODEL` rule matching deleted — it read AI signals (`suggested_category`/`category_confidence`) that no producer ever wrote, and no rule CRUD exists; the model path is the transaction classify node (§AC18.15). `RuleType.ML_MODEL` survives only as the classification-policy anchor row type {tier:CODE-LED} {proof:property} |
+| AC18.1.4 | 1 | Classification priority: KEYWORD > REGEX > Uncategorized (the ML tier moved to the classify node, §AC18.15) {tier:CODE-LED} {proof:property} |
 | AC18.1.5 | 1 | `create_entry_from_txn` reads classification before defaulting to Uncategorized |
 | AC18.1.6 | 1 | Auto-created category accounts are user-scoped and correctly typed |
 | AC18.2.1 | 2 | `CorrectionLog` model records original and corrected categories |

--- a/tests/tooling/test_issue_493_foundation_ttd_behavior.py
+++ b/tests/tooling/test_issue_493_foundation_ttd_behavior.py
@@ -103,7 +103,6 @@ def test_AC12_22_2_background_task_payload_schemas_are_module_owned() -> None:
     payload_schema_names = {
         "StatementDecisionRequest",
         "RetryParsingRequest",
-        "TransactionUpdateRequest",
         "ParsedStatementPreview",
     }
 


### PR DESCRIPTION
## Why

Historical-code audit after EPIC #1483 closed: found two **provably dead** remains of the *previous* generation of "AI classification" — the same built-but-never-wired disease the EPIC cured, one generation older.

## Evidence of death
1. **ML_MODEL rule matching** (`_extract_ai_signals` + `_match_rule` ML branch + the ML half of `_confidence_score_for_rule`):
   - reads `source_documents["suggested_category"/"category_confidence"/"ai_confidence"]` — **no producer anywhere ever writes these keys**;
   - **no rule CRUD exists** → no user can create an ML_MODEL rule; the only ML_MODEL rows are the classification-policy anchors (`is_active=False`, name-excluded) which never match;
   - the live model path is the classify node (§AC18.15). `RuleType.ML_MODEL` survives only as the policy-anchor row type.
2. **`TransactionUpdateRequest`**: zero consumers (exported, referenced by no router/service) — a dead API schema carrying the same two phantom fields.

**Kept deliberately (not legacy)**: the KEYWORD/REGEX rule engine (the node's deterministic pre-pass by design — missing CRUD is a future feature, not dead code) and `SUPERSEDED`/`superseded_by_id` (reserved for policy-v2 supersession).

## Governance
- AC18.1.3 → **RETIRED** (with the why); AC18.1.4 → `KEYWORD > REGEX > Uncategorized`; AC11.12.2 test rename; tier/proof markers on modified rows.
- **Retirement lock** `test_AC18_1_3_ml_rule_matching_is_retired`: an ACTIVE ML_MODEL rule never matches + the signal reader is gone — the retirement can't silently regress.
- 8 dead tests removed; priority test reworked sans ML.

## Proof
Backend 165 + tooling 1854 green; pinned ruff clean; ac-traceability / doc-consistency / api-reference / openapi-spec gates pass. **Pre-existing, not this PR**: `tools/validate_schemas.py` exits 1 on clean main too (98 repo-wide missing-description warnings) — latent red for any schemas/ change; noted rather than fixing 98 unrelated fields here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)