### PR TITLE
[finance_report_ui] fix(#1690): install pyyaml before generating the evidence bundle

### DIFF
--- a/.github/workflows/audit-replay.yml
+++ b/.github/workflows/audit-replay.yml
@@ -125,6 +125,9 @@ jobs:
           PROVIDER_STATUS: ${{ needs.audit-replay.outputs.ai_ocr_status }}
           PROVIDER_EXIT_CODE: ${{ needs.audit-replay.outputs.ai_ocr_exit_code }}
         run: |
+          # ac_tier_water_line() -> check_ac_tier_baseline -> generate_ac_registry
+          # -> ac_registry_format needs PyYAML; this job is bare setup-python.
+          python -m pip install --quiet pyyaml
           python tools/generate_evidence_bundle.py \
             --output evidence-bundle.json \
             --github-summary "$GITHUB_STEP_SUMMARY" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1541,6 +1541,10 @@ jobs:
 
       - name: Generate evidence bundle
         run: |
+          # ac_tier_water_line() -> check_ac_tier_baseline -> generate_ac_registry
+          # -> ac_registry_format needs PyYAML; this job is bare setup-python
+          # (matches the ac-behavioral-ratchet job's same gotcha above).
+          python -m pip install --quiet pyyaml
           python tools/generate_evidence_bundle.py \
             --output evidence-bundle.json \
             --github-summary "$GITHUB_STEP_SUMMARY" \

--- a/tests/tooling/test_evidence_bundle.py
+++ b/tests/tooling/test_evidence_bundle.py
@@ -19,6 +19,20 @@ from common.testing import evidence_bundle as eb
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def assert_pyyaml_installed_before_generator(
+    commands: str, generator_script: str
+) -> None:
+    """ac_tier_water_line() -> check_ac_tier_baseline -> generate_ac_registry ->
+    ac_registry_format needs PyYAML at import time; both producer jobs use a
+    bare setup-python step (no project dependency install), so a missing
+    `pip install pyyaml` crashes the generator with ModuleNotFoundError before
+    it ever runs (caught live on main's first real evidence-bundle run, #1690
+    follow-up) — this must run BEFORE the generator, not just be present."""
+    install_marker = "pip install --quiet pyyaml"
+    assert install_marker in commands
+    assert commands.index(install_marker) < commands.index(generator_script)
+
+
 # --------------------------------------------------------------------------- #
 # Per-water-line readers — each tolerant of a missing/empty baseline.
 # --------------------------------------------------------------------------- #
@@ -278,6 +292,7 @@ def test_AC8_13_165_both_producers_wire_the_same_generator_into_their_workflow()
     assert generator_script in ci_commands
     provider_flag = "--provider-status"
     assert provider_flag not in ci_commands
+    assert_pyyaml_installed_before_generator(ci_commands, generator_script)
 
     audit_workflow = yaml.safe_load(
         (ROOT / ".github" / "workflows" / "audit-replay.yml").read_text()
@@ -291,6 +306,7 @@ def test_AC8_13_165_both_producers_wire_the_same_generator_into_their_workflow()
     )
     assert generator_script in audit_commands
     assert provider_flag in audit_commands
+    assert_pyyaml_installed_before_generator(audit_commands, generator_script)
 
     for workflow in (ci_workflow, audit_workflow):
         job = workflow["jobs"]["evidence-bundle"]


### PR DESCRIPTION
## Summary

Caught live on main's first real run of the new `evidence-bundle` job after #1741 merged (run [29069281916](https://github.com/wangzitian0/finance_report/actions/runs/29069281916)): `ModuleNotFoundError: No module named 'yaml'`.

`ac_tier_water_line()` → `common.meta.extension.check_ac_tier_baseline` → `generate_ac_registry` → `ac_registry_format` imports `yaml` at module level. Both producer jobs (`ci.yml`'s `evidence-bundle`, `audit-replay.yml`'s `evidence-bundle`) use a bare `actions/setup-python` step with no project dependency install, so the transitive import crashed the generator before it produced anything — exactly the same gotcha `ci.yml`'s sibling `ac-behavioral-ratchet` job already works around one job up (its own "needs PyYAML... this job is bare setup-python" comment, which I read but didn't apply to my own new job).

Non-blocking (informational job, not in `finish`'s needs), so this did not redden the merge gate — but it did mean main never actually got an evidence bundle out of its first run.

**Also fixed the test gap**: `test_AC8_13_165_both_producers_wire_the_same_generator_into_their_workflow` passed even though the actual runtime was broken, because it only checked the generator script was *present* in the step text, not that PyYAML was installed *before* it. Strengthened it to assert both, and verified via mutation test that the new assertion fails against the pre-fix workflow files and passes against the fix.

## Test plan

- [x] `tests/tooling/test_evidence_bundle.py`: 22/22 passed
- [x] `tests/tooling/` full suite: 2004 passed, 1 skipped
- [x] Mutation test: reverted only the two workflow YAML files (kept the strengthened test) → confirmed it fails with the exact missing-marker assertion; reapplied the fix → passes
- [x] `.github/workflows/ci.yml` / `audit-replay.yml` YAML parses valid
- [x] `ruff check` / `ruff format --check`: clean
- [x] Pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
