### PR TITLE
[finance_report_infra] refactor(pricing): wire consumers onto pricing — PR1 (WIP, #1610 PR2)

### DIFF
--- a/apps/backend/src/services/market_data/__init__.py
+++ b/apps/backend/src/services/market_data/__init__.py
@@ -31,7 +31,6 @@ from src.services.market_data._providers import (
     _yahoo_chart_params,
 )
 from src.services.market_data._store import (
-    _active_stock_symbols,
     _derive_from_bridge_rates,
     _fallback_last_success_at,
     _is_sync_scope_fresh,
@@ -46,7 +45,6 @@ from src.services.market_data._store import (
     _load_stored_stock_price,
     _load_stored_stock_price_on_date,
     _load_sync_state,
-    _observed_fx_pairs,
     _persist_fx_rate,
     _persist_stock_price,
     _stored_fx_rate_dates,
@@ -118,7 +116,6 @@ __all__ = [
     "_STOCK_SYNC_SPEC",
     "_StoredFxRate",
     "_StoredStockPrice",
-    "_active_stock_symbols",
     "_date_to_epoch",
     "_default_start_date",
     "_derive_from_bridge_rates",
@@ -161,7 +158,6 @@ __all__ = [
     "_normalize_utc",
     "_observation_date",
     "_observations_by_date",
-    "_observed_fx_pairs",
     "_parse_fx_pair",
     "_parse_stooq_close_rows",
     "_parse_stooq_fx_csv_series",

--- a/apps/backend/src/services/market_data/_store.py
+++ b/apps/backend/src/services/market_data/_store.py
@@ -4,22 +4,14 @@ from __future__ import annotations
 
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.audit.quantity import Quantity
-from src.config import settings
-from src.models.account import Account
-from src.models.journal import JournalEntry, JournalLine
-from src.models.layer2 import AtomicPosition
-from src.models.layer3 import ManagedPosition, PositionStatus
 from src.models.market_data import FxRate, MarketDataSyncState, StockPrice
 from src.services.market_data._base import (
     _FRESHNESS_THRESHOLD,
-    MARKET_DATA_QUANTITY_UNIT,
     logger,
 )
 from src.services.market_data._types import (
@@ -447,51 +439,3 @@ async def _stored_fx_rate_dates_for_scope(
 ) -> set[date]:
     base, quote_currency = scope
     return await _stored_fx_rate_dates(db, base, quote_currency, start_date, end_date)
-
-
-async def _active_stock_symbols(db: AsyncSession, user_id: UUID | None) -> list[str]:
-    stmt = (
-        select(ManagedPosition.asset_identifier)
-        .where(ManagedPosition.status == PositionStatus.ACTIVE)
-        .where(ManagedPosition.quantity != Quantity.zero(MARKET_DATA_QUANTITY_UNIT).quantize().value)
-        .order_by(ManagedPosition.asset_identifier)
-    )
-    if user_id is not None:
-        stmt = stmt.where(ManagedPosition.user_id == user_id)
-    result = await db.execute(stmt)
-    return sorted({_normalize_symbol(row[0]) for row in result.all() if row[0]})
-
-
-async def _observed_fx_pairs(
-    db: AsyncSession,
-    user_id: UUID | None,
-    *,
-    include_default: bool = True,
-) -> list[str]:
-    base = _normalize_currency(settings.base_currency)
-    default_counterparty = "USD" if base != "USD" else "SGD"
-    currencies: set[str] = {base}
-    if include_default:
-        currencies.add(default_counterparty)
-
-    account_stmt = select(Account.currency)
-    if user_id is not None:
-        account_stmt = account_stmt.where(Account.user_id == user_id)
-    currencies.update(_normalize_currency(row[0]) for row in (await db.execute(account_stmt)).all() if row[0])
-
-    line_stmt = select(JournalLine.currency).join(JournalEntry, JournalEntry.id == JournalLine.journal_entry_id)
-    if user_id is not None:
-        line_stmt = line_stmt.where(JournalEntry.user_id == user_id)
-    currencies.update(_normalize_currency(row[0]) for row in (await db.execute(line_stmt)).all() if row[0])
-
-    position_stmt = select(ManagedPosition.currency)
-    if user_id is not None:
-        position_stmt = position_stmt.where(ManagedPosition.user_id == user_id)
-    currencies.update(_normalize_currency(row[0]) for row in (await db.execute(position_stmt)).all() if row[0])
-
-    snapshot_stmt = select(AtomicPosition.currency)
-    if user_id is not None:
-        snapshot_stmt = snapshot_stmt.where(AtomicPosition.user_id == user_id)
-    currencies.update(_normalize_currency(row[0]) for row in (await db.execute(snapshot_stmt)).all() if row[0])
-
-    return [f"{currency}/{base}" for currency in sorted(currencies) if currency != base]

--- a/apps/backend/src/services/market_data/service.py
+++ b/apps/backend/src/services/market_data/service.py
@@ -17,11 +17,9 @@ from src.services.market_data._base import (
 )
 from src.services.market_data._providers import _FX_SYNC_SPEC, _STOCK_SYNC_SPEC
 from src.services.market_data._store import (
-    _active_stock_symbols,
     _derive_from_bridge_rates,
     _is_sync_scope_fresh,
     _load_stored_direct_or_inverse,
-    _observed_fx_pairs,
     _persist_fx_rate,
     _sync_scope_status,
     _upsert_sync_state,
@@ -43,6 +41,7 @@ from src.services.market_data._util import (
     _parse_fx_pair,
     _stock_scope,
 )
+from src.services.market_data_discovery import active_stock_symbols, observed_fx_pairs
 
 
 async def _sync_market_observation_series(
@@ -148,7 +147,7 @@ async def sync_fx_rates(
 ) -> MarketDataSyncResult:
     """Incrementally fill FX rows for explicit or observed business pairs."""
     sync_end = end_date or date.today()
-    sync_pairs = list(pairs) if pairs is not None else await _observed_fx_pairs(db, user_id)
+    sync_pairs = list(pairs) if pairs is not None else await observed_fx_pairs(db, user_id)
     return await _sync_market_observation_series(
         db,
         raw_scopes=sync_pairs,
@@ -171,7 +170,7 @@ async def sync_stock_prices(
     sync_symbols = (
         sorted({_normalize_symbol(symbol) for symbol in symbols})
         if symbols is not None
-        else await _active_stock_symbols(db, user_id)
+        else await active_stock_symbols(db, user_id)
     )
     return await _sync_market_observation_series(
         db,
@@ -194,7 +193,7 @@ async def ensure_market_data_fresh(
     """Refresh observed market data once when the last successful sync is older than 24h."""
     checked_at = _normalize_utc(now or datetime.now(UTC))
     sync_end = end_date or date.today()
-    fx_pairs = set(await _observed_fx_pairs(db, user_id, include_default=include_default_fx))
+    fx_pairs = set(await observed_fx_pairs(db, user_id, include_default=include_default_fx))
     fx_pairs.update(extra_fx_pairs or [])
     stale_pairs: list[str] = []
     for raw_pair in fx_pairs:
@@ -211,7 +210,7 @@ async def ensure_market_data_fresh(
         ):
             stale_pairs.append(scope)
 
-    stock_symbols = await _active_stock_symbols(db, user_id)
+    stock_symbols = await active_stock_symbols(db, user_id)
     stale_symbols: list[str] = []
     for symbol in stock_symbols:
         scope = _stock_scope(symbol)
@@ -271,7 +270,7 @@ async def get_market_data_status(
     statuses: list[MarketDataScopeStatus] = []
 
     sync_pairs = (
-        list(pairs) if pairs is not None else await _observed_fx_pairs(db, user_id, include_default=include_default_fx)
+        list(pairs) if pairs is not None else await observed_fx_pairs(db, user_id, include_default=include_default_fx)
     )
     for raw_pair in sorted(set(sync_pairs)):
         base, quote_currency = _parse_fx_pair(raw_pair)
@@ -289,7 +288,7 @@ async def get_market_data_status(
     sync_symbols = (
         sorted({_normalize_symbol(symbol) for symbol in symbols})
         if symbols is not None
-        else await _active_stock_symbols(db, user_id)
+        else await active_stock_symbols(db, user_id)
     )
     for symbol in sync_symbols:
         if not symbol:

--- a/apps/backend/src/services/market_data_discovery.py
+++ b/apps/backend/src/services/market_data_discovery.py
@@ -1,0 +1,78 @@
+"""App-glue: discover which FX pairs / stock symbols the user's holdings need.
+
+This is the **ledger-reading** half of market-data sync — it inspects the user's
+accounts, journal, and positions to decide *which* scopes to crawl. It stays in
+the app layer on purpose: it reads ledger/portfolio models (``Account``,
+``JournalLine``, ``AtomicPosition``, ``ManagedPosition``), so it must NOT live
+inside the ``pricing`` package (pricing depends on ``audit``/``platform`` only,
+never on the domain flow). The pure crawl — *given* a set of scopes, fetch and
+store observations — is pricing's; this module is the boundary that feeds it
+(dependency inversion, meta Decision B): the caller (scheduler / router)
+discovers the scopes here and passes them to pricing's crawl.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.audit.quantity import Quantity
+from src.config import settings
+from src.models.account import Account
+from src.models.journal import JournalEntry, JournalLine
+from src.models.layer2 import AtomicPosition
+from src.models.layer3 import ManagedPosition, PositionStatus
+from src.services.market_data._base import MARKET_DATA_QUANTITY_UNIT
+from src.services.market_data._util import _normalize_currency, _normalize_symbol
+
+
+async def active_stock_symbols(db: AsyncSession, user_id: UUID | None) -> list[str]:
+    """The distinct asset identifiers of the user's active, non-zero positions."""
+    stmt = (
+        select(ManagedPosition.asset_identifier)
+        .where(ManagedPosition.status == PositionStatus.ACTIVE)
+        .where(ManagedPosition.quantity != Quantity.zero(MARKET_DATA_QUANTITY_UNIT).quantize().value)
+        .order_by(ManagedPosition.asset_identifier)
+    )
+    if user_id is not None:
+        stmt = stmt.where(ManagedPosition.user_id == user_id)
+    result = await db.execute(stmt)
+    return sorted({_normalize_symbol(row[0]) for row in result.all() if row[0]})
+
+
+async def observed_fx_pairs(
+    db: AsyncSession,
+    user_id: UUID | None,
+    *,
+    include_default: bool = True,
+) -> list[str]:
+    """The ``<currency>/<base>`` pairs implied by every currency the user holds."""
+    base = _normalize_currency(settings.base_currency)
+    default_counterparty = "USD" if base != "USD" else "SGD"
+    currencies: set[str] = {base}
+    if include_default:
+        currencies.add(default_counterparty)
+
+    account_stmt = select(Account.currency)
+    if user_id is not None:
+        account_stmt = account_stmt.where(Account.user_id == user_id)
+    currencies.update(_normalize_currency(row[0]) for row in (await db.execute(account_stmt)).all() if row[0])
+
+    line_stmt = select(JournalLine.currency).join(JournalEntry, JournalEntry.id == JournalLine.journal_entry_id)
+    if user_id is not None:
+        line_stmt = line_stmt.where(JournalEntry.user_id == user_id)
+    currencies.update(_normalize_currency(row[0]) for row in (await db.execute(line_stmt)).all() if row[0])
+
+    position_stmt = select(ManagedPosition.currency)
+    if user_id is not None:
+        position_stmt = position_stmt.where(ManagedPosition.user_id == user_id)
+    currencies.update(_normalize_currency(row[0]) for row in (await db.execute(position_stmt)).all() if row[0])
+
+    snapshot_stmt = select(AtomicPosition.currency)
+    if user_id is not None:
+        snapshot_stmt = snapshot_stmt.where(AtomicPosition.user_id == user_id)
+    currencies.update(_normalize_currency(row[0]) for row in (await db.execute(snapshot_stmt)).all() if row[0])
+
+    return [f"{currency}/{base}" for currency in sorted(currencies) if currency != base]

--- a/apps/backend/tests/market_data/test_sync.py
+++ b/apps/backend/tests/market_data/test_sync.py
@@ -13,6 +13,7 @@ from src.models.layer2 import AtomicPosition
 from src.models.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
 from src.models.market_data import FxRate, MarketDataSyncState, StockPrice
 from src.services import market_data
+from src.services.market_data_discovery import active_stock_symbols, observed_fx_pairs
 from src.services.portfolio import PortfolioService
 
 
@@ -340,7 +341,7 @@ async def test_observed_fx_pairs_include_default_and_non_base_business_currency(
     )
     await db.commit()
 
-    pairs = await market_data._observed_fx_pairs(db, test_user.id)
+    pairs = await observed_fx_pairs(db, test_user.id)
 
     assert pairs == ["HKD/SGD", "USD/SGD"]
 
@@ -397,7 +398,7 @@ async def test_active_stock_symbols_use_active_nonzero_holdings(
     )
     await db.commit()
 
-    assert await market_data._active_stock_symbols(db, test_user.id) == ["AAPL"]
+    assert await active_stock_symbols(db, test_user.id) == ["AAPL"]
 
 
 async def test_sync_stock_prices_records_missing_trading_days(

--- a/tests/tooling/test_base_package_migration_cleanup.py
+++ b/tests/tooling/test_base_package_migration_cleanup.py
@@ -43,7 +43,7 @@ BACKEND_MONEY_ADAPTER_FILES = [
 BACKEND_QUANTITY_ADAPTER_FILES = [
     Path("apps/backend/src/services/assets.py"),
     Path("apps/backend/src/portfolio/extension/accounting.py"),
-    Path("apps/backend/src/services/market_data"),
+    Path("apps/backend/src/services/market_data_discovery.py"),
     Path("apps/backend/src/services/portfolio.py"),
     Path("apps/backend/src/services/reporting"),
 ]

--- a/tests/tooling/test_decimal_boundary_policy.py
+++ b/tests/tooling/test_decimal_boundary_policy.py
@@ -65,7 +65,7 @@ def test_AC12_31_3_migrated_hotspots_use_base_packages():
     quantity_service_files = [
         Path("apps/backend/src/services/assets.py"),
         Path("apps/backend/src/portfolio/extension/accounting.py"),
-        Path("apps/backend/src/services/market_data"),
+        Path("apps/backend/src/services/market_data_discovery.py"),
         Path("apps/backend/src/services/reporting"),
     ]
     naked_quantity_zero = re.compile(


### PR DESCRIPTION
**Draft / WIP** — this is PR1 (推进) of pricing's cutover closeout (#1610 PR2), built incrementally. Only **step 1 is done** so far.

## Plan (evidence-based, from #1610's own spec + the fx.py deferral notes)

pricing was landed built-but-**unwired** (#1617): 21 live consumers still on the old flat services (fx 14 / market_data 4 / assets 3), 0 on pricing. pricing.fx is a reduced API — `fx_warnings`, `lazy_load`, `PrefetchedFxRates`, period-averaging were explicitly *deferred* in its docstring. `lazy_load` is blocked on market_data moving into pricing, which is blocked on market_data's crawler reading ledger models. So the correct order:

| step | what | status |
|---|---|---|
| **1. Invert the ledger-read discovery out of the crawl** | the "which pairs/symbols to crawl" query read `Account/JournalLine/AtomicPosition/ManagedPosition`; extracted to `services/market_data_discovery.py` (app-glue, may read ledger) so the crawl core is ledger-free (meta Decision B) | ✅ **done** — behavior-neutral, 449 tests pass |
| 2. Move the pure crawl core into `pricing/extension/market_data/` | `_sync_market_observation_series` / providers / store / `resolve_missing_fx_rate` — now ledger-free, so pricing gains no ledger dep | ⬜ |
| 3. Complete `pricing.fx` to API parity | port `fx_warnings` / `lazy_load` (now market_data is internal) / `PrefetchedFxRates` / `average_start/end` | ⬜ |
| 4. Repoint the 22 fx + 4 market_data + 3 assets-valuation consumers | drop-in incl. `FxRateError → PricingError` (verified `NoObservationError(PricingError)`, so graceful-degradation preserved) | ⬜ |
| 5. Full backend regression (money-critical) | fx / reporting / currency | ⬜ |

Cleanup (delete legacy services, migrate ACs, tier, draft→active) is the follow-up **PR2 (清理)**.

## Step 1 (this commit)

`services/market_data/` now has **zero direct ledger imports** — the ledger-reading discovery lives in the new app-glue module and the crawl calls it by dependency inversion. This is the foundational unblock: the crawl can now move into pricing without pricing depending on the ledger domain.

Behavior-neutral: **449 tests pass** (market_data / reporting / fx / assets); the 2 discovery unit tests were repointed to the new module.

Coordination: this is #1610's reserved PR2 (audit window's design). Executed per its documented plan; the currency-discovery inversion uses parameter-passing (Decision B sync form) over events — flagged for the design owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)