### PR TITLE
[finance_report_test_and_doc] feat(meta): taxonomy-drift gate — retired vocabulary becomes a CI failure (AC-meta.vocab.1)

### DIFF
--- a/.opencode/skills/domain/preflight/SKILL.md
+++ b/.opencode/skills/domain/preflight/SKILL.md
@@ -30,6 +30,7 @@ Exit code is non-zero if any gate fails; the summary names which one.
 | `docs/project/EPIC*.md`, `docs/ac_registry*.yaml`, `docs/infra_registry*.yaml` | `generate_ac_registry.py` → `check_ac_index.py` |
 | `docs/ssot/*` | `check_ssot_ownership.py`, `check_manifest.py` |
 | `docs/*`, `mkdocs.yml`, `vision.md`, `README.md` | `lint_doc_consistency.py` |
+| `*.md`, `docs/ssot/*.yaml`, `tests/*.py`, `common/*`, `tools/*.py` | `check_taxonomy_drift.py` (retired taxonomy vocabulary gate, AC-meta.vocab.1) |
 | `apps/backend/*schema*.py` | `validate_schemas.py` |
 | `apps/backend/migrations/*` | `check_migration_risk.py` |
 | `.env*` | `check_env_keys.py` |

--- a/apps/backend/src/counter/README.md
+++ b/apps/backend/src/counter/README.md
@@ -9,7 +9,9 @@ ubiquitous language, contract, roles, storage, and governance — lives in
 - Machine contract (interface, invariants, roadmap ACs): [`common/counter/contract.py`](../../../../common/counter/contract.py)
 - Package model: [`common/meta/readme.md`](../../../../common/meta/readme.md)
 
-The code here converges by role — `types/` (nouns + events), `ops/` (verbs over
-the store port), `store/` (the `CounterRepository` port + SQL adapter), `api/`
-(the thin async `read_count` boundary) — and publishes exactly its
-`__init__.__all__`, which must equal `contract.interface`.
+The code here converges into the package model's layers — `base/` (pure core:
+`types/` nouns + events, `ops/` verbs over the repository port,
+`repository.py` the `CounterRepository` port) and `extension/` (the impure
+edges: `sql.py` SQLAlchemy adapter, `api/` the thin async boundary) — and
+publishes exactly its `__init__.__all__`, which must equal
+`contract.interface`.

--- a/common/audit/money/readme.md
+++ b/common/audit/money/readme.md
@@ -7,8 +7,9 @@
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
 >
-> A **`kernel` value language**. It imports the `ratio` kernel package
-> (`MoneyTolerance` is a `Ratio`) — a declared, acyclic **same-class** edge, which
+> The **audit** package's value-language core (L1 `infra` in the five-layer
+> map). It imports the `ratio` package
+> (`MoneyTolerance` is a `Ratio`) — a declared, acyclic **same-package-family** edge, which
 > the package model allows ("never up, never sideways-cyclic").
 
 ## Why

--- a/common/audit/money/readme.md
+++ b/common/audit/money/readme.md
@@ -9,7 +9,7 @@
 >
 > The **audit** package's value-language core (L1 `infra` in the five-layer
 > map). It imports the `ratio` package
-> (`MoneyTolerance` is a `Ratio`) — a declared, acyclic **same-package-family** edge, which
+> (`MoneyTolerance` is a `Ratio`) — a declared, acyclic **same-layer** edge, which
 > the package model allows ("never up, never sideways-cyclic").
 
 ## Why

--- a/common/audit/money/todo.md
+++ b/common/audit/money/todo.md
@@ -20,6 +20,6 @@ The package-local worklist. Cross-package migration lives in
 
 ## Done (class)
 
-- [x] Classed `kernel` (the value-language layer). It imports `ratio` as a
+- [x] Classed `kernel` (then-klass, since retired; audit L1 today) — the value-language layer. It imports `ratio` as a
       declared, acyclic same-class edge — allowed by the package model's
       "never up, never sideways-cyclic" rule (no longer forced to `platform`).

--- a/common/audit/quantity/readme.md
+++ b/common/audit/quantity/readme.md
@@ -7,7 +7,7 @@
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
 >
-> A **`kernel`** value language. It imports `ratio` (a `Ratio` can scale a
+> An **audit** value language (L1 `infra`). It imports `ratio` (a `Ratio` can scale a
 > `Quantity`) — a declared, acyclic same-class edge, which the package model allows.
 
 ## Why

--- a/common/audit/quantity/todo.md
+++ b/common/audit/quantity/todo.md
@@ -9,7 +9,7 @@ The package-local worklist. Cross-package migration lives in
 - [x] Three-end parity (`common/` canonical + BE/FE mirrors) enforced by
       `conformance/vectors.json`.
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract`. Classed `kernel` (imports `ratio` as a declared,
+      `check_package_contract`. Classed `kernel` (then-klass, since retired; imports `ratio` as a declared,
       acyclic same-class edge).
 
 ## Next

--- a/common/audit/ratio/readme.md
+++ b/common/audit/ratio/readme.md
@@ -7,7 +7,7 @@
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
 >
-> A **`kernel` leaf** — it depends on nothing in the app, and is reused by
+> An **audit value-language leaf** (L1 `infra`) — it depends on nothing in the app, and is reused by
 > `money` and `quantity`.
 
 ## Why

--- a/common/audit/ratio/todo.md
+++ b/common/audit/ratio/todo.md
@@ -10,7 +10,7 @@ The package-local worklist. Cross-package migration lives in
 - [x] Three-end parity (`common/` canonical + BE/FE mirrors) enforced by
       `conformance/vectors.json`.
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract`. Classed `kernel` (a true leaf — depends on nothing).
+      `check_package_contract`. Classed `kernel` (then-klass, since retired; a true leaf — depends on nothing).
 
 ## Next
 

--- a/common/audit/unit_price/readme.md
+++ b/common/audit/unit_price/readme.md
@@ -7,7 +7,7 @@
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
 >
-> A **`kernel`** value language. It imports `money` and `quantity` (a `UnitPrice`
+> An **audit** value language (L1 `infra`). It imports `money` and `quantity` (a `UnitPrice`
 > is money per unit) — declared, acyclic same-class edges, which the model allows.
 
 ## Why

--- a/common/audit/unit_price/todo.md
+++ b/common/audit/unit_price/todo.md
@@ -10,7 +10,7 @@ The package-local worklist. Cross-package migration lives in
 - [x] Backend parity (`common/` canonical + BE mirror) enforced by
       `conformance/vectors.json`.
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract`. Classed `kernel` (imports `money` + `quantity` as
+      `check_package_contract`. Classed `kernel` (then-klass, since retired; imports `money` + `quantity` as
       declared, acyclic same-class edges).
 
 ## Next

--- a/common/config/todo.md
+++ b/common/config/todo.md
@@ -6,7 +6,7 @@ The package-local worklist. Cross-package migration lives in
 ## Done
 
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract` as a `kernel` leaf (`depends_on=[]`)
+      `check_package_contract` as a `kernel` leaf (then-klass, since retired; `depends_on=[]`)
       with invariants pinned to its tests.
 
 ## Next

--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -67,19 +67,23 @@ await db.commit()
 overall = await read_count(db, key=CounterKey("report.generated"))   # Count
 ```
 
-## Roles (files converge by role)
+## Layers (base / extension)
 
-| role | what lives here |
-|------|-----------------|
-| `types/` | `CounterKey`, `Count`, `Incremented` (a platform `DomainEvent`) + typed errors (pure; no I/O) |
-| `ops/` | `increment` (publishes `Incremented` through an `EventBus`) and `get_count` (per-user/global), over the store **port** |
-| `store/` | `CounterRepository` (a `typing.Protocol` port) + `SqlCounterRepository`/`CounterTally` (the SQLAlchemy adapter — the only role that touches the ORM) |
-| `api/` | `read_count` (thin async read) and `record_increment` (atomic write: tally bump + outbox event in one transaction) |
+The implementation converges into the package model's internal layers
+(the then-role folders `types/ops/store/api` were re-layered in #1418):
 
-Dependency rule (DAG, down only): `api → ops → {types, store}`, and the package
-depends downward on the `platform` package (the `DomainEvent`/`EventBus`/outbox
-substrate) — declared in `contract.depends_on`. The ORM/`AsyncSession` lives only
-in `store`/`api` and never leaks into `types`/`ops`.
+| layer | what lives here |
+|-------|-----------------|
+| `base/types/` | `CounterKey`, `Count`, `Incremented` (a platform `DomainEvent`) + typed errors (pure; no I/O) |
+| `base/ops/` | `increment` (publishes `Incremented` through an `EventBus`) and `get_count` (per-user/global), over the repository **port** |
+| `base/repository.py` | `CounterRepository` (a `typing.Protocol` port — mechanism B's base half) |
+| `extension/sql.py` | `SqlCounterRepository`/`CounterTally` (the SQLAlchemy adapter — the only module that touches the ORM) |
+| `extension/api/` | `read_count` (thin async read) and `record_increment` (atomic write: tally bump + outbox event in one transaction) |
+
+Dependency rule (DAG, down only): `extension → base` and never back, and the
+package depends downward on the `platform` package (the
+`DomainEvent`/`EventBus`/outbox substrate) — declared in `contract.depends_on`.
+The ORM/`AsyncSession` lives only in `extension` and never leaks into `base`.
 
 ## Public vs internal
 

--- a/common/counter/todo.md
+++ b/common/counter/todo.md
@@ -5,7 +5,7 @@ The package-local worklist. Cross-package migration lives in
 
 ## Done
 
-- [x] First worked example of the package model (`types`/`ops`/`store`/`api`,
+- [x] First worked example of the package model (the then-role folders `types`/`ops`/`store`/`api`,
       `PackageContract`, `__all__` published language).
 - [x] Become the `common/`-centric template: spec (`readme.md` + `contract.py` +
       `todo.md`) under `common/counter/`, implementation under

--- a/common/coverage/todo.md
+++ b/common/coverage/todo.md
@@ -6,7 +6,7 @@ The package-local worklist. Cross-package migration lives in
 ## Done
 
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract` as a `kernel` leaf (`depends_on=[]`)
+      `check_package_contract` as a `kernel` leaf (then-klass, since retired; `depends_on=[]`)
       with invariants pinned to its tests.
 
 ## Next

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -375,5 +375,24 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # The taxonomy migrated in place, so its retired vocabulary lingers in
+        # prose; the drift gate makes "old words presented as current" a CI
+        # failure instead of a periodic manual audit.
+        ACRecord(
+            id="AC-meta.vocab.1",
+            statement=(
+                "Retired taxonomy vocabulary (klass kernel/platform/core, "
+                "types/ops/store/api roles, asset_evaluation) presented as "
+                "current truth in docs/SSOT/EPIC/test prose fails the "
+                "taxonomy-drift gate; a mention passes only with a nearby "
+                "historical marker (formerly/replaces/retired/...)."
+            ),
+            test=(
+                "tests/tooling/test_taxonomy_drift.py"
+                "::test_AC_meta_vocab_1_repo_is_clean"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/meta/extension/check_taxonomy_drift.py
+++ b/common/meta/extension/check_taxonomy_drift.py
@@ -1,0 +1,166 @@
+"""Taxonomy-drift gate — retired package-model vocabulary must read as history.
+
+The package model migrated in-place, so its old vocabulary still appears in
+prose all over the repo. Some of it is *legitimate history* ("replaces
+kernel/platform/core"); some of it is *drift* — a doc/EPIC/SSOT entry/test
+teaching the retired model as current truth. The two are distinguishable
+mechanically: a legitimate mention sits next to a historical marker.
+
+Retired vocabulary (each -> its replacement):
+
+- klass ``kernel < platform < core``        -> the five-layer ``PACKAGE_LAYER``
+  (incl. ``klass="kernel|platform|core"``)     map (``meta<infra<middleware<
+                                                domain<app``, L0-owned)
+- ``types/ops/store/api`` role folders /    -> ``base/extension/data`` layers
+  "converge by role"
+- ``asset_evaluation``                      -> the ``pricing`` package (#1610)
+- `` `kernel` `` as a class word            -> the package's five-layer slot
+
+A mention passes when a marker (``formerly``/``replaces``/``retired``/...)
+appears on the same line or within :data:`MARKER_WINDOW` lines above — that is
+how the surviving historical notes are written. Anything else fails the gate:
+either fix the prose to the current model or mark it as history.
+
+**stdlib-only by design**, like its siblings: runnable from the lightweight CI
+lint env and from ``tools/check_taxonomy_drift.py``. Registered in preflight
+(``common/testing/preflight.py``) so a doc/test edit runs it locally, and
+enforced in CI through ``tests/tooling/test_taxonomy_drift.py``
+(AC-meta.vocab.1).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+#: rule id -> the retired-vocabulary pattern it hunts.
+RULES: dict[str, re.Pattern[str]] = {
+    "klass-trio": re.compile(
+        r"core/platform/kernel"
+        r"|platform/core/kernel"
+        r"|kernel/platform/core"
+        r"|`?kernel`?\s*<\s*`?platform`?\s*<\s*`?core`?"
+        r"|klass=[\"'](?:kernel|platform|core)[\"']"
+    ),
+    "role-folders": re.compile(
+        r"types/ops/store/api"
+        r"|`types`\s*/\s*`ops`\s*/\s*`store`\s*/\s*`api`"
+        r"|converges? by role"
+    ),
+    "asset-evaluation": re.compile(r"asset_evaluation"),
+    "kernel-class-word": re.compile(r"`kernel`"),
+}
+
+#: Lowercase substrings that frame a retired-vocabulary mention as history.
+MARKERS = (
+    "formerly",
+    "retired",
+    "legacy",
+    "replace",  # replaces / replaced
+    "renamed",
+    "superseded",
+    "pre-migration",
+    "historic",  # historical / historically
+    "folded",
+    "then-",
+    "today placement",
+    "was the",
+)
+
+#: A marker legitimizes a hit on the same line or up to this many lines above
+#: (wrapped sentences put the marker one line up).
+MARKER_WINDOW = 2
+
+#: Paths never scanned: the gate's own pattern/test sources, generated files,
+#: and the doc whose *job* is to name what the model replaces.
+EXCLUDED = (
+    "common/meta/extension/check_taxonomy_drift.py",
+    "tools/check_taxonomy_drift.py",
+    "tests/tooling/test_taxonomy_drift.py",
+    "docs/ac_registry.yaml",
+    "docs/infra_registry.yaml",
+)
+
+#: Tracked-path prefixes that are out of scope (vendored/generated/submodule).
+EXCLUDED_PREFIXES = ("repo/", "site/", "docs/reference/")
+
+
+def _in_scope(path: str) -> bool:
+    if path in EXCLUDED or path.startswith(EXCLUDED_PREFIXES):
+        return False
+    if path.endswith(".md"):
+        return True
+    if path.startswith("docs/ssot/") and path.endswith((".yaml", ".yml")):
+        return True
+    if path.endswith(".py") and path.startswith(("tests/", "common/", "tools/")):
+        return True
+    return False
+
+
+def _marked(lines: Sequence[str], index: int) -> bool:
+    lo = max(0, index - MARKER_WINDOW)
+    window = " ".join(lines[lo : index + 1]).lower()
+    return any(marker in window for marker in MARKERS)
+
+
+def scan_lines(path: str, lines: Sequence[str]) -> list[str]:
+    """Return ``path:line: [rule] text`` findings for unmarked retired vocab."""
+    findings: list[str] = []
+    for i, line in enumerate(lines):
+        for rule, pattern in RULES.items():
+            if pattern.search(line) and not _marked(lines, i):
+                findings.append(f"{path}:{i + 1}: [{rule}] {line.strip()[:120]}")
+    return findings
+
+
+def _tracked_files() -> Iterable[str]:
+    out = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return (line for line in out.splitlines() if line.strip())
+
+
+def scan_repo() -> list[str]:
+    findings: list[str] = []
+    for path in _tracked_files():
+        if not _in_scope(path):
+            continue
+        target = REPO_ROOT / path
+        if not target.is_file():
+            continue
+        text = target.read_text(encoding="utf-8", errors="replace")
+        findings.extend(scan_lines(path, text.splitlines()))
+    return findings
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail on retired package-taxonomy vocabulary presented as current."
+    )
+    parser.parse_args(argv)
+    findings = scan_repo()
+    if findings:
+        print(f"taxonomy-drift: {len(findings)} unmarked retired-vocabulary use(s):")
+        for finding in findings:
+            print(f"  {finding}")
+        print(
+            "Fix the prose to the current model (five-layer PACKAGE_LAYER, "
+            "base/extension/data, pricing) or mark the mention as history "
+            "(e.g. 'formerly', 'replaces', 'retired')."
+        )
+        return 1
+    print("taxonomy-drift: OK — no unmarked retired vocabulary.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -190,17 +190,20 @@ The recipe for moving a module (and its EPIC-table ACs) into the package model.
 [`contract.py`](../counter/contract.py).** One PR per package; `base=main`.
 
 1. **Name the bounded context and its axes.** Pick the package `name` (its
-   `common/<name>/` dir), the `klass` (`kernel` < `platform` < `core` — its
-   position in the import DAG), and the authority **tier**
+   `common/<name>/` dir), its **layer** — add the package to `PACKAGE_LAYER` in
+   [`base/layering.py`](./base/layering.py) (`meta < infra < middleware <
+   domain < app`; placement is L0-owned global topology, so the contract does
+   not self-claim a klass) — and the authority **tier**
    ([`authority` package](../authority/readme.md): CODE-ONLY/CODE-LED/LLM-LED/LLM-ONLY — how
    the module is built). If the tier is genuinely undecided, ship `status="draft"`
    with `tier=None` and resolve it before going `active` (the shipped-package
    rule). **One package = one tier**; a module mixing deterministic + LLM-emitted
    behavior is two packages.
 
-2. **Write `contract.py`.** One `PackageContract(...)` with `name`, `klass`,
+2. **Write `contract.py`.** One `PackageContract(...)` with `name`,
    `status`, `tier`, `depends_on` (down-only edges), `units` (the DDD building
-   blocks, each `Unit(kind=…, module=…)`; `roles` is the legacy form),
+   blocks, each `Unit(kind=…, module=…)`; `roles` is the legacy form) — no
+   `klass`: the model resolves it from `PACKAGE_LAYER` —
    `implementations` (`be`/`fe` paths), `interface` (must equal the BE
    `__init__.__all__`), `events`, `invariants`, `roadmap`.
 

--- a/common/observability/todo.md
+++ b/common/observability/todo.md
@@ -6,7 +6,7 @@ The package-local worklist. Cross-package migration lives in
 ## Done
 
 - [x] Migrated to the package model: ships `contract.py`, governed by
-      `check_package_contract` as a `kernel` package (`depends_on=["config"]` —
+      `check_package_contract` as a `kernel` package (then-klass, since retired; `depends_on=["config"]` —
       the OTEL runtime reads the backend config singleton) with invariants pinned
       to its tests.
 - [x] Curated a published `__all__` surface and set `contract.interface`: the BE

--- a/common/platform/contract.py
+++ b/common/platform/contract.py
@@ -256,7 +256,7 @@ CONTRACT = PackageContract(
         ACRecord(
             id="AC-platform.1.4",
             statement=(
-                "The platform package converges by role and its published "
+                "The platform package converges into the base/extension layering and its published "
                 "language equals contract.interface; check_package_contract "
                 "validates platform with no violations."
             ),

--- a/common/runtime/todo.md
+++ b/common/runtime/todo.md
@@ -8,7 +8,7 @@ invariants land (TDD).
 ## Done (the construct → switch → cleanup migration, was #1554)
 
 - [x] Package created on the model: `readme.md` + `contract.py` + `todo.md`,
-      governed by `check_package_contract` as a `kernel` leaf.
+      governed by `check_package_contract` as a `kernel` leaf (then-klass, since retired).
 - [x] **Manifest (base)** — `DependencyManifest` declares the external
       dependencies (database, object_storage, llm, cache, workflow_engine,
       telemetry, analytics, market_data) with their `Kind` and required tiers.

--- a/common/testing/preflight.py
+++ b/common/testing/preflight.py
@@ -87,7 +87,7 @@ CHECKS: tuple[Check, ...] = (
     ),
     Check(
         name="taxonomy-drift",
-        globs=("*.md", "docs/ssot/*.yaml", "tests/*.py", "common/*", "tools/*.py"),
+        globs=("*.md", "docs/ssot/*.yaml", "tests/*.py", "common/*.py", "tools/*.py"),
         commands=((PY, "tools/check_taxonomy_drift.py"),),
         why="prose/tests changed: retired package-taxonomy vocabulary must not be presented as current (AC-meta.vocab.1)",
     ),

--- a/common/testing/preflight.py
+++ b/common/testing/preflight.py
@@ -86,6 +86,12 @@ CHECKS: tuple[Check, ...] = (
         why="docs changed: nav coverage + cross-reference consistency",
     ),
     Check(
+        name="taxonomy-drift",
+        globs=("*.md", "docs/ssot/*.yaml", "tests/*.py", "common/*", "tools/*.py"),
+        commands=((PY, "tools/check_taxonomy_drift.py"),),
+        why="prose/tests changed: retired package-taxonomy vocabulary must not be presented as current (AC-meta.vocab.1)",
+    ),
+    Check(
         name="schema-validate",
         globs=("apps/backend/*schema*.py", "apps/backend/*schemas*.py"),
         commands=((PY, "tools/validate_schemas.py"),),

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -621,7 +621,7 @@ vectors) but adopted on the backend first.
 ### AC12.34: Ledger module — `Entry` value object + vertical-slice template ([#1253](https://github.com/wangzitian0/finance_report/issues/1253))
 
 The first **vertical domain module** (`src/ledger`) as the template every other
-domain follows: files converge by role (`types/` nouns, `ops/` verbs), and the
+domain follows: files converged by the then-role folders (`types/` nouns, `ops/` verbs — since re-layered into base/extension), and the
 project's layer-DAG rule is enforced (model layer never imports a service). Its
 core noun `Entry` makes the double-entry balance invariant a **type** — an
 unbalanced entry is unconstructable (`UnbalancedEntryError`), replacing scattered

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -621,7 +621,8 @@ vectors) but adopted on the backend first.
 ### AC12.34: Ledger module — `Entry` value object + vertical-slice template ([#1253](https://github.com/wangzitian0/finance_report/issues/1253))
 
 The first **vertical domain module** (`src/ledger`) as the template every other
-domain follows: files converged by the then-role folders (`types/` nouns, `ops/` verbs — since re-layered into base/extension), and the
+domain followed: files converged into the then-role folders (`types/` nouns,
+`ops/` verbs; since re-layered into `base/extension`), and the
 project's layer-DAG rule is enforced (model layer never imports a service). Its
 core noun `Entry` makes the double-entry balance invariant a **type** — an
 unbalanced entry is unconstructable (`UnbalancedEntryError`), replacing scattered

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -147,6 +147,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_check_package_contract.py` | `common/meta/readme.md` |
 | `tests/tooling/test_check_package_directory_coverage.py` | `common/meta/readme.md` |
 | `tests/tooling/test_app_boundary.py` | `common/meta/migration-standard.md` |
+| `tests/tooling/test_taxonomy_drift.py` | `common/meta/migration-standard.md` |
 | `tests/tooling/test_check_ssot_ownership.py` | `docs/ssot/MANIFEST.yaml` |
 | `tests/tooling/test_five_layer_model.py` | `common/meta/readme.md` |
 | `tests/tooling/test_counter_package.py` | `common/meta/readme.md` |

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -80,7 +80,7 @@ concepts:
 
   package_model:
     owner: common/meta/readme.md#package-model
-    description: A package = a DDD bounded context (readme.md + PackageContract + base/extension/data layers carrying DDD building-block units + __all__ published language); three classes core/platform/kernel; governance is computed from contracts by check_package_contract. The model self-hosts in the common/meta package (base = model, extension = gate, data = projection).
+    description: A package = a DDD bounded context (readme.md + PackageContract + base/extension/data layers carrying DDD building-block units + __all__ published language); placement resolved from the central five-layer map (meta<infra<middleware<domain<app, PACKAGE_LAYER in common/meta/base/layering.py); governance is computed from contracts by check_package_contract. The model self-hosts in the common/meta package (base = model, extension = gate, data = projection).
     family: platform
     kind: concept
     authority: documented_contract

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -80,7 +80,7 @@ concepts:
 
   package_model:
     owner: common/meta/readme.md#package-model
-    description: A package = a DDD bounded context (readme.md + PackageContract + base/extension/data layers carrying DDD building-block units + __all__ published language); placement resolved from the central five-layer map (meta<infra<middleware<domain<app, PACKAGE_LAYER in common/meta/base/layering.py); governance is computed from contracts by check_package_contract. The model self-hosts in the common/meta package (base = model, extension = gate, data = projection).
+    description: A package = a DDD bounded context (readme.md + PackageContract + base/extension/data layers carrying DDD building-block units + __all__ published language); placement resolved from the central five-layer map `PACKAGE_LAYER` (`meta < infra < middleware < domain < app`; defined in `common/meta/base/layering.py`); governance is computed from contracts by check_package_contract. The model self-hosts in the common/meta package (base = model, extension = gate, data = projection).
     family: platform
     kind: concept
     authority: documented_contract

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -24,6 +24,10 @@ class TestSelectChecks:
         assert "ssot-ownership" in names
         assert "doc-consistency" in names  # docs/* also matches
 
+    def test_markdown_edit_selects_taxonomy_drift(self):
+        names = [c.name for c in preflight.select_checks(["common/ledger/readme.md"])]
+        assert "taxonomy-drift" in names
+
     def test_service_edit_selects_format_and_transaction_boundary(self):
         names = [
             c.name

--- a/tests/tooling/test_taxonomy_drift.py
+++ b/tests/tooling/test_taxonomy_drift.py
@@ -1,0 +1,66 @@
+"""AC-meta.vocab.1 — the retired-vocabulary (taxonomy-drift) gate.
+
+The package taxonomy migrated: klass ``kernel<platform<core`` -> the five-layer
+``PACKAGE_LAYER`` map; ``types/ops/store/api`` roles -> ``base/extension/data``
+layers; ``asset_evaluation`` -> ``pricing``. Docs/EPICs/SSOT/tests that present
+the retired vocabulary as *current* truth are drift; a mention is legitimate
+only when a nearby marker (``formerly`` / ``replaces`` / ``retired`` / ...)
+frames it as historical. ``check_taxonomy_drift`` is the executable form of
+that rule; these tests pin its behavior and keep the live repo clean.
+"""
+
+from __future__ import annotations
+
+from common.meta.extension.check_taxonomy_drift import main, scan_lines
+
+
+def _findings(text: str, path: str = "docs/example.md"):
+    return scan_lines(path, text.splitlines())
+
+
+class TestRuleEngine:
+    def test_AC_meta_vocab_1_unmarked_klass_trio_is_flagged(self):
+        """AC-meta.vocab.1: the retired kernel/platform/core klass trio is drift."""
+        assert _findings("the three classes core/platform/kernel decide it")
+        assert _findings("pick the `klass` (`kernel` < `platform` < `core`)")
+        assert _findings('declare klass="kernel" in the contract')
+
+    def test_AC_meta_vocab_1_unmarked_role_folders_are_flagged(self):
+        """AC-meta.vocab.1: types/ops/store/api role language is drift."""
+        assert _findings("files converge into types/ops/store/api roles")
+        assert _findings("## Roles (files converge by role)")
+
+    def test_AC_meta_vocab_1_asset_evaluation_is_flagged(self):
+        """AC-meta.vocab.1: the pre-pricing package name is drift."""
+        assert _findings("the asset_evaluation package owns valuations")
+
+    def test_AC_meta_vocab_1_backticked_kernel_class_word_is_flagged(self):
+        """AC-meta.vocab.1: `kernel` used as a class word is drift."""
+        assert _findings("classed as a `kernel` leaf")
+
+    def test_AC_meta_vocab_1_marker_on_same_line_is_allowed(self):
+        """AC-meta.vocab.1: a historical marker on the line legitimizes the mention."""
+        assert not _findings(
+            "internal layering (replaces kernel/platform/core and types/ops/store/api)"
+        )
+        assert not _findings('(formerly ``klass="kernel"``, now ``infra``)')
+
+    def test_AC_meta_vocab_1_marker_within_two_lines_above_is_allowed(self):
+        """AC-meta.vocab.1: the marker window spans a wrapped sentence."""
+        text = "layering (replaces kernel/platform/core\nand types/ops/store/api)."
+        assert not _findings(text)
+
+    def test_AC_meta_vocab_1_marker_too_far_above_is_not_enough(self):
+        """AC-meta.vocab.1: a marker outside the window does not launder drift."""
+        text = "formerly things were different\n\n\n\nuse types/ops/store/api roles"
+        assert _findings(text)
+
+    def test_AC_meta_vocab_1_plain_kernel_prose_is_not_flagged(self):
+        """AC-meta.vocab.1: 'shared domain kernel' (DDD prose) is not the klass word."""
+        assert not _findings("the shared domain kernel owns the value language")
+
+
+def test_AC_meta_vocab_1_repo_is_clean():
+    """AC-meta.vocab.1: the tracked docs/SSOT/EPIC/test surface carries no
+    unmarked retired vocabulary (the gate exits 0 on the live repo)."""
+    assert main([]) == 0

--- a/tools/check_taxonomy_drift.py
+++ b/tools/check_taxonomy_drift.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Command wrapper for the taxonomy-drift (retired vocabulary) gate."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.meta.extension.check_taxonomy_drift import main  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Three manual drift-audit rounds each found more retired-vocabulary drift (docs / readmes / EPICs / SSOT / tests teaching the old package model as current truth). This PR makes that detection **mechanical** — one integrated gate instead of periodic archaeology — and fixes everything it found.

### The gate (EPIC → AC → Test → Code → Doc)

- **AC-meta.vocab.1** registered in the meta package roadmap: retired taxonomy vocabulary presented as current truth fails CI; a mention passes only with a nearby historical marker.
- **Test first (🔴)**: `tests/tooling/test_taxonomy_drift.py` — rule-engine pins + the live-repo cleanliness proof. Red on main: **20 hits**.
- **Checker (🟢)**: `common/meta/extension/check_taxonomy_drift.py` (stdlib-only, same shape as its sibling gates) + `tools/check_taxonomy_drift.py` wrapper. Rules: klass `kernel/platform/core` trio, `types/ops/store/api` + "converge(s) by role", `asset_evaluation`, backticked `` `kernel` `` as a class word. A marker (`formerly`/`replaces`/`retired`/`then-`/…) on the same line or ≤2 lines above legitimizes a mention — exactly how the surviving historical notes are written, so false positives stay near zero. Scans tracked `*.md`, `docs/ssot/*.yaml`, and `tests//common//tools/` `*.py`; excludes generated registries, `repo/`, `site/`, and its own sources.
- **Wiring**: preflight gate `taxonomy-drift` (runs on any prose/test edit, <1s) with a `select_checks` test; CI enforcement via the tooling suite (no ci.yml change needed); preflight skill doc table updated; new test classified in `traceability-exceptions.md` (word-scenario AC ids sit outside `AC_PATTERN`, same as the other package-model gate tests).

### The 20 hits it found — all fixed

Four of them were missed by **all three** manual audits (the gate paid for itself on day one):
- `apps/backend/src/counter/README.md` + `common/counter/readme.md` — still taught the `types/ops/store/api` role layout; rewritten to the real `base/extension` structure (#1418).
- `common/platform/contract.py` — AC-platform.1.4 statement said "converges by role"; now "converges into the base/extension layering".
- `docs/project/EPIC-012.foundation-libs.md:624` — AC12.34 narrative updated.
- `common/meta/readme.md` migration recipe — taught self-claimed `klass` (`kernel<platform<core`); now teaches `PACKAGE_LAYER` placement.
- `docs/ssot/MANIFEST.yaml` `package_model` description — "three classes core/platform/kernel" → the five-layer map.
- audit value sub-package readmes (money/ratio/quantity/unit_price) reworded to current truth (audit, L1 infra); their todo "Done" records + config/coverage/observability/runtime todos marked with `then-klass` historical markers.

## Verification

`tools/preflight.py`: **ac-traceability, ssot-ownership, doc-consistency, taxonomy-drift, tooling — all green** (1907 passed, 1 skipped). The gate itself: 20 findings before the fixes, 0 after.

Related: #1416 #1610 · follows #1619 #1621

🤖 Generated with [Claude Code](https://claude.com/claude-code)