### PR TITLE
[finance_report_ui] feat(#1681): corpus journeys assert income-statement values

### DIFF
--- a/apps/backend/tests/e2e/test_statement_corpus_journeys.py
+++ b/apps/backend/tests/e2e/test_statement_corpus_journeys.py
@@ -221,7 +221,7 @@ def test_corpus_manifest_is_diverse():
 
 @ac_proof(
     "extraction-corpus-journeys-pr",
-    ac_ids=["AC-llm.11.2"],
+    ac_ids=["AC-llm.11.2", "AC-llm.11.4"],
     scope="behavioral",
     ci_tier="pr_ci",
     trust_mode="deterministic_pr",
@@ -231,11 +231,13 @@ def test_corpus_manifest_is_diverse():
 @pytest.mark.e2e
 @pytest.mark.parametrize("fingerprint", CORPUS_FINGERPRINTS, ids=lambda fp: fp[:8])
 async def test_corpus_statement_full_journey(client, db, test_user, fingerprint):
-    """EPIC-023 / AC-llm.11.2: every corpus extraction output completes the downstream journey.
+    """EPIC-023 / AC-llm.11.2 / AC-llm.11.4: every corpus extraction output completes
+    the downstream journey and its report values tie to the corpus data.
 
     GIVEN a corpus cassette's frozen extraction output seeded as a parsed statement
-    WHEN driving transactions → review → approve → reconciliation → balance sheet via the API
-    THEN each stage reports the exact corpus-derived numbers with zero provider calls.
+    WHEN driving transactions → review → approve → reconciliation → reports via the API
+    THEN each stage reports the exact corpus-derived numbers with zero provider calls,
+    including the balance sheet AND income statement.
     """
     case = load_corpus_case(fingerprint)
     seeded = await seed_parsed_statement(
@@ -314,6 +316,34 @@ async def test_corpus_statement_full_journey(client, db, test_user, fingerprint)
         assert account_id in lines, f"[{case.short_id}] posting account missing from balance sheet assets"
         assert lines[account_id] == case.net_movement, (
             f"[{case.short_id}] balance sheet shows {lines[account_id]}, corpus net movement is {case.net_movement}"
+        )
+
+    # AC-llm.11.4: the income statement ties to the same corpus data by a
+    # double-entry identity, not a name heuristic. auto_create_posted_entries
+    # always posts the transaction's contra side to an Income or Expense
+    # account (a classified category, or the Income/Expense "Uncategorized"
+    # default) — never equity or another asset — so total_income minus
+    # total_expenses equals the posting account's net movement exactly, for
+    # every corpus case regardless of institution class or category
+    # granularity. (Cash-flow's ending_cash is NOT asserted here: it only
+    # includes accounts whose auto-created name matches a cash-keyword
+    # heuristic in generate_cash_flow, which brokerage-class corpus accounts
+    # do not — see #1681 follow-up.)
+    if n:
+        period_start = min(row["date"] for row in case.rows)
+        period_end = max(row["date"] for row in case.rows)
+        income_resp = await client.get(
+            "/reports/income-statement",
+            params={"start_date": period_start.isoformat(), "end_date": period_end.isoformat()},
+        )
+        assert income_resp.status_code == 200, income_resp.text
+        income = income_resp.json()
+        net_income = Decimal(str(income["total_income"])) - Decimal(str(income["total_expenses"]))
+        assert net_income == case.net_movement, (
+            f"[{case.short_id}] income statement net {net_income} != corpus net movement {case.net_movement}"
+        )
+        assert Decimal(str(income["net_income"])) == case.net_movement, (
+            f"[{case.short_id}] reported net_income {income['net_income']} != corpus net movement {case.net_movement}"
         )
 
 

--- a/common/llm/contract.py
+++ b/common/llm/contract.py
@@ -95,7 +95,9 @@ CONTRACT = PackageContract(
         ),
         # ── extension: domain services + factory ──
         # the single litellm chokepoint's provider routing
-        Unit(name="build_call", kind=Kind.DOMAIN_SERVICE, module="extension/routing.py"),
+        Unit(
+            name="build_call", kind=Kind.DOMAIN_SERVICE, module="extension/routing.py"
+        ),
         # the input-keyed record/replay mechanism (cache output by input)
         Unit(
             name="CassetteStore",
@@ -177,8 +179,12 @@ CONTRACT = PackageContract(
     invariants=[
         Invariant(
             id="interface-equals-published-language",
-            statement=("The published language (contract.interface) equals __init__.__all__."),
-            test=("tests/tooling/test_llm_package.py::test_AC_llm_1_1_only_all_is_the_published_language"),
+            statement=(
+                "The published language (contract.interface) equals __init__.__all__."
+            ),
+            test=(
+                "tests/tooling/test_llm_package.py::test_AC_llm_1_1_only_all_is_the_published_language"
+            ),
         ),
         Invariant(
             id="converges-by-layer",
@@ -186,12 +192,18 @@ CONTRACT = PackageContract(
                 "The package converges into base/ (frozen contract + usage entity) "
                 "+ extension/ (adapters) + data/ (reserved projections)."
             ),
-            test=("tests/tooling/test_llm_package.py::test_AC_llm_1_2_converges_by_layer"),
+            test=(
+                "tests/tooling/test_llm_package.py::test_AC_llm_1_2_converges_by_layer"
+            ),
         ),
         Invariant(
             id="base-layer-pure",
-            statement=("base/ never imports the package's own extension/, the ORM, or litellm."),
-            test=("tests/tooling/test_llm_package.py::test_AC_llm_1_3_base_layer_is_pure"),
+            statement=(
+                "base/ never imports the package's own extension/, the ORM, or litellm."
+            ),
+            test=(
+                "tests/tooling/test_llm_package.py::test_AC_llm_1_3_base_layer_is_pure"
+            ),
         ),
         Invariant(
             id="no-litellm-at-root",
@@ -200,7 +212,9 @@ CONTRACT = PackageContract(
                 "imports litellm — the litellm surface is lazy (PEP 562), so "
                 "minimal tooling environments can load the package."
             ),
-            test=("tests/tooling/test_llm_package.py::test_AC_llm_1_4_root_import_is_litellm_free"),
+            test=(
+                "tests/tooling/test_llm_package.py::test_AC_llm_1_4_root_import_is_litellm_free"
+            ),
         ),
         Invariant(
             id="runtime-classifies-llm-implements",
@@ -210,12 +224,16 @@ CONTRACT = PackageContract(
                 "cassette/replay implementation — it just declares the LLM "
                 "dependency and probes presence."
             ),
-            test=("tests/tooling/test_llm_package.py::test_AC_llm_1_5_cassette_mechanism_only_in_llm"),
+            test=(
+                "tests/tooling/test_llm_package.py::test_AC_llm_1_5_cassette_mechanism_only_in_llm"
+            ),
         ),
         Invariant(
             id="passes-own-governance-gate",
             statement="check_package_contract validates llm with no violations.",
-            test=("tests/tooling/test_llm_package.py::test_AC_llm_1_6_package_contract_gate_passes_for_llm"),
+            test=(
+                "tests/tooling/test_llm_package.py::test_AC_llm_1_6_package_contract_gate_passes_for_llm"
+            ),
         ),
     ],
     # The EPIC-023 ACs, migrated per Decision A (standard-preserving move; the
@@ -670,6 +688,24 @@ CONTRACT = PackageContract(
             statement="The zero-transaction corpus statement (a real brokerage month with no activity) is deterministic end-to-end: it seeds, lists, reviews with a trivially-tied balance chain, approves with journal_entries_created == 0, and a statement-scoped reconciliation run reports unmatched=0",
             test="apps/backend/tests/e2e/test_statement_corpus_journeys.py::test_corpus_zero_transaction_statement_approves_empty",
             priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
+        # #1681/#1686: the corpus proved the downstream JOURNEY completes
+        # (AC-llm.11.2) but never asserted a REPORT VALUE beyond the balance
+        # sheet's single posting-account line. This closes the residual gap
+        # #950 recorded ("fixture exists only in parsing unit tests, never
+        # wired into full E2E acceptance") for the income statement: every
+        # posted transaction's contra side is Income or Expense by
+        # construction (auto_create_posted_entries_for_statement's
+        # Uncategorized-bucket fallback), so net_income ties to the corpus
+        # data across every institution class, not just accounts whose name
+        # happens to match a heuristic.
+        ACRecord(
+            id="AC-llm.11.4",
+            statement="Every non-empty corpus statement's income statement (queried over the statement's own transaction date range) reports total_income minus total_expenses, and net_income, exactly equal to the corpus case's net movement — proving the auto-posted double entry always lands its contra side on Income/Expense, independent of category granularity or institution class",
+            test="apps/backend/tests/e2e/test_statement_corpus_journeys.py::test_corpus_statement_full_journey",
+            priority="P0",
             status="done",
             proof_kind="property",
         ),

--- a/common/llm/readme.md
+++ b/common/llm/readme.md
@@ -369,7 +369,7 @@ cassettes are balance-exempt (`balance_reconciles: false`) and field-graded only
 
 > SSOT owner for the **corpus E2E tier**: the committed extraction corpus,
 > seeded end-to-end through the statement pipeline in PR CI. Registered as
-> roadmap group 10 in [`contract.py`](contract.py); tests live in
+> roadmap group 11 in [`contract.py`](contract.py); tests live in
 > `apps/backend/tests/e2e/test_statement_corpus_journeys.py` and run in the
 > `ci.yml backend-e2e-tier1` merge gate.
 
@@ -380,7 +380,7 @@ One corpus, four consuming gates — each answers a different question:
 | Cassette integrity (AC23.7, [§5](#cassettes)) | PR CI `lint` | Is each frozen extraction output internally CONSISTENT (balance chain ties)? |
 | Graded field eval (AC23.8, [§6](#cassette-graded-eval)) | PR CI `lint` + `tooling-coverage` | Is each extraction output ACCURATE per field vs ground truth (raise-only floor)? |
 | Extraction-unit replay (AC23.6) | PR CI backend shards (the module defaults itself to replay; text modality — the vision case is gated on re-recording, #1614) | Does the extraction service still produce this output from the frozen provider seam? |
-| **Corpus E2E journeys (AC-llm.11)** | PR CI `backend-e2e-tier1` | Does each extraction output survive the full downstream pipeline — review → conflict resolution → approve → reconcile → balance sheet? |
+| **Corpus E2E journeys (AC-llm.11)** | PR CI `backend-e2e-tier1` | Does each extraction output survive the full downstream pipeline — review → conflict resolution → approve → reconcile → balance sheet → income statement — with report VALUES tying to the corpus data, not just the flow completing? |
 
 The corpus E2E tier seeds a 10-fingerprint maximally-diverse manifest
 (text+vision, real bank/brokerage + synthetic HF, 0→170-transaction scales,
@@ -390,6 +390,21 @@ because only it carries `direction`; truth files record unsigned magnitudes.
 Diversity invariants and an exact unpostable-row allowlist are asserted in
 code (AC-llm.11.1) so the corpus can neither silently shrink nor silently
 drop rows.
+
+**Report-value acceptance (AC-llm.11.4, #1681/#1686)**: the balance sheet
+assertion (AC-llm.11.2) and the income statement assertion (AC-llm.11.4)
+together are the corpus's report-correctness proof — not just "the journey
+completed" but "the numbers are right". The income statement identity holds
+universally (every institution class, not a name-dependent heuristic)
+because `auto_create_posted_entries_for_statement` always posts a
+transaction's contra side to an Income or Expense account (a classified
+category or the Income/Expense "Uncategorized" default), so
+`total_income − total_expenses` equals the posting account's net movement by
+double-entry construction. Cash flow's `ending_cash` is deliberately NOT
+asserted here: `generate_cash_flow` classifies "cash" accounts by a
+name-keyword heuristic (`cash`/`bank`/`checking`/`savings`/…) that brokerage-
+class corpus accounts (Moomoo, Futu) do not match — a follow-up under #1681
+needs a classification-aware assertion, not a blanket one.
 
 **Division of labour with staging**: PR CI proves the pipeline on committed
 extraction artifacts (zero provider spend, deterministic); the staging

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -727,7 +727,7 @@ Product E2E ownership index:
 | `tests/e2e/test_epic022_ia_shell.py` | EPIC-022 everyday-user IA shell product owner E2E (in-runner preview lane); AC22.1 references live in the test file |
 | `tests/e2e/test_institution_statement_journeys.py` | Per-institution live-extraction staging journeys (audit-replay corpus, #1613); ACs live in the `llm` package roadmap (AC-llm.12.1 AC-llm.12.2 AC-llm.12.3 AC-llm.12.4, `common/llm/contract.py`) |
 | `apps/backend/tests/e2e/test_epic025_dry_ssot_e2e.py` | EPIC-025 DRY/SSOT product owner E2E; `AC-reporting.dry-ssot.1` (reporting_calc extraction is behavior-preserving, `common/reporting/contract.py`) references live in the test file |
-| `apps/backend/tests/e2e/test_statement_corpus_journeys.py` | Extraction-corpus merge-tier E2E; ACs live in the `llm` package roadmap (AC-llm.11.1 AC-llm.11.2 AC-llm.11.3, `common/llm/contract.py`) |
+| `apps/backend/tests/e2e/test_statement_corpus_journeys.py` | Extraction-corpus merge-tier E2E; ACs live in the `llm` package roadmap (AC-llm.11.1 AC-llm.11.2 AC-llm.11.3 AC-llm.11.4, `common/llm/contract.py`) |
 | `tests/e2e/test_ac_authority_tiers_epic026.py` | EPIC-026 authority-tier pipeline product owner E2E; AC-authority.2.1/AC-authority.3.1/AC-authority.4.1 references live in the test file |
 | `tests/e2e/test_application_ai_advisor_epic021.py` | Application AI Advisor product owner E2E; AC21.1 references live in the test file |
 | `tests/e2e/test_auth_flows.py` | Deployed auth flow E2E; AC references live in the test file |


### PR DESCRIPTION
## Summary
- Phase 1 of gate re-architecture umbrella #1686 (shift-left correctness). Adds **AC-llm.11.4**: `test_corpus_statement_full_journey` now asserts the income statement (`total_income - total_expenses == net_income == case.net_movement`) for every non-empty corpus case, in addition to the existing balance-sheet check.
- This closes part of the gap #950 recorded as unmet ("fixture exists only in parsing unit tests, never wired into full E2E acceptance") and is the statement-pipeline instance of #1505 (gates that verify "it runs" but not "the result is right").
- The identity holds **universally across the corpus** (bank and brokerage institution classes alike) because `auto_create_posted_entries_for_statement` always posts a transaction's contra side to an Income or Expense account (a classified category, or the Income/Expense "Uncategorized" default) — verified by running all 10 parametrized corpus cases against a real Postgres instance.
- Deliberately does **not** assert `cash_flow`'s `ending_cash`: `generate_cash_flow` classifies "cash" accounts by a name-keyword heuristic (`cash`/`bank`/`checking`/...) that brokerage-class corpus accounts (Moomoo, Futu) don't match, so a blanket assertion would be wrong for part of the corpus. Left as documented follow-up in #1681, not silently dropped.
- Fixes a pre-existing doc-drift in `common/llm/readme.md` ("roadmap group 10" — the code has been group 11 for a while).
- **Scope constraint honored**: no new CI job, no new workflow, no new baseline file — rides the existing `backend-e2e-tier1` lane, per #1681/#1686.
- **Incidental**: pre-commit's `ruff-format` hook also reformatted ~30 unrelated lines in `common/llm/contract.py`. Confirmed against a pristine `main` checkout that this file already failed `ruff format --check` under ruff's default line-length *before* this change (no repo-root ruff config exists to give `common/**` the `apps/backend`'s `line-length=120` convention its ACRecord statements visibly follow; CI only runs `ruff format` on `apps/backend/{src,tests}`, so it never caught this). Pure mechanical whitespace — not fixing the root config gap here, that's separate scope.

## Test plan
- [x] `pytest tests/e2e/test_statement_corpus_journeys.py -m e2e` against a real local Postgres — 12/12 pass (10 parametrized corpus cases + zero-txn + manifest-diversity)
- [x] `python tools/check_ac_index.py` — AC integrity/protection gates pass (new AC-llm.11.4 registered correctly)
- [x] `python tools/check_package_contract.py` — `llm` package contract still OK (60 roadmap ACs)
- [x] `python tools/check_e2e_epic_traceability.py` — passes
- [x] `ruff check` / `ruff format --check` on the touched files (post-mechanical-reformat) — clean
- [x] `python -m py_compile common/llm/contract.py` — valid after reformat

Relations: #1686 (umbrella, phase 1) · #1681 · #950 · #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)