### PR TITLE
[finance_report_infra] docs(runtime): follow-up — apply Copilot review fixes that missed the #1583 merge

### DIFF
--- a/common/runtime/todo.md
+++ b/common/runtime/todo.md
@@ -54,7 +54,7 @@ backend through one owned module, not scattered clients.
 | Dependency | Manifest | Probe adapter | Call-site convergence | CI/local substitute | Gap |
 |---|---|---|---|---|---|
 | Postgres (`database`) | ✅ all 6 tiers | ✅ `DatabaseCheck` | ✅ `create_engine` only in `apps/backend/src/database.py` | real Postgres container (sqlite is a config-contract escape hatch only) | — |
-| S3 (`object_storage`) | ✅ all 6 tiers | ✅ `ObjectStorageCheck` | ✅ boto3 only in `apps/backend/src/services/storage.py` + `apps/backend/src/services/extraction/_media.py` | minio in compose; unit tests still monkeypatch `DummyStorage` | #1520 (invariant 4) |
+| S3 (`object_storage`) | ✅ all 6 tiers | ✅ `ObjectStorageCheck` | ✅ boto3 only in `apps/backend/src/services/storage.py`; callers (e.g. `extraction/_media.py`) go through it | minio in compose; unit tests still monkeypatch `DummyStorage` | #1520 (invariant 4) |
 | LLM (`llm`) | ✅ model-dominant | ✅ `LlmCheck`, no `skipped` | ✅ `src/llm/` (client + cassette) | cassette replay in CI, real provider on staging | #1581 (input-keyed) |
 | Redis (`cache`) | ✅ VPS tiers | ❌ | — | — | #1580 |
 | Prefect (`workflow_engine`) | ✅ staging/prod | ❌ | in-process fallback in app-owned tiers | — | #1580 |

--- a/common/runtime/todo.md
+++ b/common/runtime/todo.md
@@ -28,7 +28,7 @@ invariants land (TDD).
 
 - [ ] **#1577 — Env tier + manifest-driven validate.** Resolve the running
       `EnvTier`; `boot.validate` / the smoke test iterate
-      `DEPENDENCY_MANIFEST.required_for` and fail on any declared-required
+      `DEPENDENCY_MANIFEST.required_for(tier)` and fail on any declared-required
       dependency that is absent (invariant 2 for all deps, not just the AI
       provider). `boot.py`'s per-mode dependency lists derive from the manifest.
 - [ ] **#1578 — Smoke ↔ declaration parity** (invariant 6) + the
@@ -54,7 +54,7 @@ backend through one owned module, not scattered clients.
 | Dependency | Manifest | Probe adapter | Call-site convergence | CI/local substitute | Gap |
 |---|---|---|---|---|---|
 | Postgres (`database`) | ✅ all 6 tiers | ✅ `DatabaseCheck` | ✅ `create_engine` only in `apps/backend/src/database.py` | real Postgres container (sqlite is a config-contract escape hatch only) | — |
-| S3 (`object_storage`) | ✅ all 6 tiers | ✅ `ObjectStorageCheck` | ✅ boto3 only in `services/storage.py` + `extraction/_media.py` | minio in compose; unit tests still monkeypatch `DummyStorage` | #1520 (invariant 4) |
+| S3 (`object_storage`) | ✅ all 6 tiers | ✅ `ObjectStorageCheck` | ✅ boto3 only in `apps/backend/src/services/storage.py` + `apps/backend/src/services/extraction/_media.py` | minio in compose; unit tests still monkeypatch `DummyStorage` | #1520 (invariant 4) |
 | LLM (`llm`) | ✅ model-dominant | ✅ `LlmCheck`, no `skipped` | ✅ `src/llm/` (client + cassette) | cassette replay in CI, real provider on staging | #1581 (input-keyed) |
 | Redis (`cache`) | ✅ VPS tiers | ❌ | — | — | #1580 |
 | Prefect (`workflow_engine`) | ✅ staging/prod | ❌ | in-process fallback in app-owned tiers | — | #1580 |


### PR DESCRIPTION
Two-line doc follow-up to #1583 (merged before the review-fix commit landed on the branch):

- `DEPENDENCY_MANIFEST.required_for` → `required_for(tier)` — matches the actual method signature.
- S3 convergence-snapshot row uses full repo-relative paths (`apps/backend/src/services/storage.py`, `apps/backend/src/services/extraction/_media.py`).

Resolves the two Copilot review comments on #1583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)