### PR TITLE
[finance_report_hacker] fix(ci): coverage ratchet jitter epsilon + baseline-bot churn/push fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1254,29 +1254,47 @@ jobs:
           fi
 
           git switch -C "$BASELINE_BRANCH"
-          # Quantized-rise guard: raw covered_lines jitter ±1 between runs, so a
-          # byte-level diff churns a baseline PR on every main push. Only act
-          # when a ROUNDED percent actually rose (drops are the regression
-          # gate's job and never fold into the baseline silently).
+          # Quantized rise-only MERGE: raw covered_lines jitter ±1 between runs,
+          # so a byte-level diff churns a baseline PR on every main push. Fold
+          # in ONLY the components whose ROUNDED percent rose; a component
+          # whose percent dipped keeps its old baseline triple, so jitter (or a
+          # real drop inside the gate's epsilon) can never walk the committed
+          # baseline downward while something else rises. The written unified
+          # triple may then not equal the breakdown sums — sound, because the
+          # regression gate compares each recorded percent independently.
           if ! python3 - <<'PY'
           import json, sys
           old = json.load(open("unified-coverage.json"))
           new = json.load(open("coverage-context/unified-coverage.json"))
-          def percents(d):
-              out = {"unified": round(float(d.get("coverage_percent", 0)), 2)}
-              for name, comp in d.get("breakdown", {}).items():
-                  out[name] = round(float(comp.get("coverage_percent", 0)), 2)
-              return out
-          o, n = percents(old), percents(new)
-          rises = {k: (o.get(k), v) for k, v in n.items() if v > o.get(k, 0)}
-          print(f"baseline percents: {o} -> {n}; rises: {rises or 'none'}")
-          sys.exit(0 if rises else 1)
+          def pct(d):
+              return round(float(d.get("coverage_percent", 0)), 2)
+          merged = dict(new)
+          merged["breakdown"] = dict(new.get("breakdown", {}))
+          rises, kept = {}, []
+          for name, comp in list(merged["breakdown"].items()):
+              o = old.get("breakdown", {}).get(name)
+              if o is None or pct(comp) > pct(o):
+                  rises[name] = (pct(o) if o else None, pct(comp))
+              else:
+                  merged["breakdown"][name] = o
+                  kept.append(name)
+          if pct(new) > pct(old):
+              rises["unified"] = (pct(old), pct(new))
+          else:
+              for key in ("total_lines", "covered_lines", "coverage_percent"):
+                  merged[key] = old.get(key, merged.get(key))
+              kept.append("unified")
+          print(f"rises: {rises or 'none'}; kept old baseline for: {kept or 'none'}")
+          if not rises:
+              sys.exit(1)
+          with open("unified-coverage.json", "w") as f:
+              json.dump(merged, f, indent=2)
+              f.write("\n")
           PY
           then
             echo "No rounded-percent rise — line-count jitter only; skipping baseline PR."
             exit 0
           fi
-          cp coverage-context/unified-coverage.json unified-coverage.json
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1254,17 +1254,35 @@ jobs:
           fi
 
           git switch -C "$BASELINE_BRANCH"
-          cp coverage-context/unified-coverage.json unified-coverage.json
-          if git diff --quiet -- unified-coverage.json; then
-            echo "Unified coverage baseline is unchanged."
+          # Quantized-rise guard: raw covered_lines jitter ±1 between runs, so a
+          # byte-level diff churns a baseline PR on every main push. Only act
+          # when a ROUNDED percent actually rose (drops are the regression
+          # gate's job and never fold into the baseline silently).
+          if ! python3 - <<'PY'
+          import json, sys
+          old = json.load(open("unified-coverage.json"))
+          new = json.load(open("coverage-context/unified-coverage.json"))
+          def percents(d):
+              out = {"unified": round(float(d.get("coverage_percent", 0)), 2)}
+              for name, comp in d.get("breakdown", {}).items():
+                  out[name] = round(float(comp.get("coverage_percent", 0)), 2)
+              return out
+          o, n = percents(old), percents(new)
+          rises = {k: (o.get(k), v) for k, v in n.items() if v > o.get(k, 0)}
+          print(f"baseline percents: {o} -> {n}; rises: {rises or 'none'}")
+          sys.exit(0 if rises else 1)
+          PY
+          then
+            echo "No rounded-percent rise — line-count jitter only; skipping baseline PR."
             exit 0
           fi
+          cp coverage-context/unified-coverage.json unified-coverage.json
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add unified-coverage.json
           git commit -m "chore(ci): update unified coverage baseline"
-          # Plain --force, not --force-with-lease: the runner's shallow checkout
+          # Plain --force, not a leased push: the runner's shallow checkout
           # never fetches this branch, so the lease has no remote-tracking ref to
           # compare against and git rejects every push with "stale info". This is
           # a dedicated single-writer bot branch, so a force push is safe.

--- a/common/testing/coverage/calculate_unified_coverage.py
+++ b/common/testing/coverage/calculate_unified_coverage.py
@@ -416,13 +416,23 @@ def print_low_coverage_files(rows: list[dict], threshold: float) -> None:
         )
 
 
+# Run-to-run measurement jitter: one covered line in an ~11k-line component
+# moves the rounded percent by 0.01 — enough to flip a strict `current <
+# baseline` compare and red a main run with no code change (seen after the
+# #1631 re-baseline: common flapped 93.46<->93.47). Dips within this epsilon
+# are noise, not regressions; the baseline-PR bot quantizes its rises the same
+# way (ci.yml "Open unified coverage baseline PR").
+REGRESSION_EPSILON_PCT = 0.05
+
+
 def _format_regression_error(
     *,
     baseline_path: Path,
     regressions: list[tuple[str, float, float]],
 ) -> str:
     lines = [
-        "❌ Coverage regression detected by local deterministic gate.",
+        "❌ Coverage regression detected by local deterministic gate "
+        f"(beyond the ±{REGRESSION_EPSILON_PCT:g}% jitter epsilon).",
         f"   Baseline: {baseline_path}",
     ]
     for name, current, baseline in regressions:
@@ -535,8 +545,10 @@ def main(argv: list[str] | tuple[str, ...] = ()) -> None:
         try:
             preflight_components = resolve_required_components(required_spec)
         except ValueError as exc:
-            print(f"\n❌ Invalid --require-artifacts/{REQUIRED_COMPONENTS_ENV}: {exc}",
-                  file=sys.stderr)
+            print(
+                f"\n❌ Invalid --require-artifacts/{REQUIRED_COMPONENTS_ENV}: {exc}",
+                file=sys.stderr,
+            )
             sys.exit(2)
     else:
         preflight_components = PREFLIGHT_COMPONENTS
@@ -607,7 +619,7 @@ def main(argv: list[str] | tuple[str, ...] = ()) -> None:
             regressions: list[tuple[str, float, float]] = []
             unified_current = round(unified["coverage_percent"], 2)
             unified_floor = round(float(baseline_unified), 2)
-            if unified_current < unified_floor:
+            if unified_current < unified_floor - REGRESSION_EPSILON_PCT:
                 regressions.append(("unified", unified_current, unified_floor))
 
             # Component breakdown comparison (if available)
@@ -632,7 +644,7 @@ def main(argv: list[str] | tuple[str, ...] = ()) -> None:
             for component_name, current_data, baseline_data in components_to_check:
                 current_percent = round(float(current_data["coverage_percent"]), 2)
                 baseline_percent = round(float(baseline_data["coverage_percent"]), 2)
-                if current_percent < baseline_percent:
+                if current_percent < baseline_percent - REGRESSION_EPSILON_PCT:
                     regressions.append(
                         (component_name, current_percent, baseline_percent)
                     )

--- a/tests/tooling/test_calculate_unified_coverage.py
+++ b/tests/tooling/test_calculate_unified_coverage.py
@@ -613,6 +613,66 @@ class TestBaselineComparison:
             cuc.main()
         assert exc.value.code == 0
 
+    def test_within_epsilon_jitter_is_not_a_regression(self, tmp_path, monkeypatch):
+        """A sub-epsilon dip (one covered line of run-to-run jitter) must NOT red
+        the gate: with REGRESSION_EPSILON_PCT=0.05, 83.14% vs baseline 83.15%
+        is measurement noise, not a regression (the flap seen on main after the
+        #1631 re-baseline: common flipped 93.46<->93.47 with no code change)."""
+        baseline_file = tmp_path / "baseline.json"
+        baseline_data = {
+            "coverage_percent": 83.15,
+            "total_lines": 10000,
+            "covered_lines": 8315,
+            "breakdown": {
+                "backend": {
+                    "total_lines": 5000,
+                    "covered_lines": 4700,
+                    "coverage_percent": 94.0,
+                },
+                "frontend": {
+                    "total_lines": 3000,
+                    "covered_lines": 2494,
+                    "coverage_percent": 83.13,
+                },
+                "tools": {
+                    "total_lines": 2000,
+                    "covered_lines": 1662,
+                    "coverage_percent": 83.10,
+                },
+            },
+        }
+        baseline_file.write_text(json.dumps(baseline_data))
+        monkeypatch.setenv("BASELINE_FILE", str(baseline_file))
+        monkeypatch.setenv("COVERAGE_THRESHOLD", "0")
+        monkeypatch.setattr(cuc, "ROOT_DIR", tmp_path)
+
+        # One covered line less in tools: 1661/2000 = 83.05 (-0.05, at epsilon)
+        # and unified 8314/10000 = 83.14 (-0.01, within epsilon).
+        current = {
+            "backend": {
+                "total_lines": 5000,
+                "covered_lines": 4700,
+                "coverage_percent": 94.0,
+            },
+            "frontend": {
+                "total_lines": 3000,
+                "covered_lines": 2494,
+                "coverage_percent": 83.13,
+            },
+            "tools": {
+                "total_lines": 2000,
+                "covered_lines": 1661,
+                "coverage_percent": 83.05,
+            },
+        }
+        monkeypatch.setattr(cuc, "get_backend_coverage", lambda: current["backend"])
+        monkeypatch.setattr(cuc, "get_frontend_coverage", lambda: current["frontend"])
+        monkeypatch.setattr(cuc, "get_tools_coverage", lambda: current["tools"])
+
+        with pytest.raises(SystemExit) as exc:
+            cuc.main()
+        assert exc.value.code == 0
+
     def test_fails_when_unified_drops_below_baseline(
         self, tmp_path, monkeypatch, capfd
     ):

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -2874,12 +2874,14 @@ def test_AC8_13_143_unified_coverage_updates_baseline_through_pr_not_direct_main
         in baseline_block
     )
     assert "BASELINE_BRANCH: automation/unified-coverage-baseline" in baseline_block
-    assert "git diff --quiet -- unified-coverage.json" in baseline_block
-    # Plain --force (not --force-with-lease): the shallow CI checkout never fetches
-    # the bot branch, so a lease has no remote-tracking ref and git rejects every
-    # push with "stale info". It is a single-writer bot branch, and the push still
-    # targets $BASELINE_BRANCH (never main — asserted below), so the AC's real
-    # invariant (baseline updates via PR, not a direct main push) holds.
+    # Quantized-rise guard (replaces the old byte-level `git diff --quiet`,
+    # which churned a baseline PR on every ±1 covered-line jitter) and a plain
+    # --force push (not leased: the shallow CI checkout never fetches the bot
+    # branch, so a lease has no remote-tracking ref and rejects with "stale
+    # info"; single-writer bot branch, and the push still targets
+    # $BASELINE_BRANCH — never main, asserted below — so the AC's real
+    # invariant, baseline updates via PR, holds).
+    assert "if v > o.get(k, 0)" in baseline_block
     assert 'git push --force origin "HEAD:$BASELINE_BRANCH"' in baseline_block
     assert "gh pr create" in baseline_block
     assert "gh pr edit" in baseline_block

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -2869,10 +2869,9 @@ def test_AC8_13_143_unified_coverage_updates_baseline_through_pr_not_direct_main
         in baseline_job_block
     )
     assert "name: unified-coverage-context" in baseline_job_block
-    assert (
-        "cp coverage-context/unified-coverage.json unified-coverage.json"
-        in baseline_block
-    )
+    # The baseline content still comes from the uploaded coverage context; the
+    # rise-only merge reads it instead of a blind cp (which folded dips in).
+    assert 'open("coverage-context/unified-coverage.json")' in baseline_block
     assert "BASELINE_BRANCH: automation/unified-coverage-baseline" in baseline_block
     # Quantized-rise guard (replaces the old byte-level `git diff --quiet`,
     # which churned a baseline PR on every ±1 covered-line jitter) and a plain
@@ -2881,7 +2880,7 @@ def test_AC8_13_143_unified_coverage_updates_baseline_through_pr_not_direct_main
     # info"; single-writer bot branch, and the push still targets
     # $BASELINE_BRANCH — never main, asserted below — so the AC's real
     # invariant, baseline updates via PR, holds).
-    assert "if v > o.get(k, 0)" in baseline_block
+    assert "kept old baseline for" in baseline_block
     assert 'git push --force origin "HEAD:$BASELINE_BRANCH"' in baseline_block
     assert "gh pr create" in baseline_block
     assert "gh pr edit" in baseline_block


### PR DESCRIPTION
Follow-up to #1631/#1638: the re-baseline exposed that the coverage ratchet operates at ±1 covered-line resolution, which is below run-to-run measurement noise. Two flap sources, both observed on main:

1. **Regression gate**: strict rounded-percent compare — a 1-line dip (0.01%) reds a main run with no code change (common flapped 93.46↔93.47 across the last three main runs). Added `REGRESSION_EPSILON_PCT = 0.05`: sub-epsilon dips are noise; real regressions (like #1626's -0.12%) still fail. TDD: `test_within_epsilon_jitter_is_not_a_regression` (red before, green after; the existing beyond-epsilon test still passes).

2. **Baseline bot** (run 28786732742): byte-level `git diff --quiet` churned a baseline PR on every jittering main push, and its leased push rejected with "stale info" whenever a previous run's scratch branch survived a merge race. The bot now (a) acts only when a ROUNDED percent rose, (b) plain-force-pushes its own scratch branch. The stale `automation/unified-coverage-baseline` branch from the #1638 race has been deleted.

Contract test `test_AC8_13_143` updated to pin the new mechanics; mirror-assertion ratchet goes DOWN (2917→2916). Preflight: all relevant gates green (tooling 1923 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)