### PR TITLE
[finance_report_infra] feat(runtime): manifest-driven boot.validate — FULL derives checks from required_for(tier) (#1577)

### DIFF
--- a/apps/backend/src/boot.py
+++ b/apps/backend/src/boot.py
@@ -18,10 +18,13 @@ from enum import Enum
 from src.config import PROTECTED_ENVIRONMENTS, settings
 from src.observability import get_logger
 from src.runtime import (
+    DEPENDENCY_MANIFEST,
     DatabaseCheck,
     DependencyStatus,
+    EnvTier,
     LlmCheck,
     ObjectStorageCheck,
+    resolve_env_tier,
 )
 
 logger = get_logger(__name__)
@@ -53,12 +56,38 @@ class Bootloader:
     """Handles environment validation and service connectivity checks."""
 
     @staticmethod
-    async def validate(mode: BootMode = BootMode.CRITICAL) -> bool:
+    def _required_checks(tier: EnvTier) -> tuple[dict[str, str], list[str]]:
+        """Split ``DEPENDENCY_MANIFEST.required_for(tier)`` into (probed, unprobed).
+
+        ``probed`` maps dependency name → the ``Bootloader`` check-method name;
+        ``unprobed`` (sorted) names the declared-required dependencies that have
+        no probe adapter yet (#1580) — surfaced as warnings, never silently
+        skipped. The dependency set comes from the manifest, not a hardcoded
+        per-mode list (invariant 2, #1577).
+        """
+        probe_methods = {
+            "database": "_check_database",
+            "object_storage": "_check_s3",
+            "llm": "_check_openrouter",
+        }
+        required = DEPENDENCY_MANIFEST.required_for(tier)
+        probed = {name: probe_methods[name] for name in required if name in probe_methods}
+        unprobed = sorted(required - probed.keys())
+        return probed, unprobed
+
+    @staticmethod
+    async def validate(mode: BootMode = BootMode.CRITICAL, tier: EnvTier | None = None) -> bool:
         """Run validation checks. Returns True if passed, False if failed.
 
-        If mode is CRITICAL, this may call sys.exit(1) on failure.
+        If mode is CRITICAL, this may call sys.exit(1) on failure. ``tier``
+        defaults to the running environment (``resolve_env_tier``); FULL mode
+        asserts the manifest-declared dependency set for that tier.
         """
-        logger.info("Bootloader starting validation", mode=mode.value)
+        if tier is None:
+            tier = resolve_env_tier(
+                settings.environment, github_actions=os.getenv("GITHUB_ACTIONS", "").lower() == "true"
+            )
+        logger.info("Bootloader starting validation", mode=mode.value, tier=tier.value)
 
         # 1. Static Configuration Check (Always run)
         if not Bootloader._check_static_config():
@@ -74,13 +103,25 @@ class Bootloader:
         # 2. Connectivity Checks
         results = []
 
-        # Database (Always checked in Critical/Full)
+        # Database (Always checked in Critical/Full — Gate 2 stays DB-only)
         results.append(await Bootloader._check_database())
 
         if mode == BootMode.FULL:
-            # Add optional services for Full smoke test
-            results.append(await Bootloader._check_s3())
-            results.append(await Bootloader._check_openrouter())
+            # Gate 3: the dependency set is the manifest's declaration for this
+            # tier, not a hardcoded list (#1577).
+            probed, unprobed = Bootloader._required_checks(tier)
+            for name, method_name in sorted(probed.items()):
+                if name == "database":
+                    continue  # already probed above
+                results.append(await getattr(Bootloader, method_name)())
+            for name in unprobed:
+                # Declared-required but no probe adapter yet (#1580): loudly
+                # visible, never a silent skip (invariant 2 pending for these).
+                logger.warning(
+                    "Declared-required dependency has no probe adapter yet (#1580); presence not asserted",
+                    service=name,
+                    tier=tier.value,
+                )
             results.append(Bootloader._check_vault_secrets())
 
         # 3. Report Results

--- a/apps/backend/src/runtime/__init__.py
+++ b/apps/backend/src/runtime/__init__.py
@@ -25,7 +25,7 @@ from src.runtime.base.manifest import (
     Dependency,
     DependencyManifest,
 )
-from src.runtime.base.tiers import APP_OWNED_TIERS, VPS_TIERS, EnvTier
+from src.runtime.base.tiers import APP_OWNED_TIERS, VPS_TIERS, EnvTier, resolve_env_tier
 from src.runtime.extension.adapters import (
     DatabaseCheck,
     LlmCheck,
@@ -48,4 +48,5 @@ __all__ = [
     "ObjectStorageCheck",
     "ProbeResult",
     "check_env_classification",
+    "resolve_env_tier",
 ]

--- a/apps/backend/src/runtime/base/tiers.py
+++ b/apps/backend/src/runtime/base/tiers.py
@@ -28,3 +28,23 @@ APP_OWNED_TIERS: frozenset[EnvTier] = frozenset({EnvTier.LOCAL_DEV, EnvTier.LOCA
 
 #: The VPS tiers — provisioned by infra2.
 VPS_TIERS: frozenset[EnvTier] = frozenset({EnvTier.PREVIEW, EnvTier.STAGING, EnvTier.PRODUCTION})
+
+
+def resolve_env_tier(environment: str, *, github_actions: bool = False) -> EnvTier:
+    """Map the runtime's ENVIRONMENT value to an `EnvTier` (#1577).
+
+    The manifest speaks `EnvTier`; the running app knows `settings.environment`.
+    This is the single translation between them. An unknown value resolves to
+    PRODUCTION — the strictest tier — so a typo can only over-assert presence,
+    never under-assert (fail closed).
+    """
+    normalized = environment.strip().lower()
+    if normalized in {"development", "dev", "local"}:
+        return EnvTier.LOCAL_DEV
+    if normalized in {"test", "testing", "ci"}:
+        return EnvTier.GITHUB_CI if github_actions else EnvTier.LOCAL_CI
+    if normalized == "preview":
+        return EnvTier.PREVIEW
+    if normalized == "staging":
+        return EnvTier.STAGING
+    return EnvTier.PRODUCTION

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -544,3 +544,87 @@ class TestBootloaderVaultSecrets:
 
         assert status.status == "error"
         assert "Permission denied" in status.message
+
+
+def test_AC_runtime_3_1_required_checks_cover_the_tier_declaration():
+    """AC-runtime.3.1 (#1577): the probed + unprobed split is exactly
+    DEPENDENCY_MANIFEST.required_for(tier) — the set comes from the manifest,
+    not a hardcoded per-mode list."""
+    from src.runtime import DEPENDENCY_MANIFEST, EnvTier
+
+    for tier in EnvTier:
+        probed, unprobed = Bootloader._required_checks(tier)
+        assert set(probed) | set(unprobed) == DEPENDENCY_MANIFEST.required_for(tier)
+        assert not set(probed) & set(unprobed)
+
+
+class TestManifestDrivenValidate:
+    """AC-runtime.3.1 (#1577) — FULL mode derives its checks from the manifest."""
+
+    def test_github_ci_tier_has_no_unprobed_requirements(self):
+        """Everything github_ci requires already has a probe adapter."""
+        from src.runtime import EnvTier
+
+        probed, unprobed = Bootloader._required_checks(EnvTier.GITHUB_CI)
+        assert set(probed) == {"database", "object_storage", "llm"}
+        assert unprobed == []
+
+    def test_production_tier_names_the_unprobed_requirements(self):
+        """Declared-required deps without a probe are visible (never silently skipped)."""
+        from src.runtime import EnvTier
+
+        probed, unprobed = Bootloader._required_checks(EnvTier.PRODUCTION)
+        assert set(probed) == {"database", "object_storage", "llm"}
+        assert unprobed == sorted(["cache", "workflow_engine", "telemetry", "analytics", "market_data"])
+
+    async def test_full_mode_probes_the_manifest_set_for_the_tier(
+        self, mock_settings, mock_db_check, mock_minio_check, mock_openrouter_check
+    ):
+        from src.runtime import EnvTier
+
+        mock_db_check.return_value = ServiceStatus("database", "ok", "OK")
+        mock_minio_check.return_value = ServiceStatus("minio", "ok", "OK")
+        mock_openrouter_check.return_value = ServiceStatus("ai_provider", "ok", "OK")
+
+        with patch.object(Bootloader, "_check_vault_secrets") as mock_vault:
+            mock_vault.return_value = ServiceStatus("vault_secrets", "ok", "OK")
+            result = await Bootloader.validate(BootMode.FULL, tier=EnvTier.GITHUB_CI)
+
+        assert result is True
+        mock_db_check.assert_called_once()
+        mock_minio_check.assert_called_once()
+        mock_openrouter_check.assert_called_once()
+
+    async def test_full_mode_warns_for_unprobed_required_deps(
+        self, mock_settings, mock_db_check, mock_minio_check, mock_openrouter_check, mock_logger
+    ):
+        """On a tier requiring unprobed deps, FULL passes but surfaces them loudly (#1580)."""
+        from src.runtime import EnvTier
+
+        mock_db_check.return_value = ServiceStatus("database", "ok", "OK")
+        mock_minio_check.return_value = ServiceStatus("minio", "ok", "OK")
+        mock_openrouter_check.return_value = ServiceStatus("ai_provider", "ok", "OK")
+
+        with patch.object(Bootloader, "_check_vault_secrets") as mock_vault:
+            mock_vault.return_value = ServiceStatus("vault_secrets", "ok", "OK")
+            result = await Bootloader.validate(BootMode.FULL, tier=EnvTier.PRODUCTION)
+
+        assert result is True
+        warned = " ".join(str(call) for call in mock_logger.warning.call_args_list)
+        assert "no probe adapter" in warned and "cache" in warned
+
+    async def test_full_mode_absent_required_dep_fails(self, mock_settings, mock_db_check, mock_logger):
+        from src.runtime import EnvTier
+
+        mock_db_check.return_value = ServiceStatus("database", "error", "Connection refused")
+        with (
+            patch.object(Bootloader, "_check_s3", new_callable=AsyncMock) as mock_s3,
+            patch.object(Bootloader, "_check_openrouter", new_callable=AsyncMock) as mock_openrouter,
+            patch.object(Bootloader, "_check_vault_secrets") as mock_vault,
+        ):
+            mock_s3.return_value = ServiceStatus("minio", "ok", "OK")
+            mock_openrouter.return_value = ServiceStatus("ai_provider", "ok", "OK")
+            mock_vault.return_value = ServiceStatus("vault_secrets", "ok", "OK")
+            result = await Bootloader.validate(BootMode.FULL, tier=EnvTier.STAGING)
+
+        assert result is False

--- a/apps/backend/tests/runtime/test_tiers.py
+++ b/apps/backend/tests/runtime/test_tiers.py
@@ -1,0 +1,46 @@
+"""`resolve_env_tier` — mapping the runtime's ENVIRONMENT value to an `EnvTier` (AC-runtime.3.1, #1577).
+
+The manifest speaks `EnvTier`; the running app knows `settings.environment`.
+`resolve_env_tier` is the single translation between them, so `boot.validate`
+can iterate `DEPENDENCY_MANIFEST.required_for(tier)`. Unknown values resolve to
+PRODUCTION — the strictest tier — so a typo'd environment can only over-assert,
+never under-assert (fail closed).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.runtime import EnvTier, resolve_env_tier
+
+pytestmark = pytest.mark.no_db
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ("development", EnvTier.LOCAL_DEV),
+        ("test", EnvTier.LOCAL_CI),
+        ("testing", EnvTier.LOCAL_CI),
+        ("ci", EnvTier.LOCAL_CI),
+        ("preview", EnvTier.PREVIEW),
+        ("staging", EnvTier.STAGING),
+        ("production", EnvTier.PRODUCTION),
+    ],
+)
+def test_known_environments_resolve(environment: str, expected: EnvTier) -> None:
+    assert resolve_env_tier(environment) is expected
+
+
+def test_ci_environments_resolve_to_github_ci_on_github_actions() -> None:
+    for environment in ("test", "testing", "ci"):
+        assert resolve_env_tier(environment, github_actions=True) is EnvTier.GITHUB_CI
+
+
+def test_resolution_is_case_and_whitespace_insensitive() -> None:
+    assert resolve_env_tier("  Staging ") is EnvTier.STAGING
+
+
+def test_unknown_environment_fails_closed_to_production() -> None:
+    assert resolve_env_tier("qa-42") is EnvTier.PRODUCTION
+    assert resolve_env_tier("") is EnvTier.PRODUCTION

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -50,6 +50,7 @@ CONTRACT = PackageContract(
         "ObjectStorageCheck",
         "ProbeResult",
         "check_env_classification",
+        "resolve_env_tier",
     ],
     events=[],
     invariants=[],
@@ -92,6 +93,19 @@ CONTRACT = PackageContract(
                 "unclassified new env var fails CI (fail-closed guardrail, #1579)."
             ),
             test="apps/backend/tests/runtime/test_env_guardrail.py::test_every_config_env_var_is_classified",
+            priority="P1",
+            status="done",
+        ),
+        # ── manifest-driven validate (#1577) ──
+        ACRecord(
+            id="AC-runtime.3.1",
+            statement=(
+                "boot.validate FULL derives its dependency set from "
+                "DEPENDENCY_MANIFEST.required_for(resolve_env_tier(...)) — a declared-required "
+                "probed dependency that is absent fails validate; a declared-required dependency "
+                "without a probe adapter is a visible warning (#1580), never a silent skip (#1577)."
+            ),
+            test="apps/backend/tests/infra/test_boot.py::test_AC_runtime_3_1_required_checks_cover_the_tier_declaration",
             priority="P1",
             status="done",
         ),

--- a/common/runtime/todo.md
+++ b/common/runtime/todo.md
@@ -26,11 +26,12 @@ invariants land (TDD).
 
 ## Next (declared-required enforcement — a future feature, not the migration)
 
-- [ ] **#1577 — Env tier + manifest-driven validate.** Resolve the running
-      `EnvTier`; `boot.validate` / the smoke test iterate
-      `DEPENDENCY_MANIFEST.required_for(tier)` and fail on any declared-required
-      dependency that is absent (invariant 2 for all deps, not just the AI
-      provider). `boot.py`'s per-mode dependency lists derive from the manifest.
+- [x] **#1577 — Env tier + manifest-driven validate.** Shipped as
+      `resolve_env_tier` (ENVIRONMENT → `EnvTier`, unknown → strictest) +
+      `Bootloader._required_checks(tier)`: FULL mode derives its dependency set
+      from `DEPENDENCY_MANIFEST.required_for(tier)` (AC-runtime.3.1) — absent
+      probed dependency fails; declared-required without a probe is a visible
+      warning pending #1580. CRITICAL keeps its Gate-2 (DB-only) semantics.
 - [ ] **#1578 — Smoke ↔ declaration parity** (invariant 6) + the
       tag→staging-smoke gate. Depends on #1577.
 - [ ] **Substitutes** (invariants 4/5):
@@ -66,9 +67,11 @@ backend through one owned module, not scattered clients.
 | OpenPanel (`analytics`) | ✅ staging/prod | ❌ | ✅ `src/observability/`; frontend via `lib/api.ts` | — | #1580 |
 | Yahoo (`market_data`) | ✅ prod only | ❌ | ✅ `services/market_data/` | — | #1580 |
 
-Cross-cutting: enforcement is not yet manifest-driven (#1577) and smoke parity
-is unenforced (#1578). A new `config.py` dependency can no longer bypass the
-manifest (#1579, AC-runtime.2.1).
+Cross-cutting: `boot.validate` FULL is manifest-driven (#1577, AC-runtime.3.1)
+and a new `config.py` dependency can no longer bypass the manifest (#1579,
+AC-runtime.2.1). Still open: smoke ↔ declaration parity (#1578) and probes for
+the five unprobed dependencies (#1580) — until #1580 lands, their presence is a
+warning, not a failure.
 
 ## Notes
 

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -185,6 +185,10 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 > env var is either one of a declared dependency's env vars in the
 > `DependencyManifest` or a reasoned non-dependency entry — an unclassified new
 > env var fails CI, so a new external backend cannot bypass the manifest.
+> Its enforcement sibling is `AC-runtime.3.1` (#1577): `boot.validate` FULL
+> derives the dependency set from `DEPENDENCY_MANIFEST.required_for(tier)`
+> (tier resolved from `ENVIRONMENT` via `resolve_env_tier`, unknown → strictest)
+> instead of a hardcoded per-mode list.
 
 ### AC7.7: Health Checks — migrated to the `runtime` package
 


### PR DESCRIPTION
Closes #1577. **Stacked on #1588** (base = `feat/issue-1579-manifest-env-guardrail-infra`); merge #1588 first — GitHub retargets this PR to `main` automatically.

## What

**TDD (red→green):** `tests/runtime/test_tiers.py` + `TestManifestDrivenValidate` in `tests/infra/test_boot.py` written first.

- **`resolve_env_tier`** (`src/runtime/base/tiers.py`): the single ENVIRONMENT→`EnvTier` translation — development→local_dev; test/testing/ci→local_ci (github_ci when `GITHUB_ACTIONS=true`); preview/staging/production 1:1; **unknown → PRODUCTION** (strictest tier: a typo can only over-assert presence, never under-assert).
- **`Bootloader._required_checks(tier)`**: splits `DEPENDENCY_MANIFEST.required_for(tier)` into probed (`database`/`object_storage`/`llm` adapters) and unprobed. FULL mode iterates this split instead of the hardcoded DB+S3+AI list:
  - absent **probed** dependency → validate fails (invariant 2);
  - declared-required **without a probe adapter** (cache/workflow_engine/telemetry/analytics/market_data, pending #1580) → loud warning naming the dep and tier — never a silent skip.
- **CRITICAL unchanged**: Gate-2 startup stays DB-only per the Three Gates ladder; `validate` gains an optional `tier` override (testability + smoke callers).
- **Contract:** `AC-runtime.3.1` pinned to `test_AC_runtime_3_1_required_checks_cover_the_tier_declaration`; `resolve_env_tier` published (interface ↔ `__all__` parity). EPIC-007 references the new AC (doc-consistency check3). todo.md #1577 checked off with as-built notes.

## Verification

- `pytest apps/backend/tests/infra/test_boot.py apps/backend/tests/runtime/` → 67 passed (11 new).
- `tools/preflight.py` → ac-traceability / doc-consistency / tooling ok; backend-format red is the known PATH-ruff 0.15 skew (pinned 0.14.11: `ruff check` + `format --check` both clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)