### PR TITLE
[finance_report_test_and_doc] feat(ledger): migrate EPIC-012 AC12.34 → AC-ledger.34.* roadmap (6 ACs)

### DIFF
--- a/apps/backend/tests/ledger/test_entry.py
+++ b/apps/backend/tests/ledger/test_entry.py
@@ -19,9 +19,9 @@ def _m(x: str, ccy: str = "USD") -> Money:
     return Money(Decimal(x), ccy)
 
 
-@ac_proof(proof_id="test_entry_balances", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_entry_balances", ac_ids=["AC-ledger.34.1"], ci_tier="pr_ci")
 def test_AC12_34_1_balanced_entry_constructs():
-    """AC12.34.1: a balanced transfer / multi-leg entry constructs."""
+    """AC-ledger.34.1: a balanced transfer / multi-leg entry constructs."""
     e = Entry.transfer(debit=A, credit=B, money=_m("10.00"))
     assert len(e.legs) == 2
     # 3-leg balanced (sell shape: dr cash = cr cost + cr pnl)
@@ -33,9 +33,9 @@ def test_AC12_34_1_balanced_entry_constructs():
     assert len(e3.legs) == 3
 
 
-@ac_proof(proof_id="test_entry_unbalanced_raises", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_entry_unbalanced_raises", ac_ids=["AC-ledger.34.1"], ci_tier="pr_ci")
 def test_AC12_34_1_unbalanced_entry_is_unconstructable():
-    """AC12.34.1: an unbalanced entry cannot be constructed."""
+    """AC-ledger.34.1: an unbalanced entry cannot be constructed."""
     with pytest.raises(UnbalancedEntryError):
         Entry.of(
             Leg(A, Direction.DEBIT, _m("100.00")),
@@ -48,9 +48,9 @@ def test_AC12_34_1_unbalanced_entry_is_unconstructable():
         Entry.of(Leg(A, Direction.DEBIT, _m("10.00")))
 
 
-@ac_proof(proof_id="test_entry_per_currency", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_entry_per_currency", ac_ids=["AC-ledger.34.1"], ci_tier="pr_ci")
 def test_AC12_34_1_balance_is_checked_per_currency():
-    """AC12.34.1: balance is per currency, not a currency-blind sum."""
+    """AC-ledger.34.1: balance is per currency, not a currency-blind sum."""
     # each currency balances on its own
     ok = Entry.of(
         Leg(A, Direction.DEBIT, _m("10.00", "USD")),
@@ -67,17 +67,17 @@ def test_AC12_34_1_balance_is_checked_per_currency():
         )
 
 
-@ac_proof(proof_id="test_entry_leg_positive", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_entry_leg_positive", ac_ids=["AC-ledger.34.1"], ci_tier="pr_ci")
 def test_AC12_34_1_legs_must_be_positive():
-    """AC12.34.1: a leg amount must be positive (no zero/negative lines)."""
+    """AC-ledger.34.1: a leg amount must be positive (no zero/negative lines)."""
     with pytest.raises(UnbalancedEntryError):
         Leg(A, Direction.DEBIT, _m("0.00"))
     with pytest.raises(UnbalancedEntryError):
         Leg(A, Direction.DEBIT, _m("-1.00"))
 
 
-@ac_proof(proof_id="test_entry_leg_direction", ac_ids=["AC12.34.1"], ci_tier="pr_ci")
+@ac_proof(proof_id="test_entry_leg_direction", ac_ids=["AC-ledger.34.1"], ci_tier="pr_ci")
 def test_AC12_34_1_leg_direction_must_be_typed():
-    """AC12.34.1: a non-Direction direction is rejected (no silent credit)."""
+    """AC-ledger.34.1: a non-Direction direction is rejected (no silent credit)."""
     with pytest.raises(TypeError):
         Leg(A, "DEBIT", _m("10.00"))  # type: ignore[arg-type]

--- a/common/ledger/contract.py
+++ b/common/ledger/contract.py
@@ -1604,7 +1604,7 @@ CONTRACT = PackageContract(
                 "nouns) + extension/ (the post_entry verb + the journal "
                 "Repository adapter) + data/ (the balance projection) — and "
                 "exports Entry/Leg/post_entry/UnbalancedEntryError (the retired "
-                "types//ops//store/ dirs are gone; cutover #1420 slice 3a). Was "
+                "types/ops/store  dirs are gone; cutover #1420 slice 3a). Was "
                 "EPIC-012 AC12.34.2."
             ),
             test=(

--- a/common/ledger/contract.py
+++ b/common/ledger/contract.py
@@ -1580,6 +1580,111 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        # AC-ledger.* migrated from EPIC-012 groups 12.34 (#1419-pattern AC move).
+        ACRecord(
+            id="AC-ledger.34.1",
+            statement=(
+                "Entry/Leg make double-entry a value object: a balanced "
+                "transfer/multi-leg entry constructs; an unbalanced one raises "
+                "UnbalancedEntryError; balance is checked **per currency**; legs "
+                "must be positive Money; empty entries raise. Was EPIC-012 "
+                "AC12.34.1."
+            ),
+            test=(
+                "apps/backend/tests/ledger/test_entry.py"
+                "::test_AC12_34_1_balanced_entry_constructs"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.34.2",
+            statement=(
+                "The ledger module converges by layer — base/ (the Entry/Leg "
+                "nouns) + extension/ (the post_entry verb + the journal "
+                "Repository adapter) + data/ (the balance projection) — and "
+                "exports Entry/Leg/post_entry/UnbalancedEntryError (the retired "
+                "types//ops//store/ dirs are gone; cutover #1420 slice 3a). Was "
+                "EPIC-012 AC12.34.2."
+            ),
+            test=(
+                "tests/tooling/test_ledger_module.py"
+                "::test_AC12_34_2_ledger_module_converges_by_role"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.34.3",
+            statement=(
+                "Layer-DAG rule: the model layer imports no service (no upward "
+                "edge / import cycle); derive_confidence_tier lives in the model "
+                "and the service re-exports it (the old models.journal → "
+                "services.confidence_tier cycle is removed). Was EPIC-012 "
+                "AC12.34.3."
+            ),
+            test=(
+                "tests/tooling/test_ledger_module.py"
+                "::test_AC12_34_3_model_layer_never_imports_a_service"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.34.4",
+            statement=(
+                "Adoption: investment buy/sell/dividend build typed Entry and "
+                "post via ledger.post_entry instead of hand-rolling balanced "
+                "lines_data dicts (the legacy create_journal_entry/_post_and_load "
+                "path is gone from the service). Was EPIC-012 AC12.34.4."
+            ),
+            test=(
+                "tests/tooling/test_ledger_module.py"
+                "::test_AC12_34_4_investment_postings_use_ledger_post"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.34.5",
+            statement=(
+                "Every computed/transfer posting path gates balance through "
+                "Entry: opening-balance, fx-revaluation, and processing-account "
+                "transfers construct an Entry before persisting (fx-revaluation "
+                "and processing-account previously wrote raw JournalLines with no "
+                "balance validation at all). The remaining raw site review_queue "
+                "validates via validate_journal_balance/_posting_invariants; "
+                "reconciliation_audit is a deterministic audit fixture. Was "
+                "EPIC-012 AC12.34.5."
+            ),
+            test=(
+                "tests/tooling/test_ledger_module.py"
+                "::test_AC12_34_5_remaining_posting_paths_guard_balance_with_entry"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.34.6",
+            statement=(
+                "The journal write pipeline "
+                "(create_journal_entry/post_journal_entry/void_journal_entry + "
+                "validators) lives in the ledger package "
+                "(ledger/extension/repository.py, behind the JournalRepository "
+                "port); ledger.extension.post depends down on it instead of up on "
+                "services.accounting. After the package cutover (#1420 slice 3a) "
+                "NO services.accounting re-export shim survives — callers import "
+                "the pipeline + ValidationError from the published ledger "
+                "interface (from src.ledger import ...), zero residue. Was "
+                "EPIC-012 AC12.34.6."
+            ),
+            test=(
+                "tests/tooling/test_ledger_module.py"
+                "::test_AC12_34_6_ledger_owns_posting_pipeline_no_upward_edge"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )
 

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -618,7 +618,7 @@ vectors) but adopted on the backend first.
 > Migrated `AC-audit.33.<s>` ids (homed in the package roadmap):
 > `AC-audit.33.1` · `AC-audit.33.2` · `AC-audit.33.3`
 
-### AC12.34: Ledger module — `Entry` value object + vertical-slice template ([#1253](https://github.com/wangzitian0/finance_report/issues/1253))
+### AC12.34: Ledger module — `Entry` value object + vertical-slice template — migrated to the `ledger` package ([#1253](https://github.com/wangzitian0/finance_report/issues/1253))
 
 The first **vertical domain module** (`src/ledger`) as the template every other
 domain followed: files converged into the then-role folders (`types/` nouns,
@@ -628,14 +628,20 @@ core noun `Entry` makes the double-entry balance invariant a **type** — an
 unbalanced entry is unconstructable (`UnbalancedEntryError`), replacing scattered
 runtime `abs(debit-credit) < 0.01` checks.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC12.34.1 | `Entry`/`Leg` make double-entry a value object: a balanced transfer/multi-leg entry constructs; an unbalanced one raises `UnbalancedEntryError`; balance is checked **per currency**; legs must be positive `Money`; empty entries raise | `test_AC12_34_1_balanced_entry_constructs` (+ siblings) | `apps/backend/tests/ledger/test_entry.py` | P1 |
-| AC12.34.2 | The ledger module converges by layer — `base/` (the `Entry`/`Leg` nouns) + `extension/` (the `post_entry` verb + the journal `Repository` adapter) + `data/` (the balance projection) — and exports `Entry`/`Leg`/`post_entry`/`UnbalancedEntryError` (the retired `types/`/`ops/`/`store/` dirs are gone; cutover #1420 slice 3a) | `test_AC12_34_2_ledger_module_converges_by_role` | `tests/tooling/test_ledger_module.py` | P1 |
-| AC12.34.3 | Layer-DAG rule: the model layer imports no service (no upward edge / import cycle); `derive_confidence_tier` lives in the model and the service re-exports it (the old `models.journal → services.confidence_tier` cycle is removed) | `test_AC12_34_3_model_layer_never_imports_a_service`, `test_AC12_34_3_confidence_tier_lives_in_model_layer` | `tests/tooling/test_ledger_module.py` | P1 |
-| AC12.34.4 | Adoption: investment buy/sell/dividend build typed `Entry` and post via `ledger.post_entry` instead of hand-rolling balanced `lines_data` dicts (the legacy `create_journal_entry`/`_post_and_load` path is gone from the service) {tier:CODE-ONLY} | `test_AC12_34_4_investment_postings_use_ledger_post` | `tests/tooling/test_ledger_module.py` | P1 |
-| AC12.34.5 | Every computed/transfer posting path gates balance through `Entry`: opening-balance, fx-revaluation, and processing-account transfers construct an `Entry` before persisting (fx-revaluation and processing-account previously wrote raw `JournalLine`s with no balance validation at all). The remaining raw site `review_queue` validates via `validate_journal_balance`/`_posting_invariants`; `reconciliation_audit` is a deterministic audit fixture {tier:CODE-ONLY} | `test_AC12_34_5_remaining_posting_paths_guard_balance_with_entry` | `tests/tooling/test_ledger_module.py` | P1 |
-| AC12.34.6 | The journal write pipeline (`create_journal_entry`/`post_journal_entry`/`void_journal_entry` + validators) lives in the ledger package (`ledger/extension/repository.py`, behind the `JournalRepository` port); `ledger.extension.post` depends down on it instead of up on `services.accounting`. After the package cutover (#1420 slice 3a) NO `services.accounting` re-export shim survives — callers import the pipeline + `ValidationError` from the published ledger interface (`from src.ledger import ...`), zero residue {tier:CODE-ONLY} | `test_AC12_34_6_ledger_owns_posting_pipeline_no_upward_edge` | `tests/tooling/test_ledger_module.py` | P1 |
+> **The ACs of this group are no longer defined here.** The rows (were
+> AC12.34.* rows .1–.6) migrated into the `ledger` package and are owned
+> by, and sourced directly from,
+> [`common/ledger/contract.py`](../../common/ledger/contract.py)'s `roadmap`
+> under the package-scoped numeric `AC-ledger.<group>.<seq>` id scheme (the
+> leading "12" is dropped and the group/seq preserved, so `AC12.34.<s>`
+> becomes `AC-ledger.34.<s>`). `common/ssot/generate_ac_registry.py` reads
+> package-contract roadmaps additively, so the AC index counts them without an
+> EPIC-table mirror. This note references the new ids (keeping the
+> registry↔EPIC link intact) but defines none of them — the contract is the
+> single definition source.
+>
+> Migrated `AC-ledger.34.<s>` ids (homed in the package roadmap):
+> `AC-ledger.34.1` · `AC-ledger.34.2` · `AC-ledger.34.3` · `AC-ledger.34.4` · `AC-ledger.34.5` · `AC-ledger.34.6`
 
 ### AC12.35: ORM read layer returns value types — boundary push ([#1253](https://github.com/wangzitian0/finance_report/issues/1253))
 

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -634,7 +634,7 @@ runtime `abs(debit-credit) < 0.01` checks.
 > [`common/ledger/contract.py`](../../common/ledger/contract.py)'s `roadmap`
 > under the package-scoped numeric `AC-ledger.<group>.<seq>` id scheme (the
 > leading "12" is dropped and the group/seq preserved, so `AC12.34.<s>`
-> becomes `AC-ledger.34.<s>`). `common/ssot/generate_ac_registry.py` reads
+> becomes `AC-ledger.34.<s>`). `common/testing/generate_ac_registry.py` reads
 > package-contract roadmaps additively, so the AC index counts them without an
 > EPIC-table mirror. This note references the new ids (keeping the
 > registry↔EPIC link intact) but defines none of them — the contract is the

--- a/tests/tooling/test_ledger_module.py
+++ b/tests/tooling/test_ledger_module.py
@@ -22,9 +22,11 @@ def _read(path: str) -> str:
     return (REPO / path).read_text(encoding="utf-8")
 
 
-@ac_proof(proof_id="test_ledger_module_shape", ac_ids=["AC12.34.2"], ci_tier="pr_ci")
+@ac_proof(
+    proof_id="test_ledger_module_shape", ac_ids=["AC-ledger.34.2"], ci_tier="pr_ci"
+)
 def test_AC12_34_2_ledger_module_converges_by_role():
-    """AC12.34.2: ledger converges by layer — base/ (the Entry/Leg nouns), extension/
+    """AC-ledger.34.2: ledger converges by layer — base/ (the Entry/Leg nouns), extension/
     (the post_entry verb + the journal Repository adapter), data/ (the balance
     projection) — and exports Entry/Leg/post_entry/UnbalancedEntryError."""
     assert (SRC / "ledger/base/types/entry.py").exists()
@@ -40,10 +42,12 @@ def test_AC12_34_2_ledger_module_converges_by_role():
 
 
 @ac_proof(
-    proof_id="test_models_have_no_service_deps", ac_ids=["AC12.34.3"], ci_tier="pr_ci"
+    proof_id="test_models_have_no_service_deps",
+    ac_ids=["AC-ledger.34.3"],
+    ci_tier="pr_ci",
 )
 def test_AC12_34_3_model_layer_never_imports_a_service():
-    """AC12.34.3: the model layer has no upward edge into services (DAG rule).
+    """AC-ledger.34.3: the model layer has no upward edge into services (DAG rule).
 
     Previously models/journal.py imported services.confidence_tier inside a
     property — a model→service cycle. That edge is gone; this guard prevents any
@@ -65,10 +69,12 @@ def test_AC12_34_3_model_layer_never_imports_a_service():
 
 
 @ac_proof(
-    proof_id="test_confidence_tier_relocated", ac_ids=["AC12.34.3"], ci_tier="pr_ci"
+    proof_id="test_confidence_tier_relocated",
+    ac_ids=["AC-ledger.34.3"],
+    ci_tier="pr_ci",
 )
 def test_AC12_34_3_confidence_tier_lives_in_model_layer():
-    """AC12.34.3: derive_confidence_tier moved to the model; service re-exports it."""
+    """AC-ledger.34.3: derive_confidence_tier moved to the model; service re-exports it."""
     journal = _read("apps/backend/src/models/journal.py")
     assert "def derive_confidence_tier(" in journal
     shim = _read("apps/backend/src/services/confidence_tier.py")
@@ -79,11 +85,11 @@ def test_AC12_34_3_confidence_tier_lives_in_model_layer():
 
 @ac_proof(
     proof_id="test_ledger_investment_postings_adoption",
-    ac_ids=["AC12.34.4"],
+    ac_ids=["AC-ledger.34.4"],
     ci_tier="pr_ci",
 )
 def test_AC12_34_4_investment_postings_use_ledger_post():
-    """AC12.34.4: investment buy/sell/dividend post via Entry + post_entry."""
+    """AC-ledger.34.4: investment buy/sell/dividend post via Entry + post_entry."""
     src = _read("apps/backend/src/services/investment_accounting.py")
     assert "from src.ledger import Entry, Leg, post_entry" in src
     assert "Entry.transfer(" in src  # buy
@@ -103,11 +109,11 @@ def test_AC12_34_4_investment_postings_use_ledger_post():
 
 @ac_proof(
     proof_id="test_ledger_all_posting_paths_balance_guaranteed",
-    ac_ids=["AC12.34.5"],
+    ac_ids=["AC-ledger.34.5"],
     ci_tier="pr_ci",
 )
 def test_AC12_34_5_remaining_posting_paths_guard_balance_with_entry():
-    """AC12.34.5: the raw-ORM posting paths gate balance through Entry.
+    """AC-ledger.34.5: the raw-ORM posting paths gate balance through Entry.
 
     opening-balance, fx-revaluation, and processing-account transfers each
     construct an Entry before persisting (fx-revaluation previously had no balance
@@ -140,11 +146,11 @@ def test_AC12_34_5_remaining_posting_paths_guard_balance_with_entry():
 
 @ac_proof(
     proof_id="test_ledger_owns_posting_pipeline",
-    ac_ids=["AC12.34.6"],
+    ac_ids=["AC-ledger.34.6"],
     ci_tier="pr_ci",
 )
 def test_AC12_34_6_ledger_owns_posting_pipeline_no_upward_edge():
-    """AC12.34.6: the journal write pipeline lives in the ledger package
+    """AC-ledger.34.6: the journal write pipeline lives in the ledger package
     (``ledger/extension/repository.py``); ``ledger.extension.post`` depends down on it
     (not up on services.accounting), and after the package cutover NO ``services.accounting``
     re-export shim survives — callers import the pipeline from the published ledger


### PR DESCRIPTION
## Summary

Second AC-migration slice (one package = one transaction; sibling of #1633): the ledger Entry value-object/template group leaves the EPIC-012 table and is homed in `common/ledger/contract.py`'s `roadmap`.

| was (EPIC-012) | now | count | guards |
|---|---|---|---|
| AC12.34.1–6 | `AC-ledger.34.*` | 6 | `Entry` VO (unbalanced entry unconstructable), vertical-slice template, layer-DAG rule |

#1548 mechanics: group+seq preserved (no `AC-ledger.34.*` collision), test function names unchanged, dot-form ids in docstrings renamed (22 refs across `tests/ledger/test_entry.py` + `tests/tooling/test_ledger_module.py`), EPIC table replaced with the standard migration stub.

## Verification
- `check_ac_index`: protection dashboard non-regressing.
- `check_ac_tier_baseline`: tier debt **-7**.
- `check_package_contract`: ledger 107 roadmap ACs — OK.
- preflight: ac-traceability / doc-consistency / taxonomy-drift / tooling (1913 passed) green; `backend-format` failure is the documented PATH-ruff false positive (pinned 0.14.11 clean).
- Edited tests pass (test_entry.py 5, test_ledger_module.py 6).

Sibling slices: #1633 (audit, 18 ACs) · next: extraction (19 ACs).

Related: #1416 #1420 · mechanics: #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)