### PR TITLE
[finance_report_infra] docs(runtime): backfill enforcement issues + convergence snapshot into the package todo

### DIFF
--- a/common/runtime/todo.md
+++ b/common/runtime/todo.md
@@ -5,10 +5,10 @@ The package-local worklist. Cross-package migration lives in
 [`contract.py`](./contract.py) — pinned to a real test — when the enforcement
 invariants land (TDD).
 
-## Done (the construct → switch → cleanup migration)
+## Done (the construct → switch → cleanup migration, was #1554)
 
 - [x] Package created on the model: `readme.md` + `contract.py` + `todo.md`,
-      governed by `check_package_contract` as a `draft` `kernel` leaf.
+      governed by `check_package_contract` as a `kernel` leaf.
 - [x] **Manifest (base)** — `DependencyManifest` declares the external
       dependencies (database, object_storage, llm, cache, workflow_engine,
       telemetry, analytics, market_data) with their `Kind` and required tiers.
@@ -17,20 +17,54 @@ invariants land (TDD).
       logic; `boot.Bootloader` delegates to them.
 - [x] **Drop `skipped`** — an absent declared dependency is now an `error`, not a
       silent `skipped` (runtime invariant 2), starting with the AI provider.
+- [x] **Status `draft` → `active`** with the smoke/health ACs homed in
+      [`contract.py`](./contract.py)'s roadmap (`AC-runtime.1.*` / `AC-runtime.7.*`,
+      #1554 Step 2).
+- [x] **SSOT internalized** — `docs/ssot/env_smoke_test.md` retired; the Three
+      Gates live in [`readme.md`](./readme.md), locked by
+      `tests/tooling/test_runtime_ssot_internalized.py` (#1554 Step 3, #1569).
 
 ## Next (declared-required enforcement — a future feature, not the migration)
 
-- [ ] **Env tier + manifest-driven validate.** Resolve the running `EnvTier`;
-      `boot.validate` / the smoke test iterate `DEPENDENCY_MANIFEST.required_for`
-      and fail on any declared-required dependency that is absent (invariant 2 for
-      all deps, not just the AI provider).
-- [ ] **Smoke ↔ declaration parity** (invariant 6) + the tag→staging-smoke gate.
-- [ ] **Substitutes** (invariants 4/5): S3 → in-memory (moto), the real
-      `StorageService` runs in CI (see #1520); LLM recording input-keyed.
-- [ ] **Guardrail**: a new external dependency in `config.py` without a manifest
-      entry fails CI.
-- [ ] Promote `status` `draft` → `active` once the enforcement invariants land
-      with tests, and add their roadmap ACs.
+- [ ] **#1577 — Env tier + manifest-driven validate.** Resolve the running
+      `EnvTier`; `boot.validate` / the smoke test iterate
+      `DEPENDENCY_MANIFEST.required_for` and fail on any declared-required
+      dependency that is absent (invariant 2 for all deps, not just the AI
+      provider). `boot.py`'s per-mode dependency lists derive from the manifest.
+- [ ] **#1578 — Smoke ↔ declaration parity** (invariant 6) + the
+      tag→staging-smoke gate. Depends on #1577.
+- [ ] **Substitutes** (invariants 4/5):
+  - [ ] **#1520** — S3 → in-memory (moto); the real `StorageService` runs in CI
+        (retire the `DummyStorage` wrapper stub).
+  - [ ] **#1581** — LLM recording is input-keyed: changed input ⇒ recording
+        miss, never a stale replay.
+- [ ] **#1579 — Guardrail**: a new external-dependency env var in `config.py`
+      without a manifest entry fails CI (declared-vs-actual reconciliation, same
+      pattern as `check_pr_ci_evidence` / `check_package_directory_coverage`).
+- [ ] **#1580 — Probes for the 5 declared-but-unprobed dependencies**: cache
+      (Redis), workflow_engine (Prefect), telemetry (OTel), analytics
+      (OpenPanel), market_data (Yahoo) each get a `DependencyCheck` adapter.
+
+## Convergence snapshot (per dependency)
+
+Point-in-time view of how far the boundary is actually enforced; the rows
+change as the issues above land. "Call-site convergence" = the app talks to the
+backend through one owned module, not scattered clients.
+
+| Dependency | Manifest | Probe adapter | Call-site convergence | CI/local substitute | Gap |
+|---|---|---|---|---|---|
+| Postgres (`database`) | ✅ all 6 tiers | ✅ `DatabaseCheck` | ✅ `create_engine` only in `apps/backend/src/database.py` | real Postgres container (sqlite is a config-contract escape hatch only) | — |
+| S3 (`object_storage`) | ✅ all 6 tiers | ✅ `ObjectStorageCheck` | ✅ boto3 only in `services/storage.py` + `extraction/_media.py` | minio in compose; unit tests still monkeypatch `DummyStorage` | #1520 (invariant 4) |
+| LLM (`llm`) | ✅ model-dominant | ✅ `LlmCheck`, no `skipped` | ✅ `src/llm/` (client + cassette) | cassette replay in CI, real provider on staging | #1581 (input-keyed) |
+| Redis (`cache`) | ✅ VPS tiers | ❌ | — | — | #1580 |
+| Prefect (`workflow_engine`) | ✅ staging/prod | ❌ | in-process fallback in app-owned tiers | — | #1580 |
+| OTel (`telemetry`) | ✅ VPS tiers | ❌ | ✅ `src/observability/` | — | #1580 |
+| OpenPanel (`analytics`) | ✅ staging/prod | ❌ | ✅ `src/observability/`; frontend via `lib/api.ts` | — | #1580 |
+| Yahoo (`market_data`) | ✅ prod only | ❌ | ✅ `services/market_data/` | — | #1580 |
+
+Cross-cutting: enforcement is not yet manifest-driven (#1577), smoke parity is
+unenforced (#1578), and nothing stops a new `config.py` dependency from
+bypassing the manifest (#1579).
 
 ## Notes
 


### PR DESCRIPTION
## What

Doc-only change to `common/runtime/todo.md`:

- **Issue backfill** — every remaining enforcement item now has a tracked home: #1577 (manifest-driven validate), #1578 (smoke ↔ declaration parity + tag→staging-smoke gate), #1579 (config↔manifest guardrail), #1580 (probes for the 5 declared-but-unprobed deps), #1581 (input-keyed LLM recording); the S3 substitute half was already #1520.
- **Done-list refresh** — records the completed `draft` → `active` promotion (#1554 Step 2) and the env_smoke_test SSOT internalization (#1569), which the old todo still listed as pending.
- **Convergence snapshot** — a per-dependency table (manifest / probe / call-site convergence / substitute / gap) so the package itself states how far the boundary is actually *enforced*, not just declared. Rows reference the issues above and change as they land.

## Why

The charter (readme) records invariants and the todo recorded unowned checkboxes; nowhere did the package record the actual enforcement status per dependency. Auditing it repeatedly from scratch is wasted work — this pins the audit result where the domain lives.

## Verification

- `tools/preflight.py` → all relevant gates pass (`tooling`: 1866 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)