### PR TITLE
[finance_report_vision] feat(meta): migrate EPIC-007's release-pipeline + infra-boundary ACs (#1663 wave 3)

### DIFF
--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -787,5 +787,144 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        # ── release-pipeline: promote-not-rebuild release integrity (was
+        # EPIC-007 AC7.10, migration closeout wave 3, #1416) ──
+        ACRecord(
+            id="AC-meta.release-pipeline.1",
+            statement=(
+                "The production release workflow promotes the staging-"
+                "validated `:<sha>` image to `vX.Y.Z` via `docker buildx "
+                "imagetools create` instead of rebuilding from source; fails "
+                "closed if no staging-validated SHA image exists or if the "
+                "promoted digest differs from the staging-verified digest; "
+                "records the released commit, source CI run, and promoted "
+                "image digest in the workflow summary; keeps the SSOTs "
+                "(ci-cd.md, deployment.md) documenting the promote-not-"
+                "rebuild consistency ladder; and retains a `workflow_dispatch` "
+                "dry-run that proves the release/promote path without "
+                "mutating production."
+            ),
+            test=(
+                "tests/tooling/test_post_merge_e2e_gates.py"
+                "::test_AC7_10_production_release_promotes_not_rebuilds"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        # ── infra-boundary: delivery app/infra-boundary calibration (was
+        # EPIC-007 AC7.12, #876, migration closeout wave 3, #1416) ──
+        ACRecord(
+            id="AC-meta.infra-boundary.1",
+            statement=(
+                "The staging/prod deploy compose (infra2 10.app/compose.yaml) "
+                "cannot local-build the app services (no build:, "
+                "pull_policy: always)."
+            ),
+            test=(
+                "tests/tooling/test_deploy_compose_contract.py"
+                "::test_AC7_12_3_deploy_compose_pull_not_build"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.infra-boundary.2",
+            statement=(
+                "The postgres/redis data dirs are bind-mounted via "
+                "${DATA_PATH} (not a named volume Dokploy wipes on redeploy)."
+            ),
+            test=(
+                "tests/tooling/test_deploy_compose_contract.py"
+                "::test_AC7_12_3_data_dirs_survive_redeploy"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.infra-boundary.3",
+            statement=(
+                "ci.yml's on.push.branches includes release/** so a release-"
+                "branch commit publishes a :<sha> image."
+            ),
+            test=(
+                "tests/tooling/test_publish_only_contract.py"
+                "::test_AC7_12_4_release_branches_trigger_the_publish_workflow"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.infra-boundary.4",
+            statement=(
+                "The container-image push: conditions cover main, release-"
+                "branch, and workflow_dispatch triggers."
+            ),
+            test=(
+                "tests/tooling/test_publish_only_contract.py"
+                "::test_AC7_12_4_image_push_publishes_for_main_release_and_dispatch"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.infra-boundary.5",
+            statement=(
+                "The persistent Dokploy preview (deploy-preview) runs only "
+                "via manual workflow_dispatch, never per-PR auto-deploy, "
+                "while the in-runner e2e merge gate stays automatic."
+            ),
+            test=(
+                "tests/tooling/test_publish_only_contract.py"
+                "::test_AC7_12_4_persistent_preview_is_on_demand_not_per_pr"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.infra-boundary.6",
+            statement=(
+                "environments.md defines the derived data-lane contract for "
+                "deploy_v2(service, type, version_ref, iac_ref) — the current "
+                "data sources/defaults and the four data red lines (a PR sha "
+                "never runs on prod data; prod data is anonymized before "
+                "leaving prod; non-prod object storage holds no real "
+                "uploads; a backup is not an anonymized snapshot)."
+            ),
+            test=(
+                "tests/tooling/test_data_red_lines_contract.py"
+                "::test_AC7_12_6_environments_define_data_axis_and_red_lines"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.infra-boundary.7",
+            statement=(
+                "The root SSOT does not drift back to the retired public-"
+                "axis deploy primitive; the data lane stays derived from "
+                "the deploy_v2 coordinate."
+            ),
+            test=(
+                "tests/tooling/test_data_red_lines_contract.py"
+                "::test_AC7_12_6_deploy_v2_data_lane_is_derived_not_public_axis"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.infra-boundary.8",
+            statement=(
+                "The published :<sha> frontend image is environment-"
+                "independent (same-origin /api, no concrete environment "
+                "domain baked in)."
+            ),
+            test=(
+                "tests/tooling/test_frontend_same_origin_contract.py"
+                "::test_AC7_12_8_published_frontend_image_has_no_baked_env_domain"
+            ),
+            priority="P0",
+            status="done",
+        ),
     ],
 )

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -716,7 +716,7 @@ CONTRACT = PackageContract(
             status="done",
         ),
         # ── migration-risk: database migration risk governance (was EPIC-007
-        # AC7.11, migration closeout wave 3, #1416) ──
+        # AC7.11, migration closeout wave 3, #1663) ──
         ACRecord(
             id="AC-meta.migration-risk.1",
             statement=(
@@ -788,7 +788,7 @@ CONTRACT = PackageContract(
             status="done",
         ),
         # ── release-pipeline: promote-not-rebuild release integrity (was
-        # EPIC-007 AC7.10, migration closeout wave 3, #1416) ──
+        # EPIC-007 AC7.10, migration closeout wave 3, #1663) ──
         ACRecord(
             id="AC-meta.release-pipeline.1",
             statement=(
@@ -813,7 +813,7 @@ CONTRACT = PackageContract(
             proof_kind="property",
         ),
         # ── infra-boundary: delivery app/infra-boundary calibration (was
-        # EPIC-007 AC7.12, #876, migration closeout wave 3, #1416) ──
+        # EPIC-007 AC7.12, #876, migration closeout wave 3, #1663) ──
         ACRecord(
             id="AC-meta.infra-boundary.1",
             statement=(

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -234,13 +234,11 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 
 ### AC7.10: Promote and Release Pipeline Integrity
 
-| ID | Requirement | Test Function | File | Priority |
-|----|-------------|---------------|------|----------|
-| AC7.10.1 | `deploy.yml` promotes the staging-validated image to `vX.Y.Z` instead of rebuilding from source | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
-| AC7.10.2 | Release fails closed if no staging-validated SHA image exists or if digests differ | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
-| AC7.10.3 | Workflow summary records released commit, source CI run, promoted image digest, and no rebuild | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
-| AC7.10.4 | Deployment and CI SSOTs document the promote-not-rebuild consistency ladder | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
-| AC7.10.5 | Retain `workflow_dispatch` dry-run to prove the release/promote path without mutating production | `test_AC7_10_production_release_promotes_not_rebuilds` | `tests/tooling/test_post_merge_e2e_gates.py` | P0 |
+> (AC7.10.1 / .2 / .3 / .4 / .5 removed, canonical: all five rows are proven by
+> one test, `test_AC7_10_production_release_promotes_not_rebuilds`, and
+> migrated together into [`common/meta/contract.py`](../../common/meta/contract.py)'s
+> `roadmap` as `AC-meta.release-pipeline.1`, migration closeout wave 3,
+> #1416.)
 
 ### AC7.11: Database Migration Risk Governance
 
@@ -253,14 +251,17 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 
 ### AC7.12: Delivery App/Infra-boundary calibration (#876)
 
-> Framework doc-of-record lives in issue #876 (G1–P3). This table tracks only ACs that already have a test; the rest land with their implementing PRs.
-
-| ID | Requirement | Test Function | File | Priority |
-|----|-------------|---------------|------|----------|
-| AC7.12.3 | The staging/prod deploy compose (infra2 `10.app/compose.yaml`) cannot local-build the app services (no `build:`, `pull_policy: always`), and the postgres/redis data dirs are bind-mounted via `${DATA_PATH}` (not a named volume Dokploy wipes on redeploy) | `test_AC7_12_3_deploy_compose_pull_not_build`, `test_AC7_12_3_data_dirs_survive_redeploy` | `tests/tooling/test_deploy_compose_contract.py` | P0 |
-| AC7.12.4 | App publishes the artifact: `ci.yml` pushes `:<sha>` for `main` and release-branch (`release/**`) commits, `workflow_dispatch` can publish an arbitrary sha on demand, and the persistent Dokploy preview is on-demand only (`deploy-preview` runs via `workflow_dispatch`, not per-PR auto) while the in-runner `e2e` gate stays automatic | `test_AC7_12_4_release_branches_trigger_the_publish_workflow`, `test_AC7_12_4_image_push_publishes_for_main_release_and_dispatch`, `test_AC7_12_4_persistent_preview_is_on_demand_not_per_pr` | `tests/tooling/test_publish_only_contract.py` | P1 |
-| AC7.12.6 | SSOT (`environments.md`) defines the derived data-lane contract for `deploy_v2(service, type, version_ref, iac_ref)`, the current data sources/defaults (empty / staging / anonymized prod snapshot / prod), and the four data red lines (RL-DATA-1..4): a PR sha never runs on prod data; prod data is anonymized before leaving prod; non-prod object storage holds no real uploads; a backup is not an anonymized snapshot | `test_AC7_12_6_environments_define_data_axis_and_red_lines`, `test_AC7_12_6_deploy_v2_data_lane_is_derived_not_public_axis` | `tests/tooling/test_data_red_lines_contract.py` | P1 |
-| AC7.12.8 | The published `:<sha>` front-end image is environment-independent (same-origin `/api`, no environment domain baked in); a contract test fails if a concrete environment domain appears in the published image | `test_AC7_12_8_published_frontend_image_has_no_baked_env_domain` | `tests/tooling/test_frontend_same_origin_contract.py` | P0 |
+> Framework doc-of-record lives in issue #876 (G1–P3).
+>
+> (AC7.12.3 removed, canonical: migrated to `AC-meta.infra-boundary.1` / `.2`.)
+> (AC7.12.4 removed, canonical: migrated to `AC-meta.infra-boundary.3` / `.4` / `.5`.)
+> (AC7.12.6 removed, canonical: migrated to `AC-meta.infra-boundary.6` / `.7`.)
+> (AC7.12.8 removed, canonical: migrated to `AC-meta.infra-boundary.8`.)
+>
+> All eight records live in
+> [`common/meta/contract.py`](../../common/meta/contract.py)'s `roadmap`
+> (migration closeout wave 3, #1416) — one record per underlying test
+> function.
 
 ### AC7.13: Preview rollout proof & half-update safety (#756, #758)
 

--- a/docs/project/EPIC-007.deployment.md
+++ b/docs/project/EPIC-007.deployment.md
@@ -238,12 +238,12 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 > one test, `test_AC7_10_production_release_promotes_not_rebuilds`, and
 > migrated together into [`common/meta/contract.py`](../../common/meta/contract.py)'s
 > `roadmap` as `AC-meta.release-pipeline.1`, migration closeout wave 3,
-> #1416.)
+> #1663.)
 
 ### AC7.11: Database Migration Risk Governance
 
 > Migrated to [`common/meta/contract.py`](../../common/meta/contract.py)'s
-> `roadmap` (migration closeout wave 3, #1416): `AC-meta.migration-risk.1`
+> `roadmap` (migration closeout wave 3, #1663): `AC-meta.migration-risk.1`
 > through `.5`. Migration risk governance is a repo-wide CI/release gate, not
 > a specific backend domain's behavior, so it's homed in `meta` alongside the
 > other repo-mechanical governance gates (doc-consistency, ssot-governance,
@@ -260,7 +260,7 @@ Deploy Finance Report application to production environment using Dokploy + vaul
 >
 > All eight records live in
 > [`common/meta/contract.py`](../../common/meta/contract.py)'s `roadmap`
-> (migration closeout wave 3, #1416) — one record per underlying test
+> (migration closeout wave 3, #1663) — one record per underlying test
 > function.
 
 ### AC7.13: Preview rollout proof & half-update safety (#756, #758)

--- a/tests/tooling/test_data_red_lines_contract.py
+++ b/tests/tooling/test_data_red_lines_contract.py
@@ -71,6 +71,7 @@ def _scan_text_files():
 
 
 def test_AC7_12_6_environments_define_data_axis_and_red_lines():
+    """AC-meta.infra-boundary.6: AC7.12.6: environments.md defines the data-lane sources/defaults and the four data red lines."""
     md = read("docs/ssot/environments.md")
     sources = _subsection(md, "### Data sources")
     assert sources, (
@@ -92,7 +93,7 @@ def test_AC7_12_6_environments_define_data_axis_and_red_lines():
 
 
 def test_AC7_12_6_deploy_v2_data_lane_is_derived_not_public_axis():
-    """AC7.12.6: root SSOT must not drift back to the retired public primitive."""
+    """AC-meta.infra-boundary.7: AC7.12.6: root SSOT must not drift back to the retired public primitive."""
     md = read("docs/ssot/environments.md")
     env = md.lower()
 

--- a/tests/tooling/test_deploy_compose_contract.py
+++ b/tests/tooling/test_deploy_compose_contract.py
@@ -31,6 +31,7 @@ def load(path: str) -> dict:
 
 
 def test_AC7_12_3_deploy_compose_pull_not_build():
+    """AC-meta.infra-boundary.1: AC7.12.3: the staging/prod deploy compose cannot local-build app services."""
     services = load(APP_COMPOSE)["services"]
     for name in APP_SERVICES:
         svc = services[name]
@@ -45,6 +46,7 @@ def test_AC7_12_3_deploy_compose_pull_not_build():
 
 
 def test_AC7_12_3_data_dirs_survive_redeploy():
+    """AC-meta.infra-boundary.2: AC7.12.3: postgres/redis data dirs bind-mount via ${DATA_PATH}, not a named volume."""
     for path, data_dir in DATA_COMPOSES.items():
         services = load(path)["services"]
         mounts = [

--- a/tests/tooling/test_frontend_same_origin_contract.py
+++ b/tests/tooling/test_frontend_same_origin_contract.py
@@ -31,6 +31,7 @@ _PUBLISH_BUILD_SOURCES = (".github/workflows/ci.yml", "apps/frontend/Dockerfile"
 
 
 def test_AC7_12_8_published_frontend_image_has_no_baked_env_domain():
+    """AC-meta.infra-boundary.8: AC7.12.8: the published :<sha> frontend image is environment-independent (no baked env domain)."""
     offenders = {
         src: hits
         for src in _PUBLISH_BUILD_SOURCES

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -1975,7 +1975,7 @@ def test_AC8_13_67_production_release_preserves_version_metadata() -> None:
 
 
 def test_AC7_10_production_release_promotes_not_rebuilds() -> None:
-    """AC7.10.1 - AC7.10.5: Production release promotes staging-validated SHA image and fails closed on drift."""
+    """AC-meta.release-pipeline.1: AC7.10.1 - AC7.10.5: Production release promotes staging-validated SHA image and fails closed on drift."""
     workflow = read(".github/workflows/release.yml")
     # Tag promotion stays in deploy.yml's promote job; the release line moved to
     # release.yml (#1354 / AC8.13.154).

--- a/tests/tooling/test_publish_only_contract.py
+++ b/tests/tooling/test_publish_only_contract.py
@@ -27,6 +27,7 @@ _PUBLISH_TRIGGERS = (
 
 
 def test_AC7_12_4_release_branches_trigger_the_publish_workflow():
+    """AC-meta.infra-boundary.3: AC7.12.4: ci.yml's push branches include release/** so release commits publish a :<sha> image."""
     ci = read(".github/workflows/ci.yml")
     # Target the actual `branches:` line(s), not a stray mention in a comment, so the
     # contract can't false-pass (Copilot CR).
@@ -40,6 +41,7 @@ def test_AC7_12_4_release_branches_trigger_the_publish_workflow():
 
 
 def test_AC7_12_4_image_push_publishes_for_main_release_and_dispatch():
+    """AC-meta.infra-boundary.4: AC7.12.4: container-image push: conditions cover main, release branches, and workflow_dispatch."""
     ci = read(".github/workflows/ci.yml")
     push_lines = [ln for ln in ci.splitlines() if ln.strip().startswith("push: ${{")]
     assert push_lines, (
@@ -69,6 +71,7 @@ def test_AC7_12_4_image_push_publishes_for_main_release_and_dispatch():
 
 
 def test_AC7_12_4_persistent_preview_is_on_demand_not_per_pr():
+    """AC-meta.infra-boundary.5: AC7.12.4: the persistent Dokploy preview is on-demand only; the in-runner e2e gate stays automatic."""
     pr = read(".github/workflows/preview.yml")
     # deploy-preview runs only via manual workflow_dispatch — no per-PR auto-deploy (P1a-2).
     deploy_block = pr.split("  deploy-preview:", 1)[1].split("\n  e2e:", 1)[0]


### PR DESCRIPTION
## Summary
- `AC7.10` (Promote and Release Pipeline Integrity — 5 rows, all proven by one test `test_AC7_10_production_release_promotes_not_rebuilds`) migrates into `common/meta/contract.py`'s roadmap as `AC-meta.release-pipeline.1`.
- `AC7.12` (Delivery App/Infra-boundary calibration, #876 — 4 rows, 8 underlying test functions) migrates as `AC-meta.infra-boundary.1` through `.8`, one record per test function.
- Both are repo-wide CI/release gates rather than backend domain behavior, so they join the `migration-risk` group already in `meta` from the prior wave.
- `docs/project/EPIC-007.deployment.md` raw AC-row count: 55 → 47.

## Test plan
- [x] `check_package_contract` passes — `meta`: 59 roadmap ACs, all packages OK
- [x] `tests/tooling/` full suite: 1952 passed, 1 skipped
- [x] Doc-consistency lint (`tools/lint_doc_consistency.py`): exit 0
- [x] Touched test files (`test_post_merge_e2e_gates.py`, `test_deploy_compose_contract.py`, `test_publish_only_contract.py`, `test_data_red_lines_contract.py`, `test_frontend_same_origin_contract.py`): 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)