### PR TITLE
[finance_report_ui] chore(ac): yield AC8.25.* to #1598 — renumber Real Storage Pipeline to AC8.26.*

### DIFF
--- a/apps/backend/tests/api/test_real_storage_pipeline.py
+++ b/apps/backend/tests/api/test_real_storage_pipeline.py
@@ -2,7 +2,7 @@
 
 Until now every counted test stubbed the storage seam (DummyStorage /
 monkeypatched boto3), so a regression in the real ``StorageService`` wiring —
-upload, persist, load-back — shipped undetected (EPIC-008 AC8.25). These tests
+upload, persist, load-back — shipped undetected (EPIC-008 AC8.26). These tests
 run the REAL service and the REAL upload→store→parse pipeline against an
 in-memory S3: no stub, no monkeypatched StorageService, no service container.
 
@@ -36,7 +36,7 @@ EXPECTED_TOTAL_EXPENSES = Decimal("5600.00")
 def real_s3(monkeypatch: pytest.MonkeyPatch):
     """moto-backed S3: the real boto3 client in StorageService hits an
     in-memory backend. Only env-level config is touched — the service itself
-    is never stubbed or patched (AC8.25.1)."""
+    is never stubbed or patched (AC8.26.1)."""
     monkeypatch.setattr(settings, "s3_endpoint", None)
     monkeypatch.setattr(settings, "s3_access_key", "testing")
     monkeypatch.setattr(settings, "s3_secret_key", "testing")
@@ -70,8 +70,8 @@ async def _upload_csv(db, test_user) -> statements_router.BankStatementResponse:
     )
 
 
-async def test_AC8_25_1_upload_parses_through_real_storage_round_trip(real_s3, db, test_user):
-    """AC8.25.1: the CSV fixture uploads through the real StorageService into
+async def test_AC8_26_1_upload_parses_through_real_storage_round_trip(real_s3, db, test_user):
+    """AC8.26.1: the CSV fixture uploads through the real StorageService into
     in-memory S3, the pipeline parses it, and the stored object read back via
     the real get_object is byte-identical to the fixture."""
     user_id = test_user.id
@@ -99,8 +99,8 @@ async def test_AC8_25_1_upload_parses_through_real_storage_round_trip(real_s3, d
     assert gross == EXPECTED_TOTAL_INCOME + EXPECTED_TOTAL_EXPENSES
 
 
-async def test_AC8_25_2_retry_loads_source_back_through_real_storage(real_s3, db, test_user):
-    """AC8.25.2: the retry path re-fetches the source document through the
+async def test_AC8_26_2_retry_loads_source_back_through_real_storage(real_s3, db, test_user):
+    """AC8.26.2: the retry path re-fetches the source document through the
     real get_object (the load-back leg the in-process first parse skips), and
     deleting the stored object makes retry fail — proving the pipeline truly
     reads storage, not a cached copy (the interception proof)."""

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -641,7 +641,7 @@ an only-goes-down ratchet (`common/testing/mirror_ratchet.py`), stopping the
 | AC8.24.2 | Workflow pytest contracts declaring an environment precondition (the runtime-owned smoke gate, for the preview and staging core E2E stages) must run it before the pytest invocation in the same workflow — mechanized fault attribution: a red precondition aborts before tests start {tier:CODE-ONLY} | `test_AC8_24_2_e2e_stages_run_their_environment_precondition_first` | `tests/tooling/test_package_declaration_and_ratchet.py` | P0 |
 | AC8.24.3 | The mirror-assertion count over `tests/tooling/` is locked behind a committed baseline that may only decrease: growth fails CI, `--update` refuses to raise the baseline, and paydown lowers it — with the eight marker-literal mirrors already redundant with AC8.23.2 deleted in the same change {tier:CODE-ONLY} | `test_AC8_24_3_mirror_assertion_ratchet_is_locked_and_only_goes_down` | `tests/tooling/test_package_declaration_and_ratchet.py` | P0 |
 
-### AC8.25: Real Storage Pipeline (counted tier)
+### AC8.26: Real Storage Pipeline (counted tier)
 
 Issue #1520: every counted test stubbed the storage seam (DummyStorage /
 mocked boto3), so the real ``StorageService`` wiring — upload, persist,
@@ -657,8 +657,8 @@ retry/reparse fetched a nonexistent storage key (fixed in
 
 | AC ID | Test Case | Test Function | File | Priority |
 |---|---|---|---|---|
-| AC8.25.1 | A CSV fixture uploads through ``/statements/upload`` with the REAL StorageService into in-memory S3 (env-level config only — the service is never stubbed or patched), the pipeline parses it, the stored object read back via the real ``get_object`` is byte-identical to the fixture, and the resolved transactions carry the fixture's known business values (6 transactions, 11200.00 gross) {tier:CODE-ONLY} | `test_AC8_25_1_upload_parses_through_real_storage_round_trip` | `apps/backend/tests/api/test_real_storage_pipeline.py` | P0 |
-| AC8.25.2 | The retry path re-fetches the source document through the real ``get_object`` (the load-back leg the in-process first parse skips — this is the assertion that caught the file_path production bug), and deleting the stored object makes retry fail instead of parsing a cached copy — proving the pipeline truly reads storage {tier:CODE-ONLY} | `test_AC8_25_2_retry_loads_source_back_through_real_storage` | `apps/backend/tests/api/test_real_storage_pipeline.py` | P0 |
+| AC8.26.1 | A CSV fixture uploads through ``/statements/upload`` with the REAL StorageService into in-memory S3 (env-level config only — the service is never stubbed or patched), the pipeline parses it, the stored object read back via the real ``get_object`` is byte-identical to the fixture, and the resolved transactions carry the fixture's known business values (6 transactions, 11200.00 gross) {tier:CODE-ONLY} | `test_AC8_26_1_upload_parses_through_real_storage_round_trip` | `apps/backend/tests/api/test_real_storage_pipeline.py` | P0 |
+| AC8.26.2 | The retry path re-fetches the source document through the real ``get_object`` (the load-back leg the in-process first parse skips — this is the assertion that caught the file_path production bug), and deleting the stored object makes retry fail instead of parsing a cached copy — proving the pipeline truly reads storage {tier:CODE-ONLY} | `test_AC8_26_2_retry_loads_source_back_through_real_storage` | `apps/backend/tests/api/test_real_storage_pipeline.py` | P0 |
 
 ## 5. E2E Suite Ownership
 


### PR DESCRIPTION
## Summary

Cleanup follow-up to #1520/#1601. Resolves the AC-number collision I introduced, from my side.

When I registered the real-storage pipeline ACs in #1601 I claimed **AC8.25.1/2** without checking open PRs first — but **#1598** (vision window, extraction corpus) had already planned **AC8.25.1/2/3**. Since #1601 merged first, `main` now owns AC8.25.1/2 and #1598 would fail the AC-index/uniqueness gate on rebase.

Convention is that the later claimant yields. This PR moves the merged block to the next free slot (**AC8.26.***) and returns **AC8.25.*** to #1598, which claimed it first.

## Change

Pure rename, no behaviour change:
- `EPIC-008` section header `AC8.25 → AC8.26` + both AC row IDs and their referenced test-function names.
- Test functions `test_AC8_25_{1,2}_* → test_AC8_26_{1,2}_*` and their docstrings/module docstring.
- Regenerated AC registry (`--check` green).

Both tests still pass unchanged; tier ratchet, AC-index, mirror ratchet all green locally.

## Coordination

Posting on #1598: keep AC8.25.1/2/3, do **not** move to AC8.26 (now taken here).

Follow-up to #1520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)