### PR TITLE
[finance_report_ui] fix: resolve Copilot review comments from #1726

### DIFF
--- a/.github/workflows/notify-infra2.yml
+++ b/.github/workflows/notify-infra2.yml
@@ -96,7 +96,7 @@ jobs:
           # standalone, real-execution-testable script (not inline bash) —
           # see tools/_lib/shell/resolve_report_main_dispatch_sha.sh and
           # tests/tooling/test_report_main_dispatch.py.
-          if ! dispatch_sha="$(tools/_lib/shell/resolve_report_main_dispatch_sha.sh "${GITHUB_EVENT_NAME}" "${WORKFLOW_RUN_SHA:-}" "$latest_main_sha")"; then
+          if ! dispatch_sha="$(bash tools/_lib/shell/resolve_report_main_dispatch_sha.sh "${GITHUB_EVENT_NAME}" "${WORKFLOW_RUN_SHA:-}" "$latest_main_sha")"; then
             alert_and_fail "unresolved-workflow-run-sha" "No workflow_run head SHA resolved for report-branch-main deploy."
           fi
           if [[ -z "$dispatch_sha" ]]; then

--- a/tests/tooling/test_report_main_dispatch.py
+++ b/tests/tooling/test_report_main_dispatch.py
@@ -26,7 +26,7 @@ SCRIPT = (
 
 def _run(
     event_name: str, workflow_run_sha: str, latest_main_sha: str
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", str(SCRIPT), event_name, workflow_run_sha, latest_main_sha],
         capture_output=True,


### PR DESCRIPTION
## Summary

#1726 merged with 2 unresolved Copilot review comments (couldn't push more commits to that branch after merge). This is the follow-up, mirroring the same pattern as #1699.

- `.github/workflows/notify-infra2.yml`: invoke `resolve_report_main_dispatch_sha.sh` via `bash <script>` instead of relying on the executable bit, matching repo convention and avoiding a possible `Permission denied` if the file mode isn't preserved on checkout.
- `tests/tooling/test_report_main_dispatch.py`: use the `subprocess.CompletedProcess[str]` generic (the helper runs with `text=True`), matching other tooling tests in this repo.

Checked all other `[finance_report_ui]`-scope PRs merged in the last 24h (#1691, #1693, #1688, #1699, #1695, #1713, #1700) — no other unresolved review threads found.

## Test plan

- [x] `tests/tooling/test_report_main_dispatch.py`: 4/4 passed
- [x] `ruff check` / `ruff format --check`: clean
- [x] `.github/workflows/notify-infra2.yml` YAML parses valid
- [x] Pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
