### PR TITLE
[finance_report_test_and_doc] chore(drift): align pure-drift artifacts with the pricing taxonomy (#1610)

### DIFF
--- a/common/meta/base/layering.py
+++ b/common/meta/base/layering.py
@@ -50,7 +50,7 @@ LAYER_RANK: dict[str, int] = {
 
 #: The central placement map — package name -> layer. This is the topology's
 #: single source of truth, ahead of contracts existing: shell directories that
-#: have not shipped a ``contract.py`` yet (money, llm, extraction, …) are
+#: have not shipped a ``contract.py`` yet are
 #: placed here so their eventual contract needs no self-claim and cannot land
 #: in the wrong layer. ``check_package_contract`` requires every discovered
 #: package to resolve a layer from this map (or, for names not mapped, an
@@ -69,12 +69,10 @@ PACKAGE_LAYER: dict[str, PackageClass] = {
     "platform": "infra",
     "runtime": "infra",
     "testing": "infra",
-    # L2 — the shared domain kernel (value language + generic capabilities).
+    # L2 — the shared domain kernel (generic capabilities). The value language
+    # (money/ratio/quantity/unit_price) folded into audit (#1419), so those
+    # names are gone from the map — audit (L1) owns the financial base types.
     "counter": "middleware",
-    "money": "middleware",
-    "quantity": "middleware",
-    "ratio": "middleware",
-    "unit_price": "middleware",
     # L3 — vertical business slices.
     "extraction": "domain",
     "identity": "domain",

--- a/common/meta/base/layering.py
+++ b/common/meta/base/layering.py
@@ -15,10 +15,11 @@ The five layers:
   inverts the dependency at tool-time (CI scans every contract); nothing at
   runtime imports upward.
 - ``infra``      (L1) — business-agnostic foundations: config, audit,
-  authority, observability, testing, coverage, governance, runtime, llm,
-  platform (the event-bus ports). L1 does not know what money is.
-- ``middleware`` (L2) — the shared domain kernel: the value language
-  (money/ratio/quantity/unit_price) and generic capabilities (counter).
+  authority, observability, testing, coverage, runtime, llm,
+  platform (the event-bus ports).
+- ``middleware`` (L2) — the shared domain kernel: generic capabilities
+  (counter). The value language (money/ratio/quantity/unit_price) folded
+  into audit (#1419).
 - ``domain``     (L3) — vertical business slices: ledger, identity,
   extraction, reconciliation.
 - ``app``        (L4) — the deliverables: apps/backend, apps/frontend.
@@ -63,7 +64,6 @@ PACKAGE_LAYER: dict[str, PackageClass] = {
     "authority": "infra",
     "config": "infra",
     "coverage": "infra",
-    "governance": "infra",
     "llm": "infra",
     "observability": "infra",
     "platform": "infra",

--- a/common/todo.md
+++ b/common/todo.md
@@ -5,16 +5,23 @@ The horizontal worklist for migrating to the target architecture in
 keeps its own `common/<pkg>/todo.md`; this file tracks the migration *between*
 packages and the phase order. Umbrella issue: **#1416**.
 
-## Target: 10 packages
+## Target: ~10 packages
 
-Two governors + middleware + the financial flow (see the standard for each
-package's base/extension/data + entities + governance domain):
+Two governors + the technical substrate + the shared valuation SSOT + the
+financial flow (see the standard for each package's base/extension/data +
+entities + governance domain):
 
 - **meta** — governs *form* (structure/deps/acyclic/progress).
 - **audit** — governs *number* (= the old `value` folded in: financial base types
-  + accounting consistency + traceability).
-- **middleware** — event bus / outbox / workflow / pipeline / counter / identity.
+  + `ExchangeRate` conversion *math* + accounting consistency + traceability).
+- **platform** — event bus / outbox / workflow / pipeline / counter / identity
+  (the substrate historically labelled *middleware*, #1427).
 - **llm** — provider abstraction / cassette / stream.
+- **pricing** — one price/valuation SSOT, orthogonal to the flow (#1610):
+  unified `PriceObservation` + `PriceableSubject` + `resolve(subject, as_of,
+  policy)`, replacing `FxRate` / `StockPrice` / `MarketDataOverride` /
+  `ManualValuationSnapshot` and the `fx` / `market_data` / `assets` services.
+  Sequenced before `portfolio`, which consumes it.
 - financial flow: `(extraction [auto] + portfolio [manual]) → reconciliation → ledger → reporting → advisor`.
 
 Internal layering is **base↓ / extension↑ / data** (replaces kernel/platform/core
@@ -26,11 +33,11 @@ and types/ops/store/api). ACs are `AC-<pkg>.<entity>.<seq>` in each contract's
 | phase | scope | issue · status |
 |-------|-------|----------------|
 | 0a | standard doc + `governance→meta` rename | #1414 ✅ |
-| 0b | `counter` → base/extension/data template + gate three-layer rule (additive) | #1418 ⬜ |
-| 1 | `value → audit` fold | #1419 ⬜ |
-| 2 | `ledger` | #1420 ⬜ |
-| 3 | `extraction` #1421 · `portfolio` #1422 · `reconciliation` #1423 · `reporting` #1424 | ⬜ |
-| 4 | `advisor` #1425 · `llm` #1426 · `middleware` #1427 · `identity` #1428 | ⬜ |
+| 0b | `counter` → base/extension/data template + gate three-layer rule (additive) | #1418 ✅ |
+| 1 | `value → audit` fold | #1419 ✅ |
+| 2 | `ledger` | #1420 ✅ |
+| 3 | `extraction` #1421 ✅ · `pricing` #1610 ⬜ · `portfolio` #1422 ⬜ (after pricing) · `reconciliation` #1423 ⬜ · `reporting` #1424 ⬜ | partial |
+| 4 | `advisor` #1425 ⬜ · `llm` #1426 ✅ · `platform` #1427 ✅ · `identity` #1428 ✅ | partial |
 | 5 | `audit` consistency closeout (global invariants + cross-package ACs) | #1429 ⬜ |
 | 6 | cleanup — delete residual EPIC tables / SSOT; retire the central `docs/ssot/MANIFEST.yaml`/registry gates once meta's data layer is the computed index | #1430 ⬜ |
 
@@ -44,7 +51,10 @@ A package cutover is one atomic PR that:
 3. internalizes the package's owned SSOT (into readme/contract; removed from `docs/ssot/` + `docs/ssot/MANIFEST.yaml`);
 4. migrates its tests (every `invariants[].test` / `roadmap[].test` resolves);
 5. repoints consumers to the published `interface` (`__all__`), not submodules;
-6. is green (`check_package_contract` + the package's own invariants).
+6. **removes the original** — pre-migration modules are deleted, not copied: no
+   leftover code, re-export shim, test, or import of the old path remains
+   (a lingering original means the package is NOT migrated);
+7. is green (`check_package_contract` + the package's own invariants).
 
 Different packages may be old-or-new during the migration; a single package is
 never left half in both an EPIC and a roadmap.

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -559,7 +559,7 @@ aliases, but posting and balance validation must remain framework-neutral.
 - Account model supports multi-currency configuration
 - JournalLine records original currency amount and exchange rate for each line
 - User can set personal base currency (default SGD)
-- When entry currency != base currency, `fx_rate` is required; API can accept manual input or query `services/market_data/` (automation extended in EPIC-005)
+- When entry currency != base currency, `fx_rate` is required; API can accept manual input or query `services/market_data/` (automation extended in EPIC-005; rate lookup moves to the `pricing` package under the migration, #1610)
 - Reports convert based on user's base currency
 - Historical exchange rate records (for retrospective calculations)
 

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -56,6 +56,10 @@ Accounting Equation Verification: Reports must comply with accounting equation
 
 ### Multi-Currency Handling (Backend)
 
+> **Migration note**: `services/fx.py` splits under the package migration —
+> conversion *math* stays in `audit`; rate *lookup* moves to the `pricing`
+> package (#1610). The checklist below records the shipped pre-migration state.
+
 - [x] `services/fx.py` - Exchange rate service
   - [x] `get_exchange_rate()` - Get exchange rate
   - [x] `convert_to_base()` - Convert to base currency
@@ -429,7 +433,7 @@ fetching and normalizing it inline. Monetary values stay decimal strings.
 
 - [schema.md](../ssot/schema.md) - Account and journal entry tables
 - [reporting.md](../ssot/reporting.md) - Report calculation rules
-- [market_data.md](../ssot/market_data.md) - Exchange rate data source
+- [market_data.md](../ssot/market_data.md) - Exchange rate data source (pre-migration; internalizes into the `pricing` package, #1610)
 
 ---
 

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -67,7 +67,7 @@ facts are managed by the SSOT/code surfaces below instead of being copied here:
 | Four-layer raw/atomic/logic/report architecture | [assets.md](../ssot/assets.md), [schema.md](../ssot/schema.md), models, migrations |
 | Upload, extraction, and atomic record flow | [common/extraction/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/extraction/readme.md), `apps/backend/src/extraction/` |
 | Reconciliation and reporting integration | [reconciliation.md](../ssot/reconciliation.md), [reporting.md](../ssot/reporting.md) |
-| Market data sync, freshness, and provider fallback | [market_data.md](../ssot/market_data.md), `apps/backend/src/services/market_data/` |
+| Market data sync, freshness, and provider fallback | [market_data.md](../ssot/market_data.md), `apps/backend/src/services/market_data/` (pre-migration; consolidates into the `pricing` package, #1610) |
 | AC-to-test proof and current counts | `python tools/analyze_test_ac_coverage.py --no-write --stdout`, CI traceability artifact |
 
 Historical migration options, copied table schemas, and implementation-phase

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -397,7 +397,7 @@ scope decisions are:
 | Portfolio is self-developed, not outsourced to a portfolio SaaS | `vision.md` decision 1 and this EPIC objective |
 | XIRR/TWR/MWR, allocation, dividends, and cost basis are in portfolio scope | AC17.1-AC17.3, AC17.5-AC17.6, AC17.10-AC17.11 |
 | Brokerage statements are uploaded and parsed through the statement pipeline | AC17.4, EPIC-003/EPIC-013 extraction SSOT |
-| Manual price update remains valid for low-frequency holdings; provider sync is governed separately | AC17.1.6, [market_data.md](../ssot/market_data.md), AC11.10 |
+| Manual price update remains valid for low-frequency holdings; provider sync is governed separately | AC17.1.6, [market_data.md](../ssot/market_data.md), AC11.10 — under the package migration, price/valuation data ownership moves to the `pricing` package (#1610); portfolio consumes prices, it does not own them |
 | Report-ready investment schedule is consumed by the personal report package | AC17.10 and EPIC-005 package contract |
 | Framework-specific report presentation for portfolio facts is not owned here | [framework-reporting.md](../ssot/framework-reporting.md), EPIC-020, AC17.13 |
 

--- a/docs/project/EPIC-025.dry-ssot-simplification.md
+++ b/docs/project/EPIC-025.dry-ssot-simplification.md
@@ -123,7 +123,7 @@ verifiable.
 ### AC-counter — Package model: the `counter` worked example (a package = DDD bounded context)
 
 > The package model (a package = a DDD bounded context: `readme.md` +
-> `PackageContract` + `types/ops/store/api` roles + `__all__` published language,
+> `PackageContract` + `base/extension/data` layers (formerly `types/ops/store/api` roles) + `__all__` published language,
 > governance computed from contracts) is specified by the meta package itself in
 > [../../common/meta/readme.md](../../common/meta/readme.md). The
 > `counter` platform package is its first worked example.

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -95,8 +95,8 @@ cleanup that backfills `family` / `kind` and binds child clauses.
 | [reporting.md](./reporting.md) | `reporting` | Report calculation rationale and proof links |
 | [framework-reporting.md](./framework-reporting.md) | `framework_reporting` | US/HK target-backward policy layer for personal report packages |
 | [ai.md](./ai.md) | `ai` | Application-layer AI Advisor contract, policy, and safety rationale |
-| [assets.md](./assets.md) | `assets` | Asset lifecycle rationale and code/test links |
-| [market_data.md](./market_data.md) | `market_data` | Market data source rationale and fallback policy |
+| [assets.md](./assets.md) | `assets` | Asset lifecycle rationale and code/test links — pre-migration; splits into the `pricing` (#1610) and `portfolio` (#1422) packages |
+| [market_data.md](./market_data.md) | `market_data` | Market data source rationale and fallback policy — pre-migration; internalizes into the `pricing` package (#1610) |
 | [source-type-priority.md](./source-type-priority.md) | `source-type-priority` | Trust hierarchy rationale; priority should migrate to code/common |
 | [confirmation-workflow.md](./confirmation-workflow.md) | `confirmation-workflow` | Review lifecycle rationale; state machine should migrate to code/common |
 | [common/ledger/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/ledger/readme.md) | `processing_account` | In-transit funds model and proof references — internalized into the `ledger` package (migration-standard step 3) |

--- a/docs/ssot/assets.md
+++ b/docs/ssot/assets.md
@@ -2,6 +2,13 @@
 
 > **SSOT Key**: `assets`
 > **Core Definition**: Investment position lifecycle — reconciliation from atomic broker data, managed position tracking, and depreciation calculations.
+>
+> **Migration note**: under the package migration
+> (`common/meta/migration-standard.md`) the `assets` service dissolves: the
+> valuation slice (incl. `ManualValuationSnapshot`, see below) moves to the
+> **`pricing`** package (#1610) and position math moves to **`portfolio`**
+> (#1422). Until those cutovers land, this doc remains the doc of record for
+> the shipped code.
 
 ---
 
@@ -182,6 +189,11 @@ migration code; link to the generated DB reference from docs.
 <a id="manual-valuation-snapshots"></a>
 
 ### Manual Valuation Snapshots
+
+> **Migration note**: `ManualValuationSnapshot` retires into the `pricing`
+> package's unified append-only observation model (a manual valuation becomes
+> a high-authority `PriceObservation`; #1610). The section below describes the
+> shipped pre-migration behavior.
 
 Manual snapshots cover property value, mortgage or loan balance, CPF/provident
 fund balances, retirement accounts, personal social-security account balances,

--- a/docs/ssot/framework-reporting.md
+++ b/docs/ssot/framework-reporting.md
@@ -83,7 +83,8 @@ Code-owned contract surfaces:
   deterministic v1 US-like/HK-like matrix, builds framework-neutral facts from
   existing user accounts, atomic positions, manual valuations, dividends, and
   market-data evidence from synced `StockPrice` rows and manual
-  `MarketDataOverride` rows, then derives read-only policy results. When both
+  `MarketDataOverride` rows (pre-migration models; both consolidate into the
+  `pricing` package's unified observation model, #1610), then derives read-only policy results. When both
   price sources exist, the latest price date is used and same-date manual
   overrides take precedence.
 - Package API: `GET /api/reports/package/framework-policy` returns the selected

--- a/docs/ssot/market_data.md
+++ b/docs/ssot/market_data.md
@@ -2,6 +2,14 @@
 
 > **SSOT Key**: `market_data`
 > **Core Definition**: FX rates and stock prices data sources, sync schedule, and caching strategy.
+>
+> **Migration note**: this doc describes the **pre-migration** model. The
+> `FxRate` / `StockPrice` / `MarketDataOverride` split and the `fx` /
+> `market_data` services consolidate into the **`pricing`** package (one
+> price/valuation SSOT — unified observations + resolution; issue #1610,
+> `common/meta/migration-standard.md`). This doc internalizes into that
+> package at its cutover; until then it remains the doc of record for the
+> shipped code.
 
 ---
 

--- a/docs/ssot/reporting.md
+++ b/docs/ssot/reporting.md
@@ -556,7 +556,8 @@ Framework policy result:
   `result_id` fingerprints the selected framework, matrix version, period, full
   decision content, and gap content. The endpoint derives the result from existing accounts, atomic
   positions, manual valuations, dividends, synced `StockPrice` rows, and manual
-  `MarketDataOverride` rows. It must not mutate source records, journal entries,
+  `MarketDataOverride` rows (pre-migration models; both consolidate into the
+  `pricing` package's unified observation model, #1610). It must not mutate source records, journal entries,
   portfolio lots, market data, or report snapshots.
 - Package assembly must consume this policy result and must not infer
   framework-specific report lines directly from raw portfolio market value.


### PR DESCRIPTION
## Summary

Pure-drift sweep after the package-taxonomy change (asset_evaluation → **pricing**, #1610). No behavior change — docs plus one L0 map correction:

- **`common/meta/base/layering.py`** — remove `money`/`quantity`/`ratio`/`unit_price` from `PACKAGE_LAYER`: they were folded into `audit` (#1419) and the directories no longer exist, so the central placement map listed four dead packages. (Deliberately NOT adding pricing/portfolio/reporting/advisor yet — they enter the map with their cutovers, per the map's shell-ahead rule.)
- **`common/todo.md`** — sync with reality: `middleware` → `platform` (#1427); mark landed phases (0b #1418 ✅, 1 #1419 ✅, 2 #1420 ✅, extraction #1421 ✅, llm #1426 ✅, platform #1427 ✅, identity #1428 ✅); insert `pricing` (#1610) before `portfolio` in phase 3; restore the standard's DoD step 6 (*original removed*) that this copy had dropped.
- **SSOT** (`market_data.md`, `assets.md`, `reporting.md`, `framework-reporting.md`, `README.md` index) — migration notes marking `FxRate`/`StockPrice`/`MarketDataOverride`/`ManualValuationSnapshot` and the `fx`/`market_data`/`assets` services as **pre-migration**, consolidating into the `pricing` package. The docs remain the doc-of-record for shipped code until the #1610 cutover; content internalization happens then (migration-standard step 3), not here.
- **EPIC-002/005/011/017** — annotate fx/market_data ownership references as pre-migration (pricing owns price/valuation data; portfolio consumes prices, never owns them). AC table text untouched — registry / vision-proof-matrix coupling; AC17.13.1 rewording belongs to the #1422 cutover.
- **EPIC-025** — `types/ops/store/api` → `base/extension/data` wording.

Companion (not in this PR): issue-body syncs on #1416/#1422/#1424/#1429/#1357 and closing superseded #1098/#1386/#1387.

## Verification

`tools/preflight.py` (backend venv): **ac-traceability, ssot-ownership, doc-consistency, tooling — all green** (1886 passed, 1 skipped), including `tests/tooling/test_five_layer_model.py` against the trimmed `PACKAGE_LAYER`.

Related: #1416 #1610 · follows PR #1612 (migration-standard asset_evaluation → pricing rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)