### PR TITLE
[finance_report_ui] docs: refactor the three top-level docs — vision gaps, AGENTS.md drift, README package-model alignment (#1656)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,11 +81,15 @@ The SSOT ownership map is: **[docs/ssot/MANIFEST.yaml](docs/ssot/MANIFEST.yaml)*
 **EPIC → ACx.y.z → Test → Code → Doc**
 
 0. Frame the work with a **MECE** breakdown: mutually exclusive task slices, collectively exhaustive coverage of the stated goal, explicit dependencies, and explicit out-of-scope items.
-1. Anchor to an EPIC in `docs/project/`
-2. Register ACs in `docs/ac_registry.yaml` (feature) or `docs/infra_registry.yaml` (infra)
+1. Anchor to an EPIC in `docs/project/` (the horizontal goal)
+2. Define ACs where they live: a **migrated package** owns its ACs as
+   `AC-<pkg>.<group>.<seq>` in that package's `contract.py` `roadmap` — never
+   mirrored back into an EPIC table. Only legacy, not-yet-migrated modules
+   still register ACs in `docs/ac_registry.yaml` (feature) or
+   `docs/infra_registry.yaml` (infra)
 3. Write **failing** tests referencing AC IDs (🔴 red)
 4. Write minimal code to pass tests (🟢 green)
-5. Update SSOT docs
+5. Update the owning package contract/readme (or SSOT docs for legacy modules)
 
 Details: [docs/agents/orchestration.md](docs/agents/orchestration.md) · [docs/ssot/tdd.md](docs/ssot/tdd.md)
 
@@ -123,18 +127,22 @@ Full policy: **[docs/contributing/branch-policy.md](docs/contributing/branch-pol
 
 ## 🤖 Agent Architecture
 
-Full guide: **[docs/agents/orchestration.md](docs/agents/orchestration.md)**
+Full guide: **[docs/agents/orchestration.md](docs/agents/orchestration.md)** ·
+Per-runtime agents & MCP baseline: **[.claude/README.md](.claude/README.md)**
 
-| Agent | Cost | When |
-|-------|------|------|
-| **Sisyphus** | — | Main orchestrator |
-| `explore` | FREE | Parallel codebase exploration |
-| `librarian` | FREE | External docs |
-| `frontend-ui-ux-engineer` | MEDIUM | Mandatory for CSS/styling |
-| `multimodal-looker` | MEDIUM | Image/PDF |
-| `oracle` | EXPENSIVE | Architecture decisions |
+- The **main loop of the runtime you are in** is the orchestrator. Named
+  subagents are per-runtime mechanics (Claude Code: `.claude/agents/`;
+  OpenCode: `.opencode/oh-my-openagent.json`) — use the runtime's own list,
+  and never hard-require an agent another runtime does not have.
+- Delegate read-only fan-out (codebase search, external docs) to the cheap
+  search agents; reserve the expensive tier for genuinely hard advisory
+  reasoning. Parallelism is bounded by write conflicts, not by compute cost
+  (vision.md, Good Taste 6).
+- UI work: behavior is proven by tests; **visual quality is judged by human
+  eyes and simulators** — no agent sign-off substitutes for either.
 
-Skills: [.opencode/skills/](.opencode/skills/) · Config: [.opencode/oh-my-openagent.json](.opencode/oh-my-openagent.json)
+Skills: [.opencode/skills/](.opencode/skills/) (canonical library; other
+runtimes symlink into it — see [.claude/README.md](.claude/README.md))
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ The SSOT ownership map is: **[docs/ssot/MANIFEST.yaml](docs/ssot/MANIFEST.yaml)*
 
 ## 🔄 Mandatory Work Order
 
-**EPIC → ACx.y.z → Test → Code → Doc**
+**EPIC → AC → Test → Code → Doc**
 
 0. Frame the work with a **MECE** breakdown: mutually exclusive task slices, collectively exhaustive coverage of the stated goal, explicit dependencies, and explicit out-of-scope items.
 1. Anchor to an EPIC in `docs/project/` (the horizontal goal)

--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ README -> EPIC -> AC -> test
   entry points, and links to generated reports.
 - **EPIC documents** in `docs/project/EPIC-*.md` describe scope and acceptance
   criteria.
-- **AC registries** are generated indexes materialized from EPIC documents plus
-  explicit overrides: `docs/ac_registry.yaml`, `docs/infra_registry.yaml`, and
+- **AC homes**: a **migrated package** owns its ACs as `AC-<pkg>.<group>.<seq>`
+  in that package's `contract.py` `roadmap` (aggregated by `meta`'s data layer,
+  never mirrored back into an EPIC table — see
+  [`common/meta/migration-standard.md`](common/meta/migration-standard.md)).
+  Legacy, not-yet-migrated modules still materialize ACs from EPIC documents
+  into the generated registries: `docs/ac_registry.yaml`,
+  `docs/infra_registry.yaml`, plus explicit overrides in
   `docs/ac_registry_overrides.yaml`.
 - **Tests** are the proof. A referenced AC is not enough; behavior must be
   asserted by real tests.
@@ -64,7 +69,7 @@ Use these sources instead:
 - Traceability gate: `python tools/check_ac_index.py`
 - E2E EPIC closure gate: `python tools/check_e2e_epic_traceability.py`
 - Coverage baseline data: `unified-coverage.json`
-- Coverage policy owner: `common/coverage/policy.py`
+- Coverage policy owner: `common/testing/coverage/policy.py`
 
 The Coveralls badge is main-branch reporting only. Pull requests do not publish
 Coveralls status contexts; merge readiness follows the `finish` check and the
@@ -284,7 +289,8 @@ apps/
 ├── backend/     # FastAPI + SQLAlchemy + PostgreSQL
 └── frontend/    # Next.js + TypeScript
 
-common/          # Shared libraries for CI, coverage, SSOT, fixtures, and dev helpers
+common/          # The package model: per-domain packages (meta, testing, runtime,
+                 # ledger, extraction, llm, ...) each owning its contract + roadmap ACs
 tools/           # Command entry points that delegate to common libraries
 docs/project/    # EPICs and project audit reports
 docs/ssot/       # Rationale docs that link to code owners and proof tests

--- a/vision.md
+++ b/vision.md
@@ -87,7 +87,7 @@ Our hard constraints are managed as risk, not absolutes.
 - **Process hygiene**: the same stave discipline applies to how we build. Real
   financial data — amounts, balances, account numbers, holder names — never
   appears in issues, PRs, commits, logs, or reports; development artifacts are
-  public surface, and one leaked statement is a catastrophically short stave.
+  a public surface, and one leaked statement is a catastrophically short stave.
 
 ### Axiom D — The model generalizes; code guarantees the number; key nodes keep slack
 

--- a/vision.md
+++ b/vision.md
@@ -84,6 +84,10 @@ Our hard constraints are managed as risk, not absolutes.
   adopting the discipline of US public-company reporting. Public companies have
   already generalized the fancy operations; we align to that standard rather
   than invent our own. Minor representational gaps are tolerable.
+- **Process hygiene**: the same stave discipline applies to how we build. Real
+  financial data — amounts, balances, account numbers, holder names — never
+  appears in issues, PRs, commits, logs, or reports; development artifacts are
+  public surface, and one leaked statement is a catastrophically short stave.
 
 ### Axiom D — The model generalizes; code guarantees the number; key nodes keep slack
 
@@ -104,6 +108,25 @@ We are an AI-driven product, and the division of labor is drawn on purpose:
   sub-cent drift or a transient hiccup. The slack lives in *thresholds and flow* —
   whether to auto-accept or escalate — never in the correctness of the number
   itself. Brittleness from over-specified detail is a defect, not rigor.
+
+### Axiom E — Production trust is part of the product
+
+A system that guards the user's numbers must also guard itself, by the same
+standard it applies to data:
+
+- **The system observes itself and fails closed.** A deployed tier declares
+  what it requires; when a required dependency is absent, it refuses to look
+  healthy. An unobserved production surface is treated exactly like
+  low-confidence data — it is the part we do not yet trust, and the mission is
+  to shrink it.
+- **Required-in-production is an SLA commitment.** Declaring a dependency
+  required is a promise that someone watches it continuously — its absence is
+  discovered by the system within minutes, not by the next release's smoke
+  test days later.
+- **Alerting is judged by actionability.** One incident reads as one thread
+  with its evidence attached. A storm of technically-true alerts that nobody
+  can act on protects nothing; noise is a defect of the net, not of the
+  operator's attention.
 
 ## North-Star Metric
 
@@ -158,6 +181,16 @@ trade-off rules say *what* to choose; these say whether the thing is built well.
 4. **Simplicity is the standard.** One function, one thing, done well and
    short; past three levels of nesting, fix the function, not the symptom.
    Over-specified complexity is a defect, not rigor. (Axiom D.)
+5. **A safety net that can silently degrade is not a safety net.** Prove a
+   behavior against a real oracle, then lock the proof so no later change can
+   hollow it out. A gate that can go vacuous while staying green is worse than
+   no gate — it keeps spending trust it no longer earns. (Axiom E, pointed at
+   our own tests and gates.)
+6. **Human judgment is the scarce resource.** Machine time is cheap; the
+   user's review bandwidth is not. Parallel work is bounded by write conflicts,
+   not by compute cost. Behavior is proven by tests; visual quality is judged
+   by human eyes on real screens. Spend compute freely to save judgment, never
+   the reverse.
 
 These govern *how* a change is built; when they still leave the choice
 ambiguous, run the Decision Filter.


### PR DESCRIPTION
Closes #1656. First of the three AI-harness-audit PRs (#1656 → #1657 → #1658).

**AGENTS.md modification explicitly authorized by the user (2026-07-07).**

One commit per document:

## 1. vision.md — additive culture (no anchor changes)
- **Axiom E — Production trust is part of the product**: self-observation + fail-closed tiers, required-in-production = SLA commitment, alert actionability (one incident = one thread). Anchors this week's decisions (#1653/#1654/#1655, infra2#475) after the 10-day prod Prefect outage produced ~600 Lark messages with no cultural anchor to arbitrate.
- **Good Taste 5**: a safety net that can silently degrade is not a safety net (elevates the lived ratchet/mirror-assertion/fail-closed culture from one Decision Filter line).
- **Good Taste 6**: human judgment is the scarce resource — parallelism bounded by write conflicts not compute cost; behavior proven by tests, visuals judged by human eyes.
- **Axiom C**: the stave discipline extends to the development process (no real financial data in issues/PRs/logs — matches red-line #6).
- No new `<a id>` anchors (orphan-vision-anchor gate requires EPIC back-refs); all existing anchors untouched — `generate_vision_proof_matrix --check` green (9 nodes, unchanged).

## 2. AGENTS.md — close two drifts
- **Work order step 2**: migrated packages own ACs in their `contract.py` `roadmap` (registries = legacy path only) — the quick-reference had drifted behind orchestration.md and the package model.
- **Agent Architecture**: replaced the OpenCode-specific cost-tier table (with the zombie "frontend-ui-ux-engineer mandatory for CSS" policy — an agent that exists in 1 of 4 runtimes; UI PRs #1611/#1615/#1616 shipped without it) with runtime-truth guidance + the real UI culture, anchored to the new Good Taste 6.

## 3. README.md — package-model alignment
- Operating Model documents both AC homes (package roadmap = current, EPIC-registry = legacy).
- Fixed dead pointer `common/coverage/policy.py` → `common/testing/coverage/policy.py` (#1626 converge).
- `common/` architecture note now describes the package model.

## Verification
- `generate_vision_proof_matrix.py --check` ✅ (9 vision nodes, matrix builds)
- `test_lint_doc_consistency` + `test_generate_vision_proof_matrix` + `test_agent_runtime_symlinks` — 121 passed ✅
- All referenced paths verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)