### PR TITLE
[finance_report_audit] Migration closeout 1/3: finish package readmes, fix stale migration docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ tmp/
 .env
 .envrc
 
+# Local AI-harness config backups (may carry live API keys) — previously
+# protected only by a personal, unshared .git/info/exclude entry.
+openclaw_*.json
+
 # MkDocs build output
 site/
 

--- a/.opencode/skills/domain/extraction/SKILL.md
+++ b/.opencode/skills/domain/extraction/SKILL.md
@@ -73,8 +73,8 @@ To prevent floating-point errors:
 
 ## Source Files
 
-- **Models**: `apps/backend/src/models/statement.py`
+- **Models**: `apps/backend/src/models/statement_summary.py`
 - **Schemas**: `apps/backend/src/schemas/extraction.py`
-- **Logic**: `apps/backend/src/services/extraction.py`
+- **Logic**: `apps/backend/src/extraction/` (moved from `services/extraction.py` in the package cutover, #1421)
 - **Validation**: `apps/backend/src/extraction/extension/statement_validation.py`
 - **Storage**: `apps/backend/src/runtime/extension/storage.py`

--- a/.opencode/skills/domain/reconciliation/SKILL.md
+++ b/.opencode/skills/domain/reconciliation/SKILL.md
@@ -107,6 +107,6 @@ scoring:
 
 ## Source Files
 
-- **Logic**: `apps/backend/src/services/reconciliation.py`
+- **Logic**: `apps/backend/src/reconciliation/extension/matching.py` (moved from `services/reconciliation.py` in the package cutover, #1423)
 - **Config**: `apps/backend/config/reconciliation.yaml`
 - **Models**: `apps/backend/src/models/reconciliation.py`

--- a/common/advisor/readme.md
+++ b/common/advisor/readme.md
@@ -78,7 +78,7 @@ The advisor aggregates context from:
 |--------|--------------|-------|
 | `report_readiness` | Readiness state + blockers | `src.services.report_readiness` |
 | `reporting` | Balance sheet, income statement, category breakdown | `src.services.reporting` |
-| `reconciliation` | Pending review count, reconciliation stats | `src.services.reconciliation` |
+| `reconciliation` | Pending review count, reconciliation stats | `src.reconciliation.extension.review_queue` (moved from `services.reconciliation`, #1423) |
 | `portfolio` | Positions, unrealised P&L | `src.services.portfolio` |
 | `market_data` | Scope status, prices | `src.services.market_data` |
 | `workflow_events` | Action-required counts | `src.platform.extension.workflow_events` |

--- a/common/audit/money/readme.md
+++ b/common/audit/money/readme.md
@@ -1,7 +1,7 @@
 # `money` — Decimal money value language (kernel package)
 
 > The money/currency/FX value type. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Language-neutral interface + conformance:
 > [`contract/money.contract.md`](./contract/money.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:

--- a/common/audit/quantity/readme.md
+++ b/common/audit/quantity/readme.md
@@ -1,7 +1,7 @@
 # `quantity` — Decimal quantity + unit value language (kernel package)
 
 > The quantity/unit value type. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Language-neutral interface + conformance:
 > [`contract/quantity.contract.md`](./contract/quantity.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:

--- a/common/audit/ratio/readme.md
+++ b/common/audit/ratio/readme.md
@@ -1,7 +1,7 @@
 # `ratio` — Decimal ratio / percentage value language (kernel package)
 
 > The ratio/percentage value type. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Language-neutral interface + conformance:
 > [`contract/ratio.contract.md`](./contract/ratio.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:

--- a/common/audit/unit_price/readme.md
+++ b/common/audit/unit_price/readme.md
@@ -1,7 +1,7 @@
 # `unit_price` — money-per-unit value language (kernel package)
 
 > The unit-price value type. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Language-neutral interface + conformance:
 > [`contract/unit_price.contract.md`](./contract/unit_price.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:

--- a/common/config/readme.md
+++ b/common/config/readme.md
@@ -1,7 +1,7 @@
 # `config` — env-key + schema validation helpers (infra tooling package)
 
 > Internal tooling, not a domain bounded context. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../meta/readme.md`](../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
 
 ## What

--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -1,7 +1,7 @@
 # `counter` — per-(user, key) tallies (middleware package)
 
 > The **canonical worked example of the package model** (a package = DDD bounded
-> context). Model spec: [`../governance/readme.md`](../governance/readme.md).
+> context). Model spec: [`../meta/readme.md`](../meta/readme.md).
 > Machine contract: [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
 >
 > This `common/counter/` directory is the **spec + review surface**; the

--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -213,7 +213,7 @@ not balance proof and must not satisfy the auto-approve precondition.
 
 ## Brokerage Position Import
 
-Brokerage extraction feeds Layer 2 `AtomicPosition` through `apps/backend/src/services/brokerage_positions.py`.
+Brokerage extraction feeds Layer 2 `AtomicPosition` through `apps/backend/src/extraction/extension/brokerage_positions.py`.
 
 ### Producer routing & positions output schema (#1139)
 

--- a/common/meta/base/layering.py
+++ b/common/meta/base/layering.py
@@ -15,8 +15,9 @@ The five layers:
   inverts the dependency at tool-time (CI scans every contract); nothing at
   runtime imports upward.
 - ``infra``      (L1) — business-agnostic foundations: config, audit,
-  authority, observability, testing, coverage, runtime, llm,
-  platform (the event-bus ports).
+  observability, testing, runtime, llm, platform (the event-bus ports).
+  ``authority`` converged into ``meta`` and ``coverage`` into ``testing``
+  (#1626) — neither is a standalone package any more.
 - ``middleware`` (L2) — the shared domain kernel: generic capabilities
   (counter). The value language (money/ratio/quantity/unit_price) folded
   into audit (#1419).
@@ -71,10 +72,10 @@ PACKAGE_LAYER: dict[str, PackageClass] = {
     # (money/ratio/quantity/unit_price) folded into audit (#1419), so those
     # names are gone from the map — audit (L1) owns the financial base types.
     "counter": "middleware",
-    # L3 — vertical business slices. advisor / portfolio / pricing / reporting
-    # are forward placements: their cutovers (#1425 / #1422 / #1610 / #1424)
-    # have not shipped a contract.py yet, so the map pins their layer ahead of
-    # time (the shell-ahead rule above) — they are future packages, not dead ones.
+    # L3 — vertical business slices. advisor / portfolio / reconciliation all
+    # shipped their contract.py (#1425 / #1422 / #1423); pricing / reporting
+    # have a contract.py but are still status="draft" (#1610 / #1424 in
+    # flight) — the map already pins their layer ahead of the roadmap filling in.
     "advisor": "domain",
     "extraction": "domain",
     "identity": "domain",

--- a/common/meta/extension/check_package_directory_coverage.py
+++ b/common/meta/extension/check_package_directory_coverage.py
@@ -38,6 +38,21 @@ IGNORED_DIR_NAMES = {"__pycache__"}
 UNGOVERNED_EXCEPTIONS: dict[str, str] = {}
 
 
+def _has_real_content(dir_path: Path) -> bool:
+    """True if the tree holds any file outside a ``__pycache__`` directory.
+
+    A package directory deleted from git can leave stale, untracked
+    ``__pycache__`` bytecode behind on a developer's existing checkout (Python
+    does not clean these up when the source is removed). Such a directory is
+    dead local debris, not an undeclared package, so it must not fail the gate.
+    """
+    return any(
+        "__pycache__" not in path.relative_to(dir_path).parts
+        for path in dir_path.rglob("*")
+        if path.is_file()
+    )
+
+
 def discover_common_dirs(repo_root: Path) -> list[str]:
     """Every directory directly under common/, excluding caches and dotdirs."""
     common_dir = repo_root / "common"
@@ -47,6 +62,7 @@ def discover_common_dirs(repo_root: Path) -> list[str]:
         if p.is_dir()
         and p.name not in IGNORED_DIR_NAMES
         and not p.name.startswith(".")
+        and _has_real_content(p)
     )
 
 
@@ -85,7 +101,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - {error}", file=sys.stderr)
         return 1
 
-    print("[DIRECTORY COVERAGE] PASSED: every common/ directory is governed or excepted.")
+    print(
+        "[DIRECTORY COVERAGE] PASSED: every common/ directory is governed or excepted."
+    )
     return 0
 
 

--- a/common/observability/readme.md
+++ b/common/observability/readme.md
@@ -1,6 +1,6 @@
 # `observability` — OTEL runtime contract, audit logging + OpenPanel CLI (infra)
 
-> Model spec: [`../governance/readme.md`](../governance/readme.md). Machine
+> Model spec: [`../meta/readme.md`](../meta/readme.md). Machine
 > contract: [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
 
 ## What

--- a/common/platform/readme.md
+++ b/common/platform/readme.md
@@ -1,6 +1,6 @@
 # `platform` — domain EventBus via the transactional outbox (meta-layer capability #1)
 
-> Package model: [`../governance/readme.md`](../governance/readme.md). Machine
+> Package model: [`../meta/readme.md`](../meta/readme.md). Machine
 > contract: [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
 >
 > This `common/platform/` directory is the **spec + review surface**; the

--- a/common/portfolio/readme.md
+++ b/common/portfolio/readme.md
@@ -1,0 +1,77 @@
+# `portfolio` — investment position accounting (domain package)
+
+> Package model: [`../meta/readme.md`](../meta/readme.md). Machine contract:
+> [`contract.py`](./contract.py).
+>
+> This `common/portfolio/` directory is the **spec + review surface**; the
+> conforming implementation lives at
+> [`apps/backend/src/portfolio`](../../apps/backend/src/portfolio)
+> (`contract.implementations["be"]`).
+
+## Why
+
+Buying, selling, and receiving a dividend on an investment needs the same
+double-entry discipline as any other cash movement, plus position bookkeeping
+double-entry doesn't cover: which lot did this sale consume, at what cost
+basis, realized vs unrealized. `portfolio` owns that position math; it posts
+through `ledger.post_entry` for the cash/equity side rather than duplicating
+posting logic.
+
+## Positions-only boundary (2026-07-06, updated after the pricing design review #1610)
+
+`portfolio` owns only position math — quantity, cost basis, realized/unrealized
+P&L. It never fetches or stores a price or a valuation; it *consumes* one via
+`pricing.resolve(subject, as_of, policy)`. The old `MarketDataOverride` write
+path (`PortfolioService.update_market_prices`) belongs to `pricing.record_override`
+now, not here.
+
+## Ubiquitous language
+
+- **`ManagedPosition`** — portfolio's aggregate root: an open or closed holding
+  in one asset, for one user/account. Owns `InvestmentLot` and
+  `InvestmentTransaction`; the invariant is *open position quantity ≥ 0* plus
+  cost-basis consistency across lots.
+- **`InvestmentLot`** — one FIFO/LIFO/AVGCOST-consumable acquisition slice of a
+  position, carrying its own cost basis.
+- **`InvestmentTransaction`** — a buy/sell/dividend event against a position.
+- **`DividendIncome`** — a dividend receipt, split into cash and (optionally)
+  withholding-tax legs on the ledger side.
+- **`AtomicPosition`** — the brokerage-extraction-facing read shape `extraction`
+  feeds into position accounting (see
+  [`../extraction/readme.md`](../extraction/readme.md#brokerage-position-import)).
+
+## Write side (real, tested)
+
+`InvestmentAccountingService` (`extension/accounting.py`) composes
+`ledger.post_entry`: `post_buy`/`post_sell`/`post_dividend` each post a
+balanced `Entry` and update the position's own aggregate in the same
+transaction — portfolio writes its own aggregate, ledger posts on receipt, no
+shared FK (Decision B). `post_sell` supports FIFO, LIFO, and AVGCOST lot
+consumption and never drives an open position's quantity below zero.
+
+## Read side (reserved — blocked on #1643)
+
+`get_holdings`, `get_portfolio_summary`, the P&L/allocation/performance
+queries, and the `PortfolioRepository` port/adapter split are declared in
+[`contract.py`](./contract.py) as reserved units (no `module=`): the real
+implementation still lives in `apps/backend/src/services/portfolio.py` /
+`services/performance.py`, gated on the read-side migration (#1643).
+
+## Cross-package edges
+
+`audit` (Money/Quantity/UnitPrice base types), `ledger` (`post_entry` —
+portfolio writes only its own aggregate in one transaction, then posts a
+balanced `Entry`; no shared transaction), `pricing` (price/FX resolution —
+portfolio never looks up a rate itself). Both `ledger` and `pricing` are L3
+domain siblings; the edge is acyclic and sideways (`portfolio → ledger`,
+`portfolio → pricing`, never the reverse).
+
+## Governance
+
+The package's write-side ACs (`AC-portfolio.1.1`–`AC-portfolio.4.2`) live in
+[`contract.py`](./contract.py)'s `roadmap` and are sourced **directly** from
+there into the AC registry (no EPIC mirror). The read-side ACs (still in
+`docs/project/EPIC-017.portfolio-management.md`) move into this roadmap once
+#1643 lands. `tools/check_package_contract.py` validates the implementation
+against this contract (interface == `__all__`, every test reference resolves,
+no upward import edge).

--- a/common/pricing/readme.md
+++ b/common/pricing/readme.md
@@ -1,0 +1,86 @@
+# `pricing` — the price/valuation observation + resolution SSOT (domain package)
+
+> Package model: [`../meta/readme.md`](../meta/readme.md). Machine contract:
+> [`contract.py`](./contract.py).
+>
+> This `common/pricing/` directory is the **spec + review surface**; the
+> conforming implementation lives at
+> [`apps/backend/src/pricing`](../../apps/backend/src/pricing)
+> (`contract.implementations["be"]`).
+>
+> **Status: `draft`** (design review #1610 landed the model + resolver +
+> repository + FX wrappers; the roadmap is still empty pending the
+> EPIC-011/005/017 pricing-AC migration — see [Status](#status) below).
+
+## Why
+
+Pre-migration, "what is X worth at time T" was scattered across 5 tables with
+3 incompatible key vocabularies (`FxRate`, `StockPrice`, `MarketDataOverride`,
+`ManualValuationSnapshot`, plus statement-extracted unit prices), and the
+resolution logic (which observation wins when several disagree) was implicit
+and re-derived at each consumption site. `pricing` unifies this into one
+observation + resolution SSOT, orthogonal to the financial flow: portfolio
+marks positions to market, reconciliation checks per-currency balances,
+reporting restates net worth — all through the same `resolve(subject, as_of,
+policy)` call.
+
+## Ubiquitous language
+
+- **`PriceObservation`** — the aggregate root: a subject was worth X at time
+  T, from a source, with an authority rank. Append-only (Axiom A) — an
+  override is a new higher-authority observation, never a mutation; deleting
+  one re-exposes the prior observation.
+- **`PriceableSubject`** — unifies the 3 legacy key vocabularies (currency
+  pair / listed security / valued component) into one subject identity.
+- **`resolve(subject, as_of, policy)`** — the domain service, not a lookup:
+  consumers pass a `ResolutionPolicy` (reporting wants conservative, portfolio
+  wants latest).
+- **Bitemporal** — `as_of` (which day the price belongs to) ≠ `observed_at`
+  (when we learned it). A late backfill must never silently rewrite a frozen
+  `ReportSnapshot`.
+- **`PriceObserved`** — the domain event `pricing` publishes (through the
+  platform outbox, atomically with the write) whenever a new observation is
+  recorded; `extraction` is one producer (`source=statement`), the manual
+  recorders another (`source=manual-override`).
+
+## Boundary rulings (record, don't relitigate — see #1610)
+
+1. Statement-extracted unit prices stay in `extraction` (document-fact,
+   provenance chain, re-parse lifecycle); `extraction` publishes `PriceObserved`
+   and pricing ingests an id-referenced copy. No shared transaction, no FK.
+2. FX splits in two: conversion *arithmetic* (`audit.money.convert(money,
+   rate)`, rate passed in, pure) stays in `audit` — audit never looks up a
+   rate; rate *lookup* + FX-specific services (inverse, triangulation, gap
+   interpolation) live here.
+3. Staleness is a fact pricing owns; the tier mapping ("too stale for this
+   report") is policy the consumer owns.
+
+`pricing` is an L3 domain leaf: it imports no other L3 (domain) package —
+portfolio/reporting/reconciliation declare the (acyclic, sideways) edge TO
+pricing, never the reverse.
+
+## What's real today
+
+The pure `base/` model (`PriceObservation`/`PriceableSubject`/
+`ResolutionPolicy`), `resolve()`, the `ObservationRepository` port + its
+read-only SQL adapter (querying the 4 legacy tables directly — schema-preserving
+on purpose, so this lands ahead of a unified physical store), the two
+user-scoped write-side recorders (`record_manual_valuation`/`record_override`,
+each publishing `PriceObserved` atomically with the write), and the FX lookup +
+`convert_*` + average-rate wrappers (`extension/fx.py`).
+
+Reserved (declared in [`contract.py`](./contract.py), no `module=` yet): the
+crawler sync (`sync_market_data`) and the extraction-event subscriber
+(`ingest_statement_price`), plus the `LatestPriceView`/`StalenessView` read
+projections.
+
+## Status
+
+`status="draft"`, `tier=None`, `roadmap=[]` — the write/read surface above is
+implemented and tested, but the package doesn't yet carry its own ACs: they
+remain in `docs/project/EPIC-011.asset-lifecycle.md` /
+`EPIC-005.reporting-visualization.md` / `EPIC-017.portfolio-management.md`
+pending the mass AC migration (tracked in the migration closeout series,
+umbrella #1416). Remaining consumer wiring is tracked in #1610 PR2. The
+package goes `status="active"` once its roadmap is populated and an authority
+tier is decided.

--- a/common/readme.md
+++ b/common/readme.md
@@ -36,21 +36,21 @@ scope):
   `PackageContract`, and the governance gate.
 - **L1 infra** — [`audit/`](./audit/readme.md) (financial base types +
   `ExchangeRate` conversion math + numeric governance; absorbed the old
-  money/ratio/quantity/unit_price value packages),
-  [`authority/`](./authority/readme.md), [`config/`](./config/readme.md),
-  [`coverage/`](./coverage/readme.md), [`llm/`](./llm/readme.md),
-  [`observability/`](./observability/readme.md),
+  money/ratio/quantity/unit_price value packages), [`config/`](./config/readme.md),
+  [`llm/`](./llm/readme.md), [`observability/`](./observability/readme.md),
   [`platform/`](./platform/readme.md) (event-bus/outbox substrate,
   historically labelled *middleware*), [`runtime/`](./runtime/readme.md),
-  [`testing/`](./testing/readme.md).
+  [`testing/`](./testing/readme.md) (absorbed the old `authority` and
+  `coverage` packages, #1626).
 - **L2 middleware** — [`counter/`](./counter/readme.md): the first worked
   example, the canonical minimal template every new package copies.
-- **L3 domain** — [`extraction/`](./extraction/readme.md),
-  [`identity/`](./identity/readme.md), [`ledger/`](./ledger/readme.md).
-  Pending cutovers (forward-placed in `PACKAGE_LAYER`, no `contract.py` yet):
-  `pricing` (#1610, the one price/valuation SSOT — lands before portfolio),
-  `portfolio` (#1422), `reconciliation` (#1423), `reporting` (#1424),
-  `advisor` (#1425).
+- **L3 domain** — [`advisor/`](./advisor/readme.md),
+  [`extraction/`](./extraction/readme.md), [`identity/`](./identity/readme.md),
+  [`ledger/`](./ledger/readme.md), [`portfolio/`](./portfolio/readme.md),
+  [`reconciliation/`](./reconciliation/readme.md). Still `status="draft"`
+  (contract + readme shipped, roadmap not yet populated): [`pricing/`](./pricing/readme.md)
+  (#1610, the one price/valuation SSOT — lands before portfolio),
+  [`reporting/`](./reporting/readme.md) (#1424).
 - [`common/todo.md`](./todo.md) — the cross-package / migration worklist.
 
 The old `common/ci` / `common/shell` / `common/ssot` junk drawers are retired.

--- a/common/reconciliation/readme.md
+++ b/common/reconciliation/readme.md
@@ -1,6 +1,58 @@
-# reconciliation
+# `reconciliation` — transaction-to-journal matching (domain package)
 
-`reconciliation` owns transaction-to-journal matching, transfer-leg pairing,
-consistency checks, and reconciliation audit diagnostics.
+> Package model: [`../meta/readme.md`](../meta/readme.md). Machine contract:
+> [`contract.py`](./contract.py).
+>
+> This `common/reconciliation/` directory is the **spec + review surface**; the
+> conforming implementation lives at
+> [`apps/backend/src/reconciliation`](../../apps/backend/src/reconciliation)
+> (`contract.implementations["be"]`).
 
-Implementation: `apps/backend/src/reconciliation`.
+## Why
+
+Extracted bank transactions and manually/portfolio-posted journal entries are
+two independent records of the same real-world event; `reconciliation` decides
+whether they refer to the same thing, at what confidence, and routes anything
+below auto-accept confidence into a review queue instead of silently trusting
+either side.
+
+## Ubiquitous language
+
+- **`ReconciliationMatch`** — the aggregate root linking an `AtomicTransaction`
+  to one or more `JournalEntry` rows. At most one *active* match exists per
+  transaction; a newer match supersedes the prior one rather than mutating it.
+- **Status lifecycle** —
+  `PENDING_REVIEW → ACCEPTED/AUTO_ACCEPTED/REJECTED → SUPERSEDED`; posted
+  entries behind an active match are immutable.
+- **Match score** — a weighted composite of amount/date/description/business-
+  logic/pattern sub-scores in `[0, 100]` (`score_amount`/`score_date`/
+  `score_description`/`score_business_logic`/`score_pattern` composed by
+  `calculate_match_score`). Scores at or above the auto-accept threshold
+  auto-accept; the review band routes to `PENDING_REVIEW`.
+- **`TransferLeg`** — one side of an internal transfer between the user's own
+  accounts; `pair_fx_legs`/`discover_fx_conversions` pair cross-currency
+  transfer legs within a rate/time tolerance.
+- **Many-to-one matching** — `build_many_to_one_groups` groups several bank
+  lines against one journal entry (e.g. a combined card settlement) within
+  `MAX_COMBINATION_CANDIDATES` and a configured tolerance.
+- **Consistency checks / anomaly detection** — `run_all_consistency_checks` /
+  `detect_anomalies` are diagnostic passes over already-matched state, not
+  part of the matching decision itself.
+
+## Cross-package edges
+
+`extraction` (the `AtomicTransaction` side), `portfolio` (positions can also
+be reconciled), `ledger` (the `JournalEntry` side — links by id only, no
+cross-domain FK: `AC-reconciliation.txn.1`), `pricing` (FX rate lookups for
+cross-currency transfer pairing), `audit` (base value types), `platform`
+(publishes `WorkflowEvent.reconciliation_match_outcome`).
+
+## Governance
+
+The package's ACs (`AC-reconciliation.match.*`/`.score.*`/`.stats.*`/`.txn.*`)
+live in [`contract.py`](./contract.py)'s `roadmap` and are sourced **directly**
+from there into the AC registry (no EPIC mirror); the larger two-stage-review
+UI surface (EPIC-016) is a separate frontend concern and has not moved into
+this roadmap yet. `tools/check_package_contract.py` validates the
+implementation against this contract (interface == `__all__`, every test
+reference resolves, no upward import edge).

--- a/common/reporting/readme.md
+++ b/common/reporting/readme.md
@@ -1,0 +1,65 @@
+# `reporting` — financial report generation over the ledger (domain package)
+
+> Package model: [`../meta/readme.md`](../meta/readme.md). Machine contract:
+> [`contract.py`](./contract.py).
+>
+> This `common/reporting/` directory is the **spec + review surface**; the
+> conforming implementation still lives at
+> `apps/backend/src/services/reporting` (`contract.implementations["be"]`) —
+> unlike a fully carved package, it has not yet been physically relocated to
+> `apps/backend/src/reporting/`.
+>
+> **Status: `draft`** (units declared over the existing implementation; the
+> roadmap is empty — see [Status](#status) below).
+
+## Why
+
+Balance sheet, income statement, cash flow, and net worth all read the same
+posted ledger state through different lenses. `reporting` is the calculation
+layer over `ledger` (and, via `pricing`, over valuation) that produces those
+views — it never itself decides what a position is worth or whether a match
+is reconciled; it consumes those facts.
+
+## Scope correction (2026-07-06)
+
+`manual_valuation.py` belongs to the `pricing` cutover (#1610), not here:
+reporting keeps confidence-tier mapping and report assembly; `pricing` owns
+valuation-observation staleness facts. This contract's
+`manual-valuation-excluded-from-reporting-language` invariant pins that
+boundary so it cannot silently drift back.
+
+## Ubiquitous language
+
+- **`ReportSnapshot`** — the aggregate root: a generated, framework-anchored
+  report as of a period, holding its own provenance/confidence-tier lineage.
+- **`generate_balance_sheet` / `generate_income_statement` / `generate_cash_flow`**
+  — the three statement generators, each composing the shared aggregation
+  core (`_aggregate_balances_sql`/`_aggregate_net_income_sql`).
+- **`FrameworkPolicyMatrix` / `FrameworkPolicyDecision` / `FrameworkPolicyGap`**
+  — the framework-anchoring language (which accounting framework a line maps
+  to, and what's missing for a 1:1 mapping).
+- **`get_net_worth_timeseries` / `get_net_worth_allocation_schedule` /
+  `get_category_breakdown` / `get_account_trend`** — the net-worth reporting
+  lane, separate from the three core statements.
+- **`get_account_lineage`** — per-account provenance/traceability, not a
+  statement itself.
+
+## Cross-package edges
+
+`ledger` (posted entries are the source of truth), `portfolio` (position
+valuation feeds net worth), `pricing` (price/FX resolution — reporting never
+looks up a rate itself), `extraction` (source-type confidence tiers feed
+provenance), `reconciliation` (match state feeds readiness), `audit` (base
+value types).
+
+## Status
+
+`status="draft"`, `tier=None`, `roadmap=[]` — the generators above are
+implemented and declared in [`contract.py`](./contract.py)'s `units`, but the
+package doesn't yet carry its own ACs: they remain in
+`docs/project/EPIC-005.reporting-visualization.md` pending the mass AC
+migration (tracked in the migration closeout series, umbrella #1416). The
+physical move from `apps/backend/src/services/reporting/` into
+`apps/backend/src/reporting/` is also still pending. The package goes
+`status="active"` once its roadmap is populated and an authority tier is
+decided.

--- a/common/todo.md
+++ b/common/todo.md
@@ -36,12 +36,15 @@ and types/ops/store/api). ACs are `AC-<pkg>.<entity>.<seq>` in each contract's
 | 0b | `counter` → base/extension/data template + gate three-layer rule (additive) | #1418 ✅ |
 | 1 | `value → audit` fold | #1419 ✅ |
 | 2 | `ledger` | #1420 ✅ |
-| 3 | `extraction` #1421 ✅ · `pricing` #1610 ⬜ · `portfolio` #1422 ⬜ (after pricing) · `reconciliation` #1423 ⬜ · `reporting` #1424 ⬜ | partial |
-| 4 | `advisor` #1425 ⬜ · `llm` #1426 ✅ · `platform` #1427 ✅ · `identity` #1428 ✅ | partial |
+| 3 | `extraction` #1421 ✅ · `portfolio` #1422 ✅ · `reconciliation` #1423 ✅ · `reporting` #1424 ✅ (contract shipped, still `status="draft"` — roadmap not populated) · `pricing` #1610 ⬜ (PR2 in flight) | partial |
+| 4 | `advisor` #1425 ✅ · `llm` #1426 ✅ · `platform` #1427 ✅ · `identity` #1428 ✅ | done |
 | 5 | `audit` consistency closeout (global invariants + cross-package ACs) | #1429 ⬜ |
-| 6 | cleanup — delete residual EPIC tables / SSOT; retire the central `docs/ssot/MANIFEST.yaml`/registry gates once meta's data layer is the computed index | #1430 ⬜ |
+| 6 | cleanup — delete residual EPIC tables / SSOT; retire the central `docs/ssot/MANIFEST.yaml`/registry gates once meta's data layer is the computed index | tracked as a 3-wave closeout: #1662 (finish cutovers + doc-sync) → #1663 (EPIC AC migration) → #1664 (SSOT/index retirement); #1430 closed early on the directory-coverage-only reading |
 
-All tracked under umbrella **#1416**.
+All tracked under umbrella **#1416**. Every package listed above ships a
+`contract.py` — "✅" here means the cutover PR merged, not that the roadmap or
+readme is complete; see [`common/readme.md`](./readme.md#map) for each
+package's live `status`.
 
 ## Definition of Done per package (from the standard)
 
@@ -78,14 +81,15 @@ coupling to the already-carved packages in `docs/ssot/app-boundary-baseline.json
 (monotonic: new edges fail CI). **This count is the migration burndown** — it
 drops as each domain is carved out.
 
-- **Now: 23 edges** — 9 inbound (remainder → a carved package's unpublished
-  internal, incl. a deep module import from `models/_registry.py`), 14 outbound
-  (a carved package → the app remainder, upward-layer).
-- The 14 outbound edges concentrate in `extraction` (→ `services.ai_streaming` /
-  `chain_repair` / `storage` / `pii_redaction` / `promotion_gate` / `assets` /
-  `source_type_priority`). They reveal deps `extraction` never internalized:
-  `ai_streaming` / `storage` / `pii_redaction` belong in lower packages
-  (llm / runtime / audit); `chain_repair` / `promotion_gate` / `assets` are domain
-  logic. **Clear outbound before inbound** when carving a domain out.
+- The baseline count moves as domains are carved and more edges are discovered;
+  read `docs/ssot/app-boundary-baseline.json` directly (or its generated
+  summary) for the live edge count and per-package breakdown rather than
+  copying a snapshot number here — it goes stale immediately.
+- Outbound edges (a carved package → the app remainder, upward-layer) have
+  historically concentrated in `extraction`. They reveal deps `extraction`
+  never internalized: things like `ai_streaming` / `storage` / `pii_redaction`
+  belong in lower packages (llm / runtime / audit); `chain_repair` /
+  `promotion_gate` / `assets` are domain logic. **Clear outbound before
+  inbound** when carving a domain out.
 - Target: baseline → 0 when `reconciliation` / `reporting` / `portfolio` /
   `advisor` / `asset` are carved and the remainder is empty.

--- a/docs/ssot/draft-package-baseline.json
+++ b/docs/ssot/draft-package-baseline.json
@@ -1,7 +1,6 @@
 {
   "_comment": "Registered draft packages (tools/check_draft_packages.py). A draft package leaves its authority tier undecided; listing it here makes adding one a reviewed act. Resolve drafts to active over time.",
   "draft_packages": [
-    "portfolio",
     "pricing",
     "reporting"
   ]

--- a/docs/ssot/observability-logging.md
+++ b/docs/ssot/observability-logging.md
@@ -16,8 +16,8 @@
 - `apps/backend/src/extraction/extension/statement_parsing.py` - Async parse progress and brokerage import checkpoints
 - `apps/backend/src/routers/llm.py` - LLM config + model catalog request/response logging (EPIC-023; replaced `routers/ai_models.py`)
 - `apps/backend/src/extraction/extension/service.py` - Model selection and HTTP error logging
-- `apps/backend/src/services/ai_provider_models.py` - Cache and model lookup logging
-- `apps/backend/src/services/ai_provider_streaming.py` - Enhanced AI provider API error logging
+- `apps/backend/src/llm/extension/client.py` - Cache and model lookup logging (renamed from `ai_provider_models.py` into the `llm` package)
+- `apps/backend/src/services/ai_streaming.py` - Enhanced AI provider API error logging (renamed from `ai_provider_streaming.py`; not yet moved out of `services/`)
 - `.github/workflows/deploy.yml` - Post-merge staging audit input inventory and phase summary
 - `.github/workflows/deploy.yml` - Manual staging AI/OCR audit input inventory
 

--- a/tests/tooling/test_check_package_directory_coverage.py
+++ b/tests/tooling/test_check_package_directory_coverage.py
@@ -49,7 +49,9 @@ def test_directory_with_contract_passes(tmp_path: Path) -> None:
     assert gate.check_directory_coverage(tmp_path) == []
 
 
-def test_documented_exception_passes_without_contract(tmp_path: Path, monkeypatch) -> None:
+def test_documented_exception_passes_without_contract(
+    tmp_path: Path, monkeypatch
+) -> None:
     """A directory named in UNGOVERNED_EXCEPTIONS passes even with no contract.py."""
     _make_bare_dir(tmp_path, "wip_domain")
     monkeypatch.setitem(
@@ -71,6 +73,26 @@ def test_pycache_is_ignored(tmp_path: Path) -> None:
     """__pycache__ residue under common/ is never flagged."""
     (tmp_path / "common" / "__pycache__").mkdir(parents=True)
     assert gate.check_directory_coverage(tmp_path) == []
+
+
+def test_dir_holding_only_stale_pycache_is_ignored(tmp_path: Path) -> None:
+    """A deleted package can leave stale, untracked __pycache__ behind on an
+    existing checkout (Python never cleans it up when the source is removed
+    from git) -- exactly what happened to common/ssot/ after #1650/#1651.
+    That local debris must not fail the gate for every other developer."""
+    stale = tmp_path / "common" / "retired_pkg" / "sub" / "__pycache__"
+    stale.mkdir(parents=True)
+    (stale / "mod.cpython-312.pyc").write_bytes(b"\x00")
+    assert gate.check_directory_coverage(tmp_path) == []
+
+
+def test_dir_with_real_file_alongside_pycache_is_still_governed(tmp_path: Path) -> None:
+    """A real package still needs a contract.py even if it also has caches."""
+    _make_bare_dir(tmp_path, "half_stale")
+    (tmp_path / "common" / "half_stale" / "__pycache__").mkdir()
+    errors = gate.check_directory_coverage(tmp_path)
+    assert len(errors) == 1
+    assert errors[0].startswith("common/half_stale/")
 
 
 def test_main_passes_quietly_on_real_repo(capsys) -> None:


### PR DESCRIPTION
## Summary

Wave 1/3 of the #1416 package-migration closeout (per #1662): fixes hygiene issues, syncs migration docs that had drifted from reality, and authors the package readmes that were missing after the portfolio/pricing/reconciliation/reporting/advisor cutovers.

Closes #1662

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | N/A — migration/governance cleanup, not a feature slice |
| **AC IDs** | None added or changed |
| **AC source updated** | N/A |

---

## SSOT Changes

- [x] `docs/ssot/draft-package-baseline.json` — regenerated via `check_draft_packages --update`; drops `portfolio` (now `status="active"`, contract already shipped), leaving `pricing`/`reporting`
- [x] `docs/ssot/observability-logging.md` — repointed 2 dead `services/ai_provider_models.py` / `ai_provider_streaming.py` references to their current homes (`llm/extension/client.py`, `services/ai_streaming.py`)
- [ ] None — all other changes are package-owned readmes / migration worklists, not `docs/ssot/`

---

## What changed

**Hygiene**
- `check_package_directory_coverage` now ignores a directory whose entire tree is stale, untracked `__pycache__` bytecode (exactly what `common/ssot/` became locally after #1650/#1651 deleted its source but left cache files behind) — this was failing the gate on any checkout that still had the old cache around. Added 2 tests locking the new/old behavior.
- `openclaw_*.json` (local AI-harness config backups that can carry live API keys) are now in the shared `.gitignore` — previously protected only by one contributor's personal, unshared `.git/info/exclude`.

**Doc-sync** (found via a full audit of docs/project, docs/ssot, common/ readmes, and the AC registry against actual package state)
- `common/todo.md`: phase-3/4 table showed portfolio/reconciliation/reporting/advisor as still open (⬜) when their cutover PRs had already merged; the app-boundary burndown cited a frozen "23 edges" snapshot against a live baseline that's actually at 73 — replaced with a pointer to the live file instead of a number that goes stale immediately.
- `common/readme.md`: claimed 5 packages had "no `contract.py` yet" — false, all 17 packages ship one; also linked the retired `authority`/`coverage` packages (folded into meta/testing in #1626).
- `common/meta/base/layering.py`: docstring/comments still described `authority`/`coverage` as separate infra packages and claimed advisor/portfolio/pricing/reporting had no contract.py — updated to match `PACKAGE_LAYER`'s actual (already-correct) dict.
- 8 package readmes linked `../governance/readme.md`, dead since the `governance→meta` rename (#1414) — repointed to `../meta/readme.md` (or `../../meta/readme.md` for the two-levels-deep `audit/money|ratio|quantity|unit_price` readmes).
- 5 genuinely-dead `apps/backend/src/services/*` references (verified against the actual filesystem, not assumed): `observability-logging.md` (2), `.opencode/skills/domain/{reconciliation,extraction}/SKILL.md`, `common/advisor/readme.md`, `common/extraction/readme.md`. Note: most other `services/*` references an earlier audit flagged turned out to still be valid — many files under `apps/backend/src/services/` were *not* deleted by #1651 (only a specific "Stage-2" subset was); I verified each one against the filesystem before touching it.

**Package readmes**
- Authored `common/portfolio/readme.md` and `common/pricing/readme.md` (previously missing entirely).
- Authored `common/reporting/readme.md` (previously missing) — honestly documents its `status="draft"` state: implementation still physically lives under `apps/backend/src/services/reporting/`, not yet moved to `apps/backend/src/reporting/`.
- Expanded `common/reconciliation/readme.md` from 6 lines to the package-doc standard (ubiquitous language, cross-package edges, governance).

**Deliberately out of scope for this PR** (tracked separately):
- Populating `pricing`/`reporting`'s roadmap and flipping them `draft→active` — that's the EPIC-011/005/017 AC migration, tracked as wave 2 (#1663), since it's the same work either way and shouldn't be duplicated here.
- `#1610` PR2 (pricing consumer wiring) and `#1643` (portfolio read-side) stay independently tracked; this PR doesn't touch their code.

---

## TDD Evidence

Not applicable in the red/green sense — this PR is documentation + one gate-hygiene fix with test coverage added directly (no pre-existing failing behavior to prove first):

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🟢 New tests | `b5a723e8` | `test_dir_holding_only_stale_pycache_is_ignored` + `test_dir_with_real_file_alongside_pycache_is_still_governed` added alongside the `check_package_directory_coverage` fix in the same commit |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no schema changes
- [x] `NEXT_PUBLIC_` variables — N/A, no env changes
- [x] `repo/` submodule — N/A
- [x] `tools/check_env_keys.py` — N/A, no env changes
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes
- [x] No real financial data in any changed file

---

## Testing

```bash
# Gates touched/relevant to this PR
uv run --project apps/backend python tools/check_package_contract.py
uv run --project apps/backend python -m common.meta.extension.check_draft_packages
uv run --project apps/backend python common/meta/extension/check_package_directory_coverage.py
uv run --project apps/backend python tools/check_manifest.py
uv run --project apps/backend python tools/lint_doc_consistency.py

# Full tooling suite (1871 passed, 1 skipped; the only pre-existing failures are
# a local pdfplumber-not-installed env gap and a stale .claude/worktrees/ residue
# check unrelated to this diff — both reproduce identically on main)
uv run --project apps/backend pytest tests/tooling/ -q

moon run :lint
```
