### PR TITLE
[finance_report_vision] feat(identity,extraction,runtime,ledger): migrate 5 genuine EPIC-001 ACs into package roadmaps (#1663 wave 3)

### DIFF
--- a/apps/backend/tests/identity/test_auth.py
+++ b/apps/backend/tests/identity/test_auth.py
@@ -57,7 +57,7 @@ async def test_auth_non_existent_user(db_engine):
 
 
 async def test_auth_valid_user(client, test_user):
-    """AC8.2.4: Test 200 when valid JWT is provided."""
+    """AC-identity.2.4: AC1.2.2: AC8.2.4: Test 200 when valid JWT is provided."""
     # The client fixture already has the valid JWT in headers
     response = await client.get("/accounts")
     assert response.status_code == 200

--- a/apps/backend/tests/identity/test_auth_router.py
+++ b/apps/backend/tests/identity/test_auth_router.py
@@ -120,7 +120,7 @@ async def test_get_me_success(client, test_user):
 
 
 async def test_AC1_10_3_get_me_accepts_httponly_cookie(public_client, test_user):
-    """AC1.10.3: Auth dependency accepts the HttpOnly session cookie without localStorage bearer use."""
+    """AC-identity.2.5: AC1.10.3: Auth dependency accepts the HttpOnly session cookie without localStorage bearer use."""
     from src.identity import create_access_token
 
     token = create_access_token(data={"sub": str(test_user.id)})

--- a/apps/backend/tests/infra/test_boot.py
+++ b/apps/backend/tests/infra/test_boot.py
@@ -145,7 +145,7 @@ class TestBootloaderStaticConfig:
         assert result is True
 
     def test_AC1_10_1_static_config_rejects_default_secret_key_in_production(self, mock_settings):
-        """AC1.10.1: Production startup refuses the development JWT secret."""
+        """AC-runtime.21.1: AC1.10.1: Production startup refuses the development JWT secret."""
         mock_settings.environment = "production"
         mock_settings.secret_key = "dev_secret_key_change_in_prod"
 
@@ -154,7 +154,7 @@ class TestBootloaderStaticConfig:
         assert result is False
 
     def test_AC1_10_1_static_config_rejects_short_secret_key_in_staging(self, mock_settings):
-        """AC1.10.1: Staging startup requires a high-entropy JWT secret."""
+        """AC-runtime.21.2: AC1.10.1: Staging startup requires a high-entropy JWT secret."""
         mock_settings.environment = "staging"
         mock_settings.secret_key = "short-secret"
 
@@ -163,7 +163,7 @@ class TestBootloaderStaticConfig:
         assert result is False
 
     def test_AC1_10_1_static_config_rejects_default_db_in_protected_env(self, mock_settings):
-        """AC1.10.1: Protected runtimes cannot boot with local development DB defaults."""
+        """AC-runtime.21.3: AC1.10.1: Protected runtimes cannot boot with local development DB defaults."""
         mock_settings.environment = "production"
         mock_settings.secret_key = "a" * 32
         mock_settings.database_url = "postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/finance_report"
@@ -173,7 +173,7 @@ class TestBootloaderStaticConfig:
         assert result is False
 
     def test_AC1_10_1_static_config_rejects_default_s3_secret_in_production_like_url(self, mock_settings):
-        """AC1.10.1: Public app URLs are treated as protected even if ENV is misnamed."""
+        """AC-runtime.21.4: AC1.10.1: Public app URLs are treated as protected even if ENV is misnamed."""
         mock_settings.environment = "preview"
         mock_settings.secret_key = "a" * 32
         mock_settings.database_url = "postgresql+asyncpg://finance:secure@db.internal/finance_report"
@@ -185,7 +185,7 @@ class TestBootloaderStaticConfig:
         assert result is False
 
     def test_AC1_10_1_static_config_rejects_blank_secret_key_in_production(self, mock_settings):
-        """AC1.10.1: Protected environments require a configured JWT secret."""
+        """AC-runtime.21.5: AC1.10.1: Protected environments require a configured JWT secret."""
         mock_settings.environment = "production"
         mock_settings.secret_key = "   "
 
@@ -194,7 +194,7 @@ class TestBootloaderStaticConfig:
         assert result is False
 
     def test_AC1_10_1_static_config_allows_development_default_secret_key(self, mock_settings):
-        """AC1.10.1: Local development keeps convenient defaults."""
+        """AC-runtime.21.6: AC1.10.1: Local development keeps convenient defaults."""
         mock_settings.environment = "development"
         mock_settings.secret_key = "dev_secret_key_change_in_prod"
 

--- a/apps/backend/tests/integration/test_onboarding_e2e.py
+++ b/apps/backend/tests/integration/test_onboarding_e2e.py
@@ -13,7 +13,7 @@ async def test_AC1_9_1_first_run_registration_account_entry_journey(
     public_client: AsyncClient,
     db: AsyncSession,
 ) -> None:
-    """AC1.9.1: A new user can register, log in, create accounts, post first entry, and remain balanced."""
+    """AC-ledger.77.1: AC1.9.1: A new user can register, log in, create accounts, post first entry, and remain balanced."""
     email = "first-run-ledger@example.com"
     password = "CorrectHorseBatteryStaple1!"
 

--- a/apps/backend/tests/review/test_statement_validation.py
+++ b/apps/backend/tests/review/test_statement_validation.py
@@ -451,7 +451,7 @@ class TestGetPendingStage1Review:
         assert stmt_approved.id not in ids
 
     async def test_returns_empty_when_none_pending(self, db, user_id):
-        """AC1.6.2 get_pending_stage1_review returns empty when no pending statements."""
+        """AC-extraction.13.1: AC1.6.2 get_pending_stage1_review returns empty when no pending statements."""
         result = await get_pending_stage1_review(db, user_id)
         assert result == []
 

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -2214,5 +2214,19 @@ CONTRACT = PackageContract(
             status="done",
             proof_kind="property",
         ),
+        ACRecord(
+            id="AC-extraction.13.1",
+            statement=(
+                "get_pending_stage1_review returns an empty list for a user with "
+                "no pending-review statements. Was EPIC-001 AC1.6.2 (migration "
+                "closeout wave 3, #1416)."
+            ),
+            test=(
+                "apps/backend/tests/review/test_statement_validation.py"
+                "::test_returns_empty_when_none_pending"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/identity/contract.py
+++ b/common/identity/contract.py
@@ -300,6 +300,32 @@ CONTRACT = PackageContract(
             status="done",
         ),
         ACRecord(
+            id="AC-identity.2.4",
+            statement=(
+                "A valid JWT (bearer or cookie) grants 200 on a protected endpoint "
+                "(GET /accounts). Was EPIC-001 AC1.2.2 (migration closeout wave 3, "
+                "#1416)."
+            ),
+            test="apps/backend/tests/identity/test_auth.py::test_auth_valid_user",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-identity.2.5",
+            statement=(
+                "The auth dependency accepts the HttpOnly session cookie directly "
+                "(no bearer header required) for GET /auth/me. Was EPIC-001 "
+                "AC1.10.3 (migration closeout wave 3, #1416); the row's frontend-"
+                "storage half stays in the EPIC (no backend package home)."
+            ),
+            test=(
+                "apps/backend/tests/identity/test_auth_router.py"
+                "::test_AC1_10_3_get_me_accepts_httponly_cookie"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
             id="AC-identity.1.3",
             statement=(
                 "The /users management endpoints expose authenticated current-user "

--- a/common/ledger/contract.py
+++ b/common/ledger/contract.py
@@ -1688,6 +1688,22 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        ACRecord(
+            id="AC-ledger.77.1",
+            statement=(
+                "A brand-new user can register, log in, create their first "
+                "ledger accounts, post a first manual journal entry, and the "
+                "accounting equation stays balanced end to end. Was EPIC-001 "
+                "AC1.9.1 (migration closeout wave 3, #1416)."
+            ),
+            test=(
+                "apps/backend/tests/integration/test_onboarding_e2e.py"
+                "::test_AC1_9_1_first_run_registration_account_entry_journey"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
     ],
 )
 

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -314,6 +314,69 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── group 21: Bootloader static-config boot gate (was EPIC-001
+        # AC1.10.1, migration closeout wave 3, #1416) — each branch of
+        # Bootloader._check_static_config is a distinct rejection reason ──
+        ACRecord(
+            id="AC-runtime.21.1",
+            statement="Bootloader._check_static_config rejects the default development JWT secret in production.",
+            test=(
+                "apps/backend/tests/infra/test_boot.py"
+                "::test_AC1_10_1_static_config_rejects_default_secret_key_in_production"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.21.2",
+            statement="Bootloader._check_static_config rejects a short (low-entropy) JWT secret in staging.",
+            test=(
+                "apps/backend/tests/infra/test_boot.py"
+                "::test_AC1_10_1_static_config_rejects_short_secret_key_in_staging"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.21.3",
+            statement="Bootloader._check_static_config rejects the local-development DB default in a protected environment.",
+            test=(
+                "apps/backend/tests/infra/test_boot.py"
+                "::test_AC1_10_1_static_config_rejects_default_db_in_protected_env"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.21.4",
+            statement="Bootloader._check_static_config treats a public app URL as protected even when ENVIRONMENT is misnamed (e.g. 'preview'), rejecting a default S3 secret under it.",
+            test=(
+                "apps/backend/tests/infra/test_boot.py"
+                "::test_AC1_10_1_static_config_rejects_default_s3_secret_in_production_like_url"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.21.5",
+            statement="Bootloader._check_static_config rejects a blank/whitespace-only JWT secret in production.",
+            test=(
+                "apps/backend/tests/infra/test_boot.py"
+                "::test_AC1_10_1_static_config_rejects_blank_secret_key_in_production"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.21.6",
+            statement="Bootloader._check_static_config allows the convenient development-default JWT secret in the development environment.",
+            test=(
+                "apps/backend/tests/infra/test_boot.py"
+                "::test_AC1_10_1_static_config_allows_development_default_secret_key"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )
 

--- a/docs/project/EPIC-001.phase0-setup.md
+++ b/docs/project/EPIC-001.phase0-setup.md
@@ -78,10 +78,17 @@ Set up a runnable Monorepo development environment, complete user authentication
 | ID | Requirement | Test Function | File |
 |----|-------------|---------------|------|
 | AC1.2.1 | FastAPI project structure exists | `test_epic_001_backend_skeleton_exists()` | `infra/test_epic_001_contracts.py` |
-| AC1.2.2 | Auth integration works (register/login/JWT) | `test_register_success()`, `test_login_success()`, `test_auth_valid_user()` | `identity/test_auth_router.py`, `identity/test_auth.py` |
 | AC1.2.3 | SQLAlchemy + Alembic config valid | `test_missing_migrations_check()`, `test_single_head()` | `infra/test_schema_drift.py`, `infra/test_migrations.py` |
 | AC1.2.4 | Health endpoint returns success | `test_health_when_all_services_healthy()` | `infra/test_main.py` |
-| AC1.2.5 | structlog logging configured | `test_configure_logging_basic()` | `infra/test_logger.py` |
+
+> **AC1.2.2** ("Auth integration works") cited three tests: `test_register_success`
+> and `test_login_success` were already migrated to
+> [`common/identity/contract.py`](../../common/identity/contract.py) as
+> `AC-identity.2.1`/`.2.2`; the third, `test_auth_valid_user`, migrated to
+> `AC-identity.2.4` (migration closeout wave 3, #1416). **AC1.2.5** ("structlog
+> logging configured", `test_configure_logging_basic`) was already fully
+> migrated to `AC-observability.1.5` — this row was a stale duplicate,
+> removed with no new migration needed.
 
 ### AC1.3: Frontend Skeleton Requirements
 
@@ -124,7 +131,12 @@ Set up a runnable Monorepo development environment, complete user authentication
 | ID | Requirement | Test Function | File |
 |----|-------------|---------------|------|
 | AC1.6.1 | Pre-commit hooks configuration present | `test_epic_001_pre_commit_config_exists()` | `infra/test_epic_001_contracts.py` |
-| AC1.6.2 | get_pending_stage1_review returns empty when no pending statements. | `test_returns_empty_when_none_pending` | `review/test_statement_validation.py` | P1 |
+
+> **AC1.6.2** ("`get_pending_stage1_review` returns empty when no pending
+> statements") migrated into the `extraction` package as **`AC-extraction.13.1`**
+> — owned by, and sourced directly from,
+> [`common/extraction/contract.py`](../../common/extraction/contract.py)'s
+> `roadmap` (migration closeout wave 3, #1416).
 
 ### AC1.7: Auth Endpoint Behavioral Coverage
 
@@ -153,16 +165,31 @@ Set up a runnable Monorepo development environment, complete user authentication
 
 ### AC1.9: First-Run Ledger Journey Coverage
 
-| ID | Requirement | Test Function | File |
-|----|-------------|---------------|------|
-| AC1.9.1 | A new user can register, log in, create first ledger accounts, post a first manual entry, and preserve the accounting equation | `test_AC1_9_1_first_run_registration_account_entry_journey` | `integration/test_onboarding_e2e.py` |
+> **AC1.9.1** ("a new user can register, log in, create first ledger accounts,
+> post a first manual entry, and preserve the accounting equation") migrated
+> into the `ledger` package as **`AC-ledger.77.1`** — owned by, and sourced
+> directly from, [`common/ledger/contract.py`](../../common/ledger/contract.py)'s
+> `roadmap` (migration closeout wave 3, #1416); the journey's defining assertion
+> is the ledger's accounting equation, so ledger is the home package even
+> though the journey starts through identity's register/login endpoints.
 
 ### AC1.10: Auth & Browser Security Hardening
 
+> **AC1.10.1** ("protected runtime startup rejects missing/default/short/
+> local-development config") migrated into the `runtime` package as
+> **`AC-runtime.21.1`** through **`.6`** (one record per `Bootloader.
+> _check_static_config` rejection branch) — owned by, and sourced directly
+> from, [`common/runtime/contract.py`](../../common/runtime/contract.py)'s
+> `roadmap` (migration closeout wave 3, #1416).
+>
+> **AC1.10.3**'s backend half (`test_AC1_10_3_get_me_accepts_httponly_cookie`)
+> migrated to [`common/identity/contract.py`](../../common/identity/contract.py)'s
+> `roadmap` as **`AC-identity.2.5`** (migration closeout wave 3, #1416). The
+> row's frontend-storage half stays here (no backend package home):
+
 | ID | Requirement | Test Function | File |
 |----|-------------|---------------|------|
-| AC1.10.1 | Protected runtime startup rejects missing, default, short, or local-development secret/database/storage configuration | `test_AC1_10_1_static_config_*` | `infra/test_boot.py` |
-| AC1.10.3 | Browser authentication uses an HttpOnly session cookie by default while frontend storage keeps only non-secret user metadata | `test_AC1_10_3_get_me_accepts_httponly_cookie` / `AC1.10.3 sends HttpOnly auth cookies by default` / `auth.test.ts` session tests | `identity/test_auth_router.py`, `src/__tests__/apiFunctions.test.ts`, `src/__tests__/auth.test.ts` |
+| AC1.10.3 | Frontend storage keeps only non-secret user metadata, relying on the HttpOnly session cookie rather than localStorage for the bearer token | `AC1.10.3 sends HttpOnly auth cookies by default` / `auth.test.ts` session tests | `src/__tests__/apiFunctions.test.ts`, `src/__tests__/auth.test.ts` |
 
 > **The former email-normalization criterion (the AC1.10 normalize-email row) is
 > no longer defined here.** It migrated into the `identity` package (#1428) as

--- a/docs/project/EPIC-001.phase0-setup.md
+++ b/docs/project/EPIC-001.phase0-setup.md
@@ -81,14 +81,16 @@ Set up a runnable Monorepo development environment, complete user authentication
 | AC1.2.3 | SQLAlchemy + Alembic config valid | `test_missing_migrations_check()`, `test_single_head()` | `infra/test_schema_drift.py`, `infra/test_migrations.py` |
 | AC1.2.4 | Health endpoint returns success | `test_health_when_all_services_healthy()` | `infra/test_main.py` |
 
-> **AC1.2.2** ("Auth integration works") cited three tests: `test_register_success`
-> and `test_login_success` were already migrated to
+> (AC1.2.2 removed, canonical: "Auth integration works" cited three tests —
+> `test_register_success` and `test_login_success` were already migrated to
 > [`common/identity/contract.py`](../../common/identity/contract.py) as
 > `AC-identity.2.1`/`.2.2`; the third, `test_auth_valid_user`, migrated to
-> `AC-identity.2.4` (migration closeout wave 3, #1416). **AC1.2.5** ("structlog
-> logging configured", `test_configure_logging_basic`) was already fully
-> migrated to `AC-observability.1.5` — this row was a stale duplicate,
-> removed with no new migration needed.
+> `AC-identity.2.4`, migration closeout wave 3, #1416.)
+>
+> (AC1.2.5 removed, duplicate: "structlog logging configured"
+> (`test_configure_logging_basic`) was already fully migrated to
+> `AC-observability.1.5` — this row was a stale duplicate, no new migration
+> needed.)
 
 ### AC1.3: Frontend Skeleton Requirements
 
@@ -132,11 +134,11 @@ Set up a runnable Monorepo development environment, complete user authentication
 |----|-------------|---------------|------|
 | AC1.6.1 | Pre-commit hooks configuration present | `test_epic_001_pre_commit_config_exists()` | `infra/test_epic_001_contracts.py` |
 
-> **AC1.6.2** ("`get_pending_stage1_review` returns empty when no pending
-> statements") migrated into the `extraction` package as **`AC-extraction.13.1`**
-> — owned by, and sourced directly from,
+> (AC1.6.2 removed, canonical: "`get_pending_stage1_review` returns empty when
+> no pending statements" migrated into the `extraction` package as
+> **`AC-extraction.13.1`** — owned by, and sourced directly from,
 > [`common/extraction/contract.py`](../../common/extraction/contract.py)'s
-> `roadmap` (migration closeout wave 3, #1416).
+> `roadmap`, migration closeout wave 3, #1416.)
 
 ### AC1.7: Auth Endpoint Behavioral Coverage
 
@@ -165,22 +167,24 @@ Set up a runnable Monorepo development environment, complete user authentication
 
 ### AC1.9: First-Run Ledger Journey Coverage
 
-> **AC1.9.1** ("a new user can register, log in, create first ledger accounts,
-> post a first manual entry, and preserve the accounting equation") migrated
-> into the `ledger` package as **`AC-ledger.77.1`** — owned by, and sourced
-> directly from, [`common/ledger/contract.py`](../../common/ledger/contract.py)'s
-> `roadmap` (migration closeout wave 3, #1416); the journey's defining assertion
-> is the ledger's accounting equation, so ledger is the home package even
-> though the journey starts through identity's register/login endpoints.
+> (AC1.9.1 removed, canonical: "a new user can register, log in, create first
+> ledger accounts, post a first manual entry, and preserve the accounting
+> equation" migrated into the `ledger` package as **`AC-ledger.77.1`** — owned
+> by, and sourced directly from,
+> [`common/ledger/contract.py`](../../common/ledger/contract.py)'s `roadmap`,
+> migration closeout wave 3, #1416; the journey's defining assertion is the
+> ledger's accounting equation, so ledger is the home package even though the
+> journey starts through identity's register/login endpoints.)
 
 ### AC1.10: Auth & Browser Security Hardening
 
-> **AC1.10.1** ("protected runtime startup rejects missing/default/short/
-> local-development config") migrated into the `runtime` package as
-> **`AC-runtime.21.1`** through **`.6`** (one record per `Bootloader.
-> _check_static_config` rejection branch) — owned by, and sourced directly
-> from, [`common/runtime/contract.py`](../../common/runtime/contract.py)'s
-> `roadmap` (migration closeout wave 3, #1416).
+> (AC1.10.1 removed, canonical: "protected runtime startup rejects
+> missing/default/short/local-development config" migrated into the `runtime`
+> package as **`AC-runtime.21.1`** through **`.6`** (one record per
+> `Bootloader._check_static_config` rejection branch) — owned by, and sourced
+> directly from,
+> [`common/runtime/contract.py`](../../common/runtime/contract.py)'s
+> `roadmap`, migration closeout wave 3, #1416.)
 >
 > **AC1.10.3**'s backend half (`test_AC1_10_3_get_me_accepts_httponly_cookie`)
 > migrated to [`common/identity/contract.py`](../../common/identity/contract.py)'s


### PR DESCRIPTION
## Summary
- Cross-checked all 27 remaining EPIC-001 rows against their candidate target packages' *existing* roadmaps before migrating anything — several turned out to already be fully or partially migrated under different citations from an earlier wave (e.g. `AC1.2.2` cited `test_register_success`/`test_login_success`, which already back `AC-identity.2.1`/`.2`; `AC1.2.5` fully duplicates `AC-observability.1.5`).
- Migrated the 5 rows with genuinely new, untracked behavior:
  - `AC1.2.2`'s third (previously untracked) citation and `AC1.10.3`'s backend half → `common/identity/contract.py` as `AC-identity.2.4` / `AC-identity.2.5`
  - `AC1.6.2` (`get_pending_stage1_review` returns empty) → `common/extraction/contract.py` as `AC-extraction.13.1`
  - `AC1.10.1` (`Bootloader._check_static_config`'s 6 distinct rejection branches) → `common/runtime/contract.py` as `AC-runtime.21.1` through `.6`
  - `AC1.9.1` (first-run register → login → create accounts → post entry → balanced equation journey) → `common/ledger/contract.py` as `AC-ledger.77.1` (ledger owns it since the journey's defining assertion is the accounting equation, even though it starts through identity's endpoints)
- The remaining 22 rows stay EPIC-owned: infra/structural existence checks (`moon.yml`, `docker-compose.yml`, frontend skeleton files) and frontend-only assertions have no backend package home in the current package model.
- Updated the 6 affected test files' docstrings to carry the new AC ids (required by the docstring-based traceability gate).

## Test plan
- [x] `check_package_contract` passes for all 4 touched packages (identity: 8 roadmap ACs, extraction: 226, runtime: 27, ledger: 108 — all OK)
- [x] `tests/tooling/` full suite: 1950 passed, 1 skipped
- [x] Touched backend tests (`test_auth.py::test_auth_valid_user`, `test_auth_router.py::test_AC1_10_3_get_me_accepts_httponly_cookie`, `test_statement_validation.py::TestGetPendingStage1Review::test_returns_empty_when_none_pending`, `test_onboarding_e2e.py::test_AC1_9_1_...`, `test_boot.py::TestBootloaderStaticConfig`): 14 passed
- [x] `docs/project/EPIC-001.phase0-setup.md` raw AC-row count: 27 → 22 (5 migrated, rest genuinely non-migratable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)