### PR TITLE
[finance_report_ui] docs(#1535): annotate infra-owned scripts living in app repo

### DIFF
--- a/tools/_lib/shell/health_check.sh
+++ b/tools/_lib/shell/health_check.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # Health Check Script - Unified health check logic for all environments
 #
+# Ownership: this script's RESPONSIBILITY (post-deploy health probing) is
+# infra's, not app's — it physically lives here only because deploy.yml/
+# release.yml invoke it in-repo (#1535, surfaced by the #876 app/infra
+# boundary work). Do not add app-domain logic here; behavioral changes to
+# what "healthy" means belong in infra2's deploy contract, not a local edit.
+# Relocating to infra2 is tracked in #1535, not yet done.
+#
 # Usage:
 #   ./tools/health_check.sh <health_url> <environment> [max_attempts] [image_tag]
 #
@@ -118,12 +125,12 @@ MAX_SHA_MISMATCH_ATTEMPTS="${HEALTH_CHECK_MAX_SHA_MISMATCH_ATTEMPTS:-24}"
 
 while (( attempt <= MAX_ATTEMPTS )); do
   echo "[WAITING] Health check attempt $attempt/$MAX_ATTEMPTS..."
-  
+
   http_code=$(curl -s -o "$response_file" -w "%{http_code}" "$HEALTH_URL" 2>"$error_file" || echo "000")
-  
+
   if [[ "$http_code" == "000" ]]; then
     echo "[WARNING] Connection failed (attempt $attempt/$MAX_ATTEMPTS)"
-    
+
     if (( attempt == MAX_ATTEMPTS )); then
       timeout=$((MAX_ATTEMPTS * 10))
       echo ""
@@ -144,18 +151,18 @@ while (( attempt <= MAX_ATTEMPTS )); do
       echo "========================================="
       exit 1
     fi
-    
+
     sleep 10
     ((attempt++))
     continue
   fi
-  
+
   if ! check_http_code "$http_code" "200" "Health check" 2>/dev/null; then
     echo "[WARNING] HTTP $http_code (attempt $attempt/$MAX_ATTEMPTS)"
     if [[ "$http_code" == "404" ]] && (( attempt == 1 || attempt % 6 == 0 || attempt == MAX_ATTEMPTS )); then
       print_health_route_probe "$attempt" "$http_code"
     fi
-    
+
     if (( attempt == MAX_ATTEMPTS )); then
       timeout=$((MAX_ATTEMPTS * 10))
       echo ""
@@ -173,20 +180,20 @@ while (( attempt <= MAX_ATTEMPTS )); do
       echo "========================================="
       exit 1
     fi
-    
+
     sleep 10
     ((attempt++))
     continue
   fi
-  
+
   health_response=$(cat "$response_file" 2>/dev/null || echo "")
-  
+
   if validate_health_response "$health_response"; then
     # Verify Git SHA if provided
     if [[ -n "$IMAGE_TAG" ]]; then
       # Extract git_sha from response using safe_jq
       actual_sha=$(echo "$health_response" | jq -r '.git_sha // .version // ""')
-      
+
       # Handle short/long SHA comparison (prefix match)
       if [[ "$actual_sha" != "$IMAGE_TAG"* ]] && [[ "$IMAGE_TAG" != "$actual_sha"* ]]; then
         if [[ "$actual_sha" == "$LAST_MISMATCH_SHA" ]]; then
@@ -199,7 +206,7 @@ while (( attempt <= MAX_ATTEMPTS )); do
         echo "  Stable mismatch attempts: $SHA_MISMATCH_ATTEMPTS/$MAX_SHA_MISMATCH_ATTEMPTS"
         echo "  Expected: $IMAGE_TAG"
         echo "  Got:      $actual_sha"
-        
+
         if (( SHA_MISMATCH_ATTEMPTS >= MAX_SHA_MISMATCH_ATTEMPTS || attempt == MAX_ATTEMPTS )); then
            echo ""
            echo "========================================="
@@ -214,7 +221,7 @@ while (( attempt <= MAX_ATTEMPTS )); do
            echo "========================================="
            exit 1
         fi
-        
+
         sleep 10
         ((attempt++))
         continue
@@ -238,10 +245,10 @@ while (( attempt <= MAX_ATTEMPTS )); do
     echo "========================================="
     exit 0
   fi
-  
+
   echo "[WARNING] Backend is unhealthy (attempt $attempt/$MAX_ATTEMPTS)"
   echo "Response: $health_response"
-  
+
   if (( attempt == MAX_ATTEMPTS )); then
     timeout=$((MAX_ATTEMPTS * 10))
     echo ""
@@ -262,7 +269,7 @@ while (( attempt <= MAX_ATTEMPTS )); do
     echo "========================================="
     exit 1
   fi
-  
+
   sleep 10
   ((attempt++))
 done

--- a/tools/_lib/shell/smoke_test.sh
+++ b/tools/_lib/shell/smoke_test.sh
@@ -2,6 +2,13 @@
 # Smoke tests for Finance Report
 # Usage: bash tools/smoke_test.sh [BASE_URL] [MODE]
 #
+# Ownership: this script's RESPONSIBILITY (deployment connectivity smoke) is
+# infra's, not app's — it physically lives here only because deploy.yml/
+# release.yml/preview.yml invoke it in-repo (#1535, surfaced by the #876
+# app/infra boundary work). Do not add app-domain logic here; behavioral
+# changes to what "smoke" means belong in infra2's deploy contract, not a
+# local edit. Relocating to infra2 is tracked in #1535, not yet done.
+#
 # Arguments:
 #   BASE_URL: The root URL of the application (default: http://localhost:3000)
 #   MODE:     The environment mode: 'prod', 'staging', 'dev' (default: prod)
@@ -26,7 +33,7 @@ check_endpoint() {
     local expected="${3:-}"
     local method="${4:-GET}"
     local data="${5:-}"
-    
+
     local curl_opts=("-sS" "-w" "\n%{http_code}")
     if [ "$method" != "GET" ]; then
         curl_opts+=("-X" "$method")
@@ -59,7 +66,7 @@ check_endpoint() {
             return 0
         fi
     fi
-    
+
     echo "✗ $name (failed)"
     echo "  URL: $url"
     echo "  Method: $method"
@@ -132,7 +139,7 @@ if [ -n "${EXPECTED_SHA:-}" ]; then
     # Use python for parsing if jq is not guaranteed, or simple grep/sed
     HEALTH_RESP=$(curl -sS "$BASE_URL/api/health")
     ACTUAL_SHA=$(echo "$HEALTH_RESP" | grep -o '"git_sha":"[^"]*"' | cut -d'"' -f4 || echo "unknown")
-    
+
     if [ "$ACTUAL_SHA" = "$EXPECTED_SHA" ]; then
         echo "✓ Git SHA matches: $ACTUAL_SHA"
     else
@@ -174,7 +181,7 @@ curl -sS -I -X OPTIONS "$BASE_URL/api/ping" \
 check_endpoint "DB Connectivity" "$BASE_URL/api/health" "\"status\":\"healthy\"" || FAILED=1
 
 # 3. S3 Endpoint Validation (Network isolation check)
-# Fetch the S3 endpoint the backend is using (if exposed via a debug/config endpoint, 
+# Fetch the S3 endpoint the backend is using (if exposed via a debug/config endpoint,
 # or just check if it can be reached from the runner)
 # Note: In PR environments, backend might use 127.0.0.1 inside but needs public URL outside.
 echo "ℹ️  S3 Endpoint check: Backend is configured to use 127.0.0.1 (standardized)"
@@ -218,18 +225,18 @@ check_endpoint "Login Page" "$BASE_URL/login" || FAILED=1
 # --- Write/Mutation Checks (Staging/Dev Only) ---
 if [ "$MODE" = "dev" ] || [ "$MODE" = "staging" ]; then
     echo "--- Write Checks ($MODE) ---"
-    
+
     # Test ping/pong toggle (safe mutation without auth)
     BEFORE_STATE="$(curl -sS "$BASE_URL/api/ping" | grep -o '"state":"[^"]*"' || echo '')"
     check_endpoint "Ping Toggle (POST)" "$BASE_URL/api/ping/toggle" "" "POST" || FAILED=1
     AFTER_STATE="$(curl -sS "$BASE_URL/api/ping" | grep -o '"state":"[^"]*"' || echo '')"
-    
+
     if [ -n "$BEFORE_STATE" ] && [ -n "$AFTER_STATE" ] && [ "$BEFORE_STATE" != "$AFTER_STATE" ]; then
         echo "✓ State Changed ($BEFORE_STATE → $AFTER_STATE)"
     elif [ -z "$BEFORE_STATE" ]; then
         echo "ℹ️  Ping state verification skipped (state was empty before)"
     fi
-    
+
     echo "ℹ️  Complex authenticated write tests delegated to Python E2E suite"
 else
     echo "--- Write Checks ---"


### PR DESCRIPTION
## Summary
- Phase 2 of gate re-architecture umbrella #1686 (de-mirror), #1535's lightweight option: annotates `tools/_lib/shell/smoke_test.sh` and `tools/_lib/shell/health_check.sh` as infra-owned responsibility even though they physically live in the app repo (invoked in-repo by `deploy.yml`/`release.yml`/`preview.yml`).
- `#1535` offered two options: (a) relocate to infra2, (b) explicitly annotate with a pointer. This lands (b) — a small, non-blocking tidy that heads off the exact confusion the issue flags (#1506 previously added an app-domain guard directly to `smoke_test.sh` because that's where the script physically sits, even though the responsibility is infra's). Actually relocating to infra2 (option a) is cross-repo coordination with a separate GitHub repo and is explicitly out of scope here.
- No behavioral change — comment-only addition (plus incidental pre-existing trailing-whitespace cleanup pre-commit's hook applied on top).

## Test plan
- [x] `bash -n` on both scripts — syntax valid
- [x] `pytest tests/tooling/ -k "smoke or health_check"` — 32/32 pass

Relations: #1686 (umbrella, phase 2) · #1535 · #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)