### PR TITLE
[finance_report_audit] Migration closeout 2.1: distribute EPIC AC rows into identity roadmap

### DIFF
--- a/apps/backend/tests/e2e/test_core_journeys.py
+++ b/apps/backend/tests/e2e/test_core_journeys.py
@@ -649,7 +649,7 @@ async def test_reports_currencies_endpoint(client, test_user):
 @pytest.mark.e2e
 async def test_api_authentication_failures(client):
     """
-    EPIC-001 EPIC-016 / AC8.7.1: Authentication validation
+    AC-identity.journeys.2: EPIC-001 EPIC-016 / AC8.7.1: Authentication validation
     GIVEN invalid credentials
     WHEN making a login request
     THEN it should return 401 or 422
@@ -667,7 +667,7 @@ async def test_api_authentication_failures(client):
 @pytest.mark.e2e
 async def test_unauthorized_access_blocked(public_client):
     """
-    EPIC-001 EPIC-016 / AC8.7.2: Unauthorized access blocked
+    AC-identity.journeys.3: EPIC-001 EPIC-016 / AC8.7.2: Unauthorized access blocked
     GIVEN no authentication headers
     WHEN accessing protected endpoints
     THEN it should return 401 Unauthorized
@@ -688,7 +688,7 @@ async def test_unauthorized_access_blocked(public_client):
 @pytest.mark.e2e
 async def test_user_session_management(client, test_user):
     """
-    EPIC-001 EPIC-016 / AC8.7.3: User session management
+    AC-identity.journeys.4: EPIC-001 EPIC-016 / AC8.7.3: User session management
     GIVEN a valid authentication token
     WHEN requesting /auth/me
     THEN it should return the current user's information
@@ -704,7 +704,7 @@ async def test_user_session_management(client, test_user):
 @pytest.mark.e2e
 async def test_register_and_login_flow(public_client):
     """
-    EPIC-001 EPIC-016 / AC8.7.1 (supplementary): Full registration → login flow
+    AC-identity.journeys.1: EPIC-001 EPIC-016 / AC8.2.1: Full registration → login flow
     GIVEN a new user
     WHEN registering and then logging in
     THEN both operations should succeed with access tokens

--- a/common/identity/contract.py
+++ b/common/identity/contract.py
@@ -313,5 +313,49 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── group journeys: E2E auth/session proof (migrated from EPIC-008
+        # AC8.2.1/.7.1-3/.19.2, migration closeout continuation, #1663) ──
+        ACRecord(
+            id="AC-identity.journeys.1",
+            statement="A new user can register and log in end to end through the deployed API.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_register_and_login_flow",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-identity.journeys.2",
+            statement=(
+                "API authentication failures (missing/invalid credentials) return a "
+                "clean 401/422, not a 500."
+            ),
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_api_authentication_failures",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-identity.journeys.3",
+            statement="Unauthenticated requests to protected endpoints are blocked with 401.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_unauthorized_access_blocked",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-identity.journeys.4",
+            statement="A user's session (JWT/cookie) is created, reused, and honored consistently across requests.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_user_session_management",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-identity.journeys.5",
+            statement=(
+                "The frontend registration E2E targets the mode-toggle register control "
+                "by test id and switches into register mode without a strict-mode "
+                "locator failure."
+            ),
+            test="tests/e2e/test_auth_flows.py::test_full_registration_flow",
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/docs/project/EPIC-001.phase0-setup.md
+++ b/docs/project/EPIC-001.phase0-setup.md
@@ -75,10 +75,13 @@ Set up a runnable Monorepo development environment, complete user authentication
 
 ### AC1.2: Backend Skeleton Requirements
 
+> This group's second row removed as a stale duplicate — the cited tests
+> already prove `AC-identity.2.1`/`.2.2` in `common/identity/contract.py`'s
+> roadmap (migration closeout continuation, #1663 / #1706).
+
 | ID | Requirement | Test Function | File |
 |----|-------------|---------------|------|
 | AC1.2.1 | FastAPI project structure exists | `test_epic_001_backend_skeleton_exists()` | `infra/test_epic_001_contracts.py` |
-| AC1.2.2 | Auth integration works (register/login/JWT) | `test_register_success()`, `test_login_success()`, `test_auth_valid_user()` | `identity/test_auth_router.py`, `identity/test_auth.py` |
 | AC1.2.3 | SQLAlchemy + Alembic config valid | `test_missing_migrations_check()`, `test_single_head()` | `infra/test_schema_drift.py`, `infra/test_migrations.py` |
 | AC1.2.4 | Health endpoint returns success | `test_health_when_all_services_healthy()` | `infra/test_main.py` |
 | AC1.2.5 | structlog logging configured | `test_configure_logging_basic()` | `infra/test_logger.py` |

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -168,9 +168,12 @@ job inventories or scenario counts into this EPIC.
 
 ### AC8.2: Phase 1 - Onboarding & Account Structure
 
+> This group's first row (registration) removed — migrated to the `identity`
+> package roadmap as `AC-identity.journeys.1` (migration closeout
+> continuation, #1663 / #1706).
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC8.2.1 | New User Registration | `test_register_and_login_flow()` | `e2e/test_core_journeys.py` | P0 |
 | AC8.2.2 | Create Cash Account | `test_create_cash_account()` | `e2e/test_core_journeys.py` | P0 |
 | AC8.2.3 | Create Bank Account | `test_create_bank_account()` | `e2e/test_core_journeys.py` | P0 |
 | AC8.2.4 | Update account | `test_update_account()` | `e2e/test_core_journeys.py` | P1 |
@@ -213,11 +216,9 @@ job inventories or scenario counts into this EPIC.
 
 ### AC8.7: API Authentication & Authorization
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC8.7.1 | API authentication failures | `test_api_authentication_failures()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.7.2 | Unauthorized access blocked | `test_unauthorized_access_blocked()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.7.3 | User session management | `test_user_session_management()` | `e2e/test_core_journeys.py` | P1 |
+> This group's rows removed — migrated to the `identity` package roadmap as
+> `AC-identity.journeys.2`, `.3`, `.4` (migration closeout continuation,
+> #1663 / #1706).
 
 ### AC8.8: Core E2E Journey Tests
 
@@ -544,7 +545,10 @@ regression.
 | AC ID | Test Case | Test Function | File | Priority |
 |---|---|---|---|---|
 | AC8.19.1 | Login auth controls (mode-toggle register button and inline register CTA) expose distinct `data-testid` hooks and accessible names, so no duplicate accessible-name ambiguity remains while the visible text stays "Register" | `AC8.19.1 login register controls expose distinct test ids and accessible names` | `apps/frontend/src/__tests__/loginPage.test.tsx` | P1 |
-| AC8.19.2 | Registration E2E targets the mode-toggle register control by test id, switching into register mode without a strict-mode locator failure | `test_registration_api_path`, `test_full_registration_flow` | `tests/e2e/test_auth_flows.py` | P1 |
+
+> This group's second row removed — migrated to the `identity` package
+> roadmap as `AC-identity.journeys.5` (migration closeout continuation,
+> #1663 / #1706).
 
 ### AC8.20: PR Review Thread Merge Gate
 

--- a/tests/e2e/test_auth_flows.py
+++ b/tests/e2e/test_auth_flows.py
@@ -137,6 +137,8 @@ async def test_login_api_path(page: Page):
 @pytest.mark.asyncio
 async def test_full_registration_flow(page: Page):
     """
+    AC-identity.journeys.5.
+
     EPIC-001 EPIC-008 EPIC-016.
 
     AC8.10.8 AC16.12.6 AC1.7.1 AC8.19.2


### PR DESCRIPTION
## Summary

Closes #1706.

Migrates 5 backend-provable EPIC AC rows into `common/identity/contract.py`'s roadmap, plus deletes 1 stale duplicate row. Part of #1663's remaining backlog, reorganized by package per the research summary posted there.

Refs #1706, parent #1663, umbrella #1416.

## What moved

| Old ID | New ID | Test |
|---|---|---|
| EPIC-008 AC8.2.1 | `AC-identity.journeys.1` | `test_register_and_login_flow` |
| EPIC-008 AC8.7.1 | `AC-identity.journeys.2` | `test_api_authentication_failures` |
| EPIC-008 AC8.7.2 | `AC-identity.journeys.3` | `test_unauthorized_access_blocked` |
| EPIC-008 AC8.7.3 | `AC-identity.journeys.4` | `test_user_session_management` |
| EPIC-008 AC8.19.2 | `AC-identity.journeys.5` | `test_full_registration_flow` |
| EPIC-001 AC1.2.2 | *(deleted, stale duplicate)* | already proven by `AC-identity.2.1`/`.2.2` |

## Note on verification

Several of these initially looked like stale/orphaned references (a `grep '^def test_'` on the cited test file came up empty). Re-verified with a broader search that included `async def` — all 6 rows' underlying tests are real, current, and passing; the initial false alarm was my own grep pattern, not actual drift. Flagging this because a sibling issue (#1718, `testing` package) will hit the same file heavily and should use the same broader search pattern.

## Testing

```bash
apps/backend/.venv/bin/python3 -m pytest tests/tooling/ -n 4 --no-cov -q
# 1880 passed, 1 skipped

cd apps/backend && .venv/bin/python3 -m pytest tests/e2e/test_core_journeys.py tests/identity/ --no-cov -q
# 48 passed

moon run :lint
# All checks passed

apps/backend/.venv/bin/python3 tools/check_package_contract.py     # PASSED
apps/backend/.venv/bin/python3 tools/check_manifest.py             # clean
apps/backend/.venv/bin/python3 tools/lint_doc_consistency.py       # clean
apps/backend/.venv/bin/python3 tools/check_ac_index.py             # PASSED
apps/backend/.venv/bin/python3 tools/generate_ac_registry.py --check   # OK
apps/backend/.venv/bin/python3 tools/check_ac_tier_baseline.py     # PASSED
apps/backend/.venv/bin/python3 -m common.testing.mirror_ratchet    # 2914<=2917
```