### PR TITLE
fix: resolve Copilot review comments from #1743

### DIFF
--- a/apps/backend/src/platform/__init__.py
+++ b/apps/backend/src/platform/__init__.py
@@ -27,9 +27,6 @@ re-exported below are the *entire* public surface (``__all__`` must equal
 through its port).
 """
 
-# ORM models owned by this package (moved from src/models, #1675); imported
-# eagerly and FIRST so a re-entrant circular import finds them bound, and so
-# importing the package registers the mappers on Base.metadata.
 from __future__ import annotations
 
 from src.platform.base import (
@@ -63,6 +60,9 @@ from src.platform.extension import (
     register_readiness_provider,
     update_workflow_event_status,
 )
+
+# ORM models owned by this package (moved from src/models, #1675); imported
+# eagerly so importing the package registers the mappers on Base.metadata.
 from src.platform.orm.app_config import BASE_CURRENCY_KEY, AppConfig
 from src.platform.orm.ping_state import PingState
 

--- a/apps/backend/src/pricing/__init__.py
+++ b/apps/backend/src/pricing/__init__.py
@@ -26,9 +26,6 @@ and the ``data/`` projections are reserved (declared in the contract's
 ``units`` with no module path) for a later commit.
 """
 
-# ORM models owned by this package (moved from src/models, #1675); imported
-# eagerly and FIRST so a re-entrant circular import finds them bound, and so
-# importing the package registers the mappers on Base.metadata.
 from __future__ import annotations
 
 from src.pricing.base import (
@@ -66,6 +63,9 @@ from src.pricing.extension.valuation import (
     ValuationService,
     ValuationServiceError,
 )
+
+# ORM models owned by this package (moved from src/models, #1675); imported
+# eagerly so importing the package registers the mappers on Base.metadata.
 from src.pricing.orm.market_data import FxRate, MarketDataSyncState, StockPrice
 
 __all__ = [

--- a/apps/backend/src/reconciliation/__init__.py
+++ b/apps/backend/src/reconciliation/__init__.py
@@ -1,8 +1,5 @@
 """``reconciliation`` — matching, review consistency, and transfer pairing domain."""
 
-# ORM models owned by this package (moved from src/models, #1675); imported
-# eagerly and FIRST so a re-entrant circular import finds them bound, and so
-# importing the package registers the mappers on Base.metadata.
 from __future__ import annotations
 
 from src.reconciliation.base import (
@@ -68,6 +65,9 @@ from src.reconciliation.extension.scoring import (
     score_pattern,
     weighted_total,
 )
+
+# ORM models owned by this package (moved from src/models, #1675); imported
+# eagerly so importing the package registers the mappers on Base.metadata.
 from src.reconciliation.orm.consistency_check import CheckStatus, CheckType, ConsistencyCheck
 
 __all__ = [

--- a/tests/tooling/test_seed_fx_rates.py
+++ b/tests/tooling/test_seed_fx_rates.py
@@ -10,6 +10,7 @@ import sys
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 # ---------------------------------------------------------------------------
@@ -40,6 +41,8 @@ _MODULE_STUBS: dict[str, object] = {
     "src": MagicMock(),
     "src.config": _src_config_stub,
     "src.models": _src_models_stub,
+    "src.pricing": MagicMock(),
+    "src.pricing.orm": MagicMock(),
     "src.pricing.orm.market_data": _src_models_market_data_stub,
 }
 
@@ -158,9 +161,7 @@ class TestSeedFxRates:
         mock_rate.quote_currency = "SGD"
         mock_rate.rate = Decimal("1.28")
 
-        mock_engine, mock_session_maker, mock_session = self._make_mock_session(
-            existing_rates=[mock_rate]
-        )
+        mock_engine, mock_session_maker, mock_session = self._make_mock_session(existing_rates=[mock_rate])
 
         monkeypatch.setattr("builtins.input", lambda _: "y")
 
@@ -196,9 +197,7 @@ class TestSeedFxRates:
         mock_rate.quote_currency = "SGD"
         mock_rate.rate = Decimal("1.28")
 
-        mock_engine, mock_session_maker, mock_session = self._make_mock_session(
-            existing_rates=[mock_rate]
-        )
+        mock_engine, mock_session_maker, mock_session = self._make_mock_session(existing_rates=[mock_rate])
 
         monkeypatch.setattr("builtins.input", lambda _: "n")
 
@@ -255,9 +254,7 @@ class TestSeedFxRates:
         mock_engine, mock_session_maker, _ = self._make_mock_session()
 
         with (
-            patch.object(
-                seed_fx_rates, "get_database_url", return_value="sqlite:///test.db"
-            ),
+            patch.object(seed_fx_rates, "get_database_url", return_value="sqlite:///test.db"),
             patch(
                 "tools._lib.market_data.seed_fx_rates.create_async_engine",
                 return_value=mock_engine,
@@ -302,9 +299,7 @@ class TestSeedFxRates:
 class TestMain:
     def test_main_success(self, capsys, monkeypatch):
         """Given successful seeding, should print success message."""
-        monkeypatch.setattr(
-            "sys.argv", ["tools._lib.market_data.seed_fx_rates.py", "--env", "local"]
-        )
+        monkeypatch.setattr("sys.argv", ["tools._lib.market_data.seed_fx_rates.py", "--env", "local"])
 
         with patch(
             "tools._lib.market_data.seed_fx_rates.seed_fx_rates",
@@ -319,9 +314,7 @@ class TestMain:
 
     def test_main_error_exits_1(self, capsys, monkeypatch):
         """Given seed_fx_rates raises, should print error and sys.exit(1)."""
-        monkeypatch.setattr(
-            "sys.argv", ["tools._lib.market_data.seed_fx_rates.py", "--env", "local"]
-        )
+        monkeypatch.setattr("sys.argv", ["tools._lib.market_data.seed_fx_rates.py", "--env", "local"])
 
         with (
             patch(
@@ -357,9 +350,7 @@ class TestMain:
 
     def test_main_staging_env(self, capsys, monkeypatch):
         """Given --env staging, should pass 'staging' to seed_fx_rates."""
-        monkeypatch.setattr(
-            "sys.argv", ["tools._lib.market_data.seed_fx_rates.py", "--env", "staging"]
-        )
+        monkeypatch.setattr("sys.argv", ["tools._lib.market_data.seed_fx_rates.py", "--env", "staging"])
 
         with (
             patch(


### PR DESCRIPTION
## Summary
Addresses the 4 unresolved Copilot review comments left on already-merged PR #1743:

- **`tests/tooling/test_seed_fx_rates.py`**: the `sys.modules` stub dict covered the leaf module `src.pricing.orm.market_data` but not its parent packages `src.pricing` / `src.pricing.orm`. Python's import machinery resolves dotted imports parent-first, so `from src.pricing.orm.market_data import FxRate` could still trigger a real import of `src.pricing`'s heavy dependency tree in the tooling-only CI environment — defeating the point of stubbing. Added both parent stubs.
- **`pricing/platform/reconciliation/__init__.py`**: each had a comment claiming ORM models are "imported eagerly and FIRST", but the comment sat above `from __future__ import annotations` while the actual ORM import was at the bottom of the file — comment and code had drifted apart (an artifact of iterative edits). Moved each comment to sit directly above its real import line and dropped the now-inaccurate "FIRST" claim.

## Test plan
- [x] `check_package_contract`: all 16 packages OK
- [x] `check_app_boundary`: 14 baselined edges, none added
- [x] Doc-consistency lint: exit 0
- [x] `tests/tooling/test_seed_fx_rates.py`: 15 passed; full `tests/tooling/`: 2005 passed, 1 skipped
- [x] Functional smoke: `import src.main`, `FxRate`/`AppConfig`/`ConsistencyCheck` resolve through published roots
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)