### PR TITLE
[finance_report_ui] test(#1435,#1534): PR A — de-mirror the last two CI/deploy test gaps

### DIFF
--- a/.github/workflows/notify-infra2.yml
+++ b/.github/workflows/notify-infra2.yml
@@ -39,6 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # #1534: needed so tools/_lib/shell/resolve_report_main_dispatch_sha.sh
+      # (the extracted, testable dispatch-decision script) exists on the
+      # runner — this job previously did no repo checkout at all, since the
+      # inline bash conditional it replaces needed no file from the repo.
+      - uses: actions/checkout@v7
       - name: Dispatch repository_dispatch to infra2
         env:
           INFRA2_PAT: ${{ secrets.INFRA2_PAT }}
@@ -87,17 +92,15 @@ jobs:
             alert_and_fail "unresolved-sha" "Could not resolve current main SHA before infra2 dispatch."
           fi
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
-            dispatch_sha="${WORKFLOW_RUN_SHA:-}"
-            if [[ -z "${dispatch_sha:-}" ]]; then
-              alert_and_fail "unresolved-workflow-run-sha" "No workflow_run head SHA resolved for report-branch-main deploy."
-            fi
-            if [[ "$dispatch_sha" != "$latest_main_sha" ]]; then
-              echo "Skipping stale CI completion: workflow_run_sha=$dispatch_sha latest_main_sha=$latest_main_sha"
-              exit 0
-            fi
-          else
-            dispatch_sha="$latest_main_sha"
+          # #1534: the SHA-resolution/stale-completion decision lives in a
+          # standalone, real-execution-testable script (not inline bash) —
+          # see tools/_lib/shell/resolve_report_main_dispatch_sha.sh and
+          # tests/tooling/test_report_main_dispatch.py.
+          if ! dispatch_sha="$(tools/_lib/shell/resolve_report_main_dispatch_sha.sh "${GITHUB_EVENT_NAME}" "${WORKFLOW_RUN_SHA:-}" "$latest_main_sha")"; then
+            alert_and_fail "unresolved-workflow-run-sha" "No workflow_run head SHA resolved for report-branch-main deploy."
+          fi
+          if [[ -z "$dispatch_sha" ]]; then
+            exit 0 # stale CI completion; the resolver already logged why to stderr
           fi
 
           payload="$(jq -nc --arg sha "$dispatch_sha" \

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -16,6 +16,11 @@ import pytest
 from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 
 from tests.e2e.auth_cookie import build_auth_cookie
+from tests.e2e.critical_skip_gate import (
+    CRITICAL_MARKER,
+    critical_skip_failure_message,
+    should_convert_skip_to_failure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -93,18 +98,14 @@ def fail_or_skip_ai_ocr_gate(
 def pytest_runtest_makereport(item, call):
     outcome = yield
     report = outcome.get_result()
-    if (
-        _strict_e2e_gates_enabled()
-        and report.skipped
-        and item.get_closest_marker("critical") is not None
-        and report.when in {"setup", "call"}
+    if should_convert_skip_to_failure(
+        strict_gates_enabled=_strict_e2e_gates_enabled(),
+        skipped=report.skipped,
+        has_critical_marker=item.get_closest_marker(CRITICAL_MARKER) is not None,
+        when=report.when,
     ):
         report.outcome = "failed"
-        report.longrepr = (
-            f"Critical E2E gate skipped: {item.nodeid}. "
-            "Critical deploy usability checks must fail instead of skip when "
-            "STRICT_E2E_GATES=true."
-        )
+        report.longrepr = critical_skip_failure_message(item.nodeid)
 
 
 class AuthState:

--- a/tests/e2e/critical_skip_gate.py
+++ b/tests/e2e/critical_skip_gate.py
@@ -1,0 +1,38 @@
+"""AC8.13.6: pure predicate + message for the critical-skip-to-failure gate.
+
+Split out of conftest.py's `pytest_runtest_makereport` hookwrapper so the
+condition and message text are unit-testable without pytest's report/item
+machinery — see tests/tooling/test_critical_skip_gate.py (#1435 W1 / #1534).
+"""
+
+from __future__ import annotations
+
+CRITICAL_MARKER = "critical"
+
+
+def should_convert_skip_to_failure(
+    *,
+    strict_gates_enabled: bool,
+    skipped: bool,
+    has_critical_marker: bool,
+    when: str,
+) -> bool:
+    """A skipped result for a @pytest.mark.critical test becomes a failure
+
+    only when STRICT_E2E_GATES is enabled and the skip happened during
+    setup or the test call itself (never during teardown, which always
+    reports independently of the test outcome)."""
+    return (
+        strict_gates_enabled
+        and skipped
+        and has_critical_marker
+        and when in {"setup", "call"}
+    )
+
+
+def critical_skip_failure_message(node_id: str) -> str:
+    return (
+        f"Critical E2E gate skipped: {node_id}. "
+        "Critical deploy usability checks must fail instead of skip when "
+        "STRICT_E2E_GATES=true."
+    )

--- a/tests/tooling/test_critical_skip_gate.py
+++ b/tests/tooling/test_critical_skip_gate.py
@@ -1,0 +1,97 @@
+"""Behavioral coverage for the critical-skip-to-failure gate's decision logic.
+
+#1435 W1: replaces brittle `"text" in read("tests/e2e/conftest.py")` source
+assertions (formerly in test_AC8_13_6_critical_e2e_skips_become_failures in
+test_post_merge_e2e_gates.py) with real behavioral tests against the extracted
+pure predicate should_convert_skip_to_failure() and the message builder
+critical_skip_failure_message() — so a harmless reformat of the
+pytest_runtest_makereport hookwrapper in conftest.py can no longer accidentally
+pass or fail this check; only the actual skip-to-failure decision can.
+"""
+
+from __future__ import annotations
+
+from tests.e2e.critical_skip_gate import (
+    critical_skip_failure_message,
+    should_convert_skip_to_failure,
+)
+
+
+def test_AC8_13_6_strict_gates_off_never_converts() -> None:
+    """AC8.13.6: outside STRICT_E2E_GATES, a critical skip stays a skip."""
+    assert (
+        should_convert_skip_to_failure(
+            strict_gates_enabled=False,
+            skipped=True,
+            has_critical_marker=True,
+            when="call",
+        )
+        is False
+    )
+
+
+def test_AC8_13_6_non_critical_skip_never_converts() -> None:
+    """AC8.13.6: a skip on a test without @pytest.mark.critical is left alone."""
+    assert (
+        should_convert_skip_to_failure(
+            strict_gates_enabled=True,
+            skipped=True,
+            has_critical_marker=False,
+            when="call",
+        )
+        is False
+    )
+
+
+def test_AC8_13_6_non_skip_result_never_converts() -> None:
+    """AC8.13.6: a passing or failing critical test is untouched (only skips convert)."""
+    assert (
+        should_convert_skip_to_failure(
+            strict_gates_enabled=True,
+            skipped=False,
+            has_critical_marker=True,
+            when="call",
+        )
+        is False
+    )
+
+
+def test_AC8_13_6_teardown_phase_skip_never_converts() -> None:
+    """AC8.13.6: a skip reported during teardown does not fail the gate — only setup/call."""
+    assert (
+        should_convert_skip_to_failure(
+            strict_gates_enabled=True,
+            skipped=True,
+            has_critical_marker=True,
+            when="teardown",
+        )
+        is False
+    )
+
+
+def test_AC8_13_6_critical_skip_under_strict_gates_converts_in_setup_and_call() -> None:
+    """AC8.13.6: the ONLY converting case — strict gates on, critical marker, skipped, setup or call phase."""
+    for when in ("setup", "call"):
+        assert (
+            should_convert_skip_to_failure(
+                strict_gates_enabled=True,
+                skipped=True,
+                has_critical_marker=True,
+                when=when,
+            )
+            is True
+        )
+
+
+def test_AC8_13_6_failure_message_names_the_failing_test_and_the_reason() -> None:
+    """AC8.13.6: the converted failure's message identifies the test and demands STRICT_E2E_GATES."""
+    message = critical_skip_failure_message(
+        "tests/e2e/test_statement_full_journey.py::test_dbs_statement_full_journey"
+    )
+
+    assert (
+        "tests/e2e/test_statement_full_journey.py::test_dbs_statement_full_journey"
+        in message
+    )
+    assert "Critical E2E gate skipped" in message
+    assert "STRICT_E2E_GATES=true" in message

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -436,14 +436,19 @@ def test_AC8_10_8_registration_flow_accepts_current_landing_route() -> None:
 
 
 def test_AC8_13_6_critical_e2e_skips_become_failures() -> None:
-    """AC8.13.6: Critical staging E2E skips fail the deploy gate."""
+    """AC8.13.6: Critical staging E2E skips fail the deploy gate.
+
+    The skip-to-failure DECISION logic is covered behaviorally by
+    tests/tooling/test_critical_skip_gate.py (#1435 W1) — this checks only
+    that the hookwrapper is still wired to that logic and to the AI/OCR
+    gate helper, not the conditional itself.
+    """
     conftest = read("tests/e2e/conftest.py")
 
     assert "pytest_runtest_makereport" in conftest
     assert "fail_or_skip_ai_ocr_gate" in conftest
-    assert "critical" in conftest
+    assert "should_convert_skip_to_failure" in conftest
     assert 'report.outcome = "failed"' in conftest
-    assert "Critical E2E gate skipped" in conftest
 
 
 def test_AC8_13_7_full_statement_journey_is_a_hard_ai_ocr_gate() -> None:
@@ -1744,7 +1749,15 @@ def test_AC8_13_149_fan_in_jobs_download_only_required_artifacts() -> None:
 
 
 def test_AC8_13_146_report_main_dispatch_waits_for_ci_images() -> None:
-    """AC8.13.146: report-branch-main deploys only successful CI SHA images."""
+    """AC8.13.146: report-branch-main deploys only successful CI SHA images.
+
+    The dispatch/skip DECISION (does a workflow_run completion's SHA still
+    match main's tip, or is it stale?) is covered behaviorally by
+    tests/tooling/test_report_main_dispatch.py (#1435 W1 / #1534), which
+    executes tools/_lib/shell/resolve_report_main_dispatch_sha.sh directly.
+    This test covers the surrounding wiring: trigger config, the env-var ->
+    script-argument handoff, and the payload construction.
+    """
     notify = read(".github/workflows/notify-infra2.yml")
     notify_yaml = yaml.safe_load(notify)
     notify_on = notify_yaml.get(True) or notify_yaml.get("on")
@@ -1763,10 +1776,8 @@ def test_AC8_13_146_report_main_dispatch_waits_for_ci_images() -> None:
     )
     assert "WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}" in notify
     assert "/git/ref/heads/main" in dispatch_script
-    assert 'dispatch_sha="${WORKFLOW_RUN_SHA:-}"' in dispatch_script
-    assert 'dispatch_sha="$latest_main_sha"' in dispatch_script
+    assert "tools/_lib/shell/resolve_report_main_dispatch_sha.sh" in dispatch_script
     assert "$GITHUB_SHA" not in dispatch_script
-    assert "Skipping stale CI completion" in dispatch_script
     assert '--arg sha "$dispatch_sha"' in dispatch_script
 
     receiver = read("repo/.github/workflows/deploy-report-main.yml")

--- a/tests/tooling/test_report_main_dispatch.py
+++ b/tests/tooling/test_report_main_dispatch.py
@@ -1,0 +1,74 @@
+"""Behavioral coverage for notify-infra2.yml's dispatch-SHA decision.
+
+#1435 W1 / #1534 (AC8.13.146): replaces brittle `'dispatch_sha="${WORKFLOW_RUN_SHA:-}"'
+in dispatch_script`-style bash-line-substring assertions (formerly in
+test_AC8_13_146_report_main_dispatch_waits_for_ci_images in
+test_post_merge_e2e_gates.py) with a real execution of
+tools/_lib/shell/resolve_report_main_dispatch_sha.sh via subprocess, asserting
+on its actual stdout/exit-code behavior. A harmless reformat of the script
+(comments, whitespace, variable renaming) can no longer accidentally break
+this coverage; only the actual dispatch/skip decision can.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "tools"
+    / "_lib"
+    / "shell"
+    / "resolve_report_main_dispatch_sha.sh"
+)
+
+
+def _run(
+    event_name: str, workflow_run_sha: str, latest_main_sha: str
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCRIPT), event_name, workflow_run_sha, latest_main_sha],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_AC8_13_146_manual_dispatch_always_targets_mains_current_tip() -> None:
+    """A workflow_dispatch (manual re-trigger) always dispatches latest_main_sha, regardless of any stale workflow_run_sha value."""
+    result = _run("workflow_dispatch", "", "deadbeef0000000000000000000000000000000")
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "deadbeef0000000000000000000000000000000"
+
+
+def test_AC8_13_146_matching_workflow_run_sha_is_dispatched() -> None:
+    """A completed CI run whose SHA IS main's current tip gets dispatched."""
+    sha = "1111111111111111111111111111111111111a"
+    result = _run("workflow_run", sha, sha)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == sha
+
+
+def test_AC8_13_146_stale_workflow_run_completion_is_skipped_cleanly() -> None:
+    """A CI run that finished AFTER a later push already moved main's tip is a stale completion — skip without dispatching, and exit 0 (not an error)."""
+    result = _run(
+        "workflow_run",
+        "old0000000000000000000000000000000000000",
+        "new1111111111111111111111111111111111111",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+    assert "Skipping stale CI completion" in result.stderr
+    assert "old0000000000000000000000000000000000000" in result.stderr
+    assert "new1111111111111111111111111111111111111" in result.stderr
+
+
+def test_AC8_13_146_missing_workflow_run_sha_fails_closed() -> None:
+    """A workflow_run event with no resolvable head SHA is a real error, not a skip — the caller must alert, not silently exit 0."""
+    result = _run("workflow_run", "", "abc123")
+
+    assert result.returncode == 1
+    assert "No workflow_run head SHA resolved" in result.stderr

--- a/tools/_lib/shell/resolve_report_main_dispatch_sha.sh
+++ b/tools/_lib/shell/resolve_report_main_dispatch_sha.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Decide which SHA (if any) notify-infra2.yml should dispatch to infra2's
+# report-branch-main deploy.
+#
+# #1534 (AC8.13.146): split out of the workflow's inline bash conditional so
+# the decision is real-execution testable (tests/tooling/test_report_main_dispatch.py
+# invokes this script via subprocess with controlled inputs), not verified by
+# matching literal bash-line substrings against the workflow YAML's source text.
+#
+# Usage: resolve_report_main_dispatch_sha.sh <event_name> <workflow_run_sha> <latest_main_sha>
+#
+# Behavior:
+#   event_name != "workflow_run"   -> print latest_main_sha, exit 0 (manual
+#                                      workflow_dispatch always targets main's tip)
+#   workflow_run_sha empty         -> exit 1 (no SHA resolved for the completed run)
+#   workflow_run_sha != latest_main_sha
+#                                   -> print nothing to stdout, log why to
+#                                      stderr, exit 0 (STALE: a later push
+#                                      already superseded this CI completion —
+#                                      skip cleanly, not an error)
+#   workflow_run_sha == latest_main_sha
+#                                   -> print workflow_run_sha, exit 0
+set -euo pipefail
+
+event_name="${1:?event_name required}"
+workflow_run_sha="${2:-}"
+latest_main_sha="${3:?latest_main_sha required}"
+
+if [[ "$event_name" != "workflow_run" ]]; then
+  echo "$latest_main_sha"
+  exit 0
+fi
+
+if [[ -z "$workflow_run_sha" ]]; then
+  echo "No workflow_run head SHA resolved for report-branch-main deploy." >&2
+  exit 1
+fi
+
+if [[ "$workflow_run_sha" != "$latest_main_sha" ]]; then
+  echo "Skipping stale CI completion: workflow_run_sha=$workflow_run_sha latest_main_sha=$latest_main_sha" >&2
+  exit 0
+fi
+
+echo "$workflow_run_sha"


### PR DESCRIPTION
## Summary — PR A of the 3-PR plan closing out #1686's remaining scope

Bundles the two remaining genuine "convert to behavior" gaps found across #1435 W1's cluster audit (4 clusters, ~492 of ~548 measured assertions — see comments on #1435) plus #1534's AC8.13.146 half. Same technique for both halves: extract a pure decision function/script, add a real behavioral test, trim the now-redundant source-text assertions.

### #1435 W1 — `pytest_runtest_makereport` (AC8.13.6)
- Extracted `should_convert_skip_to_failure()` + `critical_skip_failure_message()` into `tests/e2e/critical_skip_gate.py` — a pure module with no pytest report/item objects. The hookwrapper in `conftest.py` now calls it.
- `tests/tooling/test_critical_skip_gate.py`: 6 tests covering every branch (gates off, non-critical, non-skip, teardown-phase, the converting case × 2 phases, message content).
- Trimmed `test_AC8_13_6_critical_e2e_skips_become_failures` to wiring facts only — the conditional logic is now behaviorally covered.
- Verified `tests/e2e/` still collects cleanly (49 tests) after the conftest refactor.

### #1534 — AC8.13.146 (notify-infra2.yml dispatch decision)
- The dispatch job has **no repo checkout and no Python environment** (pure bash/curl/jq/gh, 5-min timeout) — extracting to Python would add real operational cost (checkout + Python bootstrap) to a job designed to be minimal. Extracted to a standalone, real-execution-testable **shell** script instead: `tools/_lib/shell/resolve_report_main_dispatch_sha.sh`, matching the `tools/smoke_test.sh` / `tools/_lib/shell/smoke_test.sh` wrapper pattern from #1695. Added the one `actions/checkout@v7` step this now requires.
- `tests/tooling/test_report_main_dispatch.py`: 4 tests invoking the script via subprocess with controlled inputs, asserting real stdout/exit-code behavior (manual dispatch, matching SHA, **stale completion skip**, missing-SHA fail-closed).
- Trimmed `test_AC8_13_146_report_main_dispatch_waits_for_ci_images` to the surrounding wiring (trigger config, env-var handoff, payload construction) — the SHA-resolution/stale-skip decision moved to the behavioral test.

## Test plan
- [x] **Mutation testing on both new modules**: introduced a real behavioral bug in each (wrong slice comparison, inverted staleness check), confirmed the new tests fail and catch it, then reverted — proof the tests protect real behavior, not just "pass"
- [x] `pytest tests/tooling/test_critical_skip_gate.py tests/tooling/test_report_main_dispatch.py tests/tooling/test_post_merge_e2e_gates.py` — all pass
- [x] `pytest tests/e2e/ --collect-only` — 49 tests collect cleanly (conftest refactor doesn't break real e2e collection)
- [x] `pytest tests/tooling/` (full suite, 1962 tests) — all pass
- [x] `python tools/check_ac_index.py` — no regression
- [x] `python tools/check_workflow_contract.py` — OK
- [x] `actionlint .github/workflows/notify-infra2.yml` — clean
- [x] `ruff check` / `ruff format --check` — clean

Relations: #1435 (W1) · #1534 · #1686

🤖 Generated with [Claude Code](https://claude.com/claude-code)