### PR TITLE
[finance_report_hacker] docs(meta): retire every dangling common/authority + common/coverage path (#1626 residue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
       - name: AC Proof-Kind Matrix Enforcement
         run: |
           # EPIC-026 phase 2: enforce the tier->valid-proof-kind matrix
-          # (common/authority/readme.md) for ACs that carry a {tier:XX}.
+          # (common/meta/readme.md) for ACs that carry a {tier:XX}.
           # Untagged legacy ACs have no proof_kind and are ignored (non-breaking).
           # The rule with teeth: an LLM-LED AC's proof_kind MUST NOT be `exact`
           # (an LLM-emitted output cannot be proven by an exact golden assertion);
@@ -271,7 +271,7 @@ jobs:
       - name: Tier Import Guard (CODE-ONLY must not import the LLM layer)
         run: |
           # EPIC-026 phase 3: enforce the cross-tier STRUCTURAL MUST rule
-          # (common/authority/readme.md, rule 2 "CODE-ONLY stays pure"). AST-based,
+          # (common/meta/readme.md, rule 2 "CODE-ONLY stays pure"). AST-based,
           # direct-imports-only: a curated set of CODE-ONLY/financial-truth modules
           # (money/**, ledger/**, journal model, deterministic services) must
           # not import the LLM layer (src.llm) or a raw provider SDK

--- a/apps/backend/tests/extraction/test_extraction_invariants.py
+++ b/apps/backend/tests/extraction/test_extraction_invariants.py
@@ -3,7 +3,7 @@
 EPIC-026 phase 2 — the extraction ACs in EPIC-003 are tier **LLM-LED**: the LLM emits
 the parsed statement, and deterministic CODE only validates / gatekeeps it (it can
 reject or flag, never produce). Per the tier->proof matrix
-(``common/authority/readme.md``), an LLM-LED AC is proven by an
+(``common/meta/readme.md``), an LLM-LED AC is proven by an
 **invariant/property** test of that gatekeeper, NOT by an exact golden assertion
 on the LLM output (which is non-reproducible).
 

--- a/common/counter/contract.py
+++ b/common/counter/contract.py
@@ -79,7 +79,7 @@ CONTRACT = PackageContract(
             test="apps/backend/tests/counter/test_count.py::test_count_rejects_negative",
         ),
         # Structural guarantees live as invariants (no authority tier, not
-        # matrix-constrained) — see common/authority/readme.md. The roadmap
+        # matrix-constrained) — see common/meta/readme.md. The roadmap
         # below holds only the package's DOMAIN behavior, which inherits the
         # package tier.
         Invariant(

--- a/common/meta/base/authority_matrix.py
+++ b/common/meta/base/authority_matrix.py
@@ -1,6 +1,6 @@
 """Single machine source of the authority-tier vocabulary + tier->proof matrix.
 
-This is the canonical machine mirror of ``common/authority/readme.md``. It is
+This is the canonical machine mirror of ``common/meta/readme.md``. It is
 **stdlib-only by design** (``typing`` only): importable by the lightweight SSOT
 tooling — the registry generator (``generate_ac_registry``), the proof-kind gate
 (``check_ac_proof_kind``), and the CODE/LLM classifier (``authority_classifier``)

--- a/common/meta/extension/authority_classifier.py
+++ b/common/meta/extension/authority_classifier.py
@@ -1,6 +1,6 @@
 """CODE / LLM authority classifier + per-package counter (EPIC-026 AC26.9).
 
-Model (see common/authority/readme.md):
+Model (see common/meta/readme.md):
 - Every AC is one bit, **detected from its test shape** (not declared):
     * ``LLM``  — the test exercises the record/replay (cassette) harness.
     * ``CODE`` — a structured-input deterministic test, no LLM in the loop.

--- a/common/meta/extension/check_ac_proof_kind.py
+++ b/common/meta/extension/check_ac_proof_kind.py
@@ -3,7 +3,7 @@
 
 EPIC-026 phase 1 gave every acceptance criterion (AC) an authority *tier*
 (CODE-ONLY/CODE-LED/HU/LLM-LED/LLM-ONLY) and an SSOT matrix
-(``common/authority/readme.md``) saying which KIND of proof is valid for an AC
+(``common/meta/readme.md``) saying which KIND of proof is valid for an AC
 at each tier. That matrix was descriptive only. This gate makes it ENFORCED —
 but ONLY for ACs that carry a tier, so it is non-breaking for the ~1655 untagged
 legacy ACs (they have no ``proof_kind`` key and are ignored).
@@ -46,8 +46,8 @@ from common.testing.generate_ac_registry import AC_PROOF_KINDS, build_registry_e
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 # tier -> the set of proof kinds the SSOT matrix accepts for that tier. The prose
-# source of truth is common/authority/readme.md; its single MACHINE mirror is
-# common/authority/authority_matrix.TIER_VALID_PROOF_KINDS (which package_contract also
+# source of truth is common/meta/readme.md; its single MACHINE mirror is
+# common/meta/base/authority_matrix.TIER_VALID_PROOF_KINDS (which package_contract also
 # re-exports for the PackageContract model). Aliased here so this gate and the
 # contract model enforce one identical matrix — they cannot drift apart.
 VALID_PROOF_KINDS: dict[str, frozenset[str]] = TIER_VALID_PROOF_KINDS
@@ -124,7 +124,7 @@ def main(argv: list[str] | None = None) -> int:
         for message in violations:
             print(
                 f"::error title=AC proof-kind::{message} "
-                "(see common/authority/readme.md).",
+                "(see common/meta/readme.md).",
                 file=sys.stderr,
             )
         print(

--- a/common/meta/extension/check_ac_tier_baseline.py
+++ b/common/meta/extension/check_ac_tier_baseline.py
@@ -4,7 +4,7 @@
 Every acceptance criterion should eventually declare an authority *tier* (one of
 :data:`common.testing.generate_ac_registry.AC_TIERS`) — the property that says who
 holds final decision authority over the behavior the AC describes, and therefore
-what KIND of proof is valid for it (SSOT: ``common/authority/readme.md``).
+what KIND of proof is valid for it (SSOT: ``common/meta/readme.md``).
 
 The repo has ~1830 ACs that predate the tier attribute, so a hard "every AC must
 declare a tier" check would fail CI on day one. This gate instead mirrors the
@@ -145,7 +145,7 @@ def main(argv: list[str] | None = None) -> int:
                 "::error title=AC tier ratchet::"
                 f"{ac_id}: new/modified AC has no authority tier. Add a "
                 "{tier:CODE-ONLY|CODE-LED|HU|LLM-LED|LLM-ONLY} marker at its definition site "
-                "(see common/authority/readme.md).",
+                "(see common/meta/readme.md).",
                 file=sys.stderr,
             )
         print(

--- a/common/meta/extension/check_authority_reconcile.py
+++ b/common/meta/extension/check_authority_reconcile.py
@@ -2,7 +2,7 @@
 """Gate: reconcile a package's DECLARED authority tier against its DETECTED band.
 
 The authority tier has two views over one CODE↔LLM spectrum
-(``common/authority/authority_matrix.py``):
+(``common/meta/base/authority_matrix.py``):
 
 - **declared** — ``PackageContract.tier`` (the package's authorial intent);
 - **detected** — the band the ``authority_classifier`` measures from the shapes

--- a/common/meta/extension/check_ssot_ownership.py
+++ b/common/meta/extension/check_ssot_ownership.py
@@ -61,7 +61,7 @@ MUST_BE_ABSENT: list[Path] = [
     REPO_ROOT / "docs" / "ssot" / "coverage-verification.md",
     # observability.logging-improvements.md renamed to observability-logging.md
     REPO_ROOT / "docs" / "ssot" / "observability.logging-improvements.md",
-    # authority-tiers.md internalized into the authority package
+    # authority-tiers.md internalized into the owning package (common/meta since #1626)
     # (common/meta/readme.md) per migration-standard step 3 "SSOT internalized".
     REPO_ROOT / "docs" / "ssot" / "authority-tiers.md",
     # extraction.md internalized into the extraction package

--- a/common/meta/extension/check_ssot_ownership.py
+++ b/common/meta/extension/check_ssot_ownership.py
@@ -62,7 +62,7 @@ MUST_BE_ABSENT: list[Path] = [
     # observability.logging-improvements.md renamed to observability-logging.md
     REPO_ROOT / "docs" / "ssot" / "observability.logging-improvements.md",
     # authority-tiers.md internalized into the authority package
-    # (common/authority/readme.md) per migration-standard step 3 "SSOT internalized".
+    # (common/meta/readme.md) per migration-standard step 3 "SSOT internalized".
     REPO_ROOT / "docs" / "ssot" / "authority-tiers.md",
     # extraction.md internalized into the extraction package
     # (common/extraction/readme.md) per migration-standard step 3 "SSOT internalized"

--- a/common/meta/extension/check_tier_imports.py
+++ b/common/meta/extension/check_tier_imports.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Cross-tier STRUCTURAL gate: CODE-ONLY / financial-truth modules MUST NOT import the LLM layer.
 
-EPIC-026 phase 3. The authority-tier SSOT (``common/authority/readme.md``,
+EPIC-026 phase 3. The authority-tier SSOT (``common/meta/readme.md``,
 "Cross-tier MUST rules", rule 2) states:
 
     **CODE-ONLY stays pure.** A CODE-ONLY AC MUST NOT depend on an LLM client; its outcome is
@@ -31,7 +31,7 @@ Scope (v1, deliberately simple + false-positive-free):
   same letters (``src.llmx`` would not match; ``src.llm_helpers`` would not match).
 
 The protected set and forbidden targets below are the machine-checkable mirror of
-the SSOT rule; ``common/authority/readme.md`` is the single source of truth.
+the SSOT rule; ``common/meta/readme.md`` is the single source of truth.
 """
 
 from __future__ import annotations
@@ -43,7 +43,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# --- The contract (mirror of common/authority/readme.md "Cross-tier MUST
+# --- The contract (mirror of common/meta/readme.md "Cross-tier MUST
 # --- rules", rule 2). Keep these in sync with the SSOT subsection.
 
 # Protected CODE-ONLY / financial-truth modules, as path globs relative to the repo
@@ -196,7 +196,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Cross-tier structural gate: CODE-ONLY/financial-truth modules MUST NOT "
-            "import the LLM layer (common/authority/readme.md)."
+            "import the LLM layer (common/meta/readme.md)."
         )
     )
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
@@ -213,7 +213,7 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 f"::error title=Tier import guard::protected glob {glob!r} matched "
                 "no file — the curated PROTECTED_MODULE_GLOBS set has drifted from "
-                "the tree (see common/authority/readme.md).",
+                "the tree (see common/meta/readme.md).",
                 file=sys.stderr,
             )
         print(
@@ -230,7 +230,7 @@ def main(argv: list[str] | None = None) -> int:
                 f"::error title=Tier import guard::{module_path} imports {imported!r} "
                 f"(forbidden LLM-layer target {matched!r}). A CODE-ONLY/financial-truth "
                 "module MUST NOT depend on the LLM layer "
-                "(common/authority/readme.md, cross-tier MUST rule 2).",
+                "(common/meta/readme.md, cross-tier MUST rule 2).",
                 file=sys.stderr,
             )
         print(

--- a/common/testing/generate_ac_registry.py
+++ b/common/testing/generate_ac_registry.py
@@ -73,7 +73,7 @@ EPIC_NAMES: dict[int, str] = {
 AC_PATTERN = re.compile(r"\b(AC(\d+)\.(\d+)\.(\d+))\b")
 
 # Authority tier + proof-kind vocabulary and the tier->proof matrix all come from
-# the single machine source common/authority/authority_matrix.py (stdlib-only;
+# the single machine source common/meta/base/authority_matrix.py (stdlib-only;
 # package_contract re-exports the same definitions for its model validation), so
 # the EPIC-table source and the package-contract source can never disagree.
 AC_TIERS = _AC_TIERS

--- a/docs/project/EPIC-020.framework-aware-personal-reporting.md
+++ b/docs/project/EPIC-020.framework-aware-personal-reporting.md
@@ -69,7 +69,7 @@ Not owned here:
 ## Reporting Pipeline Authority Tiers (EPIC-026 applied)
 
 The personal-report pipeline is three layers, each with a distinct authority tier
-from the locked EPIC-026 5-tier set (see `common/authority/readme.md`). The tier
+from the locked EPIC-026 5-tier set (see `common/meta/readme.md`). The tier
 is assigned by *who emits the artifact that is used*, and it dictates the layer's
 valid proof type. This is the deterministic-by-construction spine of the report:
 LLM judgement is confined to the one layer where polymorphism is irreducible, and

--- a/docs/project/EPIC-025.dry-ssot-simplification.md
+++ b/docs/project/EPIC-025.dry-ssot-simplification.md
@@ -157,9 +157,9 @@ verifiable.
 > [EPIC-009](./EPIC-009.pdf-fixture-generation.md)'s PDF fixture generation
 > ACs. EPIC-023's cassette layer/streaming-bridge/integrity-gate ACs
 > (AC23.5/AC23.6/AC23.7) do NOT migrate here despite their EPIC-authored
-> `{tier:CODE-ONLY}` annotation: `common/authority/authority_classifier.py`
+> `{tier:CODE-ONLY}` annotation: `common/meta/extension/authority_classifier.py`
 > detects any cassette/replay-harness test as the `LLM` band regardless of
-> how deterministic its assertions are, which `common/authority/
+> how deterministic its assertions are, which `common/meta/extension/
 > check_authority_reconcile.py` enforces against `testing`'s single
 > package-wide `CODE-ONLY` tier — see `common/testing/contract.py`'s module
 > docstring.

--- a/docs/project/EPIC-026.ac-authority-tiers.md
+++ b/docs/project/EPIC-026.ac-authority-tiers.md
@@ -19,8 +19,8 @@ behaviors and each AC still carries its own tier.
 
 The crucial payoff: **an AC's tier dictates what KIND of proof is valid for it**,
 tying the testing strategy to intent. The tier vocabulary, the cross-tier MUST
-rules, and the tier→valid-proof matrix are owned by the `authority` package
-([common/meta/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/meta/readme.md));
+rules, and the tier→valid-proof matrix are owned by the `meta` package (converged from `authority` in #1626;
+[common/meta/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/meta/readme.md));
 this EPIC references that contract rather than restating it.
 
 ---
@@ -48,8 +48,8 @@ this EPIC references that contract rather than restating it.
 - **First batch**: tag the EPICs central to the strict↔LLM design discussion.
 
 ### Actions
-1. Author the tier vocabulary (now internalized into the `authority` package,
-   [common/meta/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/meta/readme.md));
+1. Author the tier vocabulary (now internalized into the `meta` package
+   after the #1626 authority→meta converge, [common/meta/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/meta/readme.md));
    register it in `docs/ssot/MANIFEST.yaml` (`authority_tiers`).
 2. Extend the EPIC AC declaration with a `{tier:XX}` marker and teach
    `tools/generate_ac_registry.py` to lift it into the AC value.
@@ -107,7 +107,7 @@ this EPIC references that contract rather than restating it.
 
 > **`AC-authority.1.1`, `AC-authority.2.1`, `AC-authority.3.1`, `AC-authority.4.1`,
 > `AC-authority.5.1`, `AC-authority.6.1`, and `AC-authority.7.1` are defined in the
-> `authority` package, not here.** The authority-tier *system* ACs (phases 1–3) are
+> `meta` package (converged from `authority`, #1626), not here.** The authority-tier *system* ACs (phases 1–3) are
 > homed in [`common/meta/contract.py`](../../common/meta/contract.py)'s
 > `roadmap` under the package-scoped id scheme — the contract is their single
 > definition source (resolved by `check_package_contract`). This EPIC stays the

--- a/docs/project/EPIC-026.ac-authority-tiers.md
+++ b/docs/project/EPIC-026.ac-authority-tiers.md
@@ -20,7 +20,7 @@ behaviors and each AC still carries its own tier.
 The crucial payoff: **an AC's tier dictates what KIND of proof is valid for it**,
 tying the testing strategy to intent. The tier vocabulary, the cross-tier MUST
 rules, and the tier→valid-proof matrix are owned by the `authority` package
-([common/authority/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/authority/readme.md));
+([common/meta/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/meta/readme.md));
 this EPIC references that contract rather than restating it.
 
 ---
@@ -49,7 +49,7 @@ this EPIC references that contract rather than restating it.
 
 ### Actions
 1. Author the tier vocabulary (now internalized into the `authority` package,
-   [common/authority/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/authority/readme.md));
+   [common/meta/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/meta/readme.md));
    register it in `docs/ssot/MANIFEST.yaml` (`authority_tiers`).
 2. Extend the EPIC AC declaration with a `{tier:XX}` marker and teach
    `tools/generate_ac_registry.py` to lift it into the AC value.
@@ -108,7 +108,7 @@ this EPIC references that contract rather than restating it.
 > **`AC-authority.1.1`, `AC-authority.2.1`, `AC-authority.3.1`, `AC-authority.4.1`,
 > `AC-authority.5.1`, `AC-authority.6.1`, and `AC-authority.7.1` are defined in the
 > `authority` package, not here.** The authority-tier *system* ACs (phases 1–3) are
-> homed in [`common/authority/contract.py`](../../common/authority/contract.py)'s
+> homed in [`common/meta/contract.py`](../../common/meta/contract.py)'s
 > `roadmap` under the package-scoped id scheme — the contract is their single
 > definition source (resolved by `check_package_contract`). This EPIC stays the
 > horizontal narrative. The phase 4–5 ACs below **remain here**: `AC26.8.1` is an
@@ -126,7 +126,7 @@ this EPIC references that contract rather than restating it.
 
 | ID | Requirement | Test Function | File | Priority |
 |----|-------------|---------------|------|----------|
-| AC26.9.1 | A base library classifies every AC as `CODE` or `LLM` **detected from its test shape** (a record/replay cassette test ⇒ `LLM`; a structured-input deterministic test ⇒ `CODE`), and a counter aggregates each package into an `LLM-share` mapped to one of four bands — `CODE-ONLY` (`s = 0`), `CODE-LED` (`0 < s < 50`), `LLM-LED` (`50 ≤ s < 100`), `LLM-ONLY` (`s = 100`). Classification is detected, never declared, so the band is computed not argued. See `common/authority/readme.md` §CODE/LLM bit. {tier:CODE-ONLY} {proof:property} | `test_AC26_9_1_band_boundaries`, `test_AC26_9_1_test_shape_classifies_code_vs_llm` | `tests/tooling/test_authority_classifier.py` | P0 |
+| AC26.9.1 | A base library classifies every AC as `CODE` or `LLM` **detected from its test shape** (a record/replay cassette test ⇒ `LLM`; a structured-input deterministic test ⇒ `CODE`), and a counter aggregates each package into an `LLM-share` mapped to one of four bands — `CODE-ONLY` (`s = 0`), `CODE-LED` (`0 < s < 50`), `LLM-LED` (`50 ≤ s < 100`), `LLM-ONLY` (`s = 100`). Classification is detected, never declared, so the band is computed not argued. See `common/meta/readme.md` §CODE/LLM bit. {tier:CODE-ONLY} {proof:property} | `test_AC26_9_1_band_boundaries`, `test_AC26_9_1_test_shape_classifies_code_vs_llm` | `tests/tooling/test_authority_classifier.py` | P0 |
 
 ---
 
@@ -152,7 +152,7 @@ this EPIC references that contract rather than restating it.
 
 ## 🔗 References
 
-- SSOT: [common/authority/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/authority/readme.md)
+- SSOT: [common/meta/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/meta/readme.md)
   (the tier vocabulary, internalized into the `authority` package)
 - Untagged-debt baseline: [ac-tier-baseline.json](../ssot/ac-tier-baseline.json)
 - Generator: `tools/generate_ac_registry.py` · Gate: `tools/check_ac_tier_baseline.py`

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -170,7 +170,7 @@ explicit AC IDs for the behavior.
 | `apps/backend/tests/pricing/test_resolve.py` | `common/pricing/contract.py` |
 | `apps/backend/tests/pricing/test_subject.py` | `common/pricing/contract.py` |
 | `tests/tooling/test_coverage_analyzer.py` | `docs/ssot/coverage.md` |
-| `tests/tooling/test_migration_safety_gates.py` | `common/authority/readme.md` |
+| `tests/tooling/test_migration_safety_gates.py` | `common/meta/readme.md` |
 | `tests/tooling/test_delivery_gates_contract.py` | `docs/ssot/delivery-gates.yaml` |
 | `tests/tooling/test_env_contract_boundary.py` | `docs/ssot/observability.md`, `docs/ssot/environments.md` |
 | `tests/tooling/test_github_workflow_timing_summary.py` | `docs/ssot/ci-cd.md` |

--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -80,7 +80,7 @@ New components default to `ci-critical`, so a tree is only ever down-tiered to
 tier is the lever for the guiding rule: *gate at high coverage iff CI-critical*.
 
 > **Library layering**: reusable coverage/CI implementation lives under
-> `common/` (`common/coverage`, `common/ci`); the top-level `tools/*.py` are thin
+> `common/` (`common/testing/coverage`, `common/meta/extension`); the top-level `tools/*.py` are thin
 > command wrappers. The legacy duplicate `tools/_lib/ci` and `tools/_lib/coverage`
 > trees have been consolidated into `common/` — there is one gated library tree.
 

--- a/docs/ssot/governance-exceptions.yaml
+++ b/docs/ssot/governance-exceptions.yaml
@@ -77,7 +77,7 @@ exceptions:
       deletion is merged.
 
   # SSOT internalized: the authority-tier vocabulary moved out of docs/ssot/
-  # into the authority package that owns it (common/authority/readme.md), per
+  # into the authority package that owns it (now common/meta/readme.md after the #1626 converge), per
   # the package-migration standard step 3 "SSOT internalized". The MANIFEST
   # `authority_tiers` concept now points there, so docs/ssot/authority-tiers.md
   # is deleted; its deletion shows up as a changed SSOT file with no owner. This
@@ -85,7 +85,8 @@ exceptions:
   - target: finance_report:docs/ssot/authority-tiers.md
     issue: https://github.com/wangzitian0/finance_report/issues/1459
     reason: >-
-      authority-tiers.md internalized into common/authority/readme.md (the
+      authority-tiers.md internalized into the authority readme, now
+      common/meta/readme.md after the #1626 converge (the
       authority package owns the tier vocabulary + tier->proof matrix); the
       MANIFEST authority_tiers owner now points there. Remove this exception
       once the deletion is merged.

--- a/docs/ssot/governance-exceptions.yaml
+++ b/docs/ssot/governance-exceptions.yaml
@@ -77,7 +77,8 @@ exceptions:
       deletion is merged.
 
   # SSOT internalized: the authority-tier vocabulary moved out of docs/ssot/
-  # into the authority package that owns it (now common/meta/readme.md after the #1626 converge), per
+  # into the owning package — common/meta/readme.md since the #1626
+  # authority→meta converge — per
   # the package-migration standard step 3 "SSOT internalized". The MANIFEST
   # `authority_tiers` concept now points there, so docs/ssot/authority-tiers.md
   # is deleted; its deletion shows up as a changed SSOT file with no owner. This
@@ -85,9 +86,9 @@ exceptions:
   - target: finance_report:docs/ssot/authority-tiers.md
     issue: https://github.com/wangzitian0/finance_report/issues/1459
     reason: >-
-      authority-tiers.md internalized into the authority readme, now
-      common/meta/readme.md after the #1626 converge (the
-      authority package owns the tier vocabulary + tier->proof matrix); the
+      authority-tiers.md internalized into the owning package's readme —
+      common/meta/readme.md since the #1626 authority→meta converge (meta
+      owns the tier vocabulary + tier->proof matrix); the
       MANIFEST authority_tiers owner now points there. Remove this exception
       once the deletion is merged.
   # Identity package self-hosts: the auth SSOT moved out of docs/ssot/ into the

--- a/tests/tooling/test_framework_reporting_epic_contract.py
+++ b/tests/tooling/test_framework_reporting_epic_contract.py
@@ -149,7 +149,7 @@ def test_AC20_9_1_reporting_pipeline_declares_layer_authority_tiers() -> None:
     assert "exact / property test" in epic  # CODE-ONLY
     # LLM authority confined to the LLM-LED layer; CODE-LED is code-authoritative (CODE-ONLY today).
     assert "CODE-ONLY today" in epic
-    assert "common/authority/readme.md" in epic
+    assert "common/meta/readme.md" in epic
 
 
 def test_AC2_18_1_canonical_ledger_is_framework_neutral() -> None:


### PR DESCRIPTION
Follow-up to #1631: the last residue class from the #1626 converge (authority→meta, coverage→testing). #1626 repointed all 31 *import* sites but left 34 *prose* references to the deleted package homes:

- **EPIC-026**: three absolute GitHub links to `common/authority/readme.md` (404 since the converge), a relative link to `common/authority/contract.py`, and the AC26.9.1 statement's SSOT pointer — all now point at `common/meta/readme.md` / `common/meta/contract.py`.
- **Five meta gates' own docstrings/messages** (`check_tier_imports`, `check_ac_proof_kind`, `check_ac_tier_baseline`, `check_authority_reconcile`, `check_ssot_ownership`, plus `authority_matrix` and `authority_classifier`) named the deleted readme as their SSOT — a gate telling you to consult a file that doesn't exist.
- **EPIC-020 + its contract test**: `test_framework_reporting_epic_contract` asserted the old path INTO the doc; both sides move together.
- **docs/ssot/coverage.md** presented `common/coverage` + `common/ci` as current library homes → `common/testing/coverage` + `common/meta/extension`.
- **governance-exceptions.yaml**: two prose references updated to note the current home.
- **ci.yml**: two comment references.

Deliberately untouched: historical narration in meta's docs ("how `common/ci` accumulated as undeclared junk…", the retired-tree notes in `check_package_directory_coverage`) — those describe the past, not the present.

Sweep proof: zero non-historical `common/authority` / `common.authority` / `common/coverage` matches repo-wide. Preflight: ac-traceability / ssot-ownership / doc-consistency / taxonomy-drift / tooling (1922 passed) green; backend-format flags only the documented PATH-ruff (0.15.17) drift — pinned CI ruff (0.14.11) passes 629 files clean. AC registry regenerated with no diff beyond the EPIC-026 statement text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)