### PR TITLE
[finance_report_vision] fix(#1675): post-merge cleanup for llm_config.py's move

### DIFF
--- a/apps/backend/src/llm/orm/config.py
+++ b/apps/backend/src/llm/orm/config.py
@@ -20,7 +20,7 @@ from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.database import Base
-from src.llm import ProtocolFamily, ReasoningEffort, Scene
+from src.llm.base import ProtocolFamily, ReasoningEffort, Scene
 from src.models.base import TimestampMixin, UUIDMixin
 
 

--- a/common/llm/contract.py
+++ b/common/llm/contract.py
@@ -118,11 +118,12 @@ CONTRACT = PackageContract(
             kind=Kind.DOMAIN_SERVICE,
             module="extension/factory.py",
         ),
-        # ── ORM entities: declared taxonomy-only. Their mapped classes stay in
-        # the unregistered ``src/models/llm_config.py`` (ledger precedent) —
-        # the tables carry a cross-domain FK to identity's ``users.id``, and
-        # FK→id-reference surgery is Stage-4 scope (#1416 Decision B), not this
-        # cutover's. Re-home into ``extension/sql.py`` when that FK is cut. ──
+        # ── ORM entities: taxonomy-only (module unset, like the other moved
+        # ORM units below — the gate skips placement checks for these). Their
+        # mapped classes live in orm/config.py (#1675): the FK to identity's
+        # ``users.id`` is a bare column, not a ``relationship()`` — a DB-level
+        # referential-integrity invariant, not code-level coupling, so it
+        # doesn't block homing them in this package. ──
         Unit(name="LlmProvider", kind=Kind.ENTITY),
         Unit(name="LlmSceneBinding", kind=Kind.ENTITY),
         # ── reserved growth slots for per-model usage statistics (taxonomy-only;


### PR DESCRIPTION
## Summary
Two small follow-ups caught after PR #1756 merged (found while switching branches post-merge):

- `llm/orm/config.py` imported from the package's own root (`from src.llm import ProtocolFamily, ...`) — self-referential. It happened to be safe in practice (the names it needs come from `base`, which `llm/__init__.py` imports before reaching `orm/config.py`), which is why CI never caught it as broken — but it's fragile against import-order changes. Repointed to the sibling `src.llm.base`, matching the pattern used everywhere else in #1756/#1670.
- `common/llm/contract.py`'s `LlmProvider`/`LlmSceneBinding` `Unit()` comment still said they "stay in the unregistered `src/models/llm_config.py`" — stale since #1756 moved them into `orm/config.py`. Updated the comment; left `module=` unset on both (matching the taxonomy-only pattern the other packages' moved ORM units already use — the placement gate skips units with no `module`).

## Test plan
- [x] `check_package_contract.py` — PASSED (all 16 packages)
- [x] `check_app_boundary.py` — PASSED, unchanged
- [x] `ruff check` — clean
- [x] `tests/llm/`: 143 passed
- [x] Relevant tooling tests (`test_llm_package.py`, `test_stage2_residue_closeout.py`, `test_meta_layering.py`): 20 passed

Refs #1675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)