### PR TITLE
[finance_report_ui] test(#1534): AC8.13.67 compose.yaml check becomes structural

### DIFF
--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -1965,11 +1965,13 @@ def test_AC8_13_67_production_release_preserves_version_metadata() -> None:
 
     # The backend service must carry the deployed version metadata. Other sidecars
     # (e.g. the vault-agent telemetry tags added in Infra-014 #360) may also stamp
-    # GIT_COMMIT_SHA, so assert the backend service block itself contains it rather
-    # than relying on a fragile global first-occurrence ordering.
-    assert "GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-unknown}" in app_compose
-    backend_block = app_compose[app_compose.index("backend:") :]
-    assert "GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-unknown}" in backend_block
+    # GIT_COMMIT_SHA, so parse the compose file's structure and check the backend
+    # service block specifically — #1534: a raw substring/ordering check breaks on
+    # any harmless reformat (requoting, key reordering) that a structural read does
+    # not.
+    compose = yaml.safe_load(app_compose)
+    backend_environment = compose["services"]["backend"]["environment"]
+    assert backend_environment["GIT_COMMIT_SHA"] == "${GIT_COMMIT_SHA:-unknown}"
 
 
 def test_AC7_10_production_release_promotes_not_rebuilds() -> None:
@@ -3478,7 +3480,9 @@ def test_AC8_13_10_multi_brokerage_upload_to_portfolio_value_gate() -> None:
     reusable = read(".github/workflows/staging-ai-ocr-gate.yml")
     brokerage = read("tests/e2e/test_brokerage_upload_to_portfolio_value.py")
     statements_router = read("apps/backend/src/routers/statements.py")
-    brokerage_payload = read("apps/backend/src/extraction/extension/brokerage_statement_payload.py")
+    brokerage_payload = read(
+        "apps/backend/src/extraction/extension/brokerage_statement_payload.py"
+    )
     generator = read("common/testing/fixtures/pdf/generate_pdf_fixtures.py")
 
     assert "tools/staging_ai_ocr_gate_contract.py --shell" in reusable


### PR DESCRIPTION
## Summary
- Phase 2 of gate re-architecture umbrella #1686 (de-mirror). #1534 flagged AC8.13.67 and AC8.13.146 as the two remaining string-match assertions in `test_post_merge_e2e_gates.py` that check the app's *own* deploy config (not an app↔infra2 mirror — that boundary debt is already closed per #1435) but do it via brittle raw-text search that breaks on any harmless reformat.
- This PR lands the **AC8.13.67** half: the production `compose.yaml`'s backend `GIT_COMMIT_SHA` declaration is now checked via `yaml.safe_load` + a structural `services.backend.environment.GIT_COMMIT_SHA` lookup, instead of two overlapping raw-substring/`index()` checks against the whole file text. Requoting, key reordering, or adding a sibling env var can no longer break this assertion while the behavior it verifies is unchanged.
- **AC8.13.146 is deliberately left for a follow-up**: its brittleness is in embedded bash script text inside workflow YAML (`notify-infra2.yml` / `deploy-report-main.yml`), which needs either an extracted, independently-testable Python primitive or actual script execution to fix properly — a larger, judgment-heavy change. `notify-infra2.yml` is also the exact file umbrella phase 0 (#1688, not yet merged) already modified this session; touching it again here would compound review surface across two open PRs on the same file.

## Test plan
- [x] `pytest tests/tooling/test_post_merge_e2e_gates.py -k AC8_13_67` — 2/2 pass
- [x] `pytest tests/tooling/test_post_merge_e2e_gates.py` (full suite, invoked from repo root the way CI actually does: `pytest tests/tooling/`) — 105/105 pass
- [x] `python tools/check_ac_index.py` — no regression (1982 AC nodes)
- [x] `ruff check` / `ruff format --check` on the touched file with matching cwd — clean

Relations: #1686 (umbrella, phase 2) · #1534 · #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)