### PR TITLE
[finance_report_ui] feat(testing): real StorageService pipeline over in-memory S3 — and the reparse storage-key bug it caught

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -43,6 +43,7 @@ prefect = [
 [dependency-groups]
 dev = [
     "pytest>=8.0.0",
+    "moto[s3]>=5.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=6.0.0",
     "pytest-xdist>=3.5.0",

--- a/apps/backend/src/services/statement_parsing.py
+++ b/apps/backend/src/services/statement_parsing.py
@@ -484,8 +484,14 @@ async def parse_statement_background(
         service = ExtractionService()
         try:
             checkpoint("extraction_started")
+            # file_path must be the STORAGE key, not the display filename: it
+            # is persisted as UploadedDocument.file_path, which the retry /
+            # reparse paths hand straight to storage.get_object. With the bare
+            # filename every post-success reparse 404'd against storage
+            # (caught by the #1520 real-storage pipeline test). The display
+            # name travels separately as original_filename.
             parsed_statement, transactions = await service.parse_document(
-                file_path=Path(filename),
+                file_path=Path(storage_key),
                 institution=institution,
                 user_id=user_id,
                 file_type=file_type,

--- a/apps/backend/tests/api/test_real_storage_pipeline.py
+++ b/apps/backend/tests/api/test_real_storage_pipeline.py
@@ -46,8 +46,14 @@ def real_s3(monkeypatch: pytest.MonkeyPatch):
     # the AI leg it fails in milliseconds instead of retrying a live provider.
     monkeypatch.setattr(settings, "ai_api_key", "test-placeholder-key")
     monkeypatch.setattr(settings, "ai_base_url", "http://127.0.0.1:9/unroutable")
+    # StorageService caches bucket existence at class level, but mock_aws
+    # resets the in-memory backend per test — clear the cache so each test
+    # re-creates its bucket instead of trusting a stale check (Copilot on
+    # #1601: otherwise the second test in a worker is order-dependent).
+    StorageService._checked_buckets.clear()
     with mock_aws():
         yield
+    StorageService._checked_buckets.clear()
 
 
 async def _upload_csv(db, test_user) -> statements_router.BankStatementResponse:

--- a/apps/backend/tests/api/test_real_storage_pipeline.py
+++ b/apps/backend/tests/api/test_real_storage_pipeline.py
@@ -1,0 +1,131 @@
+"""Real StorageService pipeline tests over moto's in-memory S3 (issue #1520).
+
+Until now every counted test stubbed the storage seam (DummyStorage /
+monkeypatched boto3), so a regression in the real ``StorageService`` wiring —
+upload, persist, load-back — shipped undetected (EPIC-008 AC8.25). These tests
+run the REAL service and the REAL upload→store→parse pipeline against an
+in-memory S3: no stub, no monkeypatched StorageService, no service container.
+
+The fixture is the same deterministic CSV the vision hard gate uploads in the
+in-runner E2E (tests/e2e/fixtures/vision_hard_gate_statement.csv), so the same
+known business numbers are proven here at the fast counted tier.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from moto import mock_aws
+
+import src.routers.statements as statements_router
+from src.config import settings
+from src.models.statement_enums import BankStatementStatus
+from src.services.storage import StorageService
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CSV_FIXTURE = REPO_ROOT / "tests" / "e2e" / "fixtures" / "vision_hard_gate_statement.csv"
+
+EXPECTED_TRANSACTION_COUNT = 6
+EXPECTED_TOTAL_INCOME = Decimal("5600.00")
+EXPECTED_TOTAL_EXPENSES = Decimal("5600.00")
+
+
+@pytest.fixture
+def real_s3(monkeypatch: pytest.MonkeyPatch):
+    """moto-backed S3: the real boto3 client in StorageService hits an
+    in-memory backend. Only env-level config is touched — the service itself
+    is never stubbed or patched (AC8.25.1)."""
+    monkeypatch.setattr(settings, "s3_endpoint", None)
+    monkeypatch.setattr(settings, "s3_access_key", "testing")
+    monkeypatch.setattr(settings, "s3_secret_key", "testing")
+    monkeypatch.setattr(settings, "s3_bucket", "real-pipeline-test")
+    # Same posture as docker-compose.ci-e2e.yml (#1592): placeholder provider
+    # wiring with an unroutable base URL, so if any parse path falls back to
+    # the AI leg it fails in milliseconds instead of retrying a live provider.
+    monkeypatch.setattr(settings, "ai_api_key", "test-placeholder-key")
+    monkeypatch.setattr(settings, "ai_base_url", "http://127.0.0.1:9/unroutable")
+    with mock_aws():
+        yield
+
+
+async def _upload_csv(db, test_user) -> statements_router.BankStatementResponse:
+    from tests.api.test_statements_router import make_upload_file
+
+    upload_file = make_upload_file("vision_hard_gate_statement.csv", CSV_FIXTURE.read_bytes())
+    return await statements_router.upload_statement(
+        file=upload_file,
+        institution="Generic Vision Hard Gate",
+        account_id=None,
+        model=None,
+        db=db,
+        user_id=test_user.id,
+    )
+
+
+async def test_AC8_25_1_upload_parses_through_real_storage_round_trip(real_s3, db, test_user):
+    """AC8.25.1: the CSV fixture uploads through the real StorageService into
+    in-memory S3, the pipeline parses it, and the stored object read back via
+    the real get_object is byte-identical to the fixture."""
+    user_id = test_user.id
+    result = await _upload_csv(db, test_user)
+    await statements_router.wait_for_parse_tasks()
+
+    db.expire_all()
+    statement = await statements_router._get_statement_or_404(db, result.id, user_id)
+    assert statement.status == BankStatementStatus.PARSED, statement.validation_error
+
+    # Functional round-trip (AC-2): bytes written == bytes read, via the REAL
+    # service against the in-memory backend — not a call-assertion mock.
+    key = statements_router.build_statement_storage_key(
+        statement_id=result.id, file_hash=statement.file_hash, extension="csv"
+    )
+    stored = StorageService().get_object(key)
+    assert stored == CSV_FIXTURE.read_bytes()
+
+    # Business values, not just "it ran" (#1505): the same fixture numbers the
+    # vision hard gate asserts end-to-end (5600 income + 5600 expenses), read
+    # back the way the /transactions endpoint resolves them.
+    txns = await statements_router.resolve_statement_transactions(db, statement)
+    assert len(txns) == EXPECTED_TRANSACTION_COUNT
+    gross = sum((abs(Decimal(str(t.amount))) for t in txns), Decimal("0"))
+    assert gross == EXPECTED_TOTAL_INCOME + EXPECTED_TOTAL_EXPENSES
+
+
+async def test_AC8_25_2_retry_loads_source_back_through_real_storage(real_s3, db, test_user):
+    """AC8.25.2: the retry path re-fetches the source document through the
+    real get_object (the load-back leg the in-process first parse skips), and
+    deleting the stored object makes retry fail — proving the pipeline truly
+    reads storage, not a cached copy (the interception proof)."""
+    user_id = test_user.id
+    result = await _upload_csv(db, test_user)
+    await statements_router.wait_for_parse_tasks()
+
+    retried = await statements_router.retry_statement_parsing(
+        statement_id=result.id, request=None, db=db, user_id=user_id
+    )
+    await statements_router.wait_for_parse_tasks()
+    db.expire_all()
+    statement = await statements_router._get_statement_or_404(db, retried.id, user_id)
+    assert statement.status == BankStatementStatus.PARSED, statement.validation_error
+
+    # Interception (AC-5): drop the stored object; the load-back path must
+    # fail rather than parse a cached copy. The failure may surface as an
+    # immediate error or as a non-PARSED terminal status from the background
+    # task — either proves the pipeline truly reads storage.
+    key = statements_router.build_statement_storage_key(
+        statement_id=result.id, file_hash=statement.file_hash, extension="csv"
+    )
+    StorageService().delete_object(key)
+    failed_fast = False
+    try:
+        await statements_router.retry_statement_parsing(statement_id=result.id, request=None, db=db, user_id=user_id)
+    except Exception:
+        failed_fast = True
+    await statements_router.wait_for_parse_tasks()
+    db.expire_all()
+    refreshed = await statements_router._get_statement_or_404(db, result.id, user_id)
+    assert failed_fast or refreshed.status != BankStatementStatus.PARSED, (
+        "retry parsed successfully despite the source object being deleted — the pipeline is not reading real storage"
+    )

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1000,6 +1000,7 @@ dev = [
     { name = "freezegun" },
     { name = "httpx" },
     { name = "locust" },
+    { name = "moto", extra = ["s3"] },
     { name = "pdfplumber" },
     { name = "playwright" },
     { name = "pytest" },
@@ -1051,6 +1052,7 @@ dev = [
     { name = "freezegun", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "locust", specifier = ">=2.20.0" },
+    { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "pdfplumber", specifier = ">=0.11.0" },
     { name = "playwright", specifier = ">=1.40.0" },
     { name = "pytest", specifier = ">=8.0.0" },
@@ -1918,6 +1920,30 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/63/d944f387582cc53f53febbff2b3fa36a6d2ed7c1feef8990bf646cfa9cba/moto-5.2.2.tar.gz", hash = "sha256:aac8023a429e125e91c91f8f4730a67b54f518cda587352f7e67252fe3168f75", size = 8678761, upload-time = "2026-06-06T18:57:54.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/45/13cff46f4f617a6e97e1d497d75abd913e250bb4c823a4985668c6e593e4/moto-5.2.2-py3-none-any.whl", hash = "sha256:3817f1e39721ca833579b921e53e3b68547ace6a34d848c9486fbb5905808de9", size = 6698689, upload-time = "2026-06-06T18:57:51.435Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2762,6 +2788,15 @@ redis = [
 ]
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3433,6 +3468,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
 ]
 
 [[package]]
@@ -4277,6 +4326,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]
 
 [[package]]

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -641,6 +641,25 @@ an only-goes-down ratchet (`common/testing/mirror_ratchet.py`), stopping the
 | AC8.24.2 | Workflow pytest contracts declaring an environment precondition (the runtime-owned smoke gate, for the preview and staging core E2E stages) must run it before the pytest invocation in the same workflow — mechanized fault attribution: a red precondition aborts before tests start {tier:CODE-ONLY} | `test_AC8_24_2_e2e_stages_run_their_environment_precondition_first` | `tests/tooling/test_package_declaration_and_ratchet.py` | P0 |
 | AC8.24.3 | The mirror-assertion count over `tests/tooling/` is locked behind a committed baseline that may only decrease: growth fails CI, `--update` refuses to raise the baseline, and paydown lowers it — with the eight marker-literal mirrors already redundant with AC8.23.2 deleted in the same change {tier:CODE-ONLY} | `test_AC8_24_3_mirror_assertion_ratchet_is_locked_and_only_goes_down` | `tests/tooling/test_package_declaration_and_ratchet.py` | P0 |
 
+### AC8.25: Real Storage Pipeline (counted tier)
+
+Issue #1520: every counted test stubbed the storage seam (DummyStorage /
+mocked boto3), so the real ``StorageService`` wiring — upload, persist,
+load-back — shipped unproven; green CI did not prove a user's statement
+survives storage. These tests run the REAL service and the REAL
+upload→store→parse pipeline against moto's in-memory S3 (no stub, no service
+container, fast path), reusing the vision hard gate's deterministic CSV
+fixture so the same business numbers are proven at the counted tier. Their
+first run caught a live production bug: the success path persisted the bare
+display filename as ``UploadedDocument.file_path``, so every post-success
+retry/reparse fetched a nonexistent storage key (fixed in
+``statement_parsing.py`` alongside).
+
+| AC ID | Test Case | Test Function | File | Priority |
+|---|---|---|---|---|
+| AC8.25.1 | A CSV fixture uploads through ``/statements/upload`` with the REAL StorageService into in-memory S3 (env-level config only — the service is never stubbed or patched), the pipeline parses it, the stored object read back via the real ``get_object`` is byte-identical to the fixture, and the resolved transactions carry the fixture's known business values (6 transactions, 11200.00 gross) {tier:CODE-ONLY} | `test_AC8_25_1_upload_parses_through_real_storage_round_trip` | `apps/backend/tests/api/test_real_storage_pipeline.py` | P0 |
+| AC8.25.2 | The retry path re-fetches the source document through the real ``get_object`` (the load-back leg the in-process first parse skips — this is the assertion that caught the file_path production bug), and deleting the stored object makes retry fail instead of parsing a cached copy — proving the pipeline truly reads storage {tier:CODE-ONLY} | `test_AC8_25_2_retry_loads_source_back_through_real_storage` | `apps/backend/tests/api/test_real_storage_pipeline.py` | P0 |
+
 ## 5. E2E Suite Ownership
 
 Current test counts and coverage percentages belong to generated reports and CI


### PR DESCRIPTION
## Summary

Closes #1520. The counted tier now runs the **real** `StorageService` and the **real** upload→store→parse pipeline — and the new test's *first run caught a live production bug* of exactly the class the issue predicted.

### The bug (fixed here)

The success path persisted the bare display filename as `UploadedDocument.file_path` (`parse_document(file_path=Path(filename))` → `create_uploaded_document`), while the actual object lives under the built storage key (`statements/{id}/{hash}.ext`). The retry/reparse paths hand `file_path` straight to `storage.get_object` — so **every post-success retry 404'd against storage** (`NoSuchKey` → 503), shipping green because no counted test ever ran the real seam. Fix: `statement_parsing.py` passes the storage key as `file_path`; the display name already travels separately as `original_filename`. 648 statements/extraction tests pass unchanged.

### The tests (EPIC-008 AC8.25.1–2, `{tier:CODE-ONLY}`, ~6s, coverage-counted `backend_ci` stage)

Per the issue's prescribed approach — moto `mock_aws` under the real boto3 client, **no DummyStorage, no StorageService monkeypatch, no MinIO/LocalStack container**; only env-level settings are touched:

- **AC8.25.1**: `/statements/upload` with the vision hard gate's deterministic CSV fixture → real `upload_bytes` → in-memory S3 → pipeline parses → object read back via real `get_object` is **byte-identical** (AC-2's functional round-trip) → resolved transactions carry the fixture's known business values (6 transactions, 11200.00 gross — the same numbers the in-runner E2E asserts end-to-end).
- **AC8.25.2**: retry re-fetches the source through real `get_object` (the load-back leg the in-process first parse skips — this is the assertion that caught the bug), and **deleting the stored object makes retry fail** rather than parse a cached copy (AC-5's interception proof).

The test env mirrors `docker-compose.ci-e2e.yml` (#1592): placeholder provider key + unroutable `AI_BASE_URL`, so any AI fallback fails in milliseconds instead of retrying a live provider.

### Scope notes

- AC-3's cassette leg is already covered by `tests/extraction/test_extraction_cassette_replay.py` (real ExtractionService, frozen cassette, no monkeypatch); what was missing — and lands here — is the storage seam. Chaining the two into one storage→cassette test is a natural follow-up, not blocking.
- Local `ruff` on PATH (newer than the pinned toolchain) reports 63 pre-existing UP-rule hits across the codebase, none in files touched here; CI's pinned lint is authoritative.

### Test plan

- New tests 3/3 stable locally (~6s each run); 648 statements/extraction tests green with the fix; AC-index, tier ratchet, ac-traceability, doc-consistency pass.

Closes #1520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)