### PR TITLE
[finance_report_vision] refactor(extraction,llm): route OCR layout-parsing through llm's interface (#1670)

### DIFF
--- a/apps/backend/src/extraction/extension/_ocr.py
+++ b/apps/backend/src/extraction/extension/_ocr.py
@@ -3,11 +3,8 @@
 import httpx
 
 import src.config
-from src.extraction.extension._base import (
-    ExtractionError,
-    logger,
-)
-from src.observability import safe_error_message
+from src.extraction.extension._base import ExtractionError
+from src.llm import LLMError, ocr_layout_call
 
 # Bound from the bare published root (config publishes no named symbols).
 settings = src.config.settings
@@ -41,53 +38,21 @@ class _OcrMixin:
         file_type: str,
         mime_type: str,
     ) -> str:
-        """Run dedicated OCR/layout parsing and return Markdown text."""
+        """Run dedicated OCR/layout parsing and return Markdown text.
+
+        The HTTP call itself is `llm`'s ``ocr_layout_call`` (#1670) — a
+        non-chat endpoint litellm does not wrap, so it gets its own
+        chokepoint in the `llm` package rather than a raw httpx call here.
+        """
         file_input = self._build_ai_file_input(file_content, file_url, file_type, mime_type)
-        layout_url = f"{self.base_url.rstrip('/')}/{settings.ai_layout_parsing_path.lstrip('/')}"
-        payload = {
-            "model": self.ocr_model,
-            "file": file_input,
-            "return_crop_images": False,
-            "need_layout_visualization": False,
-        }
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-        }
-
-        logger.info(
-            "Sending document to OCR layout parser",
-            provider=settings.ai_provider,
-            model=self.ocr_model,
-            file_type=file_type,
-            data_source="base64" if file_input.startswith("data:") else "url",
-        )
-
-        async with httpx.AsyncClient(timeout=httpx.Timeout(180.0, connect=10.0, read=180.0)) as client:
-            response = await client.post(layout_url, headers=headers, json=payload)
-
-        if response.status_code != 200:
-            safe_summary = safe_error_message(response.text)
-            logger.error(
-                "OCR layout parsing failed",
-                provider=settings.ai_provider,
+        try:
+            return await ocr_layout_call(
+                base_url=self.base_url,
+                layout_parsing_path=settings.ai_layout_parsing_path,
+                api_key=self.api_key,
                 model=self.ocr_model,
-                status_code=response.status_code,
-                safe_error_message=safe_summary,
+                file_input=file_input,
+                timeout=httpx.Timeout(180.0, connect=10.0, read=180.0),
             )
-            raise ExtractionError(f"OCR layout parsing failed: HTTP {response.status_code}: {safe_summary}")
-
-        result = response.json()
-        markdown = result.get("md_results")
-        if isinstance(markdown, list):
-            markdown = "\n\n".join(str(item) for item in markdown if item)
-        if not isinstance(markdown, str) or not markdown.strip():
-            raise ExtractionError("OCR layout parsing returned empty Markdown")
-
-        logger.info(
-            "OCR layout parsing completed",
-            provider=settings.ai_provider,
-            model=self.ocr_model,
-            markdown_length=len(markdown),
-        )
-        return markdown
+        except LLMError as exc:
+            raise ExtractionError(str(exc)) from exc

--- a/apps/backend/src/llm/__init__.py
+++ b/apps/backend/src/llm/__init__.py
@@ -72,6 +72,7 @@ from src.llm.extension import (
     get_config_source,
     get_usage_meter,
     miss_summary,
+    ocr_layout_call,
     protocol_for,
 )
 
@@ -136,6 +137,7 @@ __all__ = [
     "get_usage_meter",
     "litellm_stream",
     "miss_summary",
+    "ocr_layout_call",
     "protocol_for",
     "resolve_provider_and_model",
 ]

--- a/apps/backend/src/llm/extension/__init__.py
+++ b/apps/backend/src/llm/extension/__init__.py
@@ -33,6 +33,7 @@ from src.llm.extension.factory import (
     get_config_source,
     get_usage_meter,
 )
+from src.llm.extension.ocr_client import ocr_layout_call
 from src.llm.extension.routing import LitellmCall, build_call
 
 __all__ = [
@@ -53,5 +54,6 @@ __all__ = [
     "get_config_source",
     "get_usage_meter",
     "miss_summary",
+    "ocr_layout_call",
     "protocol_for",
 ]

--- a/apps/backend/src/llm/extension/ocr_client.py
+++ b/apps/backend/src/llm/extension/ocr_client.py
@@ -1,0 +1,72 @@
+"""Dedicated OCR/layout-parsing transport (#1670).
+
+Chat/JSON completions go through ``litellm_stream``; the layout-parsing OCR
+endpoint is a separate, non-chat HTTP API that litellm does not wrap, so it
+gets its own thin transport function — the single chokepoint for this call,
+mirroring ``build_call`` for the litellm path.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from src.llm.base.errors import LLMError
+from src.observability import get_logger, safe_error_message
+
+logger = get_logger(__name__)
+
+
+async def ocr_layout_call(
+    *,
+    base_url: str,
+    layout_parsing_path: str,
+    api_key: str,
+    model: str,
+    file_input: str,
+    timeout: httpx.Timeout,
+) -> str:
+    """POST a document to the OCR layout-parsing endpoint; return its Markdown.
+
+    Raises :class:`LLMError` on a non-200 response or an empty/malformed
+    result.
+    """
+    layout_url = f"{base_url.rstrip('/')}/{layout_parsing_path.lstrip('/')}"
+    payload = {
+        "model": model,
+        "file": file_input,
+        "return_crop_images": False,
+        "need_layout_visualization": False,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    logger.info(
+        "Sending document to OCR layout parser",
+        model=model,
+        data_source="base64" if file_input.startswith("data:") else "url",
+    )
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(layout_url, headers=headers, json=payload)
+
+    if response.status_code != 200:
+        safe_summary = safe_error_message(response.text)
+        logger.error(
+            "OCR layout parsing failed",
+            model=model,
+            status_code=response.status_code,
+            safe_error_message=safe_summary,
+        )
+        raise LLMError(f"OCR layout parsing failed: HTTP {response.status_code}: {safe_summary}")
+
+    result = response.json()
+    markdown = result.get("md_results")
+    if isinstance(markdown, list):
+        markdown = "\n\n".join(str(item) for item in markdown if item)
+    if not isinstance(markdown, str) or not markdown.strip():
+        raise LLMError("OCR layout parsing returned empty Markdown")
+
+    logger.info("OCR layout parsing completed", model=model, markdown_length=len(markdown))
+    return markdown

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -27,10 +27,13 @@ extracted fact to its source document.
 * ``confidence_metric`` / ``confidence_tier`` (journal-confidence metric
   snapshots) are NOT this package's — they read ledger's aggregates and stay
   in ``services/`` pending the reporting/observability re-home.
-* No ``llm`` edge yet: the OCR/vision call sites still reach the provider via
-  their own httpx path; routing them through ``src.llm`` (threading
-  ``user_id``, the AC-llm.4.5 documented follow-up) ADDS ``llm`` to
-  ``depends_on`` when it lands.
+* The OCR layout-parsing call routes through ``src.llm``'s ``ocr_layout_call``
+  chokepoint (#1670), which is why ``llm`` is now a declared dependency. The
+  JSON/vision call sites already went through ``llm`` via
+  ``services.ai_streaming``. Threading per-user provider binding (``user_id``)
+  into these OCR/vision/json call sites — so a BYO-provider user's own model
+  is used, not just the deployment default — is a separate, still-pending
+  follow-up (AC-llm.4.5), independent of the ``llm`` dependency edge itself.
 """
 
 from __future__ import annotations
@@ -51,7 +54,7 @@ CONTRACT = PackageContract(
     # vision-LLM path (the authority classifier bands cassette-driven tests as
     # LLM). Non-eval ACs carry proof_kind=property.
     tier="LLM-LED",
-    depends_on=["audit", "identity", "ledger", "observability", "platform", "runtime"],
+    depends_on=["audit", "identity", "ledger", "llm", "observability", "platform", "runtime"],
     roles=["base", "extension", "data"],
     units=[
         # ── base: the pure validation/confidence calculus lives in

--- a/common/llm/contract.py
+++ b/common/llm/contract.py
@@ -98,6 +98,13 @@ CONTRACT = PackageContract(
         Unit(
             name="build_call", kind=Kind.DOMAIN_SERVICE, module="extension/routing.py"
         ),
+        # the single chokepoint for the non-chat OCR/layout-parsing HTTP call
+        # (#1670): a separate endpoint litellm does not wrap.
+        Unit(
+            name="ocr_layout_call",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/ocr_client.py",
+        ),
         # the input-keyed record/replay mechanism (cache output by input)
         Unit(
             name="CassetteStore",
@@ -170,6 +177,7 @@ CONTRACT = PackageContract(
         "get_usage_meter",
         "litellm_stream",
         "miss_summary",
+        "ocr_layout_call",
         "protocol_for",
         "resolve_provider_and_model",
     ],


### PR DESCRIPTION
## Summary
- `common/extraction/contract.py` declares `tier="LLM-LED"` but its OCR/layout-parsing call site made a raw `httpx` request rather than going through the `llm` package's published interface — the JSON/vision call sites already did (via `services.ai_streaming`). `grep -rl "from src.llm\|src\.llm\." apps/backend/src/extraction` was zero hits before this change.
- Adds `ocr_layout_call()` as `llm`'s chokepoint for this non-chat HTTP endpoint (litellm doesn't wrap it — same rationale as the existing `build_call` chokepoint for the litellm path), publishes it through `llm`'s `contract.interface`/`__all__` (root + `extension/`).
- `extraction`'s `_extract_ocr_markdown` now calls `ocr_layout_call` and translates `LLMError` -> `ExtractionError`, instead of doing the `httpx.AsyncClient` call itself.
- `common/extraction/contract.py` now declares `depends_on: [..., "llm", ...]` — a legal downward edge (extraction is domain L3, llm is infra L1).
- Behavior is preserved: identical request payload/headers/timeout, and the `LLMError` -> `ExtractionError` message format matches what the existing tests assert via `pytest.raises(ExtractionError, match=...)`.
- Threading per-user provider binding (`user_id`) into this call site remains a separate, already-tracked follow-up (`AC-llm.4.5`) — this PR only closes the undeclared-dependency / wrong-import-path gap, not that larger BYO-provider feature.
- Closes #1670, part of the #1416 package-model migration.

## Verification
- `apps/backend/tests/extraction/` (544 tests) and `apps/backend/tests/llm/` (143 tests) both green except one pre-existing, unrelated failure (`test_AC23_4_1_config_status_flips_when_user_configures`) that reproduces identically on `git stash` (i.e. without this change) — confirmed local test-DB row pollution from a prior local run, not a regression from this PR.
- `tests/tooling/test_llm_package.py`, `tests/tooling/test_extraction_package.py`, `tests/tooling/test_check_package_contract.py` → 38 passed (governance gates: interface honesty, depends_on/DAG legality, layer placement).
- `uv run --with pyyaml python tools/check_manifest.py` / `tools/lint_doc_consistency.py` → pass.
- `ruff check` on all touched files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)