### PR TITLE
[finance_report_ui] test(#1681): corpus-count floor, cash-flow conservation, multi-statement acceptance

### DIFF
--- a/apps/backend/tests/e2e/test_statement_corpus_journeys.py
+++ b/apps/backend/tests/e2e/test_statement_corpus_journeys.py
@@ -221,7 +221,7 @@ def test_corpus_manifest_is_diverse():
 
 @ac_proof(
     "extraction-corpus-journeys-pr",
-    ac_ids=["AC-llm.11.2", "AC-llm.11.4"],
+    ac_ids=["AC-llm.11.2", "AC-llm.11.4", "AC-llm.11.5"],
     scope="behavioral",
     ci_tier="pr_ci",
     trust_mode="deterministic_pr",
@@ -231,8 +231,9 @@ def test_corpus_manifest_is_diverse():
 @pytest.mark.e2e
 @pytest.mark.parametrize("fingerprint", CORPUS_FINGERPRINTS, ids=lambda fp: fp[:8])
 async def test_corpus_statement_full_journey(client, db, test_user, fingerprint):
-    """EPIC-023 / AC-llm.11.2 / AC-llm.11.4: every corpus extraction output completes
-    the downstream journey and its report values tie to the corpus data.
+    """EPIC-023 / AC-llm.11.2 / AC-llm.11.4 / AC-llm.11.5: every corpus extraction
+    output completes the downstream journey and its report values tie to the
+    corpus data.
 
     GIVEN a corpus cassette's frozen extraction output seeded as a parsed statement
     WHEN driving transactions → review → approve → reconciliation → reports via the API
@@ -325,10 +326,7 @@ async def test_corpus_statement_full_journey(client, db, test_user, fingerprint)
     # default) — never equity or another asset — so total_income minus
     # total_expenses equals the posting account's net movement exactly, for
     # every corpus case regardless of institution class or category
-    # granularity. (Cash-flow's ending_cash is NOT asserted here: it only
-    # includes accounts whose auto-created name matches a cash-keyword
-    # heuristic in generate_cash_flow, which brokerage-class corpus accounts
-    # do not — see #1681 follow-up.)
+    # granularity.
     if n:
         period_start = min(row["date"] for row in case.rows)
         period_end = max(row["date"] for row in case.rows)
@@ -345,6 +343,52 @@ async def test_corpus_statement_full_journey(client, db, test_user, fingerprint)
         assert Decimal(str(income["net_income"])) == case.net_movement, (
             f"[{case.short_id}] reported net_income {income['net_income']} != corpus net movement {case.net_movement}"
         )
+
+    # AC-llm.11.5: cash-flow CONSERVATION — every corpus case's posting-account
+    # movement is accounted for exactly once, either in the ending_cash delta
+    # (generate_cash_flow's name-keyword heuristic classifies accounts named
+    # like "China Merchants Bank" / "MariBank" as cash) or as a single
+    # activity line keyed by account_id (accounts named like "moomoo" / "futu"
+    # don't match the cash-keyword heuristic and fall through to Investing).
+    # This is NOT a bug to patch: a brokerage account's balance change
+    # correctly belongs in Investing activities, not "cash", under standard
+    # cash-flow-statement accounting — #1681 originally proposed changing the
+    # heuristic to also call brokerage accounts "cash", which would have been
+    # wrong. What's asserted here instead is that nothing is silently
+    # dropped: the movement lands in exactly one place, with the sign
+    # convention cash_flow_amount() defines for a non-cash ASSET account
+    # (an asset increase consumes cash on the investing line).
+    if n:
+        cash_flow_resp = await client.get(
+            "/reports/cash-flow",
+            params={"start_date": period_start.isoformat(), "end_date": period_end.isoformat()},
+        )
+        assert cash_flow_resp.status_code == 200, cash_flow_resp.text
+        cash_flow = cash_flow_resp.json()
+
+        activity_line = next(
+            (
+                item
+                for section in ("operating", "investing", "financing")
+                for item in cash_flow[section]
+                if item.get("account_id") == account_id
+            ),
+            None,
+        )
+        if activity_line is not None:
+            assert Decimal(str(activity_line["amount"])) == -case.net_movement, (
+                f"[{case.short_id}] cash-flow activity line {activity_line['amount']} "
+                f"!= -{case.net_movement} (posting account not classified as cash)"
+            )
+        else:
+            summary = cash_flow["summary"]
+            assert Decimal(str(summary["beginning_cash"])) == Decimal("0"), (
+                f"[{case.short_id}] fresh test user must have zero beginning cash"
+            )
+            assert Decimal(str(summary["ending_cash"])) == case.net_movement, (
+                f"[{case.short_id}] cash-flow ending_cash {summary['ending_cash']} "
+                f"!= corpus net movement {case.net_movement} (posting account classified as cash)"
+            )
 
 
 @pytest.mark.e2e
@@ -385,3 +429,114 @@ async def test_corpus_zero_transaction_statement_approves_empty(client, db, test
     run_resp = await client.post("/reconciliation/runs", json={"statement_id": stmt_id})
     assert run_resp.status_code == 200, run_resp.text
     assert run_resp.json()["unmatched"] == 0
+
+
+# Three real, distinct-account corpus statements spanning Jan-Jun 2025 for the
+# multi-statement acceptance test below: CMB bank (own_cmb_2501_2506, 69 txns
+# across 6 months), MariBank (own_maribank_2505, 39 txns in May), Moomoo
+# brokerage (own_moomoo_2506, 48 txns in Jun). #950 (closed) recorded a
+# residual gap: "does the upload -> report derivation hold when more than one
+# statement accumulates in the same ledger" was never proven against REAL
+# (cassette-replayed) data, only a synthetic 12-month CSV sequence
+# (AC8.15.1). #950's own text pointed at tests/fixtures/2025_parsed.json for
+# this — that file no longer exists anywhere in the repo (verified via
+# repo-wide search before writing this test), so this proves the same
+# property against what actually exists: real corpus statements, same user,
+# combined period report.
+MULTI_STATEMENT_FINGERPRINTS: tuple[str, ...] = (
+    "61dcbca67c96bb5371188772a290d30d868be8c2ed4533352b4c4bb8a44fc046",  # CMB
+    "25e00d6718d89f0fe44dc9acf4333649bbfa467780422ef2c6b9db322d96ea21",  # MariBank
+    "a531a974fd0bd144fd4a31f63d94384210f043c94bfc81631b20d3f178c779ed",  # Moomoo
+)
+
+
+@pytest.mark.e2e
+async def test_corpus_multi_statement_acceptance_same_user(client, db, test_user):
+    """EPIC-023 / AC-llm.11.6: multiple REAL corpus statements accumulate correctly
+    in ONE user's ledger — #950's residual "more than one statement" gap, proven
+    against the real cassette corpus rather than synthetic CSVs (AC8.15.1).
+
+    GIVEN three real, distinct-account corpus statements (CMB Jan-Jun, MariBank
+    May, Moomoo Jun 2025) seeded and approved for the SAME test_user
+    WHEN generating the combined-period balance sheet and income statement
+    THEN both tie to the SUM of all three cases' net movements — the
+    derivation holds across statements accumulating in one ledger, not just
+    within a single statement's own journey.
+    """
+    cases = [load_corpus_case(fp) for fp in MULTI_STATEMENT_FINGERPRINTS]
+    account_ids: list[str] = []
+
+    for case in cases:
+        seeded = await seed_parsed_statement(
+            db,
+            test_user.id,
+            institution=case.institution,
+            original_filename=f"corpus_multi_{case.short_id}.pdf",
+            opening_balance=case.opening_balance,
+            transactions=[dict(row) for row in case.rows],
+        )
+        stmt_id = str(seeded.id)
+
+        review_resp = await client.get(f"/statements/{stmt_id}/review")
+        assert review_resp.status_code == 200, review_resp.text
+        review = review_resp.json()
+        assert review["balance_validation_result"]["closing_match"] is True, (
+            f"[{case.short_id}] balance chain must tie: {review['balance_validation_result']}"
+        )
+
+        conflicts_resp = await client.get(f"/review/conflicts/{stmt_id}")
+        assert conflicts_resp.status_code == 200, conflicts_resp.text
+        conflicts = conflicts_resp.json()
+        if conflicts["duplicates"] or conflicts["transfer_pairs"]:
+            resolve_resp = await client.post(
+                f"/review/conflicts/{stmt_id}/resolve",
+                json={
+                    "action": "confirm_distinct",
+                    "note": f"multi-statement corpus {case.short_id}: source rows verified",
+                },
+            )
+            assert resolve_resp.status_code == 200, resolve_resp.text
+
+        approve_resp = await client.post(
+            f"/statements/{stmt_id}/review/approve",
+            json={"create_account_if_missing": True},
+        )
+        assert approve_resp.status_code == 200, approve_resp.text
+        approved = approve_resp.json()
+        assert approved["journal_entries_created"] == len(case.rows)
+        account_ids.append(approved["account_id"])
+
+        run_resp = await client.post("/reconciliation/runs", json={"statement_id": stmt_id})
+        assert run_resp.status_code == 200, run_resp.text
+        assert run_resp.json()["unmatched"] == 0, (
+            f"[{case.short_id}] reconciliation left unmatched rows: {run_resp.json()}"
+        )
+
+    assert len(set(account_ids)) == 3, "each corpus statement must post to its own distinct account"
+
+    all_dates = [row["date"] for case in cases for row in case.rows]
+    period_start, period_end = min(all_dates), max(all_dates)
+    expected_total = sum((case.net_movement for case in cases), Decimal("0"))
+
+    balance_resp = await client.get("/reports/balance-sheet")
+    assert balance_resp.status_code == 200, balance_resp.text
+    balance = balance_resp.json()
+    assert balance["is_balanced"] is True
+
+    asset_lines = {line["account_id"]: Decimal(str(line["amount"])) for line in balance["assets"]}
+    combined_assets = sum((asset_lines[acc_id] for acc_id in account_ids), Decimal("0"))
+    assert combined_assets == expected_total, (
+        f"combined balance sheet assets {combined_assets} != sum of corpus net movements {expected_total}"
+    )
+
+    income_resp = await client.get(
+        "/reports/income-statement",
+        params={"start_date": period_start.isoformat(), "end_date": period_end.isoformat()},
+    )
+    assert income_resp.status_code == 200, income_resp.text
+    income = income_resp.json()
+    net_income = Decimal(str(income["total_income"])) - Decimal(str(income["total_expenses"]))
+    assert net_income == expected_total, (
+        f"combined income statement net {net_income} != sum of corpus net movements {expected_total}"
+    )
+    assert Decimal(str(income["net_income"])) == expected_total

--- a/common/llm/contract.py
+++ b/common/llm/contract.py
@@ -595,6 +595,20 @@ CONTRACT = PackageContract(
             status="done",
             proof_kind="eval",
         ),
+        # #1681/#1686: the per-case ratchet's "missing" finding only fires when a
+        # baseline LINE outlives its ground-truth file; a commit that removes a
+        # case's ground truth AND its baseline line together leaves no per-case
+        # floor to detect the loss. AC-llm.8.8 closes that gap with an
+        # independently-persisted, raise-only corpus SIZE floor. Deterministic
+        # pure-function check, not LLM-graded: proof_kind=property.
+        ACRecord(
+            id="AC-llm.8.8",
+            statement="The graded-eval corpus carries an independently-persisted, raise-only minimum-case-count floor (cassette-corpus-count-baseline.json) that fails the gate when the current case count drops below it — including when a case's ground-truth file AND its per-case baseline line are removed together in one commit, which the per-case ratchet's 'missing' check cannot see on its own",
+            test="tests/tooling/test_cassette_graded_eval.py::test_AC_corpus_count_floor_blocks_the_gate_when_corpus_is_below_it",
+            priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
         ACRecord(
             id="AC-llm.9.1",
             statement="Importing the litellm client disables litellm's aiohttp transport (so no per-`acompletion` unclosed-session leak); the transport resolver returns httpx | `test_AC23_9_1_litellm_aiohttp_transport_disabled_prevents_session_leak`",  # was AC23.9.1
@@ -713,6 +727,31 @@ CONTRACT = PackageContract(
             id="AC-llm.11.4",
             statement="Every non-empty corpus statement's income statement (queried over the statement's own transaction date range) reports total_income minus total_expenses, and net_income, exactly equal to the corpus case's net movement — proving the auto-posted double entry always lands its contra side on Income/Expense, independent of category granularity or institution class",
             test="apps/backend/tests/e2e/test_statement_corpus_journeys.py::test_corpus_statement_full_journey",
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-llm.11.5",
+            statement="Every non-empty corpus statement's cash-flow report accounts for the posting account's net movement exactly once — either as the ending_cash delta when generate_cash_flow classifies the account as cash, or as a single Investing/Operating/Financing line (sign-flipped per cash_flow_amount's ASSET convention) when it does not — proving conservation (nothing silently dropped) without asserting a name-heuristic result that would be wrong for brokerage-class accounts under standard cash-flow-statement accounting",
+            test="apps/backend/tests/e2e/test_statement_corpus_journeys.py::test_corpus_statement_full_journey",
+            priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
+        # #950 (closed) recorded a residual gap: "does the upload -> report
+        # derivation hold across more than one statement in the same ledger"
+        # was only proven against a synthetic 12-month CSV sequence
+        # (AC8.15.1), never against real (cassette-replayed) data. #950's own
+        # text pointed at tests/fixtures/2025_parsed.json for this; that file
+        # no longer exists anywhere in the repo (verified 2026-07-09). Proven
+        # instead against three real, distinct-account corpus statements
+        # (CMB/MariBank/Moomoo, Jan-Jun 2025) accumulated in one test user's
+        # ledger.
+        ACRecord(
+            id="AC-llm.11.6",
+            statement="Three real corpus statements (distinct accounts, Jan-Jun 2025) seeded and approved for the SAME user produce a combined-period balance sheet and income statement that tie exactly to the sum of all three cases' net movements — the upload->report derivation holds across multiple statements accumulating in one ledger, not just within a single statement's own journey",
+            test="apps/backend/tests/e2e/test_statement_corpus_journeys.py::test_corpus_multi_statement_acceptance_same_user",
             priority="P0",
             status="done",
             proof_kind="property",

--- a/common/llm/readme.md
+++ b/common/llm/readme.md
@@ -282,6 +282,16 @@ This mirrors the established AC behavioural-score ratchet
 - The baseline is a **persisted** floor — it is never regenerated from current
   scores (that would erase the floor).
 
+**Corpus-count floor (AC-llm.8.8, #1681/#1686)**: the per-case ratchet above
+only protects a case that HAS a baseline line — if a commit removes a case's
+ground-truth file **and** its `cassette-eval-baseline.jsonl` line together, the
+`missing` check has nothing left to compare against and the corpus silently
+shrinks. `cassette-corpus-count-baseline.json` is a **second, independent**
+raise-only floor on the corpus's total case count, checked by the same
+`check_cassette_graded_eval.py` gate and raised only by the same `--update`.
+It cannot be bypassed by a same-commit deletion because it lives outside the
+per-case JSONL entirely.
+
 ### 6.5 Coverage matrix (and its bounds)
 
 The eval set covers a **modality × institution-class × edge-condition** matrix:
@@ -391,20 +401,30 @@ Diversity invariants and an exact unpostable-row allowlist are asserted in
 code (AC-llm.11.1) so the corpus can neither silently shrink nor silently
 drop rows.
 
-**Report-value acceptance (AC-llm.11.4, #1681/#1686)**: the balance sheet
-assertion (AC-llm.11.2) and the income statement assertion (AC-llm.11.4)
-together are the corpus's report-correctness proof — not just "the journey
-completed" but "the numbers are right". The income statement identity holds
-universally (every institution class, not a name-dependent heuristic)
-because `auto_create_posted_entries_for_statement` always posts a
-transaction's contra side to an Income or Expense account (a classified
-category or the Income/Expense "Uncategorized" default), so
-`total_income − total_expenses` equals the posting account's net movement by
-double-entry construction. Cash flow's `ending_cash` is deliberately NOT
-asserted here: `generate_cash_flow` classifies "cash" accounts by a
-name-keyword heuristic (`cash`/`bank`/`checking`/`savings`/…) that brokerage-
-class corpus accounts (Moomoo, Futu) do not match — a follow-up under #1681
-needs a classification-aware assertion, not a blanket one.
+**Report-value acceptance (AC-llm.11.4/11.5, #1681/#1686)**: the balance
+sheet assertion (AC-llm.11.2), the income statement assertion (AC-llm.11.4),
+and the cash-flow conservation assertion (AC-llm.11.5) together are the
+corpus's report-correctness proof — not just "the journey completed" but
+"the numbers are right". The income statement identity holds universally
+(every institution class, not a name-dependent heuristic) because
+`auto_create_posted_entries_for_statement` always posts a transaction's
+contra side to an Income or Expense account (a classified category or the
+Income/Expense "Uncategorized" default), so `total_income − total_expenses`
+equals the posting account's net movement by double-entry construction.
+
+Cash flow is asserted differently: `generate_cash_flow` classifies "cash"
+accounts by a name-keyword heuristic (`cash`/`bank`/`checking`/`savings`/…)
+that brokerage-class corpus accounts (Moomoo, Futu) do not match. An earlier
+version of this plan treated that as a bug to patch (make brokerage accounts
+count as cash) — that would have been **wrong**: under standard cash-flow-
+statement accounting, an investment account's balance change belongs in
+Investing activities, not "cash". AC-llm.11.5 instead asserts
+**conservation**: every corpus case's posting-account movement lands in
+exactly one place — the `ending_cash` delta for cash-classified accounts, or
+a single Investing/Operating/Financing line (sign-flipped per
+`cash_flow_amount`'s ASSET convention) otherwise — so nothing is silently
+dropped, without asserting a name-heuristic result the accounting doesn't
+support.
 
 **Division of labour with staging**: PR CI proves the pipeline on committed
 extraction artifacts (zero provider spend, deterministic); the staging

--- a/common/testing/cassette_eval_baseline.py
+++ b/common/testing/cassette_eval_baseline.py
@@ -21,7 +21,16 @@ from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_BASELINE = REPO_ROOT / "common" / "testing" / "fixtures" / "cassette-eval-baseline.jsonl"
+DEFAULT_BASELINE = (
+    REPO_ROOT / "common" / "testing" / "fixtures" / "cassette-eval-baseline.jsonl"
+)
+CORPUS_COUNT_BASELINE = (
+    REPO_ROOT
+    / "common"
+    / "testing"
+    / "fixtures"
+    / "cassette-corpus-count-baseline.json"
+)
 
 BASELINE_VERSION = 1
 
@@ -111,3 +120,37 @@ def normalize_file(path: Path) -> dict[str, Any]:
     payload = load_jsonl(path)
     write_jsonl(path, payload)
     return payload
+
+
+# --------------------------------------------------------------------------- #
+# Corpus-count floor: a SEPARATE raise-only ratchet from the per-case JSONL
+# above. The per-case ratchet's "missing" finding only fires when a case's
+# baseline LINE outlives its ground-truth file; a commit that removes a
+# ground-truth file AND its baseline line together leaves no per-case floor to
+# detect the loss — the corpus silently shrinks with every existing check
+# green. This floor is independently persisted so only an explicit
+# `--update` (never a same-commit deletion) can raise it.
+# --------------------------------------------------------------------------- #
+def load_corpus_count_floor(path: Path = CORPUS_COUNT_BASELINE) -> int:
+    if not path.exists():
+        return 0
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return int(payload.get("min_cases", 0))
+
+
+def write_corpus_count_floor(path: Path, min_cases: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "_comment": (
+            "Raise-only floor for the number of graded-eval cases "
+            "(llm_cassettes/ground_truth/*.truth.json). Independent of "
+            "cassette-eval-baseline.jsonl's per-case floors so a commit that "
+            "removes a case's ground-truth file AND its baseline line together "
+            "cannot silently shrink the corpus. Raise only via "
+            "`python tools/check_cassette_graded_eval.py --update`."
+        ),
+        "min_cases": min_cases,
+    }
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )

--- a/common/testing/cassette_graded_eval.py
+++ b/common/testing/cassette_graded_eval.py
@@ -259,6 +259,26 @@ def load_cases(
 
 
 # --------------------------------------------------------------------------- #
+# Corpus-count floor (#1681 / #1686): independent of the per-case ratchet
+# below — see common.testing.cassette_eval_baseline's module docstring for why
+# a separate, explicitly-raised floor is needed.
+# --------------------------------------------------------------------------- #
+def corpus_shrink_findings(cases: list[EvalCase], floor: int) -> list[str]:
+    """A raise-only floor on corpus SIZE, not per-case scores.
+
+    Returns a non-empty finding when the current case count is below the
+    persisted floor — a real corpus shrink, not a case being re-scored.
+    """
+    if len(cases) < floor:
+        return [
+            f"corpus shrank to {len(cases)} case(s), below the floor of {floor} "
+            "(a ground-truth file was likely removed without lowering "
+            "cassette-corpus-count-baseline.json's min_cases)"
+        ]
+    return []
+
+
+# --------------------------------------------------------------------------- #
 # Ratchet evaluation.
 # --------------------------------------------------------------------------- #
 def ratcheted_baseline(

--- a/common/testing/check_cassette_graded_eval.py
+++ b/common/testing/check_cassette_graded_eval.py
@@ -18,9 +18,17 @@ import argparse
 import sys
 from pathlib import Path
 
-from common.testing.cassette_eval_baseline import DEFAULT_BASELINE, load_jsonl, write_jsonl
+from common.testing.cassette_eval_baseline import (
+    CORPUS_COUNT_BASELINE,
+    DEFAULT_BASELINE,
+    load_corpus_count_floor,
+    load_jsonl,
+    write_corpus_count_floor,
+    write_jsonl,
+)
 from common.testing.cassette_graded_eval import (
     GROUND_TRUTH_DIR,
+    corpus_shrink_findings,
     evaluate,
     load_cases,
     ratcheted_baseline,
@@ -32,6 +40,7 @@ def render(findings: dict[str, list[str]]) -> str:
     for title, key in (
         ("Regressions", "regressions"),
         ("Missing ground truth", "missing"),
+        ("Corpus shrink", "shrink"),
         ("Unbaselined cases (need a floor)", "new"),
     ):
         items = findings.get(key, [])
@@ -41,12 +50,17 @@ def render(findings: dict[str, list[str]]) -> str:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Cassette graded field-accuracy ratchet.")
+    parser = argparse.ArgumentParser(
+        description="Cassette graded field-accuracy ratchet."
+    )
     parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument(
+        "--corpus-count-baseline", type=Path, default=CORPUS_COUNT_BASELINE
+    )
     parser.add_argument(
         "--update",
         action="store_true",
-        help="Raise the per-case floor to the current scores (never lowers).",
+        help="Raise the per-case floor and the corpus-count floor to their current values (never lowers).",
     )
     return parser.parse_args(argv)
 
@@ -58,13 +72,19 @@ def main(argv: list[str] | None = None) -> int:
         print("[CASSETTE-EVAL] no ground-truth artifacts; nothing to grade.")
         return 0
 
+    cases = load_cases()
+    corpus_floor = load_corpus_count_floor(args.corpus_count_baseline)
+    shrink = corpus_shrink_findings(cases, corpus_floor)
+
     findings = evaluate(baseline_path=args.baseline)
-    # A regressed score or a vanished baseline line blocks BOTH paths. An
+    findings["shrink"] = shrink
+    # A regressed score, a vanished baseline line, or a corpus shrink blocks
+    # BOTH paths — none of these should be silently adoptable by --update. An
     # unbaselined ("new") case blocks the GATE path too — otherwise adding a case
     # (or accidentally deleting its floor) would leave the ratchet silently
     # disabled for that case while CI stays green. `--update` is the sanctioned way
     # to adopt new cases, so it does NOT treat "new" as blocking.
-    blocking_update = findings["regressions"] + findings["missing"]
+    blocking_update = findings["regressions"] + findings["missing"] + shrink
     blocking_gate = blocking_update + findings["new"]
 
     if args.update:
@@ -88,7 +108,12 @@ def main(argv: list[str] | None = None) -> int:
                 record["provenance"] = provenance.get(case_id, "")
             record.setdefault("metric", "field-accuracy")
         write_jsonl(args.baseline, updated)
-        print(f"Updated cassette-eval baseline: {args.baseline} ({len(updated['cases'])} case(s))")
+        new_floor = max(corpus_floor, len(cases))
+        write_corpus_count_floor(args.corpus_count_baseline, new_floor)
+        print(
+            f"Updated cassette-eval baseline: {args.baseline} ({len(updated['cases'])} case(s)); "
+            f"corpus-count floor: {args.corpus_count_baseline} (min_cases={new_floor})"
+        )
         return 0
 
     print(render(findings))
@@ -97,9 +122,10 @@ def main(argv: list[str] | None = None) -> int:
             print(f"::error title=Cassette graded eval::{item}", file=sys.stderr)
         print(
             "[CASSETTE-EVAL] FAILED: a committed cassette regressed below its "
-            "field-accuracy floor, lost its baselined floor, or has no floor yet. "
-            "Re-record correctly via `make llm-record`, fix the ground truth if the "
-            "statement legitimately changed, or adopt a new case's floor with "
+            "field-accuracy floor, lost its baselined floor, has no floor yet, or "
+            "the corpus shrank below its count floor. Re-record correctly via "
+            "`make llm-record`, fix the ground truth if the statement legitimately "
+            "changed, restore a removed case, or adopt a new case's floor with "
             "`python tools/check_cassette_graded_eval.py --update`.",
             file=sys.stderr,
         )

--- a/common/testing/fixtures/cassette-corpus-count-baseline.json
+++ b/common/testing/fixtures/cassette-corpus-count-baseline.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Raise-only floor for the number of graded-eval cases (llm_cassettes/ground_truth/*.truth.json). Independent of cassette-eval-baseline.jsonl's per-case floors so a commit that removes a case's ground-truth file AND its baseline line together cannot silently shrink the corpus. Raise only via `python tools/check_cassette_graded_eval.py --update`.",
+  "min_cases": 32
+}

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -712,7 +712,7 @@ Product E2E ownership index:
 | `tests/e2e/test_epic022_ia_shell.py` | EPIC-022 everyday-user IA shell product owner E2E (in-runner preview lane); AC22.1 references live in the test file |
 | `tests/e2e/test_institution_statement_journeys.py` | Per-institution live-extraction staging journeys (audit-replay corpus, #1613); ACs live in the `llm` package roadmap (AC-llm.12.1 AC-llm.12.2 AC-llm.12.3 AC-llm.12.4, `common/llm/contract.py`) |
 | `apps/backend/tests/e2e/test_epic025_dry_ssot_e2e.py` | EPIC-025 DRY/SSOT product owner E2E; `AC-reporting.dry-ssot.1` (reporting_calc extraction is behavior-preserving, `common/reporting/contract.py`) references live in the test file |
-| `apps/backend/tests/e2e/test_statement_corpus_journeys.py` | Extraction-corpus merge-tier E2E; ACs live in the `llm` package roadmap (AC-llm.11.1 AC-llm.11.2 AC-llm.11.3 AC-llm.11.4, `common/llm/contract.py`) |
+| `apps/backend/tests/e2e/test_statement_corpus_journeys.py` | Extraction-corpus merge-tier E2E; ACs live in the `llm` package roadmap (AC-llm.11.1 AC-llm.11.2 AC-llm.11.3 AC-llm.11.4 AC-llm.11.5 AC-llm.11.6, `common/llm/contract.py`) |
 | `tests/e2e/test_ac_authority_tiers_epic026.py` | EPIC-026 authority-tier pipeline product owner E2E; AC-authority.2.1/AC-authority.3.1/AC-authority.4.1 references live in the test file |
 | `tests/e2e/test_application_ai_advisor_epic021.py` | Application AI Advisor product owner E2E; AC21.1 references live in the test file |
 | `tests/e2e/test_auth_flows.py` | Deployed auth flow E2E; AC references live in the test file |

--- a/tests/tooling/test_cassette_graded_eval.py
+++ b/tests/tooling/test_cassette_graded_eval.py
@@ -302,11 +302,27 @@ def test_AC23_8_6_ground_truth_artifacts_are_synthetic() -> None:
     # Non-PII string fields that may stay verbatim. Description fields may be a pseudonym.
     # ANY other string field MUST be ``**`` — allowlist (deny-by-default), so a new key can't leak.
     safe_string_keys = {
-        "institution", "currency", "period_start", "period_end",
-        "opening_balance", "closing_balance", "opening", "closing",
-        "date", "amount", "direction", "balance_after", "suggested_category",
-        "symbol", "ticker", "isin", "asset_identifier", "asset_type",
-        "quantity", "market_value", "price",
+        "institution",
+        "currency",
+        "period_start",
+        "period_end",
+        "opening_balance",
+        "closing_balance",
+        "opening",
+        "closing",
+        "date",
+        "amount",
+        "direction",
+        "balance_after",
+        "suggested_category",
+        "symbol",
+        "ticker",
+        "isin",
+        "asset_identifier",
+        "asset_type",
+        "quantity",
+        "market_value",
+        "price",
     }
     # Broad CJK / kana / hangul coverage (Han + Ext-A + Hiragana/Katakana + Hangul) so a
     # name in any East-Asian script is caught, not just the basic Han block.
@@ -337,9 +353,15 @@ def test_AC23_8_6_ground_truth_artifacts_are_synthetic() -> None:
         data = json.loads(path.read_text(encoding="utf-8"))
         if data.get("synthetic") is True:
             continue
-        assert data.get("synthetic") is False, f"{path.name}: 'synthetic' must be set true or false"
-        extraction = _parse_extraction(CASSETTE_DIR / f"{path.name[: -len('.truth.json')]}.json")
-        assert extraction is not None, f"{path.name}: no scorable cassette to verify PII-masking"
+        assert data.get("synthetic") is False, (
+            f"{path.name}: 'synthetic' must be set true or false"
+        )
+        extraction = _parse_extraction(
+            CASSETTE_DIR / f"{path.name[: -len('.truth.json')]}.json"
+        )
+        assert extraction is not None, (
+            f"{path.name}: no scorable cassette to verify PII-masking"
+        )
         assert not cjk.search(json.dumps(extraction, ensure_ascii=False)), (
             f"{path.name}: a CJK character (likely a real name) survives in a committed real cassette"
         )
@@ -373,3 +395,136 @@ def test_AC23_8_7_single_sample_limitation_documented() -> None:
     doc = Path(__file__).resolve().parents[2] / "common" / "llm" / "readme.md"
     text = doc.read_text(encoding="utf-8").lower()
     assert "single" in text and "sample" in text
+
+
+# --------------------------------------------------------------------------- #
+# Corpus-count floor (#1681 / #1686): a SEPARATE raise-only ratchet from the
+# per-case floors above — catches a corpus SHRINK that "missing" cannot see
+# when a case's ground-truth file AND its baseline line are removed together.
+# --------------------------------------------------------------------------- #
+def test_corpus_shrink_findings_is_empty_at_or_above_the_floor() -> None:
+    from common.testing.cassette_graded_eval import EvalCase, corpus_shrink_findings
+
+    cases = [
+        EvalCase(
+            case_id="a",
+            modality="text",
+            institution_class="bank",
+            edge_condition="happy_path",
+            extracted={},
+            truth={},
+        )
+    ]
+    assert corpus_shrink_findings(cases, floor=0) == []
+    assert corpus_shrink_findings(cases, floor=1) == []
+
+
+def test_corpus_shrink_findings_flags_a_real_shrink() -> None:
+    from common.testing.cassette_graded_eval import EvalCase, corpus_shrink_findings
+
+    cases = [
+        EvalCase(
+            case_id="a",
+            modality="text",
+            institution_class="bank",
+            edge_condition="happy_path",
+            extracted={},
+            truth={},
+        )
+    ]
+    findings = corpus_shrink_findings(cases, floor=2)
+    assert len(findings) == 1
+    # Assert on the dynamic values themselves (not a hardcoded message mirror,
+    # per the mirror-assertion ratchet in common/testing/mirror_ratchet.py):
+    # the reported counts must be the actual case count and floor, not stale text.
+    assert str(len(cases)) in findings[0]
+    assert str(2) in findings[0]
+
+
+def test_corpus_count_floor_round_trips_and_defaults_to_zero(tmp_path: Path) -> None:
+    from common.testing.cassette_eval_baseline import (
+        load_corpus_count_floor,
+        write_corpus_count_floor,
+    )
+
+    missing = tmp_path / "does-not-exist.json"
+    assert load_corpus_count_floor(missing) == 0
+
+    path = tmp_path / "floor.json"
+    write_corpus_count_floor(path, 10)
+    assert load_corpus_count_floor(path) == 10
+
+
+def test_AC_corpus_count_floor_blocks_the_gate_when_corpus_is_below_it(
+    tmp_path: Path,
+) -> None:
+    """AC-llm.8.8: a floor set ABOVE the real committed corpus size fails the
+    gate — proves the check is wired into check_cassette_graded_eval.main(),
+    not just a pure function nobody calls."""
+    from common.testing.cassette_graded_eval import load_cases
+    from common.testing.check_cassette_graded_eval import main as gate_main
+
+    real_count = len(load_cases())
+    impossible_floor = tmp_path / "impossible-floor.json"
+    impossible_floor.write_text(
+        json.dumps({"min_cases": real_count + 1}), encoding="utf-8"
+    )
+
+    assert gate_main(["--corpus-count-baseline", str(impossible_floor)]) == 1
+
+
+def test_AC_corpus_count_floor_passes_when_corpus_meets_it(tmp_path: Path) -> None:
+    from common.testing.cassette_graded_eval import load_cases
+    from common.testing.check_cassette_graded_eval import main as gate_main
+
+    real_count = len(load_cases())
+    ok_floor = tmp_path / "ok-floor.json"
+    ok_floor.write_text(json.dumps({"min_cases": real_count}), encoding="utf-8")
+
+    assert gate_main(["--corpus-count-baseline", str(ok_floor)]) == 0
+
+
+def test_AC_corpus_count_floor_update_raises_to_current_count_never_lowers(
+    tmp_path: Path,
+) -> None:
+    from common.testing.cassette_eval_baseline import load_corpus_count_floor
+    from common.testing.cassette_graded_eval import load_cases
+    from common.testing.check_cassette_graded_eval import main as gate_main
+
+    real_count = len(load_cases())
+    # --baseline points at an ISOLATED tmp per-case file too, so --update never
+    # touches the real committed cassette-eval-baseline.jsonl in this test.
+    per_case_baseline = tmp_path / "per-case.jsonl"
+    per_case_baseline.write_text("", encoding="utf-8")
+    floor_path = tmp_path / "floor.json"
+    floor_path.write_text(json.dumps({"min_cases": 1}), encoding="utf-8")
+
+    assert (
+        gate_main(
+            [
+                "--baseline",
+                str(per_case_baseline),
+                "--corpus-count-baseline",
+                str(floor_path),
+                "--update",
+            ]
+        )
+        == 0
+    )
+    assert load_corpus_count_floor(floor_path) == real_count
+
+    # A second --update with the corpus unchanged does not lower the floor
+    # (idempotent: max(existing, current) == existing == current here).
+    assert (
+        gate_main(
+            [
+                "--baseline",
+                str(per_case_baseline),
+                "--corpus-count-baseline",
+                str(floor_path),
+                "--update",
+            ]
+        )
+        == 0
+    )
+    assert load_corpus_count_floor(floor_path) == real_count


### PR DESCRIPTION
## Summary

Delivers the achievable remainder of #1681's real-corpus test-chain integration (#1686 Phase 1). Two premises in the original #1681 plan turned out to be wrong on closer inspection — corrected here rather than implemented as originally written:

- **Item 1 (raw-bytes ingestion lane) — not attempted.** 9 of the 10 corpus cassettes are the user's own real personal statements; their original PDF bytes are gitignored/local-only per RL-6 and were never committed. Building a raw-bytes lane as scoped needs a live-provider recording session (real API spend, permanent corpus artifact). Left open on #1681 pending an explicit go-ahead — not something to do autonomously.
- **Item 4 (cash-flow "fix") — the original plan was accounting-incorrect.** `generate_cash_flow`'s `is_cash_account()` heuristic correctly classifies non-cash-named ASSET accounts (e.g. brokerage) as **Investing** activity, not cash — that's standard cash-flow-statement accounting, not a bug. "Fixing" it to also match brokerage accounts would have been wrong. Delivered a conservation assertion instead.

### Delivered

- **AC-llm.8.8 — corpus-count floor.** A second, independent raise-only ratchet on the total graded-eval case count (`common/testing/fixtures/cassette-corpus-count-baseline.json`), wired into `check_cassette_graded_eval`'s gate/`--update` paths. The pre-existing per-case ratchet's "missing" check only fires when a baseline *line* outlives its ground-truth *file*; a commit that deletes a ground-truth file **and** its baseline line together leaves no per-case floor to catch the loss. Verified via manual mutation test (delete a ground-truth file + its baseline line together → old checks stay green, new floor catches it) before writing the automated regression test.
- **AC-llm.11.5 — cash-flow conservation.** Every corpus case's posting-account movement over its statement period is asserted to land in exactly one place: the cash-flow summary's `ending_cash` delta if `is_cash_account()` classifies it as cash, or a single activity line (operating/investing/financing) otherwise. Verified across both bank-class and brokerage-class corpus cases.
- **AC-llm.11.6 — multi-statement acceptance.** `tests/fixtures/2025_parsed.json`, referenced in #950's original text, no longer exists anywhere in the repo (confirmed via repo-wide search). Delivered the same property against what actually exists: `test_corpus_multi_statement_acceptance_same_user` seeds three real, distinct-account corpus statements (CMB, MariBank, Moomoo) for one test user and asserts the combined-period balance sheet + income statement tie to the sum of all three cases' net movements.

### Incidental fix

Two new `corpus_shrink_findings` test assertions initially string-matched the finding message ("shrank to 1" / "floor of 2" `in` message), which tripped the #1435 mirror-assertion ratchet (2917 → 2919, `tests/tooling/test_package_declaration_and_ratchet.py`). Rewrote them to assert on the dynamic values themselves (`str(len(cases))` / `str(floor)` in message) — same behavioral coverage, no longer brittle to message rewording, ratchet stays at baseline.

Rebased onto latest `main` (post PR #1726 merge + 3 other merges) before finalizing; `EPIC-008.testing-strategy.md`'s ownership-row edit auto-merged cleanly against main's own edit to the same table.

Refs #1681, #1686.

## Test plan

- [x] `tests/tooling/` full suite: 1968 passed, 1 skipped (repo root, `pytest tests/tooling/ -q`)
- [x] `apps/backend/tests/e2e/test_statement_corpus_journeys.py`: 13/13 passed with real local Postgres (`-m e2e`)
- [x] `tools/check_ac_index.py`: PASSED (1990 AC nodes, no dangling links)
- [x] `tools/check_package_contract.py`: PASSED (all 16 packages OK)
- [x] `ruff check` / `ruff format --check`: clean on all changed files
- [x] Mutation-test proof for AC-llm.8.8 (delete ground-truth file + baseline line together → old checks blind, new floor catches it)
- [x] Pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
