### PR TITLE
[finance_report_test_and_doc] ci(docs): retry Pages deployment with backoff — burst merges trip 'try again later'

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,10 +57,34 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment-retry.outputs.page_url || steps.deployment-retry-2.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
+      # Pages rejects a new deployment while the previous one is still
+      # propagating ("Deployment failed, try again later") — burst merges hit
+      # this reliably (3-for-3 on 2026-07-06). Two backoff retries absorb it;
+      # a genuine outage still fails the run.
       - name: Deploy to GitHub Pages
         id: deployment
+        uses: actions/deploy-pages@v5
+        continue-on-error: true
+
+      - name: Wait before retry
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 60
+
+      - name: Deploy to GitHub Pages (retry 1)
+        id: deployment-retry
+        if: steps.deployment.outcome == 'failure'
+        uses: actions/deploy-pages@v5
+        continue-on-error: true
+
+      - name: Wait before second retry
+        if: steps.deployment.outcome == 'failure' && steps.deployment-retry.outcome == 'failure'
+        run: sleep 120
+
+      - name: Deploy to GitHub Pages (retry 2)
+        id: deployment-retry-2
+        if: steps.deployment.outcome == 'failure' && steps.deployment-retry.outcome == 'failure'
         uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url || steps.deployment-retry.outputs.page_url || steps.deployment-retry-2.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps['deployment-retry'].outputs.page_url || steps['deployment-retry-2'].outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -81,10 +81,10 @@ jobs:
         continue-on-error: true
 
       - name: Wait before second retry
-        if: steps.deployment.outcome == 'failure' && steps.deployment-retry.outcome == 'failure'
+        if: steps.deployment.outcome == 'failure' && steps['deployment-retry'].outcome == 'failure'
         run: sleep 120
 
       - name: Deploy to GitHub Pages (retry 2)
         id: deployment-retry-2
-        if: steps.deployment.outcome == 'failure' && steps.deployment-retry.outcome == 'failure'
+        if: steps.deployment.outcome == 'failure' && steps['deployment-retry'].outcome == 'failure'
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

7 of the last 10 failed post-merge runs were **Deploy Documentation**, all with the identical `actions/deploy-pages@v5` error *'Deployment failed, try again later'* — GitHub Pages rejects a new deployment while the previous one is still propagating. The correlation is clean: three merges within 17 minutes on 2026-07-06 (04:15/04:19/04:32) failed 3-for-3, and the next run at 04:52 (queue drained) succeeded. The `concurrency: pages` group serializes workflow runs but cannot serialize the server-side propagation window.

The failure mode is quietly harmful: each next merge's deploy self-heals the site, so only the **last** failure of the day persists — which is exactly what happened at `2dc3b625` (the site served stale docs missing the pricing cutover until a manual rerun, which succeeded first try, confirming transience).

### Change

`deploy` job: attempt → sleep 60 → retry 1 → sleep 120 → retry 2. First two attempts are `continue-on-error`; the final attempt fails the run, so a genuine Pages outage is still loud. Environment URL falls back across attempts.

### Verification
- YAML validated; retry/skip logic: success on attempt N skips later attempts; all-fail still fails the job.
- Evidence: manual `gh run rerun 28779960708 --failed` succeeded immediately (propagation race, not config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)