### PR TITLE
[finance_report_vision] docs(#1416): fix dead markdown links in package-model docs

### DIFF
--- a/common/audit/money/readme.md
+++ b/common/audit/money/readme.md
@@ -2,7 +2,7 @@
 
 > The money/currency/FX value type. Model spec:
 > [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
-> [`contract.py`](./contract.py). Language-neutral interface + conformance:
+> [`contract.py`](../contract.py). Language-neutral interface + conformance:
 > [`contract/money.contract.md`](./contract/money.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
@@ -51,7 +51,7 @@ prove themselves against the same vectors.
 
 ## Governance
 
-[`contract.py`](./contract.py) is validated by `tools/check_package_contract.py`:
+[`contract.py`](../contract.py) is validated by `tools/check_package_contract.py`:
 `interface` == the BE `__all__`, every invariant pins to a conformance test, and
 no upward/sideways import edge. The money ACs (`AC2.19.x` / `AC2.20.x`) are still
 owned by the EPIC-002 table; moving that AC ownership into the contract `roadmap`
@@ -64,7 +64,7 @@ owned by the EPIC-002 table; moving that AC ownership into the contract `roadmap
 
 > Internalized here from the retired `docs/ssot/accounting.md#money-type` per the
 > package-migration standard
-> ([`../meta/migration-standard.md`](../meta/migration-standard.md), step 3 "SSOT
+> ([`../../meta/migration-standard.md`](../../meta/migration-standard.md), step 3 "SSOT
 > internalized"). This is the registered owner of the `money_value_type` concept.
 
 <a id="money-type"></a>
@@ -72,7 +72,7 @@ owned by the EPIC-002 table; moving that AC ownership into the contract `roadmap
 - **Rule A3 — Money value types (narrow waist)**: The application-layer money
   primitives live in **`common/audit/money/`** (the shared waist). They sit *above* the
   DB double-entry invariant floor (`fr_validate_journal_entry_invariants`,
-  [schema.md](../../docs/ssot/schema.md)) and make bad money states unrepresentable
+  [schema.md](../../../docs/ssot/schema.md)) and make bad money states unrepresentable
   rather than merely tested-against (#1167). Dependency-light (stdlib + `Decimal`
   only) so backend, e2e, frontend helpers and tooling can share one definition. The
   backend ships its own self-contained copy at **`apps/backend/src/audit/money/`** (the

--- a/common/audit/quantity/contract/quantity.contract.md
+++ b/common/audit/quantity/contract/quantity.contract.md
@@ -2,7 +2,7 @@
 
 > The **interface** half of the quantity module's SSOT; the conformance half is
 > [`../conformance/vectors.json`](../conformance/vectors.json). Authoritative
-> prose: [`common/audit/readme.md#base-packages`](../../audit/readme.md#base-packages).
+> prose: [`common/audit/readme.md#base-packages`](../../readme.md#base-packages).
 
 ## Types
 

--- a/common/audit/quantity/readme.md
+++ b/common/audit/quantity/readme.md
@@ -2,7 +2,7 @@
 
 > The quantity/unit value type. Model spec:
 > [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
-> [`contract.py`](./contract.py). Language-neutral interface + conformance:
+> [`contract.py`](../contract.py). Language-neutral interface + conformance:
 > [`contract/quantity.contract.md`](./contract/quantity.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
@@ -42,7 +42,7 @@ errors (`QuantityError`, `FloatNotAllowedError`, `InvalidQuantityPayloadError`,
 
 ## Governance
 
-[`contract.py`](./contract.py) is validated by `tools/check_package_contract.py`
+[`contract.py`](../contract.py) is validated by `tools/check_package_contract.py`
 (interface == BE `__all__`, invariants pin to conformance tests, no forbidden
 import edge). The quantity ACs (`AC12.30.x`) are still owned by EPIC-012; moving
 them into the contract `roadmap` is a tracked follow-up — see [`todo.md`](./todo.md).

--- a/common/audit/ratio/contract/ratio.contract.md
+++ b/common/audit/ratio/contract/ratio.contract.md
@@ -2,7 +2,7 @@
 
 > The **interface** half of the ratio module's SSOT; the **conformance** half is
 > [`../conformance/vectors.json`](../conformance/vectors.json). Second instance of
-> the base-package template — see [`common/audit/readme.md#base-packages`](../../audit/readme.md#base-packages).
+> the base-package template — see [`common/audit/readme.md#base-packages`](../../readme.md#base-packages).
 
 ## Type
 

--- a/common/audit/ratio/readme.md
+++ b/common/audit/ratio/readme.md
@@ -2,7 +2,7 @@
 
 > The ratio/percentage value type. Model spec:
 > [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
-> [`contract.py`](./contract.py). Language-neutral interface + conformance:
+> [`contract.py`](../contract.py). Language-neutral interface + conformance:
 > [`contract/ratio.contract.md`](./contract/ratio.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
@@ -40,7 +40,7 @@ keeps the two ends from drifting.
 
 ## Governance
 
-[`contract.py`](./contract.py) is validated by `tools/check_package_contract.py`
+[`contract.py`](../contract.py) is validated by `tools/check_package_contract.py`
 (interface == BE `__all__`, invariants pin to conformance tests, no forbidden
 import edge). The ratio ACs (`AC12.9.x`) are still owned by EPIC-012; moving them
 into the contract `roadmap` is a tracked follow-up — see [`todo.md`](./todo.md).

--- a/common/audit/unit_price/contract/unit_price.contract.md
+++ b/common/audit/unit_price/contract/unit_price.contract.md
@@ -2,7 +2,7 @@
 
 > The **interface** half of the unit-price module's SSOT; the conformance half
 > is [`../conformance/vectors.json`](../conformance/vectors.json). Authoritative
-> prose: [`common/audit/readme.md#base-packages`](../../audit/readme.md#base-packages).
+> prose: [`common/audit/readme.md#base-packages`](../../readme.md#base-packages).
 
 ## Types
 

--- a/common/audit/unit_price/readme.md
+++ b/common/audit/unit_price/readme.md
@@ -2,7 +2,7 @@
 
 > The unit-price value type. Model spec:
 > [`../../meta/readme.md`](../../meta/readme.md). Machine contract:
-> [`contract.py`](./contract.py). Language-neutral interface + conformance:
+> [`contract.py`](../contract.py). Language-neutral interface + conformance:
 > [`contract/unit_price.contract.md`](./contract/unit_price.contract.md) +
 > [`conformance/vectors.json`](./conformance/vectors.json). Worklist:
 > [`todo.md`](./todo.md).
@@ -44,7 +44,7 @@ frontend implementation yet, so `implementations["fe"]` is `None`.
 
 ## Governance
 
-[`contract.py`](./contract.py) is validated by `tools/check_package_contract.py`
+[`contract.py`](../contract.py) is validated by `tools/check_package_contract.py`
 (interface == BE `__all__`, invariants pin to conformance tests, no forbidden
 import edge — it may import the same-class `money` and `quantity` packages,
 declared in `depends_on` and acyclic). The unit_price ACs (`AC12.32.x`) are still owned by

--- a/common/llm/readme.md
+++ b/common/llm/readme.md
@@ -123,7 +123,7 @@ runs.
 ## 5. <a id="cassettes"></a>Record/Replay Cassettes (deterministic CI)
 
 LLM calls are made **deterministic in CI** via a record/replay cassette layer
-(`apps/backend/src/llm/cassette.py`) exposed through two chokepoints:
+(`apps/backend/src/llm/extension/cassette.py`) exposed through two chokepoints:
 `client.cassette_completion` (non-streaming) and the **streaming bridge**
 `client.litellm_stream` (the real extraction transport — see below). A *cassette*
 is a committed JSON file under `common/testing/fixtures/llm_cassettes/`

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -193,8 +193,9 @@ The recipe for moving a module (and its EPIC-table ACs) into the package model.
    [`base/layering.py`](./base/layering.py) (`meta < infra < middleware <
    domain < app`; placement is L0-owned global topology, so the contract does
    not self-claim a klass) — and the authority **tier**
-   ([`authority` package](../authority/readme.md): CODE-ONLY/CODE-LED/LLM-LED/LLM-ONLY — how
-   the module is built). If the tier is genuinely undecided, ship `status="draft"`
+   ([`base/authority_matrix.py`](./base/authority_matrix.py): CODE-ONLY/CODE-LED/LLM-LED/LLM-ONLY — how
+   the module is built; the tier model is module-level on `PackageContract`,
+   not a standalone package). If the tier is genuinely undecided, ship `status="draft"`
    with `tier=None` and resolve it before going `active` (the shipped-package
    rule). **One package = one tier**; a module mixing deterministic + LLM-emitted
    behavior is two packages.
@@ -600,7 +601,7 @@ matrix + the classifier's `band` / `classify_repo` / `BANDS`.
   Test workflow and the proof matrix this tier attribute extends.
 - [EPIC-026](../../docs/project/EPIC-026.ac-authority-tiers.md) — the EPIC that
   introduced tiers (now references the homed `AC-authority.*` ids).
-- [`authority_matrix.py`](./authority_matrix.py) — the machine source of
+- [`authority_matrix.py`](./base/authority_matrix.py) — the machine source of
   `PackageTier` and the proof matrix (`PackageContract` imports it).
 - [`../extraction/readme.md`](../extraction/readme.md) — a domain
   where LLM-LED/LLM-ONLY behaviors concentrate.

--- a/docs/ssot/observability.md
+++ b/docs/ssot/observability.md
@@ -36,7 +36,7 @@
 | Component | Physical Location | Description |
 |-----------|-------------------|-------------|
 | Logging configuration | `apps/backend/src/observability/logger.py` | Structlog setup + optional OTLP log export |
-| Runtime contract | `apps/backend/src/observability.py` | Redacted observability status for health checks, startup logs, and alert triage |
+| Runtime contract | `apps/backend/src/observability/runtime.py` | Redacted observability status for health checks, startup logs, and alert triage |
 | Env settings | `apps/backend/src/config.py` | OTEL environment variables |
 | Env documentation | `.env.example` | Developer guidance for OTEL variables |
 | Infra reference | `repo/docs/ssot/ops.observability.md`, `repo/docs/ssot/ops.alerting.md` | the observability backend platform, collector, alert rule, and Lark delivery details |

--- a/docs/ssot/runtime-incident-response.md
+++ b/docs/ssot/runtime-incident-response.md
@@ -18,7 +18,7 @@ every document.
 | App deployment model and release flow | `docs/ssot/deployment.md` |
 | CI, preview, staging, and production gate semantics | `docs/ssot/ci-cd.md` |
 | Boot/runtime health validation | `common/runtime/readme.md`, `apps/backend/src/boot.py`, `apps/backend/src/main.py` |
-| App observability runtime contract | `docs/ssot/observability.md`, `apps/backend/src/observability.py` |
+| App observability runtime contract | `docs/ssot/observability.md`, `apps/backend/src/observability/runtime.py` |
 | Staging/production health and version smoke | `tools/health_check.sh`, `tools/production_infra_smoke.py`, `common/runtime/production_infra_smoke.py` |
 | Delivery-engine evidence and optimization recommendations | `docs/project/DELIVERY_ENGINE_RECOMMENDATIONS.md` |
 | Infra alerting, Lark delivery, watchdogs | `repo/docs/ssot/ops.alerting.md` |


### PR DESCRIPTION
## Summary
- Umbrella #1416 includes historical-documentation cleanup; this is a docs-only, self-contained slice of it — independent of the blocked code-move work (#1666/#1671/#1641/#1643).
- A repo-wide sweep of `common/**/*.md` and `docs/**/*.md` for backtick-wrapped file references and markdown `[text](path)` links that don't resolve on disk found 11 files with genuinely broken (not historical-record) references — see commit message for the full breakdown per file.
- Root causes cluster into 3 classes: (1) relative-path-depth bugs (`./contract.py` should be `../contract.py`, an extra spurious `audit/` segment, links one `../` short), (2) doc references that never followed a physical file move (`llm/cassette.py` → `llm/extension/cassette.py`, `observability.py` → `observability/runtime.py`), (3) references to the retired standalone `authority` package (folded into `meta` as module-level `PackageContract` tiers).
- Re-swept after fixing: zero remaining dead references.

## Test plan
- [x] Repo-wide dead-link sweep script re-run post-fix: 0 files with broken references (was 11)
- [x] Repo-root `tests/tooling/`: 2005 passed, 1 skipped (matches the known baseline)
- [x] Docs-only change — no source code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)