### PR TITLE
[finance_report_audit] Migration closeout 2.5: distribute EPIC AC rows into pricing roadmap

### DIFF
--- a/apps/backend/tests/assets/test_manual_valuation_snapshots.py
+++ b/apps/backend/tests/assets/test_manual_valuation_snapshots.py
@@ -170,7 +170,7 @@ async def test_manual_valuation_components_api_returns_latest_as_of_values(clien
 
 @pytest.mark.no_db
 def test_AC22_13_1_valuation_component_item_uses_normalized_provenance_type() -> None:
-    """AC22.13.1: Component provenance stays constrained to the shared vocabulary."""
+    """AC-pricing.provenance.1: AC22.13.1: Component provenance stays constrained to the shared vocabulary."""
     assert ValuationComponentItem.__dataclass_fields__["provenance"].type == DataProvenance
 
 
@@ -282,7 +282,7 @@ async def test_manual_valuation_snapshot_service_updates_optional_fields_and_mis
 
 @pytest.mark.asyncio
 async def test_AC11_19_1_manual_valuation_correction_appends_version_and_preserves_history(db, test_user):
-    """AC11.19.1: Correcting a manual valuation appends a new version and never edits the prior fact in place.
+    """AC-pricing.manualvaluation.1: AC11.19.1: Correcting a manual valuation appends a new version and never edits the prior fact in place.
 
     Vision Axiom A: a recorded fact is never changed in place; a later correction
     accumulates as a new version, and one version maps to exactly one value.
@@ -328,7 +328,7 @@ async def test_AC11_19_1_manual_valuation_correction_appends_version_and_preserv
 
 @pytest.mark.asyncio
 async def test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth(db, test_user, ac_evidence):
-    """AC11.19.2: Heads-only reads use the current version, so a correction never double-counts."""
+    """AC-pricing.manualvaluation.2: AC11.19.2: Heads-only reads use the current version, so a correction never double-counts."""
     service = AssetService()
     key = dict(
         component_type=ManualValuationComponentType.PROPERTY_VALUE,

--- a/apps/backend/tests/market_data/test_scheduler.py
+++ b/apps/backend/tests/market_data/test_scheduler.py
@@ -12,7 +12,7 @@ from src.services.market_data_scheduler import MARKET_DATA_SYNC_TZ, next_market_
 
 
 def test_next_market_data_sync_at_uses_nightly_sgt_schedule() -> None:
-    """AC11.10.10: Nightly sync is scheduled for 22:00 Asia/Singapore."""
+    """AC-pricing.marketdata.10: AC11.10.10: Nightly sync is scheduled for 22:00 Asia/Singapore."""
     before = datetime(2026, 1, 6, 21, 0, tzinfo=MARKET_DATA_SYNC_TZ)
     after = datetime(2026, 1, 6, 23, 0, tzinfo=MARKET_DATA_SYNC_TZ)
 

--- a/apps/backend/tests/market_data/test_sync_router.py
+++ b/apps/backend/tests/market_data/test_sync_router.py
@@ -18,7 +18,7 @@ async def test_market_data_sync_endpoints_return_counts(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC11.10.5: Market data sync endpoints return scheduler-friendly counts."""
+    """AC-pricing.marketdata.5: AC11.10.5: Market data sync endpoints return scheduler-friendly counts."""
 
     async def fake_stock_sync(*_args, **_kwargs) -> market_data.MarketDataSyncResult:
         return market_data.MarketDataSyncResult(

--- a/apps/backend/tests/portfolio/test_portfolio_service.py
+++ b/apps/backend/tests/portfolio/test_portfolio_service.py
@@ -986,7 +986,7 @@ async def test_portfolio_summary_zero_cost(db, test_user, svc, account):
 
 
 async def test_update_prices_happy(db, test_user, svc, active_position):
-    """AC17.5.1: Update market prices happy path creates override.
+    """AC-pricing.providers.1: AC17.5.1: Update market prices happy path creates override.
 
     Verify that update_market_prices creates a MarketDataOverride record.
     """

--- a/apps/backend/tests/pricing/market_data/test_provider_parsers.py
+++ b/apps/backend/tests/pricing/market_data/test_provider_parsers.py
@@ -33,7 +33,7 @@ def test_market_data_helper_boundaries() -> None:
 
 
 def test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes() -> None:
-    """AC17.33.1: HK numeric exchange codes map to the Yahoo `<4-digit>.HK` symbol.
+    """AC-pricing.providers.4: AC17.33.1: HK numeric exchange codes map to the Yahoo `<4-digit>.HK` symbol.
 
     Brokerages store Hong Kong equities by their numeric board-lot code (e.g.
     Xiaomi "01810"). Sent verbatim, Yahoo 404s; it expects "1810.HK". US
@@ -55,7 +55,7 @@ def test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes() -> None:
 
 
 def test_AC17_33_2_stooq_stock_symbol_maps_hk_numeric_codes() -> None:
-    """AC17.33.2: HK numeric codes resolve to Stooq `<4-digit>.hk`; US tickers stay `.us`."""
+    """AC-pricing.providers.5: AC17.33.2: HK numeric codes resolve to Stooq `<4-digit>.hk`; US tickers stay `.us`."""
     assert market_data._stooq_stock_symbol("01810") == "1810.hk"
     assert market_data._stooq_stock_symbol("00700") == "0700.hk"
     assert market_data._stooq_stock_symbol("AAPL") == "aapl.us"
@@ -703,7 +703,7 @@ async def test_provider_http_range_wrappers_parse_success_and_http_errors(monkey
 
 
 def test_looks_like_ticker_accepts_real_tickers_rejects_free_text() -> None:
-    """AC17.15.1: Plausible tickers pass; brokerage fund-name free text is rejected."""
+    """AC-pricing.providers.2: AC17.15.1: Plausible tickers pass; brokerage fund-name free text is rejected."""
     for symbol in ("AAPL", "MSFT", "BRK.B", "0700.HK", "USDSGD", "^GSPC", "aapl"):
         assert market_data._looks_like_ticker(symbol), symbol
 
@@ -718,7 +718,7 @@ def test_looks_like_ticker_accepts_real_tickers_rejects_free_text() -> None:
 
 
 async def test_yahoo_stock_fetch_short_circuits_for_non_ticker(monkeypatch: pytest.MonkeyPatch) -> None:
-    """AC17.15.2: A non-ticker identifier skips the Yahoo request and returns None."""
+    """AC-pricing.providers.3: AC17.15.2: A non-ticker identifier skips the Yahoo request and returns None."""
 
     async def fail_if_called(*_args: object, **_kwargs: object) -> httpx.Response | None:
         raise AssertionError("Yahoo provider must not be queried for non-ticker identifiers")

--- a/apps/backend/tests/pricing/market_data/test_sync.py
+++ b/apps/backend/tests/pricing/market_data/test_sync.py
@@ -21,7 +21,7 @@ async def test_sync_stock_prices_inserts_missing_daily_rows_and_is_idempotent(
     db: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC11.10.1: Stock sync stores daily rows once and skips existing rows on rerun."""
+    """AC-pricing.marketdata.1: AC11.10.1: Stock sync stores daily rows once and skips existing rows on rerun."""
 
     async def fake_fetch(symbol: str, start_date: date, end_date: date) -> market_data.ValidatedMarketObservationSeries:
         return market_data.ValidatedMarketObservationSeries(
@@ -74,7 +74,7 @@ async def test_sync_stock_prices_fetches_decade_range_once(
     db: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC11.10.8: Long history sync uses one provider range request per symbol."""
+    """AC-pricing.marketdata.8: AC11.10.8: Long history sync uses one provider range request per symbol."""
     start = date(2016, 1, 1)
     end = date(2026, 1, 1)
     calls: list[tuple[str, date, date]] = []
@@ -115,7 +115,7 @@ async def test_sync_fx_rates_starts_after_last_stored_date(
     db: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC11.10.2: FX sync starts after the last stored date for each explicit pair."""
+    """AC-pricing.marketdata.2: AC11.10.2: FX sync starts after the last stored date for each explicit pair."""
     db.add(
         FxRate(
             base_currency="USD",
@@ -406,7 +406,7 @@ async def test_sync_stock_prices_records_missing_trading_days(
     db: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC11.10.3: Missing provider days are counted without failing the sync."""
+    """AC-pricing.marketdata.3: AC11.10.3: Missing provider days are counted without failing the sync."""
 
     async def fake_fetch(
         _symbol: str, _start_date: date, _end_date: date
@@ -464,7 +464,7 @@ async def test_stock_provider_disagreement_is_reported_without_persisting(
     db: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC11.10.4: Provider disagreement is visible and not silently persisted."""
+    """AC-pricing.marketdata.4: AC11.10.4: Provider disagreement is visible and not silently persisted."""
 
     async def fake_fetch(
         symbol: str, start_date: date, _end_date: date
@@ -505,7 +505,7 @@ async def test_portfolio_uses_synced_stock_price_before_atomic_snapshot(
     db: AsyncSession,
     test_user,
 ) -> None:
-    """AC11.10.6: Portfolio valuation prefers synced stock prices over stale snapshots."""
+    """AC-pricing.marketdata.6: AC11.10.6: Portfolio valuation prefers synced stock prices over stale snapshots."""
     account = Account(
         user_id=test_user.id,
         name="Brokerage",
@@ -748,7 +748,7 @@ async def test_market_data_freshness_sync_runs_once_after_24h(
     test_user,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC11.10.9: Report freshness checks trigger one immediate sync after 24h."""
+    """AC-pricing.marketdata.9: AC11.10.9: Report freshness checks trigger one immediate sync after 24h."""
     account = Account(
         user_id=test_user.id,
         name="USD Brokerage",

--- a/common/pricing/contract.py
+++ b/common/pricing/contract.py
@@ -59,17 +59,20 @@ pricing, never the reverse.
 
 from __future__ import annotations
 
-from common.meta.package_contract import Invariant, Kind, PackageContract, Unit
+from common.meta.package_contract import ACRecord, Invariant, Kind, PackageContract, Unit
 
 CONTRACT = PackageContract(
     name="pricing",
     # klass is not declared here — it resolves from PACKAGE_LAYER (L0 owns
     # placement in the five-layer topology, #1595); see
     # common/meta/base/layering.py, which lists pricing as "domain" (L3).
-    # Draft until the EPIC-011/005/017 pricing-owned ACs land in `roadmap`.
-    status="draft",
-    tier=None,
-    depends_on=["audit", "platform", "observability", "config"],
+    status="active",
+    tier="CODE-ONLY",
+    # "config" was dropped from this list (migration closeout continuation,
+    # #1663 / #1710): src.config is a bare top-level module, not a registered
+    # package, so it's never governed by depends_on — no other package
+    # declares it either despite importing it directly.
+    depends_on=["audit", "platform", "observability"],
     roles=["base", "extension", "data"],
     units=[
         # ── base: the pure observation + subject-identity + policy language ──
@@ -284,8 +287,277 @@ CONTRACT = PackageContract(
             ),
         ),
     ],
-    # Filled by the EPIC-011/005/017 pricing-AC migration (a later commit in
-    # PR1); the package goes status="active" with its authority tier decided
-    # there.
-    roadmap=[],
+    roadmap=[
+        # ── group marketdata: daily FX/stock market data sync (was EPIC-011
+        # AC11.10, migration closeout continuation, #1663 / #1710) ──
+        ACRecord(
+            id="AC-pricing.marketdata.1",
+            statement=(
+                "Stock price sync fetches daily prices for active holdings "
+                "and stores idempotent rows. Was EPIC-011 AC11.10.1."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_sync.py"
+                "::test_sync_stock_prices_inserts_missing_daily_rows_and_is_idempotent"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.2",
+            statement=(
+                "FX sync fetches explicit or observed pairs incrementally, "
+                "with USD/base as the default non-empty pair. Was EPIC-011 "
+                "AC11.10.2."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_sync.py"
+                "::test_sync_fx_rates_starts_after_last_stored_date"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.3",
+            statement=(
+                "Missing trading days are recorded as misses without "
+                "failing the whole sync. Was EPIC-011 AC11.10.3."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_sync.py"
+                "::test_sync_stock_prices_records_missing_trading_days"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.4",
+            statement=(
+                "Primary and secondary providers are cross-validated and "
+                "disagreements are not silently persisted. Was EPIC-011 "
+                "AC11.10.4."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_sync.py"
+                "::test_stock_provider_disagreement_is_reported_without_persisting"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.5",
+            statement=(
+                "Market data sync endpoints expose FX and stock sync status "
+                "for scheduler/E2E callers. Was EPIC-011 AC11.10.5."
+            ),
+            test=(
+                "apps/backend/tests/market_data/test_sync_router.py"
+                "::test_market_data_sync_endpoints_return_counts"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.6",
+            statement=(
+                "Portfolio valuation prefers synced stock prices over stale "
+                "brokerage snapshots. Was EPIC-011 AC11.10.6."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_sync.py"
+                "::test_portfolio_uses_synced_stock_price_before_atomic_snapshot"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.7",
+            statement=(
+                "E2E gates cover provider-backed FX sync and stock-price "
+                "portfolio valuation paths. Was EPIC-011 AC11.10.7."
+            ),
+            test=(
+                "tests/e2e/test_market_data_price_paths.py"
+                "::test_market_data_provider_sync_feeds_fx_and_stock_price_paths"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.8",
+            statement=(
+                "Long historical market data sync uses bounded range "
+                "provider requests instead of per-day provider calls. Was "
+                "EPIC-011 AC11.10.8."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_sync.py"
+                "::test_sync_stock_prices_fetches_decade_range_once"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.9",
+            statement=(
+                "Report reads check market data freshness and trigger at "
+                "most one immediate refresh when the last successful sync "
+                "is older than 24 hours. Was EPIC-011 AC11.10.9."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_sync.py"
+                "::test_market_data_freshness_sync_runs_once_after_24h"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.10",
+            statement=(
+                "Backend scheduler runs daily market data sync at the "
+                "nightly Asia/Singapore close-refresh window. Was EPIC-011 "
+                "AC11.10.10."
+            ),
+            test=(
+                "apps/backend/tests/market_data/test_scheduler.py"
+                "::test_next_market_data_sync_at_uses_nightly_sgt_schedule"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.marketdata.11",
+            statement=(
+                "Staging E2E covers report-time market data refresh from an "
+                "authenticated ordinary-user path without manual sync. Was "
+                "EPIC-011 AC11.10.11."
+            ),
+            test=(
+                "tests/e2e/test_market_data_price_paths.py"
+                "::test_market_data_provider_sync_feeds_fx_and_stock_price_paths"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group manualvaluation: append-only manual valuation facts,
+        # Axiom A (was EPIC-011 AC11.19, migration closeout continuation,
+        # #1663 / #1710) ──
+        ACRecord(
+            id="AC-pricing.manualvaluation.1",
+            statement=(
+                "Correcting a manual valuation appends a new version and "
+                "preserves the prior fact unedited as a retrievable "
+                "superseded version. Was EPIC-011 AC11.19.1."
+            ),
+            test=(
+                "apps/backend/tests/assets/test_manual_valuation_snapshots.py"
+                "::test_AC11_19_1_manual_valuation_correction_appends_version_and_preserves_history"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.manualvaluation.2",
+            statement=(
+                "Heads-only reads use the current version so a corrected "
+                "valuation is never double-counted in net worth or "
+                "listings. Was EPIC-011 AC11.19.2."
+            ),
+            test=(
+                "apps/backend/tests/assets/test_manual_valuation_snapshots.py"
+                "::test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group providers: manual price update + provider symbol/ticker
+        # handling (was EPIC-017 AC17.1.6/AC17.15/AC17.33, migration
+        # closeout continuation, #1663 / #1710) ──
+        ACRecord(
+            id="AC-pricing.providers.1",
+            statement=(
+                "A manual price update creates a MarketDataOverride record "
+                "for the given asset/date, independent of provider sync. "
+                "Was EPIC-017 AC17.1.6."
+            ),
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_update_prices_happy"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.providers.2",
+            statement=(
+                "_looks_like_ticker accepts real tickers/FX pairs and "
+                "rejects fund-name free text. Was EPIC-017 AC17.15.1."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_provider_parsers.py"
+                "::test_looks_like_ticker_accepts_real_tickers_rejects_free_text"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.providers.3",
+            statement=(
+                "A non-ticker identifier short-circuits the Yahoo stock "
+                "fetch with no HTTP call. Was EPIC-017 AC17.15.2."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_provider_parsers.py"
+                "::test_yahoo_stock_fetch_short_circuits_for_non_ticker"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.providers.4",
+            statement=(
+                "HK numeric exchange codes map to the Yahoo <4-digit>.HK "
+                "symbol while US tickers and already-suffixed symbols pass "
+                "through unchanged. Was EPIC-017 AC17.33.1."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_provider_parsers.py"
+                "::test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.providers.5",
+            statement=(
+                "HK numeric codes resolve to the Stooq <4-digit>.hk symbol "
+                "while US tickers stay .us. Was EPIC-017 AC17.33.2."
+            ),
+            test=(
+                "apps/backend/tests/pricing/market_data/test_provider_parsers.py"
+                "::test_AC17_33_2_stooq_stock_symbol_maps_hk_numeric_codes"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group provenance: normalized data-provenance vocabulary, pricing
+        # share of a dual-package row (was EPIC-022 AC22.13.1, migration
+        # closeout continuation, #1663 / #1710) ──
+        ACRecord(
+            id="AC-pricing.provenance.1",
+            statement=(
+                "Manual valuation component items expose a provenance field "
+                "constrained to the shared Imported/Manual/Derived "
+                "vocabulary. Was EPIC-022 AC22.13.1 (pricing's "
+                "ManualValuationSnapshot share of a dual-package row; the "
+                "portfolio and reporting shares stay with their own owners)."
+            ),
+            test=(
+                "apps/backend/tests/assets/test_manual_valuation_snapshots.py"
+                "::test_AC22_13_1_valuation_component_item_uses_normalized_provenance_type"
+            ),
+            priority="P1",
+            status="done",
+        ),
+    ],
 )

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -739,7 +739,7 @@ Product E2E ownership index:
 | `tests/e2e/test_four_asset_net_worth_golden_path.py` | Critical proof: AC8.13.42, AC-extraction.813.10, AC5.7.3, AC11.9.1-AC11.9.3, AC17.5.4 |
 | `tests/e2e/test_llm_provider_abstraction_epic023.py` | LLM provider abstraction product owner E2E; EPIC-023 / AC23.1 references live in the test file |
 | `tests/e2e/test_frontend_observability_epic024.py` | EPIC-024 frontend browser observability product owner E2E; AC24.1.1 reference lives in the test file |
-| `tests/e2e/test_market_data_price_paths.py` | Critical proof: AC11.10.7, AC11.10.11 |
+| `tests/e2e/test_market_data_price_paths.py` | Critical proof; ACs live in the `pricing` package roadmap (`AC-pricing.marketdata.7`, `AC-pricing.marketdata.11`, `common/pricing/contract.py`) |
 | `tests/e2e/test_personal_financial_report_package.py` | Critical proof: AC5.1.1, AC5.1.4, AC5.2.3, AC5.3.1, AC5.8.1, AC5.12.4, AC5.13.4-AC5.13.5, AC11.8.3, AC11.9.1-AC11.9.3, AC11.11.1-AC11.11.2, AC17.10.1-AC17.10.2, AC17.12.1-AC17.12.3, AC8.13.83-AC8.13.85, AC8.13.87-AC8.13.88 |
 | `tests/e2e/test_production_readonly_smoke.py` | Production-readonly smoke E2E; AC references live in the test file |
 | `tests/e2e/test_statement_full_journey.py` | Critical proof: AC8.13.1-AC8.13.5 |

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -145,19 +145,9 @@ code, tests, issues, and git history.
 
 ### AC11.10: Daily Market Data Sync
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.10.1 | Stock price sync fetches daily prices for active holdings and stores idempotent rows | `test_sync_stock_prices_inserts_missing_daily_rows_and_is_idempotent()` | `market_data/test_sync.py` | P0 |
-| AC11.10.2 | FX sync fetches explicit or observed pairs incrementally, with USD/base as the default non-empty pair | `test_sync_fx_rates_starts_after_last_stored_date()` | `market_data/test_sync.py` | P0 |
-| AC11.10.3 | Missing trading days are recorded as misses without failing the whole sync | `test_sync_stock_prices_records_missing_trading_days()` | `market_data/test_sync.py` | P0 |
-| AC11.10.4 | Primary and secondary providers are cross-validated and disagreements are not silently persisted | `test_stock_provider_disagreement_is_reported_without_persisting()` | `market_data/test_sync.py` | P0 |
-| AC11.10.5 | Market data sync endpoints expose FX and stock sync status for scheduler/E2E callers | `test_market_data_sync_endpoints_return_counts()` | `market_data/test_sync_router.py` | P0 |
-| AC11.10.6 | Portfolio valuation prefers synced stock prices over stale brokerage snapshots | `test_portfolio_uses_synced_stock_price_before_atomic_snapshot()` | `market_data/test_sync.py` | P0 |
-| AC11.10.7 | E2E gates cover provider-backed FX sync and stock-price portfolio valuation paths | `test_market_data_provider_sync_feeds_fx_and_stock_price_paths()` | `tests/e2e/test_market_data_price_paths.py` | P0 |
-| AC11.10.8 | Long historical market data sync uses bounded range provider requests instead of per-day provider calls | `test_sync_stock_prices_fetches_decade_range_once()` | `market_data/test_sync.py` | P0 |
-| AC11.10.9 | Report reads check market data freshness and trigger at most one immediate refresh when the last successful sync is older than 24 hours | `test_market_data_freshness_sync_runs_once_after_24h()` | `market_data/test_sync.py` | P0 |
-| AC11.10.10 | Backend scheduler runs daily market data sync at the nightly Asia/Singapore close-refresh window | `test_next_market_data_sync_at_uses_nightly_sgt_schedule()` | `market_data/test_scheduler.py` | P0 |
-| AC11.10.11 | Staging E2E covers report-time market data refresh from an authenticated ordinary-user path without manual sync | `test_market_data_provider_sync_feeds_fx_and_stock_price_paths()` | `tests/e2e/test_market_data_price_paths.py` | P0 |
+> This group's rows removed — migrated to the `pricing` package roadmap as
+> `AC-pricing.marketdata.1-11` (migration closeout continuation, #1663 /
+> #1710).
 
 ### AC11.13: 4-Layer Migration — Stage 1 Dual-Write Activation — migrated to the `extraction` package
 
@@ -259,10 +249,9 @@ index over `superseded_by_id IS NULL`); read paths and net-worth aggregation use
 the current head so a correction never double-counts. (In-place value editing via
 the PATCH endpoint is the documented next slice; see #918.)
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.19.1 | Correcting a manual valuation appends a new version and preserves the prior fact unedited as a retrievable superseded version | `test_AC11_19_1_manual_valuation_correction_appends_version_and_preserves_history()` | `assets/test_manual_valuation_snapshots.py` | P1 |
-| AC11.19.2 | Heads-only reads use the current version so a corrected valuation is never double-counted in net worth or listings | `test_AC11_19_2_corrected_valuation_is_not_double_counted_in_net_worth()` | `assets/test_manual_valuation_snapshots.py` | P1 |
+> This group's rows removed — migrated to the `pricing` package roadmap as
+> `AC-pricing.manualvaluation.1-2` (migration closeout continuation, #1663 /
+> #1710).
 
 ### AC11.20: Retirement and Benefit Assets
 

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -111,7 +111,13 @@ be treated as current work.
 |----|-----------|---------------|------|----------|
 | AC17.1.1 | Holdings Summary | `test_get_holdings_happy_path` | `portfolio/test_portfolio_service.py` | P0 |
 | AC17.1.5 | Unrealized P&L Calculation | `test_unrealized_pnl_happy_path` | `portfolio/test_portfolio_service.py` | P0 |
-| AC17.1.6 | Manual Price Update | `test_update_prices_happy` | `portfolio/test_portfolio_service.py` | P1 |
+
+> *(AC17.1.6 "Manual Price Update" removed — migrated to the `pricing`
+> package roadmap as `AC-pricing.providers.1`, migration closeout
+> continuation, #1663 / #1710)*
+
+| ID | Test Case | Test Function | File | Priority |
+|----|-----------|---------------|------|----------|
 | AC17.1.7 | Portfolio summary happy path returns correct counts and totals. | `test_portfolio_summary_happy` | `portfolio/test_portfolio_service.py` | P1 |
 | AC17.1.8 | Summary includes both active and disposed positions. | `test_portfolio_summary_with_disposed` | `portfolio/test_portfolio_service.py` | P1 |
 | AC17.1.9 | Zero total cost -> net_pnl_percent = 0. | `test_portfolio_summary_zero_cost` | `portfolio/test_portfolio_service.py` | P1 |
@@ -330,10 +336,9 @@ snapshot). The unpriced-drop skip is intentionally kept at `debug` to honor the
 high-volume audit-noise contract (AC-observability.8.4); surfacing dropped positions to the
 user (e.g. a report blocker) is tracked as follow-up. Issue #1035.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.15.1 | `_looks_like_ticker` accepts real tickers/FX pairs and rejects fund-name free text | `test_looks_like_ticker_accepts_real_tickers_rejects_free_text` | `apps/backend/tests/market_data/test_provider_parsers.py` | P1 |
-| AC17.15.2 | A non-ticker identifier short-circuits the Yahoo stock fetch with no HTTP call | `test_yahoo_stock_fetch_short_circuits_for_non_ticker` | `apps/backend/tests/market_data/test_provider_parsers.py` | P1 |
+> This group's rows removed — migrated to the `pricing` package roadmap as
+> `AC-pricing.providers.2-3` (migration closeout continuation, #1663 /
+> #1710).
 
 ### AC17.30: List Endpoint Pagination
 
@@ -415,7 +420,7 @@ scope decisions are:
 | Portfolio is self-developed, not outsourced to a portfolio SaaS | `vision.md` decision 1 and this EPIC objective |
 | XIRR/TWR/MWR, allocation, dividends, and cost basis are in portfolio scope | AC17.1-AC17.3, AC17.5-AC17.6, AC17.10-AC17.11 |
 | Brokerage statements are uploaded and parsed through the statement pipeline | AC17.4, EPIC-003/EPIC-013 extraction SSOT |
-| Manual price update remains valid for low-frequency holdings; provider sync is governed separately | AC17.1.6, [market_data.md](../ssot/market_data.md), AC11.10 — under the package migration, price/valuation data ownership moves to the `pricing` package (#1610); portfolio consumes prices, it does not own them |
+| Manual price update remains valid for low-frequency holdings; provider sync is governed separately | `AC-pricing.providers.1`, `AC-pricing.marketdata.1-11` (`common/pricing/contract.py`) — price/valuation data ownership moved to the `pricing` package (#1610); portfolio consumes prices, it does not own them |
 | Report-ready investment schedule is consumed by the personal report package | AC17.10 and EPIC-005 package contract |
 | Framework-specific report presentation for portfolio facts is not owned here | [framework-reporting.md](../ssot/framework-reporting.md), EPIC-020, AC17.13 |
 
@@ -495,10 +500,10 @@ actual currency. The outbound provider symbol is now exchange-qualified
 (`<4-digit>.HK`) without changing the stored symbol scope, and a new broker
 account adopts the currency of the holding that created it.
 
+> *(AC17.33.1 removed and AC17.33.2 removed — Yahoo/Stooq HK numeric-code symbol mapping migrated to the `pricing` package roadmap as `AC-pricing.providers.4-5`, migration closeout continuation, #1663 / #1710)*
+
 | AC ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC17.33.1 | HK numeric exchange codes map to the Yahoo `<4-digit>.HK` symbol while US tickers and already-suffixed symbols pass through unchanged {tier:CODE-ONLY} | `test_AC17_33_1_yahoo_stock_symbol_maps_hk_numeric_codes` | `market_data/test_provider_parsers.py` | P1 |
-| AC17.33.2 | HK numeric codes resolve to the Stooq `<4-digit>.hk` symbol while US tickers stay `.us` {tier:CODE-ONLY} | `test_AC17_33_2_stooq_stock_symbol_maps_hk_numeric_codes` | `market_data/test_provider_parsers.py` | P1 |
 | AC17.33.3 | An auto-created broker account adopts the holding's currency instead of a hardcoded USD {tier:CODE-ONLY} | `test_AC17_33_3_broker_account_uses_snapshot_currency_not_hardcoded_usd` | `portfolio/test_brokerage_position_parsing.py` | P1 |
 
 ### AC17.34: Signed (Short) Positions ([#1448](https://github.com/wangzitian0/finance_report/issues/1448))

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -336,6 +336,13 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 > position paths. This slice also carries forward two #928 accessibility review
 > comments that belong to the same trust-surface baseline.
 
+> **AC22.13.1** is a dual-package row. Its `test_manual_valuation_snapshots.py`
+> share (manual valuation component provenance) migrated to the `pricing`
+> package roadmap as **`AC-pricing.provenance.1`** (migration closeout
+> continuation, #1663 / #1710). The `test_portfolio_service.py` and
+> `test_reporting.py` shares stay here pending the `portfolio`/`reporting`
+> package migrations.
+
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
 | AC22.13.1 | Portfolio holdings, explicit as-of holdings, manual valuation snapshots, and report amount lines expose a normalized provenance enum (`imported`, `manual`, `derived`) when the source basis is known, while ambiguous holdings remain unlabeled instead of guessed | `test_portfolio_service.py`, `test_reporting.py`, `test_manual_valuation_snapshots.py` | P1 |

--- a/tests/e2e/test_market_data_price_paths.py
+++ b/tests/e2e/test_market_data_price_paths.py
@@ -70,7 +70,7 @@ def _market_valuation_lines(report: dict, broker_name: str) -> list[dict]:
 
 @ac_proof(
     "market-data-provider-price-path",
-    ac_ids=["AC11.10.7", "AC11.10.11"],
+    ac_ids=["AC-pricing.marketdata.7", "AC-pricing.marketdata.11"],
     scope="behavioral",
     ci_tier="post_merge_environment",
     trust_mode="hybrid",
@@ -88,7 +88,7 @@ def _market_valuation_lines(report: dict, broker_name: str) -> list[dict]:
 async def test_market_data_provider_sync_feeds_fx_and_stock_price_paths(
     shared_auth_state: AuthState,
 ) -> None:
-    """EPIC-005 EPIC-008 EPIC-011 EPIC-017.
+    """AC-pricing.marketdata.7 / AC-pricing.marketdata.11: EPIC-005 EPIC-008 EPIC-011 EPIC-017.
 
     AC11.10.7 AC11.10.11: Reports auto-refresh provider FX and stock data
     from a user path.


### PR DESCRIPTION
## Summary

Closes #1710.

Migrates 19 EPIC AC rows into `common/pricing/contract.py`'s roadmap (previously empty — flips the package from `status="draft"` to `status="active"`, `tier="CODE-ONLY"`). Part of #1663's remaining backlog, reorganized by package.

Refs #1710, parent #1663, umbrella #1416.

## What moved

| Old ID(s) | New ID(s) |
|---|---|
| EPIC-011 AC11.10.1-11 | `AC-pricing.marketdata.1-11` |
| EPIC-011 AC11.19.1-2 | `AC-pricing.manualvaluation.1-2` |
| EPIC-017 AC17.1.6, AC17.15.1-2, AC17.33.1-2 | `AC-pricing.providers.1-5` |
| EPIC-022 AC22.13.1 (pricing's ManualValuationSnapshot share only) | `AC-pricing.provenance.1` |

`AC22.13.1` is a dual/triple-package row (portfolio + reporting + pricing); only the pricing-owned test (`test_AC22_13_1_valuation_component_item_uses_normalized_provenance_type`) migrated here. The row stays in EPIC-022 with a note — the portfolio/reporting shares are out of scope (tracked in #1717/#1716).

## Incidental fixes

- Dropped `depends_on=["...", "config"]`'s stale `"config"` entry: `src.config` is a bare top-level module, not a registered package (folded conceptually into `runtime` in #1669, but never had its own governed prefix), and no other package that imports it declares it either. Flipping `status` to `active` turned on the contract-honesty unused-dependency check (#1674) and caught this.
- Updated a stale `@ac_proof(ac_ids=["AC11.10.7", "AC11.10.11"])` decorator on `tests/e2e/test_market_data_price_paths.py` to the new package-scoped ids — the critical-proof matrix gate reads this decorator independently of the docstring text.

## Testing

```bash
apps/backend/.venv/bin/python3 -m pytest tests/tooling/ -n 4 --no-cov -q
# 1951 passed, 1 skipped (1 pre-existing unrelated failure from local .claude/worktrees/ residue, not present in a clean checkout)

cd apps/backend && .venv/bin/python3 -m pytest tests/pricing/market_data/ tests/market_data/ tests/assets/test_manual_valuation_snapshots.py tests/portfolio/test_portfolio_service.py --no-cov -q
# 102 passed

moon run :lint
# All checks passed

apps/backend/.venv/bin/python3 tools/check_package_contract.py     # PASSED — pricing: 19 roadmap ACs
apps/backend/.venv/bin/python3 tools/check_manifest.py             # clean
apps/backend/.venv/bin/python3 tools/lint_doc_consistency.py       # clean
apps/backend/.venv/bin/python3 tools/check_ac_index.py             # PASSED
apps/backend/.venv/bin/python3 tools/generate_ac_registry.py --check   # OK
apps/backend/.venv/bin/python3 tools/check_ac_tier_baseline.py     # PASSED
apps/backend/.venv/bin/python3 -m common.testing.mirror_ratchet    # 2913<=2917
```