### PR TITLE
[finance_report_vision] docs(meta): fix dead ../governance/ links + stale layering.py comment

### DIFF
--- a/common/audit/money/readme.md
+++ b/common/audit/money/readme.md
@@ -1,7 +1,7 @@
 # `money` — Decimal money value language (kernel package)
 
 > The money/currency/FX value type. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Language-neutral interface + conformance:
 > [`contract/money.contract.md`](./contract/money.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:

--- a/common/audit/quantity/readme.md
+++ b/common/audit/quantity/readme.md
@@ -1,7 +1,7 @@
 # `quantity` — Decimal quantity + unit value language (kernel package)
 
 > The quantity/unit value type. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Language-neutral interface + conformance:
 > [`contract/quantity.contract.md`](./contract/quantity.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:

--- a/common/audit/ratio/readme.md
+++ b/common/audit/ratio/readme.md
@@ -1,7 +1,7 @@
 # `ratio` — Decimal ratio / percentage value language (kernel package)
 
 > The ratio/percentage value type. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Language-neutral interface + conformance:
 > [`contract/ratio.contract.md`](./contract/ratio.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:

--- a/common/audit/unit_price/readme.md
+++ b/common/audit/unit_price/readme.md
@@ -1,7 +1,7 @@
 # `unit_price` — money-per-unit value language (kernel package)
 
 > The unit-price value type. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Language-neutral interface + conformance:
 > [`contract/unit_price.contract.md`](./contract/unit_price.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:

--- a/common/config/readme.md
+++ b/common/config/readme.md
@@ -1,7 +1,7 @@
 # `config` — env-key + schema validation helpers (infra tooling package)
 
 > Internal tooling, not a domain bounded context. Model spec:
-> [`../governance/readme.md`](../governance/readme.md). Machine contract:
+> [`../meta/readme.md`](../meta/readme.md). Machine contract:
 > [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
 
 ## What

--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -1,7 +1,7 @@
 # `counter` — per-(user, key) tallies (middleware package)
 
 > The **canonical worked example of the package model** (a package = DDD bounded
-> context). Model spec: [`../governance/readme.md`](../governance/readme.md).
+> context). Model spec: [`../meta/readme.md`](../meta/readme.md).
 > Machine contract: [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
 >
 > This `common/counter/` directory is the **spec + review surface**; the

--- a/common/meta/base/layering.py
+++ b/common/meta/base/layering.py
@@ -71,10 +71,12 @@ PACKAGE_LAYER: dict[str, PackageClass] = {
     # (money/ratio/quantity/unit_price) folded into audit (#1419), so those
     # names are gone from the map — audit (L1) owns the financial base types.
     "counter": "middleware",
-    # L3 — vertical business slices. advisor / portfolio / pricing / reporting
-    # are forward placements: their cutovers (#1425 / #1422 / #1610 / #1424)
-    # have not shipped a contract.py yet, so the map pins their layer ahead of
-    # time (the shell-ahead rule above) — they are future packages, not dead ones.
+    # L3 — vertical business slices. All four now have a shipped contract.py:
+    # advisor / portfolio are "active"; pricing / reporting are still "draft"
+    # (their cutovers #1610 / #1424 are in flight). The map does not wait for a
+    # contract to exist before pinning a package's layer (the shell-ahead rule
+    # above still applies to any future package placed here before its
+    # contract.py lands) — these four are simply past that stage already.
     "advisor": "domain",
     "extraction": "domain",
     "identity": "domain",

--- a/common/observability/readme.md
+++ b/common/observability/readme.md
@@ -1,6 +1,6 @@
 # `observability` — OTEL runtime contract, audit logging + OpenPanel CLI (infra)
 
-> Model spec: [`../governance/readme.md`](../governance/readme.md). Machine
+> Model spec: [`../meta/readme.md`](../meta/readme.md). Machine
 > contract: [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
 
 ## What

--- a/common/platform/readme.md
+++ b/common/platform/readme.md
@@ -1,6 +1,6 @@
 # `platform` — domain EventBus via the transactional outbox (meta-layer capability #1)
 
-> Package model: [`../governance/readme.md`](../governance/readme.md). Machine
+> Package model: [`../meta/readme.md`](../meta/readme.md). Machine
 > contract: [`contract.py`](./contract.py). Worklist: [`todo.md`](./todo.md).
 >
 > This `common/platform/` directory is the **spec + review surface**; the


### PR DESCRIPTION
## Summary
- 8 package readmes still pointed at `../governance/readme.md`, retired when `governance` was renamed to `meta` (#1414): `config`, `counter`, `platform`, `observability`, and the 4 audit value-type packages (`money`/`quantity`/`ratio`/`unit_price`). Repointed all 8 to `meta/readme.md` at the correct relative depth.
- `common/meta/base/layering.py`'s own `PACKAGE_LAYER` comment claimed `advisor`/`portfolio`/`pricing`/`reporting` "have not shipped a `contract.py` yet" as the reason for their forward placement — all four now have one (`advisor`/`portfolio` are `status="active"`, `pricing`/`reporting` are `status="draft"`). Updated the comment to reflect current state.
- Pure documentation fix, no behavior change. Surfaced during a full package-boundary/dependency audit.

## Test plan
- [x] `python3 tools/lint_doc_consistency.py` — passes
- [x] `python3 -c "import ast; ast.parse(open('common/meta/base/layering.py').read())"` — syntax valid
- [x] `grep -rl "governance/readme.md\|common/governance"` repo-wide — zero remaining hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)