### PR TITLE
[finance_report_audit] feat(#1642): first cross-domain event subscriber — pricing ingests extraction's PriceObserved

### DIFF
--- a/apps/backend/migrations/versions/0053_add_statement_price_observations.py
+++ b/apps/backend/migrations/versions/0053_add_statement_price_observations.py
@@ -1,0 +1,54 @@
+"""add statement_price_observations — pricing's PriceObserved ingest store (#1642)
+
+The event-fed, id-referenced copy of extraction's statement-extracted unit
+prices (boundary ruling 4, #1610): the authoritative document-fact stays in
+extraction; pricing keeps its own denormalized row so resolve() treats
+statement prices as first-class candidates. Zero FK by design (Decision B,
+#1416 — ids carried as provenance, no shared transaction); the UNIQUE
+constraint on source_observation_id is the idempotency backstop for
+at-least-once outbox delivery.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0053_statement_price_obs"
+down_revision = "0052_signed_positions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "statement_price_observations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("subject_kind", sa.String(length=20), nullable=False),
+        sa.Column("subject_key", sa.String(length=100), nullable=False),
+        sa.Column("value", sa.DECIMAL(precision=18, scale=6), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=True),
+        sa.Column("as_of", sa.Date(), nullable=False),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source_observation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "source_observation_id",
+            name="uq_statement_price_observations_source_id",
+        ),
+        sa.CheckConstraint("value > 0", name="ck_statement_price_observations_value_positive"),
+    )
+    op.create_index(
+        "idx_statement_price_observations_lookup",
+        "statement_price_observations",
+        ["subject_kind", "subject_key", "as_of"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_statement_price_observations_lookup",
+        table_name="statement_price_observations",
+    )
+    op.drop_table("statement_price_observations")

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -25,7 +25,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 import src.models._registry  # noqa: E402, F401
 from src.boot import Bootloader, BootMode
 from src.config import settings
-from src.database import engine, get_db, init_db
+from src.database import async_session_maker, engine, get_db, init_db
 from src.extraction import (
     find_uploaded_document_filename_by_hash,
     get_known_storage_paths,
@@ -49,12 +49,15 @@ from src.observability import (
 )
 from src.platform import (
     BaseAppException,
+    OutboxRelay,
     RateLimitConfig,
     RateLimiter,
+    SubscriberRegistry,
     register_readiness_provider,
     register_uploaded_document_readers,
 )
 from src.platform.orm.ping_state import PingState
+from src.pricing import subscribe_price_ingest
 from src.routers import (
     accounts,
     ai_feedback,
@@ -110,6 +113,41 @@ register_uploaded_document_readers(
     find_filename_by_hash=find_uploaded_document_filename_by_hash,
 )
 register_known_storage_paths_provider(get_known_storage_paths)
+
+# Wire the domain-event subscribers (#1642): the composition root owns the
+# SubscriberRegistry and the OutboxRelay that dispatches committed outbox rows
+# to them — platform (L1) must not import a domain package (L3), so the
+# registration happens here, the same inversion as the provider ports above.
+# First (precedent-setting) subscriber: pricing ingests extraction's
+# statement-extracted PriceObserved publications.
+outbox_subscribers = SubscriberRegistry()
+subscribe_price_ingest(outbox_subscribers, session_factory=async_session_maker)
+outbox_relay = OutboxRelay(outbox_subscribers)
+
+#: Seconds the outbox-relay background task sleeps between drain passes.
+OUTBOX_RELAY_POLL_SECONDS = 1.0
+
+
+async def run_outbox_relay(stop_event: asyncio.Event) -> None:
+    """Drain committed outbox rows periodically until shutdown.
+
+    The durable half of the transactional outbox (``common/platform/readme.md``
+    "Running the relay"): each pass opens a fresh session and dispatches one
+    batch of pending rows to the subscribed handlers. A failing pass is logged
+    and retried on the next pass — delivery is at-least-once and handlers are
+    idempotent, so a retry is always safe.
+    """
+    while not stop_event.is_set():
+        try:
+            async with async_session_maker() as session:
+                await outbox_relay.run_once(session)
+        except Exception:
+            logger.exception("Outbox relay pass failed")
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=OUTBOX_RELAY_POLL_SECONDS)
+        except TimeoutError:
+            continue
 
 
 def _init_otel_instrumentation() -> None:
@@ -181,6 +219,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     supervisor_task = asyncio.create_task(run_parsing_supervisor(stop_event))
     market_data_task = asyncio.create_task(run_market_data_scheduler(stop_event))
     sweep_task = asyncio.create_task(run_storage_sweep(stop_event))
+    outbox_relay_task = asyncio.create_task(run_outbox_relay(stop_event))
     log_observability_startup(logger)
     logger.info("Application started", version="0.1.0")
     yield
@@ -188,6 +227,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     supervisor_task.cancel()
     market_data_task.cancel()
     sweep_task.cancel()
+    outbox_relay_task.cancel()
 
     with suppress(asyncio.CancelledError):
         await supervisor_task
@@ -195,6 +235,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await market_data_task
     with suppress(asyncio.CancelledError):
         await sweep_task
+    with suppress(asyncio.CancelledError):
+        await outbox_relay_task
     logger.info("Application shutting down")
 
 

--- a/apps/backend/src/platform/base/bus.py
+++ b/apps/backend/src/platform/base/bus.py
@@ -24,13 +24,17 @@ recording fake in tests.
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
 
 from src.platform.base.event import DomainEvent
 
 #: A subscriber: a callable invoked by the relay with a reconstructed event.
-EventHandler = Callable[[DomainEvent], None]
+#: May be sync or async — a coroutine function's awaitable is awaited by the
+#: relay before the row is marked published (a DB-writing consumer, e.g.
+#: pricing's statement-price ingest, needs an ``AsyncSession`` inside the
+#: handler).
+EventHandler = Callable[[DomainEvent], None | Awaitable[None]]
 
 
 class SubscriberRegistry:

--- a/apps/backend/src/platform/extension/relay.py
+++ b/apps/backend/src/platform/extension/relay.py
@@ -19,6 +19,7 @@ how it would run (a periodic background task / scheduled job).
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 
@@ -80,7 +81,12 @@ class OutboxRelay:
             for row in rows:
                 event = _to_event(row)
                 for handler in self._registry.handlers_for(row.event_type):
-                    handler(event)
+                    # Handlers may be sync or async (EventHandler admits both);
+                    # an async handler's work must complete before the row is
+                    # marked published, so its awaitable is awaited here.
+                    result = handler(event)
+                    if inspect.isawaitable(result):
+                        await result
                 await repo.mark_published(row, published_at=datetime.now(UTC))
                 published += 1
         except Exception:

--- a/apps/backend/src/pricing/__init__.py
+++ b/apps/backend/src/pricing/__init__.py
@@ -20,10 +20,12 @@ FX-specific wrappers over the same subject+resolve path), and the crawler
 sync (``sync_fx_rates``/``sync_stock_prices``/``ensure_market_data_fresh``/
 ``get_market_data_status``/``resolve_missing_fx_rate`` — pure "given these
 scopes, sync/report on them"; discovering *which* scopes from the user's
-ledger is the caller's job, see ``extension/market_data/service.py``). The
-remaining ``extension/`` domain service (the extraction-event subscriber)
-and the ``data/`` projections are reserved (declared in the contract's
-``units`` with no module path) for a later commit.
+ledger is the caller's job, see ``extension/market_data/service.py``), and
+the extraction-event ingest subscriber (``ingest_statement_price`` +
+``subscribe_price_ingest``, #1642 — the first cross-domain event consumer;
+see ``extension/ingest.py``). The ``data/`` projections remain reserved
+(declared in the contract's ``units`` with no module path) for a later
+commit.
 """
 
 from __future__ import annotations
@@ -50,10 +52,12 @@ from src.pricing.extension import (
     get_average_rate,
     get_exchange_rate,
     get_market_data_status,
+    ingest_statement_price,
     record_manual_valuation,
     record_override,
     resolve,
     resolve_missing_fx_rate,
+    subscribe_price_ingest,
     sync_fx_rates,
     sync_stock_prices,
 )
@@ -68,6 +72,7 @@ from src.pricing.extension.valuation import (
 # eagerly so importing the package registers the mappers on Base.metadata.
 from src.pricing.orm.fx_conversion import FxConversion
 from src.pricing.orm.market_data import FxRate, MarketDataSyncState, StockPrice
+from src.pricing.orm.statement_observation import StatementPriceObservation
 
 __all__ = [
     "Authority",
@@ -85,6 +90,7 @@ __all__ = [
     "PricingError",
     "ResolutionPolicy",
     "SqlObservationRepository",
+    "StatementPriceObservation",
     "StockPrice",
     "ValuationComponentItem",
     "ValuationComponentsResult",
@@ -97,10 +103,12 @@ __all__ = [
     "get_average_rate",
     "get_exchange_rate",
     "get_market_data_status",
+    "ingest_statement_price",
     "record_manual_valuation",
     "record_override",
     "resolve",
     "resolve_missing_fx_rate",
+    "subscribe_price_ingest",
     "sync_fx_rates",
     "sync_stock_prices",
 ]

--- a/apps/backend/src/pricing/base/events.py
+++ b/apps/backend/src/pricing/base/events.py
@@ -1,24 +1,38 @@
-"""``PriceObserved`` — the domain event pricing publishes when a new observation lands.
+"""``PriceObserved`` — the domain event announcing a price observation fact.
 
-Consumers (e.g. a future durable rollup, or cross-package notification) react
-to this rather than polling. Per boundary ruling 4, ``extraction`` is a
-*producer* into pricing (a statement-extracted unit price arrives as an
-id-referenced observation), not a subscriber of this event; this event is
-pricing's own outbound fact, published via the platform outbox (mechanism C —
-no compile-time edge, no shared transaction).
+Two producers publish it (both via the platform outbox, mechanism C — no
+compile-time edge, no shared transaction):
+
+- **pricing itself** (``record_manual_valuation``/``record_override``): the
+  observation already lives in pricing's store; the event is pricing's own
+  outbound fact for downstream reactors (e.g. a future durable rollup).
+- **extraction** (boundary ruling 4, #1610 / #1642): a statement-extracted
+  unit price stays in ``extraction`` (document-fact, provenance chain,
+  re-parse lifecycle) and is announced with ``source=STATEMENT`` and
+  ``observation_id`` = the extraction fact id. Pricing's ingest subscriber
+  (``extension/ingest.py``) consumes it into an id-referenced observation
+  copy — extraction never subscribes to this event, and pricing never reads
+  extraction's tables.
+
+The event therefore carries the full observation value (``value``/``currency``/
+``user_id``), not just the id: a consumer must be able to build the copy from
+the payload alone, because reaching back into the producer's tables would
+re-create the compile-time/runtime coupling the event exists to remove.
+``observation_id`` doubles as the natural dedup key for at-least-once delivery.
 
 ``PriceObserved`` is a :class:`~src.platform.base.event.DomainEvent`: it
 carries the universal ``event_type``/``occurred_at`` and exposes its fields
 via :meth:`payload` so the outbox can persist it as JSON and the relay can
-rehydrate it for subscribers — the same shape as ``counter.Incremented``, the
-one other producer in this codebase. This is the one place pricing depends
-(downward) on ``platform`` for the event base.
+rehydrate it for subscribers — the same shape as ``counter.Incremented``.
+This is the one place pricing depends (downward) on ``platform`` for the
+event base.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime
+from decimal import Decimal
 from uuid import UUID
 
 from src.platform.base import DomainEvent
@@ -31,12 +45,22 @@ EVENT_TYPE = "pricing.PriceObserved"
 
 @dataclass(frozen=True)
 class PriceObserved(DomainEvent):
-    """A fact: a new ``PriceObservation`` (``observation_id``) was recorded."""
+    """A fact: a price observation (``observation_id``) was recorded.
+
+    ``observation_id`` is the producer-side fact id — a pricing store id when
+    pricing publishes, the extraction fact id when extraction publishes — and
+    is the event's natural dedup key. ``value`` is a ``Decimal`` (never
+    ``float``, the standing red line) in ``currency``; ``user_id`` scopes
+    user-owned observations (``None`` for global sources).
+    """
 
     observation_id: UUID
     subject: PriceableSubject
     as_of: date
     source: ObservationSource
+    value: Decimal
+    currency: str | None = None
+    user_id: UUID | None = None
 
     @classmethod
     def create(
@@ -46,6 +70,9 @@ class PriceObserved(DomainEvent):
         subject: PriceableSubject,
         as_of: date,
         source: ObservationSource,
+        value: Decimal,
+        currency: str | None = None,
+        user_id: UUID | None = None,
         occurred_at: datetime,
     ) -> PriceObserved:
         """Build a ``PriceObserved`` with the fixed ``pricing.PriceObserved`` type."""
@@ -56,10 +83,13 @@ class PriceObserved(DomainEvent):
             subject=subject,
             as_of=as_of,
             source=source,
+            value=value,
+            currency=currency,
+            user_id=user_id,
         )
 
     def payload(self) -> dict:
-        """JSON body persisted to the outbox: observation_id, subject, as_of, source."""
+        """JSON body persisted to the outbox: the id-referenced observation copy."""
         return {
             "aggregate_id": str(self.observation_id),
             "observation_id": str(self.observation_id),
@@ -67,4 +97,7 @@ class PriceObserved(DomainEvent):
             "subject_key": self.subject.key,
             "as_of": self.as_of.isoformat(),
             "source": self.source.value,
+            "value": str(self.value),
+            "currency": self.currency,
+            "user_id": str(self.user_id) if self.user_id is not None else None,
         }

--- a/apps/backend/src/pricing/extension/__init__.py
+++ b/apps/backend/src/pricing/extension/__init__.py
@@ -1,11 +1,14 @@
 """``pricing.extension`` — the domain services + impure edges.
 
-Real this commit: ``resolve()`` (implementation-pure — no I/O — but
+Real here: ``resolve()`` (implementation-pure — no I/O — but
 ``KIND_LAYER`` places every ``DOMAIN_SERVICE`` in ``extension/`` with no
 exception, so it lives here despite touching no database),
-``SqlObservationRepository`` (the read-only adapter over the 4 legacy
-tables), the two user-scoped write recorders
-(``record_manual_valuation``/``record_override``), ``get_exchange_rate`` +
+``SqlObservationRepository`` (the read adapter over the 4 legacy
+tables + the ingest store), the two user-scoped write recorders
+(``record_manual_valuation``/``record_override``), the ``extraction``
+``PriceObserved``-ingest subscriber (``extension/ingest.py`` —
+``ingest_statement_price`` + the ``subscribe_price_ingest`` wiring the app
+composition root calls, #1642), ``get_exchange_rate`` +
 the ``convert_*`` trio + ``get_average_rate`` (thin FX-specific wrappers over
 the same subject+resolve path — caching and the crawler lazy-fallback are
 deliberately deferred, see ``extension/fx.py``), and the crawler sync
@@ -15,10 +18,6 @@ deliberately deferred, see ``extension/fx.py``), and the crawler sync
 subpackage's own ``__all__`` stay package-internal and are deliberately NOT
 flattened here, the same way ``reconciliation.extension.phases`` never
 bubbles up to ``reconciliation``'s top level).
-
-Reserved for a later commit: the ``extraction`` ``PriceObserved``-ingest
-subscriber. See ``common/pricing/contract.py`` — declared as a taxonomy-only
-reserved unit (no module path) until then.
 """
 
 from __future__ import annotations
@@ -30,6 +29,7 @@ from src.pricing.extension.fx import (
     get_average_rate,
     get_exchange_rate,
 )
+from src.pricing.extension.ingest import ingest_statement_price, subscribe_price_ingest
 from src.pricing.extension.manual import record_manual_valuation, record_override
 from src.pricing.extension.market_data import (
     MARKET_DATA_QUANTITY_UNIT,
@@ -56,10 +56,12 @@ __all__ = [
     "get_average_rate",
     "get_exchange_rate",
     "get_market_data_status",
+    "ingest_statement_price",
     "record_manual_valuation",
     "record_override",
     "resolve",
     "resolve_missing_fx_rate",
+    "subscribe_price_ingest",
     "sync_fx_rates",
     "sync_stock_prices",
 ]

--- a/apps/backend/src/pricing/extension/ingest.py
+++ b/apps/backend/src/pricing/extension/ingest.py
@@ -1,0 +1,169 @@
+"""``ingest_statement_price`` — pricing's ``PriceObserved`` ingest subscriber (#1642).
+
+The first cross-domain event consumer in this codebase; later ``data/`` sinks
+copy this shape (``common/meta/migration-standard.md``, the wide-table
+projection contract). The design decisions every copy inherits:
+
+- **Consume from the payload alone.** The event carries the full observation
+  copy (value/currency/user/subject); the handler never reads the producer's
+  tables (boundary ruling 4: no shared transaction, no FK — the extraction
+  fact id is carried as provenance).
+- **Idempotent by the event's natural key.** Delivery is at-least-once
+  (``OutboxRelay``), so redelivery must be a no-op: the handler dedups on
+  ``observation_id`` (the upstream fact id), backed by a UNIQUE constraint on
+  ``statement_price_observations.source_observation_id``.
+- **Filter, don't loop.** Only ``source=statement`` events are ingested:
+  pricing's own publications (manual/override) already live in pricing's
+  store, and the ingest deliberately does NOT re-publish ``PriceObserved`` —
+  the copy is the same fact the original event announced, and re-publishing
+  would echo it forever.
+- **Malformed events degrade to a loud no-op.** Retrying a deterministically
+  bad payload can never succeed, and raising would wedge the relay batch
+  behind the poison row — so the handler logs at error level and skips.
+  (A dead-letter state is future platform work; see ``common/platform``.)
+
+Wiring: the app composition root (``src/main.py``) owns the
+``SubscriberRegistry`` and calls :func:`subscribe_price_ingest` at startup —
+platform (L1) must not import pricing (L3), so the registration happens at
+L4, matching the ``register_readiness_provider`` (#1676) / uploaded-document
+readers (#1675 D3) inversion precedents.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.observability import get_logger
+from src.platform.base import DomainEvent, SubscriberRegistry
+from src.pricing.base.errors import PricingError
+from src.pricing.base.events import EVENT_TYPE
+from src.pricing.base.observation import Authority, ObservationSource, PriceObservation
+from src.pricing.base.subject import PriceableSubject, SubjectKind
+from src.pricing.orm.statement_observation import StatementPriceObservation
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedStatementPrice:
+    """The validated pieces of a ``source=statement`` ``PriceObserved`` payload."""
+
+    observation: PriceObservation
+    source_observation_id: UUID
+    user_id: UUID
+
+
+def _parse_statement_payload(payload: dict, occurred_at: datetime) -> _ParsedStatementPrice:
+    """Validate and convert the JSON payload; raises on anything malformed.
+
+    Constructing :class:`PriceObservation` is the validation seam — it rejects
+    non-``Decimal``, non-finite, and non-positive values and a naive
+    ``observed_at``, so a bad copy is unrepresentable rather than checked.
+    """
+    user_id_raw = payload.get("user_id")
+    if user_id_raw is None:
+        raise ValueError("statement PriceObserved payload has no user_id")
+    source_observation_id = UUID(payload["observation_id"])
+    subject = PriceableSubject(SubjectKind(payload["subject_kind"]), payload["subject_key"])
+    observation = PriceObservation(
+        subject=subject,
+        value=Decimal(payload["value"]),
+        as_of=date.fromisoformat(payload["as_of"]),
+        observed_at=occurred_at,
+        source=ObservationSource.STATEMENT,
+        authority=Authority.STATEMENT,
+        currency=payload.get("currency"),
+    )
+    return _ParsedStatementPrice(
+        observation=observation,
+        source_observation_id=source_observation_id,
+        user_id=UUID(user_id_raw),
+    )
+
+
+async def ingest_statement_price(db: AsyncSession, event: DomainEvent) -> PriceObservation | None:
+    """Ingest one extraction-published ``PriceObserved`` into pricing's store.
+
+    Returns the ingested :class:`PriceObservation`, or ``None`` when the event
+    was skipped (not a statement source, a redelivered duplicate, or a
+    malformed payload). Flushes but never commits — the caller (the handler
+    closure in production, the test in tests) owns the transaction, and the
+    transaction touches ONLY pricing's own aggregate (no cross-domain write).
+    """
+    payload = event.payload()
+    if payload.get("source") != ObservationSource.STATEMENT.value:
+        return None
+
+    try:
+        parsed = _parse_statement_payload(payload, event.occurred_at)
+    except (KeyError, TypeError, ValueError, InvalidOperation, PricingError):
+        logger.error(
+            "Malformed statement PriceObserved payload; skipping (deterministic failure — "
+            "a raise would wedge the relay batch behind this poison event)",
+            observation_id=payload.get("observation_id"),
+            subject_kind=payload.get("subject_kind"),
+            subject_key=payload.get("subject_key"),
+            exc_info=True,
+        )
+        return None
+
+    # Idempotency (at-least-once delivery): dedup on the event's natural key —
+    # the upstream fact id. The UNIQUE constraint on source_observation_id is
+    # the hard backstop should two relay passes ever race this check.
+    existing = await db.execute(
+        select(StatementPriceObservation.id).where(
+            StatementPriceObservation.source_observation_id == parsed.source_observation_id
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        return None
+
+    obs = parsed.observation
+    db.add(
+        StatementPriceObservation(
+            id=obs.id,
+            user_id=parsed.user_id,
+            subject_kind=obs.subject.kind.value,
+            subject_key=obs.subject.key,
+            value=obs.value,
+            currency=obs.currency,
+            as_of=obs.as_of,
+            observed_at=obs.observed_at,
+            source_observation_id=parsed.source_observation_id,
+        )
+    )
+    await db.flush()
+    return obs
+
+
+def make_statement_price_handler(
+    session_factory: async_sessionmaker[AsyncSession],
+):
+    """Build the production event handler: own session, own (pricing-only) commit."""
+
+    async def _handle(event: DomainEvent) -> None:
+        async with session_factory() as session:
+            ingested = await ingest_statement_price(session, event)
+            if ingested is not None:
+                await session.commit()
+
+    return _handle
+
+
+def subscribe_price_ingest(
+    registry: SubscriberRegistry,
+    *,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Register pricing's ``PriceObserved`` ingest handler on ``registry``.
+
+    Called by the app composition root (``src/main.py``) with the registry the
+    ``OutboxRelay`` dispatches from and the app's session factory.
+    """
+    registry.subscribe(EVENT_TYPE, make_statement_price_handler(session_factory))

--- a/apps/backend/src/pricing/extension/manual.py
+++ b/apps/backend/src/pricing/extension/manual.py
@@ -112,6 +112,9 @@ async def record_manual_valuation(
             subject=subject,
             as_of=snapshot.as_of_date,
             source=ObservationSource.MANUAL,
+            value=snapshot.value,
+            currency=snapshot.currency,
+            user_id=user_id,
             occurred_at=snapshot.created_at,
         )
     )
@@ -167,6 +170,9 @@ async def record_override(
             subject=subject,
             as_of=override.price_date,
             source=ObservationSource.OVERRIDE,
+            value=override.price,
+            currency=override.currency,
+            user_id=user_id,
             occurred_at=override.created_at,
         )
     )

--- a/apps/backend/src/pricing/extension/repository.py
+++ b/apps/backend/src/pricing/extension/repository.py
@@ -2,17 +2,19 @@
 
 Queries the 4 legacy tables during the transition (``FxRate`` / ``StockPrice``
 for the global crawler sources; ``MarketDataOverride`` / ``ManualValuationSnapshot``
-for the user-scoped manual sources) and translates each row into a
-``PriceObservation``, so ``resolve()`` sees one uniform candidate list
-regardless of which table a fact actually lives in today. The unification into
-one physical table is later, package-internal work (#1610 DoD) — this adapter
-is schema-preserving on purpose, so it can land ahead of that migration.
+for the user-scoped manual sources) plus pricing's own
+``statement_price_observations`` (the event-fed ingest store, #1642) and
+translates each row into a ``PriceObservation``, so ``resolve()`` sees one
+uniform candidate list regardless of which table a fact actually lives in
+today. The unification into one physical table is later, package-internal
+work (#1610 DoD) — this adapter is schema-preserving on purpose, so it can
+land ahead of that migration.
 
 Per ``ObservationRepository``'s contract, ``user_id=None`` returns only the
-global sources: the ``MarketDataOverride``/``ManualValuationSnapshot`` queries
-below are gated on ``user_id is not None`` and always filter by it — there is
-no code path that returns one user's manual data to a caller who didn't ask
-for that user.
+global sources: the ``MarketDataOverride``/``ManualValuationSnapshot``/
+``StatementPriceObservation`` queries below are gated on ``user_id is not
+None`` and always filter by it — there is no code path that returns one
+user's data to a caller who didn't ask for that user.
 """
 
 from __future__ import annotations
@@ -28,6 +30,7 @@ from src.models.portfolio import MarketDataOverride
 from src.pricing.base.observation import Authority, ObservationSource, PriceObservation
 from src.pricing.base.subject import PriceableSubject, SubjectKind
 from src.pricing.orm.market_data import FxRate, StockPrice
+from src.pricing.orm.statement_observation import StatementPriceObservation
 
 
 class SqlObservationRepository:
@@ -40,10 +43,49 @@ class SqlObservationRepository:
         self, subject: PriceableSubject, as_of: date, user_id: UUID | None = None
     ) -> list[PriceObservation]:
         if subject.kind is SubjectKind.CURRENCY_PAIR:
-            return await self._fx_candidates(subject, as_of)
-        if subject.kind is SubjectKind.SECURITY:
-            return await self._security_candidates(subject, as_of, user_id)
-        return await self._component_candidates(subject, as_of, user_id)
+            observations = await self._fx_candidates(subject, as_of)
+        elif subject.kind is SubjectKind.SECURITY:
+            observations = await self._security_candidates(subject, as_of, user_id)
+        else:
+            observations = await self._component_candidates(subject, as_of, user_id)
+        # Ingested statement prices are subject-kind-agnostic (the ingest store
+        # keys on kind+key), so they join the candidate list for every kind.
+        observations.extend(await self._statement_candidates(subject, as_of, user_id))
+        return observations
+
+    async def _statement_candidates(
+        self, subject: PriceableSubject, as_of: date, user_id: UUID | None
+    ) -> list[PriceObservation]:
+        if user_id is None:
+            # Statement facts are inherently user-owned; there is no global
+            # statement observation to return.
+            return []
+        rows = (
+            (
+                await self._db.execute(
+                    select(StatementPriceObservation)
+                    .where(StatementPriceObservation.subject_kind == subject.kind.value)
+                    .where(StatementPriceObservation.subject_key == subject.key)
+                    .where(StatementPriceObservation.as_of <= as_of)
+                    .where(StatementPriceObservation.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return [
+            PriceObservation(
+                id=row.id,
+                subject=subject,
+                value=row.value,
+                as_of=row.as_of,
+                observed_at=row.observed_at,
+                source=ObservationSource.STATEMENT,
+                authority=Authority.STATEMENT,
+                currency=row.currency,
+            )
+            for row in rows
+        ]
 
     async def _fx_candidates(self, subject: PriceableSubject, as_of: date) -> list[PriceObservation]:
         base, quote = subject.key.split("/")

--- a/apps/backend/src/pricing/orm/statement_observation.py
+++ b/apps/backend/src/pricing/orm/statement_observation.py
@@ -1,0 +1,71 @@
+"""``StatementPriceObservation`` — pricing's store for ingested statement prices (#1642).
+
+The event-fed, id-referenced copy of a statement-extracted unit price
+(boundary ruling 4, #1610): the authoritative document-fact stays in
+``extraction``; pricing keeps its own denormalized row so ``resolve()`` can
+treat statement prices as first-class candidates without ever joining into
+extraction's write model. The table follows the wide-table projection
+contract (``common/meta/migration-standard.md``):
+
+- **event-fed** — only the ``PriceObserved`` ingest subscriber
+  (``extension/ingest.py``) writes it; rebuildable by replaying events.
+- **idempotent** — ``source_observation_id`` (the extraction fact id, the
+  event's natural dedup key) is UNIQUE, so at-least-once redelivery cannot
+  duplicate a row.
+- **zero FK** — ``user_id``/``source_observation_id`` are plain ids carried
+  as provenance (Decision B, #1416): no shared transaction, no FK into
+  another domain's tables.
+- **bitemporal** — ``as_of`` (which day the price belongs to) vs
+  ``observed_at`` (when extraction learned it); a late backfill is a new row,
+  never a rewrite (Axiom A: append-only, no updates or deletes).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+from sqlalchemy import DECIMAL, CheckConstraint, Date, DateTime, Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.database import Base
+
+
+class StatementPriceObservation(Base):
+    """One ingested copy of a statement-extracted unit price (append-only)."""
+
+    __tablename__ = "statement_price_observations"
+    __table_args__ = (
+        UniqueConstraint(
+            "source_observation_id",
+            name="uq_statement_price_observations_source_id",
+        ),
+        CheckConstraint("value > 0", name="ck_statement_price_observations_value_positive"),
+        Index("idx_statement_price_observations_lookup", "subject_kind", "subject_key", "as_of"),
+    )
+
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    #: The owning user (statement facts are inherently user-owned). A plain id,
+    #: deliberately not a FK (zero-FK projection contract).
+    user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    subject_kind: Mapped[str] = mapped_column(String(20), nullable=False)
+    subject_key: Mapped[str] = mapped_column(String(100), nullable=False)
+    value: Mapped[Decimal] = mapped_column(DECIMAL(18, 6), nullable=False)
+    currency: Mapped[str | None] = mapped_column(String(3), nullable=True)
+    as_of: Mapped[date] = mapped_column(Date, nullable=False)
+    #: When extraction learned the fact (the event's ``occurred_at``).
+    observed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    #: Provenance + dedup key: the extraction-side fact id the event announced.
+    source_observation_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    #: When pricing ingested the copy (relay dispatch time, not fact time).
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<StatementPriceObservation {self.subject_kind}:{self.subject_key} "
+            f"{self.value} {self.currency} {self.as_of}>"
+        )

--- a/apps/backend/tests/platform/test_relay.py
+++ b/apps/backend/tests/platform/test_relay.py
@@ -54,6 +54,28 @@ async def test_run_once_dispatches_and_marks_published(db):
     assert all(r.status == STATUS_PUBLISHED and r.published_at is not None for r in rows)
 
 
+@pytest.mark.asyncio
+async def test_run_once_awaits_async_handlers(db):
+    """An async subscriber (e.g. a DB-writing ingest handler) is awaited, not dropped.
+
+    Cross-domain consumers (#1642's pricing ingest is the precedent) need an
+    ``AsyncSession`` inside the handler, so ``EventHandler`` admits coroutine
+    functions and the relay awaits the returned awaitable before marking the
+    row published.
+    """
+    registry = SubscriberRegistry()
+    seen: list[int] = []
+
+    async def handler(e: DomainEvent) -> None:
+        seen.append(e.payload()["count"])
+
+    registry.subscribe("counter.Incremented", handler)
+    await _seed(db, n=1)
+
+    assert await OutboxRelay(registry).run_once(db) == 1
+    assert seen == [1]
+
+
 @ac_proof(proof_id="test_relay_no_redispatch", ac_ids=["AC-platform.1.3"], ci_tier="pr_ci")
 @pytest.mark.asyncio
 async def test_second_run_does_not_redispatch_published(db):

--- a/apps/backend/tests/pricing/test_ingest.py
+++ b/apps/backend/tests/pricing/test_ingest.py
@@ -1,0 +1,218 @@
+"""``ingest_statement_price`` — pricing's ``PriceObserved`` ingest subscriber (#1642).
+
+The first cross-domain event *consumer* in this codebase (boundary ruling 4,
+#1610): ``extraction`` publishes ``pricing.PriceObserved`` (``source=statement``)
+through the platform outbox, and pricing ingests an id-referenced observation
+copy — no shared transaction, no FK, the extraction fact id carried as
+provenance. Delivery is at-least-once, so the handler MUST be idempotent
+(dedup keyed by the event's natural key, the upstream fact id).
+
+Anchors the ``AC-pricing.ingest.*`` roadmap group:
+
+- AC-pricing.ingest.1 — a published extraction event results in exactly one
+  pricing observation with correct fields + the provenance id.
+- AC-pricing.ingest.2 — redelivering the same event does not duplicate.
+- AC-pricing.ingest.3 — ``resolve()`` sees the ingested observation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from src.database import create_session_maker_from_db
+from src.platform import DomainEvent, OutboxEventBus, OutboxRelay, SubscriberRegistry
+from src.pricing import (
+    Authority,
+    ObservationSource,
+    PriceableSubject,
+    PriceObserved,
+    ResolutionPolicy,
+    SqlObservationRepository,
+    ingest_statement_price,
+    resolve,
+    subscribe_price_ingest,
+)
+from src.pricing.base.events import EVENT_TYPE
+from src.pricing.orm.statement_observation import StatementPriceObservation
+
+pytestmark = pytest.mark.asyncio
+
+
+def _statement_event(
+    *,
+    fact_id,
+    user_id,
+    symbol: str = "AAPL",
+    as_of: date = date(2026, 6, 1),
+    value: Decimal = Decimal("185.50"),
+    currency: str = "USD",
+    occurred_at: datetime | None = None,
+) -> PriceObserved:
+    """The event extraction's publisher will emit: a statement-extracted unit price."""
+    return PriceObserved.create(
+        observation_id=fact_id,
+        subject=PriceableSubject.security(symbol),
+        as_of=as_of,
+        source=ObservationSource.STATEMENT,
+        value=value,
+        currency=currency,
+        user_id=user_id,
+        occurred_at=occurred_at or datetime.now(UTC),
+    )
+
+
+async def _ingested_rows(db) -> list[StatementPriceObservation]:
+    result = await db.execute(select(StatementPriceObservation).order_by(StatementPriceObservation.created_at))
+    return list(result.scalars().all())
+
+
+async def test_AC_pricing_ingest_1_extraction_event_lands_as_one_provenanced_observation(db, test_user):
+    """AC-pricing.ingest.1: publish from the extraction side -> relay -> exactly one copy.
+
+    End to end through the real seams: the event is enqueued through the outbox
+    (``source_pkg="extraction"``, as extraction's publisher will), committed, and
+    dispatched by ``OutboxRelay`` to the handler ``subscribe_price_ingest`` wired —
+    the same registration the app composition root performs at startup.
+    """
+    fact_id = uuid4()
+    occurred_at = datetime.now(UTC)
+    bus = OutboxEventBus(db, source_pkg="extraction")
+    bus.publish(
+        _statement_event(fact_id=fact_id, user_id=test_user.id, occurred_at=occurred_at)
+    )
+    await db.commit()
+
+    registry = SubscriberRegistry()
+    subscribe_price_ingest(registry, session_factory=create_session_maker_from_db(db))
+    published = await OutboxRelay(registry).run_once(db)
+    assert published == 1
+
+    rows = await _ingested_rows(db)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.source_observation_id == fact_id  # provenance: the extraction fact id
+    assert row.user_id == test_user.id
+    assert row.subject_kind == "security"
+    assert row.subject_key == "AAPL"
+    assert row.value == Decimal("185.50")
+    assert row.currency == "USD"
+    assert row.as_of == date(2026, 6, 1)
+    assert row.observed_at == occurred_at
+
+
+async def test_AC_pricing_ingest_2_redelivery_through_the_relay_does_not_duplicate(db, test_user):
+    """AC-pricing.ingest.2: at-least-once delivery of the same fact collapses to one row."""
+    fact_id = uuid4()
+    event = _statement_event(fact_id=fact_id, user_id=test_user.id)
+    bus = OutboxEventBus(db, source_pkg="extraction")
+    bus.publish(event)
+    bus.publish(event)  # the same fact delivered twice (at-least-once)
+    await db.commit()
+
+    registry = SubscriberRegistry()
+    subscribe_price_ingest(registry, session_factory=create_session_maker_from_db(db))
+    published = await OutboxRelay(registry).run_once(db)
+    assert published == 2  # both outbox rows were dispatched...
+
+    rows = await _ingested_rows(db)
+    assert len(rows) == 1  # ...but the duplicate was a no-op
+    assert rows[0].source_observation_id == fact_id
+
+
+async def test_AC_pricing_ingest_2_direct_redelivery_is_a_no_op(db, test_user):
+    """AC-pricing.ingest.2: calling the handler twice with the same event ingests once.
+
+    Models the crash-before-mark redelivery (the relay died after the handler ran
+    but before ``mark_published`` committed): the second delivery must not raise
+    and must not write a second row.
+    """
+    event = _statement_event(fact_id=uuid4(), user_id=test_user.id)
+
+    first = await ingest_statement_price(db, event)
+    again = await ingest_statement_price(db, event)
+
+    assert first is not None
+    assert first.source is ObservationSource.STATEMENT
+    assert again is None  # duplicate -> no-op
+    assert len(await _ingested_rows(db)) == 1
+
+
+async def test_AC_pricing_ingest_3_ingested_observation_is_resolvable(db, test_user):
+    """AC-pricing.ingest.3: the ingested copy is a first-class resolve() candidate."""
+    event = _statement_event(fact_id=uuid4(), user_id=test_user.id)
+    await ingest_statement_price(db, event)
+    await db.commit()
+
+    subject = PriceableSubject.security("AAPL")
+    repo = SqlObservationRepository(db)
+    candidates = await repo.candidates(subject, date(2026, 6, 30), user_id=test_user.id)
+    resolved = resolve(subject, date(2026, 6, 30), ResolutionPolicy(), candidates)
+
+    assert resolved.source is ObservationSource.STATEMENT
+    assert resolved.authority is Authority.STATEMENT
+    assert resolved.value == Decimal("185.50")
+    assert resolved.currency == "USD"
+
+
+async def test_statement_candidates_are_user_scoped(db, test_user):
+    """Another user's (or an anonymous) read never sees this user's statement prices."""
+    await ingest_statement_price(db, _statement_event(fact_id=uuid4(), user_id=test_user.id))
+    await db.commit()
+
+    subject = PriceableSubject.security("AAPL")
+    repo = SqlObservationRepository(db)
+    assert await repo.candidates(subject, date(2026, 6, 30), user_id=uuid4()) == []
+    assert await repo.candidates(subject, date(2026, 6, 30), user_id=None) == []
+
+
+async def test_pricing_own_manual_event_is_not_ingested(db, test_user):
+    """The handler only ingests ``source=statement``: pricing's own publications
+    (manual/override) already live in pricing's store — copying them would
+    double-count the observation."""
+    event = PriceObserved.create(
+        observation_id=uuid4(),
+        subject=PriceableSubject.component("property_value"),
+        as_of=date(2026, 6, 1),
+        source=ObservationSource.MANUAL,
+        value=Decimal("500000"),
+        currency="SGD",
+        user_id=test_user.id,
+        occurred_at=datetime.now(UTC),
+    )
+
+    assert await ingest_statement_price(db, event) is None
+    assert await _ingested_rows(db) == []
+
+
+async def test_malformed_statement_event_is_skipped_not_fatal(db, test_user):
+    """A malformed/unresolvable payload is logged and skipped, never raised.
+
+    Failure is deterministic (retrying the same bad payload can never succeed),
+    and a raise would wedge the relay batch and block every later event behind
+    the poison row — so the handler degrades to a loud no-op.
+    """
+    bad = DomainEvent(event_type=EVENT_TYPE, occurred_at=datetime.now(UTC))
+    object.__setattr__(
+        bad,
+        "payload",
+        lambda: {"source": "statement", "observation_id": "not-a-uuid"},
+    )
+    assert await ingest_statement_price(db, bad) is None
+
+    negative = _statement_event(fact_id=uuid4(), user_id=test_user.id)
+    object.__setattr__(
+        negative,
+        "payload",
+        lambda: {**PriceObserved.payload(negative), "value": "-1"},
+    )
+    assert await ingest_statement_price(db, negative) is None
+
+    missing_user = _statement_event(fact_id=uuid4(), user_id=None)
+    assert await ingest_statement_price(db, missing_user) is None
+
+    assert await _ingested_rows(db) == []

--- a/apps/backend/tests/pricing/test_ingest.py
+++ b/apps/backend/tests/pricing/test_ingest.py
@@ -82,9 +82,7 @@ async def test_AC_pricing_ingest_1_extraction_event_lands_as_one_provenanced_obs
     fact_id = uuid4()
     occurred_at = datetime.now(UTC)
     bus = OutboxEventBus(db, source_pkg="extraction")
-    bus.publish(
-        _statement_event(fact_id=fact_id, user_id=test_user.id, occurred_at=occurred_at)
-    )
+    bus.publish(_statement_event(fact_id=fact_id, user_id=test_user.id, occurred_at=occurred_at))
     await db.commit()
 
     registry = SubscriberRegistry()

--- a/common/platform/readme.md
+++ b/common/platform/readme.md
@@ -74,14 +74,27 @@ await relay.run_once(relay_session)   # drains one batch of pending rows
 `RecordingEventBus` is an in-memory fake for unit tests that assert *what was
 published* without a database.
 
-## Running the relay (deferred — not wired here)
+## Running the relay (wired at the app composition root, #1642)
 
 `run_once(session)` drains one batch; `run_forever(session_factory)` is the shape
-of a durable poll loop. **No always-on worker is wired in this slice** — by
-design. In production the relay would run as a periodic background task (e.g. an
-app-startup `asyncio` task, a cron/`schedule`d job, or — later — a Prefect flow).
-That durable worker, plus a `LISTEN/NOTIFY` fast-path, is explicitly future work
-([`todo.md`](./todo.md)).
+of a durable poll loop. The durable worker is wired at the **app composition
+root** (`apps/backend/src/main.py`), which is also where subscription happens —
+the pattern every consumer package copies:
+
+1. the composition root builds one shared `SubscriberRegistry`;
+2. each consumer package publishes a wiring helper the root calls with that
+   registry + the app session factory (first precedent: pricing's
+   `subscribe_price_ingest`, #1642) — registration lives at the root because
+   platform (L1) must never import a domain package (L3), the same inversion
+   as `register_readiness_provider`;
+3. an app-startup `asyncio` background task drains the outbox each poll
+   interval via `run_once` on a fresh session; a failing pass is logged and
+   retried next pass (at-least-once — handlers are idempotent, so retry is
+   always safe). A handler may be sync or a coroutine function; the relay
+   awaits async handlers before marking the row published.
+
+A `LISTEN/NOTIFY` fast-path and a dead-letter state for poison events remain
+future work ([`todo.md`](./todo.md)).
 
 ## Layers (files converge by layer — `base` / `extension`)
 

--- a/common/pricing/contract.py
+++ b/common/pricing/contract.py
@@ -188,22 +188,35 @@ CONTRACT = PackageContract(
         # helpers (e.g. RECONCILIATION_AUTO_ACCEPT_SCORE), don't get their own
         # taxonomy Unit() — units is a curated tactical-pattern annotation,
         # not a 1:1 mirror of interface.
-        # ── extension (reserved): the extraction event subscriber ──
-        Unit(name="ingest_statement_price", kind=Kind.DOMAIN_SERVICE),
+        # ── extension: the extraction event-ingest subscriber (#1642) — the
+        # first cross-domain event consumer in the codebase. extraction
+        # publishes PriceObserved (source=statement) through the outbox;
+        # ingest_statement_price copies it into pricing's own
+        # statement_price_observations store, idempotent on the upstream fact
+        # id (at-least-once delivery), no FK, provenance id on the row. The
+        # subscribe_price_ingest wiring helper (published, no separate Unit —
+        # curated annotation, same as the DTOs above) is called by the app
+        # composition root: platform (L1) never imports pricing (L3). ──
+        Unit(
+            name="ingest_statement_price",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/ingest.py",
+        ),
         # ── data (reserved): read-models consumed by portfolio/reporting/reconciliation ──
         Unit(name="LatestPriceView", kind=Kind.PROJECTION),
         Unit(name="StalenessView", kind=Kind.PROJECTION),
     ],
     implementations={"be": "apps/backend/src/pricing", "fe": None},
-    # This commit's real, working surface: the pure base/ model, resolve()
+    # The real, working surface: the pure base/ model, resolve()
     # (implementation-pure, physically in extension/ per KIND_LAYER), the
-    # repository port + its read-only SQL adapter (querying the 4 legacy
-    # tables), the two user-scoped write-side recorders (which also publish
-    # PriceObserved through the platform outbox, atomically with the write —
-    # pricing is a real producer on the bus, not just a declared event type),
-    # the FX lookup + convert_* + average-rate wrappers, and the crawler sync
-    # (moved in from apps/backend/src/services/market_data/, #1610 PR2 step
-    # 2). The remaining domain-service (extraction-event ingest) + 2 data
+    # repository port + its SQL adapter (querying the 4 legacy tables plus
+    # the ingest store), the two user-scoped write-side recorders (which also
+    # publish PriceObserved through the platform outbox, atomically with the
+    # write — pricing is a real producer on the bus, not just a declared
+    # event type), the extraction-event ingest subscriber + its wiring helper
+    # (#1642 — pricing is also the bus's first consumer), the FX lookup +
+    # convert_* + average-rate wrappers, and the crawler sync (moved in from
+    # apps/backend/src/services/market_data/, #1610 PR2 step 2). The 2 data
     # projections are reserved units above — they join the interface once a
     # later commit implements them for real.
     interface=[
@@ -222,6 +235,7 @@ CONTRACT = PackageContract(
         "PricingError",
         "ResolutionPolicy",
         "SqlObservationRepository",
+        "StatementPriceObservation",
         "StockPrice",
         "ValuationComponentItem",
         "ValuationComponentsResult",
@@ -234,10 +248,12 @@ CONTRACT = PackageContract(
         "get_average_rate",
         "get_exchange_rate",
         "get_market_data_status",
+        "ingest_statement_price",
         "record_manual_valuation",
         "record_override",
         "resolve",
         "resolve_missing_fx_rate",
+        "subscribe_price_ingest",
         "sync_fx_rates",
         "sync_stock_prices",
     ],
@@ -571,6 +587,54 @@ CONTRACT = PackageContract(
                 "::test_AC22_13_1_valuation_component_item_uses_normalized_provenance_type"
             ),
             priority="P1",
+            status="done",
+        ),
+        # ── group ingest: the extraction PriceObserved ingest subscriber
+        # (#1642 — the codebase's first cross-domain event consumer; boundary
+        # ruling 4: id-referenced copy, no shared transaction, no FK) ──
+        ACRecord(
+            id="AC-pricing.ingest.1",
+            statement=(
+                "An extraction-published PriceObserved (source=statement) "
+                "dispatched by the outbox relay results in exactly one "
+                "pricing observation with correct fields and the extraction "
+                "fact id carried as provenance."
+            ),
+            test=(
+                "apps/backend/tests/pricing/test_ingest.py"
+                "::test_AC_pricing_ingest_1_extraction_event_lands_as_one_provenanced_observation"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.ingest.2",
+            statement=(
+                "Ingest is idempotent under at-least-once delivery: "
+                "redelivering the same event (relay-level or direct) does "
+                "not duplicate the observation — dedup keyed by the event's "
+                "natural key (the upstream fact id), backed by a UNIQUE "
+                "constraint."
+            ),
+            test=(
+                "apps/backend/tests/pricing/test_ingest.py"
+                "::test_AC_pricing_ingest_2_redelivery_through_the_relay_does_not_duplicate"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.ingest.3",
+            statement=(
+                "An ingested statement observation is a first-class, "
+                "user-scoped resolve() candidate (source=statement, "
+                "authority=STATEMENT)."
+            ),
+            test=(
+                "apps/backend/tests/pricing/test_ingest.py"
+                "::test_AC_pricing_ingest_3_ingested_observation_is_resolvable"
+            ),
+            priority="P0",
             status="done",
         ),
     ],

--- a/common/pricing/readme.md
+++ b/common/pricing/readme.md
@@ -66,24 +66,23 @@ The pure `base/` model (`PriceObservation`/`PriceableSubject`/
 read-only SQL adapter (querying the 4 legacy tables directly — schema-preserving
 on purpose, so this lands ahead of a unified physical store), the two
 user-scoped write-side recorders (`record_manual_valuation`/`record_override`,
-each publishing `PriceObserved` atomically with the write), and the FX lookup +
-`convert_*` + average-rate wrappers (`extension/fx.py`).
+each publishing `PriceObserved` atomically with the write), the
+extraction-event ingest subscriber (`ingest_statement_price` +
+`subscribe_price_ingest`, #1642 — the codebase's first cross-domain event
+consumer: extraction's `source=statement` `PriceObserved` publications land as
+id-referenced copies in `statement_price_observations`, idempotent on the
+upstream fact id, no FK, wired by the app composition root), and the FX
+lookup + `convert_*` + average-rate wrappers (`extension/fx.py`).
 
 Reserved (declared in [`contract.py`](./contract.py), no `module=` yet): the
-crawler sync (`sync_market_data`) and the extraction-event subscriber
-(`ingest_statement_price`), plus the `LatestPriceView`/`StalenessView` read
-projections.
+`LatestPriceView`/`StalenessView` read projections.
 
 ## Status
 
-`status="draft"`, `tier=None`, `roadmap=[]` — the write/read surface above is
-implemented and tested, but the package doesn't yet carry its own ACs: they
-remain in `docs/project/EPIC-011.asset-lifecycle.md` /
-`EPIC-005.reporting-visualization.md` / `EPIC-017.portfolio-management.md`
-pending the mass AC migration (tracked in the migration closeout series,
-umbrella #1416). Remaining consumer wiring is tracked in #1610 PR2. The
-package goes `status="active"` once its roadmap is populated and an authority
-tier is decided.
+`status="active"`, `tier="CODE-ONLY"` — the package owns its ACs in
+[`contract.py`](./contract.py)'s `roadmap` (`AC-pricing.*`; the EPIC-era rows
+were distributed in the migration closeout series, umbrella #1416). Remaining
+consumer wiring is tracked in #1610 PR2.
 
 ## <a id="manual-valuation-snapshots"></a>Manual valuation snapshots (pre-#1610-cutover shipped model)
 


### PR DESCRIPTION
## Summary

Wires the codebase's **first cross-domain event subscriber** (Wave-2 PR-E of umbrella #1416's compressed plan): pricing ingests extraction's `PriceObserved` (`source=statement`) publications as id-referenced, provenance-carrying observation copies — idempotent under at-least-once outbox delivery, wired at the app composition root, and visible to `resolve()`. This originates the `subscribe()` pattern every later `data/` sink copies (the wide-table projection contract in `common/meta/migration-standard.md` names this PR's subscriber as its first live precedent).

Closes #1642

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | Umbrella #1416 (Wave-2 PR-E) / #1610 boundary ruling 4 — pricing is a migrated package, so ACs live in its contract roadmap, not an EPIC table |
| **AC IDs** | `AC-pricing.ingest.1`, `AC-pricing.ingest.2`, `AC-pricing.ingest.3` (new group, append-only) |
| **AC source updated** | `common/pricing/contract.py` `roadmap` (owning package contract) |

---

## SSOT Changes

- [x] None — existing SSOT already covers this change (`docs/ssot/` untouched). Package-spec surfaces updated instead: `common/pricing/contract.py` (ingest unit real + `AC-pricing.ingest.*` roadmap group), `common/pricing/readme.md`, `common/platform/readme.md` (the "Running the relay" section now documents the composition-root wiring pattern — issue AC1).

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (failing test) | `77a9f63c` | `tests/pricing/test_ingest.py` fails on import (`ingest_statement_price` does not exist); `tests/platform/test_relay.py::test_run_once_awaits_async_handlers` fails (coroutine returned, never awaited) |
| 🟢 Green (passing test) | `b01fc19d` | subscriber + store + wiring implemented; 11/11 new tests pass, 195 pass across pricing/platform/counter/assets |

---

## What this PR decides (the precedent later subscribers copy)

1. **Where subscription registration happens** (issue AC1): the app composition root (`src/main.py`) owns one shared `SubscriberRegistry`; each consumer package publishes a wiring helper (`pricing.subscribe_price_ingest`) the root calls with the registry + session factory. Platform (L1) never imports pricing (L3) — same inversion as `register_readiness_provider` (#1676) and the #1675-D3 reader ports.
2. **How the relay is driven**: a lifespan `asyncio` background task (`run_outbox_relay`, same shape as `run_parsing_supervisor`) drains one batch per poll interval on a fresh session; a failing pass is logged and retried (at-least-once). This is the durable worker `common/platform/readme.md` described but had deferred.
3. **Handler failure semantics** (issue AC5, first cut): a malformed/unresolvable payload is a **loud logged no-op** — retrying a deterministically bad payload can never succeed, and raising would wedge the relay batch behind the poison row. A dead-letter state remains future platform work (noted in the readme).
4. **Idempotency is the core AC**: dedup keyed by the event's natural key (`observation_id` = the upstream fact id), backed by `UNIQUE(source_observation_id)` on the new `statement_price_observations` table (event-fed, zero-FK, provenance id on every row, append-only — the `data/` projection contract).
5. **Event payload carries the full copy**: `PriceObserved` gained `value`/`currency`/`user_id` (in-scope minimal extension) so a consumer builds the copy from the payload alone — pricing never reads extraction's tables (Decision B: no shared transaction, no FK). Both existing pricing publishers now populate the new fields.
6. **No republish on ingest**: the ingested copy is the same fact the original event announced; republishing would echo it forever. The handler also filters `source=statement`, so pricing's own manual/override publications are never self-ingested.
7. **Platform change**: `EventHandler` now admits coroutine functions; `OutboxRelay.run_once` awaits async handlers before marking a row published (a DB-writing consumer needs an `AsyncSession` inside the handler). Backwards compatible with sync handlers; `common/platform/contract.py` interface unchanged.

**Deliberately out of scope** (per issue DoD: "file the implementation as its own PR against #1610"): extraction's production-side publisher (the atomic publish-with-fact write, issue AC2). Tests publish from the extraction side through the real outbox (`source_pkg="extraction"`) to prove the consumer path end to end.

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter — no `sa.Enum` added (new table stores `subject_kind` as `String` deliberately, like the outbox `status`)
- [ ] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A, no frontend change
- [ ] `repo/` submodule updated for production config changes (if applicable) — N/A
- [ ] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env change
- [ ] `tools/check_manifest.py` passes (if SSOT files changed) — N/A, no `docs/ssot/` change
- [x] `tools/lint_doc_consistency.py` passes
- [x] No real financial data — test fixtures use synthetic symbols/amounts only
- [x] Money values are `Decimal` end to end (event `value`, ORM `DECIMAL(18,6)`, `PriceObservation` validation); the one-transaction rule holds — the ingest handler writes ONLY pricing's own aggregate in its own session
- [x] New table ships with Alembic migration `0053_statement_price_obs`; `alembic upgrade head` + `alembic check` verified clean on a scratch database
- [x] `tools/check_package_contract.py` (deps honesty both directions) and `tools/check_app_boundary.py` ("5 baselined edge(s), none added") pass

---

## Testing

```bash
# The new subscriber suite + platform relay tests (11 tests)
cd apps/backend && uv run python -m pytest tests/pricing/test_ingest.py tests/platform/test_relay.py -q

# Affected suites: 195 passed (pricing/platform/counter/assets); consumer sweep: 696 + 1035 passed
uv run python -m pytest tests/pricing tests/platform tests/counter tests/assets -q
uv run python -m pytest tests/market_data tests/portfolio tests/reporting tests/services tests/unit tests/schemas tests/api tests/extraction tests/reconciliation -q

# Gates
python tools/check_package_contract.py && python tools/check_app_boundary.py
uv run python -m ruff check src tests && uv run python -m ruff format src tests --check

# Composition-root wiring smoke
ENVIRONMENT=testing python -c "from src.main import outbox_subscribers; assert len(outbox_subscribers.handlers_for('pricing.PriceObserved')) == 1"
```

Preflight note (environment artifacts, verified identical on `origin/main` at `7d99f21a`): the local `backend-format` gate picks up an asdf `ruff` 0.15.17 shim whose new rules flag 64 pre-existing findings in untouched files — the project-pinned `ruff` 0.14.11 (what CI runs via `uv`) passes cleanly, including on every file in this diff; the local `tooling` gate fails the same 23 infra/submodule tests on `origin/main` because git worktrees leave the `repo` submodule uninitialized. All 5 diff-relevant preflight gates (taxonomy-drift, api-reference, migration-risk, openapi-spec, app-boundary) pass.

---

## Screenshots / Evidence

```
tests/pricing/test_ingest.py + tests/platform/test_relay.py
======================== 11 passed, 1 warning in 7.21s =========================

tests/pricing tests/platform tests/counter tests/assets
======================= 195 passed, 1 warning in 14.21s ========================

alembic (scratch DB):
Running upgrade 0052_signed_positions -> 0053_statement_price_obs
alembic check: No new upgrade operations detected.

[APP-BOUNDARY] PASSED: 5 baselined edge(s), none added.
check_package_contract: pricing (class domain): 36 interface symbol(s), 6 invariant(s), 22 roadmap AC(s) — OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
