### PR TITLE
[finance_report_ui] fix: resolve Copilot review comments from #1692 and #1695

### DIFF
--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -36,7 +36,7 @@ main-only: unified-coverage ─→ unified-coverage-baseline-pr (not required by
 | **schema-migrations** | Run Alembic `upgrade head` followed by `alembic check` against an ephemeral Postgres service before merge | `needs: [changes]` |
 | **backend** (Shards 1-5) | Backend fast-path tests only: `-m "not slow and not e2e and not integration"` | `needs: [changes]` |
 | **backend-integration** | Backend integration stage (`-m "integration"`), deterministic service-backed behavior checks | `needs: [changes]` |
-| **backend-e2e-tier1** | Backend Tier-1 API E2E stage: the exact file set is generated, not hand-listed here — see the `backend_tier1_api_e2e` rows in [`docs/ssot/test-execution-matrix.yaml`](test-execution-matrix.yaml) (the SSOT view of `common/testing/matrix.py#WORKFLOW_PYTEST_CONTRACTS`; includes the extraction-corpus journeys, `AC-llm.11`, registered in `common/llm/contract.py`) — with `-m e2e`, executed with explicit marker override. PR runs stay fail-fast; push/main runs report the full Tier-1 failure set. | `needs: [changes]` |
+| **backend-e2e-tier1** | Backend Tier-1 API E2E stage: the exact file set is generated, not hand-listed here — see the `backend_tier1_api_e2e` rows in [`docs/ssot/test-execution-matrix.yaml`](test-execution-matrix.yaml) (the SSOT view of `common/testing/matrix.py#PATH_RULES`; includes the extraction-corpus journeys, `AC-llm.11`, registered in `common/llm/contract.py`) — with `-m "e2e and not slow and not integration and not perf"`. PR runs stay fail-fast; push/main runs report the full Tier-1 failure set. | `needs: [changes]` |
 | **frontend-build** | Frontend TypeScript typecheck + production build when heavy CI is required | `needs: [changes]` |
 | **frontend-vitest** | Frontend Vitest coverage and JUnit evidence when heavy CI is required | `needs: [changes]` |
 | **frontend-playwright** | Provider-free frontend browser UI proof when heavy CI is required | `needs: [changes]` |
@@ -276,7 +276,7 @@ be reverse-engineered from `.github/workflows/ci.yml` on every audit.
 |---|---|---|---|
 | `smoke` | root `pytest.ini`, `tests/e2e/pytest.ini` | `(smoke or e2e) and not llm` (PR preview) | Selector |
 | `e2e` | root `pytest.ini`, `apps/backend/pyproject.toml`, `tests/e2e/pytest.ini` | `e2e and not slow and not integration and not perf` (backend-tier1); `(smoke or e2e) and not llm` (PR preview) | Selector |
-| `llm` | root `pytest.ini`, `apps/backend/pyproject.toml`, `tests/e2e/pytest.ini` | staging AI/OCR gate marker; excluded everywhere else (`and not llm`) | Selector |
+| `llm` | root `pytest.ini`, `tests/e2e/pytest.ini` (not registered in `apps/backend/pyproject.toml`) | staging AI/OCR gate marker; excluded everywhere else (`and not llm`) | Selector |
 | `prod_safe` | root `pytest.ini`, `tests/e2e/pytest.ini` | production read-only smoke marker | Selector |
 | `slow` | `apps/backend/pyproject.toml` | excluded from `backend` and `backend-e2e-tier1` (`not slow`) | Selector (exclusion) |
 | `integration` | `apps/backend/pyproject.toml` | `backend-integration` job (`-m integration`) | Selector |

--- a/tools/_lib/shell/health_check.sh
+++ b/tools/_lib/shell/health_check.sh
@@ -3,10 +3,11 @@
 #
 # Ownership: this script's RESPONSIBILITY (post-deploy health probing) is
 # infra's, not app's — it physically lives here only because deploy.yml/
-# release.yml invoke it in-repo (#1535, surfaced by the #876 app/infra
-# boundary work). Do not add app-domain logic here; behavioral changes to
-# what "healthy" means belong in infra2's deploy contract, not a local edit.
-# Relocating to infra2 is tracked in #1535, not yet done.
+# release.yml invoke the thin `tools/health_check.sh` wrapper, which execs
+# into this file (#1535, surfaced by the #876 app/infra boundary work). Do
+# not add app-domain logic here; behavioral changes to what "healthy" means
+# belong in infra2's deploy contract, not a local edit. Relocating to
+# infra2 is tracked in #1535, not yet done.
 #
 # Usage:
 #   ./tools/health_check.sh <health_url> <environment> [max_attempts] [image_tag]

--- a/tools/_lib/shell/smoke_test.sh
+++ b/tools/_lib/shell/smoke_test.sh
@@ -4,10 +4,11 @@
 #
 # Ownership: this script's RESPONSIBILITY (deployment connectivity smoke) is
 # infra's, not app's — it physically lives here only because deploy.yml/
-# release.yml/preview.yml invoke it in-repo (#1535, surfaced by the #876
-# app/infra boundary work). Do not add app-domain logic here; behavioral
-# changes to what "smoke" means belong in infra2's deploy contract, not a
-# local edit. Relocating to infra2 is tracked in #1535, not yet done.
+# release.yml/preview.yml invoke the thin `tools/smoke_test.sh` wrapper,
+# which execs into this file (#1535, surfaced by the #876 app/infra
+# boundary work). Do not add app-domain logic here; behavioral changes to
+# what "smoke" means belong in infra2's deploy contract, not a local edit.
+# Relocating to infra2 is tracked in #1535, not yet done.
 #
 # Arguments:
 #   BASE_URL: The root URL of the application (default: http://localhost:3000)


### PR DESCRIPTION
## Summary
Follow-up requested after merge: both #1692 and #1695 landed with unresolved Copilot auto-review comments. All four are confirmed real inaccuracies (verified against the actual source before fixing, not just Copilot's say-so):

- **docs/ssot/ci-cd.md** (from #1692):
  - The `llm` pytest marker's "registered in" column overclaimed `apps/backend/pyproject.toml` — that file only registers `slow`/`perf`/`integration`/`e2e`/`no_db`/`needs_real_cassette`. `llm` is only in root `pytest.ini` and `tests/e2e/pytest.ini`.
  - `docs/ssot/test-execution-matrix.yaml` is generated from `common/testing/matrix.py#PATH_RULES` (confirmed: `emit_execution_matrix_yaml()` iterates `PATH_RULES`), not `#WORKFLOW_PYTEST_CONTRACTS` as I'd written.
  - Tier-1's actual marker expression is `-m "e2e and not slow and not integration and not perf"` (confirmed in `.github/workflows/ci.yml`), not the bare `-m e2e` the prose oversimplified to.
- **tools/_lib/shell/smoke_test.sh + health_check.sh** (from #1695): confirmed `deploy.yml`/`release.yml`/`preview.yml` call the thin `tools/smoke_test.sh` / `tools/health_check.sh` wrapper (which just `exec`s into these `_lib/shell/` files), not these files directly — reworded to name that indirection.

## Test plan
- [x] Verified each Copilot claim against the actual source (pyproject.toml markers list, `matrix.py`'s `emit_execution_matrix_yaml`, `ci.yml`'s tier-1 pytest invocation, the wrapper scripts) before fixing
- [x] `bash -n` on both shell scripts — valid
- [x] `pytest tests/tooling/` (full suite, 1946 tests) — all pass; nothing depended on the corrected text
- [x] `python tools/lint_doc_consistency.py` — clean

Relations: #1686 · #1692 · #1695

🤖 Generated with [Claude Code](https://claude.com/claude-code)