### PR TITLE
[finance_report_vision] docs: refresh common/readme.md's package map, fix stale common/ci mention

### DIFF
--- a/common/readme.md
+++ b/common/readme.md
@@ -25,14 +25,33 @@ ships.
 
 ## Map
 
-- [`common/meta/`](./meta/readme.md) — the meta package: the
-  package-model spec, `PackageContract`, and the governance gate.
-- [`common/counter/`](./counter/readme.md) — the first worked example
-  (`platform`): the canonical minimal template every new package copies
-  (`readme.md` + `contract.py` + `todo.md`).
-- [`common/todo.md`](./todo.md) — the cross-package / migration worklist.
+All 12 packages ship a `contract.py` and are discovered by
+`tools/check_package_contract.py`; grouped by `klass` (the DAG tier — see
+[`meta/readme.md`](./meta/readme.md#three-package-classes)):
 
-The other `common/*` directories (`ci`, `ssot`, `coverage`, `money`, `ratio`,
-`quantity`, `unit_price`, `observability`, `shell`, `testing`, …) are existing
-shared code; they adopt a full `contract.py` as the model rolls out (see the
-phase table in [`todo.md`](./todo.md)).
+- **`core`** (vertical domain slices): [`identity`](./identity/readme.md),
+  [`ledger`](./ledger/readme.md)
+- **`platform`** (reusable horizontal capabilities):
+  [`meta`](./meta/readme.md) — the meta package: the package-model spec,
+  `PackageContract`, and the governance gate;
+  [`counter`](./counter/readme.md) — the first worked example, the canonical
+  minimal template every new package copies (`readme.md` + `contract.py` +
+  `todo.md`)
+- **`kernel`** (the value-language/tooling layer reused everywhere):
+  [`audit`](./audit/readme.md), [`authority`](./authority/readme.md),
+  [`config`](./config/readme.md), [`coverage`](./coverage/readme.md),
+  [`observability`](./observability/readme.md), [`platform`](./platform/readme.md)
+  (the event-bus package — its *name* is `platform`, its *klass* is `kernel`),
+  [`runtime`](./runtime/readme.md), [`testing`](./testing/readme.md)
+
+Two directories are **not** packages (no `contract.py`) but are documented,
+reasoned exceptions to `check_package_directory_coverage`'s every-directory
+rule (see [`meta/readme.md`](./meta/readme.md)):
+
+- `common/ssot/` — 3 leftover generator scripts with no clean package fit yet
+  (`generate_api_reference.py`, `generate_db_schema_reference.py`,
+  `generate_openapi_spec.py`).
+- `common/extraction/`, `common/llm/` — SSOT-only today, pending their code
+  cutovers (#1421, #1426).
+
+[`common/todo.md`](./todo.md) is the cross-package / migration worklist.

--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -79,9 +79,10 @@ New components default to `ci-critical`, so a tree is only ever down-tiered to
 `best-effort` by an explicit, reviewable diff (per the anti-bypass guard). The
 tier is the lever for the guiding rule: *gate at high coverage iff CI-critical*.
 
-> **Library layering**: reusable coverage/CI implementation lives under
-> `common/` (`common/coverage`, `common/ci`); the top-level `tools/*.py` are thin
-> command wrappers. The legacy duplicate `tools/_lib/ci` and `tools/_lib/coverage`
+> **Library layering**: reusable coverage/CI implementation lives in the
+> packages that own it (`common/coverage`, `common/testing`, `common/runtime`,
+> `common/meta/extension`); the top-level `tools/*.py` are thin command
+> wrappers. The legacy duplicate `tools/_lib/ci` and `tools/_lib/coverage`
 > trees have been consolidated into `common/` — there is one gated library tree.
 
 ### Artifact preflight (#414)


### PR DESCRIPTION
## Summary

Two doc-staleness spots surfaced while auditing the `common/ci`/`common/shell`/
`common/ssot` dissolution (#1564-#1568, #1573):

- `common/readme.md`'s "Map" section still named retired directories (`ci`,
  `ssot` as a junk drawer, `money`/`ratio`/`quantity`/`unit_price`, `shell`) as
  if current. Replaced with an accurate `klass`-grouped map of all 12 packages
  plus the two documented non-package exceptions (`ssot`'s 3 leftover
  generators; `extraction`/`llm` pending their code cutovers).
- `docs/ssot/coverage.md` still said reusable CI implementation lives under
  `common/ci`, which no longer exists.

Pure documentation fix; no code/behavior change.

## Test plan

- [x] `lint_doc_consistency.py`, `check_manifest.py`, `check_ssot_ownership.py` pass
- [x] Full `tests/tooling/` suite: 1866 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)