### PR TITLE
[finance_report_audit] Migration closeout 2.4: distribute EPIC AC rows into audit roadmap

### DIFF
--- a/apps/backend/tests/audit/promotion/test_promotion_gate.py
+++ b/apps/backend/tests/audit/promotion/test_promotion_gate.py
@@ -21,7 +21,7 @@ from src.audit.promotion import (
 
 
 def test_AC18_13_1_failed_invariant_is_rejected_with_queryable_reason():
-    """AC18.13.1: A failed deterministic invariant is REJECTED (never authoritative), with a queryable reason."""
+    """AC-audit.41.1: AC18.13.1: A failed deterministic invariant is REJECTED (never authoritative), with a queryable reason."""
     verdict = evaluate_promotion(
         [
             InvariantResult(
@@ -41,7 +41,7 @@ def test_AC18_13_1_failed_invariant_is_rejected_with_queryable_reason():
 
 
 def test_AC18_13_2_invariants_pass_but_low_confidence_is_review():
-    """AC18.13.2: Invariants pass but confidence below threshold -> REVIEW candidate, not authoritative."""
+    """AC-audit.41.2: AC18.13.2: Invariants pass but confidence below threshold -> REVIEW candidate, not authoritative."""
     verdict = evaluate_promotion(
         [InvariantResult(name="balance_chain", passed=True)],
         confidence_rank=tier_rank("LOW"),
@@ -55,7 +55,7 @@ def test_AC18_13_2_invariants_pass_but_low_confidence_is_review():
 
 
 def test_AC18_13_3_invariants_pass_and_confidence_met_is_authoritative():
-    """AC18.13.3: Invariants pass AND confidence >= threshold -> AUTHORITATIVE. Same contract for tier and score."""
+    """AC-audit.41.3: AC18.13.3: Invariants pass AND confidence >= threshold -> AUTHORITATIVE. Same contract for tier and score."""
     by_tier = evaluate_promotion(
         [InvariantResult(name="balance_chain", passed=True)],
         confidence_rank=tier_rank("HIGH"),
@@ -80,7 +80,7 @@ def test_AC18_13_3_invariants_pass_and_confidence_met_is_authoritative():
 
 
 def test_AC18_13_4_thresholds_are_centrally_owned_and_consumed_by_services():
-    """AC18.13.4: The previously-scattered thresholds are named, centrally owned, and consumed by the services."""
+    """AC-audit.41.4: AC18.13.4: The previously-scattered thresholds are named, centrally owned, and consumed by the services."""
     assert STATEMENT_BALANCE_TOLERANCE == Decimal("0.001")
     assert RECONCILIATION_AUTO_ACCEPT_SCORE == 85
     assert RECONCILIATION_REVIEW_SCORE == 60

--- a/apps/backend/tests/infra/test_financial_fact_schema_invariants.py
+++ b/apps/backend/tests/infra/test_financial_fact_schema_invariants.py
@@ -80,7 +80,7 @@ def _source_documents() -> dict[str, list[dict[str, str]]]:
 
 
 async def test_AC11_18_1_positive_source_fact_constraints(db: AsyncSession, test_user) -> None:
-    """AC11.18.1: Source facts reject non-positive values where positive is required (transaction
+    """AC-audit.42.1: AC11.18.1: Source facts reject non-positive values where positive is required (transaction
     amount, manual-valuation value); positions are signed and may be negative (short, #1448)."""
     user_id = test_user.id
     await _expect_integrity_error(
@@ -146,7 +146,7 @@ async def test_AC11_18_2_statement_summary_approved_completeness_and_period_orde
     db: AsyncSession,
     test_user,
 ) -> None:
-    """AC11.18.2: Approved statement summaries require complete envelopes and ordered periods."""
+    """AC-audit.42.2: AC11.18.2: Approved statement summaries require complete envelopes and ordered periods."""
     user_id = test_user.id
     account = await _make_account(db, user_id)
     account_id = account.id
@@ -234,7 +234,7 @@ async def test_AC11_18_3_portfolio_fact_constraints_and_managed_position_uniquen
     db: AsyncSession,
     test_user,
 ) -> None:
-    """AC11.18.3: Portfolio facts enforce deterministic uniqueness and disposal/acquisition
+    """AC-audit.42.3: AC11.18.3: Portfolio facts enforce deterministic uniqueness and disposal/acquisition
     ordering; positions are signed and may carry negative quantity/cost basis (short, #1448)."""
     user_id = test_user.id
     account = await _make_account(db, user_id)
@@ -364,7 +364,7 @@ async def test_AC11_18_4_report_snapshot_latest_scope_and_date_constraints(
     db: AsyncSession,
     test_user,
 ) -> None:
-    """AC11.18.4: Latest report snapshots are unique per logical report scope."""
+    """AC-audit.42.4: AC11.18.4: Latest report snapshots are unique per logical report scope."""
     user_id = test_user.id
     rule = await _make_rule(db, user_id, version=1)
     second_rule = await _make_rule(db, user_id, version=2)
@@ -432,7 +432,7 @@ async def test_AC11_18_5_market_data_constraints_and_stock_price_uniqueness(
     db: AsyncSession,
     test_user,
 ) -> None:
-    """AC11.18.5: Market facts are positive and stock-price uniqueness includes provider dimensions."""
+    """AC-audit.42.5: AC11.18.5: Market facts are positive and stock-price uniqueness includes provider dimensions."""
     user_id = test_user.id
     await _expect_integrity_error(
         db,
@@ -504,7 +504,7 @@ async def test_AC11_18_5_market_data_constraints_and_stock_price_uniqueness(
 
 @pytest.mark.no_db
 def test_AC11_18_6_migration_preflights_and_risk_contract_are_declared() -> None:
-    """AC11.18.6: The migration declares preflight checks and risk classification."""
+    """AC-audit.42.6: AC11.18.6: The migration declares preflight checks and risk classification."""
     migration_source = MIGRATION_PATH.read_text()
     risk_source = RISK_PATH.read_text()
 

--- a/apps/backend/tests/review/test_statement_validation.py
+++ b/apps/backend/tests/review/test_statement_validation.py
@@ -80,7 +80,7 @@ DEFAULT_ACCOUNT_NAME = "Statement Validation Default Account"
 
 
 def test_AC18_13_5_balance_chain_decision_routes_through_promotion_gate():
-    """AC18.13.5: Stage-1 balance approval is disposed by the promotion gate, preserving the exact messages."""
+    """AC-audit.41.5: AC18.13.5: Stage-1 balance approval is disposed by the promotion gate, preserving the exact messages."""
     from src.extraction.extension.statement_validation import _raise_if_balance_chain_invalid
 
     ok = {"opening_match": True, "closing_match": True, "opening_delta": "0", "closing_delta": "0"}

--- a/common/audit/contract.py
+++ b/common/audit/contract.py
@@ -1035,5 +1035,166 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        # ── group 41: financial-invariant promotion gate (physically relocated
+        # to apps/backend/src/audit/promotion/, #1667; migrated from EPIC-018
+        # AC18.13, migration closeout continuation, #1663 / #1709) ──
+        ACRecord(
+            id="AC-audit.41.1",
+            statement=(
+                "A failed deterministic invariant rejects the version "
+                "regardless of confidence, with a queryable reason (failing "
+                "invariant + delta vs tolerance). Was EPIC-018 AC18.13.1."
+            ),
+            test=(
+                "apps/backend/tests/audit/promotion/test_promotion_gate.py"
+                "::test_AC18_13_1_failed_invariant_is_rejected_with_queryable_reason"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.41.2",
+            statement=(
+                "Invariants pass but confidence is below threshold yields a "
+                "non-authoritative review candidate. Was EPIC-018 AC18.13.2."
+            ),
+            test=(
+                "apps/backend/tests/audit/promotion/test_promotion_gate.py"
+                "::test_AC18_13_2_invariants_pass_but_low_confidence_is_review"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.41.3",
+            statement=(
+                "Invariants pass and confidence meets threshold yields "
+                "authoritative; the same contract carries both tier and "
+                "reconciliation-score confidence. Was EPIC-018 AC18.13.3."
+            ),
+            test=(
+                "apps/backend/tests/audit/promotion/test_promotion_gate.py"
+                "::test_AC18_13_3_invariants_pass_and_confidence_met_is_authoritative"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.41.4",
+            statement=(
+                "The previously-scattered thresholds (balance 0.001, "
+                "reconciliation 85/60) are named, centrally owned, and "
+                "consumed by the services. Was EPIC-018 AC18.13.4."
+            ),
+            test=(
+                "apps/backend/tests/audit/promotion/test_promotion_gate.py"
+                "::test_AC18_13_4_thresholds_are_centrally_owned_and_consumed_by_services"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.41.5",
+            statement=(
+                "Stage-1 statement balance-chain approval is disposed by the "
+                "promotion gate (balance checks as invariants), making the "
+                "gate load-bearing for a real decision while preserving "
+                "behavior. Was EPIC-018 AC18.13.5."
+            ),
+            test=(
+                "apps/backend/tests/review/test_statement_validation.py"
+                "::test_AC18_13_5_balance_chain_decision_routes_through_promotion_gate"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group 42: financial fact schema invariants (migrated from EPIC-011
+        # AC11.18, migration closeout continuation, #1663 / #1709) ──
+        ACRecord(
+            id="AC-audit.42.1",
+            statement=(
+                "Positive source fact constraints reject zero/negative "
+                "transaction amounts and manual-valuation values, while "
+                "positions are signed — a short carries negative quantity AND "
+                "negative market value (#1448). Was EPIC-011 AC11.18.1."
+            ),
+            test=(
+                "apps/backend/tests/infra/test_financial_fact_schema_invariants.py"
+                "::test_AC11_18_1_positive_source_fact_constraints"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.42.2",
+            statement=(
+                "Approved statement summaries require account, currency, "
+                "period, and balance fields, and statement periods cannot be "
+                "inverted. Was EPIC-011 AC11.18.2."
+            ),
+            test=(
+                "apps/backend/tests/infra/test_financial_fact_schema_invariants.py"
+                "::test_AC11_18_2_statement_summary_approved_completeness_and_period_order"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.42.3",
+            statement=(
+                "Managed positions, investment lots, and investment facts "
+                "enforce deterministic uniqueness and disposal/acquisition "
+                "ordering; positions are signed and may carry negative "
+                "quantity/cost basis for shorts (#1448). Was EPIC-011 AC11.18.3."
+            ),
+            test=(
+                "apps/backend/tests/infra/test_financial_fact_schema_invariants.py"
+                "::test_AC11_18_3_portfolio_fact_constraints_and_managed_position_uniqueness"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.42.4",
+            statement=(
+                "Latest report snapshots cannot conflict for the same logical "
+                "report scope and report date ranges cannot be inverted. Was "
+                "EPIC-011 AC11.18.4."
+            ),
+            test=(
+                "apps/backend/tests/infra/test_financial_fact_schema_invariants.py"
+                "::test_AC11_18_4_report_snapshot_latest_scope_and_date_constraints"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.42.5",
+            statement=(
+                "Market-data facts enforce positive rates/prices and stock "
+                "prices are unique by symbol, currency, provider source, and "
+                "date. Was EPIC-011 AC11.18.5."
+            ),
+            test=(
+                "apps/backend/tests/infra/test_financial_fact_schema_invariants.py"
+                "::test_AC11_18_5_market_data_constraints_and_stock_price_uniqueness"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.42.6",
+            statement=(
+                "The constraint migration declares preflight checks and "
+                "migration-risk classification for existing data "
+                "compatibility. Was EPIC-011 AC11.18.6."
+            ),
+            test=(
+                "apps/backend/tests/infra/test_financial_fact_schema_invariants.py"
+                "::test_AC11_18_6_migration_preflights_and_risk_contract_are_declared"
+            ),
+            priority="P0",
+            status="done",
+        ),
     ],
 )

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -245,21 +245,8 @@ the `StatementSummary` conform (DWD) instead of `bank_statements.account_id`
 
 ### AC11.18: 4-Layer Migration — Financial Fact Schema Invariants
 
-Financial source facts and derived snapshots reject invalid financial states at
-the database layer before reporting, readiness checks, or export paths need to
-guess around them. The invariant set covers positive financial facts, statement
-envelope completeness, deterministic asset and market-data uniqueness, and
-latest-report snapshot guards. Short positions remain valid: negative position
-quantity is allowed, while market value and cost facts stay non-negative.
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.18.1 | Positive source fact constraints reject zero/negative transaction amounts and manual-valuation values, while positions are signed — a short carries negative quantity AND negative market value (#1448) | `test_AC11_18_1_positive_source_fact_constraints()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
-| AC11.18.2 | Approved statement summaries require account, currency, period, and balance fields, and statement periods cannot be inverted | `test_AC11_18_2_statement_summary_approved_completeness_and_period_order()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
-| AC11.18.3 | Managed positions, investment lots, and investment facts enforce deterministic uniqueness and disposal/acquisition ordering; positions are signed and may carry negative quantity/cost basis for shorts (#1448) | `test_AC11_18_3_portfolio_fact_constraints_and_managed_position_uniqueness()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
-| AC11.18.4 | Latest report snapshots cannot conflict for the same logical report scope and report date ranges cannot be inverted | `test_AC11_18_4_report_snapshot_latest_scope_and_date_constraints()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
-| AC11.18.5 | Market-data facts enforce positive rates/prices and stock prices are unique by symbol, currency, provider source, and date | `test_AC11_18_5_market_data_constraints_and_stock_price_uniqueness()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
-| AC11.18.6 | The constraint migration declares preflight checks and migration-risk classification for existing data compatibility | `test_AC11_18_6_migration_preflights_and_risk_contract_are_declared()` | `infra/test_financial_fact_schema_invariants.py` | P0 |
+> This group's rows removed — migrated to the `audit` package roadmap as
+> `AC-audit.42.1-6` (migration closeout continuation, #1663 / #1709).
 
 ### AC11.19: Append-Only Manual Valuation Facts (Axiom A)
 

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -418,13 +418,8 @@ decision site to call the gate, and persisting the verdict on the version node,
 are incremental follow-ups; this AC owns the contract and the threshold
 consolidation.
 
-| ID | Phase | Description | Test | File | Priority |
-|----|-------|-------------|------|------|----------|
-| AC18.13.1 | Gate | A failed deterministic invariant rejects the version regardless of confidence, with a queryable reason (failing invariant + delta vs tolerance) | `test_AC18_13_1_failed_invariant_is_rejected_with_queryable_reason()` | `services/test_promotion_gate.py` | P1 |
-| AC18.13.2 | Gate | Invariants pass but confidence below threshold yields a non-authoritative review candidate | `test_AC18_13_2_invariants_pass_but_low_confidence_is_review()` | `services/test_promotion_gate.py` | P1 |
-| AC18.13.3 | Gate | Invariants pass and confidence meets threshold yields authoritative; the same contract carries both tier and reconciliation-score confidence | `test_AC18_13_3_invariants_pass_and_confidence_met_is_authoritative()` | `services/test_promotion_gate.py` | P1 |
-| AC18.13.4 | Consolidation | The previously-scattered thresholds (balance 0.001, reconciliation 85/60) are named, centrally owned, and consumed by the services | `test_AC18_13_4_thresholds_are_centrally_owned_and_consumed_by_services()` | `services/test_promotion_gate.py` | P1 |
-| AC18.13.5 | Wired | Stage-1 statement balance-chain approval is disposed by the promotion gate (balance checks as invariants), making the gate load-bearing for a real decision while preserving behavior | `test_AC18_13_5_balance_chain_decision_routes_through_promotion_gate()` | `review/test_statement_validation.py` | P1 |
+> This group's rows removed — migrated to the `audit` package roadmap as
+> `AC-audit.41.1-5` (migration closeout continuation, #1663 / #1709).
 
 ### AC18.14: Correction Feedback Loop — Corrections Drive The Proportion Down
 


### PR DESCRIPTION
## Summary

Closes #1709.

Migrates 11 backend-provable EPIC AC rows (financial-invariant promotion gate + financial fact schema invariants) into `common/audit/contract.py`'s roadmap. Part of #1663's remaining backlog, reorganized by package.

Refs #1709, parent #1663, umbrella #1416.

## What moved

| Old ID | New ID |
|---|---|
| EPIC-018 AC18.13.1-5 | `AC-audit.41.1-5` |
| EPIC-011 AC11.18.1-6 | `AC-audit.42.1-6` |

## Note on drift

`AC18.13`'s cited test file (`services/test_promotion_gate.py`) had already physically moved to `apps/backend/tests/audit/promotion/test_promotion_gate.py` in a prior PR (#1667, promotion_gate → audit.promotion relocation). Verified the current location before migrating.

## Testing

```bash
apps/backend/.venv/bin/python3 -m pytest tests/tooling/ -n 4 --no-cov -q
# 1880 passed, 1 skipped

cd apps/backend && .venv/bin/python3 -m pytest tests/audit/promotion/test_promotion_gate.py tests/review/test_statement_validation.py tests/infra/test_financial_fact_schema_invariants.py --no-cov -q
# 36 passed

moon run :lint
# All checks passed

apps/backend/.venv/bin/python3 tools/check_package_contract.py     # PASSED
apps/backend/.venv/bin/python3 tools/check_manifest.py             # clean
apps/backend/.venv/bin/python3 tools/lint_doc_consistency.py       # clean
apps/backend/.venv/bin/python3 tools/check_ac_index.py             # PASSED
apps/backend/.venv/bin/python3 tools/generate_ac_registry.py --check   # OK
apps/backend/.venv/bin/python3 tools/check_ac_tier_baseline.py     # PASSED
apps/backend/.venv/bin/python3 -m common.testing.mirror_ratchet    # 2914<=2917
```