### PR TITLE
[finance_report_vision] fix(platform): invert platform→report_readiness upward edge (#1676)

### DIFF
--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -42,7 +42,7 @@ from src.observability import (
     record_http_request,
     record_rate_limit_rejected,
 )
-from src.platform import BaseAppException, RateLimitConfig, RateLimiter
+from src.platform import BaseAppException, RateLimitConfig, RateLimiter, register_readiness_provider
 from src.routers import (
     accounts,
     ai_feedback,
@@ -76,12 +76,19 @@ from src.schemas.errors import (
     error_code_for_status,
 )
 from src.services.market_data_scheduler import run_market_data_scheduler
+from src.services.report_readiness import get_personal_report_package_readiness
 
 # Initialize logging early
 configure_logging()
 configure_otel_metrics()
 configure_database_pool_metrics(engine)
 logger = get_logger(__name__)
+
+# Wire platform's readiness port to the real reporting-domain lookup (#1676):
+# platform (L1 infra) must not import reporting logic itself; the app
+# composition root does it once here, same shape as the eager model
+# registration above.
+register_readiness_provider(get_personal_report_package_readiness)
 
 
 def _init_otel_instrumentation() -> None:

--- a/apps/backend/src/platform/__init__.py
+++ b/apps/backend/src/platform/__init__.py
@@ -55,6 +55,7 @@ from src.platform.extension import (
     raise_too_large,
     raise_too_many_requests,
     raise_unauthorized,
+    register_readiness_provider,
 )
 
 __all__ = [
@@ -81,4 +82,5 @@ __all__ = [
     "raise_too_large",
     "raise_too_many_requests",
     "raise_unauthorized",
+    "register_readiness_provider",
 ]

--- a/apps/backend/src/platform/extension/__init__.py
+++ b/apps/backend/src/platform/extension/__init__.py
@@ -40,6 +40,7 @@ from src.platform.extension.sql import (
     Outbox,
     SqlOutboxRepository,
 )
+from src.platform.extension.workflow_events import register_readiness_provider
 
 __all__ = [
     "STATUS_PENDING",
@@ -64,4 +65,5 @@ __all__ = [
     "raise_too_large",
     "raise_too_many_requests",
     "raise_unauthorized",
+    "register_readiness_provider",
 ]

--- a/apps/backend/src/platform/extension/workflow_events.py
+++ b/apps/backend/src/platform/extension/workflow_events.py
@@ -48,7 +48,10 @@ from src.schemas.workflow import (
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    ReadinessProvider = Callable[..., Awaitable[dict]]
+    # This module always calls the provider as (db: AsyncSession, user_id:
+    # UUID) — see _get_readiness_provider()'s call site — so it is typed to
+    # that exact signature, not an unconstrained Callable[..., Awaitable[dict]].
+    ReadinessProvider = Callable[[AsyncSession, UUID], Awaitable[dict]]
 
 # `platform` is L1 infra — it must never import reporting-domain logic directly
 # (issue #1676: this file previously imported `services.report_readiness`

--- a/apps/backend/src/platform/extension/workflow_events.py
+++ b/apps/backend/src/platform/extension/workflow_events.py
@@ -1,5 +1,6 @@
 """Deterministic user-facing workflow event derivation."""
 
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import and_, func, or_, select
@@ -43,7 +44,39 @@ from src.schemas.workflow import (
     WorkflowSessionSummaryResponse,
     WorkflowStatusResponse,
 )
-from src.services.report_readiness import get_personal_report_package_readiness
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    ReadinessProvider = Callable[..., Awaitable[dict]]
+
+# `platform` is L1 infra — it must never import reporting-domain logic directly
+# (issue #1676: this file previously imported `services.report_readiness`
+# module-level, the sole L1-infra→business upward edge in
+# docs/ssot/app-boundary-baseline.json). The personal-report-package readiness
+# lookup is genuinely reporting-domain logic; platform only needs *a* callable
+# with this shape, not that specific implementation. The app composition root
+# (`main.py`, itself L4 — allowed to import everything) registers the real
+# function at startup; tests register it directly since they don't run the
+# app's lifespan.
+_readiness_provider: "ReadinessProvider | None" = None
+
+
+def register_readiness_provider(provider: "ReadinessProvider") -> None:
+    """Wire the personal-report-package readiness lookup (see module note above)."""
+    global _readiness_provider
+    _readiness_provider = provider
+
+
+def _get_readiness_provider() -> "ReadinessProvider":
+    if _readiness_provider is None:
+        raise RuntimeError(
+            "workflow_events.register_readiness_provider() was never called — "
+            "main.py wires it at startup (issue #1676); a test exercising this "
+            "path must call it too."
+        )
+    return _readiness_provider
+
 
 ACTIVE_WORKFLOW_SESSION_DEDUPE_KEY = "active-upload-to-report"
 MUTABLE_DERIVED_EVENT_SOURCE_TYPES = {"bank_statement", "readiness_blocker", "report_package"}
@@ -333,7 +366,7 @@ async def sync_workflow_events_for_user(db: AsyncSession, *, user_id: UUID) -> d
         elif statement.stage1_status in {Stage1Status.APPROVED, Stage1Status.REJECTED, Stage1Status.EDITED}:
             derived_payloads.append(build_review_completed_event_payload(statement, filename))
 
-    package_readiness = await get_personal_report_package_readiness(db, user_id=user_id)
+    package_readiness = await _get_readiness_provider()(db, user_id=user_id)
     for blocker in package_readiness.get("blockers", []):
         derived_payloads.append(build_readiness_blocker_event_payload(blocker))
     report_state_payload = build_report_state_event_payload(package_readiness)

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -35,6 +35,7 @@ from src.platform.extension.workflow_events import (
     get_workflow_status,
     list_workflow_events,
     list_workflow_events_response,
+    register_readiness_provider,
     sync_workflow_events_for_user,
     update_workflow_event_status,
     upsert_workflow_event,
@@ -45,8 +46,17 @@ from src.schemas.workflow import (
     WorkflowPrimaryState,
     WorkflowReportReadinessState,
 )
+from src.services.report_readiness import get_personal_report_package_readiness
 
 ROOT_DIR = Path(__file__).resolve().parents[4]
+
+
+@pytest.fixture(autouse=True)
+def _wire_readiness_provider() -> None:
+    """workflow_events no longer imports report_readiness itself (#1676 — platform
+    must not import reporting-domain logic); production wires this in main.py,
+    tests wire the same real function here so behavior is unchanged."""
+    register_readiness_provider(get_personal_report_package_readiness)
 
 
 async def _make_statement(

--- a/apps/backend/tests/workflow/test_workflow_events.py
+++ b/apps/backend/tests/workflow/test_workflow_events.py
@@ -714,7 +714,7 @@ async def test_AC19_12_3_report_readiness_events_follow_package_readiness_withou
     async def fake_readiness(_db, **_kwargs):
         return current_payload
 
-    monkeypatch.setattr("src.platform.extension.workflow_events.get_personal_report_package_readiness", fake_readiness)
+    register_readiness_provider(fake_readiness)
 
     await sync_workflow_events_for_user(db, user_id=test_user.id)
     blocked_event = (
@@ -811,7 +811,7 @@ async def test_AC19_12_3_sync_archives_last_resolved_blocker_when_no_derived_pay
     async def fake_readiness(_db, **_kwargs):
         return current_payload
 
-    monkeypatch.setattr("src.platform.extension.workflow_events.get_personal_report_package_readiness", fake_readiness)
+    register_readiness_provider(fake_readiness)
 
     await sync_workflow_events_for_user(db, user_id=test_user.id)
     blocked_event = (
@@ -853,7 +853,7 @@ async def test_AC19_12_3_ready_package_status_wins_over_long_lived_upload_proces
             "blockers": [],
         }
 
-    monkeypatch.setattr("src.platform.extension.workflow_events.get_personal_report_package_readiness", fake_readiness)
+    register_readiness_provider(fake_readiness)
 
     status = await get_workflow_status(db, user_id=test_user.id)
 
@@ -888,7 +888,7 @@ async def test_AC19_12_4_readiness_blocker_events_are_user_action_scoped(db, tes
             ],
         }
 
-    monkeypatch.setattr("src.platform.extension.workflow_events.get_personal_report_package_readiness", fake_readiness)
+    register_readiness_provider(fake_readiness)
 
     await sync_workflow_events_for_user(db, user_id=test_user.id)
     events = (
@@ -1181,7 +1181,7 @@ async def test_AC19_2_7_events_session_summary_agrees_with_status_when_blocked(
             ],
         }
 
-    monkeypatch.setattr("src.platform.extension.workflow_events.get_personal_report_package_readiness", fake_readiness)
+    register_readiness_provider(fake_readiness)
 
     # A blocked active session derived from a balance-validation blocker.
     await sync_workflow_events_for_user(db, user_id=test_user.id)
@@ -1236,10 +1236,7 @@ async def test_AC19_2_7_events_read_computes_readiness_once(
             ],
         }
 
-    monkeypatch.setattr(
-        "src.platform.extension.workflow_events.get_personal_report_package_readiness",
-        counting_readiness,
-    )
+    register_readiness_provider(counting_readiness)
 
     events = await list_workflow_events_response(db, user_id=test_user.id, limit=10)
 

--- a/common/platform/contract.py
+++ b/common/platform/contract.py
@@ -134,6 +134,7 @@ CONTRACT = PackageContract(
         "raise_too_large",
         "raise_too_many_requests",
         "raise_unauthorized",
+        "register_readiness_provider",
     ],
     events=[],
     invariants=[

--- a/docs/ssot/app-boundary-baseline.json
+++ b/docs/ssot/app-boundary-baseline.json
@@ -57,7 +57,6 @@
   "out::apps/backend/src/ledger/extension/fx_revaluation.py::src.services.fx::FxRateError",
   "out::apps/backend/src/ledger/extension/fx_revaluation.py::src.services.fx::get_exchange_rate",
   "out::apps/backend/src/observability/audit.py::src.services.pii_redaction::detect_pii",
-  "out::apps/backend/src/platform/extension/workflow_events.py::src.services.report_readiness::get_personal_report_package_readiness",
   "out::apps/backend/src/reconciliation/extension/scoring.py::src.prompts.reconciliation::build_reconciliation_prompt",
   "out::apps/backend/src/reconciliation/extension/scoring.py::src.services.ai_streaming::AIStreamError",
   "out::apps/backend/src/reconciliation/extension/scoring.py::src.services.ai_streaming::accumulate_stream",


### PR DESCRIPTION
## Summary
- `platform/extension/workflow_events.py` imported `src.services.report_readiness.get_personal_report_package_readiness` directly — `platform` is L1 infra, report readiness is reporting-domain business logic, so this was the sole infra→business upward edge in `docs/ssot/app-boundary-baseline.json`.
- Inverted with a port: `workflow_events` now exposes `register_readiness_provider()` + a module-scoped provider slot instead of importing the concrete function. `main.py` (the app composition root, L4 — allowed to import everything) wires the real function at startup; the test file wires it via an autouse fixture since tests don't run the app's lifespan.
- `register_readiness_provider` is published through `platform`'s interface (`__all__` in both `extension/__init__.py` and the package root) rather than `main.py` reaching into the extension submodule directly — `check_app_boundary --update` correctly refused to bless that as a new edge and pointed at the published-interface route instead.

## Verification
- `apps/backend/.venv/bin/python -m pytest tests/tooling/ -q` → 1941 passed, 1 skipped.
- `check_app_boundary` baseline: 63 → 62 edges (the one real edge removed, zero new).
- `check_package_contract` → `platform` still OK (24 interface symbols).
- Manual import check (`DATABASE_URL=... python -c "import src.main; ..."`) confirms `main.py` imports cleanly and the provider is registered.
- `ruff check` + `ruff format --check` clean.
- DB-dependent backend suites not runnable locally (no Docker/Postgres here) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)