### PR TITLE
[finance_report_test_and_doc] feat(extraction): migrate EPIC-011/017 extraction-owned ACs → AC-extraction.* roadmap (12 ACs)

### DIFF
--- a/apps/backend/tests/extraction/test_brokerage_csv_routing.py
+++ b/apps/backend/tests/extraction/test_brokerage_csv_routing.py
@@ -39,7 +39,7 @@ BANK_TRANSACTION_CSV = b"""Transaction Date,Reference,Debit Amount,Credit Amount
 
 
 def test_classify_brokerage_csv_distinguishes_schemas():
-    """AC17.32.1 AC17.32.2 AC17.32.3: header classifier separates the three CSV shapes."""
+    """AC-extraction.332.1 AC-extraction.332.2 AC-extraction.332.3: header classifier separates the three CSV shapes."""
     assert classify_brokerage_csv(["Symbol", "Quantity", "Market Value", "Currency"]) == "positions"
     assert classify_brokerage_csv(["Side", "Symbol", "Fill Quantity", "Fill Price", "Total"]) == "trade_history"
     assert classify_brokerage_csv(["Transaction Date", "Debit Amount", "Credit Amount"]) is None
@@ -47,7 +47,7 @@ def test_classify_brokerage_csv_distinguishes_schemas():
 
 
 def test_parse_brokerage_positions_csv_rows_uses_decimal():
-    """AC17.32.1: positions CSV rows map to Decimal-backed position dicts."""
+    """AC-extraction.332.1: positions CSV rows map to Decimal-backed position dicts."""
     headers = ["Symbol", "Quantity", "Market Value", "Currency"]
     rows = [
         {"Symbol": "AAA", "Quantity": "10", "Market Value": "1,000.00", "Currency": "usd"},
@@ -62,11 +62,11 @@ def test_parse_brokerage_positions_csv_rows_uses_decimal():
     assert pos["currency"] == "USD"
 
 
-# --- AC17.32.1: positions CSV reaches brokerage import path -----------------
+# --- AC-extraction.332.1: positions CSV reaches brokerage import path -----------------
 
 
 async def test_AC17_32_1_brokerage_positions_csv_produces_positions_payload():
-    """AC17.32.1: Brokerage positions CSV is mapped into a ``positions`` payload.
+    """AC-extraction.332.1: Brokerage positions CSV is mapped into a ``positions`` payload.
 
     The payload must satisfy the brokerage import contract (parse_brokerage_positions
     yields snapshots) instead of failing with a bank "No valid transactions" error.
@@ -86,11 +86,11 @@ async def test_AC17_32_1_brokerage_positions_csv_produces_positions_payload():
     assert snapshots[0].currency == "USD"
 
 
-# --- AC17.32.2: trade-history CSV gives an actionable error -----------------
+# --- AC-extraction.332.2: trade-history CSV gives an actionable error -----------------
 
 
 async def test_AC17_32_2_brokerage_trade_history_csv_raises_actionable_error():
-    """AC17.32.2: Trade-history CSV raises an actionable unsupported error.
+    """AC-extraction.332.2: Trade-history CSV raises an actionable unsupported error.
 
     It must NOT surface the misleading generic bank parse failure.
     """
@@ -104,17 +104,17 @@ async def test_AC17_32_2_brokerage_trade_history_csv_raises_actionable_error():
 
 
 def test_parse_brokerage_csv_payload_rejects_trade_history():
-    """AC17.32.2: trade-history schema raises the typed unsupported error."""
+    """AC-extraction.332.2: trade-history schema raises the typed unsupported error."""
     headers = ["Side", "Symbol", "Fill Quantity", "Fill Price", "Total"]
     with pytest.raises(UnsupportedBrokerageCsvError, match="trade-history"):
         parse_brokerage_csv_payload(headers, [], institution="Interactive Brokers")
 
 
-# --- AC17.32.3: bank CSV parsing is unaffected ------------------------------
+# --- AC-extraction.332.3: bank CSV parsing is unaffected ------------------------------
 
 
 async def test_AC17_32_3_bank_csv_unaffected_by_brokerage_detection():
-    """AC17.32.3: Bank transaction CSV parsing is unchanged (no regression)."""
+    """AC-extraction.332.3: Bank transaction CSV parsing is unchanged (no regression)."""
     service = ExtractionService()
     payload = await service._parse_csv_content(BANK_TRANSACTION_CSV, "DBS")
 

--- a/apps/backend/tests/extraction/test_classification_service.py
+++ b/apps/backend/tests/extraction/test_classification_service.py
@@ -655,7 +655,7 @@ class TestClassificationService:
         assert results[0].account_id == new_account.id
 
     async def test_apply_rules_is_idempotent_for_existing_transaction_rule_version(self, db, test_user):
-        """AC11.12.1: Re-running the same rule does not duplicate Layer 3 classifications."""
+        """AC-extraction.212.1: Re-running the same rule does not duplicate Layer 3 classifications."""
         service = ClassificationService()
 
         account = Account(

--- a/apps/backend/tests/extraction/test_dual_write_layer2.py
+++ b/apps/backend/tests/extraction/test_dual_write_layer2.py
@@ -53,7 +53,7 @@ def sample_file_content():
 
 class TestDualWriteLayer2:
     async def test_dual_write_enabled_by_default(self, db, test_user, mock_ai_response, sample_file_content):
-        """AC11.13.1: After Stage 1 cutover, parsing populates Layer 1/2 without any flag override."""
+        """AC-extraction.213.1: After Stage 1 cutover, parsing populates Layer 1/2 without any flag override."""
         service = ExtractionService()
 
         with patch.object(service, "extract_financial_data", return_value=mock_ai_response):

--- a/apps/backend/tests/extraction/test_statement_summary_conform.py
+++ b/apps/backend/tests/extraction/test_statement_summary_conform.py
@@ -79,7 +79,7 @@ class TestStatementSummaryConform:
         assert summary.closing_balance == Decimal("1200.00")
 
     async def test_resolve_custody_account_from_atomic_txn(self, db, test_user):
-        """AC11.15.3: custody account resolves from an atomic txn via the conform (DWD-native)."""
+        """AC-extraction.215.3: custody account resolves from an atomic txn via the conform (DWD-native)."""
         account = await _make_account(db, test_user.id)
         doc = UploadedDocument(
             user_id=test_user.id,
@@ -136,7 +136,7 @@ class TestStatementSummaryConform:
         )
 
     async def test_resolve_handles_dict_wrapper_source_documents(self, db, test_user):
-        """AC11.15.5: a {"documents": [...]} wrapper is normalized before resolution."""
+        """AC-extraction.215.5: a {"documents": [...]} wrapper is normalized before resolution."""
         account = await _make_account(db, test_user.id)
         doc = await self._confirmed_doc(db, test_user.id, file_hash="hash-wrap", account_id=account.id)
         atomic = self._atomic(
@@ -149,7 +149,7 @@ class TestStatementSummaryConform:
         assert await resolve_custody_account_id(db, atomic) == account.id
 
     async def test_resolve_ignores_invalid_and_non_bank_sources(self, db, test_user):
-        """AC11.15.6: junk entries, non-bank doc types, and invalid UUIDs are skipped."""
+        """AC-extraction.215.6: junk entries, non-bank doc types, and invalid UUIDs are skipped."""
         atomic = self._atomic(
             test_user.id,
             source_documents=[
@@ -165,7 +165,7 @@ class TestStatementSummaryConform:
         assert await resolve_custody_account_id(db, atomic) is None
 
     async def test_resolve_returns_none_when_no_source_has_account(self, db, test_user):
-        """AC11.15.9: a known source document with no confirmed custody account resolves to None."""
+        """AC-extraction.215.9: a known source document with no confirmed custody account resolves to None."""
         doc = await self._confirmed_doc(db, test_user.id, file_hash="hash-noacct", account_id=None)
         atomic = self._atomic(
             test_user.id,
@@ -177,14 +177,14 @@ class TestStatementSummaryConform:
         assert await resolve_custody_account_id(db, atomic) is None
 
     async def test_resolve_returns_none_for_non_list_source_documents(self, db, test_user):
-        """AC11.15.7: a non-list/non-dict source_documents value resolves to None."""
+        """AC-extraction.215.7: a non-list/non-dict source_documents value resolves to None."""
         atomic = self._atomic(test_user.id, source_documents="weird", dedup_hash="dedup-weird")
         db.add(atomic)
         await db.commit()
         assert await resolve_custody_account_id(db, atomic) is None
 
     async def test_resolve_preserves_source_document_order(self, db, test_user):
-        """AC11.15.8: the first source document (in order) with a confirmed account wins."""
+        """AC-extraction.215.8: the first source document (in order) with a confirmed account wins."""
         second = Account(user_id=test_user.id, name="OCBC", type=AccountType.ASSET, currency="SGD")
         db.add(second)
         await db.flush()
@@ -204,7 +204,7 @@ class TestStatementSummaryConform:
         assert await resolve_custody_account_id(db, atomic) == second.id
 
     async def test_resolve_returns_none_without_source_documents(self, db, test_user):
-        """AC11.15.4: resolver returns None when the atomic txn has no source documents."""
+        """AC-extraction.215.4: resolver returns None when the atomic txn has no source documents."""
         atomic = AtomicTransaction(
             user_id=test_user.id,
             txn_date=date(2024, 1, 15),
@@ -221,7 +221,7 @@ class TestStatementSummaryConform:
         assert await resolve_custody_account_id(db, atomic) is None
 
     async def test_resolve_returns_none_without_account(self, db, test_user):
-        """AC11.15.4: resolver returns None when the source statement has no custody account."""
+        """AC-extraction.215.4: resolver returns None when the source statement has no custody account."""
         atomic = AtomicTransaction(
             user_id=test_user.id,
             txn_date=date(2024, 1, 15),

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -1690,6 +1690,21 @@ CONTRACT = PackageContract(
         ),
         # AC-extraction.* migrated from EPIC-011 groups 11.13, 11.15 (#1419-pattern AC move).
         ACRecord(
+            id="AC-extraction.212.1",
+            statement=(
+                "Re-applying the same rule version to the same atomic "
+                "transaction is idempotent and returns the existing "
+                "classification without inserting duplicates. Was EPIC-011 "
+                "AC11.12.1."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_classification_service.py"
+                "::test_apply_rules_is_idempotent_for_existing_transaction_rule_version"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
             id="AC-extraction.213.1",
             statement=(
                 "Parsing populates Layer 1/2 by default, without any feature-flag "
@@ -1833,21 +1848,6 @@ CONTRACT = PackageContract(
                 "::test_AC17_32_3_bank_csv_unaffected_by_brokerage_detection"
             ),
             priority="P1",
-            status="done",
-        ),
-        ACRecord(
-            id="AC-extraction.212.1",
-            statement=(
-                "Re-applying the same rule version to the same atomic "
-                "transaction is idempotent and returns the existing "
-                "classification without inserting duplicates. Was EPIC-011 "
-                "AC11.12.1."
-            ),
-            test=(
-                "apps/backend/tests/extraction/test_classification_service.py"
-                "::test_apply_rules_is_idempotent_for_existing_transaction_rule_version"
-            ),
-            priority="P0",
             status="done",
         ),
     ],

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -1688,5 +1688,167 @@ CONTRACT = PackageContract(
             status="done",
             proof_kind="property",
         ),
+        # AC-extraction.* migrated from EPIC-011 groups 11.13, 11.15 (#1419-pattern AC move).
+        ACRecord(
+            id="AC-extraction.213.1",
+            statement=(
+                "Parsing populates Layer 1/2 by default, without any feature-flag "
+                "override. Was EPIC-011 AC11.13.1."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_dual_write_layer2.py"
+                "::test_dual_write_enabled_by_default"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.215.3",
+            statement=(
+                "Custody account resolves from a Layer-2 atomic transaction via "
+                "the conform (DWD-native). Was EPIC-011 AC11.15.3."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_summary_conform.py"
+                "::test_resolve_custody_account_from_atomic_txn"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.215.4",
+            statement=(
+                "The resolver returns None when the source statement has no "
+                "confirmed custody account. Was EPIC-011 AC11.15.4."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_summary_conform.py"
+                "::test_resolve_returns_none_without_account"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.215.5",
+            statement=(
+                "The resolver normalizes a {'documents': [...]} source-documents "
+                "wrapper. Was EPIC-011 AC11.15.5."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_summary_conform.py"
+                "::test_resolve_handles_dict_wrapper_source_documents"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.215.6",
+            statement=(
+                "The resolver skips junk entries, non-bank-statement sources, and "
+                "invalid UUIDs. Was EPIC-011 AC11.15.6."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_summary_conform.py"
+                "::test_resolve_ignores_invalid_and_non_bank_sources"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.215.7",
+            statement=(
+                "A non-list/non-dict source_documents value resolves to None. Was "
+                "EPIC-011 AC11.15.7."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_summary_conform.py"
+                "::test_resolve_returns_none_for_non_list_source_documents"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.215.8",
+            statement=(
+                "The first source document (in order) with a confirmed account "
+                "wins. Was EPIC-011 AC11.15.8."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_summary_conform.py"
+                "::test_resolve_preserves_source_document_order"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.215.9",
+            statement=(
+                "A known source document with no confirmed custody account "
+                "resolves to None. Was EPIC-011 AC11.15.9."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_summary_conform.py"
+                "::test_resolve_returns_none_when_no_source_has_account"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # AC-extraction.* migrated from EPIC-017 groups 17.32 (#1419-pattern AC move).
+        ACRecord(
+            id="AC-extraction.332.1",
+            statement=(
+                "Brokerage positions CSV is mapped into a positions payload (not "
+                "a bank parse failure) so it reaches the brokerage import path. "
+                "Was EPIC-017 AC17.32.1."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_brokerage_csv_routing.py"
+                "::test_AC17_32_1_brokerage_positions_csv_produces_positions_payload"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.332.2",
+            statement=(
+                "Brokerage trade-history CSV raises an actionable unsupported- "
+                "document error, not the generic bank 'No valid transactions' "
+                "failure. Was EPIC-017 AC17.32.2."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_brokerage_csv_routing.py"
+                "::test_AC17_32_2_brokerage_trade_history_csv_raises_actionable_error"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.332.3",
+            statement=(
+                "Bank transaction CSV parsing is unaffected by brokerage CSV "
+                "detection (no regression). Was EPIC-017 AC17.32.3."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_brokerage_csv_routing.py"
+                "::test_AC17_32_3_bank_csv_unaffected_by_brokerage_detection"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.212.1",
+            statement=(
+                "Re-applying the same rule version to the same atomic "
+                "transaction is idempotent and returns the existing "
+                "classification without inserting duplicates. Was EPIC-011 "
+                "AC11.12.1."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_classification_service.py"
+                "::test_apply_rules_is_idempotent_for_existing_transaction_rule_version"
+            ),
+            priority="P0",
+            status="done",
+        ),
     ],
 )

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -171,7 +171,7 @@ alongside legacy Layer 0, with an env opt-out preserved for rollback.
 > [`common/extraction/contract.py`](../../common/extraction/contract.py)'s `roadmap`
 > under the package-scoped numeric `AC-extraction.<group>.<seq>` id scheme
 > (`AC11.13.<s>` becomes
-> `AC-extraction.213.<s>`). `common/ssot/generate_ac_registry.py` reads
+> `AC-extraction.213.<s>`). `common/testing/generate_ac_registry.py` reads
 > package-contract roadmaps additively, so the AC index counts them without an
 > EPIC-table mirror. This note references the new ids (keeping the
 > registry↔EPIC link intact) but defines none of them — the contract is the
@@ -204,7 +204,7 @@ was removed with the `bank_statements` table).
 > [`common/extraction/contract.py`](../../common/extraction/contract.py)'s `roadmap`
 > under the package-scoped numeric `AC-extraction.<group>.<seq>` id scheme
 > (`AC11.15.<s>` becomes
-> `AC-extraction.215.<s>`). `common/ssot/generate_ac_registry.py` reads
+> `AC-extraction.215.<s>`). `common/testing/generate_ac_registry.py` reads
 > package-contract roadmaps additively, so the AC index counts them without an
 > EPIC-table mirror. This note references the new ids (keeping the
 > registry↔EPIC link intact) but defines none of them — the contract is the

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -159,15 +159,26 @@ code, tests, issues, and git history.
 | AC11.10.10 | Backend scheduler runs daily market data sync at the nightly Asia/Singapore close-refresh window | `test_next_market_data_sync_at_uses_nightly_sgt_schedule()` | `market_data/test_scheduler.py` | P0 |
 | AC11.10.11 | Staging E2E covers report-time market data refresh from an authenticated ordinary-user path without manual sync | `test_market_data_provider_sync_feeds_fx_and_stock_price_paths()` | `tests/e2e/test_market_data_price_paths.py` | P0 |
 
-### AC11.13: 4-Layer Migration — Stage 1 Dual-Write Activation
+### AC11.13: 4-Layer Migration — Stage 1 Dual-Write Activation — migrated to the `extraction` package
 
 Stage 1 of the 4-layer cutover turns dual-write ON by default: every parsed
 statement populates Layer 1/2 (`UploadedDocument` + `AtomicTransaction`)
 alongside legacy Layer 0, with an env opt-out preserved for rollback.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.13.1 | Parsing populates Layer 1/2 by default, without any feature-flag override | `test_dual_write_enabled_by_default()` | `extraction/test_dual_write_layer2.py` | P0 |
+> **The ACs of this group are no longer defined here.** The rows (were
+> AC11.13.* rows .1–.1) migrated into the `extraction` package and are owned
+> by, and sourced directly from,
+> [`common/extraction/contract.py`](../../common/extraction/contract.py)'s `roadmap`
+> under the package-scoped numeric `AC-extraction.<group>.<seq>` id scheme
+> (`AC11.13.<s>` becomes
+> `AC-extraction.213.<s>`). `common/ssot/generate_ac_registry.py` reads
+> package-contract roadmaps additively, so the AC index counts them without an
+> EPIC-table mirror. This note references the new ids (keeping the
+> registry↔EPIC link intact) but defines none of them — the contract is the
+> single definition source.
+>
+> Migrated `AC-extraction.213.<s>` ids (homed in the package roadmap):
+> `AC-extraction.213.1`
 
 ### AC11.14: 4-Layer Migration — Stage 2a Layer 0→2 Backfill (RETIRED in Stage 3)
 
@@ -178,7 +189,7 @@ alongside legacy Layer 0, with an env opt-out preserved for rollback.
 > `StatementSummary` conform directly, so there is no Layer-0 source to backfill
 > from. The backfill acceptance criteria are obsolete and have been removed.
 
-### AC11.15: 4-Layer Migration — StatementSummary Conform (custody account)
+### AC11.15: 4-Layer Migration — StatementSummary Conform (custody account) — migrated to the `extraction` package
 
 The durable `StatementSummary` conform binds an uploaded statement document to its
 custody account (DIM) and carries the confirmed statement envelope (period,
@@ -187,15 +198,20 @@ reconciliation transfer detection needs. As of Stage 3 the ingestion pipeline
 writes the conform directly (the legacy `BankStatement`→`StatementSummary` sync
 was removed with the `bank_statements` table).
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.15.3 | Custody account resolves from a Layer-2 atomic transaction via the conform (DWD-native) | `test_resolve_custody_account_from_atomic_txn()` | `extraction/test_statement_summary_conform.py` | P0 |
-| AC11.15.4 | The resolver returns None when the source statement has no confirmed custody account | `test_resolve_returns_none_without_account()` | `extraction/test_statement_summary_conform.py` | P0 |
-| AC11.15.5 | The resolver normalizes a `{"documents": [...]}` source-documents wrapper | `test_resolve_handles_dict_wrapper_source_documents()` | `extraction/test_statement_summary_conform.py` | P0 |
-| AC11.15.6 | The resolver skips junk entries, non-bank-statement sources, and invalid UUIDs | `test_resolve_ignores_invalid_and_non_bank_sources()` | `extraction/test_statement_summary_conform.py` | P0 |
-| AC11.15.7 | A non-list/non-dict source_documents value resolves to None | `test_resolve_returns_none_for_non_list_source_documents()` | `extraction/test_statement_summary_conform.py` | P0 |
-| AC11.15.8 | The first source document (in order) with a confirmed account wins | `test_resolve_preserves_source_document_order()` | `extraction/test_statement_summary_conform.py` | P0 |
-| AC11.15.9 | A known source document with no confirmed custody account resolves to None | `test_resolve_returns_none_when_no_source_has_account()` | `extraction/test_statement_summary_conform.py` | P0 |
+> **The ACs of this group are no longer defined here.** The rows (were
+> AC11.15.* rows .3–.9) migrated into the `extraction` package and are owned
+> by, and sourced directly from,
+> [`common/extraction/contract.py`](../../common/extraction/contract.py)'s `roadmap`
+> under the package-scoped numeric `AC-extraction.<group>.<seq>` id scheme
+> (`AC11.15.<s>` becomes
+> `AC-extraction.215.<s>`). `common/ssot/generate_ac_registry.py` reads
+> package-contract roadmaps additively, so the AC index counts them without an
+> EPIC-table mirror. This note references the new ids (keeping the
+> registry↔EPIC link intact) but defines none of them — the contract is the
+> single definition source.
+>
+> Migrated `AC-extraction.215.<s>` ids (homed in the package roadmap):
+> `AC-extraction.215.3` · `AC-extraction.215.4` · `AC-extraction.215.5` · `AC-extraction.215.6` · `AC-extraction.215.7` · `AC-extraction.215.8` · `AC-extraction.215.9`
 
 ### AC11.16: 4-Layer Migration — Balance-aware Layer 2 dedup
 
@@ -412,7 +428,13 @@ representative fixture expansion needed before the overall
 
 ### Acceptance Criteria — Layer 3 Classification Service
 
+> **Partially migrated.** The idempotency row (was AC11.12.* row .1) is homed in the
+> `extraction` package roadmap as `AC-extraction.212.1`
+> ([`common/extraction/contract.py`](../../common/extraction/contract.py));
+> AC11.12.2 stays here for now — its row-level `{tier:CODE-LED}` is stricter
+> than the extraction package tier (LLM-LED), so moving it would downgrade its
+> proof authority (a package-boundary decision, not a mechanical move).
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC11.12.1 | Re-applying the same rule version to the same atomic transaction is idempotent and returns the existing classification without inserting duplicates | `test_apply_rules_is_idempotent_for_existing_transaction_rule_version` | `extraction/test_classification_service.py` | P0 |
 | AC11.12.2 | Classification priority is deterministic across rule type and descending rule version {tier:CODE-LED} {proof:property} | `test_classification_priority_keyword_over_regex`, `test_same_type_rules_prefer_newer_version` | `extraction/test_classification_service.py` | P0 |

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -457,7 +457,7 @@ unchanged for non-brokerage schemas.
 > [`common/extraction/contract.py`](../../common/extraction/contract.py)'s `roadmap`
 > under the package-scoped numeric `AC-extraction.<group>.<seq>` id scheme
 > (`AC17.32.<s>` becomes
-> `AC-extraction.332.<s>`). `common/ssot/generate_ac_registry.py` reads
+> `AC-extraction.332.<s>`). `common/testing/generate_ac_registry.py` reads
 > package-contract roadmaps additively, so the AC index counts them without an
 > EPIC-table mirror. This note references the new ids (keeping the
 > registry↔EPIC link intact) but defines none of them — the contract is the

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -439,7 +439,7 @@ visible in OpenAPI and the generated frontend client.
 | AC17.31.1 | `prices/update` returns the typed `{updated_count, results}` shape | `test_AC17_31_1_prices_update_returns_typed_batch_response` | `api/test_typed_contract_sweep.py` | P2 |
 | AC17.31.2 | `PATCH {ticker}` for an unknown holding returns a structured 404 | `test_AC17_31_2_patch_unknown_holding_returns_404` | `api/test_typed_contract_sweep.py` | P2 |
 
-### AC17.32: Brokerage CSV Routing ([#1255](https://github.com/wangzitian0/finance_report/issues/1255))
+### AC17.32: Brokerage CSV Routing — migrated to the `extraction` package ([#1255](https://github.com/wangzitian0/finance_report/issues/1255))
 
 CSV uploads previously routed every `.csv` through the bank transaction parser,
 so brokerage CSVs (positions/holdings or trade-history schemas) failed with a
@@ -451,11 +451,20 @@ that flows into the brokerage import path, and a brokerage **trade-history** CSV
 error instead of the misleading bank parse failure. Bank CSV parsing is
 unchanged for non-brokerage schemas.
 
-| AC ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.32.1 | Brokerage positions CSV is mapped into a `positions` payload (not a bank parse failure) so it reaches the brokerage import path | `test_AC17_32_1_brokerage_positions_csv_produces_positions_payload` | `extraction/test_brokerage_csv_routing.py` | P1 |
-| AC17.32.2 | Brokerage trade-history CSV raises an actionable unsupported-document error, not the generic bank "No valid transactions" failure | `test_AC17_32_2_brokerage_trade_history_csv_raises_actionable_error` | `extraction/test_brokerage_csv_routing.py` | P1 |
-| AC17.32.3 | Bank transaction CSV parsing is unaffected by brokerage CSV detection (no regression) | `test_AC17_32_3_bank_csv_unaffected_by_brokerage_detection` | `extraction/test_brokerage_csv_routing.py` | P1 |
+> **The ACs of this group are no longer defined here.** The rows (were
+> AC17.32.* rows .1–.3) migrated into the `extraction` package and are owned
+> by, and sourced directly from,
+> [`common/extraction/contract.py`](../../common/extraction/contract.py)'s `roadmap`
+> under the package-scoped numeric `AC-extraction.<group>.<seq>` id scheme
+> (`AC17.32.<s>` becomes
+> `AC-extraction.332.<s>`). `common/ssot/generate_ac_registry.py` reads
+> package-contract roadmaps additively, so the AC index counts them without an
+> EPIC-table mirror. This note references the new ids (keeping the
+> registry↔EPIC link intact) but defines none of them — the contract is the
+> single definition source.
+>
+> Migrated `AC-extraction.332.<s>` ids (homed in the package roadmap):
+> `AC-extraction.332.1` · `AC-extraction.332.2` · `AC-extraction.332.3`
 
 ### AC17.33: Non-US / multi-currency correctness ([#1441](https://github.com/wangzitian0/finance_report/issues/1441))
 


### PR DESCRIPTION
## Summary

Third AC-migration slice (one package = one transaction; siblings #1633 audit, #1634 ledger): the AC groups whose tests live in the migrated `extraction` package move into `common/extraction/contract.py`'s `roadmap`, extending the contract's per-EPIC hundred-block id convention (EPIC-003 kept bare groups, EPIC-013 took 1xx → EPIC-011 gets 2xx, EPIC-017 gets 3xx):

| was | now | count | guards |
|---|---|---|---|
| AC11.13.1 | `AC-extraction.213.1` | 1 | dual-write layer2 |
| AC11.15.3–9 | `AC-extraction.215.*` | 7 | statement summary conformance |
| AC17.32.1–3 | `AC-extraction.332.*` | 3 | brokerage CSV routing |
| AC11.12.1 | `AC-extraction.212.1` | 1 | classification idempotency (partial group) |

**Deliberately not moved** (row-level tier stricter than the extraction package tier `LLM-LED` — a mechanical move would downgrade proof authority; noted in the EPIC for the boundary owners): `AC11.12.2` ({tier:CODE-LED}), `AC26.8.1` ({tier:CODE-ONLY}), `AC12.40.1–4` ({tier:CODE-ONLY}, currency_resolution), `AC3.3.2` ({tier:HU} — the pre-existing precedent for leaving mismatched rows).

Mechanics as #1548: test function names unchanged; dot-form ids renamed (21 refs, 4 test files); EPIC tables replaced with migration stubs; the partial-group note uses the wildcard annotation form so lint check4 doesn't count it as a live reference; short EPIC file paths qualified to repo-root-relative in roadmap `test` refs. extraction roadmap: 188 → 200 ACs.

## Verification
- `check_ac_index`: protection dashboard non-regressing (has_mirror 37 ≥ floor 33).
- `check_ac_tier_baseline`: tier debt **-16**.
- `check_epic_package_dual`: PASSED (no id defined in both sources).
- `check_package_contract`: extraction 200 roadmap ACs — OK.
- preflight: ac-traceability / doc-consistency / taxonomy-drift / tooling (1913 passed) green; `backend-format` failure is the documented PATH-ruff false positive (pinned 0.14.11 clean).
- Edited tests pass (4 files, 41 passed).

Sibling slices: #1633 (audit) · #1634 (ledger). Follow-up candidates for the boundary owners: the tier-mismatched rows above, and the EPIC-003 AC3.3 duplicate-under-two-ids residue.

Related: #1416 #1421 · mechanics: #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)