### PR TITLE
[finance_report_test_and_doc] chore(todo): mark extraction cutover's DoD-6 residue (#1603) in the phase table

### DIFF
--- a/common/todo.md
+++ b/common/todo.md
@@ -36,7 +36,7 @@ and types/ops/store/api). ACs are `AC-<pkg>.<entity>.<seq>` in each contract's
 | 0b | `counter` → base/extension/data template + gate three-layer rule (additive) | #1418 ✅ |
 | 1 | `value → audit` fold | #1419 ✅ |
 | 2 | `ledger` | #1420 ✅ |
-| 3 | `extraction` #1421 ✅ · `pricing` #1610 ⬜ · `portfolio` #1422 ⬜ (after pricing) · `reconciliation` #1423 ⬜ · `reporting` #1424 ⬜ | partial |
+| 3 | `extraction` #1421 ✅ (DoD step 6 residue — legacy statement_*.py still imported from services/, tracked by #1603) · `pricing` #1610 ⬜ · `portfolio` #1422 ⬜ (after pricing) · `reconciliation` #1423 ⬜ · `reporting` #1424 ⬜ | partial |
 | 4 | `advisor` #1425 ⬜ · `llm` #1426 ✅ · `platform` #1427 ✅ · `identity` #1428 ✅ | partial |
 | 5 | `audit` consistency closeout (global invariants + cross-package ACs) | #1429 ⬜ |
 | 6 | cleanup — delete residual EPIC tables / SSOT; retire the central `docs/ssot/MANIFEST.yaml`/registry gates once meta's data layer is the computed index | #1430 ⬜ |


### PR DESCRIPTION
One-line drift fix: the migration phase table claimed `extraction` #1421 ✅ without qualification, but the DoD audit shows step 6 (*original removed*) is still open — `main.py` imports `src.services.statement_parsing_supervisor` directly and `services/__init__.py` lazy-loads the legacy statement modules (13 `statement_*.py` files remain; tracked by #1603, confirmed by the app-boundary baseline's extraction-concentrated edges). The row now says so.

Verification: taxonomy-drift + doc gates green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)