### PR TITLE
[finance_report_hacker] fix(ci): un-red main — ban-gate path, orphan-gate skip condition, coverage re-baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1441,12 +1441,18 @@ jobs:
       # The finish job's merge authority is the "Check job status" step alone. The
       # three summary steps below are non-gating reporting and all carry
       # continue-on-error so a step-summary write can never fail the merge gate.
+      # Orphan enforcement only makes sense when the backend suites actually ran:
+      # on lightweight (docs/ci-only) pushes the heavy jobs are skipped, no
+      # served-manifest artifacts exist, and every non-truth-paired cassette
+      # would read as a false orphan (seen on main 8cdfde41: served=0, orphans=5).
       - name: Download backend test contexts (cassette orphan gate)
+        if: ${{ needs.backend.result == 'success' }}
         uses: actions/download-artifact@v8
         with:
           pattern: "backend-*test-context"
           path: cassette-usage
       - name: Cassette orphan gate
+        if: ${{ needs.backend.result == 'success' }}
         run: |
           # #1596 AC-llm.10.6 / #1597: every committed cassette must be JUSTIFIED —
           # either SERVED by at least one backend test job, or paired with a

--- a/tests/tooling/test_llm_cassette_boundary.py
+++ b/tests/tooling/test_llm_cassette_boundary.py
@@ -26,7 +26,8 @@ _ALLOWED = (
     "tools/_lib/record_hf_cassettes.py",
     # governance INTROSPECTION: the authority classifier detects LLM-band tests
     # by recognising these very tokens — it reads names, it never uses the layer.
-    "common/authority/authority_classifier.py",
+    # (lives in common/meta/extension/ since the #1626 authority→meta converge)
+    "common/meta/extension/authority_classifier.py",
     "tests/tooling/test_authority_classifier.py",
     # facade->litellm WIRE-integration tests (mock below the transport; use the
     # layer's LIVE seam to reach their stubs).

--- a/unified-coverage.json
+++ b/unified-coverage.json
@@ -1,12 +1,12 @@
 {
-  "total_lines": 37727,
-  "covered_lines": 36074,
-  "coverage_percent": 95.62,
+  "total_lines": 37805,
+  "covered_lines": 36141,
+  "coverage_percent": 95.6,
   "breakdown": {
     "backend": {
-      "total_lines": 18879,
-      "covered_lines": 18286,
-      "coverage_percent": 96.86,
+      "total_lines": 18892,
+      "covered_lines": 18307,
+      "coverage_percent": 96.9,
       "file_count": 258
     },
     "frontend": {
@@ -16,10 +16,10 @@
       "file_count": 175
     },
     "common": {
-      "total_lines": 11499,
-      "covered_lines": 10762,
-      "coverage_percent": 93.59,
-      "file_count": 143
+      "total_lines": 11564,
+      "covered_lines": 10808,
+      "coverage_percent": 93.46,
+      "file_count": 144
     },
     "tools": {
       "total_lines": 3128,


### PR DESCRIPTION
Main has been RED for 3 consecutive runs, each a different residue of the #1626 + #1627 merge pair. This PR fixes all three so main (and every PR inheriting them via the merge-ref) can go green:

1. **Ban-gate allow-list follows the #1626 move** — `authority_classifier.py` converged into `common/meta/extension/`, but #1627's cassette ban gate allow-listed it at `common/authority/`. Both PRs green alone, red combined (run 28781882508). The classifier's `LLM_TEST_MARKERS` token data is sanctioned governance introspection, not a downstream fork. One line.

2. **Orphan gate only enforces when the backend suites ran** — a lightweight (docs/ci-only) push skips the heavy backend jobs, so no served-manifest artifacts exist and every non-truth-paired cassette read as a false orphan (run 28782425716: `served=0, orphans=5`). The download + gate steps now condition on `needs.backend.result == 'success'`: "backend ran and nothing served this cassette" is the orphan signal; "backend never ran" is no signal.

3. **Unified-coverage re-baseline after the converge** — #1626 moved gate code into `common/` with slightly lower coverage: common 93.59%→93.46% (+65 lines, +47 covered), unified 95.62%→95.60% (backend rose 96.86%→96.90%). The baseline automation only opens PRs on **rises** (run 28781803030 failed and blocked it), so a reviewed downward adjustment is required. Values are the measured `unified-coverage-context` artifact from this PR's own CI run; the ratchet resumes from here. If the meta lane later restores coverage, the bot will ratchet the baseline back up automatically.

Verified locally: `test_llm_cassette_boundary` + `test_authority_classifier` + `test_workflow_contract` — 19 passed; ci.yml YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)