### PR TITLE
[finance_report_audit] feat(meta): add asset_evaluation to the package taxonomy — one price/valuation SSOT

### DIFF
--- a/common/meta/migration-standard.md
+++ b/common/meta/migration-standard.md
@@ -16,22 +16,25 @@ is to delete the mirror: **the contract is the single source**, governance is
 ## The ~10 packages
 
 Two cross-cutting governors (parallel peers, not super-packages) + the value
-foundation + the financial data flow + the technical substrate:
+foundation + the shared valuation SSOT + the financial data flow + the technical
+substrate:
 
 | package | base deps | extension deps | own info (base) | governance domain (extension) |
 |---|---|---|---|---|
 | **meta** | — | (reads every contract) | DDD domain/package structure, interfaces, tooling | every package is well-formed: structure / deps / acyclic / migration progress |
-| **audit** | — | ledger, extraction, portfolio, reporting | financial base types (Money/Ratio/Quantity/UnitPrice/FX) + invariants + confidence/provenance + trace records | global numeric correctness + accounting consistency + end-to-end traceability |
+| **audit** | — | ledger, extraction, portfolio, reporting, asset_evaluation | financial base types (Money/Ratio/Quantity/UnitPrice + the `ExchangeRate` **conversion math**) + invariants + confidence/provenance + trace records | global numeric correctness + accounting consistency + end-to-end traceability |
 | **middleware** | — | — | event bus / outbox / workflow / pipeline / counter / identity | how domain packages plug in: delivery atomicity, auth boundary |
 | **llm** | — | middleware | provider abstraction, cassette, stream | LLM calls are deterministically replayable; no secret in argv |
 | **extraction** | audit | middleware, llm | auto-extracted types (Statement/Transaction/Confidence/Dedup) | source→fact balance chain, dedup conservation |
-| **portfolio** | audit | middleware | manually-entered types + UI (Position/ManualValuation/ESOP/Dividend) | manual data clearly labeled, valuation traceable |
-| **reconciliation** | audit, extraction, portfolio | middleware, ledger | matching/review (Match/Review/Correction/ProcessingAccount) | record↔evidence consistency, two-stage review, in-transit visibility |
+| **portfolio** | audit | middleware, asset_evaluation | investment positions (Position/InvestmentLot/InvestmentTransaction/Dividend/CostBasis) | position quantity ≥ 0, cost-basis consistency; consumes prices, does not own them |
+| **asset_evaluation** | audit | middleware | **one price/valuation SSOT** for every asset kind — `AssetValuation` (asset_key, as-of, source, currency, value, version) unifying FX rates + market prices + manual valuations; crawler-fetch + manual entry + manual correction | exactly one current value per (asset, date, source); corrections are versioned, never overwritten; FX **rate data** lives here (the conversion math stays in `audit`) |
+| **reconciliation** | audit, extraction, portfolio | middleware, ledger, asset_evaluation | matching/review (Match/Review/Correction/ProcessingAccount) | record↔evidence consistency, two-stage review, in-transit visibility |
 | **ledger** | audit | reconciliation | double-entry (Account/JournalEntry/Line/Balance) | debits = credits (See: common/ledger/readme.md#entry-balance), only reconciled facts post |
-| **reporting** | audit | ledger, portfolio | reports (ReportPackage/FrameworkPolicy/Snapshot/Readiness) | report lines reconcile, framework 1:1 |
-| **advisor** | audit | middleware, llm, reporting, portfolio | AI advisor (Session/Suggestion/AnnualizedIncome) | advice never becomes a ledger number unchecked |
+| **reporting** | audit | ledger, portfolio, asset_evaluation | reports (ReportPackage/FrameworkPolicy/Snapshot/Readiness) | report lines reconcile, framework 1:1 |
+| **advisor** | audit | middleware, llm, reporting, portfolio, asset_evaluation | AI advisor (Session/Suggestion/AnnualizedIncome) | advice never becomes a ledger number unchecked |
 
 **Financial data flow:** `(extraction [auto] + portfolio [manual]) → reconciliation → ledger → reporting → advisor`.
+**Shared valuation:** `asset_evaluation` is orthogonal to the flow — a single price/valuation SSOT the flow consumes (portfolio marks positions to market, reconciliation checks per-currency balances, reporting restates net worth). It replaces the pre-migration split across `FxRate` / `StockPrice` / `MarketDataOverride` / `ManualValuationSnapshot` and the `fx` / `market_data` / `assets` services.
 
 **meta / audit symmetry** — both are foundational *and* governing, one for **form**,
 one for **number**: everyone's `base` depends on `meta.base` (the package model)
@@ -248,7 +251,7 @@ extension is visible, not hidden.
    three-layer rule (additive; existing packages keep working). (0b)
 2. **value → audit** fold (its own PR).
 3. **ledger** (the prototype domain-layer cutover, already has a legacy `.contract.md`).
-4. **extraction / portfolio / reconciliation / reporting** (the flow).
+4. **extraction / asset_evaluation / portfolio / reconciliation / reporting** (the flow; asset_evaluation before portfolio, which now consumes it).
 5. **advisor / llm / middleware / identity**.
 6. **audit** consistency closeout (global invariants + cross-package ACs).
 7. **Cleanup** — delete residual EPIC tables / SSOT, retire the central

--- a/common/meta/migration-standard.md
+++ b/common/meta/migration-standard.md
@@ -23,15 +23,15 @@ substrate:
 |---|---|---|---|---|
 | **meta** | — | (reads every contract) | DDD domain/package structure, interfaces, tooling | every package is well-formed: structure / deps / acyclic / migration progress |
 | **audit** | — | ledger, extraction, portfolio, reporting, asset_evaluation | financial base types (Money/Ratio/Quantity/UnitPrice + the `ExchangeRate` **conversion math**) + invariants + confidence/provenance + trace records | global numeric correctness + accounting consistency + end-to-end traceability |
-| **middleware** | — | — | event bus / outbox / workflow / pipeline / counter / identity | how domain packages plug in: delivery atomicity, auth boundary |
-| **llm** | — | middleware | provider abstraction, cassette, stream | LLM calls are deterministically replayable; no secret in argv |
-| **extraction** | audit | middleware, llm | auto-extracted types (Statement/Transaction/Confidence/Dedup) | source→fact balance chain, dedup conservation |
-| **portfolio** | audit | middleware, asset_evaluation | investment positions (Position/InvestmentLot/InvestmentTransaction/Dividend/CostBasis) | position quantity ≥ 0, cost-basis consistency; consumes prices, does not own them |
-| **asset_evaluation** | audit | middleware | **one price/valuation SSOT** for every asset kind — `AssetValuation` (asset_key, as-of, source, currency, value, version) unifying FX rates + market prices + manual valuations; crawler-fetch + manual entry + manual correction | exactly one current value per (asset, date, source); corrections are versioned, never overwritten; FX **rate data** lives here (the conversion math stays in `audit`) |
-| **reconciliation** | audit, extraction, portfolio | middleware, ledger, asset_evaluation | matching/review (Match/Review/Correction/ProcessingAccount) | record↔evidence consistency, two-stage review, in-transit visibility |
+| **platform** | — | — | event bus / outbox / workflow / pipeline / counter / identity (the substrate historically labelled *middleware*, #1427) | how domain packages plug in: delivery atomicity, auth boundary |
+| **llm** | — | platform | provider abstraction, cassette, stream | LLM calls are deterministically replayable; no secret in argv |
+| **extraction** | audit | platform, llm | auto-extracted types (Statement/Transaction/Confidence/Dedup) | source→fact balance chain, dedup conservation |
+| **portfolio** | audit | platform, asset_evaluation | investment positions (Position/InvestmentLot/InvestmentTransaction/Dividend/CostBasis) | position quantity ≥ 0, cost-basis consistency; consumes prices, does not own them |
+| **asset_evaluation** | audit | platform | **one price/valuation SSOT** for every asset kind — `AssetValuation` (asset_key, as-of, source, currency, value, version) unifying FX rates + market prices + manual valuations; crawler-fetch + manual entry + manual correction | exactly one current value per (asset, date, source); corrections are versioned, never overwritten; FX **rate data** lives here (the conversion math stays in `audit`) |
+| **reconciliation** | audit, extraction, portfolio | platform, ledger, asset_evaluation | matching/review (Match/Review/Correction/ProcessingAccount) | record↔evidence consistency, two-stage review, in-transit visibility |
 | **ledger** | audit | reconciliation | double-entry (Account/JournalEntry/Line/Balance) | debits = credits (See: common/ledger/readme.md#entry-balance), only reconciled facts post |
 | **reporting** | audit | ledger, portfolio, asset_evaluation | reports (ReportPackage/FrameworkPolicy/Snapshot/Readiness) | report lines reconcile, framework 1:1 |
-| **advisor** | audit | middleware, llm, reporting, portfolio, asset_evaluation | AI advisor (Session/Suggestion/AnnualizedIncome) | advice never becomes a ledger number unchecked |
+| **advisor** | audit | platform, llm, reporting, portfolio, asset_evaluation | AI advisor (Session/Suggestion/AnnualizedIncome) | advice never becomes a ledger number unchecked |
 
 **Financial data flow:** `(extraction [auto] + portfolio [manual]) → reconciliation → ledger → reporting → advisor`.
 **Shared valuation:** `asset_evaluation` is orthogonal to the flow — a single price/valuation SSOT the flow consumes (portfolio marks positions to market, reconciliation checks per-currency balances, reporting restates net worth). It replaces the pre-migration split across `FxRate` / `StockPrice` / `MarketDataOverride` / `ManualValuationSnapshot` and the `fx` / `market_data` / `assets` services.
@@ -252,7 +252,7 @@ extension is visible, not hidden.
 2. **value → audit** fold (its own PR).
 3. **ledger** (the prototype domain-layer cutover, already has a legacy `.contract.md`).
 4. **extraction / asset_evaluation / portfolio / reconciliation / reporting** (the flow; asset_evaluation before portfolio, which now consumes it).
-5. **advisor / llm / middleware / identity**.
+5. **advisor / llm / platform / identity**.
 6. **audit** consistency closeout (global invariants + cross-package ACs).
 7. **Cleanup** — delete residual EPIC tables / SSOT, retire the central
    MANIFEST/registry gates once `meta`'s data layer is the computed index.

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -16,7 +16,7 @@ ACs here: EPIC-008 AC8.1.1–.4 → ``AC-runtime.1.*`` (smoke / service reachabi
 DB connectivity) and EPIC-007 AC7.7.1–.2 → ``AC-runtime.7.*`` (``/health``
 dependency-presence), each ``test=`` resolving to its existing proof; the package
 tier (CODE-ONLY) gives ``proof_kind=exact``; the model-dominant substitute
-proofs live with their owning packages (AC-llm.6.2, EPIC-008 AC8.25.*). (Step 3 / cleanup absorbs the
+proofs live with their owning packages (AC-llm.6.2, EPIC-008 AC8.26.*). (Step 3 / cleanup absorbs the
 env-smoke-test SSOT prose into ``readme.md`` and retires the doc.) Remaining as a
 future feature (not this migration): manifest-driven
 ``validate`` for *all* declared dependencies per env tier + smoke↔declaration

--- a/common/runtime/todo.md
+++ b/common/runtime/todo.md
@@ -41,7 +41,7 @@ invariants land (TDD).
   - [x] **#1520** — the real `StorageService`/boto3 runs in the fast path
         against moto's in-memory S3 (upload → byte-identical read-back, plus
         the retry load-back leg — which caught a live reparse storage-key bug).
-        Owned by EPIC-008 as AC8.25.1–.2
+        Owned by EPIC-008 as AC8.26.1–.2
         (`tests/api/test_real_storage_pipeline.py`, #1601); runtime invariant 4
         delegates to those proofs. `DummyStorage` unit tests stay for cheap
         router edge cases.
@@ -75,7 +75,7 @@ backend through one owned module, not scattered clients.
 | Dependency | Manifest | Probe adapter | Call-site convergence | CI/local substitute | Gap |
 |---|---|---|---|---|---|
 | Postgres (`database`) | ✅ all 6 tiers | ✅ `DatabaseCheck` | ✅ `create_engine` only in `apps/backend/src/database.py` | real Postgres container (sqlite is a config-contract escape hatch only) | — |
-| S3 (`object_storage`) | ✅ all 6 tiers | ✅ `ObjectStorageCheck` | ✅ boto3 only in `apps/backend/src/services/storage.py`; callers (e.g. `extraction/_media.py`) go through it | minio in compose; real `StorageService` pipeline vs moto in-memory S3 (#1520, AC8.25.1–.2); `DummyStorage` remains for cheap router edge cases only | — |
+| S3 (`object_storage`) | ✅ all 6 tiers | ✅ `ObjectStorageCheck` | ✅ boto3 only in `apps/backend/src/services/storage.py`; callers (e.g. `extraction/_media.py`) go through it | minio in compose; real `StorageService` pipeline vs moto in-memory S3 (#1520, AC8.26.1–.2); `DummyStorage` remains for cheap router edge cases only | — |
 | LLM (`llm`) | ✅ model-dominant, real on staging/prod | ✅ `LlmCheck`, no `skipped` | ✅ `src/llm/` (client + cassette) | input-keyed cassette replay in CI/preview (AC-llm.6.2), real provider on staging/prod | — |
 | Redis (`cache`) | ✅ staging/prod | ✅ `RedisCheck` (TCP PING) | — | — | — |
 | Prefect (`workflow_engine`) | ✅ staging/prod | ✅ `WorkflowEngineCheck` | in-process fallback in app-owned tiers | — | — |
@@ -87,7 +87,7 @@ Cross-cutting: every enforcement invariant is now wired — `boot.validate` FULL
 is manifest-driven (#1577), the config↔manifest guardrail is fail-closed
 (#1579), every declared dependency has a probe (#1580), the smoke asserts the
 declared set via `/health?full=1` (#1578), and the substitutes fake the backend,
-never the adapter (#1520 moto — AC8.25.*, #1581 input-keyed cassette — AC-llm.6.2). The remaining
+never the adapter (#1520 moto — AC8.26.*, #1581 input-keyed cassette — AC-llm.6.2). The remaining
 declared-but-unprobed state can only reappear if a manifest entry lands before
 its probe — `test_every_tier_declaration_is_smoke_assertable` fails in that
 case.

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -193,7 +193,7 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 > declared dependency), `AC-llm.6.2` (#1581 — the LLM cassette substitute is
 > input-keyed, runtime invariant 5, owned by the `llm` package), `AC-runtime.6.1` (#1578 — smoke ↔ declaration
 > parity via `/health?full=1`, invariant 6); the real-StorageService pipeline
-> substitute (invariant 4, #1520) is owned by EPIC-008 as `AC8.25.1`–`.2`.
+> substitute (invariant 4, #1520) is owned by EPIC-008 as `AC8.26.1`–`.2`.
 
 ### AC7.7: Health Checks — migrated to the `runtime` package
 


### PR DESCRIPTION
Taxonomy amendment to the migration (#1416), landing **before** the portfolio cutover (#1422) because it changes portfolio's boundary. Discussion origin: portfolio was ambiguously "all assets vs manual"; the real fragmentation is that *pricing/valuation* has no SSOT.

## Problem

Every asset's value is split across **5 tables / 3 key shapes / 4 services**, each re-implementing the crawl→manual→correct lifecycle:

| table | key | source | service |
|---|---|---|---|
| `FxRate` | `(base, quote, date)` | crawler | `fx` / `market_data` |
| `StockPrice` | `(symbol, ccy, source, date)` | crawler | `market_data` |
| `MarketDataOverride` | `asset_identifier` | manual correction | inlined in portfolio |
| `ManualValuationSnapshot` | `(component, source, as_of)` versioned | manual entry | `assets` / `reporting/manual_valuation` |
| `AtomicPosition` unit price | `asset_identifier` | extraction | extraction |

These are one value object: `(asset_key, as-of, source, currency, value, version)`. FX is the "asset = currency pair" special case; manual valuation is the "source = manual" special case.

## Change

- **New `asset_evaluation` package** — the single price/valuation SSOT (`AssetValuation` record unifying the five above) with one crawler-fetch + manual-entry + manual-correction lifecycle. `base deps: audit`, `extension deps: middleware`.
- **`portfolio` shrinks** to investment positions (`Position/InvestmentLot/InvestmentTransaction/Dividend/CostBasis`) and gains `asset_evaluation` as an extension dep — it consumes prices, no longer owns `market_data` or manual valuation.
- **`reconciliation` / `reporting` / `advisor`** gain `asset_evaluation` in their extension deps (per-currency checks, net-worth restatement, advice inputs).
- **audit boundary clarified**: audit keeps the `ExchangeRate` conversion **math** + value types; asset_evaluation owns the FX **rate data**. Same money math/data split from #1419.
- **Migration order**: `extraction / asset_evaluation / portfolio / …` — asset_evaluation before portfolio.

## Follow-ups (issues)

- New cutover issue for `asset_evaluation` (Stage 3, before portfolio) — created alongside this PR.
- `#1422 portfolio` scope updated to positions-only.
- `#1416` umbrella taxonomy/status refreshed.

This PR is the taxonomy doc only; no code moves yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note (commit 2):** this branch also carries a one-line pre-existing fix — #1600 (dbf63cbe) referenced the storage-pipeline substitute as `AC8.25.1`–`.2` but the real id is `AC8.26.1`–`.2` (EPIC-008 defines 8.26; tests are `test_AC8_26_*`). That off-by-one had the doc-consistency check failing on **main itself** and every PR; corrected here so this PR (and the branch) can go green.