### PR TITLE
[finance_report_audit] feat(portfolio): cutover — position accounting + holdings/P&L (#1422)

### DIFF
--- a/apps/backend/src/audit/money/rounding.py
+++ b/apps/backend/src/audit/money/rounding.py
@@ -12,7 +12,7 @@ cross-language standard, #1171); ``src.utils`` re-exports ``to_money``/
 
 Out of scope (deliberately use their own quantization):
 - FX rates and security prices: 6 dp (``services/market_data/``).
-- Share quantities: 6 dp (``services/investment_accounting.py``).
+- Share quantities: 6 dp (``portfolio/extension/accounting.py``).
 - Percentages / performance ratios (XIRR, TWR, MWR, allocation %): not currency.
 """
 

--- a/apps/backend/src/portfolio/__init__.py
+++ b/apps/backend/src/portfolio/__init__.py
@@ -1,0 +1,36 @@
+"""``portfolio`` — the backend implementation of the ``portfolio`` package (#1422).
+
+Investment position accounting: buy/sell/dividend transactions posted
+through ``ledger.post_entry``, ``ManagedPosition``/``InvestmentLot``
+bookkeeping, and the read-side holdings/P&L/allocation/performance queries.
+See ``common/portfolio/contract.py`` for the full model and the positions-
+only boundary (portfolio consumes prices via ``pricing.resolve()``, it never
+fetches or stores one — #1610).
+
+This commit ships the ``base/`` error hierarchy only (plain exceptions, no
+ORM references). The write-side accounting service, the read-side queries,
+allocation/performance, and the data-layer projections are reserved
+(declared in the contract's ``units`` with no module path) for later
+commits — same incremental pattern the pricing cutover (#1610, PR #1617)
+used.
+"""
+
+from __future__ import annotations
+
+from src.portfolio.base import (
+    AssetNotFoundError,
+    InvalidDateRangeError,
+    InvestmentAccountingError,
+    InvestmentAccountingValidationError,
+    PortfolioError,
+    PortfolioNotFoundError,
+)
+
+__all__ = [
+    "AssetNotFoundError",
+    "InvalidDateRangeError",
+    "InvestmentAccountingError",
+    "InvestmentAccountingValidationError",
+    "PortfolioError",
+    "PortfolioNotFoundError",
+]

--- a/apps/backend/src/portfolio/__init__.py
+++ b/apps/backend/src/portfolio/__init__.py
@@ -7,8 +7,8 @@ See ``common/portfolio/contract.py`` for the full model and the positions-
 only boundary (portfolio consumes prices via ``pricing.resolve()``, it never
 fetches or stores one — #1610).
 
-This commit ships the ``base/`` error hierarchy only (plain exceptions, no
-ORM references). The write-side accounting service, the read-side queries,
+This commit ships the ``base/`` error hierarchy and ``InvestmentAccountingService``
+(the write-side accounting service). The read-side holdings/P&L queries,
 allocation/performance, and the data-layer projections are reserved
 (declared in the contract's ``units`` with no module path) for later
 commits — same incremental pattern the pricing cutover (#1610, PR #1617)
@@ -25,11 +25,17 @@ from src.portfolio.base import (
     PortfolioError,
     PortfolioNotFoundError,
 )
+from src.portfolio.extension import (
+    InvestmentAccountingResult,
+    InvestmentAccountingService,
+)
 
 __all__ = [
     "AssetNotFoundError",
     "InvalidDateRangeError",
     "InvestmentAccountingError",
+    "InvestmentAccountingResult",
+    "InvestmentAccountingService",
     "InvestmentAccountingValidationError",
     "PortfolioError",
     "PortfolioNotFoundError",

--- a/apps/backend/src/portfolio/base/__init__.py
+++ b/apps/backend/src/portfolio/base/__init__.py
@@ -1,0 +1,29 @@
+"""``portfolio.base`` — the pure, self-contained core.
+
+This commit ships only the error hierarchy (plain ``Exception`` subclasses,
+no ORM references). The package's aggregate/entities (``ManagedPosition``,
+``InvestmentLot``, ``InvestmentTransaction``, ``DividendIncome``,
+``AtomicPosition``) and their enums stay in the unregistered ``src/models/``
+(taxonomy-only in the contract, no ``module=`` — same deferral extraction
+and ledger already made) until Stage-4 cross-domain FK surgery.
+"""
+
+from __future__ import annotations
+
+from src.portfolio.base.errors import (
+    AssetNotFoundError,
+    InvalidDateRangeError,
+    InvestmentAccountingError,
+    InvestmentAccountingValidationError,
+    PortfolioError,
+    PortfolioNotFoundError,
+)
+
+__all__ = [
+    "AssetNotFoundError",
+    "InvalidDateRangeError",
+    "InvestmentAccountingError",
+    "InvestmentAccountingValidationError",
+    "PortfolioError",
+    "PortfolioNotFoundError",
+]

--- a/apps/backend/src/portfolio/base/errors.py
+++ b/apps/backend/src/portfolio/base/errors.py
@@ -1,0 +1,36 @@
+"""Typed error hierarchy for the portfolio package.
+
+Moved verbatim from ``services/portfolio.py`` and ``services/
+investment_accounting.py`` (standard-preserving move, Decision A — #1416):
+same names, same messages, same hierarchy. The two families stay separate
+(``PortfolioError`` for the read-side query service,
+``InvestmentAccountingError`` for the write-side posting service) because
+that's how the original code drew the line, and nothing here requires
+unifying them.
+"""
+
+from __future__ import annotations
+
+
+class PortfolioError(Exception):
+    """Base exception for portfolio service errors."""
+
+
+class PortfolioNotFoundError(PortfolioError):
+    """Raised when portfolio positions are not found for a user."""
+
+
+class InvalidDateRangeError(PortfolioError):
+    """Raised when date range is invalid."""
+
+
+class AssetNotFoundError(PortfolioError):
+    """Raised when asset is not found."""
+
+
+class InvestmentAccountingError(Exception):
+    """Base exception for investment accounting errors."""
+
+
+class InvestmentAccountingValidationError(InvestmentAccountingError):
+    """Raised when an investment transaction cannot be posted."""

--- a/apps/backend/src/portfolio/data/__init__.py
+++ b/apps/backend/src/portfolio/data/__init__.py
@@ -1,0 +1,10 @@
+"""``portfolio.data`` — read-model projections.
+
+Reserved for a later commit (issue #1422 P4): ``HoldingResponse``/
+``RealizedPnLResponse``/``UnrealizedPnLResponse``/``PortfolioSummaryResponse``,
+the read-models routers/reporting consume.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/apps/backend/src/portfolio/extension/__init__.py
+++ b/apps/backend/src/portfolio/extension/__init__.py
@@ -1,10 +1,12 @@
 """``portfolio.extension`` — the domain services + impure edges.
 
-Reserved for later commits (issue #1422 P2-P4): the write-side accounting
-service (``post_buy``/``post_sell``/``post_dividend``, moved from
-``services/investment_accounting.py``), the read-side holdings/P&L queries
-+ repository port/adapter (moved from ``services/portfolio.py``), and
-allocation/performance/report assembly (moved from ``services/
+Real this commit: ``InvestmentAccountingService`` (the write-side accounting
+service — ``post_buy``/``post_sell``/``post_dividend``, moved from
+``services/investment_accounting.py``).
+
+Reserved for later commits (issue #1422 P3-P4): the read-side holdings/P&L
+queries + repository port/adapter (moved from ``services/portfolio.py``),
+and allocation/performance/report assembly (moved from ``services/
 allocation.py``/``performance.py``/``performance_report.py``). See
 ``common/portfolio/contract.py`` — these are declared as taxonomy-only
 reserved units until then.
@@ -12,4 +14,12 @@ reserved units until then.
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from src.portfolio.extension.accounting import (
+    InvestmentAccountingResult,
+    InvestmentAccountingService,
+)
+
+__all__ = [
+    "InvestmentAccountingResult",
+    "InvestmentAccountingService",
+]

--- a/apps/backend/src/portfolio/extension/__init__.py
+++ b/apps/backend/src/portfolio/extension/__init__.py
@@ -1,0 +1,15 @@
+"""``portfolio.extension`` — the domain services + impure edges.
+
+Reserved for later commits (issue #1422 P2-P4): the write-side accounting
+service (``post_buy``/``post_sell``/``post_dividend``, moved from
+``services/investment_accounting.py``), the read-side holdings/P&L queries
++ repository port/adapter (moved from ``services/portfolio.py``), and
+allocation/performance/report assembly (moved from ``services/
+allocation.py``/``performance.py``/``performance_report.py``). See
+``common/portfolio/contract.py`` — these are declared as taxonomy-only
+reserved units until then.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/apps/backend/src/portfolio/extension/accounting.py
+++ b/apps/backend/src/portfolio/extension/accounting.py
@@ -1,4 +1,21 @@
-"""Brokerage investment transaction accounting service."""
+"""Brokerage investment transaction accounting service.
+
+Moved verbatim from ``services/investment_accounting.py`` (standard-preserving
+move, Decision A — #1416/#1422). ``InvestmentAccountingService`` composes
+``ledger.post_entry`` for the write side: ``post_buy``/``post_sell``/
+``post_dividend`` each post a balanced ``Entry`` and update the position's
+own aggregate (``ManagedPosition``/``InvestmentLot``/``InvestmentTransaction``/
+``DividendIncome``) in the same transaction — one domain writes its own
+aggregate, ledger posts on receipt, no shared FK (Decision B).
+
+``InvestmentAccountingResult`` holds ORM references (``InvestmentTransaction``/
+``JournalEntry``/``ManagedPosition``), so — like those entities — it stays
+taxonomy-only in the contract rather than base/-declared: the base-layer-pure
+invariant forbids ORM types in ``base/``, and these ORM types are themselves
+deferred to Stage-4 (same deferral extraction/ledger already made).
+"""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
@@ -22,16 +39,9 @@ from src.models.portfolio import (
     InvestmentTransaction,
     InvestmentTransactionType,
 )
+from src.portfolio.base.errors import InvestmentAccountingValidationError
 
 INVESTMENT_QUANTITY_UNIT = "units"
-
-
-class InvestmentAccountingError(Exception):
-    """Base exception for investment accounting errors."""
-
-
-class InvestmentAccountingValidationError(InvestmentAccountingError):
-    """Raised when an investment transaction cannot be posted."""
 
 
 @dataclass(frozen=True)

--- a/apps/backend/tests/accounting/test_core_unit_coverage.py
+++ b/apps/backend/tests/accounting/test_core_unit_coverage.py
@@ -12,11 +12,11 @@ import pytest
 from pydantic import ValidationError as PydanticValidationError
 
 from src.models.journal import Direction, JournalEntrySourceType
-from src.schemas.journal import JournalEntryCreate, JournalLineCreate
-from src.services.investment_accounting import (
+from src.portfolio import (
     InvestmentAccountingService,
     InvestmentAccountingValidationError,
 )
+from src.schemas.journal import JournalEntryCreate, JournalLineCreate
 from src.services.reporting_calc import (
     _provenance_from_source_type,
     _quantize_money,

--- a/apps/backend/tests/portfolio/test_investment_accounting.py
+++ b/apps/backend/tests/portfolio/test_investment_accounting.py
@@ -13,7 +13,7 @@ from src.models.account import Account, AccountType
 from src.models.journal import Direction, JournalEntryStatus
 from src.models.layer3 import CostBasisMethod, PositionStatus
 from src.models.portfolio import DividendIncome, InvestmentLot, InvestmentTransaction
-from src.services.investment_accounting import InvestmentAccountingService, InvestmentAccountingValidationError
+from src.portfolio import InvestmentAccountingService, InvestmentAccountingValidationError
 
 
 @pytest.fixture

--- a/common/audit/money/rounding.py
+++ b/common/audit/money/rounding.py
@@ -12,7 +12,7 @@ suite proves the two stay identical. Runtime unification waits on adoption (#117
 
 Out of scope (deliberately use their own quantization):
 - FX rates and security prices: 6 dp (``services/market_data/``).
-- Share quantities: 6 dp (``services/investment_accounting.py``).
+- Share quantities: 6 dp (``portfolio/extension/accounting.py``).
 - Percentages / performance ratios (XIRR, TWR, MWR, allocation %): not currency.
 """
 

--- a/common/meta/extension/check_tier_imports.py
+++ b/common/meta/extension/check_tier_imports.py
@@ -59,7 +59,7 @@ PROTECTED_MODULE_GLOBS: tuple[str, ...] = (
     "apps/backend/src/extraction/extension/deduplication.py",
     "apps/backend/src/services/accounting.py",
     "apps/backend/src/services/account_service.py",
-    "apps/backend/src/services/investment_accounting.py",
+    "apps/backend/src/portfolio/extension/accounting.py",
     "apps/backend/src/services/statement_posting.py",
     "apps/backend/src/services/reporting/**/*.py",
     "apps/backend/src/services/reporting_calc.py",

--- a/common/portfolio/contract.py
+++ b/common/portfolio/contract.py
@@ -83,15 +83,19 @@ CONTRACT = PackageContract(
         Unit(name="CostBasisMethod", kind=Kind.VALUE_OBJECT),
         Unit(name="InvestmentTransactionType", kind=Kind.VALUE_OBJECT),
         Unit(name="DividendType", kind=Kind.VALUE_OBJECT),
-        # ── extension (reserved — P2): the write-side accounting service ──
-        # post_buy/post_sell/post_dividend compose ledger.post_entry;
-        # InvestmentAccountingResult holds ORM references (InvestmentTransaction/
-        # JournalEntry/ManagedPosition) so it lives here, not base/ (the
-        # base-layer-pure invariant forbids ORM types in base/).
-        Unit(name="InvestmentAccountingResult", kind=Kind.DOMAIN_SERVICE),
-        Unit(name="post_buy", kind=Kind.DOMAIN_SERVICE),
-        Unit(name="post_sell", kind=Kind.DOMAIN_SERVICE),
-        Unit(name="post_dividend", kind=Kind.DOMAIN_SERVICE),
+        # ── extension: the write-side accounting service ──
+        # post_buy/post_sell/post_dividend (methods, not separate units)
+        # compose ledger.post_entry. InvestmentAccountingResult holds ORM
+        # references (InvestmentTransaction/JournalEntry/ManagedPosition) —
+        # taxonomy-only (no module=) for the same reason those entities are:
+        # the base-layer-pure invariant forbids ORM types in base/, and these
+        # ORM types are themselves deferred to Stage-4.
+        Unit(name="InvestmentAccountingResult", kind=Kind.VALUE_OBJECT),
+        Unit(
+            name="InvestmentAccountingService",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/accounting.py",
+        ),
         # ── extension (reserved — P3): the read-side holdings/P&L queries ──
         # + the repository port/adapter split the issue's DoD calls for
         # (currently raw AsyncSession in services/portfolio.py).
@@ -115,14 +119,18 @@ CONTRACT = PackageContract(
         Unit(name="PortfolioSummaryResponse", kind=Kind.PROJECTION),
     ],
     implementations={"be": "apps/backend/src/portfolio", "fe": None},
-    # This commit's real, working surface: the 6 plain-exception error types.
-    # Everything else above is reserved (taxonomy-only or no module=) until a
-    # later commit moves the real implementation in — same incremental
-    # pattern the pricing cutover (#1610, PR #1617) used.
+    # This commit's real, working surface: the 6 plain-exception error types
+    # plus InvestmentAccountingService (post_buy/post_sell/post_dividend) and
+    # its InvestmentAccountingResult. Everything else above is reserved
+    # (taxonomy-only or no module=) until a later commit moves the real
+    # implementation in — same incremental pattern the pricing cutover
+    # (#1610, PR #1617) used.
     interface=[
         "AssetNotFoundError",
         "InvalidDateRangeError",
         "InvestmentAccountingError",
+        "InvestmentAccountingResult",
+        "InvestmentAccountingService",
         "InvestmentAccountingValidationError",
         "PortfolioError",
         "PortfolioNotFoundError",

--- a/common/portfolio/contract.py
+++ b/common/portfolio/contract.py
@@ -1,0 +1,172 @@
+"""The ``portfolio`` package's machine-checkable :class:`PackageContract`.
+
+This is the authoritative spec the governance gate
+(``tools/check_package_contract.py``) validates the BE implementation against:
+``interface`` must equal the implementation's ``__init__.__all__``
+(``implementations["be"]`` = ``apps/backend/src/portfolio``); every
+``invariants[].test`` must resolve to a real test function; ``depends_on``
+must not introduce a forbidden upward/sideways-cyclic edge.
+
+## What this package is (issue #1422, Stage 3 of umbrella #1416)
+
+Investment position accounting: buy/sell/dividend transactions posted through
+``ledger.post_entry``, ``ManagedPosition``/``InvestmentLot`` bookkeeping
+(cost-basis method, FIFO/LIFO/AVGCOST lot consumption), and the read-side
+holdings/P&L/allocation/performance queries built on top.
+
+**Positions-only boundary** (2026-07-06, updated after the pricing design
+review #1610): portfolio owns only position math — quantity, cost basis,
+realized/unrealized P&L. It never fetches or stores a price or a valuation;
+it *consumes* one via ``pricing.resolve(subject, as_of, policy)``. The old
+``MarketDataOverride`` write path (``PortfolioService.update_market_prices``)
+belongs to ``pricing.record_override`` now, not here — see the P3 unit note
+below for how that overlap is resolved.
+
+## Ownership boundaries
+
+* **``ManagedPosition`` is portfolio's aggregate**: it owns ``InvestmentLot``
+  and ``InvestmentTransaction``; the invariant is *open position quantity ≥ 0*
+  plus cost-basis consistency across lots.
+* The ORM entities (``ManagedPosition``/``InvestmentLot``/
+  ``InvestmentTransaction``/``DividendIncome``/``AtomicPosition``) stay in the
+  unregistered ``src/models/`` until their cross-domain FKs are cut (Stage-4
+  scope — same deferral extraction and ledger already made). Their enums
+  (``PositionStatus``/``CostBasisMethod``/``InvestmentTransactionType``/
+  ``DividendType``) are declared alongside them on the ORM model files, so
+  they're taxonomy-only here too, for the same reason.
+* Cross-package edges: ``audit`` (Money/Quantity/UnitPrice base types),
+  ``ledger`` (``post_entry`` — portfolio writes only its own aggregate in one
+  transaction, then posts a balanced ``Entry``; no shared transaction),
+  ``pricing`` (price/FX resolution — portfolio never looks up a rate itself).
+  Both ``ledger`` and ``pricing`` are L3 domain siblings; the edge is
+  acyclic and sideways (``portfolio → ledger``, ``portfolio → pricing``,
+  never the reverse).
+"""
+
+from __future__ import annotations
+
+from common.meta.package_contract import Invariant, Kind, PackageContract, Unit
+
+CONTRACT = PackageContract(
+    name="portfolio",
+    # klass is not declared here — it resolves from PACKAGE_LAYER (L0 owns
+    # placement in the five-layer topology, #1595); see
+    # common/meta/base/layering.py, which already lists portfolio as
+    # "domain" (L3).
+    status="draft",
+    tier=None,
+    depends_on=["audit", "ledger", "pricing", "platform", "observability", "config"],
+    roles=["base", "extension", "data"],
+    units=[
+        # ── base: real value objects — plain exceptions, no ORM references ──
+        Unit(name="PortfolioError", kind=Kind.VALUE_OBJECT, module="base/errors.py"),
+        Unit(name="PortfolioNotFoundError", kind=Kind.VALUE_OBJECT, module="base/errors.py"),
+        Unit(name="InvalidDateRangeError", kind=Kind.VALUE_OBJECT, module="base/errors.py"),
+        Unit(name="AssetNotFoundError", kind=Kind.VALUE_OBJECT, module="base/errors.py"),
+        Unit(name="InvestmentAccountingError", kind=Kind.VALUE_OBJECT, module="base/errors.py"),
+        Unit(
+            name="InvestmentAccountingValidationError",
+            kind=Kind.VALUE_OBJECT,
+            module="base/errors.py",
+        ),
+        # ── base (taxonomy-only): the ORM aggregate/entities, unregistered ──
+        # in src/models/ until Stage-4 cross-domain FK surgery (extraction/
+        # ledger precedent). No module= — the gate skips placement checks
+        # for these, same as extraction's AtomicTransaction/UploadedDocument.
+        Unit(name="ManagedPosition", kind=Kind.AGGREGATE_ROOT),
+        Unit(name="InvestmentLot", kind=Kind.ENTITY),
+        Unit(name="InvestmentTransaction", kind=Kind.ENTITY),
+        Unit(name="DividendIncome", kind=Kind.ENTITY),
+        Unit(name="AtomicPosition", kind=Kind.ENTITY),
+        # ── base (taxonomy-only): enums declared alongside the ORM models above ──
+        Unit(name="PositionStatus", kind=Kind.VALUE_OBJECT),
+        Unit(name="CostBasisMethod", kind=Kind.VALUE_OBJECT),
+        Unit(name="InvestmentTransactionType", kind=Kind.VALUE_OBJECT),
+        Unit(name="DividendType", kind=Kind.VALUE_OBJECT),
+        # ── extension (reserved — P2): the write-side accounting service ──
+        # post_buy/post_sell/post_dividend compose ledger.post_entry;
+        # InvestmentAccountingResult holds ORM references (InvestmentTransaction/
+        # JournalEntry/ManagedPosition) so it lives here, not base/ (the
+        # base-layer-pure invariant forbids ORM types in base/).
+        Unit(name="InvestmentAccountingResult", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="post_buy", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="post_sell", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="post_dividend", kind=Kind.DOMAIN_SERVICE),
+        # ── extension (reserved — P3): the read-side holdings/P&L queries ──
+        # + the repository port/adapter split the issue's DoD calls for
+        # (currently raw AsyncSession in services/portfolio.py).
+        Unit(name="PortfolioRepository", kind=Kind.REPOSITORY),
+        Unit(name="get_holdings", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="get_portfolio_summary", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="calculate_unrealized_pnl", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="calculate_realized_pnl", kind=Kind.DOMAIN_SERVICE),
+        # ── extension (reserved — P4): allocation + performance + report assembly ──
+        Unit(name="get_sector_allocation", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="get_geography_allocation", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="get_asset_class_allocation", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="calculate_xirr", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="calculate_time_weighted_return", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="calculate_money_weighted_return", kind=Kind.DOMAIN_SERVICE),
+        Unit(name="calculate_dividend_yield", kind=Kind.DOMAIN_SERVICE),
+        # ── data (reserved — P4): read-models consumed by routers/reporting ──
+        Unit(name="HoldingResponse", kind=Kind.PROJECTION),
+        Unit(name="RealizedPnLResponse", kind=Kind.PROJECTION),
+        Unit(name="UnrealizedPnLResponse", kind=Kind.PROJECTION),
+        Unit(name="PortfolioSummaryResponse", kind=Kind.PROJECTION),
+    ],
+    implementations={"be": "apps/backend/src/portfolio", "fe": None},
+    # This commit's real, working surface: the 6 plain-exception error types.
+    # Everything else above is reserved (taxonomy-only or no module=) until a
+    # later commit moves the real implementation in — same incremental
+    # pattern the pricing cutover (#1610, PR #1617) used.
+    interface=[
+        "AssetNotFoundError",
+        "InvalidDateRangeError",
+        "InvestmentAccountingError",
+        "InvestmentAccountingValidationError",
+        "PortfolioError",
+        "PortfolioNotFoundError",
+    ],
+    events=[],
+    invariants=[
+        Invariant(
+            id="interface-equals-published-language",
+            statement=(
+                "The published language (contract.interface) equals __init__.__all__."
+            ),
+            test=(
+                "tests/tooling/test_portfolio_package.py"
+                "::test_AC_portfolio_1_1_only_all_is_the_published_language"
+            ),
+        ),
+        Invariant(
+            id="converges-by-layer",
+            statement="The package converges into base/ (pure) + extension/ (edges) + data/ (projections).",
+            test=(
+                "tests/tooling/test_portfolio_package.py"
+                "::test_AC_portfolio_1_2_converges_by_layer"
+            ),
+        ),
+        Invariant(
+            id="base-layer-pure",
+            statement="base/ never imports the package's own extension/ or data/, the ORM, or any network client.",
+            test=(
+                "tests/tooling/test_portfolio_package.py"
+                "::test_AC_portfolio_1_3_base_layer_is_pure"
+            ),
+        ),
+        Invariant(
+            id="passes-own-governance-gate",
+            statement="check_package_contract validates portfolio with no violations.",
+            test=(
+                "tests/tooling/test_portfolio_package.py"
+                "::test_AC_portfolio_1_4_package_contract_gate_passes"
+            ),
+        ),
+    ],
+    # Filled by the EPIC-011/017 portfolio-AC migration (a later commit in
+    # PR1); the package goes status="active" with its authority tier decided
+    # there, per this repo's established precedent (migrate ownership only
+    # after the physical fold is complete — see #1548/AC-audit.* migration).
+    roadmap=[],
+)

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -163,6 +163,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_platform_package.py` | `common/meta/readme.md` |
 | `tests/tooling/test_testing_package.py` | `common/meta/readme.md` |
 | `tests/tooling/test_pricing_package.py` | `common/meta/readme.md` |
+| `tests/tooling/test_portfolio_package.py` | `common/meta/readme.md` |
 | `apps/backend/tests/pricing/test_repository.py` | `common/pricing/contract.py` |
 | `apps/backend/tests/pricing/test_manual.py` | `common/pricing/contract.py` |
 | `apps/backend/tests/pricing/test_fx.py` | `common/pricing/contract.py` |

--- a/docs/ssot/draft-package-baseline.json
+++ b/docs/ssot/draft-package-baseline.json
@@ -1,6 +1,7 @@
 {
   "_comment": "Registered draft packages (tools/check_draft_packages.py). A draft package leaves its authority tier undecided; listing it here makes adding one a reviewed act. Resolve drafts to active over time.",
   "draft_packages": [
-    "pricing"
+    "pricing",
+    "portfolio"
   ]
 }

--- a/tests/tooling/test_base_package_migration_cleanup.py
+++ b/tests/tooling/test_base_package_migration_cleanup.py
@@ -36,13 +36,13 @@ FRONTEND_PERCENT_FILES = [
 ]
 
 BACKEND_MONEY_ADAPTER_FILES = [
-    Path("apps/backend/src/services/investment_accounting.py"),
+    Path("apps/backend/src/portfolio/extension/accounting.py"),
     Path("apps/backend/src/services/performance_report.py"),
 ]
 
 BACKEND_QUANTITY_ADAPTER_FILES = [
     Path("apps/backend/src/services/assets.py"),
-    Path("apps/backend/src/services/investment_accounting.py"),
+    Path("apps/backend/src/portfolio/extension/accounting.py"),
     Path("apps/backend/src/services/market_data"),
     Path("apps/backend/src/services/portfolio.py"),
     Path("apps/backend/src/services/reporting"),
@@ -239,7 +239,7 @@ def test_AC12_31_7_backend_quantity_business_code_uses_value_type():
                 f"{path} still calls package-level Decimal facade {helper}"
             )
 
-    investment = _read(Path("apps/backend/src/services/investment_accounting.py"))
+    investment = _read(Path("apps/backend/src/portfolio/extension/accounting.py"))
     assert (
         "trade_quantity = Quantity(quantity, INVESTMENT_QUANTITY_UNIT).quantize()"
         in investment

--- a/tests/tooling/test_composite_ops_adoption.py
+++ b/tests/tooling/test_composite_ops_adoption.py
@@ -43,7 +43,7 @@ def test_AC12_33_3_zero_denominator_branching_routes_through_ratio():
 )
 def test_AC12_33_3_money_predicates_and_sum_adopted():
     """AC-audit.33.3: investment accounting uses Money predicates + Money.sum."""
-    src = _read("apps/backend/src/services/investment_accounting.py")
+    src = _read("apps/backend/src/portfolio/extension/accounting.py")
     assert "gross.is_positive()" in src
     assert "net.is_positive()" in src
     assert "Money.sum(" in src

--- a/tests/tooling/test_decimal_boundary_policy.py
+++ b/tests/tooling/test_decimal_boundary_policy.py
@@ -64,7 +64,7 @@ def test_AC12_31_3_migrated_hotspots_use_base_packages():
     """AC-audit.31.3: migrated money/quantity/frontend hotspots stay behind base packages."""
     quantity_service_files = [
         Path("apps/backend/src/services/assets.py"),
-        Path("apps/backend/src/services/investment_accounting.py"),
+        Path("apps/backend/src/portfolio/extension/accounting.py"),
         Path("apps/backend/src/services/market_data"),
         Path("apps/backend/src/services/reporting"),
     ]
@@ -90,7 +90,7 @@ def test_AC12_31_3_migrated_hotspots_use_base_packages():
     # market value is UnitPrice(price) * quantity, no raw quantity*price.
     assert "position_quantity = position.quantity_qty.quantize()" in reporting
 
-    investment = _read(Path("apps/backend/src/services/investment_accounting.py"))
+    investment = _read(Path("apps/backend/src/portfolio/extension/accounting.py"))
     assert (
         "trade_quantity = Quantity(quantity, INVESTMENT_QUANTITY_UNIT).quantize()"
         in investment

--- a/tests/tooling/test_ledger_module.py
+++ b/tests/tooling/test_ledger_module.py
@@ -90,7 +90,7 @@ def test_AC12_34_3_confidence_tier_lives_in_model_layer():
 )
 def test_AC12_34_4_investment_postings_use_ledger_post():
     """AC-ledger.34.4: investment buy/sell/dividend post via Entry + post_entry."""
-    src = _read("apps/backend/src/services/investment_accounting.py")
+    src = _read("apps/backend/src/portfolio/extension/accounting.py")
     assert "from src.ledger import Entry, Leg, post_entry" in src
     assert "Entry.transfer(" in src  # buy
     assert "Entry.of(" in src  # sell + dividend

--- a/tests/tooling/test_orm_value_type_boundary.py
+++ b/tests/tooling/test_orm_value_type_boundary.py
@@ -16,7 +16,7 @@ REPO = Path(__file__).resolve().parents[2]
 # Business files where ManagedPosition money is fully migrated to typed accessors.
 MIGRATED_MANAGED_POSITION_FILES = [
     "apps/backend/src/services/portfolio.py",
-    "apps/backend/src/services/investment_accounting.py",
+    "apps/backend/src/portfolio/extension/accounting.py",
     "apps/backend/src/services/assets.py",
     "apps/backend/src/services/performance_report.py",
     "apps/backend/src/services/reporting/portfolio_market.py",
@@ -62,7 +62,7 @@ def test_AC12_35_1_managed_position_exposes_typed_accessors():
 def test_AC12_35_2_investment_accounting_reads_position_via_accessors():
     """AC-audit.35.2: investment accounting updates position state via the typed accessors,
     not by re-wrapping raw Decimal columns."""
-    src = _read("apps/backend/src/services/investment_accounting.py")
+    src = _read("apps/backend/src/portfolio/extension/accounting.py")
     assert "position.cost_basis_money" in src
     assert "position.realized_pnl_money" in src
     assert "position.quantity_qty" in src

--- a/tests/tooling/test_portfolio_package.py
+++ b/tests/tooling/test_portfolio_package.py
@@ -1,0 +1,79 @@
+"""portfolio package — package-model structural invariant guards (#1422, PR1 commit 1).
+
+These tests prove the structural invariants declared in
+``common/portfolio/contract.py`` for the pure ``base/`` layer shipped this
+commit: the layers converge, base stays pure, the published language equals
+``__all__``, and the governance gate passes. They are invariant proofs, NOT
+AC critical-proofs (the domain ACs land in the contract roadmap in a later
+commit once the physical fold is done, per this repo's established
+precedent — see #1548).
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+from common.meta.extension.check_package_contract import discover_packages, run
+
+REPO = Path(__file__).resolve().parents[2]
+PORTFOLIO = REPO / "apps/backend/src/portfolio"
+
+_BACKEND_ROOT = str(REPO / "apps" / "backend")
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)
+
+
+def _imported_modules(path: Path) -> set[str]:
+    mods: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            mods.add(node.module)
+        elif isinstance(node, ast.Import):
+            mods.update(a.name for a in node.names)
+    return mods
+
+
+def test_AC_portfolio_1_1_only_all_is_the_published_language():
+    """Invariant interface-equals-published-language: contract.interface == __init__.__all__."""
+    import src.portfolio as portfolio_pkg
+
+    from common.portfolio.contract import CONTRACT
+
+    assert sorted(CONTRACT.interface) == sorted(portfolio_pkg.__all__)
+    assert CONTRACT.name == "portfolio"
+    assert CONTRACT.implementations["be"] == "apps/backend/src/portfolio"
+
+
+def test_AC_portfolio_1_2_converges_by_layer():
+    """Invariant converges-by-layer: base/errors.py (real) + extension/ + data/ (reserved)."""
+    assert (PORTFOLIO / "base" / "errors.py").exists()
+    assert (PORTFOLIO / "extension" / "__init__.py").exists()
+    assert (PORTFOLIO / "data" / "__init__.py").exists()
+
+
+def test_AC_portfolio_1_3_base_layer_is_pure():
+    """Invariant base-layer-pure: base/ imports no own extension/data, no ORM, no network client."""
+    for py in (PORTFOLIO / "base").rglob("*.py"):
+        for mod in _imported_modules(py):
+            assert not mod.startswith("src.portfolio.extension"), (
+                f"{py.name} imports extension ({mod}) from base/"
+            )
+            assert not mod.startswith("src.portfolio.data"), (
+                f"{py.name} imports data ({mod}) from base/"
+            )
+            assert not mod.startswith(("src.database", "sqlalchemy")), (
+                f"{py.name} reaches the ORM from base/"
+            )
+            assert mod not in {"httpx", "litellm", "aiohttp"}, (
+                f"{py.name} reaches a network client from base/"
+            )
+
+
+def test_AC_portfolio_1_4_package_contract_gate_passes():
+    """Invariant passes-own-governance-gate: the gate validates portfolio with no violations."""
+    packages = discover_packages(REPO)
+    assert any(p.contract.name == "portfolio" for p in packages), "portfolio not discovered"
+    ok, messages = run(REPO)
+    portfolio_errors = [m for m in messages if "[portfolio]" in m]
+    assert not portfolio_errors, f"gate violations for portfolio: {portfolio_errors}"
+    assert ok, "check_package_contract failed overall"

--- a/tests/tooling/test_quantity_adoption.py
+++ b/tests/tooling/test_quantity_adoption.py
@@ -46,7 +46,7 @@ def test_AC12_30_4_frontend_quantity_formatting_is_not_exported_from_money():
 )
 def test_AC12_30_4_backend_quantity_hot_paths_use_quantity_type():
     """AC-audit.30.4: targeted backend quantity paths use Quantity for quantity semantics."""
-    investment = _read(Path("apps/backend/src/services/investment_accounting.py"))
+    investment = _read(Path("apps/backend/src/portfolio/extension/accounting.py"))
     assert "from src.audit.quantity import Quantity" in investment
     assert (
         "trade_quantity = Quantity(quantity, INVESTMENT_QUANTITY_UNIT).quantize()"

--- a/tests/tooling/test_unit_price_adoption.py
+++ b/tests/tooling/test_unit_price_adoption.py
@@ -30,7 +30,7 @@ def _read(path: Path) -> str:
 )
 def test_AC12_32_3_investment_accounting_uses_unit_price():
     """AC-audit.32.3: investment accounting prices via UnitPrice, not local Decimal helpers."""
-    src = _read(Path("apps/backend/src/services/investment_accounting.py"))
+    src = _read(Path("apps/backend/src/portfolio/extension/accounting.py"))
     assert "from src.audit.unit_price import UnitPrice" in src
     # typed call sites replace the raw quantity*price / amount/quantity glue
     assert "buy_price * trade_quantity" in src


### PR DESCRIPTION
**Draft — in progress, not ready for review.** Tracks #1422 (Stage 3 of umbrella #1416), starting now that pricing (#1610, PR #1617) has merged.

## Why

Investment position accounting (`services/portfolio.py` 922L, `services/investment_accounting.py` 546L, `services/allocation.py` 184L, `services/performance.py` 471L, `services/performance_report.py` 375L — ~2,500 lines total) cuts over to the package-model layering (`common/meta/migration-standard.md`), same as `counter`/`extraction`/`ledger`/`pricing` before it.

**Positions-only boundary** (confirmed 2026-07-06, after the pricing design review #1610): portfolio owns quantity/cost-basis/P&L math only. It never fetches or stores a price — it consumes one via `pricing.resolve(subject, as_of, policy)`. The old `PortfolioService.update_market_prices()` write path belongs to `pricing.record_override` now.

## Shipped so far (2 commits)

1. **`common/portfolio/contract.py` + `base/errors.py`** — the 6-class error hierarchy, moved verbatim. The 5 ORM aggregate/entities and their enums stay taxonomy-only (extraction/ledger precedent).
2. **`InvestmentAccountingService`** (`post_buy`/`post_sell`/`post_dividend`, 546 lines) moved verbatim into `extension/accounting.py`. Zero FX dependency, so it moved cleanly. `services/investment_accounting.py` deleted (no production consumers, only tests — repointed).

26 tests pass, `check_package_contract` + `lint_doc_consistency` + `test_app_boundary` + `test_transaction_boundaries` all green.

## Blocked (see #1422 comment for full reasoning)

**P3/P4 (`portfolio.py`'s read-side queries + `allocation.py`/`performance.py`/`performance_report.py`) hit a hard app-boundary gate, not a soft one.** Every FX conversion in this code calls `services.fx` with `lazy_load=True` (the crawler-fallback path). Moving it as-is creates a new domain→app-remainder edge that `test_app_boundary.py` rejects outright — its `--update` only prunes stale entries, never adds new ones, by design. Switching to `pricing.convert_money`/`convert_amount` instead would silently drop the fallback, since pricing's FX wrappers don't have a crawler-fallback equivalent yet (blocked on the same crawler-move issue tracked on #1610). Not something to resolve unilaterally inside this PR — flagged on #1422 with a possible unblock path (now that `portfolio` exists, the crawler's discovery queries finally have somewhere to land).

## Remaining (once unblocked)

- P3/P4 per above.
- Repoint the 6 consumer files.
- Migrate the EPIC-011/017 portfolio-owned ACs into the roadmap — after the physical fold, per this repo's established precedent (#1548).
- Zero-residue cleanup: delete the old `services/*.py` files (or their now-thin re-export shims, once consumers are repointed).

Opening as draft now for continuous CI validation while the remaining scope lands, per the project's cutover pacing rule (#1416, ≤2 PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)