### PR TITLE
chore(ci): update unified coverage baseline

### DIFF
--- a/unified-coverage.json
+++ b/unified-coverage.json
@@ -1,6 +1,6 @@
 {
   "total_lines": 37805,
-  "covered_lines": 36141,
+  "covered_lines": 36142,
   "coverage_percent": 95.6,
   "breakdown": {
     "backend": {
@@ -17,8 +17,8 @@
     },
     "common": {
       "total_lines": 11564,
-      "covered_lines": 10808,
-      "coverage_percent": 93.46,
+      "covered_lines": 10809,
+      "coverage_percent": 93.47,
       "file_count": 144
     },
     "tools": {


### PR DESCRIPTION
## What

Updates `unified-coverage.json` from the latest successful main CI coverage calculation.

## Why

The no-regression gate still uses the committed baseline. This PR keeps branch protection intact while removing manual baseline file edits after coverage rises.
