### PR TITLE
[finance_report_audit] chore(#1751): hygiene sweep — stale status claims, coverage gitignore, worktree-scan fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ __pycache__/
 
 # Coverage reports
 .coverage
+.coverage.*
 coverage.xml
 htmlcov/
 *.lcov

--- a/common/meta/base/layering.py
+++ b/common/meta/base/layering.py
@@ -72,10 +72,9 @@ PACKAGE_LAYER: dict[str, PackageClass] = {
     # (money/ratio/quantity/unit_price) folded into audit (#1419), so those
     # names are gone from the map — audit (L1) owns the financial base types.
     "counter": "middleware",
-    # L3 — vertical business slices. advisor / portfolio / reconciliation all
-    # shipped their contract.py (#1425 / #1422 / #1423); pricing / reporting
-    # have a contract.py but are still status="draft" (#1610 / #1424 in
-    # flight) — the map already pins their layer ahead of the roadmap filling in.
+    # L3 — vertical business slices. All eight shipped their contract.py and
+    # are status="active" (pricing/reporting flipped in the wave-2 closeout,
+    # #1663; pricing's physical-table unification continues under #1610).
     "advisor": "domain",
     "extraction": "domain",
     "identity": "domain",

--- a/common/readme.md
+++ b/common/readme.md
@@ -49,10 +49,10 @@ scope):
 - **L3 domain** — [`advisor/`](./advisor/readme.md),
   [`extraction/`](./extraction/readme.md), [`identity/`](./identity/readme.md),
   [`ledger/`](./ledger/readme.md), [`portfolio/`](./portfolio/readme.md),
+  [`pricing/`](./pricing/readme.md) (the one price/valuation SSOT;
+  physical-table unification continues under #1610),
   [`reconciliation/`](./reconciliation/readme.md), [`reporting/`](./reporting/readme.md).
-  Still `status="draft"` (contract + readme shipped, roadmap not yet
-  populated): [`pricing/`](./pricing/readme.md) (#1610, the one
-  price/valuation SSOT — lands before portfolio).
+  All eight are `status="active"`.
 - [`common/todo.md`](./todo.md) — the cross-package / migration worklist.
 
 The old `common/ci` / `common/shell` / `common/ssot` junk drawers are retired.

--- a/common/todo.md
+++ b/common/todo.md
@@ -36,7 +36,7 @@ and types/ops/store/api). ACs are `AC-<pkg>.<entity>.<seq>` in each contract's
 | 0b | `counter` → base/extension/data template + gate three-layer rule (additive) | #1418 ✅ |
 | 1 | `value → audit` fold | #1419 ✅ |
 | 2 | `ledger` | #1420 ✅ |
-| 3 | `extraction` #1421 ✅ · `portfolio` #1422 ✅ · `reconciliation` #1423 ✅ · `reporting` #1424 ✅ (roadmap populated, `status="active"` — migration closeout wave 2, #1663) · `pricing` #1610 ⬜ (PR2 in flight, still `status="draft"`) | partial |
+| 3 | `extraction` #1421 ✅ · `portfolio` #1422 ✅ · `reconciliation` #1423 ✅ · `reporting` #1424 ✅ · `pricing` contract ✅ `status="active"` (roadmap populated in the wave-2 closeout, #1663/#1728; #1610 stays open for the physical-table unification) | partial |
 | 4 | `advisor` #1425 ✅ · `llm` #1426 ✅ · `platform` #1427 ✅ · `identity` #1428 ✅ | done |
 | 5 | `audit` consistency closeout (global invariants + cross-package ACs) | #1429 ⬜ |
 | 6 | cleanup — delete residual EPIC tables / SSOT; retire the central `docs/ssot/MANIFEST.yaml`/registry gates once meta's data layer is the computed index | tracked as a 3-wave closeout: #1662 (finish cutovers + doc-sync) → #1663 (EPIC AC migration) → #1664 (SSOT/index retirement); #1430 closed early on the directory-coverage-only reading |

--- a/tests/tooling/test_stage2_residue_closeout.py
+++ b/tests/tooling/test_stage2_residue_closeout.py
@@ -71,7 +71,9 @@ def test_stage2_residue_modules_left_services() -> None:
 def test_stage2_residue_old_service_imports_are_gone() -> None:
     offenders: list[str] = []
     for path in REPO.rglob("*.py"):
-        if ".venv" in path.parts:
+        if ".venv" in path.parts or ".claude" in path.parts:
+            # .claude/ holds gitignored local worktree copies of old checkouts;
+            # scanning them reports residue that is not in the repo.
             continue
         if path == Path(__file__):
             continue

--- a/tests/tooling/test_stage2_residue_closeout.py
+++ b/tests/tooling/test_stage2_residue_closeout.py
@@ -72,8 +72,10 @@ def test_stage2_residue_old_service_imports_are_gone() -> None:
     offenders: list[str] = []
     for path in REPO.rglob("*.py"):
         if ".venv" in path.parts or ".claude" in path.parts:
-            # .claude/ holds gitignored local worktree copies of old checkouts;
-            # scanning them reports residue that is not in the repo.
+            # .claude/ is the agent runtime/config dir: its committed content
+            # carries no Python, and its gitignored worktrees/ subdir holds
+            # local copies of old checkouts whose imports would otherwise be
+            # reported as residue that is not in the repo.
             continue
         if path == Path(__file__):
             continue


### PR DESCRIPTION
## Summary

Mechanical hygiene sweep from the 2026-07-11 umbrella review (#1416): stale `status="draft"` claims for `pricing`, missing `.coverage.*` gitignore, a gate test that scanned gitignored `.claude/` worktree copies (red locally, green in CI), and a stale layer-map comment. Carries two incidental fixes folded in per review follow-up (the planned #1749 PR was superseded by #1748, so they land here).

Closes #1751

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | #1416 — Package-model migration umbrella (hygiene lane) |
| **AC IDs** | N/A — #1751's own grep-based acceptance criteria, verified below |
| **AC source updated** | N/A |

---

## SSOT Changes

- [x] None — no `docs/ssot/` file touched

---

## TDD Evidence

Docs/config/test-guard sweep — no runtime surface. #1751's machine-checkable acceptance criteria replace the red/green cycle:

| Criterion | Result |
|---|---|
| Orphan `__pycache__`-only dirs under `apps/backend/src` + `common/` | **0** ✅ (`src/constants/`, `src/utils/`, `services/market_data/`, `common/config/` removed locally — gitignored bytecode, nothing to commit) |
| `common/todo.md` / `common/readme.md` no longer claim pricing `draft` | ✅ (todo.md:39 cell + readme.md L3 list rewritten; both defer remaining pricing scope to #1610) |
| `.gitignore` covers `.coverage.*`; stray artifact gone from `git status` | ✅ (verified: a test `.coverage.X.pid1.xx` file no longer shows as untracked) |

Incidental fixes (review follow-up):

- `tests/tooling/test_stage2_residue_closeout.py` skips `.claude/` — its `rglob` walked gitignored local worktree copies, so `test_stage2_residue_old_service_imports_are_gone` failed on any machine with worktrees while CI stayed green (the guard-scans-wrong-set shape, #1416 DoD-addition 1, inverted). Validated: local preflight `tooling` gate went red → green with this change (2005 passed).
- `common/meta/base/layering.py` L3 comment claimed pricing/reporting are `status="draft"` — both have been `active` since the wave-2 closeout.

---

## Engineering Audit

- [x] `tools/lint_doc_consistency.py` passes (preflight `taxonomy-drift` gate ok)
- [x] No real financial data
- (sa.Enum / env / manifest / infra items: N/A — no schema, env, SSOT, or infra touched)

---

## Testing

```bash
apps/backend/.venv/bin/python tools/preflight.py
```

Preflight ran `taxonomy-drift` + `tooling` (full `tests/tooling/` suite): **all gates passed, 2005 passed / 1 skipped** — including the previously locally-red stage2-residue test.

## Screenshots / Evidence

_N/A_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
