### PR TITLE
[finance_report_ui] docs(harness): encode PR-lifecycle loop, planning/bug-fix work orders, and QA rituals from transcript mining

### DIFF
--- a/.claude/skills/planning
+++ b/.claude/skills/planning
@@ -1,0 +1,1 @@
+../../.opencode/skills/domain/planning

--- a/.claude/skills/staging-qa
+++ b/.claude/skills/staging-qa
@@ -1,0 +1,1 @@
+../../.opencode/skills/domain/staging-qa

--- a/.claude/skills/ux-review
+++ b/.claude/skills/ux-review
@@ -1,0 +1,1 @@
+../../.opencode/skills/domain/ux-review

--- a/.codex/skills/planning
+++ b/.codex/skills/planning
@@ -1,0 +1,1 @@
+../../.opencode/skills/domain/planning

--- a/.codex/skills/staging-qa
+++ b/.codex/skills/staging-qa
@@ -1,0 +1,1 @@
+../../.opencode/skills/domain/staging-qa

--- a/.codex/skills/ux-review
+++ b/.codex/skills/ux-review
@@ -1,0 +1,1 @@
+../../.opencode/skills/domain/ux-review

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -19,7 +19,8 @@ behavioral entry point is [`AGENTS.md`](../AGENTS.md); the multi-runtime bridge
 
 Only **project-specific** skills live here (accounting, reconciliation,
 reporting, extraction, schema, development, preflight, ac-workflow,
-github-operations, secrets-management, infra-operations). Generic-expertise
+github-operations, secrets-management, infra-operations, planning,
+staging-qa, ux-review). Generic-expertise
 packs (backend/frontend/QA/PM/UI) were removed in #1657: frontier models carry
 that knowledge natively, and version-specific questions route to live docs
 (context7 MCP) rather than frozen snapshots. Before adding a skill, ask: does

--- a/.opencode/skills/domain/planning/SKILL.md
+++ b/.opencode/skills/domain/planning/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: planning
+description: Goal-first planning for finance_report system reviews, issue design/triage, prioritization, and "what should we do next" asks. Use BEFORE creating or restructuring GitHub issues, when reviewing a subsystem (testing, CI, delivery, UX), when ranking a backlog by ROI, or whenever the deliverable is a plan or issue tree rather than code. Enforces Vision → Guarantees → Gaps → Actions with a mandatory counterfactual pass and this repo's issue conventions.
+---
+
+# Planning — goal-first, counterfactual-gated
+
+The normative work order lives in
+[docs/agents/orchestration.md → Planning Work Order](../../../../docs/agents/orchestration.md).
+This skill carries the rituals and templates. History: it took one 8-round
+session (2026-07-12) for a bottom-up "survey what exists, then rationalize"
+review to converge on a usable plan; the goal-first order below is what that
+convergence actually followed.
+
+## The order (never skip step 1)
+
+1. **Vision first** — read [vision.md](../../../../vision.md); restate the
+   terminal goal, the North-Star metric, and the axioms relevant to the ask
+   *before* surveying any code or issues.
+2. **Guarantees** — derive what must hold for the goal (walk the data
+   pipeline end-to-end: source → extraction → trust boundary → ledger/report
+   math → deployed serving, plus the meta-layer "gates can't go vacuous").
+   State guarantees, not tasks. Argue completeness (what does the walk miss?).
+3. **Gaps** — audit current state against the guarantees. Bottom-up inventory
+   is evidence-gathering only — the conclusion must be derived downward.
+4. **Actions** — minimal set covering the gaps. Prefer a *mechanism* that
+   bounds work (a ratchet, a delete-as-you-touch rule) over a big-bang project
+   that will never be scheduled.
+5. **Counterfactual pass** — before presenting, answer in writing:
+   - If every acceptance criterion here is met, what still fails?
+   - Which numbers in this plan are measured vs. guessed?
+   - Does any acceptance criterion describe a task instead of a guarantee?
+   - What is each action's lock mechanism against silent regression?
+   - Which inputs can only the operator provide? (Name them.)
+
+## Root-issue template (acceptance = guarantees)
+
+```markdown
+# Root: <one-line problem statement>
+
+> Goal derivation: <which vision axiom/metric this serves, in 2-3 sentences>
+
+## Core problem
+<mechanism, with measured evidence — file:line, counts, incident links>
+
+## Solution shape
+<mechanisms are suggestions; the Acceptance guarantees are the contract>
+
+## Acceptance — each line is a guarantee, not a task
+- [ ] G-<name>: <outcome that must hold> — enforced by <lock mechanism>
+- [ ] ...
+
+## Operator dependency (if any)
+<inputs only the user can provide — real documents, product judgment, merges>
+
+## Known residuals — named, deliberately not owned here
+<what stays unguarded even at 100% acceptance, and why that's accepted>
+
+## Relations
+<peers / parents / lineage — native sub-issues for execution children>
+```
+
+## Issue hygiene
+
+- **No issues during exploration.** A structure must survive one
+  simplification pass + one counterfactual pass in conversation first
+  (create-then-close-within-days is a process failure, not progress).
+- **Orthogonality test**: orthogonal to every existing issue → new issue;
+  overlapping → amend the existing one. Prefer amending an existing EPIC over
+  creating a new one.
+- **One root per problem**, execution children as native GitHub sub-issues;
+  close superseded issues with a stated reason (`not_planned` vs `completed`
+  matters).
+- **Merge like-with-like**: the user's bar is ~4-5 issues per review round,
+  not one issue per finding.
+
+## Plan-output defaults
+
+- **Minimum-PR plan is a first-class output**: batch cohesive issues into one
+  PR; independent PRs run in parallel (bounded by write conflicts, never by
+  compute — vision Good Taste 6). State the PR count explicitly.
+- **ROI-ranked ordering**: every backlog presentation is ranked by
+  impact-per-effort, with the ranking rationale stated.
+- **Deliverable structure the user expects**: item → issue → action → goal →
+  acceptance criteria.

--- a/.opencode/skills/domain/staging-qa/SKILL.md
+++ b/.opencode/skills/domain/staging-qa/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: staging-qa
+description: Real-device staging QA ritual for finance_report — walk https://report-staging.zitian.party with the operator's real statements, read backend logs on the VPS, and file redaction-safe bug issues. Use when the user asks to test staging, find staging bugs, do a real-data QA round, or verify a staging deploy before release.
+---
+
+# Staging QA — real documents, real logs, redacted reports
+
+The one loop that has historically found the bugs CI cannot: live extraction
+against the operator's real statements. Every round of it (2026-06-26,
+2026-06-29, 2026-07-10) surfaced production-class bugs that all synthetic
+gates passed.
+
+## Setup
+
+- **App**: https://report-staging.zitian.party — verify the deployed version
+  first (health endpoint / footer) so findings attribute to the right build.
+- **Test data**: the operator's real statements (they supply; typically from
+  their local archive). NEVER copy real documents into the repo, issues, or
+  scratch dirs that outlive the session.
+- **Backend logs**: SSH to the VPS (address + credentials via local direnv /
+  1Password; see `repo/docs/ssot/ops.pipeline.md`), then
+  `docker logs finance_report-backend-staging --tail 200`. Read-only — never
+  modify via SSH (orchestration.md operational guideline #1).
+
+## The walk (assert numbers, not rendering)
+
+1. Upload — through the canonical **single statement entry** (CSV + Manual are
+   folded secondary entries; if you see parallel entries, that itself is a bug
+   — standing design decision, EPIC-019/AC19.15).
+2. Parse status → review queue → reconcile → balance sheet / dashboard →
+   reports.
+3. At each step verify **values**, not just page-loads: opening/closing
+   balances reconcile to the statement, totals match, currency labels agree
+   end-to-end, confidence/validated badges are earned (not vacuous).
+   Past bug classes to re-probe: hardcoded currency, net-flow shown as
+   balance, `balance_validated` true with nothing validated, stuck-in-parsing
+   documents.
+
+## Filing what you find
+
+- **RL-6 first**: placeholder amounts/merchants/account digits ONLY. Grep
+  every draft for real values before posting — issue titles included.
+- Each bug: root cause (mechanism, not symptom) + **which gate should have
+  caught it** (bug-fix work order in orchestration.md) — then the fix PR
+  back-fills that gate.
+- Batch findings into per-subsystem issues (the user's bar: a handful, not
+  one per symptom), ROI-ranked.
+- Every real-document extraction bug also adds a case to the real-corpus eval
+  (#1764's G-growth guarantee) before its fix-issue closes.

--- a/.opencode/skills/domain/staging-qa/SKILL.md
+++ b/.opencode/skills/domain/staging-qa/SKILL.md
@@ -18,9 +18,10 @@ gates passed.
   their local archive). NEVER copy real documents into the repo, issues, or
   scratch dirs that outlive the session.
 - **Backend logs**: SSH to the VPS (address + credentials via local direnv /
-  1Password; see `repo/docs/ssot/ops.pipeline.md`), then
-  `docker logs finance_report-backend-staging --tail 200`. Read-only — never
-  modify via SSH (orchestration.md operational guideline #1).
+  1Password; see `repo/docs/ssot/ops.pipeline.md` — `repo/` is the infra2
+  submodule, initialize with `git submodule update --init repo` if absent),
+  then `docker logs finance_report-backend-staging --tail 200`. Read-only —
+  never modify via SSH (orchestration.md operational guideline #1).
 
 ## The walk (assert numbers, not rendering)
 

--- a/.opencode/skills/domain/ux-review/SKILL.md
+++ b/.opencode/skills/domain/ux-review/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: ux-review
+description: Persona-based UI/UX review ritual for finance_report — walk the core flows as an everyday (non-accountant) user on PC and mobile/PWA, find confusion points, and deliver an ROI-ranked issue set with acceptance criteria. Use when the user asks for a UX review from an ordinary-user or top-designer perspective, or after landing a UI-heavy change.
+---
+
+# UX Review — everyday-user persona, ROI-ranked output
+
+Requested near-verbatim in 6 sessions before being encoded. The persona and
+the deliverable format below are the user's own recurring spec.
+
+## Persona
+
+An everyday user, not an accountant. They want "how much money do I have,
+where is it, what changed this month" answered in seconds. The machinery
+(audit, confidence tiers, reconciliation, traceability) must be reachable but
+never in the way — trust is shown at the moment of doubt, not up front.
+
+## Standing design decisions (violating these = the finding)
+
+- **Upload is ONE primary statement entry**, with CSV + Manual folded as
+  secondary — never a flat list of parallel entries (EPIC-019 / AC19.15).
+- **Mobile/PWA uses the bottom-tab IA**: Home · Chat · Add · Audit · More;
+  machinery lives under the Audit hub (EPIC-022 PR12).
+- **No internal jargon in UI copy** — no repo-speak (SSOT, AC, tier, layer-2);
+  plain words an everyday user recognizes.
+- Check the owning EPIC (`docs/project/EPIC-019`, `EPIC-022`) before proposing
+  IA changes — decisions recorded there outrank reviewer instinct.
+
+## The walk
+
+First-run → upload a statement → parse progress → review flagged items →
+dashboard (net worth, distribution) → monthly income/spending → reports →
+assistant. Do the full pass twice: PC viewport and mobile/PWA viewport.
+
+Judge at each step: confusion points, dead ends, unexplained states, jargon,
+trust moments (does a surprising number offer a path to its source?), and
+whether the low-confidence tail — the only thing the user is *supposed* to
+look at (vision Axiom B) — is actually the most visible thing.
+
+## Deliverable format (the user's recurring spec)
+
+Item → issue → action → goal → acceptance criteria, **ROI-ranked**. Merge
+like-with-like: ~4-5 issues per round, orthogonal to existing ones (amend,
+don't duplicate). Screenshots must not contain real financial data (RL-6).
+
+Behavior is proven by tests, but **visual quality is judged by human eyes and
+simulators** (AGENTS.md) — recommend and rank; never self-certify a visual
+outcome as done.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 > **Prohibition**: AI may NOT modify this file without explicit authorization.
 > **Prohibition**: AI deliverable = CI-passing PR. User reviews and decides whether to merge.
 > **Checklist**: Before completing a task, verify every item in [docs/agents/orchestration.md](docs/agents/orchestration.md).
-> **Language**: All code, PRs, commits, and reports must be in **English**.
+> **Language**: All code, PRs, commits, issues, and repo docs must be in **English**.
+> Conversation with the user follows the **user's language** (Chinese) — never answer a Chinese question in English.
 
 ---
 
@@ -80,6 +81,14 @@ The SSOT ownership map is: **[docs/ssot/MANIFEST.yaml](docs/ssot/MANIFEST.yaml)*
 
 **EPIC → AC → Test → Code → Doc**
 
+> **Planning-type tasks** (system reviews, issue design/triage, prioritization,
+> "what should we do next") start further upstream: **Vision → Guarantees →
+> Gaps → Actions**, with a counterfactual pass *before* any GitHub issue is
+> created. Use the `planning` skill; work order details in
+> [docs/agents/orchestration.md](docs/agents/orchestration.md).
+> **Bug fixes** follow the bug-fix work order there too: root cause → why no
+> existing gate caught it → back-fill the missing proof in the same PR.
+
 0. Frame the work with a **MECE** breakdown: mutually exclusive task slices, collectively exhaustive coverage of the stated goal, explicit dependencies, and explicit out-of-scope items.
 1. Anchor to an EPIC in `docs/project/` (the horizontal goal)
 2. Define ACs where they live: a **migrated package** owns its ACs as
@@ -107,6 +116,9 @@ Full policy: **[docs/contributing/branch-policy.md](docs/contributing/branch-pol
 - ✅ A mergeable PR must resolve all Copilot auto-review comments (either by fixing them or providing a justification for not doing so). Once resolved, resolve the comment threads on GitHub.
 - ✅ For implementation work, the final deliverable is not complete until a ready PR is pushed and the final report includes PR URL, branch, commit SHA, draft status, `mergeable`, `mergeStateStatus`, and required-check summary.
 - ✅ If GitHub does not report `mergeable=MERGEABLE` and `mergeStateStatus=CLEAN`, the task is not a mergeable-PR delivery; report the blocker, the failing/pending check or review thread, and the next action instead of calling the work complete.
+- ✅ Delivery does not end at first green: keep watching the open PR (new CI runs, late CR comments, conflicts from other merges) and fix regressions unprompted, until the user merges — see the PR Lifecycle Loop in [docs/agents/orchestration.md](docs/agents/orchestration.md).
+- ✅ The user's merge (announced or detected) is itself the continue signal: resync `main`, rebase remaining branches, and proceed to the next planned slice without waiting for a fresh instruction.
+- ✅ Blocked on a user-only action (merging, product judgment)? Don't stall — state the blocker and start the next independent planned slice.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 > **Prohibition**: AI deliverable = CI-passing PR. User reviews and decides whether to merge.
 > **Checklist**: Before completing a task, verify every item in [docs/agents/orchestration.md](docs/agents/orchestration.md).
 > **Language**: All code, PRs, commits, issues, and repo docs must be in **English**.
-> Conversation with the user follows the **user's language** (Chinese) — never answer a Chinese question in English.
+> Conversation with the user follows the **user's language** — answer in the language the question was asked in.
 
 ---
 

--- a/docs/agents/orchestration.md
+++ b/docs/agents/orchestration.md
@@ -31,10 +31,40 @@
 6. ✅ **Monitor CI until it passes** (use `gh run watch`)
    - If CI fails: find the root cause, fix, repeat
 7. ✅ **Resolve every Copilot (CR) review comment** — fix or justify each — then resolve the threads on GitHub
-8. ✅ **Report: "PR ready for your review"**
-9. ⏸️ **STOP. Wait for user decision.** (Agents never merge.)
+8. ✅ **Report: "PR ready for your review"** — with PR URL, branch, commit SHA,
+   draft status, `mergeable`, `mergeStateStatus`, and required-check summary
+9. 🔁 **Keep the PR mergeable while waiting** (agents never merge): watch for
+   new CI runs, late CR comments, and conflicts caused by other merges — fix
+   them unprompted; report state changes only
+10. ▶️ **On merge** (detected, or announced by the user): resync `main`, rebase
+    any remaining open branches, and continue the next planned slice — report
+    plan progress (done / remaining) instead of asking what to do next
 
 **User Workflow**: Review → Approve / Request changes / Reject → **User merges PR**.
+
+---
+
+## PR Lifecycle Loop (anti-babysitting)
+
+Transcript history (19 sessions, 2026-06→07) shows the expensive failure mode
+was never writing code — it was the human babysitting every PR to mergeable:
+prompting for CI failures (9 sessions), CR comments (15 sessions), and typing
+the merge-resync ritual by hand (16 sessions). The loop in steps 6–10 above is
+therefore **part of the deliverable, not aftercare**:
+
+- **Watch, don't push-and-forget.** After every push, watch checks to
+  completion (`gh pr checks <n> --watch`, or a background monitor). First
+  green is a checkpoint, not the finish line.
+- **Late CR comments are the same delivery.** Triage each on merit — fix it,
+  or justify and resolve the thread. Never blanket-accept, never ignore.
+- **A conflict appearing because another PR merged is yours** — rebase
+  immediately, don't wait to be told.
+- **Goals must never require a user-only action.** An agent goal is satisfied
+  by "PR(s) mergeable + reported", never by "PR merged" — a goal phrased on
+  merging deadlocks the session against the agents-never-merge rule.
+- **Post-merge continuation is default-on.** The user's merge is the signal to
+  resync and continue the approved plan. Ask only at a genuine decision point
+  or when the plan is exhausted.
 
 ---
 
@@ -83,6 +113,68 @@ behavior is anchored to a goal and proven by a test). The **mechanism** for
 Reference: [docs/ssot/tdd.md](../ssot/tdd.md) ·
 [package migration standard](../../common/meta/migration-standard.md)
 
+---
+
+## Bug-Fix Work Order (root-cause + gate backfill)
+
+Every bug fix (from staging QA, production, or review) must answer three
+questions in its PR — transcript history shows the user has had to ask them
+manually in 8 sessions:
+
+1. **Root cause, not symptom** — the mechanism that produced the behavior,
+   not the surface where it appeared.
+2. **Why did no existing gate catch it?** — name the tier (unit / integration /
+   tier-1 e2e / staging gate / prod smoke) that *should* have caught it.
+3. **Back-fill the missing proof in the same PR** — a failing-first test
+   (red → green) at that tier; where a same-PR gate is genuinely impossible,
+   an explicit issue for the gap. A fix without a locked proof is Good Taste
+   5's vacuous safety net — the same bug returns.
+
+Bug-fix PR bodies carry a short **Root cause / Why gates missed it / Proof
+added** block.
+
+---
+
+## Planning Work Order (goal-first, counterfactual-gated)
+
+For planning-type tasks — system reviews, issue design/triage, prioritization,
+"what next" — the implementation work order above starts too late. Upstream
+mandatory sequence (templates and rituals: `planning` skill):
+
+1. **Vision** — restate the terminal goal + North-Star (vision.md) relevant to
+   the ask, *before* surveying what exists.
+2. **Guarantees** — derive what must hold for that goal (walk the pipeline;
+   state guarantees, not tasks).
+3. **Gaps** — map the current state against the guarantees. Never rationalize
+   bottom-up from the existing inventory toward a conclusion.
+4. **Actions** — minimal set; each action's acceptance = the guarantee it
+   delivers **plus a lock mechanism** (ratchet / gate / release-evidence check)
+   so it cannot silently regress. Name residuals and operator dependencies
+   explicitly.
+5. **Counterfactual pass before presenting** — "if every acceptance criterion
+   is met, what still fails?" Run it yourself; the user should never have to
+   ask.
+
+Planning defaults: propose the **minimum-PR plan** (batch cohesive issues into
+one PR; run independent PRs in parallel, bounded by write conflicts); rank
+actions by ROI; **create no GitHub issues during exploration** — a structure
+must survive one simplification pass and one counterfactual pass in
+conversation before anything is filed.
+
+---
+
+## Migration / Refactor Closeout
+
+A migration or refactor is not done when the new path works. Done requires a
+**residue sweep** — re-requested by the user in 5+ sessions before this was
+encoded:
+
+- Old code, config, tests, and docs are deleted, or each survivor is
+  explicitly issue-tracked with a reason.
+- Rejected design options are recorded with why-not, for the next reader.
+- A drift scan of docs + tests: anything still describing the old world is
+  updated or deleted in the same PR.
+
 **Cross-cutting contract checks** (each owned by
 [red-lines.md](./red-lines.md) §Engineering Integrity — listed here only as the
 work-order reminder): sync the `repo/` submodule (`infra2`) when a change adds
@@ -123,6 +215,14 @@ Judgment, not config (vision.md, Good Taste 6):
    ```bash
    cd repo && git fetch origin main && git log --oneline -1 origin/main && git log --oneline -1 HEAD
    ```
+4. **Probe before claiming inability**: never report "can't access X / no
+   credentials" without first attempting the documented path — direnv probe
+   (`echo ${#VAR}`), the Dokploy API, a read-only VPS SSH log pull, the SigNoz
+   non-browser API recipe (see the `infra-operations` skill). If the path truly
+   fails, report the exact failing step — never a blanket "can't log in".
+5. **Post-deploy verification is part of deploying**: after any deploy or
+   release action, verify service health, the running version, and recent
+   error logs before reporting success.
 
 ---
 


### PR DESCRIPTION
## What

Mined all **571 user-typed messages across 19 sessions** (2026-06→07) for patterns where the human had to steer, repeat, or correct the agent — each recurring pattern is a harness gap that should have been encoded after its first occurrence. This PR encodes the top ones.

## Evidence → change map

| Pattern (sessions it recurs in) | Encoded as |
|---|---|
| "CI 挂了修一下" (9) + "处理 CR comment" (15) + "已经 merge，切 main 拉最新" (16) | **PR Lifecycle Loop** (orchestration.md): delivery ≠ first green; watch checks/CR/conflicts until merge; merge = continue signal → resync + next slice unprompted. Steps 8–9 of the agent workflow extended to 8–10. |
| Agent stalls awaiting authorization; ~15 consecutive stop-hook rejections in one session (10) | Continuation policy + rule: agent goals must never require a user-only action (merging) |
| Plans without goal derivation / acceptance criteria / counterfactual / ROI order (~10 combined) | **Planning Work Order** (Vision → Guarantees → Gaps → Actions) + `planning` skill (root-issue template, no-issues-during-exploration, min-PR default) |
| User manually runs "root cause? why did no gate catch it?" retro on every bug (8) | **Bug-Fix Work Order**: root cause → tier that should have caught it → back-fill proof in same PR |
| False "can't access X" (SigNoz/direnv — "第 800 次了") (7–8) | Operational guideline 4: probe documented paths before claiming inability |
| Post-deploy health checks prompted by hand (5) | Operational guideline 5: health/version/logs verification is part of deploying |
| Migration residue re-requested every time ("整体扫一下…残留物") (5) | **Migration/Refactor Closeout** residue sweep |
| Hand-retyped staging-QA ritual (3) and persona UX-review ritual (6) | `staging-qa` + `ux-review` skills — also encode standing design decisions (single upload entry, bottom-tab IA) that previously lived only in chat history and drifted |
| "说中文" (3) | Language rule scoped: repo artifacts English; conversation follows the user's language |

## AGENTS.md changes (user-authorized this session)

Three surgical edits: language-rule scoping; planning/bug-fix work-order pointer; three PR-lifecycle bullets in Branch & PR Rules. Everything heavier lives in orchestration.md + skills, per the existing pointer-ization direction (#1658).

## Verification

- `tests/tooling/test_agent_runtime_symlinks.py` — 11 passed (new skills symlinked on both `.claude/skills/` and `.codex/skills/`)
- `tools/lint_doc_consistency.py` — exit 0
- Full `tests/tooling/` — 2020 passed, 1 skipped (CI-equivalent invocation)
- Docs-only + symlinks: no runtime code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)