### PR TITLE
[finance_report_audit] Migration closeout 2.2: distribute EPIC AC rows into ledger roadmap

### DIFF
--- a/apps/backend/tests/e2e/test_core_journeys.py
+++ b/apps/backend/tests/e2e/test_core_journeys.py
@@ -80,7 +80,7 @@ async def test_api_health_check(client):
 @pytest.mark.e2e
 async def test_create_cash_account(client, test_user):
     """
-    EPIC-001 EPIC-002 / AC8.2.2: Create Cash Account
+    AC-ledger.journeys.1: EPIC-001 EPIC-002 / AC8.2.2: Create Cash Account
     GIVEN a user is authenticated
     WHEN creating a cash "Wallet" asset account in SGD
     THEN the account should be created with correct type and currency
@@ -100,7 +100,7 @@ async def test_create_cash_account(client, test_user):
 @pytest.mark.e2e
 async def test_create_bank_account(client, test_user):
     """
-    EPIC-001 EPIC-002 / AC8.2.3: Create Bank Account
+    AC-ledger.journeys.2: EPIC-001 EPIC-002 / AC8.2.3: Create Bank Account
     GIVEN a user is authenticated
     WHEN creating a "DBS Savings" asset account in SGD
     THEN the account should be created successfully
@@ -118,7 +118,7 @@ async def test_create_bank_account(client, test_user):
 @pytest.mark.e2e
 async def test_update_account(client, test_user):
     """
-    EPIC-001 EPIC-002 / AC8.2.4: Update account
+    AC-ledger.journeys.3: EPIC-001 EPIC-002 / AC8.2.4: Update account
     GIVEN an existing account
     WHEN updating its name
     THEN the account should reflect the new name
@@ -141,7 +141,7 @@ async def test_update_account(client, test_user):
 @pytest.mark.e2e
 async def test_delete_account(client, test_user):
     """
-    EPIC-001 EPIC-002 / AC8.2.5: Delete/deactivate account
+    AC-ledger.journeys.4: EPIC-001 EPIC-002 / AC8.2.5: Delete/deactivate account
     GIVEN an account with no transactions
     WHEN deleting the account
     THEN it should be removed (204 No Content)
@@ -204,7 +204,7 @@ async def test_accounts_crud_api(client, db, test_user):
 @pytest.mark.e2e
 async def test_simple_expense_entry(client, test_user):
     """
-    EPIC-002 / AC8.3.1: Simple Expense Entry
+    AC-ledger.journeys.5: EPIC-002 / AC8.3.1: Simple Expense Entry
     GIVEN a user has accounts
     WHEN creating a balanced journal entry for a $5 coffee expense
     THEN the entry should be created in draft status with correct amounts
@@ -256,7 +256,7 @@ async def test_simple_expense_entry(client, test_user):
 @pytest.mark.e2e
 async def test_void_journal_entry(client, test_user):
     """
-    EPIC-002 / AC8.3.2: Void Entry
+    AC-ledger.journeys.6: EPIC-002 / AC8.3.2: Void Entry
     GIVEN a posted journal entry
     WHEN voiding the entry with a reason
     THEN a reversal entry should be created
@@ -309,7 +309,7 @@ async def test_void_journal_entry(client, test_user):
 @pytest.mark.e2e
 async def test_post_draft_entry(client, test_user):
     """
-    EPIC-002 / AC8.3.3: Post Draft Entry
+    AC-ledger.journeys.7: EPIC-002 / AC8.3.3: Post Draft Entry
     GIVEN a journal entry in draft status
     WHEN posting the entry
     THEN its status should change to "posted"
@@ -354,7 +354,7 @@ async def test_post_draft_entry(client, test_user):
 @pytest.mark.e2e
 async def test_unbalanced_journal_entry_rejection(client, test_user):
     """
-    EPIC-002 / AC8.3.4: Unbalanced entry rejected
+    AC-ledger.journeys.8: EPIC-002 / AC8.3.4: Unbalanced entry rejected
     GIVEN a user attempts to create an unbalanced journal entry
     WHEN sending the request
     THEN it should return 422 schema validation error
@@ -394,7 +394,7 @@ async def test_unbalanced_journal_entry_rejection(client, test_user):
 @pytest.mark.e2e
 async def test_journal_entry_crud(client, test_user):
     """
-    EPIC-002 / AC8.3.5: Journal Entry CRUD
+    AC-ledger.journeys.9: EPIC-002 / AC8.3.5: Journal Entry CRUD
     AC8.8.3: Core journey — journal entry lifecycle
     GIVEN a user is authenticated
     WHEN creating, listing, getting, posting, voiding, and deleting entries
@@ -1213,7 +1213,7 @@ async def test_traceability_authentication_validation(public_client):
 
 @pytest.mark.e2e
 async def test_income_recording(client):
-    """EPIC-002 / AC8.11.1: Income Recording."""
+    """AC-ledger.journeys.10: EPIC-002 / AC8.11.1: Income Recording."""
     # AC8.11.1: Income Recording
     # GIVEN a user has an income account and a bank account
     # WHEN recording $5,000 salary deposit as a journal entry
@@ -1253,7 +1253,7 @@ async def test_income_recording(client):
 
 @pytest.mark.e2e
 async def test_credit_card_spend(client):
-    """EPIC-002 / AC8.11.2: Credit Card Spend."""
+    """AC-ledger.journeys.11: EPIC-002 / AC8.11.2: Credit Card Spend."""
     # AC8.11.2: Credit Card Spend
     # GIVEN a user has an expense account and a credit card liability account
     # WHEN recording a $2,000 laptop purchase on credit card
@@ -1292,7 +1292,7 @@ async def test_credit_card_spend(client):
 
 @pytest.mark.e2e
 async def test_credit_card_repayment(client):
-    """EPIC-002 / AC8.11.3: Credit Card Repayment."""
+    """AC-ledger.journeys.12: EPIC-002 / AC8.11.3: Credit Card Repayment."""
     # AC8.11.3: Credit Card Repayment
     # GIVEN a user has a bank account and a credit card liability account
     # WHEN paying off the credit card from bank account
@@ -1330,7 +1330,7 @@ async def test_credit_card_repayment(client):
 
 @pytest.mark.e2e
 async def test_internal_transfer(client):
-    """EPIC-002 / AC8.11.4: Internal Transfer."""
+    """AC-ledger.journeys.13: EPIC-002 / AC8.11.4: Internal Transfer."""
     # AC8.11.4: Internal Transfer
     # GIVEN a user has two asset accounts
     # WHEN moving $500 from DBS Savings to Wallet (ATM withdrawal)
@@ -1368,7 +1368,7 @@ async def test_internal_transfer(client):
 
 @pytest.mark.e2e
 async def test_split_transaction(client):
-    """EPIC-002 / AC8.11.5: Split Transaction."""
+    """AC-ledger.journeys.14: EPIC-002 / AC8.11.5: Split Transaction."""
     # AC8.11.5: Split Transaction
     # GIVEN a user has one asset and two expense accounts
     # WHEN recording a $100 supermarket trip split: $80 Groceries + $20 Household

--- a/apps/backend/tests/reporting/test_fx_revaluation.py
+++ b/apps/backend/tests/reporting/test_fx_revaluation.py
@@ -769,7 +769,7 @@ class TestCalculateAccountBalanceInCurrencyLiability:
     """Test liability/equity accounts return negated balance (line 141 else branch)."""
 
     async def test_returns_negated_balance_for_liability_account(self, db: AsyncSession, test_user_id):
-        """AC8.12.1 – Liability accounts return -net_balance so coverage hits else branch."""
+        """AC-ledger.fxrevaluation.1: AC8.12.1 – Liability accounts return -net_balance so coverage hits else branch."""
         liability_account = Account(
             user_id=test_user_id,
             name="Loan USD",
@@ -835,7 +835,7 @@ class TestGetOrCreateFxGainLossAccountFlushError:
     """Test SQLAlchemyError during flush raises RevaluationError (lines 261-262)."""
 
     async def test_flush_error_raises_revaluation_error(self, db: AsyncSession, test_user_id):
-        """AC8.12.2 – SQLAlchemyError on flush is wrapped in RevaluationError."""
+        """AC-ledger.fxrevaluation.2: AC8.12.2 – SQLAlchemyError on flush is wrapped in RevaluationError."""
         from unittest.mock import AsyncMock, patch
 
         from sqlalchemy.exc import SQLAlchemyError
@@ -850,7 +850,7 @@ class TestCalculateUnrealizedFxGainsNoneFiltering:
     """Test that accounts where reval is None are filtered out (line 209 branch)."""
 
     async def test_none_revaluation_skipped(self, db: AsyncSession, test_user_id, usd_asset_account):
-        """AC8.12.3 – Accounts that return None from calculate_unrealized_fx_for_account are skipped."""
+        """AC-ledger.fxrevaluation.3: AC8.12.3 – Accounts that return None from calculate_unrealized_fx_for_account are skipped."""
         from unittest.mock import AsyncMock, patch
 
         with patch(

--- a/common/ledger/contract.py
+++ b/common/ledger/contract.py
@@ -1688,6 +1688,140 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── group journeys: account CRUD + core financial journeys, E2E
+        # (migrated from EPIC-008 AC8.2.2-5/.3/.11, migration closeout
+        # continuation, #1663 / #1707) ──
+        ACRecord(
+            id="AC-ledger.journeys.1",
+            statement="Creating a cash asset account via the API returns the correct type/currency/active state.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_create_cash_account",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.2",
+            statement="Creating a bank asset account via the API succeeds with the correct type.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_create_bank_account",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.3",
+            statement="Updating an account's name via the API reflects the new name.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_update_account",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.4",
+            statement="Deleting an account with no transactions removes it (204), and a subsequent GET returns 404.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_delete_account",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.5",
+            statement="A simple two-account expense entry is created in draft status with correct amounts.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_simple_expense_entry",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.6",
+            statement="Voiding a posted journal entry transitions it to void state.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_void_journal_entry",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.7",
+            statement="Posting a draft journal entry transitions it to posted state.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_post_draft_entry",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.8",
+            statement="An unbalanced journal entry (debits != credits) is rejected.",
+            test=(
+                "apps/backend/tests/e2e/test_core_journeys.py"
+                "::test_unbalanced_journal_entry_rejection"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.9",
+            statement="Journal entry create/read/update/delete via the API round-trips correctly end to end.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_journal_entry_crud",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.10",
+            statement="Recording income posts a balanced entry crediting the income account.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_income_recording",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.11",
+            statement="A credit card spend posts a balanced entry against the liability account.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_credit_card_spend",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.12",
+            statement="A credit card repayment posts a balanced entry reducing the liability.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_credit_card_repayment",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.13",
+            statement="An internal transfer between two of the user's own accounts posts a balanced entry.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_internal_transfer",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.journeys.14",
+            statement="A split transaction across multiple expense categories posts one balanced multi-line entry.",
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_split_transaction",
+            priority="P0",
+            status="done",
+        ),
+        # ── group fxrevaluation: FX revaluation provider error-path unit gates
+        # (migrated from EPIC-008 AC8.12.1-3, migration closeout continuation,
+        # #1663 / #1707) ──
+        ACRecord(
+            id="AC-ledger.fxrevaluation.1",
+            statement="A liability account's unrealized FX gain/loss returns the negated net balance.",
+            test=(
+                "apps/backend/tests/reporting/test_fx_revaluation.py"
+                "::test_returns_negated_balance_for_liability_account"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fxrevaluation.2",
+            statement="A SQLAlchemyError raised during the revaluation flush is wrapped in RevaluationError.",
+            test=(
+                "apps/backend/tests/reporting/test_fx_revaluation.py"
+                "::test_flush_error_raises_revaluation_error"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fxrevaluation.3",
+            statement="An account whose unrealized-FX calculation returns None is skipped, not errored.",
+            test="apps/backend/tests/reporting/test_fx_revaluation.py::test_none_revaluation_skipped",
+            priority="P1",
+            status="done",
+        ),
     ],
 )
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -171,20 +171,15 @@ job inventories or scenario counts into this EPIC.
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
 | AC8.2.1 | New User Registration | `test_register_and_login_flow()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.2.2 | Create Cash Account | `test_create_cash_account()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.2.3 | Create Bank Account | `test_create_bank_account()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.2.4 | Update account | `test_update_account()` | `e2e/test_core_journeys.py` | P1 |
-| AC8.2.5 | Delete account | `test_delete_account()` | `e2e/test_core_journeys.py` | P1 |
+
+> This group's account-CRUD rows (formerly the second through fifth rows)
+> removed — migrated to the `ledger` package roadmap as
+> `AC-ledger.journeys.1-4` (migration closeout continuation, #1663 / #1707).
 
 ### AC8.3: Phase 2 - Manual Journal Entries
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC8.3.1 | Simple Expense Entry | `test_simple_expense_entry()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.3.2 | Void Entry | `test_void_journal_entry()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.3.3 | Post Draft Entry | `test_post_draft_entry()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.3.4 | Unbalanced Entry Rejected | `test_unbalanced_journal_entry_rejection()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.3.5 | Journal Entry CRUD | `test_journal_entry_crud()` | `e2e/test_core_journeys.py` | P1 |
+> This group's rows removed — migrated to the `ledger` package roadmap as
+> `AC-ledger.journeys.5-9` (migration closeout continuation, #1663 / #1707).
 
 ### AC8.4: Phase 3 - Statement Import & Parsing
 
@@ -254,27 +249,18 @@ job inventories or scenario counts into this EPIC.
 
 ### AC8.11: Phase 2 — Core Financial Journeys
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC8.11.1 | Income Recording | `test_income_recording()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.11.2 | Credit Card Spend | `test_credit_card_spend()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.11.3 | Credit Card Repayment | `test_credit_card_repayment()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.11.4 | Internal Transfer | `test_internal_transfer()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.11.5 | Split Transaction | `test_split_transaction()` | `e2e/test_core_journeys.py` | P0 |
+> This group's rows removed — migrated to the `ledger` package roadmap as
+> `AC-ledger.journeys.10-14` (migration closeout continuation, #1663 / #1707).
 
 ### AC8.12: Provider Error-Path Unit Gates
 
-> **Partially migrated.** The extraction-owned rows (were AC8.12.* rows
+> **Fully migrated.** The extraction-owned rows (were AC8.12.* rows
 > .6/.4/.5) are homed in the `extraction` package roadmap as
 > `AC-extraction.812.6` · `AC-extraction.812.4` · `AC-extraction.812.5`
 > ([`common/extraction/contract.py`](../../common/extraction/contract.py));
-> the remaining rows below stay with their own owners.
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC8.12.1 | Liability accounts return -net_balance so coverage hits else branch. | `test_returns_negated_balance_for_liability_account` | `reporting/test_fx_revaluation.py` | P1 |
-| AC8.12.2 | SQLAlchemyError on flush is wrapped in RevaluationError. | `test_flush_error_raises_revaluation_error` | `reporting/test_fx_revaluation.py` | P1 |
-| AC8.12.3 | Accounts that return None from calculate_unrealized_fx_for_account are skipped. | `test_none_revaluation_skipped` | `reporting/test_fx_revaluation.py` | P1 |
+> the remaining rows (were AC8.12.* rows .1/.2/.3) are homed in the `ledger`
+> package roadmap as `AC-ledger.fxrevaluation.1-3` (migration closeout
+> continuation, #1663 / #1707).
 
 ### AC8.13: Tier 3 Browser E2E — Full Statement Journey
 


### PR DESCRIPTION
## Summary

Closes #1707.

Migrates 17 backend-provable EPIC AC rows (account CRUD, manual journal entries, core financial journeys, FX-revaluation provider error paths) into `common/ledger/contract.py`'s roadmap. Part of #1663's remaining backlog, reorganized by package.

**Note**: this touches the same `docs/project/EPIC-008.testing-strategy.md` sections as #1720 (identity, AC8.2.1) — expect a small merge conflict if both are open simultaneously; will rebase whichever lands second.

Refs #1707, parent #1663, umbrella #1416.

## What moved

| Old ID | New ID |
|---|---|
| EPIC-008 AC8.2.2-5 | `AC-ledger.journeys.1-4` |
| EPIC-008 AC8.3.1-5 | `AC-ledger.journeys.5-9` |
| EPIC-008 AC8.11.1-5 | `AC-ledger.journeys.10-14` |
| EPIC-008 AC8.12.1-3 | `AC-ledger.fxrevaluation.1-3` |

## Testing

```bash
apps/backend/.venv/bin/python3 -m pytest tests/tooling/ -n 4 --no-cov -q
# 1880 passed, 1 skipped

cd apps/backend && .venv/bin/python3 -m pytest tests/e2e/test_core_journeys.py tests/reporting/test_fx_revaluation.py --no-cov -q
# 31 passed

moon run :lint
# All checks passed

apps/backend/.venv/bin/python3 tools/check_package_contract.py     # PASSED
apps/backend/.venv/bin/python3 tools/check_manifest.py             # clean
apps/backend/.venv/bin/python3 tools/lint_doc_consistency.py       # clean
apps/backend/.venv/bin/python3 tools/check_ac_index.py             # PASSED
apps/backend/.venv/bin/python3 tools/generate_ac_registry.py --check   # OK
apps/backend/.venv/bin/python3 tools/check_ac_tier_baseline.py     # PASSED
apps/backend/.venv/bin/python3 -m common.testing.mirror_ratchet    # 2914<=2917
```