### PR TITLE
[finance_report_test_and_doc] fix(gate): repoint cassette-boundary allowlist at the classifier's post-#1626 home — main is red

### DIFF
--- a/tests/tooling/test_llm_cassette_boundary.py
+++ b/tests/tooling/test_llm_cassette_boundary.py
@@ -26,7 +26,8 @@ _ALLOWED = (
     "tools/_lib/record_hf_cassettes.py",
     # governance INTROSPECTION: the authority classifier detects LLM-band tests
     # by recognising these very tokens — it reads names, it never uses the layer.
-    "common/authority/authority_classifier.py",
+    # (moved from common/authority/ by the authority→meta convergence, #1626)
+    "common/meta/extension/authority_classifier.py",
     "tests/tooling/test_authority_classifier.py",
     # facade->litellm WIRE-integration tests (mock below the transport; use the
     # layer's LIVE seam to reach their stubs).

--- a/unified-coverage.json
+++ b/unified-coverage.json
@@ -1,12 +1,12 @@
 {
-  "total_lines": 37727,
-  "covered_lines": 36074,
-  "coverage_percent": 95.62,
+  "total_lines": 37805,
+  "covered_lines": 36142,
+  "coverage_percent": 95.6,
   "breakdown": {
     "backend": {
-      "total_lines": 18879,
-      "covered_lines": 18286,
-      "coverage_percent": 96.86,
+      "total_lines": 18892,
+      "covered_lines": 18307,
+      "coverage_percent": 96.9,
       "file_count": 258
     },
     "frontend": {
@@ -16,10 +16,10 @@
       "file_count": 175
     },
     "common": {
-      "total_lines": 11499,
-      "covered_lines": 10762,
-      "coverage_percent": 93.59,
-      "file_count": 143
+      "total_lines": 11564,
+      "covered_lines": 10809,
+      "coverage_percent": 93.47,
+      "file_count": 144
     },
     "tools": {
       "total_lines": 3128,


### PR DESCRIPTION
## Summary

**main's post-merge CI is currently red** (54f1c6a6, 04ce7fbf, 8cdfde41 all failed Tooling/Common Coverage, and every open PR inherits it) due to cross-PR merge skew:

- #1627 added `tests/tooling/test_llm_cassette_boundary.py` whose allowlist sanctions the authority classifier's token-introspection at `common/authority/authority_classifier.py`;
- #1626, merged concurrently, moved that file to `common/meta/extension/authority_classifier.py` (authority→meta convergence).

Each PR was green against the main it branched from; combined, the gate flags the classifier at its new path:

```
FAILED test_llm_cassette_boundary.py::test_AC_llm_10_7_no_cassette_knowledge_outside_the_layer
['common/meta/extension/authority_classifier.py: CassetteMode', ...]
```

## Change

One-line allowlist repoint (+ a comment noting the #1626 move). The classifier's usage is unchanged — it token-matches names for governance introspection, it never uses the layer (its own allowlist rationale).

## Verification

Full tooling suite green locally on latest main (1922 passed, 1 skipped). Note for reviewers: `test_check_package_directory_coverage` can fail **locally** with ghost `common/authority/`/`common/coverage/` dirs containing only `__pycache__` after pulling #1626 — filesystem residue, not a repo defect; `rm -rf` them.

Unblocks: #1633 #1634 #1635 and every other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Update**: the same merge-skew also broke the **unified-coverage no-regression gate** — #1626 froze `unified-coverage.json` (95.62 / common 93.59) measured on its own branch, while merged with #1627 (which deleted covered cassette-fork code in `common/`) reality measures **95.60 / common 93.47**, so every run on main fails the baseline compare too. Second commit refreshes the committed baseline from this PR's own CI-measured artifact (run 28784472194). Both breakages, one cause: two concurrently-merged PRs each froze facts against the main they saw.