### PR TITLE
[finance_report_vision] docs(counter): resolve #1672 — keep counter, document its unwired status

### DIFF
--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -17,16 +17,18 @@ it tallies named events per user and lets a report read either the per-user coun
 or the global count (sum across users).
 
 **Status (2026-07-09, issue #1672):** this is real, in a real reusable shape —
-but currently unwired. No router or report-generation path calls `increment`/
-`get_count` today; `identity` and `pricing` reference its *pattern* in comments
-("like `counter`'s `CounterTally`") without importing it. It already served its
-original purpose (the worked example the package-model migration's Step 0 built
-to prove the base/extension/data + repository-split shape — `platform` and
-others copied it). Decision: **keep it** — the shape is sound and cheap to carry,
-and a real "how many times did X happen" insight-report surface is plausible
-future scope, not invented scope. If you're looking for where it's called from
-in production: it isn't yet. Wire it to a real caller when that surface gets
-built, or open a fresh issue to retire it if it's still unwired a year from now.
+but currently unwired. No router or report-generation path calls
+`increment`/`get_count` today; `identity` and `pricing` reference its
+*pattern* in comments ("like `counter`'s `CounterTally`") without importing
+it. It already served its original purpose (the worked example the
+package-model migration's Step 0 built to prove the base/extension/data +
+repository-split shape — `platform` and others copied it). Decision: **keep
+it** — the shape is sound and cheap to carry, and a real "how many times did
+X happen" insight-report surface is plausible future scope, not invented
+scope. If you're looking for where it's called from in production: it isn't
+yet. Wire it to a real caller when that surface gets built, or open a fresh
+issue to retire it if it's still unwired by 2027-07-09 (a year past this
+note).
 
 ## Ubiquitous language
 

--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -16,6 +16,18 @@ user?". `counter` is the small, reusable middleware capability that answers that
 it tallies named events per user and lets a report read either the per-user count
 or the global count (sum across users).
 
+**Status (2026-07-09, issue #1672):** this is real, in a real reusable shape —
+but currently unwired. No router or report-generation path calls `increment`/
+`get_count` today; `identity` and `pricing` reference its *pattern* in comments
+("like `counter`'s `CounterTally`") without importing it. It already served its
+original purpose (the worked example the package-model migration's Step 0 built
+to prove the base/extension/data + repository-split shape — `platform` and
+others copied it). Decision: **keep it** — the shape is sound and cheap to carry,
+and a real "how many times did X happen" insight-report surface is plausible
+future scope, not invented scope. If you're looking for where it's called from
+in production: it isn't yet. Wire it to a real caller when that surface gets
+built, or open a fresh issue to retire it if it's still unwired a year from now.
+
 ## Ubiquitous language
 
 - **Key** — a *namespaced counter identity*: a lowercase dotted `domain.action`


### PR DESCRIPTION
## Summary
- #1672 asked for a decision: `counter` has zero real production callers today — retire it, wire it to a real feature, or keep it as an explicit worked example?
- **Decision: keep it.** It already served its original purpose (the package-model migration's Step 0 worked example — `platform`, `identity`, `pricing` all copied its base/extension/data + repository-split shape) and the shape is sound and cheap to carry. A real "insight reports" surface built on it is plausible future scope, not invented scope, so retiring it now would be premature and re-wiring it to a fabricated caller would be scope invention neither of which this refactor pass should do unilaterally.
- The readme's "Why" section described a real feature ("insight reports ask how many times did X happen") without disclosing that nothing calls it yet — added a status note stating the actual wiring reality plainly, so a future reader isn't misled into thinking this is already backing a shipped feature.

## Verification
- `python3 tools/lint_doc_consistency.py` clean.
- Docs-only change, no code/behavior touched.

Closes #1672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)