### PR TITLE
[finance_report_audit] docs(#1750): ac-workflow skill routes ACs package-first; de-hardcode package counts

### DIFF
--- a/.opencode/skills/domain/ac-workflow/SKILL.md
+++ b/.opencode/skills/domain/ac-workflow/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: ac-workflow
-description: Route a new or changed acceptance criterion (AC) to its correct home — a migrated package's contract.py roadmap first, EPIC tables only for legacy surfaces — then follow the mandatory AC → Test → Code → Doc order. Use this whenever you add/modify an AC, add a test that references an AC id (AC-<pkg>.* or ACx.y.z), edit a package contract.py roadmap or a docs/project/EPIC*.md file, or need the AC registry/traceability/dual gate to pass.
+description: Route a new or changed acceptance criterion (AC) to its correct home — a migrated package's contract.py roadmap first, EPIC tables only for legacy surfaces — then follow the mandatory MECE → AC → Test → Code → Doc order. Use this whenever you add/modify an AC, add a test that references an AC id (AC-<pkg>.* or ACx.y.z), edit a package contract.py roadmap or a docs/project/EPIC*.md file, or need the AC registry/traceability/dual gate to pass.
 ---
 
 # AC workflow — package roadmap first, EPIC table only for legacy
 
 The culture is `EPIC → AC → Test → Code → Doc` (every behavior anchors to a
-goal and is proven by a test). The **mechanism** for *where an AC lives* is the
-package contract, not an EPIC table — see
+goal and is proven by a test); the mandatory sequence is
+**MECE → AC → Test → Code → Doc** — slice the work into non-overlapping,
+collectively exhaustive pieces *before* touching ACs. The **mechanism** for
+*where an AC lives* is the package contract, not an EPIC table — see
 `docs/agents/orchestration.md` (work order) and
 `common/meta/migration-standard.md` (the target architecture).
 

--- a/.opencode/skills/domain/ac-workflow/SKILL.md
+++ b/.opencode/skills/domain/ac-workflow/SKILL.md
@@ -1,47 +1,80 @@
 ---
 name: ac-workflow
-description: Follow the mandatory EPIC → AC → Test → Code → Doc order when adding or changing an acceptance criterion (AC). Use this whenever you add/modify an AC, add a test that references an ACx.y.z ID, edit a docs/project/EPIC*.md file, or need the AC registry/traceability gate to pass.
+description: Route a new or changed acceptance criterion (AC) to its correct home — a migrated package's contract.py roadmap first, EPIC tables only for legacy surfaces — then follow the mandatory AC → Test → Code → Doc order. Use this whenever you add/modify an AC, add a test that references an AC id (AC-<pkg>.* or ACx.y.z), edit a package contract.py roadmap or a docs/project/EPIC*.md file, or need the AC registry/traceability/dual gate to pass.
 ---
 
-# AC workflow — EPIC → AC → Test → Code → Doc
+# AC workflow — package roadmap first, EPIC table only for legacy
 
-The repo's work order is mandatory and gated in CI. Skipping a step is the most
-common reason a PR fails the traceability check.
+The culture is `EPIC → AC → Test → Code → Doc` (every behavior anchors to a
+goal and is proven by a test). The **mechanism** for *where an AC lives* is the
+package contract, not an EPIC table — see
+`docs/agents/orchestration.md` (work order) and
+`common/meta/migration-standard.md` (the target architecture).
 
-## The ritual
+## Step 0 — route the AC (this decides everything else)
 
-1. **Anchor to an EPIC.** Find or create the EPIC in `docs/project/EPIC-*.md`.
-   Cross-module goals are EPICs; base terms belong in `docs/ssot/`.
-2. **Register the AC.** Add a row under the right `### ACx.y:` section of the EPIC
-   with: a unique `ACx.y.z` id, a one-line test case, the **exact test function
-   name(s)**, the **test file path**, and a priority. Feature ACs live in EPIC
-   docs (indexed by `docs/ac_registry.yaml`); infra ACs use `docs/infra_registry.yaml`.
-3. **Write the failing test first (🔴).** The test must reference the AC id (in
-   the name or a comment) and live at the path you registered.
-4. **Write minimal code to pass (🟢).**
-5. **Sync SSOT docs** for any base term/contract you touched.
+Does the owning package have a `common/<pkg>/contract.py`? (Check
+`ls common/*/contract.py`; membership is `common/meta/base/layering.py::PACKAGE_LAYER`.
+In practice a new AC almost always belongs to a package now.)
+
+- **Migrated package** → the AC lives in that package's `contract.py`
+  `roadmap` as an `ACRecord` with id `AC-<pkg>.<group>.<seq>` — `<group>` is an
+  entity name or a numeric group (e.g. `AC-ledger.journal-entry.3`,
+  `AC-identity.1.2`). **Never** add it to an EPIC table and never mirror it
+  back there — `check_epic_package_dual` fails CI when the same id lives in
+  both sources.
+- **Legacy surface only** (no owning package — a shrinking set) → the old
+  flow: a row in the owning `docs/project/EPIC-*.md` table, materialized via
+  `docs/ac_registry.yaml` (feature) or `docs/infra_registry.yaml` (infra).
+- **Moving an existing EPIC row into a package is atomic**: delete the EPIC
+  row and add the roadmap entry in the *same PR* (the dual gate enforces
+  exactly this shape).
+
+Either way, still anchor the *work* to an EPIC in `docs/project/` as its
+horizontal goal — the anchor is a goal reference, not the AC's home.
+
+## The ritual (after routing)
+
+1. **Write the AC.**
+   - Package: append an `ACRecord(id=..., statement=...,
+     test="apps/backend/tests/<pkg>/test_x.py::test_name", priority=...,
+     status=...)` to the `roadmap` (schema:
+     `common/meta/base/package_contract.py`).
+   - Legacy: add a row under the right `### ACx.y:` section of the EPIC with a
+     unique `ACx.y.z` id, a one-line test case, the **exact test function
+     name(s)**, the **test file path**, and a priority.
+2. **Write the failing test first (🔴).** The test must reference the AC id
+   (in the name or a comment) and live at the path you registered.
+3. **Write minimal code to pass (🟢).**
+4. **Doc sync.** Migrated package: its `contract.py`/`readme.md`. Legacy: the
+   SSOT doc owning any base term you touched.
 
 ## Always regenerate + verify before pushing
 
-After editing any EPIC/AC, the registry is generated from the EPIC text — it will
-drift if you don't regenerate:
+The registry aggregates **both** sources (package roadmaps + legacy EPIC
+tables) — it drifts if you don't regenerate:
 
 ```bash
 apps/backend/.venv/bin/python tools/generate_ac_registry.py     # sync the index
 apps/backend/.venv/bin/python tools/check_ac_index.py           # gate: every mandatory AC has a real CI test
+apps/backend/.venv/bin/python tools/check_epic_package_dual.py  # gate: no AC id lives in both sources
 ```
 
-The **preflight** skill runs both automatically when it sees an EPIC/registry
-change in your diff — prefer `apps/backend/.venv/bin/python tools/preflight.py`
-(an interpreter with the project deps) so you can't forget.
+The **preflight** skill picks the right gates for your diff — prefer
+`apps/backend/.venv/bin/python tools/preflight.py` (an interpreter with the
+project deps) so you can't forget.
 
 ## Gotchas (learned the hard way)
 
-- The test function name in the EPIC table must **exactly** match the real test —
-  the gate parses both sides.
-- Picking an AC number already used by an open PR causes a collision; check open
-  PRs for the next free `ACx.y` before claiming one.
-- `docs/ac_registry.yaml` is generated — never hand-edit it; edit the EPIC and
-  regenerate. The only hand-authored entries live in `docs/ac_registry_overrides.yaml`.
-- A new AC with no executing test fails the gate as "missing" — write the test,
-  don't just register the row.
+- The `test` field / EPIC-table test name must **exactly** match the real
+  test — the gates parse both sides.
+- The same AC id in a roadmap AND an EPIC table turns
+  `check_epic_package_dual` red; the fix is deleting the EPIC row, not the
+  roadmap entry (migration never lowers a standard — #1416 Decision A).
+- `docs/ac_registry.yaml` is generated — never hand-edit it; edit the
+  roadmap/EPIC and regenerate. The only hand-authored entries live in
+  `docs/ac_registry_overrides.yaml`.
+- A new AC with no executing test fails the gate as "missing" — write the
+  test, don't just register the row.
+- Picking an AC number already used by an open PR causes a collision; check
+  open PRs for the next free `<group>.<seq>` before claiming one.

--- a/common/meta/migration-standard.md
+++ b/common/meta/migration-standard.md
@@ -19,11 +19,14 @@ is to delete the mirror: **the contract is the single source**, governance is
 
 Two cross-cutting governors (parallel peers, not super-packages) + the value
 foundation + the shared valuation SSOT + the financial data flow + the technical
-substrate. **This is the financial-domain core, not the whole registry**: 6 more
-business-agnostic infra leaves (`config`, `counter`, `identity`, `observability`,
-`runtime`, `testing`) exist alongside this core and are governed the same way —
-they're omitted from the table below because they carry no domain vocabulary of
-their own to describe, not because they're second-class.
+substrate. **This is the financial-domain core, not the whole registry**: more
+packages exist alongside this core and are governed the same way —
+`observability`/`runtime`/`testing` on the infra axis, `counter` in the
+middleware kernel, `identity` as a domain slice outside the financial flow
+(`config` folded into `runtime`, #1669); `PACKAGE_LAYER` is the authoritative
+list. They're omitted from the table below because they carry no
+financial-domain vocabulary of their own to describe, not because they're
+second-class.
 `common/meta/base/layering.py::PACKAGE_LAYER` is the actual current-membership
 list (a hand-synced count here went stale twice — read the code, not a snapshot
 of it); this table is target *design intent* for

--- a/common/meta/migration-standard.md
+++ b/common/meta/migration-standard.md
@@ -1,6 +1,8 @@
 # Package migration standard (the target architecture)
 
-> The standard the whole repo migrates **to**: ~10 high-cohesion packages, each
+> The standard the whole repo migrates **to**: high-cohesion packages (live
+> membership: `common/meta/base/layering.py::PACKAGE_LAYER` — the count lives in
+> code, not in this prose), each
 > code-owning its contract + docs, so EPIC tables and most SSOT prose are absorbed
 > and the repo becomes contract-driven. Owned by the `meta` package (this file is
 > its prose). The only authored horizontal docs that survive are `vision.md` and
@@ -13,17 +15,18 @@ code, because central mirrors must be hand-synced and don't stay in sync. The fi
 is to delete the mirror: **the contract is the single source**, governance is
 **computed**, and meta-info is **aggregated**, never hand-maintained.
 
-## The ~10 packages
+## The financial-domain core packages
 
 Two cross-cutting governors (parallel peers, not super-packages) + the value
 foundation + the shared valuation SSOT + the financial data flow + the technical
 substrate. **This is the financial-domain core, not the whole registry**: 6 more
 business-agnostic infra leaves (`config`, `counter`, `identity`, `observability`,
-`runtime`, `testing`) exist alongside these ~10 and are governed the same way —
+`runtime`, `testing`) exist alongside this core and are governed the same way —
 they're omitted from the table below because they carry no domain vocabulary of
 their own to describe, not because they're second-class.
 `common/meta/base/layering.py::PACKAGE_LAYER` is the actual current-membership
-list (17 packages as of 2026-07-09); this table is target *design intent* for
+list (a hand-synced count here went stale twice — read the code, not a snapshot
+of it); this table is target *design intent* for
 the financial-domain packages specifically, and **the table's `extension deps`
 column is not always what `depends_on` says today** — a package's `contract.py`
 declares only edges with a real import behind them (`check_package_contract`

--- a/common/todo.md
+++ b/common/todo.md
@@ -5,7 +5,7 @@ The horizontal worklist for migrating to the target architecture in
 keeps its own `common/<pkg>/todo.md`; this file tracks the migration *between*
 packages and the phase order. Umbrella issue: **#1416**.
 
-## Target: ~10 packages
+## Target packages (live membership: `meta/base/layering.py::PACKAGE_LAYER`)
 
 Two governors + the technical substrate + the shared valuation SSOT + the
 financial flow (see the standard for each package's base/extension/data +

--- a/common/todo.md
+++ b/common/todo.md
@@ -5,7 +5,7 @@ The horizontal worklist for migrating to the target architecture in
 keeps its own `common/<pkg>/todo.md`; this file tracks the migration *between*
 packages and the phase order. Umbrella issue: **#1416**.
 
-## Target packages (live membership: `meta/base/layering.py::PACKAGE_LAYER`)
+## Target packages (live membership: `common/meta/base/layering.py::PACKAGE_LAYER`)
 
 Two governors + the technical substrate + the shared valuation SSOT + the
 financial flow (see the standard for each package's base/extension/data +


### PR DESCRIPTION
## Summary

Fix the two harness-drift findings of #1750: the `ac-workflow` skill taught the pre-migration EPIC-only AC flow (an agent following it turns `check_epic_package_dual` red on any migrated package), and `migration-standard.md` / `common/todo.md` hardcoded "~10 packages" while the authoritative `PACKAGE_LAYER` grew past it.

Closes #1750

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | #1416 — Package-model migration umbrella (harness/guidance lane) |
| **AC IDs** | N/A — guidance-doc fix; #1750's own grep-based acceptance criteria, verified below |
| **AC source updated** | N/A |

---

## SSOT Changes

- [x] None — existing SSOT already covers this change (guidance docs + skill only; no `docs/ssot/` file touched)

---

## TDD Evidence

Docs-only change — no runtime surface, no new tests. #1750's machine-checkable acceptance criteria replace the red/green cycle:

| Criterion | Result |
|---|---|
| `grep -c 'contract.py\|roadmap' .opencode/skills/domain/ac-workflow/SKILL.md` ≥ 1 | **14** ✅ |
| skill's first routing step = package-vs-legacy check | Step 0 ✅ (consistent with `docs/agents/orchestration.md:43-67`) |
| `grep -n '~10' common/meta/migration-standard.md` empty | **0 matches** ✅ |
| `grep -rl 'Anchor to an EPIC' .opencode/skills/` empty | **0 files** ✅ |

---

## Engineering Audit

- [x] `tools/lint_doc_consistency.py` passes (preflight `taxonomy-drift` gate ok)
- [x] No real financial data
- (sa.Enum / env / manifest / infra items: N/A — no code, env, SSOT, or infra touched)

---

## Testing

```bash
apps/backend/.venv/bin/python tools/preflight.py
```

Preflight ran 2 gates: `taxonomy-drift` **ok**; `tooling` fails **locally only** on `test_stage2_residue_closeout.py` — every flagged path is under gitignored `.claude/worktrees/*` stale local worktree copies (pre-existing, unrelated to this diff; CI checks out clean and passes).

Notes:
- `.claude/skills/ac-workflow` is a symlink into the canonical `.opencode/skills/domain/ac-workflow/` — the rewrite propagates to the Claude runtime with no extra copy.
- The rewritten skill's gate commands (`tools/generate_ac_registry.py`, `tools/check_ac_index.py`, `tools/check_epic_package_dual.py`) all verified to exist as `tools/` wrappers.
- Root `AGENTS.md`/`CLAUDE.md` "Anchor to an EPIC in docs/project/ (the horizontal goal)" is deliberately unchanged — anchoring work to an EPIC as the horizontal goal is still the doctrine (per orchestration.md); what was wrong (and is fixed) is registering the *AC* in the EPIC table.

## Screenshots / Evidence

_N/A_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
