### PR TITLE
[finance_report_ui] fix: resolve Copilot review comments from #1732

### DIFF
--- a/apps/backend/tests/e2e/test_statement_corpus_journeys.py
+++ b/apps/backend/tests/e2e/test_statement_corpus_journeys.py
@@ -450,6 +450,15 @@ MULTI_STATEMENT_FINGERPRINTS: tuple[str, ...] = (
 )
 
 
+@ac_proof(
+    "extraction-corpus-multi-statement-pr",
+    ac_ids=["AC-llm.11.6"],
+    scope="behavioral",
+    ci_tier="pr_ci",
+    trust_mode="deterministic_pr",
+    source_classes=["bank_statement"],
+    issue="#1681",
+)
 @pytest.mark.e2e
 async def test_corpus_multi_statement_acceptance_same_user(client, db, test_user):
     """EPIC-023 / AC-llm.11.6: multiple REAL corpus statements accumulate correctly

--- a/common/testing/cassette_eval_baseline.py
+++ b/common/testing/cassette_eval_baseline.py
@@ -132,10 +132,21 @@ def normalize_file(path: Path) -> dict[str, Any]:
 # `--update` (never a same-commit deletion) can raise it.
 # --------------------------------------------------------------------------- #
 def load_corpus_count_floor(path: Path = CORPUS_COUNT_BASELINE) -> int:
+    """Load the persisted corpus-count floor; a missing file is a zero floor.
+
+    A missing file defaults to 0, but a PRESENT ``min_cases`` that is not a
+    non-negative integer is a hard error rather than a silent coercion:
+    ``int(-5)`` or ``int(1.5)`` would silently weaken or disable the ratchet.
+    """
     if not path.exists():
         return 0
     payload = json.loads(path.read_text(encoding="utf-8"))
-    return int(payload.get("min_cases", 0))
+    min_cases = payload.get("min_cases", 0)
+    if isinstance(min_cases, bool) or not isinstance(min_cases, int) or min_cases < 0:
+        raise ValueError(
+            f"{path}: 'min_cases' must be a non-negative integer, got {min_cases!r}"
+        )
+    return min_cases
 
 
 def write_corpus_count_floor(path: Path, min_cases: int) -> None:

--- a/common/testing/cassette_graded_eval.py
+++ b/common/testing/cassette_graded_eval.py
@@ -26,7 +26,11 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
-from common.testing.cassette_eval_baseline import DEFAULT_BASELINE, load_jsonl
+from common.testing.cassette_eval_baseline import (
+    CORPUS_COUNT_BASELINE,
+    DEFAULT_BASELINE,
+    load_jsonl,
+)
 from common.testing.check_llm_cassettes import CASSETTE_DIR, _response_text
 
 GROUND_TRUTH_DIR = CASSETTE_DIR / "ground_truth"
@@ -263,7 +267,9 @@ def load_cases(
 # below — see common.testing.cassette_eval_baseline's module docstring for why
 # a separate, explicitly-raised floor is needed.
 # --------------------------------------------------------------------------- #
-def corpus_shrink_findings(cases: list[EvalCase], floor: int) -> list[str]:
+def corpus_shrink_findings(
+    cases: list[EvalCase], floor: int, baseline_path: Path = CORPUS_COUNT_BASELINE
+) -> list[str]:
     """A raise-only floor on corpus SIZE, not per-case scores.
 
     Returns a non-empty finding when the current case count is below the
@@ -272,8 +278,8 @@ def corpus_shrink_findings(cases: list[EvalCase], floor: int) -> list[str]:
     if len(cases) < floor:
         return [
             f"corpus shrank to {len(cases)} case(s), below the floor of {floor} "
-            "(a ground-truth file was likely removed without lowering "
-            "cassette-corpus-count-baseline.json's min_cases)"
+            f"(a ground-truth file was likely removed without lowering "
+            f"{baseline_path.name}'s min_cases)"
         ]
     return []
 

--- a/common/testing/check_cassette_graded_eval.py
+++ b/common/testing/check_cassette_graded_eval.py
@@ -74,7 +74,9 @@ def main(argv: list[str] | None = None) -> int:
 
     cases = load_cases()
     corpus_floor = load_corpus_count_floor(args.corpus_count_baseline)
-    shrink = corpus_shrink_findings(cases, corpus_floor)
+    shrink = corpus_shrink_findings(
+        cases, corpus_floor, baseline_path=args.corpus_count_baseline
+    )
 
     findings = evaluate(baseline_path=args.baseline)
     findings["shrink"] = shrink
@@ -101,7 +103,7 @@ def main(argv: list[str] | None = None) -> int:
         # Carry provenance from the cases for new floors.
         provenance = {
             c.case_id: f"{c.modality}/{c.institution_class}/{c.edge_condition}"
-            for c in load_cases()
+            for c in cases
         }
         for case_id, record in updated["cases"].items():
             if not record.get("provenance"):

--- a/tests/tooling/test_cassette_graded_eval.py
+++ b/tests/tooling/test_cassette_graded_eval.py
@@ -16,6 +16,8 @@ import json
 from decimal import Decimal
 from pathlib import Path
 
+import pytest
+
 from common.testing.cassette_graded_eval import (
     GROUND_TRUTH_DIR,
     REQUIRED_EDGE_CONDITIONS,
@@ -432,13 +434,14 @@ def test_corpus_shrink_findings_flags_a_real_shrink() -> None:
             truth={},
         )
     ]
-    findings = corpus_shrink_findings(cases, floor=2)
+    floor = 2
+    findings = corpus_shrink_findings(cases, floor=floor)
     assert len(findings) == 1
     # Assert on the dynamic values themselves (not a hardcoded message mirror,
     # per the mirror-assertion ratchet in common/testing/mirror_ratchet.py):
     # the reported counts must be the actual case count and floor, not stale text.
     assert str(len(cases)) in findings[0]
-    assert str(2) in findings[0]
+    assert str(floor) in findings[0]
 
 
 def test_corpus_count_floor_round_trips_and_defaults_to_zero(tmp_path: Path) -> None:
@@ -453,6 +456,18 @@ def test_corpus_count_floor_round_trips_and_defaults_to_zero(tmp_path: Path) -> 
     path = tmp_path / "floor.json"
     write_corpus_count_floor(path, 10)
     assert load_corpus_count_floor(path) == 10
+
+
+def test_corpus_count_floor_fails_closed_on_malformed_min_cases(tmp_path: Path) -> None:
+    """A present-but-invalid min_cases (negative, non-integer, non-numeric) is a
+    hard error, not a silent coercion — a bad edit should not weaken the ratchet."""
+    from common.testing.cassette_eval_baseline import load_corpus_count_floor
+
+    for bad_value in (-5, 1.5, "not-a-number", True):
+        path = tmp_path / f"bad-{bad_value}.json"
+        path.write_text(json.dumps({"min_cases": bad_value}), encoding="utf-8")
+        with pytest.raises((ValueError, TypeError)):
+            load_corpus_count_floor(path)
 
 
 def test_AC_corpus_count_floor_blocks_the_gate_when_corpus_is_below_it(


### PR DESCRIPTION
## Summary

#1732 merged with 5 unresolved Copilot review comments (couldn't push more commits after merge). Follow-up, same pattern as #1699/#1733.

- `test_cassette_graded_eval.py`: use a local `floor` variable instead of hardcoding `floor=2` and `str(2)` separately, so the assertion can't silently diverge from the value actually passed in.
- `cassette_graded_eval.py`: `corpus_shrink_findings()` takes a `baseline_path` parameter (default `CORPUS_COUNT_BASELINE`) and names the actual file in its message instead of hardcoding the default filename — stays accurate when `--corpus-count-baseline` points elsewhere.
- `cassette_eval_baseline.py`: `load_corpus_count_floor()` now fails closed on a malformed `min_cases` (negative, non-integer, non-numeric) instead of silently coercing via `int(...)`, matching the fail-closed pattern already established by `common/testing/protection.py`'s `load_floor()`. New regression test exercises all 4 malformed-value shapes.
- `test_statement_corpus_journeys.py`: decorate the new AC-llm.11.6 (multi-statement acceptance) test with `@ac_proof` — it was missing the decorator, so it wasn't picked up by the repo's static proof-collection scan (confirmed: `@ac_proof` edge count 108 → 109 after this fix, via `tools/check_ac_index.py`).
- `check_cassette_graded_eval.py`: `--update`'s provenance dict now reuses the `cases` already loaded earlier in `main()` instead of a second `load_cases()` call.

## Test plan

- [x] `tests/tooling/test_cassette_graded_eval.py`: 20/20 passed (new malformed-`min_cases` test included)
- [x] `tests/tooling/` full suite: 1968 passed, 1 skipped
- [x] `apps/backend/tests/e2e/test_statement_corpus_journeys.py`: 13/13 passed (`-m e2e`, real local Postgres)
- [x] `tools/check_ac_index.py`: PASSED — `@ac_proof` edges 108 → 109 (new decorator picked up)
- [x] `tools/check_package_contract.py`: PASSED
- [x] Mirror-assertion ratchet (`test_AC8_24_3_...`): still passes, no growth
- [x] Manual mutation check: `load_corpus_count_floor` raises `ValueError` for `-5`, `1.5`, `"not-a-number"`, `True`; accepts valid non-negative ints
- [x] `ruff check` / `ruff format --check`: clean
- [x] Pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
