### PR TITLE
[finance_report_vision] feat(meta): migrate EPIC-014's 23 AC rows into meta's roadmap (#1663 partial)

### DIFF
--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -538,5 +538,182 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── migrated from EPIC-014 (TTD transformation), migration closeout
+        # wave 2 (#1663): foundational dev-tooling gates. Was AC14.1.1-.5. ──
+        ACRecord(
+            id="AC-meta.foundation-tooling.1",
+            statement="Backend coverage threshold is enforced locally via apps/backend/pyproject.toml's --cov-fail-under. Was AC14.1.1.",
+            test="tests/tooling/test_issue_493_foundation_ttd_behavior.py::test_AC14_1_1_backend_pyproject_enforces_local_coverage_threshold",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.foundation-tooling.2",
+            statement="The pre-commit mypy hook runs against apps/backend/src and blocks type errors before commit. Was AC14.1.2.",
+            test="tests/tooling/test_issue_493_foundation_ttd_behavior.py::test_AC14_1_2_pre_commit_mypy_hook_blocks_backend_type_errors",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.foundation-tooling.3",
+            statement="validate_schemas.py exits non-zero when a Pydantic Field() lacks a description. Was AC14.1.3.",
+            test="tests/tooling/test_issue_493_foundation_ttd_behavior.py::test_AC14_1_3_validate_schemas_exits_nonzero_for_missing_field_descriptions",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.foundation-tooling.4",
+            statement="check_env_keys.py exits non-zero on a secret/config/env three-way drift. Was AC14.1.4.",
+            test="tests/tooling/test_issue_493_foundation_ttd_behavior.py::test_AC14_1_4_check_env_keys_exits_nonzero_for_secret_config_drift",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.foundation-tooling.5",
+            statement="smoke_test.sh succeeds against a mocked local environment (health, pages, auth, CORS all pass). Was AC14.1.5.",
+            test="tests/tooling/test_issue_493_foundation_ttd_behavior.py::test_AC14_1_5_smoke_test_succeeds_against_mocked_local_environment",
+            priority="P1",
+            status="done",
+        ),
+        # ── migrated from EPIC-014, wave 2 (#1663): AC-registry generation
+        # itself. Was AC14.1.6. ──
+        ACRecord(
+            id="AC-meta.registry.1",
+            statement="generate_ac_registry.py produces zero ghost ACs (reference-only mentions never create an entry) and zero id overlap between the feature and infra registries. Was AC14.1.6.",
+            test="tests/tooling/test_issue_493_foundation_ttd_behavior.py::test_AC14_1_6_generate_ac_registry_check_rejects_ghosts_and_keeps_no_overlap",
+            priority="P1",
+            status="done",
+        ),
+        # ── migrated from EPIC-014, wave 2 (#1663): doc-consistency lint
+        # rules. Was AC14.1.7/.8/.10. ──
+        ACRecord(
+            id="AC-meta.doc-consistency.1",
+            statement="Generated analysis snapshots are not checked into docs/project/; live coverage and mismatch data come from tools or CI artifacts, not committed prose. Was AC14.1.7.",
+            test="tests/tooling/test_lint_doc_consistency.py::test_AC14_1_7_generated_analysis_snapshots_are_absent",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.doc-consistency.2",
+            statement="Reconciliation threshold prose points to its code/config owner instead of claiming the Markdown copy is the single authority. Was AC14.1.8.",
+            test="tests/tooling/test_lint_doc_consistency.py::test_AC14_1_8_reconciliation_thresholds_are_code_owned",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.doc-consistency.3",
+            statement="Frontend source cannot call raw fetch() outside apps/frontend/src/lib/api.ts. Was AC14.1.10.",
+            test="tests/tooling/test_lint_doc_consistency.py::test_AC14_1_10_frontend_raw_fetch_is_limited_to_api_wrapper",
+            priority="P0",
+            status="done",
+        ),
+        # ── migrated from EPIC-014, wave 2 (#1663): the SSOT HLS governance
+        # loop (manifest anchors, governance report/gates/ratchets, family
+        # model, threshold-cleanup proof binding). Was AC14.1.9/.12-.16/.18/.23. ──
+        ACRecord(
+            id="AC-meta.ssot-governance.1",
+            statement="SSOT manifest #anchor owners and cross-references resolve to actual Markdown anchors. Was AC14.1.9.",
+            test="tests/tooling/test_check_manifest.py::test_AC14_1_9_manifest_anchor_refs_must_exist",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.ssot-governance.2",
+            statement="SSOT governance metrics report finance_report and infra2 manifest shape, proof coverage, and future gate candidates without blocking CI. Was AC14.1.12.",
+            test="tests/tooling/test_ssot_governance_report.py::test_AC14_1_12_report_covers_finance_and_infra2_manifest_shapes",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.ssot-governance.3",
+            statement="SSOT governance gates block changed-file and changed-manifest-entry debt, explain #823/HLS ownership, and support issue-linked temporary exceptions. Was AC14.1.13.",
+            test="tests/tooling/test_ssot_governance_report.py::test_AC14_1_13_incremental_gate_only_blocks_changed_ssot_debt",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.ssot-governance.4",
+            statement="Threshold cleanup for #824 reduces finance_report.orphan_ssot_files to zero by binding orphan SSOT files to parent concepts, without runtime behavior changes. Was AC14.1.14.",
+            test="tests/tooling/test_ssot_governance_report.py::test_AC14_1_14_finance_report_orphan_ssot_files_are_manifest_owned",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.ssot-governance.5",
+            statement="Threshold cleanup for #824 migrates representative machine-owned FR SSOT entries to explicit family/kind/proofs and inbound links so machine_owner_entries_missing_proof stays zero. Was AC14.1.15.",
+            test="tests/tooling/test_ssot_governance_report.py::test_AC14_1_15_machine_owned_ssot_entries_have_explicit_shape_and_proof",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.ssot-governance.6",
+            statement="SSOT governance gates keep protected per-system governance ratios non-decreasing and protected debt counts non-increasing against the base ref. Was AC14.1.16.",
+            test="tests/tooling/test_ssot_governance_report.py::test_AC14_1_16_ssot_governance_ratios_cannot_regress",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.ssot-governance.7",
+            statement="FR (EPIC-014) and infra2 (Infra-006) each document a 6-8 family SSOT HLS model with explicit concept/clause boundaries covering every MANIFEST.yaml-inferred family, linking #821/#822/#823/#824, and the definition does not move or re-own any SSOT concept. Was AC14.1.18.",
+            test="tests/tooling/test_ssot_hls_family_model.py::test_AC14_1_18_fr_hls_family_model_is_documented_and_consistent",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.ssot-governance.8",
+            statement="Threshold cleanup for #824 reduces finance_report.high_risk_entries_missing_proof to zero by binding the flagged high-risk platform concepts to existing proof tests, without runtime behavior changes. Was AC14.1.23.",
+            test="tests/tooling/test_ssot_governance_report.py::test_AC14_1_23_high_risk_ssot_entries_bind_proof_under_platform_family",
+            priority="P1",
+            status="done",
+        ),
+        # ── migrated from EPIC-014, wave 2 (#1663): GitHub issue template
+        # contract. Was AC14.1.11. ──
+        ACRecord(
+            id="AC-meta.issue-templates.1",
+            statement="GitHub issue templates require phenomenon, reproduction, minimal-fix, and rationale/acceptance-criteria sections with valid repository labels. Was AC14.1.11.",
+            test="tests/tooling/test_issue_template_contract.py::test_AC14_1_11_issue_templates_carry_their_type_required_fields",
+            priority="P1",
+            status="done",
+        ),
+        # ── migrated from EPIC-014, wave 2 (#1663): mechanically-generated
+        # reference docs (DB schema, vision-proof matrix, EPIC status). Was
+        # AC14.1.17/.19/.22. ──
+        ACRecord(
+            id="AC-meta.generated-refs.1",
+            statement="The DB schema inventory is generated from SQLAlchemy metadata, CI-checked for deterministic generation, and linked from macro SSOT/domain docs instead of hand-maintained. Was AC14.1.17.",
+            test="tests/tooling/test_generate_db_schema_reference.py::test_AC14_1_17_render_db_schema_reference_uses_sqlalchemy_metadata",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.generated-refs.2",
+            statement="A single parseable vision-to-proof matrix is mechanically generated from vision.md anchors, EPIC Vision Anchor declarations, the AC registries, and test references, and --check fails on drift. Was AC14.1.19.",
+            test="tests/tooling/test_generate_vision_proof_matrix.py::test_AC14_1_19_matrix_maps_vision_to_ac_to_test",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.generated-refs.3",
+            statement="README EPIC status/completion is generated from the AC registries and test reports (not hand-written), reports coverage/placeholder/manual-gate/blocker categories separately, and is guarded by a generate-with---check drift gate. Was AC14.1.22.",
+            test="tests/tooling/test_generate_epic_status.py::test_AC14_1_22_check_fails_on_drift",
+            priority="P1",
+            status="done",
+        ),
+        # ── migrated from EPIC-014, wave 2 (#1663): unified-coverage artifact
+        # preflight + component tiers (#414/#923). Was AC14.1.20/.21. ──
+        ACRecord(
+            id="AC-meta.coverage-tiers.1",
+            statement="Unified coverage aggregation runs an artifact preflight that fails explicitly and names the offending component LCOV when a CI-critical artifact is missing or empty, instead of silently treating it as 0%. Was AC14.1.20.",
+            test="tests/tooling/test_coverage_artifact_preflight.py::test_AC14_1_20_preflight_fails_when_ci_critical_artifact_missing",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.coverage-tiers.2",
+            statement="Coverage components carry an explicit tier (ci-critical vs best-effort); the artifact preflight enforces presence only for ci-critical tiers so a missing best-effort tools artifact does not hard-fail aggregation. Was AC14.1.21.",
+            test="tests/tooling/test_coverage_artifact_preflight.py::test_AC14_1_21_tools_component_is_best_effort_tier",
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/docs/project/EPIC-014.ttd-transformation.md
+++ b/docs/project/EPIC-014.ttd-transformation.md
@@ -112,10 +112,10 @@ To-be:
   [#824](https://github.com/wangzitian0/finance_report/issues/824).
   - Each cleanup is selected from `python tools/report_ssot_governance.py` (not
     subjective review) and names the metric threshold it reduces:
-    - AC14.1.14 reduces `finance_report.orphan_ssot_files` to zero.
-    - AC14.1.15 keeps `finance_report.machine_owner_entries_missing_proof` at
+    - AC-meta.ssot-governance.4 (AC14.1.14 removed, canonical id moved to `common/meta/contract.py`) reduces `finance_report.orphan_ssot_files` to zero.
+    - AC-meta.ssot-governance.5 (AC14.1.15 removed, canonical id moved to `common/meta/contract.py`) keeps `finance_report.machine_owner_entries_missing_proof` at
       zero.
-    - AC14.1.23 reduces `finance_report.high_risk_entries_missing_proof` from
+    - AC-meta.ssot-governance.8 (AC14.1.23 removed, canonical id moved to `common/meta/contract.py`) reduces `finance_report.high_risk_entries_missing_proof` from
       `2` to zero by binding the flagged high-risk `platform` concepts
       (`container_naming`, `test_optimization`) to their existing proof tests.
       Metadata-only backfill (`family` / `kind` / `proofs`); no concept is moved
@@ -261,35 +261,17 @@ Historical work-progress reports and test-organization audits were removed from 
 
 ---
 
-## 🧪 Infra Test Cases (Coverage Enforcement)
+## AC14.1: Coverage Enforcement Tooling — migrated to the `meta` package
 
-> **Registry**: `docs/infra_registry.yaml`
-> **Coverage**: See `apps/backend/tests/infra/`
-
-### AC14.1: Coverage Enforcement Tooling
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC14.1.1 | Backend coverage ≥ 90% enforced locally via `pyproject.toml` (CI uses `--cov-fail-under=0`; target: 99%; local pre-push enforcement threshold: 90%) | `test_coverage_threshold_enforced` | `infra/test_coverage_enforcement.py` | P0 |
-| AC14.1.2 | Pre-commit mypy hook blocks type errors before commit | `test_mypy_precommit_blocks_type_errors` | `infra/test_precommit_hooks.py` | P0 |
-| AC14.1.3 | validate_schemas.py exits non-zero when Pydantic fields lack Field() descriptions | `test_validate_schemas_fails_missing_desc` | `infra/test_validate_schemas.py` | P0 |
-| AC14.1.4 | check_env_keys.py detects missing keys across secrets.ctmpl, config.py, .env.example | `test_env_keys_three_way_sync` | `infra/test_check_env_keys.py` | P0 |
-| AC14.1.5 | smoke_test.sh runs successfully against local docker environment | `test_smoke_test_local_pass` | `infra/test_smoke_test.py` | P1 |
-| AC14.1.6 | generate_ac_registry.py produces zero ghost ACs and zero overlap between feature and infra registries | `test_ac_registry_no_ghost_no_overlap` | `tests/tooling/test_issue_493_foundation_ttd_behavior.py` | P1 |
-| AC14.1.7 | Generated analysis snapshots are not checked into `docs/project/`; live coverage and mismatch data come from tools or CI artifacts | `test_AC14_1_7_generated_analysis_snapshots_are_absent` | `tests/tooling/test_lint_doc_consistency.py` | P0 |
-| AC14.1.8 | Reconciliation threshold prose points to code/config owners instead of claiming Markdown is the single authority | `test_AC14_1_8_reconciliation_thresholds_are_code_owned` | `tests/tooling/test_lint_doc_consistency.py` | P0 |
-| AC14.1.9 | SSOT manifest `#anchor` owners and cross-references resolve to actual Markdown anchors | `test_AC14_1_9_manifest_anchor_refs_must_exist` | `tests/tooling/test_check_manifest.py` | P0 |
-| AC14.1.10 | Frontend source cannot call raw `fetch()` outside `apps/frontend/src/lib/api.ts` | `test_AC14_1_10_frontend_raw_fetch_is_limited_to_api_wrapper` | `tests/tooling/test_lint_doc_consistency.py` | P0 |
-| AC14.1.11 | GitHub issue templates require phenomenon, reproduction, minimal fix, rationale, and acceptance criteria sections with valid repository labels | `test_AC14_1_11_issue_templates_require_diagnostic_fix_and_acceptance_sections` | `tests/tooling/test_issue_template_contract.py` | P1 |
-| AC14.1.12 | SSOT governance metrics report finance_report and infra2 manifest shape, proof coverage, and future gate candidates without blocking CI | `test_AC14_1_12_report_covers_finance_and_infra2_manifest_shapes` | `tests/tooling/test_ssot_governance_report.py` | P1 |
-| AC14.1.13 | SSOT governance gates block changed-file and changed-manifest-entry debt, explain #823/HLS ownership, and support issue-linked temporary exceptions | `test_AC14_1_13_incremental_gate_only_blocks_changed_ssot_debt` | `tests/tooling/test_ssot_governance_report.py` | P1 |
-| AC14.1.14 | Threshold cleanup for #824 reduces `finance_report.orphan_ssot_files` to zero by binding orphan SSOT files to parent concepts without runtime behavior changes | `test_AC14_1_14_finance_report_orphan_ssot_files_are_manifest_owned` | `tests/tooling/test_ssot_governance_report.py` | P1 |
-| AC14.1.15 | Threshold cleanup for #824 migrates representative machine-owned FR SSOT entries to explicit `family`, `kind`, `proofs`, and inbound SSOT Markdown links so `finance_report.machine_owner_entries_missing_proof` stays zero | `test_AC14_1_15_machine_owned_ssot_entries_have_explicit_shape_and_proof` | `tests/tooling/test_ssot_governance_report.py` | P1 |
-| AC14.1.16 | SSOT governance gates keep protected per-system governance ratios non-decreasing and protected debt counts non-increasing against the base ref | `test_AC14_1_16_ssot_governance_ratios_cannot_regress` | `tests/tooling/test_ssot_governance_report.py` | P1 |
-| AC14.1.17 | DB schema inventory is generated from SQLAlchemy metadata, published by the MkDocs build, CI-checked for deterministic generation, gitignored as generated output, and linked from macro SSOT/domain docs instead of hand-maintained table/column/API catalogs | `test_AC14_1_17_render_db_schema_reference_uses_sqlalchemy_metadata`, `test_AC14_1_17_generated_db_schema_reference_is_ci_checked` | `tests/tooling/test_generate_db_schema_reference.py`, `tests/tooling/test_post_merge_e2e_gates.py` | P1 |
-| AC14.1.18 | FR (EPIC-014) and infra2 (Infra-006) each document a 6-8 family SSOT HLS model with explicit concept/clause boundaries, the family map covers every MANIFEST.yaml-inferred family, the HLS checklist links #821/#822/#823/#824, and the definition does not move or re-own any SSOT concept | `test_AC14_1_18_fr_hls_family_model_is_documented_and_consistent`, `test_AC14_1_18_infra2_hls_family_model_is_documented_and_consistent`, `test_AC14_1_18_hls_checklist_links_governance_loop_issues`, `test_AC14_1_18_documentation_only_does_not_re_own_concepts` | `tests/tooling/test_ssot_hls_family_model.py` | P1 |
-| AC14.1.20 | Unified coverage aggregation (#414) runs an artifact preflight that fails explicitly and names the offending component LCOV when a CI-critical artifact is missing or empty, instead of silently treating it as 0% and producing a misleading unified number | `test_AC14_1_20_preflight_fails_when_ci_critical_artifact_missing`, `test_AC14_1_20_preflight_fails_when_ci_critical_artifact_empty`, `test_AC14_1_20_main_fails_fast_with_named_missing_artifact` | `tests/tooling/test_coverage_artifact_preflight.py` | P0 |
-| AC14.1.21 | Coverage components (#923) carry an explicit `tier` (`ci-critical` vs `best-effort`); the artifact preflight enforces presence only for `ci-critical` tiers so a missing best-effort `tools` artifact does not hard-fail the aggregation while application and shared-library trees stay strictly gated | `test_AC14_1_21_tools_component_is_best_effort_tier`, `test_AC14_1_21_app_and_common_components_are_ci_critical_tier`, `test_AC14_1_21_preflight_skips_best_effort_missing_artifact` | `tests/tooling/test_coverage_artifact_preflight.py` | P1 |
-| AC14.1.19 | A single parseable vision-to-proof matrix is mechanically generated from vision.md anchors, EPIC `Vision Anchor` declarations, the AC registries, and test references (mapping `vision anchor -> EPIC -> AC -> test`), published as a YAML artifact plus a MkDocs page, and `--check` fails on drift (supersedes #442, #480) | `test_AC14_1_19_matrix_parses_vision_anchors_from_vision_md`, `test_AC14_1_19_matrix_maps_vision_to_ac_to_test`, `test_AC14_1_19_rendered_yaml_is_parseable_and_deterministic`, `test_AC14_1_19_checked_in_artifacts_exist_and_are_generated`, `test_AC14_1_19_check_passes_when_artifacts_are_current`, `test_AC14_1_19_check_fails_on_drift`, `test_AC14_1_19_check_fails_when_artifact_missing` | `tests/tooling/test_generate_vision_proof_matrix.py` | P1 |
-| AC14.1.22 | README EPIC status/completion is generated from the AC registries and test reports (not hand-written) into a delimited block, reports automated AC coverage, placeholder/stub debt, manual-gate debt, and blockers as separate categories, omits mutable live CI/deploy run status, tolerates an absent `unified-coverage.json`, and is guarded by a generate-with-`--check` drift gate | `test_AC14_1_22_completions_split_four_categories_separately`, `test_AC14_1_22_render_block_has_separate_columns_and_no_live_run_status`, `test_AC14_1_22_render_block_tolerates_absent_unified_coverage`, `test_AC14_1_22_load_unified_coverage_read_if_present`, `test_AC14_1_22_splice_requires_markers`, `test_AC14_1_22_check_passes_when_block_current`, `test_AC14_1_22_check_fails_on_drift`, `test_AC14_1_22_check_fails_when_markers_missing`, `test_AC14_1_22_committed_readme_block_is_current` | `tests/tooling/test_generate_epic_status.py` | P1 |
-| AC14.1.23 | Threshold cleanup for #824 reduces `finance_report.high_risk_entries_missing_proof` to zero by binding the flagged high-risk platform concepts (`container_naming`, `test_optimization`) to existing proof tests under the #821 `platform` family without runtime behavior changes | `test_AC14_1_23_high_risk_ssot_entries_bind_proof_under_platform_family` | `tests/tooling/test_ssot_governance_report.py` | P1 |
+> **The 23 AC14.1.* rows of this group are no longer defined here.** They
+> migrated (migration closeout wave 2, #1663) into
+> [`common/meta/contract.py`](../../common/meta/contract.py)'s `roadmap`,
+> split by topic into `AC-meta.foundation-tooling.*`, `AC-meta.registry.*`,
+> `AC-meta.doc-consistency.*`, `AC-meta.ssot-governance.*`,
+> `AC-meta.issue-templates.*`, `AC-meta.generated-refs.*`, and
+> `AC-meta.coverage-tiers.*` (the leading "14" is dropped; the original
+> AC14.1.<n> id is kept as a trailing comment on each migrated record).
+> `common/meta/extension/generate_ac_registry.py` reads package-contract
+> roadmaps additively, so the AC index counts them without an EPIC-table
+> mirror. This note references the ids for traceability but defines none of
+> them — the contract is the single definition source.

--- a/tests/tooling/test_check_manifest.py
+++ b/tests/tooling/test_check_manifest.py
@@ -295,7 +295,7 @@ class TestCheckCrossrefFilesExist:
 
 class TestCheckAnchorRefsExist:
     def test_AC14_1_9_manifest_anchor_refs_must_exist(self, tmp_path: Path) -> None:
-        """AC14.1.9: Manifest owner and cross-ref anchors must exist."""
+        """AC-meta.ssot-governance.1: Manifest owner and cross-ref anchors must exist."""
         ssot = tmp_path / "docs" / "ssot"
         ssot.mkdir(parents=True)
         (ssot / "accounting.md").write_text(

--- a/tests/tooling/test_coverage_artifact_preflight.py
+++ b/tests/tooling/test_coverage_artifact_preflight.py
@@ -58,7 +58,7 @@ def _write_lcov(path: Path, covered: int, total: int) -> None:
 
 
 class TestCoverageTiering:
-    """AC14.1.21: components are tiered ci-critical vs best-effort."""
+    """AC-meta.coverage-tiers.2: components are tiered ci-critical vs best-effort."""
 
     def test_AC14_1_21_tools_component_is_best_effort_tier(self):
         # tools/ is largely one-off governance / CI glue: best-effort, not gated
@@ -90,7 +90,7 @@ class TestCoverageTiering:
 
 
 class TestRequiredArtifactsPreflight:
-    """AC14.1.20: missing/empty CI-critical artifacts fail explicitly."""
+    """AC-meta.coverage-tiers.1: missing/empty CI-critical artifacts fail explicitly."""
 
     def test_AC14_1_20_preflight_fails_when_ci_critical_artifact_missing(
         self, tmp_path

--- a/tests/tooling/test_generate_db_schema_reference.py
+++ b/tests/tooling/test_generate_db_schema_reference.py
@@ -14,7 +14,7 @@ from sqlalchemy import (
 
 
 def test_AC14_1_17_render_db_schema_reference_uses_sqlalchemy_metadata() -> None:
-    """AC14.1.17: generated DB reference renders SQLAlchemy-owned contracts."""
+    """AC-meta.generated-refs.1: generated DB reference renders SQLAlchemy-owned contracts."""
     metadata = MetaData()
     Table(
         "users",

--- a/tests/tooling/test_generate_epic_status.py
+++ b/tests/tooling/test_generate_epic_status.py
@@ -155,7 +155,7 @@ def test_AC14_1_22_check_passes_when_block_current(tmp_path: Path) -> None:
 
 
 def test_AC14_1_22_check_fails_on_drift(tmp_path: Path, capsys) -> None:
-    """AC14.1.22: --check fails when the committed pointer block is malformed/stale."""
+    """AC-meta.generated-refs.3: --check fails when the committed pointer block is malformed/stale."""
     doc = tmp_path / "README.md"
     doc.write_text(
         f"intro\n{ges.BEGIN_MARKER}\nSTALE numbers\n{ges.END_MARKER}\noutro\n",

--- a/tests/tooling/test_generate_vision_proof_matrix.py
+++ b/tests/tooling/test_generate_vision_proof_matrix.py
@@ -35,7 +35,7 @@ def test_AC14_1_19_matrix_parses_vision_anchors_from_vision_md() -> None:
 
 
 def test_AC14_1_19_matrix_maps_vision_to_ac_to_test() -> None:
-    """AC14.1.19: nodes chain vision anchor -> EPIC -> AC -> test reference."""
+    """AC-meta.generated-refs.2: nodes chain vision anchor -> EPIC -> AC -> test reference."""
     matrix = _build()
     by_anchor = {node["anchor"]: node for node in matrix["vision_nodes"]}
 

--- a/tests/tooling/test_issue_493_foundation_ttd_behavior.py
+++ b/tests/tooling/test_issue_493_foundation_ttd_behavior.py
@@ -127,7 +127,7 @@ def test_AC12_22_2_background_task_payload_schemas_are_module_owned() -> None:
 
 
 def test_AC14_1_1_backend_pyproject_enforces_local_coverage_threshold() -> None:
-    """AC14.1.1: Backend pytest config enforces coverage above the 90 percent target."""
+    """AC-meta.foundation-tooling.1: Backend pytest config enforces coverage above the 90 percent target."""
     pyproject = tomllib.loads(_read(REPO_ROOT / "apps" / "backend" / "pyproject.toml"))
     addopts = pyproject["tool"]["pytest"]["ini_options"]["addopts"]
 
@@ -139,7 +139,7 @@ def test_AC14_1_1_backend_pyproject_enforces_local_coverage_threshold() -> None:
 
 
 def test_AC14_1_2_pre_commit_mypy_hook_blocks_backend_type_errors() -> None:
-    """AC14.1.2: Pre-commit runs mypy against backend source files."""
+    """AC-meta.foundation-tooling.2: Pre-commit runs mypy against backend source files."""
     config = yaml.safe_load(_read(REPO_ROOT / ".pre-commit-config.yaml"))
     hooks = {
         hook["id"]: hook
@@ -159,7 +159,7 @@ def test_AC14_1_3_validate_schemas_exits_nonzero_for_missing_field_descriptions(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """AC14.1.3: validate_schemas.py exits non-zero for Field() without descriptions."""
+    """AC-meta.foundation-tooling.3: validate_schemas.py exits non-zero for Field() without descriptions."""
     root = tmp_path
     config_path = root / "apps" / "backend" / "src" / "config.py"
     schemas_dir = root / "apps" / "backend" / "src" / "schemas"
@@ -188,7 +188,7 @@ def test_AC14_1_4_check_env_keys_exits_nonzero_for_secret_config_drift(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """AC14.1.4: check_env_keys.py detects mismatched secrets/config/env keys."""
+    """AC-meta.foundation-tooling.4: check_env_keys.py detects mismatched secrets/config/env keys."""
     root = tmp_path
     ctmpl_path = (
         root / "repo" / "finance_report" / "finance_report" / "10.app" / "secrets.ctmpl"
@@ -218,7 +218,7 @@ def test_AC14_1_4_check_env_keys_exits_nonzero_for_secret_config_drift(
 def test_AC14_1_5_smoke_test_succeeds_against_mocked_local_environment(
     tmp_path: Path,
 ) -> None:
-    """AC14.1.5: smoke_test.sh succeeds when health, pages, auth, and CORS pass."""
+    """AC-meta.foundation-tooling.5: smoke_test.sh succeeds when health, pages, auth, and CORS pass."""
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_curl = fake_bin / "curl"
@@ -280,7 +280,7 @@ def test_AC14_1_6_generate_ac_registry_check_rejects_ghosts_and_keeps_no_overlap
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """AC14.1.6: Registry generation ignores ghost AC references and splits infra/feature IDs."""
+    """AC-meta.registry.1: Registry generation ignores ghost AC references and splits infra/feature IDs."""
     project_dir = tmp_path / "docs" / "project"
     project_dir.mkdir(parents=True)
     (project_dir / "EPIC-001.phase0-setup.md").write_text(

--- a/tests/tooling/test_issue_template_contract.py
+++ b/tests/tooling/test_issue_template_contract.py
@@ -75,7 +75,7 @@ def _required_field_ids(body: list) -> set:
 
 
 def test_AC14_1_11_issue_templates_carry_their_type_required_fields() -> None:
-    """AC14.1.11: each issue type's template carries the required fields for that
+    """AC-meta.issue-templates.1: each issue type's template carries the required fields for that
     type (issue: diagnosis; task: goal + anchor + AC; idea: problem; incident:
     impact + root cause + follow-ups). config.yml is the chooser config, not a
     template, and is skipped."""

--- a/tests/tooling/test_lint_doc_consistency.py
+++ b/tests/tooling/test_lint_doc_consistency.py
@@ -102,7 +102,7 @@ def test_module_readmes_are_thin_reports_duplicate_sections(tmp_path) -> None:
 
 
 def test_AC14_1_7_generated_analysis_snapshots_are_absent(tmp_path) -> None:
-    """AC14.1.7: Generated analysis snapshots are not checked into docs/project."""
+    """AC-meta.doc-consistency.1: Generated analysis snapshots are not checked into docs/project."""
     snapshot = tmp_path / "docs" / "project" / "test-ac-coverage-report.md"
     snapshot.parent.mkdir(parents=True)
     snapshot.write_text("# generated\n", encoding="utf-8")
@@ -121,7 +121,7 @@ def test_AC14_1_7_generated_analysis_snapshots_absent_passes(tmp_path) -> None:
 
 
 def test_AC14_1_8_reconciliation_thresholds_are_code_owned(tmp_path) -> None:
-    """AC14.1.8: Reconciliation threshold prose points to code/config owners."""
+    """AC-meta.doc-consistency.2: Reconciliation threshold prose points to code/config owners."""
     doc = tmp_path / "reconciliation.md"
     doc.write_text(
         """
@@ -159,7 +159,7 @@ def test_AC14_1_8_reconciliation_thresholds_report_unreadable_doc() -> None:
 
 
 def test_AC14_1_10_frontend_raw_fetch_is_limited_to_api_wrapper(tmp_path) -> None:
-    """AC14.1.10: Frontend raw fetch is limited to the API wrapper."""
+    """AC-meta.doc-consistency.3: Frontend raw fetch is limited to the API wrapper."""
     src = tmp_path / "apps" / "frontend" / "src"
     api = src / "lib" / "api.ts"
     page = src / "app" / "page.tsx"

--- a/tests/tooling/test_ssot_governance_report.py
+++ b/tests/tooling/test_ssot_governance_report.py
@@ -116,7 +116,7 @@ def _assert_file_mentions(path: str, expected: list[str]) -> None:
 def test_AC14_1_12_report_covers_finance_and_infra2_manifest_shapes(
     tmp_path: Path,
 ) -> None:
-    """AC14.1.12: SSOT governance metrics report finance and infra2 manifests."""
+    """AC-meta.ssot-governance.2: SSOT governance metrics report finance and infra2 manifests."""
 
     _seed_finance_manifest(tmp_path)
     _seed_infra_manifest(tmp_path)
@@ -456,7 +456,7 @@ def test_AC14_1_12_ci_publishes_report_without_fail_on_error() -> None:
 def test_AC14_1_13_incremental_gate_only_blocks_changed_ssot_debt(
     tmp_path: Path,
 ) -> None:
-    """AC14.1.13: SSOT governance gates block new debt without legacy cleanup."""
+    """AC-meta.ssot-governance.3: SSOT governance gates block new debt without legacy cleanup."""
 
     _write(tmp_path / "docs/ssot/legacy-orphan.md")
     _write(tmp_path / "docs/ssot/new-orphan.md")
@@ -858,7 +858,7 @@ def test_AC14_1_13_cli_and_ci_enable_gradual_gate(
 def test_AC14_1_16_ssot_governance_ratios_cannot_regress(
     tmp_path: Path,
 ) -> None:
-    """AC14.1.16: #823 gate keeps protected SSOT governance ratios from falling."""
+    """AC-meta.ssot-governance.6: #823 gate keeps protected SSOT governance ratios from falling."""
 
     for relative_path in (
         "docs/ssot/shaped.md",
@@ -1038,7 +1038,7 @@ def test_AC14_1_16_trend_checks_skip_invalid_or_unrelated_sources(
 
 
 def test_AC14_1_14_finance_report_orphan_ssot_files_are_manifest_owned() -> None:
-    """AC14.1.14: #824 cleanup binds finance_report orphan SSOT files."""
+    """AC-meta.ssot-governance.4: #824 cleanup binds finance_report orphan SSOT files."""
 
     report = governance_report.build_report(ROOT, include_infra2=False)
     finance = _source(report, "finance_report")
@@ -1072,7 +1072,7 @@ def test_AC14_1_14_finance_report_orphan_ssot_files_are_manifest_owned() -> None
 
 
 def test_AC14_1_15_machine_owned_ssot_entries_have_explicit_shape_and_proof() -> None:
-    """AC14.1.15: #824 migrates machine-owned FR SSOT entries by example."""
+    """AC-meta.ssot-governance.5: #824 migrates machine-owned FR SSOT entries by example."""
 
     report = governance_report.build_report(ROOT, include_infra2=False)
     finance = _source(report, "finance_report")
@@ -1139,7 +1139,7 @@ def test_AC14_1_15_machine_owned_ssot_entries_have_explicit_shape_and_proof() ->
 
 
 def test_AC14_1_23_high_risk_ssot_entries_bind_proof_under_platform_family() -> None:
-    """AC14.1.23: #824 threshold cleanup drives ``high_risk_entries_missing_proof`` to zero.
+    """AC-meta.ssot-governance.8: #824 threshold cleanup drives ``high_risk_entries_missing_proof`` to zero.
 
     The governance report flags FR SSOT concepts that match high-risk terms but
     carry no executable proof path. This cleanup binds the two flagged platform

--- a/tests/tooling/test_ssot_hls_family_model.py
+++ b/tests/tooling/test_ssot_hls_family_model.py
@@ -123,7 +123,7 @@ def _family_map_coverage(section: str, inferred: set[str]) -> set[str]:
 
 
 def test_AC14_1_18_fr_hls_family_model_is_documented_and_consistent() -> None:
-    """AC14.1.18: EPIC-014 declares 6-8 FR families consistent with MANIFEST."""
+    """AC-meta.ssot-governance.7: EPIC-014 declares 6-8 FR families consistent with MANIFEST."""
 
     text = _read(FR_EPIC)
     families = _declared_families(text)


### PR DESCRIPTION
## Summary
- Partial contribution to #1663 (migration closeout wave 2): migrates EPIC-014's (TTD transformation) 23 `AC14.1.*` rows into `common/meta/contract.py`'s roadmap, dropping the EPIC table to a pointer note.
- All 23 are meta/SSOT-governance tooling ACs (AC-registry generation, coverage policy, SSOT manifest/governance report, generated reference docs, issue templates) — several of the underlying tools already moved into `common/meta/extension/` in #1679, so this migrates cleanly to `meta` alone rather than splitting across `testing`/`meta` as #1663's original estimate guessed.
- Grouped into 7 topic-based word-entity slugs matching `meta`'s existing convention: `foundation-tooling`, `registry`, `doc-consistency`, `ssot-governance`, `issue-templates`, `generated-refs`, `coverage-tiers`.
- Each migrated test's docstring now carries the new `AC-meta.<group>.<seq>` id (the traceability gate requires it findable in a docstring, not just `contract.py`'s `test=` reference), with the original `AC14.1.<n>` id kept as a trailing note.
- Two doc-drift fixes found along the way: (1) 5 of the 23 rows' listed Test Function/File columns were stale (pointed at deleted `apps/backend/tests/infra/test_*.py` files) — the real current proofs live in `tests/tooling/test_issue_493_foundation_ttd_behavior.py`, used here; (2) 3 ids were also mentioned in EPIC-014's "SSOT HLS Governance Loop" checklist prose (not just the table) — repointed with a canonical-id annotation the doc-consistency linter's removed-annotation pattern recognizes.

**Scope note**: this is one EPIC's worth of #1663 (23 of the ~1,136 remaining rows), not the full closeout — chosen because its owning package (`meta`) was unambiguous and none of its tooling required a code move (pure documentation/roadmap work, no `check_app_boundary` risk).

## Verification
- `tests/tooling/` (1950 tests) → all pass.
- `tools/generate_ac_registry.py --check` → OK, registries include every EPIC-defined AC.
- `tools/lint_doc_consistency.py` → clean (0 violations).
- `tools/check_manifest.py` → clean.
- `check_package_contract.run()` → OK: True (all test= references resolve).
- `ruff check` on all touched files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)