### PR TITLE
[finance_report_ui] fix(ci): stop coverage-baseline automation from reddening main CI (unblocks releases)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1220,6 +1220,10 @@ jobs:
     name: Open Unified Coverage Baseline PR
     needs: [changes, unified-coverage]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.pr_required == 'true' && needs.unified-coverage.result == 'success'
+    # Best-effort post-merge automation: opening/refreshing the baseline PR must
+    # never fail the main CI run. A red run here has been silently blocking
+    # release-image promotion (the promote step gates on a green main CI run).
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -1260,7 +1264,11 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add unified-coverage.json
           git commit -m "chore(ci): update unified coverage baseline"
-          git push --force-with-lease origin "HEAD:$BASELINE_BRANCH"
+          # Plain --force, not --force-with-lease: the runner's shallow checkout
+          # never fetches this branch, so the lease has no remote-tracking ref to
+          # compare against and git rejects every push with "stale info". This is
+          # a dedicated single-writer bot branch, so a force push is safe.
+          git push --force origin "HEAD:$BASELINE_BRANCH"
 
           pr_body="$(mktemp)"
           cat > "$pr_body" <<'EOF'

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -2875,7 +2875,12 @@ def test_AC8_13_143_unified_coverage_updates_baseline_through_pr_not_direct_main
     )
     assert "BASELINE_BRANCH: automation/unified-coverage-baseline" in baseline_block
     assert "git diff --quiet -- unified-coverage.json" in baseline_block
-    assert "git push --force-with-lease origin" in baseline_block
+    # Plain --force (not --force-with-lease): the shallow CI checkout never fetches
+    # the bot branch, so a lease has no remote-tracking ref and git rejects every
+    # push with "stale info". It is a single-writer bot branch, and the push still
+    # targets $BASELINE_BRANCH (never main — asserted below), so the AC's real
+    # invariant (baseline updates via PR, not a direct main push) holds.
+    assert 'git push --force origin "HEAD:$BASELINE_BRANCH"' in baseline_block
     assert "gh pr create" in baseline_block
     assert "gh pr edit" in baseline_block
     assert "HEAD:main" not in baseline_block


### PR DESCRIPTION
## Problem

The `Open Unified Coverage Baseline PR` job (post-merge, main-only) has failed on **every** main push since #1626. Because the release-image **promote** step gates on a *green* main CI run, this single non-essential job has been silently **blocking all release-image promotion** — e.g. the `v0.1.32` tag build failed at promote even though `Build Staging Images` and `finish` passed.

## Root cause

`git push --force-with-lease origin HEAD:automation/unified-coverage-baseline` is rejected with `! [rejected] (stale info)` on every runner: the shallow checkout never fetches that bot branch, so `--force-with-lease` has no remote-tracking ref to verify its lease against and refuses — regardless of whether the branch exists. Merging the open baseline PR (#1638) and deleting the branch both failed to fix it (verified on `fbb8962f`).

## Fix

1. **`--force-with-lease` → `--force`.** It is a dedicated single-writer bot branch, so a force push is safe and always succeeds.
2. **`continue-on-error: true`** on the job — defense in depth so this best-effort automation can never fail the merge/release gate again (mirrors the existing pattern on the step-summary job).

## Verification

- After merge, the next main CI run should be **green** (baseline job either succeeds or is non-fatal), restoring release-image promotion and the auto-redeploy of `report-branch-main`.
- Then `v0.1.32` can be tagged on the green commit and deployed to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)