### PR TITLE
[finance_report_audit] fix: resolve Copilot review findings from #1683 (stale SSOT stub anchors)

### DIFF
--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -115,7 +115,7 @@ write path and no dual-write flag.
   `opening_balance` / `closing_balance` stay populated for the single-currency
   case, and reconciliation runs **per currency** (never summing across
   currencies). See
-  [reconciliation.md#per-currency-balance-reconciliation](../../docs/ssot/reconciliation.md#per-currency-balance-reconciliation).
+  [common/reconciliation/readme.md#per-currency-balance-reconciliation](../reconciliation/readme.md#per-currency-balance-reconciliation).
   (#1123 AC1; FX pairing / transfer net-worth / FX P&L deferred as #1123
   AC2/AC3/AC4.)
 - A multi-currency **brokerage** statement populates `currency_balances` from its

--- a/common/testing/generate_vision_proof_matrix.py
+++ b/common/testing/generate_vision_proof_matrix.py
@@ -399,7 +399,7 @@ def render_markdown(matrix: dict[str, Any]) -> str:
             "AC descriptions above are mirrored from the EPIC docs and may echo "
             "rule keywords. The rules themselves are owned by their SSOT files:",
             "",
-            "- See: docs/ssot/reconciliation.md#thresholds",
+            "- See: common/reconciliation/readme.md#thresholds",
             "- See: common/ledger/readme.md#decimal-rule",
             "- See: common/ledger/readme.md#async-tx-boundary",
             "- See: common/ledger/readme.md#entry-balance",

--- a/docs/project/EPIC-004.reconciliation-engine.md
+++ b/docs/project/EPIC-004.reconciliation-engine.md
@@ -318,7 +318,7 @@ Covers **AC1** (per-currency balances + per-currency reconciliation) and **AC5**
 (SSOT) of #1123. **AC2** (FX leg pairing), **AC3** (internal-transfer net-worth),
 and **AC4** (FX P&L) are deferred to a follow-up EPIC — they require a linked-leg
 event model and accounting-layer changes beyond this representation slice.
-See: docs/ssot/reconciliation.md#per-currency-balance-reconciliation
+See: `common/reconciliation/readme.md#per-currency-balance-reconciliation`
 
 > **Fully migrated.** The extraction-owned row (was AC4.13's group-6 row) is homed in the `extraction` package roadmap as
 > `AC-extraction.413.6`

--- a/tests/e2e/test_application_ai_advisor_epic021.py
+++ b/tests/e2e/test_application_ai_advisor_epic021.py
@@ -14,7 +14,9 @@ def read(path: str) -> str:
 def test_application_ai_advisor_epic021_product_owner_contract() -> None:
     """EPIC-021 / AC21.1.1 AC21.1.2: Advisor value layer has a product E2E owner."""
     epic = read("docs/project/EPIC-021.application-ai-advisor.md")
-    ssot = read("docs/ssot/ai.md")
+    # Migrated from docs/ssot/ai.md into the advisor package readme (migration
+    # closeout wave 3, #1664); docs/ssot/ai.md is now a pointer stub.
+    ssot = read("common/advisor/readme.md")
 
     assert "Advisor Brief" in epic
     assert "deterministic application facts" in ssot


### PR DESCRIPTION
## Summary

#1683 (migration closeout wave 3) merged before its 2 Copilot review
comments were addressed. Both were real, plus a repo-wide sweep found one
more instance of the same bug class. This PR fixes all three.

Refs #1664, umbrella #1416.

## What broke

1. **`tests/e2e/test_application_ai_advisor_epic021.py`** asserted a
   substring against `docs/ssot/ai.md`, which #1683 turned into a pointer
   stub — this test was silently broken on `main` since `tests/e2e/` isn't
   part of the `tests/tooling/` suite this session's verification loop
   covered. Fixed: repointed to `common/advisor/readme.md`, matching the
   already-fixed sibling test in `tests/tooling/`.
2. **`common/extraction/readme.md`** and
   **`docs/project/EPIC-004.reconciliation-engine.md`** linked to
   `docs/ssot/reconciliation.md#per-currency-balance-reconciliation` — an
   anchor the stub no longer defines, so the link now lands at the top of
   the stub instead of the actual content. Fixed: repointed both to
   `common/reconciliation/readme.md#per-currency-balance-reconciliation`.
3. **`common/testing/generate_vision_proof_matrix.py`**'s generated "Rule
   ownership" section still hardcoded `docs/ssot/reconciliation.md#thresholds`
   — found via a repo-wide sweep (not just `tests/`) for anchored
   references to all 6 SSOT docs #1683 migrated. Fixed the source string.

I considered Copilot's alternative suggestion (add legacy `<a id>` anchors
to the stub so old deep links keep working) but chose to fix the
referencing files directly instead, for consistency with the other 4
already-migrated stubs in the same PR, none of which carry legacy anchors.

## Testing

```bash
apps/backend/.venv/bin/python3 -m pytest tests/tooling/ -n 4 --no-cov -q
# 1876 passed, 1 skipped
apps/backend/.venv/bin/python3 -m pytest tests/e2e/test_application_ai_advisor_epic021.py --no-cov -q
# 1 passed (was failing on main before this fix)

moon run :lint
# All checks passed

apps/backend/.venv/bin/python3 tools/check_package_contract.py     # PASSED
apps/backend/.venv/bin/python3 tools/check_manifest.py             # clean
apps/backend/.venv/bin/python3 tools/lint_doc_consistency.py       # clean
apps/backend/.venv/bin/python3 tools/check_ssot_ownership.py       # clean
apps/backend/.venv/bin/python3 tools/check_ac_index.py             # PASSED
apps/backend/.venv/bin/python3 tools/generate_ac_registry.py --check   # OK
apps/backend/.venv/bin/python3 tools/check_ac_tier_baseline.py     # PASSED
apps/backend/.venv/bin/python3 -m common.testing.mirror_ratchet    # 2914<=2917
```