### PR TITLE
[finance_report_ui] test(#1435): W1 first slice — release-coordinate short_sha behaviorally tested

### DIFF
--- a/common/runtime/release_coordinate.py
+++ b/common/runtime/release_coordinate.py
@@ -74,6 +74,24 @@ def resolve_infra2_release_tag(repo_dir: str = "repo") -> str:
     return iac_ref
 
 
+def build_release_coordinate(
+    version_ref: str, full_sha: str, iac_ref: str
+) -> dict[str, str]:
+    """Pure assembly of the release-coordinate dict `resolve()` emits.
+
+    Split out so the coordinate SHAPE (short_sha is a 7-char prefix of
+    full_sha, the field set) is unit-testable without the git mutations
+    `resolve()` performs (fetch/checkout/submodule update) — see
+    tests/tooling/test_release_coordinate.py.
+    """
+    return {
+        "version_ref": version_ref,
+        "full_sha": full_sha,
+        "short_sha": full_sha[:7],
+        "iac_ref": iac_ref,
+    }
+
+
 def resolve(version_ref: str) -> dict[str, str]:
     if not _RELEASE_VERSION_REF_RE.fullmatch(version_ref):
         raise ValueError(
@@ -92,12 +110,7 @@ def resolve(version_ref: str) -> dict[str, str]:
 
     full_sha = _out("git", "rev-parse", "HEAD")
     iac_ref = resolve_infra2_release_tag("repo")
-    return {
-        "version_ref": version_ref,
-        "full_sha": full_sha,
-        "short_sha": full_sha[:7],
-        "iac_ref": iac_ref,
-    }
+    return build_release_coordinate(version_ref, full_sha, iac_ref)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -1980,7 +1980,6 @@ def test_AC7_10_production_release_promotes_not_rebuilds() -> None:
     # Tag promotion stays in deploy.yml's promote job; the release line moved to
     # release.yml (#1354 / AC8.13.154).
     release_images = read(".github/workflows/deploy.yml")
-    resolver = read("common/runtime/release_coordinate.py")
     release_image_tool = read("common/runtime/release_images.py")
     ci_cd = read("docs/ssot/ci-cd.md")
     deployment = read("docs/ssot/deployment.md")
@@ -1991,7 +1990,8 @@ def test_AC7_10_production_release_promotes_not_rebuilds() -> None:
     )
     assert "docker/build-push-action" not in release_images
     assert "docker buildx imagetools create --tag" not in workflow
-    assert '"short_sha": full_sha[:7]' in resolver
+    # short_sha truncation is now covered behaviorally, not by source text —
+    # see tests/tooling/test_release_coordinate.py (#1435 W1).
     # build-and-deploy (deploy.yml) + dry-run + deploy (release.yml) each resolve
     # the release coordinate once.
     assert (

--- a/tests/tooling/test_release_coordinate.py
+++ b/tests/tooling/test_release_coordinate.py
@@ -1,0 +1,39 @@
+"""Behavioral coverage for the release-coordinate dict `resolve()` emits.
+
+#1435 W1: replaces a brittle `'"short_sha": full_sha[:7]' in resolver` source-text
+assertion (formerly folded into test_AC7_10_production_release_promotes_not_rebuilds
+in test_post_merge_e2e_gates.py) with a real behavioral test — importing
+build_release_coordinate() and asserting its output shape, so a harmless reformat
+of release_coordinate.py's resolve() (whitespace, variable names, ordering) can
+no longer accidentally pass or fail this check; only the actual short_sha
+truncation logic can.
+"""
+
+from __future__ import annotations
+
+from common.runtime.release_coordinate import build_release_coordinate
+
+
+def test_AC7_10_1_short_sha_is_seven_char_prefix_of_full_sha() -> None:
+    """AC7.10.1: the release coordinate's short_sha is full_sha's first 7 chars."""
+    full_sha = "abcdef0123456789abcdef0123456789abcdef01"
+
+    coordinate = build_release_coordinate("v1.2.3", full_sha, "v0.9.1")
+
+    assert coordinate["short_sha"] == full_sha[:7]
+    assert coordinate["short_sha"] == "abcdef0"
+    assert len(coordinate["short_sha"]) == 7
+
+
+def test_AC7_10_1_release_coordinate_carries_exactly_the_deploy_inputs() -> None:
+    """AC7.10.1: the coordinate dict is exactly {version_ref, full_sha, short_sha, iac_ref} — the fields deploy_v2 consumes to promote (not rebuild) a release."""
+    coordinate = build_release_coordinate(
+        "v2.0.0", "1111111111111111111111111111111111111a", "v3.4.5"
+    )
+
+    assert coordinate == {
+        "version_ref": "v2.0.0",
+        "full_sha": "1111111111111111111111111111111111111a",
+        "short_sha": "1111111",
+        "iac_ref": "v3.4.5",
+    }


### PR DESCRIPTION
## Summary

First concrete conversion in **#1435 W1** (replace the brittle CI/deploy string-match assertions with behavior). This PR is deliberately narrow — see the scoping note below for why the cluster's true remaining size is smaller than it looks.

- Extracted `build_release_coordinate(version_ref, full_sha, iac_ref)` as a pure function from `release_coordinate.py`'s `resolve()` — which performs real git mutations (fetch / `checkout --detach` / submodule update), so it can't safely be called end-to-end in a unit test. The extraction is behavior-preserving: `resolve()` now calls the same dict-construction logic through the new function.
- Adds `tests/tooling/test_release_coordinate.py`: imports `build_release_coordinate` directly and asserts the actual `short_sha` truncation behavior and full dict shape — not source text.
- Removes the now-redundant `'"short_sha": full_sha[:7]' in resolver` text-match from `test_AC7_10_production_release_promotes_not_rebuilds` (the `resolver` variable, now unused, is also removed).

**Sanity check that the new test actually protects behavior** (not just "passes"): temporarily mutated `full_sha[:7]` → `full_sha[:6]`, confirmed the new test fails and catches the regression, then reverted.

## Scoping note — recalibrating #1435 W1's true remaining size

Before touching anything, audited the full AC7.10/AC8.13.52 "promote not rebuild" cluster the issue names as its highest-leverage target. Found:
- `release_images.py`'s `verify_release_images()` **already has real behavioral tests** (dependency-injected `inspect_image`, asserting real output) — no work needed.
- `resolve_infra2_release_tag()` **already has a dedicated behavioral test file** (`test_infra2_pin_is_release_tag.py`) covering both the happy path and the fail-closed path with real git operations.
- The `short_sha` gap this PR closes was the one genuinely uncovered piece in this cluster.
- The remaining brittle assertions in `test_AC7_10_production_release_promotes_not_rebuilds` are workflow-YAML prose / SSOT-doc-existence checks (e.g. "does `deployment.md` mention the phrase 'promote-not-rebuild consistency ladder'") — not importable behavior. Their right fix is scoping the text search to specific YAML keys (structural parsing), not "run code and assert output." That's a different, more mechanical effort than this PR.

**#1435's "548 assertions" headline count includes a lot of already-correct or doc-existence checks alongside the genuinely brittle ones** — worth knowing before committing to a "one PR converts them all" plan for the rest of the wave.

## Test plan
- [x] `pytest tests/tooling/test_release_coordinate.py` — 2/2 pass
- [x] Mutation check: `full_sha[:7]` → `full_sha[:6]` makes the new test fail; reverted
- [x] `pytest tests/tooling/` (full suite, 1952 tests) — all pass
- [x] `python tools/check_ac_index.py` — no regression (1983 AC nodes)
- [x] `python tools/check_package_contract.py` — `runtime` package still OK
- [x] `ruff check` / `ruff format --check` — clean

Relations: #1435 (W1) · #1686

🤖 Generated with [Claude Code](https://claude.com/claude-code)