### PR TITLE
[finance_report_audit] feat(#1675): D1 — cross-domain reference policy (SSOT) + ondelete=CASCADE ratchet (AC-meta.txn.4)

### DIFF
--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -406,16 +406,20 @@ CONTRACT = PackageContract(
         ACRecord(
             id="AC-meta.txn.4",
             statement=(
-                "A DB-level ondelete=CASCADE is a hidden cross-domain write (one "
-                "domain's delete mutating another domain's aggregates below the "
-                "application), against one-txn-per-domain and append-only "
-                "domains; the census of ForeignKey(..., ondelete=\"CASCADE\") "
-                "target tables under apps/backend/src only shrinks against "
-                "docs/ssot/fk-cascade-baseline.json — per-table counts never "
-                "grow, new target tables fail, a stale (over-counted) baseline "
-                "entry must be pruned in the same PR. Existing sites are "
-                "grandfathered; the end-state is saga-owned deletion "
-                "(#1675 ruling, D1/D7)."
+                "A DB-level ondelete=CASCADE is a hidden write below the "
+                "application — one table's delete silently mutating other "
+                "rows; across domains it breaks one-txn-per-domain and "
+                "append-only domains, the risk this ratchet exists for. The "
+                "census of ForeignKey(..., ondelete=\"CASCADE\") target tables "
+                "under apps/backend/src (all sites — deliberately not "
+                "domain-aware until models decentralization, #1675 D5/D6, "
+                "makes table ownership derivable) must equal "
+                "docs/ssot/fk-cascade-baseline.json: silent growth fails CI; "
+                "adding a cascade requires raising the baseline in the same "
+                "PR, where the diff makes the choice reviewable (the "
+                "app-boundary idiom); removals prune the baseline in the same "
+                "PR. Existing sites are grandfathered; the end-state is "
+                "saga-owned deletion (#1675 ruling, D1/D7)."
             ),
             test=(
                 "tests/tooling/test_fk_cascade_ratchet.py"

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -403,6 +403,27 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        ACRecord(
+            id="AC-meta.txn.4",
+            statement=(
+                "A DB-level ondelete=CASCADE is a hidden cross-domain write (one "
+                "domain's delete mutating another domain's aggregates below the "
+                "application), against one-txn-per-domain and append-only "
+                "domains; the census of ForeignKey(..., ondelete=\"CASCADE\") "
+                "target tables under apps/backend/src only shrinks against "
+                "docs/ssot/fk-cascade-baseline.json — per-table counts never "
+                "grow, new target tables fail, a stale (over-counted) baseline "
+                "entry must be pruned in the same PR. Existing sites are "
+                "grandfathered; the end-state is saga-owned deletion "
+                "(#1675 ruling, D1/D7)."
+            ),
+            test=(
+                "tests/tooling/test_fk_cascade_ratchet.py"
+                "::test_AC_meta_txn_4_cross_domain_cascade_only_shrinks"
+            ),
+            priority="P1",
+            status="done",
+        ),
         # The taxonomy migrated in place, so its retired vocabulary lingers in
         # prose; the drift gate makes "old words presented as current" a CI
         # failure instead of a periodic manual audit.

--- a/common/meta/migration-standard.md
+++ b/common/meta/migration-standard.md
@@ -81,6 +81,31 @@ Every package is, in implementation, three sub-layers — a **menu**, not a mand
   `base`/`extension` imports it, so the write side never depends on its own read
   model.
 
+### `data/` = the domain's product: the wide-table projection contract
+
+The endgame for a domain's *queryable output* is its `data/`-layer projection —
+typically one denormalized **wide table** per product (reporting's snapshot is
+the archetype). The contract that keeps CQRS honest:
+
+- **Derived, never authored.** Only projection builders write it — domain logic
+  never writes the wide table directly (invariants live in the write model);
+  it is rebuildable from the domain's facts/events at any time.
+- **Event-fed.** Own-domain writes plus subscribed upstream domain events (via
+  the platform outbox, at-least-once) are the only inputs; consumption is
+  idempotent — upsert keyed by `(aggregate_id, version)`.
+- **Late events are bitemporal**, pricing-style: a backfill never rewrites what
+  was queryable at an earlier knowledge time (Axiom A).
+- **Zero FK.** A projection carries ids + values denormalized as of event time,
+  never constraints; cross-domain reads at query time consume the other
+  domain's published wide table or interface — not runtime joins into its
+  write model.
+- **Provenance on every row** (Axiom B): the ids of the upstream facts each row
+  was computed from, so source→record→ledger→report tracing survives
+  denormalization.
+
+The first live precedent is #1642's extraction→pricing `PriceObserved`
+subscriber; later `data/` sinks copy its shape.
+
 ### The DDD building blocks → layer (the `units` taxonomy)
 
 The layer is the **universal purity axis** (every package, domain or tooling). For
@@ -293,6 +318,36 @@ removes its edges from the baseline, driving it toward zero.
 > package (a package whose `impl_dir` contains more-specific packages' dirs),
 > `backend` gets a real `common/backend/contract.py` and this gate folds into the
 > core deep-import scan. Until then it is a standalone ratchet.
+
+## Cross-domain reference policy (FK / relationship / cascade)
+
+How one domain's tables may refer to another's (#1675 ruling, 2026-07-11;
+enforced by `check_package_contract` (AC-meta.txn.3) and the cascade ratchet
+(AC-meta.txn.4)):
+
+1. **Intra-domain FK — free.** Constraints between tables of one bounded
+   context (ledger's journal↔accounts↔lines) are domain-internal integrity,
+   invisible to this policy.
+2. **Cross-domain bare `ForeignKey` column — allowed; cross-domain
+   `relationship()` — banned.** In this modular monolith (one process, one
+   database, one transaction manager) a bare FK column is a DB-level
+   referential-integrity invariant, not code-level coupling; the real coupling
+   is object-graph navigation, which the gate rejects. In code, aggregates
+   still reference each other **by id** and resolve through the published
+   interface or an event (mechanism C). `FK(users.id)` — the `UserOwnedMixin`
+   **tenancy anchor** on nearly every table — is the named degenerate case:
+   the tenancy axis is orthogonal to the business flow and never a flow edge.
+3. **Cross-domain `ondelete="CASCADE"` — shrink-only.** A DB cascade is a
+   hidden cross-domain write: one domain's delete mutates another domain's
+   aggregates below the application, against one-txn-per-domain (Decision B)
+   and append-only domains (Axiom A). The census in
+   `docs/ssot/fk-cascade-baseline.json` only shrinks — per-target-table counts
+   never grow, new target tables fail CI, an over-counted entry must be pruned
+   in the same PR. Existing sites are grandfathered; the end-state is
+   **saga-owned deletion** (identity publishes a purge event; each domain
+   deletes by its own semantics — `identity/extension/account_purge.py` is the
+   seed). Whether grandfathered cascades then flip to `RESTRICT` is a separate,
+   later decision (#1675 D7), never bundled into a move.
 
 ## Migration order
 

--- a/common/meta/migration-standard.md
+++ b/common/meta/migration-standard.md
@@ -337,17 +337,21 @@ enforced by `check_package_contract` (AC-meta.txn.3) and the cascade ratchet
    interface or an event (mechanism C). `FK(users.id)` — the `UserOwnedMixin`
    **tenancy anchor** on nearly every table — is the named degenerate case:
    the tenancy axis is orthogonal to the business flow and never a flow edge.
-3. **Cross-domain `ondelete="CASCADE"` — shrink-only.** A DB cascade is a
-   hidden cross-domain write: one domain's delete mutates another domain's
-   aggregates below the application, against one-txn-per-domain (Decision B)
-   and append-only domains (Axiom A). The census in
-   `docs/ssot/fk-cascade-baseline.json` only shrinks — per-target-table counts
-   never grow, new target tables fail CI, an over-counted entry must be pruned
-   in the same PR. Existing sites are grandfathered; the end-state is
-   **saga-owned deletion** (identity publishes a purge event; each domain
-   deletes by its own semantics — `identity/extension/account_purge.py` is the
-   seed). Whether grandfathered cascades then flip to `RESTRICT` is a separate,
-   later decision (#1675 D7), never bundled into a move.
+3. **`ondelete="CASCADE"` — ratcheted.** A DB cascade is a hidden write below
+   the application: one table's delete silently mutates other rows. Across
+   domains that breaks one-txn-per-domain (Decision B) and append-only domains
+   (Axiom A) — the case this policy exists for. The census in
+   `docs/ssot/fk-cascade-baseline.json` covers **every** CASCADE site,
+   deliberately not domain-aware (table→package ownership only becomes
+   trivially derivable after models decentralization, #1675 D5/D6); what CI
+   enforces is census == baseline — silent growth fails, adding a cascade
+   requires raising the baseline in the same PR so the diff makes the choice
+   reviewable (the app-boundary idiom), removals prune it in the same PR.
+   Existing sites are grandfathered; the end-state is **saga-owned deletion**
+   (identity publishes a purge event; each domain deletes by its own
+   semantics — `identity/extension/account_purge.py` is the seed). Whether
+   grandfathered cascades then flip to `RESTRICT` is a separate, later
+   decision (#1675 D7), never bundled into a move.
 
 ## Migration order
 

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -691,6 +691,17 @@ concepts:
       - .github/workflows/ci.yml
       - tools/check_e2e_epic_traceability.py
 
+  fk_cascade_baseline:
+    owner: docs/ssot/fk-cascade-baseline.json
+    description: Shrink-only census of ForeignKey(..., ondelete="CASCADE") target tables under apps/backend/src — a DB cascade is a hidden cross-domain write (one domain's delete mutating another domain's aggregates), so per-table counts never grow and a new cascade needs a same-PR baseline edit; end-state is saga-owned deletion (AC-meta.txn.4, #1675 ruling).
+    family: platform
+    kind: baseline
+    parent: package_model
+    authority: machine_generated
+    cross_refs:
+      - tests/tooling/test_fk_cascade_ratchet.py
+      - common/meta/migration-standard.md
+
   app_boundary_baseline:
     owner: docs/ssot/app-boundary-baseline.json
     description: Monotonic shrink-only baseline of cross-boundary edges between the un-carved apps/backend/src remainder (the L4 backend super-package) and the already-carved packages — inbound (remainder → a carved package's unpublished internal) and outbound (a carved package → the app remainder, upward-layer). A new edge fails check_app_boundary; the count is the migration burndown.

--- a/docs/ssot/MANIFEST.yaml
+++ b/docs/ssot/MANIFEST.yaml
@@ -693,7 +693,7 @@ concepts:
 
   fk_cascade_baseline:
     owner: docs/ssot/fk-cascade-baseline.json
-    description: Shrink-only census of ForeignKey(..., ondelete="CASCADE") target tables under apps/backend/src — a DB cascade is a hidden cross-domain write (one domain's delete mutating another domain's aggregates), so per-table counts never grow and a new cascade needs a same-PR baseline edit; end-state is saga-owned deletion (AC-meta.txn.4, #1675 ruling).
+    description: Ratchet census of ForeignKey(..., ondelete="CASCADE") sites under apps/backend/src, keyed by target table — a DB cascade is a hidden write below the application (across domains it breaks one-txn-per-domain and append-only, the risk the ratchet exists for); CI enforces census == baseline, so silent growth fails and adding a cascade requires a same-PR baseline edit (reviewable consent); deliberately counts all sites, not just cross-domain, until models decentralization makes ownership derivable; end-state is saga-owned deletion (AC-meta.txn.4, #1675 ruling).
     family: platform
     kind: baseline
     parent: package_model

--- a/docs/ssot/fk-cascade-baseline.json
+++ b/docs/ssot/fk-cascade-baseline.json
@@ -1,0 +1,13 @@
+{
+  "accounts": 3,
+  "atomic_positions": 1,
+  "atomic_transactions": 4,
+  "chat_sessions": 1,
+  "classification_rules": 2,
+  "investment_transactions": 1,
+  "journal_entries": 2,
+  "llm_providers": 1,
+  "managed_positions": 2,
+  "reconciliation_matches": 1,
+  "users": 9
+}

--- a/tests/tooling/test_fk_cascade_ratchet.py
+++ b/tests/tooling/test_fk_cascade_ratchet.py
@@ -1,0 +1,104 @@
+"""AC-meta.txn.4 — the cross-domain-cascade shrink-only ratchet (#1675 D1).
+
+A DB-level ``ondelete="CASCADE"`` is a hidden cross-domain write: one domain's
+delete mutates another domain's aggregates below the application, against
+one-txn-per-domain (#1416 Decision B) and append-only domains (Axiom A). The
+policy (``common/meta/migration-standard.md`` → "Cross-domain reference
+policy") grandfathers the existing sites in ``docs/ssot/fk-cascade-baseline.json``
+and lets the census only shrink; the end-state is saga-owned deletion
+(``identity/extension/account_purge.py`` is the seed).
+
+The baseline is keyed by **target table**, not file path, so package moves
+(#1675 D2–D6) do not churn it — only adding or removing a CASCADE does.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "apps/backend/src"
+BASELINE_PATH = REPO / "docs/ssot/fk-cascade-baseline.json"
+
+
+def _cascade_census() -> Counter[str]:
+    """Count ``ForeignKey(..., ondelete="CASCADE")`` calls per target table.
+
+    AST-only (no imports, minimal-env safe), same best-effort posture as the
+    cross-domain-FK gate (AC-meta.txn.3): a dynamic first argument is counted
+    under ``<dynamic>`` rather than silently skipped.
+    """
+    counts: Counter[str] = Counter()
+    for py in sorted(SRC.rglob("*.py")):
+        if "__pycache__" in py.parts:
+            continue
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name != "ForeignKey":
+                continue
+            ondelete = next((kw.value for kw in node.keywords if kw.arg == "ondelete"), None)
+            if not (isinstance(ondelete, ast.Constant) and ondelete.value == "CASCADE"):
+                continue
+            target = node.args[0] if node.args else None
+            if isinstance(target, ast.Constant) and isinstance(target.value, str):
+                table = target.value.split(".", 1)[0]
+            else:
+                table = "<dynamic>"
+            counts[table] += 1
+    return counts
+
+
+def test_AC_meta_txn_4_cascade_census_is_nonvacuous() -> None:
+    """Guard non-vacuity (#1416 DoD-addition 1): the scan must see the known set.
+
+    ``users`` is the sentinel — the ``UserOwnedMixin`` tenancy anchor declares
+    ``ForeignKey("users.id", ondelete="CASCADE")`` on nearly every table, so a
+    census that does not see it is scanning the wrong root, not a clean repo.
+    """
+    counts = _cascade_census()
+    assert counts, "cascade census scanned nothing — did apps/backend/src move?"
+    assert counts["users"] >= 1, (
+        "sentinel missing: no ForeignKey('users.id', ondelete='CASCADE') found; "
+        "the census is scanning the wrong set (UserOwnedMixin declares one)"
+    )
+
+
+def test_AC_meta_txn_4_cross_domain_cascade_only_shrinks() -> None:
+    baseline: dict[str, int] = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    counts = _cascade_census()
+
+    grown = {
+        table: (baseline.get(table, 0), n)
+        for table, n in counts.items()
+        if n > baseline.get(table, 0)
+    }
+    assert not grown, (
+        "new ondelete=CASCADE ForeignKey(s) — a DB cascade is a hidden "
+        "cross-domain write (AC-meta.txn.4; migration-standard.md 'Cross-domain "
+        "reference policy'). Prefer saga-owned deletion (purge event + each "
+        "domain deletes by its own semantics). If this cascade is genuinely "
+        "intra-domain and deliberate, raise the baseline in the same PR so the "
+        "choice is reviewed.\n"
+        f"grown (baseline, actual): {grown}\n"
+        f"full census: {json.dumps(dict(sorted(counts.items())), indent=2)}"
+    )
+
+    stale = {
+        table: (expected, counts.get(table, 0))
+        for table, expected in baseline.items()
+        if counts.get(table, 0) < expected
+    }
+    assert not stale, (
+        "the baseline over-counts — CASCADEs were removed (good!); prune "
+        "docs/ssot/fk-cascade-baseline.json to match in the same PR so the "
+        "ratchet stays tight.\n"
+        f"stale (baseline, actual): {stale}\n"
+        f"full census: {json.dumps(dict(sorted(counts.items())), indent=2)}"
+    )

--- a/tests/tooling/test_fk_cascade_ratchet.py
+++ b/tests/tooling/test_fk_cascade_ratchet.py
@@ -1,11 +1,21 @@
-"""AC-meta.txn.4 — the cross-domain-cascade shrink-only ratchet (#1675 D1).
+"""AC-meta.txn.4 — the ``ondelete="CASCADE"`` ratchet (#1675 D1).
 
-A DB-level ``ondelete="CASCADE"`` is a hidden cross-domain write: one domain's
-delete mutates another domain's aggregates below the application, against
-one-txn-per-domain (#1416 Decision B) and append-only domains (Axiom A). The
-policy (``common/meta/migration-standard.md`` → "Cross-domain reference
-policy") grandfathers the existing sites in ``docs/ssot/fk-cascade-baseline.json``
-and lets the census only shrink; the end-state is saga-owned deletion
+A DB-level ``ondelete="CASCADE"`` is a hidden write below the application:
+one table's delete silently mutates other rows. Across domains that breaks
+one-txn-per-domain (#1416 Decision B) and append-only domains (Axiom A) —
+the risk this ratchet exists for. The census is deliberately **not**
+domain-aware (it counts every CASCADE site): table→package ownership only
+becomes trivially derivable once models decentralization (#1675 D5/D6) is
+done, and a coarse ratchet that makes every new cascade a conscious,
+reviewed choice is worth more now than a precise one later.
+
+What CI enforces: the census must **equal** the checked-in baseline
+(``docs/ssot/fk-cascade-baseline.json``). Silent growth fails; adding a
+cascade is possible only by raising the baseline in the same PR, where the
+diff makes the choice reviewable (the app-boundary-baseline idiom); removed
+cascades must prune the baseline so the ratchet stays tight. The policy
+(``common/meta/migration-standard.md`` → "Cross-domain reference policy")
+grandfathers the existing sites; the end-state is saga-owned deletion
 (``identity/extension/account_purge.py`` is the seed).
 
 The baseline is keyed by **target table**, not file path, so package moves
@@ -80,12 +90,13 @@ def test_AC_meta_txn_4_cross_domain_cascade_only_shrinks() -> None:
         if n > baseline.get(table, 0)
     }
     assert not grown, (
-        "new ondelete=CASCADE ForeignKey(s) — a DB cascade is a hidden "
-        "cross-domain write (AC-meta.txn.4; migration-standard.md 'Cross-domain "
-        "reference policy'). Prefer saga-owned deletion (purge event + each "
-        "domain deletes by its own semantics). If this cascade is genuinely "
-        "intra-domain and deliberate, raise the baseline in the same PR so the "
-        "choice is reviewed.\n"
+        "new ondelete=CASCADE ForeignKey(s) — a DB cascade is a hidden write "
+        "below the application; across domains it breaks one-txn-per-domain "
+        "(AC-meta.txn.4; migration-standard.md 'Cross-domain reference "
+        "policy'). Prefer saga-owned deletion (purge event + each domain "
+        "deletes by its own semantics). If this cascade is deliberate (e.g. "
+        "genuinely intra-domain), raise the baseline in this same PR so the "
+        "choice is visible in review.\n"
         f"grown (baseline, actual): {grown}\n"
         f"full census: {json.dumps(dict(sorted(counts.items())), indent=2)}"
     )


### PR DESCRIPTION
## Summary

Delivery point **D1** of the re-scoped #1675 (see its revised body for the D1–D7 map): codify the 2026-07-11 DDD ruling as SSOT — the three-tier **cross-domain reference policy** (intra-domain FK free · bare cross-domain FK column allowed while `relationship()` navigation stays banned, matching the gate as narrowed by #1756 · `ondelete="CASCADE"` shrink-only) and the **`data/` wide-table projection contract** (each domain's queryable product is a derived, event-fed, zero-FK, provenance-carrying projection). The cascade policy is enforced by a new ratchet gate anchored as **AC-meta.txn.4**.

Part of #1675 (D1). Does **not** close the issue (D3–D7 remain).

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | #1416 — Package-model migration umbrella / #1675 D1 |
| **AC IDs** | `AC-meta.txn.4` (new, in `common/meta/contract.py` roadmap — package-first per the ac-workflow) |
| **AC source updated** | `common/meta/contract.py` `roadmap` |

---

## SSOT Changes

- [x] `docs/ssot/MANIFEST.yaml` — added concept `fk_cascade_baseline` (owner: `docs/ssot/fk-cascade-baseline.json`, kind: baseline, mirrors `app_boundary_baseline`'s registration)
- [x] `docs/ssot/fk-cascade-baseline.json` — new shrink-only baseline: 27 existing `ondelete="CASCADE"` sites grandfathered, keyed by **target table** (path-independent, so D2–D6 package moves don't churn it; `users`: 9 is the tenancy anchor)
- [x] `common/meta/migration-standard.md` — two new sections: "Cross-domain reference policy (FK / relationship / cascade)" and "`data/` = the domain's product: the wide-table projection contract"

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `ed5ba181` | `test_AC_meta_txn_4_cross_domain_cascade_only_shrinks` fails (`FileNotFoundError`: baseline absent); sentinel test passes, proving the census sees the known set |
| 🟢 Green (passing test) | `3ab19a9f` | baseline generated from the census; 2/2 pass |

Anti-vacuity per #1416 DoD-addition 1: `test_AC_meta_txn_4_cascade_census_is_nonvacuous` asserts the `users.id` tenancy-anchor sentinel is in the scanned set, so an empty scan can never go green.

---

## Engineering Audit

- [x] `tools/check_manifest.py` passes (preflight `ssot-ownership` gate ok)
- [x] `tools/lint_doc_consistency.py` passes (preflight `doc-consistency` gate ok)
- [x] `check_ac_index` protection floor + `check_epic_package_dual` both PASSED locally
- [x] No real financial data
- (sa.Enum / env / frontend / infra items: N/A)

---

## Testing

```bash
apps/backend/.venv/bin/python -m pytest tests/tooling/test_fk_cascade_ratchet.py -q   # 2 passed
apps/backend/.venv/bin/python tools/preflight.py                                      # 4 gates ok, 2020 passed
```

Design notes:
- The ratchet is AST-only (no ORM imports) — minimal-env safe, same best-effort posture as AC-meta.txn.3's detection; dynamic FK targets are counted under `<dynamic>` rather than skipped.
- Both directions fail loudly: a **grown** count = new hidden cross-domain write (message points to saga-owned deletion; a deliberate intra-domain cascade raises the baseline in the same PR, making it reviewable); a **stale** over-count = prune the baseline in the same PR, keeping the ratchet tight (the `check_app_boundary --update` idiom).
- RESTRICT-flip for the grandfathered sites is explicitly **D7** — a later, separate decision, never bundled into a move.

## Screenshots / Evidence

_N/A_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
